### PR TITLE
feat(web): seam window — ordered buffer + compaction (client-sync Phase 2a)

### DIFF
--- a/clients/web/src/domains/chat/transcript/seam-window.test.ts
+++ b/clients/web/src/domains/chat/transcript/seam-window.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  compact,
+  emptySeamWindow,
+  firstGap,
+  ingest,
+  type SeamWindow,
+} from "@/domains/chat/transcript/seam-window";
+import { applyEventsToHistory } from "@/domains/chat/transcript/rolling-base";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+
+const SEED: PaginatedHistoryResult = {
+  messages: [],
+  hasMore: false,
+  oldestTimestamp: null,
+  oldestMessageId: null,
+  seq: 0,
+};
+
+function env(seq: number, message: AssistantEvent): AssistantEventEnvelope {
+  return {
+    id: `e${seq}`,
+    seq,
+    emittedAt: new Date(1000 + seq).toISOString(),
+    message,
+  } as AssistantEventEnvelope;
+}
+const textDelta = (seq: number, id: string, text: string) =>
+  env(seq, { type: "assistant_text_delta", messageId: id, text } as AssistantEvent);
+
+// A clean, in-order turn: seqs 1..6.
+const cleanTurn = (): AssistantEventEnvelope[] => [
+  env(1, { type: "user_message_echo", messageId: "u1", text: "hi" } as AssistantEvent),
+  textDelta(2, "a1", "Here"),
+  textDelta(3, "a1", " is"),
+  textDelta(4, "a1", " your"),
+  textDelta(5, "a1", " answer."),
+  env(6, { type: "message_complete", messageId: "a1" } as AssistantEvent),
+];
+
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+function shuffle<T>(items: T[], random: () => number): T[] {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [out[i], out[j]] = [out[j]!, out[i]!];
+  }
+  return out;
+}
+
+describe("seam window", () => {
+  test("out-of-order ingestion then compaction equals the in-order rebuild", () => {
+    const clean = cleanTurn();
+    const inOrder = applyEventsToHistory(SEED, clean);
+    for (let seed = 1; seed <= 200; seed++) {
+      let window: SeamWindow = emptySeamWindow;
+      for (const e of shuffle(clean, rng(seed))) {
+        window = ingest(window, SEED.seq, e);
+      }
+      const { base, window: rest } = compact(SEED, window);
+      expect(rest.size).toBe(0); // fully contiguous once all arrived
+      expect(base).toEqual(inOrder);
+    }
+  });
+
+  test("interleaved ingest+compact also converges to the in-order rebuild", () => {
+    const clean = cleanTurn();
+    const inOrder = applyEventsToHistory(SEED, clean);
+    for (let seed = 1; seed <= 200; seed++) {
+      let base = SEED;
+      let window: SeamWindow = emptySeamWindow;
+      for (const e of shuffle(clean, rng(seed))) {
+        window = ingest(window, base.seq, e);
+        ({ base, window } = compact(base, window));
+      }
+      expect(window.size).toBe(0);
+      expect(base).toEqual(inOrder);
+    }
+  });
+
+  test("compacts only the gap-free prefix; the tail parks until backfilled", () => {
+    let window: SeamWindow = emptySeamWindow;
+    for (const e of [textDelta(1, "a", "a"), textDelta(2, "a", "b"), textDelta(4, "a", "d")]) {
+      window = ingest(window, SEED.seq, e);
+    }
+    const step1 = compact(SEED, window);
+    expect(step1.base.seq).toBe(2); // folded 1,2; 3 is missing
+    expect([...step1.window.keys()]).toEqual([4]); // 4 parked past the gap
+    expect(firstGap(step1.base, step1.window)).toEqual({ expected: 3, have: 4 });
+
+    // Backfill 3 → the prefix is contiguous again and the tail folds.
+    const filled = ingest(step1.window, step1.base.seq, textDelta(3, "a", "c"));
+    const step2 = compact(step1.base, filled);
+    expect(step2.base.seq).toBe(4);
+    expect(step2.window.size).toBe(0);
+    expect(firstGap(step2.base, step2.window)).toBeNull();
+  });
+
+  test("drops duplicates and already-folded (stale) events", () => {
+    const dup = ingest(ingest(emptySeamWindow, SEED.seq, textDelta(2, "a", "x")), SEED.seq, textDelta(2, "a", "x"));
+    expect(dup.size).toBe(1);
+
+    const base: PaginatedHistoryResult = { ...SEED, seq: 3 };
+    const stale = ingest(emptySeamWindow, base.seq, textDelta(2, "a", "old"));
+    expect(stale.size).toBe(0); // seq 2 <= base.seq 3
+  });
+
+  test("ignores events with no seq (caller owns the seqless path)", () => {
+    const after = ingest(emptySeamWindow, SEED.seq, {
+      id: "x",
+      emittedAt: new Date(0).toISOString(),
+      message: { type: "assistant_text_delta", messageId: "a", text: "x" },
+    } as AssistantEventEnvelope);
+    expect(after.size).toBe(0);
+  });
+
+  test("holds the window (no fold) until a snapshot anchors the version", () => {
+    const cold: PaginatedHistoryResult = { ...SEED, seq: null };
+    const window = ingest(emptySeamWindow, cold.seq, textDelta(5, "a", "x"));
+    const { base, window: rest } = compact(cold, window);
+    expect(base).toBe(cold); // no anchor → nothing folds
+    expect(rest.size).toBe(1);
+    expect(firstGap(cold, rest)).toBeNull(); // can't measure a gap without an anchor
+  });
+});

