### PR TITLE
Parent the CLI-started memory worker to the daemon

### DIFF
--- a/assistant/eslint-rules/cli-no-daemon-internals.js
+++ b/assistant/eslint-rules/cli-no-daemon-internals.js
@@ -57,11 +57,6 @@ const ALLOWED_PREFIXES = {
     // job handler directly. Depth-2 for commands/memory/ nesting.
     "../../memory/memory-retrospective-job",
     "../../../memory/memory-retrospective-job",
-    // Memory worker control — the `memory worker` CLI spawns/probes/stops
-    // the worker OS process directly (no daemon, no IPC), so it imports the
-    // shared PID-file control helpers. Depth-2 for commands/memory/ nesting.
-    "../../memory/worker-control",
-    "../../../memory/worker-control",
     // Standalone tool execution — `tools run` executes a single tool
     // in-process from the filesystem (no daemon, no IPC), so it imports the
     // standalone runner directly. Depth-2 for commands/ nesting.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16448,6 +16448,104 @@ paths:
                 required:
                   - ok
                 additionalProperties: false
+  /v1/memory/worker/start:
+    post:
+      operationId: memory_worker_start_post
+      summary: Start the memory worker
+      description: Spawns (or reuses) the memory worker process as a child of the daemon and enables memory.worker.enabled.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pid:
+                    type: number
+                  alreadyRunning:
+                    type: boolean
+                  workerEnabled:
+                    type: boolean
+                    const: true
+                  pidPath:
+                    type: string
+                required:
+                  - pid
+                  - alreadyRunning
+                  - workerEnabled
+                  - pidPath
+                additionalProperties: false
+  /v1/memory/worker/status:
+    get:
+      operationId: memory_worker_status_get
+      summary: Memory worker status
+      description: Reports the memory worker process state, memory.worker.enabled, and the synchronous in-process runner.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - running
+                      - not_running
+                  pid:
+                    type: number
+                  workerEnabled:
+                    type: boolean
+                  syncRunner:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - running
+                          - not_running
+                      pid:
+                        type: number
+                    required:
+                      - status
+                    additionalProperties: false
+                required:
+                  - status
+                  - workerEnabled
+                  - syncRunner
+                additionalProperties: false
+  /v1/memory/worker/stop:
+    post:
+      operationId: memory_worker_stop_post
+      summary: Stop the memory worker
+      description: Disables memory.worker.enabled and SIGTERMs the memory worker process if it is running.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workerWasRunning:
+                    type: boolean
+                  pid:
+                    type: number
+                  workerEnabled:
+                    type: boolean
+                    const: false
+                required:
+                  - workerWasRunning
+                  - workerEnabled
+                additionalProperties: false
   /v1/messages:
     get:
       operationId: messages_get
@@ -21296,7 +21394,9 @@ paths:
     get:
       operationId: ps_get
       summary: Process status
-      description: Returns a JSON summary of the assistant's process tree including qdrant and embed-worker status.
+      description:
+        "Returns the daemon's process tree: every descendant process parented to the assistant runtime, built from
+        the native OS process table."
       tags:
         - system
       responses:

--- a/assistant/src/cli/commands/memory/__tests__/worker.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/worker.test.ts
@@ -1,19 +1,15 @@
 /**
  * Tests for the `assistant memory worker` CLI subgroup.
  *
- * Validates:
+ * The subgroup is a thin IPC client over the daemon's memory-worker routes, so
+ * these validate:
  *   - Subcommand registration (start, stop, status) under `memory worker`.
- *   - `status` reports the worker process state, `memory.worker.enabled`, and
- *     the synchronous in-process runner via PID/marker-file liveness.
- *   - `stop` sends SIGTERM to a live worker and disables the config flag, and
- *     still disables the flag (success) when no worker is running.
- *   - `start` spawns/reuses the worker process and enables the config flag.
+ *   - Each subcommand calls exactly one IPC method and renders its response
+ *     (`--json` emits the raw route payload).
+ *   - IPC failures surface a non-zero exit.
  */
 
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
@@ -21,73 +17,45 @@ import { Command } from "commander";
 // Mock state
 // ---------------------------------------------------------------------------
 
-let tmpDir: string;
-let pidPath: string;
-let markerPath: string;
+let ipcCalls: string[] = [];
+const responses = new Map<
+  string,
+  { ok: boolean; result?: unknown; error?: string }
+>();
 let logOutput: string[] = [];
-
-/** In-memory stand-in for the on-disk raw config the CLI reads/writes. */
-let rawConfig: Record<string, unknown> = {};
-
-/** Records (pid, signal) pairs passed to the mocked process.kill. */
-let killCalls: Array<{ pid: number; signal: string | number }> = [];
-
-function workerEnabledFromRaw(): boolean {
-  const memory = rawConfig.memory as { worker?: { enabled?: unknown } };
-  return memory?.worker?.enabled === true;
-}
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-mock.module("../../../../util/platform.js", () => ({
-  getMemoryWorkerPidPath: () => pidPath,
-  getMemorySyncRunnerMarkerPath: () => markerPath,
-}));
-
-mock.module("../../../../config/loader.js", () => ({
-  loadRawConfig: () => structuredClone(rawConfig),
-  saveRawConfig: (config: Record<string, unknown>) => {
-    rawConfig = structuredClone(config);
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string) => {
+    ipcCalls.push(method);
+    return responses.get(method) ?? { ok: true, result: {} };
   },
-  getConfigReadOnly: () => ({
-    memory: { worker: { enabled: workerEnabledFromRaw() } },
-  }),
-  setNestedValue: (
-    obj: Record<string, unknown>,
-    path: string,
-    value: unknown,
-  ) => {
-    const keys = path.split(".");
-    let cur = obj;
-    for (let i = 0; i < keys.length - 1; i++) {
-      const k = keys[i];
-      if (cur[k] == null || typeof cur[k] !== "object") cur[k] = {};
-      cur = cur[k] as Record<string, unknown>;
-    }
-    cur[keys[keys.length - 1]] = value;
+  exitFromIpcResult: (r: { error?: string }) => {
+    process.stderr.write((r.error ?? "error") + "\n");
+    process.exitCode = 1;
   },
 }));
 
 const capture = (...args: unknown[]) => {
   logOutput.push(args.map(String).join(" "));
 };
-const fakeLogger = {
-  info: capture,
-  warn: capture,
-  error: capture,
-  debug: () => {},
-};
 mock.module("../../../../util/logger.js", () => ({
-  getLogger: () => fakeLogger,
-  getCliLogger: () => fakeLogger,
-  getCurrentLogFilePath: () => `${tmpDir}/assistant-test-mock.log`,
+  getLogger: () => ({
+    info: capture,
+    warn: capture,
+    error: capture,
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: capture,
+    warn: capture,
+    error: capture,
+    debug: () => {},
+  }),
 }));
-
-// ---------------------------------------------------------------------------
-// Import module under test (after mocks)
-// ---------------------------------------------------------------------------
 
 const { registerMemoryWorkerCommand } = await import("../worker.js");
 
@@ -98,10 +66,7 @@ const { registerMemoryWorkerCommand } = await import("../worker.js");
 function buildProgram(): Command {
   const program = new Command();
   program.exitOverride();
-  program.configureOutput({
-    writeErr: () => {},
-    writeOut: () => {},
-  });
+  program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
   const memory = program.command("memory");
   registerMemoryWorkerCommand(memory);
   return program;
@@ -118,14 +83,11 @@ async function runCommand(
     stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
     return true;
   }) as typeof process.stdout.write;
-
   process.stderr.write = (() => true) as typeof process.stderr.write;
-
   process.exitCode = 0;
 
   try {
-    const program = buildProgram();
-    await program.parseAsync(["node", "assistant", ...args]);
+    await buildProgram().parseAsync(["node", "assistant", ...args]);
   } catch {
     if (process.exitCode === 0) process.exitCode = 1;
   } finally {
@@ -135,32 +97,7 @@ async function runCommand(
 
   const exitCode = process.exitCode ?? 0;
   process.exitCode = 0;
-
   return { exitCode, stdout: stdoutChunks.join("") };
-}
-
-/**
- * Replace process.kill with a recording stub. `signal 0` is the liveness
- * probe: it resolves for `livePids` and throws ESRCH otherwise. Other signals
- * are recorded and no-oped so the test runner is never actually signalled.
- */
-function stubProcessKill(livePids: Set<number>): () => void {
-  const original = process.kill.bind(process);
-  killCalls = [];
-  process.kill = ((pid: number, signal?: string | number) => {
-    const sig = signal ?? 0;
-    if (sig === 0) {
-      if (livePids.has(pid)) return true;
-      const err = new Error("kill ESRCH") as NodeJS.ErrnoException;
-      err.code = "ESRCH";
-      throw err;
-    }
-    killCalls.push({ pid, signal: sig });
-    return true;
-  }) as typeof process.kill;
-  return () => {
-    process.kill = original;
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -168,184 +105,27 @@ function stubProcessKill(livePids: Set<number>): () => void {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "memory-worker-test-"));
-  pidPath = join(tmpDir, "memory-worker.pid");
-  markerPath = join(tmpDir, "memory-sync-runner.pid");
+  ipcCalls = [];
   logOutput = [];
-  killCalls = [];
-  rawConfig = {};
+  responses.clear();
   process.exitCode = 0;
 });
 
-afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-});
-
 // ---------------------------------------------------------------------------
