### PR TITLE
fix(macos): clean-reinstall the CLI when a stale node_modules has no bin

### DIFF
--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -504,6 +504,41 @@ describe("ensureCliInstalled", () => {
     await p2;
   });
 
+  test("wipes a stale node_modules without a bin before reinstalling", async () => {
+    // Upgrade left a partial install: node_modules exists but the bin is gone.
+    // `bun add` would no-op against the satisfied lockfile, so the installer
+    // must clear the tree first to force a clean re-link.
+    existsSyncDefault = false;
+    const nodeModulesDir = `${latestInstallDir}/node_modules`;
+    existsSyncByPath[nodeModulesDir] = true;
+
+    const promise = ensureCliInstalled();
+
+    // The wipe happens before the spawn; the reinstall then links the bin.
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await promise;
+
+    const removedPaths = rmSyncCalls.map(([p]) => p);
+    expect(removedPaths).toContain(nodeModulesDir);
+    expect(removedPaths).toContain(`${latestInstallDir}/bun.lock`);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0][1]).toEqual(["add", "vellum@latest", "--ignore-scripts"]);
+  });
+
+  test("does not wipe when node_modules is absent (fresh install)", async () => {
+    existsSyncDefault = false;
+
+    const promise = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await promise;
+
+    // No stale tree to clear — only cleanupOldVersions may rm sibling dirs,
+    // and there are none here.
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
   test("throws when the install completes but links no bin", async () => {
     existsSyncDefault = false;
 

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -290,6 +290,22 @@ async function bunInstallCli(): Promise<void> {
   const installDir = getCliInstallDir();
   mkdirSync(installDir, { recursive: true });
 
+  // Recover from a corrupt prior install. When `node_modules` already exists
+  // but no longer exposes the `vellum` bin — e.g. a partial tree left behind
+  // by an app upgrade — `bun add` treats the lockfile as satisfied and exits
+  // 0 without relinking the bin, so every relaunch repeats the same no-op and
+  // the app stays wedged on "Failed to connect". Wipe the stale tree (and its
+  // lockfile) so the install below re-extracts every package and recreates the
+  // bin from scratch, exactly as a fresh install would.
+  const nodeModulesDir = path.join(installDir, "node_modules");
+  if (existsSync(nodeModulesDir) && !existsSync(binPathIn(installDir))) {
+    log.warn(
+      "[cli-installer] stale CLI node_modules without a vellum bin; reinstalling clean",
+    );
+    rmSync(nodeModulesDir, { recursive: true, force: true });
+    rmSync(path.join(installDir, "bun.lock"), { force: true });
+  }
+
   if (PINNED_CLI_VERSION) {
     // Pinned: prefer the seeded frozen lockfile, else resolve the exact version.
     const seeded = seedCliLockfile(installDir);


### PR DESCRIPTION
## Prompt / plan

From a user report after upgrading to 0.10.3: opening the app shows **"Failed to connect. Please try again."** and the user can no longer reach their previously-working local assistant. Diagnosed from the attached Electron logs.

### Root cause

The local-assistant connect flow (`connectLocalAssistant → acquireGatewayToken → resolveCliInvocation → ensureCliInstalled`) throws:

```
CLI install reported success but no vellum binary was found at
~/Library/Application Support/@vellumai/macos/cli/latest/node_modules/.bin/vellum
```

The published `vellum` meta-package exposes its bin through a symlink (`.bin/vellum -> ../@vellumai/cli/src/index.ts`), and `isCliInstalled()` checks it with `existsSync`, which follows the link. A **fresh** install links the bin correctly (verified with the bundled bun 1.3.11). But an **upgrade** that leaves `cli/latest`'s `node_modules` in a partial state makes `bun add vellum@<tag>` treat the lockfile as already satisfied — it exits `0` *without* relinking the bin.

The app had no escalation from this state: `ensureCliInstalled` threw and cleared its install lock, so the next relaunch re-ran the **identical no-op `bun add`** into the same poisoned directory and stayed wedged. The user's logs show the same error repeating across multiple days, which is exactly this loop.

### Fix

In `bunInstallCli`, detect the precise corrupt state — `node_modules` present but the `vellum` bin missing — and wipe the stale tree and its lockfile before installing. This forces bun to re-extract every package and recreate the bin from scratch, just as a clean install does. The loud post-install `existsSync` guard is kept as a final backstop. The happy path (bin already linked) is untouched, so the fast cached install is unchanged.

## Test plan

- `bun test src/main/cli-installer.test.ts` — 43 pass (added 2 regression tests: wipes a stale `node_modules` without a bin before reinstalling; does *not* wipe on a fresh install).
- `bunx tsc --noEmit` in `clients/macos` — clean.
- Adjacent flow tests (`cli-path-flow`, `bundle-flow`, `local-mode`) pass individually.
- Reproduced empirically with the bundled bun 1.3.11: a fresh install links `.bin/vellum`; a stale `node_modules` whose lockfile is satisfied makes `bun add` a no-op that leaves the bin missing; wiping `node_modules` + lockfile and reinstalling restores the bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9dG9Lykc8inwiRmRgdPAb)_