### PR TITLE
refactor(daemon): dispatch plugin shutdown hooks through the unified runHook pipeline

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -31,6 +31,7 @@ import {
   _inspectToolCacheForTests,
   getCachedUserTools,
   getUserHooksFor,
+  markShuttingDown,
   populateCacheAtBoot,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
@@ -626,6 +627,46 @@ describe("plugin runtime activation", () => {
     expect(getPluginToolDefinitions().some((t) => t.name === "temp-tool")).toBe(
       false,
     );
+    expect(existsSync(shutdownMarker)).toBe(true);
+  });
+
+  test("markShuttingDown suppresses activating a plugin that appears during shutdown", async () => {
+    // The daemon shutdown handler calls markShuttingDown() before dispatching
+    // shutdown hooks via runHook, whose getHooksFor read triggers a scan. A
+    // plugin whose files land during that window must NOT be brought up — and
+    // must not run its init hook — mid-shutdown.
+    await populateCacheAtBoot(); // empty plugins dir
+    markShuttingDown();
+
+    const dir = freshPluginDir("shutdown-race-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "shutdown-race-plugin" });
+    writeTool(dir, "shutdown-race-tool", TOOL_SRC("shutdown-race-tool"));
+    const initMarker = join(ROOT, "shutdown-race-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    await triggerScan();
+
+    // Not activated: no tool registered and init never ran.
+    expect(getToolOwner("shutdown-race-tool")).toBeUndefined();
+    expect(existsSync(initMarker)).toBe(false);
+  });
+
+  test("a user plugin's shutdown hook is surfaced through the unified hook lookup", async () => {
+    // Plugin `shutdown` hooks fire at daemon shutdown through the same
+    // getHooksFor/runHook pipeline as every other lifecycle hook. Prove the
+    // user-land side is discoverable that way: the plugin's shutdown hook is
+    // returned by the unified per-name lookup and runs when invoked.
+    const dir = freshPluginDir("shutdown-hook-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "shutdown-hook-plugin" });
+    const shutdownMarker = join(ROOT, "user-shutdown.log");
+    writeMarkerHook(dir, "shutdown", shutdownMarker, "bye");
+
+    await populateCacheAtBoot();
+
+    const shutdownHooks = await getUserHooksFor("shutdown");
+    expect(shutdownHooks).toHaveLength(1);
+
+    await shutdownHooks[0]!({ assistantVersion: "test" });
     expect(existsSync(shutdownMarker)).toBe(true);
   });
 

--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -7,7 +7,9 @@
  * - Version-mismatch registration fails with an error that names the plugin
  *   (the registry enforces this at `registerPlugin` time, so bootstrap never
  *   sees the malformed plugin).
- * - Shutdown hook walks plugins in reverse registration order.
+ * - The shutdown-registry hook walks plugins in reverse registration order to
+ *   unregister their surfaces; the plugins' `shutdown` hooks then fire through
+ *   the unified `runHook(HOOKS.SHUTDOWN, …)` pipeline.
  *
  * `resetPluginRegistryForTests()` isolates registry state between cases.
  */
@@ -22,7 +24,9 @@ import { clearFeatureFlagOverridesCache } from "../config/assistant-feature-flag
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
 import { runShutdownHooks } from "../daemon/shutdown-registry.js";
 import { RiskLevel } from "../permissions/types.js";
+import { HOOKS } from "../plugin-api/constants.js";
 import { registerDefaultPlugins } from "../plugins/defaults/index.js";
+import { runHook } from "../plugins/pipeline.js";
 import {
   closeRegistration,
   getRegisteredPlugins,
@@ -233,7 +237,7 @@ describe("plugin bootstrap", () => {
     expect(names).toContain("default-title-generate");
   });
 
-  test("shutdown order: onShutdown fires in reverse registration order", async () => {
+  test("shutdown: onShutdown fires through the runHook pipeline in registration order", async () => {
     const callOrder: string[] = [];
     registerPlugin(
       buildPlugin("first-registered", {
@@ -251,12 +255,15 @@ describe("plugin bootstrap", () => {
     );
 
     await bootstrapPlugins();
+    // Surface teardown (reverse order) runs first; these plugins contribute no
+    // tools/routes, so it is a no-op here.
     await runShutdownHooks("test-shutdown");
+    // The plugins' `shutdown` hooks fire through the unified pipeline — the
+    // same dispatch path (and registration order) as every other lifecycle
+    // hook, so the first plugin to register runs first.
+    await runHook(HOOKS.SHUTDOWN, { assistantVersion: APP_VERSION });
 
-    // The last plugin to register must shut down first; the first to register
-    // shuts down last. Symmetric tear-down around registration order is the
-    // whole point of the reverse walk.
-    expect(callOrder).toEqual(["second-registered", "first-registered"]);
+    expect(callOrder).toEqual(["first-registered", "second-registered"]);
   });
 
   test("empty registry: bootstrap seeds the first-party defaults without throwing", async () => {
@@ -464,10 +471,12 @@ describe("plugin bootstrap", () => {
 
     await bootstrapPlugins();
     await runShutdownHooks("test-shutdown");
+    await runHook(HOOKS.SHUTDOWN, { assistantVersion: APP_VERSION });
 
-    // The shutdown hook is a single registered callback that walks a
-    // snapshot taken at bootstrap. A skipped plugin should never appear in
-    // that snapshot, so its `onShutdown` must never fire.
+    // A flag-gated plugin is dropped from the registry at bootstrap
+    // (`unregisterPlugin`), so it appears neither in the surface-teardown
+    // snapshot nor in the `getHooksFor("shutdown")` the pipeline dispatches —
+    // its `onShutdown` must never fire.
     expect(shutdownFired).toBe(false);
   });
 
@@ -547,7 +556,11 @@ describe("plugin bootstrap", () => {
 
     await bootstrapPlugins();
     await runShutdownHooks("test-shutdown");
+    await runHook(HOOKS.SHUTDOWN, { assistantVersion: APP_VERSION });
 
+    // A `.disabled` plugin keeps its hooks registered but they are filtered out
+    // at read time by `isPluginDisabled` inside `getHooksFor`, so the pipeline
+    // dispatch skips its `onShutdown` too.
     expect(shutdownFired).toBe(false);
 
     await rm(sentinelDir, { recursive: true, force: true });

--- a/assistant/src/__tests__/plugin-route-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-route-contribution.test.ts
@@ -4,11 +4,13 @@
  * A plugin may declare a `routes` array on its {@link Plugin} shape; after
  * `init()` succeeds, bootstrap wires each entry into the skill-route registry
  * via {@link registerSkillRoute}, retains the opaque {@link SkillRouteHandle}
- * it receives back, and on shutdown calls {@link unregisterSkillRoute} with
- * that exact handle. Handle-keyed unregistration ensures that two
- * owners (e.g. a plugin and a skill) that legitimately register the same
- * regex cannot have one owner's teardown silently evict another owner's
- * route, preserving the "no traffic hits a plugin handler during
+ * it receives back, and on shutdown the reverse-order surface-teardown closure
+ * calls {@link unregisterSkillRoute} with that exact handle. Handle-keyed
+ * unregistration ensures that two owners (e.g. a plugin and a skill) that
+ * legitimately register the same regex cannot have one owner's teardown
+ * silently evict another owner's route. Plugin `shutdown` hooks then fire
+ * through the unified `runHook(HOOKS.SHUTDOWN, …)` pipeline once every surface
+ * is unregistered, preserving the "no traffic hits a plugin handler during
  * onShutdown" invariant.
  *
  * The registry doesn't own HTTP itself — the tests here exercise:
@@ -18,9 +20,8 @@
  *  2. Shutdown → `unregisterSkillRoute` drops the entry, and subsequent
  *     `matchSkillRoute` lookups return `null`.
  *  3. Plugins without `routes` (or with an empty array) bootstrap cleanly.
- *  4. When two plugins register regex patterns with identical `source+flags`,
- *     each plugin's shutdown only removes its own route — the other plugin's
- *     route stays live until its own teardown runs.
+ *  4. Handle-keyed unregistration: unregistering one route's handle leaves a
+ *     sibling's identical-pattern route live until its own handle is dropped.
  *
  * `resetPluginRegistryForTests()` isolates plugin-registry state and
  * `resetSkillRoutesForTests()` isolates skill-route-registry state between
@@ -34,6 +35,8 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
 import { runShutdownHooks } from "../daemon/shutdown-registry.js";
+import { HOOKS } from "../plugin-api/constants.js";
+import { runHook } from "../plugins/pipeline.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,
@@ -41,9 +44,11 @@ import {
 import type { InitContext, Plugin } from "../plugins/types.js";
 import {
   matchSkillRoute,
+  registerSkillRoute,
   resetSkillRoutesForTests,
   type SkillRoute,
   type SkillRouteMatch,
+  unregisterSkillRoute,
 } from "../runtime/skill-route-registry.js";
 
 // Redirect plugin storage creation into a per-process temp tree so the test
@@ -184,11 +189,10 @@ describe("plugin route contributions", () => {
 
   test("shutdown tolerates a route whose registry entry was wiped externally", async () => {
     // Guard against the case where a stale handle no longer points at a live
-    // registry entry (e.g. the registry was cleared externally). The shutdown
-    // hook must not crash — unregisterSkillRoute returns false, and
-    // bootstrap's try/catch around the call swallows the signal. This
-    // exercises the defensive path so a partial-crash recovery still runs
-    // every plugin's onShutdown in reverse order.
+    // registry entry (e.g. the registry was cleared externally). The surface
+    // teardown must not crash — `unregisterSkillRoute` returns false and the
+    // closure's try/catch swallows the signal — so the subsequent `runHook`
+    // pipeline still fires the plugin's `shutdown` hook.
     let shutdownFired = false;
     registerPlugin(
       buildPlugin("echo-plugin", {
@@ -207,36 +211,60 @@ describe("plugin route contributions", () => {
 
     await bootstrapPlugins();
 
-    // Simulate an external wipe before the shutdown hook runs — e.g. a
-    // different subsystem calling `resetSkillRoutesForTests` or a hot-reload
-    // flow clearing the registry. The plugin's retained handle is now stale.
+    // Simulate an external wipe before teardown runs — e.g. a different
+    // subsystem calling `resetSkillRoutesForTests` or a hot-reload flow
+    // clearing the registry. The plugin's retained handle is now stale.
     resetSkillRoutesForTests();
 
+    // Surface teardown survives the stale handle without throwing...
     await runShutdownHooks("test-shutdown");
+    // ...and the plugin's `shutdown` hook still fires through the pipeline.
+    await runHook(HOOKS.SHUTDOWN, { assistantVersion: "test" });
 
-    // onShutdown still ran despite the stale handle — proving the
-    // route-unregister step does not short-circuit plugin teardown.
     expect(shutdownFired).toBe(true);
   });
 
-  test("shutdown of one plugin does not evict a sibling's same-pattern route", async () => {
+  test("unregistering one route handle leaves a sibling's identical-pattern route live", async () => {
     // Regression for the reviewer-flagged invariant: keying unregistration on
-    // `pattern.source + flags` would let plugin-A's teardown drop plugin-B's
-    // route when both declared regex with identical text. With handle-keyed
-    // identity, each plugin's teardown removes only its own registrations.
-    //
-    // We simulate this by wiring two plugins that both contribute a route
-    // matching `/^\/_plugin\/echo$/`. Teardown runs in reverse registration
-    // order, so plugin-B is torn down first; plugin-A's route must still
-    // match afterwards, and only disappear once plugin-A's own teardown
-    // runs.
-    let pluginAShutdown = false;
-    let pluginBShutdown = false;
-    // Capture the match result from inside plugin-B's onShutdown so assertions
-    // run after runShutdownHooks returns. teardownPlugin wraps onShutdown in a
-    // try/catch that swallows thrown assertion errors, so asserting inline
-    // would let a failing match silently pass the test.
-    let pluginBOnShutdownMatch: SkillRouteMatch | null = null;
+    // `pattern.source + flags` would let one owner's teardown drop another
+    // owner's route when both declared regex with identical text. The plugin
+    // shutdown closure unregisters routes by the opaque handle retained at
+    // registration time (`unregisterSkillRoute(handle)`), so that is the
+    // mechanism keeping sibling routes intact. Exercise it directly: two
+    // routes with byte-identical patterns, drop one handle, and the other must
+    // still match until its own handle is dropped too.
+    const handleA = registerSkillRoute({
+      pattern: /^\/_plugin\/echo$/,
+      methods: ["GET"],
+      handler: async () => new Response("a", { status: 200 }),
+    });
+    const handleB = registerSkillRoute({
+      pattern: /^\/_plugin\/echo$/,
+      methods: ["GET"],
+      handler: async () => new Response("b", { status: 200 }),
+    });
+
+    expect(matchSkillRoute("/_plugin/echo", "GET")).not.toBeNull();
+
+    // Drop B (reverse-order teardown drops the last-registered owner first).
+    expect(unregisterSkillRoute(handleB)).toBe(true);
+    // A's identical-pattern route must still be live.
+    expect(matchSkillRoute("/_plugin/echo", "GET")).not.toBeNull();
+
+    // Only once A's own handle is dropped does the route disappear.
+    expect(unregisterSkillRoute(handleA)).toBe(true);
+    expect(matchSkillRoute("/_plugin/echo", "GET")).toBeNull();
+  });
+
+  test("every contributing plugin's shutdown hook fires through the pipeline after its surfaces are gone", async () => {
+    // The daemon shutdown sequence unregisters all plugin surfaces (reverse
+    // order, via the shutdown-registry closure) and then dispatches `shutdown`
+    // hooks through the unified `runHook` pipeline — so by the time any
+    // plugin's hook runs, its routes are already unregistered. Two plugins with
+    // identical patterns prove both hooks fire and that the registry is empty
+    // by hook time.
+    const pluginsThatShutDown: string[] = [];
+    let matchAtHookTime: SkillRouteMatch | null = null;
 
     registerPlugin(
       buildPlugin("plugin-a", {
@@ -248,16 +276,10 @@ describe("plugin route contributions", () => {
           },
         ],
         async onShutdown() {
-          // When plugin-A's teardown runs, plugin-B has already been torn
-          // down — but plugin-A's route must still be live because
-          // `onShutdown` fires *after* the route-unregister step for this
-          // plugin but *before* it leaves teardownPlugin. We check liveness
-          // from plugin-B's teardown instead (see below).
-          pluginAShutdown = true;
+          pluginsThatShutDown.push("plugin-a");
         },
       }),
     );
-
     registerPlugin(
       buildPlugin("plugin-b", {
         routes: [
@@ -268,31 +290,25 @@ describe("plugin route contributions", () => {
           },
         ],
         async onShutdown() {
-          // Plugin-B's routes have already been unregistered by the time
-          // this fires, but plugin-A's route is still live — it only gets
-          // torn down after this hook returns and the loop moves on to
-          // plugin-A. Confirm the registry still has a matching route.
-          pluginBShutdown = true;
-          pluginBOnShutdownMatch = matchSkillRoute("/_plugin/echo", "GET");
+          pluginsThatShutDown.push("plugin-b");
+          // Surfaces are already unregistered by the time any hook runs.
+          matchAtHookTime = matchSkillRoute("/_plugin/echo", "GET");
         },
       }),
     );
 
     await bootstrapPlugins();
-
-    // Both plugins' routes landed in the registry; matching returns one of
-    // them (order defined by registration, but we only care that *some*
-    // route matches before shutdown starts).
     expect(matchSkillRoute("/_plugin/echo", "GET")).not.toBeNull();
 
+    // Surface teardown first, then the pipeline fires the shutdown hooks.
     await runShutdownHooks("test-shutdown");
+    await runHook(HOOKS.SHUTDOWN, { assistantVersion: "test" });
 
-    expect(pluginBShutdown).toBe(true);
-    expect(pluginAShutdown).toBe(true);
-    expect(pluginBOnShutdownMatch).not.toBeNull();
-    expect(pluginBOnShutdownMatch!.kind).toBe("match");
-
-    // After both plugins shut down, no routes remain.
+    // Both plugins' hooks fired exactly once.
+    expect(pluginsThatShutDown.sort()).toEqual(["plugin-a", "plugin-b"]);
+    // No route survived the surface teardown.
     expect(matchSkillRoute("/_plugin/echo", "GET")).toBeNull();
+    // And the hook observed an already-clean registry.
+    expect(matchAtHookTime).toBeNull();
   });
 });

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -43,15 +43,17 @@
  *    history repair, title generation) — so the daemon comes up with the
  *    failing plugin absent rather than blacking out the whole plugin layer.
  *
- * A single shutdown hook is registered via
+ * A single shutdown-registry hook is registered via
  * {@link registerShutdownHook} that walks the plugin list in **reverse
- * registration order**. Only plugins that actually initialized (i.e. were
- * not skipped by the feature-flag gate) appear in that walk. For each such
- * plugin it first unregisters the contributed tools (so `onShutdown()`
- * observes a clean model-visible surface) and then awaits the optional
- * `onShutdown()`. Per-plugin shutdown failures are logged and swallowed —
- * the hook registry already swallows hook-level throws, but we log at the
- * plugin level so the plugin name is attributed.
+ * registration order** and unregisters each plugin's contributed routes and
+ * tools, so the model-visible surface is clean before any `shutdown` hook
+ * runs. Only plugins that actually initialized (i.e. were not skipped by the
+ * feature-flag gate) appear in that walk. The plugins' `shutdown` hooks
+ * themselves are dispatched separately, through the unified
+ * `runHook(HOOKS.SHUTDOWN, …)` pipeline that the daemon shutdown handler runs
+ * once this surface teardown completes — the same path every other lifecycle
+ * hook uses. The bootstrap-failure rollback path still tears a single plugin
+ * down fully (surfaces + `shutdown` hook) via {@link teardownPlugin}.
  */
 
 import { existsSync, mkdirSync } from "node:fs";
@@ -61,7 +63,10 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { HOOKS } from "../plugin-api/constants.js";
-import { getAllDefaultPlugins, registerDefaultPlugins } from "../plugins/defaults/index.js";
+import {
+  getAllDefaultPlugins,
+  registerDefaultPlugins,
+} from "../plugins/defaults/index.js";
 import { getRegisteredPlugins, unregisterPlugin } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -226,14 +231,6 @@ export async function bootstrapPlugins(): Promise<void> {
   // onShutdown" invariant.
   const activePlugins: ActivePlugin[] = [];
 
-  // Shutdown context is identical for every plugin in this boot — construct
-  // once and reuse across the per-plugin teardown and the normal shutdown
-  // hook below. Only `assistantVersion` is exposed today; future additions
-  // live on {@link ShutdownContext}.
-  const shutdownContext: ShutdownContext = {
-    assistantVersion: APP_VERSION,
-  };
-
   for (const plugin of plugins) {
     const name = plugin.manifest.name;
     const disabledFlag = getDisabledPluginFlag(plugin, assistantConfig);
@@ -293,24 +290,24 @@ export async function bootstrapPlugins(): Promise<void> {
     }
   }
 
-  // Shutdown hook — walks plugins in REVERSE registration order. We snapshot
-  // only the plugins that actually initialized so later registrations (if
-  // any) don't end up being torn down by this hook, and plugins skipped by
+  // Shutdown-registry hook — walks plugins in REVERSE registration order and
+  // unregisters each plugin's contributed routes and tools, clearing the
+  // model-visible surface before any `shutdown` hook runs. We snapshot only
+  // the plugins that actually initialized so later registrations (if any)
+  // don't end up being torn down by this hook, and plugins skipped by
   // `requiresFlag` gating do not appear in the tear-down list. Subsequent
   // bootstraps (hot-reload) would register their own hook.
   //
-  // For each plugin we:
-  //   1. Unregister contributed HTTP routes so incoming requests stop hitting
-  //      the plugin's handlers before its state is torn down.
-  //   2. Unregister contributed tools so the model-visible tool surface is
-  //      cleared before `onShutdown()` runs.
-  //   3. Call `onShutdown()` (if defined) so the plugin can release resources
-  //      (background tasks, timers, connections) with its tools and routes
-  //      already removed.
+  // The plugins' `shutdown` hooks are NOT invoked here. They fire through the
+  // unified `runHook(HOOKS.SHUTDOWN, …)` pipeline that the daemon shutdown
+  // handler runs once this surface teardown has completed — the same dispatch
+  // path every other lifecycle hook uses. Running surface unregistration here,
+  // ahead of that dispatch, preserves the invariant that no traffic reaches a
+  // plugin handler while its `shutdown` hook executes.
   const shutdownSnapshot: ActivePlugin[] = [...activePlugins];
   registerShutdownHook("plugins", async (reason) => {
     for (let i = shutdownSnapshot.length - 1; i >= 0; i--) {
-      await teardownPlugin(shutdownSnapshot[i]!, reason, shutdownContext);
+      unregisterPluginSurfaces(shutdownSnapshot[i]!, reason);
     }
   });
 }
@@ -409,29 +406,22 @@ async function initializePlugin(
 }
 
 /**
- * Tear down a single fully-initialized plugin: unregister routes, unregister
- * tools, then invoke `onShutdown()` if present. Every step swallows errors and
- * logs with plugin attribution so one bad plugin can't block teardown of the
- * rest.
+ * Unregister a fully-initialized plugin's model-visible surfaces: its
+ * contributed HTTP routes (keyed by the opaque handles retained at
+ * registration time — pattern text is not a stable key because two owners can
+ * legitimately register the same regex) and its contributed tools.
+ * `unregisterPluginTools` is a no-op when the plugin never contributed tools.
+ * Every step swallows errors and logs with plugin attribution so one bad
+ * plugin can't block teardown of the rest.
  *
- * Shared between the normal shutdown hook and the bootstrap error path; both
- * consume plugins that already cleared every contribution step.
+ * Shared between the daemon shutdown-registry hook (which calls this alone and
+ * leaves `shutdown` hook dispatch to the unified `runHook` pipeline) and the
+ * bootstrap-failure rollback path via {@link teardownPlugin}.
  */
-async function teardownPlugin(
-  active: ActivePlugin,
-  reason: string,
-  shutdownContext: ShutdownContext,
-): Promise<void> {
+function unregisterPluginSurfaces(active: ActivePlugin, reason: string): void {
   const { plugin, routeHandles } = active;
   const name = plugin.manifest.name;
 
-  // Unregister model-visible surfaces before invoking `onShutdown()` so the
-  // plugin's onShutdown hook observes a registry state where its tools and
-  // routes are already gone. `unregisterPluginTools` is a no-op when the
-  // plugin never contributed tools, so we don't need to guard on
-  // `plugin.tools` here. Route unregistration keys on the opaque handles
-  // retained at registration time — pattern text is not a stable key because
-  // two owners can legitimately register the same regex.
   for (const handle of routeHandles) {
     try {
       unregisterSkillRoute(handle);
@@ -451,19 +441,45 @@ async function teardownPlugin(
       "plugin tool unregister failed (continuing with remaining plugins)",
     );
   }
+}
 
-  if (plugin.hooks?.[HOOKS.SHUTDOWN]) {
-    try {
-      await plugin.hooks[HOOKS.SHUTDOWN](shutdownContext);
-    } catch (err) {
-      // Swallow — we want every plugin's shutdown to get a chance to run
-      // even when an earlier one throws. The outer runShutdownHooks already
-      // logs at hook level, but the plugin-name attribution here is what
-      // operators read first.
-      log.warn(
-        { err, plugin: name, reason },
-        "plugin shutdown hook failed (continuing with remaining plugins)",
-      );
-    }
+/**
+ * Invoke a plugin's optional `shutdown` hook directly. Used only by the
+ * bootstrap-failure rollback path in {@link teardownPlugin}; the daemon
+ * shutdown path instead dispatches `shutdown` hooks through the unified
+ * `runHook(HOOKS.SHUTDOWN, …)` pipeline. Swallows and logs errors with plugin
+ * attribution so one bad plugin can't block teardown of the rest.
+ */
+async function invokePluginShutdownHook(
+  plugin: Plugin,
+  shutdownContext: ShutdownContext,
+  reason: string,
+): Promise<void> {
+  if (!plugin.hooks?.[HOOKS.SHUTDOWN]) return;
+  try {
+    await plugin.hooks[HOOKS.SHUTDOWN](shutdownContext);
+  } catch (err) {
+    log.warn(
+      { err, plugin: plugin.manifest.name, reason },
+      "plugin shutdown hook failed (continuing with remaining plugins)",
+    );
   }
+}
+
+/**
+ * Tear down a single fully-initialized plugin: unregister its surfaces, then
+ * invoke its `shutdown` hook. Used by the bootstrap-failure rollback path so a
+ * plugin that initialized and then failed a later step is fully released. The
+ * plugin's `shutdown` hook observes a registry state where its tools and routes
+ * are already gone. The normal daemon shutdown path instead unregisters
+ * surfaces via {@link unregisterPluginSurfaces} and fires `shutdown` hooks
+ * through the unified `runHook` pipeline.
+ */
+async function teardownPlugin(
+  active: ActivePlugin,
+  reason: string,
+  shutdownContext: ShutdownContext,
+): Promise<void> {
+  unregisterPluginSurfaces(active, reason);
+  await invokePluginShutdownHook(active.plugin, shutdownContext, reason);
 }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -7,11 +7,15 @@ import { stopMcpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
 import { stopMemoryWorkerProcess } from "../memory/worker-control.js";
+import { HOOKS } from "../plugin-api/constants.js";
+import { markShuttingDown } from "../plugins/mtime-cache.js";
+import { runHook } from "../plugins/pipeline.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
 import { getEnrichmentService } from "../workspace/commit-message-enrichment-service.js";
 import type { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { cleanupPidFile } from "./daemon-control.js";
@@ -76,13 +80,28 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     await deps.heartbeat.stop();
     if (deps.filing) await deps.filing.stop();
 
-    // Run registered skill shutdown hooks (e.g. meet-join session teardown)
+    // Run registered shutdown-registry hooks (e.g. meet-join session teardown,
+    // plus the plugin layer's reverse-order tool/route surface unregistration)
     // before stopping the server so any HTTP round-trips and SSE emissions
     // still have live transports.
     try {
       await runShutdownHooks("daemon-shutdown");
     } catch (err) {
       log.warn({ err }, "Skill shutdown hooks failed (non-fatal)");
+    }
+
+    // Fire plugin `shutdown` hooks through the unified hook pipeline — the same
+    // dispatch path every other lifecycle hook uses. This runs after
+    // `runShutdownHooks` has unregistered all plugin tools and routes (so no
+    // traffic reaches a plugin handler while its `shutdown` hook executes) and
+    // before the server stops (so transports stay live for any teardown work).
+    // `markShuttingDown()` first, so the `getHooksFor` scan this triggers can't
+    // activate a plugin whose files appear mid-shutdown.
+    markShuttingDown();
+    try {
+      await runHook(HOOKS.SHUTDOWN, { assistantVersion: APP_VERSION });
+    } catch (err) {
+      log.warn({ err }, "Plugin shutdown hooks failed (non-fatal)");
     }
 
     // Commit any uncommitted workspace changes before stopping the server.

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -441,6 +441,26 @@ const shutdownContext: ShutdownContext = {
 };
 
 /**
+ * Set once the daemon enters shutdown. Read by {@link activatePlugin} to
+ * suppress activating a plugin whose files happen to appear during the
+ * shutdown sequence: the daemon shutdown handler dispatches `shutdown` hooks
+ * through `runHook(HOOKS.SHUTDOWN, …)`, whose `getHooksFor` read triggers a
+ * `scanPlugins()`. Without this guard a late-appearing plugin could run its
+ * `init` hook mid-shutdown.
+ */
+let shuttingDown = false;
+
+/**
+ * Mark the process as shutting down so no further plugins are activated. Called
+ * by the daemon shutdown handler immediately before it dispatches `shutdown`
+ * hooks via the unified `runHook` pipeline. Already-activated owners stay in
+ * the cache, so their `shutdown` hooks are still collected by `getHooksFor`.
+ */
+export function markShuttingDown(): void {
+  shuttingDown = true;
+}
+
+/**
  * Activate a single discovered plugin: pre-import its hooks, register its tools
  * into the global tool registry, and run its `init` hook. Idempotent — a plugin
  * already activated (or mid-activation) is skipped. Never throws; per-surface
@@ -455,6 +475,10 @@ async function activatePlugin(
   pluginDir: string,
   pluginName: string,
 ): Promise<void> {
+  // Never bring a plugin up once shutdown has begun — a `getHooksFor` read on
+  // the shutdown path triggers a scan, and activating (and `init`-ing) a plugin
+  // mid-shutdown is never what we want.
+  if (shuttingDown) return;
   if (activatedNames.has(pluginName)) return;
   // Reserve synchronously, before any await, so a re-entrant or concurrent
   // scan observes this plugin as already handled.
@@ -556,19 +580,24 @@ export async function populateCacheAtBoot(
     activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });
   }
 
-  // Register a single shutdown hook that walks all activated owners in reverse
-  // order, unregistering tools and running shutdown hooks. It reads the live
+  // Register a single shutdown-registry hook that walks all activated owners
+  // in reverse order, unregistering their tools so the model-visible surface
+  // is clean before any `shutdown` hook runs. It reads the live
   // `activatedPlugins` array at teardown time, so plugins activated after boot
   // (runtime installs) are torn down too.
+  //
+  // The owners' `shutdown` hooks are NOT invoked here. They fire through the
+  // unified `runHook(HOOKS.SHUTDOWN, …)` pipeline that the daemon shutdown
+  // handler runs after this surface teardown completes — the same dispatch
+  // path every other lifecycle hook uses, and the same path that surfaces user
+  // and workspace hooks during a normal turn.
   registerShutdownHook("user-plugins", async (reason) => {
     for (let i = activatedPlugins.length - 1; i >= 0; i--) {
       const entry = activatedPlugins[i];
       if (entry === undefined) continue;
       const { name } = entry;
 
-      // Unregister tools before running shutdown so onShutdown sees a
-      // clean model-visible surface. (No-op for the workspace-hooks owner,
-      // which registers no tools.)
+      // (No-op for the workspace-hooks owner, which registers no tools.)
       try {
         unregisterPluginTools(name);
       } catch (err) {
@@ -577,9 +606,6 @@ export async function populateCacheAtBoot(
           "user plugin tool unregister failed (continuing)",
         );
       }
-
-      // Run the `shutdown` hook if present.
-      await runShutdownHook(name, shutdownContext, reason);
     }
   });
 }
@@ -605,6 +631,7 @@ export function resetPluginCacheForTests(): void {
   activatedPlugins.length = 0;
   activatedNames.clear();
   disabledPluginDirs.clear();
+  shuttingDown = false;
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

> we don't run the plugin shutdown hooks during the actual shutdown handler — at the same time, we have something else in the shutdown that we are running that is called `runShutdownHooks`. Time to combine these two concepts.

Investigation showed plugin shutdown hooks *did* already fire during the daemon shutdown handler, but `shutdown` was the **only** lifecycle hook never dispatched through the unified `runHook(name, ctx)` pipeline — it was special-cased through two divergent bespoke paths. The agreed direction (confirmed before implementing) was to make `shutdown` a first-class pipeline hook invoked from the shutdown handler, while preserving reverse-order surface teardown and tool/route unregistration.

### What changed
- **`runHook(HOOKS.SHUTDOWN, …)` is now fired from the daemon shutdown handler** (`shutdown-handlers.ts`) — the same dispatch path every other lifecycle hook uses. `getHooksFor` already unions default/test plugins (in-process registry) and user/workspace hooks (mtime cache), so this covers exactly the owner set the two old closures covered.
- The two shutdown-registry closures (`"plugins"` in `external-plugins-bootstrap.ts`, `"user-plugins"` in `mtime-cache.ts`) now **only unregister plugin surfaces** (tools/routes) in reverse order. The handler runs them first, so all surfaces are gone before any `shutdown` hook executes — preserving the "no traffic hits a plugin handler during onShutdown" invariant — and each hook fires exactly once (no double-dispatch).
- `teardownPlugin` split into `unregisterPluginSurfaces` + `invokePluginShutdownHook`; the composed form is kept for the **bootstrap-failure rollback** path (still needs per-owner onShutdown).
- `deactivatePlugin` (runtime plugin removal) keeps its per-owner `runShutdownHook` call — routing it through `runHook` would fire every owner's hook.
- New `markShuttingDown()` guard prevents the `getHooksFor` scan triggered on the shutdown path from activating (and `init`-ing) a plugin whose files appear mid-shutdown.

### Behavior changes (intentional)
- `shutdown` hook **functions** now run in pipeline/registration order (like `init` and every other hook). Reverse-order **surface** teardown is preserved.
- A runtime-`.disabled` plugin is now filtered from shutdown dispatch by `isPluginDisabled`, consistent with the rest of the lifecycle.

## Test plan
- Updated/added tests:
  - `plugin-bootstrap.test.ts` — shutdown hooks now asserted via `runHook` in registration order; flag-gated and `.disabled` plugins verified to not fire shutdown through the pipeline.
  - `plugin-route-contribution.test.ts` — handle-keyed identity moved to a registry-level test; new e2e asserts every contributing plugin's hook fires once *after* its surfaces are unregistered.
  - `mtime-cache.test.ts` — `markShuttingDown()` suppresses mid-shutdown activation; user-land `shutdown` hook surfaced through the unified lookup.
- `bun test` green across: plugin-bootstrap, plugin-route-contribution, plugin-tool-contribution, mtime-cache, plugin-pipeline, plugin-disabled-state, plugin-config-data-migration, user-plugin-loader, ipc skill-routes registries, wake-intent-hooks, and the default-plugin hook suites (~190 tests).
- `tsc --noEmit` (no new errors), `eslint`, and `prettier --check` clean on the changed files (enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1HBsQzMdfT45G8DfzNbk)_