### PR TITLE
refactor(memory): remove skill-linked facts (skill: field, edge, orphan validation)

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -208,46 +208,6 @@ describe("writePage + readPage round-trip", () => {
     ]);
   });
 
-  test("round-trips the skill: frontmatter link (procedural-knowledge fact)", async () => {
-    const page = makePage({
-      frontmatter: {
-        edges: [],
-        ref_files: [],
-        ref_urls: [],
-        skill: "deploy-preview",
-      },
-    });
-    await writePage(workspaceDir, page);
-
-    // The `skill:` link must survive the render → read round-trip so the edge
-    // graph can derive the `fact → skills/<id>` edge by reading it back from the
-    // rendered frontmatter.
-    const read = await readPage(workspaceDir, page.slug);
-    expect(read).not.toBeNull();
-    expect(read!.frontmatter.skill).toBe("deploy-preview");
-  });
-
-  test("tolerates a non-string skill: value — page still parses, skill coerces to undefined", async () => {
-    // A legacy page whose `skill:` is a non-string (e.g. a YAML list that
-    // predates the typed field and previously passed through via `.passthrough`)
-    // must NOT fail the whole-page parse. `.catch(undefined)` coerces the bad
-    // value to `undefined` so the page survives index/retrieval rather than being
-    // silently dropped — the loss-of-page regression #34800 guards against.
-    const slug = "legacy-list-skill";
-    const raw =
-      "---\nedges: []\nref_files: []\nskill:\n  - deploy-preview\n  - rollback\n---\nbody\n";
-    writeFileSync(
-      join(workspaceDir, "memory", "concepts", `${slug}.md`),
-      raw,
-      "utf-8",
-    );
-
-    const read = await readPage(workspaceDir, slug);
-    expect(read).not.toBeNull();
-    expect(read!.frontmatter.skill).toBeUndefined();
-    expect(read!.body).toBe("body\n");
-  });
-
   test("accepts and round-trips the v3 wiki-article frontmatter fields", async () => {
     // The full shape CONSOLIDATION_PROMPT_V3 teaches and migrated corpora
     // arrive in. readPage() throws on schema failure and one invalid page in

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -47,22 +47,6 @@ export const ConceptPageFrontmatterSchema = z
     // `renderPageContent` round-trips the field (the edge graph reads it back
     // from the rendered frontmatter).
     links: z.array(z.string()).optional(),
-    // Optional link to the one skill this page is procedural knowledge about
-    // (`skills/<skill>` capability page). Present only on the subset of memories
-    // that are facts about a skill; most pages carry none. Declared (not left to
-    // the `.passthrough()` catchall below) so it carries a real type and
-    // `renderPageContent` round-trips it — the edge graph derives the
-    // `fact → skills/<id>` edge by reading this field back from the rendered
-    // frontmatter.
-    //
-    // `.catch(undefined)`: a non-string value (e.g. a legacy YAML list/object
-    // that predates this field and previously passed through via `.passthrough`)
-    // must NOT fail the whole-page `.parse()` — that would drop the page from the
-    // index and section lane entirely, the same loss-of-page regression #34800
-    // moved to `.passthrough` to avoid. A non-string coerces to `undefined`
-    // (no edge derived — `buildEdgeGraph` already gates on a non-empty string),
-    // while valid string values still round-trip via `renderPageContent`.
-    skill: z.string().optional().catch(undefined),
     // The memory-v3 wiki-article fields — the shape CONSOLIDATION_PROMPT_V3
     // teaches and migrated corpora arrive in. Declared (not just tolerated by
     // the catchall) so `renderPageContent` round-trips them — a programmatic

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/edge.test.ts
@@ -20,11 +20,6 @@ function withLinks(links: string[], body = "body"): string {
   return `---\ntitle: x\nlinks:\n${block}\n---\n\n${body}`;
 }
 
-/** Frontmatter helper: a page with a `skill:` link and an optional body. */
-function withSkill(skill: string, body = "body"): string {
-  return `---\ntitle: x\nskill: "${skill}"\n---\n\n${body}`;
-}
-
 describe("buildEdgeGraph — links: frontmatter", () => {
   test("parses target + description split on the first ' — '", async () => {
     const articles = [entry(1, "page-a"), entry(2, "page-b")];
@@ -76,38 +71,6 @@ describe("buildEdgeGraph — links: frontmatter", () => {
     // No curated descriptions on wikilink/numeric edges.
     expect(out.get("page-b")).toBeUndefined();
     expect(out.get("topic-x")).toBeUndefined();
-  });
-});
-
-describe("buildEdgeGraph — skill: frontmatter", () => {
-  test("derives a fact → skills/<id> edge when the skill page exists", async () => {
-    const articles = [entry(1, "a-fact"), entry(2, "skills/foo")];
-    const graph = await buildEdgeGraph(
-      articles,
-      rawReader({ "a-fact": withSkill("foo") }),
-    );
-    const out = graph.adjacency.get("a-fact")!;
-    expect(out.has("skills/foo")).toBe(true);
-    expect(out.get("skills/foo")).toBe("procedural knowledge for this skill");
-  });
-
-  test("drops the edge when the skill page is absent from the corpus", async () => {
-    const articles = [entry(1, "a-fact")];
-    const graph = await buildEdgeGraph(
-      articles,
-      rawReader({ "a-fact": withSkill("foo") }),
-    );
-    // No skills/foo in the corpus → no adjacency entry at all.
-    expect(graph.adjacency.get("a-fact")).toBeUndefined();
-  });
-
-  test("ignores an empty/whitespace skill value", async () => {
-    const articles = [entry(1, "a-fact"), entry(2, "skills/")];
-    const graph = await buildEdgeGraph(
-      articles,
-      rawReader({ "a-fact": withSkill("   ") }),
-    );
-    expect(graph.adjacency.get("a-fact")).toBeUndefined();
   });
 });
 
@@ -266,55 +229,6 @@ describe("edgeExpand", () => {
     });
     expect(out.find((n) => n.article === "page-c")).toBeUndefined();
     expect(out.find((n) => n.article === "page-b")).toBeDefined();
-  });
-
-  test("exempts a popular capability target from the hub filter", async () => {
-    // skills/foo receives 3 inbound fact edges; with hubDegree=2 it is a hub.
-    // A plain hub would be filtered out of expansion, but a capability target
-    // (skills/ prefix) is exempt so it still co-surfaces with its facts.
-    const articles = [
-      entry(1, "fact-a"),
-      entry(2, "fact-b"),
-      entry(3, "fact-c"),
-      entry(4, "skills/foo"),
-    ];
-    const graph = await buildEdgeGraph(
-      articles,
-      rawReader({
-        "fact-a": withSkill("foo"),
-        "fact-b": withSkill("foo"),
-        "fact-c": withSkill("foo"),
-      }),
-      { hubDegree: 2 },
-    );
-    // It is still recorded as a hub by in-degree...
-    expect(graph.hubs.has("skills/foo")).toBe(true);
-    // ...but expansion from a linking fact still surfaces it.
-    const out = edgeExpand(graph, ["fact-a"]);
-    expect(out.find((n) => n.article === "skills/foo")).toBeDefined();
-  });
-
-  test("a non-capability hub is still filtered out", async () => {
-    // Same shape as above but the popular target is an ordinary page, so the
-    // hub filter still excludes it — the exemption is capability-only.
-    const articles = [
-      entry(1, "fact-a"),
-      entry(2, "fact-b"),
-      entry(3, "fact-c"),
-      entry(4, "plain-hub"),
-    ];
-    const graph = await buildEdgeGraph(
-      articles,
-      rawReader({
-        "fact-a": withLinks(["plain-hub — to hub"]),
-        "fact-b": withLinks(["plain-hub — to hub"]),
-        "fact-c": withLinks(["plain-hub — to hub"]),
-      }),
-      { hubDegree: 2 },
-    );
-    expect(graph.hubs.has("plain-hub")).toBe(true);
-    const out = edgeExpand(graph, ["fact-a"]);
-    expect(out.find((n) => n.article === "plain-hub")).toBeUndefined();
   });
 
   test("does not surface the seeds themselves", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -330,10 +330,8 @@ describe("maintainJob", () => {
     const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.danglingCoreSlugs).toEqual([]);
     // The reconcile and prune stages each read the index once; the empty core
-    // stage adds no further read. The skill-link stage always reads the index to
-    // derive the indexed `skills/<id>` capability set (its valid-skill source of
-    // truth), so it adds one read even when the local catalog is empty.
-    expect(indexReads).toBe(3);
+    // stage adds no further read.
+    expect(indexReads).toBe(2);
   });
 
   test("a thrown core-validation stage is contained and does not abort lane invalidation", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -96,11 +96,6 @@ describe("maintainJob", () => {
       // Core-validation stage off by default: empty core set ⇒ nothing to
       // check. The dedicated core tests below override this.
       loadCoreSet: () => [],
-      // Skill-validation stage off by default: empty catalog AND no indexed
-      // `skills/<id>` rows ⇒ nothing to check. The dedicated skill-link tests
-      // below override these.
-      loadValidSkillIds: () => [],
-      readPageSkillLink: async () => undefined,
       invalidateLanes: () => {
         calls.invalidate += 1;
       },
@@ -417,116 +412,6 @@ describe("maintainJob", () => {
     // Never replace good points with a blank: no delete, no upsert.
     expect(calls.deleted).toEqual([]);
     expect(calls.upserted).toEqual([]);
-  });
-
-  test("a fact linking a live catalog skill reports no orphan", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: true });
-    const { deps: d, calls } = deps({
-      loadValidSkillIds: () => ["meet-join"],
-      listIndexedSlugs: async () => ["fact-a"],
-      readPageSkillLink: async (slug) =>
-        slug === "fact-a" ? "meet-join" : undefined,
-    });
-    const outcome = await maintainJob(JOB, CONFIG, d);
-
-    expect(outcome.orphanSkillSlugs).toEqual([]);
-    expect(outcome.failures).toEqual([]);
-    // Report-only and read-only: no dense-store mutation.
-    expect(calls.deleted).toEqual([]);
-    expect(calls.upserted).toEqual([]);
-    expect(calls.invalidate).toBe(1);
-  });
-
-  test("a fact linking a removed skill is reported as an orphan", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: true });
-    // Two facts: one links a live skill, the other a removed/renamed one. A
-    // synthetic capability row carries no `skill:` link and is skipped. Only the
-    // dangling fact is reported.
-    const { deps: d, calls } = deps({
-      loadValidSkillIds: () => ["meet-join"],
-      listIndexedSlugs: async () => [
-        "fact-live",
-        "fact-gone",
-        "skills/example",
-      ],
-      // The capability row is already in the store, so the reconcile stage
-      // no-ops here and this test exercises skill-validation in isolation.
-      listSectionArticles: async () => ["skills/example"],
-      readPageSkillLink: async (slug) => {
-        if (slug === "fact-live") return "meet-join";
-        if (slug === "fact-gone") return "removed-skill";
-        return undefined;
-      },
-    });
-    const outcome = await maintainJob(JOB, CONFIG, d);
-
-    expect(outcome.orphanSkillSlugs).toEqual(["fact-gone"]);
-    expect(outcome.failures).toEqual([]);
-    // Report-only: the dangling link triggered no mutation.
-    expect(calls.deleted).toEqual([]);
-    expect(calls.upserted).toEqual([]);
-    expect(calls.invalidate).toBe(1);
-  });
-
-  test("a fact linking an uninstalled catalog skill with an indexed capability row is NOT an orphan", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: true });
-    // `meet-join` is absent from the local catalog (`loadValidSkillIds` empty)
-    // but IS seeded into the corpus as a live `skills/meet-join` capability row
-    // — exactly the uninstalled-first-party-catalog case. The edge derivation
-    // resolves `fact → skills/meet-join` against that indexed row, so the fact
-    // must NOT be false-flagged.
-    const { deps: d, calls } = deps({
-      loadValidSkillIds: () => [],
-      listIndexedSlugs: async () => ["fact-a", "skills/meet-join"],
-      // The capability row is already stored, so the reconcile stage no-ops.
-      listSectionArticles: async () => ["skills/meet-join"],
-      readPageSkillLink: async (slug) =>
-        slug === "fact-a" ? "meet-join" : undefined,
-    });
-    const outcome = await maintainJob(JOB, CONFIG, d);
-
-    expect(outcome.orphanSkillSlugs).toEqual([]);
-    expect(outcome.failures).toEqual([]);
-    // Report-only and read-only: no dense-store mutation.
-    expect(calls.deleted).toEqual([]);
-    expect(calls.upserted).toEqual([]);
-    expect(calls.invalidate).toBe(1);
-  });
-
-  test("a fact linking a skill absent from the indexed capability set is an orphan", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: true });
-    // `removed-skill` backs no `skills/<id>` capability row and is not in the
-    // local catalog either, so the edge lane drops `fact → skills/removed-skill`
-    // — the fact is a genuine orphan and must be flagged.
-    const { deps: d, calls } = deps({
-      loadValidSkillIds: () => [],
-      listIndexedSlugs: async () => ["fact-gone", "skills/meet-join"],
-      listSectionArticles: async () => ["skills/meet-join"],
-      readPageSkillLink: async (slug) =>
-        slug === "fact-gone" ? "removed-skill" : undefined,
-    });
-    const outcome = await maintainJob(JOB, CONFIG, d);
-
-    expect(outcome.orphanSkillSlugs).toEqual(["fact-gone"]);
-    expect(outcome.failures).toEqual([]);
-    expect(calls.deleted).toEqual([]);
-    expect(calls.upserted).toEqual([]);
-    expect(calls.invalidate).toBe(1);
-  });
-
-  test("a thrown skill-validation stage is contained and does not abort lane invalidation", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: true });
-    const { deps: d, calls } = deps({
-      loadValidSkillIds: () => {
-        throw new Error("skill boom");
-      },
-    });
-    const outcome = await maintainJob(JOB, CONFIG, d);
-
-    expect(outcome.failures).toContain("skill-validate");
-    expect(outcome.orphanSkillSlugs).toEqual([]);
-    expect(calls.invalidate).toBe(1);
-    expect(outcome.invalidated).toBe(true);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/edge.ts
@@ -1,9 +1,4 @@
-import { CLI_COMMAND_SLUG_PREFIX } from "../../../memory/v2/cli-command-store.js";
 import type { PageIndexEntry } from "../../../memory/v2/page-index.js";
