### PR TITLE
feat(memory): implement GraphMemoryProvider adapter over the v1 graph system

### DIFF
--- a/assistant/src/memory/provider/graph-provider.test.ts
+++ b/assistant/src/memory/provider/graph-provider.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { MemoryConfig } from "../../config/schemas/memory.js";
+import { userMessage } from "../../providers/provider-send-message.js";
+import type { Message } from "../../providers/types.js";
+import {
+  assembleContextBlock,
+  assembleInjectionBlock,
+} from "../graph/injection.js";
+import type { MemoryNode, ScoredNode } from "../graph/types.js";
+import { wrapMemoryBlock } from "../memory-marker.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id: "node-1",
+    content: "Sidd prefers rg over grep.",
+    type: "episodic",
+    created: Date.now() - 5 * DAY_MS,
+    lastAccessed: Date.now(),
+    lastConsolidated: Date.now(),
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: Date.now(),
+    sourceConversations: ["conv-1"],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    scopeId: "default",
+    ...overrides,
+  };
+}
+
+function makeScored(overrides: Partial<MemoryNode> = {}): ScoredNode {
+  return {
+    node: makeNode(overrides),
+    score: 0.5,
+    scoreBreakdown: {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0.5,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0.5,
+      triggerBoost: 0,
+      activationBoost: 0,
+    },
+  };
+}
+
+const ZERO_METRICS = {
+  semanticHits: 0,
+  mergedCount: 0,
+  selectedCount: 0,
+  tier1Count: 0,
+  tier2Count: 0,
+  hybridSearchLatencyMs: 0,
+  sparseVectorUsed: false,
+  embeddingProvider: null,
+  embeddingModel: null,
+  queryContext: null,
+  topCandidates: [],
+};
+
+const SEEDED_NODES = [makeScored({ id: "n1", content: "Fact one." })];
+const SEEDED_SERENDIPITY = [makeScored({ id: "n2", content: "Fact two." })];
+
+afterEach(() => {
+  mock.restore();
+});
+
+/**
+ * Load the adapter with the heavy graph retriever + config mocked out so the
+ * test exercises the adapter's mapping logic (retrieve → assemble → wrap →
+ * InjectionBlock) without touching Qdrant/embeddings.
+ */
+async function loadProviderWithMocks(
+  nodes: {
+    context: ScoredNode[];
+    turn: ScoredNode[];
+    serendipity: ScoredNode[];
+  } = {
+    context: SEEDED_NODES,
+    turn: SEEDED_NODES,
+    serendipity: SEEDED_SERENDIPITY,
+  },
+) {
+  mock.module("../../config/loader.js", () => ({
+    getConfig: () => ({}) as never,
+  }));
+  mock.module("../graph/retriever.js", () => ({
+    loadContextMemory: async () => ({
+      nodes: nodes.context,
+      serendipityNodes: nodes.serendipity,
+      triggeredNodes: [],
+      latencyMs: 0,
+      metrics: ZERO_METRICS,
+    }),
+    retrieveForTurn: async () => ({
+      nodes: nodes.turn,
+      serendipityNodes: [],
+      triggeredNodes: [],
+      latencyMs: 0,
+      metrics: ZERO_METRICS,
+    }),
+  }));
+  const { GraphMemoryProvider } = await import("./graph-provider.js");
+  return GraphMemoryProvider;
+}
+
+function ctx(messages: Message[]): {
+  conversationId: string;
+  requestId: string;
+  messages: Message[];
+  config: MemoryConfig;
+} {
+  return {
+    conversationId: "conv-1",
+    requestId: "req-1",
+    messages,
+    config: {} as MemoryConfig,
+  };
+}
+
+describe("GraphMemoryProvider", () => {
+  test("identifies as the graph provider", async () => {
+    const provider = await loadProviderWithMocks();
+    expect(provider.id).toBe("graph");
+  });
+
+  test("retrieveForContext renders the same wrapped block as the direct graph path", async () => {
+    const provider = await loadProviderWithMocks();
+    const blocks = await provider.retrieveForContext(
+      ctx([userMessage("what did I say about grep?")]),
+    );
+
+    const expected = wrapMemoryBlock(
+      assembleContextBlock(SEEDED_NODES, {
+        serendipityNodes: SEEDED_SERENDIPITY,
+      }),
+    );
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).toBe(expected);
+    expect(blocks[0].placement).toBe("prepend-user-tail");
+    expect(blocks[0].id).toBeString();
+  });
+
+  test("retrieveForTurn renders the same wrapped block as the direct graph path", async () => {
+    const provider = await loadProviderWithMocks();
+    const blocks = await provider.retrieveForTurn(
+      ctx([
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Earlier reply." }],
+        },
+        userMessage("follow-up question"),
+      ]),
+    );
+
+    const expected = wrapMemoryBlock(assembleInjectionBlock(SEEDED_NODES));
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).toBe(expected);
+    expect(blocks[0].placement).toBe("after-memory-prefix");
+  });
+
+  test("returns no blocks when retrieval yields no nodes", async () => {
+    const provider = await loadProviderWithMocks({
+      context: [],
+      turn: [],
+      serendipity: [],
+    });
+
+    expect(await provider.retrieveForContext(ctx([userMessage("hi")]))).toEqual(
+      [],
+    );
+    expect(await provider.retrieveForTurn(ctx([userMessage("hi")]))).toEqual(
+      [],
+    );
+  });
+
+  test("provideTools exposes remember and recall definitions", async () => {
+    const provider = await loadProviderWithMocks();
+    const names = provider.provideTools().map((t) => t.name);
+    expect(names).toContain("remember");
+    expect(names).toContain("recall");
+  });
+
+  test("onTurnCommit enqueues a retrospective without throwing", async () => {
+    const enqueue = mock(
+      (_args: { conversationId: string; trigger: string }) => {},
+    );
+    mock.module("../memory-retrospective-enqueue.js", () => ({
+      enqueueMemoryRetrospectiveIfEnabled: enqueue,
+    }));
+    mock.module("../../config/loader.js", () => ({
+      getConfig: () => ({}) as never,
+    }));
+    mock.module("../graph/retriever.js", () => ({
+      loadContextMemory: async () => ({ nodes: [] }),
+      retrieveForTurn: async () => ({ nodes: [] }),
+    }));
+    const { GraphMemoryProvider } = await import("./graph-provider.js");
+
+    await GraphMemoryProvider.onTurnCommit(ctx([userMessage("hi")]));
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue.mock.calls[0][0]).toEqual({
+      conversationId: "conv-1",
+      trigger: "lifecycle",
+    });
+  });
+});

