### PR TITLE
refactor(memory): make Qdrant manager a self-managed singleton for shutdown

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -51,7 +51,7 @@ import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
 import { enqueueMemoryJob, isMemoryEnabled } from "../memory/jobs-store.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient, resolveQdrantUrl } from "../memory/qdrant-client.js";
-import { QdrantManager } from "../memory/qdrant-manager.js";
+import { createQdrantManager } from "../memory/qdrant-manager.js";
 import { rotateToolInvocations } from "../memory/tool-usage-store.js";
 import { sweepConceptPageFrontmatter } from "../memory/v2/frontmatter-sweep.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
@@ -793,20 +793,18 @@ export async function runDaemon(): Promise<void> {
   startOrphanReaper();
   startEventLoopWatchdog();
 
-  // Mutable refs for Qdrant and memory worker so background
-  // init can assign them and the shutdown handler always sees the latest value.
+  // Mutable ref for the memory worker so background init can assign it and the
+  // shutdown handler always sees the latest value.
   const bgRefs: {
-    qdrantManager: QdrantManager | null;
     memoryWorker: { stop(): void } | null;
-  } = { qdrantManager: null, memoryWorker: null };
+  } = { memoryWorker: null };
 
   // Initialize Qdrant vector store and memory worker in the background so the
   // RuntimeHttpServer can start accepting requests without waiting for Qdrant.
   async function initializeQdrantAndMemory(): Promise<void> {
     const qdrantUrl = resolveQdrantUrl(config);
     log.info({ qdrantUrl }, "Daemon startup: initializing Qdrant");
-    const manager = new QdrantManager({ url: qdrantUrl });
-    bgRefs.qdrantManager = manager;
+    const manager = createQdrantManager({ url: qdrantUrl });
     const QDRANT_START_MAX_ATTEMPTS = 3;
     let qdrantStarted = false;
     for (let attempt = 1; attempt <= QDRANT_START_MAX_ATTEMPTS; attempt++) {
@@ -1382,7 +1380,6 @@ export async function runDaemon(): Promise<void> {
     runtimeHttp,
     scheduler,
     getMemoryWorker: () => bgRefs.memoryWorker,
-    getQdrantManager: () => bgRefs.qdrantManager,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -5,7 +5,7 @@ import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
-import type { QdrantManager } from "../memory/qdrant-manager.js";
+import { stopQdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
@@ -44,7 +44,6 @@ export interface ShutdownDeps {
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
   getMemoryWorker: () => { stop(): void } | null;
-  getQdrantManager: () => QdrantManager | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -156,7 +155,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       log.warn({ err }, "MCP server manager shutdown failed (non-fatal)");
     }
 
-    await deps.getQdrantManager()?.stop();
+    await stopQdrantManager();
 
     // Optimize query planner statistics before closing so they persist for
     // the next session. Checkpoint WAL and close SQLite so no writes are

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -420,3 +420,31 @@ export class QdrantManager {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let instance: QdrantManager | null = null;
+
+/**
+ * Construct the singleton Qdrant manager and store it so shutdown can reach it.
+ * The caller (daemon startup) owns starting it — start() carries
+ * lifecycle-specific retry orchestration — but the module holds the reference
+ * so it need not be threaded through call arguments.
+ */
+export function createQdrantManager(
+  config: QdrantManagerConfig,
+): QdrantManager {
+  instance = new QdrantManager(config);
+  return instance;
+}
+
+/**
+ * Stop the singleton Qdrant manager if one was created. No-op when Qdrant init
+ * never ran (e.g. shutdown before background init started).
+ */
+export async function stopQdrantManager(): Promise<void> {
+  if (!instance) return;
+  await instance.stop();
+}


### PR DESCRIPTION
## Prompt / plan

Continuing to shrink `installShutdownHandlers`' argument list. This one removes the `getQdrantManager` getter arg.

The Qdrant manager was constructed in lifecycle's background init, stashed in a mutable `bgRefs` slot, and exposed to the shutdown handler via a `getQdrantManager()` getter:

```ts
const bgRefs = { qdrantManager: null, memoryWorker: null };
// …background init…
const manager = new QdrantManager({ url: qdrantUrl });
bgRefs.qdrantManager = manager;
// …
installShutdownHandlers({ …, getQdrantManager: () => bgRefs.qdrantManager });
```

The getter (rather than a plain value) was needed because Qdrant initializes asynchronously *after* `installShutdownHandlers` runs. This PR moves the reference into the manager module so the late binding happens via module state instead of a closure:

- **`createQdrantManager(config)`** constructs the singleton and stores it; lifecycle calls it instead of `new QdrantManager(...)`. Starting it — `start()` carries lifecycle-specific retry orchestration — stays in lifecycle.
- **`stopQdrantManager()`** stops the singleton if one exists (`if (!instance) return`); shutdown-handlers imports it directly and drops the `getQdrantManager` field from `ShutdownDeps`.
- `bgRefs` now holds only the memory worker.

Late binding still works: the singleton is set synchronously at the top of background init, so shutdown sees whatever was created. `stop()` is already safe on a never-started manager (`if (!this.process) { cleanupPid(); return }`), and the `QdrantManager` class stays exported for the unit tests that construct it directly.

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test src/__tests__/qdrant-manager.test.ts src/__tests__/disk-pressure-lifecycle.test.ts src/background-wake/wake-intent-hooks.test.ts` — 32 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_