### PR TITLE
fix(web): keep full history visible during passively-observed (channel) turns

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 
 // ---------------------------------------------------------------------------
 // Module mock — `@/domains/chat/transcript/use-history-pagination`.
@@ -80,6 +83,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   __resetForTesting();
+  useChatSessionStore.getState().setLiveTurn([]);
+  useConversationStore.getState().removeProcessingConversationId("conv-A");
 });
 
 describe("useConversationHistory — refetch on SSE reopen", () => {
@@ -175,6 +180,51 @@ describe("useConversationHistory — refetch on SSE reopen", () => {
     publish("sse.opened", { assistantId: "asst-1", cause: "resume" });
 
     // THEN no history refetch is issued
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  test("hands a passively-observed turn off to history on processing→idle", () => {
+    /**
+     * Channel turns (phone, Slack, Telegram) and other-client sends stream in
+     * without a local `useSendMessage`, so `turnPhase` never enters a sending
+     * state. They still toggle the conversation's processing flag, so the
+     * finished turn must be pulled into the durable history cache on that
+     * processing→idle edge — otherwise the live view shows only the latest
+     * exchange until a reload.
+     */
+    // GIVEN an active conversation with a live turn, marked processing (a
+    // server-driven turn streaming in)
+    renderHistory("conv-A");
+    act(() => {
+      useChatSessionStore
+        .getState()
+        .setLiveTurn([
+          { id: "m1", role: "assistant" } as unknown as DisplayMessage,
+        ]);
+      useConversationStore.getState().markConversationProcessing("conv-A");
+    });
+    // No handoff while the turn is still in progress.
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    // WHEN the turn finishes and the processing flag clears
+    act(() => {
+      useConversationStore.getState().removeProcessingConversationId("conv-A");
+    });
+
+    // THEN the finished turn is handed off to the durable history cache
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not hand off on processing→idle when the live turn is empty", () => {
+    // A processing edge with nothing in the live turn has nothing to hand off,
+    // so it must not trigger a redundant refetch.
+    renderHistory("conv-A");
+    act(() => {
+      useConversationStore.getState().markConversationProcessing("conv-A");
+    });
+    act(() => {
+      useConversationStore.getState().removeProcessingConversationId("conv-A");
+    });
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -21,7 +21,7 @@
  */
 
 import { captureError } from "@/lib/sentry/capture-error";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { type InfiniteData, useQueryClient } from "@tanstack/react-query";
 
@@ -350,19 +350,13 @@ export function useConversationHistory({
   }, [pagination.dataUpdatedAt, assistantId, activeConversationId]);
 
   // -------------------------------------------------------------------------
-  // Live-turn → history handoff. On the sending→idle transition the finished
-  // turn is persisted, so refetch history (authoritative copy) and then drop
-  // only the rows that actually landed in history from the live turn. Rows not
-  // yet persisted stay live — no flash, no loss.
+  // Live-turn → history handoff. When a turn finishes, the persisted copy is
+  // authoritative, so refetch history and then drop only the rows that actually
+  // landed in history from the live turn. Rows not yet persisted stay live — no
+  // flash, no loss.
   // -------------------------------------------------------------------------
-  const wasSendingRef = useRef(false);
-  const turnPhase = useTurnStore.use.phase();
-  useEffect(() => {
-    const sending = isSending(turnPhase);
-    const justFinished = wasSendingRef.current && !sending;
-    wasSendingRef.current = sending;
-
-    if (!justFinished || !assistantId || !activeConversationId) return;
+  const handoffLiveTurnToHistory = useCallback(() => {
+    if (!assistantId || !activeConversationId) return;
     if (useChatSessionStore.getState().liveTurn.length === 0) return;
 
     const key = conversationHistoryQueryKey(assistantId, activeConversationId);
@@ -382,7 +376,31 @@ export function useConversationHistory({
           ),
         );
     });
-  }, [turnPhase, assistantId, activeConversationId, pagination, queryClient]);
+  }, [assistantId, activeConversationId, pagination, queryClient]);
+
+  // A turn is in progress for the active conversation when either the local
+  // turn store is sending (a `useSendMessage` turn this client started) or the
+  // conversation is flagged processing. The processing flag also covers
+  // passively-observed turns the local flow never initiated — external channels
+  // (phone, Slack, Telegram) and other-client sends — where `turnPhase` stays
+  // idle. Without this, such a turn's content would be stranded in the live turn
+  // while the durable history cache went stale, so the live view would show only
+  // the latest exchange until a reload. Hand off on the combined falling edge;
+  // for local sends both signals clear together in `endTurn`, so it fires
+  // exactly once per turn.
+  const turnPhase = useTurnStore.use.phase();
+  const processingConversationIds =
+    useConversationStore.use.processingConversationIds();
+  const activeInProgress =
+    isSending(turnPhase) ||
+    (!!activeConversationId &&
+      processingConversationIds.has(activeConversationId));
+  const wasInProgressRef = useRef(false);
+  useEffect(() => {
+    const justFinished = wasInProgressRef.current && !activeInProgress;
+    wasInProgressRef.current = activeInProgress;
+    if (justFinished) handoffLiveTurnToHistory();
+  }, [activeInProgress, handoffLiveTurnToHistory]);
 
   // -------------------------------------------------------------------------
   // Refetch history when the SSE connection reopens after a disconnect.


### PR DESCRIPTION
## Summary
- The live-turn→history handoff in `use-conversation-history.ts` fired only on the local turn store's `isSending` sending→idle edge. Server-driven turns the client merely observes — external channels (phone, Slack, Telegram) and other-client sends — never enter a local sending state, so the handoff never fired: completed turns stayed only in the live turn while the durable history cache went stale. Viewing such a conversation live then showed only the latest exchange until a manual reload.
- Hand off on a combined in-progress signal — `isSending(turnPhase)` OR the conversation's processing flag (`processingConversationIds`). Passive turns toggle that flag (via `markConversationProcessing` on turn start and `endTurn` on completion), so they now pull the finished turn into history on the processing→idle edge. For local sends both signals clear together in `endTurn`, so it still fires exactly once per turn — the native send path is unchanged.
- Extracted the handoff into a shared `handoffLiveTurnToHistory` callback. Added tests for the passive processing→idle handoff and the empty-live-turn no-op; existing reconnect-refetch tests stay green. Full `tsc --noEmit` is clean.

## Original prompt
Follow-up to a diagnosed bug: a live phone call with the assistant showed only the most recent exchange in the web app even though the daemon persisted and served the full conversation (verified — a reload showed everything). Root cause: the web client's live→history handoff is gated on a local-send turn phase that never fires for passively-observed (server-driven) conversations. This is PR 2 of 2 — the TTS/64106 call-drop fix shipped separately in `assistant/` (#36416).

## Verification
- `clients/web`: `bunx tsc --noEmit` (0 errors) and `bun test src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx` (10 pass).
- End-to-end (recommended): open a channel conversation (e.g. a phone call) while turns stream in and confirm earlier turns stay visible live without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)