### PR TITLE
feat(memory): author + update skills (with companion files) in the retrospective

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -17,7 +17,7 @@ mock.module("../daemon/skill-memory-refresh.js", () => ({
 }));
 
 import { loadSkillCatalog } from "../config/skills.js";
-import { readInstallMeta } from "../skills/install-meta.js";
+import { readInstallMeta, writeInstallMeta } from "../skills/install-meta.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
@@ -493,7 +493,7 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("user-authored");
+    expect(result.content).toContain("not assistant-authored");
     // The original body and authorship are untouched.
     const skillFile = join(TEST_DIR, "skills", "protected", "SKILL.md");
     expect(readFileSync(skillFile, "utf-8")).toContain("Original body.");
@@ -524,12 +524,50 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("user-authored");
+    expect(result.content).toContain("not assistant-authored");
     expect(
       existsSync(
         join(TEST_DIR, "skills", "protected-files", "references", "notes.md"),
       ),
     ).toBe(false);
+  });
+
+  test("retrospective refuses to overwrite an untagged (no-author) skill", async () => {
+    // Simulate a skill created via a path that does not tag author (e.g. the
+    // createSkill API route): install-meta with no author field.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "untagged",
+        name: "Untagged",
+        description: "No author",
+        body_markdown: "Original body.",
+      },
+      makeContext(),
+    );
+    const dir = join(TEST_DIR, "skills", "untagged");
+    writeInstallMeta(dir, {
+      origin: "custom",
+      installedAt: new Date().toISOString(),
+    });
+    expect(installMetaFor("untagged")?.author).toBeUndefined();
+
+    // The retrospective must not overwrite a skill it does not own.
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "untagged",
+        name: "Untagged",
+        description: "Rewritten by retrospective",
+        body_markdown: "Rewritten body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not assistant-authored");
+    expect(readFileSync(join(dir, "SKILL.md"), "utf-8")).toContain(
+      "Original body.",
+    );
   });
 
   test("retrospective MAY overwrite its own author:assistant skill", async () => {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -17,15 +17,26 @@ mock.module("../daemon/skill-memory-refresh.js", () => ({
 }));
 
 import { loadSkillCatalog } from "../config/skills.js";
+import { readInstallMeta } from "../skills/install-meta.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
-function makeContext(): ToolContext {
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     workingDir: "/tmp",
     conversationId: "test-conversation",
     trustClass: "guardian",
+    ...overrides,
   };
+}
+
+/** A retrospective-pass tool context (assistant-authored scaffolds). */
+function makeRetrospectiveContext(): ToolContext {
+  return makeContext({ requestOrigin: "memory_retrospective" });
+}
+
+function installMetaFor(skillId: string) {
+  return readInstallMeta(join(TEST_DIR, "skills", skillId));
 }
 
 beforeEach(() => {
@@ -422,5 +433,144 @@ describe("scaffold_managed_skill tool", () => {
     const parent = catalog.find((s) => s.id === "e2e-parent");
     expect(parent).toBeDefined();
     expect(parent!.includes).toEqual(["e2e-child"]);
+  });
+
+  // ── Authorship tagging + user-skill protection ────────────────────────────
+
+  test('tags author "assistant" under the retrospective origin', async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "retro-skill",
+        name: "Retro Skill",
+        description: "Authored by a retrospective pass",
+        body_markdown: "Do the procedure.",
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(installMetaFor("retro-skill")?.author).toBe("assistant");
+  });
+
+  test('tags author "user" for a normal (non-retrospective) scaffold', async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "user-skill",
+        name: "User Skill",
+        description: "Authored interactively",
+        body_markdown: "Do the thing.",
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(installMetaFor("user-skill")?.author).toBe("user");
+  });
+
+  test("retrospective refuses to overwrite an author:user skill", async () => {
+    // A user authors the skill first.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected",
+        name: "Protected",
+        description: "User authored",
+        body_markdown: "Original body.",
+      },
+      makeContext(),
+    );
+    expect(installMetaFor("protected")?.author).toBe("user");
+
+    // The retrospective tries to overwrite it — refused.
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected",
+        name: "Protected",
+        description: "Rewritten by retrospective",
+        body_markdown: "Rewritten body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("user-authored");
+    // The original body and authorship are untouched.
+    const skillFile = join(TEST_DIR, "skills", "protected", "SKILL.md");
+    expect(readFileSync(skillFile, "utf-8")).toContain("Original body.");
+    expect(installMetaFor("protected")?.author).toBe("user");
+  });
+
+  test("retrospective refuses to write companion files into an author:user skill", async () => {
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected-files",
+        name: "Protected Files",
+        description: "User authored",
+        body_markdown: "Original body.",
+      },
+      makeContext(),
+    );
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected-files",
+        name: "Protected Files",
+        description: "Refine attempt",
+        body_markdown: "Original body.",
+        overwrite: true,
+        files: [{ path: "references/notes.md", content: "gotchas" }],
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("user-authored");
+    expect(
+      existsSync(
+        join(TEST_DIR, "skills", "protected-files", "references", "notes.md"),
+      ),
+    ).toBe(false);
+  });
+
+  test("retrospective MAY overwrite its own author:assistant skill", async () => {
+    // The retrospective authors a skill, then refines it later.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "assistant-owned",
+        name: "Assistant Owned",
+        description: "First pass",
+        body_markdown: "V1 procedure.",
+      },
+      makeRetrospectiveContext(),
+    );
+    expect(installMetaFor("assistant-owned")?.author).toBe("assistant");
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "assistant-owned",
+        name: "Assistant Owned",
+        description: "Refined",
+        body_markdown: "V2 procedure.",
+        overwrite: true,
+        files: [{ path: "references/failure-modes.md", content: "gotchas" }],
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const skillFile = join(TEST_DIR, "skills", "assistant-owned", "SKILL.md");
+    expect(readFileSync(skillFile, "utf-8")).toContain("V2 procedure.");
+    expect(installMetaFor("assistant-owned")?.author).toBe("assistant");
+    expect(
+      existsSync(
+        join(
+          TEST_DIR,
+          "skills",
+          "assistant-owned",
+          "references",
+          "failure-modes.md",
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -54,6 +54,15 @@ export interface WakeToolContextPin {
   hasNoClient: boolean;
   /** The interface the source's live turns ran on (e.g. `"macos"`). */
   transportInterface?: InterfaceId;
+  /**
+   * Origin tag stamped onto `ToolContext.requestOrigin` for the duration of
+   * the wake (e.g. `"memory_retrospective"`). Wakes bypass `runAgentLoopImpl`,
+   * which is what normally sets `currentTurnRequestOrigin`, so the pin carries
+   * the origin through to `buildPolicyContext` → the permission checker's
+   * origin-scoped auto-grants. Applied and restored alongside the allowlist by
+   * `scopeWakeAllowedTools`. Unset for wakes that need no origin-scoped grant.
+   */
+  requestOrigin?: string;
 }
 
 /**

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -335,7 +335,9 @@ export async function persistWakeTriggerMessage(
  * {@link SubagentToolGateMode}. `toolContextPin`, when provided
  * (execution-gate-mode cache-parity wakes), freezes the client-context
  * inputs for tool-definition resolution — see {@link WakeToolContextPin}.
- * Both are set and restored alongside the allowlist.
+ * Its `requestOrigin`, when set, is stamped onto the conversation's per-turn
+ * origin so the permission checker's origin-scoped auto-grants fire for the
+ * wake. All are set and restored alongside the allowlist.
  */
 export function scopeWakeAllowedTools(
   conversation: Conversation,
@@ -346,12 +348,17 @@ export function scopeWakeAllowedTools(
   const previous = conversation.subagentAllowedTools;
   const previousGateMode = conversation.subagentToolGateMode;
   const previousToolContextPin = conversation.toolContextPin;
+  const previousRequestOrigin = conversation.currentTurnRequestOrigin;
   conversation.setSubagentAllowedTools(new Set(tools));
   conversation.subagentToolGateMode = gateMode;
   conversation.toolContextPin = toolContextPin;
+  if (toolContextPin?.requestOrigin !== undefined) {
+    conversation.currentTurnRequestOrigin = toolContextPin.requestOrigin;
+  }
   return () => {
     conversation.setSubagentAllowedTools(previous);
     conversation.subagentToolGateMode = previousGateMode;
     conversation.toolContextPin = previousToolContextPin;
+    conversation.currentTurnRequestOrigin = previousRequestOrigin;
   };
 }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -255,6 +255,16 @@ mock.module("../jobs-store.js", () => ({
   enqueueMemoryJob: () => "follow-up-job-id",
 }));
 
+// proc-to-skills gate. Drives both `buildForkInstruction`'s skill-authoring
+// section and the wake's origin pin behavior. Default inactive (remember-only),
+// matching a stock install; tests flip it on to assert the authoring section.
+let mockProcToSkillsActive = false;
+mock.module("../../config/memory-v3-gate.js", () => ({
+  isProcToSkillsActive: () => mockProcToSkillsActive,
+  isProcToSkillsEnabled: () => mockProcToSkillsActive,
+  isMemoryV3Live: () => mockProcToSkillsActive,
+}));
+
 import type { MemoryJob } from "../jobs-store.js";
 import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
 
@@ -354,6 +364,7 @@ describe("memoryRetrospectiveJob", () => {
     loadedConversations = {};
     mockResolvedUserSlug = "alice";
     resolveUserSlugCalls = [];
+    mockProcToSkillsActive = false;
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -435,19 +446,37 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls).toHaveLength(0);
   });
 
-  test("wake is scoped to memory saves and suppresses the internal wake surface", async () => {
+  test("wake allows memory saves + skill authoring and suppresses the internal wake surface", async () => {
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(forkCalls).toHaveLength(1);
     expect(wakeCalls).toHaveLength(1);
     expect(wakeCalls[0]!.conversationId).toBe("fork-conv-1");
     const opts = wakeCalls[0]!.opts;
-    expect(opts.allowedTools).toEqual(["remember"]);
+    expect(opts.allowedTools).toEqual([
+      "remember",
+      "scaffold_managed_skill",
+      "skill_load",
+      "find_similar_skills",
+    ]);
     expect(opts.suppressWakeSurface).toBe(true);
     // Sanity: the other fork-specific opts the handler relies on are still set.
     expect(opts.skipHintInjection).toBe(true);
     expect(opts.suppressAutoCompaction).toBe(true);
     expect(opts.hintRole).toBe("user");
+  });
+
+  test("wake pins the memory_retrospective origin on the tool-context pin so the checker's grant can fire", async () => {
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    const pin = wakeCalls[0]!.opts.toolContextPin as {
+      requestOrigin?: string;
+    };
+    expect(pin.requestOrigin).toBe("memory_retrospective");
+    // The origin pin rides unconditionally — even when proc-to-skills is
+    // inactive the checker independently denies the grant, so it stays inert.
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
   });
 
   test("forked retrospective is bucketed as background under the retrospective group", async () => {
@@ -830,6 +859,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
       hasNoClient: false,
       transportInterface: "web",
+      requestOrigin: "memory_retrospective",
     });
   });
 
@@ -886,6 +916,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
       hasNoClient: false,
       transportInterface: "macos",
+      requestOrigin: "memory_retrospective",
     });
   });
 
