### PR TITLE
feat(plugin-api): add turn-commit hook fired after turn persistence

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -66,7 +66,10 @@ import {
 } from "../memory/llm-request-log-store.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../memory/memory-retrospective-enqueue.js";
 import { HOOKS } from "../plugin-api/constants.js";
-import type { UserPromptSubmitContext } from "../plugin-api/types.js";
+import type {
+  TurnCommitContext,
+  UserPromptSubmitContext,
+} from "../plugin-api/types.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
@@ -1537,6 +1540,23 @@ export async function runAgentLoopImpl(
       // here so a regression in the writer can never bubble out of the
       // agent loop and reject an otherwise-complete turn.
       void writeRelationshipState().catch(() => {});
+
+      // Fire the post-persistence turn-commit hook (fire-and-forget). This
+      // turn's messages are already persisted; it is the seam where a memory
+      // plugin enqueues consolidation for the turn that just landed. The hook
+      // runner already contains thrown hooks; the catch() additionally guards
+      // hook-discovery failure so neither can reject an otherwise-complete turn.
+      const turnCommitCtx: TurnCommitContext = {
+        conversationId: ctx.conversationId,
+        userMessageId,
+        messages: lastRunNewMessages,
+        turnCount: ctx.turnCount,
+        isNonInteractive,
+        logger: rlog,
+      };
+      void runHook(HOOKS.TURN_COMMIT, turnCommitCtx).catch((err) => {
+        rlog.error({ err }, "turn-commit hook failed");
+      });
     }
 
     ctx.profiler.emitSummary(ctx.traceEmitter, reqId);

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -30,6 +30,14 @@ export const HOOKS = {
   POST_MODEL_CALL: "post-model-call",
   /** Fires after the loop successfully compacts a conversation mid-turn. */
   POST_COMPACT: "post-compact",
+  /**
+   * Fires once per turn AFTER the turn's user + assistant messages are
+   * persisted — the seam for memory consolidation enqueue. NO synchronous LLM
+   * work may run in this hook (enqueue only): it runs on the turn-commit path,
+   * and spending on generation here would charge the user before they have
+   * asked for anything (the no-LLM-at-boot/turn-cost rule).
+   */
+  TURN_COMMIT: "turn-commit",
 } as const;
 
 /** Union of every hook name declared in {@link HOOKS}. */

