### PR TITLE
refactor(memory): drive retrospective enqueue from MemoryProvider.onTurnCommit

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -94,21 +94,13 @@ mock.module("../../memory/auto-analysis-enqueue.js", () => ({
   },
 }));
 
-const memoryRetroCalls: Array<{
-  conversationId: string;
-  trigger: string;
-}> = [];
-
+// `disposeConversation` no longer enqueues memory-retrospectives — that now
+// runs on the per-turn `turn-commit` hook (see the memory-retrieval plugin's
+// `turn-commit.test.ts`). The enqueue module is still stubbed here so the
+// `disposeConversation` dynamic-import chain doesn't pull the real DB-backed
+// implementation.
 mock.module("../../memory/memory-retrospective-enqueue.js", () => ({
-  enqueueMemoryRetrospectiveIfEnabled: (args: {
-    conversationId: string;
-    trigger: string;
-  }) => {
-    memoryRetroCalls.push(args);
-  },
-  // Also export sibling functions other modules import from this file, so
-  // mocking it here doesn't break transitive imports loaded during the
-  // `disposeConversation` dynamic-import chain.
+  enqueueMemoryRetrospectiveIfEnabled: () => {},
   enqueueMemoryRetrospectiveOnCompaction: () => {},
   isMemoryRetrospectiveConversation: (_id: string) => false,
 }));
