### PR TITLE
refactor(telemetry): make usage telemetry reporter a self-managed singleton

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -86,10 +86,7 @@ import {
   setCesClient,
   setCesReconnect,
 } from "../security/secure-keys.js";
-import {
-  setUsageTelemetryReporter,
-  UsageTelemetryReporter,
-} from "../telemetry/usage-telemetry-reporter.js";
+import { startUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -666,29 +663,6 @@ export async function runDaemon(): Promise<void> {
     await closeSentry();
   }
 
-  // Construct and start the reporter even when usage collection is disabled:
-  // flush() re-checks the platform share_analytics consent each cycle and,
-  // when opted out, sends nothing but advances all watermarks (including the
-  // final flush in stop()). New opted-out tool_invocations rows are already
-  // unreportable by construction — the audit listener persists NULL telemetry
-  // columns for them, which the tool_executed projection filters out — so the
-  // opted-out
-  // flushes are defense in depth there (covering rows recorded under builds
-  // that predate that write-time gate) and remain the primary guard for the
-  // always-on tables without a write-time gate (llm_usage, turn events).
-  // Deliberately NOT gated on dbReady: getDb()
-  // can still work when initializeDb() failed mid-migration, in which case
-  // the audit listener keeps writing rows that the opt-out branch must keep
-  // covered. The reporter is degraded-mode safe — its constructor and
-  // flush() treat DB errors as non-fatal.
-  let telemetryReporter: UsageTelemetryReporter | null = null;
-  if (!isDevMode) {
-    telemetryReporter = new UsageTelemetryReporter();
-    setUsageTelemetryReporter(telemetryReporter);
-    telemetryReporter.start();
-    log.info("Usage telemetry reporter started");
-  }
-
   // Refresh the consent cache regardless of dev mode so record-time telemetry
   // writes (gated on getCachedShareAnalytics()) work in dev too. The reporter
   // flush stays dev-gated above, so dev still never sends telemetry to the
@@ -815,6 +789,7 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, "Guardian principal cache warm failed — continuing"),
   );
 
+  startUsageTelemetryReporter();
   startDiskPressureGuardForLifecycle();
   startOrphanReaper();
   startEventLoopWatchdog();
@@ -1417,7 +1392,6 @@ export async function runDaemon(): Promise<void> {
     getMemoryWorker: () => bgRefs.memoryWorker,
     getQdrantManager: () => bgRefs.qdrantManager,
     mcpManager,
-    telemetryReporter,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -8,6 +8,7 @@ import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
+import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
@@ -45,7 +46,6 @@ export interface ShutdownDeps {
   getMemoryWorker: () => { stop(): void } | null;
   getQdrantManager: () => QdrantManager | null;
   mcpManager: McpServerManager | null;
-  telemetryReporter: { stop(): Promise<void> } | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -117,18 +117,13 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       log.warn({ err }, "Enrichment service shutdown failed (non-fatal)");
     }
 
-    if (deps.telemetryReporter) {
-      try {
-        const timeout = new Promise<void>((_, reject) =>
-          setTimeout(
-            () => reject(new Error("Telemetry flush timed out")),
-            3_000,
-          ),
-        );
-        await Promise.race([deps.telemetryReporter.stop(), timeout]);
-      } catch (err) {
-        log.warn({ err }, "Telemetry reporter shutdown failed (non-fatal)");
-      }
+    try {
+      const timeout = new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("Telemetry flush timed out")), 3_000),
+      );
+      await Promise.race([stopUsageTelemetryReporter(), timeout]);
+    } catch (err) {
+      log.warn({ err }, "Telemetry reporter shutdown failed (non-fatal)");
     }
 
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -122,10 +122,42 @@ export function getUsageTelemetryReporter(): UsageTelemetryReporter | null {
   return _instance;
 }
 
-export function setUsageTelemetryReporter(
-  reporter: UsageTelemetryReporter | null,
-): void {
-  _instance = reporter;
+/**
+ * Construct and start the singleton usage telemetry reporter. No-op in dev mode
+ * (VELLUM_DEV=1) and idempotent if already started.
+ *
+ * Started even when share_analytics consent is opted out: flush() re-checks
+ * consent each cycle and, when opted out, sends nothing but advances all
+ * watermarks (including the final flush in stop()). New opted-out
+ * tool_invocations rows are already unreportable by construction — the audit
+ * listener persists NULL telemetry columns for them, which the tool_executed
+ * projection filters out — so the opted-out flushes are defense in depth there
+ * (covering rows recorded under builds that predate that write-time gate) and
+ * remain the primary guard for the always-on tables without a write-time gate
+ * (llm_usage, turn events). Not gated on DB readiness: getDb() can still work
+ * when initializeDb() failed mid-migration, in which case the audit listener
+ * keeps writing rows the opt-out branch must keep covered. The reporter is
+ * degraded-mode safe — its constructor and flush() treat DB errors as non-fatal.
+ */
+export function startUsageTelemetryReporter(): void {
+  if (process.env.VELLUM_DEV === "1") return;
+  if (_instance) return;
+  _instance = new UsageTelemetryReporter();
+  _instance.start();
+  log.info("Usage telemetry reporter started");
+}
+
+/**
+ * Stop the singleton usage telemetry reporter (final flush + timer teardown)
+ * and clear it. No-op when the reporter was never started (e.g. dev mode).
+ */
+export async function stopUsageTelemetryReporter(): Promise<void> {
+  if (!_instance) return;
+  try {
+    await _instance.stop();
+  } finally {
+    _instance = null;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Prompt / plan

Continuing the effort to shrink `lifecycle.ts`. Removes the `telemetryReporter` arg threaded into `installShutdownHandlers` by making `UsageTelemetryReporter` own its own singleton lifecycle.

Previously lifecycle constructed the reporter, injected it into the module via `setUsageTelemetryReporter()`, started it, and then passed the instance through `ShutdownDeps` so the shutdown handler could call `.stop()`. That's three places coordinating one process-wide singleton.

This PR moves ownership into the telemetry module:

- **`startUsageTelemetryReporter()`** — dev-mode gate (`VELLUM_DEV=1` → no-op) + idempotent singleton construction + `start()`. The rationale for starting even when `share_analytics` consent is opted out (flush re-checks consent each cycle and advances watermarks) moves into this function's doc comment, where the behavior now lives.
- **`stopUsageTelemetryReporter()`** — final flush + timer teardown, clears the singleton. Safe no-op when never started (e.g. dev mode).
- **Drop `setUsageTelemetryReporter()`** — the module owns the instance; nothing injects it.
- **lifecycle** now just calls `startUsageTelemetryReporter()` alongside the other background-service starters (`startDiskPressureGuardForLifecycle()` etc.), instead of a bespoke `let telemetryReporter` + `if (!isDevMode)` block earlier in startup.
- **shutdown-handlers** imports `stopUsageTelemetryReporter()` directly and drops the `telemetryReporter` field from `ShutdownDeps`. The 3s flush-timeout race stays in the shutdown handler.

`getUsageTelemetryReporter()` (used by the telemetry flush route) and the `UsageTelemetryReporter` class (constructed directly in unit tests) are unchanged.

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test src/telemetry/usage-telemetry-reporter.test.ts src/background-wake/wake-intent-hooks.test.ts src/__tests__/disk-pressure-lifecycle.test.ts` — 69 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_