### PR TITLE
fix(daemon): reconcile mid-turn conversations on startup

### DIFF
--- a/assistant/src/config/schemas/conversations.ts
+++ b/assistant/src/config/schemas/conversations.ts
@@ -20,6 +20,14 @@ export const ConversationsConfigSchema = z
       .describe(
         "Inner text injected into the tail user message of non-interactive turns in background/scheduled conversations. The injector wraps this in <background_turn>...</background_turn> tags. Empty string disables the injection.",
       ),
+    resumeProcessingOnStartup: z
+      .boolean({
+        error: "conversations.resumeProcessingOnStartup must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "Controls how conversations left mid-turn by a previous shutdown are handled on startup. When false (default), their stale processing flag is cleared so they come up idle. When true, the daemon will instead automatically resume the interrupted turn for each such conversation.",
+      ),
   })
   .describe("Conversation behavior configuration");
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -44,7 +44,11 @@ import {
   getSourcePathsForAttachments,
 } from "../memory/attachments-store.js";
 import { expireAllPendingCanonicalRequests } from "../memory/canonical-guardian-store.js";
-import { deleteMessageById, getMessages } from "../memory/conversation-crud.js";
+import {
+  clearStaleProcessingFlags,
+  deleteMessageById,
+  getMessages,
+} from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
@@ -627,6 +631,31 @@ export async function runDaemon(): Promise<void> {
 
   log.info("Daemon startup: loading config");
   const config = loadConfig();
+
+  // Reconcile conversations left mid-turn by the previous shutdown. Their
+  // `processing_started_at` is still set even though the in-memory agent loop
+  // that owned the turn is gone.
+  if (dbReady) {
+    if (config.conversations.resumeProcessingOnStartup) {
+      // TODO: automatically resume the interrupted turn for each conversation
+      // whose processing flag is still set instead of clearing it.
+    } else {
+      try {
+        const cleared = clearStaleProcessingFlags();
+        if (cleared > 0) {
+          log.info(
+            { count: cleared },
+            "Cleared stale conversation processing flags from previous process",
+          );
+        }
+      } catch (err) {
+        log.warn(
+          { err },
+          "Failed to clear stale conversation processing flags — continuing startup",
+        );
+      }
+    }
+  }
 
   // Seed module-level ingress state from the workspace config so that
   // getIngressPublicBaseUrl() returns the correct value immediately after

--- a/assistant/src/memory/__tests__/clear-stale-processing-flags.test.ts
+++ b/assistant/src/memory/__tests__/clear-stale-processing-flags.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  clearStaleProcessingFlags,
+  createConversation,
+  isConversationProcessing,
+  setConversationProcessingStartedAt,
+} from "../conversation-crud.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+}
+
+describe("clearStaleProcessingFlags", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("clears the processing flag on conversations left mid-turn", () => {
+    const processing = createConversation("mid-turn");
+    const idle = createConversation("idle");
+    setConversationProcessingStartedAt(processing.id, Date.now());
+
+    expect(isConversationProcessing(processing.id)).toBe(true);
+    expect(isConversationProcessing(idle.id)).toBe(false);
+
+    const cleared = clearStaleProcessingFlags();
+
+    expect(cleared).toBe(1);
+    expect(isConversationProcessing(processing.id)).toBe(false);
+    expect(isConversationProcessing(idle.id)).toBe(false);
+  });
+
+  test("returns 0 when no conversation is processing", () => {
+    createConversation("idle");
+
+    expect(clearStaleProcessingFlags()).toBe(0);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -2237,6 +2237,19 @@ export function setConversationProcessingStartedAt(
 }
 
 /**
+ * Clear the persisted processing flag on every conversation that still has one
+ * set, returning the number of rows cleared. Called at daemon startup to reset
+ * conversations whose `processing_started_at` was left non-NULL because the
+ * previous process shut down mid-turn — the in-memory agent loop driving that
+ * turn is gone, so the flag is stale.
+ */
+export function clearStaleProcessingFlags(): number {
+  return rawRun(
+    "UPDATE conversations SET processing_started_at = NULL WHERE processing_started_at IS NOT NULL",
+  );
+}
+
+/**
  * Read whether a conversation is currently processing. Checks the in-memory
  * `Conversation._processing` flag first (hot path for resident conversations),
  * falling back to the persisted `processing_started_at` column for cold


### PR DESCRIPTION
## Prompt / plan

> If conversations were in the middle of processing during the last shutdown, they still carry their processing flags when the daemon comes back up. Introduce a config that lets users opt into those conversations continuing automatically on come-up, otherwise mark them as not processing. Implement only the false case for now, with a one-sentence comment describing the true case.

A conversation's mid-turn state is tracked by the `conversations.processing_started_at` column (the cross-process source of truth; the in-memory `Conversation._processing` flag is the hot-path read). When the daemon is killed mid-turn, that column stays set, so on the next boot the conversation appears stuck "processing" even though the agent loop that owned the turn is gone. Nothing in startup reconciled this.

### Changes

- **`conversations.resumeProcessingOnStartup`** (default `false`) added to `ConversationsConfigSchema` — the natural home alongside other conversation-behavior toggles.
- **False case (implemented):** new `clearStaleProcessingFlags()` CRUD helper does a single `UPDATE ... SET processing_started_at = NULL WHERE processing_started_at IS NOT NULL` and returns the count. Wired into `runDaemon()` right after config load, guarded by `dbReady`, with the same log-and-continue posture as the surrounding startup recovery steps (orphaned work items, stale schedules, interrupted workflow runs).
- **True case (deferred):** a one-line `TODO` marks where the daemon would instead auto-resume each interrupted turn.

Since conversations load lazily and `_processing` initializes to `false` in memory, clearing the DB column at startup is sufficient — cold conversations never hydrate a stale `true`.

## Test plan

- New `src/memory/__tests__/clear-stale-processing-flags.test.ts`: clears the flag on a mid-turn conversation while leaving idle ones untouched, and returns `0` when nothing is processing. **2 pass.**
- Regression: `processing-flag-persist-failure.test.ts` (3 pass), `injector-background-turn.test.ts` (7 pass).
- `bunx tsc --noEmit` clean on all edited files; pre-commit lint / format / type-check hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAX8LWauV5fCzbNxrNJV7W)_