### PR TITLE
fix(test): deflake workspace-lifecycle by draining enrichment after heartbeat

### DIFF
--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -126,6 +126,26 @@ describe("Workspace git lifecycle (integration)", () => {
       .filter(Boolean);
   }
 
+  // Quiesce the fire-and-forget enrichment queue and clear any stale
+  // `.git/index.lock` its `git notes` subprocess can leave behind on some git
+  // versions. Enrichment runs git subprocesses asynchronously and outside the
+  // service mutex that guards the test's direct git reads, so it must be
+  // drained before the test reads the repo or commits again — otherwise an
+  // in-flight `git notes` write races those operations and the direct
+  // `git log` / `git rev-list` reads observe a transient, inconsistent repo.
+  async function drainEnrichment(): Promise<void> {
+    await getEnrichmentService().shutdown();
+    _resetEnrichmentService();
+    const lockPath = join(testDir, ".git", "index.lock");
+    if (existsSync(lockPath)) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        /* race: already gone */
+      }
+    }
+  }
+
   test("full lifecycle: init → turns → heartbeat → history", async () => {
     const conversationId = "sess_lifecycle_test";
 
@@ -191,25 +211,10 @@ describe("Workspace git lifecycle (integration)", () => {
     await commitTurnChanges(testDir, conversationId, 3);
     expect(commitCount(testDir)).toBe(3); // Still 3
 
-    // Drain fire-and-forget enrichment from turn commits before heartbeat
-    // testing. Enrichment's writeNote() can leave a stale index.lock on
-    // some git versions (see heartbeat-service.ts:240-242), causing the
-    // heartbeat commit to fail with "index.lock: File exists".
-    await getEnrichmentService().shutdown();
-    _resetEnrichmentService();
-
-    // On CI, the enrichment service's spawned git child processes may still
-    // be alive briefly after the queue drains, holding index.lock. Remove it
-    // unconditionally and reset the circuit breaker so the heartbeat portion
+    // Drain fire-and-forget enrichment from the turn commits before exercising
+    // the heartbeat, then reset the circuit breaker so the heartbeat portion
     // starts clean.
-    const lockPath = join(testDir, ".git", "index.lock");
-    if (existsSync(lockPath)) {
-      try {
-        unlinkSync(lockPath);
-      } catch {
-        /* race: already gone */
-      }
-    }
+    await drainEnrichment();
     _resetBreaker(service);
 
     // ----------------------------------------------------------------
@@ -243,6 +248,12 @@ describe("Workspace git lifecycle (integration)", () => {
 
     const secondCheck = await heartbeat.check();
     expect(secondCheck.committed).toBe(1);
+
+    // The heartbeat commit enqueues its own fire-and-forget enrichment job.
+    // Drain it before the synchronous git reads below so its `git notes`
+    // subprocess cannot mutate .git concurrently with them.
+    await drainEnrichment();
+
     expect(commitCount(testDir)).toBe(4);
 
     const heartbeatMsg = lastCommitMessage(testDir);


### PR DESCRIPTION
## Summary
- Fixes a flaky failure in `workspace-lifecycle.test.ts` ("full lifecycle: init → turns → heartbeat → history") on main CI, where the commit-history assertion got `Expected: 4, Received: 1` from `git log --oneline`.
- **Root cause:** the heartbeat commit enqueues its *own* fire-and-forget enrichment `writeNote()` job (`heartbeat-service.ts:353`) — a `git notes` subprocess that runs asynchronously and outside the service mutex. It races the test's direct `git log` / `git rev-list` reads, which then observe a transient, inconsistent `.git` state (`git rev-list --count HEAD` returned 4 while `git log --oneline` returned an inconsistent count). The test already drains enrichment *before* the heartbeat, but never drains the heartbeat's own job before reading the log.
- **Fix:** drain enrichment after the heartbeat commit too, and extract the shared drain + stale-`index.lock` cleanup into a `drainEnrichment()` helper (removing a duplicated lock-cleanup block). Test-only change; no production behavior change.

## Original prompt
Fix the specific CI failure in the Test job of main CI run 28304164804 (job 83857436517): the `workspace-lifecycle.test.ts` "full lifecycle" integration test failed at the commit-history assertion (`Expected: 4, Received: 1`). Target only this failing job — a flaky enrichment/git race in the test, not a production behavior change.

## Verification
- 8/8 local runs green (5 tests each); `typecheck:fast` and `eslint` clean.