### PR TITLE
feat(memory): retrospective durationMs + runAsyncSqlite labels & slow-write warn

### DIFF
--- a/assistant/src/memory/__tests__/db-async-query.test.ts
+++ b/assistant/src/memory/__tests__/db-async-query.test.ts
@@ -55,13 +55,13 @@ function inflateAndDelete(byteTarget: number): void {
 
 describe("runAsyncSqlite", () => {
   test("returns ok=true for a trivial statement", async () => {
-    const result = await runAsyncSqlite("SELECT 1");
+    const result = await runAsyncSqlite("SELECT 1", "test:trivial-select");
     expect(result.ok).toBe(true);
     expect(result.error).toBeNull();
   });
 
   test("in-process fallback reports the right backend", async () => {
-    const result = await runAsyncSqlite("SELECT 1", {
+    const result = await runAsyncSqlite("SELECT 1", "test:in-process-backend", {
       forceBackend: "in-process-blocking",
     });
     expect(result.ok).toBe(true);
@@ -87,6 +87,7 @@ describe("runAsyncSqlite", () => {
 
     const result = await runAsyncSqlite(
       "DELETE FROM async_changes_probe WHERE id <= 3; SELECT changes();",
+      "test:in-process-changes-count",
       { forceBackend: "in-process-blocking" },
     );
 
@@ -103,7 +104,10 @@ describe("runAsyncSqlite", () => {
   test.if(sqlite3Available)(
     "sqlite3 CLI backend reports the right backend on success",
     async () => {
-      const result = await runAsyncSqlite("SELECT 1");
+      const result = await runAsyncSqlite(
+        "SELECT 1",
+        "test:cli-backend-success",
+      );
       expect(result.ok).toBe(true);
       expect(result.backend).toBe("sqlite3-cli");
     },
@@ -113,7 +117,10 @@ describe("runAsyncSqlite", () => {
     "surfaces sqlite3 errors as ok=false with the message preserved",
     async () => {
       // Intentional SQL syntax error.
-      const result = await runAsyncSqlite("THIS IS NOT VALID SQL");
+      const result = await runAsyncSqlite(
+        "THIS IS NOT VALID SQL",
+        "test:cli-error",
+      );
       expect(result.ok).toBe(false);
       expect(result.backend).toBe("sqlite3-cli");
       expect(result.error).toBeTruthy();
@@ -148,7 +155,7 @@ describe("runAsyncSqlite", () => {
 
       let result;
       try {
-        result = await runAsyncSqlite("VACUUM");
+        result = await runAsyncSqlite("VACUUM", "test:vacuum-anti-block");
       } finally {
         probing = false;
       }

--- a/assistant/src/memory/__tests__/db-logs-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-logs-attach.test.ts
@@ -74,6 +74,7 @@ describe("logs database connection", () => {
       try {
         const result = await runAsyncSqlite(
           "CREATE TABLE dbpath_probe (x INTEGER); INSERT INTO dbpath_probe VALUES (42); SELECT changes();",
+          "test:logs-attach-dbpath",
           { dbPath: targetPath, forceBackend: "sqlite3-cli" },
         );
         expect(result.ok).toBe(true);

--- a/assistant/src/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-memory-attach.test.ts
@@ -77,6 +77,7 @@ describe("memory database connection", () => {
       try {
         const result = await runAsyncSqlite(
           "CREATE TABLE dbpath_probe (x INTEGER); INSERT INTO dbpath_probe VALUES (42); SELECT changes();",
+          "test:memory-attach-dbpath",
           { dbPath: targetPath, forceBackend: "sqlite3-cli" },
         );
         expect(result.ok).toBe(true);

--- a/assistant/src/memory/__tests__/fork-message-copy.test.ts
+++ b/assistant/src/memory/__tests__/fork-message-copy.test.ts
@@ -25,7 +25,7 @@ import {
 import { getDb, getSqlite } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import {
-  buildForkCopyScript,
+  buildForkCopyBatchScript,
   copyForkMessagesViaSubprocess,
   type ForkIdPair,
 } from "../fork-message-copy.js";
@@ -211,22 +211,18 @@ describe("copyForkMessagesViaSubprocess", () => {
   });
 });
 
-describe("buildForkCopyScript", () => {
+describe("buildForkCopyBatchScript", () => {
   test("rejects an unsafe fork id", () => {
     expect(() =>
-      buildForkCopyScript({
-        forkConversationId: "abc'); DROP TABLE messages;--",
-        idPairs: [],
-      }),
+      buildForkCopyBatchScript("abc'); DROP TABLE messages;--", []),
     ).toThrow(/unsafe id/);
   });
 
   test("rejects an unsafe message id", () => {
     expect(() =>
-      buildForkCopyScript({
-        forkConversationId: crypto.randomUUID(),
-        idPairs: [{ oldId: "ok", newId: "bad'id" }],
-      }),
+      buildForkCopyBatchScript(crypto.randomUUID(), [
+        { oldId: "ok", newId: "bad'id" },
+      ]),
     ).toThrow(/unsafe id/);
   });
 });

--- a/assistant/src/memory/__tests__/fork-message-copy.test.ts
+++ b/assistant/src/memory/__tests__/fork-message-copy.test.ts
@@ -25,7 +25,7 @@ import {
 import { getDb, getSqlite } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import {
-  buildForkCopyBatchScript,
+  buildForkCopyScript,
   copyForkMessagesViaSubprocess,
   type ForkIdPair,
 } from "../fork-message-copy.js";
@@ -211,18 +211,22 @@ describe("copyForkMessagesViaSubprocess", () => {
   });
 });
 
-describe("buildForkCopyBatchScript", () => {
+describe("buildForkCopyScript", () => {
   test("rejects an unsafe fork id", () => {
     expect(() =>
-      buildForkCopyBatchScript("abc'); DROP TABLE messages;--", []),
+      buildForkCopyScript({
+        forkConversationId: "abc'); DROP TABLE messages;--",
+        idPairs: [],
+      }),
     ).toThrow(/unsafe id/);
   });
 
   test("rejects an unsafe message id", () => {
     expect(() =>
-      buildForkCopyBatchScript(crypto.randomUUID(), [
-        { oldId: "ok", newId: "bad'id" },
-      ]),
+      buildForkCopyScript({
+        forkConversationId: crypto.randomUUID(),
+        idPairs: [{ oldId: "ok", newId: "bad'id" }],
+      }),
     ).toThrow(/unsafe id/);
   });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -69,6 +69,7 @@ import {
   getDb,
   getLogsDb,
   getSqliteFrom,
+  SQLITE_BUSY_TIMEOUT_MS,
 } from "./db-connection.js";
 import {
   copyForkMessagesViaSubprocess,
@@ -105,6 +106,32 @@ import {
 import { extractInjectedConceptSlugs } from "./v2/injected-block-slugs.js";
 
 const log = getLogger("conversation-store");
+
+/**
+ * A synchronous main-connection write that takes at least this long almost
+ * certainly spent the time blocked inside `busy_timeout` waiting for the write
+ * lock (a live insert does single-digit-ms of real work), so crossing it is
+ * logged as direct contention evidence rather than inferring it from the event
+ * loop watchdog's `blockedMs`. Kept well under {@link SQLITE_BUSY_TIMEOUT_MS}
+ * so a genuinely contended write surfaces before it fails with `SQLITE_BUSY`.
+ */
+const LOCK_WAIT_LOG_THRESHOLD_MS = 1000;
+
+/**
+ * Log when a main-thread write spent long enough that the time was almost
+ * certainly lock-wait inside `busy_timeout` (see
+ * {@link LOCK_WAIT_LOG_THRESHOLD_MS}). No-op below the threshold.
+ */
+function logIfLockWait(
+  elapsedMs: number,
+  fields: Record<string, unknown>,
+): void {
+  if (elapsedMs < LOCK_WAIT_LOG_THRESHOLD_MS) return;
+  log.warn(
+    { ...fields, elapsedMs, busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS },
+    "main-thread DB write exceeded lock-wait threshold (likely busy_timeout contention)",
+  );
+}
 
 /**
  * The logs connection (`assistant-logs.db`), where `llm_request_logs` lives.
@@ -459,6 +486,7 @@ async function insertMessageCore(
   let now!: number;
   for (let attempt = 0; ; attempt++) {
     now = monotonicNow();
+    const writeStartMs = Date.now();
     try {
       const values = {
         id: messageId,
@@ -545,6 +573,11 @@ async function insertMessageCore(
             .run();
         });
       }
+      logIfLockWait(Date.now() - writeStartMs, {
+        conversationId,
+        messageId,
+        attempt,
+      });
       break;
     } catch (err) {
       const errCode = (err as { code?: string }).code ?? "";
@@ -1454,6 +1487,16 @@ export async function forkConversationForRetrospective(params: {
         `fork message copy failed (${copy.backend}): ${copy.error ?? "unknown"}`,
       );
     }
+    log.info(
+      {
+        forkConversationId: fork.id,
+        sourceConversationId: sourceConversation.id,
+        rowCount: idPairs.length,
+        elapsedMs: copy.elapsedMs,
+        backend: copy.backend,
+      },
+      "fork message-copy completed",
+    );
 
     // Phase 3 (in-process): attachments + memory-state seeding, reusing the
     // same helper as the synchronous fork. Disk-view projection is skipped.

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -69,7 +69,6 @@ import {
   getDb,
   getLogsDb,
   getSqliteFrom,
-  SQLITE_BUSY_TIMEOUT_MS,
 } from "./db-connection.js";
 import {
   copyForkMessagesViaSubprocess,
@@ -106,32 +105,6 @@ import {
 import { extractInjectedConceptSlugs } from "./v2/injected-block-slugs.js";
 
 const log = getLogger("conversation-store");
-
-/**
- * A synchronous main-connection write that takes at least this long almost
- * certainly spent the time blocked inside `busy_timeout` waiting for the write
- * lock (a live insert does single-digit-ms of real work), so crossing it is
- * logged as direct contention evidence rather than inferring it from the event
- * loop watchdog's `blockedMs`. Kept well under {@link SQLITE_BUSY_TIMEOUT_MS}
- * so a genuinely contended write surfaces before it fails with `SQLITE_BUSY`.
- */
-const LOCK_WAIT_LOG_THRESHOLD_MS = 1000;
-
-/**
- * Log when a main-thread write spent long enough that the time was almost
- * certainly lock-wait inside `busy_timeout` (see
- * {@link LOCK_WAIT_LOG_THRESHOLD_MS}). No-op below the threshold.
- */
-function logIfLockWait(
-  elapsedMs: number,
-  fields: Record<string, unknown>,
-): void {
-  if (elapsedMs < LOCK_WAIT_LOG_THRESHOLD_MS) return;
-  log.warn(
-    { ...fields, elapsedMs, busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS },
-    "main-thread DB write exceeded lock-wait threshold (likely busy_timeout contention)",
-  );
-}
 
 /**
  * The logs connection (`assistant-logs.db`), where `llm_request_logs` lives.
@@ -486,7 +459,6 @@ async function insertMessageCore(
   let now!: number;
   for (let attempt = 0; ; attempt++) {
     now = monotonicNow();
-    const writeStartMs = Date.now();
     try {
       const values = {
         id: messageId,
@@ -573,11 +545,6 @@ async function insertMessageCore(
             .run();
         });
       }
-      logIfLockWait(Date.now() - writeStartMs, {
-        conversationId,
-        messageId,
-        attempt,
-      });
       break;
     } catch (err) {
       const errCode = (err as { code?: string }).code ?? "";
@@ -1487,16 +1454,6 @@ export async function forkConversationForRetrospective(params: {
         `fork message copy failed (${copy.backend}): ${copy.error ?? "unknown"}`,
       );
     }
-    log.info(
-      {
-        forkConversationId: fork.id,
-        sourceConversationId: sourceConversation.id,
-        rowCount: idPairs.length,
-        elapsedMs: copy.elapsedMs,
-        backend: copy.backend,
-      },
-      "fork message-copy completed",
-    );
 
     // Phase 3 (in-process): attachments + memory-state seeding, reusing the
     // same helper as the synchronous fork. Disk-view projection is skipped.
@@ -2608,7 +2565,7 @@ export async function clearAll(): Promise<{
     sql: string,
     options?: { dbPath?: string },
   ): Promise<void> => {
-    const result = await runAsyncSqlite(sql, options);
+    const result = await runAsyncSqlite(sql, `clearAll: ${sql}`, options);
     if (!result.ok) {
       throw new Error(
         `clearAll: \`${sql}\` failed (${result.backend}): ${result.error ?? "unknown"}`,
@@ -2640,7 +2597,10 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM tool_invocations");
   await runOrThrow("DELETE FROM skill_loaded_events");
   let messagesFtsCorrupted = false;
-  const ftsResult = await runAsyncSqlite("DELETE FROM messages_fts");
+  const ftsResult = await runAsyncSqlite(
+    "DELETE FROM messages_fts",
+    "clearAll:messages-fts",
+  );
   if (!ftsResult.ok) {
     log.warn(
       { error: ftsResult.error, backend: ftsResult.backend },

--- a/assistant/src/memory/db-async-query.ts
+++ b/assistant/src/memory/db-async-query.ts
@@ -43,6 +43,14 @@ const log = getLogger("db-async-query");
  */
 const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 
+/**
+ * A successful async statement that runs longer than this is logged at WARN.
+ * These dispatches are meant to be heavy-but-bounded; crossing this threshold
+ * is a signal worth surfacing (lock contention, an unexpectedly large sweep,
+ * a degraded disk) even when the statement ultimately succeeds.
+ */
+const SLOW_WRITE_WARN_MS = 2000;
+
 export type AsyncSqliteBackend = "sqlite3-cli" | "in-process-blocking";
 
 export interface AsyncSqliteResult {
@@ -95,12 +103,14 @@ let warnedAboutFallback = false;
 
 export async function runAsyncSqlite(
   sql: string,
+  label: string,
   options: RunAsyncSqliteOptions = {},
 ): Promise<AsyncSqliteResult> {
   const forced = options.forceBackend;
   const sqlite3Path =
     forced === "in-process-blocking" ? undefined : findSqlite3();
 
+  let result: AsyncSqliteResult;
   if (sqlite3Path && forced !== "in-process-blocking") {
     const attachPrefix = (options.attach ?? [])
       .map(
@@ -108,23 +118,32 @@ export async function runAsyncSqlite(
           `ATTACH DATABASE '${a.path.replace(/'/g, "''")}' AS ${a.alias};\n`,
       )
       .join("");
-    return runViaCli(
+    result = await runViaCli(
       sqlite3Path,
       attachPrefix + sql,
       options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       options.dbPath ?? getDbPath(),
+      label,
     );
+  } else {
+    if (!warnedAboutFallback) {
+      warnedAboutFallback = true;
+      log.warn(
+        "No sqlite3 CLI found on host — falling back to in-process blocking " +
+          "execution for slow SQLite statements. Install sqlite3 to keep the " +
+          "event loop responsive during VACUUM and other long operations.",
+      );
+    }
+    result = await runInProcessBlocking(sql, options);
   }
 
-  if (!warnedAboutFallback) {
-    warnedAboutFallback = true;
+  if (result.ok && result.elapsedMs > SLOW_WRITE_WARN_MS) {
     log.warn(
-      "No sqlite3 CLI found on host — falling back to in-process blocking " +
-        "execution for slow SQLite statements. Install sqlite3 to keep the " +
-        "event loop responsive during VACUUM and other long operations.",
+      { label, elapsedMs: result.elapsedMs, backend: result.backend },
+      "Async SQL completed but exceeded slow-write threshold",
     );
   }
-  return runInProcessBlocking(sql, options);
+  return result;
 }
 
 /** For tests: reset the once-only fallback warning. */
@@ -155,11 +174,12 @@ async function runViaCli(
   sql: string,
   timeoutMs: number,
   dbPath: string,
+  label: string,
 ): Promise<AsyncSqliteResult> {
   const startMs = Date.now();
 
   log.info(
-    { sqlite3Path, dbPath, timeoutMs, sqlPreview: sql.slice(0, 80) },
+    { label, sqlite3Path, dbPath, timeoutMs, sqlPreview: sql.slice(0, 80) },
     "Running async SQL via sqlite3 CLI subprocess",
   );
 
@@ -203,7 +223,7 @@ async function runViaCli(
 
   if (timedOut) {
     log.error(
-      { timeoutMs, elapsedMs, stderr: stderr.slice(0, 2000) },
+      { label, timeoutMs, elapsedMs, stderr: stderr.slice(0, 2000) },
       "Async SQL subprocess timed out — killed",
     );
     return {
@@ -218,7 +238,7 @@ async function runViaCli(
   }
   if (exitCode !== 0) {
     log.error(
-      { exitCode, elapsedMs, stderr: stderr.slice(0, 2000) },
+      { label, exitCode, elapsedMs, stderr: stderr.slice(0, 2000) },
       "Async SQL subprocess failed",
     );
     return {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -181,7 +181,10 @@ function saveTemplate(): void {
 export async function checkpointWalBeforeOpen(): Promise<void> {
   const log = getLogger("db-init");
   try {
-    const result = await runAsyncSqlite("PRAGMA wal_checkpoint(TRUNCATE)");
+    const result = await runAsyncSqlite(
+      "PRAGMA wal_checkpoint(TRUNCATE)",
+      "db-init:pre-open-wal-checkpoint",
+    );
     if (result.ok) {
       log.info(
         { backend: result.backend, elapsedMs: result.elapsedMs },

--- a/assistant/src/memory/db-maintenance.ts
+++ b/assistant/src/memory/db-maintenance.ts
@@ -74,7 +74,10 @@ async function runDbMaintenance(): Promise<void> {
   // Refresh the query planner's statistics. PRAGMA optimize is cheap; it is
   // routed through the async path for consistency and to keep it off the main
   // thread when the sqlite3 CLI backend is available.
-  const optimizeResult = await runAsyncSqlite("PRAGMA optimize");
+  const optimizeResult = await runAsyncSqlite(
+    "PRAGMA optimize",
+    "db-maintenance:optimize",
+  );
   if (!optimizeResult.ok) {
     log.warn(
       { error: optimizeResult.error, backend: optimizeResult.backend },
@@ -97,6 +100,7 @@ async function runDbMaintenance(): Promise<void> {
   // best-effort no-op and the next maintenance pass retries.
   const checkpointResult = await runAsyncSqlite(
     "PRAGMA wal_checkpoint(TRUNCATE)",
+    "db-maintenance:wal-checkpoint-truncate",
   );
   if (!checkpointResult.ok) {
     log.warn(

--- a/assistant/src/memory/fork-message-copy.ts
+++ b/assistant/src/memory/fork-message-copy.ts
@@ -35,14 +35,11 @@
 
 import { setTimeout as sleep } from "node:timers/promises";
 
-import { getLogger } from "../util/logger.js";
 import {
   type AsyncSqliteBackend,
   type AsyncSqliteResult,
   runAsyncSqlite,
 } from "./db-async-query.js";
-
-const log = getLogger("fork-message-copy");
 
 /**
  * Default batch size for the chunked copy. Each batch is one `INSERT … SELECT`
@@ -113,61 +110,71 @@ const METADATA_CLONE_EXPR = `CASE
 END`;
 
 /**
- * Build the self-contained SQL script that copies a single batch of id pairs
- * into the fork conversation. Each batch runs as its own {@link runAsyncSqlite}
- * call (its own subprocess/connection), so the staging table is created and
- * dropped within the batch rather than shared across batches. The batch is one
- * implicit auto-committing transaction, so the write lock is released once the
- * script returns — letting in-process writers slip in before the next batch.
- *
- * Exported for unit testing the generated SQL without spawning a subprocess.
+ * Build the multi-statement SQL script that copies the given id pairs into the
+ * fork conversation in lock-friendly batches. Exported for unit testing the
+ * generated SQL without spawning a subprocess.
  */
-export function buildForkCopyBatchScript(
-  forkConversationId: string,
-  batch: readonly ForkIdPair[],
-): string {
+export function buildForkCopyScript(options: CopyForkMessagesOptions): string {
+  const { forkConversationId, idPairs } = options;
   assertSafeId(forkConversationId);
-  const values = batch
-    .map(({ oldId, newId }) => {
-      assertSafeId(oldId);
-      assertSafeId(newId);
-      return `('${oldId}','${newId}')`;
-    })
-    .join(",");
+  const batchSize = Math.max(
+    1,
+    options.batchSize ?? DEFAULT_FORK_COPY_BATCH_SIZE,
+  );
 
-  return [
-    // Connection-scoped staging table holding this batch's id map. The
+  const statements: string[] = [
+    // Connection-scoped staging table holding the current batch's id map. The
     // unqualified `messages` reference in the SELECT resolves to the main DB.
     `CREATE TEMP TABLE IF NOT EXISTS _fork_id_map (old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);`,
-    `DELETE FROM _fork_id_map;`,
-    `INSERT INTO _fork_id_map (old_id, new_id) VALUES ${values};`,
-    `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+  ];
+
+  for (let i = 0; i < idPairs.length; i += batchSize) {
+    const batch = idPairs.slice(i, i + batchSize);
+    const values = batch
+      .map(({ oldId, newId }) => {
+        assertSafeId(oldId);
+        assertSafeId(newId);
+        return `('${oldId}','${newId}')`;
+      })
+      .join(",");
+
+    // Each batch auto-commits (no surrounding BEGIN), so the write lock is
+    // released between batches for in-process writers.
+    statements.push(`DELETE FROM _fork_id_map;`);
+    statements.push(
+      `INSERT INTO _fork_id_map (old_id, new_id) VALUES ${values};`,
+    );
+    statements.push(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
 SELECT map.new_id, '${forkConversationId}', m.role, m.content, m.created_at, ${METADATA_CLONE_EXPR}
 FROM messages m JOIN _fork_id_map map ON map.old_id = m.id;`,
-    // Drop the staging table so the in-process fallback (which runs on the
-    // shared daemon connection) does not leave it lingering; harmless for the
-    // subprocess backend, whose connection is discarded on exit.
-    `DROP TABLE IF EXISTS _fork_id_map;`,
-  ].join("\n");
+    );
+  }
+
+  // Drop the staging table so the in-process fallback (which runs on the shared
+  // daemon connection) does not leave it lingering; harmless for the subprocess
+  // backend, whose connection is discarded on exit.
+  statements.push(`DROP TABLE IF EXISTS _fork_id_map;`);
+
+  return statements.join("\n");
 }
 
 /**
- * batches. Each batch runs as its own {@link runAsyncSqlite} call with a brief
- * yield in between (see {@link DEFAULT_FORK_COPY_INTER_BATCH_DELAY_MS}) so
- * foreground writers reliably acquire the write lock between batches instead of
- * losing every race to the copy's greedy lock re-acquisition. Each batch's
- * `elapsedMs` is logged so lock-wait is visible at batch granularity. Resolves
- * once every batch has committed (or returns the failing batch's `ok: false`
- * result on subprocess failure — the caller is responsible for cleaning up the
- * partially-built fork). The returned `elapsedMs` is the sum across batches.
+ * Copy the message rows for a fork off the event loop, in lock-friendly
+ * batches. Each batch runs as its own subprocess call with a brief yield in
+ * between (see {@link DEFAULT_FORK_COPY_INTER_BATCH_DELAY_MS}) so foreground
+ * writers reliably acquire the write lock between batches instead of losing
+ * every race to the copy's greedy lock re-acquisition. Resolves once every
+ * batch has committed (or returns the failing batch's `ok: false` result on
+ * subprocess failure — the caller is responsible for cleaning up the
+ * partially-built fork).
  *
  * No-op (returns a synthetic ok result) when there is nothing to copy.
  */
 export async function copyForkMessagesViaSubprocess(
   options: CopyForkMessagesOptions,
 ): Promise<AsyncSqliteResult> {
-  const { forkConversationId, idPairs } = options;
-  if (idPairs.length === 0) {
+  if (options.idPairs.length === 0) {
     return {
       ok: true,
       backend: "in-process-blocking",
@@ -183,49 +190,36 @@ export async function copyForkMessagesViaSubprocess(
   const runOptions = options.forceInProcess
     ? { forceBackend: "in-process-blocking" as const }
     : {};
-  const batchCount = Math.ceil(idPairs.length / batchSize);
 
   let totalElapsedMs = 0;
   let backend: AsyncSqliteBackend = "in-process-blocking";
 
-  for (let i = 0, batchIndex = 0; i < idPairs.length; i += batchSize) {
-    const batch = idPairs.slice(i, i + batchSize);
-    const sql = buildForkCopyBatchScript(forkConversationId, batch);
-    const result = await runAsyncSqlite(sql, runOptions);
+  for (let i = 0; i < options.idPairs.length; i += batchSize) {
+    const batch = options.idPairs.slice(i, i + batchSize);
+    // One subprocess call per batch. Each generated script is self-contained
+    // (it creates and drops its own staging table), so splitting execution
+    // across calls is safe — and it's what lets us yield between batches below.
+    const sql = buildForkCopyScript({
+      forkConversationId: options.forkConversationId,
+      idPairs: batch,
+      batchSize,
+    });
+    const result = await runAsyncSqlite(
+      sql,
+      `fork-message-copy:copy-batch:${options.forkConversationId}`,
+      runOptions,
+    );
     totalElapsedMs += result.elapsedMs;
     backend = result.backend;
-
-    log.info(
-      {
-        forkConversationId,
-        batchIndex,
-        batchCount,
-        batchRows: batch.length,
-        elapsedMs: result.elapsedMs,
-        backend: result.backend,
-      },
-      "fork message-copy batch committed",
-    );
-
     if (!result.ok) {
       return { ...result, elapsedMs: totalElapsedMs };
     }
 
-    // Yield between batches so a concurrent foreground writer (a live user
-    // turn persisting a message) can acquire the write lock instead of losing
-    // every race to the copy's greedy lock re-acquisition. Skipped after the
-    // final batch.
-    const isLastBatch = i + batchSize >= idPairs.length;
+    const isLastBatch = i + batchSize >= options.idPairs.length;
     if (!isLastBatch) {
       await sleep(DEFAULT_FORK_COPY_INTER_BATCH_DELAY_MS);
     }
-    batchIndex++;
   }
 
-  return {
-    ok: true,
-    backend,
-    error: null,
-    elapsedMs: totalElapsedMs,
-  };
+  return { ok: true, backend, error: null, elapsedMs: totalElapsedMs };
 }

--- a/assistant/src/memory/fork-message-copy.ts
+++ b/assistant/src/memory/fork-message-copy.ts
@@ -33,7 +33,14 @@
 //      `client_message_id` is intentionally NOT copied, matching the
 //      in-process fork (a forked row is not a client-submitted message).
 
-import { type AsyncSqliteResult, runAsyncSqlite } from "./db-async-query.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type AsyncSqliteBackend,
+  type AsyncSqliteResult,
+  runAsyncSqlite,
+} from "./db-async-query.js";
+
+const log = getLogger("fork-message-copy");
 
 /**
  * Default batch size for the chunked copy. Each batch is one `INSERT … SELECT`
@@ -92,67 +99,61 @@ const METADATA_CLONE_EXPR = `CASE
 END`;
 
 /**
- * Build the multi-statement SQL script that copies the given id pairs into the
- * fork conversation in lock-friendly batches. Exported for unit testing the
- * generated SQL without spawning a subprocess.
+ * Build the self-contained SQL script that copies a single batch of id pairs
+ * into the fork conversation. Each batch runs as its own {@link runAsyncSqlite}
+ * call (its own subprocess/connection), so the staging table is created and
+ * dropped within the batch rather than shared across batches. The batch is one
+ * implicit auto-committing transaction, so the write lock is released once the
+ * script returns — letting in-process writers slip in before the next batch.
+ *
+ * Exported for unit testing the generated SQL without spawning a subprocess.
  */
-export function buildForkCopyScript(options: CopyForkMessagesOptions): string {
-  const { forkConversationId, idPairs } = options;
+export function buildForkCopyBatchScript(
+  forkConversationId: string,
+  batch: readonly ForkIdPair[],
+): string {
   assertSafeId(forkConversationId);
-  const batchSize = Math.max(
-    1,
-    options.batchSize ?? DEFAULT_FORK_COPY_BATCH_SIZE,
-  );
+  const values = batch
+    .map(({ oldId, newId }) => {
+      assertSafeId(oldId);
+      assertSafeId(newId);
+      return `('${oldId}','${newId}')`;
+    })
+    .join(",");
 
-  const statements: string[] = [
-    // Connection-scoped staging table holding the current batch's id map. The
+  return [
+    // Connection-scoped staging table holding this batch's id map. The
     // unqualified `messages` reference in the SELECT resolves to the main DB.
     `CREATE TEMP TABLE IF NOT EXISTS _fork_id_map (old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);`,
-  ];
-
-  for (let i = 0; i < idPairs.length; i += batchSize) {
-    const batch = idPairs.slice(i, i + batchSize);
-    const values = batch
-      .map(({ oldId, newId }) => {
-        assertSafeId(oldId);
-        assertSafeId(newId);
-        return `('${oldId}','${newId}')`;
-      })
-      .join(",");
-
-    // Each batch auto-commits (no surrounding BEGIN), so the write lock is
-    // released between batches for in-process writers.
-    statements.push(`DELETE FROM _fork_id_map;`);
-    statements.push(
-      `INSERT INTO _fork_id_map (old_id, new_id) VALUES ${values};`,
-    );
-    statements.push(
-      `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+    `DELETE FROM _fork_id_map;`,
+    `INSERT INTO _fork_id_map (old_id, new_id) VALUES ${values};`,
+    `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
 SELECT map.new_id, '${forkConversationId}', m.role, m.content, m.created_at, ${METADATA_CLONE_EXPR}
 FROM messages m JOIN _fork_id_map map ON map.old_id = m.id;`,
-    );
-  }
-
-  // Drop the staging table so the in-process fallback (which runs on the shared
-  // daemon connection) does not leave it lingering; harmless for the subprocess
-  // backend, whose connection is discarded on exit.
-  statements.push(`DROP TABLE IF EXISTS _fork_id_map;`);
-
-  return statements.join("\n");
+    // Drop the staging table so the in-process fallback (which runs on the
+    // shared daemon connection) does not leave it lingering; harmless for the
+    // subprocess backend, whose connection is discarded on exit.
+    `DROP TABLE IF EXISTS _fork_id_map;`,
+  ].join("\n");
 }
 
 /**
  * Copy the message rows for a fork off the event loop, in lock-friendly
- * batches. Resolves once every batch has committed (or rejects via the
- * returned result's `ok: false` on subprocess failure — the caller is
- * responsible for cleaning up the partially-built fork).
+ * batches. Each batch is a separate {@link runAsyncSqlite} call: the `await`
+ * between batches yields the event loop (the hook for an inter-batch
+ * throttle/yield), and each batch's `elapsedMs` is logged so lock-wait is
+ * visible at batch granularity. Resolves once every batch has committed (or
+ * returns an `ok: false` result on the first batch failure — the caller is
+ * responsible for cleaning up the partially-built fork). The returned
+ * `elapsedMs` is the sum across batches.
  *
  * No-op (returns a synthetic ok result) when there is nothing to copy.
  */
 export async function copyForkMessagesViaSubprocess(
   options: CopyForkMessagesOptions,
 ): Promise<AsyncSqliteResult> {
-  if (options.idPairs.length === 0) {
+  const { forkConversationId, idPairs } = options;
+  if (idPairs.length === 0) {
     return {
       ok: true,
       backend: "in-process-blocking",
@@ -161,10 +162,47 @@ export async function copyForkMessagesViaSubprocess(
     };
   }
 
-  const sql = buildForkCopyScript(options);
-  return runAsyncSqlite(sql, {
-    ...(options.forceInProcess
-      ? { forceBackend: "in-process-blocking" as const }
-      : {}),
-  });
+  const batchSize = Math.max(
+    1,
+    options.batchSize ?? DEFAULT_FORK_COPY_BATCH_SIZE,
+  );
+  const forceOpts = options.forceInProcess
+    ? { forceBackend: "in-process-blocking" as const }
+    : {};
+  const batchCount = Math.ceil(idPairs.length / batchSize);
+
+  let totalElapsedMs = 0;
+  let backend: AsyncSqliteBackend = "in-process-blocking";
+
+  for (let i = 0, batchIndex = 0; i < idPairs.length; i += batchSize) {
+    const batch = idPairs.slice(i, i + batchSize);
+    const sql = buildForkCopyBatchScript(forkConversationId, batch);
+    const result = await runAsyncSqlite(sql, forceOpts);
+    totalElapsedMs += result.elapsedMs;
+    backend = result.backend;
+
+    log.info(
+      {
+        forkConversationId,
+        batchIndex,
+        batchCount,
+        batchRows: batch.length,
+        elapsedMs: result.elapsedMs,
+        backend: result.backend,
+      },
+      "fork message-copy batch committed",
+    );
+
+    if (!result.ok) {
+      return { ...result, elapsedMs: totalElapsedMs };
+    }
+    batchIndex++;
+  }
+
+  return {
+    ok: true,
+    backend,
+    error: null,
+    elapsedMs: totalElapsedMs,
+  };
 }

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -57,6 +57,7 @@ export async function pruneOldLlmRequestLogsJob(
   const result = await runAsyncSqlite(
     `DELETE FROM llm_request_logs WHERE rowid IN (SELECT rowid FROM llm_request_logs WHERE created_at < ${cutoffMs} LIMIT ${PRUNE_LOG_BATCH_LIMIT});
 SELECT changes();`,
+    "cleanup:prune-llm-request-logs",
     { dbPath: getLogsDbPath() },
   );
   if (!result.ok) {
@@ -112,6 +113,7 @@ export async function pruneOldTraceEventsJob(
   const result = await runAsyncSqlite(
     `DELETE FROM trace_events WHERE rowid IN (SELECT rowid FROM trace_events WHERE created_at < ${cutoffMs} LIMIT ${PRUNE_LOG_BATCH_LIMIT});
 SELECT changes();`,
+    "cleanup:prune-trace-events",
   );
   if (!result.ok) {
     log.warn(

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -135,6 +135,9 @@ export async function runForkBasedRetrospective(
   sourceConversationId: string,
   config: AssistantConfig,
 ): Promise<MemoryRetrospectiveOutcome> {
+  // Start stamp for the retrospective's end-to-end wall time, surfaced as
+  // `durationMs` on the "invoked" log (start → invoked).
+  const startedAtMs = Date.now();
   const sourceConversation = getConversation(sourceConversationId);
   if (!sourceConversation) {
     log.warn(
@@ -365,7 +368,11 @@ export async function runForkBasedRetrospective(
       newMessageCount: newMessages.length,
       prior,
       priorRemembers,
-      logFields: { kind: "fork", windowStartTimestamp },
+      logFields: {
+        kind: "fork",
+        windowStartTimestamp,
+        durationMs: Date.now() - startedAtMs,
+      },
     });
   }
 

--- a/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
+++ b/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
@@ -160,10 +160,14 @@ export async function migrateStripThinkingFromConsolidated(
   while (lo < maxRow) {
     const hi = Math.min(lo + ROWID_WINDOW, maxRow);
 
-    const res = await runAsyncSqlite(windowSql(lo, hi), {
-      dbPath,
-      timeoutMs: WINDOW_TIMEOUT_MS,
-    });
+    const res = await runAsyncSqlite(
+      windowSql(lo, hi),
+      `migration-209:strip-thinking-window:(${lo},${hi}]`,
+      {
+        dbPath,
+        timeoutMs: WINDOW_TIMEOUT_MS,
+      },
+    );
     if (!res.ok) {
       // Leave the watermark at the last completed window; throwing reports the
       // step failed so the runner retries it (from the watermark) next boot
@@ -179,7 +183,11 @@ export async function migrateStripThinkingFromConsolidated(
 
   // Bound WAL growth left by the windowed rewrites, then drop the watermark so
   // a future re-run (e.g. after a rollback) starts clean.
-  await runAsyncSqlite(`PRAGMA wal_checkpoint(TRUNCATE);`, { dbPath });
+  await runAsyncSqlite(
+    `PRAGMA wal_checkpoint(TRUNCATE);`,
+    "migration-209:wal-checkpoint-truncate",
+    { dbPath },
+  );
   raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(WATERMARK_KEY);
 
   log.info(

--- a/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
+++ b/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
@@ -153,10 +153,14 @@ export async function migrateStripPlaceholderSentinelsFromMessages(
   for (let lo = 0; lo < maxRow; lo += ROWID_WINDOW) {
     const hi = Math.min(lo + ROWID_WINDOW, maxRow);
 
-    const res = await runAsyncSqlite(windowSql(lo, hi), {
-      dbPath,
-      timeoutMs: WINDOW_TIMEOUT_MS,
-    });
+    const res = await runAsyncSqlite(
+      windowSql(lo, hi),
+      `migration-222:strip-placeholder-window:(${lo},${hi}]`,
+      {
+        dbPath,
+        timeoutMs: WINDOW_TIMEOUT_MS,
+      },
+    );
     if (!res.ok) {
       // Surface the failure so the runner leaves the step un-checkpointed and
       // retries the whole sweep on the next boot.
@@ -167,5 +171,9 @@ export async function migrateStripPlaceholderSentinelsFromMessages(
   }
 
   // Bound WAL growth left by the windowed rewrites.
-  await runAsyncSqlite(`PRAGMA wal_checkpoint(TRUNCATE);`, { dbPath });
+  await runAsyncSqlite(
+    `PRAGMA wal_checkpoint(TRUNCATE);`,
+    "migration-222:wal-checkpoint-truncate",
+    { dbPath },
+  );
 }

--- a/assistant/src/memory/migrations/helpers/relocation.ts
+++ b/assistant/src/memory/migrations/helpers/relocation.ts
@@ -174,6 +174,7 @@ export async function drainStagedTable(
         `DELETE FROM "${staging}" WHERE rowid IN (` +
           `SELECT rowid FROM "${staging}" WHERE NOT (${spec.copyWhere}) LIMIT ${DRAIN_BATCH});\n` +
           `SELECT changes();`,
+        `relocation:purge-batch:${table}`,
         { dbPath },
       );
       if (!res.ok) {
@@ -194,6 +195,7 @@ export async function drainStagedTable(
         `DELETE FROM "${staging}" WHERE rowid IN (` +
         `SELECT rowid FROM "${staging}" ${whereCopy} ORDER BY rowid LIMIT ${DRAIN_BATCH});\n` +
         `SELECT changes();`,
+      `relocation:copy-batch:${table}`,
       {
         dbPath,
         attach: [{ path: spec.targetDbPath(), alias: "_reloc_target" }],
@@ -216,6 +218,7 @@ export async function drainStagedTable(
   // Drained — drop the (now empty) staging table and truncate the main WAL.
   const finalizeRes = await runAsyncSqlite(
     `DROP TABLE IF EXISTS "${staging}";\nPRAGMA wal_checkpoint(TRUNCATE);`,
+    `relocation:finalize:${table}`,
     { dbPath },
   );
   if (!finalizeRes.ok) {

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -97,6 +97,7 @@ export async function rotateToolInvocations(
   // integer (see Math.floor above), so inlining it here is safe.
   const result = await runAsyncSqlite(
     `DELETE FROM tool_invocations WHERE created_at < ${cutoffMs}`,
+    "tool-usage-store:prune-tool-invocations",
   );
   if (!result.ok) {
     log.error(

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -171,7 +171,10 @@ const log = getLogger("migration-routes");
  * all the copy needs.
  */
 async function checkpointDbsForExport(): Promise<void> {
-  const mainResult = await runAsyncSqlite("PRAGMA wal_checkpoint(FULL)");
+  const mainResult = await runAsyncSqlite(
+    "PRAGMA wal_checkpoint(FULL)",
+    "export-checkpoint:wal-checkpoint-full",
+  );
   if (!mainResult.ok) {
     log.warn(
       { error: mainResult.error, backend: mainResult.backend, db: "main" },


### PR DESCRIPTION
## Prompt / plan

Lightweight observability around the off-event-loop SQLite path. Three changes:

1. **Retrospective `durationMs`** — stamp end-to-end wall time (start → invoked) on the `memory-retrospective invoked` log line, via a `startedAtMs` captured at the top of `runForkBasedRetrospective` and added to its `logFields`.
2. **Slow-write WARN in `runAsyncSqlite`** — when a statement *succeeds* but runs longer than `SLOW_WRITE_WARN_MS` (2s), log a WARN with `{ label, elapsedMs, backend }`. Surfaces lock contention / oversized sweeps / degraded disk even on the success path. Covers both the `sqlite3-cli` and in-process backends (checked centrally on the returned result).
3. **Required `label` on `runAsyncSqlite`** — the function now takes a required human-readable `label` as its second argument, threaded into its info/warn/error log lines (the subprocess-start info log, the timeout error, the exit-code error, and the new slow-write warn). Every caller passes a unique label, e.g. `db-maintenance:optimize`, `cleanup:prune-llm-request-logs`, `relocation:copy-batch:<table>`, `migration-209:strip-thinking-window:(lo,hi]`, `fork-message-copy:copy-batch:<forkId>`.

### Why

Async SQL dispatches (checkpoints, prunes, migrations, the fork copy) all funnel through `runAsyncSqlite` but were indistinguishable in the logs. A required label makes every dispatch attributable, and the slow-write warn flags a successful-but-slow statement directly instead of waiting for a timeout or inferring contention elsewhere.

### Scope note

This replaces the earlier, broader version of this PR. The fork-copy per-batch logging, the `insertMessageCore` lock-wait instrumentation, and the `buildForkCopyScript` → `buildForkCopyBatchScript` rename were all reverted to `main`; only `durationMs` survives from the original fork-copy work.

## Test plan

- `bun test src/memory/__tests__/db-async-query.test.ts` + the `db-logs-attach` / `db-memory-attach` / `fork-message-copy` / `table-relocation` / migration-209 / migration-222 suites — all pass with the new label argument.
- `tsc --noEmit` clean: because `label` is a required positional, the typechecker confirms every caller (production + tests) passes one — no call site missed.
- Lint + prettier clean; pre-commit and pre-push hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2aYYKJRggQ9hVVrRgsHDn