### PR TITLE
refactor(mcp): make MCP server manager stop self-contained in its module

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -39,7 +39,6 @@ import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
-import { getMcpServerManager } from "../mcp/manager.js";
 import {
   getAttachmentsByIds,
   getSourcePathsForAttachments,
@@ -1375,13 +1374,6 @@ export async function runDaemon(): Promise<void> {
     );
   }
 
-  // Retrieve the MCP manager if MCP servers were configured.
-  // The manager is a singleton created during initializeProvidersAndTools().
-  const mcpManager =
-    config.mcp?.servers && Object.keys(config.mcp.servers).length > 0
-      ? getMcpServerManager()
-      : null;
-
   installShutdownHandlers({
     server,
     workspaceHeartbeat,
@@ -1391,7 +1383,6 @@ export async function runDaemon(): Promise<void> {
     scheduler,
     getMemoryWorker: () => bgRefs.memoryWorker,
     getQdrantManager: () => bgRefs.qdrantManager,
-    mcpManager,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/node";
 import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
-import type { McpServerManager } from "../mcp/manager.js";
+import { stopMcpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
@@ -45,7 +45,6 @@ export interface ShutdownDeps {
   scheduler: { stop(): void };
   getMemoryWorker: () => { stop(): void } | null;
   getQdrantManager: () => QdrantManager | null;
-  mcpManager: McpServerManager | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -151,12 +150,10 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       log.warn({ err }, "Failed to stop memory worker process (non-fatal)");
     }
 
-    if (deps.mcpManager) {
-      try {
-        await deps.mcpManager.stop();
-      } catch (err) {
-        log.warn({ err }, "MCP server manager shutdown failed (non-fatal)");
-      }
+    try {
+      await stopMcpServerManager();
+    } catch (err) {
+      log.warn({ err }, "MCP server manager shutdown failed (non-fatal)");
     }
 
     await deps.getQdrantManager()?.stop();

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -169,3 +169,14 @@ export function getMcpServerManager(): McpServerManager {
   }
   return instance;
 }
+
+/**
+ * Stop the MCP server manager singleton (disconnect all servers) if one was
+ * created. No-op when no manager exists — e.g. no MCP servers were ever
+ * configured — so shutdown callers don't need to gate on configuration. Acts on
+ * the live singleton, so it also stops servers added at runtime via MCP reload.
+ */
+export async function stopMcpServerManager(): Promise<void> {
+  if (!instance) return;
+  await instance.stop();
+}


### PR DESCRIPTION
## Prompt / plan

Continuing the effort to shrink `lifecycle.ts` by removing args from `installShutdownHandlers`. This one is the `mcpManager` dependency.

Previously lifecycle fetched the MCP manager singleton (gated on whether servers were configured) and threaded it through `ShutdownDeps` so the shutdown handler could call `.stop()`:

```ts
const mcpManager =
  config.mcp?.servers && Object.keys(config.mcp.servers).length > 0
    ? getMcpServerManager()
    : null;
installShutdownHandlers({ …, mcpManager });
```

This PR moves the stop logic into the manager module:

- **`stopMcpServerManager()`** — stops the singleton only if one exists (`if (!instance) return`), so it never *creates* a manager just to stop it, and shutdown callers don't need to gate on configuration.
- **shutdown-handlers** imports `stopMcpServerManager()` directly and drops the `mcpManager` field from `ShutdownDeps` (and the now-unused `McpServerManager` type import).
- **lifecycle** drops the `const mcpManager = …` block and the `getMcpServerManager` import.

### Behavior note (latent fix)

The old wiring computed `mcpManager` **once at startup** — `null` when no servers were configured at boot. But `mcp-reload-service.ts` creates the manager singleton on demand when MCP config is reloaded at runtime. So servers added after boot were never disconnected on shutdown. Keying off the live singleton stops whatever is actually running, closing that gap. No change for the common case (servers configured at boot).

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test src/__tests__/mcp-abort-signal.test.ts src/__tests__/disk-pressure-lifecycle.test.ts src/background-wake/wake-intent-hooks.test.ts` — 23 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_