### PR TITLE
feat(memory): reference memory plugin built entirely on the public host facets

### DIFF
--- a/assistant/examples/plugins/memory-reference/README.md
+++ b/assistant/examples/plugins/memory-reference/README.md
@@ -1,0 +1,94 @@
+# memory-reference plugin
+
+The **reference implementation of a long-term memory plugin** built entirely on
+the public `@vellumai/plugin-api` contract. It implements a real (if
+deliberately simple) memory system — `remember`/`recall` tools, per-turn
+`<memory>` injection, and post-turn consolidation — using **only the host
+facets** the assistant hands a plugin at `init`. It imports nothing from
+`assistant/` source: no `getDb`, no `persistence/`, no internal memory modules.
+
+Its purpose is to prove the public contract is sufficient: a third party could
+ship this exact plugin against the published `@vellumai/plugin-api` package
+alone. It is a bundled **example**, not the live default memory — installing it
+does not change the assistant's default behavior.
+
+## What it does
+
+| Surface                 | File                          | Host facet(s) used                                                                                                                                                            |
+| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bootstrap               | `hooks/init.ts`               | `host.store` (migrate the fact table), `host.vectorStore` (resolve the collection), `host.jobs` (register the consolidation handler), `host.embeddings` (size the collection) |
+| `remember` tool         | `tools/remember.ts`           | `host.embeddings` → `host.store` → `host.vectorStore`                                                                                                                         |
+| `recall` tool           | `tools/recall.ts`             | `host.embeddings` → `host.vectorStore` → `host.store`                                                                                                                         |
+| Per-turn injection      | `hooks/user-prompt-submit.ts` | `host.history` (recent context) + vector search → injects a `<memory>` block                                                                                                  |
+| Post-turn consolidation | `hooks/turn-commit.ts`        | `host.jobs.enqueue` (NO synchronous LLM work)                                                                                                                                 |
+
+The plugin declares `vellum.provides: "memory"` in its manifest — the capability
+marker that lets it stand in for the built-in memory system. (Wiring it as a
+_selectable / live_ provider is explicit follow-up; this PR ships it as an
+example only.)
+
+## How memory is stored
+
+- **Facts** live in a durable, plugin-owned table the host namespaces to
+  `plugin_memoryreference_facts`. The store rejects any statement that touches a
+  table outside the plugin's `plugin_<id>_` prefix, so the plugin can only read
+  and write its own rows.
+- **Embeddings** go into a plugin-namespaced dense-vector collection via
+  `host.vectorStore`. The plugin learns the backend's vector dimensionality from
+  a probe embed at `init` and sizes the collection to match.
+- The durable store is the **source of truth** for fact text; the vector
+  payload is a denormalized convenience. `recall` searches the vectors, then
+  hydrates the canonical rows from the store.
+
+## Consolidation is off the hot path
+
+`turn-commit` does no synchronous work beyond `host.jobs.enqueue` — the
+salient-fact extraction, embed, and store run later on the assistant's worker
+loop, off the commit path. A production plugin would summarize the turn in that
+job handler (still on the worker, never synchronously, never at boot). This
+reference keeps the handler LLM-free for determinism: it stores the turn's user
+prompt as a fact.
+
+## Layout
+
+```
+memory-reference/
+├── package.json               # Manifest; peerDependencies["@vellumai/plugin-api"]; vellum.provides = "memory"
+├── README.md
+├── hooks/
+│   ├── init.ts                # Migrate tables, resolve collection, register job handler
+│   ├── user-prompt-submit.ts  # Vector search + history context → inject <memory>
+│   └── turn-commit.ts         # Enqueue consolidation job (no synchronous work)
+├── tools/
+│   ├── remember.ts            # embed → store → upsert vector
+│   └── recall.ts              # embed query → search → hydrate rows
+├── src/
+│   └── state.ts               # Shared runtime + pure helpers (NOT a loader surface)
+└── __tests__/
+    └── memory-reference.test.ts  # remember→recall + injection through mocked host facets
+```
+
+## Install locally
+
+The assistant scans `<workspaceDir>/plugins/*` for subdirectories containing a
+`package.json` and loads each one at startup. Symlink (or copy) this directory
+in:
+
+```bash
+mkdir -p "$VELLUM_WORKSPACE_DIR"/plugins
+ln -s "$(pwd)/assistant/examples/plugins/memory-reference" "$VELLUM_WORKSPACE_DIR"/plugins/memory-reference
+vellum restart
+```
+
+Because it declares `provides: "memory"`, the assistant treats it as a memory
+provider; with it installed, the built-in memory plugins yield to it.
+
+## Build your own
+
+Copy this directory, rename the manifest `name`, and replace the fact model and
+consolidation logic with whatever your memory system needs. As long as you reach
+the assistant only through `InitContext.host`, your plugin stays portable across
+assistant versions — the host facets are the stable contract.
+
+See [`plugins/README.md`](../../../../plugins/README.md) for the full plugin
+authoring guide.

