### PR TITLE
refactor(web): rolling-base reducer — full event coverage + deterministic fold

### DIFF
--- a/clients/web/src/domains/chat/transcript/rolling-base.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, test } from "bun:test";
 
 import {
   applyEvent,
-  rebuildBase,
-  type RollingBase,
-  type SeqEnvelope,
+  applyEventsToHistory,
 } from "@/domains/chat/transcript/rolling-base";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const SEED: RollingBase = {
+const SEED: PaginatedHistoryResult = {
   messages: [],
   hasMore: false,
   oldestTimestamp: null,
@@ -20,38 +20,56 @@ const SEED: RollingBase = {
   seq: 0,
 };
 
-// Minimal valid wire events — the reducer reads only the fields below.
-function ev(seq: number, message: AssistantEvent): SeqEnvelope {
-  return { seq, timestampMs: 1_000 + seq, message };
+// `emittedAt` is derived from `seq` so the deterministic creation stamp is
+// `1000 + seq` — the reducer parses it back to that epoch ms.
+function env(seq: number, message: AssistantEvent): AssistantEventEnvelope {
+  return {
+    id: `e${seq}`,
+    seq,
+    emittedAt: new Date(1000 + seq).toISOString(),
+    message,
+  } as AssistantEventEnvelope;
 }
-function userEcho(seq: number, id: string, text: string): SeqEnvelope {
-  return ev(seq, { type: "user_message_echo", messageId: id, text } as AssistantEvent);
-}
-function textDelta(seq: number, id: string, text: string): SeqEnvelope {
-  return ev(seq, { type: "assistant_text_delta", messageId: id, text } as AssistantEvent);
-}
-function thinkingDelta(seq: number, id: string, thinking: string): SeqEnvelope {
-  return ev(seq, {
+const stampOf = (seq: number) => 1000 + seq;
+
+const userEcho = (seq: number, id: string, text: string) =>
+  env(seq, { type: "user_message_echo", messageId: id, text } as AssistantEvent);
+const textDelta = (seq: number, id: string, text: string) =>
+  env(seq, { type: "assistant_text_delta", messageId: id, text } as AssistantEvent);
+const thinkingDelta = (seq: number, id: string, thinking: string) =>
+  env(seq, {
     type: "assistant_thinking_delta",
     messageId: id,
     thinking,
   } as AssistantEvent);
-}
-function complete(seq: number, id: string): SeqEnvelope {
-  return ev(seq, { type: "message_complete", messageId: id } as AssistantEvent);
-}
+const complete = (seq: number, id: string) =>
+  env(seq, { type: "message_complete", messageId: id } as AssistantEvent);
+const toolUseStart = (seq: number, id: string, toolUseId: string, name: string) =>
+  env(seq, {
+    type: "tool_use_start",
+    messageId: id,
+    toolUseId,
+    toolName: name,
+    input: {},
+  } as AssistantEvent);
+const surfaceShow = (seq: number, id: string, surfaceId: string) =>
+  env(seq, {
+    type: "ui_surface_show",
+    messageId: id,
+    surfaceId,
+    surfaceType: "form",
+    data: {},
+  } as AssistantEvent);
 
 // A representative turn: user echo → reasoning → answer → finalize.
-function cleanTurn(): SeqEnvelope[] {
-  return [
-    userEcho(1, "u1", "build me a dashboard"),
-    thinkingDelta(2, "a1", "let me consider the layout"),
-    thinkingDelta(3, "a1", " and the data model"),
-    textDelta(4, "a1", "Here is"),
-    textDelta(5, "a1", " your dashboard."),
-    complete(6, "a1"),
-  ];
-}
+const cleanTurn = (): AssistantEventEnvelope[] => [
+  userEcho(1, "u1", "build me a dashboard"),
+  thinkingDelta(2, "a1", "let me consider the layout"),
+  thinkingDelta(3, "a1", " and the data model"),
+  textDelta(4, "a1", "Here is"),
+  textDelta(5, "a1", " your dashboard."),
+  complete(6, "a1"),
+];
 
 // Deterministic PRNG (mulberry32) so the randomized cases are reproducible.
 function rng(seed: number): () => number {
@@ -65,19 +83,17 @@ function rng(seed: number): () => number {
   };
 }
 
-// Inject replays of already-emitted events at random positions. Every injected
-// event has seq <= some earlier event, modelling reconnect replay / resync
-// overlap — all must be idempotent no-ops.
+// Inject replays of already-emitted events at random positions — every injected
+// event has seq <= an earlier one, modelling reconnect replay / resync overlap.
 function withReplays(
-  events: SeqEnvelope[],
+  events: AssistantEventEnvelope[],
   random: () => number,
-): SeqEnvelope[] {
-  const out: SeqEnvelope[] = [];
+): AssistantEventEnvelope[] {
+  const out: AssistantEventEnvelope[] = [];
   for (let i = 0; i < events.length; i++) {
     out.push(events[i]!);
     if (i > 0 && random() < 0.6) {
-      const replayIdx = Math.floor(random() * (i + 1));
-      out.push(events[replayIdx]!); // a duplicate of an already-applied event
+      out.push(events[Math.floor(random() * (i + 1))]!);
     }
   }
   return out;
@@ -89,21 +105,29 @@ function withReplays(
 
 describe("rolling-base reducer", () => {
   test("rebuild is deterministic — no clock/uuid leak in the fold", () => {
-    // Re-deriving the same seed+events twice must be byte-identical. A
-    // `Date.now()` / `crypto.randomUUID()` in a row-opening path would fail
-    // this immediately.
     const events = cleanTurn();
-    expect(rebuildBase(SEED, events)).toEqual(rebuildBase(SEED, events));
+    expect(applyEventsToHistory(SEED, events)).toEqual(
+      applyEventsToHistory(SEED, events),
+    );
+  });
+
+  test("terminal tool-call finalize is deterministic (Codex P2)", () => {
+    // A running tool call finalized by `message_complete` must stamp
+    // `completedAt` from the event, not `Date.now()`, or rebuild diverges.
+    const events = [toolUseStart(1, "a1", "t1", "bash"), complete(2, "a1")];
+    const a = applyEventsToHistory(SEED, events);
+    const b = applyEventsToHistory(SEED, events);
+    expect(a).toEqual(b);
+    const tool = a.messages[0]?.toolCalls?.[0];
+    expect(tool?.completedAt).toBe(stampOf(2));
   });
 
   test("the invariant: a noisy (replayed) stream equals the clean stream", () => {
-    // doc §10 — incremental application of a stream carrying duplicates equals
-    // full re-derivation of the clean stream. Certified across many seeds.
     const clean = cleanTurn();
-    const cleanBase = rebuildBase(SEED, clean);
+    const cleanHistory = applyEventsToHistory(SEED, clean);
     for (let seed = 1; seed <= 200; seed++) {
       const noisy = withReplays(clean, rng(seed));
-      expect(rebuildBase(SEED, noisy)).toEqual(cleanBase);
+      expect(applyEventsToHistory(SEED, noisy)).toEqual(cleanHistory);
     }
   });
 
@@ -113,48 +137,52 @@ describe("rolling-base reducer", () => {
     expect(twice).toBe(once);
   });
 
-  test("drops any event at or below the base version", () => {
-    const base = rebuildBase(SEED, cleanTurn()); // seq advances to 6
-    const stale = applyEvent(base, textDelta(4, "a1", " (replayed)"));
-    expect(stale).toBe(base);
+  test("drops any event at or below the history version", () => {
+    const base = applyEventsToHistory(SEED, cleanTurn()); // seq advances to 6
+    expect(applyEvent(base, textDelta(4, "a1", " (replayed)"))).toBe(base);
   });
 
   test("advances the version to the highest seq folded in", () => {
-    const base = rebuildBase(SEED, cleanTurn());
-    expect(base.seq).toBe(6);
+    expect(applyEventsToHistory(SEED, cleanTurn()).seq).toBe(6);
   });
 
-  test("total: an unfolded event type leaves the base unchanged", () => {
-    const base = rebuildBase(SEED, cleanTurn());
-    const after = applyEvent(base, {
-      seq: 7,
-      message: { type: "sync_changed" } as AssistantEvent,
-    });
-    // Content is untouched; only the version cursor advances.
-    expect(after.messages).toBe(base.messages);
-    expect(after.seq).toBe(7);
+  test("total: an unfolded event type leaves message content unchanged", () => {
+    const base = applyEventsToHistory(SEED, cleanTurn());
+    const after = applyEvent(base, env(7, { type: "sync_changed" } as AssistantEvent));
+    expect(after.messages).toBe(base.messages); // content untouched...
+    expect(after.seq).toBe(7); // ...only the version cursor advances
   });
 
   test("opens a row stamped deterministically from the event, then appends", () => {
-    const base = rebuildBase(SEED, [
+    const base = applyEventsToHistory(SEED, [
       thinkingDelta(2, "a1", "reasoning"),
       textDelta(3, "a1", "answer"),
     ]);
     const assistant = base.messages.find((m) => m.id === "a1");
-    expect(assistant?.timestamp).toBe(1_002); // 1000 + seq(2): the opening event
+    expect(assistant?.timestamp).toBe(stampOf(2)); // the opening event's stamp
     expect(assistant?.thinkingSegments).toEqual(["reasoning"]);
     expect(assistant?.textSegments).toEqual(["answer"]);
   });
 
+  test("folds tool-call and surface events into the turn", () => {
+    const base = applyEventsToHistory(SEED, [
+      toolUseStart(1, "a1", "t1", "bash"),
+      surfaceShow(2, "a1", "s1"),
+    ]);
+    const assistant = base.messages.find((m) => m.id === "a1");
+    expect(assistant?.toolCalls?.map((t) => t.id)).toEqual(["t1"]);
+    expect(assistant?.surfaces?.map((s) => s.surfaceId)).toEqual(["s1"]);
+  });
+
   test("preserves the snapshot page fields (it IS the /messages shape)", () => {
-    const seeded: RollingBase = {
+    const seeded: PaginatedHistoryResult = {
       messages: [],
       hasMore: true,
       oldestTimestamp: 123,
       oldestMessageId: "old",
       seq: 0,
     };
-    const after = rebuildBase(seeded, [textDelta(1, "a1", "hi")]);
+    const after = applyEventsToHistory(seeded, [textDelta(1, "a1", "hi")]);
     expect(after.hasMore).toBe(true);
     expect(after.oldestTimestamp).toBe(123);
     expect(after.oldestMessageId).toBe("old");

--- a/clients/web/src/domains/chat/transcript/rolling-base.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.ts
@@ -1,39 +1,19 @@
 /**
- * Rolling-base reducer — Phase 1 of the client-sync materialized-view design
- * (see the Client Sync "Rolling-Base Materialized View" proposal).
- *
- * The **base** is the client's continuously-advanced view of a conversation:
- * the `/messages` snapshot shape, projected to `DisplayMessage[]`, carrying its
- * own provenance in `seq` — the highest global event `seq` folded in (the
- * doc's `version`). It is *not* the frozen page-load payload; it is a running
- * balance seeded once by the snapshot and advanced by `applyEvent`.
- *
- * `RollingBase` is deliberately `PaginatedHistoryResult` verbatim — the
- * `/messages` response shape with `messages: DisplayMessage[]` instead of the
- * raw `ConversationMessage[]` — so the base and the snapshot are the same type
- * until the runtime/display models are fully unified.
- *
- * This module is the reducer ONLY (doc §4): one pure, total, idempotent
- * function the live path and the rebuild path will both run, so they can never
- * diverge. It is unwired in this phase — ingestion (the seam window: ordering,
- * gap detection) and render derivation come in later phases. What it
- * guarantees now is certified by `rolling-base.test.ts` against the doc's
- * invariant (§10): a noisy event stream (duplicates + already-folded replays)
- * produces the same base as the clean stream.
- *
- *   - **Pure** — no side effects, no `Date.now()` / `crypto.randomUUID()` in
- *     the fold: a row this event opens is stamped from the event itself, so
- *     re-derivation is byte-identical.
- *   - **Total** — events it does not fold (tool/surface/queue/lifecycle, and
- *     unknowns) return the base unchanged rather than throwing. Folding for
- *     those is the next increment.
- *   - **Idempotent** — keyed by `event.seq`: an event at or below the base's
- *     `seq` has already been folded and is dropped. This is what makes replay
- *     after reconnect and overlap with a resync safe.
+ * Advances a conversation's materialized history — the `/messages` page shape
+ * (`PaginatedHistoryResult`), with `messages` already projected to
+ * `DisplayMessage[]` — by folding stream events into it. The fold is pure,
+ * total, and idempotent by `seq`, so the same events produce the same history
+ * whether applied live or rebuilt from a snapshot.
  */
 
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { AssistantEvent } from "@/types/event-types";
-import type { DisplayMessage } from "@/domains/chat/types/types";
+import {
+  type Surface,
+  classifySurfaceDisplay,
+  type DisplayMessage,
+} from "@/domains/chat/types/types";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import {
   appendTextDelta,
@@ -43,122 +23,164 @@ import {
   finalizeOnIdle,
   handleConversationError,
 } from "@/domains/chat/utils/stream-updaters/message-updaters";
-import { messageIdentityKeys } from "@/domains/chat/utils/message-identity";
+import {
+  appendToolOutputChunk,
+  applyToolResult,
+  upsertToolCall,
+} from "@/domains/chat/utils/stream-updaters/tool-call-updaters";
+import {
+  attachSurface,
+  completeSurface,
+  dismissSurface,
+  updateSurfaceData,
+} from "@/domains/chat/utils/stream-updaters/surface-updaters";
 
-/**
- * The client-side materialized base. Identical to a `/messages` page result;
- * `seq` is the version — the highest global event seq folded in, or `null`
- * before any seq-bearing input has landed.
- */
-export type RollingBase = PaginatedHistoryResult;
-
-/**
- * An event as the reducer consumes it: the wire `message`, its global `seq`
- * (the SSE envelope's), and a `timestampMs` used as the deterministic creation
- * stamp for any row the event opens. All three come straight off the
- * `AssistantEventEnvelope` at ingestion time.
- */
-export interface SeqEnvelope {
-  seq?: number | null;
-  timestampMs?: number;
-  message: AssistantEvent;
+/** Parse the envelope's ISO `emittedAt` to epoch ms, the deterministic stamp
+ *  for any row an event opens. Falls back to `seq` so a malformed/absent time
+ *  still yields a stable, monotonic value. */
+function emittedAtMs(emittedAt: string, seq: number | null | undefined): number {
+  const parsed = Date.parse(emittedAt);
+  return Number.isFinite(parsed) ? parsed : typeof seq === "number" ? seq : 0;
 }
 
-/** Fold one event's effect into the message list. Pure; no row creation here
- *  reads a clock — the reducer re-stamps opened rows deterministically. */
-function foldMessages(
+/**
+ * Fold one event's effect into the message list, reusing the same updaters the
+ * live path runs. Every row an event opens is stamped from `at` (no clock read
+ * here), so a created row is identical live or on rebuild. Event types that
+ * don't change message content return the list unchanged.
+ */
+export function appendEventToMessages(
   messages: DisplayMessage[],
-  message: AssistantEvent,
+  event: AssistantEvent,
+  at: number,
 ): DisplayMessage[] {
-  switch (message.type) {
+  switch (event.type) {
     case "assistant_text_delta":
-      return appendTextDelta(messages, message.text, message.messageId);
+      return appendTextDelta(messages, event.text, event.messageId, undefined, at);
     case "assistant_thinking_delta":
-      return appendThinkingDelta(messages, message.thinking, message.messageId);
+      return appendThinkingDelta(
+        messages,
+        event.thinking,
+        event.messageId,
+        undefined,
+        at,
+      );
     case "message_complete":
-      return finalizeMessageComplete(messages, message);
+      return finalizeMessageComplete(messages, event, at);
     case "user_message_echo":
-      return applyUserMessageEcho(messages, {
-        text: message.text,
-        messageId: message.messageId,
-        clientMessageId: message.clientMessageId,
-      });
+      return applyUserMessageEcho(
+        messages,
+        {
+          text: event.text,
+          messageId: event.messageId,
+          clientMessageId: event.clientMessageId,
+        },
+        at,
+      );
     case "assistant_activity_state":
       // Only the terminal `idle` phase changes message content (it finalizes
-      // running tool calls). Other phases drive turn state, not the base.
-      return message.phase === "idle" ? finalizeOnIdle(messages) : messages;
+      // running tool calls); other phases drive turn state, not history.
+      return event.phase === "idle" ? finalizeOnIdle(messages, at) : messages;
     case "conversation_error":
-      return handleConversationError(messages);
+      return handleConversationError(messages, at);
+    case "tool_use_start": {
+      const toolCall: ChatMessageToolCall = {
+        id: event.toolUseId ?? `tool-${at}`,
+        name: event.toolName,
+        input: event.input,
+        startedAt:
+          "startedAt" in event && typeof event.startedAt === "number"
+            ? event.startedAt
+            : at,
+      };
+      return upsertToolCall(messages, toolCall, event.messageId, at);
+    }
+    case "tool_result":
+      return applyToolResult(messages, {
+        toolUseId: event.toolUseId,
+        result: event.result,
+        isError: event.isError,
+        riskLevel: event.riskLevel,
+        riskReason: event.riskReason,
+        matchedTrustRuleId: event.matchedTrustRuleId,
+        approvalMode: event.approvalMode,
+        approvalReason: event.approvalReason,
+        riskThreshold: event.riskThreshold,
+        riskAllowlistOptions: event.riskAllowlistOptions,
+        riskScopeOptions: event.riskScopeOptions,
+        riskDirectoryScopeOptions: event.riskDirectoryScopeOptions,
+        imageData: event.imageData,
+        imageDataList: event.imageDataList,
+        activityMetadata: event.activityMetadata,
+        completedAt:
+          "completedAt" in event && typeof event.completedAt === "number"
+            ? event.completedAt
+            : at,
+      });
+    case "tool_output_chunk":
+      if (!event.chunk) return messages;
+      return appendToolOutputChunk(messages, {
+        chunk: event.chunk,
+        toolUseId: event.toolUseId,
+        messageId: event.messageId,
+      });
+    case "ui_surface_show": {
+      const surface: Surface = {
+        surfaceId: event.surfaceId,
+        surfaceType: event.surfaceType,
+        title: event.title,
+        data: event.data,
+        actions: event.actions,
+        display: event.display,
+      };
+      surface.display = classifySurfaceDisplay(surface);
+      return attachSurface(messages, surface, event.messageId, at);
+    }
+    case "ui_surface_update":
+      return updateSurfaceData(messages, event.surfaceId, event.data);
+    case "ui_surface_dismiss":
+      return dismissSurface(messages, event.surfaceId);
+    case "ui_surface_complete":
+      return completeSurface(messages, event.surfaceId, event.summary);
     default:
-      // Total: every event the reducer does not yet fold leaves the base
-      // untouched. Tool/surface/queue folding is the next increment.
+      // Total: events that don't change message content (turn lifecycle,
+      // queue, subagent/workflow, sync, unknowns) leave the list untouched.
       return messages;
   }
 }
 
 /**
- * Re-stamp the `timestamp` of any row this event opened with a value derived
- * from the event, so a created row is identical whether folded live or on
- * rebuild. Rows that already existed in `before` (appends, finalizes) keep
- * their timestamps. Allocates only the newly-created rows.
+ * Fold one event envelope into the history. Drops an event whose `seq` is at or
+ * below the history's `seq` — it is already folded — which is what makes replay
+ * after reconnect and overlap with a resync safe. `seq` advances to the highest
+ * folded value.
  */
-function stampOpenedRows(
-  before: DisplayMessage[],
-  after: DisplayMessage[],
-  createdAt: number,
-): DisplayMessage[] {
-  if (after === before) return after;
-  const knownIds = new Set<string>();
-  for (const row of before) {
-    for (const key of messageIdentityKeys(row)) knownIds.add(key);
-  }
-  let changed = false;
-  const stamped = after.map((row) => {
-    const isNew = !messageIdentityKeys(row).some((key) => knownIds.has(key));
-    if (!isNew) return row;
-    changed = true;
-    return { ...row, timestamp: createdAt };
-  });
-  return changed ? stamped : after;
-}
-
-/**
- * Fold one event into the base. Pure, total, idempotent.
- *
- * Idempotency: an event whose `seq` is at or below the base's `seq` has
- * already been folded — return the base unchanged. Events without a `seq` (or
- * onto a base without one) can't be deduped, so they always apply; the seam
- * window upstream is what keeps the stream contiguous and seq-bearing.
- */
-export function applyEvent(base: RollingBase, env: SeqEnvelope): RollingBase {
-  const { seq, message } = env;
+export function applyEvent(
+  history: PaginatedHistoryResult,
+  envelope: AssistantEventEnvelope,
+): PaginatedHistoryResult {
+  const { seq } = envelope;
   if (
     typeof seq === "number" &&
-    typeof base.seq === "number" &&
-    seq <= base.seq
+    typeof history.seq === "number" &&
+    seq <= history.seq
   ) {
-    return base;
+    return history;
   }
 
-  const folded = foldMessages(base.messages, message);
-  const createdAt = env.timestampMs ?? (typeof seq === "number" ? seq : 0);
-  const messages = stampOpenedRows(base.messages, folded, createdAt);
-
+  const at = emittedAtMs(envelope.emittedAt, seq);
+  const messages = appendEventToMessages(history.messages, envelope.message, at);
   const nextSeq =
-    typeof seq === "number" ? Math.max(base.seq ?? -1, seq) : base.seq ?? null;
+    typeof seq === "number" ? Math.max(history.seq ?? -1, seq) : history.seq ?? null;
 
-  if (messages === base.messages && nextSeq === base.seq) return base;
-  return { ...base, messages, seq: nextSeq };
+  return { ...history, messages, seq: nextSeq };
 }
 
-/**
- * Rebuild the base from a seed snapshot and a sequence of events — the
- * full-recomputation path the invariant (doc §10) certifies against the
- * incremental path. Pure: `events.reduce(applyEvent, seed)`.
- */
-export function rebuildBase(
-  seed: RollingBase,
-  events: readonly SeqEnvelope[],
-): RollingBase {
-  return events.reduce(applyEvent, seed);
+/** Rebuild the history from a snapshot and a run of events — the full
+ *  recomputation the invariant certifies against the incremental path. */
+export function applyEventsToHistory(
+  history: PaginatedHistoryResult,
+  events: readonly AssistantEventEnvelope[],
+): PaginatedHistoryResult {
+  return events.reduce(applyEvent, history);
 }

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -32,6 +32,7 @@ export function createStreamingBubble(
   prev: DisplayMessage[],
   text: string,
   messageId?: string,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   return [
     ...prev,
@@ -42,7 +43,7 @@ export function createStreamingBubble(
       textSegments: [text],
       contentOrder: [{ type: "text", id: "0" }],
       contentBlocks: [{ type: "text", text }],
-      timestamp: Date.now(),
+      timestamp: at,
     },
   ];
 }
@@ -182,6 +183,7 @@ export function appendTextDelta(
   text: string,
   messageId?: string,
   seedTwin?: () => DisplayMessage | undefined,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   if (messageId) {
     const idx = findAssistantRowIndexByMessageId(prev, messageId);
@@ -205,11 +207,11 @@ export function appendTextDelta(
     if (twin) {
       return appendTextSegmentIntoRow([...prev, twin], prev.length, text, messageId);
     }
-    return createStreamingBubble(prev, text, messageId);
+    return createStreamingBubble(prev, text, messageId, at);
   }
 
   if (!tailIsAssistant(prev)) {
-    return createStreamingBubble(prev, text, messageId);
+    return createStreamingBubble(prev, text, messageId, at);
   }
   return appendTextSegmentIntoRow(prev, prev.length - 1, text, undefined);
 }
@@ -228,6 +230,7 @@ export function createStreamingThinkingBubble(
   prev: DisplayMessage[],
   thinking: string,
   messageId?: string,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   return [
     ...prev,
@@ -238,7 +241,7 @@ export function createStreamingThinkingBubble(
       thinkingSegments: [thinking],
       contentOrder: [{ type: "thinking", id: "0" }],
       contentBlocks: [{ type: "thinking", thinking }],
-      timestamp: Date.now(),
+      timestamp: at,
     },
   ];
 }
@@ -257,6 +260,7 @@ export function appendThinkingDelta(
   thinking: string,
   messageId?: string,
   seedTwin?: () => DisplayMessage | undefined,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   if (messageId) {
     const idx = findAssistantRowIndexByMessageId(prev, messageId);
@@ -283,11 +287,11 @@ export function appendThinkingDelta(
         messageId,
       );
     }
-    return createStreamingThinkingBubble(prev, thinking, messageId);
+    return createStreamingThinkingBubble(prev, thinking, messageId, at);
   }
 
   if (!tailIsAssistant(prev)) {
-    return createStreamingThinkingBubble(prev, thinking, messageId);
+    return createStreamingThinkingBubble(prev, thinking, messageId, at);
   }
   return appendThinkingSegmentIntoRow(prev, prev.length - 1, thinking, undefined);
 }
@@ -302,11 +306,14 @@ export function appendThinkingDelta(
  * conversation's processing state (see `liveAssistantRowId`), which the
  * idle event clears, so no per-row flag needs flipping here.
  */
-export function finalizeOnIdle(prev: DisplayMessage[]): DisplayMessage[] {
+export function finalizeOnIdle(
+  prev: DisplayMessage[],
+  at: number = Date.now(),
+): DisplayMessage[] {
   let changed = false;
   const updated = prev.map((m) => {
     if (m.role !== "assistant") return m;
-    const finalized = finalizeRunningToolCalls(m);
+    const finalized = finalizeRunningToolCalls(m, at);
     if (!finalized) return m;
     changed = true;
     return { ...m, ...finalized };
@@ -347,6 +354,7 @@ export function finalizeOnIdle(prev: DisplayMessage[]): DisplayMessage[] {
 export function finalizeMessageComplete(
   prev: DisplayMessage[],
   event: MessageCompleteEvent,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   const last = prev[prev.length - 1];
   const attachments = toDisplayAttachments(event.attachments);
@@ -359,13 +367,13 @@ export function finalizeMessageComplete(
         id: event.messageId ?? crypto.randomUUID(),
         ...(event.messageId ? {} : { isOptimistic: true }),
         role: "assistant" as const,
-        timestamp: Date.now(),
+        timestamp: at,
         attachments,
       },
     ];
   }
 
-  const finalized = finalizeRunningToolCalls(last);
+  const finalized = finalizeRunningToolCalls(last, at);
   const adoptServerId = last.isOptimistic === true && !!event.messageId;
   return [
     ...prev.slice(0, -1),
@@ -445,6 +453,7 @@ function findOptimisticUserEchoIdx(
 export function applyUserMessageEcho(
   prev: DisplayMessage[],
   event: { text: string; messageId?: string; clientMessageId?: string },
+  at: number = Date.now(),
 ): DisplayMessage[] {
   const serverId = event.messageId;
 
@@ -484,7 +493,7 @@ export function applyUserMessageEcho(
       textSegments: [event.text],
       contentOrder: [{ type: "text", id: "0" }],
       contentBlocks: [{ type: "text", text: event.text }],
-      timestamp: Date.now(),
+      timestamp: at,
     },
   ];
 }
@@ -496,12 +505,13 @@ export function applyUserMessageEcho(
 /** Handle conversation error: finalize tool calls, remove empty bubbles. */
 export function handleConversationError(
   prev: DisplayMessage[],
+  at: number = Date.now(),
 ): DisplayMessage[] {
   const lastIdx = prev.length - 1;
   const last = prev[lastIdx];
   if (!last || last.role !== "assistant") return prev;
 
-  const finalized = finalizeRunningToolCalls(last);
+  const finalized = finalizeRunningToolCalls(last, at);
   const hasContent =
     messagePlainText(last).trim().length > 0 ||
     (last.thinkingSegments != null && last.thinkingSegments.length > 0) ||

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -109,11 +109,12 @@ export function withMergedAlias(
  */
 export function finalizeRunningToolCalls(
   row: Pick<DisplayMessage, "toolCalls" | "contentBlocks">,
+  at: number = Date.now(),
 ): Pick<DisplayMessage, "toolCalls" | "contentBlocks"> | null {
   if (!row.toolCalls?.some((tc) => isToolCallRunning(tc))) {
     return null;
   }
-  const completedAt = Date.now();
+  const completedAt = at;
   const toolCalls = row.toolCalls.map((tc) =>
     isToolCallRunning(tc) ? { ...tc, completedAt } : tc,
   );

--- a/clients/web/src/domains/chat/utils/stream-updaters/surface-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/surface-updaters.ts
@@ -27,6 +27,7 @@ export function attachSurface(
   prev: DisplayMessage[],
   surface: Surface,
   messageId?: string,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   let targetIdx = -1;
 
@@ -51,7 +52,7 @@ export function attachSurface(
       surfaces: [surface],
       contentOrder: [{ type: "surface", id: surface.surfaceId }],
       contentBlocks: [{ type: "surface", surface }],
-      timestamp: Date.now(),
+      timestamp: at,
     });
   } else {
     const target = withMergedAlias(prev[targetIdx]!, messageId);

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
@@ -108,6 +108,7 @@ export function upsertToolCall(
   prev: DisplayMessage[],
   toolCall: ChatMessageToolCall,
   messageId?: string,
+  at: number = Date.now(),
 ): DisplayMessage[] {
   if (messageId) {
     const idx = findAssistantRowIndexByMessageId(prev, messageId);
@@ -128,7 +129,7 @@ export function upsertToolCall(
       toolCalls: [toolCall],
       contentOrder: [{ type: "toolCall", id: toolCall.id }],
       contentBlocks: [{ type: "tool_use", toolCall }],
-      timestamp: Date.now(),
+      timestamp: at,
     },
   ];
 }


### PR DESCRIPTION
Follow-up to the merged Phase 1 (#36317), addressing all the review feedback there.

## Changes

**Types / naming (per review):**
- Dropped the `RollingBase` alias and the bespoke `SeqEnvelope`. The reducer now operates on **`PaginatedHistoryResult` directly** and consumes the backend **`AssistantEventEnvelope`** (which already carries `seq`).
- Renamed `foldMessages` → `appendEventToMessages`, `rebuildBase` → `applyEventsToHistory(history, events)`.

**Full event coverage (was "missing a bunch of cases, including the tool-based ones"):**
The fold now handles every message-mutating event, reusing the same updaters the live path runs:
`assistant_text_delta`, `assistant_thinking_delta`, `message_complete`, `user_message_echo`, `assistant_activity_state(idle)`, `conversation_error`, `tool_use_start`, `tool_result`, `tool_output_chunk`, and the four `ui_surface_*` events. Queue / subagent / workflow events drive their own stores and the pending overlay (design §8), not the server-confirmed base, so they're intentionally out of scope here.

**Determinism handled in the fold (no more `stampOpenedRows`):**
The time-stamping updaters now take an optional `at` (default `Date.now()`, so the **live path is unchanged**); the reducer passes the envelope's `emittedAt`. A row an event opens is stamped identically whether folded live or on rebuild — so the post-pass row-stamper is gone, as requested.

**Codex P2 — terminal folding determinism:**
`finalizeRunningToolCalls` stamped `completedAt` with `Date.now()`, making `message_complete` on a tool turn time-dependent and able to break the invariant. It now takes `at`, threaded from `message_complete` / idle / error. New test `terminal tool-call finalize is deterministic` asserts a tool turn rebuilds byte-identically and stamps `completedAt` from the event.

**Misc:**
- Removed the redundant post-fold no-op guard — the `seq` idempotency check is the single drop path, and the updaters already preserve the `messages` reference.
- Trimmed the file docstring to two present-tense sentences (no rollout history), per root `AGENTS.md` "Code Comments".

## Tests
`rolling-base.test.ts` (10 tests, 216 assertions): the §10 invariant across 200 seeds, tool-turn determinism, tool+surface coverage, idempotency, seq-drop, version-advance, total-degradation, deterministic row-open stamping, page-field preservation. Existing updater suites (74 + 15 + 18) stay green — the optional `at` defaults preserve live behavior. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_