### PR TITLE
feat(runtime): surface in-memory queued user messages in GET /messages

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17577,8 +17577,13 @@ paths:
                             - channelId
                             - channelTs
                           additionalProperties: false
-                        queued:
-                          type: boolean
+                        queueStatus:
+                          type: string
+                          enum:
+                            - queued
+                            - processing
+                        queuePosition:
+                          type: number
                       required:
                         - id
                         - role

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17577,6 +17577,8 @@ paths:
                             - channelId
                             - channelTs
                           additionalProperties: false
+                        queued:
+                          type: boolean
                       required:
                         - id
                         - role

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -3,9 +3,10 @@
  *
  * Messages enqueued while the agent is mid-turn live only in the live
  * conversation's in-memory queue until the queue drains and persists them.
- * The messages snapshot appends them (flagged `queued: true`) to the newest
- * page so a cold reload restores the queued rows that the `message_queued`
- * SSE events would otherwise be the only source of.
+ * The messages snapshot appends them (carrying `queueStatus: "queued"` and a
+ * 1-based `queuePosition`, mirroring the client `DisplayMessage` shape) to the
+ * newest page so a cold reload restores the queued rows that the
+ * `message_queued` SSE events would otherwise be the only source of.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -52,7 +53,8 @@ interface MessagePayload {
   role: string;
   content?: string;
   clientMessageId?: string;
-  queued?: boolean;
+  queueStatus?: "queued" | "processing";
+  queuePosition?: number;
   attachments?: Array<{ id: string; filename: string; kind: string }>;
 }
 