-// Subcommand registration
+// Registration
 // ---------------------------------------------------------------------------
 
 describe("subcommand registration", () => {
   test("registers worker under memory with start/stop/status", () => {
     const program = buildProgram();
     const memory = program.commands.find((c) => c.name() === "memory");
-    expect(memory).toBeDefined();
     const worker = memory!.commands.find((c) => c.name() === "worker");
     expect(worker).toBeDefined();
-    const subcommandNames = worker!.commands.map((c) => c.name()).sort();
-    expect(subcommandNames).toEqual(["start", "status", "stop"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// status
-// ---------------------------------------------------------------------------
-
-describe("memory worker status", () => {
-  test("reports not_running with workerEnabled and syncRunner when nothing is running", async () => {
-    const { exitCode, stdout } = await runCommand([
-      "memory",
-      "worker",
+    expect(worker!.commands.map((c) => c.name()).sort()).toEqual([
+      "start",
       "status",
-      "--json",
-    ]);
-    expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout)).toEqual({
-      status: "not_running",
-      workerEnabled: false,
-      syncRunner: { status: "not_running" },
-    });
-  });
-
-  test("reports running when PID file points at a live process", async () => {
-    writeFileSync(pidPath, String(process.pid));
-    const restore = stubProcessKill(new Set([process.pid]));
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "status",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
-        status: "running",
-        pid: process.pid,
-        workerEnabled: false,
-        syncRunner: { status: "not_running" },
-      });
-    } finally {
-      restore();
-    }
-  });
-
-  test("reflects memory.worker.enabled from config", async () => {
-    rawConfig = { memory: { worker: { enabled: true } } };
-    const restore = stubProcessKill(new Set());
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "status",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toMatchObject({ workerEnabled: true });
-    } finally {
-      restore();
-    }
-  });
-
-  test("reports the synchronous runner as running when its marker is live", async () => {
-    writeFileSync(markerPath, String(process.pid));
-    const restore = stubProcessKill(new Set([process.pid]));
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "status",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toMatchObject({
-        status: "not_running",
-        syncRunner: { status: "running", pid: process.pid },
-      });
-    } finally {
-      restore();
-    }
-  });
-
-  test("treats a stale PID file as not_running and cleans it up", async () => {
-    writeFileSync(pidPath, "999999");
-    const restore = stubProcessKill(new Set());
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "status",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
-        status: "not_running",
-        workerEnabled: false,
-        syncRunner: { status: "not_running" },
-      });
-      expect(existsSync(pidPath)).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// stop
-// ---------------------------------------------------------------------------
-
-describe("memory worker stop", () => {
-  test("disables the config flag and succeeds when no worker is running", async () => {
-    rawConfig = { memory: { worker: { enabled: true } } };
-    const { exitCode, stdout } = await runCommand([
-      "memory",
-      "worker",
       "stop",
-      "--json",
     ]);
-    expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout)).toMatchObject({
-      ok: true,
-      workerWasRunning: false,
-      workerEnabled: false,
-    });
-    expect(workerEnabledFromRaw()).toBe(false);
-  });
-
-  test("sends SIGTERM to a running worker and disables the flag", async () => {
-    rawConfig = { memory: { worker: { enabled: true } } };
-    writeFileSync(pidPath, String(process.pid));
-    const restore = stubProcessKill(new Set([process.pid]));
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "stop",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
-        ok: true,
-        pid: process.pid,
-        workerEnabled: false,
-      });
-      expect(killCalls).toContainEqual({
-        pid: process.pid,
-        signal: "SIGTERM",
-      });
-      expect(workerEnabledFromRaw()).toBe(false);
-    } finally {
-      restore();
-    }
   });
 });
 
