### PR TITLE
feat(inspector): expand the full cache diff on demand, even when large

### DIFF
--- a/clients/web/src/domains/chat/inspector/cache-diff.test.ts
+++ b/clients/web/src/domains/chat/inspector/cache-diff.test.ts
@@ -229,6 +229,36 @@ describe("diffLines", () => {
     expect(result?.truncated).toBe(true);
     expect(result?.lines).toEqual([]);
   });
+
+  test("aligns multiple changed hunks via the flat-table LCS", () => {
+    const result = diffLines("a\nb\nc\nd\ne", "a\nB\nc\nD\ne");
+    expect(result?.truncated).toBe(false);
+    const byType = (type: CacheDiffLine["type"]) =>
+      result?.lines.filter((l) => l.type === type).map((l) => l.text);
+    expect(byType("context")).toEqual(["a", "c", "e"]);
+    expect(byType("removed")).toEqual(["b", "d"]);
+    expect(byType("added")).toEqual(["B", "D"]);
+  });
+
+  test("computes past the default cap when given a higher ceiling", () => {
+    const base = Array.from({ length: 600 }, (_, i) => `line ${i}`).join("\n");
+    const next = `${base}\nextra`;
+    // The default cap still bails on this input...
+    expect(diffLines(base, next)?.truncated).toBe(true);
+    // ...but an explicit higher ceiling diffs it.
+    const result = diffLines(base, next, 4000);
+    expect(result?.truncated).toBe(false);
+    expect(
+      result?.lines.some((l) => l.type === "added" && l.text === "extra"),
+    ).toBe(true);
+  });
+
+  test("still bails when the text exceeds the higher ceiling", () => {
+    const huge = Array.from({ length: 4100 }, (_, i) => `line ${i}`).join("\n");
+    const result = diffLines(huge, `${huge}\nextra`, 4000);
+    expect(result?.truncated).toBe(true);
+    expect(result?.lines).toEqual([]);
+  });
 });
 
 describe("collapseDiffContext", () => {

--- a/clients/web/src/domains/chat/inspector/cache-diff.ts
+++ b/clients/web/src/domains/chat/inspector/cache-diff.ts
@@ -58,6 +58,15 @@ export interface CacheDiffChangedGroups {
   settings: boolean;
 }
 
+/**
+ * Raw text a line diff was derived from, kept so an oversized diff
+ * (skipped on the default render) can be recomputed on demand.
+ */
+export interface LineDiffSource {
+  previousText: string;
+  currentText: string;
+}
+
 export interface CacheDiffResult {
   cause: CacheDiffCause;
   changedGroups: CacheDiffChangedGroups;
@@ -79,6 +88,8 @@ export interface CacheDiffResult {
   lineDiffTruncated: boolean;
   /** Heading for the line diff, e.g. "System prompt" or "user message". */
   lineDiffLabel: string | null;
+  /** Source text for the line diff, or `null` when none was attempted. */
+  lineDiffSource: LineDiffSource | null;
 }
 
 /** Resolved inputs for one call: its request sections plus the model id. */
@@ -89,6 +100,13 @@ export interface CacheDiffInput {
 
 /** Largest line count we will run the O(n·m) LCS diff over before bailing. */
 const MAX_DIFF_LINES = 500;
+
+/**
+ * Higher ceiling for an explicit, user-initiated diff of text that exceeded
+ * {@link MAX_DIFF_LINES} on the default render. Bounded so a pathological
+ * input can't exhaust memory even when the diff is requested on demand.
+ */
+export const MAX_ON_DEMAND_DIFF_LINES = 4000;
 
 type GroupKind = "system" | "tools" | "settings" | "messages";
 
@@ -144,31 +162,33 @@ function describeSection(section: LLMContextSection): string {
 /**
  * Line-level diff via longest-common-subsequence. Returns `null` when
  * the texts are identical, and a truncated marker when either side
- * exceeds {@link MAX_DIFF_LINES} so the quadratic table stays bounded.
+ * exceeds `maxLines` so the quadratic table stays bounded. The DP table is
+ * a single flat `Int32Array` of `(m + 1) * (n + 1)` cells, which keeps the
+ * higher on-demand ceiling memory-safe (no array-of-arrays overhead).
  */
 export function diffLines(
   previousText: string,
   currentText: string,
+  maxLines = MAX_DIFF_LINES,
 ): { lines: CacheDiffLine[]; truncated: boolean } | null {
   if (previousText === currentText) return null;
 
   const a = previousText.split("\n");
   const b = currentText.split("\n");
-  if (Math.max(a.length, b.length) > MAX_DIFF_LINES) {
+  if (Math.max(a.length, b.length) > maxLines) {
     return { lines: [], truncated: true };
   }
 
   const m = a.length;
   const n = b.length;
-  const dp: number[][] = Array.from({ length: m + 1 }, () =>
-    new Array<number>(n + 1).fill(0),
-  );
+  const width = n + 1;
+  const dp = new Int32Array((m + 1) * width);
   for (let i = m - 1; i >= 0; i--) {
     for (let j = n - 1; j >= 0; j--) {
-      dp[i][j] =
+      dp[i * width + j] =
         a[i] === b[j]
-          ? dp[i + 1][j + 1] + 1
-          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+          ? dp[(i + 1) * width + (j + 1)] + 1
+          : Math.max(dp[(i + 1) * width + j], dp[i * width + (j + 1)]);
     }
   }
 
@@ -180,7 +200,7 @@ export function diffLines(
       lines.push({ type: "context", text: a[i] });
       i++;
       j++;
-    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + (j + 1)]) {
       lines.push({ type: "removed", text: a[i] });
       i++;
     } else {
@@ -225,6 +245,7 @@ export function computeCacheDiff(
       lineDiff: null,
       lineDiffTruncated: false,
       lineDiffLabel: null,
+      lineDiffSource: null,
     };
   }
 
@@ -290,16 +311,17 @@ export function computeCacheDiff(
   let lineDiff: CacheDiffLine[] | null = null;
   let lineDiffTruncated = false;
   let lineDiffLabel: string | null = null;
+  let lineDiffSource: LineDiffSource | null = null;
 
   if (cause === "system") {
-    const result = diffLines(
-      prevSystem.map((s) => s.text ?? "").join("\n"),
-      curSystem.map((s) => s.text ?? "").join("\n"),
-    );
+    const previousText = prevSystem.map((s) => s.text ?? "").join("\n");
+    const currentText = curSystem.map((s) => s.text ?? "").join("\n");
+    const result = diffLines(previousText, currentText);
     if (result) {
       lineDiff = result.lines;
       lineDiffTruncated = result.truncated;
       lineDiffLabel = "System prompt";
+      lineDiffSource = { previousText, currentText };
     }
   } else if (cause === "messages" && firstChangedMessageIndex >= 0) {
     const changed = curMessages[firstChangedMessageIndex];
@@ -316,6 +338,7 @@ export function computeCacheDiff(
         lineDiff = result.lines;
         lineDiffTruncated = result.truncated;
         lineDiffLabel = describeSection(changed);
+        lineDiffSource = { previousText: prior.text, currentText: changed.text };
       }
     }
   }
@@ -333,6 +356,7 @@ export function computeCacheDiff(
     lineDiff,
     lineDiffTruncated,
     lineDiffLabel,
+    lineDiffSource,
   };
 }
 

--- a/clients/web/src/domains/chat/inspector/components/cache-diff-card.stories.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-diff-card.stories.tsx
@@ -169,3 +169,55 @@ export const UnchangedPrefix: Story = {
     ]),
   },
 };
+
+const scatteredPrompt = (variant: string): string =>
+  Array.from({ length: 200 }, (_, i) =>
+    i % 4 === 0 ? `- rule ${variant} ${i}: be precise` : `  note line ${i}`,
+  ).join("\n");
+
+/**
+ * Many scattered single-line changes overflow the in-panel display cap, so
+ * the diff shows the first hunks and offers a "Show N more diff line(s)"
+ * toggle to reveal the rest inline.
+ */
+export const LargeScatteredDiff: Story = {
+  args: {
+    assistantId: "assistant-1",
+    previous: call("call-prev", [
+      { kind: "system", label: "System prompt", text: scatteredPrompt("A") },
+      { kind: "message", label: "User", role: "user", text: "What changed?" },
+    ]),
+    current: call("call-cur", [
+      { kind: "system", label: "System prompt", text: scatteredPrompt("B") },
+      { kind: "message", label: "User", role: "user", text: "What changed?" },
+    ]),
+  },
+};
+
+const HUGE_PROMPT = Array.from(
+  { length: 600 },
+  (_, i) => `Policy ${i}: follow the rules carefully.`,
+).join("\n");
+
+/**
+ * A system prompt over the eager line cap isn't diffed on the default
+ * render; the card explains why and offers a "Diff anyway" button that
+ * computes the full diff on demand.
+ */
+export const TooLargeToDiff: Story = {
+  args: {
+    assistantId: "assistant-1",
+    previous: call("call-prev", [
+      { kind: "system", label: "System prompt", text: HUGE_PROMPT },
+      { kind: "message", label: "User", role: "user", text: "What changed?" },
+    ]),
+    current: call("call-cur", [
+      {
+        kind: "system",
+        label: "System prompt",
+        text: `${HUGE_PROMPT}\nPolicy 600: and one additional rule.`,
+      },
+      { kind: "message", label: "User", role: "user", text: "What changed?" },
+    ]),
+  },
+};

--- a/clients/web/src/domains/chat/inspector/components/cache-diff-card.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-diff-card.test.tsx
@@ -1,15 +1,22 @@
 /**
- * Tests for the CacheDiffCard prefix-comparison rendering. Renders to
- * static markup (no DOM), mirroring `cache-health-card.test.tsx`, and
- * asserts the status banner copy, the changed-group chips, and the
- * optional line diff for each bust cause. The card calls
+ * Tests for the CacheDiffCard prefix-comparison rendering. The bust-cause
+ * cases render to static markup (no DOM), mirroring `cache-health-card.test.tsx`,
+ * and assert the status banner copy, the changed-group chips, and the optional
+ * line diff. The diff-expansion cases render to the DOM (happy-dom) to drive the
+ * click-to-expand and on-demand "Diff anyway" affordances. The card calls
  * `useLlmCallDetail` before its early returns, so every render is wrapped
  * in a `QueryClientProvider`; passing the previous call's `requestSections`
  * inline keeps that query disabled (no network) for these unit cases.
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render as renderDom,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { CacheDiffCard } from "./cache-diff-card";
@@ -152,5 +159,69 @@ describe("CacheDiffCard", () => {
     const html = render(current, previous);
 
     expect(html).toContain("Request settings changed");
+  });
+});
+
+afterEach(cleanup);
+
+function renderCard(
+  current: LLMRequestLogEntry,
+  previous: LLMRequestLogEntry,
+): HTMLElement {
+  return renderDom(
+    <QueryClientProvider client={queryClient}>
+      <CacheDiffCard
+        current={current}
+        previous={previous}
+        assistantId="assistant-1"
+      />
+    </QueryClientProvider>,
+  ).container;
+}
+
+describe("CacheDiffCard diff expansion", () => {
+  test("expands the diff past the display cap on click", () => {
+    // Many scattered single-line changes blow past the 120-entry display cap.
+    const scattered = (variant: string): string =>
+      Array.from({ length: 200 }, (_, i) =>
+        i % 5 === 0 ? `changed-${variant}-${i}` : `same-${i}`,
+      ).join("\n");
+    const previous = entry("call-1", [
+      system(scattered("old")),
+      message("user", "hi"),
+    ]);
+    const current = entry("call-2", [
+      system(scattered("new")),
+      message("user", "hi"),
+    ]);
+
+    const container = renderCard(current, previous);
+    const collapsed = container.querySelectorAll("pre > div").length;
+    expect(collapsed).toBe(120);
+
+    fireEvent.click(screen.getByText(/more diff line/));
+
+    expect(container.querySelectorAll("pre > div").length).toBeGreaterThan(
+      collapsed,
+    );
+    expect(screen.getByText("Show less")).toBeTruthy();
+  });
+
+  test("computes an oversized diff on demand", () => {
+    // Over the eager 500-line cap, so nothing is diffed until the user opts in.
+    const base = Array.from({ length: 600 }, (_, i) => `line ${i}`).join("\n");
+    const previous = entry("call-1", [system(base), message("user", "hi")]);
+    const current = entry("call-2", [
+      system(`${base}\nextra line at the end`),
+      message("user", "hi"),
+    ]);
+
+    const container = renderCard(current, previous);
+    expect(container.querySelector("pre")).toBeNull();
+
+    fireEvent.click(screen.getByText(/Diff anyway/));
+
+    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.getByText(/extra line at the end/)).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/inspector/components/cache-diff-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-diff-card.tsx
@@ -12,19 +12,29 @@
  * component owns only fetching and presentation.
  */
 
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import {
   collapseDiffContext,
   computeCacheDiff,
+  diffLines,
+  MAX_ON_DEMAND_DIFF_LINES,
   type CacheDiffChangedGroups,
   type CacheDiffLine,
   type CacheDiffResult,
+  type LineDiffSource,
 } from "@/domains/chat/inspector/cache-diff";
 import { useLlmCallDetail } from "@/domains/chat/inspector/inspector-detail-api";
 import { formatCount } from "@/domains/chat/inspector/inspector-formatters";
 import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
-import { Card, Notice, type NoticeTone, Tag, type TagTone } from "@vellumai/design-library";
+import {
+  Button,
+  Card,
+  Notice,
+  type NoticeTone,
+  Tag,
+  type TagTone,
+} from "@vellumai/design-library";
 
 export interface CacheDiffCardProps {
   current: LLMRequestLogEntry;
@@ -193,24 +203,139 @@ function diffLineStyle(type: CacheDiffLine["type"]): DiffLineStyle {
   };
 }
 
+type OnDemandDiff =
+  | { status: "idle" }
+  | { status: "tooLarge" }
+  | { status: "ready"; lines: CacheDiffLine[] };
+
+interface DiffPreviewActionsProps {
+  truncated: boolean;
+  onDemand: OnDemandDiff;
+  source: LineDiffSource | null;
+  cappedCount: number;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onComputeFull: () => void;
+}
+
+/**
+ * The footnote affordance under a diff: an expand/collapse toggle for the
+ * display cap, or — when the text was too large to diff eagerly — a
+ * "Diff anyway" button (and the still-too-large fallback).
+ */
+function DiffPreviewActions({
+  truncated,
+  onDemand,
+  source,
+  cappedCount,
+  expanded,
+  onToggleExpanded,
+  onComputeFull,
+}: DiffPreviewActionsProps): ReactNode {
+  if (truncated) {
+    if (onDemand.status === "tooLarge") {
+      return (
+        <p
+          className="mt-1 text-label-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {`Still too large to diff here (over ${formatCount(MAX_ON_DEMAND_DIFF_LINES)} lines) — open the Raw tab for the full payload.`}
+        </p>
+      );
+    }
+    if (!source) {
+      return (
+        <p
+          className="mt-1 text-label-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          The changed text is too large to diff here — open the Raw tab for the
+          full payload.
+        </p>
+      );
+    }
+    const lineCount = Math.max(
+      source.previousText.split("\n").length,
+      source.currentText.split("\n").length,
+    );
+    return (
+      <div className="mt-1 flex flex-col items-start gap-1">
+        <p
+          className="text-label-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          The changed text is large, so it isn't diffed by default.
+        </p>
+        <Button variant="ghost" size="compact" onClick={onComputeFull}>
+          {`Diff anyway (${formatCount(lineCount)} lines)`}
+        </Button>
+      </div>
+    );
+  }
+
+  if (cappedCount > 0) {
+    return (
+      <Button
+        variant="ghost"
+        size="compact"
+        className="mt-1"
+        onClick={onToggleExpanded}
+      >
+        {expanded
+          ? "Show less"
+          : `Show ${formatCount(cappedCount)} more diff line(s)`}
+      </Button>
+    );
+  }
+
+  return null;
+}
+
 interface DiffPreviewProps {
   label: string;
   lines: CacheDiffLine[];
   truncated: boolean;
+  source: LineDiffSource | null;
 }
 
-/** Renders a collapsed, focused line diff with gap markers for context runs. */
-function DiffPreview({ label, lines, truncated }: DiffPreviewProps): ReactNode {
-  const entries = collapseDiffContext(lines);
-  const visible = entries.slice(0, MAX_VISIBLE_DIFF_ENTRIES);
-  const hiddenCount = entries.length - visible.length;
+/**
+ * Renders a collapsed, focused line diff with gap markers for context runs.
+ * The display is capped at {@link MAX_VISIBLE_DIFF_ENTRIES} entries with a
+ * click-to-expand toggle, and an oversized diff that was skipped on the
+ * default render (`truncated`) can be computed on demand from `source`.
+ */
+function DiffPreview({
+  label,
+  lines,
+  truncated,
+  source,
+}: DiffPreviewProps): ReactNode {
+  const [expanded, setExpanded] = useState(false);
+  const [onDemand, setOnDemand] = useState<OnDemandDiff>({ status: "idle" });
 
-  let footnote: string | null = null;
-  if (truncated) {
-    footnote =
-      "The changed text is too large to diff here — open the Raw tab for the full payload.";
-  } else if (hiddenCount > 0) {
-    footnote = `${formatCount(hiddenCount)} more diff line(s) hidden — open the Raw tab for the full diff.`;
+  // Computing an oversized diff on demand swaps in the freshly diffed lines
+  // and clears the truncation, so the display-cap toggle below takes over.
+  const effectiveLines = onDemand.status === "ready" ? onDemand.lines : lines;
+  const effectiveTruncated = onDemand.status === "ready" ? false : truncated;
+
+  const entries = collapseDiffContext(effectiveLines);
+  const cappedCount = Math.max(entries.length - MAX_VISIBLE_DIFF_ENTRIES, 0);
+  const visible = expanded
+    ? entries
+    : entries.slice(0, MAX_VISIBLE_DIFF_ENTRIES);
+
+  function computeFullDiff(): void {
+    if (!source) return;
+    const result = diffLines(
+      source.previousText,
+      source.currentText,
+      MAX_ON_DEMAND_DIFF_LINES,
+    );
+    setOnDemand(
+      result && !result.truncated
+        ? { status: "ready", lines: result.lines }
+        : { status: "tooLarge" },
+    );
   }
 
   return (
@@ -254,14 +379,15 @@ function DiffPreview({ label, lines, truncated }: DiffPreviewProps): ReactNode {
           })}
         </pre>
       ) : null}
-      {footnote ? (
-        <p
-          className="mt-1 text-label-default"
-          style={{ color: "var(--content-tertiary)" }}
-        >
-          {footnote}
-        </p>
-      ) : null}
+      <DiffPreviewActions
+        truncated={effectiveTruncated}
+        onDemand={onDemand}
+        source={source}
+        cappedCount={cappedCount}
+        expanded={expanded}
+        onToggleExpanded={() => setExpanded((value) => !value)}
+        onComputeFull={computeFullDiff}
+      />
     </div>
   );
 }