@@ -84,8 +86,8 @@ function makeQueued(overrides: Partial<QueuedMessage>): QueuedMessage {
 describe("handleListMessages in-memory queue", () => {
   beforeEach(resetTables);
 
-  test("appends queued messages flagged queued:true after persisted history", async () => {
-    // GIVEN a persisted user turn and a message still waiting in the queue
+  test("appends queued rows in FIFO order with 1-based queuePosition", async () => {
+    // GIVEN a persisted user turn and two messages still waiting in the queue
     const conv = createConversation();
     await addMessage(
       conv.id,
@@ -95,10 +97,11 @@ describe("handleListMessages in-memory queue", () => {
     );
     registerLiveConversation(conv.id, [
       makeQueued({
-        requestId: "req-queued",
+        requestId: "req-queued-1",
         content: "please also do this",
         clientMessageId: "nonce-queued",
       }),
+      makeQueued({ requestId: "req-queued-2", content: "and then this" }),
     ]);
 
     // WHEN the messages snapshot is built for the newest page
@@ -107,16 +110,23 @@ describe("handleListMessages in-memory queue", () => {
     });
     const body = response as { messages: MessagePayload[] };
 
-    // THEN the queued message is appended after the persisted row, flagged and
-    // keyed by its requestId for the delete/steer endpoints
-    expect(body.messages).toHaveLength(2);
-    expect(body.messages[0].queued).toBeUndefined();
-    const queuedRow = body.messages[1];
-    expect(queuedRow.queued).toBe(true);
-    expect(queuedRow.role).toBe("user");
-    expect(queuedRow.id).toBe("req-queued");
-    expect(queuedRow.content).toBe("please also do this");
-    expect(queuedRow.clientMessageId).toBe("nonce-queued");
+    // THEN the queued messages are appended after the persisted row, carrying
+    // queue state and keyed by their requestId for the delete/steer endpoints
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[0].queueStatus).toBeUndefined();
+
+    const first = body.messages[1];
+    expect(first.queueStatus).toBe("queued");
+    expect(first.queuePosition).toBe(1);
+    expect(first.role).toBe("user");
+    expect(first.id).toBe("req-queued-1");
+    expect(first.content).toBe("please also do this");
+    expect(first.clientMessageId).toBe("nonce-queued");
+
+    const second = body.messages[2];
+    expect(second.queueStatus).toBe("queued");
+    expect(second.queuePosition).toBe(2);
+    expect(second.id).toBe("req-queued-2");
   });
 
   test("prefers displayContent over the model-facing content", async () => {
@@ -186,7 +196,7 @@ describe("handleListMessages in-memory queue", () => {
     const body = response as { messages: MessagePayload[] };
 
     // THEN the queued message is not mixed into the older page
-    expect(body.messages.every((m) => m.queued !== true)).toBe(true);
+    expect(body.messages.every((m) => m.queueStatus == null)).toBe(true);
   });
 
   test("returns only persisted rows when the conversation is not live", async () => {
@@ -205,6 +215,6 @@ describe("handleListMessages in-memory queue", () => {
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
-    expect(body.messages[0].queued).toBeUndefined();
+    expect(body.messages[0].queueStatus).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for handleListMessages surfacing the in-memory message queue.
+ *
+ * Messages enqueued while the agent is mid-turn live only in the live
+ * conversation's in-memory queue until the queue drains and persists them.
+ * The messages snapshot appends them (flagged `queued: true`) to the newest
+ * page so a cold reload restores the queued rows that the `message_queued`
+ * SSE events would otherwise be the only source of.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import type { Conversation } from "../daemon/conversation.js";
+import type { QueuedMessage } from "../daemon/conversation-queue-manager.js";
+import {
+  clearConversations,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  clearConversations();
+}
+
+interface MessagePayload {
+  id: string;
+  role: string;
+  content?: string;
+  clientMessageId?: string;
+  queued?: boolean;
+  attachments?: Array<{ id: string; filename: string; kind: string }>;
+}
+
+/** Register a live conversation whose in-memory queue holds `queued`. */
+function registerLiveConversation(
+  conversationId: string,
+  queued: QueuedMessage[],
+): void {
+  const stub = {
+    snapshotQueuedMessages: () => queued,
+    // A conversation only holds a queue while it is mid-turn; mirror that so
+    // `isConversationProcessing` (which prefers the live instance) reports busy.
+    isProcessing: () => true,
+  } as unknown as Conversation;
+  setConversation(conversationId, stub);
+}
+
+function makeQueued(overrides: Partial<QueuedMessage>): QueuedMessage {
+  return {
+    content: "queued body",
+    attachments: [],
+    requestId: "req-1",
+    onEvent: () => {},
+    sentAt: 1_700_000_000_000,
+    ...overrides,
+  } as QueuedMessage;
+}
+
+describe("handleListMessages in-memory queue", () => {
+  beforeEach(resetTables);
+
+  test("appends queued messages flagged queued:true after persisted history", async () => {
+    // GIVEN a persisted user turn and a message still waiting in the queue
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "first" }]),
+      { skipIndexing: true },
+    );
+    registerLiveConversation(conv.id, [
+      makeQueued({
+        requestId: "req-queued",
+        content: "please also do this",
+        clientMessageId: "nonce-queued",
+      }),
+    ]);
+
+    // WHEN the messages snapshot is built for the newest page
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    // THEN the queued message is appended after the persisted row, flagged and
+    // keyed by its requestId for the delete/steer endpoints
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].queued).toBeUndefined();
+    const queuedRow = body.messages[1];
+    expect(queuedRow.queued).toBe(true);
+    expect(queuedRow.role).toBe("user");
+    expect(queuedRow.id).toBe("req-queued");
+    expect(queuedRow.content).toBe("please also do this");
+    expect(queuedRow.clientMessageId).toBe("nonce-queued");
+  });
+
+  test("prefers displayContent over the model-facing content", async () => {
+    const conv = createConversation();
+    registerLiveConversation(conv.id, [
+      makeQueued({
+        requestId: "req-display",
+        content: "stripped recording intent",
+        displayContent: "what the user actually typed",
+      }),
+    ]);
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].content).toBe("what the user actually typed");
+  });
+
+  test("renders queued attachments with a derived kind", async () => {
+    const conv = createConversation();
+    registerLiveConversation(conv.id, [
+      makeQueued({
+        requestId: "req-att",
+        content: "see attached",
+        attachments: [
+          {
+            filename: "diagram.png",
+            mimeType: "image/png",
+            data: "AAAA",
+          },
+        ],
+      }),
+    ]);
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    const att = body.messages[0].attachments?.[0];
+    expect(att?.filename).toBe("diagram.png");
+    expect(att?.kind).toBe("image");
+    expect(att?.id).toBe("req-att:attachment:0");
+  });
+
+  test("does not append queued messages to an older-history page", async () => {
+    // GIVEN history requested with beforeTimestamp (older page)
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "old" }]),
+      { skipIndexing: true },
+    );
+    registerLiveConversation(conv.id, [makeQueued({ requestId: "req-old" })]);
+
+    // WHEN paging older history
+    const response = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        beforeTimestamp: String(Date.now() + 1_000),
+      },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    // THEN the queued message is not mixed into the older page
+    expect(body.messages.every((m) => m.queued !== true)).toBe(true);
+  });
+
+  test("returns only persisted rows when the conversation is not live", async () => {
+    // GIVEN a conversation with no live in-memory instance (cold / aged out)
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "only persisted" }]),
+      { skipIndexing: true },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].queued).toBeUndefined();
+  });
+});

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -522,5 +522,15 @@ export const ConversationMessageSchema = z.object({
   contentBlocks: z.array(ConversationContentBlockSchema).optional(),
   subagentNotification: ConversationSubagentNotificationSchema.optional(),
   slackMessage: ConversationSlackMessageSchema.optional(),
+  /**
+   * True for a user message that is still waiting in the daemon's in-memory
+   * queue (enqueued while the agent was mid-turn, not yet drained or persisted
+   * to the database). Derived at render time from the live conversation's
+   * queue, so it appears only while the message is genuinely pending and lets a
+   * cold reload restore the queued rows the live `message_queued` SSE events
+   * would otherwise be the only source of. Absent (rather than `false`) for
+   * already-persisted rows.
+   */
+  queued: z.boolean().optional(),
 });
 export type ConversationMessage = z.infer<typeof ConversationMessageSchema>;

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -523,14 +523,17 @@ export const ConversationMessageSchema = z.object({
   subagentNotification: ConversationSubagentNotificationSchema.optional(),
   slackMessage: ConversationSlackMessageSchema.optional(),
   /**
-   * True for a user message that is still waiting in the daemon's in-memory
-   * queue (enqueued while the agent was mid-turn, not yet drained or persisted
-   * to the database). Derived at render time from the live conversation's
-   * queue, so it appears only while the message is genuinely pending and lets a
-   * cold reload restore the queued rows the live `message_queued` SSE events
-   * would otherwise be the only source of. Absent (rather than `false`) for
-   * already-persisted rows.
+   * Queue state for a user message that is still waiting in the daemon's
+   * in-memory queue (enqueued while the agent was mid-turn, not yet drained or
+   * persisted to the database). Derived at render time from the live
+   * conversation's queue, so it is present only while the message is genuinely
+   * pending and lets a cold reload restore the queued rows the live
+   * `message_queued` SSE events would otherwise be the only source of. Absent
+   * on already-persisted rows. Mirrors the client `DisplayMessage` fields so
+   * the wire and display shapes converge.
    */
-  queued: z.boolean().optional(),
+  queueStatus: z.enum(["queued", "processing"]).optional(),
+  /** 1-based position in the queue, mirroring the `message_queued` SSE event. */
+  queuePosition: z.number().optional(),
 });
 export type ConversationMessage = z.infer<typeof ConversationMessageSchema>;

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -130,6 +130,12 @@ export class MessageQueue {
     return this.items[index];
   }
 
