### PR TITLE
feat(plugin-api): allow external memory plugins; enforce one active memory plugin

### DIFF
--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -66,6 +66,7 @@ import {
   getAllDefaultPlugins,
   registerDefaultPlugins,
 } from "../plugins/defaults/index.js";
+import { assertSingleMemoryPlugin } from "../plugins/memory-capability.js";
 import { getRegisteredPlugins, unregisterPlugin } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -211,6 +212,20 @@ function getDisabledPluginFlag(
 export async function initializePlugins(): Promise<void> {
   registerDefaultPlugins();
   await loadUserPlugins();
+  // Enforce the single-active-memory-plugin rule now that user plugins are
+  // discovered. Two simultaneously-active external memory plugins is a
+  // misconfiguration the built-in cannot yield to; surface it loudly. We log
+  // rather than throw so one misconfigured pair never blocks daemon startup —
+  // the read-time guards fail safe (built-in stays active) until the operator
+  // disables the extras.
+  try {
+    assertSingleMemoryPlugin();
+  } catch (err) {
+    log.error(
+      { err },
+      'memory-capability conflict — multiple plugins declare provides: "memory"; the built-in memory system stays active until only one external memory plugin is enabled',
+    );
+  }
   try {
     await bootstrapPlugins();
   } catch (err) {

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -18,6 +18,10 @@
  */
 
 import { isPluginDisabled } from "../plugins/disabled-state.js";
+import {
+  isBuiltinMemoryPlugin,
+  shouldBuiltinMemoryYield,
+} from "../plugins/memory-capability.js";
 import { getUserHooksFor } from "../plugins/mtime-cache.js";
 import type { HookFunction } from "../plugins/types.js";
 
@@ -93,19 +97,30 @@ export function unregisterPluginHooks(pluginName: string): void {
 export async function getHooksFor<TCtx = unknown>(
   name: string,
 ): Promise<HookFunction<TCtx>[]> {
+  // User-land hooks from the mtime cache (async, may re-import). Fetched first
+  // because the same call refreshes plugin discovery — including the
+  // memory-capability set the built-in-yield check below reads — so an external
+  // memory plugin installed/removed this turn is reflected immediately.
+  const userHooks = await getUserHooksFor<TCtx>(name);
+
+  // When an external `provides: "memory"` plugin is active, the built-in memory
+  // plugins yield: their hooks are dropped here so injection and turn-commit are
+  // driven solely by the external plugin (read-time, like the `.disabled`
+  // sentinel). Two active external memory plugins fail safe (built-in stays
+  // active); `assertSingleMemoryPlugin` surfaces that misconfiguration.
+  const builtinMemoryYields = shouldBuiltinMemoryYield();
+
   // First-party defaults from the hook registry, filtered by the `.disabled`
   // sentinel at read time. This is what makes `assistant plugins disable
   // default-*` take effect immediately in a running assistant: the hooks stay
   // registered but are filtered out on the next turn.
   const defaultHooks: HookFunction<TCtx>[] = [];
   for (const entry of hookRegistry.get(name) ?? []) {
-    if (!isPluginDisabled(entry.pluginName)) {
-      defaultHooks.push(entry.fn as HookFunction<TCtx>);
-    }
+    if (isPluginDisabled(entry.pluginName)) continue;
+    if (builtinMemoryYields && isBuiltinMemoryPlugin(entry.pluginName))
+      continue;
+    defaultHooks.push(entry.fn as HookFunction<TCtx>);
   }
-
-  // User-land hooks from the mtime cache (async, may re-import).
-  const userHooks = await getUserHooksFor<TCtx>(name);
 
   return [...defaultHooks, ...userHooks];
 }

--- a/assistant/src/plugins/__tests__/memory-capability.test.ts
+++ b/assistant/src/plugins/__tests__/memory-capability.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the single-active-memory-plugin rule.
+ *
+ * An external plugin declaring `vellum.provides === "memory"` in its
+ * `package.json` takes over the conversation's memory system: the built-in
+ * memory plugins (`memory-retrieval`, `memory-v3-shadow`) yield, so their hooks
+ * are filtered out at read time. Two simultaneously-active external memory
+ * plugins is a misconfiguration rejected by `assertSingleMemoryPlugin`. With no
+ * external memory plugin installed, the built-ins run exactly as before.
+ *
+ * Discovery is driven by the mtime cache (`scanPlugins`), which `getHooksFor`
+ * refreshes via `getUserHooksFor`, so creating/removing plugin directories at
+ * runtime is reflected on the next read — the same semantics as the `.disabled`
+ * sentinel.
+ */
+
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const TEST_WORKSPACE_DIR = join(
+  tmpdir(),
+  `vellum-memory-capability-test-${process.pid}-${Date.now()}`,
+);
+process.env.VELLUM_WORKSPACE_DIR = TEST_WORKSPACE_DIR;
+
+import { getHooksFor, registerPluginHooks } from "../../hooks/registry.js";
+import { assertSingleMemoryPlugin } from "../memory-capability.js";
+import { resetPluginCacheForTests } from "../mtime-cache.js";
+import { resetPluginRegistryForTests } from "../registry.js";
+
+/**
+ * Create an external plugin directory with a `package.json`. When `provides` is
+ * given, the manifest declares `vellum.provides`. A trivial `user-prompt-submit`
+ * hook is written so the plugin contributes a hook of its own (proving the
+ * external plugin drives injection).
+ */
+async function createExternalPlugin(
+  name: string,
+  opts: { provides?: "memory" } = {},
+): Promise<void> {
+  const dir = join(TEST_WORKSPACE_DIR, "plugins", name);
+  await mkdir(join(dir, "hooks"), { recursive: true });
+  const pkg: Record<string, unknown> = { name, version: "1.0.0" };
+  if (opts.provides !== undefined) {
+    pkg.vellum = { provides: opts.provides };
+  }
+  await writeFile(join(dir, "package.json"), JSON.stringify(pkg, null, 2));
+  await writeFile(
+    join(dir, "hooks", "user-prompt-submit.ts"),
+    "export default async function () {}\n",
+  );
+}
+
+/**
+ * Register the two built-in memory plugins' `user-prompt-submit` hooks into the
+ * in-process registry under their canonical names, mirroring what
+ * `registerDefaultPlugins` does at boot. We register only the hook surface here
+ * so the test exercises the read-time yield without booting the full default
+ * set.
+ */
+function registerBuiltinMemoryHooks(): void {
+  registerPluginHooks("memory-retrieval", {
+    "user-prompt-submit": async () => {},
+  });
+  registerPluginHooks("memory-v3-shadow", {
+    "user-prompt-submit": async () => {},
+  });
+}
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+  resetPluginCacheForTests();
+});
+
+afterEach(async () => {
+  await rm(join(TEST_WORKSPACE_DIR, "plugins"), {
+    recursive: true,
+    force: true,
+  });
+  resetPluginCacheForTests();
+  resetPluginRegistryForTests();
+});
+
+describe("single-active-memory-plugin rule", () => {
+  test("an enabled external memory plugin disables the built-in memory hooks", async () => {
+    registerBuiltinMemoryHooks();
+
+    // Baseline: with no external memory plugin, both built-in memory hooks run.
+    let hooks = await getHooksFor("user-prompt-submit");
+    expect(hooks).toHaveLength(2);
+
+    // Install an external plugin that provides memory.
+    await createExternalPlugin("external-memory", { provides: "memory" });
+
+    // The external plugin's own hook is included, and BOTH built-in memory
+    // hooks are filtered out — only the external memory hook remains.
+    hooks = await getHooksFor("user-prompt-submit");
+    expect(hooks).toHaveLength(1);
+  });
+
+  test("removing the external memory plugin restores the built-in memory hooks", async () => {
+    registerBuiltinMemoryHooks();
+    await createExternalPlugin("external-memory", { provides: "memory" });
+
+    let hooks = await getHooksFor("user-prompt-submit");
+    expect(hooks).toHaveLength(1);
+
+    // Remove the external plugin — the built-ins stop yielding on the next read.
+    await rm(join(TEST_WORKSPACE_DIR, "plugins", "external-memory"), {
+      recursive: true,
+      force: true,
+    });
+
+    hooks = await getHooksFor("user-prompt-submit");
+    expect(hooks).toHaveLength(2);
+  });
+
+  test("a non-memory external plugin does not make the built-in yield", async () => {
+    registerBuiltinMemoryHooks();
+
+    // External plugin with no `provides` marker — its hook adds to the chain but
+    // the built-in memory hooks stay active.
+    await createExternalPlugin("regular-plugin");
+
+    const hooks = await getHooksFor("user-prompt-submit");
+    // 2 built-in memory hooks + 1 external plugin hook.
+    expect(hooks).toHaveLength(3);
+  });
+
+  test("two active memory-capability plugins are rejected with a clear error", async () => {
+    await createExternalPlugin("memory-a", { provides: "memory" });
+    await createExternalPlugin("memory-b", { provides: "memory" });
+
+    // Trigger a discovery scan so the mtime cache observes both plugins.
+    await getHooksFor("user-prompt-submit");
+
+    expect(() => assertSingleMemoryPlugin()).toThrow(
+      /multiple memory-capability plugins are active/,
+    );
+    // The error names both offenders so an operator can disable one.
+    expect(() => assertSingleMemoryPlugin()).toThrow(/memory-a/);
+    expect(() => assertSingleMemoryPlugin()).toThrow(/memory-b/);
+  });
+
+  test("two active memory plugins fail safe: the built-in stays active", async () => {
+    registerBuiltinMemoryHooks();
+    await createExternalPlugin("memory-a", { provides: "memory" });
+    await createExternalPlugin("memory-b", { provides: "memory" });
+
+    // With two external memory plugins, the built-in does NOT yield (fail safe).
+    // Hooks: 2 built-in memory + 2 external plugin hooks.
+    const hooks = await getHooksFor("user-prompt-submit");
+    expect(hooks).toHaveLength(4);
+  });
+
+  test("no external memory plugin: assertSingleMemoryPlugin does not throw", async () => {
+    await getHooksFor("user-prompt-submit");
+    expect(() => assertSingleMemoryPlugin()).not.toThrow();
+  });
+});

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -85,6 +85,17 @@ const PluginPackageJsonSchema = z
     name: z.string().min(1, "package.json `name` must be a non-empty string"),
     version: z.string().optional(),
     peerDependencies: z.record(z.string(), z.string()).optional(),
+    /**
+     * Vellum-specific manifest metadata namespaced under `vellum` so it does
+     * not collide with standard npm fields. `provides` declares a host
+     * capability the plugin satisfies (today only `"memory"`).
+     */
+    vellum: z
+      .object({
+        provides: z.literal("memory").optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough();
 
@@ -275,6 +286,9 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
   }
 
   const manifest: PluginManifest = { name, version };
+  if (pkg.vellum?.provides !== undefined) {
+    manifest.provides = pkg.vellum.provides;
+  }
   const plugin: Plugin = { manifest };
 
   const hooks = await loadHooks(pluginDir, name);
@@ -389,7 +403,7 @@ export async function loadExternalPlugin(
  */
 export async function parsePluginManifest(
   pluginDir: string,
-): Promise<{ name: string; version: string } | undefined> {
+): Promise<{ name: string; version: string; provides?: "memory" } | undefined> {
   const pkgPath = join(pluginDir, "package.json");
   let rawPkg: unknown;
   try {
@@ -413,5 +427,8 @@ export async function parsePluginManifest(
   const pkg: PluginPackageJson = parsed.data;
   const name = stripScope(pkg.name);
   const version = pkg.version && pkg.version.length > 0 ? pkg.version : "0.0.0";
-  return { name, version };
+  const provides = pkg.vellum?.provides;
+  return provides !== undefined
+    ? { name, version, provides }
+    : { name, version };
 }

--- a/assistant/src/plugins/memory-capability.ts
+++ b/assistant/src/plugins/memory-capability.ts
@@ -1,0 +1,81 @@
+/**
+ * Memory-capability arbiter — enforces the single-active-memory-plugin rule.
+ *
+ * The conversation's memory system (per-turn `<memory>` injection + post-turn
+ * consolidation enqueue) is owned by exactly one plugin at a time. The built-in
+ * memory plugins (`memory-retrieval`, `memory-v3-shadow`) provide it by default.
+ * An external plugin can take over by declaring `vellum.provides === "memory"`
+ * in its `package.json`; when such a plugin is installed and enabled, the
+ * built-in memory plugins yield — their hooks are filtered out at read time so
+ * they contribute neither injection nor turn-commit work.
+ *
+ * "Active" is read from the live mtime-cache discovery set
+ * ({@link getDiscoveredMemoryCapabilityPlugins}), so installing, disabling, or
+ * removing an external memory plugin takes effect on the next turn without a
+ * restart — the same read-time semantics as the `.disabled` sentinel.
+ *
+ * Two simultaneously-active external memory plugins is a misconfiguration: the
+ * built-in cannot yield to both. {@link assertSingleMemoryPlugin} throws a clear
+ * error so bootstrap can surface it loudly; the read-time guards fail safe by
+ * leaving the built-in active rather than silently routing to an arbitrary
+ * external plugin.
+ */
+
+import { getDiscoveredMemoryCapabilityPlugins } from "./mtime-cache.js";
+import { PluginExecutionError } from "./types.js";
+
+/**
+ * Built-in plugin names that provide the memory system. These yield when an
+ * external `provides: "memory"` plugin is active. Recognized by name (not by a
+ * manifest `provides` field) because they are first-party defaults.
+ */
+const BUILTIN_MEMORY_PLUGIN_NAMES: ReadonlySet<string> = new Set([
+  "memory-retrieval",
+  "memory-v3-shadow",
+]);
+
+/**
+ * Whether `pluginName` is one of the built-in memory plugins that must yield to
+ * an active external memory-capability plugin.
+ */
+export function isBuiltinMemoryPlugin(pluginName: string): boolean {
+  return BUILTIN_MEMORY_PLUGIN_NAMES.has(pluginName);
+}
+
+/**
+ * The enabled external plugins currently declaring `provides: "memory"`, read
+ * from the live mtime-cache discovery set.
+ */
+export function getActiveExternalMemoryPlugins(): string[] {
+  return getDiscoveredMemoryCapabilityPlugins();
+}
+
+/**
+ * Whether the built-in memory plugins should yield this read. True when exactly
+ * one external memory-capability plugin is active. When two or more are active
+ * we fail safe (return false → built-in stays active) rather than route to an
+ * arbitrary one; {@link assertSingleMemoryPlugin} surfaces the misconfiguration.
+ */
+export function shouldBuiltinMemoryYield(): boolean {
+  return getActiveExternalMemoryPlugins().length === 1;
+}
+
+/**
+ * Throw when two or more external memory-capability plugins are active
+ * simultaneously — only one plugin may own the conversation's memory system.
+ * Called at bootstrap so the misconfiguration is surfaced loudly at startup.
+ * A single active external memory plugin (or none) is valid and returns.
+ */
+export function assertSingleMemoryPlugin(): void {
+  const active = getActiveExternalMemoryPlugins();
+  if (active.length > 1) {
+    throw new PluginExecutionError(
+      `multiple memory-capability plugins are active (${active
+        .sort()
+        .join(
+          ", ",
+        )}) — at most one plugin may declare provides: "memory". Disable all but one and restart.`,
+      undefined,
+    );
+  }
+}

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -171,6 +171,26 @@ const discoveredPluginDirs = new Map<string, string>();
  */
 const disabledPluginDirs = new Set<string>();
 
+/**
+ * Names of currently-discovered, enabled user plugins that declare
+ * `vellum.provides === "memory"` in their `package.json`. Refreshed on every
+ * `scanPlugins` so the set tracks live install/uninstall/disable transitions.
+ * Read by the memory-capability arbiter (`plugins/memory-capability.ts`) to
+ * decide whether the built-in memory plugins yield. `.disabled` plugins are
+ * excluded — a disabled external memory plugin must not make the built-in yield.
+ */
+const memoryCapabilityPluginNames = new Set<string>();
+
+/**
+ * Names of currently-discovered, enabled user plugins that declare
+ * `vellum.provides === "memory"`. The arbiter in `plugins/memory-capability.ts`
+ * uses this to enforce the single-active-memory-plugin rule and to suppress the
+ * built-in memory hooks when an external memory plugin is installed.
+ */
+export function getDiscoveredMemoryCapabilityPlugins(): string[] {
+  return Array.from(memoryCapabilityPluginNames);
+}
+
 // ─── Hook reads ──────────────────────────────────────────────────────────────
 
 /**
@@ -302,6 +322,10 @@ async function scanPlugins(): Promise<void> {
   }
 
   const currentDirs = new Map<string, string>();
+  // Rebuilt fresh each scan from the enabled plugins discovered below, so a
+  // disabled/removed external memory plugin drops out and the built-in stops
+  // yielding to it.
+  const currentMemoryCapabilityNames = new Set<string>();
 
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
@@ -339,6 +363,9 @@ async function scanPlugins(): Promise<void> {
 
     currentDirs.set(pluginDir, pluginName);
     disabledPluginDirs.delete(pluginDir);
+    if (manifest.provides === "memory") {
+      currentMemoryCapabilityNames.add(pluginName);
+    }
 
     if (!discoveredPluginDirs.has(pluginDir)) {
       log.info({ plugin: pluginName, pluginDir }, "plugin discovered");
@@ -364,6 +391,13 @@ async function scanPlugins(): Promise<void> {
   );
   for (const [dir, name] of sorted) {
     discoveredPluginDirs.set(dir, name);
+  }
+
+  // Swap in the freshly-computed memory-capability set so a disabled or removed
+  // external memory plugin stops suppressing the built-in memory hooks.
+  memoryCapabilityPluginNames.clear();
+  for (const name of currentMemoryCapabilityNames) {
+    memoryCapabilityPluginNames.add(name);
   }
 
   // Activate any plugin not yet brought up. Idempotent: already-active plugins
@@ -416,6 +450,7 @@ async function evictAll(): Promise<void> {
   discoveredPluginDirs.clear();
   installDateCache.clear();
   disabledPluginDirs.clear();
+  memoryCapabilityPluginNames.clear();
 }
 
 // ─── Activation lifecycle ────────────────────────────────────────────────────
@@ -605,6 +640,7 @@ export function resetPluginCacheForTests(): void {
   activatedPlugins.length = 0;
   activatedNames.clear();
   disabledPluginDirs.clear();
+  memoryCapabilityPluginNames.clear();
 }
 
 /**

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -28,18 +28,32 @@ import { AssistantError, ErrorCode } from "../util/errors.js";
 // ─── Manifest ────────────────────────────────────────────────────────────────
 
 /**
+ * A capability a plugin can declare it satisfies via `manifest.provides`.
+ *
+ * `"memory"` marks a plugin as the conversation's memory system — the producer
+ * of per-turn `<memory>` injection and the post-turn consolidation enqueue. At
+ * most one memory-capability plugin may be active at a time: when an external
+ * `provides: "memory"` plugin is enabled, the built-in memory plugins yield (see
+ * `plugins/memory-capability.ts`).
+ */
+export type PluginCapability = "memory";
+
+/**
  * Static metadata describing a plugin — declared at module load time and
  * validated by the registry (duplicate-name check, API-version compatibility).
- *
- * `provides` and `requires` are capability → semantic-version maps. The
- * registry checks each entry in `requires` against the assistant's exposed
- * capability table and refuses to register plugins that ask for a version the
- * assistant does not expose. `provides` is currently declared-but-unused —
- * see the field docstring below.
  */
 export interface PluginManifest {
   /** Unique plugin identifier (kebab-case). Duplicate names fail registration. */
   name: string;
+  /**
+   * Capability this plugin declares it satisfies. Currently only `"memory"` is
+   * recognized — it marks the plugin as the active memory system. The
+   * single-active-memory-plugin rule is enforced at bootstrap and at hook
+   * read time (see `plugins/memory-capability.ts`). External plugins declare
+   * this via `package.json` `vellum.provides`; built-in memory plugins are
+   * recognized by name, not by this field.
+   */
+  provides?: PluginCapability;
   /**
    * Plugin version (semver). Informational. Host-compat negotiation lives
    * in the plugin's `package.json` `peerDependencies["@vellumai/plugin-api"]`


### PR DESCRIPTION
## Summary
- Add provides:'memory' capability marker; built-in memory yields to an enabled external memory plugin
- Two active memory plugins rejected; default (no external) behavior unchanged
- External plugins can register user-prompt-submit/post-compact/turn-commit hooks

Part of plan: memory-plugin-extraction.md (PR 27 of 32)