@@ -908,6 +939,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
       hasNoClient: false,
       transportInterface: "macos",
+      requestOrigin: "memory_retrospective",
     });
   });
 
@@ -932,6 +964,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
       hasNoClient: true,
       transportInterface: "telegram",
+      requestOrigin: "memory_retrospective",
     });
     // The persona pin carries the same live-turn hasNoClient value.
     expect(wakeCalls[0]!.opts.personaOverride).toEqual({ hasNoClient: true });
@@ -1439,5 +1472,60 @@ describe("memoryRetrospectiveJob", () => {
     expect(stateUpserts).toHaveLength(1);
     expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
     expect(deletedConversationIds).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Skill-authoring instruction section (gated on proc-to-skills active)
+  // -------------------------------------------------------------------------
+
+  test("proc-to-skills inactive (default): instruction is remember-only, no skill directives", async () => {
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    const instructionText = persistedInstructionText();
+    // The remember-only "only X is available" framing names just `remember`.
+    expect(instructionText).toContain(
+      "Only the `remember` tool is available for this pass",
+    );
+    // None of the skill-authoring directives appear.
+    expect(instructionText).not.toContain("find_similar_skills");
+    expect(instructionText).not.toContain("scaffold_managed_skill");
+    expect(instructionText).not.toContain("companion file");
+    expect(instructionText).not.toContain("user-authored");
+  });
+
+  test("proc-to-skills active: instruction carries the pre-check + dedup + companion-file directives", async () => {
+    mockProcToSkillsActive = true;
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    const instructionText = persistedInstructionText();
+
+    // Available-tools line names the skill-authoring trio.
+    expect(instructionText).toContain("find_similar_skills");
+    expect(instructionText).toContain("scaffold_managed_skill");
+    expect(instructionText).toContain("skill_load skill-management");
+
+    // Permissive relevance pre-check keyed on actually-executed procedures.
+    expect(instructionText).toContain("a PROCEDURE you actually carried out");
+    expect(instructionText).toContain("real `tool_use` steps you executed");
+
+    // Agent-judged sibling dedup: find → same procedure ⇒ overwrite, else create.
+    expect(instructionText).toContain("`find_similar_skills`");
+    expect(instructionText).toContain("`overwrite: true`");
+    expect(instructionText).toContain("CREATE a new skill");
+
+    // Companion-file capture of failure modes / gotchas / cached values.
+    expect(instructionText).toContain("references/failure-modes.md");
+    expect(instructionText).toContain("`files`");
+
+    // User-skill protection directive.
+    expect(instructionText).toContain(
+      "Never folder-rewrite a user-authored skill",
+    );
+
+    // No skill:-link directive (that layer was removed); ordinary facts stay
+    // unlinked remembers.
+    expect(instructionText).not.toContain("skill:");
+    expect(instructionText).toContain("Ordinary facts still go through");
   });
 });

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -447,6 +447,7 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("wake allows memory saves + skill authoring and suppresses the internal wake surface", async () => {
+    mockProcToSkillsActive = true;
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(forkCalls).toHaveLength(1);
@@ -464,6 +465,15 @@ describe("memoryRetrospectiveJob", () => {
     expect(opts.skipHintInjection).toBe(true);
     expect(opts.suppressAutoCompaction).toBe(true);
     expect(opts.hintRole).toBe("user");
+  });
+
+  test("wake is remember-only when proc-to-skills is inactive", async () => {
+    mockProcToSkillsActive = false;
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    // The authoring trio is not even named on the allowlist when inactive.
+    expect(wakeCalls[0]!.opts.allowedTools).toEqual(["remember"]);
   });
 
   test("wake pins the memory_retrospective origin on the tool-context pin so the checker's grant can fire", async () => {

--- a/assistant/src/memory/memory-retrospective-constants.ts
+++ b/assistant/src/memory/memory-retrospective-constants.ts
@@ -48,3 +48,13 @@ export const MEMORY_RETROSPECTIVE_GROUP_ID = "system:background";
  */
 export const MEMORY_RETROSPECTIVE_INSTRUCTION_KIND =
   "memory_retrospective_instruction";
+
+/**
+ * Request-origin tag the fork wake stamps onto `ToolContext.requestOrigin`
+ * (via the wake's tool-context pin). The permission checker scopes its
+ * non-interactive skill-authoring auto-grant to this origin, so a retrospective
+ * pass can call `scaffold_managed_skill` / `find_similar_skills` /
+ * `skill_load skill-management` without an interactive approval prompt. Matches
+ * the `"memory_retrospective"` member of `TitleOrigin`.
+ */
+export const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -244,13 +244,14 @@ export async function runForkBasedRetrospective(
   }
   const forkId = forkConversationRow.id;
 
+  const procToSkillsActive = isProcToSkillsActive(config);
   const instruction = buildForkInstruction({
     windowStartTimestamp,
     windowAnchorKind: turnContextTimestamp ? "turn_context" : "created_at",
     priorRemembers,
     timeZone: timezoneContext.effectiveTimezone,
     isFirstPass: lastProcessedMessageId == null,
-    procToSkillsActive: isProcToSkillsActive(config),
+    procToSkillsActive,
   });
   try {
     await addMessage(
@@ -318,17 +319,18 @@ export async function runForkBasedRetrospective(
       // `remember` saves ordinary facts; the skill-authoring trio
       // (`scaffold_managed_skill` / `skill_load` / `find_similar_skills`) lets a
       // pass author or refine a managed skill from an observed procedure. The
-      // checker's origin-scoped grant only ALLOWs the trio non-interactively
-      // when proc-to-skills is active and the pinned origin matches; the fork
-      // instruction only directs their use under the same gate, so an inactive
-      // install keeps remember-only behavior even though the allowlist names
-      // them. Any tool outside this set is rejected at execution time.
-      allowedTools: [
-        "remember",
-        "scaffold_managed_skill",
-        "skill_load",
-        "find_similar_skills",
-      ],
+      // allowlist is gated on the same `procToSkillsActive` predicate as the
+      // fork instruction and the checker's origin-scoped grant, so an inactive
+      // install is remember-only — the authoring trio is not even named on the
+      // allowlist. Any tool outside the active set is rejected at execution time.
+      allowedTools: procToSkillsActive
+        ? [
+            "remember",
+            "scaffold_managed_skill",
+            "skill_load",
+            "find_similar_skills",
+          ]
+        : ["remember"],
       // Always keep the source's full tool surface on the wire and resolve it
       // under the source's client context (`toolContextPin`). The wire tool
       // block is the first tier of the provider cache prefix

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -42,6 +42,7 @@ import {
   isInteractiveInterface,
   parseInterfaceId,
 } from "../channels/types.js";
+import { isProcToSkillsActive } from "../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import { extractTurnContextTimestamp } from "../context/compactor.js";
@@ -75,6 +76,7 @@ import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+  MEMORY_RETROSPECTIVE_ORIGIN,
   MEMORY_RETROSPECTIVE_SOURCE,
 } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
@@ -248,6 +250,7 @@ export async function runForkBasedRetrospective(
     priorRemembers,
     timeZone: timezoneContext.effectiveTimezone,
     isFirstPass: lastProcessedMessageId == null,
+    procToSkillsActive: isProcToSkillsActive(config),
   });
   try {
     await addMessage(
@@ -312,16 +315,28 @@ export async function runForkBasedRetrospective(
       source: MEMORY_RETROSPECTIVE_SOURCE,
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
-      allowedTools: ["remember"],
+      // `remember` saves ordinary facts; the skill-authoring trio
+      // (`scaffold_managed_skill` / `skill_load` / `find_similar_skills`) lets a
+      // pass author or refine a managed skill from an observed procedure. The
+      // checker's origin-scoped grant only ALLOWs the trio non-interactively
+      // when proc-to-skills is active and the pinned origin matches; the fork
+      // instruction only directs their use under the same gate, so an inactive
+      // install keeps remember-only behavior even though the allowlist names
+      // them. Any tool outside this set is rejected at execution time.
+      allowedTools: [
+        "remember",
+        "scaffold_managed_skill",
+        "skill_load",
+        "find_similar_skills",
+      ],
       // Always keep the source's full tool surface on the wire and resolve it
       // under the source's client context (`toolContextPin`). The wire tool
       // block is the first tier of the provider cache prefix
-      // (tools → system → messages), so a `remember`-only wire filter busts
-      // cache parity with the source's live turns — re-creating the cached
-      // prefix instead of reading it. The allowlist still holds at execution
-      // time: non-`remember` calls are rejected before any executor or side
-      // effect runs. See {@link SubagentToolGateMode} and
-      // {@link WakeToolContextPin}.
+      // (tools → system → messages), so a wire filter busts cache parity with
+      // the source's live turns — re-creating the cached prefix instead of
+      // reading it. The allowlist still holds at execution time: non-allowlisted
+      // calls are rejected before any executor or side effect runs. See
+      // {@link SubagentToolGateMode} and {@link WakeToolContextPin}.
       toolGateMode: "execution" as const,
       toolContextPin,
       // Message-tier cache-prefix parity — reproducing the source's
@@ -486,7 +501,15 @@ function resolveSourceParityPins(
       };
   return {
     personaOverride,
-    toolContextPin: { hasNoClient, transportInterface },
+    // Pin the retrospective origin so the wake's tool calls resolve under it
+    // (`buildPolicyContext` → the checker's origin-scoped skill-authoring
+    // grant). The grant is independently gated on proc-to-skills being active,
+    // so stamping the origin unconditionally is inert when the feature is off.
+    toolContextPin: {
+      hasNoClient,
+      transportInterface,
+      requestOrigin: MEMORY_RETROSPECTIVE_ORIGIN,
+    },
   };
 }
 
@@ -833,6 +856,13 @@ interface ForkInstructionArgs {
   timeZone: string;
   /** True when this is the first retrospective pass over the source conversation. */
   isFirstPass: boolean;
+  /**
+   * Whether procedural-memory-as-skills is active (flag on AND memory-v3 live).
+   * Gates the skill-authoring section of the instruction: when false the pass
+   * keeps its remember-only behavior, matching the permission checker's grant
+   * gate so the directives never appear when the tools would be denied anyway.
+   */
+  procToSkillsActive: boolean;
 }
 
 /**
@@ -849,6 +879,7 @@ function buildForkInstruction({
   priorRemembers,
   timeZone,
   isFirstPass,
+  procToSkillsActive,
 }: ForkInstructionArgs): string {
   const renderedPrior =
     priorRemembers.length === 0
@@ -863,7 +894,11 @@ function buildForkInstruction({
     ? "Your review window is the full conversation above, ending just before this instruction message."
     : `Your review window starts at ${anchorDescription} and ends just before this instruction message. If you cannot locate that anchoring turn in your visible history (for example, it is behind the compaction summary), fail closed: review only the most recent visible messages after the summary, not the whole conversation.`;
 
-  return `This is an automated background memory pass over the conversation above — not a message from the user. Do not reply conversationally; just perform the review described here. Only the \`remember\` tool is available for this pass — any other tool call will be rejected, so don't attempt one.
+  const availableToolsLine = procToSkillsActive
+    ? "Only `remember`, `find_similar_skills`, `scaffold_managed_skill`, and `skill_load skill-management` are available for this pass — any other tool call will be rejected, so don't attempt one."
+    : "Only the `remember` tool is available for this pass — any other tool call will be rejected, so don't attempt one.";
+
+  return `This is an automated background memory pass over the conversation above — not a message from the user. Do not reply conversationally; just perform the review described here. ${availableToolsLine}
 
 ${windowAnchor}
 
@@ -880,5 +915,30 @@ Two dedup sources to skip:
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
 For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+${procToSkillsActive ? buildSkillAuthoringSection() : ""}`;
+}
+
+/**
+ * Skill-authoring addendum appended to the fork instruction when
+ * procedural-memory-as-skills is active. Directs the pass to capture a
+ * genuinely-executed, reusable procedure as a managed skill — preferring to
+ * refine an existing assistant-authored sibling over spawning a new one, and
+ * never folder-rewriting a user-authored skill.
+ */
+function buildSkillAuthoringSection(): string {
+  return `
+---
+
+If your review window contains a PROCEDURE you actually carried out — a sequence of real \`tool_use\` steps you executed (not merely discussed or planned) that is plausibly worth reusing later — also consider capturing it as a managed skill. Keep this bar low: when in doubt and the procedure looks reusable, author it. If the window contains no executed, reusable procedure, skip this entirely and just \`remember\` as above.
+
+When you do capture a procedure:
+
+1. Deduplicate against existing skills first. Call \`find_similar_skills\` with a short description of the procedure's goal. If a returned skill is the SAME procedure (not just an adjacent one), UPDATE it rather than creating a sibling: call \`scaffold_managed_skill\` with that skill's existing \`skill_id\` and \`overwrite: true\`, rewriting the body from what you actually observed in the trace. Otherwise CREATE a new skill with a fresh \`skill_id\`. Bias strongly toward reusing or refining over spawning near-duplicates.
+
+2. Capture procedure-scoped knowledge alongside the body. Failure modes, gotchas, and cached values you observed in the trace (error signatures and how you recovered, preconditions, IDs/paths/endpoints that held steady) belong in companion files passed via \`scaffold_managed_skill\`'s \`files\` input (for example \`references/failure-modes.md\`), and the SKILL.md body should reference them so a future load surfaces them.
+
+3. Never folder-rewrite a user-authored skill. If \`find_similar_skills\` returns a skill a person wrote or installed, do not \`overwrite\` it or write companion \`files\` into it — refine conservatively or skip. Companion-file capture and overwrites apply only to skills you authored.
+
+Ordinary facts still go through \`remember\` (unlinked) exactly as above — skills are for executed, reusable procedures, not for facts.
 `;
 }

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -623,40 +623,56 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    // ── Memory-consolidation skill-authoring auto-grant ─────────────────────
-    // The background consolidation guardian session (sourceChannel "vellum",
-    // trustClass "guardian", origin "memory_consolidation") cannot answer
-    // interactive prompts, so `scaffold_managed_skill` and
-    // `skill_load skill-management` resolve to allow without prompting. The
-    // grant is scoped to that origin + those two tools, and ONLY fires when the
+    // ── Memory-retrospective skill-authoring auto-grant ─────────────────────
+    // The background retrospective guardian session (sourceChannel "vellum",
+    // trustClass "guardian", origin "memory_retrospective") cannot answer
+    // interactive prompts, so `scaffold_managed_skill`, `find_similar_skills`,
+    // and `skill_load skill-management` resolve to allow without prompting. The
+    // grant is scoped to that origin + those tools, and ONLY fires when the
     // feature is active (`procToSkillsActive: true`).
 
-    const consolidationContext = {
-      requestOrigin: "memory_consolidation",
+    const retrospectiveContext = {
+      requestOrigin: "memory_retrospective",
       trustClass: "guardian",
       sourceChannel: "vellum",
       executionContext: "background" as const,
       procToSkillsActive: true,
     };
 
-    test("allows scaffold_managed_skill for the consolidation origin without prompting", async () => {
+    test("allows scaffold_managed_skill for the retrospective origin without prompting", async () => {
       // High risk would normally force a prompt — the grant short-circuits
       // before classification, so no IPC result is needed.
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "deploy-preview" },
         "/home/user/project",
-        consolidationContext,
+        retrospectiveContext,
       );
       expect(result.decision).toBe("allow");
     });
 
-    test("allows skill_load skill-management for the consolidation origin without prompting", async () => {
+    test("allows find_similar_skills for the retrospective origin without prompting", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill discovery",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const result = await check(
+        "find_similar_skills",
+        { goal: "deploy a preview" },
+        "/home/user/project",
+        retrospectiveContext,
+      );
+      expect(result.decision).toBe("allow");
+    });
+
+    test("allows skill_load skill-management for the retrospective origin without prompting", async () => {
       const result = await check(
         "skill_load",
         { skill: "skill-management" },
         "/home/user/project",
-        consolidationContext,
+        retrospectiveContext,
       );
       expect(result.decision).toBe("allow");
     });
@@ -672,12 +688,12 @@ describe("Permission Checker (gateway IPC)", () => {
         "skill_load",
         { skill: "some-other-skill" },
         "/home/user/project",
-        consolidationContext,
+        retrospectiveContext,
       );
       expect(result.decision).toBe("prompt");
     });
 
-    test("does not grant for tools outside the scaffold/skill_load pair", async () => {
+    test("does not grant for tools outside the scaffold/find/skill_load set", async () => {
       mockIpcClassifyRiskResult = {
         risk: "high",
         reason: "Managed skill delete",
@@ -688,7 +704,7 @@ describe("Permission Checker (gateway IPC)", () => {
         "delete_managed_skill",
         { skill_id: "deploy-preview" },
         "/home/user/project",
-        consolidationContext,
+        retrospectiveContext,
       );
       expect(result.decision).toBe("prompt");
     });
@@ -700,12 +716,37 @@ describe("Permission Checker (gateway IPC)", () => {
         matchType: "registry",
         scopeOptions: [],
       };
-      // A normal interactive turn carries no consolidation origin signals.
+      // A normal interactive turn carries no retrospective origin signals.
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "deploy-preview" },
         "/home/user/project",
         { executionContext: "conversation" },
+      );
+      expect(result.decision).toBe("prompt");
+    });
+
+    test("the old memory_consolidation origin no longer grants skill authoring", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "Skill scaffold",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      // Same guardian/vellum background trust and active feature, but the
+      // consolidation origin — which previously held the grant — must no longer
+      // authorize skill authoring now that it re-points to the retrospective.
+      const result = await check(
+        "scaffold_managed_skill",
+        { skill_id: "deploy-preview" },
+        "/home/user/project",
+        {
+          requestOrigin: "memory_consolidation",
+          trustClass: "guardian",
+          sourceChannel: "vellum",
+          executionContext: "background",
+          procToSkillsActive: true,
+        },
       );
       expect(result.decision).toBe("prompt");
     });
@@ -718,7 +759,7 @@ describe("Permission Checker (gateway IPC)", () => {
         scopeOptions: [],
       };
       // Same guardian/vellum background trust, but a different origin (e.g.
-      // the memory sweep job) must not inherit the consolidation grant.
+      // the memory sweep job) must not inherit the retrospective grant.
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "deploy-preview" },
@@ -728,6 +769,7 @@ describe("Permission Checker (gateway IPC)", () => {
           trustClass: "guardian",
           sourceChannel: "vellum",
           executionContext: "background",
+          procToSkillsActive: true,
         },
       );
       expect(result.decision).toBe("prompt");
@@ -745,10 +787,11 @@ describe("Permission Checker (gateway IPC)", () => {
         { skill_id: "deploy-preview" },
         "/home/user/project",
         {
-          requestOrigin: "memory_consolidation",
+          requestOrigin: "memory_retrospective",
           trustClass: "unknown",
           sourceChannel: "vellum",
           executionContext: "background",
+          procToSkillsActive: true,
         },
       );
       expect(result.decision).toBe("prompt");
@@ -761,14 +804,14 @@ describe("Permission Checker (gateway IPC)", () => {
         matchType: "registry",
         scopeOptions: [],
       };
-      // The exact consolidation origin/trust/channel, but the feature is
+      // The exact retrospective origin/trust/channel, but the feature is
       // inactive — `procToSkillsActive` is not true — so the grant must NOT
       // fire and the high-risk tool prompts.
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "deploy-preview" },
         "/home/user/project",
-        { ...consolidationContext, procToSkillsActive: false },
+        { ...retrospectiveContext, procToSkillsActive: false },
       );
       expect(result.decision).toBe("prompt");
     });
@@ -778,25 +821,25 @@ describe("Permission Checker (gateway IPC)", () => {
     // exercise the WIRING: a `ToolContext` (the shape the agent loop actually
     // builds — see conversation-tool-setup.ts) is run through the real
     // `buildPolicyContext`, and only then handed to `check`. Without the
-    // origin/trust/channel threading added here, `buildPolicyContext` would
-    // drop those fields and the grant would be dead code (Codex #35987).
+    // origin/trust/channel threading, `buildPolicyContext` would drop those
+    // fields and the grant would be dead code.
 
     /** A bare core tool — `buildPolicyContext` reads only `tool.name`/owner. */
     const scaffoldTool = {
       name: "scaffold_managed_skill",
     } as unknown as Tool;
 
-    /** The ToolContext a memory-consolidation distillation turn produces. */
-    const consolidationToolContext: ToolContext = {
-      conversationId: "conv-distill",
+    /** The ToolContext a memory-retrospective pass produces. */
+    const retrospectiveToolContext: ToolContext = {
+      conversationId: "conv-retro",
       workingDir: "/home/user/project",
       trustClass: "guardian",
       executionChannel: "vellum",
-      requestOrigin: "memory_consolidation",
+      requestOrigin: "memory_retrospective",
       isInteractive: false,
     };
 
-    test("grant fires through the real buildPolicyContext path for the consolidation turn", async () => {
+    test("grant fires through the real buildPolicyContext path for the retrospective turn", async () => {
       // High risk would normally force a prompt; the grant short-circuits it.
       mockIpcClassifyRiskResult = {
         risk: "high",
@@ -806,11 +849,11 @@ describe("Permission Checker (gateway IPC)", () => {
       };
       const policyContext = buildPolicyContext(
         scaffoldTool,
-        consolidationToolContext,
+        retrospectiveToolContext,
       );
       // Prove the threading: buildPolicyContext copied the ToolContext signals
       // and stamped the active proc-to-skills gate.
-      expect(policyContext.requestOrigin).toBe("memory_consolidation");
+      expect(policyContext.requestOrigin).toBe("memory_retrospective");
       expect(policyContext.trustClass).toBe("guardian");
       expect(policyContext.sourceChannel).toBe("vellum");
       expect(policyContext.procToSkillsActive).toBe(true);
@@ -831,7 +874,7 @@ describe("Permission Checker (gateway IPC)", () => {
         matchType: "registry",
         scopeOptions: [],
       };
-      // A normal interactive turn: a guardian on the desktop, no consolidation
+      // A normal interactive turn: a guardian on the desktop, no retrospective
       // origin. buildPolicyContext leaves `requestOrigin` unset, so the grant
       // must not fire and the high-risk tool prompts.
       const interactiveContext: ToolContext = {
@@ -856,8 +899,8 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    test("grant does NOT fire when proc-to-skills is inactive, even for the consolidation turn", async () => {
-      // Same consolidation ToolContext, but the feature is inactive (flag off
+    test("grant does NOT fire when proc-to-skills is inactive, even for the retrospective turn", async () => {
+      // Same retrospective ToolContext, but the feature is inactive (flag off
       // or v3 not live). buildPolicyContext stamps `procToSkillsActive: false`,
       // so the grant is dead and the high-risk scaffold prompts.
       mockProcToSkillsActive = false;
@@ -869,10 +912,10 @@ describe("Permission Checker (gateway IPC)", () => {
       };
       const policyContext = buildPolicyContext(
         scaffoldTool,
-        consolidationToolContext,
+        retrospectiveToolContext,
       );
       expect(policyContext.procToSkillsActive).toBe(false);
-      expect(policyContext.requestOrigin).toBe("memory_consolidation");
+      expect(policyContext.requestOrigin).toBe("memory_retrospective");
 
       const result = await check(
         "scaffold_managed_skill",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -671,38 +671,41 @@ export async function classifyRisk(
   return result;
 }
 
-// ── Background memory-consolidation skill-authoring auto-grant ────────────────
-// Skill scaffolding (`scaffold_managed_skill`, risk: high + allowlist-gated) and
-// loading the `skill-management` skill (`skill_load skill-management`, which
-// exposes that tool) require an interactive approval. The memory-consolidation
+// ── Background memory-retrospective skill-authoring auto-grant ────────────────
+// Skill scaffolding (`scaffold_managed_skill`, risk: high + allowlist-gated),
+// finding similar skills (`find_similar_skills`), and loading the
+// `skill-management` skill (`skill_load skill-management`, which exposes the
+// scaffold tool) require an interactive approval. The memory-retrospective
 // background job runs without any connected client, so it can never answer that
-// prompt. The grant resolves these two tools to ALLOW non-interactively, and
-// ONLY when all of these hold:
+// prompt. The grant resolves these tools to ALLOW non-interactively, and ONLY
+// when all of these hold:
 //   - procedural-memory-as-skills is active (`policyContext.procToSkillsActive`,
 //     precomputed by buildPolicyContext: the flag is on AND memory-v3 is live),
-//   - the turn is the consolidation background source — guardian trust, `vellum`
-//     source channel, `memory_consolidation` origin (set in consolidation-job.ts).
+//   - the turn is the retrospective background source — guardian trust, `vellum`
+//     source channel, `memory_retrospective` origin (set in
+//     memory-retrospective-job.ts).
 //
-// The grant is intentionally narrow: it matches exactly these two tools AND the
-// consolidation origin under the active flag, so no interactive session, other
+// The grant is intentionally narrow: it matches exactly these tools AND the
+// retrospective origin under the active flag, so no interactive session, other
 // origin, or feature-off install is affected.
-const MEMORY_CONSOLIDATION_ORIGIN = "memory_consolidation";
+const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
 const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
 
-function isMemoryConsolidationSkillAuthoringGrant(
+function isRetrospectiveSkillAuthoringGrant(
   toolName: string,
   input: Record<string, unknown>,
   policyContext?: PolicyContext,
 ): boolean {
   if (
     policyContext?.procToSkillsActive !== true ||
-    policyContext.requestOrigin !== MEMORY_CONSOLIDATION_ORIGIN ||
+    policyContext.requestOrigin !== MEMORY_RETROSPECTIVE_ORIGIN ||
     policyContext.trustClass !== "guardian" ||
     policyContext.sourceChannel !== "vellum"
   ) {
     return false;
   }
   if (toolName === "scaffold_managed_skill") return true;
+  if (toolName === "find_similar_skills") return true;
   if (toolName === "skill_load") {
     return (
       getStringField(input, "skill", "skill_id").trim() ===
@@ -722,13 +725,11 @@ export async function check(
 ): Promise<PermissionCheckResult> {
   signal?.throwIfAborted();
 
-  if (
-    isMemoryConsolidationSkillAuthoringGrant(toolName, input, policyContext)
-  ) {
+  if (isRetrospectiveSkillAuthoringGrant(toolName, input, policyContext)) {
     return {
       decision: "allow",
       reason:
-        "Memory consolidation background session: skill authoring auto-approved",
+        "Memory retrospective background session: skill authoring auto-approved",
     };
   }
 

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -76,7 +76,7 @@ export interface PolicyContext {
   conversationId?: string;
   /**
    * Origin tag of the turn driving this permission check (the conversation's
-   * `TitleOrigin`, e.g. "memory_consolidation"). Background jobs cannot answer
+   * `TitleOrigin`, e.g. "memory_retrospective"). Background jobs cannot answer
    * interactive approval prompts, so the checker uses this — together with
    * {@link trustClass} / {@link sourceChannel} — to scope narrow non-interactive
    * auto-grants to a specific internal origin without broadening any other
@@ -90,7 +90,7 @@ export interface PolicyContext {
   /**
    * Whether procedural-memory-as-skills is active for this assistant (the
    * `procedural-memory-as-skills` flag is on AND memory-v3 is live). Precomputed
-   * in {@link buildPolicyContext} so the checker can gate the memory-consolidation
+   * in {@link buildPolicyContext} so the checker can gate the memory-retrospective
    * skill-authoring auto-grant on the feature without reading config itself.
    * Undefined/false when the feature is inactive — the grant then never fires.
    */

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -39,7 +39,8 @@ function getManagedSkillsDir(): string {
   return getWorkspaceSkillsDir();
 }
 
-function getManagedSkillDir(id: string): string {
+/** Absolute path of a managed skill's directory (whether or not it exists). */
+export function getManagedSkillDir(id: string): string {
   return join(getManagedSkillsDir(), id);
 }
 

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -35,7 +35,7 @@ export function buildPolicyContext(
   const conversationId = context?.conversationId;
 
   // Origin/trust/channel signals the checker uses to scope narrow
-  // non-interactive auto-grants (e.g. the memory-consolidation skill-authoring
+  // non-interactive auto-grants (e.g. the memory-retrospective skill-authoring
   // grant) to a specific internal origin. Background-job turns populate
   // `requestOrigin`; `trustClass`/`executionChannel` come from the turn's
   // resolved trust context. Undefined for normal interactive turns, so no
@@ -46,7 +46,7 @@ export function buildPolicyContext(
     sourceChannel: context?.executionChannel,
     // Precompute the proc-to-skills gate (flag on AND v3 live) here so the
     // permission checker — a leaf module that must not read config — can deny
-    // the memory-consolidation skill-authoring grant whenever the feature is
+    // the memory-retrospective skill-authoring grant whenever the feature is
     // inactive, just by reading this boolean.
     procToSkillsActive: isProcToSkillsActive(getConfig()),
   };

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -1,6 +1,17 @@
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
-import { createManagedSkill } from "../../skills/managed-store.js";
+import { readInstallMeta } from "../../skills/install-meta.js";
+import {
+  createManagedSkill,
+  getManagedSkillDir,
+} from "../../skills/managed-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Origin tag the memory-retrospective wake stamps onto `ToolContext`. Scaffolds
+ * under this origin are tagged `author: "assistant"` and may not folder-rewrite
+ * a `author: "user"` skill (see the backstop in `executeScaffoldManagedSkill`).
+ */
+const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
 
 /** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
 function sanitizeFrontmatterValue(value: string): string {
@@ -13,7 +24,7 @@ function sanitizeFrontmatterValue(value: string): string {
  */
 export async function executeScaffoldManagedSkill(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const skillId = input.skill_id;
   if (typeof skillId !== "string" || !skillId.trim()) {
@@ -122,6 +133,26 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  const fromRetrospective =
+    context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
+  const author = fromRetrospective ? "assistant" : "user";
+
+  // Backstop: a retrospective pass must never folder-rewrite a user-authored
+  // skill. Refuse an overwrite OR a companion-file write that targets an
+  // existing skill whose install metadata is `author: "user"`. The prompt
+  // already directs the model to refine such skills conservatively; this is the
+  // enforcement layer behind that judgement call. `readInstallMeta` returns
+  // null for a not-yet-existing skill, so a fresh create falls through.
+  if (fromRetrospective && (input.overwrite === true || files !== undefined)) {
+    const existingMeta = readInstallMeta(getManagedSkillDir(skillId.trim()));
+    if (existingMeta?.author === "user") {
+      return {
+        content: `Error: skill "${skillId.trim()}" is user-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
+        isError: true,
+      };
+    }
+  }
+
   const result = createManagedSkill({
     id: skillId.trim(),
     name: sanitizeFrontmatterValue(name),
@@ -134,6 +165,7 @@ export async function executeScaffoldManagedSkill(
     overwrite: input.overwrite === true,
     includes,
     files,
+    author,
   });
 
   if (!result.created) {

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -137,17 +137,21 @@ export async function executeScaffoldManagedSkill(
     context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
   const author = fromRetrospective ? "assistant" : "user";
 
-  // Backstop: a retrospective pass must never folder-rewrite a user-authored
-  // skill. Refuse an overwrite OR a companion-file write that targets an
-  // existing skill whose install metadata is `author: "user"`. The prompt
-  // already directs the model to refine such skills conservatively; this is the
-  // enforcement layer behind that judgement call. `readInstallMeta` returns
-  // null for a not-yet-existing skill, so a fresh create falls through.
+  // Backstop: a retrospective pass may only overwrite or write companion files
+  // into a skill IT authored. Refuse an overwrite OR companion-file write that
+  // targets an EXISTING skill that is not `author: "assistant"` — i.e. both
+  // `author: "user"` AND untagged/legacy skills (e.g. those created via the
+  // `createSkill` API route, whose install-meta carries no author) are
+  // protected, matching the prune side where untagged skills are never pruned.
+  // The prompt already directs the model to refine such skills conservatively or
+  // author a new one; this is the enforcement layer behind that judgement call.
+  // `readInstallMeta` returns null for a not-yet-existing skill, so a fresh
+  // create falls through.
   if (fromRetrospective && (input.overwrite === true || files !== undefined)) {
     const existingMeta = readInstallMeta(getManagedSkillDir(skillId.trim()));
-    if (existingMeta?.author === "user") {
+    if (existingMeta !== null && existingMeta.author !== "assistant") {
       return {
-        content: `Error: skill "${skillId.trim()}" is user-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
+        content: `Error: skill "${skillId.trim()}" is not assistant-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
         isError: true,
       };
     }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -377,11 +377,13 @@ export interface ToolContext {
   executionChannel?: string;
   /**
    * Origin tag of the turn driving this tool invocation (the conversation's
-   * `TitleOrigin`, e.g. "memory_consolidation"). Set for background-job turns
-   * that pass `requestOrigin` to `runBackgroundJob`. `buildPolicyContext`
-   * copies it onto the `PolicyContext` so the permission checker can scope
-   * narrow non-interactive auto-grants (e.g. consolidation skill authoring) to
-   * a specific internal origin. Unset for normal interactive turns.
+   * `TitleOrigin`, e.g. "memory_retrospective"). Set for background-job turns
+   * that pass `requestOrigin` to `runBackgroundJob`, and for the
+   * memory-retrospective wake (which pins it via {@link WakeToolContextPin}).
+   * `buildPolicyContext` copies it onto the `PolicyContext` so the permission
+   * checker can scope narrow non-interactive auto-grants (e.g. retrospective
+   * skill authoring) to a specific internal origin. Unset for normal
+   * interactive turns.
    */
   requestOrigin?: string;
   /**


### PR DESCRIPTION
## Summary
Re-points the skill-authoring permission grant to the retrospective origin, expands the retrospective wake's allowedTools (remember + scaffold_managed_skill + skill_load + find_similar_skills), extends buildForkInstruction with a permissive relevance pre-check + agent-judged sibling dedup + companion-file capture, and tags authorship (assistant under the retrospective origin, else user) while refusing to rewrite user-authored skills.

Part of plan: procedural-memory-as-skills.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->