--- a/assistant/examples/plugins/memory-reference/__tests__/memory-reference.test.ts
+++ b/assistant/examples/plugins/memory-reference/__tests__/memory-reference.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Exercises the memory-reference plugin against the public host-facet contract
+ * ALONE: remember → recall, per-turn `<memory>` injection, and turn-commit
+ * consolidation, all driven through hand-rolled in-memory implementations of the
+ * `@vellumai/plugin-api` facets. If the plugin ever reached for an `assistant/`
+ * internal, these fakes could not satisfy it — so a passing test is the proof
+ * the contract surface is sufficient.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  InitContext,
+  PluginHost,
+  PluginJob,
+  TurnCommitContext,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import init from "../hooks/init.js";
+import turnCommit from "../hooks/turn-commit.js";
+import userPromptSubmit from "../hooks/user-prompt-submit.js";
+import { resetRuntime } from "../src/state.js";
+import recallTool from "../tools/recall.js";
+import rememberTool from "../tools/remember.js";
+
+// ─── In-memory host facets (the public contract, nothing more) ───────────────
+
+/**
+ * A deterministic bag-of-words embedding: each distinct token maps to a fixed
+ * dimension, and the vector counts token occurrences. Cosine similarity then
+ * tracks lexical overlap — enough to make "remember X" retrievable by a query
+ * that mentions X, with no real model.
+ */
+function makeEmbedder(): {
+  embed: (texts: string[]) => Promise<number[][]>;
+  size: number;
+} {
+  const vocab = new Map<string, number>();
+  const size = 256;
+  const vectorize = (text: string): number[] => {
+    const v = new Array<number>(size).fill(0);
+    for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+      if (raw.length === 0) continue;
+      let dim = vocab.get(raw);
+      if (dim === undefined) {
+        dim = vocab.size % size;
+        vocab.set(raw, dim);
+      }
+      v[dim] = (v[dim] ?? 0) + 1;
+    }
+    return v;
+  };
+  return {
+    size,
+    embed: async (texts: string[]) => texts.map(vectorize),
+  };
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+interface StoredPoint {
+  id: string;
+  vector: number[];
+  payload: Record<string, unknown>;
+}
+
+/** Minimal table store keyed by SQL shape the plugin actually issues. */
+function makeStore() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const applied = new Set<string>();
+  return {
+    rows,
+    facet: {
+      migrate(
+        migrations: {
+          name: string;
+          up: (exec: (sql: string, params?: unknown[]) => void) => void;
+        }[],
+      ) {
+        for (const m of migrations) {
+          if (applied.has(m.name)) continue;
+          m.up(() => {
+            // DDL only — the in-memory store has no schema to enforce.
+          });
+          applied.add(m.name);
+        }
+      },
+      exec(sql: string, params: unknown[] = []) {
+        if (/INSERT\s+OR\s+REPLACE\s+INTO/i.test(sql)) {
+          const [id, conversation_id, text, created_at] = params as [
+            string,
+            string,
+            string,
+            number,
+          ];
+          rows.set(id, { id, conversation_id, text, created_at });
+          return;
+        }
+        throw new Error(`unexpected exec: ${sql}`);
+      },
+      query<T = Record<string, unknown>>(
+        sql: string,
+        params: unknown[] = [],
+      ): T[] {
+        if (/SELECT[\s\S]+FROM[\s\S]+WHERE\s+id\s+IN/i.test(sql)) {
+          return (params as string[])
+            .map((id) => rows.get(id))
+            .filter(
+              (r): r is Record<string, unknown> => r !== undefined,
+            ) as T[];
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    },
+  };
+}
+
+function makeVectorStore() {
+  const collections = new Map<string, StoredPoint[]>();
+  return {
+    collections,
+    facet: {
+      async collection(name: string, _opts: { vectorSize: number }) {
+        if (!collections.has(name)) collections.set(name, []);
+        const points = collections.get(name)!;
+        return {
+          async upsert(newPoints: StoredPoint[]) {
+            for (const p of newPoints) {
+              const idx = points.findIndex((e) => e.id === p.id);
+              const entry: StoredPoint = { ...p, payload: p.payload ?? {} };
+              if (idx >= 0) points[idx] = entry;
+              else points.push(entry);
+            }
+          },
+          async search(vector: number[], limit: number) {
+            return points
+              .map((p) => ({
+                id: p.id,
+                score: cosine(vector, p.vector),
+                payload: p.payload,
+              }))
+              .sort((x, y) => y.score - x.score)
+              .slice(0, limit);
+          },
+          async delete(ids: string[]) {
+            for (const id of ids) {
+              const idx = points.findIndex((e) => e.id === id);
+              if (idx >= 0) points.splice(idx, 1);
+            }
+          },
+        };
+      },
+    },
+  };
+}
+
+interface HistoryRow {
+  id: string;
+  conversationId: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+}
+
+function makeHistory(messages: HistoryRow[]) {
+  return {
+    async getConversation() {
+      return null;
+    },
+    async getRecentMessages(conversationId: string, n: number) {
+      return messages
+        .filter((m) => m.conversationId === conversationId)
+        .slice(-n);
+    },
+    async getMessages(conversationId: string) {
+      return {
+        messages: messages.filter((m) => m.conversationId === conversationId),
+        hasMore: false,
+      };
+    },
+  };
+}
+
+function makeJobs() {
+  const handlers = new Map<string, (job: PluginJob) => void | Promise<void>>();
+  const queue: PluginJob[] = [];
+  return {
+    queue,
+    facet: {
+      enqueue(type: string, payload: Record<string, unknown>) {
+        const id = `job_${queue.length}`;
+        queue.push({ type, payload, attempts: 0 });
+        return id;
+      },
+      registerHandler(
+        type: string,
+        handler: (job: PluginJob) => void | Promise<void>,
+      ) {
+        handlers.set(type, handler);
+      },
+    },
+    async drain() {
+      while (queue.length > 0) {
+        const job = queue.shift()!;
+        const handler = handlers.get(job.type);
+        if (handler) await handler(job);
+      }
+    },
+  };
+}
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+interface Harness {
+  host: PluginHost;
+  store: ReturnType<typeof makeStore>;
+  vectorStore: ReturnType<typeof makeVectorStore>;
+  jobs: ReturnType<typeof makeJobs>;
+  history: HistoryRow[];
+}
+
+function makeHarness(historyRows: HistoryRow[] = []): Harness {
+  const store = makeStore();
+  const vectorStore = makeVectorStore();
+  const embedder = makeEmbedder();
+  const jobs = makeJobs();
+  const history = historyRows;
+  const host = {
+    store: store.facet,
+    embeddings: { embed: embedder.embed },
+    vectorStore: vectorStore.facet,
+    history: makeHistory(history),
+    jobs: jobs.facet,
+  } as unknown as PluginHost;
+  return { host, store, vectorStore, jobs, history };
+}
+
+function initCtx(host: PluginHost): InitContext {
+  return {
+    config: {},
+    logger: silentLogger,
+    pluginStorageDir: "/tmp/memory-reference-test",
+    assistantVersion: "0.8.0",
+    host,
+  };
+}
+
+const toolCtx = (conversationId: string) => ({
+  conversationId,
+  workingDir: "/tmp",
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("memory-reference plugin", () => {
+  beforeEach(() => {
+    resetRuntime();
+  });
+
+  test("remember → recall round-trips a fact through the public facets", async () => {
+    const h = makeHarness();
+    await init(initCtx(h.host));
+
+    const remembered = await rememberTool.execute(
+      { text: "The user prefers dark roast coffee in the morning." },
+      toolCtx("conv-1") as never,
+    );
+    expect(remembered.isError).toBe(false);
+    expect(h.store.rows.size).toBe(1);
+
+    const recalled = await recallTool.execute(
+      { query: "what coffee does the user like" },
+      toolCtx("conv-1") as never,
+    );
+    expect(recalled.isError).toBe(false);
+    expect(recalled.content).toContain("dark roast coffee");
+  });
+
+  test("recall returns nothing before anything is remembered", async () => {
+    const h = makeHarness();
+    await init(initCtx(h.host));
+
+    const recalled = await recallTool.execute(
+      { query: "anything" },
+      toolCtx("conv-1") as never,
+    );
+    expect(recalled.isError).toBe(false);
+    expect(recalled.content).toContain("No relevant memories");
+  });
+
+  test("user-prompt-submit injects a <memory> block for a relevant prompt", async () => {
+    const h = makeHarness();
+    await init(initCtx(h.host));
+    await rememberTool.execute(
+      { text: "The user lives in Berlin and works as an architect." },
+      toolCtx("conv-1") as never,
+    );
+
+    const latestMessages = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "Where do I live again?" }],
+      },
+    ];
+    const ctx: UserPromptSubmitContext = {
+      conversationId: "conv-1",
+      userMessageId: "msg-1",
+      requestId: "req-1",
+      modelProfileKey: null,
+      isNonInteractive: false,
+      prompt: "Where do I live again?",
+      originalMessages: latestMessages.slice(),
+      latestMessages,
+      logger: silentLogger,
+    };
+
+    await userPromptSubmit(ctx);
+
+    expect(ctx.latestMessages.length).toBe(2);
+    const injected = ctx.latestMessages[0]!;
+    expect(injected.role).toBe("user");
+    const block = injected.content[0];
+    expect(block?.type).toBe("text");
+    expect((block as { text: string }).text).toContain("<memory>");
+    expect((block as { text: string }).text).toContain("Berlin");
+  });
+
+  test("user-prompt-submit injects nothing when no memory is relevant", async () => {
+    const h = makeHarness();
+    await init(initCtx(h.host));
+
+    const latestMessages = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "Hello there." }],
+      },
+    ];
+    const ctx: UserPromptSubmitContext = {
+      conversationId: "conv-1",
+      userMessageId: "msg-1",
+      requestId: "req-1",
+      modelProfileKey: null,
+      isNonInteractive: false,
+      prompt: "Hello there.",
+      originalMessages: latestMessages.slice(),
+      latestMessages,
+      logger: silentLogger,
+    };
+
+    await userPromptSubmit(ctx);
+    expect(ctx.latestMessages.length).toBe(1);
+  });
+
+  test("turn-commit enqueues a consolidation job that, when drained, stores a fact", async () => {
+    const historyRows: HistoryRow[] = [
+      {
+        id: "msg-user",
+        conversationId: "conv-1",
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Remember that my dog is named Pixel." },
+        ]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ];
+    const h = makeHarness(historyRows);
+    await init(initCtx(h.host));
+
+    const ctx: TurnCommitContext = {
+      conversationId: "conv-1",
+      userMessageId: "msg-user",
+      messages: [],
+      turnCount: 1,
+      isNonInteractive: false,
+      logger: silentLogger,
+    };
+    await turnCommit(ctx);
+
+    // The hook only enqueues — no fact is written synchronously.
+    expect(h.jobs.queue.length).toBe(1);
+    expect(h.store.rows.size).toBe(0);
+
+    // Draining the worker queue runs the registered handler, which consolidates.
+    await h.jobs.drain();
+    expect(h.store.rows.size).toBe(1);
+
+    const recalled = await recallTool.execute(
+      { query: "what is my dog's name" },
+      toolCtx("conv-1") as never,
+    );
+    expect(recalled.content).toContain("Pixel");
+  });
+
+  test("hooks no-op gracefully when init ran without a host", async () => {
+    await init({
+      config: {},
+      logger: silentLogger,
+      pluginStorageDir: "/tmp/x",
+      assistantVersion: "0.8.0",
+      // no host
+    });
+
+    const latestMessages = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "hi" }],
+      },
+    ];
+    const ctx: UserPromptSubmitContext = {
+      conversationId: "conv-1",
+      userMessageId: "msg-1",
+      requestId: "req-1",
+      modelProfileKey: null,
+      isNonInteractive: false,
+      prompt: "hi",
+      originalMessages: latestMessages.slice(),
+      latestMessages,
+      logger: silentLogger,
+    };
+    // Should not throw even though the runtime was never installed.
+    await userPromptSubmit(ctx);
+    expect(ctx.latestMessages.length).toBe(1);
+  });
+});