--- a/clients/web/src/domains/chat/transcript/seam-window.ts
+++ b/clients/web/src/domains/chat/transcript/seam-window.ts
@@ -1,0 +1,82 @@
+/**
+ * The seam window: a short buffer of stream events that have arrived but are
+ * not yet folded into the history base, holding them keyed by `seq` so the base
+ * only ever absorbs a gap-free, in-order prefix. `ingest` buffers an event
+ * (dropping duplicates and ones already folded), `compact` folds the contiguous
+ * prefix into the base via `applyEvent`, and a non-empty remainder marks a gap
+ * the base must wait on.
+ */
+
+import { applyEvent } from "@/domains/chat/transcript/rolling-base";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+
+/** Buffered-but-unfolded events, keyed by global `seq`. */
+export type SeamWindow = ReadonlyMap<number, AssistantEventEnvelope>;
+
+export const emptySeamWindow: SeamWindow = new Map();
+
+/**
+ * Buffer an event for later compaction. An event with no `seq` can't be
+ * ordered or deduped and is left to the caller; one at or below the base's
+ * `seq` is already folded, and one already buffered is a duplicate — both are
+ * dropped (the window is returned unchanged). Otherwise the event is inserted
+ * keyed by its `seq`.
+ */
+export function ingest(
+  window: SeamWindow,
+  baseSeq: number | null | undefined,
+  envelope: AssistantEventEnvelope,
+): SeamWindow {
+  const { seq } = envelope;
+  if (typeof seq !== "number") return window;
+  if (typeof baseSeq === "number" && seq <= baseSeq) return window;
+  if (window.has(seq)) return window;
+  const next = new Map(window);
+  next.set(seq, envelope);
+  return next;
+}
+
+/**
+ * Fold the gap-free prefix of the window into the base. Starting at
+ * `base.seq + 1`, each consecutive buffered event is applied and removed; the
+ * walk stops at the first missing `seq`, so a hole parks the rest of the window
+ * until it is backfilled. A base with no `seq` has no version anchor to fold
+ * from — the window is held until a snapshot seeds one — so this is a no-op.
+ * Returns the same references when nothing folds.
+ */
+export function compact(
+  base: PaginatedHistoryResult,
+  window: SeamWindow,
+): { base: PaginatedHistoryResult; window: SeamWindow } {
+  if (typeof base.seq !== "number") return { base, window };
+  let expected = base.seq + 1;
+  if (!window.has(expected)) return { base, window };
+
+  const remaining = new Map(window);
+  let folded = base;
+  while (remaining.has(expected)) {
+    folded = applyEvent(folded, remaining.get(expected)!);
+    remaining.delete(expected);
+    expected += 1;
+  }
+  return { base: folded, window: remaining };
+}
+
+/**
+ * The gap between what the base has folded and the earliest buffered event, or
+ * `null` when the window is empty, contiguous with the base, or has no version
+ * anchor to measure against. `expected` is the next `seq` the base needs;
+ * `have` is the earliest one buffered — the daemon can replay `(expected, have)`
+ * to close it. Most useful after `compact`, when any remainder sits past a gap.
+ */
+export function firstGap(
+  base: PaginatedHistoryResult,
+  window: SeamWindow,
+): { expected: number; have: number } | null {
+  if (window.size === 0 || typeof base.seq !== "number") return null;
+  let have = Infinity;
+  for (const seq of window.keys()) have = Math.min(have, seq);
+  const expected = base.seq + 1;
+  return have > expected ? { expected, have } : null;
+}


### PR DESCRIPTION
Next step of the rolling-base migration, after the merged reducer (#36317, #36318). The pure **seam** between the stream and the materialized base — completing the engine (`reducer + window + compaction`). **Unwired** in this phase; ingestion + render derivation are Phase 2b.

## What it adds (design §5–§6)

- **`ingest(window, baseSeq, env)`** — buffer an event keyed by `seq`, dropping duplicates and events already folded into the base. Absorbs out-of-order arrival; seqless events are left to the caller.
- **`compact(base, window)`** — fold the **gap-free prefix** (`base.seq + 1` upward) into the base via `applyEvent`, stopping at the first missing `seq` so a hole parks the tail until backfilled. No version anchor (`base.seq == null`) → hold the window until a snapshot seeds one. Returns the same refs when nothing folds.
- **`firstGap(base, window)`** — the `(expected, have)` hole the daemon can replay to close (for `Last-Event-ID` backfill), or `null` when contiguous / unanchored.

## Why this slice
Pure and unwired, like the reducer PRs — fast to review, no rendering change, no ownership change. It lets the invariant test reach the cases the reducer alone couldn't: **out-of-order delivery and gap→backfill**.

## Tests
`seam-window.test.ts` (6 tests, 812 assertions): any out-of-order permutation — ingested-then-compacted **and** interleaved ingest+compact — produces the same base as the clean in-order rebuild (200 seeds each); plus gap-parks-tail → backfill closes it, duplicate/stale drops, the seqless-ignored path, and the unanchored cold-start hold. Lint + typecheck clean.

## Scope note / next
This implements the full §5 window (genuine out-of-order absorption), not just a seq-ordered buffer. At **Phase 2b** (wiring ingestion + deriving the transcript from `base ⊕ window`) we consolidate with the existing `sse-event-consumer` gap/dedup machinery so there's one seam, not two — and that's where the base gains an owner and we revisit `clients/web/AGENTS.md:30`, doc update included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_