### PR TITLE
Dedupe Slack error taxonomy into @vellumai/slack-text

### DIFF
--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -6,6 +6,9 @@
  * classification, and payload shapes follow Slack Web API conventions.
  */
 
+import type { SlackErrorCategory } from "@vellumai/slack-text/errors";
+import { classifySlackError } from "@vellumai/slack-text/errors";
+
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
 import { getLogger } from "../../../util/logger.js";
@@ -19,44 +22,6 @@ const SLACK_DEFAULT_RETRY_AFTER_S = 1;
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
-
-export type SlackErrorCategory =
-  | "auth"
-  | "rate_limit"
-  | "not_found"
-  | "permission"
-  | "channel_not_found"
-  | "client_error"
-  | "transient"
-  | "unknown";
-
-const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
-  invalid_auth: "auth",
-  token_expired: "auth",
-  token_revoked: "auth",
-  not_authed: "auth",
-  account_inactive: "auth",
-  org_login_required: "auth",
-  rate_limited: "rate_limit",
-  ratelimited: "rate_limit",
-  channel_not_found: "channel_not_found",
-  is_archived: "channel_not_found",
-  not_in_channel: "permission",
-  missing_scope: "permission",
-  ekm_access_denied: "permission",
-  not_allowed_token_type: "permission",
-  restricted_action: "permission",
-  cannot_dm_bot: "permission",
-  user_not_found: "not_found",
-  message_not_found: "not_found",
-  thread_not_found: "not_found",
-  invalid_blocks: "client_error",
-};
-
-function classifySlackError(errorCode: string | undefined): SlackErrorCategory {
-  if (!errorCode) return "unknown";
-  return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
-}
 
 export class SlackApiError extends Error {
   readonly slackError: string | undefined;

--- a/gateway/src/__tests__/slack-errors.test.ts
+++ b/gateway/src/__tests__/slack-errors.test.ts
@@ -40,8 +40,9 @@ describe("classifySlackError", () => {
     expect(classifySlackError("thread_not_found")).toBe("not_found");
   });
 
-  test("classifies invalid_blocks as client_error", () => {
+  test("classifies oversized Block Kit payload errors as client_error", () => {
     expect(classifySlackError("invalid_blocks")).toBe("client_error");
+    expect(classifySlackError("msg_blocks_too_long")).toBe("client_error");
   });
 
   test("returns unknown for unrecognized error codes", () => {

--- a/gateway/src/slack/errors.ts
+++ b/gateway/src/slack/errors.ts
@@ -1,65 +1,16 @@
 /**
- * Slack error classification for smarter retry and error handling decisions.
- *
- * Maps Slack API error codes to semantic categories so callers can decide
- * whether to retry, surface a user-facing message, or escalate.
+ * Slack error handling for the gateway: retry decisions and user-facing
+ * messages. The Slack error-code → category classification is shared with the
+ * assistant via `@vellumai/slack-text/errors` (single source of truth — see the
+ * root AGENTS.md); this module layers the gateway's retry and messaging policy
+ * on top and re-exports the shared classifier so existing importers stay
+ * unaffected.
  */
 
-export type SlackErrorCategory =
-  | "auth"
-  | "rate_limit"
-  | "not_found"
-  | "permission"
-  | "channel_not_found"
-  | "client_error"
-  | "transient"
-  | "unknown";
+import { classifySlackError } from "@vellumai/slack-text/errors";
+import type { SlackErrorCategory } from "@vellumai/slack-text/errors";
 
-const ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
-  // Auth errors — token is invalid or revoked, do not retry
-  invalid_auth: "auth",
-  token_expired: "auth",
-  token_revoked: "auth",
-  not_authed: "auth",
-  account_inactive: "auth",
-  org_login_required: "auth",
-
-  // Rate limit — retry after backoff
-  rate_limited: "rate_limit",
-  ratelimited: "rate_limit",
-
-  // Channel-specific not-found errors
-  channel_not_found: "channel_not_found",
-  is_archived: "channel_not_found",
-
-  // Permission errors — bot lacks required scopes or access
-  not_in_channel: "permission",
-  missing_scope: "permission",
-  ekm_access_denied: "permission",
-  not_allowed_token_type: "permission",
-  restricted_action: "permission",
-  cannot_dm_bot: "permission",
-
-  // General not-found errors
-  user_not_found: "not_found",
-  message_not_found: "not_found",
-  thread_not_found: "not_found",
-
-  // Client-side errors — the payload itself is invalid, retrying the same
-  // request will fail identically. Callers that inspect the category should
-  // treat these as permanent failures and not re-send the same payload.
-  invalid_blocks: "client_error",
-};
-
-/**
- * Classify a Slack error code into a semantic category.
- */
-export function classifySlackError(
-  errorCode: string | undefined,
-): SlackErrorCategory {
-  if (!errorCode) return "unknown";
-  return ERROR_CODE_MAP[errorCode] ?? "unknown";
-}
+export { classifySlackError };
 
 /**
  * Whether the error category indicates the request could succeed on retry.
@@ -86,8 +37,7 @@ const CATEGORY_USER_MESSAGES: Record<SlackErrorCategory, string | undefined> = {
     "I don't have the required permissions for this channel. Please check my access.",
   not_found: "The requested resource could not be found in Slack.",
   rate_limit: "Slack rate limit reached. Please try again in a moment.",
-  client_error:
-    "I couldn't format that message for Slack. Please try again.",
+  client_error: "I couldn't format that message for Slack. Please try again.",
   transient: undefined,
   unknown: undefined,
 };

--- a/packages/slack-text/package.json
+++ b/packages/slack-text/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./errors": "./src/errors.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/slack-text/src/errors.test.ts
+++ b/packages/slack-text/src/errors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifySlackError } from "./errors.js";
+
+describe("classifySlackError", () => {
+  test("classifies known error codes by category", () => {
+    expect(classifySlackError("invalid_auth")).toBe("auth");
+    expect(classifySlackError("rate_limited")).toBe("rate_limit");
+    expect(classifySlackError("channel_not_found")).toBe("channel_not_found");
+    expect(classifySlackError("missing_scope")).toBe("permission");
+    expect(classifySlackError("user_not_found")).toBe("not_found");
+  });
+
+  test("classifies oversized Block Kit payload errors as client_error", () => {
+    expect(classifySlackError("invalid_blocks")).toBe("client_error");
+    expect(classifySlackError("msg_blocks_too_long")).toBe("client_error");
+  });
+
+  test("returns unknown for unrecognized codes and missing input", () => {
+    expect(classifySlackError("some_new_error")).toBe("unknown");
+    expect(classifySlackError(undefined)).toBe("unknown");
+    expect(classifySlackError("")).toBe("unknown");
+  });
+});

--- a/packages/slack-text/src/errors.ts
+++ b/packages/slack-text/src/errors.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared Slack Web API error classification.
+ *
+ * Maps Slack error codes to semantic categories so callers — the assistant's
+ * outbound client and the gateway — can decide whether to retry, surface a
+ * user-facing message, or escalate. This is the single source of truth for the
+ * code → category mapping; both packages import it instead of keeping copies
+ * that drift (see the root AGENTS.md "Single Source of Truth" rule).
+ */
+
+export type SlackErrorCategory =
+  | "auth"
+  | "rate_limit"
+  | "not_found"
+  | "permission"
+  | "channel_not_found"
+  | "client_error"
+  | "transient"
+  | "unknown";
+
+const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
+  // Auth errors — token is invalid or revoked, do not retry
+  invalid_auth: "auth",
+  token_expired: "auth",
+  token_revoked: "auth",
+  not_authed: "auth",
+  account_inactive: "auth",
+  org_login_required: "auth",
+
+  // Rate limit — retry after backoff
+  rate_limited: "rate_limit",
+  ratelimited: "rate_limit",
+
+  // Channel-specific not-found errors
+  channel_not_found: "channel_not_found",
+  is_archived: "channel_not_found",
+
+  // Permission errors — bot lacks required scopes or access
+  not_in_channel: "permission",
+  missing_scope: "permission",
+  ekm_access_denied: "permission",
+  not_allowed_token_type: "permission",
+  restricted_action: "permission",
+  cannot_dm_bot: "permission",
+
+  // General not-found errors
+  user_not_found: "not_found",
+  message_not_found: "not_found",
+  thread_not_found: "not_found",
+
+  // Client-side errors — the Block Kit payload itself is invalid or too big,
+  // retrying the same request will fail identically. `invalid_blocks` covers
+  // malformed blocks and over-the-50-block-limit messages; `msg_blocks_too_long`
+  // is Slack's code for cumulative block text over its ~13k ceiling.
+  invalid_blocks: "client_error",
+  msg_blocks_too_long: "client_error",
+};
+
+/**
+ * Classify a Slack error code into a semantic category. Returns "unknown" for
+ * unrecognized codes and for missing input.
+ */
+export function classifySlackError(
+  errorCode: string | undefined,
+): SlackErrorCategory {
+  if (!errorCode) return "unknown";
+  return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
+}


### PR DESCRIPTION
## What & why

The Slack error-code → category map, its `SlackErrorCategory` type, and `classifySlackError` were **duplicated verbatim** in the assistant (`messaging/providers/slack/api.ts`) and the gateway (`slack/errors.ts`). Duplicated logic drifts — root `AGENTS.md` "Single Source of Truth" — and Devin flagged exactly this on #36291.

This extracts the shared classification into **`@vellumai/slack-text`** (a package both already depend on), under a new `./errors` subpath export.

## Changes

- **`packages/slack-text/src/errors.ts`** (new): `SlackErrorCategory`, the code→category map, and `classifySlackError`. The map includes `msg_blocks_too_long` (cumulative Block Kit text over Slack's ~13k ceiling) as `client_error`.
- **`packages/slack-text/package.json`**: add `"./errors"` subpath export.
- **assistant `api.ts`**: import `classifySlackError` / `SlackErrorCategory` from the package; `SlackApiError` is unchanged.
- **gateway `errors.ts`**: import from the package and **re-export `classifySlackError`** so existing importers (incl. `slack-errors.test.ts`) are unaffected. Its gateway-specific `isRetryable` / `getUserMessage` policy stays — those aren't duplicated, so they aren't moved (per the rule-of-three / "only extract what's actually shared").

## Behavior

No behavior change except that `msg_blocks_too_long` is now classified as `client_error` — which fixes the gateway's `isRetryable` previously treating it as retryable, and gives it a user-facing message.

## Tests / checks

- New `packages/slack-text/src/errors.test.ts` covers `classifySlackError` (incl. both `invalid_blocks` and `msg_blocks_too_long` → `client_error`).
- Gateway `slack-errors.test.ts` extended with the `msg_blocks_too_long` case (still imports the re-exported classifier).
- typecheck / eslint / knip clean across slack-text, assistant, and gateway; Slack test suites green in both packages.

## Relationship to #36291

#36291 (Slack message-size policy → transport) keys on the error **code** directly, so it does not depend on this map. The two PRs touch disjoint files and can merge in either order. This is the "separate dedup PR" companion to #36291. Part of LUM-2618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWYzuhpe55HvTjPsMNy5Jv)_