--- a/assistant/examples/plugins/memory-reference/hooks/init.ts
+++ b/assistant/examples/plugins/memory-reference/hooks/init.ts
@@ -1,0 +1,114 @@
+/**
+ * `init` hook for the memory-reference plugin.
+ *
+ * Bootstraps the plugin's durable state entirely through the public host
+ * facets handed in on {@link InitContext.host}:
+ *   - declares its fact table via `host.store.migrate` (append-only, idempotent)
+ *   - resolves its dense-vector collection via `host.vectorStore`, sized to the
+ *     host's embedding backend
+ *   - registers the post-turn consolidation job handler via `host.jobs`
+ *
+ * Imports ONLY `@vellumai/plugin-api`. No `assistant/` source, no `getDb`, no
+ * `persistence/`.
+ */
+
+import type { InitContext, PluginJob } from "@vellumai/plugin-api";
+
+import {
+  CONSOLIDATE_JOB,
+  DEFAULT_VECTOR_SIZE,
+  embedOne,
+  ensureCollection,
+  extractText,
+  FACTS_TABLE,
+  rememberFact,
+  setRuntime,
+} from "../src/state.js";
+
+/** Payload the turn-commit hook enqueues for the consolidation job. */
+interface ConsolidatePayload {
+  conversationId: string;
+  userMessageId: string;
+  turnCount: number;
+}
+
+export default async function init(ctx: InitContext): Promise<void> {
+  if (ctx.host === undefined) {
+    // Lightweight test contexts may construct an InitContext without a host;
+    // a plugin that needs the host simply no-ops when it is absent rather than
+    // throwing during a host-less bootstrap.
+    ctx.logger.warn(
+      {},
+      "memory-reference: no host on init context — skipping setup",
+    );
+    return;
+  }
+
+  const rt = setRuntime(ctx.host);
+
+  // 1) Declare the durable fact table. Append-only & idempotent — safe on every
+  // boot. The host namespaces the table under `plugin_<id>_` and rejects DDL
+  // that touches anything outside that prefix.
+  rt.store.migrate([
+    {
+      name: "0001-create-facts",
+      up: (exec) => {
+        exec(
+          `CREATE TABLE IF NOT EXISTS ${FACTS_TABLE} (
+             id TEXT PRIMARY KEY,
+             conversation_id TEXT NOT NULL,
+             text TEXT NOT NULL,
+             created_at INTEGER NOT NULL
+           )`,
+        );
+      },
+    },
+    {
+      name: "0002-index-facts-conversation",
+      up: (exec) => {
+        exec(
+          `CREATE INDEX IF NOT EXISTS ${FACTS_TABLE}_conversation_idx
+             ON ${FACTS_TABLE} (conversation_id)`,
+        );
+      },
+    },
+  ]);
+
+  // 2) Size and resolve the vector collection. Probe the embedding backend once
+  // to learn its dimensionality; if no backend is configured the probe throws —
+  // defer collection creation to the first successful embed (in remember).
+  let vectorSize = DEFAULT_VECTOR_SIZE;
+  try {
+    const probe = await embedOne(rt, "memory-reference dimension probe");
+    vectorSize = probe.length;
+    await ensureCollection(rt, vectorSize);
+  } catch (err) {
+    ctx.logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-reference: embedding probe failed — deferring vector collection creation",
+    );
+  }
+
+  // 3) Register the consolidation job handler. The handler runs on the worker
+  // loop (never synchronously, never at boot), so the salient-fact extraction it
+  // does is off the turn-commit hot path. This reference keeps the handler
+  // LLM-free: it stores the user's prompt text as a fact rather than calling a
+  // model. A production plugin would summarize the turn here — still on the
+  // worker, still off the commit path.
+  rt.jobs.registerHandler(CONSOLIDATE_JOB, async (job: PluginJob) => {
+    const payload = job.payload as unknown as ConsolidatePayload;
+    const recent = await rt.history.getRecentMessages(
+      payload.conversationId,
+      2,
+    );
+    const userTurn = recent.find((m) => m.role === "user");
+    if (userTurn === undefined) return;
+
+    const text = extractText(userTurn.content).slice(0, 2000).trim();
+    if (text.length === 0) return;
+
+    await rememberFact(rt, payload.conversationId, text);
+  });
+
+  ctx.logger.info({ vectorSize }, "memory-reference: initialized");
+}

