### PR TITLE
test(acp): lock rawInput/rawOutput through buffer, persistence, /acp/sessions

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -240,6 +240,49 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(eventBuffers.has(id)).toBe(false);
   });
 
+  test("persists tool_call rawInput/rawOutput verbatim through the event log", async () => {
+    const id = "session-raw-io-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-raw",
+      protocolSessionId: "proto-raw",
+      parentConversationId: "conv-raw",
+    });
+
+    const rawInput = { command: "ls -la", args: ["-la"] };
+    const rawOutput = "total 0\ndrwxr-xr-x  2 user  staff  64 .";
+
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "tool_call",
+      toolCallId: "tc-raw",
+      toolTitle: "Run command",
+      toolKind: "execute",
+      toolStatus: "running",
+      rawInput,
+    });
+    handles.emitUpdate({
+      type: "acp_session_update",
+      acpSessionId: id,
+      updateType: "tool_call_update",
+      toolCallId: "tc-raw",
+      toolStatus: "completed",
+      rawOutput,
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    expect(log).toHaveLength(2);
+    expect(log[0]!.rawInput).toEqual(rawInput);
+    expect(log[1]!.rawOutput).toBe(rawOutput);
+  });
+
   test("persists status='failed' with the error message on prompt rejection", async () => {
     const id = "session-failed-1";
     const handles = buildSessionWithFakeProcess({

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -155,6 +155,57 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     expect(eventLog[0]?.content).toBe("persisted");
   });
 
+  test("active and terminal sessions both surface tool_call rawInput/rawOutput in eventLog", async () => {
+    const rawInput = { command: "grep -rn foo", pattern: "foo" };
+    const rawOutput = "src/a.ts:1: foo\nsrc/b.ts:9: foo";
+
+    const activeToolCall: AcpSessionUpdate = {
+      type: "acp_session_update",
+      acpSessionId: "active",
+      updateType: "tool_call",
+      toolCallId: "tc-active",
+      toolKind: "search",
+      toolStatus: "completed",
+      rawInput,
+      rawOutput,
+      seq: 1,
+    };
+    inMemoryStates.set("active", makeInMemoryState("active", "conv-1"));
+    bufferedUpdates.set("active", [activeToolCall]);
+
+    insertHistoryRow({
+      id: "terminal",
+      parentConversationId: "conv-1",
+      eventLogJson: JSON.stringify([
+        {
+          type: "acp_session_update",
+          acpSessionId: "terminal",
+          updateType: "tool_call",
+          toolCallId: "tc-terminal",
+          toolKind: "search",
+          toolStatus: "completed",
+          rawInput,
+          rawOutput,
+          seq: 1,
+        } satisfies AcpSessionUpdate,
+      ]),
+    });
+
+    const handler = getListHandler();
+    const result = (await handler({
+      queryParams: { conversationId: "conv-1" },
+    })) as { sessions: Array<Record<string, unknown>> };
+
+    for (const id of ["active", "terminal"]) {
+      const session = result.sessions.find((s) => s.id === id);
+      expect(session).toBeDefined();
+      const eventLog = session?.eventLog as AcpSessionUpdate[];
+      expect(eventLog).toHaveLength(1);
+      expect(eventLog[0]?.rawInput).toEqual(rawInput);
+      expect(eventLog[0]?.rawOutput).toBe(rawOutput);
+    }
+  });
+
   test("active in-memory session surfaces latestUsage as the usage fields", async () => {
     inMemoryStates.set(
       "active",


### PR DESCRIPTION
## Summary
- Regression tests proving ACP rawInput/rawOutput survive buffer → persistence → /acp/sessions for active + history sessions

Part of plan: acp-tool-raw-io-and-labels.md (PR 3 of 7)