### PR TITLE
Regenerate openapi.yaml for the `ps` route description

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21296,7 +21296,9 @@ paths:
     get:
       operationId: ps_get
       summary: Process status
-      description: Returns a JSON summary of the assistant's process tree including qdrant and embed-worker status.
+      description:
+        "Returns the daemon's process tree: every descendant process parented to the assistant runtime, built from
+        the native OS process table."
       tags:
         - system
       responses:


### PR DESCRIPTION
## Why

PR #36310 (the `assistant ps` process-tree walk) changed the `ps` route's description but didn't regenerate the committed OpenAPI spec, so the **OpenAPI Spec Check** CI job (`bun run generate:openapi -- --check` in `pr-assistant.yaml`) failed — the spec still carried the old qdrant/embed-worker wording. That PR was merged with the check red; this PR fixes it forward.

## What

Ran `bun run generate:openapi` to regenerate `assistant/openapi.yaml`. The only change is the `/v1/ps` `description`:

```diff
-      description: Returns a JSON summary of the assistant's process tree including qdrant and embed-worker status.
+      description:
+        "Returns the daemon's process tree: every descendant process parented to the assistant runtime, built from
+        the native OS process table."
```

No other paths changed.

## Verification

- `bun run generate:openapi -- --check` → `openapi.yaml is up to date.` (exit 0) — the exact command the failing CI job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZdVtmezMXKMVof8PaAVzc)_