### PR TITLE
fix(memory): stop `memory worker start` from orphaning a slow-starting worker

### DIFF
--- a/assistant/src/cli/commands/memory/__tests__/worker.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/worker.test.ts
@@ -408,11 +408,14 @@ describe("memory worker start", () => {
   test("leaves the config flag untouched when the spawn fails", async () => {
     const restore = stubProcessKill(new Set());
     const originalSpawn = Bun.spawn;
-    // Spawn returns but never writes a PID file → spawnMemoryWorkerProcess
-    // throws after its wait loop, so the flag must stay disabled.
+    // Spawn returns a child that exits during startup without writing a PID file
+    // → spawnMemoryWorkerProcess detects the early exit and throws, so the flag
+    // must stay disabled.
     (Bun as { spawn: typeof Bun.spawn }).spawn = (() => ({
       unref: () => {},
-      pid: 0,
+      kill: () => {},
+      exited: Promise.resolve(1),
+      pid: 123,
     })) as unknown as typeof Bun.spawn;
     try {
       const { exitCode, stdout } = await runCommand([

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -60,7 +60,10 @@ async function startWorker(
 ): Promise<void> {
   let result: { pid: number; alreadyRunning: boolean };
   try {
-    result = await spawnMemoryWorkerProcess();
+    // Terminate the child if it times out: this path leaves
+    // `memory.worker.enabled` off on failure, so a worker that came up late
+    // would drain the queue alongside the daemon's synchronous runner.
+    result = await spawnMemoryWorkerProcess({ terminateOnTimeout: true });
   } catch (err) {
     // Spawn failed — leave `memory.worker.enabled` untouched so the daemon's
     // synchronous runner keeps draining the queue rather than standing down

--- a/assistant/src/memory/__tests__/worker-control.test.ts
+++ b/assistant/src/memory/__tests__/worker-control.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for `spawnMemoryWorkerProcess` — the detached worker-process spawner.
+ *
+ * Focuses on the readiness wait, which gates whether `assistant memory worker
+ * start` reports success and flips `memory.worker.enabled`:
+ *   - succeeds when the worker writes its PID file (immediately or a little
+ *     late — a cold `bun run` start takes seconds),
+ *   - fails fast when the child exits during startup,
+ *   - on timeout, terminates a still-alive child only when asked, so the CLI
+ *     (which leaves the flag off on failure) cannot orphan a worker that would
+ *     then drain the queue alongside the daemon's synchronous runner.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+let tmpDir: string;
+let pidPath: string;
+let markerPath: string;
+
+mock.module("../../util/platform.js", () => ({
+  getMemoryWorkerPidPath: () => pidPath,
+  getMemorySyncRunnerMarkerPath: () => markerPath,
+}));
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  getCurrentLogFilePath: () => join(tmpDir, "worker-control-test.log"),
+}));
+
+const { spawnMemoryWorkerProcess, MemoryWorkerSpawnError } =
+  await import("../worker-control.js");
+
+/**
+ * Install a stub `Bun.spawn`. The `onSpawn` callback receives the resolved PID
+ * path so a test can simulate the worker writing its PID file (now or later),
+ * and returns the fake child handle.
+ */
+function stubBunSpawn(
+  makeChild: () => {
+    unref: () => void;
+    kill: () => void;
+    pid: number;
+    exited?: Promise<unknown>;
+  },
+): () => void {
+  const original = Bun.spawn;
+  (Bun as { spawn: typeof Bun.spawn }).spawn = (() =>
+    makeChild()) as unknown as typeof Bun.spawn;
+  return () => {
+    (Bun as { spawn: typeof Bun.spawn }).spawn = original;
+  };
+}
+
+/** A promise that never resolves — stands in for a still-alive child. */
+function neverExits(): Promise<unknown> {
+  return new Promise(() => {});
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "worker-control-test-"));
+  pidPath = join(tmpDir, "memory-worker.pid");
+  markerPath = join(tmpDir, "memory-sync-runner.pid");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("spawnMemoryWorkerProcess", () => {
+  test("returns the PID when the worker writes its file immediately", async () => {
+    const restore = stubBunSpawn(() => {
+      writeFileSync(pidPath, "4242");
+      return {
+        unref: () => {},
+        kill: () => {},
+        pid: 4242,
+        exited: neverExits(),
+      };
+    });
+    try {
+      const result = await spawnMemoryWorkerProcess({
+        pidWaitTimeoutMs: 1_000,
+        pidPollIntervalMs: 10,
+      });
+      expect(result).toEqual({ pid: 4242, alreadyRunning: false });
+    } finally {
+      restore();
+    }
+  });
+
+  test("succeeds when the worker writes its PID file slightly late", async () => {
+    const restore = stubBunSpawn(() => {
+      // Worker takes ~120ms to come up — would have failed under the old 1s/10x
+      // loop's tight window only if shorter; here we prove the wait spans it.
+      setTimeout(() => writeFileSync(pidPath, "777"), 120);
+      return {
+        unref: () => {},
+        kill: () => {},
+        pid: 777,
+        exited: neverExits(),
+      };
+    });
+    try {
+      const result = await spawnMemoryWorkerProcess({
+        pidWaitTimeoutMs: 2_000,
+        pidPollIntervalMs: 20,
+      });
+      expect(result).toEqual({ pid: 777, alreadyRunning: false });
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails fast when the child exits during startup", async () => {
+    let killed = false;
+    const restore = stubBunSpawn(() => ({
+      unref: () => {},
+      kill: () => {
+        killed = true;
+      },
+      pid: 99,
+      // Never writes a PID file; exits immediately.
+      exited: Promise.resolve(1),
+    }));
+    try {
+      await expect(
+        spawnMemoryWorkerProcess({
+          // Long timeout so the test only passes if early-exit short-circuits it.
+          pidWaitTimeoutMs: 10_000,
+          pidPollIntervalMs: 10,
+          terminateOnTimeout: true,
+        }),
+      ).rejects.toBeInstanceOf(MemoryWorkerSpawnError);
+      // It exited on its own — nothing to terminate.
+      expect(killed).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("terminates a still-alive child on timeout when terminateOnTimeout is set", async () => {
+    let killed = false;
+    const restore = stubBunSpawn(() => ({
+      unref: () => {},
+      kill: () => {
+        killed = true;
+      },
+      pid: 55,
+      exited: neverExits(),
+    }));
+    try {
+      await expect(
+        spawnMemoryWorkerProcess({
+          pidWaitTimeoutMs: 150,
+          pidPollIntervalMs: 20,
+          terminateOnTimeout: true,
+        }),
+      ).rejects.toBeInstanceOf(MemoryWorkerSpawnError);
+      expect(killed).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  test("does not terminate the child on timeout when terminateOnTimeout is false", async () => {
+    let killed = false;
+    const restore = stubBunSpawn(() => ({
+      unref: () => {},
+      kill: () => {
+        killed = true;
+      },
+      pid: 55,
+      exited: neverExits(),
+    }));
+    try {
+      await expect(
+        spawnMemoryWorkerProcess({
+          pidWaitTimeoutMs: 150,
+          pidPollIntervalMs: 20,
+          terminateOnTimeout: false,
+        }),
+      ).rejects.toBeInstanceOf(MemoryWorkerSpawnError);
+      expect(killed).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("reuses an already-running worker without spawning", async () => {
+    // A live PID file (this test process) makes the probe report running.
+    writeFileSync(pidPath, String(process.pid));
+    let spawned = false;
+    const restore = stubBunSpawn(() => {
+      spawned = true;
+      return { unref: () => {}, kill: () => {}, pid: 1, exited: neverExits() };
+    });
+    try {
+      const result = await spawnMemoryWorkerProcess({ pidWaitTimeoutMs: 100 });
+      expect(result).toEqual({ pid: process.pid, alreadyRunning: true });
+      expect(spawned).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -197,7 +197,10 @@ export interface MemoryJobsWorker {
  */
 export function startMemoryJobsWorker(): MemoryJobsWorker {
   if (getConfig().memory.worker?.enabled === true) {
-    void spawnMemoryWorkerProcess()
+    // The flag is on, so the supervisor below stands the synchronous runner
+    // down: a worker that comes up late is the desired sole drainer, so do not
+    // terminate it on a slow start (the default).
+    void spawnMemoryWorkerProcess({ terminateOnTimeout: false })
       .then(({ pid, alreadyRunning }) =>
         log.info(
           { pid, alreadyRunning },

--- a/assistant/src/memory/worker-control.ts
+++ b/assistant/src/memory/worker-control.ts
@@ -119,16 +119,99 @@ export function removeSyncRunnerMarker(): void {
 export class MemoryWorkerSpawnError extends Error {}
 
 /**
+ * How long {@link spawnMemoryWorkerProcess} waits for the freshly-spawned worker
+ * to write its PID file before treating the spawn as failed. A cold
+ * `bun run worker-process.ts` start — new runtime, config load, DB open —
+ * routinely takes several seconds, so this is deliberately generous: a premature
+ * timeout makes `assistant memory worker start` report failure for a worker that
+ * is merely slow, and (because the CLI failure path leaves
+ * `memory.worker.enabled` off) leaves that detached worker draining the queue
+ * alongside the daemon's synchronous in-process runner — two drainers racing on
+ * the same jobs.
+ */
+const PID_FILE_WAIT_TIMEOUT_MS = 15_000;
+
+/** Poll interval while waiting for the worker's PID file to appear. */
+const PID_FILE_POLL_INTERVAL_MS = 100;
+
+export interface SpawnMemoryWorkerOptions {
+  /**
+   * Override how long to wait for the worker's PID file, in ms. Defaults to
+   * {@link PID_FILE_WAIT_TIMEOUT_MS}. Primarily a testing seam.
+   */
+  pidWaitTimeoutMs?: number;
+  /**
+   * Override the PID-file poll interval, in ms. Defaults to
+   * {@link PID_FILE_POLL_INTERVAL_MS}. Primarily a testing seam.
+   */
+  pidPollIntervalMs?: number;
+  /**
+   * When the wait times out while the child is still alive (a hung or very slow
+   * start), terminate that child before throwing. Callers that leave
+   * `memory.worker.enabled` off on failure — the CLI `memory worker start` —
+   * MUST set this: otherwise the detached worker keeps coming up and drains the
+   * queue behind the daemon's still-active synchronous runner. The daemon's own
+   * startup spawn leaves the flag on, so a late worker there becomes the sole
+   * drainer; it passes `false` to let that worker live.
+   */
+  terminateOnTimeout?: boolean;
+}
+
+type WorkerReadyOutcome = "ready" | "exited" | "timeout";
+
+/**
+ * Wait for the worker to signal readiness by writing its PID file.
+ *
+ *   - `"ready"`   — the PID file appeared.
+ *   - `"exited"`  — the child exited first (it crashed during startup).
+ *   - `"timeout"` — neither happened within `timeoutMs`.
+ *
+ * Polls for the PID file but also watches `exited`, so a crash-on-startup fails
+ * fast instead of waiting out the whole timeout.
+ */
+async function waitForWorkerPidFile(
+  pidPath: string,
+  exited: Promise<unknown> | undefined,
+  timeoutMs: number,
+  pollIntervalMs: number,
+): Promise<WorkerReadyOutcome> {
+  let childExited = false;
+  const markExited = () => {
+    childExited = true;
+  };
+  // A pending `exited` promise does not keep the event loop alive once the child
+  // is unref'd, so this floating wait won't hang the process.
+  void exited?.then(markExited, markExited);
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(pidPath)) return "ready";
+    if (childExited) {
+      // The worker could write the PID file and exit in the same tick — re-check
+      // before declaring it dead.
+      return existsSync(pidPath) ? "ready" : "exited";
+    }
+    await Bun.sleep(pollIntervalMs);
+  }
+  return existsSync(pidPath) ? "ready" : "timeout";
+}
+
+/**
  * Spawn the memory worker as a detached background process.
  *
  * If a worker is already running, returns its PID with `alreadyRunning: true`
  * rather than spawning a second one. Throws {@link MemoryWorkerSpawnError} if
- * the child is spawned but never writes its PID file (i.e. failed to start).
+ * the child crashes during startup or never writes its PID file within the
+ * wait window (i.e. failed to start).
  */
-export async function spawnMemoryWorkerProcess(): Promise<{
+export async function spawnMemoryWorkerProcess(
+  opts: SpawnMemoryWorkerOptions = {},
+): Promise<{
   pid: number;
   alreadyRunning: boolean;
 }> {
+  const pidWaitTimeoutMs = opts.pidWaitTimeoutMs ?? PID_FILE_WAIT_TIMEOUT_MS;
+  const pidPollIntervalMs = opts.pidPollIntervalMs ?? PID_FILE_POLL_INTERVAL_MS;
   const current = probeMemoryWorker();
   if (current.status === "running" && current.pid != null) {
     return { pid: current.pid, alreadyRunning: true };
@@ -168,19 +251,34 @@ export async function spawnMemoryWorkerProcess(): Promise<{
   // Unreference so the spawning process doesn't wait for the child.
   child.unref();
 
-  // Wait briefly for the PID file to appear (the worker writes it on startup).
-  let pidWritten = false;
-  for (let i = 0; i < 10; i++) {
-    await Bun.sleep(100);
-    if (existsSync(pidPath)) {
-      pidWritten = true;
-      break;
-    }
-  }
+  // Wait for the worker to report readiness by writing its PID file (the worker
+  // writes it on startup). The child is detached, so a worker that is merely
+  // slow keeps coming up after we stop waiting.
+  const outcome = await waitForWorkerPidFile(
+    pidPath,
+    child.exited,
+    pidWaitTimeoutMs,
+    pidPollIntervalMs,
+  );
 
-  if (!pidWritten) {
+  if (outcome !== "ready") {
+    // On a plain timeout the child may still be alive (hung or very slow start).
+    // Terminate it when asked so a worker we are reporting as failed cannot come
+    // up later and drain the queue behind the daemon's synchronous runner. On an
+    // early exit the child is already gone, so there is nothing to kill.
+    if (outcome === "timeout" && opts.terminateOnTimeout) {
+      try {
+        child.kill();
+      } catch {
+        // best-effort — the child may already be gone
+      }
+    }
     throw new MemoryWorkerSpawnError(
-      "Memory worker was spawned but PID file did not appear within 1s",
+      outcome === "exited"
+        ? "Memory worker exited during startup before writing its PID file"
+        : `Memory worker was spawned but did not write its PID file within ${Math.round(
+            pidWaitTimeoutMs / 1000,
+          )}s`,
     );
   }
 


### PR DESCRIPTION
## What's wrong

Running `assistant memory worker` produces this contradictory state:

```
$ assistant memory worker start
Memory worker was spawned but PID file did not appear within 1s

$ assistant memory worker status
Memory worker process is running (PID 13068)    # it DID start
memory.worker.enabled: false                     # but the flag is off
```

## Why

`spawnMemoryWorkerProcess` waited only **1s** for the detached worker to write its PID file. A cold `bun run worker-process.ts` start — new runtime, config load, DB open — routinely takes several seconds, so `start` threw a **false-negative** spawn error even though the worker came up fine moments later.

That false negative is dangerous: the CLI's failure path leaves `memory.worker.enabled` off, but the worker is detached and keeps coming up — so it drains the queue **alongside** the daemon's synchronous in-process runner. Two drainers race on the same jobs (and on the worker's startup `resetRunningJobsToPending`), breaking the "exactly one drainer" invariant.

## The fix

- **Wait up to 15s** for the PID file (a realistic ceiling for a cold start), and **watch the child's `exited`** so a genuine crash-on-startup fails fast instead of waiting out the timeout.
- **On a true timeout** where the child is still alive, terminate it when the caller opts in via `terminateOnTimeout`:
  - The **CLI `start`** passes `true` — its failure path leaves the flag off, so a worker reported as failed must not be left running behind the sync runner.
  - The **daemon startup spawn** passes `false` — it keeps the flag on, so a late worker there is the *desired* sole drainer and should be allowed to live.
- Added direct unit tests for the spawner's readiness / late-PID / timeout-kill / crash-on-startup paths.

> A follow-up PR addresses a separate issue surfaced in the same `status` output — the `Synchronous in-process runner is running (PID 1)` line being unreliable when the daemon runs as PID 1.

## Testing

- `bun test src/memory/__tests__/worker-control.test.ts` and `src/cli/commands/memory/__tests__/worker.test.ts` — pass
- `eslint` and `tsc --noEmit` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuWSJimv7hoaFGBfxjmDuQ