### PR TITLE
Move Slack message-size policy from the renderer to the transport

### DIFF
--- a/assistant/src/messaging/providers/slack/render.test.ts
+++ b/assistant/src/messaging/providers/slack/render.test.ts
@@ -126,21 +126,22 @@ describe("renderSlackBlocks", () => {
     expect(blocks!.some((b) => b.type === "markdown")).toBe(true);
   });
 
-  test("caps output at Slack's 50-block limit with a truncation note", () => {
+  test("emits one block per element with no whole-message cap (transport owns size)", () => {
+    // The renderer does not police total block count — Slack's 50-block limit is
+    // the transport's concern (it resends as plain text on rejection). 60
+    // headings render as 60 header blocks, not a truncated-with-note set.
     const text = Array.from({ length: 60 }, (_, i) => `# H${i}`).join("\n\n");
     const blocks = renderSlackBlocks(text);
-    expect(blocks!.length).toBe(50);
-    expect(blocks![49].type).toBe("context");
-    expect(JSON.stringify(blocks![49])).toContain("omitted");
+    expect(blocks!.length).toBe(60);
+    expect(blocks!.every((b) => b.type === "header")).toBe(true);
   });
 
-  test("falls back to plain text when cumulative markdown exceeds the payload budget", () => {
-    // Two ~7k prose runs split by a heading produce two markdown blocks summing
-    // to ~14k — over Slack's cumulative markdown-block budget — so the whole
-    // reply is delivered as plain text (no blocks) rather than a reject-prone
-    // payload.
-    const para = "word ".repeat(1400).trim();
-    const blocks = renderSlackBlocks(`${para}\n\n# Heading\n\n${para}`);
-    expect(blocks).toBeUndefined();
+  test("keeps an oversized run in a single markdown block (no chunking)", () => {
+    // A run over Slack's 12k per-block limit is left whole rather than split
+    // mid-content; the transport degrades to plain text if Slack rejects it.
+    const para = "word ".repeat(3000).trim();
+    expect(para.length).toBeGreaterThan(12_000);
+    const blocks = renderSlackBlocks(para);
+    expect(blocks).toEqual([{ type: "markdown", text: para }]);
   });
 });

--- a/assistant/src/messaging/providers/slack/render.ts
+++ b/assistant/src/messaging/providers/slack/render.ts
@@ -2,11 +2,22 @@
  * Slack Block Kit rendering: mdast → Slack blocks.
  *
  * The channel-neutral parse (markdown → mdast) lives in `messaging/content`;
- * this module is Slack's "how". Prose, lists, quotes, and code render to Slack
- * `markdown` blocks (native GFM, 12k-char limit) sliced straight from the
- * original source by node position — so there is no inline→mrkdwn serializer to
- * hand-roll. Headings become `header` blocks, GFM tables become `table` blocks
- * (with Slack's row / column / character caps), and a `---` becomes a divider.
+ * this module is Slack's "how". It maps each top-level mdast node to its
+ * natural Slack block: a heading → `header`, a GFM table → `table` (or markdown
+ * when it exceeds Slack's table limits), a thematic break → `divider`, and every
+ * other run of content → a `markdown` block carrying the exact original GFM,
+ * sliced from the source by node position (so there is no inline → mrkdwn
+ * serializer to hand-roll).
+ *
+ * Scope: this renderer enforces only Slack's documented *per-element* limits —
+ * a header's 150 characters, a table's row / column / cell budgets. It does NOT
+ * police whole-message size (total block count, or cumulative `markdown` text).
+ * Those ceilings — the 50-block limit, and an undocumented cumulative-markdown
+ * limit Slack surfaces as `msg_blocks_too_long` around ~13k characters — are the
+ * transport's responsibility: `send.ts` posts the blocks and resends the
+ * message as plain text if Slack rejects the payload. Keeping size policy at the
+ * send boundary lets Slack stay the authority on its own limits and keeps this
+ * module a straight mapping with no guessed byte ceiling.
  */
 
 import type { KnownBlock, RawTextElement, TableBlock } from "@slack/types";
@@ -21,19 +32,6 @@ import type {
 
 import { parseMarkdown } from "../../content/parse.js";
 
-/** Slack rejects messages with more than 50 Block Kit blocks. */
-const SLACK_BLOCK_LIMIT = 50;
-/** A `markdown` block's text is capped at 12,000 characters. */
-const SLACK_MARKDOWN_MAX_CHARS = 12_000;
-/**
- * Slack also caps the *cumulative* `markdown`-block text across a single message
- * payload, not just per block — an over-limit payload is rejected as
- * `invalid_blocks`. The exact ceiling isn't documented in `@slack/types`; 12,000
- * is conservative (it matches the documented per-block limit and stays under the
- * observed cumulative threshold). Past it, the reply is delivered as plain text
- * rather than risking rejection.
- */
-const SLACK_MARKDOWN_PAYLOAD_MAX_CHARS = 12_000;
 /** A `header` block's plain_text is capped at 150 characters. */
 const SLACK_HEADER_MAX_CHARS = 150;
 /**
@@ -66,10 +64,8 @@ export function renderSlack(tree: Root, source: string): KnownBlock[] {
   let tableCharsUsed = 0;
 
   const flushRun = (): void => {
-    if (run.length === 0) return;
-    for (const chunk of runToMarkdownChunks(run, source)) {
-      blocks.push({ type: "markdown", text: chunk });
-    }
+    const md = sliceRun(run, source);
+    if (md.length > 0) blocks.push({ type: "markdown", text: md });
     run = [];
   };
 
@@ -84,12 +80,11 @@ export function renderSlack(tree: Root, source: string): KnownBlock[] {
         blocks.push(built.block);
         tableCharsUsed += built.cellChars;
       } else {
-        // Too big for a `table` block (Slack would reject the payload). Fall
-        // back to the raw table markdown in `markdown` blocks so the content
-        // still shows, just not as a rendered table.
-        for (const chunk of splitAtLines(sliceNode(node, source))) {
-          if (chunk.length > 0) blocks.push({ type: "markdown", text: chunk });
-        }
+        // Too big for a `table` block (Slack would reject it). Keep the content
+        // as its raw table markdown so it still shows, just not as a rendered
+        // table.
+        const md = sliceNode(node, source).trim();
+        if (md.length > 0) blocks.push({ type: "markdown", text: md });
       }
     } else if (node.type === "thematicBreak") {
       flushRun();
@@ -100,18 +95,7 @@ export function renderSlack(tree: Root, source: string): KnownBlock[] {
   }
   flushRun();
 
-  // Slack caps cumulative `markdown`-block text per payload (see
-  // SLACK_MARKDOWN_PAYLOAD_MAX_CHARS). If the rendered markdown would exceed it,
-  // deliver the whole reply as plain text instead of a reject-prone payload —
-  // the same outcome as the `invalid_blocks` retry, but without the failed
-  // round trip. Returning an empty array makes the caller fall back to `text`.
-  const markdownChars = blocks.reduce(
-    (sum, block) => (block.type === "markdown" ? sum + block.text.length : sum),
-    0,
-  );
-  if (markdownChars > SLACK_MARKDOWN_PAYLOAD_MAX_CHARS) return [];
-
-  return capBlocks(blocks);
+  return blocks;
 }
 
 // ---------------------------------------------------------------------------
@@ -127,71 +111,17 @@ function sliceNode(node: RootContent, source: string): string {
 }
 
 /**
- * Turn a run of ordinary (non-heading / non-table / non-rule) nodes into
- * `markdown`-block-sized chunks, splitting at node boundaries so a chunk never
- * bisects a node unless that single node is itself over the limit.
+ * Slice a run of consecutive ordinary (non-heading / non-table / non-rule)
+ * nodes back to one markdown string, spanning the first node's start to the last
+ * node's end so the original GFM — and the blank lines between nodes — is
+ * preserved verbatim. Returns "" for an empty run.
  */
-function runToMarkdownChunks(run: RootContent[], source: string): string[] {
-  const chunks: string[] = [];
-  let current = "";
-
-  for (const node of run) {
-    const md = sliceNode(node, source).trim();
-    if (md.length === 0) continue;
-
-    if (md.length > SLACK_MARKDOWN_MAX_CHARS) {
-      if (current.length > 0) {
-        chunks.push(current);
-        current = "";
-      }
-      chunks.push(...splitAtLines(md));
-      continue;
-    }
-
-    if (
-      current.length > 0 &&
-      current.length + 2 + md.length > SLACK_MARKDOWN_MAX_CHARS
-    ) {
-      chunks.push(current);
-      current = "";
-    }
-    current = current.length > 0 ? `${current}\n\n${md}` : md;
-  }
-
-  if (current.length > 0) chunks.push(current);
-  return chunks;
-}
-
-/** Split text into ≤`max` chunks, preferring line boundaries, hard-slicing only an over-long single line. */
-function splitAtLines(
-  text: string,
-  max: number = SLACK_MARKDOWN_MAX_CHARS,
-): string[] {
-  if (text.length <= max) return [text];
-
-  const chunks: string[] = [];
-  let current = "";
-
-  for (const line of text.split("\n")) {
-    if (line.length > max) {
-      if (current.length > 0) {
-        chunks.push(current);
-        current = "";
-      }
-      for (let i = 0; i < line.length; i += max) {
-        chunks.push(line.slice(i, i + max));
-      }
-      continue;
-    }
-    if (current.length > 0 && current.length + 1 + line.length > max) {
-      chunks.push(current);
-      current = "";
-    }
-    current = current.length > 0 ? `${current}\n${line}` : line;
-  }
-
-  if (current.length > 0) chunks.push(current);
-  return chunks;
+function sliceRun(run: RootContent[], source: string): string {
+  if (run.length === 0) return "";
+  const start = run[0]?.position?.start.offset;
+  const end = run[run.length - 1]?.position?.end.offset;
+  if (start === undefined || end === undefined) return "";
+  return source.slice(start, end).trim();
 }
 
 /** A `header` block from a heading node (plain text, formatting stripped, ≤150 chars). */
@@ -273,22 +203,4 @@ function serializePlain(nodes: PhrasingContent[]): string {
     }
   }
   return out;
-}
-
-/** Cap output at Slack's 50-block limit, appending a truncation note when over. */
-function capBlocks(blocks: KnownBlock[]): KnownBlock[] {
-  if (blocks.length <= SLACK_BLOCK_LIMIT) return blocks;
-  const omitted = blocks.length - (SLACK_BLOCK_LIMIT - 1);
-  return [
-    ...blocks.slice(0, SLACK_BLOCK_LIMIT - 1),
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: `_${omitted} more block${omitted === 1 ? "" : "s"} omitted (Slack's ${SLACK_BLOCK_LIMIT}-block limit)._`,
-        },
-      ],
-    },
-  ];
 }

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -234,4 +234,43 @@ describe("sendSlackReply post path", () => {
       callSlackApiMock.mock.calls.filter((call) => call[0] === "chat.update"),
     ).toHaveLength(0);
   });
