### PR TITLE
fix(memory): share busy_timeout between daemon and runAsyncSqlite connections

### DIFF
--- a/assistant/src/memory/__tests__/db-busy-timeout.test.ts
+++ b/assistant/src/memory/__tests__/db-busy-timeout.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Locks in that every assistant SQLite connection shares one busy_timeout.
+ *
+ * `runAsyncSqlite` can open an out-of-process (sqlite3 CLI) or transient
+ * in-process connection that writes the same database file as the live
+ * daemon connection. If those connections don't wait the same amount of
+ * time for a lock, a concurrent writer fails immediately with SQLITE_BUSY
+ * instead of waiting its turn. The shared `SQLITE_BUSY_TIMEOUT_MS` constant
+ * is the single source of truth; this test guards against the live daemon
+ * connection drifting away from it.
+ */
+import { expect, test } from "bun:test";
+
+const { getSqlite, SQLITE_BUSY_TIMEOUT_MS } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+
+await initializeDb();
+
+test("the daemon connection runs with the shared busy_timeout", () => {
+  const sqlite = getSqlite();
+  const value = (
+    sqlite.query("PRAGMA busy_timeout").get() as { timeout: number }
+  ).timeout;
+  expect(value).toBe(SQLITE_BUSY_TIMEOUT_MS);
+});

--- a/assistant/src/memory/db-async-query.ts
+++ b/assistant/src/memory/db-async-query.ts
@@ -31,7 +31,7 @@ import { Database } from "bun:sqlite";
 import { getLogger } from "../util/logger.js";
 import { getDbPath } from "../util/platform.js";
 import { findSqlite3 } from "../util/sqlite3-runtime.js";
-import { getSqlite } from "./db-connection.js";
+import { getSqlite, SQLITE_BUSY_TIMEOUT_MS } from "./db-connection.js";
 
 const log = getLogger("db-async-query");
 
@@ -172,8 +172,14 @@ async function runViaCli(
     stderr: "pipe",
   });
 
+  // Match the busy_timeout the daemon connection uses so this subprocess
+  // waits for — rather than instantly failing against — a lock held by the
+  // still-running in-process connection (and vice versa). Prepended to the
+  // piped SQL so it takes effect before the statement runs.
+  const sqlWithPragma = `PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS};\n${sql}`;
+
   // Write the SQL and close stdin so sqlite3 sees EOF and exits.
-  proc.stdin.write(sql + "\n");
+  proc.stdin.write(sqlWithPragma + "\n");
   await proc.stdin.end();
 
   // Begin draining the streams immediately so the subprocess never
@@ -253,6 +259,11 @@ async function runInProcessBlocking(
     let sqlite: Database;
     if (usesDedicatedFile) {
       transient = new Database(options.dbPath ?? getDbPath());
+      // Match the daemon connection's busy_timeout so this transient
+      // connection waits for a lock held by another writer rather than
+      // failing immediately with SQLITE_BUSY. (The daemon connection reused
+      // in the else branch already has it set via applyConnectionPragmas.)
+      transient.exec(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`);
       for (const a of options.attach ?? []) {
         transient.exec(
           `ATTACH DATABASE '${a.path.replace(/'/g, "''")}' AS ${a.alias}`,

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -78,6 +78,16 @@ export function assertTestDbIsIsolated(): void {
 }
 
 /**
+ * How long a SQLite connection waits to acquire a lock held by another
+ * writer before giving up with `SQLITE_BUSY`. Every connection that touches
+ * an assistant database — the main/dedicated daemon connections here and the
+ * out-of-process / transient connections in `db-async-query.ts` — must set
+ * the same value, so a writer that grabs the lock can finish without a
+ * concurrent writer failing immediately instead of waiting its turn.
+ */
+export const SQLITE_BUSY_TIMEOUT_MS = 5000;
+
+/**
  * Apply the connection-wide PRAGMAs every assistant SQLite connection runs
  * with. These are per-connection settings, so the dedicated logs/memory
  * connections set them independently of the main connection.
@@ -85,7 +95,7 @@ export function assertTestDbIsIsolated(): void {
 function applyConnectionPragmas(sqlite: Database): void {
   sqlite.exec("PRAGMA journal_mode=WAL");
   sqlite.exec("PRAGMA synchronous=FULL");
-  sqlite.exec("PRAGMA busy_timeout=5000");
+  sqlite.exec(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`);
   sqlite.exec("PRAGMA foreign_keys = ON");
   sqlite.exec("PRAGMA cache_size=-256000");
   sqlite.exec("PRAGMA temp_store=MEMORY");


### PR DESCRIPTION
## Prompt / plan

> runAsyncSqlite can lock the db for other writers. We should use the same busy timeout that we do in the main thread, and likely set it to a constant to be reused in both places.

`runAsyncSqlite` opens its own SQLite connection — either a `sqlite3` CLI subprocess or a transient in-process `bun:sqlite` handle — that writes the same database files as the live daemon connection. Neither of those connections set `busy_timeout`, while the daemon connection runs `PRAGMA busy_timeout=5000` via `applyConnectionPragmas`. The result: when one of these connections races the other for a write lock, it fails immediately with `SQLITE_BUSY` instead of waiting its turn.

Changes:
- Extract the daemon's `5000` ms busy timeout into a shared `SQLITE_BUSY_TIMEOUT_MS` constant in `db-connection.ts`, used by `applyConnectionPragmas`.
- Apply the same timeout in both `runAsyncSqlite` backends:
  - **sqlite3 CLI**: prepend `PRAGMA busy_timeout=<N>;` to the SQL piped into the subprocess so it takes effect before the statement runs.
  - **in-process transient connection**: set the pragma right after opening the transient `Database` (the reused daemon connection in the other branch already has it).

Scope is the two places the task calls out — the main daemon connection and `runAsyncSqlite`. The offline `db repair` CLI command and the separate `gateway` package each open their own connections and are outside this concurrent-writer path, so they're left unchanged.

## Test plan

- New `db-busy-timeout.test.ts` asserts the live daemon connection reports `PRAGMA busy_timeout` equal to `SQLITE_BUSY_TIMEOUT_MS`, guarding against drift between the constant and the actual connection.
- Existing `db-async-query.test.ts` continues to pass (the `sqlite3-cli` cases are skipped on hosts without the binary; the in-process path is exercised).
- Pre-commit format, lint, and type-check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQzPqqjo2hdpRHx7JAWm1E)_