### PR TITLE
refactor(memory): derive sync-runner status from config, drop the redundant marker file

### DIFF
--- a/assistant/src/memory/__tests__/worker-control.test.ts
+++ b/assistant/src/memory/__tests__/worker-control.test.ts
@@ -17,13 +17,18 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mock } from "bun:test";
 
+import * as realLogger from "../../util/logger.js";
+import * as realPlatform from "../../util/platform.js";
+
 let tmpDir: string;
 let pidPath: string;
-let markerPath: string;
 
+// Spread the real modules and override only what we need: `mock.module` is
+// global across the test process, so a partial mock missing exports that other
+// co-run files import (e.g. jobs-worker's `getWorkspaceDir`) would break them.
 mock.module("../../util/platform.js", () => ({
+  ...realPlatform,
   getMemoryWorkerPidPath: () => pidPath,
-  getMemorySyncRunnerMarkerPath: () => markerPath,
 }));
 
 const noopLogger = {
@@ -33,13 +38,41 @@ const noopLogger = {
   debug: () => {},
 };
 mock.module("../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () => noopLogger,
   getCliLogger: () => noopLogger,
   getCurrentLogFilePath: () => join(tmpDir, "worker-control-test.log"),
 }));
 
-const { spawnMemoryWorkerProcess, MemoryWorkerSpawnError } =
+const { spawnMemoryWorkerProcess, MemoryWorkerSpawnError, probeMemoryWorker } =
   await import("../worker-control.js");
