### PR TITLE
feat(plugins): install untrusted plugins directly from a GitHub URL

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -9,6 +9,7 @@
 
 import type { Command } from "commander";
 
+import { yellow } from "../lib/cli-colors.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import {
   diffPlugin,
@@ -27,13 +28,21 @@ import {
   type InstallPluginOptions,
   InvalidPluginNameError,
   PluginAlreadyInstalledError,
+  type PluginFetchSource,
   PluginNotFoundError,
+  sanitizePluginName,
 } from "../lib/install-from-github.js";
 import {
   type AllPluginInfo,
   listAllPlugins,
   listInstalledPlugins,
 } from "../lib/list-installed-plugins.js";
+import {
+  DEFAULT_DIRECT_REF,
+  InvalidGitHubPluginSpecError,
+  looksLikeGitHubSpec,
+  parseGitHubPluginSpec,
+} from "../lib/parse-github-plugin-spec.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
@@ -84,6 +93,8 @@ export function registerPluginsCommand(program: Command): void {
 Examples:
   $ assistant plugins install example
   $ assistant plugins install example --force
+  $ assistant plugins install https://github.com/owner/repo
+  $ assistant plugins install https://github.com/owner/repo/tree/main/sub/path --name my-plugin
   $ assistant plugins install example --ref my-feature-branch
   $ assistant plugins versions example
   $ assistant plugins versions example --json
@@ -110,38 +121,67 @@ Examples:
       );
 
       plugins
