### PR TITLE
Collapse assistant IPC timeout spam into a single down/up signal

### DIFF
--- a/gateway/src/ipc/ipc-health.test.ts
+++ b/gateway/src/ipc/ipc-health.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture log calls so we can assert on the edge-triggered down/up lines.
+const warnCalls: Array<{ obj: unknown; msg: string }> = [];
+const infoCalls: Array<{ obj: unknown; msg: string }> = [];
+
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    warn: (obj: unknown, msg: string) => warnCalls.push({ obj, msg }),
+    info: (obj: unknown, msg: string) => infoCalls.push({ obj, msg }),
+    error: () => {},
+    debug: () => {},
+  }),
+  initLogger: () => {},
+}));
+
+const { noteIpcReachable, noteIpcTransportError, __resetIpcHealthForTests } =
+  await import("./ipc-health.js");
+const { IpcHandlerError, IpcTransportError } =
+  await import("./assistant-client.js");
+
+describe("ipc-health", () => {
+  beforeEach(() => {
+    warnCalls.length = 0;
+    infoCalls.length = 0;
+    __resetIpcHealthForTests();
+  });
+
+  afterEach(() => {
+    __resetIpcHealthForTests();
+  });
+
+  test("logs a single down line across many transport errors", () => {
+    const err = new IpcTransportError("Call timed out after 30000ms");
+
+    // First error => one WARN, caller told to stay silent.
+    expect(noteIpcTransportError(err, "voice-approval-sync")).toBe(true);
+    // Many subsequent errors => no further logs, still silent.
+    for (let i = 0; i < 10; i++) {
+      expect(noteIpcTransportError(err, "voice-approval-sync")).toBe(true);
+    }
+
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0].msg).toBe(
+      "Assistant IPC is down — suppressing repeat sync errors until it recovers",
+    );
+  });
+
+  test("a single recovery logs one back line with the suppressed count", () => {
+    const err = new IpcTransportError("Call timed out after 30000ms");
+    noteIpcTransportError(err); // down (logged)
+    noteIpcTransportError(err); // suppressed
+    noteIpcTransportError(err); // suppressed
+
+    noteIpcReachable();
+
+    expect(infoCalls).toHaveLength(1);
+    expect(infoCalls[0].msg).toBe("Assistant IPC is back");
+    expect(
+      (infoCalls[0].obj as { suppressedErrors: number }).suppressedErrors,
+    ).toBe(2);
+  });
+
+  test("noteIpcReachable is a no-op while already healthy", () => {
+    noteIpcReachable();
+    noteIpcReachable();
+    expect(infoCalls).toHaveLength(0);
+  });
+
+  test("recovers and can go down again, logging each edge once", () => {
+    const err = new IpcTransportError("boom");
+
+    noteIpcTransportError(err);
+    noteIpcReachable();
+    noteIpcTransportError(err);
+    noteIpcReachable();
+
+    expect(warnCalls).toHaveLength(2);
+    expect(infoCalls).toHaveLength(2);
+  });
+
+  test("down/up state is shared across callers (single signal)", () => {
+    const err = new IpcTransportError("boom");
+
+    // Loop A goes down (logs), Loop B sees it already down (silent).
+    expect(noteIpcTransportError(err, "voice-approval-sync")).toBe(true);
+    expect(noteIpcTransportError(err, "outbound-voice-verification-sync")).toBe(
+      true,
+    );
+    expect(warnCalls).toHaveLength(1);
+
+    // Either loop recovering clears the shared state once.
+    noteIpcReachable();
+    expect(infoCalls).toHaveLength(1);
+  });
+
+  test("non-transport errors are not owned by the tracker", () => {
+    const handlerErr = new IpcHandlerError("nope", 404, "NOT_FOUND");
+    expect(noteIpcTransportError(handlerErr)).toBe(false);
+
+    const domainErr = new Error("upsert failed");
+    expect(noteIpcTransportError(domainErr)).toBe(false);
+
+    // No state change, so no recovery line either.
+    noteIpcReachable();
+    expect(warnCalls).toHaveLength(0);
+    expect(infoCalls).toHaveLength(0);
+  });
+});

