### PR TITLE
feat(config): migrate memory.v2.enabled / memory.v3.live to memory.provider

### DIFF
--- a/assistant/src/__tests__/workspace-migration-memory-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-memory-provider.test.ts
@@ -1,0 +1,203 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { memoryProviderMigration } from "../workspace/migrations/116-memory-provider.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-116-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function provider(): unknown {
+  return (readConfig().memory as Record<string, unknown>).provider;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("116-memory-provider migration", () => {
+  test("has correct migration id and description", () => {
+    expect(memoryProviderMigration.id).toBe("116-memory-provider");
+    expect(memoryProviderMigration.description).toBe(
+      "Pin memory.provider from legacy memory.v2.enabled / memory.v3.live gates",
+    );
+  });
+
+  // ─── Legacy mapping ─────────────────────────────────────────────────────
+
+  test("maps v3.live=true to provider 'v3'", () => {
+    writeConfig({ memory: { v2: { enabled: true }, v3: { live: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v3");
+  });
+
+  test("v3.live wins over v2.enabled", () => {
+    writeConfig({ memory: { v2: { enabled: false }, v3: { live: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v3");
+  });
+
+  test("maps v2.enabled=true (v3 not live) to provider 'v2'", () => {
+    writeConfig({ memory: { v2: { enabled: true }, v3: { live: false } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v2");
+  });
+
+  test("maps neither-flag to provider 'graph'", () => {
+    writeConfig({ memory: { v2: { enabled: false }, v3: { live: false } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("graph");
+  });
+
+  test("maps missing v2/v3 entirely to provider 'graph'", () => {
+    writeConfig({ memory: {} });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("graph");
+  });
+
+  test("absent provider key with auto-equivalent legacy state derives provider", () => {
+    writeConfig({ memory: { v3: { live: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v3");
+  });
+
+  test("explicit provider 'auto' is treated as derivable", () => {
+    writeConfig({ memory: { provider: "auto", v2: { enabled: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v2");
+  });
+
+  // ─── Already-explicit provider is untouched ─────────────────────────────
+
+  test("leaves an explicit non-auto provider untouched (v3)", () => {
+    writeConfig({ memory: { provider: "v3", v2: { enabled: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("v3");
+  });
+
+  test("leaves an explicit 'none' provider untouched", () => {
+    writeConfig({ memory: { provider: "none", v3: { live: true } } });
+    memoryProviderMigration.run(workspaceDir);
+    expect(provider()).toBe("none");
+  });
+
+  test("does not rewrite the file when provider is already explicit", () => {
+    writeConfig({ memory: { provider: "graph", v3: { live: true } } });
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    memoryProviderMigration.run(workspaceDir);
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  // ─── Idempotency ────────────────────────────────────────────────────────
+
+  test("idempotency: re-running after derivation is a no-op", () => {
+    writeConfig({ memory: { v2: { enabled: true } } });
+
+    memoryProviderMigration.run(workspaceDir);
+    const afterFirst = readConfig();
+    expect((afterFirst.memory as Record<string, unknown>).provider).toBe("v2");
+
+    memoryProviderMigration.run(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  // ─── Preserves siblings & legacy keys ───────────────────────────────────
+
+  test("retains legacy keys and other config after derivation", () => {
+    writeConfig({
+      memory: { enabled: true, v2: { enabled: true }, v3: { live: false } },
+      llm: { default: { provider: "anthropic" } },
+    });
+    memoryProviderMigration.run(workspaceDir);
+    const config = readConfig();
+    const memory = config.memory as Record<string, unknown>;
+    expect(memory.provider).toBe("v2");
+    expect(memory.enabled).toBe(true);
+    expect((memory.v2 as Record<string, unknown>).enabled).toBe(true);
+    expect((memory.v3 as Record<string, unknown>).live).toBe(false);
+    expect(config.llm).toEqual({ default: { provider: "anthropic" } });
+  });
+
+  // ─── Graceful no-ops ────────────────────────────────────────────────────
+
+  test("no-op when config.json does not exist", () => {
+    memoryProviderMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no memory key", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    memoryProviderMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    memoryProviderMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("gracefully handles array-shaped config", () => {
+    writeFileSync(join(workspaceDir, "config.json"), JSON.stringify([1, 2, 3]));
+    memoryProviderMigration.run(workspaceDir);
+    const raw = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(raw).toEqual([1, 2, 3]);
+  });
+
+  test("gracefully handles non-object memory value", () => {
+    writeConfig({ memory: 42, other: true });
+    memoryProviderMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ memory: 42, other: true });
+  });
+});

--- a/assistant/src/workspace/migrations/116-memory-provider.ts
+++ b/assistant/src/workspace/migrations/116-memory-provider.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Pin `memory.provider` from the legacy gates so existing installs keep running
+ * the same memory system after `provider` becomes the source of truth.
+ *
+ * Mapping (highest precedence first):
+ *   - `memory.v3.live === true`    → "v3"
+ *   - `memory.v2.enabled === true` → "v2"
+ *   - otherwise                    → "graph"
+ *
+ * The legacy keys (`memory.v2.enabled`, `memory.v3.live`) are left in place for
+ * read-compat during the transition release.
+ *
+ * Only writes when `memory.provider` is absent or the behavior-neutral "auto"
+ * sentinel. An explicit non-auto provider (a deliberate user/operator choice or
+ * a prior run of this migration) is left untouched. Idempotent: a re-run finds a
+ * concrete provider already set and no-ops.
+ */
+export const memoryProviderMigration: WorkspaceMigration = {
+  id: "116-memory-provider",
+  description:
+    "Pin memory.provider from legacy memory.v2.enabled / memory.v3.live gates",
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const memory = config.memory;
+    if (memory === null || typeof memory !== "object" || Array.isArray(memory))
+      return;
+    const memoryConfig = memory as Record<string, unknown>;
+
+    // Respect an explicit non-auto provider — a deliberate choice or a prior
+    // run of this migration. Only "auto" / absent is up for derivation.
+    const current = memoryConfig.provider;
+    if (current !== undefined && current !== "auto") return;
+
+    const v2 = memoryConfig.v2;
+    const v2Enabled =
+      v2 !== null &&
+      typeof v2 === "object" &&
+      !Array.isArray(v2) &&
+      (v2 as Record<string, unknown>).enabled === true;
+
+    const v3 = memoryConfig.v3;
+    const v3Live =
+      v3 !== null &&
+      typeof v3 === "object" &&
+      !Array.isArray(v3) &&
+      (v3 as Record<string, unknown>).live === true;
+
+    const provider = v3Live ? "v3" : v2Enabled ? "v2" : "graph";
+
+    memoryConfig.provider = provider;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: cannot distinguish a derived provider from a user's
+    // explicit choice, so reverting would risk discarding a deliberate value.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -113,6 +113,7 @@ import { removeAdvisorCallsiteOverrideMigration } from "./112-remove-advisor-cal
 import { swapBalancedProfileToGlm52Migration } from "./113-swap-balanced-profile-to-glm-5p2.js";
 import { swapQualityProfileToOpusMigration } from "./114-swap-quality-profile-to-opus.js";
 import { dropFrontierProfileMigration } from "./115-drop-frontier-profile.js";
+import { memoryProviderMigration } from "./116-memory-provider.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -237,4 +238,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   swapBalancedProfileToGlm52Migration,
   swapQualityProfileToOpusMigration,
   dropFrontierProfileMigration,
+  memoryProviderMigration,
 ];


### PR DESCRIPTION
## Summary
- Append-only workspace migration mapping legacy v2.enabled/v3.live to memory.provider
- Idempotent; legacy keys retained for read-compat

Part of plan: memory-plugin-extraction.md (PR 17 of 32)