### PR TITLE
refactor(image-fallback): inline text extraction instead of the extractAllText host helper

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -65,12 +65,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../types.js",
   ],
   "exploration-drift": ["../../../../subagent/index.js"],
-  "image-fallback": [
-    "../../../../providers/provider-send-message.js",
-    "node:crypto",
-    "node:fs",
-    "node:path",
-  ],
+  "image-fallback": ["node:crypto", "node:fs", "node:path"],
   "image-recovery": [
     "../../../agent/image-optimize.js",
     "../../../context/image-dimensions.js",

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -16,7 +16,6 @@ import {
   type PluginLogger,
 } from "@vellumai/plugin-api";
 
-import { extractAllText } from "../../../../providers/provider-send-message.js";
 import {
   getCachedCaption,
   imageHash,
@@ -30,7 +29,8 @@ const CAPTION_SYSTEM_PROMPT =
   "Focus on the key visual content, text, charts, or UI elements that would be " +
   "relevant for a text-based assistant to understand and reason about.";
 
-const CAPTION_USER_PROMPT = "Describe this image concisely for a text-only assistant.";
+const CAPTION_USER_PROMPT =
+  "Describe this image concisely for a text-only assistant.";
 
 /**
  * Find a vision-capable, enabled profile key for captioning.
@@ -102,13 +102,21 @@ export async function captionImage(
       },
     );
 
-    const caption = extractAllText(response).trim();
+    // Vision captioning returns text content; concatenate any text blocks
+    // (effectively always one here, since tool use is disabled).
+    const caption = response.content
+      .flatMap((block) => (block.type === "text" ? [block.text] : []))
+      .join(" ")
+      .trim();
     if (caption.length > 0) {
       setCachedCaption(hash, caption);
       return caption;
     }
 
-    logger.warn({ plugin: "image-fallback" }, "Vision captioning returned empty text");
+    logger.warn(
+      { plugin: "image-fallback" },
+      "Vision captioning returned empty text",
+    );
     return null;
   } catch (err) {
     logger.warn(


### PR DESCRIPTION
## Summary

- `image-fallback`'s `vision-caption` module imported `extractAllText` from `providers/provider-send-message.js` — its only reach into assistant host code. The helper's sole non-trivial behavior (a whitespace-aware join separator) is irrelevant here: the captioning call disables tools and reads a single text block, then `.trim()`s it.
- Replaced it with an inline extraction over `response.content` using types `@vellumai/plugin-api` already exposes (`ProviderResponse` / `ContentBlock`). No plugin-api surface growth, no helper re-export, no behavior change — all 22 image-fallback tests pass; `tsc --noEmit`, eslint, and prettier are clean.
- Updated the plugin import-boundary guard baseline: `image-fallback` no longer lists `providers/provider-send-message.js` (only the harmless `node:` builtins remain).

## Original prompt

Continuing the plugin import-boundary cleanup (after PRs #36421 and #36424) and leaving the two memory plugins for the in-progress retrieval refactor, `image-fallback` was the easiest next target. Rather than re-export the `extractAllText` helper through `@vellumai/plugin-api` (which would bloat the public surface with a utility), the result is computed inline from primitives the API already exposes.