### PR TITLE
feat(plugin-api): add embeddings + vector-store facet to the plugin host

### DIFF
--- a/assistant/src/daemon/__tests__/embeddings-facet.test.ts
+++ b/assistant/src/daemon/__tests__/embeddings-facet.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Verifies the embeddings + vector-store host facets:
+ *
+ * 1. A plugin can embed text via `host.embeddings.embed(...)`, which delegates
+ *    to the configured embedding backend — the plugin never sees the backend.
+ * 2. A plugin can upsert/search/delete vectors in its OWN namespaced
+ *    collection via `host.vectorStore.collection(...)`, and two plugins asking
+ *    for the same logical name get distinct, collision-free collections.
+ *
+ * The persistence layer is stubbed with `mock.module` so the test exercises
+ * the facet wiring (and the host-side namespacing) without a live Qdrant or
+ * embedding backend — and the plugin code under test imports only the facet,
+ * never `persistence/`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module-level stubs — installed before importing the modules under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+  }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({}),
+  getNestedValue: () => undefined,
+}));
+
+const embedWithBackendSpy = mock(async (_config: unknown, texts: string[]) => ({
+  provider: "local",
+  model: "stub-model",
+  // Deterministic 2-dim vector per input so assertions are stable.
+  vectors: texts.map((_t, i) => [i, i + 1]),
+}));
+mock.module("../../persistence/embeddings/embedding-backend.js", () => ({
+  embedWithBackend: embedWithBackendSpy,
+}));
+
+/**
+ * In-memory fake of one Qdrant collection. Keyed by collection name so the
+ * namespacing assertion can inspect which collection a plugin actually wrote.
+ */
+const collections = new Map<
+  string,
+  Map<string, { vector: number[]; payload: Record<string, unknown> }>
+>();
+
+function fakeCollection(name: string) {
+  let store = collections.get(name);
+  if (!store) {
+    store = new Map();
+    collections.set(name, store);
+  }
+  return {
+    upsert: mock(
+      async (
+        points: Array<{
+          id: string;
+          vector: number[];
+          payload?: Record<string, unknown>;
+        }>,
+      ) => {
+        for (const p of points) {
+          store!.set(p.id, { vector: p.vector, payload: p.payload ?? {} });
+        }
+      },
+    ),
+    search: mock(async (_vector: number[], limit: number) =>
+      [...store!.entries()].slice(0, limit).map(([id, v], idx) => ({
+        id,
+        score: 1 - idx * 0.1,
+        payload: v.payload,
+      })),
+    ),
+    delete: mock(async (ids: string[]) => {
+      for (const id of ids) store!.delete(id);
+    }),
+  };
+}
+
+const openSpy = mock((hostId: string, name: string, _vectorSize: number) =>
+  fakeCollection(`plugin_${hostId}_${name}`),
+);
+mock.module("../../persistence/embeddings/plugin-vector-store.js", () => ({
+  openPluginVectorCollection: openSpy,
+}));
+
+// ---------------------------------------------------------------------------
+// Modules under test — imported after every stub is in place
+// ---------------------------------------------------------------------------
+
+import {
+  buildEmbeddingsFacet,
+  buildVectorStoreFacet,
+} from "../skill-host-facets.js";
+
+describe("embeddings + vector-store host facets", () => {
+  test("a plugin embeds text via the facet without touching persistence", async () => {
+    const embeddings = buildEmbeddingsFacet();
+    const vectors = await embeddings.embed(["alpha", "beta"]);
+
+    expect(vectors).toEqual([
+      [0, 1],
+      [1, 2],
+    ]);
+    expect(embedWithBackendSpy).toHaveBeenCalled();
+  });
+
+  test("a plugin upserts and searches vectors in its own namespaced collection", async () => {
+    const vectorStore = buildVectorStoreFacet("plugin-a");
+    const col = await vectorStore.collection("pages", { vectorSize: 2 });
+
+    await col.upsert([
+      { id: "p1", vector: [0.1, 0.2], payload: { kind: "page" } },
+      { id: "p2", vector: [0.3, 0.4], payload: { kind: "page" } },
+    ]);
+
+    const hits = await col.search([0.1, 0.2], 5);
+    expect(hits.map((h) => h.id).sort()).toEqual(["p1", "p2"]);
+    expect(hits[0].payload).toEqual({ kind: "page" });
+
+    // The host namespaced the collection by the plugin id.
+    expect(openSpy).toHaveBeenCalledWith("plugin-a", "pages", 2);
+    expect(collections.has("plugin_plugin-a_pages")).toBe(true);
+
+    await col.delete(["p1"]);
+    const afterDelete = await col.search([0.1, 0.2], 5);
+    expect(afterDelete.map((h) => h.id)).toEqual(["p2"]);
+  });
+
+  test("two plugins using the same collection name do not collide", async () => {
+    const colA = await buildVectorStoreFacet("plugin-a").collection("notes", {
+      vectorSize: 2,
+    });
+    const colB = await buildVectorStoreFacet("plugin-b").collection("notes", {
+      vectorSize: 2,
+    });
+
+    await colA.upsert([{ id: "x", vector: [1, 0], payload: { owner: "a" } }]);
+    await colB.upsert([{ id: "x", vector: [0, 1], payload: { owner: "b" } }]);
+
+    const fromA = await colA.search([1, 0], 5);
+    const fromB = await colB.search([0, 1], 5);
+
+    expect(fromA).toHaveLength(1);
+    expect(fromA[0].payload).toEqual({ owner: "a" });
+    expect(fromB[0].payload).toEqual({ owner: "b" });
+    expect(collections.has("plugin_plugin-a_notes")).toBe(true);
+    expect(collections.has("plugin_plugin-b_notes")).toBe(true);
+  });
+});

