### PR TITLE
feat(memory): add memory.provider config field and provider registry

### DIFF
--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -29,6 +29,12 @@ export const MemoryConfigSchema = z
       .describe(
         "Whether the long-term memory system is enabled — gates background memory jobs, embedding generation, and `<memory>` block injection into user messages",
       ),
+    provider: z
+      .enum(["auto", "graph", "v2", "v3", "none"])
+      .default("auto")
+      .describe(
+        'Which memory provider drives retrieval and post-turn writes. "auto" (the default) preserves the existing selection derived from `v2.enabled` and the memory-v3-live flag, so it is behavior-neutral; the concrete provider resolution is wired in a later change. "graph"/"v2"/"v3" pin a specific system and "none" disables memory.',
+      ),
     embeddings: MemoryEmbeddingsConfigSchema.default(
       MemoryEmbeddingsConfigSchema.parse({}),
     ),

--- a/assistant/src/memory/provider/registry.test.ts
+++ b/assistant/src/memory/provider/registry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemoryConfigSchema } from "../../config/schemas/memory.js";
+import { MemoryProviderRegistry, NullMemoryProvider } from "./registry.js";
+import type { MemoryProvider, MemoryProviderId } from "./types.js";
+
+function stubProvider(id: MemoryProviderId): MemoryProvider {
+  return {
+    id,
+    async retrieveForContext() {
+      return [];
+    },
+    async retrieveForTurn() {
+      return [];
+    },
+    async onTurnCommit() {},
+    provideTools() {
+      return [];
+    },
+    async init() {},
+    async shutdown() {},
+  };
+}
+
+describe("NullMemoryProvider", () => {
+  test("is behavior-neutral: empty retrieval, no tools, resolving lifecycle", async () => {
+    const provider = new NullMemoryProvider();
+    expect(provider.id).toBe("none");
+    expect(await provider.retrieveForContext()).toEqual([]);
+    expect(await provider.retrieveForTurn()).toEqual([]);
+    expect(provider.provideTools()).toEqual([]);
+    expect(provider.provideRoutes()).toEqual([]);
+    await expect(provider.onTurnCommit()).resolves.toBeUndefined();
+    await expect(provider.init()).resolves.toBeUndefined();
+    await expect(provider.shutdown()).resolves.toBeUndefined();
+  });
+});
+
+describe("MemoryProviderRegistry", () => {
+  test("resolves a registered provider for a pinned config", () => {
+    const registry = new MemoryProviderRegistry();
+    const v2 = stubProvider("v2");
+    registry.register("v2", () => v2);
+
+    const config = MemoryConfigSchema.parse({ provider: "v2" });
+    expect(registry.resolve(config)).toBe(v2);
+  });
+
+  test("invokes the factory on each resolve", () => {
+    const registry = new MemoryProviderRegistry();
+    let calls = 0;
+    registry.register("v3", () => {
+      calls += 1;
+      return stubProvider("v3");
+    });
+
+    const config = MemoryConfigSchema.parse({ provider: "v3" });
+    registry.resolve(config);
+    registry.resolve(config);
+    expect(calls).toBe(2);
+  });
+
+  test("throws on duplicate registration for the same id", () => {
+    const registry = new MemoryProviderRegistry();
+    registry.register("graph", () => stubProvider("graph"));
+    expect(() =>
+      registry.register("graph", () => stubProvider("graph")),
+    ).toThrow(/already registered/);
+  });
+
+  test("falls back to a null provider when the resolved id is unregistered", () => {
+    const registry = new MemoryProviderRegistry();
+    const config = MemoryConfigSchema.parse({ provider: "v2" });
+    const resolved = registry.resolve(config);
+    expect(resolved).toBeInstanceOf(NullMemoryProvider);
+  });
+
+  test('falls back to a null provider for the "auto" default', () => {
+    const registry = new MemoryProviderRegistry();
+    registry.register("v2", () => stubProvider("v2"));
+
+    const config = MemoryConfigSchema.parse({});
+    expect(config.provider).toBe("auto");
+    expect(registry.resolve(config)).toBeInstanceOf(NullMemoryProvider);
+  });
+});
+
+describe("MemoryConfigSchema provider field", () => {
+  test('defaults provider to "auto" when omitted', () => {
+    expect(MemoryConfigSchema.parse({}).provider).toBe("auto");
+  });
+
+  test("accepts an explicit provider value", () => {
+    expect(MemoryConfigSchema.parse({ provider: "none" }).provider).toBe(
+      "none",
+    );
+  });
+
+  test("rejects an unknown provider value", () => {
+    expect(() => MemoryConfigSchema.parse({ provider: "bogus" })).toThrow();
+  });
+});

