### PR TITLE
refactor(daemon): inline shutdown cleanup steps instead of injecting cleanupPidFile

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -38,10 +38,7 @@ import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
-import {
-  startGatewayFlagListener,
-  stopGatewayFlagListener,
-} from "../ipc/gateway-flag-listener.js";
+import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import {
   getAttachmentsByIds,
@@ -112,11 +109,7 @@ import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-t
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
-import {
-  cleanupPidFile,
-  cleanupPidFileIfOwner,
-  writePid,
-} from "./daemon-control.js";
+import { cleanupPidFileIfOwner, writePid } from "./daemon-control.js";
 import {
   evaluateDiskPressureNow,
   startDiskPressureGuard,
@@ -1440,13 +1433,6 @@ export async function runDaemon(): Promise<void> {
       getQdrantManager: () => bgRefs.qdrantManager,
       mcpManager,
       telemetryReporter,
-      cleanupPidFile: () => {
-        stopGatewayFlagListener();
-        stopDiskPressureGuardForLifecycle();
-        stopOrphanReaper();
-        stopEventLoopWatchdog();
-        cleanupPidFile();
-      },
     });
 
     log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 
 import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import type { McpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
@@ -12,10 +13,27 @@ import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
 import { getEnrichmentService } from "../workspace/commit-message-enrichment-service.js";
 import type { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
+import { cleanupPidFile } from "./daemon-control.js";
+import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
+import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
+import { stopOrphanReaper } from "./orphan-reaper.js";
 import type { DaemonServer } from "./server.js";
 import { runShutdownHooks } from "./shutdown-registry.js";
 
 const log = getLogger("lifecycle");
+
+/**
+ * Stop the daemon's background services and remove the PID file. Invoked on
+ * both the graceful-shutdown and force-exit-timeout paths so the process never
+ * leaves a stale PID file or orphaned timers behind.
+ */
+function stopBackgroundServicesAndCleanupPidFile(): void {
+  stopGatewayFlagListener();
+  stopDiskPressureGuardForLifecycle();
+  stopOrphanReaper();
+  stopEventLoopWatchdog();
+  cleanupPidFile();
+}
 
 export interface ShutdownDeps {
   server: DaemonServer;
@@ -28,7 +46,6 @@ export interface ShutdownDeps {
   getQdrantManager: () => QdrantManager | null;
   mcpManager: McpServerManager | null;
   telemetryReporter: { stop(): Promise<void> } | null;
-  cleanupPidFile: () => void;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -51,7 +68,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     // bump only changes behavior for the stuck-shutdown path.
     const forceTimer = setTimeout(() => {
       log.warn("Graceful shutdown timed out, forcing exit");
-      deps.cleanupPidFile();
+      stopBackgroundServicesAndCleanupPidFile();
       process.exit(1);
     }, 20_000);
     forceTimer.unref();
@@ -171,7 +188,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     await Sentry.flush(2000);
     clearTimeout(forceTimer);
-    deps.cleanupPidFile();
+    stopBackgroundServicesAndCleanupPidFile();
     process.exit(exitCode);
   };
 


### PR DESCRIPTION
## Prompt / plan

> `installShutdownHandlers` doesn't need the `cleanupPidFile` — all five methods it calls can be imported directly into the method that invokes it.

`installShutdownHandlers` took a `cleanupPidFile` closure dependency, but that closure was just a bundle of five module-level teardown calls wired up in `lifecycle.ts`:

```ts
cleanupPidFile: () => {
  stopGatewayFlagListener();
  stopDiskPressureGuardForLifecycle();
  stopOrphanReaper();
  stopEventLoopWatchdog();
  cleanupPidFile();
},
```

All five are plain exported functions, so there's no reason to thread them through `ShutdownDeps`. This PR:

- Imports the five functions directly into `shutdown-handlers.ts` and runs them from a local `stopBackgroundServicesAndCleanupPidFile()` helper.
- Calls that helper from both shutdown paths (graceful exit and the force-exit timeout), matching the prior behavior.
- Drops the `cleanupPidFile` field from the `ShutdownDeps` interface and removes the closure (and now-unused imports) from `lifecycle.ts`.

No behavioral change — the same five steps run in the same order on shutdown. `stopDiskPressureGuardForLifecycle` stays defined in `lifecycle.ts` (its dedicated test mocks the underlying disk-pressure-guard primitives while exercising the real wrapper), so it's imported from there.

## Test plan

- `bun run lint` — clean on both changed files.
- `bun run typecheck` — no errors in the changed files (pre-commit scoped type check passed).
- `bun test src/__tests__/disk-pressure-lifecycle.test.ts` — 4 pass / 0 fail.
- Smoke-loaded `shutdown-handlers.ts` to confirm the module graph resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_