### PR TITLE
feat(chat): thread ACP rawInput/rawOutput through store and projection

### DIFF
--- a/clients/web/src/domains/chat/acp-run-message-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.test.ts
@@ -423,6 +423,61 @@ describe("tool blocks", () => {
     expect(tool.rawOutput).toBe("second");
   });
 
+  it("projects an explicit null rawInput/rawOutput over a prior value", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Bash",
+        rawInput: { command: "ls" },
+        rawOutput: "first",
+      }),
+      // A JSON `null` is a real value, not an omission — it must overwrite the
+      // prior rawInput/rawOutput rather than be treated as "field absent".
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+        rawInput: null,
+        rawOutput: null,
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.rawInput).toBeNull();
+    expect(tool.rawOutput).toBeNull();
+  });
+
+  it("keeps a prior value when a later update omits rawInput/rawOutput", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Bash",
+        rawInput: { command: "ls" },
+        rawOutput: "out",
+      }),
+      // Sets a null value...
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        rawInput: null,
+        rawOutput: null,
+      }),
+      // ...then a later update omits both fields entirely — the prior (null)
+      // value is preserved, not reset to undefined.
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.rawInput).toBeNull();
+    expect(tool.rawOutput).toBeNull();
+  });
+
   it("leaves rawInput/rawOutput undefined when no event carries them", () => {
     const blocks = computeAcpRunChatBlocks([
       event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),

--- a/clients/web/src/domains/chat/acp-run-message-projection.test.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.test.ts
@@ -383,6 +383,60 @@ describe("tool blocks", () => {
     const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
     expect(tool.locations).toEqual([{ path: "a.ts", line: 12 }]);
   });
+
+  it("carries rawInput/rawOutput from a tool_call when present", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Bash",
+        rawInput: { command: "ls -la" },
+        rawOutput: "total 0",
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.rawInput).toEqual({ command: "ls -la" });
+    expect(tool.rawOutput).toBe("total 0");
+  });
+
+  it("overrides rawInput/rawOutput on update only when the field is present", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({
+        updateType: "tool_call",
+        toolCallId: "tc1",
+        toolTitle: "Bash",
+        rawInput: { command: "ls" },
+        rawOutput: "first",
+      }),
+      // Updates rawOutput but omits rawInput — the prior rawInput is preserved.
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+        rawOutput: "second",
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.rawInput).toEqual({ command: "ls" });
+    expect(tool.rawOutput).toBe("second");
+  });
+
+  it("leaves rawInput/rawOutput undefined when no event carries them", () => {
+    const blocks = computeAcpRunChatBlocks([
+      event({ updateType: "tool_call", toolCallId: "tc1", toolTitle: "Read" }),
+      event({
+        updateType: "tool_call_update",
+        toolCallId: "tc1",
+        toolStatus: "completed",
+      }),
+    ]);
+
+    const tool = blocks[0] as Extract<AcpChatBlock, { kind: "tool" }>;
+    expect(tool.rawInput).toBeUndefined();
+    expect(tool.rawOutput).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/acp-run-message-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.ts
@@ -50,6 +50,8 @@ export type AcpChatBlock =
       status: AcpToolStatus;
       content?: string;
       locations?: { path: string; line?: number }[];
+      rawInput?: unknown;
+      rawOutput?: unknown;
     }
   | { kind: "plan"; entries: { label: string; checked: boolean }[] };
 
@@ -225,6 +227,8 @@ export function applyAcpChatEvent(
         status: mapToolStatus(event.toolStatus, "running"),
         content: event.content,
         locations: parseLocations(event),
+        rawInput: event.rawInput,
+        rawOutput: event.rawOutput,
       });
       return;
     }
@@ -249,6 +253,8 @@ export function applyAcpChatEvent(
         // ACP `ToolCallUpdate.content` REPLACES the snapshot, not a delta.
         content: event.content ?? target.content,
         locations: parsedLocations ?? target.locations,
+        rawInput: event.rawInput ?? target.rawInput,
+        rawOutput: event.rawOutput ?? target.rawOutput,
       };
       return;
     }

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -50,6 +50,9 @@ export interface AcpRunRawEvent {
   toolStatus?: string;
   /** Files touched by this tool call (for the file-diff affordance). */
   locations?: { path: string; line?: number }[];
+  /** Raw tool input/output (ACP rawInput/rawOutput); absent on older daemons. */
+  rawInput?: unknown;
+  rawOutput?: unknown;
   messageId?: string;
 }
 

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.test.ts
@@ -178,6 +178,36 @@ describe("rehydration — terminal session", () => {
     ]);
   });
 
+  test("carries persisted rawInput/rawOutput onto the rehydrated event", async () => {
+    await seed([
+      {
+        id: "acp-1",
+        acpSessionId: "proto-1",
+        agentId: "claude",
+        parentConversationId: "conv-1",
+        status: "completed",
+        startedAt: 1000,
+        completedAt: 5000,
+        eventLog: [
+          {
+            type: "acp_session_update",
+            updateType: "tool_call",
+            toolCallId: "t-1",
+            toolTitle: "Bash",
+            rawInput: { command: "ls -la" },
+            rawOutput: "total 0",
+            seq: 4,
+          },
+        ],
+      },
+    ]);
+
+    // Raw I/O survives history rehydration so a reopened run keeps it.
+    const event = getState().byId["acp-1"]!.events[0]!;
+    expect(event.rawInput).toEqual({ command: "ls -la" });
+    expect(event.rawOutput).toBe("total 0");
+  });
+
   test("carries cumulative input/output tokens from the session row", async () => {
     await seed([
       {

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -44,6 +44,9 @@ export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
       toolStatus: event.toolStatus,
       // Tool-call locations[]; absent on older daemons.
       locations: event.locations,
+      // Raw tool input/output; absent on older daemons.
+      rawInput: event.rawInput,
+      rawOutput: event.rawOutput,
       messageId: event.messageId,
     },
   });

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -44,7 +44,7 @@ export function handleAcpSessionUpdate(event: AcpSessionUpdateEvent): void {
       toolStatus: event.toolStatus,
       // Tool-call locations[]; absent on older daemons.
       locations: event.locations,
-      // Raw tool input/output; absent on older daemons.
+      // Optional raw tool input/output, when the daemon forwards them.
       rawInput: event.rawInput,
       rawOutput: event.rawOutput,
       messageId: event.messageId,


### PR DESCRIPTION
## Summary
- Carry optional rawInput/rawOutput through AcpRunRawEvent, the handler, and the tool block projection (no UI yet)

Part of plan: acp-tool-raw-io-and-labels.md (PR 4 of 7)