### PR TITLE
refactor(filing): make filing service a self-managed singleton for shutdown

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,7 +32,7 @@ import {
   DEFAULT_CES_STARTUP_TIMEOUT_MS,
   injectCesClientWhenReady,
 } from "../credential-execution/startup-timeout.js";
-import { FilingService } from "../filing/filing-service.js";
+import { startFilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
@@ -1344,34 +1344,16 @@ export async function runDaemon(): Promise<void> {
     "Heartbeat service configured",
   );
 
-  // Filing yields to the memory v2 consolidation job when v2 is enabled —
-  // both serve the same role (periodic background memory processing) and
-  // running both is redundant. The consolidation job runs through the
-  // memory jobs worker (see `maybeEnqueueGraphMaintenanceJobs`).
-  const memoryV2Enabled = config.memory.v2.enabled;
-  let filing: FilingService | null = null;
-  if (!memoryV2Enabled) {
-    const filingConfig = config.filing;
-    filing = new FilingService();
-    filing.start();
-    log.info(
-      {
-        enabled: filingConfig.enabled,
-        intervalMs: filingConfig.intervalMs,
-      },
-      "Filing service configured",
-    );
-  } else {
-    log.info(
-      "Filing service skipped — memory v2 consolidation is the active background memory job",
-    );
-  }
+  // Filing yields to the memory v2 consolidation job when v2 is enabled — both
+  // serve the same role (periodic background memory processing) and running both
+  // is redundant. The consolidation job runs through the memory jobs worker
+  // (see `maybeEnqueueGraphMaintenanceJobs`).
+  startFilingService();
 
   installShutdownHandlers({
     server,
     workspaceHeartbeat,
     heartbeat,
-    filing,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node";
 
-import type { FilingService } from "../filing/filing-service.js";
+import { stopFilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
@@ -42,7 +42,6 @@ export interface ShutdownDeps {
   server: DaemonServer;
   workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
-  filing: FilingService | null;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -72,7 +71,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     await deps.workspaceHeartbeat.stop();
     await deps.heartbeat.stop();
-    if (deps.filing) await deps.filing.stop();
+    await stopFilingService();
 
     // Run registered skill shutdown hooks (e.g. meet-join session teardown)
     // before stopping the server so any HTTP round-trips and SSE emissions

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -417,6 +417,26 @@ export class FilingService {
   }
 }
 
+/**
+ * Construct and start the filing service singleton. Skipped under memory v2 —
+ * the v2 consolidation job owns periodic background memory processing, so
+ * running filing too would be redundant.
+ */
+export function startFilingService(): void {
+  if (getConfig().memory.v2.enabled) {
+    log.info(
+      "Filing service skipped — memory v2 consolidation is the active background memory job",
+    );
+    return;
+  }
+  new FilingService().start();
+}
+
+/** Stop the filing service singleton if one is running; no-op otherwise. */
+export async function stopFilingService(): Promise<void> {
+  await FilingService.getInstance()?.stop();
+}
+
 function isWithinActiveHours(
   hour: number,
   start: number,


### PR DESCRIPTION
## Prompt / plan

Continuing to shrink `installShutdownHandlers` — the `filing` arg.

lifecycle constructed the `FilingService` (only when memory v2 was off), started it, and threaded it through `ShutdownDeps` so the shutdown handler could call `.stop()`. `FilingService` already keeps a static singleton (`getInstance()`), so this just wraps the lifecycle around it:

- **`startFilingService()`** skips under memory v2 — the v2 consolidation job owns periodic background memory processing, so running filing too would be redundant — and otherwise constructs and starts the service. The "skipped" log moves here.
- **`stopFilingService()`** stops the singleton if one is running (`getInstance()?.stop()`); shutdown-handlers imports it directly and drops the `filing` field from `ShutdownDeps`.

lifecycle now just calls `startFilingService()`.

Behavior is preserved: under v2 the service is still not constructed (so `FilingService.getInstance()` stays `undefined`, which the filing routes already handle via optional chaining / the `isFilingAvailable()` gate). The redundant lifecycle "Filing service configured" log is dropped — `FilingService.start()` already logs "Filing service started" with the interval.

## Test plan

- `bun run lint` on all three changed files — clean.
- `bun run typecheck` — passed (pre-commit full type check green).
- `bun test filing-service background-workers-disk-pressure disk-pressure-lifecycle wake-intent-hooks` — 39 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_