### PR TITLE
feat(chat): show ACP command from rawInput and expandable raw input/output

### DIFF
--- a/clients/web/src/domains/chat/acp-tool-content.test.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  formatRawValue,
   getAcpFileChanges,
+  getAcpToolCommand,
   parseAcpToolContent,
   type AcpToolContentBlock,
 } from "@/domains/chat/acp-tool-content";
@@ -114,5 +116,44 @@ describe("getAcpFileChanges", () => {
 
   it("returns [] when there are no diffs and no locations", () => {
     expect(getAcpFileChanges([])).toEqual([]);
+  });
+});
+
+describe("getAcpToolCommand", () => {
+  it("returns the command from an object with a string command", () => {
+    expect(getAcpToolCommand({ command: "npm test" })).toBe("npm test");
+  });
+
+  it("returns undefined for an object without a string command", () => {
+    expect(getAcpToolCommand({ command: 42 })).toBeUndefined();
+    expect(getAcpToolCommand({ other: "x" })).toBeUndefined();
+  });
+
+  it("returns undefined for non-object input", () => {
+    expect(getAcpToolCommand("npm test")).toBeUndefined();
+    expect(getAcpToolCommand(undefined)).toBeUndefined();
+    expect(getAcpToolCommand(null)).toBeUndefined();
+  });
+});
+
+describe("formatRawValue", () => {
+  it("returns undefined for undefined and null", () => {
+    expect(formatRawValue(undefined)).toBeUndefined();
+    expect(formatRawValue(null)).toBeUndefined();
+  });
+
+  it("passes strings through verbatim", () => {
+    expect(formatRawValue("hello")).toBe("hello");
+  });
+
+  it("pretty-prints objects as JSON", () => {
+    expect(formatRawValue({ a: 1, b: "x" })).toBe(
+      JSON.stringify({ a: 1, b: "x" }, null, 2),
+    );
+  });
+
+  it("stringifies other primitives", () => {
+    expect(formatRawValue(42)).toBe("42");
+    expect(formatRawValue(true)).toBe("true");
   });
 });

