### PR TITLE
refactor(runtime): make runtime HTTP server a self-managed singleton for shutdown

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -12,8 +12,6 @@ import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import {
   getPlatformAssistantId,
-  getRuntimeHttpHost,
-  getRuntimeHttpPort,
   setIngressPublicBaseUrl,
   validateEnv,
 } from "../config/env.js";
@@ -73,7 +71,7 @@ import {
   initAuthSigningKey,
   resolveSigningKey,
 } from "../runtime/auth/token-service.js";
-import { RuntimeHttpServer } from "../runtime/http-server.js";
+import { startRuntimeHttpServer } from "../runtime/http-server.js";
 import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
@@ -330,34 +328,9 @@ export async function runDaemon(): Promise<void> {
   const signingKey = resolveSigningKey();
   initAuthSigningKey(signingKey);
 
-  // Start the runtime HTTP server early so /healthz answers ASAP.
-  let runtimeHttp: RuntimeHttpServer | null = null;
-  const httpPort = getRuntimeHttpPort();
-  const httpHostname = getRuntimeHttpHost();
-  log.info({ httpPort }, "Daemon startup: starting runtime HTTP server");
-
-  runtimeHttp = new RuntimeHttpServer({
-    port: httpPort,
-    hostname: httpHostname,
-  });
-
-  // Isolated try/catch around start() — a bind failure (port in use,
-  // permission denied, fd exhaustion) must not tear down the rest of
-  // daemon startup. The daemon falls back to IPC-only operation when
-  // runtimeHttp is null.
-  try {
-    await runtimeHttp.start();
-    log.info(
-      { port: httpPort, hostname: httpHostname },
-      "Daemon startup: runtime HTTP server listening",
-    );
-  } catch (err) {
-    log.warn(
-      { err, port: httpPort },
-      "Failed to start runtime HTTP server, continuing without it",
-    );
-    runtimeHttp = null;
-  }
+  // Start the runtime HTTP server early so /healthz answers ASAP. A bind
+  // failure is non-fatal — the daemon falls back to IPC-only operation.
+  await startRuntimeHttpServer();
 
   // Pre-populate feature flag overrides so subsequent sync
   // isAssistantFeatureFlagEnabled() calls have data. Fired non-blocking
@@ -1108,7 +1081,7 @@ export async function runDaemon(): Promise<void> {
   });
 
   // Fire-and-forget: Qdrant init and memory worker startup run concurrently
-  // with the rest of daemon boot. Must run AFTER `new RuntimeHttpServer(...)`
+  // with the rest of daemon boot. Must run AFTER `startRuntimeHttpServer()`
   // so the analyze-deps singleton (populated inside `buildRouteTable()`) is
   // available before the memory worker can claim leftover
   // `conversation_analyze` jobs from a prior run. See the daemon-startup
@@ -1278,7 +1251,6 @@ export async function runDaemon(): Promise<void> {
       { err },
       "Failed to wire runtime HTTP server deps, continuing without them",
     );
-    runtimeHttp = null;
   }
 
   // Register built-in TTS providers so the provider abstraction can resolve
@@ -1400,7 +1372,6 @@ export async function runDaemon(): Promise<void> {
     workspaceHeartbeat,
     heartbeat,
     filing,
-    runtimeHttp,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -8,7 +8,7 @@ import { getSqlite, resetDb } from "../memory/db-connection.js";
 import { stopMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { stopQdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
-import type { RuntimeHttpServer } from "../runtime/http-server.js";
+import { stopRuntimeHttpServer } from "../runtime/http-server.js";
 import { stopScheduler } from "../schedule/scheduler.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
@@ -43,7 +43,6 @@ export interface ShutdownDeps {
   workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
   filing: FilingService | null;
-  runtimeHttp: RuntimeHttpServer | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -124,7 +123,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       log.warn({ err }, "Telemetry reporter shutdown failed (non-fatal)");
     }
 
-    if (deps.runtimeHttp) await deps.runtimeHttp.stop();
+    await stopRuntimeHttpServer();
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
     stopScheduler();

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -21,7 +21,11 @@ import {
   handleStatusCallback,
   handleVoiceWebhook,
 } from "../calls/twilio-routes.js";
-import { isHttpAuthDisabled } from "../config/env.js";
+import {
+  getRuntimeHttpHost,
+  getRuntimeHttpPort,
+  isHttpAuthDisabled,
+} from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { processMessage } from "../daemon/process-message.js";
@@ -1072,4 +1076,44 @@ export class RuntimeHttpServer {
 
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let instance: RuntimeHttpServer | null = null;
+
+/**
+ * Start the runtime HTTP server singleton early in daemon startup so /healthz
+ * answers ASAP. A bind failure (port in use, permission denied, fd exhaustion)
+ * is non-fatal: it is logged and the daemon falls back to IPC-only operation,
+ * leaving the singleton unset.
+ */
+export async function startRuntimeHttpServer(): Promise<void> {
+  const port = getRuntimeHttpPort();
+  const hostname = getRuntimeHttpHost();
+  log.info({ port }, "Daemon startup: starting runtime HTTP server");
+  const server = new RuntimeHttpServer({ port, hostname });
+  try {
+    await server.start();
+    instance = server;
+    log.info(
+      { port, hostname },
+      "Daemon startup: runtime HTTP server listening",
+    );
+  } catch (err) {
+    log.warn(
+      { err, port },
+      "Failed to start runtime HTTP server, continuing without it",
+    );
+    instance = null;
+  }
+}
+
+/** Stop the runtime HTTP server singleton if one is running; no-op otherwise. */
+export async function stopRuntimeHttpServer(): Promise<void> {
+  if (!instance) return;
+  await instance.stop();
+  instance = null;
 }


### PR DESCRIPTION
## Prompt / plan

Continuing to shrink `installShutdownHandlers`. This removes the `runtimeHttp` arg.

lifecycle constructed the `RuntimeHttpServer`, started it (nulling the local ref on bind failure), and threaded it through `ShutdownDeps` so the shutdown handler could call `.stop()`. Move ownership into the `http-server` module, matching the `start*/stop*` singleton pattern used for telemetry/mcp/qdrant/scheduler:

- **`startRuntimeHttpServer()`** reads the configured port/host (`getRuntimeHttpPort`/`getRuntimeHttpHost`), constructs and starts the server, and stores it as the module singleton. A bind failure stays non-fatal — logged, singleton left unset — so the daemon falls back to IPC-only operation.
- **`stopRuntimeHttpServer()`** stops the singleton if one is running (`if (!instance) return`); shutdown-handlers imports it directly and drops the `runtimeHttp` field from `ShutdownDeps`.

lifecycle now calls `await startRuntimeHttpServer()` and holds no local ref. The early-start-for-`/healthz` ordering is unchanged (still the same point in startup).

### Behavior note

The dep-wiring failure path used to do `runtimeHttp = null`, which orphaned the (still-listening) server from shutdown so `.stop()` was skipped. With the singleton, the server keeps serving `/healthz` after a dep-wiring failure and is now properly stopped via `stopRuntimeHttpServer()` at shutdown — a small improvement, and a no-op on the happy path. (The process exits regardless, so this only affects graceful HTTP drain.)

The `RuntimeHttpServer` class stays exported and unchanged — the many tests that construct it directly are unaffected by the new module singleton.

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test runtime-events-sse gateway-only-enforcement disk-pressure-lifecycle wake-intent-hooks` — 86 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_