### PR TITLE
fix(web): stop full-conversation download alongside paginated history fetch

### DIFF
--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -11,11 +11,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
+  fetchConversationMessages,
   getChatHistory,
   mapRuntimeToolCalls,
   normalizeContentBlocks,
   normalizeContentOrder,
   postChatMessage,
+  RECONCILE_LATEST_PAGE_LIMIT,
 } from "@/domains/chat/api/messages";
 import { messageText } from "@/domains/chat/utils/message-test-helpers";
 import type {
@@ -389,6 +391,53 @@ describe("getChatHistory", () => {
       timestamp: Date.parse("2026-05-15T12:34:56.000Z"),
     });
     expect(messageText(result.messages[0])).toBe("Slack reply");
+  });
+});
+
+describe("fetchConversationMessages — request shape", () => {
+  function captureQuery(): { current: Record<string, unknown> | null } {
+    const captured: { current: Record<string, unknown> | null } = {
+      current: null,
+    };
+    daemonClient.get = mock(
+      async (options: { query?: Record<string, unknown> }) => {
+        captured.current = options.query ?? null;
+        return {
+          data: { messages: [], seq: 7 },
+          error: null,
+          response: new Response(null, { status: 200 }),
+        };
+      },
+    ) as typeof daemonClient.get;
+    return captured;
+  }
+
+  test("downloads the full conversation when no page limit is given", async () => {
+    const captured = captureQuery();
+
+    await fetchConversationMessages("assistant-1", "conv-1");
+
+    expect(captured.current).toEqual({ conversationId: "conv-1" });
+    // Full-snapshot callers (the inspector) must not page.
+    expect(captured.current).not.toHaveProperty("page");
+    expect(captured.current).not.toHaveProperty("limit");
+  });
+
+  test("requests only the latest page when a page limit is given", async () => {
+    const captured = captureQuery();
+
+    const result = await fetchConversationMessages("assistant-1", "conv-1", {
+      latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT,
+    });
+
+    expect(captured.current).toEqual({
+      conversationId: "conv-1",
+      page: "latest",
+      limit: RECONCILE_LATEST_PAGE_LIMIT,
+    });
+    // The paginated response still carries the snapshot watermark the
+    // reconcile/seq callers depend on.
+    expect(result?.seq).toBe(7);
   });
 });
 

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -25,6 +25,7 @@ import {
   messagesQueuedByIdDelete,
 } from "@/generated/daemon/sdk.gen";
 import type {
+  MessagesGetData,
   MessagesGetResponse,
   MessagesPostData,
 } from "@/generated/daemon/types.gen";