@@ -354,82 +134,98 @@ describe("memory worker stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory worker start", () => {
-  test("reuses an already-running worker and enables the flag", async () => {
-    writeFileSync(pidPath, String(process.pid));
-    const restore = stubProcessKill(new Set([process.pid]));
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "start",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toMatchObject({
-        ok: true,
-        pid: process.pid,
-        alreadyRunning: true,
+  test("calls memory_worker_start and renders the PID", async () => {
+    responses.set("memory_worker_start", {
+      ok: true,
+      result: {
+        pid: 4242,
+        alreadyRunning: false,
         workerEnabled: true,
-      });
-      expect(workerEnabledFromRaw()).toBe(true);
-    } finally {
-      restore();
-    }
+        pidPath: "/x/memory-worker.pid",
+      },
+    });
+
+    const { exitCode } = await runCommand(["memory", "worker", "start"]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual(["memory_worker_start"]);
+    expect(logOutput.join("\n")).toContain("Memory worker started (PID 4242)");
   });
 
-  test("spawns the worker, reports its PID, and enables the flag", async () => {
-    const restore = stubProcessKill(new Set());
-    const originalSpawn = Bun.spawn;
-    // Simulate the spawned worker writing its PID file on startup.
-    (Bun as { spawn: typeof Bun.spawn }).spawn = (() => {
-      writeFileSync(pidPath, "424242");
-      return { unref: () => {}, pid: 424242 };
-    }) as unknown as typeof Bun.spawn;
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "start",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toMatchObject({
-        ok: true,
-        pid: 424242,
-        workerEnabled: true,
-      });
-      expect(workerEnabledFromRaw()).toBe(true);
-    } finally {
-      (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
-      restore();
-    }
+  test("--json emits the raw route payload", async () => {
+    const result = {
+      pid: 7,
+      alreadyRunning: true,
+      workerEnabled: true,
+      pidPath: "/x/p.pid",
+    };
+    responses.set("memory_worker_start", { ok: true, result });
+
+    const { exitCode, stdout } = await runCommand([
+      "memory",
+      "worker",
+      "start",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(result);
   });
 
-  test("leaves the config flag untouched when the spawn fails", async () => {
-    const restore = stubProcessKill(new Set());
-    const originalSpawn = Bun.spawn;
-    // Spawn returns a child that exits during startup without writing a PID file
-    // → spawnMemoryWorkerProcess detects the early exit and throws, so the flag
-    // must stay disabled.
-    (Bun as { spawn: typeof Bun.spawn }).spawn = (() => ({
-      unref: () => {},
-      kill: () => {},
-      exited: Promise.resolve(1),
-      pid: 123,
-    })) as unknown as typeof Bun.spawn;
-    try {
-      const { exitCode, stdout } = await runCommand([
-        "memory",
-        "worker",
-        "start",
-        "--json",
-      ]);
-      expect(exitCode).toBe(1);
-      expect(JSON.parse(stdout)).toMatchObject({ ok: false });
-      expect(workerEnabledFromRaw()).toBe(false);
-    } finally {
-      (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
-      restore();
-    }
+  test("exits non-zero when the daemon reports a spawn failure", async () => {
+    responses.set("memory_worker_start", { ok: false, error: "spawn failed" });
+
+    const { exitCode } = await runCommand(["memory", "worker", "start"]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toEqual(["memory_worker_start"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stop
+// ---------------------------------------------------------------------------
+
+describe("memory worker stop", () => {
+  test("calls memory_worker_stop and renders the signalled PID", async () => {
+    responses.set("memory_worker_stop", {
+      ok: true,
+      result: { workerWasRunning: true, pid: 555, workerEnabled: false },
+    });
+
+    const { exitCode } = await runCommand(["memory", "worker", "stop"]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual(["memory_worker_stop"]);
+    expect(logOutput.join("\n")).toContain(
+      "Memory worker stop signal sent (PID 555)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+describe("memory worker status", () => {
+  test("calls memory_worker_status and emits the raw payload with --json", async () => {
+    const result = {
+      status: "running",
+      pid: 321,
+      workerEnabled: true,
+      syncRunner: { status: "not_running" },
+    };
+    responses.set("memory_worker_status", { ok: true, result });
+
+    const { exitCode, stdout } = await runCommand([
+      "memory",
+      "worker",
+      "status",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual(["memory_worker_status"]);
+    expect(JSON.parse(stdout)).toEqual(result);
   });
 });

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -14,175 +14,43 @@
  *   - `status` — report the worker process state, the `memory.worker.enabled`
  *     config value, and whether the synchronous in-process runner is going.
  *
- * All three run directly in the CLI process (transport: "local") — no IPC
- * round-trip to the daemon. The daemon's worker supervisor re-reads
- * `memory.worker.enabled` each poll and stands its synchronous runner down (or
- * resumes it) accordingly, so flipping the flag here switches the running
- * daemon's mode without a restart.
+ * All three are thin IPC wrappers (transport: "ipc"): the daemon owns the
+ * worker process so it is spawned as a *child of the daemon* — which is what
+ * makes it appear in `assistant ps` and lets the daemon tear it down on
+ * shutdown. (If the CLI spawned the worker itself, the short-lived CLI process
+ * would be its parent and the worker would be reparented to init.)
  */
 
 import type { Command } from "commander";
 
-import {
-  getConfigReadOnly,
-  loadRawConfig,
-  saveRawConfig,
-  setNestedValue,
-} from "../../../config/loader.js";
-import {
-  probeMemoryWorker,
-  probeSyncRunner,
-  spawnMemoryWorkerProcess,
-} from "../../../memory/worker-control.js";
-import { getMemoryWorkerPidPath } from "../../../util/platform.js";
+import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
-/**
- * Persist `memory.worker.enabled` to the on-disk config via the shared
- * raw-config helpers, so only this leaf changes (schema defaults are not baked
- * into the file). The assistant picks the change up on its next config read.
- */
-function setWorkerEnabled(enabled: boolean): void {
-  const raw = loadRawConfig();
-  setNestedValue(raw, "memory.worker.enabled", enabled);
-  saveRawConfig(raw);
+interface WorkerProcessState {
+  status: "running" | "not_running";
+  pid?: number;
 }
 
-// ---------------------------------------------------------------------------
-// `start`
-// ---------------------------------------------------------------------------
-
-async function startWorker(
-  opts: { json?: boolean },
-  cmd: Command,
-): Promise<void> {
-  let result: { pid: number; alreadyRunning: boolean };
-  try {
-    // Terminate the child if it times out: this path leaves
-    // `memory.worker.enabled` off on failure, so a worker that came up late
-    // would drain the queue alongside the daemon's synchronous runner.
-    result = await spawnMemoryWorkerProcess({ terminateOnTimeout: true });
-  } catch (err) {
-    // Spawn failed — leave `memory.worker.enabled` untouched so the daemon's
-    // synchronous runner keeps draining the queue rather than standing down
-    // for a worker that never came up.
-    const msg = err instanceof Error ? err.message : String(err);
-    if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg });
-    } else {
-      log.error(msg);
-    }
-    process.exitCode = 1;
-    return;
-  }
-
-  // The worker process is up (freshly spawned or already running). Enable the
-  // flag so the daemon's supervisor stands its synchronous runner down (and so
-  // the daemon spawns the worker again on the next restart).
-  setWorkerEnabled(true);
-
-  if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, {
-      ok: true,
-      pid: result.pid,
-      alreadyRunning: result.alreadyRunning,
-      pidPath: getMemoryWorkerPidPath(),
-      workerEnabled: true,
-    });
-  } else {
-    log.info(
-      result.alreadyRunning
-        ? `Memory worker is already running (PID ${result.pid})`
-        : `Memory worker started (PID ${result.pid})`,
-    );
-    log.info(
-      "Enabled memory.worker.enabled; the synchronous in-process runner will stand down",
-    );
-  }
+interface StartResponse {
+  pid: number;
+  alreadyRunning: boolean;
+  workerEnabled: true;
+  pidPath: string;
 }
 
-// ---------------------------------------------------------------------------
-// `stop`
-// ---------------------------------------------------------------------------
-
-function stopWorker(opts: { json?: boolean }, cmd: Command): void {
-  // Persist the preference first: `stop` means "hand the queue back to the
-  // synchronous in-process runner." Disabling the flag makes the daemon's
-  // supervisor resume processing in-process on its next poll and lines the next
-  // daemon restart up with synchronous mode; the SIGTERM below then stops the
-  // now-redundant worker process.
-  setWorkerEnabled(false);
-
-  const current = probeMemoryWorker();
-  if (current.status !== "running" || current.pid == null) {
-    // No worker process to signal — flipping the flag alone restores
-    // synchronous mode, so this is success, not an error.
-    if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, {
-        ok: true,
-        workerWasRunning: false,
-        workerEnabled: false,
-      });
-    } else {
-      log.info(
-        "Memory worker process was not running; disabled memory.worker.enabled (synchronous runner active)",
-      );
-    }
-    return;
-  }
-
-  const pid = current.pid;
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (shouldOutputJson(cmd)) {
-      writeOutput(cmd, { ok: false, error: msg, pid, workerEnabled: false });
-    } else {
-      log.error(`Failed to stop memory worker (PID ${pid}): ${msg}`);
-    }
-    process.exitCode = 1;
-    return;
-  }
-
-  if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, { ok: true, pid, workerEnabled: false });
-  } else {
-    log.info(`Memory worker stop signal sent (PID ${pid})`);
-    log.info(
-      "Disabled memory.worker.enabled; the synchronous in-process runner will take over",
-    );
-  }
+interface StopResponse {
+  workerWasRunning: boolean;
+  pid?: number;
+  workerEnabled: false;
 }
 
-// ---------------------------------------------------------------------------
-// `status`
-// ---------------------------------------------------------------------------
-
-function statusWorker(opts: { json?: boolean }, cmd: Command): void {
-  const worker = probeMemoryWorker();
-  const syncRunner = probeSyncRunner();
-  const workerEnabled = getConfigReadOnly().memory.worker.enabled;
-
-  if (shouldOutputJson(cmd)) {
-    writeOutput(cmd, { ...worker, workerEnabled, syncRunner });
-  } else {
-    if (worker.status === "running") {
-      log.info(`Memory worker process is running (PID ${worker.pid})`);
-    } else {
-      log.info("Memory worker process is not running");
-    }
-    log.info(`memory.worker.enabled: ${workerEnabled}`);
-    if (syncRunner.status === "running") {
-      log.info(
-        `Synchronous in-process runner is running (PID ${syncRunner.pid})`,
-      );
-    } else {
-      log.info("Synchronous in-process runner is not running");
-    }
-  }
+interface StatusResponse {
+  status: "running" | "not_running";
+  pid?: number;
+  workerEnabled: boolean;
+  syncRunner: WorkerProcessState;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,14 +60,16 @@ function statusWorker(opts: { json?: boolean }, cmd: Command): void {
 export function registerMemoryWorkerCommand(memory: Command): void {
   registerCommand(memory, {
     name: "worker",
-    transport: "local",
+    transport: "ipc",
     description: "Manage the memory jobs worker process (start/stop/status)",
     build: (worker) => {
       worker.addHelpText(
         "after",
         `
 The memory worker processes embedding, consolidation, and cleanup jobs in a
-separate OS process so they do not block the assistant's main event loop.
+separate OS process so they do not block the assistant's main event loop. The
+daemon owns the process, so it is spawned as a child of the daemon and shows up
+in \`assistant ps\`.
 
 \`start\` enables memory.worker.enabled and \`stop\` disables it, so the
 assistant's synchronous in-process runner stands down (start) or takes back over
@@ -217,8 +87,23 @@ Examples:
           "Start the memory worker process and enable memory.worker.enabled",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (opts: { json?: boolean }, cmd: Command) => {
-          await startWorker(opts, cmd);
+        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+          const r = await cliIpcCall<StartResponse>("memory_worker_start");
+          if (!r.ok) return exitFromIpcResult(r);
+          const res = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, res);
+            return;
+          }
+          log.info(
+            res.alreadyRunning
+              ? `Memory worker is already running (PID ${res.pid})`
+              : `Memory worker started (PID ${res.pid})`,
+          );
+          log.info(
+            "Enabled memory.worker.enabled; the synchronous in-process runner will stand down",
+          );
         });
 
       worker
@@ -227,8 +112,23 @@ Examples:
           "Stop the memory worker process and disable memory.worker.enabled",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action((opts: { json?: boolean }, cmd: Command) => {
-          stopWorker(opts, cmd);
+        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+          const r = await cliIpcCall<StopResponse>("memory_worker_stop");
+          if (!r.ok) return exitFromIpcResult(r);
+          const res = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, res);
+            return;
+          }
+          if (res.workerWasRunning) {
+            log.info(`Memory worker stop signal sent (PID ${res.pid})`);
+          } else {
+            log.info("Memory worker process was not running");
+          }
+          log.info(
+            "Disabled memory.worker.enabled; the synchronous in-process runner will take over",
+          );
         });
 
       worker
@@ -237,8 +137,28 @@ Examples:
           "Report worker process state, memory.worker.enabled, and the synchronous runner",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action((opts: { json?: boolean }, cmd: Command) => {
-          statusWorker(opts, cmd);
+        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+          const r = await cliIpcCall<StatusResponse>("memory_worker_status");
+          if (!r.ok) return exitFromIpcResult(r);
+          const res = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, res);
+            return;
+          }
+          if (res.status === "running") {
+            log.info(`Memory worker process is running (PID ${res.pid})`);
+          } else {
+            log.info("Memory worker process is not running");
+          }
+          log.info(`memory.worker.enabled: ${res.workerEnabled}`);
+          if (res.syncRunner.status === "running") {
+            log.info(
+              `Synchronous in-process runner is running (PID ${res.syncRunner.pid})`,
+            );
+          } else {
+            log.info("Synchronous in-process runner is not running");
+          }
         });
     },
   });

--- a/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for the memory worker control routes (start / stop / status).
+ *
+ * The route handlers run inside the daemon and own the worker process. We mock
+ * worker-control + config so the tests assert the handler behaviour:
+ *   - start spawns as a daemon child (detached:false), enables the flag only on
+ *     success, and throws on spawn failure (flag untouched).
+ *   - stop disables the flag and signals the worker.
+ *   - status reports worker + sync-runner + flag.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as actualLoader from "../../../config/loader.js";
+import { getMemoryWorkerPidPath } from "../../../util/platform.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+class FakeSpawnError extends Error {}
+
+let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
+let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let stopImpl: () => { status: "running" | "not_running"; pid?: number };
+/** Records the `memory.worker.enabled` values written via saveRawConfig. */
+let enabledCalls: boolean[] = [];
+let workerProbe: { status: "running" | "not_running"; pid?: number } = {
+  status: "not_running",
+};
+let syncProbe: { status: "running" | "not_running"; pid?: number } = {
+  status: "not_running",
+};
+let configEnabled = false;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../memory/worker-control.js", () => ({
+  MemoryWorkerSpawnError: FakeSpawnError,
+  spawnMemoryWorkerProcess: async (opts: {
+    detached?: boolean;
+    terminateOnTimeout?: boolean;
+  }) => {
+    spawnArgs.push(opts);
+    return spawnImpl();
+  },
+  stopMemoryWorkerProcess: () => stopImpl(),
+  probeMemoryWorker: () => workerProbe,
+  probeSyncRunner: () => syncProbe,
+}));
+
+// Spread the real loader so the route-policy import chain keeps every other
+// export (getConfig, …). Override the flag read, and capture the flag write
+// (the route's setMemoryWorkerEnabled goes through loadRawConfig/saveRawConfig).
+mock.module("../../../config/loader.js", () => ({
+  ...actualLoader,
+  getConfigReadOnly: () => ({ memory: { worker: { enabled: configEnabled } } }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: (cfg: { memory?: { worker?: { enabled?: boolean } } }) => {
+    enabledCalls.push(cfg.memory?.worker?.enabled === true);
+  },
+}));
+
+const { ROUTES } = await import("../memory-worker-routes.js");
+
+function handler(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`route ${operationId} not registered`);
+  return route.handler as () => Promise<Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  spawnArgs = [];
+  enabledCalls = [];
+  spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
+  stopImpl = () => ({ status: "not_running" });
+  workerProbe = { status: "not_running" };
+  syncProbe = { status: "not_running" };
+  configEnabled = false;
+});
+
+// ---------------------------------------------------------------------------
+// start
+// ---------------------------------------------------------------------------
+
+describe("memory_worker_start", () => {
+  test("spawns as a daemon child and enables the flag on success", async () => {
+    spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
+
+    const res = await handler("memory_worker_start")();
+
+    expect(spawnArgs).toEqual([{ detached: false, terminateOnTimeout: true }]);
+    expect(enabledCalls).toEqual([true]);
+    expect(res).toEqual({
+      pid: 4242,
+      alreadyRunning: false,
+      workerEnabled: true,
+      pidPath: getMemoryWorkerPidPath(),
+    });
+  });
+
+  test("reports an already-running worker without re-spawning", async () => {
+    spawnImpl = async () => ({ pid: 99, alreadyRunning: true });
+
+    const res = await handler("memory_worker_start")();
+
+    expect(res).toMatchObject({ pid: 99, alreadyRunning: true });
+    expect(enabledCalls).toEqual([true]);
+  });
+
+  test("throws and leaves the flag untouched when the spawn fails", async () => {
+    spawnImpl = async () => {
+      throw new FakeSpawnError("worker exited during startup");
+    };
+
+    await expect(handler("memory_worker_start")()).rejects.toThrow(
+      "worker exited during startup",
+    );
+    expect(enabledCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stop
+// ---------------------------------------------------------------------------
+
+describe("memory_worker_stop", () => {
+  test("disables the flag and reports a signalled running worker", async () => {
+    stopImpl = () => ({ status: "running", pid: 555 });
+
+    const res = await handler("memory_worker_stop")();
+
+    expect(enabledCalls).toEqual([false]);
+    expect(res).toEqual({
+      workerWasRunning: true,
+      pid: 555,
+      workerEnabled: false,
+    });
+  });
+
+  test("disables the flag and succeeds when no worker is running", async () => {
+    stopImpl = () => ({ status: "not_running" });
+
+    const res = await handler("memory_worker_stop")();
+
+    expect(enabledCalls).toEqual([false]);
+    expect(res).toEqual({ workerWasRunning: false, workerEnabled: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+describe("memory_worker_status", () => {
+  test("reports worker, sync runner, and the config flag", async () => {
+    workerProbe = { status: "running", pid: 321 };
+    syncProbe = { status: "not_running" };
+    configEnabled = true;
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toEqual({
+      status: "running",
+      pid: 321,
+      workerEnabled: true,
+      syncRunner: { status: "not_running" },
+    });
+  });
+
+  test("omits pid when the worker is not running", async () => {
+    workerProbe = { status: "not_running" };
+    syncProbe = { status: "running", pid: 12 };
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toEqual({
+      status: "not_running",
+      workerEnabled: false,
+      syncRunner: { status: "running", pid: 12 },
+    });
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -94,6 +94,7 @@ import { ROUTES as MEMORY_EVAL_ROUTES } from "./memory-eval-routes.js";
 import { ROUTES as MEMORY_ITEM_ROUTES } from "./memory-item-routes.js";
 import { ROUTES as MEMORY_V2_ROUTES } from "./memory-v2-routes.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "./memory-v3-routes.js";
+import { ROUTES as MEMORY_WORKER_ROUTES } from "./memory-worker-routes.js";
 import { ROUTES as MIGRATION_ROLLBACK_ROUTES } from "./migration-rollback-routes.js";
 import { ROUTES as MIGRATION_ROUTES } from "./migration-routes.js";
 import { ROUTES as NOTIFICATION_ROUTES } from "./notification-routes.js";
@@ -228,6 +229,7 @@ export const ROUTES: RouteDefinition[] = [
   ...MEMORY_ITEM_ROUTES,
   ...MEMORY_V2_ROUTES,
   ...MEMORY_V3_ROUTES,
+  ...MEMORY_WORKER_ROUTES,
   ...MIGRATION_ROLLBACK_ROUTES,
   ...MIGRATION_ROUTES,
   ...NOTIFICATION_ROUTES,

--- a/assistant/src/runtime/routes/memory-worker-routes.ts
+++ b/assistant/src/runtime/routes/memory-worker-routes.ts
@@ -1,0 +1,199 @@
+/**
+ * Memory worker control endpoints (start / stop / status).
+ *
+ * These run inside the daemon so the worker process the daemon spawns is a
+ * direct child of the daemon — which is what makes it show up in the daemon's
+ * process tree (`assistant ps`) and lets the daemon tear it down on shutdown.
+ * The `assistant memory worker` CLI is a thin IPC client over these routes; if
+ * it spawned the worker itself, the worker would be parented to the short-lived
+ * CLI process (reparented to init) instead of the daemon.
+ */
+
+import { z } from "zod";
+
+import {
+  getConfigReadOnly,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import {
+  MemoryWorkerSpawnError,
+  probeMemoryWorker,
+  probeSyncRunner,
+  spawnMemoryWorkerProcess,
+  stopMemoryWorkerProcess,
+} from "../../memory/worker-control.js";
+import { getLogger } from "../../util/logger.js";
+import { getMemoryWorkerPidPath } from "../../util/platform.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { InternalError } from "./errors.js";
+import type { RouteDefinition } from "./types.js";
+
+const log = getLogger("memory-worker-routes");
+
+/**
+ * Persist `memory.worker.enabled` to the on-disk config via the shared
+ * raw-config helpers, so only this leaf changes (schema defaults are not baked
+ * into the file). The daemon's worker supervisor re-reads the flag from disk on
+ * its next poll, so the change takes effect without a restart.
+ */
+function setMemoryWorkerEnabled(enabled: boolean): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "memory.worker.enabled", enabled);
+  saveRawConfig(raw);
+}
+
+const workerStatusSchema = z.object({
+  status: z.enum(["running", "not_running"]),
+  pid: z.number().optional(),
+});
+
+const startResponseSchema = z.object({
+  pid: z.number(),
+  alreadyRunning: z.boolean(),
+  workerEnabled: z.literal(true),
+  pidPath: z.string(),
+});
+
+const stopResponseSchema = z.object({
+  workerWasRunning: z.boolean(),
+  pid: z.number().optional(),
+  workerEnabled: z.literal(false),
+});
+
+const statusResponseSchema = z.object({
+  status: z.enum(["running", "not_running"]),
+  pid: z.number().optional(),
+  workerEnabled: z.boolean(),
+  syncRunner: workerStatusSchema,
+});
+
+/**
+ * Start (or reuse) the memory worker process as a child of the daemon, then
+ * enable `memory.worker.enabled` so the daemon's supervisor stands its
+ * synchronous in-process runner down. The flag is only enabled once the worker
+ * is confirmed up — on spawn failure it is left untouched so the synchronous
+ * runner keeps draining the queue rather than standing down for a worker that
+ * never came up.
+ */
+async function startMemoryWorker() {
+  let result: { pid: number; alreadyRunning: boolean };
+  try {
+    // `detached: false` parents the worker to the daemon. `terminateOnTimeout`
+    // matches the leave-the-flag-off-on-failure contract below: a worker that
+    // came up late would otherwise drain the queue alongside the synchronous
+    // runner.
+    result = await spawnMemoryWorkerProcess({
+      detached: false,
+      terminateOnTimeout: true,
+    });
+  } catch (err) {
+    const message =
+      err instanceof MemoryWorkerSpawnError || err instanceof Error
+        ? err.message
+        : String(err);
+    log.warn({ err }, "Failed to start memory worker process");
+    throw new InternalError(message);
+  }
+
+  setMemoryWorkerEnabled(true);
+
+  return {
+    pid: result.pid,
+    alreadyRunning: result.alreadyRunning,
+    workerEnabled: true as const,
+    pidPath: getMemoryWorkerPidPath(),
+  };
+}
+
+/**
+ * Disable `memory.worker.enabled` (handing the queue back to the synchronous
+ * in-process runner) and SIGTERM the worker process if it is running. A worker
+ * that is not running is not an error — flipping the flag alone restores
+ * synchronous mode.
+ */
+function stopMemoryWorker() {
+  setMemoryWorkerEnabled(false);
+
+  let before: ReturnType<typeof stopMemoryWorkerProcess>;
+  try {
+    before = stopMemoryWorkerProcess();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn({ err }, "Failed to signal memory worker process");
+    throw new InternalError(message);
+  }
+
+  return {
+    workerWasRunning: before.status === "running",
+    ...(before.pid != null ? { pid: before.pid } : {}),
+    workerEnabled: false as const,
+  };
+}
+
+/**
+ * Report the worker process state, the `memory.worker.enabled` config value,
+ * and whether the daemon's synchronous in-process runner is currently draining
+ * the queue.
+ */
+function memoryWorkerStatus() {
+  const worker = probeMemoryWorker();
+  const syncRunner = probeSyncRunner();
+  const workerEnabled = getConfigReadOnly().memory.worker.enabled;
+
+  return {
+    status: worker.status,
+    ...(worker.pid != null ? { pid: worker.pid } : {}),
+    workerEnabled,
+    syncRunner,
+  };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "memory_worker_start",
+    endpoint: "memory/worker/start",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: startMemoryWorker,
+    summary: "Start the memory worker",
+    description:
+      "Spawns (or reuses) the memory worker process as a child of the daemon and enables memory.worker.enabled.",
+    tags: ["system"],
+    responseBody: startResponseSchema,
+  },
+  {
+    operationId: "memory_worker_stop",
+    endpoint: "memory/worker/stop",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: stopMemoryWorker,
+    summary: "Stop the memory worker",
+    description:
+      "Disables memory.worker.enabled and SIGTERMs the memory worker process if it is running.",
+    tags: ["system"],
+    responseBody: stopResponseSchema,
+  },
+  {
+    operationId: "memory_worker_status",
+    endpoint: "memory/worker/status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: memoryWorkerStatus,
+    summary: "Memory worker status",
+    description:
+      "Reports the memory worker process state, memory.worker.enabled, and the synchronous in-process runner.",
+    tags: ["system"],
+    responseBody: statusResponseSchema,
+  },
+];


### PR DESCRIPTION
## Why

Follow-up to the `assistant ps` work. `assistant memory worker start` ran in the **short-lived CLI process** and spawned the worker with `spawnMemoryWorkerProcess({ terminateOnTimeout: true })` — i.e. `detached: true`. The CLI then exited, so the worker was reparented to init and was **never a child of the daemon**. `assistant ps` walks the *daemon's* descendants, so a CLI-started worker never appeared there (the `detached: false` fix from the prior PR only covered the daemon's own boot spawn).

A CLI process is ephemeral, so it can never be the lasting parent — the only fix is for **the daemon to fork the worker**.

## What

- **New shared routes** `memory_worker_start` / `memory_worker_stop` / `memory_worker_status` (`memory-worker-routes.ts`). They run in the daemon and spawn the worker as the daemon's **own child** (`detached: false`).
- **`memory worker` CLI converted from `local` to thin IPC wrappers** over those routes. One IPC call per subcommand, response rendered as-is (`--json` emits the raw payload).
- `start` semantics are **preserved**: the daemon spawns synchronously, waits for the PID file, and only flips `memory.worker.enabled` on success (so a failed spawn leaves the synchronous in-process runner draining the queue). It's just the daemon doing it now, so the worker is daemon-parented and shows up in `assistant ps`. This matches the daemon's boot-time spawn, which already used `detached: false`.
- Removed the now-dead `worker-control` entry from the CLI `local` import-allowlist (`cli-no-daemon-internals.js`), and regenerated `openapi.yaml` for the three new routes.

## Trade-off

`status`/`stop` now go through the daemon too (the CLI group is single-transport). Since the worker is a daemon-managed child, this is logical — but it does mean these require the daemon to be running, whereas before they read the PID file directly. I judged that acceptable; happy to revisit if you'd rather keep them daemon-independent.

## Testing

- New `memory-worker-routes.test.ts` (7) — start spawns with `detached:false`+`terminateOnTimeout:true`, enables the flag only on success, throws (flag untouched) on spawn failure; stop disables the flag + signals; status composition.
- Rewrote `worker.test.ts` (6) as IPC-wrapper tests.
- `worker-control.test.ts` (6), `ps-routes.test.ts` (4), `ps.test.ts` (6) still green.
- `generate:openapi -- --check` passes; typecheck + lint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZdVtmezMXKMVof8PaAVzc)_