### PR TITLE
refactor(memory): gate memory routes on the active provider

### DIFF
--- a/assistant/src/memory/provider/v2-provider.test.ts
+++ b/assistant/src/memory/provider/v2-provider.test.ts
@@ -49,12 +49,17 @@ mock.module("../../util/platform.js", () => ({
   getWorkspaceDir: () => "/tmp/ws",
 }));
 
+const realConfigLoader = await import("../../config/loader.js");
 mock.module("../../config/loader.js", () => ({
+  ...realConfigLoader,
   getConfig: () => ({ memory: { v2: { enabled: true } } }),
 }));
 
 const enqueueCalls: Array<Record<string, unknown>> = [];
+const realRetrospectiveEnqueue =
+  await import("../memory-retrospective-enqueue.js");
 mock.module("../memory-retrospective-enqueue.js", () => ({
+  ...realRetrospectiveEnqueue,
   enqueueMemoryRetrospectiveIfEnabled: (args: Record<string, unknown>) => {
     enqueueCalls.push(args);
   },
@@ -103,6 +108,14 @@ describe("V2MemoryProvider", () => {
     const names = V2MemoryProvider.provideTools().map((t) => t.name);
     expect(names).toContain("remember");
     expect(names).toContain("recall");
+  });
+
+  test("provideRoutes contributes the v2 maintenance routes", () => {
+    const operationIds = (V2MemoryProvider.provideRoutes?.() ?? []).map(
+      (r) => r.operationId,
+    );
+    expect(operationIds).toContain("memory_v2_backfill");
+    expect(operationIds).toContain("memory_v2_list_concept_pages");
   });
 
   test("retrieve* return no blocks when v2 is disabled", async () => {

--- a/assistant/src/memory/provider/v2-provider.ts
+++ b/assistant/src/memory/provider/v2-provider.ts
@@ -15,11 +15,13 @@
  */
 
 import { getConfig } from "../../config/loader.js";
+import { getDb } from "../../persistence/db-connection.js";
 import type { InjectionBlock } from "../../plugins/types.js";
+import { ROUTES as MEMORY_V2_ROUTES } from "../../runtime/routes/memory-v2-routes.js";
+import type { RouteDefinition } from "../../runtime/routes/types.js";
 import { recallTool, rememberTool } from "../../tools/memory/register.js";
 import type { ToolDefinition } from "../../tools/types.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import { getDb } from "../../persistence/db-connection.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "../memory-retrospective-enqueue.js";
 import {
   injectMemoryV2Block,
@@ -106,6 +108,10 @@ export const V2MemoryProvider = {
 
   provideTools(): ToolDefinition[] {
     return [rememberTool, recallTool];
+  },
+
+  provideRoutes(): RouteDefinition[] {
+    return MEMORY_V2_ROUTES;
   },
 
   async init(): Promise<void> {},

--- a/assistant/src/runtime/routes/__tests__/memory-provider-gate.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-provider-gate.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests that the memory v2/v3 maintenance routes are gated on the active
+ * memory provider (PR 21).
+ *
+ * The v2/v3 route modules live in the shared ROUTES array and are always
+ * registered, but a route that drives one memory system must report
+ * not-applicable when a different provider is active rather than execute
+ * against the inactive system. The active provider is derived from a per-test
+ * workspace `config.json` via the real `loadConfig`.
+ *
+ * The v3 `backfill-sections` body is heavy (embeds every page), so its one
+ * underlying call is stubbed (preserving the module's other exports) — the
+ * gate runs before that work, so a gated call must reject without ever
+ * touching it. `invalidateLanes` (the rebuild-index body) is a cheap in-memory
+ * op and runs unmocked.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { invalidateConfigCache } from "../../../config/loader.js";
+
+// ─── stub the heavy v3 backfill body (must precede route import) ─────────────
+
+let backfillCalls = 0;
+
+const maintainJobActual =
+  await import("../../../plugins/defaults/memory-v3-shadow/maintain-job.js");
+mock.module(
+  "../../../plugins/defaults/memory-v3-shadow/maintain-job.js",
+  () => ({
+    ...maintainJobActual,
+    backfillAllSections: async () => {
+      backfillCalls += 1;
+      return { articles: 0, sections: 0, failures: 0 };
+    },
+  }),
+);
+
+const { ROUTES: memoryV2Routes, MEMORY_V2_DISABLED_CODE } =
+  await import("../memory-v2-routes.js");
+const { ROUTES: memoryV3Routes } = await import("../memory-v3-routes.js");
+const { MEMORY_PROVIDER_NOT_ACTIVE_CODE } =
+  await import("../memory-provider-gate.js");
+const { RouteError } = await import("../errors.js");
+const { ROUTES } = await import("../index.js");
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+function writeWorkspaceConfig(json: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(json, null, 2),
+    "utf-8",
+  );
+  invalidateConfigCache();
+}
+
+function findRoute(
+  routes: typeof memoryV2Routes,
+  operationId: string,
+): (typeof memoryV2Routes)[number] {
+  const route = routes.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route;
+}
+
+/** Provider-pinned config helpers. */
+const asV2 = () => writeWorkspaceConfig({ memory: { provider: "v2" } });
+const asV3 = () => writeWorkspaceConfig({ memory: { provider: "v3" } });
+
+beforeEach(() => {
+  backfillCalls = 0;
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-mem-provider-gate-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  invalidateConfigCache();
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  invalidateConfigCache();
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ─── shared aggregator contract ──────────────────────────────────────────────
+
+describe("shared ROUTES still register both memory route families", () => {
+  test("v2 and v3 routes are present in the aggregated ROUTES array", () => {
+    const ids = new Set(ROUTES.map((r) => r.operationId));
+    expect(ids.has("memory_v2_backfill")).toBe(true);
+    expect(ids.has("memory_v3_rebuild_index")).toBe(true);
+    expect(ids.has("memory_v3_backfill_sections")).toBe(true);
+  });
+});
+
+// ─── provider = v2 ───────────────────────────────────────────────────────────
+
+describe("with provider = v2", () => {
+  test("v2 maintenance routes execute", async () => {
+    asV2();
+    // list-concept-pages reads the on-disk workspace (no DB), so a passing
+    // gate yields the empty-workspace listing rather than the not-active error.
+    const route = findRoute(memoryV2Routes, "memory_v2_list_concept_pages");
+    const result = (await route.handler({ body: {} })) as {
+      pages: unknown[];
+    };
+    expect(result.pages).toEqual([]);
+  });
+
+  test("v3 routes report not-applicable (404), without running their body", async () => {
+    asV2();
+    const route = findRoute(memoryV3Routes, "memory_v3_rebuild_index");
+    try {
+      await route.handler({ body: {} });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RouteError);
+      const e = err as InstanceType<typeof RouteError>;
+      expect(e.code).toBe(MEMORY_PROVIDER_NOT_ACTIVE_CODE);
+      expect(e.statusCode).toBe(404);
+    }
+  });
+
+  test("v3 backfill-sections reports not-applicable without embedding", async () => {
+    asV2();
+    const route = findRoute(memoryV3Routes, "memory_v3_backfill_sections");
+    await expect(route.handler({ body: {} })).rejects.toBeInstanceOf(
+      RouteError,
+    );
+    expect(backfillCalls).toBe(0);
+  });
+});
+
+// ─── provider = v3 ───────────────────────────────────────────────────────────
+
+describe("with provider = v3", () => {
+  test("v3 maintenance routes execute", async () => {
+    asV3();
+    const rebuild = findRoute(memoryV3Routes, "memory_v3_rebuild_index");
+    const result = (await rebuild.handler({ body: {} })) as { ok: boolean };
+    expect(result.ok).toBe(true);
+
+    const backfill = findRoute(memoryV3Routes, "memory_v3_backfill_sections");
+    await backfill.handler({ body: {} });
+    expect(backfillCalls).toBe(1);
+  });
+
+  test("v2 routes report disabled (409 + MEMORY_V2_DISABLED)", async () => {
+    asV3();
+    const route = findRoute(memoryV2Routes, "memory_v2_backfill");
+    try {
+      await route.handler({ body: { op: "migrate" } });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RouteError);
+      const e = err as InstanceType<typeof RouteError>;
+      expect(e.code).toBe(MEMORY_V2_DISABLED_CODE);
+      expect(e.statusCode).toBe(409);
+    }
+  });
+});

--- a/assistant/src/runtime/routes/memory-provider-gate.ts
+++ b/assistant/src/runtime/routes/memory-provider-gate.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared guard that gates provider-specific memory routes on the active memory
+ * system.
+ *
+ * The memory v2/v3 maintenance routes live in the shared `ROUTES` array and are
+ * always registered, but a route that drives the v2 concept-page system must
+ * not execute when the active provider is v3 (and vice versa) — running a
+ * maintenance verb against an inactive system would act on stale or empty
+ * state. Each provider-owned handler calls {@link requireActiveMemoryProvider}
+ * with its own id; when a different provider is active the request is rejected
+ * with a clean not-applicable {@link RouteError} (404) instead of a 500 from
+ * executing against the wrong system.
+ */
+
+import { loadConfig } from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { resolveMemoryProviderId } from "../../memory/provider/provider-id.js";
+import type { MemoryProviderId } from "../../memory/provider/types.js";
+import { RouteError } from "./errors.js";
+
+/**
+ * Wire-format error code emitted when a provider-specific memory route is hit
+ * while a different memory provider is active. Exported so tests and clients
+ * reference the same string without drift.
+ */
+export const MEMORY_PROVIDER_NOT_ACTIVE_CODE = "MEMORY_PROVIDER_NOT_ACTIVE";
+
+/**
+ * Reject the request when `provider` is not the active memory system.
+ *
+ * Returns a 404 (not 500): from the client's perspective the endpoint does not
+ * apply to the running configuration, so it is "not found for this provider"
+ * rather than a server fault. The desktop Memories surface reads the code to
+ * render an explicit "not applicable for the active memory system" state.
+ *
+ * `config` is injectable so handlers that already resolve a (possibly
+ * test-supplied) config gate against the same one; it defaults to the live
+ * `loadConfig()`.
+ */
+export function requireActiveMemoryProvider(
+  provider: MemoryProviderId,
+  config: AssistantConfig = loadConfig(),
+): void {
+  const active = resolveMemoryProviderId(config);
+  if (active !== provider) {
+    throw new RouteError(
+      `This endpoint applies to the "${provider}" memory system, but the active provider is "${active}".`,
+      MEMORY_PROVIDER_NOT_ACTIVE_CODE,
+      404,
+    );
+  }
+}

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -13,6 +13,7 @@ import {
   type ConceptFrequencyResponse,
   getConceptFrequencySummary,
 } from "../../memory/memory-v2-concept-frequency.js";
+import { resolveMemoryProviderId } from "../../memory/provider/provider-id.js";
 import {
   getEdgeIndex,
   totalEdgeCount,
@@ -49,22 +50,28 @@ import type { RouteHandlerArgs } from "./types.js";
 const log = getLogger("memory-v2-routes");
 
 /**
- * Wire-format error code emitted when v2 routes reject a request because
- * `memory.v2.enabled` is false. Exported so tests and the macOS client can
+ * Wire-format error code emitted when v2 routes reject a request because the
+ * active memory provider is not v2. Exported so tests and the macOS/web client
  * reference the same string without drift.
  */
 export const MEMORY_V2_DISABLED_CODE = "MEMORY_V2_DISABLED";
 
 /**
- * Reject the request when memory v2 is not active. Returning 409 (rather
- * than serving a partial response) keeps clients honest — the desktop
- * Memories panel reads this code to render an explicit "disabled in
- * config" empty state.
+ * Reject the request when the v2 concept-page system is not the active memory
+ * provider. The v2 maintenance verbs operate on the live v2 corpus, so running
+ * one while a different provider (graph/v3/none) is active would act on a
+ * system the assistant isn't using.
+ *
+ * Returns 409 + `MEMORY_V2_DISABLED` (rather than serving a partial response)
+ * — the desktop Memories panel reads this code to render an explicit "disabled
+ * in config" empty state. Under the default `"auto"` selector this fires
+ * exactly when v2 is not the derived provider, so existing installs are
+ * unaffected.
  */
-function requireMemoryV2Enabled(): void {
-  if (!loadConfig().memory.v2.enabled) {
+function requireMemoryV2Active(): void {
+  if (resolveMemoryProviderId(loadConfig()) !== "v2") {
     throw new RouteError(
-      "Memory v2 is not enabled — set memory.v2.enabled to true to use this command.",
+      "Memory v2 is not the active memory provider — select the v2 memory system to use this command.",
       MEMORY_V2_DISABLED_CODE,
       409,
     );
@@ -95,7 +102,7 @@ const OP_TO_JOB_TYPE: Record<MemoryV2BackfillOp, MemoryJobType> = {
 async function handleBackfill({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2BackfillResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const { op, force } = MemoryV2BackfillParams.parse(body);
   const payload: Record<string, unknown> =
     op === "migrate" && force === true ? { force: true } : {};
@@ -122,11 +129,11 @@ export type MemoryV2ValidateResult = {
 async function handleValidate({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ValidateResult> {
-  // Intentionally NOT gated on `memory.v2.enabled`. Validate is a read-only
+  // Intentionally NOT gated on the active provider. Validate is a read-only
   // diagnostic walk over the on-disk concept-page workspace and must be
-  // runnable before flipping the flag — operators (and the
+  // runnable before selecting v2 — operators (and the
   // vellum-memory-v2-migration skill) use it as the final dry-run check
-  // immediately before enabling v2.
+  // immediately before switching to v2.
   MemoryV2ValidateParams.parse(body);
 
   const workspaceDir = getWorkspaceDir();
@@ -183,7 +190,7 @@ export type MemoryV2GetConceptPageResult = {
 async function handleGetConceptPage({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2GetConceptPageResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const { slug } = MemoryV2GetConceptPageParams.parse(body);
   const workspaceDir = getWorkspaceDir();
   let page;
@@ -228,7 +235,7 @@ export type MemoryV2ListConceptPagesResult = z.infer<
 async function handleListConceptPages({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ListConceptPagesResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   MemoryV2ListConceptPagesParams.parse(body);
 
   const workspaceDir = getWorkspaceDir();
@@ -276,7 +283,7 @@ export type MemoryV2ReembedSkillsResult = {
 async function handleReembedSkills({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ReembedSkillsResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   MemoryV2ReembedSkillsParams.parse(body);
 
   // Unlike the queued backfill jobs above, this is a CLI-driven sync
@@ -301,7 +308,7 @@ const MemoryV2ConceptFrequencyParams = z
 async function handleConceptFrequency({
   body = {},
 }: RouteHandlerArgs): Promise<ConceptFrequencyResponse> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const { conversationId, sinceMs } =
     MemoryV2ConceptFrequencyParams.parse(body);
   const workspaceDir = getWorkspaceDir();
@@ -328,9 +335,9 @@ export interface MemoryV2EmaScoresResult {
 async function handleEmaScores({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2EmaScoresResult> {
-  // Intentionally NOT gated on `memory.v2.enabled` — operators inspecting
-  // EMA data before flipping tier-2 routing on is a legitimate dry-run
-  // use case, mirroring `memory_v2_validate`.
+  // Intentionally NOT gated on the active provider — operators inspecting
+  // EMA data before selecting v2 is a legitimate dry-run use case,
+  // mirroring `memory_v2_validate`.
   MemoryV2EmaScoresParams.parse(body);
 
   const pageIndex = await getPageIndex(getWorkspaceDir());
@@ -481,7 +488,7 @@ function applySimulateOverrides(
 export async function handleSimulateRouter({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2SimulateRouterResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const {
     recentTurnPairs,
     nowText: rawNowText,
@@ -605,7 +612,7 @@ export type MemoryV2RouterPromptTemplateResult = z.infer<
 >;
 
 async function handleGetRouterPromptTemplate(): Promise<MemoryV2RouterPromptTemplateResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   return { template: ROUTER_PROMPT };
 }
 
@@ -619,7 +626,7 @@ export const MemoryV2NowTextResultSchema = z.object({
 export type MemoryV2NowTextResult = z.infer<typeof MemoryV2NowTextResultSchema>;
 
 async function handleGetNowText(): Promise<MemoryV2NowTextResult> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const workspaceDir = getWorkspaceDir();
   const nowText = await loadNowText(workspaceDir);
   return { nowText };
@@ -648,7 +655,7 @@ export async function handleCompareRetrievers({
   body = {},
   abortSignal,
 }: RouteHandlerArgs): Promise<ComparisonReport> {
-  requireMemoryV2Enabled();
+  requireMemoryV2Active();
   const { limit, strategy, conversationIds, ks, includeNotInjected } =
     MemoryV2CompareRetrieversParams.parse(body);
 

--- a/assistant/src/runtime/routes/memory-v3-routes.ts
+++ b/assistant/src/runtime/routes/memory-v3-routes.ts
@@ -23,6 +23,7 @@ import { backfillAllSections } from "../../plugins/defaults/memory-v3-shadow/mai
 import { invalidateLanes } from "../../plugins/defaults/memory-v3-shadow/shadow-plugin.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS, type RoutePolicy } from "../auth/route-policy.js";
+import { requireActiveMemoryProvider } from "./memory-provider-gate.js";
 import type { RouteDefinition } from "./types.js";
 
 const log = getLogger("memory-v3-routes");
@@ -44,6 +45,7 @@ export type MemoryV3RebuildIndexResult = z.infer<
  * process's cached lanes (an in-CLI call would invalidate nothing).
  */
 export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndexResult> {
+  requireActiveMemoryProvider("v3");
   invalidateLanes();
   log.info("memory-v3 lanes invalidated (rebuild-index)");
   return { ok: true };
@@ -78,6 +80,7 @@ export type MemoryV3BackfillSectionsResult = z.infer<
 export async function handleMemoryV3BackfillSections(
   config: AssistantConfig = getConfig(),
 ): Promise<MemoryV3BackfillSectionsResult> {
+  requireActiveMemoryProvider("v3", config);
   const outcome = await backfillAllSections(config);
   log.info(outcome, "memory-v3 section backfill complete (route)");
   return outcome;


### PR DESCRIPTION
## Summary
- Providers contribute provideRoutes(); v2/v3 maintenance routes served only when that provider is active
- Inactive-provider routes return a clean not-applicable error

Part of plan: memory-plugin-extraction.md (PR 21 of 32)