### PR TITLE
fix(memory-v2): enqueue migration embed jobs into the memory DB

### DIFF
--- a/assistant/src/memory/v2/__tests__/migration.test.ts
+++ b/assistant/src/memory/v2/__tests__/migration.test.ts
@@ -637,7 +637,7 @@ describe("collapseEdges", () => {
 
 describe("enqueueEmbeds", () => {
   test("enqueues one embed_concept_page job per slug", () => {
-    expect(enqueueEmbeds(["alice", "bob", "carol"], database)).toBe(3);
+    expect(enqueueEmbeds(["alice", "bob", "carol"])).toBe(3);
     expect(enqueuedJobs).toEqual([
       { type: "embed_concept_page", payload: { slug: "alice" } },
       { type: "embed_concept_page", payload: { slug: "bob" } },
@@ -646,7 +646,7 @@ describe("enqueueEmbeds", () => {
   });
 
   test("empty list is a no-op", () => {
-    expect(enqueueEmbeds([], database)).toBe(0);
+    expect(enqueueEmbeds([])).toBe(0);
     expect(enqueuedJobs).toEqual([]);
   });
 });

--- a/assistant/src/memory/v2/migration.ts
+++ b/assistant/src/memory/v2/migration.ts
@@ -465,19 +465,16 @@ export function collapseEdges(
  * is implemented separately — we just stage the queue here so the embeddings
  * are ready by the time activation needs them.
  *
- * `database` is threaded through to `enqueueMemoryJob` as the override DB
- * handle. Without this, jobs would be written to the global `getDb()` instead
- * of the migration's DB — which is wrong for tests, isolated runners, and
- * multi-workspace processes that pass an explicit `database`.
+ * The `memory_jobs` queue lives in the dedicated memory database
+ * (`assistant-memory.db`), not the main DB. `enqueueMemoryJob` targets it by
+ * default, so we pass no DB override here: the migration's `database` handle is
+ * the *main* DB (the v1 graph source read by `gatherV1State`) and must not
+ * receive `memory_jobs` writes — doing so silently drops the jobs into a table
+ * that doesn't exist there.
  */
-export function enqueueEmbeds(slugs: string[], database: DrizzleDb): number {
+export function enqueueEmbeds(slugs: string[]): number {
   for (const slug of slugs) {
-    enqueueMemoryJob(
-      "embed_concept_page",
-      { slug },
-      undefined,
-      database as never,
-    );
+    enqueueMemoryJob("embed_concept_page", { slug });
   }
   return slugs.length;
 }
@@ -621,10 +618,7 @@ export async function runMemoryV2Migration(
   }
   await appendPromotions(workspaceDir, promotions);
 
-  const embedsEnqueued = enqueueEmbeds(
-    finalizedPages.map((p) => p.slug),
-    database,
-  );
+  const embedsEnqueued = enqueueEmbeds(finalizedPages.map((p) => p.slug));
 
   await writeSentinel(workspaceDir);
 


### PR DESCRIPTION
## Prompt / plan

QA flagged that the `memory_v2_migrate` backfill handler in `backfill-jobs.ts` passes `getDb()` (the main `assistant.db`) into `runMemoryV2Migration()`. The migration internally forwards that handle to `enqueueEmbeds()` → `enqueueMemoryJob()`, but the `memory_jobs` queue lives in the dedicated `assistant-memory.db` (relocated by migration 298), not the main DB — so the `embed_concept_page` jobs were being written against a connection that has no `memory_jobs` table.

The QA suggestion ("pass `getMemoryDb()` instead of `getDb()`") would fix the enqueue but **break `gatherV1State()`**, which reads `memory_graph_nodes` / `memory_graph_edges` — those tables live in the main DB and were never relocated. The migration handle is genuinely the main DB and must stay so for the graph reads.

The real fix is at the enqueue layer: `enqueueEmbeds()` should not force a DB override at all. `enqueueMemoryJob()` already defaults to `memoryDb()` (the memory connection), which is exactly where the jobs belong — and is the same pattern the sibling `enqueueEmbedConceptPageJob()` (used by the `memory_v2_reembed` backfill path) already follows.

Changes:
- `migration.ts`: `enqueueEmbeds(slugs)` drops its `database` parameter and the `enqueueMemoryJob` DB override, so embed jobs land in `assistant-memory.db` by default. Updated the now-stale comment.
- `migration.test.ts`: updated the two `enqueueEmbeds` call sites to the new signature.

The `memoryV2MigrateJob` handler is unchanged — it correctly keeps passing `getDb()` so the migration's graph reads still hit the main DB.

## Test plan

- `bun test src/memory/v2/__tests__/migration.test.ts` — 38 pass
- `bun test src/memory/v2/__tests__/backfill-jobs.test.ts` — 10 pass
- `bunx tsc --noEmit` — clean
- Pre-commit hooks (eslint, prettier, typecheck) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vT2S5p1HPPx5itf4Y537u)_