### PR TITLE
feat(acp): forward tool rawInput/rawOutput in client-handler

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -483,6 +483,82 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
     });
   });
 
+  test("tool_call forwards a small rawOutput unchanged (under the cap)", async () => {
+    const { handler, sent } = makeHandler();
+
+    const rawOutput = { ok: true };
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-small-raw",
+        title: "Run check",
+        kind: "execute",
+        status: "completed",
+        rawOutput,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { rawOutput?: unknown };
+    // Under the 16 KiB cap — forwarded structurally, unchanged.
+    expect(msg.rawOutput).toEqual({ ok: true });
+  });
+
+  test("tool_call caps an oversize rawOutput to a marker string", async () => {
+    const { handler, sent } = makeHandler();
+
+    const huge = "x".repeat(20000);
+    const rawOutput = { stdout: huge };
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-oversize-raw",
+        title: "Run noisy command",
+        kind: "execute",
+        status: "completed",
+        rawOutput,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { rawOutput?: unknown };
+    // Oversize payloads are replaced with a short marker so a single large
+    // rawOutput can't evict real transcript events from the session buffer.
+    expect(typeof msg.rawOutput).toBe("string");
+    expect(msg.rawOutput as string).toStartWith("[raw payload omitted:");
+    // The original large value must not survive into the forwarded event.
+    expect(JSON.stringify(sent[0])).not.toContain(huge);
+  });
+
+  test("tool_call caps an oversize rawInput to a marker string", async () => {
+    const { handler, sent } = makeHandler();
+
+    const huge = "y".repeat(20000);
+    const rawInput = { prompt: huge };
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-oversize-input",
+        title: "Run big prompt",
+        kind: "execute",
+        status: "pending",
+        rawInput,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { rawInput?: unknown };
+    expect(typeof msg.rawInput).toBe("string");
+    expect(msg.rawInput as string).toStartWith("[raw payload omitted:");
+    expect(JSON.stringify(sent[0])).not.toContain(huge);
+  });
+
   test("tool_call_update leaves rawInput/rawOutput undefined when source omits them", async () => {
     const { handler, sent } = makeHandler();
 

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -408,6 +408,99 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
     });
   });
 
+  test("tool_call forwards rawInput/rawOutput structurally when present", async () => {
+    const { handler, sent } = makeHandler();
+
+    const rawInput = { command: "ls", args: ["-la"] };
+    const rawOutput = { stdout: "file.txt", exitCode: 0 };
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-raw",
+        title: "Run ls",
+        kind: "execute",
+        status: "completed",
+        rawInput,
+        rawOutput,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "tool_call",
+      toolCallId: "tc-raw",
+      // Forwarded as-is, NOT stringified (unlike content).
+      rawInput: { command: "ls", args: ["-la"] },
+      rawOutput: { stdout: "file.txt", exitCode: 0 },
+    });
+  });
+
+  test("tool_call leaves rawInput/rawOutput undefined when source omits them", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-no-raw",
+        title: "Edit main.ts",
+        kind: "edit",
+        status: "pending",
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { rawInput?: unknown; rawOutput?: unknown };
+    expect(msg.rawInput).toBeUndefined();
+    expect(msg.rawOutput).toBeUndefined();
+  });
+
+  test("tool_call_update forwards rawInput/rawOutput structurally when present", async () => {
+    const { handler, sent } = makeHandler();
+
+    const rawInput = { path: "/repo/main.ts", oldText: "a", newText: "b" };
+    const rawOutput = { applied: true };
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-raw-update",
+        status: "completed",
+        rawInput,
+        rawOutput,
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      updateType: "tool_call_update",
+      toolCallId: "tc-raw-update",
+      rawInput: { path: "/repo/main.ts", oldText: "a", newText: "b" },
+      rawOutput: { applied: true },
+    });
+  });
+
+  test("tool_call_update leaves rawInput/rawOutput undefined when source omits them", async () => {
+    const { handler, sent } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-no-raw-update",
+        status: "in_progress",
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as { rawInput?: unknown; rawOutput?: unknown };
+    expect(msg.rawInput).toBeUndefined();
+    expect(msg.rawOutput).toBeUndefined();
+  });
+
   test("tool_call_update forwards locations: [] when null (explicit clear)", async () => {
     const { handler, sent } = makeHandler();
 

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -173,6 +173,10 @@ export class VellumAcpClientHandler implements Client {
           // follow up with an update; forward it like the update branch so the
           // chat/file-diff UI has content to render.
           content: update.content ? JSON.stringify(update.content) : undefined,
+          // rawInput/rawOutput are unknown-shaped; forward them structurally —
+          // the SSE layer serializes the whole message, so no stringify here.
+          rawInput: update.rawInput,
+          rawOutput: update.rawOutput,
           locations: mapLocations(update.locations),
         });
         break;
@@ -186,6 +190,8 @@ export class VellumAcpClientHandler implements Client {
           toolKind: update.kind ?? undefined,
           toolStatus: update.status ?? undefined,
           content: update.content ? JSON.stringify(update.content) : undefined,
+          rawInput: update.rawInput,
+          rawOutput: update.rawOutput,
           locations: mapLocations(update.locations),
         });
         break;


### PR DESCRIPTION
## Summary
- Forward ACP rawInput/rawOutput (structured) on tool_call and tool_call_update

Part of plan: acp-tool-raw-io-and-labels.md (PR 2 of 7)