--- a/gateway/src/ipc/ipc-health.ts
+++ b/gateway/src/ipc/ipc-health.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared down/up tracker for the gateway → assistant IPC channel.
+ *
+ * The gateway runs several independent 5s polling loops (voice-approval-sync,
+ * outbound-voice-verification-sync) that each call the assistant over the
+ * reverse IPC socket. When the assistant daemon is unreachable — typically a
+ * 30s call timeout while it is hung or restarting — every loop logs a fresh
+ * WARN on every poll, producing a steady stream of identical timeout errors.
+ *
+ * This module collapses that spam into a single edge-triggered signal shared
+ * across all callers: one WARN when the channel first goes down, and one INFO
+ * when it next comes back. Per-poll transport errors in between are counted but
+ * not logged.
+ *
+ * Only {@link IpcTransportError} (timeout / socket closed / unreachable) is
+ * treated as "down". Handler-level errors (a real RouteError from the daemon)
+ * and domain errors are genuine signal — callers should keep logging those.
+ */
+
+import { getLogger } from "../logger.js";
+import { IpcTransportError } from "./assistant-client.js";
+
+const log = getLogger("ipc-health");
+
+let down = false;
+let downSince = 0;
+let suppressedWhileDown = 0;
+
+/**
+ * Record the outcome of a failed IPC attempt for down/up tracking.
+ *
+ * Returns `true` when the caller should stay silent about this error because
+ * the health tracker has accounted for it (i.e. it is a transport error and
+ * the channel is — or just became — down). Returns `false` for non-transport
+ * errors, which the caller should continue to log as usual.
+ *
+ * The first transport error after a healthy period logs a single "down" WARN;
+ * subsequent transport errors are silently counted until recovery.
+ */
+export function noteIpcTransportError(err: unknown, context?: string): boolean {
+  if (!(err instanceof IpcTransportError)) return false;
+
+  if (down) {
+    suppressedWhileDown++;
+    return true;
+  }
+
+  down = true;
+  downSince = Date.now();
+  suppressedWhileDown = 0;
+  log.warn(
+    { err, context },
+    "Assistant IPC is down — suppressing repeat sync errors until it recovers",
+  );
+  return true;
+}
+
+/**
+ * Record a successful IPC round-trip. Logs a single "back" INFO on the
+ * recovering edge (including how long the channel was down and how many
+ * repeat errors were suppressed), and is a no-op while already healthy.
+ */
+export function noteIpcReachable(): void {
+  if (!down) return;
+
+  down = false;
+  log.info(
+    {
+      downForMs: Date.now() - downSince,
+      suppressedErrors: suppressedWhileDown,
+    },
+    "Assistant IPC is back",
+  );
+  suppressedWhileDown = 0;
+}
+
+/** Test-only: reset the shared health state between cases. */
+export function __resetIpcHealthForTests(): void {
+  down = false;
+  downSince = 0;
+  suppressedWhileDown = 0;
+}

--- a/gateway/src/verification/outbound-voice-verification-sync.ts
+++ b/gateway/src/verification/outbound-voice-verification-sync.ts
@@ -29,6 +29,7 @@ import { existsSync } from "node:fs";
 
 import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
+import { noteIpcReachable, noteIpcTransportError } from "../ipc/ipc-health.js";
 import { getLogger } from "../logger.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import {
@@ -60,6 +61,10 @@ export function startOutboundVoiceVerificationSync(): void {
   lastSyncAt = Date.now() - STARTUP_LOOKBACK_MS;
   timer = setInterval(() => {
     void syncOutboundVoiceVerifications().catch((err: unknown) => {
+      // Assistant-down timeouts are collapsed into a single shared down/up
+      // signal by the health tracker; only log errors it does not own.
+      if (noteIpcTransportError(err, "outbound-voice-verification-sync"))
+        return;
       log.warn({ err }, "Outbound voice verification sync error");
     });
   }, POLL_INTERVAL_MS);
@@ -103,6 +108,10 @@ async function syncOutboundVoiceVerifications(): Promise<void> {
     mode: "query",
     bind: [since],
   })) as DbProxyResult;
