### PR TITLE
feat(migrations): gate expensive message-table sweeps behind migrations.worker.enabled

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -42,6 +42,7 @@ import {
 } from "./schemas/logging.js";
 import { McpConfigSchema } from "./schemas/mcp.js";
 import { MemoryConfigSchema } from "./schemas/memory.js";
+import { MigrationsConfigSchema } from "./schemas/migrations.js";
 import { NotificationsConfigSchema } from "./schemas/notifications.js";
 import {
   DaemonConfigSchema,
@@ -63,6 +64,7 @@ export const AssistantConfigSchema = z
   .object({
     services: ServicesSchema.default(ServicesSchema.parse({})),
     memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),
+    migrations: MigrationsConfigSchema.default(MigrationsConfigSchema.parse({})),
     dataDir: z
       .string({ error: "dataDir must be a string" })
       .default(getDataDir())

--- a/assistant/src/config/schemas/migrations.ts
+++ b/assistant/src/config/schemas/migrations.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const MigrationsWorkerConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "migrations.worker.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Enable the async migration worker. While false, migrations that are too expensive to run inside the synchronous startup migration runner skip their work and pass, deferring until the async runner is in place.",
+      ),
+  })
+  .describe("Async migration worker configuration");
+
+export const MigrationsConfigSchema = z
+  .object({
+    worker: MigrationsWorkerConfigSchema.default(
+      MigrationsWorkerConfigSchema.parse({}),
+    ),
+  })
+  .describe("Workspace/database migration configuration");
+
+export type MigrationsWorkerConfig = z.infer<
+  typeof MigrationsWorkerConfigSchema
+>;
+export type MigrationsConfig = z.infer<typeof MigrationsConfigSchema>;

--- a/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
+++ b/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
 import { getDbPath } from "../../util/platform.js";
 import { runAsyncSqlite } from "../db-async-query.js";
