### PR TITLE
Wait for period before showing thinking preview

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
@@ -99,6 +99,22 @@ describe("firstSentenceOfLatestThinkingParagraph", () => {
     ).toBe("Why? Because this is enough.");
   });
 
+  test("does not stop at periods inside dotted identifiers", () => {
+    expect(
+      firstSentenceOfLatestThinkingParagraph(
+        "I need to check v2.0 of config.json before acting. Then continue.",
+      ),
+    ).toBe("I need to check v2.0 of config.json before acting.");
+  });
+
+  test("returns null for question-only paragraphs without a period", () => {
+    expect(
+      firstSentenceOfLatestThinkingParagraph(
+        "What should I check? Where is the bug?",
+      ),
+    ).toBeNull();
+  });
+
   test("returns null for blank thinking text", () => {
     expect(firstSentenceOfLatestThinkingParagraph("\n\n  ")).toBeNull();
   });
@@ -157,5 +173,40 @@ describe("useStreamingThinkingPreview", () => {
     firePendingTimers();
 
     expect(result.current).toBe("Newest paragraph should win.");
+  });
+
+  test("keeps the current preview while the latest paragraph has no period", () => {
+    const { result, rerender } = renderHook(
+      ({ content }) => useStreamingThinkingPreview(content, true),
+      {
+        initialProps: {
+          content: "First visible thought.",
+        },
+      },
+    );
+
+    expect(result.current).toBe("First visible thought.");
+
+    setSystemTime(new Date(START + 1_000));
+    rerender({ content: "First visible thought.\n\nI" });
+
+    expect(result.current).toBe("First visible thought.");
+    expect(pendingTimeouts()).toHaveLength(0);
+
+    setSystemTime(new Date(START + 2_000));
+    rerender({
+      content: "First visible thought.\n\nNext paragraph is ready. More detail.",
+    });
+
+    expect(result.current).toBe("First visible thought.");
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(
+      STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS - 2_000,
+    );
+
+    setSystemTime(new Date(START + STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS));
+    firePendingTimers();
+
+    expect(result.current).toBe("Next paragraph is ready.");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx
@@ -82,12 +82,21 @@ describe("firstSentenceOfLatestThinkingParagraph", () => {
     ).toBe("I should inspect the route first.");
   });
 
-  test("returns an incomplete latest paragraph when no sentence terminator has streamed", () => {
+  test("returns null until the latest paragraph streams a period", () => {
     expect(
       firstSentenceOfLatestThinkingParagraph(
         "Complete prior thought.\n\nStill forming the latest idea",
       ),
-    ).toBe("Still forming the latest idea");
+    ).toBeNull();
+    expect(firstSentenceOfLatestThinkingParagraph("I")).toBeNull();
+  });
+
+  test("parses through the first period in the latest paragraph", () => {
+    expect(
+      firstSentenceOfLatestThinkingParagraph(
+        "Complete prior thought.\n\nWhy? Because this is enough. Later sentence.",
+      ),
+    ).toBe("Why? Because this is enough.");
   });
 
   test("returns null for blank thinking text", () => {
@@ -101,17 +110,17 @@ describe("useStreamingThinkingPreview", () => {
       ({ content }) => useStreamingThinkingPreview(content, true),
       {
         initialProps: {
-          content: "First visible thought",
+          content: "First visible thought.",
         },
       },
     );
 
-    expect(result.current).toBe("First visible thought");
+    expect(result.current).toBe("First visible thought.");
 
     setSystemTime(new Date(START + 1_000));
     rerender({ content: "Second visible thought. More detail follows." });
 
-    expect(result.current).toBe("First visible thought");
+    expect(result.current).toBe("First visible thought.");
     expect(pendingTimeouts()).toHaveLength(1);
     expect(pendingTimeouts()[0]!.ms).toBe(
       STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS - 1_000,
@@ -128,7 +137,7 @@ describe("useStreamingThinkingPreview", () => {
       ({ content }) => useStreamingThinkingPreview(content, true),
       {
         initialProps: {
-          content: "First visible thought",
+          content: "First visible thought.",
         },
       },
     );
@@ -141,7 +150,7 @@ describe("useStreamingThinkingPreview", () => {
         "Second visible thought.\n\nNewest paragraph should win. Later sentence.",
     });
 
-    expect(result.current).toBe("First visible thought");
+    expect(result.current).toBe("First visible thought.");
     expect(pendingTimeouts()).toHaveLength(1);
 
     setSystemTime(new Date(START + STREAMING_THINKING_PREVIEW_UPDATE_INTERVAL_MS));

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
@@ -40,9 +40,9 @@ export function useStreamingThinkingPreview(
 
     updatedAtRef.current ??= now;
 
-    if (nextPreview === displayedPreview) return;
-
     if (!nextPreview) return;
+
+    if (nextPreview === displayedPreview) return;
 
     if (!displayedPreview) {
       updatedAtRef.current = now;

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
@@ -13,8 +13,9 @@ export function firstSentenceOfLatestThinkingParagraph(
   if (!latestParagraph) return null;
 
   const normalized = latestParagraph.replace(/\s+/g, " ");
-  const periodIndex = normalized.indexOf(".");
-  if (periodIndex === -1) return null;
+  const sentencePeriod = normalized.match(/\.(?=\s|$)/);
+  const periodIndex = sentencePeriod?.index;
+  if (periodIndex == null) return null;
   return normalized.slice(0, periodIndex + 1).trim() || null;
 }
 
@@ -41,7 +42,9 @@ export function useStreamingThinkingPreview(
 
     if (nextPreview === displayedPreview) return;
 
-    if (!nextPreview || !displayedPreview) {
+    if (!nextPreview) return;
+
+    if (!displayedPreview) {
       updatedAtRef.current = now;
       setDisplayedPreview(nextPreview);
       return;

--- a/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
+++ b/clients/web/src/domains/chat/hooks/use-streaming-thinking-preview.ts
@@ -13,8 +13,9 @@ export function firstSentenceOfLatestThinkingParagraph(
   if (!latestParagraph) return null;
 
   const normalized = latestParagraph.replace(/\s+/g, " ");
-  const firstSentence = normalized.match(/^.*?[.!?](?=\s|$)/)?.[0];
-  return (firstSentence ?? normalized).trim() || null;
+  const periodIndex = normalized.indexOf(".");
+  if (periodIndex === -1) return null;
+  return normalized.slice(0, periodIndex + 1).trim() || null;
 }
 
 export function useStreamingThinkingPreview(


### PR DESCRIPTION
## Summary
- Change the streaming thinking preview parser to return text only through the first period in the latest paragraph.
- Keep the generic “Thinking” label while the latest paragraph has no period yet, avoiding one-character previews like “I”.
- Add regression tests for period-less thinking text, single-character thinking text, and question-mark text before the first period.

## Validation
- `bun test ./src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx ./src/domains/chat/components/single-activity/single-activity.test.tsx`
- `bunx eslint src/domains/chat/hooks/use-streaming-thinking-preview.ts src/domains/chat/hooks/use-streaming-thinking-preview.test.tsx src/domains/chat/components/single-activity/single-activity.tsx src/domains/chat/components/single-activity/single-activity.test.tsx`
- `bun run typecheck`
- `npx react-doctor@latest --verbose --scope changed --base origin/main`

## Original prompt
The streaming thinking preview was sometimes showing a single character. Update it so previews parse through the first period, and open a new PR because the previous one was already merged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->