### PR TITLE
refactor(heartbeat): make heartbeat service a self-managed singleton for shutdown

### DIFF
--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -235,10 +235,11 @@ describe("background wake intent publisher hooks", () => {
       "utf-8",
     );
 
-    // Match the three calls in order, tolerant of indentation, so the
-    // assertion survives reformatting/re-indentation of lifecycle.ts.
+    // The wake intent is published once, immediately after the scheduler and
+    // heartbeat are wired into the background-wake runtime. Tolerant of
+    // indentation so the assertion survives reformatting of lifecycle.ts.
     expect(lifecycleSource).toMatch(
-      /heartbeat\.start\(\);\n[ \t]*registerBackgroundWakeRuntime\(\{ scheduler, heartbeat \}\);\n[ \t]*refreshBackgroundWakeIntent\("daemon-startup"\);/,
+      /registerBackgroundWakeRuntime\(\{ scheduler, heartbeat \}\);\n[ \t]*refreshBackgroundWakeIntent\("daemon-startup"\);/,
     );
   });
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -33,7 +33,7 @@ import {
   injectCesClientWhenReady,
 } from "../credential-execution/startup-timeout.js";
 import { startFilingService } from "../filing/filing-service.js";
-import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { startHeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
@@ -1323,8 +1323,7 @@ export async function runDaemon(): Promise<void> {
   const workspaceHeartbeat = new WorkspaceHeartbeatService();
   workspaceHeartbeat.start();
 
-  const heartbeatConfig = config.heartbeat;
-  const heartbeat = new HeartbeatService({
+  const heartbeat = startHeartbeatService({
     alerter: (alert) => broadcastMessage(alert),
     onConversationCreated: (info) =>
       broadcastMessage({
@@ -1333,16 +1332,8 @@ export async function runDaemon(): Promise<void> {
         title: info.title,
       }),
   });
-  heartbeat.start();
   registerBackgroundWakeRuntime({ scheduler, heartbeat });
   refreshBackgroundWakeIntent("daemon-startup");
-  log.info(
-    {
-      enabled: heartbeatConfig.enabled,
-      intervalMs: heartbeatConfig.intervalMs,
-    },
-    "Heartbeat service configured",
-  );
 
   // Filing yields to the memory v2 consolidation job when v2 is enabled — both
   // serve the same role (periodic background memory processing) and running both
@@ -1353,7 +1344,6 @@ export async function runDaemon(): Promise<void> {
   installShutdownHandlers({
     server,
     workspaceHeartbeat,
-    heartbeat,
   });
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 
 import { stopFilingService } from "../filing/filing-service.js";
-import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { stopHeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
@@ -41,7 +41,6 @@ function stopBackgroundServicesAndCleanupPidFile(): void {
 export interface ShutdownDeps {
   server: DaemonServer;
   workspaceHeartbeat: WorkspaceHeartbeatService;
-  heartbeat: HeartbeatService;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -70,7 +69,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     forceTimer.unref();
 
     await deps.workspaceHeartbeat.stop();
-    await deps.heartbeat.stop();
+    await stopHeartbeatService();
     await stopFilingService();
 
     // Run registered skill shutdown hooks (e.g. meet-join session teardown)

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -919,6 +919,22 @@ This is one of your first heartbeats. Your user hasn't heard from you yet and ma
   }
 }
 
+/**
+ * Construct and start the heartbeat service singleton, returning it so callers
+ * can wire it into the background-wake runtime. start() self-gates on
+ * `heartbeat.enabled` and logs its own status.
+ */
+export function startHeartbeatService(deps: HeartbeatDeps): HeartbeatService {
+  const service = new HeartbeatService(deps);
+  service.start();
+  return service;
+}
+
+/** Stop the heartbeat service singleton if one is running; no-op otherwise. */
+export async function stopHeartbeatService(): Promise<void> {
+  await HeartbeatService.getInstance()?.stop();
+}
+
 function isDiskPressureBackgroundLocked(logKey: string): boolean {
   const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
   if (diskPressureGate.action === "allow") return false;


### PR DESCRIPTION
## Prompt / plan

Continuing to shrink `installShutdownHandlers` — the `heartbeat` arg.

lifecycle constructed the `HeartbeatService` with its broadcast callbacks, started it, used the handle for `registerBackgroundWakeRuntime`, and threaded it through `ShutdownDeps`. `HeartbeatService` already keeps a static singleton, so this wraps it (same shape as the `scheduler` change, which also needs the handle afterward):

- **`startHeartbeatService(deps)`** constructs and starts the service and returns it — lifecycle still needs the handle for `registerBackgroundWakeRuntime({ scheduler, heartbeat })`.
- **`stopHeartbeatService()`** stops the singleton if one is running (`getInstance()?.stop()`); shutdown-handlers imports it directly and drops the `heartbeat` field from `ShutdownDeps`.

The redundant lifecycle "Heartbeat service configured" log is dropped — `start()` already logs its own status ("Heartbeat service started (interval mode)" / "Heartbeat disabled by config").

### Test update

`wake-intent-hooks.test.ts` has a source-text assertion that keyed off the now-removed `heartbeat.start()` call. Updated it to assert the actual invariant it cares about — `registerBackgroundWakeRuntime(...)` immediately followed by the single `refreshBackgroundWakeIntent("daemon-startup")` (heartbeat startup is now implicit in the `heartbeat` handle passed to `registerBackgroundWakeRuntime`).

## Test plan

- `bun run lint` + `bun run typecheck` — clean (pre-commit full type check green).
- Each affected suite passes in isolation (the way CI runs them, one `bun test` process per file): `heartbeat-service` 13/0, `wake-intent-hooks` 8/0, `heartbeat-disk-pressure` 3/0, `heartbeat-routes` 2/0, `disk-pressure-lifecycle` 4/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_