### PR TITLE
feat(web): rolling-base reducer core + invariant test (client-sync Phase 1)

### DIFF
--- a/clients/web/src/domains/chat/transcript/rolling-base.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyEvent,
+  rebuildBase,
+  type RollingBase,
+  type SeqEnvelope,
+} from "@/domains/chat/transcript/rolling-base";
+import type { AssistantEvent } from "@/types/event-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SEED: RollingBase = {
+  messages: [],
+  hasMore: false,
+  oldestTimestamp: null,
+  oldestMessageId: null,
+  seq: 0,
+};
+
+// Minimal valid wire events — the reducer reads only the fields below.
+function ev(seq: number, message: AssistantEvent): SeqEnvelope {
+  return { seq, timestampMs: 1_000 + seq, message };
+}
+function userEcho(seq: number, id: string, text: string): SeqEnvelope {
+  return ev(seq, { type: "user_message_echo", messageId: id, text } as AssistantEvent);
+}
+function textDelta(seq: number, id: string, text: string): SeqEnvelope {
+  return ev(seq, { type: "assistant_text_delta", messageId: id, text } as AssistantEvent);
+}
+function thinkingDelta(seq: number, id: string, thinking: string): SeqEnvelope {
+  return ev(seq, {
+    type: "assistant_thinking_delta",
+    messageId: id,
+    thinking,
+  } as AssistantEvent);
+}
+function complete(seq: number, id: string): SeqEnvelope {
+  return ev(seq, { type: "message_complete", messageId: id } as AssistantEvent);
+}
+
+// A representative turn: user echo → reasoning → answer → finalize.
+function cleanTurn(): SeqEnvelope[] {
+  return [
+    userEcho(1, "u1", "build me a dashboard"),
+    thinkingDelta(2, "a1", "let me consider the layout"),
+    thinkingDelta(3, "a1", " and the data model"),
+    textDelta(4, "a1", "Here is"),
+    textDelta(5, "a1", " your dashboard."),
+    complete(6, "a1"),
+  ];
+}
+
+// Deterministic PRNG (mulberry32) so the randomized cases are reproducible.
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Inject replays of already-emitted events at random positions. Every injected
+// event has seq <= some earlier event, modelling reconnect replay / resync
+// overlap — all must be idempotent no-ops.
+function withReplays(
+  events: SeqEnvelope[],
+  random: () => number,
+): SeqEnvelope[] {
+  const out: SeqEnvelope[] = [];
+  for (let i = 0; i < events.length; i++) {
+    out.push(events[i]!);
+    if (i > 0 && random() < 0.6) {
+      const replayIdx = Math.floor(random() * (i + 1));
+      out.push(events[replayIdx]!); // a duplicate of an already-applied event
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("rolling-base reducer", () => {
+  test("rebuild is deterministic — no clock/uuid leak in the fold", () => {
+    // Re-deriving the same seed+events twice must be byte-identical. A
+    // `Date.now()` / `crypto.randomUUID()` in a row-opening path would fail
+    // this immediately.
+    const events = cleanTurn();
+    expect(rebuildBase(SEED, events)).toEqual(rebuildBase(SEED, events));
+  });
+
+  test("the invariant: a noisy (replayed) stream equals the clean stream", () => {
+    // doc §10 — incremental application of a stream carrying duplicates equals
+    // full re-derivation of the clean stream. Certified across many seeds.
+    const clean = cleanTurn();
+    const cleanBase = rebuildBase(SEED, clean);
+    for (let seed = 1; seed <= 200; seed++) {
+      const noisy = withReplays(clean, rng(seed));
+      expect(rebuildBase(SEED, noisy)).toEqual(cleanBase);
+    }
+  });
+
+  test("idempotent: re-applying a folded event is a no-op (same reference)", () => {
+    const once = applyEvent(SEED, textDelta(1, "a1", "hello"));
+    const twice = applyEvent(once, textDelta(1, "a1", "hello"));
+    expect(twice).toBe(once);
+  });
+
+  test("drops any event at or below the base version", () => {
+    const base = rebuildBase(SEED, cleanTurn()); // seq advances to 6
+    const stale = applyEvent(base, textDelta(4, "a1", " (replayed)"));
+    expect(stale).toBe(base);
+  });
+
+  test("advances the version to the highest seq folded in", () => {
+    const base = rebuildBase(SEED, cleanTurn());
+    expect(base.seq).toBe(6);
+  });
+
+  test("total: an unfolded event type leaves the base unchanged", () => {
+    const base = rebuildBase(SEED, cleanTurn());
+    const after = applyEvent(base, {
+      seq: 7,
+      message: { type: "sync_changed" } as AssistantEvent,
+    });
+    // Content is untouched; only the version cursor advances.
+    expect(after.messages).toBe(base.messages);
+    expect(after.seq).toBe(7);
+  });
+
+  test("opens a row stamped deterministically from the event, then appends", () => {
+    const base = rebuildBase(SEED, [
+      thinkingDelta(2, "a1", "reasoning"),
+      textDelta(3, "a1", "answer"),
+    ]);
+    const assistant = base.messages.find((m) => m.id === "a1");
+    expect(assistant?.timestamp).toBe(1_002); // 1000 + seq(2): the opening event
+    expect(assistant?.thinkingSegments).toEqual(["reasoning"]);
+    expect(assistant?.textSegments).toEqual(["answer"]);
+  });
+
+  test("preserves the snapshot page fields (it IS the /messages shape)", () => {
+    const seeded: RollingBase = {
+      messages: [],
+      hasMore: true,
+      oldestTimestamp: 123,
+      oldestMessageId: "old",
+      seq: 0,
+    };
+    const after = rebuildBase(seeded, [textDelta(1, "a1", "hi")]);
+    expect(after.hasMore).toBe(true);
+    expect(after.oldestTimestamp).toBe(123);
+    expect(after.oldestMessageId).toBe("old");
+  });
+});

--- a/clients/web/src/domains/chat/transcript/rolling-base.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.ts
@@ -1,0 +1,164 @@
+/**
+ * Rolling-base reducer — Phase 1 of the client-sync materialized-view design
+ * (see the Client Sync "Rolling-Base Materialized View" proposal).
+ *
+ * The **base** is the client's continuously-advanced view of a conversation:
+ * the `/messages` snapshot shape, projected to `DisplayMessage[]`, carrying its
+ * own provenance in `seq` — the highest global event `seq` folded in (the
+ * doc's `version`). It is *not* the frozen page-load payload; it is a running
+ * balance seeded once by the snapshot and advanced by `applyEvent`.
+ *
+ * `RollingBase` is deliberately `PaginatedHistoryResult` verbatim — the
+ * `/messages` response shape with `messages: DisplayMessage[]` instead of the
+ * raw `ConversationMessage[]` — so the base and the snapshot are the same type
+ * until the runtime/display models are fully unified.
+ *
+ * This module is the reducer ONLY (doc §4): one pure, total, idempotent
+ * function the live path and the rebuild path will both run, so they can never
+ * diverge. It is unwired in this phase — ingestion (the seam window: ordering,
+ * gap detection) and render derivation come in later phases. What it
+ * guarantees now is certified by `rolling-base.test.ts` against the doc's
+ * invariant (§10): a noisy event stream (duplicates + already-folded replays)
+ * produces the same base as the clean stream.
+ *
+ *   - **Pure** — no side effects, no `Date.now()` / `crypto.randomUUID()` in
+ *     the fold: a row this event opens is stamped from the event itself, so
+ *     re-derivation is byte-identical.
+ *   - **Total** — events it does not fold (tool/surface/queue/lifecycle, and
+ *     unknowns) return the base unchanged rather than throwing. Folding for
+ *     those is the next increment.
+ *   - **Idempotent** — keyed by `event.seq`: an event at or below the base's
+ *     `seq` has already been folded and is dropped. This is what makes replay
+ *     after reconnect and overlap with a resync safe.
+ */
+
+import type { AssistantEvent } from "@/types/event-types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import {
+  appendTextDelta,
+  appendThinkingDelta,
+  applyUserMessageEcho,
+  finalizeMessageComplete,
+  finalizeOnIdle,
+  handleConversationError,
+} from "@/domains/chat/utils/stream-updaters/message-updaters";
+import { messageIdentityKeys } from "@/domains/chat/utils/message-identity";
+
+/**
+ * The client-side materialized base. Identical to a `/messages` page result;
+ * `seq` is the version — the highest global event seq folded in, or `null`
+ * before any seq-bearing input has landed.
+ */
+export type RollingBase = PaginatedHistoryResult;
+
+/**
+ * An event as the reducer consumes it: the wire `message`, its global `seq`
+ * (the SSE envelope's), and a `timestampMs` used as the deterministic creation
+ * stamp for any row the event opens. All three come straight off the
+ * `AssistantEventEnvelope` at ingestion time.
+ */
+export interface SeqEnvelope {
+  seq?: number | null;
+  timestampMs?: number;
+  message: AssistantEvent;
+}
+
+/** Fold one event's effect into the message list. Pure; no row creation here
+ *  reads a clock — the reducer re-stamps opened rows deterministically. */
+function foldMessages(
+  messages: DisplayMessage[],
+  message: AssistantEvent,
+): DisplayMessage[] {
+  switch (message.type) {
+    case "assistant_text_delta":
+      return appendTextDelta(messages, message.text, message.messageId);
+    case "assistant_thinking_delta":
+      return appendThinkingDelta(messages, message.thinking, message.messageId);
+    case "message_complete":
+      return finalizeMessageComplete(messages, message);
+    case "user_message_echo":
+      return applyUserMessageEcho(messages, {
+        text: message.text,
+        messageId: message.messageId,
+        clientMessageId: message.clientMessageId,
+      });
+    case "assistant_activity_state":
+      // Only the terminal `idle` phase changes message content (it finalizes
+      // running tool calls). Other phases drive turn state, not the base.
+      return message.phase === "idle" ? finalizeOnIdle(messages) : messages;
+    case "conversation_error":
+      return handleConversationError(messages);
+    default:
+      // Total: every event the reducer does not yet fold leaves the base
+      // untouched. Tool/surface/queue folding is the next increment.
+      return messages;
+  }
+}
+
+/**
+ * Re-stamp the `timestamp` of any row this event opened with a value derived
+ * from the event, so a created row is identical whether folded live or on
+ * rebuild. Rows that already existed in `before` (appends, finalizes) keep
+ * their timestamps. Allocates only the newly-created rows.
+ */
+function stampOpenedRows(
+  before: DisplayMessage[],
+  after: DisplayMessage[],
+  createdAt: number,
+): DisplayMessage[] {
+  if (after === before) return after;
+  const knownIds = new Set<string>();
+  for (const row of before) {
+    for (const key of messageIdentityKeys(row)) knownIds.add(key);
+  }
+  let changed = false;
+  const stamped = after.map((row) => {
+    const isNew = !messageIdentityKeys(row).some((key) => knownIds.has(key));
+    if (!isNew) return row;
+    changed = true;
+    return { ...row, timestamp: createdAt };
+  });
+  return changed ? stamped : after;
+}
+
+/**
+ * Fold one event into the base. Pure, total, idempotent.
+ *
+ * Idempotency: an event whose `seq` is at or below the base's `seq` has
+ * already been folded — return the base unchanged. Events without a `seq` (or
+ * onto a base without one) can't be deduped, so they always apply; the seam
+ * window upstream is what keeps the stream contiguous and seq-bearing.
+ */
+export function applyEvent(base: RollingBase, env: SeqEnvelope): RollingBase {
+  const { seq, message } = env;
+  if (
+    typeof seq === "number" &&
+    typeof base.seq === "number" &&
+    seq <= base.seq
+  ) {
+    return base;
+  }
+
+  const folded = foldMessages(base.messages, message);
+  const createdAt = env.timestampMs ?? (typeof seq === "number" ? seq : 0);
+  const messages = stampOpenedRows(base.messages, folded, createdAt);
+
+  const nextSeq =
+    typeof seq === "number" ? Math.max(base.seq ?? -1, seq) : base.seq ?? null;
+
+  if (messages === base.messages && nextSeq === base.seq) return base;
+  return { ...base, messages, seq: nextSeq };
+}
+
+/**
+ * Rebuild the base from a seed snapshot and a sequence of events — the
+ * full-recomputation path the invariant (doc §10) certifies against the
+ * incremental path. Pure: `events.reduce(applyEvent, seed)`.
+ */
+export function rebuildBase(
+  seed: RollingBase,
+  events: readonly SeqEnvelope[],
+): RollingBase {
+  return events.reduce(applyEvent, seed);
+}


### PR DESCRIPTION
## Client-sync rolling-base migration — Phase 1 (foundations)

First foundation of the [rolling-base materialized-view design](#): the **pure event reducer** the live path and the rebuild path will both run, so they can never diverge (design §4). **Unwired** in this phase — no behavior change. Ingestion (the seam window: ordering + gap detection) and render derivation land in later phases.

This replaces the abandoned Phase-0 stopgap (#36313): instead of patching the snapshot seam with more identity-key matching + an effect, we're building the real reducer + the invariant that certifies it.

### The base shape
`RollingBase` is **`PaginatedHistoryResult` verbatim** — the `/messages` response shape with `messages: DisplayMessage[]` instead of the raw `ConversationMessage[]` — so the base and the snapshot are the same type until the runtime/display models are unified. `seq` is the **version**: the highest global event seq folded in.

### The reducer — `applyEvent(base, env)`
- **Pure** — no `Date.now()` / `crypto.randomUUID()` in the fold. A row the event opens is stamped deterministically from the event, so re-derivation is byte-identical (the precondition the invariant needs). Folding reuses the existing message-content updaters (text / thinking / complete / echo / idle / error) so the canonical fold matches the live path.
- **Total** — event types it doesn't yet fold (tool / surface / queue / lifecycle, and unknowns) return the base unchanged rather than throwing. Folding those is the next increment.
- **Idempotent** — keyed by `event.seq`; an event at or below `base.seq` is already folded and dropped. This is what makes reconnect replay and resync overlap safe.

`rebuildBase(seed, events)` = `events.reduce(applyEvent, seed)`.

### The invariant (design §10)
> `rebuild(snapshot, allEvents)` deep-equals the view produced by applying those same events incrementally.

`rolling-base.test.ts` certifies it: a **noisy stream** (replayed / duplicate events injected at random positions) produces the **same base** as the clean stream — across 200 deterministic seeds — plus determinism (no clock/uuid leak), version-advance, seq-drop, total-degradation, deterministic row-open stamping, and snapshot-page-field preservation. **8 tests, 212 assertions, all green.** Lint + typecheck clean.

### What this is *not* yet
No seam window (out-of-order absorption / gap→backfill) and no render rewrite — those are Phase 2, which is where the base gains an *owner* and we consciously revisit the `clients/web/AGENTS.md:30` single-source rule (the #35894 stance that server data lives only in the Query cache and deltas never fold into a client-advanced base). The reducer here is a standalone pure function and doesn't create a second source, so it doesn't touch that rule yet — I'll bring the doc update with the wiring.

### Note for reviewers
The reducer currently folds the **message-content** event set. Tool-call and surface folding reuse existing pure updaters but need their event→arg mapping (and the live handlers' id-counter) untangled from side effects; that's the immediate follow-up so the invariant test grows to cover them before Phase 2 wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_