### PR TITLE
docs(acp): fix incorrect comments and trim stale/slop in ACP run-detail

### DIFF
--- a/assistant/src/api/events/acp-session-completed.ts
+++ b/assistant/src/api/events/acp-session-completed.ts
@@ -4,9 +4,8 @@
  * Server → client notification that an ACP session has finished its
  * turn. `stopReason` mirrors the ACP `StopReason` set.
  *
- * Canonical wire-contract source. Daemon code imports the type
- * directly from this file; external consumers import via
- * `@vellumai/assistant-api`.
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
  */
 
 import { z } from "zod";

--- a/assistant/src/api/events/acp-session-error.ts
+++ b/assistant/src/api/events/acp-session-error.ts
@@ -4,9 +4,8 @@
  * Server → client notification that an ACP session has errored.
  * Carries the session identity and a human-readable `error` message.
  *
- * Canonical wire-contract source. Daemon code imports the type
- * directly from this file; external consumers import via
- * `@vellumai/assistant-api`.
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
  */
 
 import { z } from "zod";

--- a/assistant/src/api/events/acp-session-spawned.ts
+++ b/assistant/src/api/events/acp-session-spawned.ts
@@ -8,9 +8,8 @@
  * anchors the inline card to the `acp_spawn` tool-use block, and `task`
  * carries the objective text.
  *
- * Canonical wire-contract source. Daemon code imports the type
- * directly from this file; external consumers import via
- * `@vellumai/assistant-api`.
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
  */
 
 import { z } from "zod";

--- a/assistant/src/api/events/acp-session-update.ts
+++ b/assistant/src/api/events/acp-session-update.ts
@@ -7,9 +7,8 @@
  * since they apply only to the relevant `updateType`s. `messageId` and
  * `seq` let clients correlate and order chunks within a session.
  *
- * Canonical wire-contract source. Daemon code imports the type
- * directly from this file; external consumers import via
- * `@vellumai/assistant-api`.
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
  */
 
 import { z } from "zod";

--- a/assistant/src/api/events/acp-session-usage.ts
+++ b/assistant/src/api/events/acp-session-usage.ts
@@ -9,9 +9,8 @@
  * agent's cumulative cost. A side gauge, not part of the ordered update
  * timeline — carries no `seq`.
  *
- * Canonical wire-contract source. Daemon code imports the type
- * directly from this file; external consumers import via
- * `@vellumai/assistant-api`.
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
  */
 
 import { z } from "zod";

