### PR TITLE
refactor(memory): delete internal memory coupling superseded by the plugin contract

### DIFF
--- a/assistant/src/memory/provider/graph-provider.ts
+++ b/assistant/src/memory/provider/graph-provider.ts
@@ -5,8 +5,8 @@
  * Thin adapter over the existing graph modules: it delegates retrieval to
  * `graph/retriever.ts`, rendering to `graph/injection.ts`, and post-turn
  * consolidation enqueue to `memory/memory-retrospective-enqueue.ts`, then maps
- * the results into the {@link InjectionBlock} shape daemon core consumes. No
- * call site selects this provider yet — wiring lands in a later PR.
+ * the results into the {@link InjectionBlock} shape daemon core consumes.
+ * Selected by `memory.provider` through `resolveMemoryProvider`.
  */
 
 import { getConfig } from "../../config/loader.js";

--- a/assistant/src/memory/provider/v2-provider.ts
+++ b/assistant/src/memory/provider/v2-provider.ts
@@ -10,8 +10,7 @@
  *   - consolidation/write enqueue: `enqueueMemoryRetrospectiveIfEnabled`,
  *     the same post-turn trigger the live v2 path fires.
  *
- * No call site consumes this yet — it is additive scaffolding selected by
- * `memory.provider` in a later PR.
+ * Selected by `memory.provider` through `resolveMemoryProvider`.
  */
 
 import { getConfig } from "../../config/loader.js";


### PR DESCRIPTION
## Summary
- Conservative removal of code orphaned by the provider/facet cutover (proven-unused only)
- The named PR 32 candidates (`isMemoryV3Live`, `config/memory-v3-gate.ts`, the lifecycle retrospective enqueue, static `tools/memory/register.ts` registration) were already removed inline by the cutover PRs (16/19/20/21) — verified grep-clean, each guarded. The reference plugin (PR 28) landed as an additive example under `plugin-api/examples/`, so the built-in graph/v2/v3 provider path remains the live code and could not be removed without breaking behavior.
- The only provably-stale coupling artifacts remaining were two scaffolding doc-comments on the v2/graph provider adapters claiming "no call site consumes this yet / wiring lands in a later PR" — false since PR 16 wired `resolveMemoryProvider` to consume them, and a temporal-language violation per CLAUDE.md. Corrected to describe the present (selected via `memory.provider`).
- Guards + default-config injection tests still pass; typecheck:fast clean.

Part of plan: memory-plugin-extraction.md (PR 32 of 32)