+
+/**
+ * Replace process.kill with a stub. `signal 0` (liveness) resolves for
+ * `livePids`, throws ESRCH otherwise — unless `permissionErrorPids` includes
+ * the pid, in which case it throws EPERM ("exists but not signalable").
+ */
+function stubProcessKill(
+  livePids: Set<number>,
+  permissionErrorPids: Set<number> = new Set(),
+): () => void {
+  const original = process.kill.bind(process);
+  process.kill = ((pid: number, signal?: string | number) => {
+    if ((signal ?? 0) !== 0) return true;
+    if (permissionErrorPids.has(pid)) {
+      const err = new Error("kill EPERM") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    }
+    if (livePids.has(pid)) return true;
+    const err = new Error("kill ESRCH") as NodeJS.ErrnoException;
+    err.code = "ESRCH";
+    throw err;
+  }) as typeof process.kill;
+  return () => {
+    process.kill = original;
+  };
+}
 
 /**
  * Install a stub `Bun.spawn`. The `onSpawn` callback receives the resolved PID
@@ -70,7 +103,6 @@ function neverExits(): Promise<unknown> {
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "worker-control-test-"));
   pidPath = join(tmpDir, "memory-worker.pid");
-  markerPath = join(tmpDir, "memory-sync-runner.pid");
 });
 
 afterEach(() => {
@@ -209,6 +241,18 @@ describe("spawnMemoryWorkerProcess", () => {
       const result = await spawnMemoryWorkerProcess({ pidWaitTimeoutMs: 100 });
       expect(result).toEqual({ pid: process.pid, alreadyRunning: true });
       expect(spawned).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("probeMemoryWorker", () => {
+  test("reports running (not throws) when the process exists but is not signalable (EPERM)", () => {
+    writeFileSync(pidPath, "4321");
+    const restore = stubProcessKill(new Set(), new Set([4321]));
+    try {
+      expect(probeMemoryWorker()).toEqual({ status: "running", pid: 4321 });
     } finally {
       restore();
     }

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -93,11 +93,7 @@ import {
   memoryV2ConsolidateJob,
 } from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
-import {
-  removeSyncRunnerMarker,
-  spawnMemoryWorkerProcess,
-  writeSyncRunnerMarker,
-} from "./worker-control.js";
+import { spawnMemoryWorkerProcess } from "./worker-control.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -173,10 +169,8 @@ export interface MemoryJobsWorker {
  * supervisor owns the synchronous in-process runner and reconciles to
  * `memory.worker.enabled` on every poll, re-reading the flag from disk so a
  * runtime change takes effect without a restart:
- *   - flag off (default): drain the queue in-process and publish the
- *     sync-runner marker so `status` reports the synchronous runner as going.
- *   - flag on: stand down (the out-of-process worker owns the queue) and clear
- *     the marker.
+ *   - flag off (default): drain the queue in-process (the synchronous runner).
+ *   - flag on: stand down (the out-of-process worker owns the queue).
  * Gating on the flag — rather than on the worker process actually being present
  * — keeps exactly one drainer active and avoids a boot race: when the flag is
  * on the supervisor never processes, so it can't claim jobs that the spawning
@@ -234,10 +228,9 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
  *
  * When `standDownForWorkerProcess` is set the loop acts as the daemon's
  * synchronous-runner supervisor: each tick it skips processing while
- * `memory.worker.enabled` is on (clearing the sync-runner marker), and
- * publishes the marker while it owns processing. The standalone worker process
- * must NOT set this — it runs precisely when the flag is on and would otherwise
- * stand itself down forever.
+ * `memory.worker.enabled` is on, and drains the queue while it is off. The
+ * standalone worker process must NOT set this — it runs precisely when the flag
+ * is on and would otherwise stand itself down forever.
  */
 export function startInProcessMemoryJobsWorker(
   opts: { standDownForWorkerProcess?: boolean } = {},
@@ -265,10 +258,6 @@ export function startInProcessMemoryJobsWorker(
   let tickRunning = false;
   let timer: ReturnType<typeof setTimeout>;
   let currentIntervalMs = POLL_INTERVAL_MIN_MS;
-  // Tracks whether this supervisor currently owns processing (and so has
-  // published the sync-runner marker). Only meaningful when
-  // `standDownForWorkerProcess` is set.
-  let syncRunnerMarked = false;
 
   const tick = async () => {
     if (stopped || tickRunning) return;
@@ -279,24 +268,14 @@ export function startInProcessMemoryJobsWorker(
         getConfig().memory.worker?.enabled === true
       ) {
         // The out-of-process worker owns the queue — stand the synchronous
-        // runner down so jobs aren't processed twice, and retract the marker.
-        if (syncRunnerMarked) {
-          removeSyncRunnerMarker();
-          syncRunnerMarked = false;
-        }
+        // runner down so jobs aren't processed twice.
+        //
         // Switching modes is a rare operator action, so poll at the slow cap
         // while standing down: it still picks up a `memory worker stop` (which
         // flips the flag back off) within one interval, without waking every
         // couple seconds for the whole time the worker owns the queue.
         currentIntervalMs = POLL_INTERVAL_MAX_MS;
         return;
-      }
-      if (standDownForWorkerProcess && !syncRunnerMarked) {
-        // The flag is off — this in-process runner owns processing. Publish the
-        // marker so `memory worker status` reports the synchronous runner as
-        // going.
-        writeSyncRunnerMarker(process.pid);
-        syncRunnerMarked = true;
       }
       const processed = await runMemoryJobsOnce({
         enableScheduledCleanup: true,
@@ -346,10 +325,6 @@ export function startInProcessMemoryJobsWorker(
     stop(): void {
       stopped = true;
       clearTimeout(timer);
-      if (syncRunnerMarked) {
-        removeSyncRunnerMarker();
-        syncRunnerMarked = false;
-      }
     },
   };
 }

--- a/assistant/src/memory/worker-control.ts
+++ b/assistant/src/memory/worker-control.ts
@@ -14,15 +14,11 @@ import {
   openSync,
   readFileSync,
   unlinkSync,
-  writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
 
 import { getCurrentLogFilePath } from "../util/logger.js";
-import {
-  getMemorySyncRunnerMarkerPath,
-  getMemoryWorkerPidPath,
-} from "../util/platform.js";
+import { getMemoryWorkerPidPath } from "../util/platform.js";
 
 export interface MemoryWorkerStatus {
   status: "running" | "not_running";
@@ -42,8 +38,8 @@ function isEsrchError(err: unknown): boolean {
 /**
  * Read a PID file and report liveness. A missing or malformed file reports
  * not_running; a file pointing at a dead process is cleaned up and reported as
- * not_running. Shared by the worker-process PID file and the sync-runner
- * marker so both probe identically.
+ * not_running. Used for the worker-process PID file, whose PID is a normal
+ * spawned child (never PID 1), so `process.kill(pid, 0)` liveness is reliable.
  */
 function probePidFile(path: string): MemoryWorkerStatus {
   if (!existsSync(path)) return { status: "not_running" };
@@ -65,7 +61,10 @@ function probePidFile(path: string): MemoryWorkerStatus {
       }
       return { status: "not_running" };
     }
-    throw err;
+    // Any other error (e.g. EPERM: the process exists but this caller may not
+    // signal it) means the process is alive. Report it running rather than
+    // letting the error escape a status probe.
+    return { status: "running", pid };
   }
 }
 
@@ -76,44 +75,6 @@ function probePidFile(path: string): MemoryWorkerStatus {
  */
 export function probeMemoryWorker(): MemoryWorkerStatus {
   return probePidFile(getMemoryWorkerPidPath());
-}
-
-/**
- * Inspect the sync-runner marker to determine whether the daemon's in-process
- * synchronous runner is currently draining the memory-job queue. The daemon's
- * worker supervisor writes the marker (with its own PID) only while it owns
- * processing, so a live marker means the synchronous runner is going. A stale
- * marker (daemon gone) is cleaned up and reported as not_running.
- */
-export function probeSyncRunner(): MemoryWorkerStatus {
-  return probePidFile(getMemorySyncRunnerMarkerPath());
-}
-
-/**
- * Publish the sync-runner marker recording `pid` (the daemon process). Called
- * by the worker supervisor when its in-process synchronous runner takes over
- * processing. Best-effort: a write failure only affects status reporting, not
- * job processing.
- */
-export function writeSyncRunnerMarker(pid: number): void {
-  try {
-    writeFileSync(getMemorySyncRunnerMarkerPath(), String(pid), { flag: "w" });
-  } catch {
-    // best-effort — the marker is a status hint, not a correctness invariant
-  }
-}
-
-/**
- * Remove the sync-runner marker. Called by the worker supervisor when it stands
- * down for an out-of-process worker, and on daemon shutdown. Best-effort.
- */
-export function removeSyncRunnerMarker(): void {
-  try {
-    const path = getMemorySyncRunnerMarkerPath();
-    if (existsSync(path)) unlinkSync(path);
-  } catch {
-    // best-effort
-  }
 }
 
 export class MemoryWorkerSpawnError extends Error {}

--- a/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
@@ -28,10 +28,8 @@ let enabledCalls: boolean[] = [];
 let workerProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
 };
-let syncProbe: { status: "running" | "not_running"; pid?: number } = {
-  status: "not_running",
-};
 let configEnabled = false;
+let memoryEnabled = true;
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -48,7 +46,6 @@ mock.module("../../../memory/worker-control.js", () => ({
   },
   stopMemoryWorkerProcess: () => stopImpl(),
   probeMemoryWorker: () => workerProbe,
-  probeSyncRunner: () => syncProbe,
 }));
 
 // Spread the real loader so the route-policy import chain keeps every other
@@ -56,7 +53,9 @@ mock.module("../../../memory/worker-control.js", () => ({
 // (the route's setMemoryWorkerEnabled goes through loadRawConfig/saveRawConfig).
 mock.module("../../../config/loader.js", () => ({
   ...actualLoader,
-  getConfigReadOnly: () => ({ memory: { worker: { enabled: configEnabled } } }),
+  getConfigReadOnly: () => ({
+    memory: { enabled: memoryEnabled, worker: { enabled: configEnabled } },
+  }),
   loadRawConfig: () => ({}),
   saveRawConfig: (cfg: { memory?: { worker?: { enabled?: boolean } } }) => {
     enabledCalls.push(cfg.memory?.worker?.enabled === true);
@@ -81,8 +80,8 @@ beforeEach(() => {
   spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
   stopImpl = () => ({ status: "not_running" });
   workerProbe = { status: "not_running" };
-  syncProbe = { status: "not_running" };
   configEnabled = false;
+  memoryEnabled = true;
 });
 
 // ---------------------------------------------------------------------------
@@ -159,9 +158,8 @@ describe("memory_worker_stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory_worker_status", () => {
-  test("reports worker, sync runner, and the config flag", async () => {
+  test("reports the sync runner down when the worker flag is on", async () => {
     workerProbe = { status: "running", pid: 321 };
-    syncProbe = { status: "not_running" };
     configEnabled = true;
 
     const res = await handler("memory_worker_status")();
@@ -174,16 +172,29 @@ describe("memory_worker_status", () => {
     });
   });
 
-  test("omits pid when the worker is not running", async () => {
+  test("derives the sync runner (with the daemon's pid) from the flag being off", async () => {
     workerProbe = { status: "not_running" };
-    syncProbe = { status: "running", pid: 12 };
+    configEnabled = false;
 
     const res = await handler("memory_worker_status")();
 
     expect(res).toEqual({
       status: "not_running",
       workerEnabled: false,
-      syncRunner: { status: "running", pid: 12 },
+      syncRunner: { status: "running", pid: process.pid },
+    });
+  });
+
+  test("reports the sync runner down when memory is disabled", async () => {
+    workerProbe = { status: "not_running" };
+    configEnabled = false;
+    memoryEnabled = false;
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toMatchObject({
+      workerEnabled: false,
+      syncRunner: { status: "not_running" },
     });
   });
 });

--- a/assistant/src/runtime/routes/memory-worker-routes.ts
+++ b/assistant/src/runtime/routes/memory-worker-routes.ts
@@ -20,7 +20,6 @@ import {
 import {
   MemoryWorkerSpawnError,
   probeMemoryWorker,
-  probeSyncRunner,
   spawnMemoryWorkerProcess,
   stopMemoryWorkerProcess,
 } from "../../memory/worker-control.js";
@@ -136,11 +135,23 @@ function stopMemoryWorker() {
  * Report the worker process state, the `memory.worker.enabled` config value,
  * and whether the daemon's synchronous in-process runner is currently draining
  * the queue.
+ *
+ * The supervisor drains in-process exactly when memory is enabled and the
+ * out-of-process worker is not (it stands down on `memory.worker.enabled`).
+ * This handler runs inside the daemon — the very process that is (or isn't) the
+ * synchronous runner — so the runner's state is derived directly from config,
+ * with the daemon's own PID, rather than read back from a marker file.
  */
 function memoryWorkerStatus() {
   const worker = probeMemoryWorker();
-  const syncRunner = probeSyncRunner();
-  const workerEnabled = getConfigReadOnly().memory.worker.enabled;
+  const config = getConfigReadOnly();
+  const workerEnabled = config.memory.worker.enabled;
+
+  const syncRunnerActive = config.memory.enabled !== false && !workerEnabled;
+  const syncRunner: { status: "running" | "not_running"; pid?: number } =
+    syncRunnerActive
+      ? { status: "running", pid: process.pid }
+      : { status: "not_running" };
 
   return {
     status: worker.status,

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -248,20 +248,6 @@ export function getMemoryWorkerPidPath(): string {
 }
 
 /**
- * Returns the path to the memory sync-runner marker file
- * ($VELLUM_WORKSPACE_DIR/memory-sync-runner.pid).
- *
- * The daemon's in-process memory-jobs supervisor writes this marker (with its
- * own PID) while the synchronous in-process runner is actively draining the
- * queue, and removes it when it stands down for an out-of-process worker. It
- * lets `assistant memory worker status` report whether the synchronous runner
- * is still going without an IPC round-trip to the daemon.
- */
-export function getMemorySyncRunnerMarkerPath(): string {
-  return join(getWorkspaceDir(), "memory-sync-runner.pid");
-}
-
-/**
  * Returns the workspace root for user-facing state.
  *
  * When the VELLUM_WORKSPACE_DIR env var is set, returns that value (used in


### PR DESCRIPTION
Follow-up to #36306, addressing the `Synchronous in-process runner is running (PID 1)` line in `assistant memory worker status`.

## The realisation

The sync-runner state was tracked via a marker file (`memory-sync-runner.pid`) that the daemon's supervisor wrote with its own PID, which `probeSyncRunner` read back via `process.kill(pid, 0)`.

That marker only existed so `status` could report the runner **without an IPC round-trip to the daemon** — back when `status` ran locally in the CLI. **#36315 moved `status` to an IPC route served by the daemon**, so the handler now runs *inside the very process that is (or isn't) the synchronous runner*. The marker became redundant: the daemon knows its own state.

It was also actively unreliable — the daemon runs as **PID 1** in containers, and PID 1 is always occupied, so `process.kill(1, 0)` can never report it dead. A marker left behind by a hard daemon crash (SIGKILL/OOM, which skip graceful cleanup) would read `running (PID 1)` forever.

So rather than patch the marker's liveness check (heartbeat + freshness — the earlier version of this PR), the right fix is to **delete the marker** and derive the state directly.

## Changes

- **Status route derives the sync-runner from config:** `memory.enabled !== false && !memory.worker.enabled`, reported with the daemon's own PID. No file, no staleness, no PID-1 ambiguity. It's also strictly more accurate — it now reports the runner *down* when memory is disabled entirely (the old marker reported it up).
- **Removed** `getMemorySyncRunnerMarkerPath`, `probeSyncRunner`, `writeSyncRunnerMarker`, `removeSyncRunnerMarker`, and the supervisor's marker bookkeeping. The supervisor's stand-down gating on `memory.worker.enabled` is unchanged, so "exactly one drainer" still holds.
- **Hardened `probePidFile`** (still used for the worker-process PID file, which is a real child process — legitimately probed): a non-ESRCH error (EPERM = process exists) reports running instead of throwing out of a status probe.

Net: **-12 lines**, one fewer file in the workspace, and the entire PID-1 staleness bug class is gone (no file ⇒ nothing to go stale).

## Testing

- `bun test src/memory/__tests__/worker-control.test.ts` — spawn paths + EPERM
- `bun test src/runtime/routes/__tests__/memory-worker-routes.test.ts` — status now driven by config (flag-on, flag-off→running with daemon pid, memory-disabled→down)
- `jobs-worker-v2` suites pass alongside the supervisor change
- `eslint` and `tsc --noEmit` clean; grep confirms no remaining references to the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuWSJimv7hoaFGBfxjmDuQ