### PR TITLE
feat(skills): write procedure-scoped companion files via scaffold_managed_skill

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -34,6 +34,7 @@ import {
   buildSkillMarkdown,
   createManagedSkill,
   deleteManagedSkill,
+  validateCompanionPath,
   validateManagedSkillId,
 } from "../skills/managed-store.js";
 
@@ -350,6 +351,190 @@ describe("createManagedSkill", () => {
     const skill = catalog.find((s) => s.id === "discovered-skill");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Discovered");
+  });
+});
+
+describe("validateCompanionPath", () => {
+  const skillDir = "/workspace/skills/my-skill";
+
+  test("accepts a nested relative path", () => {
+    const result = validateCompanionPath(
+      skillDir,
+      "references/failure-modes.md",
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.resolvedPath).toBe(
+      join(skillDir, "references", "failure-modes.md"),
+    );
+  });
+
+  test("rejects absolute paths", () => {
+    expect(validateCompanionPath(skillDir, "/etc/passwd").error).toContain(
+      "relative",
+    );
+  });
+
+  test("rejects traversal with leading ..", () => {
+    expect(
+      validateCompanionPath(skillDir, "../sibling/evil.md").error,
+    ).toContain("..");
+  });
+
+  test("rejects traversal in a middle segment", () => {
+    expect(
+      validateCompanionPath(skillDir, "references/../../escape.md").error,
+    ).toContain("..");
+  });
+
+  test("rejects empty path", () => {
+    expect(validateCompanionPath(skillDir, "").error).not.toBeUndefined();
+  });
+
+  test("rejects path resolving to the skill dir itself", () => {
+    expect(validateCompanionPath(skillDir, ".").error).not.toBeUndefined();
+  });
+});
+
+describe("createManagedSkill companion files", () => {
+  test("writes companion files under the skill dir and round-trips on disk", () => {
+    const result = createManagedSkill({
+      id: "with-files",
+      name: "With Files",
+      description: "Has companion files",
+      bodyMarkdown: "See references/failure-modes.md.",
+      files: [
+        {
+          path: "references/failure-modes.md",
+          content: "# Failure modes\n\nThings that break.\n",
+        },
+      ],
+    });
+
+    expect(result.created).toBe(true);
+    const companionPath = join(
+      TEST_DIR,
+      "skills",
+      "with-files",
+      "references",
+      "failure-modes.md",
+    );
+    expect(existsSync(companionPath)).toBe(true);
+    expect(readFileSync(companionPath, "utf-8")).toBe(
+      "# Failure modes\n\nThings that break.\n",
+    );
+  });
+
+  test("rejects path traversal and writes nothing", () => {
+    const result = createManagedSkill({
+      id: "traversal",
+      name: "Traversal",
+      description: "Bad companion path",
+      bodyMarkdown: "Body.",
+      files: [{ path: "../escape.md", content: "owned" }],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).toContain("..");
+    // No SKILL.md written, no escaped file written.
+    expect(existsSync(join(TEST_DIR, "skills", "traversal", "SKILL.md"))).toBe(
+      false,
+    );
+    expect(existsSync(join(TEST_DIR, "skills", "escape.md"))).toBe(false);
+  });
+
+  test("rejects absolute companion paths and writes nothing", () => {
+    const result = createManagedSkill({
+      id: "abs-path",
+      name: "Absolute",
+      description: "Absolute companion path",
+      bodyMarkdown: "Body.",
+      files: [{ path: "/tmp/evil.md", content: "owned" }],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).toContain("relative");
+    expect(existsSync(join(TEST_DIR, "skills", "abs-path", "SKILL.md"))).toBe(
+      false,
+    );
+  });
+
+  test("rejects a path resolving outside the skill dir and writes nothing", () => {
+    const result = createManagedSkill({
+      id: "outside",
+      name: "Outside",
+      description: "Resolves outside",
+      bodyMarkdown: "Body.",
+      files: [
+        { path: "ok.md", content: "ok" },
+        { path: "nested/../../sneaky.md", content: "owned" },
+      ],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).not.toBeUndefined();
+    // First file must not be written because validation runs before any write.
+    expect(existsSync(join(TEST_DIR, "skills", "outside", "ok.md"))).toBe(
+      false,
+    );
+    expect(existsSync(join(TEST_DIR, "skills", "outside", "SKILL.md"))).toBe(
+      false,
+    );
+  });
+
+  test("does not write companion files when create errors on an existing skill", () => {
+    createManagedSkill({
+      id: "exists-files",
+      name: "Exists",
+      description: "Already here",
+      bodyMarkdown: "Body.",
+    });
+
+    const result = createManagedSkill({
+      id: "exists-files",
+      name: "Exists Again",
+      description: "Should not write",
+      bodyMarkdown: "Body.",
+      files: [{ path: "references/new.md", content: "new" }],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).toContain("already exists");
+    expect(
+      existsSync(
+        join(TEST_DIR, "skills", "exists-files", "references", "new.md"),
+      ),
+    ).toBe(false);
+  });
+
+  test("overwrite re-writes companion files", () => {
+    createManagedSkill({
+      id: "overwrite-files",
+      name: "V1",
+      description: "First",
+      bodyMarkdown: "Body.",
+      files: [{ path: "references/notes.md", content: "v1 notes" }],
+    });
+
+    const companionPath = join(
+      TEST_DIR,
+      "skills",
+      "overwrite-files",
+      "references",
+      "notes.md",
+    );
+    expect(readFileSync(companionPath, "utf-8")).toBe("v1 notes");
+
+    const result = createManagedSkill({
+      id: "overwrite-files",
+      name: "V2",
+      description: "Second",
+      bodyMarkdown: "Body.",
+      overwrite: true,
+      files: [{ path: "references/notes.md", content: "v2 notes" }],
+    });
+
+    expect(result.created).toBe(true);
+    expect(readFileSync(companionPath, "utf-8")).toBe("v2 notes");
   });
 });
 

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -393,6 +393,18 @@ describe("validateCompanionPath", () => {
   test("rejects path resolving to the skill dir itself", () => {
     expect(validateCompanionPath(skillDir, ".").error).not.toBeUndefined();
   });
+
+  test("rejects store-owned top-level files", () => {
+    for (const reserved of ["SKILL.md", "install-meta.json", "version.json"]) {
+      expect(validateCompanionPath(skillDir, reserved).error).toContain(
+        "store-owned",
+      );
+    }
+    // The same name nested under a subdirectory is allowed (only top-level reserved).
+    expect(
+      validateCompanionPath(skillDir, "references/SKILL.md").error,
+    ).toBeUndefined();
+  });
 });
 
 describe("createManagedSkill companion files", () => {

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -436,6 +436,34 @@ describe("createManagedSkill companion files", () => {
     );
   });
 
+  test("rejects a companion path colliding with an existing directory on overwrite, leaving SKILL.md intact", () => {
+    const first = createManagedSkill({
+      id: "dir-collide",
+      name: "Dir Collide",
+      description: "v1",
+      bodyMarkdown: "Body v1.",
+      files: [{ path: "references/note.md", content: "note" }],
+    });
+    expect(first.created).toBe(true);
+    const skillMd = join(TEST_DIR, "skills", "dir-collide", "SKILL.md");
+    const before = readFileSync(skillMd, "utf-8");
+
+    // Overwrite with a companion path that names the existing references/ dir.
+    const second = createManagedSkill({
+      id: "dir-collide",
+      name: "Dir Collide",
+      description: "v2",
+      bodyMarkdown: "Body v2.",
+      overwrite: true,
+      files: [{ path: "references", content: "clobber" }],
+    });
+
+    expect(second.created).toBe(false);
+    expect(second.error).toContain("existing directory");
+    // The pre-flight runs before any write, so SKILL.md is untouched.
+    expect(readFileSync(skillMd, "utf-8")).toBe(before);
+  });
+
   test("rejects path traversal and writes nothing", () => {
     const result = createManagedSkill({
       id: "traversal",

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -309,6 +309,82 @@ describe("scaffold_managed_skill tool", () => {
     expect(result.content).toContain("traversal");
   });
 
+  test("writes companion files under the skill dir", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "files-skill",
+        name: "Files Skill",
+        description: "Has companion files",
+        body_markdown: "See references/failure-modes.md.",
+        files: [
+          {
+            path: "references/failure-modes.md",
+            content: "# Failure modes\n",
+          },
+        ],
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const companionPath = join(
+      TEST_DIR,
+      "skills",
+      "files-skill",
+      "references",
+      "failure-modes.md",
+    );
+    expect(existsSync(companionPath)).toBe(true);
+    expect(readFileSync(companionPath, "utf-8")).toBe("# Failure modes\n");
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects companion file path traversal with no partial writes", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "files-traversal",
+        name: "Traversal",
+        description: "Bad path",
+        body_markdown: "Body.",
+        files: [{ path: "../escape.md", content: "owned" }],
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("..");
+    expect(
+      existsSync(join(TEST_DIR, "skills", "files-traversal", "SKILL.md")),
+    ).toBe(false);
+    expect(existsSync(join(TEST_DIR, "skills", "escape.md"))).toBe(false);
+    expect(mockRefreshSkillCapabilityMemories).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed files input", async () => {
+    const cases: unknown[] = [
+      "not-an-array",
+      [{ content: "missing path" }],
+      [{ path: "ok.md" }],
+      [{ path: 42, content: "bad path type" }],
+      [{ path: "ok.md", content: 7 }],
+      ["just-a-string"],
+    ];
+
+    for (const files of cases) {
+      const result = await executeScaffoldManagedSkill(
+        {
+          skill_id: "bad-files",
+          name: "Bad",
+          description: "Bad files",
+          body_markdown: "Body.",
+          files,
+        },
+        makeContext(),
+      );
+      expect(result.isError).toBe(true);
+    }
+  });
+
   test("e2e: scaffold child then parent with includes, verify file discovery", async () => {
     const childResult = await executeScaffoldManagedSkill(
       {

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -38,6 +38,24 @@
             "items": { "type": "string" },
             "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
           },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "Path relative to the skill directory (e.g. \"references/failure-modes.md\"). Absolute paths and \"..\" segments are rejected."
+                },
+                "content": {
+                  "type": "string",
+                  "description": "File contents."
+                }
+              },
+              "required": ["path", "content"]
+            },
+            "description": "Optional companion files written under the skill directory (e.g. references/*.md referenced from SKILL.md). Paths must resolve inside the skill folder."
+          },
           "add_to_index": {
             "type": "boolean",
             "description": "Deprecated no-op compatibility field. Skills are discovered from top-level SKILL.md files."

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, normalize, relative, sep } from "node:path";
@@ -232,6 +233,16 @@ export function createManagedSkill(
         created: false,
         path: skillFilePath,
         error: error ?? "invalid companion file path",
+      };
+    }
+    // Reject a companion path that resolves to an existing directory before any
+    // write: the atomic rename would throw mid-loop (after SKILL.md is already
+    // rewritten on overwrite), leaving a half-updated skill.
+    if (existsSync(resolvedPath) && statSync(resolvedPath).isDirectory()) {
+      return {
+        created: false,
+        path: skillFilePath,
+        error: `companion file path resolves to an existing directory: "${file.path}"`,
       };
     }
     companionWrites.push({ resolvedPath, content: file.content });

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -6,7 +6,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, normalize, relative, sep } from "node:path";
 
 import { stringify as stringifyYaml } from "yaml";
 
@@ -40,6 +40,46 @@ function getManagedSkillsDir(): string {
 
 function getManagedSkillDir(id: string): string {
   return join(getManagedSkillsDir(), id);
+}
+
+interface ResolvedCompanionPath {
+  resolvedPath?: string;
+  error?: string;
+}
+
+/**
+ * Validate a companion file path and resolve it under the skill directory.
+ * Rejects absolute paths, `..` segments, and any path that resolves outside
+ * the skill dir. Returns the resolved absolute path or an error.
+ */
+export function validateCompanionPath(
+  skillDir: string,
+  filePath: string,
+): ResolvedCompanionPath {
+  if (!filePath || typeof filePath !== "string") {
+    return { error: "companion file path is required" };
+  }
+  if (isAbsolute(filePath)) {
+    return { error: `companion file path must be relative: "${filePath}"` };
+  }
+  const normalized = normalize(filePath);
+  if (
+    normalized === ".." ||
+    normalized.startsWith(`..${sep}`) ||
+    normalized.split(sep).includes("..")
+  ) {
+    return {
+      error: `companion file path must not contain ".." segments: "${filePath}"`,
+    };
+  }
+  const resolvedPath = join(skillDir, normalized);
+  const rel = relative(skillDir, resolvedPath);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    return {
+      error: `companion file path must resolve under the skill directory: "${filePath}"`,
+    };
+  }
+  return { resolvedPath };
 }
 
 // ─── SKILL.md generation ─────────────────────────────────────────────────────
@@ -120,6 +160,7 @@ interface CreateManagedSkillParams {
   version?: string;
   contactId?: string;
   author?: "assistant" | "user";
+  files?: Array<{ path: string; content: string }>;
 }
 
 interface CreateManagedSkillResult {
@@ -166,6 +207,21 @@ export function createManagedSkill(
     };
   }
 
+  // Resolve and validate every companion path before any write so an invalid
+  // path leaves no partial files behind.
+  const companionWrites: Array<{ resolvedPath: string; content: string }> = [];
+  for (const file of params.files ?? []) {
+    const { resolvedPath, error } = validateCompanionPath(skillDir, file.path);
+    if (error || !resolvedPath) {
+      return {
+        created: false,
+        path: skillFilePath,
+        error: error ?? "invalid companion file path",
+      };
+    }
+    companionWrites.push({ resolvedPath, content: file.content });
+  }
+
   const content = buildSkillMarkdown({
     name: params.name,
     description: params.description,
@@ -176,6 +232,11 @@ export function createManagedSkill(
 
   mkdirSync(skillDir, { recursive: true });
   atomicWriteFile(skillFilePath, content);
+
+  for (const { resolvedPath, content: fileContent } of companionWrites) {
+    mkdirSync(dirname(resolvedPath), { recursive: true });
+    atomicWriteFile(resolvedPath, fileContent);
+  }
 
   // Write install metadata
   writeInstallMeta(skillDir, {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -79,8 +79,23 @@ export function validateCompanionPath(
       error: `companion file path must resolve under the skill directory: "${filePath}"`,
     };
   }
+  // A companion write must never clobber a top-level store-owned file: SKILL.md
+  // is the discovery entry point (generated from name/description/body), and the
+  // metadata files carry provenance the store owns.
+  if (RESERVED_COMPANION_NAMES.has(rel.replaceAll(sep, "/"))) {
+    return {
+      error: `companion file path must not overwrite the store-owned file: "${filePath}"`,
+    };
+  }
   return { resolvedPath };
 }
+
+/** Top-level files owned by the store; companion writes may never target them. */
+const RESERVED_COMPANION_NAMES = new Set([
+  "SKILL.md",
+  "install-meta.json",
+  "version.json",
+]);
 
 // ─── SKILL.md generation ─────────────────────────────────────────────────────
 

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -84,6 +84,44 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  // Validate and normalize companion files
+  let files: Array<{ path: string; content: string }> | undefined;
+  if (input.files !== undefined) {
+    if (!Array.isArray(input.files)) {
+      return {
+        content: "Error: files must be an array of { path, content } objects",
+        isError: true,
+      };
+    }
+    const collected: Array<{ path: string; content: string }> = [];
+    for (const item of input.files) {
+      if (typeof item !== "object" || item === null) {
+        return {
+          content:
+            "Error: each element in files must be a { path, content } object",
+          isError: true,
+        };
+      }
+      const { path, content } = item as Record<string, unknown>;
+      if (typeof path !== "string" || !path.trim()) {
+        return {
+          content: "Error: each file must have a non-empty string path",
+          isError: true,
+        };
+      }
+      if (typeof content !== "string") {
+        return {
+          content: "Error: each file must have a string content",
+          isError: true,
+        };
+      }
+      collected.push({ path: path.trim(), content });
+    }
+    if (collected.length > 0) {
+      files = collected;
+    }
+  }
+
   const result = createManagedSkill({
     id: skillId.trim(),
     name: sanitizeFrontmatterValue(name),
@@ -95,6 +133,7 @@ export async function executeScaffoldManagedSkill(
         : undefined,
     overwrite: input.overwrite === true,
     includes,
+    files,
   });
 
   if (!result.created) {


### PR DESCRIPTION
## Summary
Extends scaffold_managed_skill / createManagedSkill with an optional files:[{path,content}] input, path-validated and scoped under the skill dir (rejects absolute/.. /out-of-dir), atomic, overwrite-aware. Inert until PR7's retrospective uses it.

Part of plan: procedural-memory-as-skills.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->