### PR TITLE
fix(daemon): revert in-memory processing flag when its DB write fails

### DIFF
--- a/assistant/src/__tests__/processing-flag-persist-failure.test.ts
+++ b/assistant/src/__tests__/processing-flag-persist-failure.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Regression: `Conversation.setProcessing(value)` flips the in-memory flag and
+ * then persists it to the `processing_started_at` column. If that DB write
+ * throws (e.g. SQLITE_BUSY under contention), the in-memory flag must not be
+ * left stranded out of sync with the column — it reverts to its prior value
+ * and the error re-throws so callers' existing failure handling still runs.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent } from "../agent/loop.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Persistence mock — `setConversationProcessingStartedAt` throws on demand so
+// the test can simulate a locked SQLite write.
+// ---------------------------------------------------------------------------
+
+let persistShouldThrow = false;
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    llm: {
+      default: {
+        provider: "mock-provider",
+        model: "mock-model",
+        maxTokens: 4096,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: false, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 100000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    memory: { enabled: false },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {
+    if (persistShouldThrow) {
+      throw new Error("database is locked (SQLITE_BUSY)");
+    }
+  },
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationHistoryStrippedAt: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => [],
+  getConversation: () => ({
+    id: "conv-1",
+    createdAt: Date.parse("2026-03-19T12:00:00.000Z"),
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  addMessage: () => ({ id: "msg-1" }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
+  deleteLastExchange: () => 0,
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../memory/conversation-queries.js", () => ({
+  isLastUserMessageToolResult: () => false,
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  uploadAttachment: () => ({ id: "att-1" }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => null,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+mock.module("../memory/query-builder.js", () => ({
+  buildMemoryQuery: () => "",
+}));
+
+mock.module("../memory/retrieval-budget.js", () => ({
+  computeRecallBudget: () => 0,
+}));
+
+mock.module("../runtime/sync/sync-publisher.js", () => ({
+  publishSyncInvalidation: () => {},
+}));
+
+mock.module("../daemon/message-types/sync.js", () => ({
+  conversationMetadataSyncTag: (id: string) => `conversation-metadata:${id}`,
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../memory/llm-usage-store.js", () => ({
+  recordUsageEvent: () => ({ id: "usage-1", createdAt: Date.now() }),
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: () => null,
+  updateApp: () => {},
+}));
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<Message[]> {
+      return options.messages;
+    }
+  },
+}));
+
+import { Conversation } from "../daemon/conversation.js";
+
+function makeConversation(): Conversation {
+  const provider = {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return new Conversation(
+    "conv-1",
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+}
+
+describe("Conversation.setProcessing persistence failure", () => {
+  let conversation: Conversation;
+
+  beforeEach(() => {
+    persistShouldThrow = false;
+    conversation = makeConversation();
+  });
+
+  test("reverts the in-memory flag and re-throws when the DB write fails", () => {
+    expect(conversation.isProcessing()).toBe(false);
+
+    persistShouldThrow = true;
+    expect(() => conversation.setProcessing(true)).toThrow(
+      "database is locked",
+    );
+
+    // The persisted column never landed, so the in-memory flag must not be
+    // stranded at `true`.
+    expect(conversation.isProcessing()).toBe(false);
+  });
+
+  test("restores the prior value when clearing fails mid-turn", () => {
+    conversation.setProcessing(true);
+    expect(conversation.isProcessing()).toBe(true);
+
+    persistShouldThrow = true;
+    expect(() => conversation.setProcessing(false)).toThrow(
+      "database is locked",
+    );
+
+    // Clear didn't persist, so the flag stays consistent with the column.
+    expect(conversation.isProcessing()).toBe(true);
+  });
+
+  test("commits the flag when the DB write succeeds", () => {
+    conversation.setProcessing(true);
+    expect(conversation.isProcessing()).toBe(true);
+
+    conversation.setProcessing(false);
+    expect(conversation.isProcessing()).toBe(false);
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1352,11 +1352,20 @@ export class Conversation {
     this._processing = value;
     // Persist the cross-process source of truth so out-of-process callers
     // (retrospective CLI, future detached workers) can detect mid-turn state
-    // by reading the conversations row directly.
-    setConversationProcessingStartedAt(
-      this.conversationId,
-      value ? Date.now() : null,
-    );
+    // by reading the conversations row directly. If the write fails (e.g.
+    // SQLITE_BUSY), the persisted column keeps its prior value, so revert the
+    // in-memory flag to match rather than stranding `processing = true` in
+    // memory against a NULL column. Re-throw so callers' existing failure
+    // handling still runs.
+    try {
+      setConversationProcessingStartedAt(
+        this.conversationId,
+        value ? Date.now() : null,
+      );
+    } catch (err) {
+      this._processing = wasProcessing;
+      throw err;
+    }
     if (wasProcessing && !value) {
       void publishSyncInvalidation([
         conversationMetadataSyncTag(this.conversationId),


### PR DESCRIPTION
## Prompt / plan

`handleSendMessage → persistUserMessage → setProcessing(true)` flips the in-memory `processing` flag to `true`, then persists it via `setConversationProcessingStartedAt`. When that write throws `SQLiteError: database is locked (SQLITE_BUSY)` (observed 236× in one day), the throw left the conversation with in-memory `processing = true` but `processing_started_at` still `NULL` — the write never landed. The conversation then looked permanently busy and rejected/queued every subsequent send.

The request: make the in-memory flag set processing back to its prior value if the SQLite write fails.

### Change

`Conversation.setProcessing(value)` (`assistant/src/daemon/conversation.ts`) flipped `_processing` and *then* wrote the column. Now the persistence call is wrapped: if the write throws, the in-memory flag reverts to its prior value — keeping it consistent with the column that never changed — and the error re-throws so callers' existing failure handling (`persistUserMessage`'s catch, `agent-wake`'s try/catch around the clear) still runs unchanged.

The fix lives in `setProcessing` itself so it covers every caller (user sends, wakes, analysis, voice) rather than just the one call site in the report. On the clear path (`setProcessing(false)`), a failed write likewise leaves the flag at `true`, matching the still-populated column, and the sync invalidation is no longer published for a clear that didn't persist.

## Test plan

- New regression test `assistant/src/__tests__/processing-flag-persist-failure.test.ts` drives a real `Conversation` against a persistence layer that throws on demand:
  - `setProcessing(true)` with a failing write re-throws and leaves `isProcessing()` `false`.
  - `setProcessing(false)` with a failing write re-throws and leaves `isProcessing()` `true`.
  - Successful writes commit the flag in both directions.
- `bun test src/runtime/__tests__/agent-wake.test.ts src/__tests__/cancel-clears-processing.test.ts` → 64 pass, 0 fail (existing processing-flag behavior unchanged).
- `bun run typecheck:fast` clean; pre-commit lint/format/secret hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2fM3xTBmoPoDCZ58SKd9y)_