### PR TITLE
feat(chat): kind-driven ACP tool-card labels, per-kind icons, no header truncation

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -65,6 +65,21 @@ describe("AcpChatToolCard", () => {
     expect(screen.queryByTestId("acp-chat-tool-detail")).toBeNull();
   });
 
+  test("a file-op block with no chips falls back to showing its title", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({ toolKind: "read", title: "src/foo.ts" })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    // No locations/diff → no chip → the title must still surface as the detail.
+    expect(screen.getByText("Read file")).toBeDefined();
+    expect(screen.queryByTestId("acp-chat-tool-file-ref")).toBeNull();
+    expect(screen.getByTestId("acp-chat-tool-detail").textContent).toBe(
+      "src/foo.ts",
+    );
+  });
+
   test("an unknown kind falls back to the Tool call label and Code icon", () => {
     const { container } = render(
       <AcpChatToolCard

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -20,9 +20,60 @@ function toolBlock(overrides: Partial<ToolBlock> = {}): ToolBlock {
 }
 
 describe("AcpChatToolCard", () => {
-  test("renders the tool title", () => {
-    render(<AcpChatToolCard block={toolBlock()} onOpenDiff={() => {}} />);
+  test("renders the kind label in the header", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({ toolKind: "read", title: "cat ./README.md" })}
+        onOpenDiff={() => {}}
+      />,
+    );
     expect(screen.getByText("Read file")).toBeDefined();
+  });
+
+  test("renders an execute command as a full, wrapping body line", () => {
+    const command = "git log --oneline | grep something && echo ".repeat(10);
+    render(
+      <AcpChatToolCard
+        block={toolBlock({ toolKind: "execute", title: command })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByText("Run command")).toBeDefined();
+    const detail = screen.getByTestId("acp-chat-tool-detail");
+    // Full command present in the DOM (not truncated) and set to wrap.
+    expect(detail.textContent).toBe(command);
+    expect(detail.className).toContain("whitespace-pre-wrap");
+    expect(detail.className).toContain("break-words");
+    expect(detail.className).not.toContain("truncate");
+  });
+
+  test("a read block shows the kind label + path chip with no duplicate title line", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({
+          toolKind: "read",
+          title: "src/touched.ts",
+          locations: [{ path: "src/touched.ts" }],
+        })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByText("Read file")).toBeDefined();
+    expect(screen.getByTestId("acp-chat-tool-file-ref").textContent).toContain(
+      "src/touched.ts",
+    );
+    expect(screen.queryByTestId("acp-chat-tool-detail")).toBeNull();
+  });
+
+  test("an unknown kind falls back to the Tool call label and Code icon", () => {
+    const { container } = render(
+      <AcpChatToolCard
+        block={toolBlock({ toolKind: "other", title: "mystery" })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByText("Tool call")).toBeDefined();
+    expect(container.querySelector(".lucide-code")).not.toBeNull();
   });
 
   test("renders the status pill per status", () => {

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -1,12 +1,27 @@
 /**
  * A tool call rendered as a distinct card in the ACP chat transcript: a kind
- * glyph, the tool title, a status pill, and a streaming indicator while
- * running. Inline output (parsed from the tool content) renders in a monospace
+ * glyph, a standardized kind label, a status pill, and a streaming indicator
+ * while running. For non-file-op kinds the raw agent title/command surfaces as
+ * a wrapping body line. Inline output (parsed from the tool content) renders in a monospace
  * block, collapsed behind a toggle when long. Any file changes the call touched
  * surface as clickable chips that invoke `onOpenDiff`.
  */
 
-import { ChevronDown, ChevronRight, Code, FileText } from "lucide-react";
+import {
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Code,
+  FilePen,
+  FileText,
+  FolderInput,
+  Globe,
+  Repeat,
+  Search,
+  Terminal,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Tag, Typography, type TagTone } from "@vellumai/design-library";
@@ -67,9 +82,40 @@ const STATUS_LABEL: Record<ToolDisplayStatus, string> = {
   ended: "Ended",
 };
 
-/** Leading kind glyph — file glyph for read/edit, code brackets otherwise. */
+/** Standardized, human-readable header label per ACP tool kind. */
+const KIND_LABEL: Record<string, string> = {
+  read: "Read file",
+  edit: "Edit file",
+  delete: "Delete file",
+  move: "Move file",
+  search: "Search",
+  execute: "Run command",
+  think: "Thinking",
+  fetch: "Fetch",
+  switch_mode: "Switch mode",
+};
+
+const DEFAULT_KIND_LABEL = "Tool call";
+
+/** Leading kind glyph per ACP tool kind. */
+const KIND_ICON: Record<string, LucideIcon> = {
+  read: FileText,
+  edit: FilePen,
+  delete: Trash2,
+  move: FolderInput,
+  search: Search,
+  execute: Terminal,
+  think: Brain,
+  fetch: Globe,
+  switch_mode: Repeat,
+};
+
+/** Kinds whose specifics already surface via file chips, so the raw title
+ *  would be redundant as a body detail line. */
+const FILE_OP_KINDS = new Set(["read", "edit", "delete", "move"]);
+
 function KindIcon({ toolKind }: { toolKind?: string }) {
-  const Icon = toolKind === "read" || toolKind === "edit" ? FileText : Code;
+  const Icon = (toolKind && KIND_ICON[toolKind]) || Code;
   return (
     <Icon
       aria-hidden
@@ -111,6 +157,17 @@ export function AcpChatToolCard({
   const isLong = outputText.length > COLLAPSE_THRESHOLD;
   const showOutput = outputText.length > 0 && (!isLong || expanded);
 
+  const kindLabel =
+    (block.toolKind && KIND_LABEL[block.toolKind]) || DEFAULT_KIND_LABEL;
+  // Surface the raw agent title only for kinds without file chips, where the
+  // header label alone hides what the tool actually did (e.g. the command).
+  const detailLine =
+    !FILE_OP_KINDS.has(block.toolKind ?? "") &&
+    block.title &&
+    block.title !== kindLabel
+      ? block.title
+      : null;
+
   return (
     <div
       data-testid="acp-chat-tool-card"
@@ -124,7 +181,7 @@ export function AcpChatToolCard({
           className="min-w-0 flex-1 truncate text-[var(--content-default)]"
           title={block.title}
         >
-          {block.title || "Tool call"}
+          {kindLabel}
         </Typography>
         <Tag
           tone={STATUS_TONE[displayStatus]}
@@ -139,6 +196,15 @@ export function AcpChatToolCard({
           />
         )}
       </div>
+
+      {detailLine && (
+        <div
+          data-testid="acp-chat-tool-detail"
+          className="mt-1.5 font-mono text-body-small-default whitespace-pre-wrap break-words text-[var(--content-secondary)]"
+        >
+          {detailLine}
+        </div>
+      )}
 
       {fileChanges.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -159,12 +159,14 @@ export function AcpChatToolCard({
 
   const kindLabel =
     (block.toolKind && KIND_LABEL[block.toolKind]) || DEFAULT_KIND_LABEL;
-  // Surface the raw agent title only for kinds without file chips, where the
-  // header label alone hides what the tool actually did (e.g. the command).
+  // Surface the raw agent title when the header label alone hides what the tool
+  // did (e.g. the command). File-op kinds normally show their path via chips, so
+  // suppress it there — but fall back to the title when no chips rendered (a
+  // title-only tool call with no locations/diff).
   const detailLine =
-    !FILE_OP_KINDS.has(block.toolKind ?? "") &&
     block.title &&
-    block.title !== kindLabel
+    block.title !== kindLabel &&
+    (!FILE_OP_KINDS.has(block.toolKind ?? "") || fileChanges.length === 0)
       ? block.title
       : null;
 


### PR DESCRIPTION
## Summary
- Standardized per-kind header labels + per-kind lucide icons for ACP tool cards
- Relocated the raw command/title to a wrapping body line (fixes header truncation); file-op kinds rely on chips

Part of plan: acp-tool-raw-io-and-labels.md (PR 5 of 7)