### PR TITLE
feat(memory): implement V2MemoryProvider adapter over the concept-page system

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -37,7 +37,7 @@ import {
   type InjectMemoryV2Mode,
 } from "../v2/injection.js";
 import { loadNowText } from "../v2/now-text.js";
-import type { RouterTurnPair } from "../v2/router.js";
+import { extractRecentTurnPairs } from "../v2/router.js";
 import {
   loadGraphMemoryState,
   saveGraphMemoryState,
@@ -1120,66 +1120,4 @@ function readRawUserText(message: Message | undefined): string | null {
     .filter((t) => t.length > 0);
   if (texts.length === 0) return null;
   return texts.join(" ");
-}
-
-/**
- * Walk back through the conversation history and collect the most recent
- * `K` `(assistant, user)` turn pairs for the router prompt. Each pair
- * represents the assistant's reply followed by the user message that
- * came after — the last pair's `userMessage` is the just-arrived turn
- * that triggered this call.
- *
- * Behavior at K=1 is bit-identical to the pre-knob signature: one pair
- * with the prior assistant reply + the just-arrived user message.
- *
- * Edge cases:
- *   - If history has fewer than K full pairs available (e.g. early in a
- *     conversation), returns however many pairs were found, oldest first.
- *     The oldest pair may have `assistantMessage: ""` when there is a
- *     user message with no preceding assistant reply — `runRouterBatch`
- *     skips the `[assistant]:` line in that case.
- *   - Non-text content (tool_use, tool_result, images) is collapsed by
- *     joining all text blocks within a single message with spaces. This
- *     matches the v1-style extraction the router has used since K=1.
- */
-function extractRecentTurnPairs(
-  messages: Message[],
-  k: number,
-): RouterTurnPair[] {
-  const messageText = (msg: Message): string =>
-    msg.content
-      .filter(
-        (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",
-      )
-      .map((b) => b.text)
-      .join(" ");
-
-  const pairs: RouterTurnPair[] = [];
-  let pendingUser: string | null = null;
-  for (let i = messages.length - 1; i >= 0 && pairs.length < k; i--) {
-    const msg = messages[i];
-    if (msg.role === "user" && pendingUser === null) {
-      pendingUser = messageText(msg);
-    } else if (msg.role === "assistant" && pendingUser !== null) {
-      pairs.unshift({
-        assistantMessage: messageText(msg),
-        userMessage: pendingUser,
-      });
-      pendingUser = null;
-    }
-  }
-  // Conversation start: a user message with no preceding assistant reply
-  // still belongs in the prompt as the just-arrived turn. Emit it with an
-  // empty `assistantMessage` so `runRouterBatch` renders only `[user]:`.
-  if (pendingUser !== null && pairs.length < k) {
-    pairs.unshift({ assistantMessage: "", userMessage: pendingUser });
-  }
-  // Defensive fallback: the router contract requires a non-empty array.
-  // This only fires when `messages` has no user-text content at all
-  // (currently impossible since the agent loop always appends a user
-  // turn before invoking the v2 path, but cheap to keep correct).
-  if (pairs.length === 0) {
-    pairs.push({ assistantMessage: "", userMessage: "" });
-  }
-  return pairs;
 }

--- a/assistant/src/memory/provider/v2-provider.test.ts
+++ b/assistant/src/memory/provider/v2-provider.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for `V2MemoryProvider` — the {@link MemoryProvider} adapter over the
+ * v2 concept-page system.
+ *
+ * The v2 injector reaches a SQLite handle, the embedding backend, and the
+ * Qdrant client; a full end-to-end fixture is heavy and already exercised by
+ * `v2/__tests__/injection.test.ts`. These tests assert the adapter's
+ * contract: it satisfies `MemoryProvider`, surfaces the v2 remember-write
+ * tools, gates injection on `memory.v2.enabled`, and maps a non-null v2
+ * `<memory>` block onto a `prepend-user-tail` injection block by delegating
+ * to `injectMemoryV2Block`.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { MemoryConfig } from "../../config/schemas/memory.js";
+import type { Message } from "../../providers/types.js";
+import type { MemoryProvider, MemoryProviderContext } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — keep the adapter off real DB / workspace / v2 internals.
+// ---------------------------------------------------------------------------
+
+const injectCalls: Array<Record<string, unknown>> = [];
+let injectResult: { block: string | null; toInject: string[] } = {
+  block: null,
+  toInject: [],
+};
+
+mock.module("../v2/injection.js", () => ({
+  injectMemoryV2Block: async (params: Record<string, unknown>) => {
+    injectCalls.push(params);
+    return injectResult;
+  },
+}));
+
+mock.module("../v2/now-text.js", () => ({
+  loadNowText: async () => "NOW",
+}));
+
+const realDbConnection = await import("../db-connection.js");
+mock.module("../db-connection.js", () => ({
+  ...realDbConnection,
+  getDb: () => ({}) as unknown,
+}));
+
+const realPlatform = await import("../../util/platform.js");
+mock.module("../../util/platform.js", () => ({
+  ...realPlatform,
+  getWorkspaceDir: () => "/tmp/ws",
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ memory: { v2: { enabled: true } } }),
+}));
+
+const enqueueCalls: Array<Record<string, unknown>> = [];
+mock.module("../memory-retrospective-enqueue.js", () => ({
+  enqueueMemoryRetrospectiveIfEnabled: (args: Record<string, unknown>) => {
+    enqueueCalls.push(args);
+  },
+}));
+
+const { V2MemoryProvider } = await import("./v2-provider.js");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeMemoryConfig(v2Enabled: boolean): MemoryConfig {
+  return {
+    v2: {
+      enabled: v2Enabled,
+      router: { historical_pairs: 3 },
+    },
+  } as unknown as MemoryConfig;
+}
+
+function makeCtx(v2Enabled: boolean): MemoryProviderContext {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "hello" }] },
+  ];
+  return {
+    conversationId: "conv-1",
+    requestId: "req-1",
+    messages,
+    config: makeMemoryConfig(v2Enabled),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("V2MemoryProvider", () => {
+  test("satisfies MemoryProvider with id 'v2'", () => {
+    const provider: MemoryProvider = V2MemoryProvider;
+    expect(provider.id).toBe("v2");
+  });
+
+  test("provideTools surfaces the remember/recall write path", () => {
+    const names = V2MemoryProvider.provideTools().map((t) => t.name);
+    expect(names).toContain("remember");
+    expect(names).toContain("recall");
+  });
+
+  test("retrieve* return no blocks when v2 is disabled", async () => {
+    injectCalls.length = 0;
+    const ctx = makeCtx(false);
+    expect(await V2MemoryProvider.retrieveForContext(ctx)).toEqual([]);
+    expect(await V2MemoryProvider.retrieveForTurn(ctx)).toEqual([]);
+    // The injector is never reached when v2 is off.
+    expect(injectCalls).toHaveLength(0);
+  });
+
+  test("retrieveForContext maps a v2 block to a prepend-user-tail injection block", async () => {
+    injectCalls.length = 0;
+    injectResult = { block: "<memory>\nfoo\n</memory>", toInject: ["foo"] };
+
+    const blocks = await V2MemoryProvider.retrieveForContext(makeCtx(true));
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      id: "memory-v2",
+      text: "<memory>\nfoo\n</memory>",
+      placement: "prepend-user-tail",
+    });
+    // Delegated to the v2 injector in context-load mode.
+    expect(injectCalls).toHaveLength(1);
+    expect(injectCalls[0].mode).toBe("context-load");
+    expect(injectCalls[0].conversationId).toBe("conv-1");
+  });
+
+  test("retrieveForTurn delegates in per-turn mode and returns [] on a null block", async () => {
+    injectCalls.length = 0;
+    injectResult = { block: null, toInject: [] };
+
+    const blocks = await V2MemoryProvider.retrieveForTurn(makeCtx(true));
+
+    expect(blocks).toEqual([]);
+    expect(injectCalls).toHaveLength(1);
+    expect(injectCalls[0].mode).toBe("per-turn");
+  });
+
+  test("onTurnCommit enqueues the v2 consolidation/retrospective trigger", async () => {
+    enqueueCalls.length = 0;
+    await V2MemoryProvider.onTurnCommit(makeCtx(true));
+    expect(enqueueCalls).toEqual([
+      { conversationId: "conv-1", trigger: "lifecycle" },
+    ]);
+  });
+});

