### PR TITLE
feat(skills): stamp lastUsedAt into install-meta on managed-skill load

### DIFF
--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -201,6 +201,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 mock.module("../skills/install-meta.js", () => ({
   readInstallMeta: () => null,
+  touchSkillLastUsed: () => false,
 }));
 mock.module("../memory/skill-loaded-events-store.js", () => ({
   recordSkillLoadedEvent: () => {},

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -38,6 +38,8 @@ let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
 let mockRecordSkillLoadedFailure = false;
 /** Skill IDs for which registerSkillTools throws (simulates a different-owner tool name collision). */
 let mockRegisterFailures: Set<string> = new Set();
+/** `(skillDir, today)` pairs captured by the mocked touchSkillLastUsed. */
+let recordedLastUsedTouches: Array<{ skillDir: string; today: string }> = [];
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -248,6 +250,10 @@ mock.module("../skills/install-meta.js", () => ({
     const parts = skillDir.split("/");
     const skillId = parts[parts.length - 1];
     return mockInstallMetas[skillId] ?? null;
+  },
+  touchSkillLastUsed: (skillDir: string, today: string) => {
+    recordedLastUsedTouches.push({ skillDir, today });
+    return true;
   },
 }));
 
@@ -1171,6 +1177,153 @@ describe("skill_loaded telemetry recording", () => {
 
     expect(recordedSkillLoadedEvents).toHaveLength(0);
     expect(result.allowedToolNames.has("notes_add")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lastUsedAt stamping on managed-skill load
+// ---------------------------------------------------------------------------
+
+describe("lastUsedAt stamping on managed-skill load", () => {
+  let sessionState: Map<string, string>;
+
+  // The projection layer computes `today` from the local clock; mirror that
+  // expression so the assertion stays correct regardless of the run date.
+  const expectedToday = new Date().toLocaleDateString("en-CA");
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
+    mockInstallMetas = {};
+    recordedSkillLoadedEvents = [];
+    recordedLastUsedTouches = [];
+    sessionState = new Map<string, string>();
+  });
+
+  test("managed skill load stamps lastUsedAt with today's date and its directory", () => {
+    mockCatalog = [makeSkill("homemade")];
+    mockManifests = { homemade: makeManifest(["hm_run"]) };
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(recordedLastUsedTouches).toEqual([
+      { skillDir: "/skills/homemade", today: expectedToday },
+    ]);
+  });
+
+  test("stamps managed skills even when telemetry is off (ungated)", () => {
+    // origin: "custom" is suppressed for telemetry but must still be stamped.
+    mockCatalog = [makeSkill("homemade")];
+    mockManifests = { homemade: makeManifest(["hm_run"]) };
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    // No telemetry option passed.
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(recordedLastUsedTouches).toHaveLength(1);
+    expect(recordedLastUsedTouches[0].skillDir).toBe("/skills/homemade");
+  });
+
+  test("instruction-only managed skill (no TOOLS.json) is stamped", () => {
+    mockCatalog = [makeSkill("catalog-skill")];
+    // No manifest — instruction-only managed skill.
+    mockInstallMetas = {
+      "catalog-skill": {
+        origin: "vellum",
+        installedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="catalog-skill" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(recordedLastUsedTouches).toEqual([
+      { skillDir: "/skills/catalog-skill", today: expectedToday },
+    ]);
+  });
+
+  test("bundled skills are NOT stamped", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: { conversationId: "conv-xyz", attribution: null },
+    });
+
+    // Telemetry still fires for the bundled skill, but no usage stamp.
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedLastUsedTouches).toHaveLength(0);
+  });
+
+  test("workspace skills are NOT stamped", () => {
+    mockCatalog = [makeSkill("local-helper", undefined, "workspace")];
+    mockManifests = { "local-helper": makeManifest(["lh_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="local-helper" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(recordedLastUsedTouches).toHaveLength(0);
+  });
+
+  test("a still-active skill on a later turn does not re-stamp", () => {
+    mockCatalog = [makeSkill("homemade")];
+    mockManifests = { homemade: makeManifest(["hm_run"]) };
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    // Stamping rides the same load events as telemetry — once per activation.
+    expect(recordedLastUsedTouches).toHaveLength(1);
+  });
+
+  test("version-hash change re-registers and re-stamps the managed skill", () => {
+    mockCatalog = [makeSkill("homemade")];
+    mockManifests = { homemade: makeManifest(["hm_run"]) };
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+    mockVersionHashes = { homemade: "v1:hash-aaa" };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    mockVersionHashes = { homemade: "v1:hash-bbb" };
+    projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
+
+    expect(recordedLastUsedTouches).toHaveLength(2);
   });
 });
 

--- a/assistant/src/__tests__/install-meta.test.ts
+++ b/assistant/src/__tests__/install-meta.test.ts
@@ -15,6 +15,7 @@ import {
   computeSkillHash,
   readInstallMeta,
   type SkillInstallMeta,
+  touchSkillLastUsed,
   writeInstallMeta,
 } from "../skills/install-meta.js";
 
@@ -354,6 +355,79 @@ describe("readInstallMeta", () => {
       expect(typeof result!.installedAt).toBe("string");
       expect(new Date(result!.installedAt).getTime()).not.toBeNaN();
     });
+  });
+});
+
+// ─── touchSkillLastUsed ─────────────────────────────────────────────────────
+
+describe("touchSkillLastUsed", () => {
+  function lastUsedDate(dir: string): string | undefined {
+    return readInstallMeta(dir)?.lastUsedAt?.slice(0, 10);
+  }
+
+  test("returns false and writes nothing when install metadata is absent", () => {
+    const dir = makeTempDir();
+    expect(touchSkillLastUsed(dir, "2026-06-22")).toBe(false);
+    expect(existsSync(join(dir, "install-meta.json"))).toBe(false);
+  });
+
+  test("first stamp writes today's date and returns true", () => {
+    const dir = makeTempDir();
+    writeInstallMeta(dir, {
+      origin: "custom",
+      installedAt: "2026-01-15T10:30:00.000Z",
+      author: "assistant",
+    });
+
+    expect(touchSkillLastUsed(dir, "2026-06-22")).toBe(true);
+    expect(lastUsedDate(dir)).toBe("2026-06-22");
+    // Existing fields are preserved.
+    const meta = readInstallMeta(dir);
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.author).toBe("assistant");
+    expect(meta!.installedAt).toBe("2026-01-15T10:30:00.000Z");
+    // The stamp is a full ISO timestamp, not a bare date.
+    expect(meta!.lastUsedAt).toBe("2026-06-22T00:00:00.000Z");
+  });
+
+  test("second stamp on the same day is a no-op (debounced)", () => {
+    const dir = makeTempDir();
+    writeInstallMeta(dir, {
+      origin: "custom",
+      installedAt: "2026-01-15T10:30:00.000Z",
+      lastUsedAt: "2026-06-22T08:00:00.000Z",
+    });
+
+    expect(touchSkillLastUsed(dir, "2026-06-22")).toBe(false);
+    // The existing timestamp is untouched.
+    expect(readInstallMeta(dir)!.lastUsedAt).toBe("2026-06-22T08:00:00.000Z");
+  });
+
+  test("stamp on a later day rewrites lastUsedAt", () => {
+    const dir = makeTempDir();
+    writeInstallMeta(dir, {
+      origin: "custom",
+      installedAt: "2026-01-15T10:30:00.000Z",
+      lastUsedAt: "2026-06-22T08:00:00.000Z",
+    });
+
+    expect(touchSkillLastUsed(dir, "2026-06-23")).toBe(true);
+    expect(lastUsedDate(dir)).toBe("2026-06-23");
+  });
+
+  test("stamps over a malformed install-meta.json via legacy version.json fallback", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "install-meta.json"), "{bad json", "utf-8");
+    writeFileSync(
+      join(dir, "version.json"),
+      JSON.stringify({ version: "1.0.0" }),
+      "utf-8",
+    );
+
+    expect(touchSkillLastUsed(dir, "2026-06-22")).toBe(true);
+    const meta = readInstallMeta(dir);
+    expect(meta!.origin).toBe("vellum");
+    expect(meta!.lastUsedAt).toBe("2026-06-22T00:00:00.000Z");
   });
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -230,6 +230,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 mock.module("../skills/install-meta.js", () => ({
   readInstallMeta: () => null,
+  touchSkillLastUsed: () => false,
 }));
 mock.module("../memory/skill-loaded-events-store.js", () => ({
   recordSkillLoadedEvent: () => {},

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -104,6 +104,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 mock.module("../skills/install-meta.js", () => ({
   readInstallMeta: () => null,
+  touchSkillLastUsed: () => false,
 }));
 mock.module("../memory/skill-loaded-events-store.js", () => ({
   recordSkillLoadedEvent: () => {},

--- a/assistant/src/__tests__/skill-version-hash.test.ts
+++ b/assistant/src/__tests__/skill-version-hash.test.ts
@@ -53,6 +53,38 @@ describe("computeSkillVersionHash", () => {
     expect(hash1).not.toBe(hash2);
   });
 
+  test("ignores top-level provenance/usage metadata files", () => {
+    const dir = makeTempSkill();
+    writeFileSync(join(dir, "SKILL.md"), "# Skill\n");
+    const base = computeSkillVersionHash(dir);
+
+    // Writing install-meta.json / version.json must NOT change the version hash.
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify({
+        origin: "custom",
+        lastUsedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    writeFileSync(join(dir, "version.json"), JSON.stringify({ version: "1" }));
+    expect(computeSkillVersionHash(dir)).toBe(base);
+
+    // A later lastUsedAt usage stamp also leaves the hash unchanged.
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify({
+        origin: "custom",
+        lastUsedAt: "2026-12-31T23:59:59.000Z",
+      }),
+    );
+    expect(computeSkillVersionHash(dir)).toBe(base);
+
+    // Only TOP-LEVEL metadata is excluded; a nested same-named file is hashed.
+    mkdirSync(join(dir, "references"), { recursive: true });
+    writeFileSync(join(dir, "references", "install-meta.json"), "nested");
+    expect(computeSkillVersionHash(dir)).not.toBe(base);
+  });
+
   test("changes when a new file is added", () => {
     const dir = makeTempSkill();
     writeFileSync(join(dir, "SKILL.md"), "# Skill\n");

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -21,7 +21,7 @@ import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
 import { getCachedCatalogSync } from "../skills/catalog-cache.js";
-import { readInstallMeta } from "../skills/install-meta.js";
+import { readInstallMeta, touchSkillLastUsed } from "../skills/install-meta.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import {
@@ -191,6 +191,20 @@ function recordSkillLoadedTelemetry(
       "Failed to record skill_loaded telemetry event (non-fatal)",
     );
   }
+}
+
+/**
+ * Stamp `lastUsedAt` (day-debounced) on a newly-loaded managed skill's
+ * install metadata. Independent of telemetry consent and the
+ * `isVellumProducedSkill` gate — those suppress `origin: "custom"` skills,
+ * which are exactly the assistant-authored skills the usage-based prune must
+ * track. Only managed skills carry install metadata; bundled, workspace, and
+ * plugin skills are skipped. Best-effort: the underlying write never throws.
+ */
+function stampManagedSkillUsage(skill: SkillSummary): void {
+  if (skill.source !== "managed") return;
+  const today = new Date().toLocaleDateString("en-CA");
+  touchSkillLastUsed(skill.directoryPath, today);
 }
 
 // ---------------------------------------------------------------------------
@@ -403,6 +417,7 @@ export function projectSkillTools(
       successfulEntries.set(skillId, NO_TOOLS_VERSION);
       if (prevHash === undefined) {
         recordSkillLoadedTelemetry(skill, options?.telemetry);
+        stampManagedSkillUsage(skill);
       }
       continue;
     }
@@ -446,6 +461,7 @@ export function projectSkillTools(
         // activation gaining a TOOLS.json re-registers, which — like a
         // version-hash change — counts as a new load.
         recordSkillLoadedTelemetry(skill, options?.telemetry);
+        stampManagedSkillUsage(skill);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -466,6 +482,7 @@ export function projectSkillTools(
         }
         // A version change that re-registers counts as a new skill load.
         recordSkillLoadedTelemetry(skill, options?.telemetry);
+        stampManagedSkillUsage(skill);
       } else {
         // Hash unchanged — filter to only tools that are actually registered
         // for this skill. Some tools may have been skipped during initial

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -203,8 +203,15 @@ function recordSkillLoadedTelemetry(
  */
 function stampManagedSkillUsage(skill: SkillSummary): void {
   if (skill.source !== "managed") return;
-  const today = new Date().toLocaleDateString("en-CA");
-  touchSkillLastUsed(skill.directoryPath, today);
+  try {
+    const today = new Date().toLocaleDateString("en-CA");
+    touchSkillLastUsed(skill.directoryPath, today);
+  } catch (err) {
+    log.warn(
+      { err, skillId: skill.id },
+      "Failed to stamp managed-skill lastUsedAt (non-fatal)",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -10,6 +10,10 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("install-meta");
+
 // ─── SkillInstallMeta type ──────────────────────────────────────────────────
 
 export interface SkillInstallMeta {
@@ -26,7 +30,8 @@ export interface SkillInstallMeta {
   // are protected. Set by install/scaffold callers, never defaulted here.
   author?: "assistant" | "user";
   // Day-granularity stamp of the last time the skill was loaded (ISO 8601).
-  // Written by a later PR (skill-load instrumentation); unused for now.
+  // Stamped by `touchSkillLastUsed` on the managed-skill activation path; the
+  // usage-based prune reads its date portion as the last-used signal.
   lastUsedAt?: string;
 }
 
@@ -141,6 +146,38 @@ function inferFromLegacyVersionJson(
         ? raw.installedAt
         : new Date().toISOString(),
   };
+}
+
+// ─── Last-used stamp (day-debounced) ────────────────────────────────────────
+
+/**
+ * Stamp `lastUsedAt` on the skill's `install-meta.json` for `today` (a
+ * `YYYY-MM-DD` string), debounced to at most one write per calendar day.
+ *
+ * Returns `true` when a write happened, `false` otherwise (no install metadata,
+ * already stamped for `today`, or an IO failure). `today` is injected rather
+ * than read from a clock so the debounce window is testable.
+ *
+ * Best-effort: any IO failure is logged and swallowed — callers stamp on the
+ * hot tool-projection path and must never have it throw.
+ */
+export function touchSkillLastUsed(skillDir: string, today: string): boolean {
+  try {
+    const meta = readInstallMeta(skillDir);
+    if (!meta) return false;
+
+    // Compare only the date portion so multiple loads within a day are a no-op.
+    if (meta.lastUsedAt?.slice(0, 10) === today) return false;
+
+    writeInstallMeta(skillDir, {
+      ...meta,
+      lastUsedAt: new Date(`${today}T00:00:00.000Z`).toISOString(),
+    });
+    return true;
+  } catch (err) {
+    log.debug({ err, skillDir }, "Failed to stamp lastUsedAt (non-fatal)");
+    return false;
+  }
 }
 
 // ─── Content hash computation ───────────────────────────────────────────────

--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -91,6 +91,18 @@ function collectFiles(
 }
 
 /**
+ * Top-level provenance/usage metadata excluded from the version hash. These
+ * files carry no skill behavior, and the `lastUsedAt` usage stamp rewrites
+ * `install-meta.json` on load — including it here would trip version-change
+ * detection on the first stamped load each day. Mirrors the content-hash
+ * exclusion in `install-meta.ts`.
+ */
+const VERSION_HASH_EXCLUDED_FILES = new Set([
+  "install-meta.json",
+  "version.json",
+]);
+
+/**
  * Compute a deterministic version hash for a skill directory.
  *
  * The hash is computed from:
@@ -107,6 +119,14 @@ export function computeSkillVersionHash(skillDir: string): string {
 
   for (const relPath of files) {
     const normalized = relPath.replaceAll("\\", "/");
+    // Skip top-level provenance/usage metadata so author tags and lastUsedAt
+    // usage stamps never change the content-version hash.
+    if (
+      !normalized.includes("/") &&
+      VERSION_HASH_EXCLUDED_FILES.has(normalized)
+    ) {
+      continue;
+    }
     const content = readFileSync(join(skillDir, relPath));
     hash.update(normalized);
     hash.update("\0");


### PR DESCRIPTION
## Summary
Adds touchSkillLastUsed (day-debounced) and calls it on the managed-skill activation path, outside the telemetry/isVellumProducedSkill gates so origin:custom skills are tracked. Feeds PR8's usage prune.

Part of plan: procedural-memory-as-skills.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->