@@ -124,6 +125,19 @@ function windowSql(lo: number, hi: number): string {
 export async function migrateStripThinkingFromConsolidated(
   database: DrizzleDb,
 ): Promise<void> {
+  // Gated on the async migration worker. This sweep proved too expensive for
+  // the synchronous startup migration runner — on a large `messages` table it
+  // can hold the daemon for minutes and trip the startup probe into a restart
+  // loop. While `migrations.worker.enabled` is false, skip the work and let the
+  // step pass so startup is never blocked; performing the sweep is deferred to
+  // the new async migration runner once it takes shape.
+  if (!getConfig().migrations.worker.enabled) {
+    log.info(
+      "Migration 209: skipped — migrations.worker.enabled is false; deferring the strip-thinking sweep to the async migration runner",
+    );
+    return;
+  }
+
   const raw = getSqliteFrom(database);
   const dbPath = getDbPath();
 

--- a/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
+++ b/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
@@ -1,11 +1,15 @@
+import { getConfig } from "../../config/loader.js";
 import {
   PLACEHOLDER_BLOCKS_OMITTED,
   PLACEHOLDER_EMPTY_TURN,
 } from "../../providers/placeholder-sentinels.js";
+import { getLogger } from "../../util/logger.js";
 import { getDbPath } from "../../util/platform.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("db-init");
 
 /**
  * Number of `rowid` values swept per `runAsyncSqlite` dispatch. Each window is
@@ -123,6 +127,19 @@ function windowSql(lo: number, hi: number): string {
 export async function migrateStripPlaceholderSentinelsFromMessages(
   database: DrizzleDb,
 ): Promise<void> {
+  // Gated on the async migration worker. This full-table sweep proved too
+  // expensive for the synchronous startup migration runner — on a large
+  // `messages` table it can hold the daemon's event loop and write lock for
+  // minutes. While `migrations.worker.enabled` is false, skip the work and let
+  // the step pass so startup is never blocked; performing the sweep is deferred
+  // to the new async migration runner once it takes shape.
+  if (!getConfig().migrations.worker.enabled) {
+    log.info(
+      "Migration 222: skipped — migrations.worker.enabled is false; deferring the placeholder-sentinel sweep to the async migration runner",
+    );
+    return;
+  }
+
   const raw = getSqliteFrom(database);
   const dbPath = getDbPath();
 

--- a/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
+++ b/assistant/src/memory/migrations/__tests__/209-strip-thinking-from-consolidated.test.ts
@@ -17,8 +17,17 @@ const {
   ROWID_WINDOW,
   WINDOW_TIMEOUT_MS,
 } = await import("../209-strip-thinking-from-consolidated.js");
+const { loadRawConfig, saveRawConfig } =
+  await import("../../../config/loader.js");
 
 await initializeDb();
+
+// The sweep is gated behind `migrations.worker.enabled` (default false), under
+// which it short-circuits and passes. Enable it so the migration does its work
+// for these tests.
+const rawConfig = loadRawConfig();
+rawConfig.migrations = { worker: { enabled: true } };
+saveRawConfig(rawConfig);
 
 const CONV = "conv-209";
 getSqlite()
@@ -281,6 +290,28 @@ describe("migration 209 — strip thinking from consolidated assistant messages"
     expect(blocks(first.id)).toEqual([{ type: "text", text: "first" }]);
     expect(blocks(second.id)).toEqual([{ type: "text", text: "second" }]);
     expect(watermark()).toBeNull();
+  });
+
+  test("skips the sweep and passes when migrations.worker.enabled is false", async () => {
+    const original = JSON.stringify([
+      { type: "thinking", thinking: "secret", signature: "s" },
+      { type: "text", text: "gated" },
+    ]);
+    const { id } = insert("assistant", original);
+
+    const disabled = loadRawConfig();
+    disabled.migrations = { worker: { enabled: false } };
+    saveRawConfig(disabled);
+    try {
+      // Resolves without throwing and leaves the row untouched — the work is
+      // deferred to the async migration runner.
+      await migrateStripThinkingFromConsolidated(getDb());
+      expect(content(id)).toBe(original);
+    } finally {
+      const enabled = loadRawConfig();
+      enabled.migrations = { worker: { enabled: true } };
+      saveRawConfig(enabled);
+    }
   });
 
   test("keeps the sweep window and timeout bounded so it cannot overrun a whole table", () => {

--- a/assistant/src/memory/migrations/__tests__/222-strip-placeholder-sentinels-from-messages.test.ts
+++ b/assistant/src/memory/migrations/__tests__/222-strip-placeholder-sentinels-from-messages.test.ts
@@ -20,8 +20,17 @@ const {
   ROWID_WINDOW,
   WINDOW_TIMEOUT_MS,
 } = await import("../222-strip-placeholder-sentinels-from-messages.js");
+const { loadRawConfig, saveRawConfig } =
+  await import("../../../config/loader.js");
 
 await initializeDb();
+
+// The sweep is gated behind `migrations.worker.enabled` (default false), under
+// which it short-circuits and passes. Enable it so the migration does its work
+// for these tests.
+const rawConfig = loadRawConfig();
+rawConfig.migrations = { worker: { enabled: true } };
+saveRawConfig(rawConfig);
 
 const CONV = "conv-222";
 getSqlite()
@@ -233,6 +242,28 @@ describe("migration 222 — strip placeholder sentinels from assistant messages"
 
     expect(blocks(first.id)).toEqual([{ type: "text", text: "first" }]);
     expect(blocks(second.id)).toEqual([{ type: "text", text: "second" }]);
+  });
+
+  test("skips the sweep and passes when migrations.worker.enabled is false", async () => {
+    const original = JSON.stringify([
+      { type: "text", text: PLACEHOLDER_EMPTY_TURN },
+      { type: "text", text: "gated" },
+    ]);
+    const { id } = insert("assistant", original);
+
+    const disabled = loadRawConfig();
+    disabled.migrations = { worker: { enabled: false } };
+    saveRawConfig(disabled);
+    try {
+      // Resolves without throwing and leaves the row untouched — the work is
+      // deferred to the async migration runner.
+      await migrateStripPlaceholderSentinelsFromMessages(getDb());
+      expect(content(id)).toBe(original);
+    } finally {
+      const enabled = loadRawConfig();
+      enabled.migrations = { worker: { enabled: true } };
+      saveRawConfig(enabled);
+    }
   });
 
   test("keeps the sweep window and timeout bounded so it cannot overrun a whole table", () => {


### PR DESCRIPTION
## Prompt / plan

Add a `config.json` block for `migrations.worker.enabled` (default `false`). For the two full-table `messages` rewrites that were too expensive for the synchronous migration runner, add a check so that when `migrations.worker.enabled` is `false` we skip the rest of the migration and still let the step pass — deferring the actual work to the forthcoming async migration runner.

## Changes

- **New config block** `migrations.worker.enabled` (`assistant/src/config/schemas/migrations.ts`), defaulting to `false`, wired into `AssistantConfigSchema`. Defaults flow automatically from the Zod schema, so `config.json` needs no manual entry.
- **Migration 209** (`209-strip-thinking-from-consolidated`) and **Migration 222** (`222-strip-placeholder-sentinels-from-messages`) now short-circuit at the top of `run()` when the worker is disabled: they log a skip reason and return early, leaving the step to be recorded as passed.

### Why

On a large `messages` table these JSON1 sweeps can hold the daemon's event loop and write lock for minutes, tripping the startup probe into a restart loop. Gating them keeps startup unblocked while the async migration runner takes shape; performing the sweep is deferred to that runner rather than the synchronous startup path.

## Test plan

- `bunx tsgo --noEmit` passes clean (full `tsc` errors only on a pre-existing `bun-types` resolution issue unrelated to this change).
- Importing `config/loader` from a DB migration follows existing precedent (migrations 140, 296, 306).
- ESLint/full test suite not run here — `node_modules` is not installed in this environment; CI will exercise lint and tests.

## CLI verb checklist

N/A — no new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhFM28AEhdFKh9bRpuhvVJ)_