--- a/assistant/src/memory/provider/v2-provider.ts
+++ b/assistant/src/memory/provider/v2-provider.ts
@@ -1,0 +1,114 @@
+/**
+ * `V2MemoryProvider` — {@link MemoryProvider} adapter over the v2
+ * concept-page (activation) memory system.
+ *
+ * Delegates to the existing v2 surface rather than re-implementing it:
+ *   - injection: `v2/injection.ts` `injectMemoryV2Block` (context-load and
+ *     per-turn modes) → mapped to {@link InjectionBlock}s.
+ *   - remember-write tools: the shared `remember`/`recall` tools, whose
+ *     handlers append to the concept-page corpus that v2 reads from.
+ *   - consolidation/write enqueue: `enqueueMemoryRetrospectiveIfEnabled`,
+ *     the same post-turn trigger the live v2 path fires.
+ *
+ * No call site consumes this yet — it is additive scaffolding selected by
+ * `memory.provider` in a later PR.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import type { InjectionBlock } from "../../plugins/types.js";
+import { recallTool, rememberTool } from "../../tools/memory/register.js";
+import type { ToolDefinition } from "../../tools/types.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { getDb } from "../db-connection.js";
+import { enqueueMemoryRetrospectiveIfEnabled } from "../memory-retrospective-enqueue.js";
+import {
+  injectMemoryV2Block,
+  type InjectMemoryV2Mode,
+} from "../v2/injection.js";
+import { loadNowText } from "../v2/now-text.js";
+import { extractRecentTurnPairs } from "../v2/router.js";
+import type { MemoryProvider, MemoryProviderContext } from "./types.js";
+
+/**
+ * Stable id for the `<memory>` injection block this provider contributes.
+ * Mirrors the placement the live v2 path uses (the block is prepended onto
+ * the current user message's content).
+ */
+const V2_MEMORY_BLOCK_ID = "memory-v2";
+
+/**
+ * Run the v2 injector for the given mode and map its `<memory>` block onto an
+ * {@link InjectionBlock} array. Returns an empty array when v2 is disabled or
+ * the injector renders nothing new (the cache-stable empty path).
+ */
+async function inject(
+  ctx: MemoryProviderContext,
+  mode: InjectMemoryV2Mode,
+): Promise<InjectionBlock[]> {
+  if (!ctx.config.v2.enabled) {
+    return [];
+  }
+
+  const config = getConfig();
+  const workspaceDir = getWorkspaceDir();
+  const nowText = await loadNowText(workspaceDir);
+  const recentTurnPairs = extractRecentTurnPairs(
+    ctx.messages,
+    ctx.config.v2.router.historical_pairs,
+  );
+
+  const result = await injectMemoryV2Block({
+    database: getDb(),
+    conversationId: ctx.conversationId,
+    currentTurn: 0,
+    recentTurnPairs,
+    nowText,
+    messageId: ctx.requestId,
+    mode,
+    config,
+  });
+
+  if (!result.block) {
+    return [];
+  }
+
+  return [
+    {
+      id: V2_MEMORY_BLOCK_ID,
+      text: result.block,
+      placement: "prepend-user-tail",
+      meta: { mode, toInject: result.toInject },
+    },
+  ];
+}
+
+/**
+ * The v2 (concept-page activation) memory system expressed as a
+ * {@link MemoryProvider}.
+ */
+export const V2MemoryProvider = {
+  id: "v2",
+
+  retrieveForContext(ctx: MemoryProviderContext): Promise<InjectionBlock[]> {
+    return inject(ctx, "context-load");
+  },
+
+  retrieveForTurn(ctx: MemoryProviderContext): Promise<InjectionBlock[]> {
+    return inject(ctx, "per-turn");
+  },
+
+  async onTurnCommit(ctx: MemoryProviderContext): Promise<void> {
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: ctx.conversationId,
+      trigger: "lifecycle",
+    });
+  },
+
+  provideTools(): ToolDefinition[] {
+    return [rememberTool, recallTool];
+  },
+
+  async init(): Promise<void> {},
+
+  async shutdown(): Promise<void> {},
+} satisfies MemoryProvider;