--- a/assistant/examples/plugins/memory-reference/hooks/turn-commit.ts
+++ b/assistant/examples/plugins/memory-reference/hooks/turn-commit.ts
@@ -1,0 +1,33 @@
+/**
+ * `turn-commit` hook for the memory-reference plugin.
+ *
+ * Fires after the turn's messages are persisted. It does NO synchronous work
+ * beyond enqueuing a durable background job via `host.jobs` — the consolidation
+ * (salient-fact extraction + embed + store) runs later on the worker loop, off
+ * the commit hot path, so a turn is never charged generation cost just by
+ * committing. The handler is registered in the `init` hook.
+ *
+ * Imports ONLY `@vellumai/plugin-api`.
+ */
+
+import type { TurnCommitContext } from "@vellumai/plugin-api";
+
+import { CONSOLIDATE_JOB, tryGetRuntime } from "../src/state.js";
+
+export default async function turnCommit(
+  ctx: TurnCommitContext,
+): Promise<void> {
+  const rt = tryGetRuntime();
+  if (rt === null) return;
+
+  rt.jobs.enqueue(CONSOLIDATE_JOB, {
+    conversationId: ctx.conversationId,
+    userMessageId: ctx.userMessageId,
+    turnCount: ctx.turnCount,
+  });
+
+  ctx.logger.info(
+    { plugin: "memory-reference", turnCount: ctx.turnCount },
+    "memory-reference: enqueued consolidation job",
+  );
+}