--- a/assistant/src/plugin-api/turn-commit.test.ts
+++ b/assistant/src/plugin-api/turn-commit.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { runHook } from "../plugins/pipeline.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type { Message } from "../providers/types.js";
+import { HOOKS } from "./constants.js";
+import type { PluginLogger, TurnCommitContext } from "./types.js";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function makeCtx(
+  overrides: Partial<TurnCommitContext> = {},
+): TurnCommitContext {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+    { role: "assistant", content: [{ type: "text", text: "hello" }] },
+  ];
+  return {
+    conversationId: "conv-1",
+    userMessageId: "msg-user-1",
+    messages,
+    turnCount: 1,
+    isNonInteractive: false,
+    logger: noopLogger,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+});
+
+describe("turn-commit hook", () => {
+  test("fires once per committed turn with the right context", async () => {
+    const seen: TurnCommitContext[] = [];
+    registerPlugin({
+      manifest: { name: "test-turn-commit-consumer", version: "1.0.0" },
+      hooks: {
+        [HOOKS.TURN_COMMIT]: async (ctx: TurnCommitContext) => {
+          seen.push(ctx);
+        },
+      },
+    });
+
+    const ctx = makeCtx({ turnCount: 7, userMessageId: "msg-user-7" });
+    await runHook(HOOKS.TURN_COMMIT, ctx);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.conversationId).toBe("conv-1");
+    expect(seen[0]!.userMessageId).toBe("msg-user-7");
+    expect(seen[0]!.turnCount).toBe(7);
+    expect(seen[0]!.isNonInteractive).toBe(false);
+    expect(seen[0]!.messages).toHaveLength(2);
+  });
+
+  test("a throwing hook is contained — runHook resolves and the turn still commits", async () => {
+    const observed: string[] = [];
+    registerPlugin({
+      manifest: { name: "test-turn-commit-thrower", version: "1.0.0" },
+      hooks: {
+        [HOOKS.TURN_COMMIT]: async () => {
+          throw new Error("consolidation enqueue blew up");
+        },
+      },
+    });
+    registerPlugin({
+      manifest: { name: "test-turn-commit-after", version: "1.0.0" },
+      hooks: {
+        [HOOKS.TURN_COMMIT]: async () => {
+          observed.push("after");
+        },
+      },
+    });
+
+    // The hook runner contains the throw: the chain continues and resolves.
+    await expect(runHook(HOOKS.TURN_COMMIT, makeCtx())).resolves.toBeDefined();
+    // A later hook still ran, mirroring the loop's fire-and-forget guarantee
+    // that a failing consolidation hook cannot fail the committed turn.
+    expect(observed).toEqual(["after"]);
+  });
+
+  test("with no registered consumer the hook is a no-op (additive)", async () => {
+    const ctx = makeCtx();
+    const result = await runHook(HOOKS.TURN_COMMIT, ctx);
+    // Same reference back when no plugin registers the hook.
+    expect(result).toBe(ctx);
+  });
+});

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -64,6 +64,7 @@ export interface PluginLogger {
  *   - `post-tool-use` — {@link PostToolUseContext}
  *   - `stop` — {@link StopContext}
  *   - `post-model-call` — {@link PostModelCallContext}
+ *   - `turn-commit` — {@link TurnCommitContext}
  */
 export type HookFunction<TCtx = unknown> = (
   ctx: TCtx,
@@ -615,5 +616,56 @@ export interface PostModelCallContext {
    */
   decision: PostModelCallDecision;
   /** Logger scoped to the current turn (tag structured fields with `{ plugin }`). */
+  readonly logger: PluginLogger;
+}
+
+// ─── Turn-commit hook context ────────────────────────────────────────────────
+
+/**
+ * Context passed to the `turn-commit` hook. Fires once per turn AFTER the
+ * turn's user + assistant messages have been persisted — the post-persistence
+ * seam where a memory system enqueues consolidation work for the turn that just
+ * landed.
+ *
+ * The hook is fired-and-forget: the loop does not await it and contains any
+ * throw, so a hook failure can never fail or delay the turn's commit. It runs
+ * on the turn-commit path, so it must do **no synchronous LLM work** — enqueue
+ * a background job and return. Spending on generation here would charge the
+ * user on every turn before they have asked for anything.
+ *
+ * Multiple plugins' hooks chain in registration order over the same context;
+ * the hook is observational (consolidation enqueue is a side effect), so
+ * mutating the context has no effect on the committed turn.
+ */
+export interface TurnCommitContext {
+  /** Conversation ID the committed turn belongs to. */
+  readonly conversationId: string;
+  /**
+   * Persisted ID of the user message that triggered this turn. Mirrors
+   * {@link UserPromptSubmitContext.userMessageId}: hooks that key turn-scoped
+   * consolidation off the originating message row use this rather than the
+   * message array, whose entries carry no id.
+   */
+  readonly userMessageId: string;
+  /**
+   * The messages this turn appended and persisted — the user prompt followed by
+   * the assistant's reply (and any tool-result messages). Provided for
+   * inspection; the turn is already committed, so mutating it has no effect.
+   */
+  readonly messages: ReadonlyArray<Message>;
+  /** The turn number that just committed (incremented at the commit boundary). */
+  readonly turnCount: number;
+  /**
+   * Whether the turn had no human present (e.g. a scheduled, background, or
+   * headless run). Mirrors the field of the same name on
+   * {@link UserPromptSubmitContext}: resolved once at turn start so consolidation
+   * reflects the turn's interactivity rather than mutable client-presence state.
+   */
+  readonly isNonInteractive: boolean;
+  /**
+   * Logger scoped to the current turn. The same instance is shared by every
+   * hook in the chain, so plugins should tag their structured log fields (e.g.
+   * `{ plugin: "<name>" }`) for attribution.
+   */
   readonly logger: PluginLogger;
 }


### PR DESCRIPTION
## Summary
- Add TURN_COMMIT hook + TurnCommitContext to plugin-api
- Fire runHook after turn persistence in the agent loop (fire-and-forget, error-contained)
- No consumer yet (additive)

Part of plan: memory-plugin-extraction.md (PR 18 of 32)