### PR TITLE
refactor(plugins): source plugin-api-provided types from @vellumai/plugin-api

### DIFF
--- a/assistant/src/plugins/defaults/compaction/compact.ts
+++ b/assistant/src/plugins/defaults/compaction/compact.ts
@@ -10,7 +10,8 @@
  * This module is side-effect free: importing it does not register any plugin.
  */
 
-import type { Message } from "../../../providers/types.js";
+import type { Message } from "@vellumai/plugin-api";
+
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { PluginExecutionError } from "../../types.js";
 import { getContextWindowManager } from "./manager-store.js";

--- a/assistant/src/plugins/defaults/compaction/context-overflow-reducer.ts
+++ b/assistant/src/plugins/defaults/compaction/context-overflow-reducer.ts
@@ -25,6 +25,8 @@
  * `state.exhausted` is true.
  */
 
+import type { Message } from "@vellumai/plugin-api";
+
 import type { ContextWindowConfig } from "../../../config/types.js";
 import {
   estimateContentBlockTokens,
@@ -37,7 +39,6 @@ import {
   stripMediaPayloadsForRetry,
 } from "../../../daemon/conversation-media-retry.js";
 import type { InjectionMode } from "../../../daemon/conversation-runtime-assembly.js";
-import type { Message } from "../../../providers/types.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { getLogger } from "../../../util/logger.js";
 import { defaultCompact, defaultEmergencyCompact } from "./compact.js";

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -14,9 +14,15 @@
  * marker is wrapped around the assistant-role memory message we emit on
  * successful compaction so those code paths keep working unchanged.
  */
+import type {
+  ContentBlock,
+  LLMCallSite,
+  Message,
+  Provider,
+} from "@vellumai/plugin-api";
+
 import { getConfig } from "../../../config/loader.js";
 import type { CompactionConfig } from "../../../config/schemas/compaction.js";
-import type { LLMCallSite } from "../../../config/schemas/llm.js";
 import type { ContextWindowConfig } from "../../../config/types.js";
 import {
   type CompactionRunArgs,
@@ -30,12 +36,7 @@ import {
 } from "../../../context/token-estimator.js";
 import { findConversationOrSubagent } from "../../../daemon/conversation-registry.js";
 import type { InjectionMode } from "../../../daemon/conversation-runtime-assembly.js";
-import type {
-  ContentBlock,
-  Message,
-  Provider,
-  ToolDefinition,
-} from "../../../providers/types.js";
+import type { ToolDefinition } from "../../../providers/types.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { getLogger } from "../../../util/logger.js";
 import {

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -46,9 +46,13 @@
  * ignores the decision — so the hook returns early for both.
  */
 
-import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
+import type {
+  ContentBlock,
+  HookFunction,
+  Message,
+  PostModelCallContext,
+} from "@vellumai/plugin-api";
 
-import type { ContentBlock, Message } from "../../../../providers/types.js";
 import {
   isEmptyResponseNudged,
   markEmptyResponseNudged,

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -55,9 +55,11 @@
  * per-tool-result hot path.
  */
 
-import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
-
-import type { Message } from "../../../../providers/types.js";
+import type {
+  HookFunction,
+  Message,
+  PostToolUseContext,
+} from "@vellumai/plugin-api";
 
 /**
  * Canonical long-dig notice. Module-level constant so tests and wrapping

--- a/assistant/src/plugins/defaults/history-repair/terminal.ts
+++ b/assistant/src/plugins/defaults/history-repair/terminal.ts
@@ -18,7 +18,7 @@ import type {
   ServerToolUseContent,
   ToolResultContent,
   ToolUseContent,
-} from "../../../providers/types.js";
+} from "@vellumai/plugin-api";
 
 interface RepairStats {
   assistantToolResultsMigrated: number;

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -13,13 +13,14 @@
  * so a rejected image cannot resurface and re-reject on every later turn.
  */
 
+import type { ContentBlock, Message } from "@vellumai/plugin-api";
+
 import { optimizeImageForTransport } from "../../../agent/image-optimize.js";
 import { parseImageDimensions } from "../../../context/image-dimensions.js";
 import {
   getMessages,
   updateMessageContent,
 } from "../../../memory/conversation-crud.js";
-import type { ContentBlock, Message } from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("image-recovery");
@@ -195,7 +196,9 @@ export function recoverOversizedImages(
             {
               ...b,
               contentBlocks: b.contentBlocks.map((cb) =>
-                cb.type === "image" ? (oversizedImageReplacement(cb) ?? cb) : cb,
+                cb.type === "image"
+                  ? (oversizedImageReplacement(cb) ?? cb)
+                  : cb,
               ),
             },
           ];

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -47,6 +47,8 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 
+import type { Message } from "@vellumai/plugin-api";
+
 import { getConfig } from "../../../config/loader.js";
 import type { InjectionMatcher } from "../../../context/strip-injections.js";
 import { findConversationOrSubagent } from "../../../daemon/conversation-registry.js";
@@ -65,7 +67,6 @@ import { readPkbContext } from "../../../memory/pkb/context.js";
 import { searchPkbFiles } from "../../../memory/pkb/pkb-search.js";
 import { getPkbRoot, PKB_WORKSPACE_SCOPE } from "../../../memory/pkb/types.js";
 import { readMemoryV2StaticContent } from "../../../memory/v2/static-context.js";
-import type { Message } from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   getConfigQuarantineNoticePath,

--- a/assistant/src/plugins/defaults/memory-retrieval/tail-reinjection-strip.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/tail-reinjection-strip.ts
@@ -13,12 +13,13 @@
  * keeping injection idempotency a property of the injection machinery rather
  * than of the agent loop that drives compaction.
  */
+import type { Message } from "@vellumai/plugin-api";
+
 import {
   type InjectionMatcher,
   RUNTIME_INJECTION_PREFIXES,
   stripTailUserTextBlocksByPrefix,
 } from "../../../context/strip-injections.js";
-import type { Message } from "../../../providers/types.js";
 
 /**
  * Per-turn blocks that `stripInjectionsForCompaction` deliberately keeps in the

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -46,6 +46,11 @@
  *     it so v2 retrieval can serve the turn.
  */
 
+import type {
+  ContentBlock,
+  Message,
+  ToolUseContent,
+} from "@vellumai/plugin-api";
 import { z } from "zod";
 
 import { classifyConversationError } from "../../../daemon/conversation-error.js";
@@ -56,12 +61,7 @@ import {
   extractToolUse,
   getConfiguredProvider,
 } from "../../../providers/provider-send-message.js";
-import type {
-  ContentBlock,
-  Message,
-  ToolDefinition,
-  ToolUseContent,
-} from "../../../providers/types.js";
+import type { ToolDefinition } from "../../../providers/types.js";
 import { redactLogString } from "../../../util/log-redact.js";
 import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";

--- a/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/prune.ts
@@ -58,6 +58,8 @@
  * bytes it cannot free.
  */
 
+import type { ContentBlock, Message } from "@vellumai/plugin-api";
+
 import { getConfig } from "../../../config/loader.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
 import {
@@ -68,7 +70,6 @@ import {
   INJECTED_CONCEPT_HEADER_REGEX,
   readInjectedBlock,
 } from "../../../memory/v2/injected-block-slugs.js";
-import type { ContentBlock, Message } from "../../../providers/types.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   getActiveEntries,

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -45,9 +45,13 @@
  * the `post-model-call` chain — later hooks see (and may override) its decision.
  */
 
-import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
+import type {
+  ContentBlock,
+  HookFunction,
+  Message,
+  PostModelCallContext,
+} from "@vellumai/plugin-api";
 
-import type { ContentBlock, Message } from "../../../../providers/types.js";
 import {
   isSurfaceCompletionNudged,
   markSurfaceCompletionNudged,

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -45,9 +45,13 @@
  * below it (a new turn restarts counting low).
  */
 
-import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
+import type {
+  ContentBlock,
+  HookFunction,
+  Message,
+  PostToolUseContext,
+} from "@vellumai/plugin-api";
 
-import type { ContentBlock, Message } from "../../../../providers/types.js";
 import { isWeakOpenModel } from "../../../../providers/weak-open-model.js";
 
 /**

--- a/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
@@ -18,7 +18,7 @@
  * stateless and means a mid-run array rewrite (compaction) can't invalidate it.
  */
 
-import type { HookFunction, StopContext } from "@vellumai/plugin-api";
+import type { HookFunction, Message, StopContext } from "@vellumai/plugin-api";
 
 import { getConfig } from "../../../../config/loader.js";
 import { getConversation } from "../../../../memory/conversation-crud.js";
@@ -27,7 +27,6 @@ import {
   isReplaceableTitle,
   queueRegenerateConversationTitle,
 } from "../../../../memory/conversation-title-service.js";
-import type { Message } from "../../../../providers/types.js";
 
 /**
  * User turn at which the second title pass fires. Matches the

--- a/assistant/src/plugins/defaults/tool-error/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/tool-error/hooks/post-tool-use.ts
@@ -22,9 +22,11 @@
  * result for the tool resets its streak.
  */
 
-import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
-
-import type { Message } from "../../../../providers/types.js";
+import type {
+  HookFunction,
+  Message,
+  PostToolUseContext,
+} from "@vellumai/plugin-api";
 
 /**
  * Canonical tool-error coaching text. Kept as a module-level constant so tests


### PR DESCRIPTION
## Summary

- Default plugins under `assistant/src/plugins/defaults/` imported types like `Message`, `ContentBlock`, `ToolUseContent`, `Provider`, and `LLMCallSite` directly from host-internal paths (`../providers/types.js`, `../config/schemas/llm.js`), bypassing the public plugin API even though `@vellumai/plugin-api` re-exports those exact symbols.
- Re-pointed those production imports (15 files) at `@vellumai/plugin-api`, merging into each file's existing plugin-api import where present. Pure import-source change — no behavior change; full `tsc --noEmit` passes and eslint/prettier are clean.
- Left `ToolDefinition` in `compaction/window-manager.ts` and `memory-v3-shadow/pool-select.ts` on `providers/types.js`: that path re-exports the `@vellumai/skill-host-contracts` `ToolDefinition`, a **different** type than plugin-api's `tools/types.js` one. Test files and host-internal imports with no plugin-api equivalent (memory/daemon/context/etc.) were out of scope.

## Original prompt

Audited `assistant/src/plugins/defaults/` for imports that escape a plugin's own directory and aren't from `@vellumai/plugin-api`. This PR fixes the "Tier-1" subset: production imports of symbols the plugin API already re-exports, which should go through the API surface rather than reaching into host internals. The remaining escapes (memory/daemon/context/config-loader/etc.) have no plugin-api equivalent and are intentionally left untouched.