--- a/assistant/examples/plugins/memory-reference/hooks/user-prompt-submit.ts
+++ b/assistant/examples/plugins/memory-reference/hooks/user-prompt-submit.ts
@@ -1,0 +1,83 @@
+/**
+ * `user-prompt-submit` hook for the memory-reference plugin.
+ *
+ * Before the turn reaches the agent loop, retrieve memories relevant to the
+ * submitted prompt (vector search via the runtime captured at `init`, biased by
+ * recent conversation context from `host.history`) and inject them as a
+ * `<memory>` block. The hook mutates `latestMessages` in place — prepending a
+ * synthetic user message that carries the block — and returns void, so the rest
+ * of the threaded context flows through untouched.
+ *
+ * Imports ONLY `@vellumai/plugin-api`.
+ */
+
+import type {
+  Message,
+  TextContent,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import {
+  DEFAULT_RECALL_LIMIT,
+  extractText,
+  recallFacts,
+  renderMemoryBlock,
+  tryGetRuntime,
+} from "../src/state.js";
+
+export default async function userPromptSubmit(
+  ctx: UserPromptSubmitContext,
+): Promise<void> {
+  const rt = tryGetRuntime();
+  if (rt === null) return;
+
+  // Build the retrieval query from the submitted prompt plus a little recent
+  // context, so a terse follow-up ("and the second one?") still retrieves
+  // against what the conversation is actually about.
+  let query = ctx.prompt;
+  try {
+    const recent = await rt.history.getRecentMessages(ctx.conversationId, 4);
+    const context = recent
+      .map((m) => extractText(m.content))
+      .filter((t) => t.length > 0)
+      .join("\n");
+    if (context.length > 0) {
+      query = `${context}\n${ctx.prompt}`;
+    }
+  } catch (err) {
+    ctx.logger.warn(
+      {
+        plugin: "memory-reference",
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "memory-reference: history fetch failed; querying on prompt alone",
+    );
+  }
+
+  let facts;
+  try {
+    facts = await recallFacts(rt, query, DEFAULT_RECALL_LIMIT);
+  } catch (err) {
+    ctx.logger.warn(
+      {
+        plugin: "memory-reference",
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "memory-reference: recall failed; skipping injection",
+    );
+    return;
+  }
+  if (facts.length === 0) return;
+
+  const block: TextContent = {
+    type: "text",
+    text: renderMemoryBlock(facts.map((f) => f.text)),
+  };
+  const memoryMessage: Message = { role: "user", content: [block] };
+  ctx.latestMessages.unshift(memoryMessage);
+
+  ctx.logger.info(
+    { plugin: "memory-reference", injected: facts.length },
+    "memory-reference: injected memory block",
+  );
+}

--- a/assistant/examples/plugins/memory-reference/package.json
+++ b/assistant/examples/plugins/memory-reference/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@vellumai/plugin-memory-reference-example",
+  "version": "0.1.0",
+  "description": "Reference memory plugin built entirely on the public @vellumai/plugin-api host facets (store / embeddings / vectorStore / history / jobs). Implements remember/recall tools, per-turn <memory> injection, and post-turn consolidation — proving a third party can build a long-term memory system against the public contract alone.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.10",
+    "@types/node": "25.5.0",
+    "typescript": "5.9.3"
+  },
+  "vellum": {
+    "provides": "memory"
+  }
+}

--- a/assistant/examples/plugins/memory-reference/src/state.ts
+++ b/assistant/examples/plugins/memory-reference/src/state.ts
@@ -1,0 +1,281 @@
+/**
+ * Shared module state and pure helpers for the memory-reference plugin.
+ *
+ * Files under `src/` are NOT walked by the external-plugin loader, so this
+ * module contributes no surface of its own — it is the plugin's internal
+ * glue. The `init` hook stashes the resolved {@link PluginHost} here; the
+ * `tools/` and `hooks/` files read it back when they run.
+ *
+ * The whole module imports ONLY from `@vellumai/plugin-api` (+ stdlib). It is
+ * the proof point of the reference plugin: a third party can build a real
+ * long-term memory entirely against the public host facets, with no
+ * `assistant/` source import.
+ */
+
+import type {
+  EmbeddingsFacet,
+  HistoryFacet,
+  JobsFacet,
+  PluginHost,
+  StoreFacet,
+  VectorStoreFacet,
+} from "@vellumai/plugin-api";
+
+/** Plugin id — also the namespace prefix the host applies to tables/collections/jobs. */
+export const PLUGIN_ID = "memoryreference";
+
+/** The plugin's durable fact table (host-namespaced to `plugin_memoryreference_facts`). */
+export const FACTS_TABLE = `plugin_${PLUGIN_ID}_facts`;
+
+/** The plugin's dense-vector collection (host-namespaced under the plugin id). */
+export const VECTOR_COLLECTION = "facts";
+
+/** Background job type that runs post-turn consolidation (host-namespaced under the plugin id). */
+export const CONSOLIDATE_JOB = "consolidate-turn";
+
+/**
+ * Embedding dimensionality the collection is created with. The host's embed
+ * backend determines the actual vector size; the plugin learns it from the
+ * first embed at init and creates the collection to match. This constant is the
+ * fallback used only when a fresh init cannot embed a probe (e.g. no backend
+ * configured) — in that case the plugin defers collection creation until the
+ * first successful embed.
+ */
+export const DEFAULT_VECTOR_SIZE = 1024;
+
+/** Max characters of a stored fact (defensive cap; facts are short by design). */
+export const MAX_FACT_CHARS = 4000;
+
+/** How many memories `recall` / the injection hook pull back by default. */
+export const DEFAULT_RECALL_LIMIT = 5;
+
+/** A handle to the plugin's vector collection (resolved lazily at first use). */
+export interface VectorCollectionHandle {
+  upsert(
+    points: {
+      id: string;
+      vector: number[];
+      payload?: Record<string, unknown>;
+    }[],
+  ): Promise<void>;
+  search(
+    vector: number[],
+    limit: number,
+  ): Promise<{ id: string; score: number; payload: Record<string, unknown> }[]>;
+  delete(ids: string[]): Promise<void>;
+}
+
+/**
+ * The live host facets the plugin operates against, captured at `init`. The
+ * tools and hooks read this back; it is `null` until `init` runs (and in
+ * lightweight test contexts the test injects a host directly via
+ * {@link setRuntime}).
+ */
+export interface MemoryRuntime {
+  store: StoreFacet;
+  embeddings: EmbeddingsFacet;
+  vectorStore: VectorStoreFacet;
+  history: HistoryFacet;
+  jobs: JobsFacet;
+  /** Resolved lazily: the namespaced vector collection. */
+  collection: VectorCollectionHandle | null;
+  /** Embedding size the collection was (or will be) created with. */
+  vectorSize: number;
+}
+
+let runtime: MemoryRuntime | null = null;
+
+/** Install the runtime (called from `init`, or directly from tests). */
+export function setRuntime(host: PluginHost): MemoryRuntime {
+  runtime = {
+    store: host.store,
+    embeddings: host.embeddings,
+    vectorStore: host.vectorStore,
+    history: host.history,
+    jobs: host.jobs,
+    collection: null,
+    vectorSize: DEFAULT_VECTOR_SIZE,
+  };
+  return runtime;
+}
+
+/** Read the installed runtime, throwing a clear error if `init` has not run. */
+export function getRuntime(): MemoryRuntime {
+  if (runtime === null) {
+    throw new Error(
+      "memory-reference: runtime not initialized — the init hook must run before tools/hooks fire",
+    );
+  }
+  return runtime;
+}
+
+/**
+ * Read the installed runtime, or `null` when `init` has not run (or ran without
+ * a host). Hooks fire-and-forget over a turn that may predate init, so they
+ * degrade gracefully on `null` rather than throwing; the tools, which the model
+ * only sees once registered, use {@link getRuntime} and surface a hard error.
+ */
+export function tryGetRuntime(): MemoryRuntime | null {
+  return runtime;
+}
+
+/** Reset module state (test isolation only). */
+export function resetRuntime(): void {
+  runtime = null;
+}
+
+/**
+ * Resolve (and cache) the plugin's vector collection, sizing it to `vectorSize`.
+ * Idempotent: the host's `collection()` returns the same logical collection for
+ * a given (plugin, name), so calling this repeatedly is cheap.
+ */
+export async function ensureCollection(
+  rt: MemoryRuntime,
+  vectorSize: number,
+): Promise<VectorCollectionHandle> {
+  if (rt.collection !== null && rt.vectorSize === vectorSize) {
+    return rt.collection;
+  }
+  const collection = await rt.vectorStore.collection(VECTOR_COLLECTION, {
+    vectorSize,
+  });
+  rt.collection = collection;
+  rt.vectorSize = vectorSize;
+  return collection;
+}
+
+/** A single stored fact row, as persisted in the durable store. */
+export interface FactRow {
+  id: string;
+  conversation_id: string;
+  text: string;
+  created_at: number;
+}
+
+/**
+ * Embed one text and return its dense vector. Centralizes the "embed a single
+ * string" call the tools and hooks share, so the batch-shaped facet is invoked
+ * the same way everywhere.
+ */
+export async function embedOne(
+  rt: MemoryRuntime,
+  text: string,
+  signal?: AbortSignal,
+): Promise<number[]> {
+  const [vector] = await rt.embeddings.embed(
+    [text],
+    signal ? { signal } : undefined,
+  );
+  if (vector === undefined) {
+    throw new Error("memory-reference: embeddings backend returned no vector");
+  }
+  return vector;
+}
+
+/** Generate a stable, collision-resistant fact id. */
+export function newFactId(): string {
+  return `fact_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Render the retrieved facts into the `<memory>` block text injected into the
+ * turn. Pure: takes the already-fetched fact texts and returns the block body.
+ */
+export function renderMemoryBlock(facts: string[]): string {
+  const lines = facts.map((f) => `- ${f}`).join("\n");
+  return `<memory>\nRelevant long-term memories (memory-reference plugin):\n${lines}\n</memory>`;
+}
+
+/**
+ * Persist a fact: store the row in the durable store and upsert its embedding
+ * into the vector collection. Shared by the `remember` tool and the
+ * consolidation job so both write a fact the exact same way. Returns the new
+ * fact id.
+ */
+export async function rememberFact(
+  rt: MemoryRuntime,
+  conversationId: string,
+  text: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const trimmed = text.trim().slice(0, MAX_FACT_CHARS);
+  if (trimmed.length === 0) {
+    throw new Error("memory-reference: cannot remember empty text");
+  }
+  const id = newFactId();
+  const createdAt = Date.now();
+  rt.store.exec(
+    `INSERT OR REPLACE INTO ${FACTS_TABLE} (id, conversation_id, text, created_at)
+       VALUES (?, ?, ?, ?)`,
+    [id, conversationId, trimmed, createdAt],
+  );
+  const vector = await embedOne(rt, trimmed, signal);
+  const collection = await ensureCollection(rt, vector.length);
+  await collection.upsert([
+    { id, vector, payload: { conversationId, text: trimmed } },
+  ]);
+  return id;
+}
+
+/**
+ * Recall facts most similar to `query`: embed the query, search the vector
+ * collection, then hydrate the matching rows from the durable store (the store
+ * is the source of truth for fact text; the vector payload is a denormalized
+ * convenience). Returns fact texts, best match first. Shared by the `recall`
+ * tool and the injection hook.
+ */
+export async function recallFacts(
+  rt: MemoryRuntime,
+  query: string,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<FactRow[]> {
+  if (rt.collection === null) {
+    // No collection yet means nothing has been remembered — nothing to recall.
+    return [];
+  }
+  const vector = await embedOne(rt, query, signal);
+  const collection = await ensureCollection(rt, vector.length);
+  const hits = await collection.search(vector, limit);
+  if (hits.length === 0) return [];
+
+  const ids = hits.map((h) => h.id);
+  const placeholders = ids.map(() => "?").join(", ");
+  const rows = rt.store.query<FactRow>(
+    `SELECT id, conversation_id, text, created_at
+       FROM ${FACTS_TABLE}
+      WHERE id IN (${placeholders})`,
+    ids,
+  );
+  // Re-order rows to match the vector-search ranking (SQL IN does not preserve order).
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((r): r is FactRow => r !== undefined);
+}
+
+/**
+ * Pull plain text out of a stored content string. History rows carry the raw
+ * stored content — a JSON content-block array or plain text. This narrows to the
+ * text the plugin embeds/searches, with a plain-string fallback.
+ */
+export function extractText(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter(
+          (b): b is { type: "text"; text: string } =>
+            typeof b === "object" &&
+            b !== null &&
+            (b as { type?: unknown }).type === "text" &&
+            typeof (b as { text?: unknown }).text === "string",
+        )
+        .map((b) => b.text)
+        .join("\n");
+    }
+  } catch {
+    // Not JSON — fall through to the raw string.
+  }
+  return content;
+}

--- a/assistant/examples/plugins/memory-reference/tools/recall.ts
+++ b/assistant/examples/plugins/memory-reference/tools/recall.ts
@@ -1,0 +1,72 @@
+/**
+ * `recall` tool for the memory-reference plugin.
+ *
+ * The model calls this to retrieve relevant memories: the query is embedded via
+ * `host.embeddings`, searched against `host.vectorStore`, and the matching rows
+ * are hydrated from `host.store`. The loader derives the model-visible tool name
+ * from this filename (`recall`).
+ *
+ * Imports ONLY `@vellumai/plugin-api`.
+ */
+
+import type { ToolContext, ToolExecutionResult } from "@vellumai/plugin-api";
+
+import { DEFAULT_RECALL_LIMIT, getRuntime, recallFacts } from "../src/state.js";
+
+interface RecallInput {
+  /** What to search long-term memory for. */
+  query?: unknown;
+  /** Max memories to return (defaults to DEFAULT_RECALL_LIMIT). */
+  limit?: unknown;
+}
+
+export default {
+  description:
+    "Search long-term memory for facts relevant to a query. Returns the most similar stored memories, best match first.",
+
+  input_schema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "What to look up in long-term memory.",
+      },
+      limit: {
+        type: "integer",
+        description: `Max memories to return (default ${DEFAULT_RECALL_LIMIT}).`,
+        minimum: 1,
+        maximum: 50,
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+
+  async execute(
+    input: RecallInput,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const query = typeof input.query === "string" ? input.query : "";
+    if (query.trim().length === 0) {
+      return { content: "recall: `query` is required.", isError: true };
+    }
+    const limit =
+      typeof input.limit === "number" && Number.isFinite(input.limit)
+        ? Math.max(1, Math.min(50, Math.trunc(input.limit)))
+        : DEFAULT_RECALL_LIMIT;
+    try {
+      const rt = getRuntime();
+      const rows = await recallFacts(rt, query, limit, ctx.signal);
+      if (rows.length === 0) {
+        return { content: "No relevant memories found.", isError: false };
+      }
+      const body = rows.map((r) => `- ${r.text}`).join("\n");
+      return { content: `Relevant memories:\n${body}`, isError: false };
+    } catch (err) {
+      return {
+        content: `recall failed: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  },
+};

