### PR TITLE
test(guards): repoint credential + assistant-id guards to persistence/ paths

### DIFF
--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -486,6 +486,8 @@ describe("assistant ID boundary", () => {
     const schemaGlobs = [
       "assistant/src/memory/schema/*.ts",
       "assistant/src/memory/schema/**/*.ts",
+      "assistant/src/persistence/schema/*.ts",
+      "assistant/src/persistence/schema/**/*.ts",
     ];
 
     let grepOutput = "";
@@ -551,6 +553,8 @@ describe("assistant ID boundary", () => {
     // multiple lines) from exported functions to catch multiline signatures.
     const storeGlobs = [
       "assistant/src/memory/*.ts",
+      "assistant/src/persistence/*.ts",
+      "assistant/src/persistence/embeddings/*.ts",
       "assistant/src/contacts/*.ts",
       "assistant/src/notifications/*.ts",
       "assistant/src/calls/call-store.ts",

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -206,9 +206,9 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/chatgpt-subscription-auth-routes.ts", // ChatGPT subscription daemon OAuth flow (stores tokens in CES)
       "providers/provider-availability.ts", // provider availability API key check
       "media/image-credentials.ts", // shared image-gen credential resolver (provider API key lookup)
-      "memory/embedding-backend.ts", // embedding backend API key lookup
-      "memory/llm-request-log-source-clickhouse.ts", // ClickHouse read source — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped mirror reads
-      "memory/compaction-log-store-clickhouse.ts", // ClickHouse compaction log writer — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped event writes
+      "persistence/embeddings/embedding-backend.ts", // embedding backend API key lookup
+      "persistence/llm-request-log-source-clickhouse.ts", // ClickHouse read source — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped mirror reads
+      "persistence/compaction-log-store-clickhouse.ts", // ClickHouse compaction log writer — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped event writes
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
       "workspace/migrations/018-rekey-compound-credential-keys.ts", // re-key compound credential storage keys


### PR DESCRIPTION
## Summary
- credential-security-invariants: repoint 3 stale memory/ allowlist paths to persistence/
- assistant-id-boundary-guard: add persistence/schema/ + persistence/ to schema/store globs (restore coverage lost in the move)

Addresses self-review gaps. Part of plan: memory-plugin-extraction.md (remediation)