@@ -298,6 +299,16 @@ export async function getChatHistory(
 }
 
 /**
+ * Default page size for reconciliation/seq snapshot fetches. The silent-stall
+ * watchdog and post-send seq probes only ever inspect the conversation tail
+ * (the current turn and any newly-appended rows) plus the snapshot `seq`, so
+ * pulling the latest page is sufficient — and avoids re-downloading the entire
+ * conversation, which on a long chat is a large payload fetched alongside the
+ * paginated history query that already loads the same tail.
+ */
+export const RECONCILE_LATEST_PAGE_LIMIT = 50;
+
+/**
  * Fetch the server's authoritative `/messages` snapshot for a conversation.
  * Used for post-stream reconciliation to ensure local state matches the
  * backend even if events were dropped or the stream was interrupted.
@@ -307,14 +318,26 @@ export async function getChatHistory(
  * read `messages` directly and use `seq` for the seq-aware reconcile, which
  * compares it against the live applied frontier. `seq` is absent on daemons
  * that predate the seq-on-snapshot contract.
+ *
+ * Pass `latestPageLimit` to fetch only the newest page (`page=latest`) instead
+ * of the full conversation. Reconciliation and seq probes use this: they only
+ * read the tail and `seq`, both of which the `page=latest` response carries
+ * (the daemon emits `seq`/`processing` on the paginated path identically to the
+ * full-snapshot path). Omit it — as the inspector does — to download every
+ * message, which the inspector genuinely needs to enumerate the conversation.
  */
 export async function fetchConversationMessages(
   assistantId: string,
   conversationId: string,
+  options?: { latestPageLimit?: number },
 ): Promise<MessagesGetResponse | undefined> {
+  const query: NonNullable<MessagesGetData["query"]> =
+    options?.latestPageLimit != null
+      ? { conversationId, page: "latest", limit: options.latestPageLimit }
+      : { conversationId };
   const { data, error, response } = await messagesGet({
     path: { assistant_id: assistantId },
-    query: { conversationId },
+    query,
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to fetch conversation messages");

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -19,7 +19,10 @@ import {
   serverSnapshotHasNewContent,
 } from "@/domains/chat/utils/reconcile-detection";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
-import { fetchConversationMessages } from "@/domains/chat/api/messages";
+import {
+  fetchConversationMessages,
+  RECONCILE_LATEST_PAGE_LIMIT,
+} from "@/domains/chat/api/messages";
 import type { ConversationMessage } from "@vellumai/assistant-api";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -136,7 +139,20 @@ export function useMessageReconciliation({
         isSending(useTurnStore.getState().phase),
       );
       const changed = serverSnapshotHasNewContent(serverView, localView);
-      const messagesAdded = serverView.length - localView.length;
+      // Count server rows absent from the local view by id rather than a raw
+      // length diff: the server snapshot is the latest page only, while the
+      // local view spans every loaded page, so a length subtraction would go
+      // negative once older history is paged in. Counting unmatched ids stays
+      // correct under that windowing (this feeds diagnostics / the Sentry
+      // rescue breadcrumb, not control flow).
+      const localIds = new Set<string>();
+      for (const m of localView) {
+        if (m.id) localIds.add(m.id);
+      }
+      const messagesAdded = serverView.reduce(
+        (count, sm) => (sm.id && !localIds.has(sm.id) ? count + 1 : count),
+        0,
+      );
 
       // Refresh the single source — history flows into the query cache and the
       // transcript (its union with the live turn) re-renders. No client-side
@@ -296,7 +312,9 @@ export function useMessageReconciliation({
         }
         const snapshotTurnId = useTurnStore.getState().activeTurnId;
 
-        fetchConversationMessages(ctx.assistantId, ctx.conversationId)
+        fetchConversationMessages(ctx.assistantId, ctx.conversationId, {
+          latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT,
+        })
           .then((snapshot) => {
             if (epoch !== useStreamStore.getState().streamEpoch) return;
             const serverMessages = snapshot?.messages ?? [];
@@ -393,6 +411,7 @@ export function useMessageReconciliation({
         const snapshot = await fetchConversationMessages(
           ctx.assistantId,
           ctx.conversationId,
+          { latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT },
         );
         const serverMessages = snapshot?.messages ?? [];
         const serverSeq = snapshot?.seq ?? null;

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -85,6 +85,7 @@ import {
   fetchConversationMessages,
   postChatMessage,
   pollForResponse,
+  RECONCILE_LATEST_PAGE_LIMIT,
 } from "@/domains/chat/api/messages";
 import { surfaceConversation } from "@/domains/chat/api/conversations";
 import { supportsServerMintedConversation } from "@/lib/backwards-compat/server-minted-conversation";
@@ -470,6 +471,7 @@ export function useSendMessage({
             const snapshot = await fetchConversationMessages(
               postResult.assistantId,
               effectiveConversationId,
+              { latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT },
             );
             serverSeq = snapshot?.seq ?? null;
           } catch {


### PR DESCRIPTION
## Prompt / plan

> Every API call for GET /messages where we are paginating has one next to it where we aren't paginating and downloading the full conversation, which can be a massive download

**Root cause.** The chat transcript loads history through a paginated `page=latest` query (`useHistoryPagination` → `fetchLatestHistoryPage`). But three other paths called `fetchConversationMessages(assistantId, conversationId)` with **no** pagination params:

- the silent-stall reconcile loop (`useMessageReconciliation.startReconciliationLoop`)
- the active-conversation reconcile (`reconcileActiveConversation`)
- the post-send `seq` probe (`useSendMessage`)

The daemon's `GET /messages` (`handleListMessages`) returns the **entire** conversation when neither `page` nor `beforeTimestamp` is set. So each paginated history fetch was shadowed by a sibling request that re-downloaded the full conversation — a large payload on long chats.

**Fix.** Those callers only ever inspect the conversation **tail** (the current turn / newly-appended rows) and the snapshot `seq`. The daemon's `page=latest` response carries both `seq` and `processing` identically to the full-snapshot path, so the tail-only fetch is sufficient. Added an optional `latestPageLimit` to `fetchConversationMessages` and pass it from the three callers above so they fetch only the latest page. The **inspector** (`useConversationMessageList`, the per-message LLM-context fallback) genuinely enumerates every message and keeps the full-snapshot path unchanged.

Also hardened the reconcile `messagesAdded` diagnostic to count server rows absent from the local view by id, rather than a raw `serverView.length - localView.length` diff that would skew negative now that the server snapshot is windowed while the local view spans every loaded page. This value feeds diagnostics / the Sentry rescue breadcrumb only — not control flow — and the behavior gates (`serverSnapshotHasNewContent`, `serverHasAssistantProgress`) are already scope-robust to a windowed server view.

No wire-contract change: `page=latest` is an existing, supported query on the daemon route.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bunx eslint` on changed files — 0 errors (only pre-existing `exhaustive-deps` warnings untouched by this change).
- `bun test` (run per-file, matching the CI runner) for `messages`, `inspector-api`, `reconcile-on-reopen`, `use-event-stream-resume-reconcile`, and `history` — all pass.
- Added two cases to `messages.test.ts` asserting the request shape: no pagination params when `latestPageLimit` is omitted (inspector path), and `page=latest` + `limit` plus a preserved `seq` when it is supplied (reconcile/seq path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9pCC1Y5MkpmtwhTL9Y2oe)_