### PR TITLE
refactor(daemon): extract CES process management out of DaemonServer into a singleton

### DIFF
--- a/assistant/src/credential-execution/ces-runtime.ts
+++ b/assistant/src/credential-execution/ces-runtime.ts
@@ -1,0 +1,94 @@
+import type { CesClient } from "./client.js";
+import type { CesProcessManager } from "./process-manager.js";
+
+/**
+ * Process-level singleton holding the daemon's live CES (Credential Execution
+ * Service) connection. The startup flow is driven by `startCesProcess()` in
+ * lifecycle.ts, which hands the result here via `setCes()`; shutdown tears it
+ * down via `stopCes()`.
+ */
+
+let processManager: CesProcessManager | undefined;
+let clientPromise: Promise<CesClient | undefined> | undefined;
+let initAbortController: AbortController | undefined;
+let clientRef: CesClient | undefined;
+/** Monotonically increasing counter to detect stale client updates. */
+let clientGeneration = 0;
+
+/**
+ * Inject the CES client and process manager produced during startup. Must be
+ * called before any consumer reads the client via `getCesClient()`.
+ */
+export function setCes(result: {
+  client: CesClient | undefined;
+  processManager: CesProcessManager | undefined;
+  clientPromise: Promise<CesClient | undefined> | undefined;
+  abortController: AbortController | undefined;
+}): void {
+  clientRef = result.client;
+  processManager = result.processManager;
+  initAbortController = result.abortController;
+
+  // Wrap the external promise so that clientRef stays in sync once the
+  // handshake completes — the async work runs in lifecycle.ts but consumers
+  // need the resolved client reference for getCesClient(). Use a generation
+  // snapshot so a late-resolving promise doesn't overwrite a newer client set
+  // by updateCesClient().
+  if (result.clientPromise) {
+    const gen = clientGeneration;
+    clientPromise = result.clientPromise.then((client) => {
+      if (clientGeneration === gen) {
+        clientRef = client;
+      }
+      return client;
+    });
+  }
+}
+
+/**
+ * Return the CES client reference (if available). Used by routes that need to
+ * push updates to CES (e.g. secret-routes).
+ */
+export function getCesClient(): CesClient | undefined {
+  return clientRef;
+}
+
+/**
+ * Update the CES client reference after a successful reconnection. Called via
+ * the `onCesClientChanged` listener registered in lifecycle.ts. Bumps the
+ * generation counter so any pending setCes() promise callback won't overwrite
+ * this newer client.
+ */
+export function updateCesClient(client: CesClient | undefined): void {
+  clientGeneration++;
+  clientRef = client;
+}
+
+/** Tear down the CES connection during daemon shutdown. */
+export async function stopCes(): Promise<void> {
+  // Abort any in-flight CES initialization so it fails fast instead of
+  // blocking shutdown for up to ~15s (socket connect + handshake timeouts).
+  if (initAbortController) {
+    initAbortController.abort();
+    initAbortController = undefined;
+  }
+  // Force-stop the CES process immediately — forceStop() works even if
+  // start() hasn't finished (unlike stop() which is a no-op when !running).
+  if (processManager) {
+    await processManager.forceStop().catch(() => {});
+  }
+  // Cancel in-flight handshake/RPC timers by closing the client directly.
+  // Without this, the handshake setTimeout (~10s) keeps the init promise
+  // pending even after the transport is killed.
+  if (clientRef) {
+    clientRef.close();
+    clientRef = undefined;
+  }
+  // Now await the init promise (which should settle immediately since we
+  // killed the transport and cancelled pending timers above).
+  if (clientPromise) {
+    await clientPromise.catch(() => undefined);
+    clientPromise = undefined;
+  }
+  processManager = undefined;
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,6 +18,11 @@ import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
+import {
+  getCesClient as getActiveCesClient,
+  setCes,
+  updateCesClient,
+} from "../credential-execution/ces-runtime.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import { refreshManagedConnectionCache } from "../credential-execution/managed-catalog.js";
@@ -772,11 +777,11 @@ export async function runDaemon(): Promise<void> {
   // routes can begin accepting requests while Qdrant initializes.
   log.info("Daemon startup: starting DaemonServer");
   const server = new DaemonServer();
-  server.setCes(await cesStartupPromise);
+  setCes(await cesStartupPromise);
 
-  // Keep the server's CES client ref in sync after reconnection so that
-  // secret routes and new conversations use the fresh client.
-  onCesClientChanged((client) => server.updateCesClient(client));
+  // Keep the CES client ref in sync after reconnection so that secret routes
+  // and new conversations use the fresh client.
+  onCesClientChanged(updateCesClient);
 
   await server.start();
   log.info("Daemon startup: DaemonServer started");
@@ -1075,7 +1080,7 @@ export async function runDaemon(): Promise<void> {
   // the running routes. They're module-level state, so they're effective
   // even when the HTTP server failed to bind (IPC clients still work).
   registerSecretsDeps({
-    getCesClient: () => server.getCesClient(),
+    getCesClient: getActiveCesClient,
     onProviderCredentialsChanged: () =>
       server.refreshConversationsForProviderChange(),
   });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -5,8 +5,6 @@ import { disposeAcpSessionManager } from "../acp/index.js";
 import { compileApp } from "../bundler/app-compiler.js";
 import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
-import type { CesClient } from "../credential-execution/client.js";
-import type { CesProcessManager } from "../credential-execution/process-manager.js";
 import { AssistantIpcServer } from "../ipc/assistant-server.js";
 import { SkillIpcServer } from "../ipc/skill-server.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
@@ -84,65 +82,6 @@ export class DaemonServer {
   private appSourceWatcher = new AppSourceWatcher();
   private cliIpc = new AssistantIpcServer();
   private skillIpc = new SkillIpcServer();
-
-  // CES (Credential Execution Service) — process-level singleton.
-  // Lifecycle is managed by startCesProcess() in lifecycle.ts; the server
-  // receives the result via setCes().
-  private cesProcessManager?: CesProcessManager;
-  private cesClientPromise?: Promise<CesClient | undefined>;
-  private cesInitAbortController?: AbortController;
-  private cesClientRef?: CesClient;
-  /** Monotonically increasing counter to detect stale client updates. */
-  private cesClientGeneration = 0;
-
-  /**
-   * Inject the CES client and process manager from the caller (lifecycle.ts).
-   * Must be called before start().
-   */
-  setCes(result: {
-    client: CesClient | undefined;
-    processManager: CesProcessManager | undefined;
-    clientPromise: Promise<CesClient | undefined> | undefined;
-    abortController: AbortController | undefined;
-  }): void {
-    this.cesClientRef = result.client;
-    this.cesProcessManager = result.processManager;
-    this.cesInitAbortController = result.abortController;
-
-    // Wrap the external promise so that cesClientRef stays in sync once the
-    // handshake completes — the async work runs in lifecycle.ts but the
-    // server needs the resolved client reference for getCesClient().
-    // Use a generation snapshot so a late-resolving promise doesn't overwrite
-    // a newer client set by updateCesClient().
-    if (result.clientPromise) {
-      const gen = this.cesClientGeneration;
-      this.cesClientPromise = result.clientPromise.then((client) => {
-        if (this.cesClientGeneration === gen) {
-          this.cesClientRef = client;
-        }
-        return client;
-      });
-    }
-  }
-
-  /**
-   * Return the CES client reference (if available).
-   * Used by routes that need to push updates to CES (e.g. secret-routes).
-   */
-  getCesClient(): CesClient | undefined {
-    return this.cesClientRef;
-  }
-
-  /**
-   * Update the CES client reference after a successful reconnection.
-   * Called via the `onCesClientChanged` listener registered in lifecycle.ts.
-   * Bumps the generation counter so any pending setCes().then() callback
-   * won't overwrite this newer client.
-   */
-  updateCesClient(client: CesClient | undefined): void {
-    this.cesClientGeneration++;
-    this.cesClientRef = client;
-  }
 
   constructor() {
     this.evictor = new ConversationEvictor(getConversationMap());
@@ -332,34 +271,6 @@ export class DaemonServer {
       conversation.dispose();
     }
     clearConversations();
-
-    // Abort any in-flight CES initialization so it fails fast instead of
-    // blocking shutdown for up to ~15s (socket connect + handshake timeouts).
-    if (this.cesInitAbortController) {
-      this.cesInitAbortController.abort();
-      this.cesInitAbortController = undefined;
-    }
-    // Force-stop the CES process immediately — forceStop() works even if
-    // start() hasn't finished (unlike stop() which is a no-op when !running).
-    if (this.cesProcessManager) {
-      await this.cesProcessManager.forceStop().catch(() => {});
-    }
-    // Cancel in-flight handshake/RPC timers by closing the client directly.
-    // Without this, the handshake setTimeout (~10s) keeps the init promise
-    // pending even after the transport is killed.
-    if (this.cesClientRef) {
-      this.cesClientRef.close();
-      this.cesClientRef = undefined;
-    }
-    // Now await the init promise (which should settle immediately since we
-    // killed the transport and cancelled pending timers above).
-    if (this.cesClientPromise) {
-      await this.cesClientPromise.catch(() => undefined);
-      this.cesClientPromise = undefined;
-    }
-    if (this.cesProcessManager) {
-      this.cesProcessManager = undefined;
-    }
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import { stopCes } from "../credential-execution/ces-runtime.js";
 import { stopFilingService } from "../filing/filing-service.js";
 import { stopHeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
@@ -93,6 +94,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    await stopCes();
 
     // Final commit sweep: catch any writes that occurred during server.stop()
     // (e.g. in-flight tool executions completing during drain).


### PR DESCRIPTION
## Prompt / plan

First step of dissolving `DaemonServer` — it's not really a server, more an envelope of unrelated process-level singletons. Working `DaemonServer.stop()` bottom-to-top, the first one out is **all of the CES (Credential Execution Service) process management**.

`DaemonServer` held:
- the CES state — `cesProcessManager`, `cesClientPromise`, `cesInitAbortController`, `cesClientRef`, and the `cesClientGeneration` counter;
- `setCes()` / `getCesClient()` / `updateCesClient()`;
- the CES teardown block at the bottom of `stop()`.

None of it is server-specific. Moved verbatim (logic + comments) into **`credential-execution/ces-runtime.ts`** as a module singleton: `setCes` / `getCesClient` / `updateCesClient` / `stopCes`.

Wiring:
- **lifecycle** calls the module functions directly — `setCes(await cesStartupPromise)`, `onCesClientChanged(updateCesClient)`, and `registerSecretsDeps({ getCesClient })`. (Imported as `getActiveCesClient` to avoid colliding with `secure-keys`' own `getCesClient`, which is a different thing.)
- **shutdown-handlers** calls `stopCes()` immediately after `deps.server.stop()` — the exact point the teardown ran before (it was the tail of `stop()`).

No behavior change: same generation-guarded client sync, same teardown order (abort init → forceStop process → close client → await promise).

## Test plan

- `bun run lint` + `bun run typecheck` — clean (pre-commit full type check green).
- In isolation: the 4 suites that construct `DaemonServer` (`daemon-assistant-events` 7/0, `btw-routes` 14/0, `secret-ingress-cli` 6/0, `daemon-server-persist-and-process-callsite` 3/0), plus `secure-keys` 24/0, `disk-pressure-lifecycle` 4/0, `wake-intent-hooks` 8/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_