--- a/clients/web/src/domains/chat/acp-tool-content.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.ts
@@ -109,6 +109,30 @@ function extractTerminalText(obj: Record<string, unknown>): string | undefined {
 }
 
 /**
+ * Read the agent's command from a tool's `rawInput`, when present. ACP rawInput
+ * shapes are tool-specific, so this is defensive: only a non-null object with a
+ * string `command` yields a value; anything else (including older daemons that
+ * send no rawInput) returns `undefined`.
+ */
+export function getAcpToolCommand(rawInput: unknown): string | undefined {
+  if (typeof rawInput !== "object" || rawInput === null) return undefined;
+  const command = (rawInput as Record<string, unknown>).command;
+  return typeof command === "string" ? command : undefined;
+}
+
+/**
+ * Format a raw ACP input/output value for display. `undefined`/`null` → no
+ * value; strings pass through verbatim; objects pretty-print as JSON; anything
+ * else stringifies. Used to render the expandable Raw input/output section.
+ */
+export function formatRawValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+/**
  * Collect file changes from `diff` blocks, then union in any `locations[].path`
  * not already represented (path-only). Deduped by path; diff entries win over
  * a path-only `locations` entry for the same file.

--- a/clients/web/src/domains/chat/acp-tool-content.ts
+++ b/clients/web/src/domains/chat/acp-tool-content.ts
@@ -110,9 +110,9 @@ function extractTerminalText(obj: Record<string, unknown>): string | undefined {
 
 /**
  * Read the agent's command from a tool's `rawInput`, when present. ACP rawInput
- * shapes are tool-specific, so this is defensive: only a non-null object with a
- * string `command` yields a value; anything else (including older daemons that
- * send no rawInput) returns `undefined`.
+ * is optional and its shape is tool-specific, so this is defensive: only a
+ * non-null object with a string `command` yields a value; anything else
+ * returns `undefined`.
  */
 export function getAcpToolCommand(rawInput: unknown): string | undefined {
   if (typeof rawInput !== "object" || rawInput === null) return undefined;

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.test.tsx
@@ -91,6 +91,57 @@ describe("AcpChatToolCard", () => {
     expect(container.querySelector(".lucide-code")).not.toBeNull();
   });
 
+  test("shows the command from rawInput.command as the detail line", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({
+          toolKind: "execute",
+          title: "fallback title",
+          rawInput: { command: "npm test" },
+        })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("acp-chat-tool-detail").textContent).toBe(
+      "npm test",
+    );
+  });
+
+  test("falls back to the title and hides the raw section when rawInput is absent", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({ toolKind: "execute", title: "npm test" })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("acp-chat-tool-detail").textContent).toBe(
+      "npm test",
+    );
+    expect(screen.queryByTestId("acp-chat-tool-raw")).toBeNull();
+  });
+
+  test("renders a collapsible raw input/output section that expands to pretty-printed values", () => {
+    render(
+      <AcpChatToolCard
+        block={toolBlock({
+          toolKind: "execute",
+          rawInput: { command: "npm test" },
+          rawOutput: { exitCode: 0, stdout: "ok" },
+        })}
+        onOpenDiff={() => {}}
+      />,
+    );
+    // Collapsed by default — sub-blocks not yet rendered.
+    expect(screen.queryByTestId("acp-chat-tool-raw-input")).toBeNull();
+    fireEvent.click(screen.getByTestId("acp-chat-tool-raw-toggle"));
+    expect(screen.getByTestId("acp-chat-tool-raw-input").textContent).toContain(
+      JSON.stringify({ command: "npm test" }, null, 2),
+    );
+    expect(
+      screen.getByTestId("acp-chat-tool-raw-output").textContent,
+    ).toContain(JSON.stringify({ exitCode: 0, stdout: "ok" }, null, 2));
+  });
+
   test("renders the status pill per status", () => {
     const { rerender } = render(
       <AcpChatToolCard block={toolBlock({ status: "running" })} onOpenDiff={() => {}} />,

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -188,7 +188,7 @@ export function AcpChatToolCard({
   const kindLabel =
     (block.toolKind && KIND_LABEL[block.toolKind]) || DEFAULT_KIND_LABEL;
   // Prefer a structured command from rawInput; fall back to the agent's title
-  // when absent (older daemons send no rawInput — must degrade gracefully).
+  // when rawInput is absent (it is optional).
   const command = getAcpToolCommand(block.rawInput);
   const detailText = command ?? block.title;
   // Surface the command/title when the header label alone hides what the tool

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-tool-card.tsx
@@ -1,10 +1,12 @@
 /**
  * A tool call rendered as a distinct card in the ACP chat transcript: a kind
  * glyph, a standardized kind label, a status pill, and a streaming indicator
- * while running. For non-file-op kinds the raw agent title/command surfaces as
- * a wrapping body line. Inline output (parsed from the tool content) renders as
- * markdown, collapsed behind a toggle when long. Any file changes the call touched
- * surface as clickable chips that invoke `onOpenDiff`.
+ * while running. For non-file-op kinds the command (from `rawInput`, falling
+ * back to the agent title) surfaces as a wrapping body line. Inline output
+ * (parsed from the tool content) renders as markdown, collapsed behind a toggle
+ * when long. Any file changes the call touched surface as clickable chips that
+ * invoke `onOpenDiff`. When the call carries raw input/output, a collapsible
+ * section pretty-prints them.
  */
 
 import {
@@ -27,7 +29,9 @@ import { useMemo, useState } from "react";
 import { Tag, Typography, type TagTone } from "@vellumai/design-library";
 
 import {
+  formatRawValue,
   getAcpFileChanges,
+  getAcpToolCommand,
   parseAcpToolContent,
 } from "@/domains/chat/acp-tool-content";
 import type { AcpChatBlock } from "@/domains/chat/acp-run-message-projection";
@@ -125,12 +129,35 @@ function KindIcon({ toolKind }: { toolKind?: string }) {
   );
 }
 
+/** A labeled, scrollable monospace block for a pretty-printed raw payload. */
+function RawBlock({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: string;
+  testId: string;
+}) {
+  return (
+    <div data-testid={testId}>
+      <div className="mb-1 text-body-small-default text-[var(--content-tertiary)]">
+        {label}
+      </div>
+      <pre className="max-h-60 overflow-auto rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] p-2.5 font-mono text-body-small-default text-[var(--content-secondary)]">
+        {value}
+      </pre>
+    </div>
+  );
+}
+
 export function AcpChatToolCard({
   block,
   isTerminal = false,
   onOpenDiff,
 }: AcpChatToolCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const [expandedRaw, setExpandedRaw] = useState(false);
 
   const parsed = useMemo(
     () => parseAcpToolContent(block.content),
@@ -160,16 +187,24 @@ export function AcpChatToolCard({
 
   const kindLabel =
     (block.toolKind && KIND_LABEL[block.toolKind]) || DEFAULT_KIND_LABEL;
-  // Surface the raw agent title when the header label alone hides what the tool
-  // did (e.g. the command). File-op kinds normally show their path via chips, so
-  // suppress it there — but fall back to the title when no chips rendered (a
-  // title-only tool call with no locations/diff).
+  // Prefer a structured command from rawInput; fall back to the agent's title
+  // when absent (older daemons send no rawInput — must degrade gracefully).
+  const command = getAcpToolCommand(block.rawInput);
+  const detailText = command ?? block.title;
+  // Surface the command/title when the header label alone hides what the tool
+  // did. File-op kinds normally show their path via chips, so suppress it there
+  // — but fall back when no chips rendered (a detail-only call with no
+  // locations/diff).
   const detailLine =
-    block.title &&
-    block.title !== kindLabel &&
+    detailText &&
+    detailText !== kindLabel &&
     (!FILE_OP_KINDS.has(block.toolKind ?? "") || fileChanges.length === 0)
-      ? block.title
+      ? detailText
       : null;
+
+  const rawInputText = formatRawValue(block.rawInput);
+  const rawOutputText = formatRawValue(block.rawOutput);
+  const hasRaw = rawInputText !== undefined || rawOutputText !== undefined;
 
   return (
     <div
@@ -277,6 +312,43 @@ export function AcpChatToolCard({
               className="max-h-60 overflow-auto rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] p-2.5"
             >
               <ChatMarkdownMessage content={outputText} hardLineBreaks />
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasRaw && (
+        <div className="mt-2" data-testid="acp-chat-tool-raw">
+          <button
+            type="button"
+            data-testid="acp-chat-tool-raw-toggle"
+            aria-expanded={expandedRaw}
+            onClick={() => setExpandedRaw((prev) => !prev)}
+            className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-default)]"
+          >
+            {expandedRaw ? (
+              <ChevronDown aria-hidden className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+              <ChevronRight aria-hidden className="h-3.5 w-3.5 shrink-0" />
+            )}
+            <span>{expandedRaw ? "Hide raw input/output" : "Show raw input/output"}</span>
+          </button>
+          {expandedRaw && (
+            <div className="mt-1.5 flex flex-col gap-2">
+              {rawInputText !== undefined && (
+                <RawBlock
+                  label="Raw input"
+                  value={rawInputText}
+                  testId="acp-chat-tool-raw-input"
+                />
+              )}
+              {rawOutputText !== undefined && (
+                <RawBlock
+                  label="Raw output"
+                  value={rawOutputText}
+                  testId="acp-chat-tool-raw-output"
+                />
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- execute cards show the command from rawInput.command (fallback to title)
- collapsible Raw input/output section, pretty-printed, shown only when present

Part of plan: acp-tool-raw-io-and-labels.md (PR 7 of 7)