### PR TITLE
refactor(memory): register remember/recall via MemoryProvider.provideTools()

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -20,7 +20,11 @@ import {
   unregisterSkillTools,
   unregisterWorkspaceTool,
 } from "../tools/registry.js";
-import { eagerModuleToolNames, explicitTools } from "../tools/tool-manifest.js";
+import {
+  eagerModuleToolNames,
+  explicitTools,
+  getMemoryToolsForActiveProvider,
+} from "../tools/tool-manifest.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
 
 // Clean up global registry after this file completes to prevent
@@ -114,11 +118,22 @@ describe("tool manifest", () => {
     expect(eagerModuleToolNames.length).toBe(12);
   });
 
-  test("explicit tools list includes memory tools", () => {
-    const names = explicitTools.map((t) => t.name);
-    expect(names).toContain("recall");
-    expect(names.filter((name) => name === "recall")).toHaveLength(1);
-    expect(names).toContain("remember");
+  test("memory tools are provider-owned, not in the static explicit list", () => {
+    const explicitNames = explicitTools.map((t) => t.name);
+    expect(explicitNames).not.toContain("remember");
+    expect(explicitNames).not.toContain("recall");
+
+    // The active memory provider (default config → v2) supplies them instead.
+    const memoryNames = getMemoryToolsForActiveProvider()
+      .map((t) => t.name)
+      .sort();
+    expect(memoryNames).toEqual(["recall", "remember"]);
+  });
+
+  test("active-provider memory tools are registered after initializeTools()", async () => {
+    await initializeTools();
+    expect(getTool("remember")).toBeDefined();
+    expect(getTool("recall")).toBeDefined();
   });
 
   test("registered tool count is at least eager + host", async () => {

--- a/assistant/src/memory/provider/graph-provider.ts
+++ b/assistant/src/memory/provider/graph-provider.ts
@@ -12,6 +12,7 @@
 import { getConfig } from "../../config/loader.js";
 import type { InjectionBlock } from "../../plugins/types.js";
 import type { ContentBlock, Message } from "../../providers/types.js";
+import { recallTool, rememberTool } from "../../tools/memory/register.js";
 import type { ToolDefinition } from "../../tools/types.js";
 import {
   assembleContextBlock,
@@ -19,10 +20,6 @@ import {
   InContextTracker,
 } from "../graph/injection.js";
 import { loadContextMemory, retrieveForTurn } from "../graph/retriever.js";
-import {
-  graphRecallDefinition,
-  graphRememberDefinition,
-} from "../graph/tools.js";
 import { wrapMemoryBlock } from "../memory-marker.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "../memory-retrospective-enqueue.js";
 import type { MemoryProvider, MemoryProviderContext } from "./types.js";
@@ -150,7 +147,7 @@ export const GraphMemoryProvider = {
   },
 
   provideTools(): ToolDefinition[] {
-    return [graphRememberDefinition, graphRecallDefinition];
+    return [rememberTool, recallTool];
   },
 
   async init(): Promise<void> {},

--- a/assistant/src/tools/memory/active-provider-tools.test.ts
+++ b/assistant/src/tools/memory/active-provider-tools.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for `getMemoryToolsForActiveProvider()` — the manifest accessor that
+ * sources the `remember`/`recall` tools from the active memory provider's
+ * `provideTools()`. `initializeTools()` registers exactly this set, so the
+ * accessor is the seam that decides which memory tools exist per
+ * `memory.provider`:
+ *
+ * - graph / v2 expose `remember` + `recall` (the executable tools whose
+ *   schemas mirror the canonical graph definitions),
+ * - v3 / `none` expose nothing.
+ *
+ * The provider modules are not mocked — the real graph/v2/v3 providers all
+ * resolve to the shared `rememberTool`/`recallTool` (or to empty), and that
+ * sharing is exactly what this test pins.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as configLoader from "../../config/loader.js";
+import { AssistantConfigSchema } from "../../config/schema.js";
+import {
+  graphRecallDefinition,
+  graphRememberDefinition,
+} from "../../memory/graph/tools.js";
+import { getMemoryToolsForActiveProvider } from "../tool-manifest.js";
+
+afterEach(() => {
+  spyOn(configLoader, "getConfig").mockRestore();
+});
+
+/**
+ * Run `getMemoryToolsForActiveProvider()` with `getConfig()` pinned to a config
+ * whose `memory.provider` is `provider`.
+ */
+function memoryToolsFor(provider: string) {
+  const config = AssistantConfigSchema.parse({ memory: { provider } });
+  spyOn(configLoader, "getConfig").mockReturnValue(config);
+  return getMemoryToolsForActiveProvider();
+}
+
+describe("getMemoryToolsForActiveProvider", () => {
+  test.each(["graph", "v2"] as const)(
+    'provider "%s" exposes remember + recall',
+    (provider) => {
+      const names = memoryToolsFor(provider)
+        .map((t) => t.name)
+        .sort();
+      expect(names).toEqual(["recall", "remember"]);
+    },
+  );
+
+  test.each(["v3", "none"] as const)(
+    'provider "%s" exposes no memory tools',
+    (provider) => {
+      expect(memoryToolsFor(provider)).toEqual([]);
+    },
+  );
+
+  test("registered tool schemas match the canonical graph definitions", () => {
+    const tools = memoryToolsFor("graph");
+    const remember = tools.find((t) => t.name === "remember");
+    const recall = tools.find((t) => t.name === "recall");
+
+    expect(remember?.description).toBe(graphRememberDefinition.description);
+    expect(remember?.input_schema).toEqual(
+      graphRememberDefinition.input_schema,
+    );
+    expect(recall?.description).toBe(graphRecallDefinition.description);
+    expect(recall?.input_schema).toEqual(graphRecallDefinition.input_schema);
+  });
+
+  test("graph and v2 register the same executable tool instances", () => {
+    const graphTools = memoryToolsFor("graph");
+    const v2Tools = memoryToolsFor("v2");
+
+    // Both providers contribute the shared `rememberTool`/`recallTool`
+    // instances — the same objects carrying the real `execute` handlers.
+    expect(graphTools).toEqual(v2Tools);
+    for (const tool of graphTools) {
+      expect(typeof tool.execute).toBe("function");
+    }
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -939,6 +939,7 @@ export async function initializeTools(): Promise<void> {
     eagerModuleToolNames,
     explicitTools,
     getCesToolsIfEnabled,
+    getMemoryToolsForActiveProvider,
     cesTools,
   } = await import("./tool-manifest.js");
 
@@ -986,6 +987,14 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
+  // Memory tools (`remember`/`recall`) are owned by the active memory
+  // provider: the resolved provider's `provideTools()` decides which tools
+  // exist. A `memory.provider: "none"` install registers nothing here.
+  const activeMemoryTools = getMemoryToolsForActiveProvider();
+  for (const tool of activeMemoryTools) {
+    registerTool(tool);
+  }
+
   registerUiSurfaceTools();
   registerAppTools();
   registerSystemTools();
@@ -1008,6 +1017,7 @@ export async function initializeTools(): Promise<void> {
       ...extEntries.map(({ tool }) => tool.name),
       ...hostTools.map((t) => t.name!),
       ...cesTools.map((t) => t.name!),
+      ...activeMemoryTools.map((t) => t.name!),
       ...allUiSurfaceTools.map((t) => t.name!),
       ...coreAppProxyTools.map((t) => t.name!),
     ]);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -11,6 +11,7 @@ import {
   isCesSecureInstallEnabled,
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
+import { resolveMemoryProvider } from "../memory/provider/resolve.js";
 import { askQuestionTool } from "./ask-question/ask-question-tool.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
@@ -20,7 +21,6 @@ import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
 import { codeSearchTool } from "./filesystem/search.js";
 import { fileWriteTool } from "./filesystem/write.js";
-import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";
 import { skillExecuteTool } from "./skills/execute.js";
@@ -90,8 +90,6 @@ export const explicitTools: ToolDefinition[] = [
   skillLoadTool,
   requestSystemPermissionTool,
   // Always-explicit tools
-  rememberTool,
-  recallTool,
   notifyParentTool,
   askQuestionTool,
   // NOTE: external skill tools (registered via registerExternalTools in
@@ -135,4 +133,26 @@ export function getCesToolsIfEnabled(): ToolDefinition[] {
     // Config not yet loaded (e.g. during test setup) - CES tools stay off.
   }
   return [];
+}
+
+// ── Memory tools (active-provider owned) ────────────────────────────
+// The `remember`/`recall` tools are owned by the active memory provider:
+// `initializeTools()` registers the tools the resolved provider contributes
+// via `provideTools()`. The graph and v2 providers expose `remember`/`recall`;
+// v3 and `none` expose nothing, so a `memory.provider: "none"` install
+// registers no memory tools.
+
+/**
+ * Return the memory tools the active provider contributes, resolved from the
+ * current config. Returns an empty array when the provider exposes no tools
+ * (v3 / `none`) or when config is not yet loaded (e.g. test setup) so callers
+ * can unconditionally iterate the result.
+ */
+export function getMemoryToolsForActiveProvider(): ToolDefinition[] {
+  try {
+    return resolveMemoryProvider(getConfig()).provideTools();
+  } catch {
+    // Config not yet loaded (e.g. during test setup) - no memory tools.
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- Memory tools registered from the resolved provider's provideTools() at plugin init
- provider=none registers no memory tools; default graph behavior unchanged
- Remove static tools/memory/register.ts wiring

Part of plan: memory-plugin-extraction.md (PR 20 of 32)