### PR TITLE
fix(chat): anchor tool-call perceived latency to tool_use_preview_start

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16670,6 +16670,8 @@ paths:
                                   type: string
                               startedAt:
                                 type: number
+                              previewStartedAt:
+                                type: number
                               completedAt:
                                 type: number
                               confirmationDecision:
@@ -17099,6 +17101,8 @@ paths:
                                         items:
                                           type: string
                                       startedAt:
+                                        type: number
+                                      previewStartedAt:
                                         type: number
                                       completedAt:
                                         type: number

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -256,6 +256,72 @@ describe("tool preview lifecycle", () => {
       expect((emitted as any).conversationId).toBe("test-session-id");
     });
 
+    test("stamps previewStartedAt on the event and stores it in state", () => {
+      const collector = createEventCollector();
+      const deps = createMockDeps({
+        onEvent: collector.onEvent,
+        ctx: {
+          ...createMockDeps().ctx,
+          emitActivityState: collector.emitActivityState,
+        } as unknown as EventHandlerDeps["ctx"],
+      });
+
+      const before = Date.now();
+      handleToolUsePreviewStart(state, deps, {
+        type: "tool_use_preview_start",
+        toolUseId: "toolu_preview_ts",
+        toolName: "bash",
+      });
+      const after = Date.now();
+
+      const emitted = collector.events[0] as { previewStartedAt?: number };
+      expect(typeof emitted.previewStartedAt).toBe("number");
+      expect(emitted.previewStartedAt!).toBeGreaterThanOrEqual(before);
+      expect(emitted.previewStartedAt!).toBeLessThanOrEqual(after);
+      // The same first-byte timestamp is retained in state so tool_use_start
+      // can carry it through.
+      expect(state.toolPreviewStartedAt.get("toolu_preview_ts")).toBe(
+        emitted.previewStartedAt,
+      );
+    });
+
+    test("handleToolUse carries the stored previewStartedAt onto tool_use_start", () => {
+      const collector = createEventCollector();
+      const deps = createMockDeps({
+        onEvent: collector.onEvent,
+        ctx: {
+          ...createMockDeps().ctx,
+          emitActivityState: collector.emitActivityState,
+        } as unknown as EventHandlerDeps["ctx"],
+      });
+
+      // GIVEN a preview was recognized first
+      handleToolUsePreviewStart(state, deps, {
+        type: "tool_use_preview_start",
+        toolUseId: "toolu_carry",
+        toolName: "bash",
+      });
+      const previewStartedAt = state.toolPreviewStartedAt.get("toolu_carry");
+
+      // WHEN the tool actually begins executing
+      handleToolUse(state, deps, {
+        type: "tool_use",
+        id: "toolu_carry",
+        name: "bash",
+        input: { command: "ls" },
+      });
+
+      // THEN the tool_use_start event carries the first-byte anchor alongside
+      // its own (later) execution startedAt
+      const toolUseStart = collector.events.find(
+        (e) => e.type === "tool_use_start",
+      ) as { previewStartedAt?: number; startedAt?: number };
+      expect(toolUseStart).toBeDefined();
+      expect(toolUseStart.previewStartedAt).toBe(previewStartedAt);
+      expect(typeof toolUseStart.startedAt).toBe("number");
+      expect(toolUseStart.startedAt!).toBeGreaterThanOrEqual(previewStartedAt!);
+    });
+
     test("emits activity state with tool_running phase and preview_start reason", () => {
       const collector = createEventCollector();
       const deps = createMockDeps({

--- a/assistant/src/__tests__/tool-start-timestamp.test.ts
+++ b/assistant/src/__tests__/tool-start-timestamp.test.ts
@@ -202,6 +202,69 @@ describe("handleToolUse — tool start timestamp", () => {
     expect(block._startedAt).toBe(startedAt);
   });
 
+  test("stamps _previewStartedAt onto the persisted block when a preview start was recorded", () => {
+    // GIVEN a durable tool_use block AND a recorded first-byte preview timestamp
+    const toolUseId = "tu_bash";
+    const previewStartedAt = 1_700_000_000_000;
+    const state: EventHandlerState = createEventHandlerState();
+    state.lastAssistantMessageId = "msg-1";
+    state.toolPreviewStartedAt.set(toolUseId, previewStartedAt);
+    mockedRowContent = JSON.stringify([
+      {
+        type: "tool_use",
+        id: toolUseId,
+        name: "bash",
+        input: { command: "ls" },
+      },
+    ]);
+
+    // WHEN the tool begins (the block now exists, unlike at preview-event time)
+    handleToolUse(
+      state,
+      makeDeps(() => {}),
+      toolUseEvent(toolUseId, "bash"),
+    );
+
+    // THEN a persisted write carries the first-byte anchor as _previewStartedAt,
+    // so a mid-tool snapshot keeps the perceived-start rather than falling back
+    // to execution start
+    const previewWrite = updates.find(
+      (u) =>
+        findBlockById(u.content, toolUseId)._previewStartedAt ===
+        previewStartedAt,
+    );
+    expect(previewWrite).toBeDefined();
+  });
+
+  test("does not stamp _previewStartedAt when no preview start was recorded", () => {
+    // GIVEN a durable tool_use block and NO recorded preview timestamp
+    const toolUseId = "tu_bash";
+    const state: EventHandlerState = createEventHandlerState();
+    state.lastAssistantMessageId = "msg-1";
+    mockedRowContent = JSON.stringify([
+      {
+        type: "tool_use",
+        id: toolUseId,
+        name: "bash",
+        input: { command: "ls" },
+      },
+    ]);
+
+    // WHEN the tool begins
+    handleToolUse(
+      state,
+      makeDeps(() => {}),
+      toolUseEvent(toolUseId, "bash"),
+    );
+
+    // THEN no persisted write carries a _previewStartedAt (only _startedAt)
+    for (const u of updates) {
+      expect(
+        findBlockById(u.content, toolUseId)._previewStartedAt,
+      ).toBeUndefined();
+    }
+  });
+
   test("does not write when no persisted block matches the tool id", () => {
     // GIVEN a persisted message whose only block is unrelated to the tool
     const state: EventHandlerState = createEventHandlerState();

--- a/assistant/src/api/events/tool-use-preview-start.ts
+++ b/assistant/src/api/events/tool-use-preview-start.ts
@@ -25,6 +25,17 @@ export const ToolUsePreviewStartEventSchema = z.object({
   toolName: z.string(),
   conversationId: z.string().optional(),
   messageId: z.string().optional(),
+  /**
+   * Unix ms when the daemon recognized this tool_use block in the model stream
+   * — the first byte of the tool call, before its input has finished streaming.
+   * Clients anchor the user-perceived latency timer to this server clock so the
+   * elapsed counter captures the gap until the tool actually executes (which can
+   * be many seconds while a large input streams). The tool's own execution time
+   * is measured separately from `tool_use_start.startedAt`. Absent on streams
+   * from older daemons that pre-date this field; clients fall back to the
+   * execution `startedAt`.
+   */
+  previewStartedAt: z.number().optional(),
 });
 
 export type ToolUsePreviewStartEvent = z.infer<

--- a/assistant/src/api/events/tool-use-start.ts
+++ b/assistant/src/api/events/tool-use-start.ts
@@ -30,8 +30,22 @@ export const ToolUseStartEventSchema = z.object({
    * live elapsed-time counter to the server clock instead of the moment the
    * event was received over SSE. Absent on streams from older daemons that
    * pre-date this field; clients fall back to their own receipt time.
+   *
+   * This is the tool's *execution* start, distinct from `previewStartedAt`
+   * (when the tool call was first recognized). The execution duration
+   * (`completedAt - startedAt`) is the tool's own latency, surfaced as a
+   * secondary on-expand field; the user-perceived latency anchors on
+   * `previewStartedAt`.
    */
   startedAt: z.number().optional(),
+  /**
+   * Unix ms when the tool call was first recognized in the model stream (the
+   * `tool_use_preview_start` timestamp), carried through here so a client that
+   * connected after the preview event — or rehydrates from a snapshot — can
+   * still anchor the user-perceived latency timer to first-byte rather than
+   * execution start. Absent when no preview was emitted or on older daemons.
+   */
+  previewStartedAt: z.number().optional(),
 });
 
 export type ToolUseStartEvent = z.infer<typeof ToolUseStartEventSchema>;

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -153,8 +153,17 @@ export const ConversationMessageToolCallSchema = z.object({
   imageData: z.string().optional(),
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList: z.array(z.string()).optional(),
-  /** Unix ms when the tool started executing. */
+  /** Unix ms when the tool started executing (the `tool_use_start` time). */
   startedAt: z.number().optional(),
+  /**
+   * Unix ms when the tool call was first recognized in the model stream (the
+   * `tool_use_preview_start` time), before its input finished streaming. The
+   * user-perceived latency anchors here so a snapshot fetched mid-tool (refresh
+   * / reconnect) restores the first-byte elapsed counter; the tool's own
+   * execution latency stays `completedAt - startedAt`. Absent for tool calls
+   * that produced no preview (e.g. native server tools) or older history rows.
+   */
+  previewStartedAt: z.number().optional(),
   /** Unix ms when the tool completed. */
   completedAt: z.number().optional(),
   /**

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -214,6 +214,15 @@ export interface EventHandlerState {
     string,
     { startedAt: number; completedAt?: number }
   >;
+  /**
+   * Tracks tool_use_id → the `tool_use_preview_start` timestamp (Unix ms), the
+   * first byte of the tool call. Stamped before execution begins, so it lives
+   * in its own map rather than `toolCallTimestamps` (whose record requires an
+   * execution `startedAt`). Read when emitting `tool_use_start` and when
+   * annotating the persisted block so the user-perceived latency survives a
+   * refresh.
+   */
+  readonly toolPreviewStartedAt: Map<string, number>;
   /** The tool_use_id of the currently executing tool (set in handleToolUse, cleared in handleToolResult). */
   currentToolUseId: string | undefined;
   /** Maps confirmation requestId → tool_use_id for linking decisions to tools. */
@@ -362,6 +371,7 @@ export function createEventHandlerState(): EventHandlerState {
     firstThinkingDeltaEmitted: false,
     lastCompletedToolName: undefined,
     toolCallTimestamps: new Map(),
+    toolPreviewStartedAt: new Map(),
     currentToolUseId: undefined,
     requestIdToToolUseId: new Map(),
     toolConfirmationOutcomes: new Map(),
@@ -916,6 +926,9 @@ export function handleToolUse(
     toolUseId: event.id,
     messageId: state.lastAssistantMessageId,
     startedAt,
+    // Carry the first-byte timestamp through so a client that connected after
+    // the preview event still anchors the perceived-latency timer to it.
+    previewStartedAt: state.toolPreviewStartedAt.get(event.id),
   });
   // `message_complete` always precedes tool events (see handleMessageComplete),
   // so this tool_use block is already durable in the assistant row. The
@@ -932,12 +945,26 @@ export function handleToolUsePreviewStart(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "tool_use_preview_start" }>,
 ): void {
+  // Stamp the first-byte timestamp on the server clock. The user-perceived
+  // latency timer anchors here, so clients can start rendering the tool card
+  // and ticking elapsed time the moment the call is recognized — well before
+  // its input finishes streaming (which can lag many seconds on a large input).
+  const previewStartedAt = Date.now();
+  state.toolPreviewStartedAt.set(event.toolUseId, previewStartedAt);
+  // Mirror it onto the durable tool_use block so a snapshot fetched mid-preview
+  // (refresh / reconnect) carries the perceived-start anchor.
+  recordToolPreviewStartOnPersistedMessage(
+    state,
+    event.toolUseId,
+    previewStartedAt,
+  );
   deps.onEvent({
     type: "tool_use_preview_start",
     toolUseId: event.toolUseId,
     toolName: event.toolName,
     conversationId: deps.ctx.conversationId,
     messageId: state.lastAssistantMessageId,
+    previewStartedAt,
   });
   const statusText = `Preparing ${friendlyToolName(event.toolName)}...`;
   deps.ctx.emitActivityState("tool_running", "preview_start", {
@@ -1476,6 +1503,44 @@ function recordToolStartOnPersistedMessage(
 }
 
 /**
+ * Stamp `_previewStartedAt` onto the in-flight tool_use block the moment the
+ * tool call is recognized (before its input finishes streaming), mirroring
+ * `recordToolStartOnPersistedMessage`. The block is already durable
+ * (message_complete precedes tool events), so without this a `/messages`
+ * snapshot fetched mid-tool would lose the perceived-start anchor and clients
+ * would fall back to execution start — hiding the input-streaming gap the user
+ * actually waited through.
+ */
+function recordToolPreviewStartOnPersistedMessage(
+  state: EventHandlerState,
+  toolUseId: string,
+  previewStartedAt: number,
+): void {
+  const messageId = state.lastAssistantMessageId;
+  if (!messageId) return;
+
+  const row = getMessageById(messageId);
+  if (!row) return;
+
+  let content: ContentBlock[];
+  try {
+    content = JSON.parse(row.content) as ContentBlock[];
+  } catch {
+    return;
+  }
+
+  for (const block of content) {
+    if (block.type !== "tool_use") continue;
+    const rec = block as unknown as Record<string, unknown>;
+    if (rec.id !== toolUseId) continue;
+    if (rec._previewStartedAt === previewStartedAt) return;
+    rec._previewStartedAt = previewStartedAt;
+    updateMessageContent(messageId, JSON.stringify(content));
+    return;
+  }
+}
+
+/**
  * After all tools for the current turn complete, fetch the persisted assistant
  * message, annotate its tool_use blocks with timing and confirmation metadata,
  * and update the DB. This runs post-tool-execution so the metadata maps are
@@ -1511,6 +1576,11 @@ function annotatePersistedAssistantMessage(
         if (ts.completedAt != null) {
           rec._completedAt = ts.completedAt;
         }
+        modified = true;
+      }
+      const previewStartedAt = state.toolPreviewStartedAt.get(id);
+      if (previewStartedAt != null) {
+        rec._previewStartedAt = previewStartedAt;
         modified = true;
       }
       const confirmation = state.toolConfirmationOutcomes.get(id);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -913,6 +913,14 @@ export function handleToolUse(
   // fetched mid-tool (refresh / reconnect) carries it and clients can render a
   // running timer without having seen the live `tool_use_start` event.
   recordToolStartOnPersistedMessage(state, event.id, startedAt);
+  // Mirror the first-byte preview timestamp onto the same durable block so a
+  // mid-tool snapshot keeps the perceived-start anchor instead of falling back
+  // to execution start. The block exists now (message_complete wrote it before
+  // this tool event), unlike at `tool_use_preview_start` time.
+  const previewStartedAt = state.toolPreviewStartedAt.get(event.id);
+  if (previewStartedAt != null) {
+    recordToolPreviewStartOnPersistedMessage(state, event.id, previewStartedAt);
+  }
   const statusText = computeToolUseStatusText(event.name, event.input);
   deps.ctx.emitActivityState("tool_running", "tool_use_start", {
     requestId: deps.reqId,
@@ -949,15 +957,13 @@ export function handleToolUsePreviewStart(
   // latency timer anchors here, so clients can start rendering the tool card
   // and ticking elapsed time the moment the call is recognized — well before
   // its input finishes streaming (which can lag many seconds on a large input).
+  //
+  // We only record it in state here, not onto the persisted assistant row: the
+  // tool_use block does not exist yet (message_complete writes it after the
+  // stream ends, which is after this preview event). `handleToolUse` mirrors
+  // this timestamp onto the durable block once it exists.
   const previewStartedAt = Date.now();
   state.toolPreviewStartedAt.set(event.toolUseId, previewStartedAt);
-  // Mirror it onto the durable tool_use block so a snapshot fetched mid-preview
-  // (refresh / reconnect) carries the perceived-start anchor.
-  recordToolPreviewStartOnPersistedMessage(
-    state,
-    event.toolUseId,
-    previewStartedAt,
-  );
   deps.onEvent({
     type: "tool_use_preview_start",
     toolUseId: event.toolUseId,
@@ -1503,13 +1509,14 @@ function recordToolStartOnPersistedMessage(
 }
 
 /**
- * Stamp `_previewStartedAt` onto the in-flight tool_use block the moment the
- * tool call is recognized (before its input finishes streaming), mirroring
- * `recordToolStartOnPersistedMessage`. The block is already durable
- * (message_complete precedes tool events), so without this a `/messages`
- * snapshot fetched mid-tool would lose the perceived-start anchor and clients
- * would fall back to execution start — hiding the input-streaming gap the user
- * actually waited through.
+ * Stamp `_previewStartedAt` (the first-byte timestamp) onto the durable
+ * tool_use block, mirroring `recordToolStartOnPersistedMessage`. Called from
+ * `handleToolUse` rather than `handleToolUsePreviewStart`: the block only exists
+ * once message_complete has written it, which happens after the preview event
+ * but before the tool event. Without this a `/messages` snapshot fetched
+ * mid-tool would lose the perceived-start anchor and clients would fall back to
+ * execution start — hiding the input-streaming gap the user actually waited
+ * through.
  */
 function recordToolPreviewStartOnPersistedMessage(
   state: EventHandlerState,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -496,6 +496,8 @@ export function renderHistoryContent(
       // Extract persisted timing/confirmation metadata
       if (typeof block._startedAt === "number")
         entry.startedAt = block._startedAt;
+      if (typeof block._previewStartedAt === "number")
+        entry.previewStartedAt = block._previewStartedAt;
       if (typeof block._completedAt === "number")
         entry.completedAt = block._completedAt;
       const confirmationDecision = ConfirmationDecisionSchema.safeParse(

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -170,7 +170,6 @@ function InlineConfirmationCard({
       {/* Row 1: title + risk badge */}
       <div className="flex items-center gap-2">
         {/* typography: off-scale — semibold to match macOS bodyMediumEmphasised */}
-        {}
         <span className="text-body-medium-default font-semibold text-[var(--content-default)]">
           {confirmation.title ?? "Confirmation required"}
         </span>

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -1,4 +1,3 @@
-
 import { BusyIndicator } from "@/domains/chat/components/busy-indicator";
 import {
   Camera,
@@ -18,16 +17,35 @@ import {
   Wrench,
   XCircle,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
-import { getRiskBadgeStyle, getProvenanceText, wasExpected, getEffectiveRiskDisplay } from "@/domains/chat/utils/risk";
-import { formatStartTime, useElapsedTime } from "@/domains/chat/hooks/use-elapsed-time";
+import {
+  getRiskBadgeStyle,
+  getProvenanceText,
+  wasExpected,
+  getEffectiveRiskDisplay,
+} from "@/domains/chat/utils/risk";
+import {
+  formatStartTime,
+  useElapsedTime,
+} from "@/domains/chat/hooks/use-elapsed-time";
 
 import type { ConfirmationDecision } from "@/types/event-types";
-import type { AllowlistOption, DirectoryScopeOption, ScopeOption } from "@/types/interaction-ui-types";
+import type {
+  AllowlistOption,
+  DirectoryScopeOption,
+  ScopeOption,
+} from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import { perceivedStartedAt } from "@/domains/chat/utils/tool-call-status";
 import {
   extractInputSummary,
   friendlyRunningLabel,
@@ -51,7 +69,9 @@ export interface ToolCallChipProps {
     decision: ConfirmationDecision,
     toolCall: ChatMessageToolCall,
   ) => void | Promise<void>;
-  onAllowAndCreateRule?: (toolCall: ChatMessageToolCall) => void | Promise<void>;
+  onAllowAndCreateRule?: (
+    toolCall: ChatMessageToolCall,
+  ) => void | Promise<void>;
   /** When true, skip the outer header row ("Running 1 step") and render
    *  the sub-item row + details directly. Used inside MultiActivityGroup
    *  to avoid double-nesting. */
@@ -75,7 +95,13 @@ function getIcon(toolName: string, inputSummary: string = ""): ReactNode {
   return ICON_MAP[iconKey] ?? <Wrench className="h-3.5 w-3.5" />;
 }
 
-function StatusIcon({ isRunning, isError }: { isRunning: boolean; isError: boolean }) {
+function StatusIcon({
+  isRunning,
+  isError,
+}: {
+  isRunning: boolean;
+  isError: boolean;
+}) {
   if (isRunning) {
     // Wrap in a fixed-size slot so the layout doesn't shift when the icon
     // transitions from the 16px circle icons to the 6px pulsing dot.
@@ -86,9 +112,13 @@ function StatusIcon({ isRunning, isError }: { isRunning: boolean; isError: boole
     );
   }
   if (isError) {
-    return <XCircle className="h-4 w-4 text-[var(--system-negative-strong)] shrink-0" />;
+    return (
+      <XCircle className="h-4 w-4 text-[var(--system-negative-strong)] shrink-0" />
+    );
   }
-  return <CheckCircle2 className="h-4 w-4 text-[var(--system-positive-strong)] shrink-0" />;
+  return (
+    <CheckCircle2 className="h-4 w-4 text-[var(--system-positive-strong)] shrink-0" />
+  );
 }
 
 /**
@@ -115,7 +145,10 @@ function InlineConfirmationCard({
   useEffect(() => {
     if (!showSplitMenu) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (splitMenuRef.current && !splitMenuRef.current.contains(e.target as Node)) {
+      if (
+        splitMenuRef.current &&
+        !splitMenuRef.current.contains(e.target as Node)
+      ) {
         setShowSplitMenu(false);
       }
     };
@@ -130,22 +163,21 @@ function InlineConfirmationCard({
     ? getRiskBadgeStyle(confirmation.riskLevel)
     : null;
   const hasDetails = !!confirmation.input;
-  const hasAllowlistOptions =
-    (confirmation.allowlistOptions?.length ?? 0) > 0;
+  const hasAllowlistOptions = (confirmation.allowlistOptions?.length ?? 0) > 0;
 
   return (
     <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3">
       {/* Row 1: title + risk badge */}
       <div className="flex items-center gap-2">
         {/* typography: off-scale — semibold to match macOS bodyMediumEmphasised */}
-        { }
+        {}
         <span className="text-body-medium-default font-semibold text-[var(--content-default)]">
           {confirmation.title ?? "Confirmation required"}
         </span>
         {riskBadge && (
           <span
             // typography: off-scale — compact risk badge pill
-             
+
             className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium leading-tight ${riskBadge.bg} ${riskBadge.text}`}
           >
             {riskBadge.label}
@@ -257,8 +289,8 @@ export function ToolCallChip({
   onAllowAndCreateRule,
   embedded = false,
 }: ToolCallChipProps) {
-  const expanded = useChatSessionStore(
-    (s) => s.expandedToolCallIds.has(toolCall.id),
+  const expanded = useChatSessionStore((s) =>
+    s.expandedToolCallIds.has(toolCall.id),
   );
   const toggleExpanded = useCallback(
     (next: boolean) => {
@@ -279,20 +311,39 @@ export function ToolCallChip({
   const isRunning =
     !isError && toolCall.result === undefined && toolCall.completedAt == null;
   const hasPendingConfirmation = !!toolCall.pendingConfirmation;
-  const duration = useElapsedTime(toolCall.startedAt, !isRunning, toolCall.completedAt);
-  const startTimeLabel = formatStartTime(toolCall.startedAt);
+  // Headline duration is the user-perceived "time they feel": it anchors on the
+  // first-byte `previewStartedAt` (falling back to execution start) so the
+  // counter captures the input-streaming gap before the tool actually runs.
+  const perceivedStart = perceivedStartedAt(toolCall);
+  const duration = useElapsedTime(
+    perceivedStart,
+    !isRunning,
+    toolCall.completedAt,
+  );
+  const startTimeLabel = formatStartTime(perceivedStart);
+  // The tool's own execution latency (`startedAt` → `completedAt`), surfaced as
+  // a separate field on expand. Distinct from the perceived `duration` above.
+  const executionDuration = useElapsedTime(
+    toolCall.startedAt,
+    !isRunning,
+    toolCall.completedAt,
+  );
 
   const inputSummary = extractInputSummary(toolCall.name, toolCall.input);
   const activity = toolCall.input?.activity ?? toolCall.input?.reason;
-  const activityLabel = typeof activity === "string" && activity.trim() ? activity.trim() : null;
-  const label = activityLabel
-    ?? (isRunning
+  const activityLabel =
+    typeof activity === "string" && activity.trim() ? activity.trim() : null;
+  const label =
+    activityLabel ??
+    (isRunning
       ? friendlyRunningLabel(toolCall.name, inputSummary)
       : friendlyToolLabel(toolCall.name, inputSummary));
 
   const canExpand =
     hasPendingConfirmation ||
-    (!isRunning && (toolCall.result !== undefined || Object.keys(toolCall.input).length > 0));
+    (!isRunning &&
+      (toolCall.result !== undefined ||
+        Object.keys(toolCall.input).length > 0));
 
   // Auto-expand on the false→true transition of pendingConfirmation so the
   // inline approve/deny card is immediately visible. Initialized to `false`
@@ -344,54 +395,79 @@ export function ToolCallChip({
       : "Completed 1 step";
 
   const subItemRow = (
-    <div className={`flex min-w-0 items-center gap-2 py-2 ${embedded ? "pl-6 pr-3 text-body-small-default" : ""}`}>
+    <div
+      className={`flex min-w-0 items-center gap-2 py-2 ${embedded ? "pl-6 pr-3 text-body-small-default" : ""}`}
+    >
       <StatusIcon isRunning={isRunning} isError={isError} />
       {!embedded && getIcon(toolCall.name, inputSummary)}
-      <span className="min-w-0 truncate text-[var(--content-secondary)]">{label}</span>
-      {toolCall.riskLevel && !isRunning && !hasPendingConfirmation && (() => {
-        const { displayLevel, inherentRisk } = getEffectiveRiskDisplay(toolCall.approvalReason, toolCall.riskLevel);
-        const badge = getRiskBadgeStyle(displayLevel);
-        const isWorkspace = displayLevel === "workspace";
+      <span className="min-w-0 truncate text-[var(--content-secondary)]">
+        {label}
+      </span>
+      {toolCall.riskLevel &&
+        !isRunning &&
+        !hasPendingConfirmation &&
+        (() => {
+          const { displayLevel, inherentRisk } = getEffectiveRiskDisplay(
+            toolCall.approvalReason,
+            toolCall.riskLevel,
+          );
+          const badge = getRiskBadgeStyle(displayLevel);
+          const isWorkspace = displayLevel === "workspace";
 
-        // For workspace chips, skip provenance — the chip itself is the provenance indicator.
-        // For normal badges, check wasExpected against the original riskLevel.
-        const unexpected = !isWorkspace && !wasExpected(toolCall.approvalMode, toolCall.riskLevel, toolCall.riskThreshold);
-        const provenance = unexpected ? getProvenanceText(toolCall.approvalReason) : null;
+          // For workspace chips, skip provenance — the chip itself is the provenance indicator.
+          // For normal badges, check wasExpected against the original riskLevel.
+          const unexpected =
+            !isWorkspace &&
+            !wasExpected(
+              toolCall.approvalMode,
+              toolCall.riskLevel,
+              toolCall.riskThreshold,
+            );
+          const provenance = unexpected
+            ? getProvenanceText(toolCall.approvalReason)
+            : null;
 
-        let displayLabel: string;
-        if (isWorkspace) {
-          const capitalizedRisk = inherentRisk ? inherentRisk.charAt(0).toUpperCase() + inherentRisk.slice(1) : "Unknown";
-          displayLabel = `Workspace · Inherent risk: ${capitalizedRisk}`;
-        } else {
-          displayLabel = provenance ? `${badge.label} ${provenance}` : badge.label;
-        }
+          let displayLabel: string;
+          if (isWorkspace) {
+            const capitalizedRisk = inherentRisk
+              ? inherentRisk.charAt(0).toUpperCase() + inherentRisk.slice(1)
+              : "Unknown";
+            displayLabel = `Workspace · Inherent risk: ${capitalizedRisk}`;
+          } else {
+            displayLabel = provenance
+              ? `${badge.label} ${provenance}`
+              : badge.label;
+          }
 
-        return (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenRuleEditor?.({
-                toolName: toolCall.name,
-                riskLevel: toolCall.riskLevel,
-                riskReason: toolCall.riskReason,
-                input: toolCall.input,
-                allowlistOptions: toolCall.riskAllowlistOptions ?? [],
-                scopeOptions: toolCall.scopeOptions ?? [],
-                directoryScopeOptions: toolCall.riskDirectoryScopeOptions ?? [],
-                matchedTrustRuleId: toolCall.matchedTrustRuleId,
-              });
-            }}
-            // typography: off-scale — compact risk badge pill
+          return (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenRuleEditor?.({
+                  toolName: toolCall.name,
+                  riskLevel: toolCall.riskLevel,
+                  riskReason: toolCall.riskReason,
+                  input: toolCall.input,
+                  allowlistOptions: toolCall.riskAllowlistOptions ?? [],
+                  scopeOptions: toolCall.scopeOptions ?? [],
+                  directoryScopeOptions:
+                    toolCall.riskDirectoryScopeOptions ?? [],
+                  matchedTrustRuleId: toolCall.matchedTrustRuleId,
+                });
+              }}
+              // typography: off-scale — compact risk badge pill
 
-            className={`${embedded ? "" : "ml-auto "}max-w-[45%] shrink-0 truncate rounded-full px-2 py-0.5 text-[11px] font-medium leading-tight ${badge.bg} ${badge.text} ${badge.border ?? ""} ${onOpenRuleEditor ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
-            title={displayLabel}
-          >
-            <span className="sm:hidden">{badge.label}</span>
-            <span className="hidden sm:inline">{isWorkspace ? badge.label : displayLabel}</span>
-          </button>
-        );
-      })()}
+              className={`${embedded ? "" : "ml-auto "}max-w-[45%] shrink-0 truncate rounded-full px-2 py-0.5 text-[11px] font-medium leading-tight ${badge.bg} ${badge.text} ${badge.border ?? ""} ${onOpenRuleEditor ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
+              title={displayLabel}
+            >
+              <span className="sm:hidden">{badge.label}</span>
+              <span className="hidden sm:inline">
+                {isWorkspace ? badge.label : displayLabel}
+              </span>
+            </button>
+          );
+        })()}
       {embedded && (
         <span className="ml-auto flex items-center gap-1.5 text-[var(--content-tertiary)]">
           {duration && (
@@ -399,7 +475,12 @@ export function ToolCallChip({
               {duration}
             </span>
           )}
-          {canExpand && (expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />)}
+          {canExpand &&
+            (expanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            ))}
         </span>
       )}
     </div>
@@ -428,10 +509,24 @@ export function ToolCallChip({
             </div>
             <div className="text-[var(--content-secondary)]">Tool Name</div>
             <div className="text-[var(--content-secondary)]">
-              {toolCall.name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+              {toolCall.name
+                .replace(/_/g, " ")
+                .replace(/\b\w/g, (c) => c.toUpperCase())}
             </div>
             {startTimeLabel && (
-              <div className="mt-0.5 text-[var(--content-tertiary)]">{startTimeLabel}</div>
+              <div className="mt-0.5 text-[var(--content-tertiary)]">
+                {startTimeLabel}
+              </div>
+            )}
+            {executionDuration && (
+              <div className="mt-0.5">
+                <span className="text-label-medium-default text-[var(--content-default)]">
+                  Tool latency:
+                </span>{" "}
+                <span className="text-[var(--content-tertiary)]">
+                  {executionDuration}
+                </span>
+              </div>
             )}
             {Object.entries(toolCall.input).map(([key, value]) => (
               <div key={key} className="mt-0.5">
@@ -455,16 +550,20 @@ export function ToolCallChip({
               <div className="mb-1.5 text-label-small-default uppercase tracking-wider text-[var(--content-tertiary)]">
                 Output
               </div>
-              <div className={`relative rounded-md border p-3 ${
-                isError
-                  ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)]"
-                  : "border-[var(--border-element)] bg-[var(--surface-base)]"
-              }`}>
-                <pre className={`whitespace-pre-wrap break-words text-body-small-default max-h-60 overflow-y-auto pr-8 ${
+              <div
+                className={`relative rounded-md border p-3 ${
                   isError
-                    ? "text-[var(--system-negative-strong)]"
-                    : "text-[var(--content-default)]"
-                }`}>
+                    ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)]"
+                    : "border-[var(--border-element)] bg-[var(--surface-base)]"
+                }`}
+              >
+                <pre
+                  className={`whitespace-pre-wrap break-words text-body-small-default max-h-60 overflow-y-auto pr-8 ${
+                    isError
+                      ? "text-[var(--system-negative-strong)]"
+                      : "text-[var(--content-default)]"
+                  }`}
+                >
                   {toolCall.result.length > 2000
                     ? toolCall.result.slice(0, 2000) + "..."
                     : toolCall.result}
@@ -507,8 +606,9 @@ export function ToolCallChip({
         >
           {subItemRow}
         </div>
-        {expanded && canExpand && (
-          hasPendingConfirmation ? (
+        {expanded &&
+          canExpand &&
+          (hasPendingConfirmation ? (
             // Confirmation card gets full-width (px-3) to match macOS PermissionPromptView
             <div className="px-3 pt-1 pb-2">
               <InlineConfirmationCard
@@ -520,9 +620,10 @@ export function ToolCallChip({
             </div>
           ) : (
             // Technical details stay indented under the tool label
-            <div className="pl-6 pr-3 pb-2 text-label-medium-default">{detailsPanel}</div>
-          )
-        )}
+            <div className="pl-6 pr-3 pb-2 text-label-medium-default">
+              {detailsPanel}
+            </div>
+          ))}
       </div>
     );
   }
@@ -544,7 +645,13 @@ export function ToolCallChip({
         }`}
       >
         <StatusIcon isRunning={isRunning} isError={isError} />
-        <span className={isError ? "text-[var(--system-negative-strong)]" : "text-[var(--content-default)]"}>
+        <span
+          className={
+            isError
+              ? "text-[var(--system-negative-strong)]"
+              : "text-[var(--content-default)]"
+          }
+        >
           {statusLabel}
         </span>
         <span className="ml-auto flex items-center gap-1.5 text-[var(--content-tertiary)]">
@@ -556,17 +663,24 @@ export function ToolCallChip({
               {duration}
             </span>
           )}
-          {canExpand && (expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />)}
+          {canExpand &&
+            (expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            ))}
         </span>
       </button>
 
       {/* Expanded details panel */}
       {expanded && canExpand && (
-        <div className={`rounded-b-lg border-t px-3 pb-3 text-label-medium-default ${
-          isError
-            ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)]"
-            : "border-[var(--border-element)] bg-[var(--surface-base)]"
-        }`}>
+        <div
+          className={`rounded-b-lg border-t px-3 pb-3 text-label-medium-default ${
+            isError
+              ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)]"
+              : "border-[var(--border-element)] bg-[var(--surface-base)]"
+          }`}
+        >
           {subItemRow}
           {detailsPanel}
         </div>

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -44,6 +44,7 @@ import {
   handleUISurfaceComplete,
 } from "@/domains/chat/utils/stream-handlers/surface-handlers";
 import {
+  handleToolUsePreviewStart,
   handleToolUseStart,
   handleToolResult,
   handleToolOutputChunk,
@@ -333,8 +334,11 @@ export function useStreamEventHandler(
         case "tool_result":
           handleToolResult(event, ctx);
           break;
-        // The optimistic pre-input affordance has no transcript treatment.
+        // Optimistic pre-input affordance: seed a running tool card the moment
+        // the call is recognized, so the user-perceived elapsed timer starts at
+        // first byte rather than after the input-streaming gap.
         case "tool_use_preview_start":
+          handleToolUsePreviewStart(event, ctx);
           break;
         // Incremental tool output (e.g. foreground bash stdout/stderr) is
         // buffered onto the matching tool call's live `streamedOutput` tail

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
@@ -3,16 +3,93 @@ import { describe, expect, it } from "bun:test";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleToolResult,
+  handleToolUsePreviewStart,
   handleToolUseStart,
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
+describe("handleToolUsePreviewStart", () => {
+  it("seeds a running tool call with previewStartedAt and empty input", () => {
+    const ctx = makeCtx();
+    handleToolUsePreviewStart(
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "tc-1",
+        toolName: "bash",
+        previewStartedAt: 1_000,
+        messageId: "anchor-1",
+      },
+      ctx,
+    );
+    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>)
+      .mock.calls[0][0] as (prev: DisplayMessage[]) => DisplayMessage[];
+    const next = updater([]);
+    const tc = next[0]!.toolCalls![0]!;
+    expect(tc.id).toBe("tc-1");
+    expect(tc.name).toBe("bash");
+    expect(tc.previewStartedAt).toBe(1_000);
+    // No execution start yet, and the call reads as running (no result/completedAt).
+    expect(tc.startedAt).toBeUndefined();
+    expect(tc.input).toEqual({});
+  });
+
+  it("tool_use_start merges onto the preview-seeded call, preserving previewStartedAt and adding the execution start", () => {
+    const ctx = makeCtx();
+    let current: DisplayMessage[] = [];
+    const setMessages = ctx.setMessages as unknown as {
+      mock: { calls: unknown[][] };
+    };
+
+    handleToolUsePreviewStart(
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "tc-1",
+        toolName: "bash",
+        previewStartedAt: 1_000,
+        messageId: "anchor-1",
+      },
+      ctx,
+    );
+    current = (
+      setMessages.mock.calls[0]![0] as (p: DisplayMessage[]) => DisplayMessage[]
+    )(current);
+
+    handleToolUseStart(
+      {
+        type: "tool_use_start",
+        toolName: "bash",
+        input: { command: "ls" },
+        toolUseId: "tc-1",
+        messageId: "anchor-1",
+        startedAt: 21_000,
+        previewStartedAt: 1_000,
+      },
+      ctx,
+    );
+    current = (
+      setMessages.mock.calls[1]![0] as (p: DisplayMessage[]) => DisplayMessage[]
+    )(current);
+
+    // One bubble, one tool call: the preview seed and the execution start are the same call.
+    expect(current).toHaveLength(1);
+    expect(current[0]!.toolCalls).toHaveLength(1);
+    const tc = current[0]!.toolCalls![0]!;
+    expect(tc.previewStartedAt).toBe(1_000);
+    expect(tc.startedAt).toBe(21_000);
+    expect(tc.input).toEqual({ command: "ls" });
+  });
+});
+
 describe("handleToolUseStart", () => {
   it("cancels reconciliation and creates tool call with generated id", () => {
     const ctx = makeCtx();
     handleToolUseStart(
-      { type: "tool_use_start", toolName: "web_search", input: { query: "test" } },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "test" },
+      },
       ctx,
     );
     expect(ctx.cancelReconciliation).toHaveBeenCalled();
@@ -38,11 +115,17 @@ describe("handleToolUseStart", () => {
   it("creates a new bubble when there is no assistant tail to fold into", () => {
     const ctx = makeCtx();
     handleToolUseStart(
-      { type: "tool_use_start", toolName: "web_search", input: {}, toolUseId: "tc-1" },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: {},
+        toolUseId: "tc-1",
+      },
       ctx,
     );
     expect(ctx.setMessages).toHaveBeenCalled();
-    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>).mock.calls[0][0] as (
+    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>)
+      .mock.calls[0][0] as (
       prev: never[],
     ) => Array<{ role: string; toolCalls: Array<{ id: string }> }>;
     const next = updater([]);
@@ -67,7 +150,8 @@ describe("handleToolUseStart", () => {
       },
       ctx,
     );
-    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>).mock.calls[0][0] as (
+    const updater = (ctx.setMessages as unknown as ReturnType<typeof Object>)
+      .mock.calls[0][0] as (
       prev: never[],
     ) => Array<{ id: string; isOptimistic?: boolean }>;
     const next = updater([]);
@@ -81,8 +165,14 @@ describe("handleToolUseStart", () => {
     // must produce ONE assistant row with three tool calls, not three
     // overlapping bubbles or a duplicate.
     const ctx = makeCtx();
-    let current: Array<{ id: string; toolCalls?: Array<{ id: string }>; isOptimistic?: boolean }> = [];
-    const setMessages = ctx.setMessages as unknown as { mock: { calls: unknown[][] } };
+    let current: Array<{
+      id: string;
+      toolCalls?: Array<{ id: string }>;
+      isOptimistic?: boolean;
+    }> = [];
+    const setMessages = ctx.setMessages as unknown as {
+      mock: { calls: unknown[][] };
+    };
 
     for (const [i, toolUseId] of ["tc-1", "tc-2", "tc-3"].entries()) {
       handleToolUseStart(
@@ -105,7 +195,11 @@ describe("handleToolUseStart", () => {
     expect(current[0]!.id).toBe("anchor-1");
     expect(current[0]!.isOptimistic).toBeUndefined();
     expect(current[0]!.toolCalls).toHaveLength(3);
-    expect(current[0]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-1", "tc-2", "tc-3"]);
+    expect(current[0]!.toolCalls!.map((tc) => tc.id)).toEqual([
+      "tc-1",
+      "tc-2",
+      "tc-3",
+    ]);
   });
 });
 
@@ -193,10 +287,7 @@ describe("handleToolResult", () => {
     const next = updater(initial);
 
     expect(next[0]!.toolCalls![0]!.imageData).toBe("img-a");
-    expect(next[0]!.toolCalls![0]!.imageDataList).toEqual([
-      "img-a",
-      "img-b",
-    ]);
+    expect(next[0]!.toolCalls![0]!.imageDataList).toEqual(["img-a", "img-b"]);
   });
 
   it("does NOT route activityMetadata when toolUseId is missing", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -10,11 +10,44 @@ import { useStreamStore } from "@/domains/chat/stream-store";
 import type {
   ToolOutputChunkEvent,
   ToolResultEvent,
+  ToolUsePreviewStartEvent,
   ToolUseStartEvent,
 } from "@vellumai/assistant-api";
 
 /** Buffer key for chunks that arrive without a `toolUseId` (pre-anchor daemons). */
 const NO_TOOL_ID = "no-tool-id";
+
+/**
+ * Optimistic pre-input affordance: the moment the daemon recognizes a tool call
+ * (before its input finishes streaming), render the tool card so the user sees
+ * activity immediately rather than after the input-streaming gap — which can run
+ * many seconds on a large input. We seed a running tool call with the
+ * first-byte `previewStartedAt` anchor and an empty input; `handleToolUseStart`
+ * fills in the real input and execution `startedAt` once the call begins.
+ */
+export function handleToolUsePreviewStart(
+  event: ToolUsePreviewStartEvent,
+  ctx: StreamHandlerContext,
+): void {
+  const previewStartedAt =
+    typeof event.previewStartedAt === "number"
+      ? event.previewStartedAt
+      : Date.now();
+  const previewToolCall: ChatMessageToolCall = {
+    id: event.toolUseId,
+    name: event.toolName,
+    input: {},
+    previewStartedAt,
+  };
+  ctx.setMessages((prev) => {
+    const next = upsertToolCall(prev, previewToolCall, event.messageId);
+    const tail = next[next.length - 1];
+    if (tail?.role === "assistant") {
+      ctx.currentAssistantMessageIdRef.current = tail.id;
+    }
+    return next;
+  });
+}
 
 export function handleToolUseStart(
   event: ToolUseStartEvent,
@@ -29,10 +62,17 @@ export function handleToolUseStart(
     name: event.toolName,
     input: event.input,
     startedAt:
-      "startedAt" in event &&
-      typeof event.startedAt === "number"
+      "startedAt" in event && typeof event.startedAt === "number"
         ? event.startedAt
         : Date.now(),
+    // Carried through so a client that connected after the preview event still
+    // anchors the perceived-latency timer to first-byte. `upsertToolCall`
+    // merges onto the preview-seeded call, so an already-present
+    // `previewStartedAt` is preserved when this is omitted.
+    ...("previewStartedAt" in event &&
+    typeof event.previewStartedAt === "number"
+      ? { previewStartedAt: event.previewStartedAt }
+      : {}),
   };
   ctx.setMessages((prev) => {
     const next = upsertToolCall(prev, newToolCall, event.messageId);
@@ -84,8 +124,7 @@ export function handleToolResult(
       imageDataList: event.imageDataList,
       activityMetadata: event.activityMetadata,
       completedAt:
-        "completedAt" in event &&
-        typeof event.completedAt === "number"
+        "completedAt" in event && typeof event.completedAt === "number"
           ? event.completedAt
           : undefined,
     }),

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -6,7 +6,10 @@
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
+import {
+  isToolCallRunning,
+  perceivedStartedAt,
+} from "@/domains/chat/utils/tool-call-status";
 import type {
   ToolActivityMetadata,
   WebSearchResultItem,
@@ -404,12 +407,11 @@ function computeDurationLabel(
   return ms == null ? "" : formatMs(ms);
 }
 
-function computeToolDurationMs(tc: ChatMessageToolCall): number | null {
-  return computeDurationMs(tc.startedAt ?? undefined, tc.completedAt ?? undefined);
-}
-
 function computeToolDurationLabel(tc: ChatMessageToolCall): string {
-  return computeDurationLabel(tc.startedAt ?? undefined, tc.completedAt ?? undefined);
+  return computeDurationLabel(
+    tc.startedAt ?? undefined,
+    tc.completedAt ?? undefined,
+  );
 }
 
 /** True for a tool call that is rendered as a step AND still in flight. */
@@ -446,9 +448,16 @@ function computeItemDurationMs(
   }
   const tc = item.toolCall;
   if (isSubagentSpawnCall(tc)) return null;
-  if (tc.completedAt != null) return computeToolDurationMs(tc);
-  if (isToolCallRunning(tc) && tc.startedAt != null && nowMs != null) {
-    return Math.max(0, nowMs - tc.startedAt);
+  // The header total is the user-perceived "time they feel", so it anchors on
+  // the first-byte `previewStartedAt` (falling back to execution start) rather
+  // than `tc.startedAt`. This includes the input-streaming gap before the tool
+  // actually runs. The per-step rows still show the tool's own execution
+  // latency via `computeToolDurationLabel`.
+  const perceived = perceivedStartedAt(tc);
+  if (tc.completedAt != null)
+    return computeDurationMs(perceived, tc.completedAt);
+  if (isToolCallRunning(tc) && perceived != null && nowMs != null) {
+    return Math.max(0, nowMs - perceived);
   }
   return null;
 }
@@ -462,9 +471,7 @@ function computeItemDurationMs(
 export function hasRunningItem(items: ToolCallCardItem[]): boolean {
   return items.some((item) =>
     item.kind === "thinking"
-      ? Boolean(item.text) &&
-        item.startedAt != null &&
-        item.completedAt == null
+      ? Boolean(item.text) && item.startedAt != null && item.completedAt == null
       : isRenderableRunningCall(item.toolCall),
   );
 }
@@ -764,7 +771,9 @@ function buildStepForToolCall(
       : buildWebFetchPlaceholderStep();
   }
   if (tc.name === "web_search" && typeof tc.result === "string") {
-    return buildWebSearchStepFromResultText(tc.result) ?? buildEmptyWebSearchStep();
+    return (
+      buildWebSearchStepFromResultText(tc.result) ?? buildEmptyWebSearchStep()
+    );
   }
   return buildEmptyWebSearchStep();
 }
@@ -781,8 +790,9 @@ export function computeToolCallCardDataFromItems(
   nowMs?: number,
 ): ToolCallCardData {
   const toolCalls = items
-    .filter((i): i is { kind: "toolCall"; toolCall: ChatMessageToolCall } =>
-      i.kind === "toolCall",
+    .filter(
+      (i): i is { kind: "toolCall"; toolCall: ChatMessageToolCall } =>
+        i.kind === "toolCall",
     )
     .map((i) => i.toolCall);
   // `subagent_spawn` calls are rendered inline by `SubagentInlineProgressCard`

--- a/clients/web/src/domains/chat/utils/tool-call-status.test.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-status.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   isToolCallCompleted,
   isToolCallRunning,
+  perceivedStartedAt,
   toolCallRank,
 } from "@/domains/chat/utils/tool-call-status";
 import type { ConversationMessageToolCall } from "@vellumai/assistant-api";
@@ -16,6 +17,22 @@ function make(
     ...overrides,
   } as ConversationMessageToolCall;
 }
+
+describe("perceivedStartedAt", () => {
+  test("prefers previewStartedAt (first byte) over execution startedAt", () => {
+    expect(
+      perceivedStartedAt(make({ previewStartedAt: 1_000, startedAt: 21_000 })),
+    ).toBe(1_000);
+  });
+
+  test("falls back to execution startedAt when no preview timestamp", () => {
+    expect(perceivedStartedAt(make({ startedAt: 21_000 }))).toBe(21_000);
+  });
+
+  test("is undefined when neither timestamp is present", () => {
+    expect(perceivedStartedAt(make())).toBeUndefined();
+  });
+});
 
 describe("isToolCallRunning", () => {
   test("is running when neither result, completedAt, nor isError are set", () => {

--- a/clients/web/src/domains/chat/utils/tool-call-status.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-status.ts
@@ -5,6 +5,28 @@ type ToolCallStateFields = Pick<
   "isError" | "result" | "completedAt"
 >;
 
+type ToolCallTimingFields = Pick<
+  ConversationMessageToolCall,
+  "previewStartedAt" | "startedAt"
+>;
+
+/**
+ * The user-perceived start of a tool call: when its first byte was recognized
+ * (`previewStartedAt`), falling back to its execution start (`startedAt`) for
+ * tool calls that produced no preview (e.g. native server tools) or for
+ * snapshots from older daemons that pre-date the preview timestamp.
+ *
+ * This is the anchor for the headline "time they feel" elapsed counter — the
+ * span from first byte through to completion, which includes the
+ * input-streaming gap before execution. The tool's own execution latency is
+ * measured separately as `completedAt - startedAt`.
+ */
+export function perceivedStartedAt(
+  tc: ToolCallTimingFields,
+): number | undefined {
+  return tc.previewStartedAt ?? tc.startedAt ?? undefined;
+}
+
 /**
  * A tool call is still running until it carries a terminal signal.
  *


### PR DESCRIPTION
## Prompt / plan

We sometimes see ~20s between `tool_use_preview_start` and `tool_use_start` (the model streaming a large tool input). The web client treated `tool_use_preview_start` as a no-op, so a tool card only appeared at `tool_use_start` — the user saw nothing during the wait, and the elapsed timer (anchored on the execution `startedAt`) never reflected it.

Goal: render the tool card the moment the call is recognized, anchor the user-perceived latency timer to that first-byte timestamp, and keep the tool's own execution latency (`startedAt` → `completedAt`) as a separate field shown on expand. The headline is a single live timer from first byte to completion ("the time they feel"); execution time is secondary.

### What changed

**Wire contract** (`assistant/src/api/`)
- Add `previewStartedAt` to the `tool_use_preview_start` and `tool_use_start` events and to the persisted history tool call (`ConversationMessageToolCall`). Additive and optional — `startedAt` keeps its meaning (execution start), so persisted history and other consumers are unaffected.

**Daemon** (`assistant/src/daemon/`)
- Stamp `previewStartedAt` (server clock) when a tool call is first recognized, store it in `EventHandlerState.toolPreviewStartedAt`, and include it on the emitted `tool_use_preview_start` event.
- Mirror it onto the in-flight `tool_use` block (`recordToolPreviewStartOnPersistedMessage`) and stamp `_previewStartedAt` in the post-turn annotation, so a `/messages` snapshot fetched mid-tool (refresh / reconnect) restores the perceived-start anchor. Mapped back to the wire `previewStartedAt` in the history renderer.
- Carry `previewStartedAt` through on `tool_use_start` so a client that connected after the preview event still anchors correctly.

**Web client** (`clients/web/`)
- `tool_use_preview_start` is no longer a no-op: it seeds a running tool card (empty input, `previewStartedAt`) so the card appears immediately; `tool_use_start` then fills in the real input and execution `startedAt`, merging onto the same call.
- New `perceivedStartedAt(tc)` helper = `previewStartedAt ?? startedAt`. The card-header "Working/Worked for Xs" total and the inline chip's headline duration anchor on it; the per-step row durations and a new "Tool latency" field on the chip keep the tool's own execution latency (`startedAt` → `completedAt`).

## Test plan

- `assistant`: added coverage in `tool-preview-lifecycle.test.ts` (preview stamps `previewStartedAt`, stores it in state, and `tool_use_start` carries it through); full suite green for the touched files. `bunx tsc --noEmit` clean.
- `clients/web`: added coverage in `tool-call-handlers.test.ts` (preview seeds a running call; `tool_use_start` merges preserving `previewStartedAt` and adding execution start) and `tool-call-status.test.ts` (`perceivedStartedAt` precedence). `bunx tsc --noEmit` clean; lint clean.
- Verified the 20 pre-existing failures in a combined `bun test` run are present on the base branch too (cross-file mock leakage from single-process runs) — unrelated to this change; every touched file passes in isolation.

CLI verb checklist: N/A — no new IPC routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk2trhrXtPmLBThbfJcTNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk2trhrXtPmLBThbfJcTNN)_