### PR TITLE
fix(calls): give synthesized-play TTS a valid native fallback voice (fixes 64106 call drop)

### DIFF
--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -378,8 +378,34 @@ describe("resolveVoiceQualityProfile", () => {
       },
     };
     const profile = resolveVoiceQualityProfile();
-    expect(profile.ttsProvider).toBe("Google");
-    expect(profile.voice).toBe("");
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
+  });
+
+  test("synthesized-play TwiML carries a non-empty native fallback voice (64106 regression)", () => {
+    // Regression for the dropped-call bug: when a synthesized-play provider's
+    // mid-call synthesis fails, the controller falls back to native token TTS.
+    // If the TwiML voice is empty, Twilio rejects the turn with error 64106
+    // ("TTS provider rejected the request due to invalid parameters") and the
+    // call drops. The profile must expose a real ElevenLabs fallback voice.
+    mockConfig = {
+      calls: {
+        voice: { language: "en-US", transcriptionProvider: "Deepgram" },
+      },
+      services: {
+        tts: {
+          provider: "fish-audio",
+          providers: {
+            elevenlabs: { voiceId: "fallback-voice-xyz" },
+            "fish-audio": { referenceId: "ref-123" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe("fallback-voice-xyz");
+    expect(profile.voice).not.toBe("");
   });
 
   test("preserves language setting for synthesized providers", () => {
@@ -429,8 +455,8 @@ describe("resolveVoiceQualityProfile", () => {
     };
     const profile = resolveVoiceQualityProfile();
     // Should resolve to fish-audio from canonical config
-    expect(profile.ttsProvider).toBe("Google");
-    expect(profile.voice).toBe("");
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 
   // -- Strategy-based behavior (explicit call strategy) -------------------
@@ -457,8 +483,8 @@ describe("resolveVoiceQualityProfile", () => {
       },
     };
     const profile = resolveVoiceQualityProfile();
-    expect(profile.ttsProvider).toBe("Google");
-    expect(profile.voice).toBe("");
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 
   test("native-twilio strategy delegates voice-spec to registered builder", () => {
@@ -567,10 +593,10 @@ describe("resolveVoiceQualityProfile", () => {
       },
     };
     const profile = resolveVoiceQualityProfile();
-    // Deepgram is synthesized-play in the catalog, so Twilio gets the
-    // placeholder ttsProvider and an empty voice string.
-    expect(profile.ttsProvider).toBe("Google");
-    expect(profile.voice).toBe("");
+    // Deepgram is synthesized-play in the catalog. The TwiML still carries the
+    // ElevenLabs fallback voice so a synthesis failure can speak natively.
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 
   test("Deepgram preserves language setting on synthesized-play path", () => {
@@ -594,7 +620,7 @@ describe("resolveVoiceQualityProfile", () => {
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.language).toBe("fr-FR");
-    expect(profile.ttsProvider).toBe("Google");
-    expect(profile.voice).toBe("");
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 });

--- a/assistant/src/calls/tts-call-strategy.ts
+++ b/assistant/src/calls/tts-call-strategy.ts
@@ -16,9 +16,10 @@
  *   routing logic required.
  *
  * - **synthesized-play** -- The assistant synthesises audio and streams
- *   chunks to Twilio via `play` messages. The profile uses a
- *   placeholder TTS provider (`"Google"`) and an empty voice string
- *   because Twilio never drives TTS itself on this path.
+ *   chunks to Twilio via `play` messages, so Twilio does not drive TTS on
+ *   the happy path. The profile still carries a valid native fallback voice
+ *   (see `resolveVoiceQualityProfile`) so a mid-call synthesis failure can
+ *   degrade to native token TTS instead of being rejected with error 64106.
  *
  * @module
  */

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,6 +1,5 @@
 import { loadConfig } from "../config/loader.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
-import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import {
   getNativeTwilioVoiceSpec,
@@ -48,24 +47,52 @@ export function buildElevenLabsVoiceSpec(config: {
 }
 
 /**
+ * Resolve a valid native Twilio voice for the ConversationRelay TwiML.
+ *
+ * Returns the registered {@link NativeTwilioVoiceSpec} for `providerId` when one
+ * exists; otherwise — no builder registered (e.g. a synthesized-play provider
+ * like Fish Audio), or config unavailable — falls back to the ElevenLabs config
+ * block, or the shipped default voice. The result is always a non-empty,
+ * Twilio-valid `ttsProvider` + `voice`.
+ */
+function resolveNativeTwilioVoice(
+  cfg: ReturnType<typeof loadConfig>,
+  providerId: string,
+): { ttsProvider: string; voice: string } {
+  try {
+    const spec = getNativeTwilioVoiceSpec(providerId);
+    const resolved = resolveTtsConfig(cfg);
+    return {
+      ttsProvider: spec.twilioProviderName,
+      voice: spec.buildVoiceSpec(resolved.providerConfig),
+    };
+  } catch {
+    return {
+      ttsProvider: "ElevenLabs",
+      voice: buildElevenLabsVoiceSpec(
+        cfg.services?.tts?.providers?.elevenlabs ?? {
+          voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
+        },
+      ),
+    };
+  }
+}
+
+/**
  * Resolve the effective voice quality profile from config.
  *
- * Uses the explicit call strategy from the TTS provider catalog to
- * determine the call path. The catalog's `callMode` field
- * (`"native-twilio"` vs `"synthesized-play"`) drives the decision
- * rather than inferring behavior from runtime `supportsStreaming`
- * capability.
+ * The TwiML always carries a valid, non-empty native Twilio voice:
  *
- * For **synthesized-play** providers (e.g. Fish Audio),
- * ConversationRelay needs a valid TTS provider in TwiML, so we set
- * `ttsProvider` to `"Google"` as a placeholder and leave `voice` empty
- * since actual audio is delivered via `play` messages.
- *
- * For **native-twilio** providers (e.g. ElevenLabs), `ttsProvider` and
- * `voice` are populated via the provider's registered
- * {@link NativeTwilioVoiceSpec} builder so Twilio handles TTS natively.
- * New native providers plug in by registering a voice-spec builder --
- * no edits to this module required.
+ * - **native-twilio** providers (e.g. ElevenLabs): Twilio drives TTS with this
+ *   voice directly, built from the provider's registered
+ *   {@link NativeTwilioVoiceSpec} builder.
+ * - **synthesized-play** providers (e.g. Fish Audio): audio is delivered via
+ *   `play` messages, so Twilio's native TTS is unused on the happy path. The
+ *   voice still matters as a fallback — if synthesis fails mid-call the
+ *   controller falls back to native token TTS, and an empty voice makes Twilio
+ *   reject the turn with error 64106 ("TTS provider rejected the request due to
+ *   invalid parameters") and drop the call. These providers have no registered
+ *   native builder, so they resolve to the ElevenLabs fallback voice.
  *
  * NOTE: STT provider and speech model are intentionally NOT part of this
  * profile. STT resolution is handled once in the voice webhook route
@@ -82,49 +109,10 @@ export function resolveVoiceQualityProfile(
   // Falls back to native ElevenLabs when config/catalog is unavailable.
   const strategy = resolveCallStrategy(cfg);
 
-  // Before committing to the catalog-derived strategy, verify the
-  // runtime provider is actually registered. If the provider registry
-  // hasn't been initialised (early startup, test mocks), fall back to
-  // native mode so this function and resolveCallTtsProvider agree on
-  // the same degraded-mode path.
-  let runtimeAvailable = false;
-  try {
-    const resolved = resolveTtsConfig(cfg);
-    getTtsProvider(resolved.provider);
-    runtimeAvailable = true;
-  } catch {
-    // Provider not registered — will fall through to native path below.
-  }
-
-  let ttsProvider: string;
-  let voiceSpec: string;
-
-  if (runtimeAvailable && strategy.callMode === "synthesized-play") {
-    // Synthesized providers stream audio via `play` messages.
-    // Twilio still needs a valid ttsProvider in TwiML, so use a
-    // placeholder and leave voice empty.
-    ttsProvider = "Google";
-    voiceSpec = "";
-  } else {
-    // Native providers: delegate voice-spec building to the
-    // provider's registered builder.
-    try {
-      const spec = getNativeTwilioVoiceSpec(strategy.providerId);
-      ttsProvider = spec.twilioProviderName;
-
-      const resolved = resolveTtsConfig(cfg);
-      voiceSpec = spec.buildVoiceSpec(resolved.providerConfig);
-    } catch {
-      // Voice-spec builder not registered or config unavailable --
-      // fall back to ElevenLabs using the config's elevenlabs block.
-      ttsProvider = "ElevenLabs";
-      voiceSpec = buildElevenLabsVoiceSpec(
-        cfg.services?.tts?.providers?.elevenlabs ?? {
-          voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
-        },
-      );
-    }
-  }
+  const { ttsProvider, voice: voiceSpec } = resolveNativeTwilioVoice(
+    cfg,
+    strategy.providerId,
+  );
 
   return {
     language: voice.language,


### PR DESCRIPTION
## Summary
- Synthesized-play call providers (e.g. Fish Audio) built ConversationRelay TwiML with `ttsProvider="Google"` and an empty `voice`. When mid-call synthesis fails or times out, the call controller falls back to native Twilio token TTS — but the empty voice makes Twilio reject the turn with error **64106** ("TTS provider rejected the request due to invalid parameters") and drop the call.
- `resolveVoiceQualityProfile` now always emits a valid, non-empty native voice in the TwiML, routing both `native-twilio` and `synthesized-play` providers through a shared `resolveNativeTwilioVoice` helper. Synthesized-play providers have no registered native voice builder, so they resolve to the ElevenLabs fallback voice. On the happy synthesized path Twilio's TTS is never invoked (audio is delivered via `play` messages), so the fallback voice only takes effect when synthesis fails — exactly when it's needed.
- Dropped the now-redundant `runtimeAvailable`/`getTtsProvider` gate; added a regression test asserting synthesized-play TwiML carries a non-empty fallback voice. Existing voice-quality, twilio-routes-twiml, and call-controller suites stay green.

## Original prompt
Diagnosing a dropped phone call with the assistant. The daemon log showed Fish Audio streaming synthesis timing out ("Fish Audio read timed out after 5000ms"), the controller falling back to native token TTS, and Twilio then rejecting with error 64106 and ending the call. This PR fixes the 64106 call-drop in `assistant/` as its own change. The Fish Audio latency / call-provider choice (the underlying "audio latency") is a separate follow-up and is intentionally not included here.

## Follow-up (not in this PR)
- **Latency:** Fish Audio streaming synthesis hit its 5000 ms read timeout (the actual "audio latency"). Consider raising the timeout, tuning Fish Audio streaming, or switching the call default to a `native-twilio` provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)