### PR TITLE
feat(memory): nearestExistingSkills shortlist + internal find_similar_skills tool

### DIFF
--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -69,6 +69,29 @@
       },
       "executor": "tools/delete-managed.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "find_similar_skills",
+      "description": "Find the existing skills most similar to a goal. Scores the goal against the skill catalog's capability pages and returns a ranked shortlist of nearest skills, each with its name, description, and similarity score. Read-only — it never creates, edits, or deletes anything.",
+      "category": "skills",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "goal": {
+            "type": "string",
+            "description": "The goal or intent to match against existing skills."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of nearest skills to return (default: 5)."
+          }
+        },
+        "required": ["goal"]
+      },
+      "executor": "tools/find-similar.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/skill-management/tools/find-similar.ts
+++ b/assistant/src/config/bundled-skills/skill-management/tools/find-similar.ts
@@ -1,0 +1,12 @@
+import { executeFindSimilarSkills } from "../../../../tools/skills/find-similar-skills.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeFindSimilarSkills(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -118,6 +118,7 @@ import * as openSystemSettings from "./bundled-skills/settings/tools/open-system
 import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
 // ── skill-management ───────────────────────────────────────────────────────────
 import * as deleteManaged from "./bundled-skills/skill-management/tools/delete-managed.js";
+import * as findSimilarSkills from "./bundled-skills/skill-management/tools/find-similar.js";
 import * as scaffoldManaged from "./bundled-skills/skill-management/tools/scaffold-managed.js";
 // ── subagent ───────────────────────────────────────────────────────────────────
 import * as subagentAbort from "./bundled-skills/subagent/tools/subagent-abort.js";
@@ -262,6 +263,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   // skill-management
   ["skill-management:tools/scaffold-managed.ts", scaffoldManaged],
   ["skill-management:tools/delete-managed.ts", deleteManaged],
