### PR TITLE
fix(web): heal prefix-less re-attach bubbles so a finished reply survives refresh [Phase 0]

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-seed-race-heal.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-seed-race-heal.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { __resetForTesting } from "@/lib/event-bus";
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+// ---------------------------------------------------------------------------
+// Stub the pagination layer so only the seed-race heal effect is exercised.
+// `isSuccess: false` keeps the snapshot-apply effect dormant; `dataUpdatedAt`
+// is driven by a mutable so a test can simulate a fresh snapshot landing
+// (the heal effect's trigger) on a rerender.
+// ---------------------------------------------------------------------------
+const realPaginationModule = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
+
+let dataUpdatedAt = 1;
+
+function paginationStub(): HistoryPaginationResult {
+  return {
+    messages: [],
+    latestPage: undefined,
+    subagentNotifications: undefined,
+    isLoading: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+    hasMore: false,
+    isFetchingOlderPages: false,
+    isFetching: false,
+    fetchOlderPage: () => {},
+    invalidate: async () => {},
+    removeCache: () => {},
+    latestPageOldestTimestamp: null,
+    oldestLoadedTimestamp: null,
+    dataUpdatedAt,
+  };
+}
+
+mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
+  ...realPaginationModule,
+  useHistoryPagination: () => paginationStub(),
+}));
+
+const { useConversationHistory } = await import(
+  "@/domains/chat/hooks/use-conversation-history"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { conversationHistoryQueryKey } = realPaginationModule;
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-A";
+
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function row(overrides: Partial<DisplayMessage> & { id: string }): DisplayMessage {
+  return { role: "assistant", ...overrides } as DisplayMessage;
+}
+
+function seedHistory(messages: DisplayMessage[]) {
+  queryClient.setQueryData(
+    conversationHistoryQueryKey(ASSISTANT_ID, CONVERSATION_ID),
+    { pages: [{ messages }], pageParams: [null] },
+  );
+}
+
+function renderHistory() {
+  return renderHook(
+    () =>
+      useConversationHistory({
+        assistantId: ASSISTANT_ID,
+        assistantStateKind: "active",
+        activeConversationId: CONVERSATION_ID,
+      }),
+    { wrapper: Wrapper },
+  );
+}
+
+beforeEach(() => {
+  __resetForTesting();
+  dataUpdatedAt = 1;
+  queryClient = new QueryClient();
+  useChatSessionStore.getState().setLiveTurn([]);
+});
+
+afterEach(() => {
+  cleanup();
+  useChatSessionStore.getState().setLiveTurn([]);
+  __resetForTesting();
+});
+
+describe("useConversationHistory — seed-race heal", () => {
+  test("drops a prefix-less re-attach shadow when a fresh snapshot lands", () => {
+    // GIVEN a mounted hook (the conversation-switch reset has already run)...
+    const { rerender } = renderHistory();
+
+    // ...then a prefix-less live bubble opened under the streamed call's id
+    // `call-2`, and a snapshot landing with the rich turn anchored on `call-1`
+    // that folded `call-2` in as an alias.
+    seedHistory([
+      row({ id: "u1", role: "user" }),
+      row({ id: "call-1", mergedMessageIds: ["call-2"] }),
+    ]);
+    act(() => {
+      useChatSessionStore.getState().setLiveTurn([row({ id: "call-2" })]);
+    });
+
+    // WHEN the fresh snapshot bumps dataUpdatedAt (heal effect trigger)
+    dataUpdatedAt = 2;
+    act(() => rerender());
+
+    // THEN the shadow is pruned so the authoritative history row renders
+    expect(useChatSessionStore.getState().liveTurn).toEqual([]);
+  });
+
+  test("leaves a seeded live row that carries the history row's id", () => {
+    // GIVEN a mounted hook...
+    const { rerender } = renderHistory();
+
+    // ...the normal case: history row `a1` and the live row IS that row.
+    seedHistory([row({ id: "a1" })]);
+    const live = [row({ id: "a1" })];
+    act(() => {
+      useChatSessionStore.getState().setLiveTurn(live);
+    });
+
+    // WHEN a fresh snapshot lands
+    dataUpdatedAt = 2;
+    act(() => rerender());
+
+    // THEN the live row is untouched — it legitimately wins on content
+    expect(useChatSessionStore.getState().liveTurn).toBe(live);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -42,6 +42,8 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { reconcileSubagentStoreFromNotifications } from "@/domains/chat/hooks/reconcile-subagent-hydration";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { mergeAdjacentAssistantMessages } from "@/domains/chat/utils/message-merge";
+import { pruneShadowedReattachRows } from "@/domains/chat/utils/reattach-shadow";
 
 import {
   parsePendingSecretState,
@@ -348,6 +350,35 @@ export function useConversationHistory({
     // `isFetchingOlderPages`) would re-run these side effects on older-page loads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pagination.dataUpdatedAt, assistantId, activeConversationId]);
+
+  // -------------------------------------------------------------------------
+  // Seed-race heal. A client that re-attaches to an in-flight turn can open a
+  // prefix-less live bubble when the first replayed delta beats the initial
+  // `/messages` fetch — `resolveHistoryTwin` finds no twin to seed from, so a
+  // suffix-only bubble is opened under the streamed call's id. Once the
+  // snapshot lands, that bubble would shadow the full persisted answer in the
+  // overlay (the "messages disappearing on refresh" bug). Drop it here, keyed
+  // on `dataUpdatedAt` so it runs exactly when a fresh snapshot arrives; the
+  // next delta re-seeds the live row from its now-cached twin. See
+  // `pruneShadowedReattachRows` for the full rationale.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!assistantId || !activeConversationId) return;
+    if (useChatSessionStore.getState().liveTurn.length === 0) return;
+
+    const data = queryClient.getQueryData<HistoryCache>(
+      conversationHistoryQueryKey(assistantId, activeConversationId),
+    );
+    if (!data) return;
+    // Fold page-boundary-straddling turns the same way the transcript does, so
+    // an alias the daemon recorded on the merged row is visible to the heal.
+    const history = mergeAdjacentAssistantMessages(
+      [...data.pages].reverse().flatMap((page) => page.messages),
+    );
+    useChatSessionStore
+      .getState()
+      .setLiveTurn((prev) => pruneShadowedReattachRows(prev, history));
+  }, [pagination.dataUpdatedAt, assistantId, activeConversationId, queryClient]);
 
   // -------------------------------------------------------------------------
   // Live-turn → history handoff. On the sending→idle transition the finished

--- a/clients/web/src/domains/chat/utils/reattach-shadow.test.ts
+++ b/clients/web/src/domains/chat/utils/reattach-shadow.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import { pruneShadowedReattachRows } from "@/domains/chat/utils/reattach-shadow";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { textBody, thinkingBodyWithBlocks } from "@/domains/chat/utils/message-test-helpers";
+
+function makeRow(
+  overrides: Omit<DisplayMessage, "id"> & { id?: string },
+): DisplayMessage {
+  const { id, ...rest } = overrides;
+  return { id: id ?? crypto.randomUUID(), ...rest };
+}
+
+describe("pruneShadowedReattachRows", () => {
+  test("drops a prefix-less re-attach bubble shadowed by a richer history twin", () => {
+    // History anchor `call-1` carries the streamed call's id `call-2` as a
+    // merged alias and holds the full answer. The live bubble was opened
+    // prefix-less under `call-2` and has only the post-reconnect thinking.
+    const history = [
+      makeRow({ id: "u1", role: "user", ...textBody("hi"), timestamp: 1 }),
+      makeRow({
+        id: "call-1",
+        mergedMessageIds: ["call-2"],
+        role: "assistant",
+        ...textBody("the full answer"),
+        timestamp: 2,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "call-2",
+        role: "assistant",
+        ...thinkingBodyWithBlocks("reconsidering"),
+        timestamp: 3,
+      }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toEqual([]);
+  });
+
+  test("keeps a seeded live row that carries the history row's primary id", () => {
+    // The normal single-call streaming case: live row IS the twin, with fuller
+    // streamed content. It legitimately wins on content — must not be pruned.
+    const history = [
+      makeRow({ id: "a1", role: "assistant", ...textBody("partial"), timestamp: 1 }),
+    ];
+    const live = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody("partial + more streamed"),
+        timestamp: 1,
+      }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toBe(live);
+  });
+
+  test("keeps a live row that folded the history row in as its own alias", () => {
+    // Multi-call turn folded client-side: live anchor `a2` carries history's
+    // `a1` as a merged alias, so it already contains that content and wins.
+    const history = [
+      makeRow({ id: "a1", role: "assistant", ...textBody("history copy"), timestamp: 1 }),
+    ];
+    const live = [
+      makeRow({
+        id: "a2",
+        mergedMessageIds: ["a1"],
+        role: "assistant",
+        ...textBody("live copy"),
+        timestamp: 1,
+      }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toBe(live);
+  });
+
+  test("keeps a live row with no history twin (a genuinely new turn)", () => {
+    const history = [
+      makeRow({ id: "a1", role: "assistant", ...textBody("old answer"), timestamp: 1 }),
+    ];
+    const live = [
+      makeRow({ id: "new", role: "assistant", ...textBody("streaming"), timestamp: 2 }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toBe(live);
+  });
+
+  test("ignores optimistic live rows even when an alias matches", () => {
+    // An optimistic row's id is a client nonce the daemon hasn't echoed; it is
+    // not a re-attach shadow and must be left for the echo-swap path.
+    const history = [
+      makeRow({
+        id: "call-1",
+        mergedMessageIds: ["nonce"],
+        role: "assistant",
+        ...textBody("answer"),
+        timestamp: 1,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "nonce",
+        isOptimistic: true,
+        role: "assistant",
+        ...textBody("optimistic"),
+        timestamp: 2,
+      }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toBe(live);
+  });
+
+  test("does not treat a user row as a shadow", () => {
+    const history = [
+      makeRow({
+        id: "u-srv",
+        mergedMessageIds: ["u-live"],
+        role: "user",
+        ...textBody("a question"),
+        timestamp: 1,
+      }),
+    ];
+    const live = [
+      makeRow({ id: "u-live", role: "user", ...textBody("a question"), timestamp: 2 }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result).toBe(live);
+  });
+
+  test("prunes only the shadow, keeping other live rows in order", () => {
+    const history = [
+      makeRow({
+        id: "call-1",
+        mergedMessageIds: ["call-2"],
+        role: "assistant",
+        ...textBody("the full answer"),
+        timestamp: 2,
+      }),
+    ];
+    const live = [
+      makeRow({
+        id: "u-next",
+        clientMessageId: "u-next",
+        isOptimistic: true,
+        role: "user",
+        ...textBody("a follow-up"),
+        timestamp: 3,
+      }),
+      makeRow({
+        id: "call-2",
+        role: "assistant",
+        ...thinkingBodyWithBlocks("reconsidering"),
+        timestamp: 4,
+      }),
+    ];
+
+    const result = pruneShadowedReattachRows(live, history);
+
+    expect(result.map((m) => m.id)).toEqual(["u-next"]);
+  });
+
+  test("returns the same reference when history is empty", () => {
+    const live = [makeRow({ id: "a1", role: "assistant", ...textBody("x"), timestamp: 1 })];
+    expect(pruneShadowedReattachRows(live, [])).toBe(live);
+  });
+});

--- a/clients/web/src/domains/chat/utils/reattach-shadow.ts
+++ b/clients/web/src/domains/chat/utils/reattach-shadow.ts
@@ -1,0 +1,92 @@
+/**
+ * Seed-race heal for prefix-less re-attach bubbles.
+ *
+ * When a client re-attaches to an in-flight turn it didn't start (a refresh or
+ * a visibility-driven reconnect), the daemon replays the current LLM call's
+ * deltas under *that call's* `messageId`. The persisted turn row, though, is
+ * anchored on an earlier call's id, with the replayed id folded in as a
+ * `mergedMessageIds` alias (the daemon's `mergeConsecutiveAssistantMessages`
+ * collapses a multi-call turn onto the first row's id).
+ *
+ * `resolveHistoryTwin` (stream-handlers/message-handlers.ts) normally seeds a
+ * re-attaching live row from its persisted prefix so the live row stays a
+ * superset of its history twin — the invariant `selectTranscriptMessages`
+ * relies on when it lets the live copy win on content. But the seed lookup is
+ * lazy and reads the history cache at delta time: if the first replayed delta
+ * beats the initial `/messages` fetch, the cache is empty, no twin is found,
+ * and a fresh prefix-less bubble is opened (`createStreamingBubble`). It then
+ * holds only the post-reconnect suffix and carries none of the persisted
+ * prefix. Once the snapshot lands, the overlay matches that suffix-only bubble
+ * to the rich history row *via the history-side alias* and — under "live wins"
+ * — the bubble shadows the full answer (a finished reply collapses to a bare
+ * "thinking…" fragment: the "messages disappearing on refresh" report).
+ *
+ * This module is the heal: when a fresh snapshot arrives, drop any live row
+ * that is exactly this shape so the authoritative history row renders. The
+ * next streamed delta re-seeds the live row from its twin (now cached),
+ * restoring the superset invariant. Dropping — rather than merging the two
+ * rows at render — is deliberate: a render-time concat can't tell which
+ * segments overlap (the per-event `seq` is gone once a delta folds into a
+ * row), so it risks double-counting; re-seeding rebuilds the row from the
+ * prefix and lets `local-seq` idempotency keep the streamed suffix disjoint.
+ */
+
+import {
+  messageIdentityKeys,
+  messageMatchKeys,
+} from "@/domains/chat/utils/message-identity";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * A live assistant row shadows a history row when the history row folded the
+ * live row's id in as an alias, yet the live row does NOT itself carry the
+ * history row's primary id. That asymmetry is the prefix-less signature: the
+ * match exists only because the daemon merged the ids server-side, not because
+ * the live row is the seeded twin (which carries the primary id and
+ * legitimately wins on content).
+ */
+function isShadowedByHistory(
+  liveRow: DisplayMessage,
+  historyByKey: Map<string, DisplayMessage>,
+): boolean {
+  if (liveRow.role !== "assistant" || liveRow.isOptimistic) return false;
+  const liveKeys = messageMatchKeys(liveRow);
+  for (const key of liveKeys) {
+    const twin = historyByKey.get(key);
+    // A shadow only when the matched persisted row's *primary* id is not one
+    // the live row carries — otherwise this is the seeded / client-merged row
+    // that should keep winning.
+    if (twin && !liveKeys.includes(twin.id)) return true;
+  }
+  return false;
+}
+
+/**
+ * Drop live-turn rows that are prefix-less re-attach shadows of a richer
+ * persisted history row. Returns the same `live` reference when nothing is
+ * shadowed, so a no-op snapshot update doesn't churn the live turn.
+ */
+export function pruneShadowedReattachRows(
+  live: DisplayMessage[],
+  history: DisplayMessage[],
+): DisplayMessage[] {
+  if (live.length === 0 || history.length === 0) return live;
+
+  // Index persisted assistant rows by every identity key (primary id + merged
+  // aliases) so a live row's id resolves to the row that folded it in.
+  // Optimistic rows have client-minted ids the daemon hasn't echoed yet and
+  // can't be the authoritative twin.
+  const historyByKey = new Map<string, DisplayMessage>();
+  for (const row of history) {
+    if (row.role !== "assistant" || row.isOptimistic) continue;
+    for (const key of messageIdentityKeys(row)) {
+      if (!historyByKey.has(key)) historyByKey.set(key, row);
+    }
+  }
+  if (historyByKey.size === 0) return live;
+
+  if (!live.some((row) => isShadowedByHistory(row, historyByKey))) {
+    return live;
+  }
+  return live.filter((row) => !isShadowedByHistory(row, historyByKey));
+}


### PR DESCRIPTION
## Phase 0 of the client-sync rolling-base migration

This is the **seam-correct** fix for "messages disappearing on refresh" — the safety fix that unblocks users while staying aligned with the rolling-base end state. It supersedes the earlier render-time fold approach (closed), which was unsound: it merged two rows at render with no `seq` to dedup overlap, so it could transiently double-count.

## Root cause (recap)

The transcript renders `history (Query cache) ⊕ liveTurn`, overlaid by identity in `selectTranscriptMessages`, under a "live row wins on content" rule. That rule is lossless **only because** the live row is normally a *superset* of its history twin: `local-seq` idempotency keeps the live turn to `seq > S` content, and `resolveHistoryTwin` seeds a re-attaching live row from its persisted prefix.

On refresh/reconnect mid-turn that invariant breaks via a race:
1. The daemon replays the in-flight LLM call's deltas under that call's own `messageId`; the persisted turn row is anchored on an **earlier** call's id, with the replayed id folded in as a `mergedMessageIds` alias.
2. The **first replayed delta beats the initial `/messages` fetch**, so `resolveHistoryTwin` reads an empty cache, finds no twin, and opens a **prefix-less** bubble (only the post-reconnect suffix).
3. When the snapshot lands, the overlay matches that suffix-only bubble to the rich history row **via the history-side alias** and — "live wins" — it **shadows the full answer**. The reply collapses to a bare "thinking…" fragment until the turn fully ends.

(Confirmed against the support triage: rendered transcript held only `[user, <thinking-only call-2>]` while history held the full `call-1` answer; `reconciliation_applied` reported `messagesAdded: 0`.)

## The fix

Heal the live row **where the snapshot lands** rather than papering over it at render:

- **`pruneShadowedReattachRows`** (new, pure) detects the exact shadow shape — a live assistant row whose id appears as an alias on a history assistant row whose **primary id the live row does not itself carry** — and drops it. The normal seeded / client-merged row (which *does* carry the history row's primary id) is left to win on content. Returns the same reference when nothing is shadowed.
- **`use-conversation-history`** runs the prune on the `dataUpdatedAt` snapshot signal, mirroring the existing turn-idle handoff prune right above it.

Once the shadow is dropped, the authoritative history row renders immediately and the **next streamed delta re-seeds** the live row from its now-cached twin — restoring the superset invariant the overlay depends on.

### Why drop, not merge

Per-event `seq` is discarded the moment a delta folds into a `DisplayMessage` (rows carry no seq). So a render-time concat of history + live can't tell which segments overlap and risks double-counting when the snapshot has partially absorbed the live call. Dropping + re-seeding rebuilds the row from the prefix and lets `local-seq` idempotency keep the streamed suffix disjoint — no seq blind spot.

## How this fits the rolling-base end state

This is deliberately the smallest change that restores the superset invariant. It does **not** introduce the seam window / versioned base yet (Phase 2) — it keeps the current overlay correct in the interim and is made moot, not contradicted, by the window work.

## Tests

- `reattach-shadow.test.ts` — pure detector: shadow pruned; seeded/same-id kept; client-merged-alias kept; new turn kept; optimistic & user rows ignored; reference stability; prune-only-the-shadow.
- `use-conversation-history-seed-race-heal.test.ts` — hook wiring: a fresh snapshot prunes the shadow; a seeded same-id row is left intact.

All affected suites pass (43 tests). Lint clean.

> Sandbox note: the broader chat suite and full `tsc` have pre-existing failures from unbuilt `@vellumai/*` workspace packages (design-library, generated `assistant-api` types) — present on `main`. My changed files lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_