### PR TITLE
fix(memory): harden retrospective skill-authoring backstop (self-review remediation)

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -1,6 +1,14 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillSource } from "../config/skills.js";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 const mockRefreshSkillCapabilityMemories = mock(() => {});
@@ -15,6 +23,17 @@ mock.module("../util/logger.js", () => ({
 mock.module("../daemon/skill-memory-refresh.js", () => ({
   refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
+
+/**
+ * Build the injected catalog seam for the ownership-backstop tests. Seeds the
+ * given non-managed (bundled / plugin / workspace) or managed entry so the
+ * backstop's collision check runs without standing up a real catalog. Injecting
+ * via `deps` keeps the mock local — it never leaks `loadSkillCatalog` into other
+ * suites the way a process-global module mock would.
+ */
+function catalogSeam(...entries: { id: string; source: SkillSource }[]) {
+  return { loadCatalog: () => entries };
+}
 
 import { loadSkillCatalog } from "../config/skills.js";
 import { readInstallMeta, writeInstallMeta } from "../skills/install-meta.js";
@@ -493,7 +512,7 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("not assistant-authored");
+    expect(result.content).toContain("not verifiably assistant-authored");
     // The original body and authorship are untouched.
     const skillFile = join(TEST_DIR, "skills", "protected", "SKILL.md");
     expect(readFileSync(skillFile, "utf-8")).toContain("Original body.");
@@ -524,7 +543,7 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("not assistant-authored");
+    expect(result.content).toContain("not verifiably assistant-authored");
     expect(
       existsSync(
         join(TEST_DIR, "skills", "protected-files", "references", "notes.md"),
@@ -564,7 +583,7 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("not assistant-authored");
+    expect(result.content).toContain("not verifiably assistant-authored");
     expect(readFileSync(join(dir, "SKILL.md"), "utf-8")).toContain(
       "Original body.",
     );
@@ -610,5 +629,151 @@ describe("scaffold_managed_skill tool", () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  // ── Ownership backstop: never shadow/overwrite a non-managed skill ─────────
+
+  test("retrospective refuses to CREATE a skill whose id is owned by a bundled skill", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "deep-research",
+        name: "Deep Research",
+        description: "Shadow attempt",
+        body_markdown: "Body.",
+      },
+      makeRetrospectiveContext(),
+      catalogSeam({ id: "deep-research", source: "bundled" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("owned by a bundled skill");
+    // No managed skill was written under that id.
+    expect(
+      existsSync(join(TEST_DIR, "skills", "deep-research", "SKILL.md")),
+    ).toBe(false);
+    expect(mockRefreshSkillCapabilityMemories).not.toHaveBeenCalled();
+  });
+
+  test("retrospective refuses to OVERWRITE a skill whose id is owned by a bundled skill", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "blitz",
+        name: "Blitz",
+        description: "Shadow-overwrite attempt",
+        body_markdown: "Body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+      catalogSeam({ id: "blitz", source: "bundled" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("owned by a bundled skill");
+    expect(mockRefreshSkillCapabilityMemories).not.toHaveBeenCalled();
+  });
+
+  test("retrospective refuses an id owned by a plugin or workspace skill", async () => {
+    for (const source of ["plugin", "workspace"] as const) {
+      const result = await executeScaffoldManagedSkill(
+        {
+          skill_id: "covered-proc",
+          name: "Covered",
+          description: "Shadow attempt",
+          body_markdown: "Body.",
+        },
+        makeRetrospectiveContext(),
+        catalogSeam({ id: "covered-proc", source }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(`owned by a ${source} skill`);
+    }
+  });
+
+  test("retrospective fails closed on an existing managed skill with missing install-meta", async () => {
+    // Seed a managed skill on disk, then strip its install metadata so author
+    // is unverifiable. The seam keeps it managed (no non-managed collision), so
+    // the disk fail-closed branch is what must refuse.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "no-meta",
+        name: "No Meta",
+        description: "Lost provenance",
+        body_markdown: "Original body.",
+      },
+      makeContext(),
+    );
+    const dir = join(TEST_DIR, "skills", "no-meta");
+    rmSync(join(dir, "install-meta.json"));
+    expect(installMetaFor("no-meta")).toBeNull();
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "no-meta",
+        name: "No Meta",
+        description: "Rewrite attempt",
+        body_markdown: "Rewritten body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+      catalogSeam({ id: "no-meta", source: "managed" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not verifiably assistant-authored");
+    expect(readFileSync(join(dir, "SKILL.md"), "utf-8")).toContain(
+      "Original body.",
+    );
+  });
+
+  test("retrospective fails closed on an existing managed skill with corrupt install-meta", async () => {
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "corrupt-meta",
+        name: "Corrupt Meta",
+        description: "Bad provenance",
+        body_markdown: "Original body.",
+      },
+      makeContext(),
+    );
+    const dir = join(TEST_DIR, "skills", "corrupt-meta");
+    writeFileSync(join(dir, "install-meta.json"), "{not valid json");
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "corrupt-meta",
+        name: "Corrupt Meta",
+        description: "Rewrite attempt",
+        body_markdown: "Rewritten body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+      catalogSeam({ id: "corrupt-meta", source: "managed" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not verifiably assistant-authored");
+    expect(readFileSync(join(dir, "SKILL.md"), "utf-8")).toContain(
+      "Original body.",
+    );
+  });
+
+  test("retrospective MAY create a fresh skill whose id is free of any catalog collision", async () => {
+    // Catalog holds only an unrelated bundled skill — no collision on the id.
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "fresh-proc",
+        name: "Fresh Proc",
+        description: "Newly observed procedure",
+        body_markdown: "Do the procedure.",
+      },
+      makeRetrospectiveContext(),
+      catalogSeam({ id: "something-else", source: "bundled" }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(installMetaFor("fresh-proc")?.author).toBe("assistant");
+    expect(existsSync(join(TEST_DIR, "skills", "fresh-proc", "SKILL.md"))).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "find_similar_skills",
-      "description": "Find the existing skills most similar to a goal. Scores the goal against the skill catalog's capability pages and returns a ranked shortlist of nearest skills, each with its name, description, and similarity score. Read-only — it never creates, edits, or deletes anything.",
+      "description": "Find the existing skills most similar to a goal. Scores the goal against the skill catalog's capability pages and returns a ranked shortlist of nearest skills, each with its name, description, source (bundled, managed, plugin, workspace, or extra), and similarity score. Read-only — it never creates, edits, or deletes anything.",
       "category": "skills",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1727,6 +1727,7 @@ export async function createSkill(
       bodyMarkdown: params.bodyMarkdown,
       overwrite: params.overwrite,
       contactId: params.contactId,
+      author: "user",
     });
 
     if (!result.created) {

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -1528,9 +1528,15 @@ describe("memoryRetrospectiveJob", () => {
     expect(instructionText).toContain("references/failure-modes.md");
     expect(instructionText).toContain("`files`");
 
-    // User-skill protection directive.
+    // Ownership directive: only overwrite/refine your own skills; skip
+    // (don't shadow or duplicate) a match of any other source.
     expect(instructionText).toContain(
-      "Never folder-rewrite a user-authored skill",
+      "You may only overwrite or refine a skill YOU authored",
+    );
+    expect(instructionText).toContain("ALREADY COVERED");
+    expect(instructionText).toContain("do not shadow it");
+    expect(instructionText).toContain(
+      "Only CREATE a new skill (fresh `skill_id`) when no existing skill of any source covers the procedure",
     );
 
     // Ordinary facts stay plain remembers — the instruction carries no

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -923,9 +923,9 @@ ${procToSkillsActive ? buildSkillAuthoringSection() : ""}`;
 /**
  * Skill-authoring addendum appended to the fork instruction when
  * procedural-memory-as-skills is active. Directs the pass to capture a
- * genuinely-executed, reusable procedure as a managed skill — preferring to
- * refine an existing assistant-authored sibling over spawning a new one, and
- * never folder-rewriting a user-authored skill.
+ * genuinely-executed, reusable procedure as a managed skill — but only to
+ * overwrite or refine a skill it authored, never to overwrite or shadow a
+ * skill of any other source.
  */
 function buildSkillAuthoringSection(): string {
   return `
@@ -935,11 +935,9 @@ If your review window contains a PROCEDURE you actually carried out — a sequen
 
 When you do capture a procedure:
 
-1. Deduplicate against existing skills first. Call \`find_similar_skills\` with a short description of the procedure's goal. If a returned skill is the SAME procedure (not just an adjacent one), UPDATE it rather than creating a sibling: call \`scaffold_managed_skill\` with that skill's existing \`skill_id\` and \`overwrite: true\`, rewriting the body from what you actually observed in the trace. Otherwise CREATE a new skill with a fresh \`skill_id\`. Bias strongly toward reusing or refining over spawning near-duplicates.
+1. Deduplicate against existing skills first. Call \`find_similar_skills\` with a short description of the procedure's goal. Each hit carries a \`source\` (bundled, managed, plugin, workspace, or extra). You may only overwrite or refine a skill YOU authored — a managed skill you created. If a hit is bundled, plugin, or workspace, or is a managed skill a person wrote, the procedure is ALREADY COVERED: do not \`overwrite\` it, do not shadow it by creating a skill with its \`skill_id\`, and do not create a near-duplicate — skip it. Only when a returned skill is one of your own (a managed skill you authored) and is the SAME procedure, UPDATE it: call \`scaffold_managed_skill\` with that \`skill_id\` and \`overwrite: true\`, rewriting the body from what you actually observed in the trace. Only CREATE a new skill (fresh \`skill_id\`) when no existing skill of any source covers the procedure. Bias strongly toward reusing or refining your own skills over spawning near-duplicates.
 
 2. Capture procedure-scoped knowledge alongside the body. Failure modes, gotchas, and cached values you observed in the trace (error signatures and how you recovered, preconditions, IDs/paths/endpoints that held steady) belong in companion files passed via \`scaffold_managed_skill\`'s \`files\` input (for example \`references/failure-modes.md\`), and the SKILL.md body should reference them so a future load surfaces them.
-
-3. Never folder-rewrite a user-authored skill. If \`find_similar_skills\` returns a skill a person wrote or installed, do not \`overwrite\` it or write companion \`files\` into it — refine conservatively or skip. Companion-file capture and overwrites apply only to skills you authored.
 
 Ordinary facts still go through \`remember\` (unlinked) exactly as above — skills are for executed, reusable procedures, not for facts.
 `;

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -726,16 +726,16 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    test("the old memory_consolidation origin no longer grants skill authoring", async () => {
+    test("only the memory_retrospective origin grants skill authoring", async () => {
       mockIpcClassifyRiskResult = {
         risk: "high",
         reason: "Skill scaffold",
         matchType: "registry",
         scopeOptions: [],
       };
-      // Same guardian/vellum background trust and active feature, but the
-      // consolidation origin — which previously held the grant — must no longer
-      // authorize skill authoring now that it re-points to the retrospective.
+      // Same guardian/vellum background trust and active feature: the
+      // consolidation origin does not authorize skill authoring; only the
+      // retrospective origin holds this grant.
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "deploy-preview" },

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -6,6 +6,7 @@ import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
 import { ipcClassifyRisk } from "../ipc/gateway-client.js";
+import { MEMORY_RETROSPECTIVE_ORIGIN } from "../memory/memory-retrospective-constants.js";
 import { indexCatalogById } from "../skills/include-graph.js";
 import { getSkillRoots } from "../skills/path-classifier.js";
 import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
@@ -688,7 +689,6 @@ export async function classifyRisk(
 // The grant is intentionally narrow: it matches exactly these tools AND the
 // retrospective origin under the active flag, so no interactive session, other
 // origin, or feature-off install is affected.
-const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
 const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
 
 function isRetrospectiveSkillAuthoringGrant(

--- a/assistant/src/tools/skills/find-similar-skills.test.ts
+++ b/assistant/src/tools/skills/find-similar-skills.test.ts
@@ -4,13 +4,15 @@
  * The tool's shortlist + catalog seams are dependency-injected via `deps`, so
  * these tests exercise the input validation, the catalog name/description join,
  * and the `limit` pass-through without Qdrant. Coverage:
- *   - Maps each shortlist hit to its catalog name/description and score.
+ *   - Maps each shortlist hit to its catalog name/description/source and score.
  *   - Drops a shortlist hit whose id is absent from the catalog.
  *   - Passes `limit` through to the shortlist (and defaults when omitted).
  *   - Rejects a missing/blank goal and a non-positive-integer limit.
  */
 
 import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillSource } from "../../config/skills.js";
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -31,11 +33,16 @@ function makeContext(): ToolContext {
 }
 
 const catalog = (
-  ...skills: { id: string; name: string; description: string }[]
+  ...skills: {
+    id: string;
+    name: string;
+    description: string;
+    source: SkillSource;
+  }[]
 ) => skills;
 
 describe("find_similar_skills — enrichment", () => {
-  test("maps each hit to its catalog name/description and score", async () => {
+  test("maps each hit to its catalog name/description/source and score", async () => {
     const result = await executeFindSimilarSkills(
       { goal: "ship the web app" },
       makeContext(),
@@ -50,11 +57,13 @@ describe("find_similar_skills — enrichment", () => {
               id: "deploy-web",
               name: "Deploy Web",
               description: "Ship the web app to prod",
+              source: "managed",
             },
             {
               id: "clean-disk",
               name: "Clean Disk",
               description: "Free up disk space",
+              source: "bundled",
             },
           ),
       },
@@ -67,12 +76,14 @@ describe("find_similar_skills — enrichment", () => {
           skill_id: "deploy-web",
           name: "Deploy Web",
           description: "Ship the web app to prod",
+          source: "managed",
           score: 0.91,
         },
         {
           skill_id: "clean-disk",
           name: "Clean Disk",
           description: "Free up disk space",
+          source: "bundled",
           score: 0.7,
         },
       ],
@@ -93,6 +104,7 @@ describe("find_similar_skills — enrichment", () => {
             id: "present",
             name: "Present",
             description: "Exists in catalog",
+            source: "plugin",
           }),
       },
     );
@@ -103,6 +115,7 @@ describe("find_similar_skills — enrichment", () => {
           skill_id: "present",
           name: "Present",
           description: "Exists in catalog",
+          source: "plugin",
           score: 0.9,
         },
       ],

--- a/assistant/src/tools/skills/find-similar-skills.ts
+++ b/assistant/src/tools/skills/find-similar-skills.ts
@@ -1,12 +1,19 @@
+import type { SkillSource } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { nearestExistingSkills } from "../../plugins/defaults/memory-v3-shadow/candidate-match.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
-/** A shortlisted skill enriched with its catalog name and description. */
+/**
+ * A shortlisted skill enriched with its catalog name, description, and source.
+ * `source` lets the caller see whether an existing skill of ANY origin already
+ * covers the goal — a bundled/plugin/workspace match (or a person-authored
+ * managed one) is not the retrospective's to overwrite or duplicate.
+ */
 interface EnrichedHit {
   skill_id: string;
   name: string;
   description: string;
+  source: SkillSource;
   score: number;
 }
 
@@ -23,7 +30,12 @@ export async function executeFindSimilarSkills(
   _context: ToolContext,
   deps: {
     nearestExistingSkills?: typeof nearestExistingSkills;
-    loadCatalog?: () => { id: string; name: string; description: string }[];
+    loadCatalog?: () => {
+      id: string;
+      name: string;
+      description: string;
+      source: SkillSource;
+    }[];
   } = {},
 ): Promise<ToolExecutionResult> {
   const goal = input.goal;
@@ -65,6 +77,7 @@ export async function executeFindSimilarSkills(
       skill_id: hit.skillId,
       name: skill.name,
       description: skill.description,
+      source: skill.source,
       score: hit.score,
     });
   }

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -1,17 +1,16 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import type { SkillSource } from "../../config/skills.js";
+import { loadSkillCatalog } from "../../config/skills.js";
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
+import { MEMORY_RETROSPECTIVE_ORIGIN } from "../../memory/memory-retrospective-constants.js";
 import { readInstallMeta } from "../../skills/install-meta.js";
 import {
   createManagedSkill,
   getManagedSkillDir,
 } from "../../skills/managed-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-
-/**
- * Origin tag the memory-retrospective wake stamps onto `ToolContext`. Scaffolds
- * under this origin are tagged `author: "assistant"` and may not folder-rewrite
- * a `author: "user"` skill (see the backstop in `executeScaffoldManagedSkill`).
- */
-const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
 
 /** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
 function sanitizeFrontmatterValue(value: string): string {
@@ -21,10 +20,15 @@ function sanitizeFrontmatterValue(value: string): string {
 /**
  * Core execution logic for scaffold_managed_skill.
  * Exported so bundled-skill executors and tests can call it directly.
+ *
+ * `deps` injects the catalog seam so the ownership backstop's non-managed
+ * collision check can be exercised without standing up a real bundled/plugin
+ * catalog.
  */
 export async function executeScaffoldManagedSkill(
   input: Record<string, unknown>,
   context: ToolContext,
+  deps: { loadCatalog?: () => { id: string; source: SkillSource }[] } = {},
 ): Promise<ToolExecutionResult> {
   const skillId = input.skill_id;
   if (typeof skillId !== "string" || !skillId.trim()) {
@@ -133,32 +137,54 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  const id = skillId.trim();
   const fromRetrospective =
     context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
   const author = fromRetrospective ? "assistant" : "user";
 
-  // Backstop: a retrospective pass may only overwrite or write companion files
-  // into a skill IT authored. Refuse an overwrite OR companion-file write that
-  // targets an EXISTING skill that is not `author: "assistant"` — i.e. both
-  // `author: "user"` AND untagged/legacy skills (e.g. those created via the
-  // `createSkill` API route, whose install-meta carries no author) are
-  // protected, matching the prune side where untagged skills are never pruned.
-  // The prompt already directs the model to refine such skills conservatively or
-  // author a new one; this is the enforcement layer behind that judgement call.
-  // `readInstallMeta` returns null for a not-yet-existing skill, so a fresh
-  // create falls through.
-  if (fromRetrospective && (input.overwrite === true || files !== undefined)) {
-    const existingMeta = readInstallMeta(getManagedSkillDir(skillId.trim()));
-    if (existingMeta !== null && existingMeta.author !== "assistant") {
+  // Ownership backstop (retrospective origin only): the retrospective may author
+  // a skill ONLY if it owns it. Fail closed on either of two collisions.
+  if (fromRetrospective) {
+    // (1) A non-managed catalog entry (bundled, plugin, workspace, extra) owns
+    // this id. Creating a managed skill with that id SHADOWS the catalog entry,
+    // and an overwrite under the managed dir would never touch it — either way
+    // the retrospective must not stand on a skill it did not author. This covers
+    // create AND overwrite. The prompt directs the model to skip when an
+    // existing skill of any source already covers the procedure; this enforces
+    // it.
+    const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
+    const nonManagedOwner = loadCatalog().find(
+      (s) => s.id === id && s.source !== "managed",
+    );
+    if (nonManagedOwner) {
       return {
-        content: `Error: skill "${skillId.trim()}" is not assistant-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
+        content: `Error: skill "${id}" is owned by a ${nonManagedOwner.source} skill; the retrospective may not create, overwrite, or shadow it. The procedure is already covered — skip it.`,
+        isError: true,
+      };
+    }
+
+    // (2) A managed skill already exists on disk but is not VERIFIABLY
+    // assistant-authored. `readInstallMeta` returns null for a fresh create AND
+    // for an existing skill whose install-meta/version.json is missing or
+    // corrupt — so gate on the SKILL.md existing and the author tag reading
+    // exactly "assistant". This fails closed on user-authored, untagged, and
+    // unverifiable (missing/corrupt meta) managed skills alike, matching the
+    // prune side where such skills are never pruned.
+    const managedDir = getManagedSkillDir(id);
+    const managedSkillExists = existsSync(join(managedDir, "SKILL.md"));
+    if (
+      managedSkillExists &&
+      readInstallMeta(managedDir)?.author !== "assistant"
+    ) {
+      return {
+        content: `Error: skill "${id}" is not verifiably assistant-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
         isError: true,
       };
     }
   }
 
   const result = createManagedSkill({
-    id: skillId.trim(),
+    id,
     name: sanitizeFrontmatterValue(name),
     description: sanitizeFrontmatterValue(description),
     bodyMarkdown: bodyMarkdown,
@@ -181,7 +207,7 @@ export async function executeScaffoldManagedSkill(
   return {
     content: JSON.stringify({
       created: true,
-      skill_id: skillId.trim(),
+      skill_id: id,
       path: result.path,
     }),
     isError: false,


### PR DESCRIPTION
## Summary
Self-review remediation for the procedural-memory-as-skills feature branch:
- Backstop now ownership-based + fail-closed: the retrospective may only create/overwrite a MANAGED skill it authored (author:assistant); it refuses to shadow/overwrite bundled/plugin/workspace skills (id collision) and refuses an existing managed skill with missing/corrupt/non-assistant meta.
- find_similar_skills surfaces each hit's source; the fork instruction directs skip (don't shadow/duplicate) for non-owned matches.
- Consolidated the triple-defined memory_retrospective origin constant to one definition.
- Present-tense checker test comments; desktop createSkill route tags author:user.

Part of plan: procedural-memory-as-skills.md (self-review remediation, round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->