+  ["skill-management:tools/find-similar.ts", findSimilarSkills],
 
   // subagent
   ["subagent:tools/subagent-spawn.ts", subagentSpawn],

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/candidate-match.test.ts
@@ -1,33 +1,28 @@
 /**
- * Tests for `candidate-match.ts` — the procedural-memory candidate-identity
- * matcher (Tier 0 existing-skill + Tier 1 candidate-cluster).
+ * Tests for `candidate-match.ts` — `nearestExistingSkills`, the skill-catalog
+ * ANN shortlist.
  *
- * The matcher's ANN/embedding seam and its catalog/registry reads are
- * dependency-injected via `MatchCandidateOptions`, so these tests exercise the
- * pure tier logic with a fake scorer + fake catalog/candidate sets — no Qdrant,
- * no embedding backend. Coverage:
- *   - Tier 0: a goal scoring at/above the existing-skill threshold against a
- *     skill capability page resolves to `existing-skill` (and short-circuits
- *     Tier 1).
- *   - Tier 1: a goal scoring at/above the cluster threshold against a candidate
- *     member note resolves to `cluster` carrying the OWNING cluster's id — not
- *     the matched note slug (the store keys every mutator on `cluster_id`).
- *   - Novel: a goal below the gray band against everything resolves to `new`.
- *   - Gray band: a goal whose best candidate match lands in
- *     `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` resolves to `gray`
- *     carrying the owning cluster id (the Tier-2 judge is the caller's job,
- *     never invoked here).
- *   - Threshold precedence (Tier 0 beats Tier 1) + read-only invariant (no
- *     writes, default registry reader only SELECTs).
+ * The matcher's ANN/embedding seam and its catalog read are dependency-injected
+ * via `NearestExistingSkillsOptions`, so these tests exercise the pure ranking
+ * with a fake scorer + fake catalog — no Qdrant, no embedding backend. Coverage:
+ *   - Ranking: hits come back descending by score, each resolved from its
+ *     capability-page slug to its skill id.
+ *   - Top-K: the shortlist is bounded by `limit` (default 5).
+ *   - Floor: hits below `SHORTLIST_THRESHOLD` are excluded; the floor is
+ *     inclusive at the boundary.
+ *   - Empty catalog → `[]` (the scorer is never called).
+ *   - Default-scorer retry: a transient embedding failure is retried; a
+ *     persistent transient error degrades to `[]` after the budget; a
+ *     non-transient error degrades immediately without retry.
  *
  * The logger is stubbed so the default-scorer failure path stays quiet; the
- * tier-logic tests never reach it because they inject a fake scorer.
+ * ranking tests never reach it because they inject a fake scorer.
  */
 
 import { describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
-import type { CandidateClusterRef, ScoredSlug } from "../candidate-match.js";
+import type { ScoredSlug } from "../candidate-match.js";
 
 // Spread the real logger module so we override ONLY `getLogger`. The matcher's
 // import graph transitively reaches CLI modules that import `getCliLogger` from
@@ -43,8 +38,8 @@ mock.module("../../../../util/logger.js", () => ({
 // `simBatch` is the matcher's DEFAULT scorer (used only when the caller does not
 // inject `scoreSlugs`). The retry tests below drive this default path, so the
 // real `simBatch` is replaced by a programmable stub whose behavior each test
-// sets via `simBatchImpl`. The tier-logic tests inject their own `scoreSlugs`
-// and never touch this stub.
+// sets via `simBatchImpl`. The ranking tests inject their own `scoreSlugs` and
+// never touch this stub.
 let simBatchImpl: (
   text: string,
   slugs: readonly string[],
@@ -65,16 +60,16 @@ mock.module("../../../../util/retry.js", () => ({
 }));
 
 const {
-  matchCandidate,
+  nearestExistingSkills,
   EXISTING_SKILL_THRESHOLD,
-  CLUSTER_MATCH_THRESHOLD,
-  GRAY_BAND_THRESHOLD,
+  SHORTLIST_THRESHOLD,
+  DEFAULT_SHORTLIST_LIMIT,
 } = await import("../candidate-match.js");
 
 // ---------------------------------------------------------------------------
-// Test helpers — a fake scorer driven by a slug→score table, plus fake catalog
-// and candidate-note sources. The scorer only returns hits for the slugs it was
-// restricted to, mirroring `hybridQueryConceptPages`'s server-side filter.
+// Test helpers — a fake scorer driven by a slug→score table, plus a fake
+// catalog source. The scorer only returns hits for the slugs it was restricted
+// to, mirroring `simBatch`'s server-side slug filter.
 // ---------------------------------------------------------------------------
 
 function fakeScorer(scores: Record<string, number>) {
@@ -96,226 +91,147 @@ const catalog =
   () =>
     ids.map((id) => ({ id }));
 
-// A Tier-1 candidate-cluster source. Each cluster carries its own `clusterId`
-// plus the member-note slugs that are actually embedded; the matcher ANN-scores
-// the slugs but must report the owning clusterId. Fixtures deliberately give
-// clusters a `clusterId` that DIFFERS from any member-note slug so a test fails
-// if the matcher leaks a note slug as the clusterId.
-const clusters =
-  (...refs: CandidateClusterRef[]) =>
-  () =>
-    refs;
-const cluster = (
-  clusterId: string,
-  ...memberNoteSlugs: string[]
-): CandidateClusterRef => ({ clusterId, memberNoteSlugs });
-
-describe("matchCandidate — Tier 0 (existing skill)", () => {
-  test("a goal matching a skill capability page → existing-skill", async () => {
-    const { fn } = fakeScorer({ "skills/deploy-web": 0.91 });
-
-    const result = await matchCandidate("ship the web app to prod", {
-      scoreSlugs: fn,
-      loadCatalog: catalog("deploy-web", "rotate-secrets"),
-      listCandidateClusters: clusters(
-        cluster("cluster/other", "proc/something-else"),
-      ),
-    });
-
-    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
-  });
-
-  test("Tier 0 short-circuits before Tier 1 is even queried", async () => {
-    const { fn, calls } = fakeScorer({
-      "skills/deploy-web": EXISTING_SKILL_THRESHOLD,
-      // A candidate note that would ALSO match — but Tier 1 must never run.
-      "proc/deploy-candidate": 0.99,
-    });
-
-    const result = await matchCandidate("deploy the app", {
-      scoreSlugs: fn,
-      loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(
-        cluster("cluster/deploy", "proc/deploy-candidate"),
-      ),
-    });
-
-    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
-    // Only the Tier-0 (skill) restriction was scored.
-    expect(calls).toEqual([["skills/deploy-web"]]);
-  });
-
-  test("a skill hit just below the threshold does NOT match Tier 0", async () => {
+describe("nearestExistingSkills — ranking", () => {
+  test("returns hits descending by score, each resolved to its skill id", async () => {
     const { fn } = fakeScorer({
-      "skills/deploy-web": EXISTING_SKILL_THRESHOLD - 0.01,
+      "skills/deploy-web": 0.91,
+      "skills/rotate-secrets": 0.7,
+      "skills/clean-disk": 0.83,
     });
 
-    const result = await matchCandidate("deploy the app", {
+    const result = await nearestExistingSkills("ship the web app to prod", {
       scoreSlugs: fn,
-      loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(),
+      loadCatalog: catalog("deploy-web", "rotate-secrets", "clean-disk"),
     });
 
-    // Falls through Tier 0 and Tier 1 (no candidates) → new.
-    expect(result).toEqual({ kind: "new" });
+    expect(result).toEqual([
+      { skillId: "deploy-web", score: 0.91 },
+      { skillId: "clean-disk", score: 0.83 },
+      { skillId: "rotate-secrets", score: 0.7 },
+    ]);
+  });
+
+  test("scores the capability-page slugs for the whole catalog", async () => {
+    const { fn, calls } = fakeScorer({ "skills/a": 0.9 });
+
+    await nearestExistingSkills("goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("a", "b"),
+    });
+
+    expect(calls).toEqual([["skills/a", "skills/b"]]);
   });
 });
 
-describe("matchCandidate — Tier 1 (candidate cluster)", () => {
-  test("a goal matching a member note → cluster carrying the OWNING clusterId (not the note slug)", async () => {
-    const { fn } = fakeScorer({
-      "skills/unrelated": 0.1,
-      "proc/cleanup-disk": 0.85,
-    });
+describe("nearestExistingSkills — top-K bound", () => {
+  test("caps the shortlist at the default limit", async () => {
+    const scores: Record<string, number> = {};
+    const ids: string[] = [];
+    // Seven above-floor hits, strictly descending so order is deterministic.
+    for (let i = 0; i < 7; i++) {
+      const id = `skill-${i}`;
+      ids.push(id);
+      scores[`skills/${id}`] = 0.95 - i * 0.01;
+    }
+    const { fn } = fakeScorer(scores);
 
-    // The owning cluster's id DIFFERS from the matched member-note slug. The
-    // matcher must report the clusterId — the store keys every mutator on it.
-    const result = await matchCandidate("clear out the disk", {
+    const result = await nearestExistingSkills("goal", {
       scoreSlugs: fn,
-      loadCatalog: catalog("unrelated"),
-      listCandidateClusters: clusters(
-        cluster("cluster/disk-housekeeping", "proc/cleanup-disk", "proc/other"),
-      ),
+      loadCatalog: catalog(...ids),
     });
 
-    expect(result).toEqual({
-      kind: "cluster",
-      clusterId: "cluster/disk-housekeeping",
-    });
-    // Regression guard: the matched note slug must NOT leak out as the clusterId.
-    expect(result).not.toEqual({
-      kind: "cluster",
-      clusterId: "proc/cleanup-disk",
-    });
+    expect(result).toHaveLength(DEFAULT_SHORTLIST_LIMIT);
+    // The highest-scoring five survive the cap.
+    expect(result.map((h) => h.skillId)).toEqual([
+      "skill-0",
+      "skill-1",
+      "skill-2",
+      "skill-3",
+      "skill-4",
+    ]);
   });
 
-  test("the highest-scoring candidate wins, reported as its owning clusterId", async () => {
+  test("respects an explicit limit", async () => {
     const { fn } = fakeScorer({
-      "proc/a": CLUSTER_MATCH_THRESHOLD + 0.01,
-      "proc/b": CLUSTER_MATCH_THRESHOLD + 0.1,
-      "proc/c": CLUSTER_MATCH_THRESHOLD + 0.05,
+      "skills/a": 0.9,
+      "skills/b": 0.85,
+      "skills/c": 0.8,
     });
 
-    // Each note lives in a distinct cluster whose id differs from the note slug.
-    const result = await matchCandidate("do the thing", {
+    const result = await nearestExistingSkills("goal", {
       scoreSlugs: fn,
-      loadCatalog: catalog(),
-      listCandidateClusters: clusters(
-        cluster("cluster/a", "proc/a"),
-        cluster("cluster/b", "proc/b"),
-        cluster("cluster/c", "proc/c"),
-      ),
+      loadCatalog: catalog("a", "b", "c"),
+      limit: 2,
     });
 
-    // Winner is proc/b's score → its owning cluster, not the note slug.
-    expect(result).toEqual({ kind: "cluster", clusterId: "cluster/b" });
-  });
-
-  test("a candidate exactly at the cluster threshold matches (inclusive)", async () => {
-    const { fn } = fakeScorer({ "proc/edge": CLUSTER_MATCH_THRESHOLD });
-
-    const result = await matchCandidate("boundary goal", {
-      scoreSlugs: fn,
-      loadCatalog: catalog(),
-      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
-    });
-
-    expect(result).toEqual({ kind: "cluster", clusterId: "cluster/edge" });
+    expect(result).toEqual([
+      { skillId: "a", score: 0.9 },
+      { skillId: "b", score: 0.85 },
+    ]);
   });
 });
 
-describe("matchCandidate — novel goal", () => {
-  test("nothing close enough → new", async () => {
+describe("nearestExistingSkills — shortlist floor", () => {
+  test("excludes hits below the floor", async () => {
     const { fn } = fakeScorer({
-      "skills/deploy-web": 0.2,
-      "proc/cleanup-disk": GRAY_BAND_THRESHOLD - 0.01,
+      "skills/keep": SHORTLIST_THRESHOLD + 0.05,
+      "skills/drop": SHORTLIST_THRESHOLD - 0.01,
     });
 
-    const result = await matchCandidate("a totally unrelated brand-new task", {
+    const result = await nearestExistingSkills("goal", {
       scoreSlugs: fn,
-      loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(
-        cluster("cluster/disk-housekeeping", "proc/cleanup-disk"),
-      ),
+      loadCatalog: catalog("keep", "drop"),
     });
 
-    expect(result).toEqual({ kind: "new" });
+    expect(result).toEqual([
+      { skillId: "keep", score: SHORTLIST_THRESHOLD + 0.05 },
+    ]);
   });
 
-  test("empty catalog + empty candidate pool → new", async () => {
+  test("includes a hit exactly at the floor (inclusive)", async () => {
+    const { fn } = fakeScorer({ "skills/edge": SHORTLIST_THRESHOLD });
+
+    const result = await nearestExistingSkills("goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("edge"),
+    });
+
+    expect(result).toEqual([{ skillId: "edge", score: SHORTLIST_THRESHOLD }]);
+  });
+
+  test("everything below the floor → empty shortlist", async () => {
+    const { fn } = fakeScorer({
+      "skills/a": SHORTLIST_THRESHOLD - 0.2,
+      "skills/b": SHORTLIST_THRESHOLD - 0.01,
+    });
+
+    const result = await nearestExistingSkills("goal", {
+      scoreSlugs: fn,
+      loadCatalog: catalog("a", "b"),
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("nearestExistingSkills — empty catalog", () => {
+  test("empty catalog → [] without calling the scorer", async () => {
     const { fn, calls } = fakeScorer({});
 
-    const result = await matchCandidate("anything", {
+    const result = await nearestExistingSkills("anything", {
       scoreSlugs: fn,
       loadCatalog: catalog(),
-      listCandidateClusters: clusters(),
     });
 
-    expect(result).toEqual({ kind: "new" });
+    expect(result).toEqual([]);
     // No slugs to restrict to → scorer is never called (empty-set short-circuit).
     expect(calls).toEqual([]);
   });
 });
 
-describe("matchCandidate — gray band (deferred to caller's Tier-2 judge)", () => {
-  test("a borderline member note → gray carrying the OWNING clusterId (not the note slug)", async () => {
-    const { fn } = fakeScorer({
-      "proc/deploy-preview":
-        (GRAY_BAND_THRESHOLD + CLUSTER_MATCH_THRESHOLD) / 2,
-    });
-
-    // The owning cluster's id DIFFERS from the matched member-note slug; the
-    // gray result must hand the Tier-2 judge the clusterId, not the note slug.
-    const result = await matchCandidate("deploy to production", {
-      scoreSlugs: fn,
-      loadCatalog: catalog(),
-      listCandidateClusters: clusters(
-        cluster("cluster/deploy-rituals", "proc/deploy-preview"),
-      ),
-    });
-
-    expect(result).toEqual({
-      kind: "gray",
-      clusterId: "cluster/deploy-rituals",
-    });
-    // Regression guard: the matched note slug must NOT leak out as the clusterId.
-    expect(result).not.toEqual({
-      kind: "gray",
-      clusterId: "proc/deploy-preview",
-    });
-  });
-
-  test("a candidate exactly at the gray-band floor → gray (inclusive)", async () => {
-    const { fn } = fakeScorer({ "proc/edge": GRAY_BAND_THRESHOLD });
-
-    const result = await matchCandidate("boundary goal", {
-      scoreSlugs: fn,
-      loadCatalog: catalog(),
-      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
-    });
-
-    expect(result).toEqual({ kind: "gray", clusterId: "cluster/edge" });
-  });
-
-  test("just below the gray-band floor → new, not gray", async () => {
-    const { fn } = fakeScorer({ "proc/edge": GRAY_BAND_THRESHOLD - 0.001 });
-
-    const result = await matchCandidate("boundary goal", {
-      scoreSlugs: fn,
-      loadCatalog: catalog(),
-      listCandidateClusters: clusters(cluster("cluster/edge", "proc/edge")),
-    });
-
-    expect(result).toEqual({ kind: "new" });
-  });
-});
-
-describe("matchCandidate — thresholds are ordered for precision bias", () => {
-  test("gray floor < cluster bar < existing-skill bar", () => {
-    expect(GRAY_BAND_THRESHOLD).toBeLessThan(CLUSTER_MATCH_THRESHOLD);
-    expect(CLUSTER_MATCH_THRESHOLD).toBeLessThanOrEqual(
-      EXISTING_SKILL_THRESHOLD,
-    );
+describe("nearestExistingSkills — threshold sanity", () => {
+  test("the shortlist floor sits below the confident same-skill mark", () => {
+    expect(SHORTLIST_THRESHOLD).toBeLessThan(EXISTING_SKILL_THRESHOLD);
   });
 });
 
@@ -323,10 +239,10 @@ describe("matchCandidate — thresholds are ordered for precision bias", () => {
 // Default-scorer retry. These tests do NOT inject `scoreSlugs`, so the matcher
 // uses its real `scoreSlugsWithSimBatch` path, which calls the (stubbed)
 // `simBatch`. `simBatch` embeds via `embedWithBackend` ONCE with no retry, so a
-// transient provider blip would throw and degrade the matcher to a no-hit —
-// silently missing an existing skill or forking a duplicate cluster. The
-// matcher wraps `simBatch` in a bounded retry mirroring `embedWithRetry`'s
-// policy and degrades to no-hit ONLY after the budget is exhausted.
+// transient provider blip would throw and degrade the shortlist to `[]` —
+// silently hiding an existing skill. The matcher wraps `simBatch` in a bounded
+// retry mirroring `embedWithRetry`'s policy and degrades to `[]` ONLY after the
+// budget is exhausted.
 // ---------------------------------------------------------------------------
 
 // A 429 / 5xx-shaped transient error (recognized by `isTransientEmbeddingError`
@@ -336,13 +252,13 @@ const transientError = () =>
   Object.assign(new Error("rate limited"), { status: 429 });
 const persistentError = () => new Error("qdrant collection not found");
 
-// A config stub — the stubbed `simBatch` ignores it, but `matchCandidate` reads
-// `opts.config ?? getConfig()`, and passing one keeps the test off the real
-// config loader.
+// A config stub — the stubbed `simBatch` ignores it, but `nearestExistingSkills`
+// reads `opts.config ?? getConfig()`, and passing one keeps the test off the
+// real config loader.
 const fakeConfig = {} as never;
 
-describe("matchCandidate — default scorer retries transient embedding failures", () => {
-  test("a transient embedding error that succeeds on retry yields the correct hit, not []", async () => {
+describe("nearestExistingSkills — default scorer retries transient failures", () => {
+  test("a transient error that succeeds on retry yields the hit, not []", async () => {
     let calls = 0;
     simBatchImpl = async (_text, slugs) => {
       calls++;
@@ -355,51 +271,45 @@ describe("matchCandidate — default scorer retries transient embedding failures
       );
     };
 
-    const result = await matchCandidate("ship the web app to prod", {
+    const result = await nearestExistingSkills("ship the web app to prod", {
       config: fakeConfig,
       loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(),
     });
 
-    // Without retry the first throw would degrade to `new`; with retry we get
-    // the existing-skill hit on the second attempt.
-    expect(result).toEqual({ kind: "existing-skill", skillId: "deploy-web" });
+    expect(result).toEqual([{ skillId: "deploy-web", score: 0.95 }]);
     expect(calls).toBe(2);
   });
 
-  test("a persistent transient error still degrades to no-hit after the retry budget", async () => {
+  test("a persistent transient error degrades to [] after the retry budget", async () => {
     let calls = 0;
     simBatchImpl = async () => {
       calls++;
       throw transientError();
     };
 
-    const result = await matchCandidate("ship the web app to prod", {
+    const result = await nearestExistingSkills("ship the web app to prod", {
       config: fakeConfig,
       loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(),
     });
 
-    // Retries exhausted → scorer returns [] → matcher treats the goal as new.
-    expect(result).toEqual({ kind: "new" });
+    expect(result).toEqual([]);
     // 1 initial attempt + EMBED_MAX_RETRIES (3) retries = 4 calls.
     expect(calls).toBe(4);
   });
 
-  test("a non-transient error is NOT retried — degrades to no-hit immediately", async () => {
+  test("a non-transient error is NOT retried — degrades to [] immediately", async () => {
     let calls = 0;
     simBatchImpl = async () => {
       calls++;
       throw persistentError();
     };
 
-    const result = await matchCandidate("ship the web app to prod", {
+    const result = await nearestExistingSkills("ship the web app to prod", {
       config: fakeConfig,
       loadCatalog: catalog("deploy-web"),
-      listCandidateClusters: clusters(),
     });
 
-    expect(result).toEqual({ kind: "new" });
+    expect(result).toEqual([]);
     // No retry on a non-transient failure: exactly one attempt.
     expect(calls).toBe(1);
   });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/candidate-match.ts
@@ -1,32 +1,23 @@
 // ---------------------------------------------------------------------------
-// Procedural-memory candidate-identity matcher (Tier 0 + Tier 1)
+// Nearest-existing-skills shortlist (skill-catalog ANN)
 // ---------------------------------------------------------------------------
 //
-// Recurrence-gating needs to recognize that a freshly-captured procedure is
-// *the same procedure* as one we have seen before, so it can count toward the
-// distillation threshold. Identity keys on the procedure's **goal/intent**, not
-// its step sequence — two runs of one procedure routinely differ in steps (one
-// hit a retry), and averaging out that noise is the whole point of waiting for
-// recurrence.
+// Given a procedure's **goal/intent**, return a ranked shortlist of the existing
+// skills whose capability pages are most similar to it. Identity keys on the
+// goal, not the step sequence — two runs of one procedure routinely differ in
+// steps, so the goal is the stable signal.
 //
-// The matcher is tiered, cheap → expensive, riding existing memory infra (no
-// new substrate):
+// The shortlist lets a caller judge whether a freshly-captured procedure is a
+// run of a skill it already has (overwrite that skill) or something genuinely
+// new (author a new skill). The confident same-skill mark
+// ({@link EXISTING_SKILL_THRESHOLD}) is kept as a score the caller can compare
+// against, but the shortlist floor ({@link SHORTLIST_THRESHOLD}) is lower so
+// near-matches still surface for the caller to weigh.
 //
-//   Tier 0 — existing skill. ANN the goal against the **skill catalog** first.
-//     A high-similarity hit means this is a *run of an existing skill*, not a
-//     new candidate — the caller routes any knowledge to a `skill:`-linked
-//     fact rather than opening a cluster.
-//   Tier 1 — candidate cluster. ANN the goal against the **candidate-note pool**
-//     (member-note slugs already embedded as ordinary memory). A high hit means
-//     it is provisionally the same procedure → join that cluster. A gray-band
-//     hit is ambiguous → defer to the caller's Tier-2 LLM judge (a later PR).
-//     Below the gray band → a genuinely new procedure.
-//
-// This module is a **pure, read-only matcher**: it embeds + queries but never
-// writes, never touches the registry except to read member slugs, and never
-// calls an LLM (the Tier-2 judge is the caller's job). The ANN/embedding seam
-// and the catalog/registry reads are dependency-injected so tests exercise the
-// tier logic without standing up Qdrant.
+// This module is a **pure, read-only matcher**: it embeds + queries the skill
+// catalog but never writes and never calls an LLM. The ANN/embedding seam and
+// the catalog read are dependency-injected so tests exercise the ranking without
+// standing up Qdrant.
 
 import { getConfig } from "../../../config/loader.js";
 import { loadSkillCatalog } from "../../../config/skills.js";
@@ -45,34 +36,24 @@ import { abortableSleep, computeRetryDelay } from "../../../util/retry.js";
 const log = getLogger("memory-v3-candidate-match");
 
 // ─── Thresholds ──────────────────────────────────────────────────────────────
-//
-// Bias precision over recall (per the design doc). Over-merging ships a skill
-// that conflates two procedures — a permanent bad catalog entry, the exact
-// pollution we are killing. Under-merging just delays a promotion, nearly free.
-// So both bars are HIGH, and the gray band between them is narrow.
 
 /**
- * Tier 0 — a goal at or above this fused similarity to a skill capability page
- * is treated as a *run of that existing skill*. High, since a false positive
- * here silently suppresses a legitimately new procedure.
+ * A goal at or above this fused similarity to a skill capability page is the
+ * "confident same-skill" mark — a caller can treat such a hit as a run of that
+ * existing skill. High, since a false positive here conflates two procedures.
  */
 export const EXISTING_SKILL_THRESHOLD = 0.82;
 
 /**
- * Tier 1 — a goal at or above this fused similarity to a candidate note joins
- * that note's cluster. Deliberately high: over-merging two distinct procedures
- * is the costly failure, so the bar to declare "same procedure" is strict.
+ * The shortlist floor. Hits at or above this similarity surface in the
+ * shortlist so near-matches (below the confident mark) are still presented for
+ * the caller to judge. Lower than {@link EXISTING_SKILL_THRESHOLD} so a
+ * borderline skill is not dropped before the caller can weigh it.
  */
-export const CLUSTER_MATCH_THRESHOLD = 0.78;
+export const SHORTLIST_THRESHOLD = 0.6;
 
-/**
- * Tier 1 gray band — a goal whose best candidate similarity falls in
- * `[GRAY_BAND_THRESHOLD, CLUSTER_MATCH_THRESHOLD)` is ambiguous (a borderline
- * match or a dangerous near-miss like "deploy preview" vs "deploy production").
- * The matcher reports `gray` and the caller's Tier-2 LLM judge breaks the tie
- * — toward "different" — in a later PR.
- */
-export const GRAY_BAND_THRESHOLD = 0.7;
+/** How many shortlist entries to return when the caller does not specify. */
+export const DEFAULT_SHORTLIST_LIMIT = 5;
 
 /** A scored ANN hit: a corpus slug and its fused dense+sparse similarity. */
 export interface ScoredSlug {
@@ -80,158 +61,89 @@ export interface ScoredSlug {
   score: number;
 }
 
+/** A shortlisted existing skill and its similarity to the goal. */
+export interface SkillShortlistHit {
+  skillId: string;
+  score: number;
+}
+
 /**
  * The injectable scoring seam. Given the goal text and a slug restriction,
  * return each restricted slug's fused dense+sparse similarity to the goal.
  * Defaults to {@link simBatch} (the v2 slug-restricted hybrid scorer, including
- * its adaptive dense/sparse reweighting, so candidate-match scores stay on the
- * same scale as v2 recall); tests pass a fake so the tier logic runs without a
- * live collection.
+ * its adaptive dense/sparse reweighting, so shortlist scores stay on the same
+ * scale as v2 recall); tests pass a fake so the ranking runs without a live
+ * collection.
  */
 export type ScoreSlugsFn = (
   goal: string,
   restrictToSlugs: readonly string[],
 ) => Promise<ScoredSlug[]>;
 
-/**
- * A registered candidate cluster reduced to what Tier 1 needs: its identity
- * (`clusterId` — the registry/store key) and the member-note slugs embedded for
- * it. The matcher restricts the ANN to the member-note slugs but always reports
- * the OWNING `clusterId`, never a note slug — the store keys every mutator
- * (`getCandidate`/`incrementCandidate`/`addMemberNote`) on `cluster_id`.
- */
-export interface CandidateClusterRef {
-  clusterId: string;
-  memberNoteSlugs: readonly string[];
-}
-
-export interface MatchCandidateOptions {
-  /**
-   * Existing candidate clusters (Tier 1 targets), each carrying its `clusterId`
-   * and its embedded member-note slugs. The matcher ANN-restricts to the union
-   * of member-note slugs but maps any hit back to its owning `clusterId`. The
-   * caller owns enumeration of the candidate pool (the trigger re-reads it per
-   * note so a cluster opened earlier in the pass is visible to later notes).
-   */
-  listCandidateClusters: () => CandidateClusterRef[];
+export interface NearestExistingSkillsOptions {
   /** Config used for embedding + fusion weights. Defaults to `getConfig()`. */
   config?: AssistantConfig;
-  /** ANN scorer (Tier 0 + Tier 1). Defaults to the {@link simBatch} scorer. */
+  /** ANN scorer. Defaults to the {@link simBatch} scorer. */
   scoreSlugs?: ScoreSlugsFn;
-  /** Live skill catalog (Tier 0 targets). Defaults to `loadSkillCatalog()`. */
+  /** Live skill catalog. Defaults to `loadSkillCatalog()`. */
   loadCatalog?: () => { id: string }[];
+  /** Max shortlist entries. Defaults to {@link DEFAULT_SHORTLIST_LIMIT}. */
+  limit?: number;
 }
 
-/** The matcher's verdict — which tier (if any) claimed the goal. */
-export type MatchResult =
-  | { kind: "existing-skill"; skillId: string }
-  | { kind: "cluster"; clusterId: string }
-  | { kind: "gray"; clusterId: string }
-  | { kind: "new" };
-
 /**
- * Classify a captured procedure's `goal` against existing skills (Tier 0) and
- * candidate clusters (Tier 1).
- *
- *   - `existing-skill` — the goal matches a live skill at/above
- *     {@link EXISTING_SKILL_THRESHOLD}; it is a run of that skill, not a new
- *     candidate.
- *   - `cluster` — the goal matches a candidate note at/above
- *     {@link CLUSTER_MATCH_THRESHOLD}; it joins that note's cluster.
- *   - `gray` — the best candidate match is in the gray band; ambiguous, deferred
- *     to the caller's Tier-2 judge. Carries the borderline `clusterId` so the
- *     judge knows which cluster it is weighing the goal against.
- *   - `new` — no skill or candidate is close enough; a genuinely new procedure.
+ * Rank the existing skills whose capability pages are most similar to `goal`
+ * and return the top-K at or above {@link SHORTLIST_THRESHOLD}, descending by
+ * score. An empty catalog (or no hit clearing the floor) yields `[]`.
  *
  * Pure and read-only: no writes, no LLM call.
  */
-export async function matchCandidate(
+export async function nearestExistingSkills(
   goal: string,
-  opts: MatchCandidateOptions,
-): Promise<MatchResult> {
+  opts: NearestExistingSkillsOptions = {},
+): Promise<SkillShortlistHit[]> {
   const config = opts.config ?? getConfig();
   const scoreSlugs =
     opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithSimBatch(config, g, slugs));
   const loadCatalog = opts.loadCatalog ?? (() => loadSkillCatalog());
-  const { listCandidateClusters } = opts;
+  const limit = opts.limit ?? DEFAULT_SHORTLIST_LIMIT;
 
-  // ── Tier 0 — existing skill. ───────────────────────────────────────────────
-  // Map each skill id to its capability-page slug, score them, and resolve the
-  // best back to its id.
+  // Map each skill id to its capability-page slug, score them, and resolve each
+  // hit back to its id.
   const slugToSkillId = new Map<string, string>();
   for (const skill of loadCatalog()) {
     slugToSkillId.set(skillSlugFor(skill.id), skill.id);
   }
-  const skillBest = await bestHit(scoreSlugs, goal, [...slugToSkillId.keys()]);
-  if (skillBest && skillBest.score >= EXISTING_SKILL_THRESHOLD) {
-    const skillId = slugToSkillId.get(skillBest.slug);
-    if (skillId) {
-      return { kind: "existing-skill", skillId };
-    }
-  }
+  const slugs = [...slugToSkillId.keys()];
+  if (slugs.length === 0) return [];
 
-  // ── Tier 1 — candidate cluster. ────────────────────────────────────────────
-  // Member-note slugs are EMBEDDED, so the ANN must run against them — but a
-  // note slug is NOT a clusterId. Build a `memberNoteSlug → clusterId` map so a
-  // hit resolves back to the OWNING cluster's store key; the caller keys every
-  // mutator (`incrementCandidate`/`addMemberNote`) on `cluster_id`, so returning
-  // a note slug would update zero rows or fork a duplicate cluster.
-  const slugToClusterId = new Map<string, string>();
-  for (const cluster of listCandidateClusters()) {
-    for (const slug of cluster.memberNoteSlugs) {
-      slugToClusterId.set(slug, cluster.clusterId);
-    }
+  const scored = await scoreSlugs(goal, slugs);
+  const hits: SkillShortlistHit[] = [];
+  for (const { slug, score } of scored) {
+    if (score < SHORTLIST_THRESHOLD) continue;
+    const skillId = slugToSkillId.get(slug);
+    if (skillId) hits.push({ skillId, score });
   }
-  const candidateBest = await bestHit(scoreSlugs, goal, [
-    ...slugToClusterId.keys(),
-  ]);
-  if (candidateBest) {
-    const clusterId = slugToClusterId.get(candidateBest.slug);
-    if (clusterId) {
-      if (candidateBest.score >= CLUSTER_MATCH_THRESHOLD) {
-        return { kind: "cluster", clusterId };
-      }
-      if (candidateBest.score >= GRAY_BAND_THRESHOLD) {
-        return { kind: "gray", clusterId };
-      }
-    }
-  }
-
-  return { kind: "new" };
-}
-
-/** Score a slug restriction and return its single best (highest-scoring) hit. */
-async function bestHit(
-  scoreSlugs: ScoreSlugsFn,
-  goal: string,
-  restrictToSlugs: readonly string[],
-): Promise<ScoredSlug | null> {
-  if (restrictToSlugs.length === 0) return null;
-  const scored = await scoreSlugs(goal, restrictToSlugs);
-  let best: ScoredSlug | null = null;
-  for (const hit of scored) {
-    if (!best || hit.score > best.score) best = hit;
-  }
-  return best;
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, limit);
 }
 
 /**
  * Default scorer: delegate to {@link simBatch}, the v2 slug-restricted hybrid
  * scorer. `simBatch` embeds the goal (dense + BM25 sparse), runs the
  * slug-restricted hybrid query, applies the adaptive dense/sparse reweighting,
- * and fuses the body/summary halves — so candidate-match scores land on the
- * same scale as v2 recall scores against the configured thresholds.
+ * and fuses the body/summary halves — so shortlist scores land on the same
+ * scale as v2 recall scores against {@link SHORTLIST_THRESHOLD}.
  *
  * `simBatch` embeds via `embedWithBackend` ONCE (not `embedWithRetry`), so a
  * brief provider blip (429 / 5xx / transient network error) would throw and
- * make this scorer return `[]` — a no-hit. For the matcher that silently means
- * "treat as new", so a momentary outage could miss an existing skill or fork a
- * duplicate cluster (a permanent bad catalog entry). To prevent that we wrap
- * the `simBatch` call in a bounded retry mirroring {@link embedWithRetry}'s
- * policy (same max-retries / base-delay / exponential backoff, same transient
- * predicate, same abort handling). Only AFTER retries are exhausted — or on a
- * non-transient error (a real Qdrant/config bug, where retrying is pointless) —
- * do we degrade to `[]`, logged at warn.
+ * make this scorer return `[]` — an empty shortlist. To avoid a momentary
+ * outage hiding an existing skill, the `simBatch` call is wrapped in a bounded
+ * retry mirroring {@link embedWithRetry}'s policy (same max-retries / base-delay
+ * / exponential backoff, same transient predicate, same abort handling). Only
+ * AFTER retries are exhausted — or on a non-transient error (a real
+ * Qdrant/config bug, where retrying is pointless) — do we degrade to `[]`,
+ * logged at warn.
  */
 async function scoreSlugsWithSimBatch(
   config: AssistantConfig,
@@ -244,7 +156,7 @@ async function scoreSlugsWithSimBatch(
   } catch (err) {
     log.warn(
       { err },
-      "candidate-match scorer failed after retries; degrading to no hits (treat as new)",
+      "nearest-existing-skills scorer failed after retries; degrading to empty shortlist",
     );
     return [];
   }
@@ -255,7 +167,8 @@ async function scoreSlugsWithSimBatch(
  * (`simBatch` itself embeds via `embedWithBackend` with no retry). Retries only
  * transient embedding failures (429 / 5xx / retryable network error); a
  * non-transient error or an exhausted retry budget rethrows so the caller can
- * degrade to no-hit. Aborts propagate immediately and are never retried.
+ * degrade to an empty shortlist. Aborts propagate immediately and are never
+ * retried.
  */
 async function simBatchWithRetry(
   config: AssistantConfig,
@@ -275,7 +188,7 @@ async function simBatchWithRetry(
       const delay = computeRetryDelay(attempt, EMBED_BASE_DELAY_MS);
       log.warn(
         { err, attempt: attempt + 1, delayMs: Math.round(delay) },
-        "transient candidate-match embedding failure, retrying",
+        "transient nearest-existing-skills embedding failure, retrying",
       );
       await abortableSleep(delay);
     }

--- a/assistant/src/tools/skills/find-similar-skills.test.ts
+++ b/assistant/src/tools/skills/find-similar-skills.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for `find-similar-skills.ts` — the read-only `find_similar_skills` tool.
+ *
+ * The tool's shortlist + catalog seams are dependency-injected via `deps`, so
+ * these tests exercise the input validation, the catalog name/description join,
+ * and the `limit` pass-through without Qdrant. Coverage:
+ *   - Maps each shortlist hit to its catalog name/description and score.
+ *   - Drops a shortlist hit whose id is absent from the catalog.
+ *   - Passes `limit` through to the shortlist (and defaults when omitted).
+ *   - Rejects a missing/blank goal and a non-positive-integer limit.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { ToolContext } from "../types.js";
+import { executeFindSimilarSkills } from "./find-similar-skills.js";
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "test-conversation",
+    trustClass: "guardian",
+  };
+}
+
+const catalog = (
+  ...skills: { id: string; name: string; description: string }[]
+) => skills;
+
+describe("find_similar_skills — enrichment", () => {
+  test("maps each hit to its catalog name/description and score", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "ship the web app" },
+      makeContext(),
+      {
+        nearestExistingSkills: async () => [
+          { skillId: "deploy-web", score: 0.91 },
+          { skillId: "clean-disk", score: 0.7 },
+        ],
+        loadCatalog: () =>
+          catalog(
+            {
+              id: "deploy-web",
+              name: "Deploy Web",
+              description: "Ship the web app to prod",
+            },
+            {
+              id: "clean-disk",
+              name: "Clean Disk",
+              description: "Free up disk space",
+            },
+          ),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.content)).toEqual({
+      skills: [
+        {
+          skill_id: "deploy-web",
+          name: "Deploy Web",
+          description: "Ship the web app to prod",
+          score: 0.91,
+        },
+        {
+          skill_id: "clean-disk",
+          name: "Clean Disk",
+          description: "Free up disk space",
+          score: 0.7,
+        },
+      ],
+    });
+  });
+
+  test("drops a shortlist hit whose id is not in the catalog", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "do the thing" },
+      makeContext(),
+      {
+        nearestExistingSkills: async () => [
+          { skillId: "present", score: 0.9 },
+          { skillId: "missing", score: 0.8 },
+        ],
+        loadCatalog: () =>
+          catalog({
+            id: "present",
+            name: "Present",
+            description: "Exists in catalog",
+          }),
+      },
+    );
+
+    expect(JSON.parse(result.content)).toEqual({
+      skills: [
+        {
+          skill_id: "present",
+          name: "Present",
+          description: "Exists in catalog",
+          score: 0.9,
+        },
+      ],
+    });
+  });
+
+  test("empty shortlist → empty skills array", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "nothing matches" },
+      makeContext(),
+      {
+        nearestExistingSkills: async () => [],
+        loadCatalog: () => catalog(),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.content)).toEqual({ skills: [] });
+  });
+});
+
+describe("find_similar_skills — limit pass-through", () => {
+  test("forwards an explicit limit to the shortlist", async () => {
+    let seenLimit: number | undefined;
+    await executeFindSimilarSkills({ goal: "g", limit: 3 }, makeContext(), {
+      nearestExistingSkills: async (_goal, opts) => {
+        seenLimit = opts?.limit;
+        return [];
+      },
+      loadCatalog: () => catalog(),
+    });
+
+    expect(seenLimit).toBe(3);
+  });
+
+  test("leaves the limit unset when omitted (shortlist owns the default)", async () => {
+    let seenLimit: number | undefined = -1;
+    await executeFindSimilarSkills({ goal: "g" }, makeContext(), {
+      nearestExistingSkills: async (_goal, opts) => {
+        seenLimit = opts?.limit;
+        return [];
+      },
+      loadCatalog: () => catalog(),
+    });
+
+    expect(seenLimit).toBeUndefined();
+  });
+});
+
+describe("find_similar_skills — input validation", () => {
+  test("rejects a missing goal", async () => {
+    const result = await executeFindSimilarSkills({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("goal is required");
+  });
+
+  test("rejects a blank goal", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "   " },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("goal is required");
+  });
+
+  test("rejects a non-positive-integer limit", async () => {
+    for (const limit of [0, -1, 2.5, "5"]) {
+      const result = await executeFindSimilarSkills(
+        { goal: "g", limit },
+        makeContext(),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("limit must be a positive integer");
+    }
+  });
+});

--- a/assistant/src/tools/skills/find-similar-skills.ts
+++ b/assistant/src/tools/skills/find-similar-skills.ts
@@ -1,0 +1,76 @@
+import { loadSkillCatalog } from "../../config/skills.js";
+import { nearestExistingSkills } from "../../plugins/defaults/memory-v3-shadow/candidate-match.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/** A shortlisted skill enriched with its catalog name and description. */
+interface EnrichedHit {
+  skill_id: string;
+  name: string;
+  description: string;
+  score: number;
+}
+
+/**
+ * Core execution logic for find_similar_skills. Read-only: scores `goal`
+ * against the skill catalog's capability pages and returns the nearest skills,
+ * each joined to its catalog name/description. Exported so bundled-skill
+ * executors and tests can call it directly.
+ *
+ * `deps` injects the shortlist + catalog seams so tests run without Qdrant.
+ */
+export async function executeFindSimilarSkills(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+  deps: {
+    nearestExistingSkills?: typeof nearestExistingSkills;
+    loadCatalog?: () => { id: string; name: string; description: string }[];
+  } = {},
+): Promise<ToolExecutionResult> {
+  const goal = input.goal;
+  if (typeof goal !== "string" || !goal.trim()) {
+    return {
+      content: "Error: goal is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  let limit: number | undefined;
+  if (input.limit !== undefined) {
+    if (
+      typeof input.limit !== "number" ||
+      !Number.isInteger(input.limit) ||
+      input.limit < 1
+    ) {
+      return {
+        content: "Error: limit must be a positive integer",
+        isError: true,
+      };
+    }
+    limit = input.limit;
+  }
+
+  const findNearest = deps.nearestExistingSkills ?? nearestExistingSkills;
+  const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
+
+  const hits = await findNearest(goal, { limit });
+
+  const catalog = loadCatalog();
+  const byId = new Map(catalog.map((s) => [s.id, s]));
+
+  const enriched: EnrichedHit[] = [];
+  for (const hit of hits) {
+    const skill = byId.get(hit.skillId);
+    if (!skill) continue;
+    enriched.push({
+      skill_id: hit.skillId,
+      name: skill.name,
+      description: skill.description,
+      score: hit.score,
+    });
+  }
+
+  return {
+    content: JSON.stringify({ skills: enriched }),
+    isError: false,
+  };
+}


### PR DESCRIPTION
## Summary
Refactors candidate-match.ts to a Tier-0-only nearestExistingSkills shortlist and adds a read-only find_similar_skills built-in tool (registered, not yet granted). Consumed by PR7's retrospective sibling-dedup.

Part of plan: procedural-memory-as-skills.md (PR 5 of 9)