### PR TITLE
fix(calls): run call-status pointer turns under guardian trust so history isn't filtered on cold load

### DIFF
--- a/assistant/src/__tests__/pointer-conversation-trust.test.ts
+++ b/assistant/src/__tests__/pointer-conversation-trust.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import { elevatePointerConversationToGuardian } from "../daemon/pointer-conversation-trust.js";
+import {
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  type TrustContext,
+} from "../daemon/trust-context.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
+
+/**
+ * Fake conversation that mirrors `Conversation.loadFromDb`'s trust gate: a
+ * memory-capable (guardian) trust class sees the full guardian history; any
+ * other class sees an empty (filtered) history. `ensureActorScopedHistory`
+ * re-applies that gate against the current trust context, exactly like the real
+ * reload path.
+ */
+class FakeConversation {
+  trustContext: TrustContext | undefined;
+  visibleHistory: string[] = [];
+  setTrustContextCalls: Array<TrustContext | null> = [];
+  ensureCalls = 0;
+  private readonly guardianHistory: string[];
+  private readonly processing: boolean;
+
+  constructor(opts: {
+    trustContext?: TrustContext;
+    guardianHistory?: string[];
+    processing?: boolean;
+  }) {
+    this.trustContext = opts.trustContext;
+    this.guardianHistory = opts.guardianHistory ?? ["m1", "m2", "m3"];
+    this.processing = opts.processing ?? false;
+    this.applyHistoryForTrust();
+  }
+
+  private applyHistoryForTrust(): void {
+    this.visibleHistory = resolveCapabilities(this.trustContext?.trustClass)
+      .canAccessMemory
+      ? [...this.guardianHistory]
+      : [];
+  }
+
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  setTrustContext(ctx: TrustContext | null): void {
+    this.setTrustContextCalls.push(ctx);
+    this.trustContext = ctx ?? undefined;
+  }
+
+  async ensureActorScopedHistory(): Promise<void> {
+    this.ensureCalls++;
+    this.applyHistoryForTrust();
+  }
+}
+
+const CONTACT_CONTEXT: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "unverified_contact",
+};
+
+const GUARDIAN_CONTEXT: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+describe("elevatePointerConversationToGuardian", () => {
+  test("elevates a cold trust-less conversation and rehydrates guardian history", async () => {
+    const conv = new FakeConversation({ trustContext: undefined });
+    // A cold (trust-less) load filters guardian history to empty.
+    expect(conv.visibleHistory).toEqual([]);
+
+    const restore = await elevatePointerConversationToGuardian(conv);
+
+    expect(conv.trustContext).toBe(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    expect(conv.ensureCalls).toBe(1);
+    // History is rehydrated rather than shipped empty.
+    expect(conv.visibleHistory).toEqual(["m1", "m2", "m3"]);
+
+    restore();
+    expect(conv.trustContext).toBeUndefined();
+  });
+
+  test("restores the prior non-memory trust context after the turn", async () => {
+    const conv = new FakeConversation({ trustContext: CONTACT_CONTEXT });
+    expect(conv.visibleHistory).toEqual([]);
+
+    const restore = await elevatePointerConversationToGuardian(conv);
+    expect(conv.trustContext).toBe(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    expect(conv.visibleHistory).toEqual(["m1", "m2", "m3"]);
+
+    restore();
+    expect(conv.trustContext).toBe(CONTACT_CONTEXT);
+  });
+
+  test("no-ops for a conversation that already has memory access", async () => {
+    const conv = new FakeConversation({ trustContext: GUARDIAN_CONTEXT });
+    expect(conv.visibleHistory).toEqual(["m1", "m2", "m3"]);
+
+    const restore = await elevatePointerConversationToGuardian(conv);
+
+    // No elevation, no redundant reload.
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.ensureCalls).toBe(0);
+    expect(conv.trustContext).toBe(GUARDIAN_CONTEXT);
+
+    restore();
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.trustContext).toBe(GUARDIAN_CONTEXT);
+  });
+
+  test("does not mutate trust while the conversation is processing", async () => {
+    const conv = new FakeConversation({
+      trustContext: undefined,
+      processing: true,
+    });
+
+    const restore = await elevatePointerConversationToGuardian(conv);
+
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.ensureCalls).toBe(0);
+    expect(conv.trustContext).toBeUndefined();
+
+    restore();
+    expect(conv.setTrustContextCalls).toEqual([]);
+  });
+
+  test("restore leaves trust alone when a later turn replaced it", async () => {
+    const conv = new FakeConversation({ trustContext: undefined });
+    const restore = await elevatePointerConversationToGuardian(conv);
+    expect(conv.trustContext).toBe(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+
+    // Simulate a new turn legitimately replacing the trust context mid-flight.
+    conv.setTrustContext(GUARDIAN_CONTEXT);
+    restore();
+
+    // The restorer must not clobber the new turn's context.
+    expect(conv.trustContext).toBe(GUARDIAN_CONTEXT);
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -122,6 +122,7 @@ import {
   rebuildBm25CorpusStatsAndReseedSkills,
 } from "./memory-v2-startup.js";
 import { startOrphanReaper } from "./orphan-reaper.js";
+import { elevatePointerConversationToGuardian } from "./pointer-conversation-trust.js";
 import { processMessage } from "./process-message.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
 import {
@@ -1117,6 +1118,14 @@ export async function runDaemon(): Promise<void> {
         const conversation =
           await server.getConversationForMessages(conversationId);
 
+        // Pointer turns are guardian-gated owner self-maintenance: elevate to
+        // the internal guardian context and rehydrate history so a cold
+        // (evicted) load doesn't filter guardian history to empty and ship a
+        // cache-missing turn. `restoreTrustContext` undoes the elevation after
+        // the turn. See pointer-conversation-trust.ts for the full rationale.
+        const restoreTrustContext =
+          await elevatePointerConversationToGuardian(conversation);
+
         // Constrain pointer generation to a tool-disabled path so call-
         // status events cannot trigger unintended side-effect tools.
         // Incrementing toolsDisabledDepth causes the resolveTools callback
@@ -1242,6 +1251,8 @@ export async function runDaemon(): Promise<void> {
         } finally {
           // Restore tool availability so subsequent turns aren't affected.
           conversation.toolsDisabledDepth--;
+          // Undo the temporary guardian elevation installed above.
+          restoreTrustContext();
         }
       },
     );

--- a/assistant/src/daemon/pointer-conversation-trust.ts
+++ b/assistant/src/daemon/pointer-conversation-trust.ts
@@ -1,0 +1,66 @@
+/**
+ * Guardian-trust elevation for call-status pointer turns.
+ *
+ * Call-status pointer messages are generated as owner self-maintenance turns:
+ * only guardian-gated audiences route through the daemon processor (see
+ * `resolvePointerAudienceTrust` in `calls/call-pointer-messages.ts`), so the
+ * generation should run under the internal guardian context.
+ *
+ * The subtlety is history: `Conversation.loadFromDb` filters the persisted
+ * history to non-guardian provenance whenever the active trust context cannot
+ * access memory. On a cold (evicted) load — common on a memory-pressured daemon
+ * that evicts idle conversations — a freshly rebuilt conversation has no trust
+ * context, so a guardian-authored conversation's entire history is filtered to
+ * empty. The pointer turn would then ship with only its freshly persisted
+ * instruction, and because dropping the prior history (and tools) shifts the
+ * cacheable prefix, the request misses the prompt cache completely.
+ *
+ * Elevating to the guardian context and rehydrating before the turn restores
+ * the full history and makes the turn's shape deterministic regardless of
+ * eviction state.
+ */
+import { resolveCapabilities } from "../runtime/capabilities.js";
+import {
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  type TrustContext,
+} from "./trust-context.js";
+
+/** Minimal `Conversation` surface needed to elevate pointer trust. */
+export interface GuardianElevatableConversation {
+  readonly trustContext?: TrustContext | undefined;
+  isProcessing(): boolean;
+  setTrustContext(ctx: TrustContext | null): void;
+  ensureActorScopedHistory(): Promise<void>;
+}
+
+/**
+ * Elevate a pointer conversation to the internal guardian context and rehydrate
+ * its history so guardian-authored history is not filtered to empty on a cold
+ * load. Returns a function that restores the prior trust context.
+ *
+ * No-ops (returning a no-op restorer) when the conversation is already
+ * memory-capable, or when it is mid-turn — mutating `trustContext` during an
+ * active loop would elevate that turn's actor trust (mirrors the warm-path guard
+ * in `conversation-store.ts`).
+ */
+export async function elevatePointerConversationToGuardian(
+  conversation: GuardianElevatableConversation,
+): Promise<() => void> {
+  const priorTrustContext = conversation.trustContext;
+  const shouldElevate =
+    !conversation.isProcessing() &&
+    !resolveCapabilities(priorTrustContext?.trustClass).canAccessMemory;
+  if (!shouldElevate) return () => {};
+
+  conversation.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  await conversation.ensureActorScopedHistory();
+
+  return () => {
+    // Undo only the elevation this call installed. If a new turn started at an
+    // await boundary and legitimately updated trustContext, the reference will
+    // differ and we leave it alone.
+    if (conversation.trustContext === INTERNAL_GUARDIAN_TRUST_CONTEXT) {
+      conversation.setTrustContext(priorTrustContext ?? null);
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- **Bug:** Call-status pointer turns (the brief "call completed/failed/started" status updates posted to the initiating conversation) ran the daemon agent loop **without a trust context**. On a cold conversation load — e.g. after the conversation was evicted under memory pressure — `Conversation.loadFromDb` filters guardian-authored history to non-guardian provenance (`resolveCapabilities(undefined).canAccessMemory === false`), which empties the history entirely. The pointer turn then shipped with only its freshly-persisted instruction and no prior history. Because dropping the history (on top of the intentionally tool-disabled request) shifts the cacheable prefix, the request **fully missed the prompt cache** (`cache_read_input_tokens: 0`). The outcome was also non-deterministic: a warm conversation included full history, an evicted one did not.
- **Fix:** Elevate the pointer conversation to the internal guardian context and rehydrate history *before* running the loop, then restore the prior context afterward. This path is already guardian-gated — only trusted audiences route through the daemon processor (`resolvePointerAudienceTrust`); untrusted audiences use the deterministic fallback — so running it as owner self-maintenance under `INTERNAL_GUARDIAN_TRUST_CONTEXT` is correct. Extracted into `elevatePointerConversationToGuardian` (`assistant/src/daemon/pointer-conversation-trust.ts`), mirroring the existing `/clean` elevate-then-restore pattern in `daemon/handlers/conversations.ts`.
- **Scope:** The no-tools shape of pointer requests is intentional and unchanged (`toolsDisabledDepth`); that cache forfeit is separate by design. This change only restores history so the turn shape is deterministic regardless of eviction state. Elevation is skipped while the conversation is mid-turn so an in-flight turn's actor trust is never mutated.

## Original prompt

Investigated why one call-status pointer turn shipped with no conversation history and no tools, producing a full prompt-cache miss. Root-caused it to the pointer processor in `daemon/lifecycle.ts` invoking `loadFromDb` without a guardian trust context on a cold (evicted) conversation, which filters guardian history to empty. Asked to fix the trust-context handling so the pointer path preserves history; the no-tools behavior is a separate, intentional design choice and stays.

## Testing

- New unit test `assistant/src/__tests__/pointer-conversation-trust.test.ts` (5 cases): cold trust-less load elevates + rehydrates; prior non-memory context is restored after the turn; already-memory-capable conversations no-op; no trust mutation while processing; restore leaves a replaced context alone.
- Existing `call-pointer-messages` / `call-pointer-message-composer` suites still pass; `typecheck:fast` clean.

## Deploy note

Already-running daemons need a pull + restart to pick up this fix.