+
+  test("retries chat.postMessage without blocks on msg_blocks_too_long", async () => {
+    // Cumulative block text over Slack's ~13k ceiling comes back as
+    // `msg_blocks_too_long`, not `invalid_blocks`; it must still degrade to text.
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("msg_blocks_too_long");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000300",
+      }));
+
+    const result = await sendSlackReply("C123", "Fresh reply", {
+      threadTs,
+      blocks,
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1700000000.000300" });
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
+      channel: "C123",
+      text: "Fresh reply",
+      thread_ts: threadTs,
+    });
+  });
+
+  test("does not drop blocks on a non-payload error", async () => {
+    // Errors unrelated to the Block Kit payload (here `channel_not_found`) must
+    // propagate, not trigger a wasteful block-free retry.
+    callSlackApiMock.mockImplementationOnce(async () => {
+      throw new SlackApiError("channel_not_found");
+    });
+
+    await expect(
+      sendSlackReply("C123", "Fresh reply", { threadTs, blocks }),
+    ).rejects.toThrow();
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -27,6 +27,21 @@ const log = getLogger("slack-send");
 // Use a generous 100 MB cap for outbound attachments.
 const SLACK_MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 
+/**
+ * Slack errors meaning the Block Kit payload is too big for one message:
+ * `invalid_blocks` (malformed blocks, or over the 50-block limit) and
+ * `msg_blocks_too_long` (cumulative block text over Slack's ~13k, undocumented,
+ * content-dependent ceiling). The remedy is identical — resend the same message
+ * without `blocks` so the text body is still delivered — which keeps Slack the
+ * authority on its own limits instead of pre-guessing a byte ceiling here. Other
+ * client errors (e.g. `msg_too_long`, where the text itself is too long) are
+ * deliberately excluded: dropping `blocks` wouldn't help, so retrying is waste.
+ */
+const SLACK_OVERSIZED_BLOCKS_ERRORS = new Set([
+  "invalid_blocks",
+  "msg_blocks_too_long",
+]);
+
 // ---------------------------------------------------------------------------
 // Approval Block Kit builder
 // ---------------------------------------------------------------------------
@@ -124,12 +139,13 @@ export interface SlackSendResult {
 
 /**
  * Call a Slack message API once, retrying a single time without Block Kit
- * blocks if Slack rejects the payload with `invalid_blocks`.
+ * blocks if Slack rejects the payload as too big (see
+ * `SLACK_OVERSIZED_BLOCKS_ERRORS`).
  *
- * `invalid_blocks` faults the Block Kit payload, not the target — the retry
- * repeats the *same* operation (same `chat.update` ts, same `chat.postMessage`
- * thread) without blocks, so it edits/posts in place rather than spawning a
- * second message. Any other error propagates to the caller.
+ * Those errors fault the Block Kit payload, not the target — the retry repeats
+ * the *same* operation (same `chat.update` ts, same `chat.postMessage` thread)
+ * without blocks, so it edits/posts in place rather than spawning a second
+ * message. Any other error propagates to the caller.
  */
 async function sendWithBlockFallback(
   method: string,
@@ -148,9 +164,13 @@ async function sendWithBlockFallback(
       options.fallbackWithoutBlocks &&
       blocks.length > 0 &&
       err instanceof SlackApiError &&
-      err.slackError === "invalid_blocks"
+      err.slackError !== undefined &&
+      SLACK_OVERSIZED_BLOCKS_ERRORS.has(err.slackError)
     ) {
-      log.warn({ method }, "Slack rejected blocks; retrying without blocks");
+      log.warn(
+        { method, slackError: err.slackError },
+        "Slack rejected blocks; retrying without blocks",
+      );
       const result = await callSlackApi(method, baseBody);
       return { ok: true, ts: result.ts };
     }
@@ -198,16 +218,16 @@ export async function sendSlackReply(
   if (options?.ephemeral) {
     if (!options.user)
       throw new Error("user is required for ephemeral messages");
-    const result = await callSlackApi("chat.postEphemeral", {
-      ...postBase,
-      ...(blocks.length > 0 ? { blocks } : {}),
-      user: options.user,
-    });
-    return { ok: true, ts: result.ts };
+    return sendWithBlockFallback(
+      "chat.postEphemeral",
+      { ...postBase, user: options.user },
+      blocks,
+      { fallbackWithoutBlocks: !options.approval },
+    );
   }
 
-  // Approval prompts carry their action buttons in `blocks`; dropping them on
-  // `invalid_blocks` would post a card with no way to respond, so only
+  // Approval prompts carry their action buttons in `blocks`; dropping them when
+  // Slack rejects the payload would post a card with no way to respond, so only
   // non-approval posts fall back to a block-free retry.
   const result = await sendWithBlockFallback(
     "chat.postMessage",


### PR DESCRIPTION
## What & why

Follow-up to the Codex / Devin reviews on #36273, which added a proactive cumulative-markdown valve (`SLACK_MARKDOWN_PAYLOAD_MAX_CHARS = 12_000`). Devin correctly flagged that 12,000 **equals** the per-block limit, degrading realistic two-block replies to plain text — and it was a guessed number.

This splits responsibility cleanly and grounds the transport in Slack's **actual** error codes.

### The verified fact

Slack rejects cumulative `markdown`-block text over its ~13k (content-dependent) ceiling with **`msg_blocks_too_long`** — a *different* code from `invalid_blocks` (confirmed via [slackapi/bolt-js#2509](https://github.com/slackapi/bolt-js/issues/2509)). The old `sendWithBlockFallback` caught only `invalid_blocks`, so cumulative overflow slipped through — the gap the removed valve had been masking with a guess.

### Changes

- **`render.ts`** → a straight `mdast → blocks` mapping that enforces only Slack's documented **per-element** limits (header 150 chars; table dims/cells). Drops the cumulative valve, the per-block char chunker (which split prose/code mid-content), and the 50-block truncation cap.
- **`send.ts`** (transport) owns whole-message size: posts the blocks and resends as plain text on `invalid_blocks` / `msg_blocks_too_long` (`SLACK_OVERSIZED_BLOCKS_ERRORS`). `msg_too_long` is excluded (dropping blocks wouldn't help). Ephemeral sends route through the same fallback.

### Why safe

`callSlackApi` exhausts transient retries (429/5xx/rate-limit) *below* this layer, so an error reaching the fallback is a real rejection. Every removed renderer guard maps to a caught code.

### Tests

render: one block per element (no whole-message cap); oversized run kept whole. send: falls back on `msg_blocks_too_long`; does not drop blocks on a non-payload error.

### Scope note

This PR keys on the Slack error **code** directly, so it does **not** depend on the error-category map. Classifying `msg_blocks_too_long` in that map — and **deduping the duplicated assistant + gateway error maps into `@vellumai/slack-text`** (the AGENTS.md Single-Source-of-Truth item Devin flagged) — is the companion PR #36302. The two touch disjoint files and can merge in either order.

Part of LUM-2618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)