@@ -372,9 +498,11 @@ export function CacheDiffCard({
 
       {result.lineDiff && result.lineDiffLabel ? (
         <DiffPreview
+          key={current.id}
           label={result.lineDiffLabel}
           lines={result.lineDiff}
           truncated={result.lineDiffTruncated}
+          source={result.lineDiffSource}
         />
       ) : null}
     </Card>


### PR DESCRIPTION
## Summary
- The Prompt-tab cache-diff panel no longer dead-ends at the Raw tab when diff lines are hidden. The 120-entry display cap is now a click-to-expand "Show N more diff line(s)" / "Show less" toggle (the data is already computed, so expansion is instant).
- When a diff is skipped because the text exceeds the eager 500-line compute cap, a "Diff anyway" button computes it lazily on click against a higher bounded ceiling (MAX_ON_DEMAND_DIFF_LINES = 4000); the default render stays cheap.
- diffLines now takes a maxLines ceiling and backs its LCS table with a flat Int32Array (no array-of-arrays overhead), keeping the higher on-demand ceiling memory-safe. Adds unit + happy-dom interaction tests and two Storybook stories.

## Original prompt
In the LLM Call Inspector, diff lines are hidden in two cases — the 120-line display cap ("61 more diff line(s) hidden") and the 500-line compute cap ("too large to diff here"); both told the user to open the Raw tab instead. The ask was to click to see the full diff inline even when it is large, covering both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)