--- a/assistant/examples/plugins/memory-reference/tools/remember.ts
+++ b/assistant/examples/plugins/memory-reference/tools/remember.ts
@@ -1,0 +1,57 @@
+/**
+ * `remember` tool for the memory-reference plugin.
+ *
+ * The model calls this to commit a durable fact: the text is embedded via
+ * `host.embeddings`, the row is written via `host.store`, and the vector is
+ * upserted into `host.vectorStore` — all through the runtime the `init` hook
+ * captured from the public {@link PluginHost}. The loader derives the
+ * model-visible tool name from this filename (`remember`).
+ *
+ * Imports ONLY `@vellumai/plugin-api`.
+ */
+
+import type { ToolContext, ToolExecutionResult } from "@vellumai/plugin-api";
+
+import { getRuntime, rememberFact } from "../src/state.js";
+
+interface RememberInput {
+  /** The fact to store in long-term memory. */
+  text?: unknown;
+}
+
+export default {
+  description:
+    "Store a durable long-term memory (a fact about the user, a preference, a decision). Embedded and retrievable later via recall.",
+
+  input_schema: {
+    type: "object",
+    properties: {
+      text: {
+        type: "string",
+        description: "The fact to remember. One concise statement.",
+      },
+    },
+    required: ["text"],
+    additionalProperties: false,
+  },
+
+  async execute(
+    input: RememberInput,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const text = typeof input.text === "string" ? input.text : "";
+    if (text.trim().length === 0) {
+      return { content: "remember: `text` is required.", isError: true };
+    }
+    try {
+      const rt = getRuntime();
+      const id = await rememberFact(rt, ctx.conversationId, text, ctx.signal);
+      return { content: `Remembered (id ${id}).`, isError: false };
+    } catch (err) {
+      return {
+        content: `remember failed: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- New examples/plugins/memory-reference: a working memory system using only @vellumai/plugin-api host facets (store/embeddings/vectorStore/history/jobs + hooks + tools)
- Proves the public contract is sufficient for a third-party memory plugin; does not alter the live default

Part of plan: memory-plugin-extraction.md (PR 28 of 32)