### PR TITLE
Render server-queued messages with queued UI on the active-send path

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -415,6 +415,36 @@ export function useSendMessage({
       });
 
       if (postResult.queued) {
+        // The client believed the conversation was idle (so it took the
+        // active-send path), but the assistant was still processing and
+        // queued this message instead. Reflect the queued state on the
+        // optimistic row so it renders with queued affordances rather than
+        // as a normal in-flight send: tag it `queueStatus: "queued"`, track
+        // it in the pending-queue FIFO so the `message_queued` SSE event can
+        // assign its real position, and register the request id eagerly so
+        // steer/cancel work before the event arrives. Mirrors the
+        // willQueue path in `sendMessage`.
+        if (clientMessageId) {
+          useChatSessionStore
+            .getState()
+            .pushPendingQueuedMessageId(clientMessageId);
+          setLiveTurn((prev) =>
+            prev.map((m) =>
+              m.id === clientMessageId
+                ? {
+                    ...m,
+                    queueStatus: "queued" as const,
+                    queuePosition: m.queuePosition ?? 0,
+                  }
+                : m,
+            ),
+          );
+          if (postResult.requestId) {
+            useChatSessionStore
+              .getState()
+              .setRequestIdMapping(postResult.requestId, clientMessageId);
+          }
+        }
         return {
           status: "ok",
           resolvedConversationId: postResult.conversationId,


### PR DESCRIPTION
## Why

When a user sends a message and `POST /messages` returns `queued: true`, the web UI was rendering it as a normal **un**queued, in-flight message — no queued affordance, no entry in the queued-messages drawer.

This happens on the **active-send path**: the client decides whether to queue locally via `isSending(turnPhase)`. There's a race — the client can believe the conversation is idle while the assistant is actually still processing (e.g. the SSE terminal event reached the client before the server cleared `isProcessing()`, or another channel/client started a turn this client wasn't tracking). In that case the client takes the active-send path, but the daemon enqueues the message and responds `{ queued: true, requestId }`.

`sendMessageViaStream` handled this by simply returning `ok`, so the optimistic row built without `queueStatus` stayed in the transcript looking like a live send.

## What changed

`clients/web/src/domains/chat/hooks/use-send-message.ts` — in the `postResult.queued` branch, reflect the queued state on the optimistic row, mirroring the existing `willQueue` path in `sendMessage`:

- Tag the optimistic row `queueStatus: "queued"` (which routes it out of the transcript and into the `QueuedMessagesDrawer` via `build-items.ts` / `useMessageQueue`).
- Push its id into the pending-queue FIFO so the `message_queued` SSE event can assign its real position.
- Register the `requestId → messageId` mapping eagerly so steer/cancel work before the SSE event arrives.

The message then follows the normal queued lifecycle (`message_queued` → `message_dequeued` → process) already wired through the turn store and SSE handlers.

## Testing

- `bunx tsc --noEmit` (web) — clean
- `bun test` on `queue-handlers.test.ts` and `stream-updaters.test.ts` — 82 pass
- Lint — only pre-existing `exhaustive-deps` warnings, no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APJVofSTBMd9JU7iE1GaBY)_