-import {
-  SKILL_SLUG_PREFIX,
-  skillSlugFor,
-} from "../../../memory/v2/skill-store.js";
 import { parseFrontmatterFields } from "../../../skills/frontmatter.js";
 import type { Slug } from "./types.js";
 
@@ -46,21 +41,6 @@ const LINK_SEPARATOR = " — ";
 /** Matches `[[target]]` wikilinks; captures the raw target before any `|`
  * display-text or `#section` anchor. */
 const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
-
-/** Slug prefixes for capability pages (skills, CLI commands). These are the
- * targets of derived `fact → skills/<id>` edges; a popular capability linked by
- * many facts would otherwise be flagged a hub and filtered out of expansion, so
- * it is exempt from the hub filter — a skill should still co-surface with its
- * facts no matter how many link to it. */
-const CAPABILITY_TARGET_PREFIXES = [
-  SKILL_SLUG_PREFIX,
-  CLI_COMMAND_SLUG_PREFIX,
-] as const;
-
-/** Whether `slug` names a capability page exempt from the hub filter. */
-function isCapabilityTarget(slug: Slug): boolean {
-  return CAPABILITY_TARGET_PREFIXES.some((prefix) => slug.startsWith(prefix));
-}
 
 /**
  * The directed link-graph. `adjacency` maps each source slug to its outbound
@@ -201,19 +181,6 @@ export async function buildEdgeGraph(
       }
     }
 
-    // (a′) the `skill:` frontmatter link — derives a `fact → skills/<id>` edge
-    // so a fact about a skill co-surfaces with the skill's capability page via
-    // the edge lane. `addEdge` drops the edge when `skills/<id>` is absent from
-    // the corpus, so a skill with no capability page is a safe no-op.
-    const skill = parsed?.fields.skill;
-    if (typeof skill === "string" && skill.trim() !== "") {
-      addEdge(
-        source,
-        skillSlugFor(skill),
-        "procedural knowledge for this skill",
-      );
-    }
-
     // (b) inline `[[wikilink]]` targets from the body. `parsed.body` strips
     // the frontmatter; a page without frontmatter has `parsed === null`, so
     // the whole raw text is the body.
@@ -242,11 +209,9 @@ export async function buildEdgeGraph(
 /**
  * Expand `seeds` outward along the graph. For each of the top `seedCount`
  * seeds (in input order), surface up to `perSeed` non-hub, `alive`-passing
- * neighbours, capped at `cap` total distinct articles. Capability targets
- * (`skills/` / `cli-commands/`) are exempt from the hub filter so a popular
- * skill still co-surfaces with its facts. Seeds themselves are not surfaced
- * (they are already in the pool). Each surfaced article carries the curated
- * `links` description of the traversed edge when it had one.
+ * neighbours, capped at `cap` total distinct articles. Seeds themselves are
+ * not surfaced (they are already in the pool). Each surfaced article carries
+ * the curated `links` description of the traversed edge when it had one.
  *
  * Deterministic given the input seed order and the graph's insertion order.
  */