--- a/assistant/src/memory/provider/registry.ts
+++ b/assistant/src/memory/provider/registry.ts
@@ -1,0 +1,87 @@
+/**
+ * `MemoryProviderRegistry` — a name-keyed registry of memory-provider
+ * factories.
+ *
+ * Memory systems (graph/v2/v3) register a factory under their
+ * `MemoryProviderId`; daemon core resolves the active provider from
+ * configuration. Until a provider is registered for the resolved id, `resolve`
+ * returns a null provider that contributes nothing — no injection, no tools,
+ * no post-turn work. No call site consumes this registry yet.
+ */
+
+import type { MemoryConfig } from "../../config/schemas/memory.js";
+import type { InjectionBlock } from "../../plugins/types.js";
+import type { RouteDefinition } from "../../runtime/routes/types.js";
+import type { ToolDefinition } from "../../tools/types.js";
+import type { MemoryProvider, MemoryProviderId } from "./types.js";
+
+/**
+ * A no-op `MemoryProvider`. Retrieval returns empty injection, post-turn and
+ * lifecycle hooks resolve immediately, and it contributes no tools. Used as
+ * the safe fallback when no provider is registered for a resolved id.
+ */
+export class NullMemoryProvider implements MemoryProvider {
+  readonly id: MemoryProviderId = "none";
+
+  async retrieveForContext(): Promise<InjectionBlock[]> {
+    return [];
+  }
+
+  async retrieveForTurn(): Promise<InjectionBlock[]> {
+    return [];
+  }
+
+  async onTurnCommit(): Promise<void> {}
+
+  provideTools(): ToolDefinition[] {
+    return [];
+  }
+
+  provideRoutes(): RouteDefinition[] {
+    return [];
+  }
+
+  async init(): Promise<void> {}
+
+  async shutdown(): Promise<void> {}
+}
+
+/** Factory producing a `MemoryProvider` instance. */
+export type MemoryProviderFactory = () => MemoryProvider;
+
+export class MemoryProviderRegistry {
+  private readonly factories = new Map<
+    MemoryProviderId,
+    MemoryProviderFactory
+  >();
+
+  /**
+   * Register a factory for a provider id. Throws if `id` is already
+   * registered — registration is a one-time wiring step, so a duplicate
+   * indicates a programming error rather than an intended override.
+   */
+  register(id: MemoryProviderId, factory: MemoryProviderFactory): void {
+    if (this.factories.has(id)) {
+      throw new Error(`Memory provider already registered for id: ${id}`);
+    }
+    this.factories.set(id, factory);
+  }
+
+  /**
+   * Resolve the provider for the given memory config. The concrete mapping
+   * from `config.provider` (including `"auto"`) to a registered id is wired in
+   * a later change; for now, when no provider is registered for the resolved
+   * id, a {@link NullMemoryProvider} is returned so callers always get a safe,
+   * behavior-neutral provider.
+   */
+  resolve(config: MemoryConfig): MemoryProvider {
+    const requested = config.provider;
+    if (requested !== "auto") {
+      const factory = this.factories.get(requested);
+      if (factory) {
+        return factory();
+      }
+    }
+    return new NullMemoryProvider();
+  }
+}


### PR DESCRIPTION
## Summary
- Add memory.provider enum (auto|graph|v2|v3|none, default auto) to MemoryConfigSchema
- Add MemoryProviderRegistry with null-provider fallback; no consumers yet

Part of plan: memory-plugin-extraction.md (PR 12 of 32)