### PR TITLE
Add gpt-image-2 to managed image generation settings

### DIFF
--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -15,7 +15,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { LS_IMAGE_GEN_MODE, LS_IMAGE_GEN_MODEL } from "@/domains/settings/ai/local-storage-keys";
-import { AVAILABLE_IMAGE_GEN_MODELS, IMAGE_GEN_MODEL_DISPLAY_NAMES } from "@/domains/settings/ai/provider-catalogs";
+import { AVAILABLE_IMAGE_GEN_MODELS, IMAGE_GEN_MODEL_DISPLAY_NAMES, providerForImageGenModel } from "@/domains/settings/ai/provider-catalogs";
 import { parseServiceMode } from "@/domains/settings/ai/utils";
 import type { ServiceMode } from "@/generated/daemon/types.gen";
 
@@ -67,7 +67,7 @@ export function ImageGenerationCard() {
     const hasUserKey = imageGenMode === "your-own" && trimmed.length > 0;
     try {
       if (hasUserKey) {
-        await provisionProviderKey("gemini", trimmed);
+        await provisionProviderKey(providerForImageGenModel(imageGenModel), trimmed);
       }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
@@ -159,7 +159,11 @@ export function ImageGenerationCard() {
             type="password"
             value={imageGenApiKey}
             onChange={(e) => setImageGenApiKey(e.target.value)}
-            placeholder="Enter your Gemini API key"
+            placeholder={
+              providerForImageGenModel(imageGenModel) === "openai"
+                ? "Enter your OpenAI API key"
+                : "Enter your Gemini API key"
+            }
             fullWidth
           />
 

--- a/clients/web/src/domains/settings/ai/provider-catalogs.ts
+++ b/clients/web/src/domains/settings/ai/provider-catalogs.ts
@@ -191,9 +191,26 @@ export const EMAIL_BYO_PROVIDERS: readonly EmailByoProvider[] = [
 export const AVAILABLE_IMAGE_GEN_MODELS = [
   "gemini-3.1-flash-image-preview",
   "gemini-3-pro-image-preview",
+  "gpt-image-2",
 ] as const;
 
 export const IMAGE_GEN_MODEL_DISPLAY_NAMES: Record<string, string> = {
   "gemini-3.1-flash-image-preview": "Nano Banana 2",
   "gemini-3-pro-image-preview": "Nano Banana Pro",
+  "gpt-image-2": "GPT Image 2",
 };
+
+/**
+ * Image-generation provider for a model id, by prefix. Mirrors the daemon's
+ * `providerForImageModelPrefix` / `providerForModel` (`assistant/src/media/`):
+ * `gpt-*` / `dall-e-*` → openai, `gemini-*` → gemini, otherwise gemini.
+ */
+export function providerForImageGenModel(modelId: string): "openai" | "gemini" {
+  if (modelId.startsWith("gpt-") || modelId.startsWith("dall-e-")) {
+    return "openai";
+  }
+  if (modelId.startsWith("gemini-")) {
+    return "gemini";
+  }
+  return "gemini";
+}


### PR DESCRIPTION
## Summary

Surfaces OpenAI **gpt-image-2** in the image-generation settings UI. The assistant daemon and the platform's runtime already support gpt-image-2 — the only gap was the web settings card, which previously listed Gemini image models only.

Two files changed (both in `clients/web/src/domains/settings/ai/`):

- **`provider-catalogs.ts`**
  - Add `"gpt-image-2"` to `AVAILABLE_IMAGE_GEN_MODELS` (after the two Gemini entries) so it becomes selectable in both managed and bring-your-own-key modes.
  - Add `"gpt-image-2": "GPT Image 2"` to `IMAGE_GEN_MODEL_DISPLAY_NAMES`.
  - Add + export `providerForImageGenModel(modelId)` returning `"openai"` for `gpt-`/`dall-e-` prefixes and `"gemini"` for `gemini-` (default `"gemini"`), mirroring the daemon's `providerForImageModelPrefix` / `providerForModel` prefix logic in `assistant/src/media/`.

- **`image-generation-card.tsx`**
  - Make the bring-your-own-key path provider-aware: `provisionProviderKey(...)` now keys the credential by `providerForImageGenModel(imageGenModel)` instead of a hardcoded `"gemini"`.
  - The API-key input placeholder now reflects the selected model's provider ("Enter your OpenAI API key" vs "Enter your Gemini API key").
  - Managed mode needs no key changes — selecting the model calls the existing `modelImagegenPut({ modelId })`, and the daemon's `setImageGenModel` updates both the model and the derived provider.

The generated LLM text-model catalog is intentionally untouched — image-gen models live only in `AVAILABLE_IMAGE_GEN_MODELS`.

## Backend / daemon support

- **Daemon**: already supports gpt-image-2 — `assistant/src/media/image-models.ts` (`IMAGE_MODELS`), `openai-image-service.ts` (`ALLOWED_MODELS`), and the `PUT /v1/model/image-gen` handler `setImageGenModel`.
- **Django backend**: the platform-hosted (managed) allowlist + billing rate card for gpt-image-2 lands in a **separate `vellum-assistant-platform` PR**.

## Checks

- `bun run lint` (eslint) on the two changed files — pass (exit 0).
- `bunx tsc --noEmit` — my changes add **zero** new type errors. The project currently has 19 pre-existing tsc errors on `main` (generated-type drift in `earn-credits-modal`, `status-banner` `migrating` state, `acp-handlers`, `referral-panel`); verified the count is identical with and without these changes (stash comparison). None touch `settings/ai`.

## Do not merge yet

Please hold merge pending review and the companion `vellum-assistant-platform` backend PR (managed allowlist + billing for gpt-image-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)