### PR TITLE
feat(web): add download button to workspace binary file viewer

### DIFF
--- a/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -12,6 +12,7 @@ import {
     useQueryClient,
 } from "@tanstack/react-query";
 import {
+    Download,
     FileIcon,
     FileText,
     FolderOpen,
@@ -33,6 +34,7 @@ import {
     SourcePre,
 } from "@/components/file-editor";
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+import { downloadWorkspaceFile } from "@/domains/workspace/utils/download-workspace-file";
 import { isJson, prettifyJson } from "@/domains/workspace/utils/file-json";
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
 import { isHiddenPath } from "@/domains/workspace/utils/is-hidden-path";
@@ -252,11 +254,117 @@ function BinaryContentViewer({
   return null;
 }
 
+function BinaryFileCard({
+  assistantId,
+  path,
+  name,
+  mimeType,
+  size,
+  modifiedAt,
+  showHidden,
+}: {
+  assistantId: string;
+  path: string;
+  name: string;
+  mimeType: string;
+  size?: number;
+  modifiedAt?: string | null;
+  showHidden?: boolean;
+}) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState(false);
 
+  const handleDownload = useCallback(async () => {
+    setError(false);
+    setIsDownloading(true);
+    try {
+      await downloadWorkspaceFile({ assistantId, path, filename: name, showHidden });
+    } catch {
+      setError(true);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [assistantId, path, name, showHidden]);
 
-
-
-
+  return (
+    <div className="flex h-full flex-col">
+      <FileHeader name={name} mimeType={mimeType} size={size} />
+      <div className="flex flex-1 items-center justify-center p-8">
+        <div
+          className="w-full max-w-sm rounded-lg border p-6 text-center"
+          style={{
+            borderColor: "var(--border-base)",
+            backgroundColor: "var(--surface-lift)",
+          }}
+        >
+          <FileIcon
+            className="mx-auto h-10 w-10"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+          <p
+            className="mt-3 text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {name}
+          </p>
+          <div className="mt-2 space-y-1">
+            <p
+              className="text-body-small-default"
+              style={{
+                color: "var(--content-secondary, var(--content-tertiary))",
+              }}
+            >
+              {mimeType}
+            </p>
+            <p
+              className="text-body-small-default"
+              style={{
+                color: "var(--content-secondary, var(--content-tertiary))",
+              }}
+            >
+              {formatFileSize(size, "Unknown size")}
+            </p>
+            {modifiedAt && (
+              <p
+                className="text-body-small-default"
+                style={{
+                  color: "var(--content-secondary, var(--content-tertiary))",
+                }}
+              >
+                Modified: {new Date(modifiedAt).toLocaleString()}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="outlined"
+            size="compact"
+            leftIcon={
+              isDownloading ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <Download aria-hidden />
+              )
+            }
+            onClick={handleDownload}
+            disabled={isDownloading}
+            aria-label={`Download ${name}`}
+            className="mt-4"
+          >
+            {isDownloading ? "Downloading…" : "Download"}
+          </Button>
+          {error && (
+            <p
+              className="mt-2 text-body-small-default"
+              style={{ color: "var(--system-error)" }}
+            >
+              Download failed. Try again.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function WorkspaceFileViewer({
   assistantId,
@@ -612,58 +720,16 @@ export function WorkspaceFileViewer({
     );
   }
 
-  // Binary fallback — metadata card
+  // Binary fallback — metadata card with download
   return (
-    <div className="flex h-full flex-col">
-      <FileHeader name={name} mimeType={mimeType} size={data.size} />
-      <div className="flex flex-1 items-center justify-center p-8">
-        <div
-          className="w-full max-w-sm rounded-lg border p-6 text-center"
-          style={{
-            borderColor: "var(--border-base)",
-            backgroundColor: "var(--surface-lift)",
-          }}
-        >
-          <FileIcon
-            className="mx-auto h-10 w-10"
-            style={{ color: "var(--content-tertiary)" }}
-          />
-          <p
-            className="mt-3 text-body-medium-default"
-            style={{ color: "var(--content-default)" }}
-          >
-            {name}
-          </p>
-          <div className="mt-2 space-y-1">
-            <p
-              className="text-body-small-default"
-              style={{
-                color: "var(--content-secondary, var(--content-tertiary))",
-              }}
-            >
-              {mimeType}
-            </p>
-            <p
-              className="text-body-small-default"
-              style={{
-                color: "var(--content-secondary, var(--content-tertiary))",
-              }}
-            >
-              {formatFileSize(data.size, "Unknown size")}
-            </p>
-            {data.modifiedAt && (
-              <p
-                className="text-body-small-default"
-                style={{
-                  color: "var(--content-secondary, var(--content-tertiary))",
-                }}
-              >
-                Modified: {new Date(data.modifiedAt).toLocaleString()}
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+    <BinaryFileCard
+      assistantId={assistantId}
+      path={selectedPath}
+      name={name}
+      mimeType={mimeType}
+      size={data.size}
+      modifiedAt={data.modifiedAt}
+      showHidden={showHidden}
+    />
   );
 }

--- a/clients/web/src/domains/workspace/utils/download-workspace-file.test.ts
+++ b/clients/web/src/domains/workspace/utils/download-workspace-file.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+
+type ContentResult = { data: Blob | null; error: { message: string } | null };
+
+const workspaceFileContentGet = mock(
+  async (): Promise<ContentResult> => ({
+    data: new Blob(["binary"]),
+    error: null,
+  }),
+);
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  workspaceFileContentGet,
+}));
+
+const saveFile = mock(async (): Promise<void> => undefined);
+
+mock.module("@/runtime/native-file", () => ({ saveFile }));
+
+const { downloadWorkspaceFile } = await import(
+  "@/domains/workspace/utils/download-workspace-file"
+);
+
+describe("downloadWorkspaceFile", () => {
+  beforeEach(() => {
+    workspaceFileContentGet.mockClear();
+    saveFile.mockClear();
+  });
+
+  test("fetches content and hands the blob to the saver", async () => {
+    await downloadWorkspaceFile({
+      assistantId: "asst-1",
+      path: "exports/report.tar.gz",
+      filename: "report.tar.gz",
+    });
+
+    expect(workspaceFileContentGet).toHaveBeenCalledTimes(1);
+    const call = workspaceFileContentGet.mock.calls[0]![0] as {
+      path: { assistant_id: string };
+      query: { path: string; showHidden?: string };
+      parseAs: string;
+    };
+    expect(call.path.assistant_id).toBe("asst-1");
+    expect(call.query.path).toBe("exports/report.tar.gz");
+    expect(call.query.showHidden).toBeUndefined();
+    expect(call.parseAs).toBe("blob");
+
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    const [blob, filename] = saveFile.mock.calls[0]! as [Blob, string];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(filename).toBe("report.tar.gz");
+  });
+
+  test("forwards showHidden when set", async () => {
+    await downloadWorkspaceFile({
+      assistantId: "asst-1",
+      path: ".secret/key.bin",
+      filename: "key.bin",
+      showHidden: true,
+    });
+
+    const call = workspaceFileContentGet.mock.calls[0]![0] as {
+      query: { showHidden?: string };
+    };
+    expect(call.query.showHidden).toBe("true");
+  });
+
+  test("throws and never saves when the endpoint errors", async () => {
+    workspaceFileContentGet.mockResolvedValueOnce({
+      data: null,
+      error: { message: "boom" },
+    });
+
+    await expect(
+      downloadWorkspaceFile({
+        assistantId: "asst-1",
+        path: "exports/report.tar.gz",
+        filename: "report.tar.gz",
+      }),
+    ).rejects.toThrow("Failed to download file");
+
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/workspace/utils/download-workspace-file.test.ts
+++ b/clients/web/src/domains/workspace/utils/download-workspace-file.test.ts
@@ -4,8 +4,14 @@ import * as daemonSdk from "@/generated/daemon/sdk.gen";
 
 type ContentResult = { data: Blob | null; error: { message: string } | null };
 
+type ContentRequest = {
+  path: { assistant_id: string };
+  query: { path: string; showHidden?: string };
+  parseAs: string;
+};
+
 const workspaceFileContentGet = mock(
-  async (): Promise<ContentResult> => ({
+  async (_request: ContentRequest): Promise<ContentResult> => ({
     data: new Blob(["binary"]),
     error: null,
   }),
@@ -16,7 +22,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   workspaceFileContentGet,
 }));
 
-const saveFile = mock(async (): Promise<void> => undefined);
+const saveFile = mock(
+  async (_source: Blob | string, _filename: string): Promise<void> =>
+    undefined,
+);
 
 mock.module("@/runtime/native-file", () => ({ saveFile }));
 
@@ -38,18 +47,14 @@ describe("downloadWorkspaceFile", () => {
     });
 
     expect(workspaceFileContentGet).toHaveBeenCalledTimes(1);
-    const call = workspaceFileContentGet.mock.calls[0]![0] as {
-      path: { assistant_id: string };
-      query: { path: string; showHidden?: string };
-      parseAs: string;
-    };
+    const call = workspaceFileContentGet.mock.calls[0]![0];
     expect(call.path.assistant_id).toBe("asst-1");
     expect(call.query.path).toBe("exports/report.tar.gz");
     expect(call.query.showHidden).toBeUndefined();
     expect(call.parseAs).toBe("blob");
 
     expect(saveFile).toHaveBeenCalledTimes(1);
-    const [blob, filename] = saveFile.mock.calls[0]! as [Blob, string];
+    const [blob, filename] = saveFile.mock.calls[0]!;
     expect(blob).toBeInstanceOf(Blob);
     expect(filename).toBe("report.tar.gz");
   });
@@ -62,9 +67,7 @@ describe("downloadWorkspaceFile", () => {
       showHidden: true,
     });
 
-    const call = workspaceFileContentGet.mock.calls[0]![0] as {
-      query: { showHidden?: string };
-    };
+    const call = workspaceFileContentGet.mock.calls[0]![0];
     expect(call.query.showHidden).toBe("true");
   });
 

--- a/clients/web/src/domains/workspace/utils/download-workspace-file.ts
+++ b/clients/web/src/domains/workspace/utils/download-workspace-file.ts
@@ -1,0 +1,31 @@
+import { workspaceFileContentGet } from "@/generated/daemon/sdk.gen";
+
+/**
+ * Download a workspace file to the user's device. Fetches the raw bytes from
+ * the daemon content endpoint and hands them to the cross-platform saver
+ * (browser download on web, native Share Sheet on iOS).
+ */
+export async function downloadWorkspaceFile(opts: {
+  assistantId: string;
+  path: string;
+  filename: string;
+  showHidden?: boolean;
+}): Promise<void> {
+  const { saveFile } = await import("@/runtime/native-file");
+
+  const { data, error } = await workspaceFileContentGet({
+    path: { assistant_id: opts.assistantId },
+    query: {
+      path: opts.path,
+      ...(opts.showHidden ? { showHidden: "true" } : {}),
+    },
+    parseAs: "blob",
+    throwOnError: false,
+  });
+
+  if (error || !(data instanceof Blob)) {
+    throw new Error("Failed to download file");
+  }
+
+  await saveFile(data, opts.filename);
+}

--- a/clients/web/src/domains/workspace/utils/download-workspace-file.ts
+++ b/clients/web/src/domains/workspace/utils/download-workspace-file.ts
@@ -1,4 +1,5 @@
 import { workspaceFileContentGet } from "@/generated/daemon/sdk.gen";
+import { saveFile } from "@/runtime/native-file";
 
 /**
  * Download a workspace file to the user's device. Fetches the raw bytes from
@@ -11,8 +12,6 @@ export async function downloadWorkspaceFile(opts: {
   filename: string;
   showHidden?: boolean;
 }): Promise<void> {
-  const { saveFile } = await import("@/runtime/native-file");
-
   const { data, error } = await workspaceFileContentGet({
     path: { assistant_id: opts.assistantId },
     query: {


### PR DESCRIPTION
## Prompt / plan

The workspace file viewer renders a binary-fallback metadata card for files it can't preview inline (e.g. `.tar.gz` archives, `application/gzip`). That card showed the filename, MIME type, size, and modified timestamp — but gave the user no way to actually get the file off the device. This PR adds a Download affordance to that card.

Approach:
- Add a Download button to the binary-fallback card in `WorkspaceFileViewer`. It fetches the raw bytes from the daemon content endpoint (`workspaceFileContentGet`) and routes them through the existing cross-platform saver (`saveFile` — `<a download>` on web, native iOS Share Sheet via `@capacitor/share`).
- Extract the fetch+save into a reusable `downloadWorkspaceFile` helper, mirroring the existing `downloadAttachment` pattern in the chat domain rather than inlining a one-off.
- The binary card is extracted into a small `BinaryFileCard` component that owns its own download/error state (in-flight spinner, disabled button, inline error message on failure).

## Test plan

- New unit test `download-workspace-file.test.ts` covers the happy path (fetches content, hands the blob to the saver with the right filename), `showHidden` forwarding, and the error path (throws and never calls the saver). 3 pass.
- `bunx tsc --noEmit` — clean.
- `bunx eslint` on all changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJpiut8ym9btY6sdfLEJA7)_