### PR TITLE
feat(web): URL routing for the Schedules tab and per-schedule deep links

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -238,7 +238,10 @@ export function ChatLayout() {
     navigate(1);
   }, [navigate]);
 
-  const isHomeActive = location.pathname === routes.home;
+  const isHomeActive =
+    location.pathname === routes.home ||
+    location.pathname === routes.schedules.root ||
+    location.pathname.startsWith(`${routes.schedules.root}/`);
   const isIdentityActive =
     location.pathname === routes.identity ||
     location.pathname === routes.skills ||

--- a/clients/web/src/domains/chat/hooks/use-command-palette-sections.ts
+++ b/clients/web/src/domains/chat/hooks/use-command-palette-sections.ts
@@ -173,10 +173,12 @@ function dispatchCommandPaletteAction(
       } else if (item.id.startsWith("search-conv-")) {
         const convId = item.id.slice("search-conv-".length);
         ctx.switchConversation(convId);
-      } else if (
-        item.id.startsWith("search-schedule-") ||
-        item.id.startsWith("search-contact-")
-      ) {
+      } else if (item.id.startsWith("search-schedule-")) {
+        haptic.light();
+        ctx.navigate(
+          routes.schedules.detail(item.id.slice("search-schedule-".length)),
+        );
+      } else if (item.id.startsWith("search-contact-")) {
         haptic.light();
         ctx.navigate(routes.identity);
       }

