### PR TITLE
refactor(plugins): drop getHooksFor re-export, fix registry doc comment

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -504,7 +504,7 @@ describe("plugin bootstrap", () => {
     const names = getRegisteredPlugins().map((p) => p.manifest.name);
     expect(names).toContain("sentinel-off");
     // But its hooks are filtered out at read time by `isPluginDisabled`.
-    const { getHooksFor } = await import("../plugins/registry.js");
+    const { getHooksFor } = await import("../hooks/registry.js");
     const hooks = await getHooksFor("init");
     expect(hooks).toHaveLength(0);
 

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -14,9 +14,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { getHooksFor } from "../hooks/registry.js";
 import { RiskLevel } from "../permissions/types.js";
 import {
-  getHooksFor,
   registerPlugin,
   resetPluginRegistryForTests,
   unregisterPlugin,

--- a/assistant/src/plugins/registry.ts
+++ b/assistant/src/plugins/registry.ts
@@ -1,16 +1,11 @@
 /**
- * Plugin registry — backward-compat wrapper.
+ * Plugin registry — tracks registered plugins by name and delegates hook
+ * registration to {@link ../hooks/registry.ts}.
  *
- * The hook registry has moved to {@link ../hooks/registry.ts}. This module
- * preserves the `registerPlugin` / `getRegisteredPlugins` / `unregisterPlugin`
- * API that many test files depend on, while delegating hook registration to
- * the new hooks registry. It tracks only plugin names (for
- * `getRegisteredPlugins` assertions in tests) — the actual hook surface
- * lives in `hooks/registry.ts`.
- *
- * Production code no longer imports from this module. It exists for test
- * compatibility and can be removed once tests are migrated to
- * `registerPluginHooks` / `getHooksFor` directly.
+ * `registerPlugin` validates a plugin manifest, records its name (so
+ * `getRegisteredPlugins` can enumerate registered plugins), and forwards the
+ * plugin's hooks to the hooks registry. The hook surface itself lives in
+ * `hooks/registry.ts`; this module owns only the plugin-name bookkeeping.
  */
 
 import {
@@ -127,10 +122,6 @@ export function unregisterPlugin(name: string): void {
   registeredPlugins.delete(name);
   unregisterPluginHooks(name);
 }
-
-// ─── Re-exports ──────────────────────────────────────────────────────────────
-
-export { getHooksFor } from "../hooks/registry.js";
 
 // ─── Test hooks ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Follow-up to #36156, addressing the two review comments left on it.

## Changes

- **`plugins/registry.ts` doc comment** — Rewritten to describe present behavior. The previous comment claimed _"Production code no longer imports from this module. It exists for test compatibility and can be removed once tests are migrated…"_. That was both factually wrong — the production startup path still imports `getRegisteredPlugins` / `unregisterPlugin` from this module in `daemon/external-plugins-bootstrap.ts` — and a migration-history note that violates the repo's [Code Comments rule](https://github.com/vellum-ai/vellum-assistant/blob/main/AGENTS.md) ("Comments describe the present; PRs describe the history"). The new comment describes what the module *is* and *does*: it tracks registered plugins by name and delegates hook registration to `hooks/registry.ts`.

- **Removed the `getHooksFor` re-export** from `plugins/registry.ts`. `getHooksFor` lives in `hooks/registry.ts`; the registry module no longer forwards it. The two test consumers (`plugin-disabled-state.test.ts`, `plugin-bootstrap.test.ts`) now import `getHooksFor` from its canonical home.

## Why

Both items were flagged by Vargas's review on #36156 (the doc comment matching Codex's P1, and "Remove this re-export"). Keeping the re-export and the misleading removal note made future cleanup unsafe and left a comment that narrated history rather than current state.

## Testing

- 76 plugin-related tests pass (`plugin-disabled-state`, `plugin-bootstrap`, `plugin-registry`, `plugin-pipeline`, `plugin-tool-contribution`, `plugin-route-contribution`, `external-plugin-loader`).
- Lint and type-check clean on changed files (verified by pre-commit hook).

No production behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krgy4vt8bf17NbbQAaVKc6)_