### PR TITLE
refactor: workspace heartbeat singleton + heartbeat self-broadcast

### DIFF
--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -70,8 +70,8 @@ mock.module("../schedule/recurrence-engine.js", () => ({
 
 const createdConversations: Array<{ conversationType: string }> = [];
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   getConversation: () => null,
   getMessages: () => [],
   createConversation: (opts: { conversationType: string }) => {
@@ -164,9 +164,7 @@ describe("HeartbeatService disk pressure gate", () => {
   });
 
   test("skips without creating heartbeat rows, conversations, or notifications", async () => {
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
 
     const ran = await service.runOnce();
 
@@ -181,9 +179,7 @@ describe("HeartbeatService disk pressure gate", () => {
   });
 
   test("allows forced user-initiated heartbeat runs while locked", async () => {
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
 
     const ran = await service.runOnce({ force: true });
 
@@ -199,9 +195,7 @@ describe("HeartbeatService disk pressure gate", () => {
 
   test("start recovery skips missed-run notifications while locked", async () => {
     mockMarkStaleRunsAsMissed.mockImplementationOnce(() => 1);
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
 
     service.start();
     await service.stop();

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -137,8 +137,8 @@ const mockStoredMessages: Array<{
 }> = [];
 
 mock.module("../memory/conversation-crud.js", () => ({
-    setConversationProcessingStartedAt: () => {},
-    isConversationProcessing: () => false,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
   deleteMessageById: () => {},
@@ -335,6 +335,23 @@ const LLM_DEFAULT = {
   },
 };
 
+// Capture broadcastMessage so tests can observe the alerts and
+// conversation-created events the heartbeat service emits directly.
+type BroadcastedMessage = { type: string; [key: string]: unknown };
+const broadcastedMessages: BroadcastedMessage[] = [];
+let onBroadcast: ((msg: BroadcastedMessage) => void) | null = null;
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: async () => {},
+    subscribe: () => () => {},
+  },
+  broadcastMessage: (msg: BroadcastedMessage) => {
+    broadcastedMessages.push(msg);
+    onBroadcast?.(msg);
+  },
+}));
+
 describe("HeartbeatService", () => {
   let processMessageCalls: Array<{
     conversationId: string;
@@ -353,6 +370,12 @@ describe("HeartbeatService", () => {
   beforeEach(() => {
     processMessageCalls = [];
     alerterCalls = [];
+    broadcastedMessages.length = 0;
+    onBroadcast = (msg) => {
+      if (msg.type === "heartbeat_alert") {
+        alerterCalls.push(msg as { type: string; title: string; body: string });
+      }
+    };
     createdConversations.length = 0;
     conversationIdCounter = 0;
     mockStoredMessages.length = 0;
@@ -413,19 +436,11 @@ describe("HeartbeatService", () => {
   function createService(overrides?: {
     processMessage?: (...args: unknown[]) => Promise<{ messageId: string }>;
     getCurrentHour?: () => number;
-    onConversationCreated?: (info: {
-      conversationId: string;
-      title: string;
-    }) => void;
   }) {
     if (overrides?.processMessage) {
       setTestProcessMessage(overrides.processMessage);
     }
     return new HeartbeatService({
-      alerter: (alert: { type: string; title: string; body: string }) => {
-        alerterCalls.push(alert);
-      },
-      onConversationCreated: overrides?.onConversationCreated,
       getCurrentHour: overrides?.getCurrentHour,
     });
   }
@@ -770,17 +785,14 @@ describe("HeartbeatService", () => {
   });
 
   test("conversation surfaces to the sidebar on every successful run", async () => {
-    const conversationCreatedCalls: Array<{
-      conversationId: string;
-      title: string;
-    }> = [];
-    const service = createService({
-      onConversationCreated: (info) => conversationCreatedCalls.push(info),
-    });
+    const service = createService();
 
     await service.runOnce();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    const conversationCreatedCalls = broadcastedMessages
+      .filter((m) => m.type === "heartbeat_conversation_created")
+      .map((m) => ({ conversationId: m.conversationId, title: m.title }));
     expect(conversationCreatedCalls).toEqual([
       { conversationId: "conv-1", title: "Heartbeat" },
     ]);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1322,15 +1322,7 @@ export async function runDaemon(): Promise<void> {
 
   startWorkspaceHeartbeatService();
 
-  const heartbeat = startHeartbeatService({
-    alerter: (alert) => broadcastMessage(alert),
-    onConversationCreated: (info) =>
-      broadcastMessage({
-        type: "heartbeat_conversation_created",
-        conversationId: info.conversationId,
-        title: info.title,
-      }),
-  });
+  const heartbeat = startHeartbeatService();
   registerBackgroundWakeRuntime({ scheduler, heartbeat });
   refreshBackgroundWakeIntent("daemon-startup");
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -104,7 +104,7 @@ import {
 } from "../work-items/work-item-store.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
-import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
+import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import { writePid } from "./daemon-control.js";
@@ -1320,8 +1320,7 @@ export async function runDaemon(): Promise<void> {
     });
   }
 
-  const workspaceHeartbeat = new WorkspaceHeartbeatService();
-  workspaceHeartbeat.start();
+  startWorkspaceHeartbeatService();
 
   const heartbeat = startHeartbeatService({
     alerter: (alert) => broadcastMessage(alert),
@@ -1341,10 +1340,7 @@ export async function runDaemon(): Promise<void> {
   // (see `maybeEnqueueGraphMaintenanceJobs`).
   startFilingService();
 
-  installShutdownHandlers({
-    server,
-    workspaceHeartbeat,
-  });
+  installShutdownHandlers({ server });
 
   log.info(
     {

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -15,7 +15,10 @@ import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
 import { getEnrichmentService } from "../workspace/commit-message-enrichment-service.js";
-import type { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
+import {
+  commitAllPendingWorkspaceChanges,
+  stopWorkspaceHeartbeatService,
+} from "../workspace/heartbeat-service.js";
 import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
@@ -40,7 +43,6 @@ function stopBackgroundServicesAndCleanupPidFile(): void {
 
 export interface ShutdownDeps {
   server: DaemonServer;
-  workspaceHeartbeat: WorkspaceHeartbeatService;
 }
 
 export function installShutdownHandlers(deps: ShutdownDeps): void {
@@ -68,7 +70,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }, 20_000);
     forceTimer.unref();
 
-    await deps.workspaceHeartbeat.stop();
+    await stopWorkspaceHeartbeatService();
     await stopHeartbeatService();
     await stopFilingService();
 
@@ -85,7 +87,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     // This ensures no workspace state is lost during graceful shutdown.
     try {
       log.info({ phase: "pre_stop" }, "Committing pending workspace changes");
-      await deps.workspaceHeartbeat.commitAllPending();
+      await commitAllPendingWorkspaceChanges();
     } catch (err) {
       log.warn({ err, phase: "pre_stop" }, "Shutdown workspace commit failed");
     }
@@ -96,7 +98,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     // (e.g. in-flight tool executions completing during drain).
     try {
       log.info({ phase: "post_stop" }, "Final workspace commit sweep");
-      await deps.workspaceHeartbeat.commitAllPending();
+      await commitAllPendingWorkspaceChanges();
     } catch (err) {
       log.warn(
         { err, phase: "post_stop" },

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -9,12 +9,21 @@ let workspaceDir: string;
 // no-op in these tests.
 const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
 
+// Capture broadcastMessage calls so tests can assert on the alerts and
+// conversation-created events the heartbeat service emits directly.
+type BroadcastedMessage = { type: string; [key: string]: unknown };
+const broadcastedMessages: BroadcastedMessage[] = [];
+let onBroadcast: ((msg: BroadcastedMessage) => void) | null = null;
+
 mock.module("../../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: {
     publish: publishSpy,
     subscribe: () => () => {},
   },
-  broadcastMessage: () => {},
+  broadcastMessage: (msg: BroadcastedMessage) => {
+    broadcastedMessages.push(msg);
+    onBroadcast?.(msg);
+  },
 }));
 
 // Stub workspace prompt reads so the heartbeat service doesn't try to
@@ -224,6 +233,8 @@ beforeEach(() => {
   origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
   process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
   publishSpy.mockClear();
+  broadcastedMessages.length = 0;
+  onBroadcast = null;
   runBackgroundJobCalls.length = 0;
   skipHeartbeatRunCalls.length = 0;
   preFirstMessageGateOpen = true;
@@ -249,9 +260,7 @@ afterEach(() => {
 
 describe("HeartbeatService", () => {
   test("invokes runBackgroundJob with expected options on each tick", async () => {
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
@@ -286,13 +295,17 @@ describe("HeartbeatService", () => {
       return { conversationId: STUB_CONVERSATION_ID, ok: true };
     };
 
-    const service = new HeartbeatService({
-      alerter: () => {},
-      onConversationCreated: (info) => {
-        created.push(info);
+    onBroadcast = (msg) => {
+      if (msg.type === "heartbeat_conversation_created") {
+        created.push({
+          conversationId: msg.conversationId as string,
+          title: msg.title as string,
+        });
         callbackFiredBeforeRunnerResolved = !runnerHasResolved;
-      },
-    });
+      }
+    };
+
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
@@ -314,17 +327,16 @@ describe("HeartbeatService", () => {
       return { conversationId: STUB_CONVERSATION_ID, ok: true };
     };
 
-    const alerts: unknown[] = [];
-    const service = new HeartbeatService({
-      alerter: (alert) => alerts.push(alert),
-    });
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
     expect(runnerCompleted).toBe(true);
-    // No alerter call because the runner returned ok=true and there was no
-    // outer-timeout failure to surface.
-    expect(alerts).toHaveLength(0);
+    // No heartbeat_alert broadcast because the runner returned ok=true and
+    // there was no outer-timeout failure to surface.
+    expect(
+      broadcastedMessages.filter((m) => m.type === "heartbeat_alert"),
+    ).toHaveLength(0);
   });
 
   test("calls alerter with the failure message when the runner reports ok=false", async () => {
@@ -335,14 +347,13 @@ describe("HeartbeatService", () => {
       errorKind: "exception",
     });
 
-    const alerts: Array<{ type: string; title: string; body: string }> = [];
-    const service = new HeartbeatService({
-      alerter: (alert) =>
-        alerts.push(alert as { type: string; title: string; body: string }),
-    });
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
+    const alerts = broadcastedMessages.filter(
+      (m) => m.type === "heartbeat_alert",
+    );
     expect(alerts).toHaveLength(1);
     expect(alerts[0]).toMatchObject({
       type: "heartbeat_alert",
@@ -352,21 +363,18 @@ describe("HeartbeatService", () => {
   });
 
   test("does not call alerter when the runner reports ok=true", async () => {
-    const alerts: unknown[] = [];
-    const service = new HeartbeatService({
-      alerter: (alert) => alerts.push(alert),
-    });
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
-    expect(alerts).toHaveLength(0);
+    expect(
+      broadcastedMessages.filter((m) => m.type === "heartbeat_alert"),
+    ).toHaveLength(0);
   });
 
   test("scheduled run skips with reason 'pre_first_user_message' when the user has not yet interacted", async () => {
     preFirstMessageGateOpen = false;
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
     // start() seeds `_pendingRunId` via `scheduleNextRun` so the skip is
     // recorded with the pending run id. Without start() the test still
     // passes the no-LLM-call assertion but the skip record would be a
@@ -393,9 +401,7 @@ describe("HeartbeatService", () => {
 
   test("forced run bypasses the pre-first-message gate (manual operator action)", async () => {
     preFirstMessageGateOpen = false;
-    const service = new HeartbeatService({
-      alerter: () => {},
-    });
+    const service = new HeartbeatService();
 
     await service.runOnce({ force: true });
 
@@ -408,7 +414,7 @@ describe("HeartbeatService", () => {
   describe("max consecutive runs cap", () => {
     test("skips with reason 'max_consecutive_runs' after the cap is hit", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = 2;
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
 
       expect(await service.runOnce({ force: false })).toBe(true);
       expect(await service.runOnce({ force: false })).toBe(true);
@@ -422,7 +428,7 @@ describe("HeartbeatService", () => {
 
     test("resetTimer() clears the counter so auto runs resume", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = 1;
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
       service.start();
       try {
         await service.runOnce({ force: false });
@@ -452,7 +458,7 @@ describe("HeartbeatService", () => {
         return { conversationId: STUB_CONVERSATION_ID, ok: true };
       };
 
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
       service.start();
       try {
         const runPromise = service.runOnce({ force: false });
@@ -480,7 +486,7 @@ describe("HeartbeatService", () => {
 
     test("null disables the cap entirely", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = null;
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
 
       for (let i = 0; i < 5; i++) {
         expect(await service.runOnce({ force: false })).toBe(true);
@@ -493,7 +499,7 @@ describe("HeartbeatService", () => {
 
     test("force runs bypass the cap and do not increment the counter", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = 2;
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
 
       // Five force runs would push us well past the cap if force counted.
       for (let i = 0; i < 5; i++) {
@@ -511,7 +517,7 @@ describe("HeartbeatService", () => {
 
     test("reconfigure() resets the counter", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = 1;
-      const service = new HeartbeatService({ alerter: () => {} });
+      const service = new HeartbeatService();
       service.start();
       try {
         await service.runOnce({ force: false });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -16,6 +16,7 @@ import {
   resolveGuardianPersona,
 } from "../prompts/persona-resolver.js";
 import { isTemplateContent } from "../prompts/system-prompt.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { hasReceivedUserMessage } from "../runtime/pre-first-message-gate.js";
 import { computeNextRunAt } from "../schedule/recurrence-engine.js";
@@ -110,11 +111,6 @@ function refreshBackgroundWakeIntentSoon(reason: string): void {
 }
 
 export interface HeartbeatDeps {
-  alerter: (alert: HeartbeatAlert) => void;
-  onConversationCreated?: (info: {
-    conversationId: string;
-    title: string;
-  }) => void;
   /** Override for current hour (0-23), for testing. */
   getCurrentHour?: () => number;
 }
@@ -163,7 +159,7 @@ export class HeartbeatService {
   // after a guardian message can detect the reset and skip its increment.
   private _resetGeneration = 0;
 
-  constructor(deps: HeartbeatDeps) {
+  constructor(deps: HeartbeatDeps = {}) {
     this.deps = deps;
     HeartbeatService.instance = this;
   }
@@ -670,13 +666,13 @@ export class HeartbeatService {
     } catch (err) {
       log.error({ err }, "Credential health check failed");
       try {
-        this.deps.alerter({
+        broadcastMessage({
           type: "heartbeat_alert",
           title: "Credential Health Check Failed",
           body:
             "Could not verify OAuth credential health. " +
             (err instanceof Error ? err.message : String(err)),
-        });
+        } satisfies HeartbeatAlert);
       } catch {
         // Last resort — alerter itself failed. Already logged above.
       }
@@ -798,7 +794,8 @@ export class HeartbeatService {
       deferNotifications: true,
       onConversationCreated: (newConversationId) => {
         conversationId = newConversationId;
-        this.deps.onConversationCreated?.({
+        broadcastMessage({
+          type: "heartbeat_conversation_created",
           conversationId: newConversationId,
           title: "Heartbeat",
         });
@@ -860,11 +857,11 @@ export class HeartbeatService {
     // recovery sweep) already alerted for this run.
     if (transitioned) {
       try {
-        this.deps.alerter({
+        broadcastMessage({
           type: "heartbeat_alert",
           title: "Heartbeat Failed",
           body: result.error?.message ?? "Unknown error",
-        });
+        } satisfies HeartbeatAlert);
       } catch (alertErr) {
         log.error({ alertErr }, "Failed to broadcast heartbeat alert");
       }
@@ -924,8 +921,8 @@ This is one of your first heartbeats. Your user hasn't heard from you yet and ma
  * can wire it into the background-wake runtime. start() self-gates on
  * `heartbeat.enabled` and logs its own status.
  */
-export function startHeartbeatService(deps: HeartbeatDeps): HeartbeatService {
-  const service = new HeartbeatService(deps);
+export function startHeartbeatService(): HeartbeatService {
+  const service = new HeartbeatService();
   service.start();
   return service;
 }

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -374,6 +374,35 @@ export class WorkspaceHeartbeatService {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let instance: WorkspaceHeartbeatService | null = null;
+
+/** Construct and start the workspace heartbeat service singleton. */
+export function startWorkspaceHeartbeatService(): void {
+  instance = new WorkspaceHeartbeatService();
+  instance.start();
+}
+
+/**
+ * Stop the workspace heartbeat service singleton if one is running. The instance
+ * is retained so a final commitAllPendingWorkspaceChanges() during shutdown can
+ * still flush after the periodic loop has stopped.
+ */
+export async function stopWorkspaceHeartbeatService(): Promise<void> {
+  await instance?.stop();
+}
+
+/**
+ * Commit any uncommitted workspace changes via the singleton; no-op when the
+ * service was never started.
+ */
+export async function commitAllPendingWorkspaceChanges(): Promise<void> {
+  await instance?.commitAllPending();
+}
+
 /**
  * @internal Test-only: clear the dirty tracking state
  */


### PR DESCRIPTION
## Prompt / plan

Two commits: the last `installShutdownHandlers` dep (`workspaceHeartbeat`), plus one of the review comments from #36404.

### 1. Workspace heartbeat → self-managed singleton

lifecycle constructed `WorkspaceHeartbeatService`, started it, and threaded it through `ShutdownDeps` so the shutdown handler could stop it and flush pending commits. Moved ownership into the module:

- `startWorkspaceHeartbeatService()` constructs and starts the singleton.
- `stopWorkspaceHeartbeatService()` stops it — **intentionally does not clear the singleton**, because shutdown flushes a final commit *after* stopping the periodic loop.
- `commitAllPendingWorkspaceChanges()` flushes via the singleton (shutdown calls it before and after `server.stop()`).

This was the last dep besides the `DaemonServer`, so **`installShutdownHandlers` is now called with just `{ server }`**.

### 2. HeartbeatService broadcasts directly (review feedback on #36404)

> remove both of these args. `HeartbeatService` can just import `broadcastMessage` directly

The heartbeat service took `alerter`/`onConversationCreated` callbacks that lifecycle wired straight to `broadcastMessage`. Now it imports `broadcastMessage` and emits `heartbeat_alert` / `heartbeat_conversation_created` directly; both callbacks are gone from `HeartbeatDeps` (only the test-only `getCurrentHour` override remains), and `startHeartbeatService()` / the lifecycle call site no longer pass deps. Tests that asserted on the injected callbacks now assert on a captured `broadcastMessage` mock.

## Note on the other review comment

The third comment — `registerBackgroundWakeRuntime` shouldn't take `scheduler`/`heartbeat` as args — is a separate background-wake-plumbing change with its own test-file rewrite (`background-wake-routes.test.ts` injects mock scheduler/heartbeat via that function). I'm doing it as a focused **follow-up PR** rather than bundling it here.

## Test plan

- `bun run lint` + `bun run typecheck` — clean (pre-commit full type check green).
- Affected suites pass in isolation (CI runs one process per file): `heartbeat-service` (both files) 13/0 + 78/0, `heartbeat-disk-pressure` 3/0, `workspace-heartbeat-service` 19/0, `commit-guarantee` 7/0, `workspace-lifecycle` 5/0, `wake-intent-hooks` 8/0, `heartbeat-routes` 2/0, `next-wake` 13/0, `background-workers-disk-pressure` 4/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_