--- a/clients/web/src/domains/home/home-page.tsx
+++ b/clients/web/src/domains/home/home-page.tsx
@@ -42,6 +42,14 @@ function HomePageSkeleton() {
 export interface HomePageProps {
   assistantId: string;
   validConversationIds: Set<string>;
+  /** Active tab, derived from the URL by `HomePageRoute`. */
+  activeTab: "schedules" | "notifications";
+  /** Navigate to a tab's URL (`/home` or `/schedules`). */
+  onTabChange: (tab: "schedules" | "notifications") => void;
+  /** Focused schedule id from the URL (`/schedules/:scheduleId`), or null. */
+  routeScheduleId: string | null;
+  /** Navigate to focus a schedule (id) or clear it (null → `/schedules`). */
+  onSelectScheduleId: (scheduleId: string | null) => void;
   onStartNewChat: () => void;
   onOpenConversation: (conversationId: string) => void;
 }
@@ -59,6 +67,10 @@ function getFeedItemScheduleId(item: FeedItem | null): string | null {
 export function HomePage({
   assistantId,
   validConversationIds,
+  activeTab,
+  onTabChange,
+  routeScheduleId,
+  onSelectScheduleId,
   onStartNewChat,
   onOpenConversation,
 }: HomePageProps) {
@@ -82,13 +94,10 @@ export function HomePage({
   });
 
   const [createScheduleOpen, setCreateScheduleOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<"schedules" | "notifications">(
-    "notifications",
-  );
+  // `activeTab` and the focused schedule are URL-owned (see HomePageRoute);
+  // selecting a schedule navigates rather than setting local state.
+  const selectedScheduleId = routeScheduleId;
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
-  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
-    null,
-  );
   const [selectedSystemTaskKind, setSelectedSystemTaskKind] =
     useState<SystemTaskKind | null>(null);
   // Accordion open-states are lifted here so they survive the section remount
@@ -105,10 +114,14 @@ export function HomePage({
       null)
     : null;
 
-  // Drop the selection if the schedule disappears (e.g. after a delete/refetch).
+  // Drop the selection if the schedule disappears (e.g. after a delete/refetch,
+  // or a deep link to a now-deleted id). Gate on `!isLoading` so a deep link to
+  // `/schedules/:id` doesn't clear the URL before the list has loaded.
   useEffect(() => {
-    if (selectedScheduleId && !selectedSchedule) setSelectedScheduleId(null);
-  }, [selectedScheduleId, selectedSchedule]);
+    if (selectedScheduleId && !schedules.isLoading && !selectedSchedule) {
+      onSelectScheduleId(null);
+    }
+  }, [selectedScheduleId, selectedSchedule, schedules.isLoading, onSelectScheduleId]);
 
   const systemTaskAvailable =
     selectedSystemTaskKind === "heartbeat"
@@ -129,21 +142,30 @@ export function HomePage({
 
   // The right pane shows one detail at a time — selecting one kind (user
   // schedule, system task, or feed item) closes the others.
-  const handleSelectSchedule = useCallback((scheduleId: string) => {
-    setSelectedItem(null);
-    setSelectedSystemTaskKind(null);
-    setSelectedScheduleId(scheduleId);
-  }, []);
+  const handleSelectSchedule = useCallback(
+    (scheduleId: string) => {
+      setSelectedItem(null);
+      setSelectedSystemTaskKind(null);
+      onSelectScheduleId(scheduleId);
+    },
+    [onSelectScheduleId],
+  );
 
-  const handleSelectSystemTask = useCallback((kind: SystemTaskKind) => {
-    setSelectedItem(null);
-    setSelectedScheduleId(null);
-    setSelectedSystemTaskKind(kind);
-  }, []);
+  const handleSelectSystemTask = useCallback(
+    (kind: SystemTaskKind) => {
+      setSelectedItem(null);
+      // Clear the focused schedule from the URL only when one is set, so
+      // selecting a system task doesn't push a redundant history entry.
+      if (selectedScheduleId) onSelectScheduleId(null);
+      setSelectedSystemTaskKind(kind);
+    },
+    [onSelectScheduleId, selectedScheduleId],
+  );
 
   const handleSelectItem = useCallback(
     (item: FeedItem) => {
-      setSelectedScheduleId(null);
+      // Feed items only render on the Notifications tab, where no schedule is
+      // focused — nothing to clear from the URL here.
       setSelectedSystemTaskKind(null);
       if (item.status === "new") {
         setSelectedItem({ ...item, status: "seen" });
@@ -218,7 +240,8 @@ export function HomePage({
       onViewSchedule={
         canViewSelectedItemSchedule
           ? () => {
-              setActiveTab("schedules");
+              // Navigating to the schedule's URL opens the Schedules tab and
+              // focuses the drawer in one step.
               handleSelectSchedule(selectedItemScheduleId);
             }
           : undefined
@@ -232,9 +255,9 @@ export function HomePage({
       assistantId={assistantId}
       usage={schedules.usageForSchedule(selectedSchedule.id)}
       isMobile={isMobile}
-      onClose={() => setSelectedScheduleId(null)}
+      onClose={() => onSelectScheduleId(null)}
       onDeleted={() => {
-        setSelectedScheduleId(null);
+        onSelectScheduleId(null);
         schedules.refetch();
       }}
     />
@@ -363,7 +386,7 @@ export function HomePage({
     <Tabs.Root
       value={activeTab}
       onValueChange={(value) =>
-        setActiveTab(value as "schedules" | "notifications")
+        onTabChange(value as "schedules" | "notifications")
       }
       className="flex min-h-0 flex-1 flex-col"
     >

--- a/clients/web/src/home-page-route.tsx
+++ b/clients/web/src/home-page-route.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo } from "react";
-import { useNavigate } from "react-router";
+import { useCallback, useEffect, useMemo } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
@@ -20,7 +20,33 @@ import { Typography } from "@vellumai/design-library";
 
 export function HomePageRoute() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { scheduleId } = useParams();
   const assistantId = useActiveAssistantId();
+
+  // The Activity page is one component served at two URL families: `/home`
+  // (Notifications) and `/schedules[/:id]` (Schedules). Derive the active tab
+  // and focused schedule from the URL so both are bookmarkable and the back
+  // button works, then navigate on tab / selection changes below.
+  const onSchedulesRoute =
+    location.pathname === routes.schedules.root ||
+    location.pathname.startsWith(`${routes.schedules.root}/`);
+  const activeTab = onSchedulesRoute ? "schedules" : "notifications";
+  const routeScheduleId = scheduleId ?? null;
+
+  const handleTabChange = useCallback(
+    (tab: "schedules" | "notifications") => {
+      navigate(tab === "schedules" ? routes.schedules.root : routes.home);
+    },
+    [navigate],
+  );
+
+  const handleSelectScheduleId = useCallback(
+    (id: string | null) => {
+      navigate(id ? routes.schedules.detail(id) : routes.schedules.root);
+    },
+    [navigate],
+  );
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
   const isMobile = useIsMobile();
   const { conversations: foregroundConversations } =
@@ -64,6 +90,10 @@ export function HomePageRoute() {
     <HomePage
       assistantId={assistantId}
       validConversationIds={validConversationIds}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+      routeScheduleId={routeScheduleId}
+      onSelectScheduleId={handleSelectScheduleId}
       onStartNewChat={() => {
         useViewerStore.getState().setMainView("chat");
         const draftConversationId = createDraftConversationId();

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -108,6 +108,25 @@ describe("remote web pairing route", () => {
   });
 });
 
+describe("schedules routes", () => {
+  // The Schedules tab and per-schedule deep links render the same lazy
+  // HomePageRoute as /home, inside the auth-protected assistant tree.
+  test.each([
+    "/assistant/schedules",
+    "/assistant/schedules/sch_123",
+  ])("%s matches inside the auth-protected app tree", (path) => {
+    const matches = matchRoutes(routeTree as never, path) ?? [];
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.at(-1)?.pathname).toBe(path);
+    expect(hasRouteMiddleware(path)).toBe(true);
+  });
+
+  test("captures the schedule id as a route param", () => {
+    const matches = matchRoutes(routeTree as never, "/assistant/schedules/sch_123") ?? [];
+    expect(matches.at(-1)?.params.scheduleId).toBe("sch_123");
+  });
+});
+
 describe("settings route compatibility", () => {
   test("legacy MCP settings URL redirects to the Integrations MCP tab", () => {
     expect(leafRouteComponentName("/assistant/settings/mcp")).toBe(

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -321,6 +321,17 @@ export const routeTree = [
                   path: "home",
                   lazy: { Component: () => import("@/home-page-route").then((m) => m.HomePageRoute) },
                 },
+                // Schedules tab + per-schedule deep links. Same component as
+                // `home`; HomePageRoute reads the pathname / `:scheduleId` to
+                // open the Schedules tab and focus a schedule's drawer.
+                {
+                  path: "schedules",
+                  lazy: { Component: () => import("@/home-page-route").then((m) => m.HomePageRoute) },
+                },
+                {
+                  path: "schedules/:scheduleId",
+                  lazy: { Component: () => import("@/home-page-route").then((m) => m.HomePageRoute) },
+                },
                 {
                   lazy: { Component: () => import("@/domains/intelligence/intelligence-layout").then((m) => m.IntelligenceLayout) },
                   children: [

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -14,4 +14,11 @@ describe("routes", () => {
       "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule+with+spaces",
     );
   });
+
+  test("builds the schedules tab and per-schedule detail paths", () => {
+    expect(routes.schedules.root).toBe("/assistant/schedules");
+    expect(routes.schedules.detail("sch_123")).toBe(
+      "/assistant/schedules/sch_123",
+    );
+  });
 });

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -119,6 +119,18 @@ export const routes = {
   },
 
   home: r("/assistant/home"),
+  /**
+   * Schedules surface — the same Activity page as `home`, opened with the
+   * Schedules tab active. `detail` deep-links a single schedule's drawer.
+   * Path-based (not `?tab=`) so the tab and the focused schedule are
+   * bookmarkable and shareable. Both render `HomePageRoute`, which derives
+   * the active tab + selected schedule from the URL.
+   */
+  schedules: {
+    root: r("/assistant/schedules"),
+    detail: (scheduleId: string) =>
+      dyn(r("/assistant/schedules"), scheduleId),
+  },
   identity: r("/assistant/identity"),
   plugins: r("/assistant/plugins"),
   plugin: (name: string) => dyn(r("/assistant/plugins"), name),


### PR DESCRIPTION
## Prompt / plan

The Activity (home) page held its active tab and focused schedule in local React state, so the URL stayed `/assistant/home` no matter what you were viewing. Two behaviors were requested:

- On the **Schedules tab**, the URL should be `/assistant/schedules`.
- When **focused on a specific schedule**, the URL should be `/assistant/schedules/{id}`.

### Approach

Make those two pieces of view state URL-owned rather than local state:

- Added `routes.schedules.root` (`/assistant/schedules`) and `routes.schedules.detail(id)` (`/assistant/schedules/{id}`) to the route registry, plus matching routes in `routes.tsx`. Both render the same lazy `HomePageRoute` already used by `/assistant/home`.
- `HomePageRoute` now derives the active tab (from the pathname) and the focused schedule (from the `:scheduleId` param) and passes navigation callbacks down. `HomePage` reads `activeTab` / `routeScheduleId` as props and navigates on tab switches and schedule selection/close instead of mutating local state.
- The stale-selection effect is gated on `!schedules.isLoading` so a deep link to `/assistant/schedules/{id}` isn't cleared before the schedule list has loaded.
- The sidebar **Activity** item stays highlighted across the schedules paths (`chat-layout` `isHomeActive`).
- Bonus: command-palette schedule search results now deep-link to the schedule drawer (`routes.schedules.detail`) instead of routing to the identity page.

Notifications behavior and URL (`/assistant/home`) are unchanged.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bun run lint` — 0 errors (only pre-existing warnings in unrelated files).
- `bun test src/routes.test.ts src/utils/routes.test.ts src/domains/chat/hooks/use-command-palette-sections.test.ts src/domains/home` — all pass.
- Added route-tree tests asserting `/assistant/schedules` and `/assistant/schedules/:scheduleId` match inside the auth-protected app tree and capture `scheduleId`, plus URL-builder tests for `routes.schedules.*`.

<!-- CLI verb checklist omitted: no new IPC routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017V8EGmo8EAXKHwGHPc5Gtb)_