### PR TITLE
feat(daemon): /readyz returns 503 until startup completes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -47,9 +47,52 @@ paths:
   /readyz:
     get:
       operationId: readyz_get
+      summary: Readiness probe
+      description:
+        Strict readiness probe. Returns 503 with { status, ready, notReady } until the daemon's synchronous startup
+        latches (isStartupComplete() && isDbReady()) are set, then a stable 200. notReady lists the gates still failing
+        ("startup", "db"). CES is informational and never gates readiness.
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  ready:
+                    type: boolean
+                  notReady:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - status
+                  - ready
+                  - notReady
+                additionalProperties: false
+        "503":
+          description: Not ready — startup incomplete or database not ready.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  ready:
+                    type: boolean
+                  notReady:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - status
+                  - ready
+                  - notReady
+                additionalProperties: false
   /v1/acp/{id}/cancel:
     post:
       operationId: acp_by_id_cancel_post

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -227,6 +227,18 @@ const trivialHealthSchema = z.object({
 });
 
 /**
+ * Strict readiness probe response. `/readyz` gates on the daemon's synchronous
+ * startup latches (`isStartupComplete() && isDbReady()`), returning 503 with
+ * `ready: false` until both are set, then a stable 200. `notReady` lists the
+ * gates still failing (`"startup"`, `"db"`). CES is never consulted.
+ */
+const readyzSchema = z.object({
+  status: z.string(),
+  ready: z.boolean(),
+  notReady: z.array(z.string()),
+});
+
+/**
  * Top-level routes outside the /v1/ namespace.
  * These are added to the spec separately.
  */
@@ -236,6 +248,10 @@ const NON_V1_ROUTES: Array<{
   summary?: string;
   description?: string;
   responseBody?: z.ZodType;
+  additionalResponses?: Record<
+    string,
+    { description: string; schema?: unknown }
+  >;
 }> = [
   {
     method: "GET",
@@ -246,7 +262,23 @@ const NON_V1_ROUTES: Array<{
       "the HTTP server is up, with zero DB/CES/lifecycle access.",
     responseBody: trivialHealthSchema,
   },
-  { method: "GET", path: "/readyz" },
+  {
+    method: "GET",
+    path: "/readyz",
+    summary: "Readiness probe",
+    description:
+      "Strict readiness probe. Returns 503 with { status, ready, notReady } until " +
+      "the daemon's synchronous startup latches (isStartupComplete() && isDbReady()) " +
+      "are set, then a stable 200. notReady lists the gates still failing " +
+      '("startup", "db"). CES is informational and never gates readiness.',
+    responseBody: readyzSchema,
+    additionalResponses: {
+      "503": {
+        description: "Not ready — startup incomplete or database not ready.",
+        schema: readyzSchema,
+      },
+    },
+  },
   { method: "GET", path: "/pages/{id}" },
 ];
 
@@ -352,6 +384,9 @@ function buildSpec(
           ...(r.summary ? { summary: r.summary } : {}),
           ...(r.description ? { description: r.description } : {}),
           ...(r.responseBody ? { responseBody: r.responseBody } : {}),
+          ...(r.additionalResponses
+            ? { additionalResponses: r.additionalResponses }
+            : {}),
         },
       });
     }

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -23,6 +23,11 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import {
+  resetReadinessForTest,
+  setDbReady,
+  setStartupComplete,
+} from "../daemon/daemon-readiness.js";
+import {
   handleDetailedHealth,
   handleHealth,
   handleReadyz,
@@ -196,31 +201,6 @@ describe("identity routes — health endpoint", () => {
   describe("CES readiness", () => {
     beforeEach(() => {
       setCesClient(undefined);
-    });
-
-    test("readyz returns 200 and logs warning when CES is unavailable", () => {
-      const res = handleReadyz();
-      expect(res.status).toBe(200);
-    });
-
-    test("readyz returns 200 when CES is connected and ready", () => {
-      const mockClient = {
-        isReady: () => true,
-        close: () => {},
-      } as unknown as import("../credential-execution/client.js").CesClient;
-      setCesClient(mockClient);
-      const res = handleReadyz();
-      expect(res.status).toBe(200);
-    });
-
-    test("readyz returns 200 when CES client exists but is not ready", () => {
-      const mockClient = {
-        isReady: () => false,
-        close: () => {},
-      } as unknown as import("../credential-execution/client.js").CesClient;
-      setCesClient(mockClient);
-      const res = handleReadyz();
-      expect(res.status).toBe(200);
     });
 
     test("/v1/health reports ces.connected=true when CES is ready", async () => {
@@ -445,6 +425,73 @@ describe("identity routes — trivial /healthz liveness probe", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ status: "ok", version: APP_VERSION });
+  });
+});
+
+describe("identity routes — /readyz readiness gate", () => {
+  afterEach(() => {
+    resetReadinessForTest();
+    setCesClient(undefined);
+  });
+
+  test("returns 503 with notReady:['startup','db'] before startup", async () => {
+    resetReadinessForTest();
+    const res = handleReadyz();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      status: "unready",
+      ready: false,
+      notReady: ["startup", "db"],
+    });
+  });
+
+  test("returns 503 with notReady:['startup'] when db is ready but startup isn't", async () => {
+    resetReadinessForTest();
+    setDbReady(true);
+    const res = handleReadyz();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ready).toBe(false);
+    expect(body.notReady).toEqual(["startup"]);
+  });
+
+  test("returns 503 with notReady:['db'] when started but db not ready", async () => {
+    resetReadinessForTest();
+    setStartupComplete();
+    const res = handleReadyz();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ready).toBe(false);
+    expect(body.notReady).toEqual(["db"]);
+  });
+
+  test("returns 200 when started and db ready even if CES is down", async () => {
+    resetReadinessForTest();
+    setStartupComplete();
+    setDbReady(true);
+    const explodingClient = {
+      isReady: () => {
+        throw new Error("/readyz must not consult CES");
+      },
+      close: () => {},
+    } as unknown as import("../credential-execution/client.js").CesClient;
+    setCesClient(explodingClient);
+
+    const res = handleReadyz();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ready).toBe(true);
+  });
+
+  test("returns 200 with the ok body when fully ready", async () => {
+    resetReadinessForTest();
+    setStartupComplete();
+    setDbReady(true);
+    const res = handleReadyz();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ status: "ok", ready: true, notReady: [] });
   });
 });
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -8,6 +8,7 @@ import { availableParallelism, cpus, totalmem } from "node:os";
 import { z } from "zod";
 
 import { getCpuLimit, getIsPlatform } from "../../config/env-registry.js";