--- a/assistant/src/memory/v2/harness/replay-input.ts
+++ b/assistant/src/memory/v2/harness/replay-input.ts
@@ -28,7 +28,7 @@ import type { DrizzleDb } from "../../db-connection.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
 import { memoryV2ActivationLogs, messages } from "../../schema.js";
 import { loadNowText } from "../now-text.js";
-import type { RouterTurnPair } from "../router.js";
+import { extractRecentTurnPairs } from "../router.js";
 import type { EverInjectedEntry } from "../types.js";
 import type { OracleTurn } from "./oracle.js";
 import type { RetrievalInput } from "./retriever.js";
@@ -57,47 +57,6 @@ export interface ReconstructedInput {
 interface PlainMessage {
   role: string;
   content: ContentBlock[];
-}
-
-/**
- * Mirror of production `extractRecentTurnPairs`: walk messages newest-first,
- * pair each user message with the preceding assistant reply, keep the last `k`
- * pairs (oldest first). A leading user message with no prior assistant reply is
- * emitted with an empty `assistantMessage`.
- */
-function extractRecentTurnPairs(
-  msgs: readonly PlainMessage[],
-  k: number,
-): RouterTurnPair[] {
-  const messageText = (msg: PlainMessage): string =>
-    msg.content
-      .filter(
-        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
-      )
-      .map((b) => b.text)
-      .join(" ");
-
-  const pairs: RouterTurnPair[] = [];
-  let pendingUser: string | null = null;
-  for (let i = msgs.length - 1; i >= 0 && pairs.length < k; i--) {
-    const msg = msgs[i]!;
-    if (msg.role === "user" && pendingUser === null) {
-      pendingUser = messageText(msg);
-    } else if (msg.role === "assistant" && pendingUser !== null) {
-      pairs.unshift({
-        assistantMessage: messageText(msg),
-        userMessage: pendingUser,
-      });
-      pendingUser = null;
-    }
-  }
-  if (pendingUser !== null && pairs.length < k) {
-    pairs.unshift({ assistantMessage: "", userMessage: pendingUser });
-  }
-  if (pairs.length === 0) {
-    pairs.push({ assistantMessage: "", userMessage: "" });
-  }
-  return pairs;
 }
 
 function parseContent(raw: string): ContentBlock[] {

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -44,7 +44,11 @@ import {
   extractToolUse,
   getConfiguredProvider,
 } from "../../providers/provider-send-message.js";
-import type { Message, ToolDefinition } from "../../providers/types.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { computeInjectionScores } from "./injection-events.js";
@@ -167,6 +171,58 @@ function emptyBatchResult(
 export interface RouterTurnPair {
   assistantMessage: string;
   userMessage: string;
+}
+
+/**
+ * Structural message shape `extractRecentTurnPairs` reads. Both the
+ * production `Message` and the harness's reconstructed rows satisfy it.
+ */
+interface TurnPairMessage {
+  role: string;
+  content: ContentBlock[];
+}
+
+/**
+ * Walk `messages` newest-first, pairing each user message with the
+ * assistant reply that preceded it, and return the last `k` pairs oldest
+ * first. A leading user message with no prior assistant reply is emitted
+ * with an empty `assistantMessage`; an empty/text-less window yields a
+ * single empty pair so the router contract's non-empty-array invariant
+ * holds.
+ */
+export function extractRecentTurnPairs(
+  messages: readonly TurnPairMessage[],
+  k: number,
+): RouterTurnPair[] {
+  const messageText = (msg: TurnPairMessage): string =>
+    msg.content
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" ");
+
+  const pairs: RouterTurnPair[] = [];
+  let pendingUser: string | null = null;
+  for (let i = messages.length - 1; i >= 0 && pairs.length < k; i--) {
+    const msg = messages[i]!;
+    if (msg.role === "user" && pendingUser === null) {
+      pendingUser = messageText(msg);
+    } else if (msg.role === "assistant" && pendingUser !== null) {
+      pairs.unshift({
+        assistantMessage: messageText(msg),
+        userMessage: pendingUser,
+      });
+      pendingUser = null;
+    }
+  }
+  if (pendingUser !== null && pairs.length < k) {
+    pairs.unshift({ assistantMessage: "", userMessage: pendingUser });
+  }
+  if (pairs.length === 0) {
+    pairs.push({ assistantMessage: "", userMessage: "" });
+  }
+  return pairs;
 }
 
 interface RunRouterParams {


### PR DESCRIPTION
## Summary
- Add V2MemoryProvider (satisfies MemoryProvider) delegating to v2 injection/activation/router + remember-write
- No call-site change yet
- Consolidate the triplicated `extractRecentTurnPairs` helper into one exported `v2/router.ts` function (was copy-pasted across conversation-graph-memory.ts, the new provider, and the replay-input harness)

Part of plan: memory-plugin-extraction.md (PR 14 of 32)