+  /** FIFO snapshot of the queued messages. The array is a copy; the items are
+   * the live references (callers must treat them as read-only). */
+  snapshot(): QueuedMessage[] {
+    return [...this.items];
+  }
+
   /**
    * Pop up to `count` messages FIFO and return them in order.
    * Decrements the byte budget for each popped item using the same

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -129,7 +129,10 @@ import {
   drainQueue as drainQueueImpl,
   processMessage as processMessageImpl,
 } from "./conversation-process.js";
-import type { QueueDrainReason } from "./conversation-queue-manager.js";
+import type {
+  QueuedMessage,
+  QueueDrainReason,
+} from "./conversation-queue-manager.js";
 import { MessageQueue } from "./conversation-queue-manager.js";
 import {
   type ChannelCapabilities,
@@ -1464,6 +1467,12 @@ export class Conversation {
 
   hasQueuedMessages(): boolean {
     return !this.queue.isEmpty;
+  }
+
+  /** FIFO snapshot of the messages currently waiting in the in-memory queue.
+   * Read-only — used to surface queued user messages in history responses. */
+  snapshotQueuedMessages(): QueuedMessage[] {
+    return this.queue.snapshot();
   }
 
   removeQueuedMessage(requestId: string): boolean {

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -37,7 +37,7 @@ export interface StoredAttachment {
   createdAt: number;
 }
 
-function classifyKind(mimeType: string): string {
+export function classifyKind(mimeType: string): string {
   if (mimeType.startsWith("image/")) return "image";
   if (mimeType.startsWith("video/")) return "video";
   return "document";

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -38,6 +38,7 @@ import {
   formatCompactResult,
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
+import { findConversation } from "../../daemon/conversation-registry.js";
 import {
   buildSlashContextForContent,
   resolveSlash,
@@ -76,6 +77,7 @@ import {
 } from "../../home/relationship-state-writer.js";
 import { ipcCall } from "../../ipc/gateway-client.js";
 import {
+  classifyKind,
   getAttachmentById,
   getAttachmentMetadataForMessage,
   getAttachmentsByIds,
@@ -603,6 +605,63 @@ async function tryConsumeCanonicalGuardianReply(params: {
   return { consumed: true, messageId };
 }
 
+/**
+ * Render the live conversation's in-memory message queue into history rows.
+ *
+ * Messages enqueued while the agent is mid-turn live only in memory until the
+ * queue drains and persists them, so they never reach the DB-sourced history
+ * list. The live path surfaces them via `message_queued` SSE events; a cold
+ * reload (no event replay) would otherwise drop them. Each queued row is
+ * flagged `queued: true` and ordered FIFO so it appends to the newest page in
+ * send order, mirroring how the agent will drain them.
+ *
+ * Returns an empty array when the conversation is not live in memory (cold, or
+ * aged out of the registry) — there is no queue to read in that case.
+ */
+function buildQueuedMessagePayloads(
+  conversationId: string,
+): RuntimeMessagePayload[] {
+  const conversation = findConversation(conversationId);
+  if (!conversation) return [];
+
+  return conversation.snapshotQueuedMessages().map((item) => {
+    const text = item.displayContent ?? item.content;
+    const attachments: RuntimeAttachmentMetadata[] = item.attachments.map(
+      (a, idx) => ({
+        id: a.id ?? `${item.requestId}:attachment:${idx}`,
+        filename: a.filename,
+        mimeType: a.mimeType,
+        sizeBytes:
+          a.sizeBytes ?? (a.data ? Math.floor((a.data.length * 3) / 4) : 0),
+        kind: classifyKind(a.mimeType),
+        ...(a.mimeType.startsWith("image/") && a.data ? { data: a.data } : {}),
+        ...(a.thumbnailData ? { thumbnailData: a.thumbnailData } : {}),
+      }),
+    );
+
+    const contentBlocks: ConversationContentBlock[] = [];
+    if (text.length > 0) contentBlocks.push({ type: "text", text });
+    for (const attachment of attachments) {
+      contentBlocks.push({ type: "attachment", attachment });
+    }
+
+    return {
+      // The queued message has no DB row yet; its requestId is the stable
+      // identifier the queued-message delete/steer endpoints key on.
+      id: item.requestId,
+      role: "user" as const,
+      content: text,
+      timestamp: new Date(item.sentAt).toISOString(),
+      attachments,
+      ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
+      ...(item.clientMessageId
+        ? { clientMessageId: item.clientMessageId }
+        : {}),
+      queued: true,
+    };
+  });
+}
+
 export function handleListMessages({
   queryParams,
 }: RouteHandlerArgs): Record<string, unknown> {
@@ -1023,6 +1082,15 @@ export function handleListMessages({
   // turn that silently died — without it, a dropped SSE stream leaves the
   // UI spinning forever with no way to learn the server is actually idle.
   const processing = isConversationProcessing(resolvedConversationId);
+
+  // Append the in-memory queue's pending user messages to the newest page so a
+  // cold reload restores them alongside persisted history. They are the newest
+  // rows in the conversation (enqueued during the in-flight turn) and are not
+  // yet persisted, so they belong only on a request for the latest content —
+  // never on an older-history page (`beforeTimestamp` set).
+  if (beforeTimestamp == null) {
+    messages.push(...buildQueuedMessagePayloads(resolvedConversationId));
+  }
 
   if (isPaginated) {
     // Prefer the page's oldest visible row (the documented cursor semantic).

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -611,9 +611,10 @@ async function tryConsumeCanonicalGuardianReply(params: {
  * Messages enqueued while the agent is mid-turn live only in memory until the
  * queue drains and persists them, so they never reach the DB-sourced history
  * list. The live path surfaces them via `message_queued` SSE events; a cold
- * reload (no event replay) would otherwise drop them. Each queued row is
- * flagged `queued: true` and ordered FIFO so it appends to the newest page in
- * send order, mirroring how the agent will drain them.
+ * reload (no event replay) would otherwise drop them. Each queued row carries
+ * `queueStatus: "queued"` with its 1-based `queuePosition` (mirroring the
+ * client `DisplayMessage` queue fields) and is ordered FIFO so it appends to
+ * the newest page in send order, mirroring how the agent will drain them.
  *
  * Returns an empty array when the conversation is not live in memory (cold, or
  * aged out of the registry) — there is no queue to read in that case.
@@ -624,7 +625,7 @@ function buildQueuedMessagePayloads(
   const conversation = findConversation(conversationId);
   if (!conversation) return [];
 
-  return conversation.snapshotQueuedMessages().map((item) => {
+  return conversation.snapshotQueuedMessages().map((item, index) => {
     const text = item.displayContent ?? item.content;
     const attachments: RuntimeAttachmentMetadata[] = item.attachments.map(
       (a, idx) => ({
@@ -657,7 +658,8 @@ function buildQueuedMessagePayloads(
       ...(item.clientMessageId
         ? { clientMessageId: item.clientMessageId }
         : {}),
-      queued: true,
+      queueStatus: "queued" as const,
+      queuePosition: index + 1,
     };
   });
 }


### PR DESCRIPTION
## Prompt / plan

> Our `GET /messages` command should return a flag for each user message that is queued, derived from the in-mem queue.

**Why:** Messages a user sends while the agent is mid-turn are enqueued in the live conversation's in-memory `MessageQueue` and are not persisted to the DB until the queue drains. `GET /v1/messages` builds its history from DB rows, so those pending messages never appear in a history snapshot. The live UI only learns about them through `message_queued` SSE events — on a cold reload (no event replay) the queued rows are lost entirely.

**Approach:** `handleListMessages` now reads the live conversation's queue via a new read-only snapshot accessor and appends each pending user message to the response, flagged `queued: true`. The flag is derived at render time (same pattern as `pendingConfirmation` / `processing`), so it appears only while a message is genuinely waiting and is absent on already-persisted rows.

Details:
- Add optional `queued` to the `ConversationMessage` wire contract (`@vellumai/assistant-api`).
- Add `MessageQueue.snapshot()` and `Conversation.snapshotQueuedMessages()` for a read-only FIFO view of the queue (keeps queue internals encapsulated in the daemon layer).
- Append queued rows in FIFO order, keyed by `requestId` (the identifier the existing `DELETE /v1/messages/queued/:id` and steer endpoints already use), and only on a latest/full page — never on an older-history `beforeTimestamp` page.
- Export `classifyKind` (single source of truth) to derive attachment `kind` for queued rows.
- Regenerate `openapi.yaml` (purely additive: one `queued: boolean` property on the `GET /v1/messages` response).

This is server-side only. Wiring the web client to restore queued rows from the flag on cold reload (mapping `queued` → `queueStatus`, using `id` as the steer/cancel `requestId`) is a natural follow-up.

## Test plan

New unit suite `assistant/src/__tests__/list-messages-queued.test.ts` covers:
- Queued message appended after persisted history, flagged `queued: true`, keyed by `requestId`, with `clientMessageId` echoed.
- `displayContent` preferred over the model-facing `content`.
- Queued attachments rendered with a derived `kind`.
- Queued messages **not** appended to an older-history (`beforeTimestamp`) page.
- Only persisted rows returned when the conversation is not live in memory.

```
bun test src/__tests__/list-messages-queued.test.ts        # 5 pass
bun test src/__tests__/list-messages-*.test.ts             # 63 pass (no regressions)
bun test src/__tests__/conversation-queue.test.ts src/__tests__/http-user-message-parity.test.ts  # 65 pass
```

Pre-commit hooks (prettier, eslint, tsc typecheck) all pass; `bun run generate:openapi` produces only the additive `queued` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB7BovvsEjCgnWGCuGTmPX)_