### PR TITLE
feat(memory): implement V3MemoryProvider adapter over the shadow engine

### DIFF
--- a/assistant/src/memory/provider/v3-provider.test.ts
+++ b/assistant/src/memory/provider/v3-provider.test.ts
@@ -1,0 +1,182 @@
+/**
+ * {@link V3MemoryProvider} adapter tests.
+ *
+ * The adapter is a thin delegation layer over the real v3 injectors. These
+ * tests stub `memory-v3-shadow/injector.js` so they can assert the adapter's
+ * contract structurally (a full corpus fixture is heavy and already covered by
+ * the shadow plugin's own `injection.test.ts`): the adapter maps the provider
+ * context onto the injectors' {@link TurnContext}, returns the cards + spotlight
+ * blocks in injector order, drops nulls, and preserves the frozen net-new card
+ * block — including the deferred-commit meta key that carries v3's
+ * carry-forward (everInjected) semantics — exactly as the injector produced it.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { TrustContext } from "../../daemon/trust-context.js";
+import {
+  MEMORY_V3_BLOCK_ID,
+  MEMORY_V3_COMMIT_META_KEY,
+  MEMORY_V3_SPOTLIGHT_BLOCK_ID,
+} from "../../plugins/defaults/memory-v3-shadow/types.js";
+import type { InjectionBlock, TurnContext } from "../../plugins/types.js";
+import { ROUTES as MEMORY_V3_ROUTES } from "../../runtime/routes/memory-v3-routes.js";
+
+// ─── injector stubs ──────────────────────────────────────────────────────────
+
+let cardsBlock: InjectionBlock | null = null;
+let spotlightBlock: InjectionBlock | null = null;
+const cardsContexts: TurnContext[] = [];
+const spotlightContexts: TurnContext[] = [];
+
+mock.module("../../plugins/defaults/memory-v3-shadow/injector.js", () => ({
+  memoryV3Injector: {
+    name: "memory-v3-shadow",
+    order: 1000,
+    produce: async (ctx: TurnContext) => {
+      cardsContexts.push(ctx);
+      return cardsBlock;
+    },
+  },
+  memoryV3SpotlightInjector: {
+    name: "memory-v3-spotlight",
+    order: 1001,
+    produce: async (ctx: TurnContext) => {
+      spotlightContexts.push(ctx);
+      return spotlightBlock;
+    },
+  },
+}));
+
+const { V3MemoryProvider } = await import("./v3-provider.js");
+const { MemoryConfigSchema } = await import("../../config/schemas/memory.js");
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+const MEMORY_CONFIG = MemoryConfigSchema.parse({});
+
+function ctx(overrides: Record<string, unknown> = {}) {
+  return {
+    conversationId: "conv-1",
+    requestId: "req-1",
+    messages: [],
+    config: MEMORY_CONFIG,
+    turnIndex: 3,
+    trust: TRUST,
+    ...overrides,
+  } as never;
+}
+
+/** A frozen net-new card block as the real cards injector emits it: the
+ *  `<memory>` block id plus the deferred-commit meta key that drives v3's
+ *  carry-forward everInjected write. */
+function freshCardsBlock(): InjectionBlock {
+  const commit = mock(() => {});
+  return {
+    id: MEMORY_V3_BLOCK_ID,
+    text: "<memory __injected>\ncard body\n</memory>",
+    placement: "after-memory-prefix",
+    meta: { [MEMORY_V3_COMMIT_META_KEY]: commit },
+  };
+}
+
+function spotlightBlockFixture(): InjectionBlock {
+  return {
+    id: MEMORY_V3_SPOTLIGHT_BLOCK_ID,
+    text: "<memory_spotlight>\nsection\n</memory_spotlight>",
+    placement: "after-memory-prefix",
+  };
+}
+
+beforeEach(() => {
+  cardsBlock = null;
+  spotlightBlock = null;
+  cardsContexts.length = 0;
+  spotlightContexts.length = 0;
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+// ─── adapter conformance ─────────────────────────────────────────────────────
+
+describe("V3MemoryProvider", () => {
+  test("satisfies MemoryProvider with id 'v3'", () => {
+    expect(V3MemoryProvider.id).toBe("v3");
+  });
+
+  test("retrieveForContext contributes nothing (v3 has no context-load prefix)", async () => {
+    cardsBlock = freshCardsBlock();
+    spotlightBlock = spotlightBlockFixture();
+    expect(await V3MemoryProvider.retrieveForContext(ctx())).toEqual([]);
+    expect(cardsContexts).toHaveLength(0);
+  });
+
+  test("retrieveForTurn maps the provider context onto the injectors' TurnContext", async () => {
+    await V3MemoryProvider.retrieveForTurn(ctx());
+    expect(cardsContexts).toHaveLength(1);
+    expect(cardsContexts[0]).toMatchObject({
+      requestId: "req-1",
+      conversationId: "conv-1",
+      turnIndex: 3,
+      trust: TRUST,
+    });
+    expect(spotlightContexts[0]).toMatchObject({
+      conversationId: "conv-1",
+      turnIndex: 3,
+    });
+  });
+
+  test("retrieveForTurn returns cards then spotlight, preserving frozen-card structure", async () => {
+    const cards = freshCardsBlock();
+    cardsBlock = cards;
+    spotlightBlock = spotlightBlockFixture();
+
+    const blocks = await V3MemoryProvider.retrieveForTurn(ctx());
+
+    expect(blocks).toHaveLength(2);
+    // Order: cards (injector order 1000) before spotlight (1001).
+    expect(blocks[0]!.id).toBe(MEMORY_V3_BLOCK_ID);
+    expect(blocks[1]!.id).toBe(MEMORY_V3_SPOTLIGHT_BLOCK_ID);
+    // The frozen card block rides through byte-identical, carry-forward commit
+    // callback intact.
+    expect(blocks[0]).toBe(cards);
+    expect(blocks[0]!.meta?.[MEMORY_V3_COMMIT_META_KEY]).toBe(
+      cards.meta![MEMORY_V3_COMMIT_META_KEY],
+    );
+  });
+
+  test("retrieveForTurn drops null injector results", async () => {
+    cardsBlock = null;
+    spotlightBlock = spotlightBlockFixture();
+    const blocks = await V3MemoryProvider.retrieveForTurn(ctx());
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.id).toBe(MEMORY_V3_SPOTLIGHT_BLOCK_ID);
+  });
+
+  test("retrieveForTurn contributes nothing without turn fields (no call-site wiring yet)", async () => {
+    cardsBlock = freshCardsBlock();
+    const blocks = await V3MemoryProvider.retrieveForTurn(
+      ctx({ turnIndex: undefined, trust: undefined }),
+    );
+    expect(blocks).toEqual([]);
+    expect(cardsContexts).toHaveLength(0);
+  });
+
+  test("provideTools is empty; provideRoutes returns the v3 maintenance routes", () => {
+    expect(V3MemoryProvider.provideTools()).toEqual([]);
+    expect(V3MemoryProvider.provideRoutes()).toBe(MEMORY_V3_ROUTES);
+  });
+
+  test("onTurnCommit / init / shutdown are no-ops", async () => {
+    await expect(V3MemoryProvider.onTurnCommit(ctx())).resolves.toBeUndefined();
+    await expect(V3MemoryProvider.init()).resolves.toBeUndefined();
+    await expect(V3MemoryProvider.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/memory/provider/v3-provider.ts
+++ b/assistant/src/memory/provider/v3-provider.ts
@@ -1,0 +1,126 @@
+/**
+ * {@link MemoryProvider} adapter over the memory-v3 shadow engine.
+ *
+ * Thin delegation layer: every retrieval call routes through the EXISTING v3
+ * injectors (`memoryV3Injector`, `memoryV3SpotlightInjector` in
+ * `plugins/defaults/memory-v3-shadow/injector.ts`), which share one
+ * orchestration result per turn via the `observeTurnOnce` memo. The adapter
+ * reuses that path verbatim — it never re-runs `orchestrate`/`selectPool`
+ * itself, so the memo, the everInjected store, the prune valve, and the
+ * `memory_v3_selections` write remain the single source of truth.
+ *
+ * v3 has no context-load prefix distinct from its per-turn injection: both the
+ * frozen net-new card block and the ephemeral spotlight block are produced on
+ * the per-turn path. So {@link V3MemoryProvider.retrieveForContext} contributes
+ * nothing and {@link V3MemoryProvider.retrieveForTurn} returns the card +
+ * spotlight blocks in injector order.
+ *
+ * The cross-directory import (`memory/provider/` → `plugins/defaults/
+ * memory-v3-shadow/`) is the established direction — `memory/
+ * register-job-handlers.ts` and `memory/graph/conversation-graph-memory.ts`
+ * already import from the same shadow tree, and no boundary guard forbids it.
+ */
+
+import type { TrustContext } from "../../daemon/trust-context.js";
+import {
+  memoryV3Injector,
+  memoryV3SpotlightInjector,
+} from "../../plugins/defaults/memory-v3-shadow/injector.js";
+import type { InjectionBlock, TurnContext } from "../../plugins/types.js";
+import { ROUTES as MEMORY_V3_ROUTES } from "../../runtime/routes/memory-v3-routes.js";
+import type { RouteDefinition } from "../../runtime/routes/types.js";
+import type { ToolDefinition } from "../../tools/types.js";
+import type { MemoryProvider, MemoryProviderContext } from "./types.js";
+
+/**
+ * The turn-level fields the v3 injectors require beyond the base
+ * {@link MemoryProviderContext}: the 0-based `turnIndex` (the orchestration
+ * memo key and shadow-turn `turnNumber`) and the {@link TrustContext} that
+ * drives the personal-memory trust gate. Call sites that wire the provider in
+ * (a later PR) pass these through alongside the base context; until then the
+ * adapter reads them off the context when present and otherwise contributes
+ * nothing (the injectors no-op without a routable turn).
+ */
+export interface V3MemoryProviderContext extends MemoryProviderContext {
+  /** 0-based turn index within the conversation. */
+  readonly turnIndex: number;
+  /** Trust classification and channel identity for the inbound actor. */
+  readonly trust: TrustContext;
+}
+
+function hasTurnFields(
+  ctx: MemoryProviderContext,
+): ctx is V3MemoryProviderContext {
+  const c = ctx as Partial<V3MemoryProviderContext>;
+  return typeof c.turnIndex === "number" && c.trust != null;
+}
+
+/**
+ * Build the {@link TurnContext} the v3 injectors consume from the provider
+ * context. Only the fields the injectors read (`requestId`, `conversationId`,
+ * `turnIndex`, `trust`) are populated; every other `TurnContext` field is an
+ * optional per-turn injection input the v3 injectors ignore.
+ */
+function toTurnContext(ctx: V3MemoryProviderContext): TurnContext {
+  return {
+    requestId: ctx.requestId,
+    conversationId: ctx.conversationId,
+    turnIndex: ctx.turnIndex,
+    trust: ctx.trust,
+  };
+}
+
+/**
+ * v3 implementation of {@link MemoryProvider}. Delegates all retrieval to the
+ * shadow injectors; contributes no model-visible tools (v3 is a
+ * retrieval/injection system with no `remember`-style tool surface) and the v3
+ * maintenance routes. `onTurnCommit`, `init`, and `shutdown` are no-ops: v3's
+ * everInjected write and prune-valve schedule are driven by the injector's
+ * commit callback at runtime assembly, and its consolidation enqueue rides the
+ * v2 consolidation job — neither is a per-turn provider hook.
+ */
+export const V3MemoryProvider = {
+  id: "v3",
+
+  async retrieveForContext(
+    _ctx: MemoryProviderContext,
+  ): Promise<InjectionBlock[]> {
+    // v3 produces no context-load prefix distinct from its per-turn injection.
+    return [];
+  },
+
+  async retrieveForTurn(ctx: MemoryProviderContext): Promise<InjectionBlock[]> {
+    if (!hasTurnFields(ctx)) return [];
+    const turnCtx = toTurnContext(ctx);
+    // Cards first, then spotlight — the injectors' own order (1000 then 1001),
+    // preserved so the spotlight block splices immediately after the cards
+    // block. Each injector shares the per-turn orchestration memo internally.
+    const cards = await memoryV3Injector.produce(turnCtx);
+    const spotlight = await memoryV3SpotlightInjector.produce(turnCtx);
+    return [cards, spotlight].filter(
+      (block): block is InjectionBlock => block != null,
+    );
+  },
+
+  async onTurnCommit(_ctx: MemoryProviderContext): Promise<void> {
+    // No-op: v3 writes (everInjected + prune valve) are deferred to the
+    // injector's commit callback fired by runtime assembly, and its
+    // consolidation enqueue rides the v2 consolidation job.
+  },
+
+  provideTools(): ToolDefinition[] {
+    return [];
+  },
+
+  provideRoutes(): RouteDefinition[] {
+    return MEMORY_V3_ROUTES;
+  },
+
+  async init(): Promise<void> {
+    // No-op: the v3 lanes lazy-init on first orchestration.
+  },
+
+  async shutdown(): Promise<void> {
+    // No-op.
+  },
+} satisfies MemoryProvider;


### PR DESCRIPTION
## Summary
- Add V3MemoryProvider (satisfies MemoryProvider) delegating to memory-v3-shadow orchestrate/injector/pool-select
- Preserves observeTurnOnce + selection/ever-injected stores; no call-site change yet

Part of plan: memory-plugin-extraction.md (PR 15 of 32)