### PR TITLE
fix(daemon): handle setProcessing failure in persistUserMessage

### DIFF
--- a/assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts
+++ b/assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: `persistUserMessage` calls `ctx.setProcessing(true)`, which
+ * persists the flag to the DB and can throw (e.g. SQLITE_BUSY). That call must
+ * run inside the function's try/catch so a failure unwinds the request-id and
+ * abort-controller bookkeeping instead of stranding it on the conversation.
+ * A later failure while clearing the flag must not mask the original error.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
+import { persistUserMessage } from "../daemon/conversation-messaging.js";
+
+type SetProcessingBehavior = (value: boolean) => void;
+
+function makeContext(
+  setProcessing: SetProcessingBehavior,
+): MessagingConversationContext & {
+  processing: boolean;
+} {
+  let processing = false;
+  const ctx = {
+    conversationId: "conv-set-processing-failure",
+    messages: [],
+    abortController: null,
+    currentRequestId: undefined,
+    queue: {} as never,
+    get processing() {
+      return processing;
+    },
+    isProcessing: () => processing,
+    setProcessing: (value: boolean) => {
+      setProcessing(value);
+      processing = value;
+    },
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+  } as unknown as MessagingConversationContext & { processing: boolean };
+  return ctx;
+}
+
+describe("persistUserMessage setProcessing failure", () => {
+  test("clears request-id and abort bookkeeping when setProcessing(true) throws", async () => {
+    const ctx = makeContext((value) => {
+      if (value) throw new Error("database is locked (SQLITE_BUSY)");
+    });
+
+    await expect(
+      persistUserMessage(ctx, { content: "hello", requestId: "req-1" }),
+    ).rejects.toThrow("database is locked");
+
+    expect(ctx.currentRequestId).toBeUndefined();
+    expect(ctx.abortController).toBeNull();
+    expect(ctx.isProcessing()).toBe(false);
+  });
+
+  test("a failing clear does not mask the original persist error", async () => {
+    // setProcessing throws on both the set and the clear; the original error
+    // must still propagate and the bookkeeping must still be reset.
+    const ctx = makeContext(() => {
+      throw new Error("database is locked (SQLITE_BUSY)");
+    });
+
+    await expect(
+      persistUserMessage(ctx, { content: "hello", requestId: "req-2" }),
+    ).rejects.toThrow("database is locked");
+
+    expect(ctx.currentRequestId).toBeUndefined();
+    expect(ctx.abortController).toBeNull();
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -412,10 +412,13 @@ export async function persistUserMessage(
 
   const reqId = options.requestId ?? uuid();
   ctx.currentRequestId = reqId;
-  ctx.setProcessing(true);
   ctx.abortController = new AbortController();
 
   try {
+    // `setProcessing(true)` persists the flag and can throw (e.g.
+    // SQLITE_BUSY). Keeping it inside the try ensures a failure here unwinds
+    // the request-id/abort bookkeeping below rather than stranding it.
+    ctx.setProcessing(true);
     const result = await persistQueuedMessageBody(ctx, {
       ...options,
       attachments,
@@ -428,7 +431,18 @@ export async function persistUserMessage(
     }
     return result;
   } catch (err) {
-    ctx.setProcessing(false);
+    // Clear the flag, but never let a clear failure mask the original error
+    // or skip the bookkeeping reset. `setProcessing` reverts its own
+    // in-memory flag when its persist throws, so the conversation is left
+    // consistent either way.
+    try {
+      ctx.setProcessing(false);
+    } catch (clearErr) {
+      log.error(
+        { err: clearErr, conversationId: ctx.conversationId },
+        "Failed to clear processing flag after persistUserMessage failure",
+      );
+    }
     ctx.abortController = null;
     ctx.currentRequestId = undefined;
     throw err;


### PR DESCRIPTION
## Prompt / plan

`conversation-messaging.ts` — `persistUserMessage` calls `ctx.setProcessing(true)`, which can throw but was not handled gracefully.

`persistUserMessage` set `ctx.currentRequestId = reqId` and then called `ctx.setProcessing(true)` **outside** the function's `try/catch`. `setProcessing` persists the processing flag to the `processing_started_at` column and can throw (e.g. `SQLITE_BUSY` under write contention — see `Conversation.setProcessing`, which reverts its own in-memory flag and re-throws on a failed write). When it threw:

- `ctx.currentRequestId` was left stranded at `reqId` even though no turn ever started,
- `ctx.abortController` was never reset,
- the error propagated to callers (e.g. the queue drain path in `conversation-process.ts`) without the turn bookkeeping being unwound.

### Fix

- Move `setProcessing(true)` **inside** the `try` so any failure flows through the existing cleanup that clears `currentRequestId` and `abortController`.
- Guard the `catch` block's `setProcessing(false)` clear in its own `try/catch` so a clear failure logs instead of masking the original error or skipping the bookkeeping reset. `setProcessing` already reverts its own in-memory flag when its persist throws, so the conversation flag is left consistent either way.

## Test plan

- New regression test `assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts`:
  - `setProcessing(true)` throwing clears `currentRequestId`/`abortController` and leaves `isProcessing()` false.
  - A failing clear in the catch does not mask the original persist error and still resets bookkeeping.
- Existing `processing-flag-persist-failure.test.ts` still passes.
- `bun run typecheck:fast` clean; `eslint` clean on changed files.

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRAZyX8NNZ8jUqJTVkWrb3)_