### PR TITLE
fix(web): show real title for background conversations in chat header

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -2,7 +2,6 @@ import {
     lazy,
     useCallback,
     useEffect,
-    useMemo,
     useRef,
     useState,
     type ReactNode,
@@ -24,6 +23,7 @@ import {
 import { useHomeUnreadBadge } from "@/hooks/use-home-unread-badge";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
+import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import { useAttentionTracking } from "@/domains/chat/hooks/use-attention-tracking";
 import { useChatLayoutDrawer } from "@/domains/chat/hooks/use-chat-layout-drawer";
 import { useChatLayoutShortcuts } from "@/domains/chat/hooks/use-chat-layout-shortcuts";
@@ -349,10 +349,19 @@ export function ChatLayout() {
     prePinGroupIdsRef,
   });
 
-  const activeConversation = useMemo(
-    () => conversations.find((c) => c.conversationId === activeConversationId) ?? null,
-    [conversations, activeConversationId],
-  );
+  // Resolve the active row from whichever list cache holds it (foreground,
+  // background, or scheduled), fetching the single row when an open
+  // background/scheduled thread is in none. The foreground `conversations`
+  // list deliberately excludes background jobs, so a directly-opened
+  // background conversation — e.g. a memory retrospective ("… (Retrospective)")
+  // — is absent from it and the header would otherwise fall back to "New
+  // conversation". `ActiveChatView` resolves its copy through the same hook.
+  const activeConversation =
+    useActiveConversation(
+      assistantId,
+      activeConversationId,
+      isAssistantActive,
+    ) ?? null;
 
   const topBarCenter = topBarCenterSlot ?? (headerSupplements ? (
     <ChatConversationHeader


### PR DESCRIPTION
## Prompt / plan

Reported bug: when loading a memory retrospective conversation in the web client, the title at the top of the page shows `New conversation` instead of the conversation's actual title (e.g. `Evals (Retrospective)`).

**Root cause:** `chat-layout.tsx` resolved the header's `activeConversation` only from the foreground conversation list (`useConversationListQuery`), which **deliberately excludes background and scheduled jobs**. Memory retrospectives are created as `background` conversations (`conversationType: "background"`, title `"<source> (Retrospective)"`), so a directly-opened retrospective is never in that list. The lookup returned `null`, and `ChatConversationHeader` falls back to rendering `New conversation` whenever `activeConversation` is null.

Notably, `ActiveChatView` already resolves the *same* conversation correctly via the `useActiveConversation` hook (which reads the foreground, background, and scheduled caches and fetches the single row when an open thread is in none), but the header in the layout used its own foreground-only `conversations.find(...)`.

**Fix:** Resolve the header's active row through `useActiveConversation` — the same hook `ActiveChatView` uses — so background/scheduled threads (including retrospectives) opened directly resolve to their real row and title. The foreground `conversations` list is still used for the sidebar, command palette, and conversation actions; only the header's active-row derivation changed.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — no new errors (only pre-existing warnings in unrelated files)
- `bun test src/domains/chat/hooks/use-active-conversation.test.tsx` — 6 pass
- Manual reasoning: a `background` retrospective opened by URL is absent from the foreground cache; `useActiveConversation` fetches the single row into the background cache and the header now renders `activeConversation.title` (`… (Retrospective)`) instead of the `New conversation` fallback. The fetch is deduped with the identical call in `ActiveChatView` via TanStack Query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8pCEdb8jXkb73v8LWhVfe)_