### PR TITLE
[codex] Make memory v3 selection configurable

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -22,6 +22,7 @@ describe("MemoryV3ConfigSchema", () => {
       needleK: 100,
       denseK: 100,
       replyQueryK: 12,
+      selectorEnabled: true,
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
@@ -85,10 +86,19 @@ describe("MemoryV3ConfigSchema", () => {
     ).toThrow();
   });
 
-  test("accepts explicit lane-K overrides", () => {
-    const parsed = MemoryV3ConfigSchema.parse({ needleK: 50, denseK: 75 });
-    expect(parsed.needleK).toBe(50);
+  test("accepts explicit lane-K overrides including zero", () => {
+    const parsed = MemoryV3ConfigSchema.parse({ needleK: 0, denseK: 75 });
+    expect(parsed.needleK).toBe(0);
     expect(parsed.denseK).toBe(75);
+
+    const zeroDense = MemoryV3ConfigSchema.parse({ needleK: 50, denseK: 0 });
+    expect(zeroDense.needleK).toBe(50);
+    expect(zeroDense.denseK).toBe(0);
+  });
+
+  test("accepts selector bypass override", () => {
+    const parsed = MemoryV3ConfigSchema.parse({ selectorEnabled: false });
+    expect(parsed.selectorEnabled).toBe(false);
   });
 
   test("accepts a partial edge override, defaulting the rest", () => {
@@ -101,9 +111,9 @@ describe("MemoryV3ConfigSchema", () => {
     });
   });
 
-  test("rejects non-positive or non-integer lane knobs", () => {
-    expect(() => MemoryV3ConfigSchema.parse({ needleK: 0 })).toThrow();
+  test("rejects negative or non-integer lane knobs", () => {
     expect(() => MemoryV3ConfigSchema.parse({ denseK: -4 })).toThrow();
+    expect(() => MemoryV3ConfigSchema.parse({ needleK: -1 })).toThrow();
     expect(() => MemoryV3ConfigSchema.parse({ needleK: 1.5 })).toThrow();
     expect(() =>
       MemoryV3ConfigSchema.parse({ edge: { perSeed: 0 } }),

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -249,7 +249,7 @@ export const MemoryV3ConfigSchema = z
       .nonnegative("memory.v3.denseK must be a non-negative integer")
       .default(100)
       .describe(
-        "Number of dense-lane articles folded into the candidate pool each turn after embedding the turn query. 0 disables the dense lane.",
+        "Number of dense-lane articles folded into the candidate pool each turn after embedding the turn query. 0 disables dense retrieval for both current-message and reply-query passes.",
       ),
     replyQueryK: z
       .number({ error: "memory.v3.replyQueryK must be a number" })

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -48,10 +48,10 @@ export const MemoryV3HotSetSchema = z
     k: z
       .number({ error: "memory.v3.hotSet.k must be a number" })
       .int("memory.v3.hotSet.k must be an integer")
-      .positive("memory.v3.hotSet.k must be a positive integer")
+      .nonnegative("memory.v3.hotSet.k must be a non-negative integer")
       .default(40)
       .describe(
-        "Number of top frecency-scored pages included in the hot-set lane.",
+        "Number of top frecency-scored pages included in the hot-set lane. 0 disables the lane.",
       ),
     halfLifeDays: z
       .number({ error: "memory.v3.hotSet.halfLifeDays must be a number" })
@@ -238,18 +238,18 @@ export const MemoryV3ConfigSchema = z
     needleK: z
       .number({ error: "memory.v3.needleK must be a number" })
       .int("memory.v3.needleK must be an integer")
-      .positive("memory.v3.needleK must be a positive integer")
+      .nonnegative("memory.v3.needleK must be a non-negative integer")
       .default(100)
       .describe(
-        "Number of section-grain BM25 needle articles folded into the candidate pool each turn.",
+        "Number of section-grain BM25 needle articles folded into the candidate pool each turn. 0 disables the needle lane.",
       ),
     denseK: z
       .number({ error: "memory.v3.denseK must be a number" })
       .int("memory.v3.denseK must be an integer")
-      .positive("memory.v3.denseK must be a positive integer")
+      .nonnegative("memory.v3.denseK must be a non-negative integer")
       .default(100)
       .describe(
-        "Number of dense-lane articles folded into the candidate pool each turn.",
+        "Number of dense-lane articles folded into the candidate pool each turn after embedding the turn query. 0 disables the dense lane.",
       ),
     replyQueryK: z
       .number({ error: "memory.v3.replyQueryK must be a number" })
@@ -258,6 +258,12 @@ export const MemoryV3ConfigSchema = z
       .default(12)
       .describe(
         "Per-lane article budget for the reply-query finder pass: needle and dense each re-run over the assistant's previous message as separate queries (never concatenated with the user's message). 0 disables the pass. Deliberately small next to needleK/denseK — the pass adds the assistant-side retrieval signal, not a second full sweep.",
+      ),
+    selectorEnabled: z
+      .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to run the memory-v3 selector LLM callsite over the candidate pool. When false, every pooled candidate is passed through to injection directly; an empty pool produces no memory block.",
       ),
     selectorPromptPath: z
       .string({ error: "memory.v3.selectorPromptPath must be a string" })

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -60,10 +60,14 @@ mock.module("../../../../util/logger.js", () => ({
 const realDense = { ...(await import("../dense.js")) };
 let denseMockActive = false;
 let denseHits: Array<{ article: Slug; section: number }> = [];
+let denseCalls: Array<{ query: string; k: number }> = [];
 mock.module("../dense.js", () => ({
   ...realDense,
-  denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
-    denseMockActive ? denseHits : realDense.denseLane(...args),
+  denseLane: async (...args: Parameters<typeof realDense.denseLane>) => {
+    if (!denseMockActive) return realDense.denseLane(...args);
+    denseCalls.push({ query: args[1], k: args[2] });
+    return args[2] <= 0 ? [] : denseHits;
+  },
 }));
 
 const { orchestrate, DEFAULT_NEEDLE_K, DEFAULT_DENSE_K } =
@@ -250,6 +254,7 @@ beforeEach(() => {
   denseMockActive = true;
   providerStub = null;
   denseHits = [];
+  denseCalls = [];
   lastPool = [];
   lastPoolLines = [];
   lastPrefixBlock = null;
@@ -357,7 +362,52 @@ describe("orchestrate — candidate pool composition", () => {
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "x"), depsOf(lanes, { needle }));
     expect(needleK).toBe(DEFAULT_NEEDLE_K);
+    expect(denseCalls[0]?.k).toBe(DEFAULT_DENSE_K);
     expect(DEFAULT_DENSE_K).toBe(100);
+  });
+
+  test("denseK override controls the embedding-backed candidate budget", async () => {
+    const lanes = await buildLanes();
+    providerStub = selectProvider([]);
+
+    await orchestrate(makeTurn(1, "apple"), depsOf(lanes, { denseK: 7 }));
+
+    expect(denseCalls.map((call) => call.k)).toEqual([7]);
+  });
+
+  test("selectorEnabled=false keeps all pooled candidates without calling the selector provider", async () => {
+    const lanes = await buildLanes();
+    // "apple" hits topic-a (needle), dense returns topic-b, and topic-a links
+    // to topic-d. With the selector disabled, every pooled candidate is passed
+    // through as a selection without requiring the L2 callsite.
+    denseHits = [{ article: "topic-b", section: 0 }];
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { selectorEnabled: false }),
+    );
+
+    expect(selectCalls).toBe(0);
+    expect(new Set(result.selections.map((s) => s.slug))).toEqual(
+      new Set(["topic-a", "topic-b", "topic-d"]),
+    );
+  });
+
+  test("selectorEnabled=false with zero candidate lanes returns no selections", async () => {
+    const lanes = await buildLanes();
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        needleK: 0,
+        denseK: 0,
+        replyQueryK: 0,
+        selectorEnabled: false,
+      }),
+    );
+
+    expect(selectCalls).toBe(0);
+    expect(result.selections).toEqual([]);
+    expect(result.lanes).toEqual({ core: [], hot: [], fresh: [], finder: [] });
   });
 
   test("matchedSections is populated from matched lane sections", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -375,6 +375,18 @@ describe("orchestrate — candidate pool composition", () => {
     expect(denseCalls.map((call) => call.k)).toEqual([7]);
   });
 
+  test("denseK = 0 disables dense retrieval for both current and reply queries", async () => {
+    const lanes = await buildLanes();
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "apple", "previous reply mentioned cherry"),
+      depsOf(lanes, { denseK: 0, replyQueryK: 12 }),
+    );
+
+    expect(denseCalls).toEqual([]);
+  });
+
   test("selectorEnabled=false keeps all pooled candidates without calling the selector provider", async () => {
     const lanes = await buildLanes();
     // "apple" hits topic-a (needle), dense returns topic-b, and topic-a links

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -196,6 +196,7 @@ mock.module("../../../../config/loader.js", () => ({
         needleK: 100,
         denseK: 100,
         replyQueryK: 12,
+        selectorEnabled: true,
         learnedEdges: {
           halfLifeDays: 30,
           minCount: 3,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/hot-set.test.ts
@@ -126,6 +126,11 @@ describe("MemoryV3ConfigSchema hotSet", () => {
     expect(config.hotSet).toEqual({ k: 5, halfLifeDays: 7 });
   });
 
+  test("zero k disables the lane", () => {
+    const config = MemoryV3ConfigSchema.parse({ hotSet: { k: 0 } });
+    expect(config.hotSet.k).toBe(0);
+  });
+
   test("rejects negative k", () => {
     expect(() => MemoryV3ConfigSchema.parse({ hotSet: { k: -1 } })).toThrow();
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -51,7 +51,7 @@ import { denseLane } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
 import type { PoolCandidate, StableCandidate } from "./pool-select.js";
-import { selectPool } from "./pool-select.js";
+import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
 import type {
   FinderLane,
@@ -123,6 +123,9 @@ export interface OrchestrateDeps {
    *  The live caller resolves `memory.v3.selectorPromptPath` (workspace-relative
    *  file override) via `resolveSelectorPrompt` and threads the result here. */
   selectorPrompt?: string;
+  /** Whether to run the selector LLM. False passes all pooled candidates
+   *  straight through as selections, preserving pool-order slug dedup. */
+  selectorEnabled?: boolean;
 }
 
 /** A finder-lane candidate: the slug, the descriptor that justified it, and
@@ -384,11 +387,11 @@ export async function orchestrate(
   // selections come back slug-deduped (pinned flags ORed) — `selectPool`'s
   // contract. `selectorPrompt` is the (optionally overridden) instruction
   // scaffold; `undefined` falls through to the bundled default.
-  const selections = await selectPool(
-    { stable, finder: finderTail },
-    turn,
-    deps.selectorPrompt,
-  );
+  const pool = { stable, finder: finderTail };
+  const selections =
+    deps.selectorEnabled === false
+      ? selectAllPoolCandidates(pool)
+      : await selectPool(pool, turn, deps.selectorPrompt);
 
   return {
     selections,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -198,22 +198,28 @@ export async function orchestrate(
   );
   const stablePrefix = new Set<Slug>([...coreHotFresh, ...always]);
 
-  // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
-  // parallel. Both return distinct articles each tagged with their best-scoring
-  // section index/ordinal. The reply-query pass re-runs both lanes over the
-  // assistant's previous message as SEPARATE queries (concatenating the two
-  // speakers would average their retrieval intents into a vector that matches
-  // neither) at its own, smaller budget; it runs in the same parallel batch.
+  // Step 1: needle (sync BM25) and the enabled dense lane (async embed +
+  // Qdrant) run in parallel. Both return distinct articles each tagged with
+  // their best-scoring section index/ordinal. The reply-query pass re-runs the
+  // enabled lanes over the assistant's previous message as SEPARATE queries
+  // (concatenating the two speakers would average their retrieval intents into
+  // a vector that matches neither) at its own, smaller budget; it runs in the
+  // same parallel batch.
+  // `denseK = 0` disables dense retrieval for the whole turn, including the
+  // reply-query dense pass.
   const replyK = deps.replyQueryK ?? 0;
   const replyQuery =
     replyK > 0 ? (turn.previousAssistantMessage ?? "").trim() : "";
+  const denseEnabled = denseK > 0;
   const [needled, densed, replyNeedled, replyDensed] = await Promise.all([
     Promise.resolve(deps.needle.query(turn.currentMessage, needleK)),
-    denseLane(deps.denseConfig, turn.currentMessage, denseK),
+    denseEnabled
+      ? denseLane(deps.denseConfig, turn.currentMessage, denseK)
+      : Promise.resolve([]),
     Promise.resolve(
       replyQuery.length > 0 ? deps.needle.query(replyQuery, replyK) : [],
     ),
-    replyQuery.length > 0
+    replyQuery.length > 0 && denseEnabled
       ? denseLane(deps.denseConfig, replyQuery, replyK)
       : Promise.resolve([]),
   ]);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -355,6 +355,15 @@ function dedupeBySlug(
   return [...bySlug].map(([slug, pinned]) => ({ slug, pinned }));
 }
 
+/** Return every candidate in pool order, deduped by slug. */
+export function selectAllPoolCandidates(pool: SelectorPool): SelectedPage[] {
+  const ordered: Slug[] = [
+    ...pool.stable.map((c) => c.slug),
+    ...pool.finder.map((c) => c.slug),
+  ];
+  return dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
+}
+
 /**
  * Run the single forced-tool selector over the unified candidate pool. Returns
  * the pages to inject, deduped by slug (a page that appeared as both a card
@@ -382,8 +391,7 @@ export async function selectPool(
   ];
   if (ordered.length === 0) return [];
 
-  const keepAll = (): SelectedPage[] =>
-    dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
+  const keepAll = (): SelectedPage[] => selectAllPoolCandidates(pool);
 
   const provider = await getConfiguredProvider(MEMORY_V3_SELECT_CALL_SITE);
   if (!provider) {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -579,6 +579,7 @@ export async function observeTurn(
       learnedGraph: lanes.learnedGraph,
       learnedPerSeed: v3.learnedEdges.perSeed,
       learnedCap: v3.learnedEdges.cap,
+      selectorEnabled: v3.selectorEnabled,
       selectorPrompt: resolveSelectorPrompt(
         v3.selectorPromptPath,
         getWorkspaceDir(),


### PR DESCRIPTION
## Summary
- Add `memory.v3.denseK` as the configurable dense post-embedding candidate budget, with `0` disabling the dense lane.
- Allow `memory.v3.needleK` and `memory.v3.hotSet.k` to be set to `0` so candidate lanes can be fully disabled when desired.
- Add `memory.v3.selectorEnabled`; when false, memory-v3 skips the selector LLM callsite and passes the deduped candidate pool directly to injection.
- Preserve the empty-pool behavior so disabling selection with no candidates produces no memory block instead of an empty wrapper.

## Validation
- `bun test src/config/schemas/__tests__/memory-v3.test.ts src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts src/plugins/defaults/memory-v3-shadow/hot-set.test.ts`
- `bun test src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts`
- `bun test src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts`
- `bun run typecheck:fast`
- Commit hook: secrets scan, generic examples, Prettier, changed-file ESLint
- Pre-push hook: assistant `tsc --noEmit`, changed-file ESLint

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->