@@ -204,7 +196,6 @@ describe("disposeConversation — auto-analysis enqueue", () => {
   beforeEach(() => {
     memoryJobCalls.length = 0;
     autoAnalyzeCalls.length = 0;
-    memoryRetroCalls.length = 0;
     autoAnalyzeEnabled = true;
     autoAnalysisConversations.clear();
     v2Enabled = false;
@@ -382,65 +373,5 @@ describe("disposeConversation — auto-analysis enqueue", () => {
       conversationId: "conv-v2-on",
       trigger: "lifecycle",
     });
-  });
-});
-
-describe("disposeConversation — memory-retrospective lifecycle safety net", () => {
-  beforeEach(() => {
-    memoryJobCalls.length = 0;
-    autoAnalyzeCalls.length = 0;
-    memoryRetroCalls.length = 0;
-    autoAnalyzeEnabled = false;
-    autoAnalysisConversations.clear();
-    v2Enabled = false;
-  });
-
-  test("guardian conversation — enqueues memory-retrospective with trigger 'lifecycle'", () => {
-    const ctx = makeDisposeContext({
-      conversationId: "conv-retro",
-      trustClass: "guardian",
-    });
-
-    disposeConversation(ctx);
-
-    expect(memoryRetroCalls).toHaveLength(1);
-    expect(memoryRetroCalls[0]).toEqual({
-      conversationId: "conv-retro",
-      trigger: "lifecycle",
-    });
-  });
-
-  test("untrusted actor — no memory-retrospective enqueue", () => {
-    const ctx = makeDisposeContext({
-      conversationId: "conv-retro-untrusted",
-      trustClass: "unknown",
-    });
-
-    disposeConversation(ctx);
-
-    // The outer trust-class guard in disposeConversation gates ALL three
-    // enqueues (graph_extract, auto-analyze, memory-retrospective). When
-    // the actor is untrusted, none of them fire.
-    expect(memoryRetroCalls).toHaveLength(0);
-    expect(autoAnalyzeCalls).toHaveLength(0);
-  });
-
-  // Regression test: the retrospective lifecycle enqueue was previously
-  // outside the `!isAutoAnalysis` guard, so it fired even for auto-analysis
-  // conversations. Mirrors the indexer-time gate in `indexer.ts` and
-  // matches the existing graph_extract recursion-guard semantics.
-  test("auto-analysis conversation — does NOT enqueue memory-retrospective", () => {
-    autoAnalysisConversations.add("conv-auto-retro");
-    const ctx = makeDisposeContext({
-      conversationId: "conv-auto-retro",
-      trustClass: "guardian",
-    });
-
-    disposeConversation(ctx);
-
-    expect(memoryRetroCalls).toHaveLength(0);
-    // graph_extract is also recursion-guarded by the same `!isAutoAnalysis`
-    // block, so it should be skipped here too.
-    expect(memoryJobCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -10,7 +10,6 @@ import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { enqueueAutoAnalysisIfEnabled } from "../memory/auto-analysis-enqueue.js";
 import { isAutoAnalysisConversation } from "../memory/auto-analysis-guard.js";
-import { enqueueMemoryRetrospectiveIfEnabled } from "../memory/memory-retrospective-enqueue.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import {
@@ -186,23 +185,6 @@ export function disposeConversation(ctx: DisposeContext): void {
         } catch {
           // Best-effort — don't block conversation disposal
         }
-      }
-
-      try {
-        // Memory-retrospective lifecycle safety-net. The periodic triggers
-        // (interval / message_count / pre-compaction) handle the common
-        // path; lifecycle catches the gap between the last interval fire
-        // and conversation eviction. The job's `no_new_messages` early
-        // return makes this a cheap no-op when the periodic path already
-        // covered things. Lives inside the `!isAutoAnalysis` guard so
-        // auto-analysis conversations don't trigger retrospective enqueues
-        // on disposal — mirrors the indexer-time gate in `indexer.ts`.
-        enqueueMemoryRetrospectiveIfEnabled({
-          conversationId: ctx.conversationId,
-          trigger: "lifecycle",
-        });
-      } catch {
-        // Best-effort — don't block conversation disposal
       }
     }
 

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -55,6 +55,8 @@
  * - {@link PostModelCallContext} — passed to `post-model-call` hook, fired at
  *   every model-call outcome (a finalized reply or a provider rejection) to
  *   transform content and decide whether to retry
+ * - {@link TurnCommitContext} — passed to `turn-commit` hook, fired after the
+ *   turn's messages are persisted to enqueue post-turn consolidation work
  * - {@link HookFunction} — signature every lifecycle hook implements
  * - {@link PluginLogger} — pino-compatible logger shape on the contexts
  * - {@link ToolDefinition} — author-facing tool spec (default-export shape
@@ -112,6 +114,7 @@ export type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
+  TurnCommitContext,
   UserPromptSubmitContext,
 } from "./types.js";
 export { RiskLevel } from "./types.js";

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -53,6 +53,7 @@ import maxTokensContinuePostModelCall from "./max-tokens-continue/hooks/post-mod
 import maxTokensContinueStop from "./max-tokens-continue/hooks/stop.js";
 import maxTokensContinuePkg from "./max-tokens-continue/package.json" with { type: "json" };
 import memoryRetrievalPostCompact from "./memory-retrieval/hooks/post-compact.js";
+import memoryRetrievalTurnCommit from "./memory-retrieval/hooks/turn-commit.js";
 import memoryRetrievalUserPromptSubmit from "./memory-retrieval/hooks/user-prompt-submit.js";
 import memoryRetrievalPkg from "./memory-retrieval/package.json" with { type: "json" };
 import memoryV3PostCompact from "./memory-v3-shadow/hooks/post-compact.js";
@@ -129,11 +130,13 @@ export const defaultEmptyResponsePlugin: Plugin = {
 /**
  * `memory-retrieval` — assembles the turn's runtime injections (the unified
  * `<turn_context>` block, Slack chronological transcript, NOW.md / PKB /
- * memory-v2 / workspace blocks) via two hooks: `user-prompt-submit` runs
- * memory-graph retrieval and the initial injection, and `post-compact`
- * re-applies the injections onto the compacted history after a mid-turn
- * compaction. Registered first in the chain so later `user-prompt-submit`
- * hooks (history repair, title) see the fully memory-injected history.
+ * memory-v2 / workspace blocks) via three hooks: `user-prompt-submit` runs
+ * memory-graph retrieval and the initial injection, `post-compact` re-applies
+ * the injections onto the compacted history after a mid-turn compaction, and
+ * `turn-commit` drives the active memory provider's post-turn consolidation
+ * enqueue once the turn's messages are persisted. Registered first in the chain
+ * so later `user-prompt-submit` hooks (history repair, title) see the fully
+ * memory-injected history.
  */
 export const defaultMemoryRetrievalPlugin: Plugin = {
   manifest: {
@@ -143,6 +146,7 @@ export const defaultMemoryRetrievalPlugin: Plugin = {
   hooks: {
     "user-prompt-submit": memoryRetrievalUserPromptSubmit,
     "post-compact": memoryRetrievalPostCompact,
+    "turn-commit": memoryRetrievalTurnCommit,
   },
 };
 

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/__tests__/turn-commit.test.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/__tests__/turn-commit.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { TurnCommitContext } from "@vellumai/plugin-api";
+
+import type { MemoryProviderContext } from "../../../../../memory/provider/types.js";
+
+/**
+ * The default `turn-commit` hook drives the active memory provider's
+ * post-turn consolidation enqueue. These tests assert the two gates the hook
+ * inherits from the conversation-disposal safety-net it replaces (trust +
+ * auto-analysis recursion) and trigger parity: that a committed turn for a
+ * trusted, non-auto-analysis conversation still enqueues a retrospective on the
+ * `lifecycle` trigger, now routed through `resolveMemoryProvider().onTurnCommit`.
+ */
+
+const NOOP_LOGGER = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function turnCommitCtx(
+  overrides: Partial<TurnCommitContext> = {},
+): TurnCommitContext {
+  return {
+    conversationId: "conv-1",
+    userMessageId: "msg-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    turnCount: 3,
+    isNonInteractive: false,
+    logger: NOOP_LOGGER,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+/**
+ * Mock the hook's collaborators and import the hook fresh. `provider` is the
+ * spy `onTurnCommit` the resolved provider exposes; `enqueue` is the underlying
+ * retrospective-enqueue the real providers call (mocked here so the
+ * trigger-parity test can run the real graph provider through the route).
+ */
+async function loadHookWithMocks(opts: {
+  trustClass?: string;
+  canAccessMemory?: boolean;
+  isAutoAnalysis?: boolean;
+  resolvedOnTurnCommit?: (ctx: MemoryProviderContext) => Promise<void>;
+}) {
+  const {
+    trustClass = "guardian",
+    canAccessMemory = true,
+    isAutoAnalysis = false,
+    resolvedOnTurnCommit,
+  } = opts;
+
+  const loaderActual = await import("../../../../../config/loader.js");
+  mock.module("../../../../../config/loader.js", () => ({
+    ...loaderActual,
+    getConfig: () => ({ memory: { providerSlice: true } }) as never,
+  }));
+  mock.module("../../../../../daemon/conversation-registry.js", () => ({
+    findConversationOrSubagent: () => ({
+      currentTurnTrustContext: { sourceChannel: "vellum", trustClass },
+    }),
+  }));
+  mock.module("../../../../../runtime/capabilities.js", () => ({
+    resolveCapabilities: () => ({ canAccessMemory }),
+  }));
+  mock.module("../../../../../memory/auto-analysis-guard.js", () => ({
+    isAutoAnalysisConversation: () => isAutoAnalysis,
+  }));
+
+  const onTurnCommit =
+    resolvedOnTurnCommit ?? mock(async (_ctx: MemoryProviderContext) => {});
+  mock.module("../../../../../memory/provider/resolve.js", () => ({
+    resolveMemoryProvider: () => ({ id: "graph", onTurnCommit }),
+  }));
+
+  const hook = (await import("../turn-commit.js")).default;
+  return { hook, onTurnCommit };
+}
+
+describe("memory-retrieval turn-commit hook", () => {
+  test("delegates to the resolved provider's onTurnCommit with a context built from the turn", async () => {
+    let received: MemoryProviderContext | null = null;
+    const { hook } = await loadHookWithMocks({
+      resolvedOnTurnCommit: async (ctx) => {
+        received = ctx;
+      },
+    });
+
+    await hook(turnCommitCtx());
+
+    expect(received).not.toBeNull();
+    const ctx = received as unknown as MemoryProviderContext;
+    expect(ctx.conversationId).toBe("conv-1");
+    expect(ctx.requestId).toBe("msg-1");
+    expect(ctx.turnIndex).toBe(3);
+    expect(ctx.trust.trustClass).toBe("guardian");
+  });
+
+  test("skips delegation when the actor cannot access memory", async () => {
+    const { hook, onTurnCommit } = await loadHookWithMocks({
+      trustClass: "unknown",
+      canAccessMemory: false,
+    });
+
+    await hook(turnCommitCtx());
+
+    expect(onTurnCommit).not.toHaveBeenCalled();
+  });
+
+  test("skips delegation for auto-analysis conversations (recursion guard)", async () => {
+    const { hook, onTurnCommit } = await loadHookWithMocks({
+      isAutoAnalysis: true,
+    });
+
+    await hook(turnCommitCtx());
+
+    expect(onTurnCommit).not.toHaveBeenCalled();
+  });
+
+  test("trigger parity: a committed turn enqueues a retrospective on the lifecycle trigger via the real graph provider", async () => {
+    const enqueue = mock(
+      (_args: { conversationId: string; trigger: string }) => {},
+    );
+
+    const loaderActual = await import("../../../../../config/loader.js");
+    mock.module("../../../../../config/loader.js", () => ({
+      ...loaderActual,
+      getConfig: () => ({ memory: { provider: "graph" } }) as never,
+    }));
+    mock.module("../../../../../daemon/conversation-registry.js", () => ({
+      findConversationOrSubagent: () => ({
+        currentTurnTrustContext: {
+          sourceChannel: "vellum",
+          trustClass: "guardian",
+        },
+      }),
+    }));
+    mock.module("../../../../../runtime/capabilities.js", () => ({
+      resolveCapabilities: () => ({ canAccessMemory: true }),
+    }));
+    mock.module("../../../../../memory/auto-analysis-guard.js", () => ({
+      isAutoAnalysisConversation: () => false,
+    }));
+
+    // Intercept the underlying enqueue the real providers call, then resolve
+    // the real graph provider so the hook exercises the full route
+    // (hook → resolveMemoryProvider → GraphMemoryProvider.onTurnCommit →
+    // enqueue) rather than a stub.
+    mock.module(
+      "../../../../../memory/memory-retrospective-enqueue.js",
+      () => ({
+        enqueueMemoryRetrospectiveIfEnabled: enqueue,
+      }),
+    );
+    const { GraphMemoryProvider } =
+      await import("../../../../../memory/provider/graph-provider.js");
+    mock.module("../../../../../memory/provider/resolve.js", () => ({
+      resolveMemoryProvider: () => GraphMemoryProvider,
+    }));
+
+    const hook = (await import("../turn-commit.js")).default;
+    await hook(turnCommitCtx({ conversationId: "conv-parity" }));
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue.mock.calls[0][0]).toEqual({
+      conversationId: "conv-parity",
+      trigger: "lifecycle",
+    });
+  });
+});

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/turn-commit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/turn-commit.ts
@@ -1,0 +1,79 @@
+/**
+ * Default `memoryRetrieval` turn-commit hook.
+ *
+ * Fires once per turn after the turn's user + assistant messages are persisted,
+ * and drives the active memory system's post-turn work through
+ * {@link MemoryProvider.onTurnCommit}: the graph/v2 providers enqueue a
+ * `lifecycle`-trigger retrospective for the conversation that just committed,
+ * while v3 is a no-op (its writes ride the injector's commit callback).
+ *
+ * Two gates guard the delegation, preserving the semantics of the conversation
+ * disposal safety-net this replaces:
+ *
+ * - **Trust** — only conversations whose turn-start actor can access memory
+ *   ({@link resolveCapabilities}.canAccessMemory) drive consolidation, so an
+ *   untrusted actor's turn never seeds a guardian-trust background loop. Trust
+ *   is read from the conversation's turn-start snapshot rather than live state,
+ *   mirroring the post-compaction hook.
+ * - **Auto-analysis recursion** — auto-analysis conversations write memory
+ *   directly via tools, so a retrospective over their reflective musings would
+ *   double-write; they are skipped here, mirroring the indexer-time gate.
+ *
+ * The hook is observational and fire-and-forget — the turn is already
+ * committed, so mutating the context has no effect and a throw is contained by
+ * the loop.
+ */
+
+import type { HookFunction, TurnCommitContext } from "@vellumai/plugin-api";
+
+import { getConfig } from "../../../../config/loader.js";
+import { findConversationOrSubagent } from "../../../../daemon/conversation-registry.js";
+import { FALLBACK_TURN_TRUST } from "../../../../daemon/trust-context.js";
+import { isAutoAnalysisConversation } from "../../../../memory/auto-analysis-guard.js";
+import { resolveMemoryProvider } from "../../../../memory/provider/resolve.js";
+import type { MemoryProviderContext } from "../../../../memory/provider/types.js";
+import { resolveCapabilities } from "../../../../runtime/capabilities.js";
+
+const turnCommitMemoryConsolidation: HookFunction<TurnCommitContext> = async (
+  ctx,
+) => {
+  const { conversationId } = ctx;
+  const config = getConfig();
+  const conversation = findConversationOrSubagent(conversationId);
+
+  // Trust gate: only conversations whose actor can access memory drive
+  // consolidation. Read the turn-start snapshot rather than live state, since
+  // a concurrent request can overwrite the live trust context.
+  const trust =
+    conversation?.currentTurnTrustContext ??
+    conversation?.trustContext ??
+    FALLBACK_TURN_TRUST;
+  if (!resolveCapabilities(trust.trustClass).canAccessMemory) {
+    return;
+  }
+
+  // Recursion guard: auto-analysis conversations write memory directly via
+  // tools, so a retrospective over their writes would double-write. Fail open
+  // (don't skip) when the lookup throws so consolidation still runs.
+  let isAutoAnalysis = false;
+  try {
+    isAutoAnalysis = isAutoAnalysisConversation(conversationId);
+  } catch {
+    // Best-effort — fall through to enqueue.
+  }
+  if (isAutoAnalysis) {
+    return;
+  }
+
+  const providerCtx: MemoryProviderContext = {
+    conversationId,
+    requestId: ctx.userMessageId,
+    messages: [...ctx.messages],
+    config: config.memory,
+    turnIndex: ctx.turnCount,
+    trust,
+  };
+  await resolveMemoryProvider(config).onTurnCommit(providerCtx);
+};
+
+export default turnCommitMemoryConsolidation;


### PR DESCRIPTION
## Summary
- memory-retrieval plugin gains a turn-commit hook delegating to resolveMemoryProvider().onTurnCommit
- Move retrospective enqueue out of conversation-lifecycle into the provider; triggers preserved

Part of plan: memory-plugin-extraction.md (PR 19 of 32)