### PR TITLE
refactor(schedule): make scheduler a self-managed singleton for shutdown

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1401,7 +1401,6 @@ export async function runDaemon(): Promise<void> {
     heartbeat,
     filing,
     runtimeHttp,
-    scheduler,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -9,6 +9,7 @@ import { stopMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { stopQdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
+import { stopScheduler } from "../schedule/scheduler.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
@@ -43,7 +44,6 @@ export interface ShutdownDeps {
   heartbeat: HeartbeatService;
   filing: FilingService | null;
   runtimeHttp: RuntimeHttpServer | null;
-  scheduler: { stop(): void };
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -127,7 +127,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
-    deps.scheduler.stop();
+    stopScheduler();
 
     // Stop the in-process memory worker supervisor if it was started on the
     // daemon's event loop (memory.worker.enabled = false).

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -163,7 +163,7 @@ export interface MemoryJobsWorker {
 }
 
 /** The daemon's in-process supervisor, retained so shutdown can stop it. */
-let daemonSupervisor: MemoryJobsWorker | null = null;
+let instance: MemoryJobsWorker | null = null;
 
 /**
  * Start the daemon's memory jobs worker supervisor.
@@ -220,10 +220,10 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
       );
   }
 
-  daemonSupervisor = startInProcessMemoryJobsWorker({
+  instance = startInProcessMemoryJobsWorker({
     standDownForWorkerProcess: true,
   });
-  return daemonSupervisor;
+  return instance;
 }
 
 /**
@@ -232,9 +232,9 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
  * stopMemoryWorkerProcess() in worker-control.ts.
  */
 export function stopMemoryJobsWorker(): void {
-  if (!daemonSupervisor) return;
-  daemonSupervisor.stop();
-  daemonSupervisor = null;
+  if (!instance) return;
+  instance.stop();
+  instance = null;
 }
 
 /**

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -117,6 +117,9 @@ function handleExecutionFailure(params: {
   });
 }
 
+/** The running scheduler, retained so shutdown can stop it. */
+let instance: SchedulerHandle | null = null;
+
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
   notifyScheduleOneShot: ScheduleNotifyModeNotifier,
@@ -149,7 +152,7 @@ export function startScheduler(
   timer.unref();
   void tick();
 
-  return {
+  instance = {
     async runOnce(): Promise<number> {
       return runScheduleOnce(
         processMessage,
@@ -174,6 +177,14 @@ export function startScheduler(
       clearInterval(timer);
     },
   };
+  return instance;
+}
+
+/** Stop the running scheduler if one was started; no-op otherwise. */
+export function stopScheduler(): void {
+  if (!instance) return;
+  instance.stop();
+  instance = null;
 }
 
 export async function runScheduleOnce(


### PR DESCRIPTION
## Prompt / plan

Two commits.

### 1. Rename memory jobs supervisor singleton to `instance`

Addresses the review comment on #36398 — the in-process memory worker singleton was named `daemonSupervisor`; renamed to `instance` to match the convention used by the other self-managed modules (telemetry, mcp, qdrant).

### 2. Make the scheduler a self-managed singleton

The scheduler handle from `startScheduler()` was threaded through `ShutdownDeps` so the shutdown handler could call `.stop()`. Move the handle into the scheduler module:

- **`startScheduler()`** stores the handle it creates in a module-level `instance` (still returns it — lifecycle uses the handle for `registerBackgroundWakeRuntime`, and many unit tests use the return value directly).
- **`stopScheduler()`** stops that handle if one was started (`if (!instance) return`), then clears it. shutdown-handlers imports it directly and drops the `scheduler` field from `ShutdownDeps`.

Tests that create multiple schedulers and stop them via their own handles are unaffected — they never call `stopScheduler()`, and the returned handle is unchanged.

## Test plan

- `bun run lint` on all changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test task-scheduler scheduler-recurrence scheduler-wake disk-pressure-lifecycle wake-intent-hooks` — 49 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_