--- a/assistant/src/daemon/__tests__/plugin-host-facets.test.ts
+++ b/assistant/src/daemon/__tests__/plugin-host-facets.test.ts
@@ -158,6 +158,7 @@ import type {
 import { createDaemonSkillHost } from "../daemon-skill-host.js";
 import {
   buildConfigFacet,
+  buildEmbeddingsFacet,
   buildEventsFacet,
   buildIdentityFacet,
   buildLoggerFacet,
@@ -165,6 +166,7 @@ import {
   buildPlatformFacet,
   buildProvidersFacet,
   buildRegistriesFacet,
+  buildVectorStoreFacet,
 } from "../skill-host-facets.js";
 
 /**
@@ -182,6 +184,8 @@ function buildPluginHost(pluginName: string): PluginHost {
     platform: buildPlatformFacet(),
     logger: buildLoggerFacet(pluginName),
     registries: buildRegistriesFacet(pluginName),
+    embeddings: buildEmbeddingsFacet(),
+    vectorStore: buildVectorStoreFacet(pluginName),
   };
 }
 
@@ -231,7 +235,7 @@ describe("external-plugin host bundle", () => {
     expect(getConfiguredProviderSpy).toHaveBeenCalled();
   });
 
-  test("host bundle exposes the eight facets that exist today", () => {
+  test("host bundle exposes the facets that exist today", () => {
     const host = buildPluginHost("example-plugin");
     for (const key of [
       "providers",
@@ -242,6 +246,8 @@ describe("external-plugin host bundle", () => {
       "platform",
       "logger",
       "registries",
+      "embeddings",
+      "vectorStore",
     ] as const) {
       expect(host[key]).toBeDefined();
     }
@@ -263,6 +269,8 @@ describe("external-plugin host bundle", () => {
       "platform",
       "logger",
       "registries",
+      "embeddings",
+      "vectorStore",
     ] as const;
 
     for (const facet of facets) {

--- a/assistant/src/daemon/daemon-skill-host.ts
+++ b/assistant/src/daemon/daemon-skill-host.ts
@@ -18,6 +18,7 @@ import type { SkillHost } from "@vellumai/skill-host-contracts";
 
 import {
   buildConfigFacet,
+  buildEmbeddingsFacet,
   buildEventsFacet,
   buildIdentityFacet,
   buildLoggerFacet,
@@ -26,6 +27,7 @@ import {
   buildProvidersFacet,
   buildRegistriesFacet,
   buildSpeakersFacet,
+  buildVectorStoreFacet,
 } from "./skill-host-facets.js";
 
 /**
@@ -46,5 +48,7 @@ export function createDaemonSkillHost(skillId: string): SkillHost {
     events: buildEventsFacet(),
     registries: buildRegistriesFacet(skillId),
     speakers: buildSpeakersFacet(),
+    embeddings: buildEmbeddingsFacet(),
+    vectorStore: buildVectorStoreFacet(skillId),
   };
 }

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -88,6 +88,7 @@ import { APP_VERSION } from "../version.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
 import {
   buildConfigFacet,
+  buildEmbeddingsFacet,
   buildEventsFacet,
   buildIdentityFacet,
   buildLoggerFacet,
@@ -95,6 +96,7 @@ import {
   buildPlatformFacet,
   buildProvidersFacet,
   buildRegistriesFacet,
+  buildVectorStoreFacet,
 } from "./skill-host-facets.js";
 
 const log = getLogger("plugins-bootstrap");
@@ -171,6 +173,8 @@ function buildPluginHost(pluginName: string): PluginHost {
     platform: buildPlatformFacet(),
     logger: buildLoggerFacet(pluginName),
     registries: buildRegistriesFacet(pluginName),
+    embeddings: buildEmbeddingsFacet(),
+    vectorStore: buildVectorStoreFacet(pluginName),
   };
 }
 

--- a/assistant/src/daemon/skill-host-facets.ts
+++ b/assistant/src/daemon/skill-host-facets.ts
@@ -25,6 +25,7 @@ import type {
   AssistantEvent,
   AssistantEventCallback,
   ConfigFacet,
+  EmbeddingsFacet,
   EventsFacet,
   Filter,
   IdentityFacet,
@@ -49,6 +50,8 @@ import type {
   TtsProvider,
   TtsProvidersFacet,
   UserMessage,
+  VectorCollection,
+  VectorStoreFacet,
 } from "@vellumai/skill-host-contracts";
 
 import { SpeakerIdentityTracker } from "../calls/speaker-identification.js";
@@ -56,6 +59,8 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig, getNestedValue } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { addMessage } from "../persistence/conversation-crud.js";
+import { embedWithBackend } from "../persistence/embeddings/embedding-backend.js";
+import { openPluginVectorCollection } from "../persistence/embeddings/plugin-vector-store.js";
 import {
   createTimeout,
   extractToolUse,
@@ -239,5 +244,37 @@ export function buildRegistriesFacet(hostId: string): RegistriesFacet {
 export function buildSpeakersFacet(): SpeakersFacet {
   return {
     createTracker: () => new SpeakerIdentityTracker(),
+  };
+}
+
+export function buildEmbeddingsFacet(): EmbeddingsFacet {
+  return {
+    embed: async (texts, opts) => {
+      // The host resolves the active embedding backend from config; the
+      // plugin only ever sees vectors out, never the backend identity.
+      const { vectors } = await embedWithBackend(getConfig(), texts, {
+        signal: opts?.signal,
+      });
+      return vectors;
+    },
+  };
+}
+
+export function buildVectorStoreFacet(hostId: string): VectorStoreFacet {
+  return {
+    collection: async (name, options): Promise<VectorCollection> => {
+      // Namespacing by hostId happens inside `openPluginVectorCollection`,
+      // so two hosts asking for the same `name` get distinct collections.
+      const handle = openPluginVectorCollection(
+        hostId,
+        name,
+        options.vectorSize,
+      );
+      return {
+        upsert: (points) => handle.upsert(points),
+        search: (vector, limit) => handle.search(vector, limit),
+        delete: (ids) => handle.delete(ids),
+      };
+    },
   };
 }

--- a/assistant/src/persistence/embeddings/plugin-vector-store.ts
+++ b/assistant/src/persistence/embeddings/plugin-vector-store.ts
@@ -1,0 +1,140 @@
+/**
+ * Generic, plugin-namespaced dense-vector store over Qdrant.
+ *
+ * The memory feature's {@link VellumQdrantClient} is bound to one collection
+ * and carries a memory-specific payload schema (`target_type`, sentinels,
+ * named dense+sparse vectors). Plugins need a neutral surface: a collection
+ * they own, addressed by their own ids, carrying an opaque payload. This
+ * module provides exactly that, sharing only the URL-resolution helper
+ * (`resolveQdrantUrl`, which honours `QDRANT_HTTP_PORT`) with the memory
+ * client so port allocation stays consistent across the process.
+ */
+
+import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
+
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
+import { resolveQdrantUrl } from "./qdrant-client.js";
+
+const log = getLogger("plugin-vector-store");
+
+/** A single dense-vector point. */
+export interface PluginVectorPoint {
+  id: string;
+  vector: number[];
+  payload?: Record<string, unknown>;
+}
+
+/** A search hit, ordered most-similar first. */
+export interface PluginVectorSearchResult {
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Build the Qdrant collection name for a plugin-owned vector store. Namespaced
+ * by `hostId` so two plugins using the same logical `name` never collide.
+ */
+export function pluginCollectionName(hostId: string, name: string): string {
+  return `plugin_${hostId}_${name}`;
+}
+
+/**
+ * A handle to one plugin-owned Qdrant collection. Lazily creates the
+ * collection on first write/read.
+ */
+export class PluginVectorCollection {
+  private readonly client: QdrantRestClient;
+  private readonly collection: string;
+  private readonly vectorSize: number;
+  private ready = false;
+
+  constructor(args: { url: string; collection: string; vectorSize: number }) {
+    this.client = new QdrantRestClient({
+      url: args.url,
+      checkCompatibility: false,
+    });
+    this.collection = args.collection;
+    this.vectorSize = args.vectorSize;
+  }
+
+  private async ensureCollection(): Promise<void> {
+    if (this.ready) return;
+    try {
+      const exists = await this.client.collectionExists(this.collection);
+      if (!exists.exists) {
+        await this.client.createCollection(this.collection, {
+          vectors: { size: this.vectorSize, distance: "Cosine" },
+        });
+      }
+    } catch (err) {
+      // 409 = a concurrent caller created it first — that's fine.
+      if (
+        !(
+          err instanceof Error &&
+          "status" in err &&
+          (err as { status: number }).status === 409
+        )
+      ) {
+        throw err;
+      }
+    }
+    this.ready = true;
+  }
+
+  async upsert(points: PluginVectorPoint[]): Promise<void> {
+    if (points.length === 0) return;
+    await this.ensureCollection();
+    await this.client.upsert(this.collection, {
+      wait: true,
+      points: points.map((p) => ({
+        id: p.id,
+        vector: p.vector,
+        payload: p.payload ?? {},
+      })),
+    });
+  }
+
+  async search(
+    vector: number[],
+    limit: number,
+  ): Promise<PluginVectorSearchResult[]> {
+    await this.ensureCollection();
+    const results = await this.client.search(this.collection, {
+      vector,
+      limit,
+      with_payload: true,
+    });
+    return results.map((r) => ({
+      id: typeof r.id === "string" ? r.id : String(r.id),
+      score: r.score,
+      payload: (r.payload ?? {}) as Record<string, unknown>,
+    }));
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    await this.ensureCollection();
+    await this.client.delete(this.collection, {
+      wait: true,
+      points: ids,
+    });
+  }
+}
+
+/**
+ * Open (or lazily create) a plugin-namespaced vector collection. The Qdrant
+ * URL is resolved per-process via {@link resolveQdrantUrl}, which prefers
+ * `QDRANT_HTTP_PORT` so multi-local instances each talk to their own sidecar.
+ */
+export function openPluginVectorCollection(
+  hostId: string,
+  name: string,
+  vectorSize: number,
+): PluginVectorCollection {
+  const collection = pluginCollectionName(hostId, name);
+  const url = resolveQdrantUrl(getConfig());
+  log.debug({ hostId, collection, vectorSize }, "Opening plugin vector store");
+  return new PluginVectorCollection({ url, collection, vectorSize });
+}

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -107,6 +107,7 @@ export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
   ConfigFacet,
+  EmbeddingsFacet,
   EventsFacet,
   HookFunction,
   IdentityFacet,
@@ -131,6 +132,7 @@ export type {
   ToolExecutionResult,
   TurnCommitContext,
   UserPromptSubmitContext,
+  VectorStoreFacet,
 } from "./types.js";
 export { RiskLevel } from "./types.js";
 

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -6,6 +6,7 @@
 
 import type {
   ConfigFacet,
+  EmbeddingsFacet,
   EventsFacet,
   IdentityFacet,
   LoggerFacet,
@@ -13,6 +14,7 @@ import type {
   PlatformFacet,
   ProvidersFacet,
   RegistriesFacet,
+  VectorStoreFacet,
 } from "@vellumai/skill-host-contracts";
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -41,9 +43,9 @@ export { RiskLevel } from "../tools/types.js";
  * {@link InitContext.host}.
  *
  * Direct `assistant/` source imports remain forbidden for external plugins:
- * this bundle is the only supported path to those subsystems. Embeddings,
- * history, store, and jobs facets are added by later PRs; this surface
- * exposes the facets that exist today.
+ * this bundle is the only supported path to those subsystems. History, store,
+ * and jobs facets are added by later PRs; this surface exposes the facets that
+ * exist today.
  */
 export interface PluginHost {
   /** Resolve LLM/STT/TTS providers and secure keys for the workspace. */
@@ -62,10 +64,15 @@ export interface PluginHost {
   logger: LoggerFacet;
   /** Register tools, skill routes, and shutdown hooks. */
   registries: RegistriesFacet;
+  /** Embed text into dense vectors via the host's configured backend. */
+  embeddings: EmbeddingsFacet;
+  /** Upsert/search/delete dense vectors in a plugin-namespaced collection. */
+  vectorStore: VectorStoreFacet;
 }
 
 export type {
   ConfigFacet,
+  EmbeddingsFacet,
   EventsFacet,
   IdentityFacet,
   LoggerFacet,
@@ -73,6 +80,7 @@ export type {
   PlatformFacet,
   ProvidersFacet,
   RegistriesFacet,
+  VectorStoreFacet,
 } from "@vellumai/skill-host-contracts";
 
 // ─── Logger ──────────────────────────────────────────────────────────────────

--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -105,6 +105,7 @@ import type {
   AssistantEventCallback,
   ConfigFacet,
   EventsFacet,
+  EmbeddingsFacet,
   Filter,
   IdentityFacet,
   InsertMessageFn,
@@ -128,6 +129,10 @@ import type {
   TtsProvider,
   TtsProvidersFacet,
   UserMessage,
+  VectorCollection,
+  VectorPoint,
+  VectorSearchResult,
+  VectorStoreFacet,
 } from "./skill-host.js";
 import type { Tool, ToolContext } from "./tool-types.js";
 
@@ -274,6 +279,8 @@ export class SkillHostClient implements SkillHost {
   readonly events: EventsFacet;
   readonly registries: RegistriesFacet;
   readonly speakers: SpeakersFacet;
+  readonly embeddings: EmbeddingsFacet;
+  readonly vectorStore: VectorStoreFacet;
 
   private readonly options: Required<
     Pick<
@@ -363,6 +370,8 @@ export class SkillHostClient implements SkillHost {
     this.events = this.buildEventsFacet();
     this.registries = this.buildRegistriesFacet();
     this.speakers = this.buildSpeakersFacet();
+    this.embeddings = this.buildEmbeddingsFacet();
+    this.vectorStore = this.buildVectorStoreFacet();
   }
 
   // ── Public lifecycle ────────────────────────────────────────────────────
@@ -1328,6 +1337,43 @@ export class SkillHostClient implements SkillHost {
         ({
           __vellumSkillHostClientHandle: "speaker-tracker",
         }) as unknown,
+    };
+  }
+
+  private buildEmbeddingsFacet(): EmbeddingsFacet {
+    return {
+      // `signal` is local to this process; only the texts cross the wire. The
+      // daemon resolves the active embedding backend from config.
+      embed: async (texts) =>
+        this.call<number[][]>("host.embeddings.embed", { texts }),
+    };
+  }
+
+  private buildVectorStoreFacet(): VectorStoreFacet {
+    const call = this.call.bind(this);
+    return {
+      collection: async (name, options): Promise<VectorCollection> => {
+        // Round-trip once so the daemon can provision the namespaced
+        // collection; subsequent ops carry the same `name`.
+        await call("host.vectorStore.ensure", {
+          name,
+          vectorSize: options.vectorSize,
+        });
+        return {
+          upsert: async (points: VectorPoint[]) => {
+            await call("host.vectorStore.upsert", { name, points });
+          },
+          search: async (vector: number[], limit: number) =>
+            call<VectorSearchResult[]>("host.vectorStore.search", {
+              name,
+              vector,
+              limit,
+            }),
+          delete: async (ids: string[]) => {
+            await call("host.vectorStore.delete", { name, ids });
+          },
+        };
+      },
     };
   }
 

--- a/packages/skill-host-contracts/src/skill-host.ts
+++ b/packages/skill-host-contracts/src/skill-host.ts
@@ -163,7 +163,7 @@ export interface SttProvidersFacet {
    * the daemon's resolver reads credentials and pings the provider catalog.
    */
   resolveStreamingTranscriber(
-    spec: SttSpec,
+    spec: SttSpec
   ): Promise<StreamingTranscriber | null>;
 }
 
@@ -216,7 +216,7 @@ export type InsertMessageFn = (
   conversationId: string,
   role: MessageRole,
   content: string,
-  options?: InsertMessageOptions,
+  options?: InsertMessageOptions
 ) => Promise<unknown>;
 
 /** Opaque payload passed to `memory.wakeAgentForOpportunity`. */
@@ -239,7 +239,7 @@ export interface Filter {
 
 /** Callback invoked for each event that matches a subscriber's filter. */
 export type AssistantEventCallback = (
-  event: AssistantEvent,
+  event: AssistantEvent
 ) => void | Promise<void>;
 
 /** Opaque handle returned by `events.subscribe`. Calling `dispose()` unsubscribes. */
@@ -290,8 +290,80 @@ export interface RegistriesFacet {
    */
   registerShutdownHook(
     name: string,
-    hook: (reason: string) => Promise<void>,
+    hook: (reason: string) => Promise<void>
   ): void;
+}
+
+// ---------------------------------------------------------------------------
+// Embeddings
+//
+// A thin wrapper over the host's configured embedding backend. The host
+// resolves which backend serves the request (local / remote / managed) from
+// the assistant's config; the plugin only sees vectors out. Provider-agnostic
+// by design — no backend identity leaks across this surface.
+// ---------------------------------------------------------------------------
+
+export interface EmbedOptions {
+  /** Abort the in-flight embed request when this signal fires. */
+  signal?: AbortSignal;
+}
+
+export interface EmbeddingsFacet {
+  /**
+   * Embed a batch of texts into dense vectors. Returns one vector per input,
+   * in input order. The host selects the active embedding backend from the
+   * assistant's config; the vector dimensionality matches that backend's
+   * configured size. Rejects when no embedding backend is available.
+   */
+  embed(texts: string[], opts?: EmbedOptions): Promise<number[][]>;
+}
+
+// ---------------------------------------------------------------------------
+// Vector store
+//
+// A plugin-namespaced dense-vector collection. The host names the underlying
+// collection by the plugin's id so two plugins using the same logical name
+// (e.g. "pages") never collide. The plugin supplies its own point ids and an
+// opaque metadata payload; the store round-trips both.
+// ---------------------------------------------------------------------------
+
+/** A single dense-vector point to upsert. */
+export interface VectorPoint {
+  /** Caller-stable id; re-upserting the same id overwrites the point. */
+  id: string;
+  /** Dense embedding for this point. */
+  vector: number[];
+  /** Opaque metadata round-tripped on search results. */
+  payload?: Record<string, unknown>;
+}
+
+/** A search hit, ordered most-similar first. */
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}
+
+export interface VectorStoreFacet {
+  /**
+   * Obtain a handle to a plugin-owned collection. `name` is namespaced by the
+   * plugin id under the hood, so the same `name` from two different plugins
+   * refers to two distinct collections. `vectorSize` fixes the dimensionality
+   * of the collection (must match the embeddings the plugin will write).
+   */
+  collection(
+    name: string,
+    options: { vectorSize: number }
+  ): Promise<VectorCollection>;
+}
+
+export interface VectorCollection {
+  /** Upsert one or more points (overwrites by id). */
+  upsert(points: VectorPoint[]): Promise<void>;
+  /** Nearest-neighbour search; returns up to `limit` hits, best first. */
+  search(vector: number[], limit: number): Promise<VectorSearchResult[]>;
+  /** Delete points by id. Unknown ids are ignored. */
+  delete(ids: string[]): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -330,4 +402,6 @@ export interface SkillHost {
   events: EventsFacet;
   registries: RegistriesFacet;
   speakers: SpeakersFacet;
+  embeddings: EmbeddingsFacet;
+  vectorStore: VectorStoreFacet;
 }


### PR DESCRIPTION
## Summary
- Add EmbeddingsFacet + VectorStoreFacet (skill-host-contracts) backed by persistence/embeddings + Qdrant
- Plugin-namespaced collections; QDRANT_HTTP_PORT preserved; wired into the plugin host bundle

Part of plan: memory-plugin-extraction.md (PR 23 of 32)