--- a/assistant/src/memory/provider/graph-provider.ts
+++ b/assistant/src/memory/provider/graph-provider.ts
@@ -1,0 +1,159 @@
+/**
+ * `GraphMemoryProvider` — the v1 graph memory system expressed as a
+ * {@link MemoryProvider}.
+ *
+ * Thin adapter over the existing graph modules: it delegates retrieval to
+ * `graph/retriever.ts`, rendering to `graph/injection.ts`, and post-turn
+ * consolidation enqueue to `memory/memory-retrospective-enqueue.ts`, then maps
+ * the results into the {@link InjectionBlock} shape daemon core consumes. No
+ * call site selects this provider yet — wiring lands in a later PR.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import type { InjectionBlock } from "../../plugins/types.js";
+import type { ContentBlock, Message } from "../../providers/types.js";
+import type { ToolDefinition } from "../../tools/types.js";
+import {
+  assembleContextBlock,
+  assembleInjectionBlock,
+  InContextTracker,
+} from "../graph/injection.js";
+import { loadContextMemory, retrieveForTurn } from "../graph/retriever.js";
+import {
+  graphRecallDefinition,
+  graphRememberDefinition,
+} from "../graph/tools.js";
+import { wrapMemoryBlock } from "../memory-marker.js";
+import { enqueueMemoryRetrospectiveIfEnabled } from "../memory-retrospective-enqueue.js";
+import type { MemoryProvider, MemoryProviderContext } from "./types.js";
+
+/** Memory isolation scope used by the live graph path. */
+const GRAPH_SCOPE_ID = "default";
+
+/** Stable injection-block ids matching the two graph injection modes. */
+const CONTEXT_BLOCK_ID = "memory-graph-context-load";
+const TURN_BLOCK_ID = "memory-graph-per-turn";
+
+/** Read the text content of a single message, joined and trimmed. */
+function messageText(message: Message): string {
+  return message.content
+    .filter(
+      (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+    )
+    .map((b) => b.text.trim())
+    .filter((t) => t.length > 0)
+    .join(" ");
+}
+
+/**
+ * Pull the last user message's text and raw blocks plus the preceding
+ * assistant message's text from a turn's working message array — the inputs the
+ * graph retriever's per-turn path consumes.
+ */
+function lastExchange(messages: Message[]): {
+  userLast: string;
+  userLastBlocks: ContentBlock[];
+  assistantLast: string;
+} {
+  let userLast = "";
+  let userLastBlocks: ContentBlock[] = [];
+  let assistantLast = "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    const text = messageText(msg);
+    if (msg.role === "user") {
+      if (userLastBlocks.length === 0) {
+        userLastBlocks = msg.content;
+        userLast = text;
+      }
+    } else if (msg.role === "assistant" && !assistantLast) {
+      assistantLast = text;
+    }
+    if (userLastBlocks.length > 0 && assistantLast) break;
+  }
+  return { userLast, userLastBlocks, assistantLast };
+}
+
+/**
+ * The v1 graph system as a {@link MemoryProvider}. Retrieval and rendering
+ * delegate to the existing graph modules; the adapter only maps their output
+ * into {@link InjectionBlock}s and forwards the retrospective enqueue.
+ */
+export const GraphMemoryProvider = {
+  id: "graph",
+
+  async retrieveForContext(
+    ctx: MemoryProviderContext,
+  ): Promise<InjectionBlock[]> {
+    const config = getConfig();
+    const userQuery = ctx.messages.length
+      ? messageText(ctx.messages[ctx.messages.length - 1])
+      : "";
+    const recentSummaries = ctx.messages
+      .filter((m) => m.role === "user")
+      .map(messageText)
+      .filter((t) => t.length > 0);
+
+    const result = await loadContextMemory({
+      scopeId: GRAPH_SCOPE_ID,
+      recentSummaries,
+      config,
+      userQuery: userQuery.length > 0 ? userQuery : undefined,
+    });
+
+    const block = assembleContextBlock(result.nodes, {
+      serendipityNodes: result.serendipityNodes,
+    });
+    if (!block) return [];
+
+    return [
+      {
+        id: CONTEXT_BLOCK_ID,
+        text: wrapMemoryBlock(block),
+        placement: "prepend-user-tail",
+      },
+    ];
+  },
+
+  async retrieveForTurn(ctx: MemoryProviderContext): Promise<InjectionBlock[]> {
+    const config = getConfig();
+    const { userLast, userLastBlocks, assistantLast } = lastExchange(
+      ctx.messages,
+    );
+
+    const result = await retrieveForTurn({
+      assistantLastMessage: assistantLast,
+      userLastMessage: userLast,
+      userLastMessageBlocks: userLastBlocks,
+      scopeId: GRAPH_SCOPE_ID,
+      config,
+      tracker: new InContextTracker(),
+    });
+
+    const block = assembleInjectionBlock(result.nodes);
+    if (!block) return [];
+
+    return [
+      {
+        id: TURN_BLOCK_ID,
+        text: wrapMemoryBlock(block),
+        placement: "after-memory-prefix",
+      },
+    ];
+  },
+
+  async onTurnCommit(ctx: MemoryProviderContext): Promise<void> {
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: ctx.conversationId,
+      trigger: "lifecycle",
+    });
+  },
+
+  provideTools(): ToolDefinition[] {
+    return [graphRememberDefinition, graphRecallDefinition];
+  },
+
+  async init(): Promise<void> {},
+
+  async shutdown(): Promise<void> {},
+} satisfies MemoryProvider;


### PR DESCRIPTION
## Summary
- Add GraphMemoryProvider (satisfies MemoryProvider) delegating to graph retriever/injection/tool-handlers
- onTurnCommit wraps retrospective enqueue; no call-site change yet

Part of plan: memory-plugin-extraction.md (PR 13 of 32)