### PR TITLE
feat(skills): add author + lastUsedAt provenance to managed-skill install-meta

### DIFF
--- a/assistant/src/__tests__/clawhub.test.ts
+++ b/assistant/src/__tests__/clawhub.test.ts
@@ -130,6 +130,10 @@ describe("clawhubInstall staging", () => {
         "# Staged Skill\n",
       );
       expect(existsSync(join(stagedSkillDir, "install-meta.json"))).toBe(true);
+      const meta = JSON.parse(
+        readFileSync(join(stagedSkillDir, "install-meta.json"), "utf-8"),
+      ) as SkillInstallMeta;
+      expect(meta.author).toBe("user");
     } finally {
       Bun.spawn = originalSpawn;
       rmSync(projectRoot, { recursive: true, force: true });

--- a/assistant/src/__tests__/install-meta.test.ts
+++ b/assistant/src/__tests__/install-meta.test.ts
@@ -108,6 +108,36 @@ describe("writeInstallMeta", () => {
     expect(parsed.contentHash).toBe("v2:abc123def456");
   });
 
+  test("round-trips optional author and lastUsedAt fields", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "custom",
+      installedAt: "2026-01-15T10:30:00.000Z",
+      author: "user",
+      lastUsedAt: "2026-02-01",
+    };
+
+    writeInstallMeta(dir, meta);
+
+    const result = readInstallMeta(dir);
+    expect(result).not.toBeNull();
+    expect(result!.author).toBe("user");
+    expect(result!.lastUsedAt).toBe("2026-02-01");
+  });
+
+  test("leaves author and lastUsedAt unset when omitted", () => {
+    const dir = makeTempDir();
+    writeInstallMeta(dir, {
+      origin: "custom",
+      installedAt: "2026-01-15T10:30:00.000Z",
+    });
+
+    const result = readInstallMeta(dir);
+    expect(result).not.toBeNull();
+    expect(result!.author).toBeUndefined();
+    expect(result!.lastUsedAt).toBeUndefined();
+  });
+
   test("overwrites existing install-meta.json", () => {
     const dir = makeTempDir();
     writeInstallMeta(dir, {

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -50,6 +50,7 @@ interface TestInstallMeta {
   version?: string;
   installedAt?: string;
   installedBy?: string;
+  author?: string;
 }
 
 function readInstallMetaFile(skillId: string): TestInstallMeta {
@@ -587,6 +588,29 @@ describe("version metadata", () => {
     const meta = readInstallMetaFile("with-contact");
     expect(meta.origin).toBe("custom");
     expect(meta.installedBy).toBe("contact-uuid-456");
+  });
+
+  test("install-meta.json forwards author when provided", () => {
+    createManagedSkill({
+      id: "with-author",
+      name: "With Author",
+      description: "Has author",
+      bodyMarkdown: "Body.",
+      author: "user",
+    });
+
+    expect(readInstallMetaFile("with-author").author).toBe("user");
+  });
+
+  test("install-meta.json omits author when not provided", () => {
+    createManagedSkill({
+      id: "no-author",
+      name: "No Author",
+      description: "No author",
+      bodyMarkdown: "Body.",
+    });
+
+    expect(readInstallMetaFile("no-author").author).toBeUndefined();
   });
 
   test("overwrite updates install-meta.json", () => {

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -321,6 +321,7 @@ describe("installPlugin — install lifecycle", () => {
     expect(meta?.source.ref).toBe(OLD_SHA);
     expect(meta?.source.repo).toBe("caveman");
     expect(meta?.source.owner).toBe("JuliusBrussee");
+    expect(meta?.author).toBe("user");
   });
 
   test("--force preserves the existing install when the clone fails", async () => {

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -578,6 +578,12 @@ export interface InstallMeta {
    * {@link InstallMeta.fingerprint}.
    */
   readonly contentHash?: string;
+  /**
+   * Authorship provenance, mirroring the skills' `SkillInstallMeta.author`.
+   * GitHub installs are user-initiated, so they record `"user"`; this protects
+   * them from the usage-based prune that only targets `"assistant"` entries.
+   */
+  readonly author?: "assistant" | "user";
 
   /** Install name. Matches the plugins directory and `plugins install <name>`. */
   readonly name: string;
@@ -1169,6 +1175,7 @@ function writeInstallMeta(
     version: readStagedPackageVersion(stagingDir),
     sourceRepo: `${source.owner}/${source.repo}`,
     contentHash,
+    author: "user",
     name,
     source: {
       kind: "github",
@@ -1238,6 +1245,10 @@ export function readInstallMeta(pluginDir: string): InstallMeta | null {
     slug: optionalString(obj.slug),
     sourceRepo: optionalString(obj.sourceRepo),
     contentHash: optionalString(obj.contentHash),
+    author:
+      obj.author === "assistant" || obj.author === "user"
+        ? obj.author
+        : undefined,
     name: obj.name,
     source: {
       kind: typeof source.kind === "string" ? source.kind : "github",

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -508,6 +508,7 @@ export async function installSkillLocally(
       installedAt: new Date().toISOString(),
       ...(catalogEntry.version ? { version: catalogEntry.version } : {}),
       ...(contactId ? { installedBy: contactId } : {}),
+      author: "user",
       contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
 

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -300,6 +300,7 @@ export async function clawhubInstall(
       slug,
       installedAt: new Date().toISOString(),
       ...(opts?.contactId ? { installedBy: opts.contactId } : {}),
+      author: "user",
       contentHash: computeSkillHash(installed.skillDir) ?? undefined,
     });
 

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -21,6 +21,13 @@ export interface SkillInstallMeta {
   slug?: string; // registry slug
   sourceRepo?: string; // GitHub repo (e.g. "vercel-labs/agent-skills")
   contentHash?: string; // SHA-256 content hash (v2:hex format)
+  // Authorship provenance. Drives prune protection: only "assistant"-authored
+  // skills are eligible for the usage-based prune; "user" and untagged skills
+  // are protected. Set by install/scaffold callers, never defaulted here.
+  author?: "assistant" | "user";
+  // Day-granularity stamp of the last time the skill was loaded (ISO 8601).
+  // Written by a later PR (skill-load instrumentation); unused for now.
+  lastUsedAt?: string;
 }
 
 // ─── Atomic write helper ────────────────────────────────────────────────────

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -119,6 +119,7 @@ interface CreateManagedSkillParams {
   includes?: string[];
   version?: string;
   contactId?: string;
+  author?: "assistant" | "user";
 }
 
 interface CreateManagedSkillResult {
@@ -182,6 +183,7 @@ export function createManagedSkill(
     installedAt: new Date().toISOString(),
     ...(params.version ? { version: params.version } : {}),
     ...(params.contactId ? { installedBy: params.contactId } : {}),
+    ...(params.author ? { author: params.author } : {}),
   });
 
   // Clean up legacy version.json if present (superseded by install-meta.json)

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -464,6 +464,7 @@ export async function installExternalSkill(
       sourceRepo: `${owner}/${repo}`,
       installedAt: new Date().toISOString(),
       ...(contactId ? { installedBy: contactId } : {}),
+      author: "user",
       contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
 


### PR DESCRIPTION
## Summary
Adds optional `author` (assistant|user) and `lastUsedAt` fields to SkillInstallMeta, threads `author` through createManagedSkill, and tags all user/external install paths with `author: "user"`. Inert until consumed by later PRs.

Part of plan: procedural-memory-as-skills.md (PR 3 of 9)