@@ -273,9 +238,7 @@ export function edgeExpand(
       if (surfaced.size >= cap) break;
       if (seedSet.has(target)) continue; // already in the pool
       if (surfaced.has(target)) continue; // already surfaced via another seed
-      // Hubs are too-generic to surface — except capability targets, which a
-      // popular skill must still co-surface with its facts through.
-      if (graph.hubs.has(target) && !isCapabilityTarget(target)) continue;
+      if (graph.hubs.has(target)) continue; // hubs excluded
       if (alive && !alive(target)) continue;
       surfaced.set(target, description);
       added++;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs six independent stages, in order:
+ * store and the in-memory lanes. It runs five independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -34,15 +34,7 @@
  *      in the page index (dangling slugs) via the log + outcome. The file is
  *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
  *      dangling entries at the next consolidation pass.
- *   5. **Skill-link validation** — read each indexed concept page's `skill:`
- *      frontmatter and report pages whose link points at a skill that backs no
- *      `skills/<id>` capability row (removed or renamed) via the log + outcome.
- *      The valid set is the indexed `skills/<id>` capability slugs — the same
- *      set the edge derivation resolves `fact → skills/<id>` edges against — so
- *      an uninstalled first-party catalog skill with a live capability row is not
- *      false-flagged. Report-only like core-set validation — the pages are never
- *      auto-edited.
- *   6. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   5. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
@@ -61,7 +53,6 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
-import { loadSkillCatalog } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import {
   getMemoryCheckpoint,
@@ -75,10 +66,6 @@ import { EmbeddingBillingBlockError } from "../../../memory/embedding-billing-br
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
-import {
-  isSkillSlug,
-  SKILL_SLUG_PREFIX,
-} from "../../../memory/v2/skill-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { capabilityOrDiskBody, isCapabilitySlug } from "./capabilities.js";
@@ -170,24 +157,6 @@ export interface MaintainJobDeps {
    * entries only — the file is maintainer-owned and is never edited here.
    */
   loadCoreSet: () => Slug[];
-  /**
-   * Extra valid skill ids beyond the indexed `skills/<id>` capability set — the
-   * local skill catalog. The skill-link validation stage treats a fact's
-   * `skill: <id>` as orphaned ONLY when `skills/<id>` is absent from the indexed
-   * capability rows (the set the edge derivation resolves against; see
-   * {@link addEdge}), UNIONED with these ids as belt-and-suspenders. The indexed
-   * set is the source of truth: uninstalled first-party catalog skills are
-   * seeded as live `skills/<id>` rows even though they are not in the local
-   * catalog, so validating against the catalog alone false-flags a fact that
-   * validly links such a skill.
-   */
-  loadValidSkillIds: () => string[];
-  /**
-   * A page's `skill:` frontmatter value (a bare skill id) or `undefined` when
-   * the page carries no `skill:` link. Reads through the page store rather than
-   * Qdrant; missing/unreadable pages degrade to `undefined`.
-   */
-  readPageSkillLink: (slug: Slug) => Promise<string | undefined>;
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
   invalidateLanes: () => void;
   /** Active assistant config (for the dense-store/embedding calls). */
@@ -277,14 +246,6 @@ export interface MaintainOutcome {
    * consolidation pass — the file itself is never mutated.
    */
   danglingCoreSlugs: Slug[];
-  /**
-   * Indexed concept pages whose `skill:` frontmatter link points at a skill that
-   * backs no `skills/<id>` capability row in the index (removed or renamed).
-   * Validated against the indexed capability set (the edge-target source of
-   * truth), not just the local catalog. Reported for review — the pages
-   * themselves are never mutated.
-   */
-  orphanSkillSlugs: Slug[];
   /** Whether the in-memory lanes were invalidated. */
   invalidated: boolean;
   /** Stages that threw (and were contained). */
@@ -346,19 +307,6 @@ async function readPageBodyFromWorkspace(
   }
 }
 
-/** Read a page's `skill:` frontmatter link; missing/failed reads degrade to undefined. */
-async function readPageSkillLinkFromWorkspace(
-  workspaceDir: string,
-  slug: Slug,
-): Promise<string | undefined> {
-  try {
-    const page = await readPage(workspaceDir, slug);
-    return page?.frontmatter.skill;
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Capability-aware page-body reader for the full backfill: synthetic skill/CLI
  * slugs have no on-disk page, so they contribute their rendered capability
@@ -397,9 +345,6 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     listSectionArticles: () => realListSectionArticles(config),
     listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
     loadCoreSet: () => realLoadCoreSet(workspaceDir),
-    loadValidSkillIds: () => loadSkillCatalog().map((s) => s.id),
-    readPageSkillLink: (slug) =>
-      readPageSkillLinkFromWorkspace(workspaceDir, slug),
     invalidateLanes: realInvalidateLanes,
     config,
   };
@@ -707,7 +652,6 @@ export async function maintainJob(
     pruned: 0,
     pruneFailures: 0,
     danglingCoreSlugs: [],
-    orphanSkillSlugs: [],
     invalidated: false,
     failures: [],
   };
@@ -819,58 +763,7 @@ export async function maintainJob(
     );
   }
 
-  // Stage 5: validate fact `skill:` links against the indexed `skills/<id>`
-  // capability set. Read each indexed concept page's `skill:` frontmatter and
-  // REPORT pages whose link points at a skill that backs no `skills/<id>`
-  // capability row (removed or renamed) through the log + outcome.
-  //
-  // The valid-skill set is the `skills/<id>` slugs present in the page index
-  // (prefix stripped), NOT just `loadValidSkillIds()` (the local catalog). This
-  // is the exact set the edge derivation resolves a `fact → skills/<id>` edge
-  // against (see `edge.ts` `addEdge`): uninstalled first-party catalog skills are
-  // seeded into the corpus as live `skills/<id>` rows even though they are absent
-  // from the local catalog, so validating against the catalog alone would
-  // false-flag a fact that validly links such a skill. The catalog ids are
-  // unioned in as belt-and-suspenders, but the indexed capability set is the
-  // source of truth. Synthetic capability rows carry no `skill:` link, so they
-  // are skipped. Report-only, mirroring core-set validation: the pages are never
-  // auto-edited; the maintainer fixes a dangling link at the next consolidation.
-  try {
-    const indexedSlugs = await deps.listIndexedSlugs();
-    // The set the edge lane actually resolves `skills/<id>` targets against:
-    // every `skills/<id>` capability row in the index, by bare id.
-    const validSkills = new Set<string>(
-      indexedSlugs
-        .filter((slug) => isSkillSlug(slug))
-        .map((slug) => slug.slice(SKILL_SLUG_PREFIX.length)),
-    );
-    // Union the local catalog ids as belt-and-suspenders.
-    for (const id of deps.loadValidSkillIds()) validSkills.add(id);
-
-    if (validSkills.size > 0) {
-      const orphans: Slug[] = [];
-      for (const slug of indexedSlugs) {
-        if (isCapabilitySlug(slug)) continue;
-        const skill = await deps.readPageSkillLink(slug);
-        if (skill && !validSkills.has(skill)) orphans.push(slug);
-      }
-      outcome.orphanSkillSlugs = orphans;
-      if (orphans.length > 0) {
-        log.warn(
-          { orphans },
-          "memory-v3 maintain: pages link a `skill:` with no indexed capability row — review the links at the next consolidation",
-        );
-      }
-    }
-  } catch (err) {
-    outcome.failures.push("skill-validate");
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "memory-v3 maintain: skill-link validation failed (non-fatal)",
-    );
-  }
-
-  // Stage 6: rebuild section index + needle + edge graph on the next turn.
+  // Stage 5: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -891,7 +784,6 @@ export async function maintainJob(
       pruned: outcome.pruned,
       pruneFailures: outcome.pruneFailures,
       danglingCoreSlugs: outcome.danglingCoreSlugs,
-      orphanSkillSlugs: outcome.orphanSkillSlugs,
       invalidated: outcome.invalidated,
       failures: outcome.failures,
     },


### PR DESCRIPTION
## Summary
Removes the skill-linked-facts layer: the `skill:` frontmatter field, the `fact → skills/<id>` edge derivation (+ its capability hub-filter exemption), and the maintain-pass skill-link validation stage. Memory and skills are now decoupled.

Part of plan: procedural-memory-as-skills.md (PR 2 of 9)