### PR TITLE
feat(memory): observe-first usage-prune stage for assistant-authored skills

### DIFF
--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -190,6 +190,15 @@ export const MemoryMaintenanceConfigSchema = z
       .describe(
         "Database maintenance is deferred unless at least this many milliseconds have elapsed since the last user message, so maintenance's write locks never collide with an active user (0 disables the quiet-period gate)",
       ),
+    skillPruneDays: z
+      .number({ error: "memory.maintenance.skillPruneDays must be a number" })
+      .int("memory.maintenance.skillPruneDays must be an integer")
+      .min(1, "memory.maintenance.skillPruneDays must be at least 1")
+      .nullable()
+      .default(null)
+      .describe(
+        'Usage-based prune threshold for assistant-authored skills, in days. `null` (the default) = never prune — the maintain stage runs observe-only and deletes nothing (it still reports stale skills for observability). Set a positive integer to enable deletion of assistant-authored skills unused (lastUsedAt, else installedAt) for at least that many days. Shipped default-off so skill accumulation can be observed before deletion is enabled. Only `author:"assistant"` skills are ever eligible; user-authored and untagged skills are always protected.',
+      ),
   })
   .describe(
     "Database maintenance (PRAGMA optimize / WAL checkpoint) scheduling",

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -6,6 +6,7 @@ import type { AssistantConfig } from "../../../../config/types.js";
 import { EmbeddingBackendUnavailableError } from "../../../../memory/embedding-backend.js";
 import { EmbeddingBillingBlockError } from "../../../../memory/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../../memory/jobs-store.js";
+import { skillSlugFor } from "../../../../memory/v2/skill-store.js";
 import type { SkillInstallMeta } from "../../../../skills/install-meta.js";
 import { renderCapabilityContent } from "../capabilities.js";
 import {
@@ -476,15 +477,22 @@ describe("maintainJob skill usage-prune", () => {
     metas: Record<string, SkillInstallMeta | null>,
     skillPruneDays: number | null,
     overrides: Partial<MaintainJobDeps> = {},
-  ): { deps: MaintainJobDeps; deletedSkills: string[] } {
+  ): {
+    deps: MaintainJobDeps;
+    deletedSkills: string[];
+    sectionDeletes: string[];
+  } {
     const deletedSkills: string[] = [];
+    const sectionDeletes: string[] = [];
     const d: MaintainJobDeps = {
       config: makeConfig(skillPruneDays),
       selectChangedPages: async () => [],
       buildSectionIndex: async (slugs) => makeIndex(slugs),
       readPageBody: async (s) => `body for ${s}`,
       readCapabilityBody: async (s) => `capability body for ${s}`,
-      deleteSectionsForArticle: async () => {},
+      deleteSectionsForArticle: async (_config, article) => {
+        sectionDeletes.push(article);
+      },
       upsertSections: async () => {},
       commitEmbedHighWater: () => {},
       listSectionArticles: async () => [],
@@ -502,7 +510,7 @@ describe("maintainJob skill usage-prune", () => {
       nowMs: () => NOW,
       ...overrides,
     };
-    return { deps: d, deletedSkills };
+    return { deps: d, deletedSkills, sectionDeletes };
   }
 
   describe("default (skillPruneDays: null) — observe-only, deletes nothing", () => {
@@ -554,7 +562,11 @@ describe("maintainJob skill usage-prune", () => {
   describe("enabled (skillPruneDays: 30) — deletes via executeDeleteManagedSkill", () => {
     test("prunes a stale assistant skill via deleteSkill", async () => {
       setOverridesForTesting({ [FLAG_SHADOW]: true });
-      const { deps: d, deletedSkills } = pruneDeps(
+      const {
+        deps: d,
+        deletedSkills,
+        sectionDeletes,
+      } = pruneDeps(
         [skill("stale-assistant")],
         { "stale-assistant": meta("assistant", "lastUsedAt", 45) },
         30,
@@ -565,6 +577,8 @@ describe("maintainJob skill usage-prune", () => {
       expect(outcome.prunedSkills).toEqual(["stale-assistant"]);
       expect(outcome.prunableSkills).toEqual(["stale-assistant"]);
       expect(outcome.skillPruneFailures).toEqual([]);
+      // The pruned skill's v3 capability sections are cleared the same pass.
+      expect(sectionDeletes).toContain(skillSlugFor("stale-assistant"));
     });
 
     test("never prunes author:user or untagged skills", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { setOverridesForTesting } from "../../../../__tests__/feature-flag-test-helpers.js";
+import type { SkillSummary } from "../../../../config/skills.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { EmbeddingBackendUnavailableError } from "../../../../memory/embedding-backend.js";
 import { EmbeddingBillingBlockError } from "../../../../memory/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../../memory/jobs-store.js";
+import type { SkillInstallMeta } from "../../../../skills/install-meta.js";
 import { renderCapabilityContent } from "../capabilities.js";
 import {
   backfillAllSections,
@@ -22,8 +24,15 @@ const FLAG_SHADOW = "memory-v3-shadow";
 // The shadow flag resolver ignores the passed config and reads the override
 // cache; the config arg only satisfies the signature. Shadow is driven via
 // `setOverridesForTesting`; v3-live (now config-gated) is driven through the
-// `isMemoryV3Live` mock slot below.
-const CONFIG = {} as AssistantConfig;
+// `isMemoryV3Live` mock slot below. The maintenance branch the skill usage-prune
+// stage reads (`memory.maintenance.skillPruneDays`) is the only config path the
+// job touches; default it off (null = never prune), and override per test.
+function makeConfig(skillPruneDays: number | null = null): AssistantConfig {
+  return {
+    memory: { maintenance: { skillPruneDays } },
+  } as unknown as AssistantConfig;
+}
+const CONFIG = makeConfig();
 
 let memoryV3LiveSlot = false;
 mock.module("../../../../config/memory-v3-gate.js", () => ({
@@ -62,6 +71,7 @@ describe("maintainJob", () => {
       upserted: Section[][];
       invalidate: number;
       commit: number;
+      deletedSkills: string[];
     };
   } {
     const calls = {
@@ -70,6 +80,7 @@ describe("maintainJob", () => {
       upserted: [] as Section[][],
       invalidate: 0,
       commit: 0,
+      deletedSkills: [] as string[],
     };
     const base: MaintainJobDeps = {
       config: CONFIG,
@@ -99,6 +110,14 @@ describe("maintainJob", () => {
       invalidateLanes: () => {
         calls.invalidate += 1;
       },
+      // Skill usage-prune stage off by default: no managed skills ⇒ nothing to
+      // report or delete. The dedicated usage-prune tests below override these.
+      listManagedSkills: () => [],
+      readSkillMeta: () => null,
+      deleteSkill: async (skillId) => {
+        calls.deletedSkills.push(skillId);
+      },
+      nowMs: () => Date.parse("2026-06-22T00:00:00.000Z"),
     };
     return { deps: { ...base, ...overrides }, calls };
   }
@@ -410,6 +429,236 @@ describe("maintainJob", () => {
     // Never replace good points with a blank: no delete, no upsert.
     expect(calls.deleted).toEqual([]);
     expect(calls.upserted).toEqual([]);
+  });
+});
+
+describe("maintainJob skill usage-prune", () => {
+  const NOW = Date.parse("2026-06-22T00:00:00.000Z");
+
+  afterEach(() => {
+    setOverridesForTesting({});
+    memoryV3LiveSlot = false;
+  });
+
+  function skill(id: string): SkillSummary {
+    return {
+      id,
+      name: id,
+      displayName: id,
+      description: "",
+      directoryPath: `/skills/${id}`,
+      skillFilePath: `/skills/${id}/SKILL.md`,
+      source: "managed",
+    };
+  }
+
+  /** Build install-meta `daysAgo` old via the chosen field. */
+  function meta(
+    author: SkillInstallMeta["author"] | undefined,
+    field: "lastUsedAt" | "installedAt" | "none",
+    daysAgo = 0,
+  ): SkillInstallMeta {
+    const ts = new Date(NOW - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+    const base: SkillInstallMeta = {
+      origin: "custom",
+      // A never-used skill (`field: "none"`) still needs an installedAt; make it
+      // very old so it falls back to installedAt for the age math.
+      installedAt: field === "lastUsedAt" ? new Date(NOW).toISOString() : ts,
+    };
+    if (author) base.author = author;
+    if (field === "lastUsedAt") base.lastUsedAt = ts;
+    return base;
+  }
+
+  /** Wire managed skills + their metas + an injected clock at NOW. */
+  function pruneDeps(
+    skills: SkillSummary[],
+    metas: Record<string, SkillInstallMeta | null>,
+    skillPruneDays: number | null,
+    overrides: Partial<MaintainJobDeps> = {},
+  ): { deps: MaintainJobDeps; deletedSkills: string[] } {
+    const deletedSkills: string[] = [];
+    const d: MaintainJobDeps = {
+      config: makeConfig(skillPruneDays),
+      selectChangedPages: async () => [],
+      buildSectionIndex: async (slugs) => makeIndex(slugs),
+      readPageBody: async (s) => `body for ${s}`,
+      readCapabilityBody: async (s) => `capability body for ${s}`,
+      deleteSectionsForArticle: async () => {},
+      upsertSections: async () => {},
+      commitEmbedHighWater: () => {},
+      listSectionArticles: async () => [],
+      listIndexedSlugs: async () => [],
+      loadCoreSet: () => [],
+      invalidateLanes: () => {},
+      listManagedSkills: () => skills,
+      readSkillMeta: (dir) => {
+        const id = dir.split("/").pop()!;
+        return metas[id] ?? null;
+      },
+      deleteSkill: async (id) => {
+        deletedSkills.push(id);
+      },
+      nowMs: () => NOW,
+      ...overrides,
+    };
+    return { deps: d, deletedSkills };
+  }
+
+  describe("default (skillPruneDays: null) — observe-only, deletes nothing", () => {
+    test("reports stale assistant skills but deletes none", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const skills = [skill("stale-assistant"), skill("fresh-assistant")];
+      const { deps: d, deletedSkills } = pruneDeps(
+        skills,
+        {
+          "stale-assistant": meta("assistant", "lastUsedAt", 90),
+          "fresh-assistant": meta("assistant", "lastUsedAt", 1),
+        },
+        null,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      // Default-off: nothing deleted even though one skill is 90 days stale.
+      expect(deletedSkills).toEqual([]);
+      expect(outcome.prunedSkills).toEqual([]);
+      expect(outcome.skillPruneFailures).toEqual([]);
+      // Observe-only report still surfaces the stale skill (≥ 30-day window).
+      expect(outcome.prunableSkills).toEqual(["stale-assistant"]);
+    });
+
+    test("excludes author:user and untagged skills from prunableSkills", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const skills = [
+        skill("old-assistant"),
+        skill("old-user"),
+        skill("old-untagged"),
+      ];
+      const { deps: d, deletedSkills } = pruneDeps(
+        skills,
+        {
+          "old-assistant": meta("assistant", "lastUsedAt", 90),
+          "old-user": meta("user", "lastUsedAt", 90),
+          "old-untagged": meta(undefined, "lastUsedAt", 90),
+        },
+        null,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual([]);
+      // Only the assistant-authored skill is reported; user + untagged protected.
+      expect(outcome.prunableSkills).toEqual(["old-assistant"]);
+    });
+  });
+
+  describe("enabled (skillPruneDays: 30) — deletes via executeDeleteManagedSkill", () => {
+    test("prunes a stale assistant skill via deleteSkill", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const { deps: d, deletedSkills } = pruneDeps(
+        [skill("stale-assistant")],
+        { "stale-assistant": meta("assistant", "lastUsedAt", 45) },
+        30,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual(["stale-assistant"]);
+      expect(outcome.prunedSkills).toEqual(["stale-assistant"]);
+      expect(outcome.prunableSkills).toEqual(["stale-assistant"]);
+      expect(outcome.skillPruneFailures).toEqual([]);
+    });
+
+    test("never prunes author:user or untagged skills", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const { deps: d, deletedSkills } = pruneDeps(
+        [skill("old-user"), skill("old-untagged")],
+        {
+          "old-user": meta("user", "lastUsedAt", 999),
+          "old-untagged": meta(undefined, "lastUsedAt", 999),
+        },
+        30,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual([]);
+      expect(outcome.prunedSkills).toEqual([]);
+      expect(outcome.prunableSkills).toEqual([]);
+    });
+
+    test("keeps a recently-used assistant skill", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const { deps: d, deletedSkills } = pruneDeps(
+        [skill("fresh-assistant")],
+        { "fresh-assistant": meta("assistant", "lastUsedAt", 5) },
+        30,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual([]);
+      expect(outcome.prunedSkills).toEqual([]);
+      // Under the 30-day observe window too, so not even reported.
+      expect(outcome.prunableSkills).toEqual([]);
+    });
+
+    test("a never-used skill falls back to installedAt", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      // No lastUsedAt; installedAt is 60 days old ⇒ eligible at the 30-day
+      // threshold via the installedAt fallback.
+      const { deps: d, deletedSkills } = pruneDeps(
+        [skill("never-used")],
+        { "never-used": meta("assistant", "installedAt", 60) },
+        30,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual(["never-used"]);
+      expect(outcome.prunedSkills).toEqual(["never-used"]);
+    });
+
+    test("a deleteSkill rejection lands in skillPruneFailures without aborting", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      const deleted: string[] = [];
+      const { deps: d } = pruneDeps(
+        [skill("doomed"), skill("bad"), skill("survivor")],
+        {
+          doomed: meta("assistant", "lastUsedAt", 45),
+          bad: meta("assistant", "lastUsedAt", 45),
+          survivor: meta("assistant", "lastUsedAt", 45),
+        },
+        30,
+        {
+          deleteSkill: async (id) => {
+            if (id === "bad") throw new Error("delete boom");
+            deleted.push(id);
+          },
+        },
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      // The failing delete did not abort the others.
+      expect(deleted).toEqual(["doomed", "survivor"]);
+      expect(outcome.prunedSkills).toEqual(["doomed", "survivor"]);
+      expect(outcome.skillPruneFailures).toEqual([
+        { skillId: "bad", error: "delete boom" },
+      ]);
+      // A contained per-skill failure is NOT a stage failure.
+      expect(outcome.failures).not.toContain("skill-prune");
+    });
+
+    test("honors the threshold: a skill below skillPruneDays is kept", async () => {
+      setOverridesForTesting({ [FLAG_SHADOW]: true });
+      // 20 days old, threshold 30 ⇒ not deleted, and under the 30-day observe
+      // window so not reported either.
+      const { deps: d, deletedSkills } = pruneDeps(
+        [skill("borderline")],
+        { borderline: meta("assistant", "lastUsedAt", 20) },
+        30,
+      );
+      const outcome = await maintainJob(JOB, CONFIG, d);
+
+      expect(deletedSkills).toEqual([]);
+      expect(outcome.prunedSkills).toEqual([]);
+      expect(outcome.prunableSkills).toEqual([]);
+    });
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs five independent stages, in order:
+ * store and the in-memory lanes. It runs six independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -34,7 +34,14 @@
  *      in the page index (dangling slugs) via the log + outcome. The file is
  *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
  *      dangling entries at the next consolidation pass.
- *   5. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   5. **Skill usage-prune (observe-first, default-off)** — REPORT
+ *      assistant-authored managed skills unused for at least
+ *      {@link SKILL_OBSERVE_WINDOW_DAYS} days (in `prunableSkills`) on every
+ *      pass for observability, and DELETE them (via `executeDeleteManagedSkill`)
+ *      only when `memory.maintenance.skillPruneDays` is a positive integer
+ *      (default `null` = never prune). `author:"user"` and untagged skills are
+ *      always protected. See {@link pruneStaleSkills}.
+ *   6. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
@@ -53,6 +60,7 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
+import { loadSkillCatalog, type SkillSummary } from "../../../config/skills.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import {
   getMemoryCheckpoint,
@@ -66,6 +74,11 @@ import { EmbeddingBillingBlockError } from "../../../memory/embedding-billing-br
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
+import {
+  readInstallMeta,
+  type SkillInstallMeta,
+} from "../../../skills/install-meta.js";
+import { executeDeleteManagedSkill } from "../../../tools/skills/delete-managed.js";
 import { getLogger } from "../../../util/logger.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
 import { capabilityOrDiskBody, isCapabilitySlug } from "./capabilities.js";
@@ -101,6 +114,18 @@ const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
  */
 const MAINTAIN_EMBED_HIGH_WATER_KEY =
   "memory_v3_maintain:sections_embedded_through_ms" as const;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Age (in days) past which an assistant-authored managed skill is reported in
+ * `prunableSkills`. This is the OBSERVE-ONLY window: it drives the report the
+ * usage-prune stage emits on EVERY pass, independent of the delete threshold
+ * (`memory.maintenance.skillPruneDays`). We ship deletion default-off and watch
+ * this report to learn whether skills actually accumulate before enabling any
+ * deletion.
+ */
+const SKILL_OBSERVE_WINDOW_DAYS = 30;
 
 const log = getLogger("memory-v3-maintain");
 
@@ -159,6 +184,24 @@ export interface MaintainJobDeps {
   loadCoreSet: () => Slug[];
   /** Drop the memoized v3 lanes so the next turn rebuilds them. */
   invalidateLanes: () => void;
+  /**
+   * The managed (assistant-installed) skills in the catalog. The usage-prune
+   * stage reads each one's install-meta to find stale assistant-authored skills.
+   */
+  listManagedSkills: () => SkillSummary[];
+  /**
+   * Read a skill's install metadata from its directory. The prune stage reads
+   * `author`, `lastUsedAt`, and `installedAt` to decide eligibility.
+   */
+  readSkillMeta: (skillDir: string) => SkillInstallMeta | null;
+  /**
+   * Delete a managed skill by id (dir + companion files + graph node + v2
+   * page/vectors + v3 sections reconcile), as the `delete_managed_skill` tool
+   * does. Called only when deletion is enabled and a skill is stale.
+   */
+  deleteSkill: (skillId: string) => Promise<void>;
+  /** Injected clock (epoch ms) for the usage-prune age math; testable. */
+  nowMs: () => number;
   /** Active assistant config (for the dense-store/embedding calls). */
   config: AssistantConfig;
 }
@@ -246,6 +289,22 @@ export interface MaintainOutcome {
    * consolidation pass — the file itself is never mutated.
    */
   danglingCoreSlugs: Slug[];
+  /**
+   * Assistant-authored managed skills actually deleted this pass by the
+   * usage-prune stage. Always empty when deletion is disabled
+   * (`memory.maintenance.skillPruneDays` is `null`).
+   */
+  prunedSkills: string[];
+  /**
+   * Observe-only report: assistant-authored managed skills unused (by
+   * `lastUsedAt`, else `installedAt`) for at least {@link SKILL_OBSERVE_WINDOW_DAYS}
+   * days. Reported on EVERY pass regardless of the delete threshold so skill
+   * accumulation is visible before deletion is enabled. User-authored and
+   * untagged skills are excluded.
+   */
+  prunableSkills: string[];
+  /** Skill deletes that threw (and were contained). */
+  skillPruneFailures: Array<{ skillId: string; error: string }>;
   /** Whether the in-memory lanes were invalidated. */
   invalidated: boolean;
   /** Stages that threw (and were contained). */
@@ -346,6 +405,21 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     listIndexedSlugs: () => selectAllPagesFromWorkspace(workspaceDir),
     loadCoreSet: () => realLoadCoreSet(workspaceDir),
     invalidateLanes: realInvalidateLanes,
+    listManagedSkills: () =>
+      loadSkillCatalog().filter((s) => s.source === "managed"),
+    readSkillMeta: (skillDir) => readInstallMeta(skillDir),
+    deleteSkill: async (skillId) => {
+      const result = await executeDeleteManagedSkill(
+        { skill_id: skillId },
+        {
+          conversationId: "memory-v3-maintain",
+          workingDir: workspaceDir,
+          trustClass: "guardian",
+        },
+      );
+      if (result.isError) throw new Error(result.content);
+    },
+    nowMs: () => Date.now(),
     config,
   };
 }
@@ -487,6 +561,86 @@ async function pruneDeletedPages(
     }
   }
   return { pruned, pruneFailures };
+}
+
+/**
+ * Usage-based prune of assistant-authored managed skills — OBSERVE-FIRST and
+ * DEFAULT-OFF. The retrospective stage authors/updates skills eagerly; this is
+ * the backstop for skills that never recur. Two independent behaviors:
+ *
+ *   1. **Observe (always):** for every managed skill, read its install-meta and
+ *      consider only `author === "assistant"` skills — `author:"user"` AND
+ *      untagged legacy skills are protected and skipped. Reference time is
+ *      `lastUsedAt ?? installedAt`; a skill whose age ≥
+ *      {@link SKILL_OBSERVE_WINDOW_DAYS} is reported in `prunableSkills` EVERY
+ *      pass, regardless of the delete threshold. This is the observability
+ *      signal we watch before enabling deletion.
+ *   2. **Delete (opt-in):** ONLY when `skillPruneDays` is a positive number does
+ *      a skill whose age ≥ `skillPruneDays` get deleted via `deleteSkill`
+ *      (recorded in `prunedSkills`). When `skillPruneDays` is `null` (the
+ *      default) nothing is deleted.
+ *
+ * Each deletion is independent: a single `deleteSkill` rejection is recorded in
+ * `skillPruneFailures` and the loop continues. The whole stage is wrapped by the
+ * caller's try/catch per the job's contained-stage convention.
+ */
+async function pruneStaleSkills(deps: MaintainJobDeps): Promise<{
+  prunedSkills: string[];
+  prunableSkills: string[];
+  skillPruneFailures: Array<{ skillId: string; error: string }>;
+}> {
+  const skillPruneDays = deps.config.memory.maintenance.skillPruneDays;
+  const deleteEnabled =
+    typeof skillPruneDays === "number" && skillPruneDays > 0;
+
+  const managed = deps.listManagedSkills();
+  const prunableSkills: string[] = [];
+  const prunedSkills: string[] = [];
+  const skillPruneFailures: Array<{ skillId: string; error: string }> = [];
+
+  const now = deps.nowMs();
+  let assistantAuthored = 0;
+
+  for (const skill of managed) {
+    const meta = deps.readSkillMeta(skill.directoryPath);
+    // Protect user-authored AND untagged (legacy) skills — only the
+    // assistant's own skills are ever eligible.
+    if (meta?.author !== "assistant") continue;
+    assistantAuthored += 1;
+
+    const referenceTime = Date.parse(meta.lastUsedAt ?? meta.installedAt);
+    if (Number.isNaN(referenceTime)) continue;
+    const ageDays = (now - referenceTime) / DAY_MS;
+
+    if (ageDays >= SKILL_OBSERVE_WINDOW_DAYS) {
+      prunableSkills.push(skill.id);
+    }
+
+    if (deleteEnabled && ageDays >= skillPruneDays) {
+      try {
+        await deps.deleteSkill(skill.id);
+        prunedSkills.push(skill.id);
+      } catch (err) {
+        skillPruneFailures.push({
+          skillId: skill.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  log.info(
+    {
+      managed: managed.length,
+      assistantAuthored,
+      prunable: prunableSkills.length,
+      deleteEnabled,
+      pruned: prunedSkills.length,
+    },
+    "memory-v3 maintain: skill usage-prune pass",
+  );
+
+  return { prunedSkills, prunableSkills, skillPruneFailures };
 }
 
 /**
@@ -652,6 +806,9 @@ export async function maintainJob(
     pruned: 0,
     pruneFailures: 0,
     danglingCoreSlugs: [],
+    prunedSkills: [],
+    prunableSkills: [],
+    skillPruneFailures: [],
     invalidated: false,
     failures: [],
   };
@@ -763,7 +920,28 @@ export async function maintainJob(
     );
   }
 
-  // Stage 5: rebuild section index + needle + edge graph on the next turn.
+  // Stage 5: usage-prune assistant-authored skills. OBSERVE-FIRST and
+  // DEFAULT-OFF: it always REPORTS assistant-authored managed skills unused for
+  // at least SKILL_OBSERVE_WINDOW_DAYS days (prunableSkills) so accumulation is
+  // visible, and only DELETES — via executeDeleteManagedSkill — when
+  // memory.maintenance.skillPruneDays is a positive integer (default null = never
+  // prune). User-authored and untagged skills are always protected. Contained: a
+  // failure is logged + recorded without aborting invalidation.
+  try {
+    const { prunedSkills, prunableSkills, skillPruneFailures } =
+      await pruneStaleSkills(deps);
+    outcome.prunedSkills = prunedSkills;
+    outcome.prunableSkills = prunableSkills;
+    outcome.skillPruneFailures = skillPruneFailures;
+  } catch (err) {
+    outcome.failures.push("skill-prune");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: skill usage-prune failed (non-fatal)",
+    );
+  }
+
+  // Stage 6: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -784,6 +962,9 @@ export async function maintainJob(
       pruned: outcome.pruned,
       pruneFailures: outcome.pruneFailures,
       danglingCoreSlugs: outcome.danglingCoreSlugs,
+      prunedSkills: outcome.prunedSkills,
+      prunableSkills: outcome.prunableSkills,
+      skillPruneFailures: outcome.skillPruneFailures,
       invalidated: outcome.invalidated,
       failures: outcome.failures,
     },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -74,6 +74,7 @@ import { EmbeddingBillingBlockError } from "../../../memory/embedding-billing-br
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
+import { skillSlugFor } from "../../../memory/v2/skill-store.js";
 import {
   readInstallMeta,
   type SkillInstallMeta,
@@ -625,6 +626,23 @@ async function pruneStaleSkills(deps: MaintainJobDeps): Promise<{
           skillId: skill.id,
           error: err instanceof Error ? err.message : String(err),
         });
+        continue;
+      }
+      // Best-effort: clear the deleted skill's capability sections this pass.
+      // The deleted-page prune already ran earlier in the job, and the dense
+      // lane queries Qdrant without filtering on the live page index, so the
+      // `skills/<id>` article could otherwise surface until a later pass. The
+      // next pass's deleted-page prune is the backstop if this throws.
+      try {
+        await deps.deleteSectionsForArticle(
+          deps.config,
+          skillSlugFor(skill.id),
+        );
+      } catch (err) {
+        log.warn(
+          { err, skillId: skill.id },
+          "memory-v3 maintain: skill section prune failed (non-fatal)",
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
Adds a maintain-job stage that reports stale assistant-authored skills (prunableSkills, observe-only) every pass and deletes them via executeDeleteManagedSkill only when memory.maintenance.skillPruneDays is set to a positive integer (default null = never prune). author:user and untagged skills are always protected.

Part of plan: procedural-memory-as-skills.md (PR 8 of 9)