### PR TITLE
fix(chat): render ACP tool output as markdown so console fences style correctly

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -116,7 +116,7 @@ describe("AcpChatToolCard", () => {
     expect(screen.queryByTestId("acp-chat-tool-running")).toBeNull();
   });
 
-  test("renders inline content output in a monospace block", () => {
+  test("renders inline content output through the markdown renderer", () => {
     const content = JSON.stringify([
       { type: "content", content: { type: "text", text: "file contents here" } },
     ]);
@@ -125,7 +125,26 @@ describe("AcpChatToolCard", () => {
     );
     const output = screen.getByTestId("acp-chat-tool-output");
     expect(output.textContent).toContain("file contents here");
-    expect(output.className).toContain("font-mono");
+    // Routed through ChatMarkdownMessage rather than a raw <pre>.
+    expect(output.querySelector("[data-slot='markdown-message']")).not.toBeNull();
+  });
+
+  test("renders a ```console fence as a code block, not literal backticks", () => {
+    const text = "```console\n$ ls -la\ntotal 0\n```";
+    const content = JSON.stringify([
+      { type: "content", content: { type: "text", text } },
+    ]);
+    render(
+      <AcpChatToolCard block={toolBlock({ content })} onOpenDiff={() => {}} />,
+    );
+    const output = screen.getByTestId("acp-chat-tool-output");
+    // The fence is parsed into a styled code block — no leaked backticks.
+    expect(output.textContent).not.toContain("```console");
+    expect(output.textContent).not.toContain("```");
+    // The inner command + stdout still render.
+    expect(output.textContent).toContain("$ ls -la");
+    expect(output.textContent).toContain("total 0");
+    expect(output.querySelector("code.language-console")).not.toBeNull();
   });
 
   test("renders a file chip per diff and fires onOpenDiff with the tool id + file change", () => {

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -147,6 +147,22 @@ describe("AcpChatToolCard", () => {
     expect(output.querySelector("code.language-console")).not.toBeNull();
   });
 
+  test("preserves single newlines in unfenced output as hard line breaks", () => {
+    // Unfenced terminal-style output: single newlines must survive as <br>,
+    // not collapse into one wrapped paragraph (hardLineBreaks).
+    const content = JSON.stringify([
+      { type: "content", content: { type: "text", text: "line1\nline2" } },
+    ]);
+    render(
+      <AcpChatToolCard block={toolBlock({ content })} onOpenDiff={() => {}} />,
+    );
+    const output = screen.getByTestId("acp-chat-tool-output");
+    // The single newline renders as an explicit <br>, keeping the lines apart.
+    expect(output.querySelector("br")).not.toBeNull();
+    expect(output.textContent).toContain("line1");
+    expect(output.textContent).toContain("line2");
+  });
+
   test("renders a file chip per diff and fires onOpenDiff with the tool id + file change", () => {
     const content = JSON.stringify([
       { type: "diff", path: "src/a.ts", oldText: "old", newText: "new" },

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -2,8 +2,8 @@
  * A tool call rendered as a distinct card in the ACP chat transcript: a kind
  * glyph, a standardized kind label, a status pill, and a streaming indicator
  * while running. For non-file-op kinds the raw agent title/command surfaces as
- * a wrapping body line. Inline output (parsed from the tool content) renders in a monospace
- * block, collapsed behind a toggle when long. Any file changes the call touched
+ * a wrapping body line. Inline output (parsed from the tool content) renders as
+ * markdown, collapsed behind a toggle when long. Any file changes the call touched
  * surface as clickable chips that invoke `onOpenDiff`.
  */
 
@@ -32,6 +32,7 @@ import {
 } from "@/domains/chat/acp-tool-content";
 import type { AcpChatBlock } from "@/domains/chat/acp-run-message-projection";
 import type { AcpToolStatus } from "@/domains/chat/acp-run-step-projection";
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
 
 type AcpToolBlock = Extract<AcpChatBlock, { kind: "tool" }>;
@@ -271,12 +272,12 @@ export function AcpChatToolCard({
             </button>
           )}
           {showOutput && (
-            <pre
+            <div
               data-testid="acp-chat-tool-output"
-              className="max-h-60 overflow-auto rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] p-2.5 font-mono text-body-small-default whitespace-pre-wrap break-words text-[var(--content-default)]"
+              className="max-h-60 overflow-auto rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] p-2.5"
             >
-              {outputText}
-            </pre>
+              <ChatMarkdownMessage content={outputText} />
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Render tool-call output via ChatMarkdownMessage so ```console fences become styled code blocks instead of literal backticks; scroll + collapse preserved

Part of plan: acp-tool-raw-io-and-labels.md (PR 6 of 7)