### PR TITLE
feat(web): base-store foundation — seed/resync + base/optimistic slices (client-sync)

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  pushSseEvent,
+  registerSseClient,
+  resetSseDebugStateForTests,
+} from "@/lib/streaming/stream-debug";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+
+const CONV = "conv-A";
+
+function snapshot(
+  messages: DisplayMessage[],
+  seq: number | null,
+): PaginatedHistoryResult {
+  return { messages, hasMore: false, oldestTimestamp: null, oldestMessageId: null, seq };
+}
+function textRow(id: string, text: string): DisplayMessage {
+  return {
+    id,
+    role: "assistant",
+    textSegments: [text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text }],
+  };
+}
+function envelope(seq: number, conversationId: string, message: AssistantEvent): AssistantEventEnvelope {
+  return {
+    id: `e${seq}`,
+    conversationId,
+    seq,
+    emittedAt: new Date(1000 + seq).toISOString(),
+    message,
+  } as AssistantEventEnvelope;
+}
+const textDelta = (seq: number, conv: string, id: string, text: string) =>
+  envelope(seq, conv, { type: "assistant_text_delta", messageId: id, text } as AssistantEvent);
+
+const store = () => useChatSessionStore.getState();
+
+beforeEach(() => {
+  resetSseDebugStateForTests();
+  store().setLiveTurn([]);
+  useChatSessionStore.setState({ base: null, optimisticSends: [] });
+});
+afterEach(() => {
+  resetSseDebugStateForTests();
+  useChatSessionStore.setState({ base: null, optimisticSends: [] });
+});
+
+describe("chat-session-store — base + optimistic", () => {
+  test("seedBase with no buffered tail uses the snapshot as-is", () => {
+    const snap = snapshot([textRow("a1", "persisted")], 5);
+    store().seedBase(CONV, snap);
+    expect(store().base).toBe(snap); // resolveBase returns the snapshot ref
+  });
+
+  test("seedBase replays the buffered tail (events that raced the fetch)", () => {
+    const id = registerSseClient(new AbortController().signal);
+    // The ring reaches back to the cursor (oldest retained seq 6 <= snapshot.seq+1).
+    pushSseEvent(id, textDelta(6, CONV, "a1", " + live"));
+
+    store().seedBase(CONV, snapshot([textRow("a1", "persisted")], 5));
+
+    expect(store().base?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+      "persisted + live",
+    ]);
+    expect(store().base?.seq).toBe(6);
+  });
+
+  test("seedBase takes the snapshot wholesale when the tail is an eviction gap", () => {
+    const id = registerSseClient(new AbortController().signal);
+    // Oldest retained seq (50) is past snapshot.seq+1 → getSseEnvelopesSince → null.
+    pushSseEvent(id, textDelta(50, CONV, "a1", " evicted-gap"));
+
+    const snap = snapshot([textRow("a1", "persisted")], 5);
+    store().seedBase(CONV, snap);
+    expect(store().base).toBe(snap); // wholesale, no partial replay
+  });
+
+  test("applyEnvelopeToBase folds a live event once seeded; idempotent by seq", () => {
+    store().seedBase(CONV, snapshot([textRow("a1", "persisted")], 5));
+    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", " live"));
+    expect(store().base?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+      "persisted live",
+    ]);
+    // Re-applying seq 6 is a no-op.
+    const before = store().base;
+    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", " live"));
+    expect(store().base).toBe(before);
+  });
+
+  test("applyEnvelopeToBase is a no-op before the base is seeded", () => {
+    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", "x"));
+    expect(store().base).toBeNull();
+  });
+
+  test("optimistic sends add and clear by clientMessageId", () => {
+    const send: DisplayMessage = { ...textRow("u1", "hi"), role: "user", clientMessageId: "nonce-1" };
+    store().addOptimisticSend(send);
+    expect(store().optimisticSends.map((m) => m.clientMessageId)).toEqual(["nonce-1"]);
+    store().clearOptimisticSend("nonce-1");
+    expect(store().optimisticSends).toEqual([]);
+  });
+
+  test("switching conversation resets base and optimistic sends", () => {
+    store().seedBase(CONV, snapshot([textRow("a1", "x")], 1));
+    store().addOptimisticSend({ ...textRow("u1", "hi"), role: "user", clientMessageId: "n" });
+
+    store().switchToConversation({ assistantId: "asst-1", activeConversationId: "conv-B" });
+
+    expect(store().base).toBeNull();
+    expect(store().optimisticSends).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -38,7 +38,13 @@ import type {
 } from "@/domains/chat/types/types";
 import type { ChatError } from "@/domains/chat/types";
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator";
-import type { TranscriptPaginationState } from "@/domains/chat/transcript/types";
+import type {
+  PaginatedHistoryResult,
+  TranscriptPaginationState,
+} from "@/domains/chat/transcript/types";
+import { applyEvent, resolveBase } from "@/domains/chat/transcript/rolling-base";
+import { getSseEnvelopesSince } from "@/lib/streaming/stream-debug";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
 // State
@@ -52,6 +58,19 @@ export interface ChatSessionState {
   // lives in the TanStack Query cache. The rendered transcript is the union of
   // cached history and this live turn (`selectTranscriptMessages`).
   liveTurn: DisplayMessage[];
+
+  // --- Materialized base (client-sync rolling base) ---
+  // The active conversation's history materialized as the `/messages` page
+  // shape, seeded from the snapshot and advanced by the stream reducer
+  // (`applyEvent`). `null` until seeded. Unwired: the rendered transcript still
+  // reads cached history ⊕ `liveTurn` today; this is the home the cutover
+  // moves it to.
+  base: PaginatedHistoryResult | null;
+  // Optimistic user sends not yet confirmed by their `user_message_echo`.
+  // Held apart from `base` so it's clear they're unconfirmed until an event
+  // clears them; rebased onto a fresh `base` on resync.
+  optimisticSends: DisplayMessage[];
+
   error: ChatError | null;
   notice: ChatError | null;
   isLoadingHistory: boolean;
@@ -113,6 +132,19 @@ export interface ChatSessionState {
 export interface ChatSessionActions {
   // --- Setters ---
   setLiveTurn: (updater: DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[])) => void;
+
+  // --- Materialized base ---
+  /** Seed (or resync) the base from a fresh snapshot, replaying the buffered
+   *  event tail with `seq > snapshot.seq` onto it so events that raced the
+   *  fetch aren't lost. A gap (evicted tail) falls back to the snapshot alone. */
+  seedBase: (conversationId: string, snapshot: PaginatedHistoryResult) => void;
+  /** Fold one live stream event into the base (no-op until seeded; the seed's
+   *  replay covers anything that arrived first). Idempotent by `seq`. */
+  applyEnvelopeToBase: (envelope: AssistantEventEnvelope) => void;
+  /** Add an optimistic user send; cleared when its echo lands. */
+  addOptimisticSend: (message: DisplayMessage) => void;
+  /** Drop the optimistic send correlated by `clientMessageId`. */
+  clearOptimisticSend: (clientMessageId: string) => void;
   setError: (updater: ChatError | null | ((prev: ChatError | null) => ChatError | null)) => void;
   setNotice: (updater: ChatError | null | ((prev: ChatError | null) => ChatError | null)) => void;
   setIsLoadingHistory: (value: boolean) => void;
@@ -196,6 +228,8 @@ const INITIAL_PAGINATION: Omit<TranscriptPaginationState, "items"> = {
 function initialState(): ChatSessionState {
   return {
     liveTurn: [],
+    base: null,
+    optimisticSends: [],
     error: null,
     notice: null,
     isLoadingHistory: true,
@@ -238,6 +272,24 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
   // --- Setters ---
   setLiveTurn: (updater) =>
     set((s) => ({ liveTurn: applyUpdater(s.liveTurn, updater) })),
+
+  seedBase: (conversationId, snapshot) => {
+    const tail = getSseEnvelopesSince(conversationId, snapshot.seq ?? null);
+    set({ base: resolveBase(snapshot, tail) });
+  },
+
+  applyEnvelopeToBase: (envelope) =>
+    set((s) => (s.base ? { base: applyEvent(s.base, envelope) } : {})),
+
+  addOptimisticSend: (message) =>
+    set((s) => ({ optimisticSends: [...s.optimisticSends, message] })),
+
+  clearOptimisticSend: (clientMessageId) =>
+    set((s) => ({
+      optimisticSends: s.optimisticSends.filter(
+        (m) => m.clientMessageId !== clientMessageId,
+      ),
+    })),
 
   setError: (updater) =>
     set((s) => ({ error: applyUpdater(s.error, updater) })),
@@ -324,6 +376,8 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
     set({
       liveTurn: [],
+      base: null,
+      optimisticSends: [],
       ephemeralMetaResults: [],
       error: shouldSuppressGenericChatErrorNotice(state.error) ? state.error : null,
       notice: null,

--- a/clients/web/src/domains/chat/transcript/rolling-base.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   applyEvent,
   applyEventsToHistory,
+  resolveBase,
 } from "@/domains/chat/transcript/rolling-base";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import type { AssistantEvent } from "@/types/event-types";
@@ -186,5 +187,31 @@ describe("rolling-base reducer", () => {
     expect(after.hasMore).toBe(true);
     expect(after.oldestTimestamp).toBe(123);
     expect(after.oldestMessageId).toBe("old");
+  });
+
+  describe("resolveBase (seed / resync)", () => {
+    test("a null tail (gap / no anchor) leaves the snapshot standing alone", () => {
+      const snapshot = applyEventsToHistory(SEED, [textDelta(1, "a1", "persisted")]);
+      expect(resolveBase(snapshot, null)).toBe(snapshot);
+    });
+
+    test("replays the buffered tail onto the snapshot", () => {
+      const snapshot = applyEventsToHistory(SEED, [
+        userEcho(1, "u1", "hi"),
+        textDelta(2, "a1", "persisted"),
+      ]);
+      const resolved = resolveBase(snapshot, [textDelta(3, "a1", " + live")]);
+      expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+        "persisted + live",
+      ]);
+      expect(resolved.seq).toBe(3);
+    });
+
+    test("idempotent: tail events already in the snapshot are dropped", () => {
+      const snapshot = applyEventsToHistory(SEED, [textDelta(5, "a1", "x")]); // seq 5
+      // A stale tail (<= snapshot.seq) folds to nothing.
+      const resolved = resolveBase(snapshot, [textDelta(4, "a1", " stale")]);
+      expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
+    });
   });
 });

--- a/clients/web/src/domains/chat/transcript/rolling-base.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.ts
@@ -184,3 +184,16 @@ export function applyEventsToHistory(
 ): PaginatedHistoryResult {
   return events.reduce(applyEvent, history);
 }
+
+/**
+ * Resolve the base from a fresh snapshot and the buffered event tail to replay
+ * onto it (seed and resync share this). A `null` tail means the buffer can't
+ * cover the snapshot's watermark (eviction, or no anchor), so the snapshot
+ * stands alone; otherwise the tail's `seq > snapshot.seq` events fold on top.
+ */
+export function resolveBase(
+  snapshot: PaginatedHistoryResult,
+  tail: readonly AssistantEventEnvelope[] | null,
+): PaginatedHistoryResult {
+  return tail === null ? snapshot : applyEventsToHistory(snapshot, tail);
+}


### PR DESCRIPTION
Cutover **part 1**: the home the rendered transcript will move to. **Unwired** today — render still reads cached history ⊕ `liveTurn`; this just adds the store slices and the seed/resync logic so the wiring PR is a focused swap.

## `resolveBase(snapshot, tail)` (rolling-base.ts)
The seed/resync combiner — and seed *is* resync, same operation:
- `tail === null` (eviction gap, or no version anchor) → the snapshot stands alone.
- otherwise the buffered tail's `seq > snapshot.seq` events fold on top via the reducer.

This is what makes the original disappearing-message race structurally impossible: the base is always `snapshot ⊕ buffered-tail`, so events that arrived before/during the snapshot fetch can't be lost.

## `chat-session-store` gains two slices
- **`base: PaginatedHistoryResult | null`** — the active conversation's history materialized in the `/messages` shape, advanced by the reducer.
- **`optimisticSends: DisplayMessage[]`** — unconfirmed user sends, held apart so it's obvious they're optimistic until an echo clears them; rebased on resync.

Actions: `seedBase` (resolves the snapshot + the buffered tail from `getSseEnvelopesSince`, falling back to the snapshot wholesale on an eviction gap), `applyEnvelopeToBase` (idempotent live fold; no-op until seeded — the seed's replay covers anything that raced it), `addOptimisticSend` / `clearOptimisticSend`. Both slices reset on conversation switch.

## Tests
- `resolveBase`: null→snapshot (same ref), replay-onto-snapshot, idempotent stale-tail drop.
- store actions: seed-with-replay, eviction-gap→wholesale, idempotent live fold, no-op before seed, optimistic add/clear, switch reset.

20 tests across the two suites; lint + typecheck clean.

## Next (the wiring)
Route the consumer to `applyEnvelopeToBase` + `addOptimisticSend`, derive the transcript from `base ⊕ optimisticSends`, retire `liveTurn` + the seed-twin overlay, and flip the `clients/web/AGENTS.md:30` single-source note (deltas now fold into the materialized base through the certified reducer; `optimisticSends` is genuinely-client, not a second copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_