--- a/assistant/src/memory/schema/acp.ts
+++ b/assistant/src/memory/schema/acp.ts
@@ -30,7 +30,7 @@ export const acpSessionHistory = sqliteTable(
     // resume a persisted session; null for rows written before migration
     // 272 (those sessions are not resumable).
     cwd: text("cwd"),
-    // Usage metadata. Null for rows written before migration 302.
+    // Usage metadata. Null for rows written before these columns existed.
     task: text("task"),
     parentToolUseId: text("parent_tool_use_id"),
     usedTokens: integer("used_tokens"),
@@ -38,7 +38,7 @@ export const acpSessionHistory = sqliteTable(
     costAmount: real("cost_amount"),
     costCurrency: text("cost_currency"),
     // Cumulative input/output tokens across all turns. Null for rows written
-    // before migration 305.
+    // before these columns existed.
     inputTokens: integer("input_tokens"),
     outputTokens: integer("output_tokens"),
   },

--- a/clients/web/src/domains/chat/acp-run-message-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-message-projection.ts
@@ -437,7 +437,7 @@ export function useAcpRunChatBlocks(events: AcpRunRawEvent[]): AcpChatBlock[] {
 
   // Intentional render-phase ref usage: the projector is a per-instance
   // diff-aware cache (like `useMemo`, but it must run every render to fold in
-  // new events). Mirrors `useAcpRunSteps`.
+  // new events).
   /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
   if (projectorRef.current == null) {
     projectorRef.current = createAcpRunChatProjection();

--- a/clients/web/src/domains/chat/acp-run-step-projection.ts
+++ b/clients/web/src/domains/chat/acp-run-step-projection.ts
@@ -367,7 +367,7 @@ export function useAcpRunSteps(events: AcpRunRawEvent[]): AcpTimelineStep[] {
 
   // Intentional render-phase ref usage: the projector is a per-instance
   // diff-aware cache (like `useMemo`, but it must run every render to fold in
-  // new events). Mirrors `useSubagentSteps`.
+  // new events).
   /* eslint-disable react-hooks/refs -- per-instance projection cache (see above) */
   if (projectorRef.current == null) {
     projectorRef.current = createAcpRunStepProjection();
@@ -416,8 +416,7 @@ function carouselStatus(step: AcpTimelineStep): AcpToolStatus {
 }
 
 /**
- * Derive the last N header-carousel items from the projected steps, mirroring
- * how the subagent card feeds its `HeaderStepCarousel`.
+ * Derive the last N header-carousel items from the projected steps.
  */
 export function acpStepsToCarousel(
   steps: AcpTimelineStep[],

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -2,9 +2,9 @@
  * Zustand store for ACP run lifecycle state.
  *
  * Maintains a map of AcpRunEntry records keyed by acpSessionId, with an
- * ordered list of IDs for stable rendering. Event buffers are append-only;
- * consecutive message/thought chunks of the same `messageId` are coalesced
- * into the last event so high-frequency streaming stays O(1) for projections.
+ * ordered list of IDs for stable rendering. Event buffers are append-only —
+ * message/thought chunks are stored as individual events and coalesced by the
+ * projections for display, so the buffer stays a cheap append.
  *
  * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
  * @see https://zustand.docs.pmnd.rs/guides/updating-state
@@ -178,8 +178,7 @@ export interface AcpRunActions {
    * reports — the daemon restarted and lost the in-memory subprocess before it
    * persisted a terminal history row, so no event will ever settle the run.
    * Marks each still-active run `cancelled` with a `daemon_restarted` stop
-   * reason, mirroring the daemon's own boot-time `cleanupStaleRunningRows`.
-   * No-op for runs already terminal.
+   * reason. No-op for runs already terminal.
    */
   retireMissingRuns: (params: {
     acpSessionIds: string[];

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-agent-message.tsx
@@ -1,7 +1,7 @@
 /**
  * A streamed agent response in the ACP chat transcript. Left-aligned and
- * full-width with no bubble — mirrors the main chat's assistant styling. A
- * trailing `ThreeDotIndicator` marks the block as still streaming.
+ * full-width with no bubble. A trailing `ThreeDotIndicator` marks the block as
+ * still streaming.
  */
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-plan-block.tsx
@@ -1,6 +1,5 @@
 /**
- * A plan checklist in the ACP chat transcript. Renders one row per entry with a
- * checked/unchecked glyph; completed rows read as muted with a strikethrough.
+ * A plan checklist in the ACP chat transcript.
  */
 
 import { Circle, CheckCircle2, ListChecks } from "lucide-react";

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
@@ -3,9 +3,8 @@
  * ended: a completed run differentiates its `stopReason`; a failed run renders
  * with error styling and surfaces the `error` message.
  *
- * Reuses the shared `AcpRunStatus` type from `acp-run-status.ts`. Only terminal
- * statuses produce a block — active statuses render nothing (the trailing
- * agent/thinking block already shows the live indicator).
+ * Only terminal statuses produce a block — active statuses render nothing (the
+ * trailing agent/thinking block already shows the live indicator).
  */
 
 import { AlertTriangle, CheckCircle2, MinusCircle } from "lucide-react";

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -1,9 +1,5 @@
 /**
- * A tool call rendered as a distinct card in the ACP chat transcript: a kind
- * glyph, the tool title, a status pill, and a streaming indicator while
- * running. Inline output (parsed from the tool content) renders in a monospace
- * block, collapsed behind a toggle when long. Any file changes the call touched
- * surface as clickable chips that invoke `onOpenDiff`.
+ * A tool call rendered as a card in the ACP chat transcript.
  */
 
 import { ChevronDown, ChevronRight, Code, FileText } from "lucide-react";

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-user-turn.tsx
@@ -1,6 +1,5 @@
 /**
- * A user turn in the ACP chat transcript — right-aligned bubble mirroring the
- * main chat's user message styling.
+ * A user turn in the ACP chat transcript — right-aligned bubble.
  */
 
 export interface AcpChatUserTurnProps {

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/file-diff-view.tsx
@@ -41,7 +41,7 @@ function rowMarker(type: DiffRow["type"]): string {
  * `computeLineDiff` and renders monospace add/del/ctx lines with design tokens.
  *
  * Body-only: navigation (Back + breadcrumb) lives in the chat view's shared
- * header, mirroring the subagent/workflow detail panels.
+ * header.
  */
 export function FileDiffView({ path, oldText, newText }: FileDiffViewProps) {
   const rows = computeLineDiff(oldText ?? "", newText ?? "");

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.ts
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/use-stick-to-bottom.ts
@@ -24,12 +24,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 const PIN_THRESHOLD = 80;
 
 export interface UseStickToBottomReturn {
-  /**
-   * Callback ref for the scroll container. A callback ref (not a ref object)
-   * so the scroll listener follows the node across remounts — the conversation
-   * div unmounts when a file diff opens and remounts on Back, and a plain
-   * ref + effect with stable deps would leave the listener on the detached node.
-   */
+  // Callback ref so the scroll listener follows the node across remounts (see impl).
   scrollRef: (node: HTMLDivElement | null) => void;
   showScrollToLatest: boolean;
   scrollToLatest: () => void;

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card.tsx
@@ -58,14 +58,11 @@ export function AcpRunInlineProgressCard({
     [acpSessionId],
   );
 
-  // Spawn race: assistant message references a run before its spawn event
-  // lands. Render `null` rather than a blank shell so the transcript doesn't
-  // flicker an empty card.
+  // Spawn race: no entry yet (see header).
   if (!data) return null;
 
   const leadingIcon = <Code size={20} aria-hidden />;
 
-  // Stop cancels the run directly whenever it is in-flight.
   const actionSlot = isRunning ? (
     <Button
       variant="dangerGhost"

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
@@ -11,10 +11,7 @@
  * `null` in that window so the transcript layout doesn't jiggle, mirroring
  * `useWorkflowCardData`.
  *
- * State mapping (see `deriveCardState`): `initializing`/`running` → `loading`;
- * `completed` with `stopReason === "cancelled"` → `warning` (a user-aborted
- * run still produced partial work, so it's not a clean finish nor an error);
- * `completed` → `complete`; `failed`/`cancelled` → `error`.
+ * Visual-state mapping lives in `deriveCardState`.
  */
 
 import { useMemo } from "react";
@@ -29,7 +26,7 @@ import type { AcpRunStatus } from "@/utils/acp-run-status";
 import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
 
 /**
- * Stable frozen empty buffer for the spawn-race window (no entry yet). A stable
+ * Stable shared empty buffer for the spawn-race window (no entry yet). A stable
  * reference keeps the projector's identity check happy so the hook doesn't
  * churn while waiting for the spawn event.
  */
@@ -45,8 +42,7 @@ export interface AcpRunCardData {
 
 /**
  * Translate the run status to a shell-compatible visual state. A `completed`
- * run that was cancelled reads as a `warning` (partial work); a clean
- * `completed` reads as `complete`; `failed`/`cancelled` read as `error`.
+ * run that was cancelled reads as a `warning` (partial work).
  */
 function deriveCardState(
   status: AcpRunStatus,

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -302,7 +302,7 @@ export function ChatBody({
         showScrollToLatest &&
         (activeSubagentsSlot || activeAcpRunsSlot || activeWorkflowsSlot) && (
           <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-            {/* subagents on the left, workflows on the right (do not reorder) */}
+            {/* subagents, then active acp runs, then workflows (do not reorder) */}
             {activeSubagentsSlot}
             {activeAcpRunsSlot}
             {activeWorkflowsSlot}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -167,7 +167,8 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
-  // thought process, subagent detail, document viewer). Surfaces stacked
+  // thought process, subagent detail, workflow detail, acp run detail,
+  // document viewer). Surfaces stacked
   // above the panel that own Escape — Radix layers (dialogs, popovers,
   // dropdowns), the command palette, voice recording, the attachment
   // preview — all run before this bubble-phase window listener (document

--- a/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-acp-run-detail-overlay.tsx
@@ -10,9 +10,7 @@ const AcpRunDetailPanel = lazy(() =>
 );
 
 interface MobileAcpRunDetailOverlayProps {
-  /** When `null`, the overlay renders nothing. */
   entry: AcpRunEntry | null;
-  /** Closes the overlay. */
   onClose: () => void;
 }
 

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -11,8 +11,7 @@
  * replay skips them — leaving a stale transcript/status until the user
  * navigates away. Re-fetching routes the catch-up through the seed path, and an
  * authoritative snapshot that no longer reports a previously-active run retires
- * it (the daemon restarted and lost an unpersisted subprocess). Mirrors the
- * conversation-history hook's reconnect refetch.
+ * it (the daemon restarted and lost an unpersisted subprocess).
  *
  * Seeding sets each run's `highWaterMark` to the max `seq` over its events.
  * The live SSE handler drops updates whose `seq <= highWaterMark`, so events

--- a/clients/web/src/domains/chat/utils/acp-run-actions.ts
+++ b/clients/web/src/domains/chat/utils/acp-run-actions.ts
@@ -10,7 +10,7 @@ import { client } from "@/generated/daemon/client.gen";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
-/** Response of `POST /v1/acp/:id/steer`. Mirrors the daemon's responseBody. */
+/** Response of `POST /v1/acp/:id/steer`. Hand-maintained to match the daemon's action response shape. */
 export interface SteerAcpRunResponse {
   acpSessionId: string;
   steered: boolean;


### PR DESCRIPTION
## What

Comment-only cleanup of files introduced/modified by #36212 (ACP run-detail chat view), following an audit for "AI slop" / stale comments. **No logic, type, JSX, or test changes** — every changed line is a comment (23 files, +37 / −65).

## Why

A four-way reviewer pass over the touched source flagged a tail of comments that were either wrong, stale-prone, or pure restatement. The wrong ones actively mislead; the rest are the "will it go stale?" risk.

### Tier 1 — factually wrong (the ones that matter)
- **`memory/schema/acp.ts`** — the usage/token columns cited "migration 302" and "migration 305", which were **renumbered to 307/308 during rebase**. 302/305 now point at *unrelated* migrations, so the comment sent readers to the wrong place. Dropped the brittle numbers (kept the accurate 230/272 ones).
- **`acp-run-store.ts`** — module docstring claimed the event buffer *coalesces* consecutive chunks. It's **append-only**; coalescing happens in the projections (contradicted its own `appendEvent` doc). Corrected.
- **`use-acp-run-card-data.ts`** — comment called the empty buffer "frozen", but it isn't `Object.freeze`d. Changed to "shared".

### Tier 2 — stale "Mirrors X / mirroring Y" cross-references (10 sites)
Decorative sibling/cross-repo references (`cleanupStaleRunningRows`, `useSubagentSteps`, `HeaderStepCarousel`, "mirrors the main chat's styling", etc.) that rot when the named symbol moves. Removed the clause, kept the load-bearing rationale. (Left the two that carry a real invariant: the projection "lockstep" note and the chat-view "reversibility" note.)

### Tier 3 — restatement / duplication slop
State-mapping enumerated three times, obvious prop-doc restatements ("Closes the overlay."), a duplicated callback-ref rationale, render-narration headers, and an imprecise "Daemon code imports the type directly from this file" line across the 5 `api/events/acp-session-*.ts` files.

### Tier 4 — comments #36212 left stale next door
- `chat-content-layout.tsx` — Escape-handler list was missing the `workflow-detail` / `acp-run-detail` cases the PR added to that switch.
- `chat-body.tsx` — "subagents on the left, workflows on the right" no longer matched after an `activeAcpRunsSlot` was inserted as a middle slot.

## Verification
- Confirmed comment-only via a diff guard (no non-comment `+/-` line).
- Pre-commit prettier + secret-scan passed; eslint skipped only because the binary isn't installed in the fresh worktree (comment-only changes can't introduce lint errors). CI will lint on a full checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