+import { isDbReady, isStartupComplete } from "../../daemon/daemon-readiness.js";
 import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getProfilerRuntimeStatus } from "../../daemon/profiler-run-store.js";
 import { getMaxRollbackVersion } from "../../memory/migrations/run-migrations.js";
@@ -17,7 +18,6 @@ import {
   getDiskUsageInfo,
   parseK8sMemoryBytes,
 } from "../../util/disk-usage.js";
-import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
 import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
@@ -362,17 +362,28 @@ export function handleDetailedHealth(): Response {
   return Response.json(getDetailedHealth());
 }
 
+/**
+ * Strict readiness probe (`GET /readyz`).
+ *
+ * Reports whether the daemon can actually serve requests, gating on two
+ * monotonic startup latches read SYNCHRONOUSLY (no `await`, DB query, or
+ * subprocess) so the probe stays cheap on a ~10s interval. Returns 503 until
+ * both latches are set, then a stable 200 for the rest of the process lifetime.
+ *
+ * CES is intentionally never consulted: it is informational only. Gating on it
+ * would leave a pod permanently NotReady whenever CES never handshakes, even
+ * though the daemon serves degraded with an encrypted-store fallback.
+ */
 export function handleReadyz(): Response {
-  const cesClient = getCesClient();
-  if (!cesClient?.isReady()) {
-    // TODO: Return 503 once we confirm via logs that this won't cause
-    // regressions in the K8s readinessProbe.
-    getLogger("health").warn(
-      { reason: cesClient ? "ces_not_ready" : "ces_unavailable" },
-      "CES not ready — pod would be unready if 503 were enabled",
-    );
-  }
-  return Response.json({ status: "ok" });
+  const notReady: string[] = [];
+  if (!isStartupComplete()) notReady.push("startup");
+  if (!isDbReady()) notReady.push("db");
+  const ready = notReady.length === 0;
+
+  return Response.json(
+    { status: ready ? "ok" : "unready", ready, notReady },
+    { status: ready ? 200 : 503 },
+  );
 }
 
 function getIdentity() {


### PR DESCRIPTION
## Summary
- /readyz now gates on isStartupComplete() && isDbReady(), returning 503 until ready then 200
- CES is informational and never gates readiness
- Lightweight body {status, ready, notReady}; /v1/health(z) unchanged
- Regenerated assistant/openapi.yaml; /readyz stays excluded from web SDK

Part of plan: health-consolidation.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->