+
+  // The call returned, so the assistant IPC channel is reachable — clears any
+  // outstanding "down" state and logs the single recovery line.
+  noteIpcReachable();
 
   const row = result.rows?.[0];
   if (!row) {

--- a/gateway/src/verification/voice-approval-sync.ts
+++ b/gateway/src/verification/voice-approval-sync.ts
@@ -20,6 +20,7 @@
 import { existsSync } from "node:fs";
 
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
+import { noteIpcReachable, noteIpcTransportError } from "../ipc/ipc-health.js";
 import { getLogger } from "../logger.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { upsertVerifiedContactChannel } from "./contact-helpers.js";
@@ -44,6 +45,9 @@ export function startVoiceApprovalSync(): void {
   lastSyncAt = Date.now() - STARTUP_LOOKBACK_MS;
   timer = setInterval(() => {
     void syncVoiceApprovals().catch((err: unknown) => {
+      // Assistant-down timeouts are collapsed into a single shared down/up
+      // signal by the health tracker; only log errors it does not own.
+      if (noteIpcTransportError(err, "voice-approval-sync")) return;
       log.warn({ err }, "Voice approval sync error");
     });
   }, POLL_INTERVAL_MS);
@@ -74,6 +78,10 @@ async function syncVoiceApprovals(): Promise<void> {
     mode: "query",
     bind: [since],
   })) as DbProxyResult;
+
+  // The call returned, so the assistant IPC channel is reachable — clears any
+  // outstanding "down" state and logs the single recovery line.
+  noteIpcReachable();
 
   if (!result.rows?.length) {
     lastSyncAt = now;


### PR DESCRIPTION
## Why

The `voice-approval-sync` and `outbound-voice-verification-sync` loops each poll the assistant over the reverse IPC socket every 5s. When the assistant daemon is unreachable (typically a 30s call timeout while it's hung or restarting), **every poll** logged a fresh WARN — producing a steady stream of identical `IpcTransportError` lines from both loops:

```
[12:51:27] WARN [voice-approval-sync] Voice approval sync error
    err: IpcTransportError: Call timed out after 30000ms
[12:51:32] WARN [outbound-voice-verification-sync] Outbound voice verification sync error
    err: IpcTransportError: Call timed out after 30000ms
...repeated every 5s...
```

The ask: a single "assistant IPC is down" log, followed some time later by a single "assistant IPC is back".

## What

Adds a shared, edge-triggered health tracker — `gateway/src/ipc/ipc-health.ts`:

- **One WARN** when the channel first goes down: `Assistant IPC is down — suppressing repeat sync errors until it recovers`.
- **One INFO** when it next comes back: `Assistant IPC is back`, with `downForMs` and `suppressedErrors` (how many repeat timeouts were swallowed).
- State is **shared across both loops**, so a single down/back pair covers all callers rather than one per loop.
- Only `IpcTransportError` (timeout / socket closed / unreachable) counts as "down". Handler-level (`IpcHandlerError`) and domain errors are genuine signal and are still logged exactly as before.

Both poll loops are wired through it: their top-level `.catch()` defers transport errors to the tracker (and stays silent), and each clears the down state by calling `noteIpcReachable()` right after a successful `ipcCallAssistant` round-trip.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Assistant hung for 5 min | ~120 WARN lines (2 loops × every 5s) | 1 WARN + 1 INFO on recovery |
| Recovery | silent | 1 INFO with downtime + suppressed count |
| Real handler / domain error | WARN | WARN (unchanged) |

## Tests

New `gateway/src/ipc/ipc-health.test.ts` covers: single down line across many errors, single recovery line with suppressed count, no-op while healthy, down→up→down re-arming, shared-state across both callers, and non-transport errors passing through. Existing `outbound-voice-verification-sync.test.ts` still green (11/11). Typecheck, lint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpMhRo8ahW834kUAfVVgHw)_