### PR TITLE
feat(acp): add optional rawInput/rawOutput to acp_session_update contract

### DIFF
--- a/assistant/src/api/events/acp-session-update.test.ts
+++ b/assistant/src/api/events/acp-session-update.test.ts
@@ -42,6 +42,58 @@ describe("AcpSessionUpdateEventSchema", () => {
     ).toEqual([{ path: "src/baz.ts", line: 7 }]);
   });
 
+  test("accepts a tool_call event carrying object rawInput/rawOutput", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call" as const,
+      toolCallId: "tool-1",
+      rawInput: { command: "ls -la", cwd: "/tmp" },
+      rawOutput: { exitCode: 0, stdout: "file.txt" },
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.rawInput).toEqual({
+      command: "ls -la",
+      cwd: "/tmp",
+    });
+    expect(result.success && result.data.rawOutput).toEqual({
+      exitCode: 0,
+      stdout: "file.txt",
+    });
+  });
+
+  test("accepts a tool_call_update event carrying string rawInput/rawOutput", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call_update" as const,
+      toolCallId: "tool-1",
+      rawInput: "ls -la",
+      rawOutput: "file.txt",
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.rawInput).toBe("ls -la");
+    expect(result.success && result.data.rawOutput).toBe("file.txt");
+  });
+
+  test("still accepts a tool_call event omitting rawInput/rawOutput (optional)", () => {
+    const event = {
+      type: "acp_session_update" as const,
+      acpSessionId: "acp-1",
+      updateType: "tool_call" as const,
+      toolCallId: "tool-1",
+    };
+
+    const result = AcpSessionUpdateEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.rawInput).toBeUndefined();
+    expect(result.success && result.data.rawOutput).toBeUndefined();
+  });
+
   test("still accepts a normal event without locations", () => {
     const event = {
       type: "acp_session_update" as const,

--- a/assistant/src/api/events/acp-session-update.ts
+++ b/assistant/src/api/events/acp-session-update.ts
@@ -35,6 +35,9 @@ export const AcpSessionUpdateEventSchema = z
     toolTitle: z.string().optional(),
     toolKind: z.string().optional(),
     toolStatus: z.string().optional(),
+    /** Raw tool input/output (ACP rawInput/rawOutput); apply to tool_call/tool_call_update. Absent on older daemons. */
+    rawInput: z.unknown().optional(),
+    rawOutput: z.unknown().optional(),
     /** Files touched by this tool call (for the file-diff affordance). */
     locations: z
       .array(z.object({ path: z.string(), line: z.number().optional() }))

--- a/assistant/src/api/events/acp-session-update.ts
+++ b/assistant/src/api/events/acp-session-update.ts
@@ -35,7 +35,7 @@ export const AcpSessionUpdateEventSchema = z
     toolTitle: z.string().optional(),
     toolKind: z.string().optional(),
     toolStatus: z.string().optional(),
-    /** Raw tool input/output (ACP rawInput/rawOutput); apply to tool_call/tool_call_update. Absent on older daemons. */
+    /** Optional raw tool input/output (ACP rawInput/rawOutput); apply to tool_call/tool_call_update. */
     rawInput: z.unknown().optional(),
     rawOutput: z.unknown().optional(),
     /** Files touched by this tool call (for the file-diff affordance). */

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -28,9 +28,9 @@ export interface AcpSessionUpdate {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
-  /** Raw input parameters sent to the tool (ACP `rawInput`); shape is tool-specific. Absent on older daemons. */
+  /** Optional raw input parameters sent to the tool (ACP `rawInput`); shape is tool-specific. */
   rawInput?: unknown;
-  /** Raw output returned by the tool (ACP `rawOutput`); shape is tool-specific. Absent on older daemons. */
+  /** Optional raw output returned by the tool (ACP `rawOutput`); shape is tool-specific. */
   rawOutput?: unknown;
   /** Files touched by this tool call (for the file-diff affordance). */
   locations?: { path: string; line?: number }[];

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -28,6 +28,10 @@ export interface AcpSessionUpdate {
   toolTitle?: string;
   toolKind?: string;
   toolStatus?: string;
+  /** Raw input parameters sent to the tool (ACP `rawInput`); shape is tool-specific. Absent on older daemons. */
+  rawInput?: unknown;
+  /** Raw output returned by the tool (ACP `rawOutput`); shape is tool-specific. Absent on older daemons. */
+  rawOutput?: unknown;
   /** Files touched by this tool call (for the file-diff affordance). */
   locations?: { path: string; line?: number }[];
   /** Stable id for the message this chunk belongs to. */


### PR DESCRIPTION
## Summary
- Add optional rawInput/rawOutput to the AcpSessionUpdate wire type and the .strict() SSE schema
- Schema test covers object/string forms and omission

Part of plan: acp-tool-raw-io-and-labels.md (PR 1 of 7)