### PR TITLE
chore(memory): update proc-to-skills gate rationale and scrub stale references

### DIFF
--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -13,9 +13,10 @@ export function isMemoryV3Live(config: AssistantConfig): boolean {
 
 /**
  * Whether the procedural-memory-as-skills behavior is enabled. Gated by the
- * `procedural-memory-as-skills` assistant feature flag (default off). Routes
- * procedures to candidate notes and procedural knowledge to skill-linked facts,
- * and distills recurring procedures into managed skills.
+ * `procedural-memory-as-skills` assistant feature flag (default off). When on,
+ * the retrospective background task may author and update managed skills (with
+ * procedure-scoped companion files), and the observe-first usage-prune stage may
+ * retire assistant-authored skills that have gone stale.
  */
 export function isProcToSkillsEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled("procedural-memory-as-skills", config);
@@ -23,13 +24,13 @@ export function isProcToSkillsEnabled(config: AssistantConfig): boolean {
 
 /**
  * Whether procedural-memory-as-skills is ACTIVE: the flag is on AND memory-v3 is
- * the live injected source. The feature requires v3-live because the only place
- * the consolidation pass captures candidate notes is the
- * `{{PROC_TO_SKILLS_SECTION}}` of the v3 prompt template — the v2 template has no
- * such placeholder, so with the flag on but v3 not live the pass writes no
- * candidate notes. Gating the whole feature (prompt section, distill follow-up
- * enqueue, distill job, and the skill-authoring permission grant) on this
- * combined predicate keeps it coherently inert unless both are on.
+ * the live injected source. The feature requires v3-live because the
+ * usage-prune backstop — which retires stale assistant-authored skills — runs
+ * only in the v3 maintain job. Enabling eager retrospective authoring without
+ * that backstop would let assistant-authored skills accumulate unbounded, so
+ * the feature is scoped to v3-live assistants. Gating the whole feature (the
+ * retrospective skill-authoring step and its skill-authoring permission grant)
+ * on this combined predicate keeps it coherently inert unless both are on.
  */
 export function isProcToSkillsActive(config: AssistantConfig): boolean {
   return isProcToSkillsEnabled(config) && isMemoryV3Live(config);

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -1533,8 +1533,8 @@ describe("memoryRetrospectiveJob", () => {
       "Never folder-rewrite a user-authored skill",
     );
 
-    // No skill:-link directive (that layer was removed); ordinary facts stay
-    // unlinked remembers.
+    // Ordinary facts stay plain remembers — the instruction carries no
+    // skill-linking directive.
     expect(instructionText).not.toContain("skill:");
     expect(instructionText).toContain("Ordinary facts still go through");
   });

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -126,14 +126,15 @@ const procToSkillsFlagOn = () =>
   flagStates["procedural-memory-as-skills"] ?? false;
 mock.module("../../../config/memory-v3-gate.js", () => ({
   isMemoryV3Live: () => procToSkillsLive(),
-  // Proc-to-skills routing is gated by the `procedural-memory-as-skills`
-  // assistant flag (default off). Drive it through `flagStates` so suites that
-  // need the proc-to-skills consolidation section ON can flip it the same way
-  // they flip the other gates, while existing cases keep the default-off shape.
+  // Proc-to-skills is gated by the `procedural-memory-as-skills` assistant flag
+  // (default off). Drive it through `flagStates` so suites can flip it the same
+  // way they flip the other gates, while existing cases keep the default-off
+  // shape.
   isProcToSkillsEnabled: () => procToSkillsFlagOn(),
-  // Active = flag on AND v3 live. The consolidation prompt section, the distill
-  // follow-up enqueue, and the skill-authoring grant all gate on this combined
-  // predicate, so drive it from the same flag slots.
+  // Active = flag on AND v3 live. The retrospective skill-authoring step and its
+  // skill-authoring grant gate on this combined predicate, so drive it from the
+  // same flag slots. (The v2 consolidation job itself only reads
+  // `isMemoryV3Live`; these are mocked to satisfy the module shape.)
   isProcToSkillsActive: () => procToSkillsFlagOn() && procToSkillsLive(),
 }));
 


### PR DESCRIPTION
## Summary
Rewrites the isProcToSkillsActive / isProcToSkillsEnabled doc comments to the current retrospective-authoring + companion-files + usage-pruning model (gate behavior unchanged) and scrubs surviving comments that referenced the removed candidate/recurrence/distill pipeline and the skill-linked-facts layer.

Part of plan: procedural-memory-as-skills.md (PR 9 of 9)