-        .command("install <name>")
+        .command("install <name-or-url>")
         .description(
-          "Install a plugin from the curated plugins/marketplace.json catalog",
+          "Install a plugin by name from the curated plugins/marketplace.json catalog, or directly from a GitHub URL (untrusted)",
         )
         .option("--force", "Overwrite an existing install")
         .option(
           "--ref <ref>",
-          `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF})`,
+          `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). Marketplace installs only — for a GitHub URL, put the ref in the URL (.../tree/<ref>/...)`,
         )
         .option(
           "--pin <sha>",
-          "Install a specific reviewed marketplace pin (full commit SHA); run `plugins versions <name>` to list them",
+          "Install a specific reviewed marketplace pin (full commit SHA); run `plugins versions <name>` to list them. Marketplace installs only",
         )
         .option(
           "--allow-unreviewed",
-          "With --pin, install a SHA that is not in the reviewed marketplace history (advanced; the curated adapter may not match)",
+          "With --pin, install a SHA that is not in the reviewed marketplace history (advanced; the curated adapter may not match). Marketplace installs only",
+        )
+        .option(
+          "--name <name>",
+          "Install directory name for a GitHub-URL install (default: derived from the repo or sub-path leaf). Ignored for marketplace installs",
+        )
+        .addHelpText(
+          "after",
+          `
+A GitHub URL (anything containing a slash) installs directly from that repo,
+bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
+been reviewed and its hooks/tools run with full assistant access — so the
+install prints a warning. Use it for a plugin still under development that is
+not in the catalog yet. The ref comes from the URL's /tree/<ref>/ segment, or
+defaults to the repository's default branch.
+
+Examples:
+  $ assistant plugins install https://github.com/owner/repo
+  $ assistant plugins install https://github.com/owner/repo/tree/my-branch/path/to/plugin
+  $ assistant plugins install owner/repo --name my-plugin --force`,
         )
         .action(
           async (
-            name: string,
+            nameOrUrl: string,
             opts: {
               force?: boolean;
               ref?: string;
               pin?: string;
               allowUnreviewed?: boolean;
+              name?: string;
             },
           ) => {
             try {
-              const installOpts = await resolveInstallOptions(name, opts);
+              const direct = looksLikeGitHubSpec(nameOrUrl);
+              const installOpts = direct
+                ? resolveDirectInstallOptions(nameOrUrl, opts)
+                : await resolveInstallOptions(nameOrUrl, opts);
               if (installOpts === null) {
                 process.exitCode = 1;
                 return;
+              }
+              if (installOpts.directSource) {
+                printUntrustedPluginWarning(
+                  installOpts.name,
+                  installOpts.directSource,
+                );
               }
               const result = await installPlugin(installOpts, {
                 fetch: globalThis.fetch.bind(globalThis),
@@ -153,14 +193,18 @@ Examples:
                   fileCount: result.fileCount,
                   ref: result.ref,
                   commit: result.commit,
+                  untrusted: Boolean(installOpts.directSource),
                 },
                 "external plugin installed",
               );
               const pinned = result.commit
                 ? ` at ${result.commit.slice(0, 7)}`
                 : "";
+              const label = installOpts.directSource
+                ? "untrusted plugin"
+                : "plugin";
               console.log(
-                `Installed plugin "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
+                `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
               );
             } catch (err) {
               if (err instanceof PluginAlreadyInstalledError) {
@@ -804,6 +848,99 @@ async function resolveInstallOptions(
     return null;
   }
   return { name, force, ref: entry.marketplaceCommit };
+}
+
+/**
+ * Resolve a GitHub-URL argument into {@link InstallPluginOptions} for an
+ * untrusted direct install, or `null` when the URL or flag combination is
+ * invalid (a message is printed in that case, and the caller exits non-zero).
+ *
+ * The marketplace-only flags (`--ref`, `--pin`, `--allow-unreviewed`) do not
+ * apply to a direct install — the ref lives in the URL — so combining them is
+ * rejected. The install name defaults to the repo / sub-path leaf and can be
+ * overridden with `--name`.
+ */
+function resolveDirectInstallOptions(
+  spec: string,
+  opts: {
+    force?: boolean;
+    ref?: string;
+    pin?: string;
+    allowUnreviewed?: boolean;
+    name?: string;
+  },
+): InstallPluginOptions | null {
+  if (opts.ref) {
+    console.error(
+      "--ref does not apply to a GitHub-URL install; put the ref in the URL (e.g. .../tree/<ref>/...).",
+    );
+    return null;
+  }
+  if (opts.pin || opts.allowUnreviewed) {
+    console.error(
+      "--pin and --allow-unreviewed only apply to marketplace installs by name, not a GitHub URL.",
+    );
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = parseGitHubPluginSpec(spec);
+  } catch (err) {
+    if (err instanceof InvalidGitHubPluginSpecError) {
+      console.error(err.message);
+      return null;
+    }
+    throw err;
+  }
+
+  const requested = opts.name ?? parsed.defaultName;
+  let name: string;
+  try {
+    name = sanitizePluginName(requested);
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      console.error(
+        opts.name
+          ? err.message
+          : `Could not derive a valid plugin name from "${parsed.defaultName}". ` +
+              "Pass --name <name> to choose one (lowercase letters, digits, '-', '_').",
+      );
+      return null;
+    }
+    throw err;
+  }
+
+  const directSource: PluginFetchSource = {
+    owner: parsed.owner,
+    repo: parsed.repo,
+    rootPath: parsed.path,
+    ref: parsed.ref,
+  };
+  return { name, force: opts.force ?? false, directSource };
+}
+
+/**
+ * Print a prominent yellow warning before an untrusted direct install. Such a
+ * plugin is not in the curated marketplace, has not been reviewed, and its
+ * hooks/tools run inside the assistant with full access — so the user must
+ * decide whether they trust the source. Goes to stderr so it stays visible
+ * alongside (not interleaved with) the stdout result line.
+ */
+function printUntrustedPluginWarning(
+  name: string,
+  source: PluginFetchSource,
+): void {
+  const location = source.rootPath
+    ? `${source.owner}/${source.repo}/${source.rootPath}`
+    : `${source.owner}/${source.repo}`;
+  const ref = source.ref === DEFAULT_DIRECT_REF ? "default branch" : source.ref;
+  const lines = [
+    `⚠ Installing "${name}" from an unreviewed GitHub source: ${location} @ ${ref}.`,
+    "  This plugin is NOT in the Vellum marketplace and has not been reviewed.",
+    "  Its hooks and tools run inside the assistant with full access — install it only if you trust the source.",
+  ];
+  console.error(yellow(lines.join("\n")));
 }
 
 /**

--- a/assistant/src/cli/lib/__tests__/cli-colors.test.ts
+++ b/assistant/src/cli/lib/__tests__/cli-colors.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
-import { red } from "../cli-colors.js";
+import { red, yellow } from "../cli-colors.js";
 
 const originalIsTTY = process.stderr.isTTY;
 const originalNoColor = process.env.NO_COLOR;
@@ -44,5 +44,34 @@ describe("red", () => {
     setTTY(true);
     process.env.NO_COLOR = "";
     expect(red("oops")).toBe("\x1b[31moops\x1b[0m");
+  });
+});
+
+describe("yellow", () => {
+  afterEach(() => {
+    setTTY(originalIsTTY);
+    if (originalNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = originalNoColor;
+    }
+  });
+
+  it("returns plain text when stderr is not a TTY", () => {
+    setTTY(false);
+    delete process.env.NO_COLOR;
+    expect(yellow("warn")).toBe("warn");
+  });
+
+  it("wraps text in ANSI yellow when stderr is a TTY", () => {
+    setTTY(true);
+    delete process.env.NO_COLOR;
+    expect(yellow("warn")).toBe("\x1b[33mwarn\x1b[0m");
+  });
+
+  it("respects NO_COLOR even when stderr is a TTY", () => {
+    setTTY(true);
+    process.env.NO_COLOR = "1";
+    expect(yellow("warn")).toBe("warn");
   });
 });

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -939,6 +939,165 @@ describe("installPlugin — marketplace resolution", () => {
   });
 });
 
+describe("installPlugin — direct (untrusted) install", () => {
+  let ws: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "vellum-plugins-direct-"));
+    pluginsDir = join(ws, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  test("installs from a caller-supplied source, bypassing the marketplace", async () => {
+    // GIVEN no marketplace manifest at all (a direct install must not consult it)
+    const fetch = makeContentsFetch({ tree: {} });
+    const calls: string[][] = [];
+    const runGit = fakeGitRunner({
+      tree: { "package.json": '{"name":"dev-plugin"}', "hooks/init.ts": "//" },
+      commit: "a".repeat(40),
+      calls,
+    });
+
+    // WHEN we install directly from owner/repo on its default branch (HEAD)
+    const result = await installPlugin(
+      {
+        name: "dev-plugin",
+        directSource: {
+          owner: "owner",
+          repo: "dev-plugin",
+          rootPath: "",
+          ref: "HEAD",
+        },
+      },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the tree is materialized and provenance records the direct source.
+    const target = join(pluginsDir, "dev-plugin");
+    expect(result.target).toBe(target);
+    expect(result.fileCount).toBe(2);
+    // A non-SHA ref (HEAD/branch) does NOT trip the pinned-commit integrity
+    // check — the resolved commit is recorded as-is.
+    expect(result.ref).toBe("HEAD");
+    expect(result.commit).toBe("a".repeat(40));
+
+    const fetchCall = calls.find((c) => c[0] === "fetch");
+    expect(fetchCall?.at(-1)).toBe("HEAD");
+    const remoteCall = calls.find((c) => c[0] === "remote");
+    expect(remoteCall?.at(-1)).toBe("https://github.com/owner/dev-plugin.git");
+
+    const meta = readInstallMeta(target);
+    expect(meta?.source.owner).toBe("owner");
+    expect(meta?.source.repo).toBe("dev-plugin");
+    expect(meta?.source.ref).toBe("HEAD");
+    expect(meta?.commit).toBe("a".repeat(40));
+  });
+
+  test("never overlays a curated adapter stub, even if one matches the name", async () => {
+    // GIVEN a fetch that WOULD serve an adapter stub for the name, and a
+    // postinstall runner that fails the test if it is ever invoked
+    const fetch = makeContentsFetch({
+      tree: {
+        "plugins/caveman/package.json": JSON.stringify({
+          name: "caveman",
+          scripts: { postinstall: "bun ./postinstall.ts" },
+        }),
+        "plugins/caveman/postinstall.ts": "// adapter",
+      },
+    });
+    const runGit = fakeGitRunner({
+      tree: { "package.json": '{"name":"caveman-fork"}' },
+      commit: "b".repeat(40),
+    });
+    const runPostinstall: PostinstallRunner = async () => {
+      throw new Error("adapter stub must not run for a direct install");
+    };
+
+    // WHEN we install directly
+    await installPlugin(
+      {
+        name: "caveman",
+        directSource: {
+          owner: "someone",
+          repo: "caveman-fork",
+          rootPath: "",
+          ref: "HEAD",
+        },
+      },
+      { fetch, runGit, runPostinstall, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the upstream manifest is installed verbatim — no stub transform ran
+    const pkg = readFileSync(
+      join(pluginsDir, "caveman", "package.json"),
+      "utf-8",
+    );
+    expect(pkg).toBe('{"name":"caveman-fork"}');
+  });
+
+  test("a direct install from a sub-path copies only that subtree", async () => {
+    const fetch = makeContentsFetch({ tree: {} });
+    const runGit = fakeGitRunner({
+      tree: {
+        "package.json": '{"name":"monorepo"}',
+        "packages/leaf/package.json": '{"name":"leaf"}',
+      },
+      commit: "c".repeat(40),
+    });
+
+    const result = await installPlugin(
+      {
+        name: "leaf",
+        directSource: {
+          owner: "owner",
+          repo: "monorepo",
+          rootPath: "packages/leaf",
+          ref: "main",
+        },
+      },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    const target = join(pluginsDir, "leaf");
+    expect(result.fileCount).toBe(1);
+    expect(readFileSync(join(target, "package.json"), "utf-8")).toBe(
+      '{"name":"leaf"}',
+    );
+    expect(existsSync(join(target, "packages"))).toBe(false);
+  });
+
+  test("a direct install pinned to a full SHA still enforces the integrity check", async () => {
+    // GIVEN a pinned SHA whose checked-out commit diverges
+    const fetch = makeContentsFetch({ tree: {} });
+    const runGit = fakeGitRunner({
+      tree: { "package.json": '{"name":"x"}' },
+      commit: "d".repeat(40),
+    });
+
+    // WHEN the direct ref is a full SHA, the resolved commit must match it
+    await expect(
+      installPlugin(
+        {
+          name: "x",
+          directSource: {
+            owner: "owner",
+            repo: "x",
+            rootPath: "",
+            ref: "e".repeat(40),
+          },
+        },
+        { fetch, runGit, workspacePluginsDir: pluginsDir },
+      ),
+    ).rejects.toBeInstanceOf(PluginSourceUnavailableError);
+    expect(readdirSync(pluginsDir)).toEqual([]);
+  });
+});
+
 describe("sanitizePluginName", () => {
   test.each([
     ["../escape"],

--- a/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
+++ b/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_DIRECT_REF,
+  InvalidGitHubPluginSpecError,
+  looksLikeGitHubSpec,
+  parseGitHubPluginSpec,
+} from "../parse-github-plugin-spec.js";
+
+describe("looksLikeGitHubSpec", () => {
+  test.each([
+    "https://github.com/owner/repo",
+    "github.com/owner/repo",
+    "owner/repo",
+    "owner/repo/sub/path",
+    "http://github.com/owner/repo",
+  ])("treats %p as a GitHub locator", (spec) => {
+    expect(looksLikeGitHubSpec(spec)).toBe(true);
+  });
+
+  test.each(["example", "simple-memory", "plugin_2", "a"])(
+    "treats marketplace name %p as not a GitHub locator",
+    (name) => {
+      expect(looksLikeGitHubSpec(name)).toBe(false);
+    },
+  );
+});
+
+describe("parseGitHubPluginSpec", () => {
+  test("parses a bare repo URL with default ref and root path", () => {
+    const spec = parseGitHubPluginSpec("https://github.com/owner/my-plugin");
+    expect(spec).toEqual({
+      owner: "owner",
+      repo: "my-plugin",
+      path: "",
+      ref: DEFAULT_DIRECT_REF,
+      defaultName: "my-plugin",
+    });
+  });
+
+  test("strips a trailing .git and a trailing slash", () => {
+    const spec = parseGitHubPluginSpec(
+      "https://github.com/owner/my-plugin.git/",
+    );
+    expect(spec.repo).toBe("my-plugin");
+    expect(spec.path).toBe("");
+  });
+
+  test("parses the canonical /tree/<ref>/<path> form", () => {
+    const spec = parseGitHubPluginSpec(
+      "https://github.com/owner/repo/tree/my-branch/packages/cool-plugin",
+    );
+    expect(spec).toEqual({
+      owner: "owner",
+      repo: "repo",
+      path: "packages/cool-plugin",
+      ref: "my-branch",
+      defaultName: "cool-plugin",
+    });
+  });
+
+  test("a /tree/<ref> with no sub-path keeps the root and uses the repo name", () => {
+    const spec = parseGitHubPluginSpec(
+      "https://github.com/owner/repo/tree/v1.2.3",
+    );
+    expect(spec.path).toBe("");
+    expect(spec.ref).toBe("v1.2.3");
+    expect(spec.defaultName).toBe("repo");
+  });
+
+  test("treats a non-tree trailing segment as the sub-path", () => {
+    const spec = parseGitHubPluginSpec("github.com/owner/repo/sub/leaf");
+    expect(spec.path).toBe("sub/leaf");
+    expect(spec.ref).toBe(DEFAULT_DIRECT_REF);
+    expect(spec.defaultName).toBe("leaf");
+  });
+
+  test("accepts the scheme-less owner/repo shorthand", () => {
+    const spec = parseGitHubPluginSpec("owner/repo");
+    expect(spec.owner).toBe("owner");
+    expect(spec.repo).toBe("repo");
+  });
+
+  test("lower-cases the derived default name", () => {
+    const spec = parseGitHubPluginSpec("https://github.com/Owner/Caveman");
+    expect(spec.defaultName).toBe("caveman");
+  });
+
+  test("drops a query string and fragment", () => {
+    const spec = parseGitHubPluginSpec(
+      "https://github.com/owner/repo/tree/main/pkg?tab=readme#install",
+    );
+    expect(spec.path).toBe("pkg");
+    expect(spec.ref).toBe("main");
+  });
+
+  test.each([
+    ["https://gitlab.com/owner/repo", "only github.com"],
+    ["https://example.com/owner/repo", "only github.com"],
+  ])("rejects non-github hosts %p", (spec, needle) => {
+    expect(() => parseGitHubPluginSpec(spec)).toThrow(
+      InvalidGitHubPluginSpecError,
+    );
+    expect(() => parseGitHubPluginSpec(spec)).toThrow(needle);
+  });
+
+  test.each(["owner", "github.com/owner", "https://github.com/owner", ""])(
+    "rejects a locator missing the repo %p",
+    (spec) => {
+      expect(() => parseGitHubPluginSpec(spec)).toThrow(
+        InvalidGitHubPluginSpecError,
+      );
+    },
+  );
+
+  test("rejects a sub-path that escapes the repo with ..", () => {
+    expect(() =>
+      parseGitHubPluginSpec("github.com/owner/repo/tree/main/../etc"),
+    ).toThrow(InvalidGitHubPluginSpecError);
+  });
+});

--- a/assistant/src/cli/lib/cli-colors.ts
+++ b/assistant/src/cli/lib/cli-colors.ts
@@ -23,6 +23,12 @@ export function green(text: string): string {
   return `\x1b[32m${text}\x1b[0m`;
 }
 
+export function yellow(text: string): string {
+  if (!process.stderr.isTTY) return text;
+  if (colorsDisabled()) return text;
+  return `\x1b[33m${text}\x1b[0m`;
+}
+
 export function dim(text: string): string {
   if (!process.stdout.isTTY) return text;
   if (colorsDisabled()) return text;

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -61,6 +61,14 @@ const PLUGIN_SOURCE_PATH_PREFIX = "plugins";
 /** Default git ref to fetch from when callers don't override. */
 export const DEFAULT_PLUGIN_REF = "main";
 
+/** Full Git commit SHA — 40 hex chars (SHA-1) or 64 (SHA-256). */
+const FULL_COMMIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+/** True when `ref` is a full, immutable commit SHA (not a branch/tag/HEAD). */
+export function isFullCommitSha(ref: string): boolean {
+  return FULL_COMMIT_SHA_RE.test(ref);
+}
+
 /** Entry shape returned by the GitHub Contents API for a directory listing. */
 interface GitHubContentEntry {
   readonly name: string;
@@ -122,6 +130,17 @@ export interface InstallPluginOptions {
    * Unset for normal installs, which take the reviewed pin from the manifest.
    */
   readonly commitOverride?: string;
+  /**
+   * Install directly from these GitHub coordinates, bypassing the curated
+   * `plugins/marketplace.json` whitelist. The tree is materialized verbatim —
+   * no curated adapter stub is overlaid — and the source is *untrusted*, so the
+   * caller is responsible for surfacing a warning. Used to install a plugin not
+   * yet in the marketplace (typically one still under development). When set,
+   * {@link InstallPluginOptions.ref}, {@link InstallPluginOptions.commitOverride},
+   * and marketplace resolution are all skipped; `directSource.ref` selects the
+   * commit to clone (a branch, tag, `HEAD`, or full SHA).
+   */
+  readonly directSource?: PluginFetchSource;
 }
 
 /** Dependencies injected by the caller. */
@@ -367,20 +386,32 @@ export async function installPlugin(
   const marketplaceRef = opts.ref ?? DEFAULT_PLUGIN_REF;
   const force = opts.force ?? false;
 
-  const source = await resolvePluginSource(name, marketplaceRef, deps.fetch);
-  if (!source) {
-    throw new PluginNotFoundError(
-      name,
-      marketplaceRef,
-      "plugins/marketplace.json",
-    );
+  // A direct install bypasses the marketplace whitelist entirely: the source is
+  // supplied by the caller and the tree is materialized verbatim (no curated
+  // adapter stub). Otherwise the name is resolved against the reviewed manifest.
+  let effectiveSource: PluginFetchSource;
+  // Ref the curated adapter stub is fetched at, or `null` to skip the overlay.
+  let stubRef: string | null;
+  if (opts.directSource) {
+    effectiveSource = opts.directSource;
+    stubRef = null;
+  } else {
+    const source = await resolvePluginSource(name, marketplaceRef, deps.fetch);
+    if (!source) {
+      throw new PluginNotFoundError(
+        name,
+        marketplaceRef,
+        "plugins/marketplace.json",
+      );
+    }
+    // A commit override installs a specific plugin revision while still taking
+    // owner/repo/path (and the adapter stub, via `marketplaceRef`) from the
+    // manifest; otherwise the reviewed pin from the manifest is materialized.
+    effectiveSource = opts.commitOverride
+      ? { ...source, ref: opts.commitOverride }
+      : source;
+    stubRef = marketplaceRef;
   }
-  // A commit override installs a specific plugin revision while still taking
-  // owner/repo/path (and the adapter stub, via `marketplaceRef`) from the
-  // manifest; otherwise the reviewed pin from the manifest is materialized.
-  const effectiveSource: PluginFetchSource = opts.commitOverride
-    ? { ...source, ref: opts.commitOverride }
-    : source;
   const ref = effectiveSource.ref;
 
   const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
@@ -416,7 +447,7 @@ export async function installPlugin(
       {
         source: effectiveSource,
         name,
-        stubRef: marketplaceRef,
+        stubRef,
         destDir: stagingDir,
       },
       deps,
@@ -630,8 +661,13 @@ export async function materializePluginTree(
     readonly source: PluginFetchSource;
     /** Install name, used to locate the curated adapter stub. */
     readonly name: string;
-    /** Ref the curated adapter stub is fetched at (the canonical repo ref). */
-    readonly stubRef: string;
+    /**
+     * Ref the curated adapter stub is fetched at (the canonical repo ref), or
+     * `null` to skip the adapter overlay entirely. Direct (untrusted) installs
+     * pass `null`: they are materialized verbatim, never reshaped by a curated
+     * stub keyed on the install name.
+     */
+    readonly stubRef: string | null;
     /** Directory the tree is written into. */
     readonly destDir: string;
   },
@@ -646,7 +682,7 @@ export async function materializePluginTree(
   // plugin) that the Vellum loader can't run as-is. When we curate an adapter
   // stub for it, overlay the stub and run its transform so the materialized
   // tree is a valid Vellum plugin. Raw clones (no stub) are left untouched.
-  if (cloned.fileCount > 0) {
+  if (cloned.fileCount > 0 && opts.stubRef !== null) {
     await applyAdapterStub(opts.name, opts.stubRef, opts.destDir, deps);
   }
   return cloned;
@@ -732,11 +768,17 @@ async function copyExternalViaGit(
       }
     }
 
-    // Defense in depth: external marketplace refs are full commit SHAs (the
-    // manifest schema rejects mutable tags/branches), so the checked-out
-    // commit must equal the requested ref. If it ever diverges, refuse the
-    // install rather than materialize and `import()` unexpected code.
-    if (commit && commit.toLowerCase() !== source.ref.toLowerCase()) {
+    // Defense in depth: when the requested ref is a full commit SHA (every
+    // marketplace ref is — the manifest schema rejects mutable tags/branches),
+    // the checked-out commit must equal it. If it ever diverges, refuse the
+    // install rather than materialize and `import()` unexpected code. A direct
+    // install from a branch/tag/HEAD has no fixed SHA to compare against, so the
+    // check only applies to pinned refs.
+    if (
+      commit &&
+      isFullCommitSha(source.ref) &&
+      commit.toLowerCase() !== source.ref.toLowerCase()
+    ) {
       throw new PluginSourceUnavailableError(
         `git checkout of ${sourceLabel(source)} resolved to ${commit}, ` +
           `which does not match the pinned commit ${source.ref}`,

--- a/assistant/src/cli/lib/parse-github-plugin-spec.ts
+++ b/assistant/src/cli/lib/parse-github-plugin-spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Parse a GitHub locator for an *untrusted* direct plugin install.
+ *
+ * `assistant plugins install <name>` resolves a single kebab-case segment
+ * against the curated `plugins/marketplace.json` whitelist. As a convenience
+ * for installing a plugin that is not in that catalog yet — typically one still
+ * under development — the same command also accepts a GitHub URL (with an
+ * optional sub-path). Such installs bypass marketplace curation entirely, so
+ * the caller must surface an untrusted-plugin warning.
+ *
+ * This module owns only the *parsing*: it turns a locator string into the
+ * concrete `owner` / `repo` / sub-`path` / `ref` an install clones from, plus a
+ * derived default install name. {@link looksLikeGitHubSpec} is the cheap
+ * discriminator the CLI uses to decide whether an argument is a marketplace
+ * name or a direct GitHub locator — a marketplace name can never contain a
+ * slash, so any slash routes here.
+ *
+ * Accepted forms (scheme and `github.com` host are optional):
+ *   - `https://github.com/<owner>/<repo>`
+ *   - `https://github.com/<owner>/<repo>.git`
+ *   - `https://github.com/<owner>/<repo>/tree/<ref>/<sub/path>`
+ *   - `github.com/<owner>/<repo>/<sub/path>`
+ *   - `<owner>/<repo>[/<sub/path>]`
+ *
+ * The `tree`/`blob` segment is GitHub's own way of expressing a ref + sub-path;
+ * when present the segment after it is the ref and the remainder is the
+ * sub-path. Otherwise everything past `<owner>/<repo>` is the sub-path and the
+ * ref defaults to the repository's default branch ({@link DEFAULT_DIRECT_REF}).
+ */
+
+/**
+ * Default git ref a direct install fetches when the locator names none.
+ * `HEAD` resolves to the remote's default branch in a single `git fetch`, so no
+ * extra API round-trip is needed to discover it.
+ */
+export const DEFAULT_DIRECT_REF = "HEAD";
+
+/** GitHub owner/org slug: alphanumerics and hyphens. */
+const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
+/** GitHub repo slug: alphanumerics plus `.`, `_`, `-`. */
+const REPO_RE = /^[A-Za-z0-9_.-]+$/;
+
+/** Concrete coordinates a direct GitHub install resolves to. */
+export interface GitHubPluginSpec {
+  readonly owner: string;
+  readonly repo: string;
+  /** Repo-relative directory holding the plugin root; `""` = repo root. */
+  readonly path: string;
+  /** Git ref (branch, tag, or commit SHA) to fetch from. */
+  readonly ref: string;
+  /**
+   * Default install name derived from the locator (the sub-path leaf, or the
+   * repo name), lower-cased. May still fail {@link sanitizePluginName}, in which
+   * case the caller asks the user to supply `--name`.
+   */
+  readonly defaultName: string;
+}
+
+/** The locator could not be parsed as a GitHub plugin source. */
+export class InvalidGitHubPluginSpecError extends Error {
+  constructor(spec: string, reason: string) {
+    super(`Invalid GitHub plugin URL "${spec}". ${reason}`);
+    this.name = "InvalidGitHubPluginSpecError";
+  }
+}
+
+/**
+ * Cheap discriminator: is this argument a direct GitHub locator rather than a
+ * marketplace install name? Marketplace names are a single kebab-case segment
+ * (`/^[a-z0-9][a-z0-9_-]*$/`) and therefore never contain a slash, so the
+ * presence of a slash (or an explicit scheme / `github.com` host) routes the
+ * argument to {@link parseGitHubPluginSpec}.
+ */
+export function looksLikeGitHubSpec(arg: string): boolean {
+  const s = arg.trim();
+  return (
+    s.includes("/") ||
+    /^https?:\/\//i.test(s) ||
+    /(^|\.)github\.com($|\/)/i.test(s)
+  );
+}
+
+/**
+ * Parse a GitHub locator into the coordinates a direct install clones from.
+ * Throws {@link InvalidGitHubPluginSpecError} when the string is not a usable
+ * GitHub source (wrong host, missing owner/repo, or a sub-path that escapes the
+ * repo).
+ */
+export function parseGitHubPluginSpec(input: string): GitHubPluginSpec {
+  const raw = input.trim();
+  if (raw === "") {
+    throw new InvalidGitHubPluginSpecError(input, "empty locator.");
+  }
+
+  let s = raw;
+
+  // Strip an optional scheme. When one is present the next token is the host,
+  // which must be github.com — we don't clone arbitrary hosts.
+  const scheme = /^https?:\/\//i.exec(s);
+  const hadScheme = scheme !== null;
+  if (scheme) s = s.slice(scheme[0].length);
+
+  // Strip an optional `github.com` (or `www.github.com`) host prefix.
+  const host = /^(?:www\.)?github\.com\//i.exec(s);
+  if (host) {
+    s = s.slice(host[0].length);
+  } else if (hadScheme) {
+    throw new InvalidGitHubPluginSpecError(
+      input,
+      "only github.com URLs are supported.",
+    );
+  }
+
+  // Drop a query string / fragment and trailing slashes before splitting.
+  s = s.split(/[?#]/)[0]!.replace(/\/+$/, "");
+  const segments = s.split("/").filter((seg) => seg.length > 0);
+
+  if (segments.length < 2) {
+    throw new InvalidGitHubPluginSpecError(
+      input,
+      "expected github.com/<owner>/<repo> with an optional /tree/<ref>/<path>.",
+    );
+  }
+
+  const owner = segments[0]!;
+  const repo = segments[1]!.replace(/\.git$/i, "");
+  if (!OWNER_RE.test(owner) || !REPO_RE.test(repo)) {
+    throw new InvalidGitHubPluginSpecError(
+      input,
+      `"${owner}/${repo}" is not a valid owner/repo.`,
+    );
+  }
+
+  const rest = segments.slice(2);
+  let ref = DEFAULT_DIRECT_REF;
+  let pathSegments: string[];
+  // `/tree/<ref>/<path>` (and the equivalent `/blob/…`) is GitHub's canonical
+  // encoding of a ref + sub-path. A ref containing slashes (e.g. `feature/x`)
+  // is not expressible this way — the first segment after `tree` is taken as
+  // the whole ref — so such refs must instead be a single segment or a commit
+  // SHA. The non-`tree` form treats everything past the repo as the sub-path.
+  if (rest.length > 0 && (rest[0] === "tree" || rest[0] === "blob")) {
+    if (rest.length >= 2) ref = rest[1]!;
+    pathSegments = rest.slice(2);
+  } else {
+    pathSegments = rest;
+  }
+
+  for (const seg of pathSegments) {
+    if (seg === "." || seg === "..") {
+      throw new InvalidGitHubPluginSpecError(
+        input,
+        "the sub-path must not contain '.' or '..' segments.",
+      );
+    }
+  }
+
+  const path = pathSegments.join("/");
+  const leaf = pathSegments.at(-1) ?? repo;
+  const defaultName = leaf.toLowerCase();
+
+  return { owner, repo, path, ref, defaultName };
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -623,6 +623,32 @@ name**. It does not by itself guarantee the plugin's hooks/tools match this
 loader's conventions — a plugin authored for another ecosystem may install yet
 contribute nothing on boot. A **postinstall adapter** bridges that gap.
 
+### Installing a plugin not in the marketplace (untrusted)
+
+While a plugin is still under development — before it is whitelisted here —
+install it directly from its GitHub repo by passing a URL (anything containing a
+slash) instead of a marketplace name:
+
+```bash
+assistant plugins install https://github.com/owner/repo
+assistant plugins install https://github.com/owner/repo/tree/my-branch/sub/path
+assistant plugins install owner/repo --name my-plugin
+```
+
+The ref comes from the URL's `/tree/<ref>/` segment, or defaults to the
+repository's default branch. The install directory name is derived from the repo
+(or sub-path leaf) and can be overridden with `--name`.
+
+A direct install **bypasses marketplace curation entirely**: the tree is
+materialized verbatim (no [postinstall adapter](#postinstall-adapters) is
+overlaid), and the source is **untrusted** — it has not been reviewed and its
+hooks/tools run inside the assistant with full access. The CLI prints a yellow
+warning naming the source, so the choice to trust it is explicit. Unlike
+marketplace installs — which pin an immutable, reviewed commit SHA — a branch or
+`HEAD` ref is mutable, so a direct install is a development convenience, not a
+reproducible pin. The marketplace-only flags (`--ref`, `--pin`,
+`--allow-unreviewed`) do not apply.
+
 ### Postinstall adapters
 
 External ecosystem plugins are often shaped for a different host (e.g. a Claude


### PR DESCRIPTION
## Prompt / plan

> `assistant plugins install <name>` installs from our registry. We need a convention for installing plugins not in our registry while development is in progress. Let's support `assistant plugins install github_url/with/optional/subpath` and doing so prints a yellow text warning about it being an untrusted plugin.

### Why

`assistant plugins install <name>` only resolves a single kebab-case name against the curated `plugins/marketplace.json` whitelist. There was no way to install a plugin that isn't whitelisted yet — the common case while a plugin is still under development. This adds a direct-from-GitHub install path as a development convenience, while keeping the marketplace's reviewed-and-pinned guarantees intact for normal installs.

### What changed

- **GitHub-URL installs.** `assistant plugins install` now accepts a GitHub locator (anything containing a slash) in addition to a marketplace name:
  - `https://github.com/owner/repo`
  - `https://github.com/owner/repo/tree/<ref>/<sub/path>` (GitHub's canonical ref+subpath form)
  - `owner/repo` shorthand
  - The ref comes from the URL's `/tree/<ref>/` segment, or defaults to the repo's default branch (fetched via `HEAD`, so no extra API round-trip).
  - The install directory name is derived from the repo / sub-path leaf and can be overridden with `--name`.
- **Untrusted warning.** A direct install bypasses marketplace curation entirely: the tree is materialized verbatim (no curated adapter stub is overlaid) and the source is untrusted, so the CLI prints a prominent **yellow** warning naming the source before installing.
- **Integrity check generalized.** The pinned-commit integrity check (checked-out commit must equal the requested ref) now applies only when the ref is a full SHA. Marketplace refs are always full SHAs so their behavior is unchanged; a mutable branch/`HEAD` ref is permitted for direct dev installs.
- **Marketplace-only flags rejected** for URL installs (`--ref`, `--pin`, `--allow-unreviewed`) with actionable errors.
- **Security boundary preserved.** This is a local-CLI-only affordance. The HTTP `plugins_install` route is intentionally left restricted to reviewed marketplace installs — a `settings.write` principal still cannot install arbitrary code from any URL.

New module `parse-github-plugin-spec.ts` owns locator parsing (`looksLikeGitHubSpec` + `parseGitHubPluginSpec`); `cli-colors.ts` gains a `yellow()` helper. Docs added to `plugins/README.md`.

## Test plan

- New `parse-github-plugin-spec.test.ts` — URL/shorthand/`tree` forms, host rejection, `..` escape rejection, name derivation.
- New direct-install cases in `install-from-github.test.ts` — bypasses marketplace, never overlays an adapter stub, copies a sub-path subtree, branch/`HEAD` ref skips the integrity check while a full-SHA ref still enforces it.
- `yellow()` cases added to `cli-colors.test.ts` (TTY / `NO_COLOR` gating).
- `bun test src/cli/lib/__tests__/` → **308 pass, 0 fail**. Lint and Prettier clean on changed files. Changed files type-check clean (the repo's pre-existing tsc errors in unrelated files / sibling packages are unchanged by this PR — verified against the base branch).

## CLI verb checklist

No new IPC routes added. This change extends the existing `plugins install` CLI verb (a `local`-transport command) and its `install-from-github` lib; the HTTP/IPC `plugins_install` route is intentionally not extended (see "Security boundary preserved" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkDzb3j1Yuy45MG6But36a

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkDzb3j1Yuy45MG6But36a)_