### PR TITLE
refactor(memory): make in-process memory worker stop self-contained, drop bgRefs

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -822,12 +822,6 @@ export async function runDaemon(): Promise<void> {
   startOrphanReaper();
   startEventLoopWatchdog();
 
-  // Mutable ref for the memory worker so background init can assign it and the
-  // shutdown handler always sees the latest value.
-  const bgRefs: {
-    memoryWorker: { stop(): void } | null;
-  } = { memoryWorker: null };
-
   // Initialize Qdrant vector store and memory worker in the background so the
   // RuntimeHttpServer can start accepting requests without waiting for Qdrant.
   async function initializeQdrantAndMemory(): Promise<void> {
@@ -964,7 +958,7 @@ export async function runDaemon(): Promise<void> {
     // `memory.worker.enabled` is set. Shutdown stops whichever worker is
     // actually running — see shutdown-handlers.ts.
     log.info("Daemon startup: starting memory worker");
-    bgRefs.memoryWorker = startMemoryJobsWorker();
+    startMemoryJobsWorker();
 
     // Seed capability graph nodes (new memory graph system)
     try {
@@ -1408,7 +1402,6 @@ export async function runDaemon(): Promise<void> {
     filing,
     runtimeHttp,
     scheduler,
-    getMemoryWorker: () => bgRefs.memoryWorker,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -5,6 +5,7 @@ import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { stopMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { stopQdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
@@ -43,7 +44,6 @@ export interface ShutdownDeps {
   filing: FilingService | null;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
-  getMemoryWorker: () => { stop(): void } | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -129,9 +129,9 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     cleanupShellOutputTempFiles();
     deps.scheduler.stop();
 
-    // Stop the in-process memory worker if one was started on the daemon's
-    // event loop (memory.worker.enabled = false).
-    deps.getMemoryWorker()?.stop();
+    // Stop the in-process memory worker supervisor if it was started on the
+    // daemon's event loop (memory.worker.enabled = false).
+    stopMemoryJobsWorker();
 
     // Stop the out-of-process memory worker if it's actually running. This is
     // keyed off live state rather than config: the worker may have been

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -162,6 +162,9 @@ export interface MemoryJobsWorker {
   stop(): void;
 }
 
+/** The daemon's in-process supervisor, retained so shutdown can stop it. */
+let daemonSupervisor: MemoryJobsWorker | null = null;
+
 /**
  * Start the daemon's memory jobs worker supervisor.
  *
@@ -217,7 +220,21 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
       );
   }
 
-  return startInProcessMemoryJobsWorker({ standDownForWorkerProcess: true });
+  daemonSupervisor = startInProcessMemoryJobsWorker({
+    standDownForWorkerProcess: true,
+  });
+  return daemonSupervisor;
+}
+
+/**
+ * Stop the daemon's in-process memory jobs supervisor if it was started; no-op
+ * otherwise. Does not touch the out-of-process worker — see
+ * stopMemoryWorkerProcess() in worker-control.ts.
+ */
+export function stopMemoryJobsWorker(): void {
+  if (!daemonSupervisor) return;
+  daemonSupervisor.stop();
+  daemonSupervisor = null;
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

The last getter arg on `installShutdownHandlers` — `getMemoryWorker`.

The in-process memory jobs supervisor returned by `startMemoryJobsWorker()` was stashed in a mutable `bgRefs` slot and exposed to the shutdown handler via a `getMemoryWorker()` getter:

```ts
const bgRefs = { memoryWorker: null };
bgRefs.memoryWorker = startMemoryJobsWorker();
installShutdownHandlers({ …, getMemoryWorker: () => bgRefs.memoryWorker });
```

This moves the handle into the `jobs-worker` module:

- **`startMemoryJobsWorker()`** now retains the supervisor it creates in a module-level `daemonSupervisor` (still returns it, since a unit test and other callers use the return value).
- **`stopMemoryJobsWorker()`** stops that supervisor if one was started (`if (!daemonSupervisor) return`), then clears it. shutdown-handlers imports it directly.
- The **out-of-process** worker stop (`stopMemoryWorkerProcess()` from `worker-control.ts`) is unchanged — these are two distinct workers and both stops still run.

Since this was the last getter, **`bgRefs` is gone entirely** from lifecycle, and `ShutdownDeps` no longer has any `get*` fields.

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test src/__tests__/memory-jobs-worker-backoff.test.ts src/__tests__/disk-pressure-lifecycle.test.ts src/background-wake/wake-intent-hooks.test.ts` — 15 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_