### PR TITLE
fix(memory): v3 provider exposes remember/recall (backward-compat for v3-live installs)

### DIFF
--- a/assistant/src/memory/provider/v3-provider.test.ts
+++ b/assistant/src/memory/provider/v3-provider.test.ts
@@ -50,6 +50,8 @@ mock.module("../../plugins/defaults/memory-v3-shadow/injector.js", () => ({
 
 const { V3MemoryProvider } = await import("./v3-provider.js");
 const { MemoryConfigSchema } = await import("../../config/schemas/memory.js");
+const { rememberTool, recallTool } =
+  await import("../../tools/memory/register.js");
 
 // ─── fixtures ────────────────────────────────────────────────────────────────
 
@@ -160,8 +162,12 @@ describe("V3MemoryProvider", () => {
     expect(blocks[0]!.id).toBe(MEMORY_V3_SPOTLIGHT_BLOCK_ID);
   });
 
-  test("provideTools is empty; provideRoutes returns the v3 maintenance routes", () => {
-    expect(V3MemoryProvider.provideTools()).toEqual([]);
+  test("provideTools exposes the shared remember/recall instances (matching v2/graph), preserving base behavior for v3-live installs; provideRoutes returns the v3 maintenance routes", () => {
+    const tools = V3MemoryProvider.provideTools();
+    // Same instances v2/graph return — remember/recall handlers are
+    // provider-agnostic and write to the shared corpus v3 consolidation consumes.
+    expect(tools).toEqual([rememberTool, recallTool]);
+    expect(tools.map((t) => t.name)).toEqual(["remember", "recall"]);
     expect(V3MemoryProvider.provideRoutes()).toBe(MEMORY_V3_ROUTES);
   });
 

--- a/assistant/src/memory/provider/v3-provider.ts
+++ b/assistant/src/memory/provider/v3-provider.ts
@@ -28,6 +28,7 @@ import {
 import type { InjectionBlock, TurnContext } from "../../plugins/types.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "../../runtime/routes/memory-v3-routes.js";
 import type { RouteDefinition } from "../../runtime/routes/types.js";
+import { recallTool, rememberTool } from "../../tools/memory/register.js";
 import type { ToolDefinition } from "../../tools/types.js";
 import type { MemoryProvider, MemoryProviderContext } from "./types.js";
 
@@ -48,9 +49,9 @@ function toTurnContext(ctx: MemoryProviderContext): TurnContext {
 
 /**
  * v3 implementation of {@link MemoryProvider}. Delegates all retrieval to the
- * shadow injectors; contributes no model-visible tools (v3 is a
- * retrieval/injection system with no `remember`-style tool surface) and the v3
- * maintenance routes. `onTurnCommit`, `init`, and `shutdown` are no-ops: v3's
+ * shadow injectors; contributes the shared `remember`/`recall` tools (their
+ * handlers write to the concept-page corpus that v3 consolidation consumes) and
+ * the v3 maintenance routes. `onTurnCommit`, `init`, and `shutdown` are no-ops: v3's
  * everInjected write and prune-valve schedule are driven by the injector's
  * commit callback at runtime assembly, and its consolidation enqueue rides the
  * v2 consolidation job — neither is a per-turn provider hook.
@@ -84,7 +85,7 @@ export const V3MemoryProvider = {
   },
 
   provideTools(): ToolDefinition[] {
-    return [];
+    return [rememberTool, recallTool];
   },
 
   provideRoutes(): RouteDefinition[] {

--- a/assistant/src/tools/memory/active-provider-tools.test.ts
+++ b/assistant/src/tools/memory/active-provider-tools.test.ts
@@ -5,13 +5,13 @@
  * accessor is the seam that decides which memory tools exist per
  * `memory.provider`:
  *
- * - graph / v2 expose `remember` + `recall` (the executable tools whose
+ * - graph / v2 / v3 expose `remember` + `recall` (the executable tools whose
  *   schemas mirror the canonical graph definitions),
- * - v3 / `none` expose nothing.
+ * - `none` exposes nothing.
  *
  * The provider modules are not mocked — the real graph/v2/v3 providers all
- * resolve to the shared `rememberTool`/`recallTool` (or to empty), and that
- * sharing is exactly what this test pins.
+ * resolve to the shared `rememberTool`/`recallTool`, and `none` resolves to
+ * empty; that sharing is exactly what this test pins.
  */
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
@@ -39,7 +39,7 @@ function memoryToolsFor(provider: string) {
 }
 
 describe("getMemoryToolsForActiveProvider", () => {
-  test.each(["graph", "v2"] as const)(
+  test.each(["graph", "v2", "v3"] as const)(
     'provider "%s" exposes remember + recall',
     (provider) => {
       const names = memoryToolsFor(provider)
@@ -49,12 +49,9 @@ describe("getMemoryToolsForActiveProvider", () => {
     },
   );
 
-  test.each(["v3", "none"] as const)(
-    'provider "%s" exposes no memory tools',
-    (provider) => {
-      expect(memoryToolsFor(provider)).toEqual([]);
-    },
-  );
+  test('provider "none" exposes no memory tools', () => {
+    expect(memoryToolsFor("none")).toEqual([]);
+  });
 
   test("registered tool schemas match the canonical graph definitions", () => {
     const tools = memoryToolsFor("graph");
@@ -69,13 +66,15 @@ describe("getMemoryToolsForActiveProvider", () => {
     expect(recall?.input_schema).toEqual(graphRecallDefinition.input_schema);
   });
 
-  test("graph and v2 register the same executable tool instances", () => {
+  test("graph, v2, and v3 register the same executable tool instances", () => {
     const graphTools = memoryToolsFor("graph");
     const v2Tools = memoryToolsFor("v2");
+    const v3Tools = memoryToolsFor("v3");
 
-    // Both providers contribute the shared `rememberTool`/`recallTool`
+    // All three providers contribute the shared `rememberTool`/`recallTool`
     // instances — the same objects carrying the real `execute` handlers.
     expect(graphTools).toEqual(v2Tools);
+    expect(v3Tools).toEqual(v2Tools);
     for (const tool of graphTools) {
       expect(typeof tool.execute).toBe("function");
     }


### PR DESCRIPTION
## Summary
- V3MemoryProvider.provideTools() returns [remember, recall] like v2/graph
- Restores tools that were unconditional at base and silently dropped for migrated v3-live installs

Addresses self-review gap. Part of plan: memory-plugin-extraction.md (remediation)