### PR TITLE
refactor(plugins): expose isMaxTokensStopReason via plugin-api; max-tokens-continue stops importing the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/agent-loop-exit-reason.test.ts
@@ -22,7 +22,7 @@ import type {
   CheckpointDecision,
   CheckpointInfo,
 } from "../agent/loop.js";
-import { AgentLoop, isMaxTokensStopReason } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
 import type { ContextWindowConfig } from "../config/types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { HOOKS } from "../plugin-api/constants.js";
@@ -35,6 +35,7 @@ import {
   registerPlugin,
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
+import { isMaxTokensStopReason } from "../providers/stop-reasons.js";
 import type {
   Message,
   Provider,

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -72,7 +72,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../persistence/conversation-crud.js",
     "../../../util/logger.js",
   ],
-  "max-tokens-continue": ["../../../../agent/loop.js"],
   "memory-retrieval": [
     "../../../../config/loader.js",
     "../../../../config/memory-v3-gate.js",
@@ -333,7 +332,7 @@ describe("plugin import boundary", () => {
 
     const exampleFile = new Map<string, string>();
     for (const e of escapes) {
-      exampleFile.set(`${e.plugin} ${e.specifier}`, e.relPath);
+      exampleFile.set(`${e.plugin} ${e.specifier}`, e.relPath);
     }
 
     const plugins = new Set([...byPlugin.keys(), ...Object.keys(BASELINE)]);
@@ -344,7 +343,7 @@ describe("plugin import boundary", () => {
       const allowed = new Set(BASELINE[plugin] ?? []);
       for (const spec of [...found].sort()) {
         if (!allowed.has(spec)) {
-          const where = exampleFile.get(`${plugin} ${spec}`);
+          const where = exampleFile.get(`${plugin} ${spec}`);
           added.push(`  - ${plugin}: "${spec}"  (e.g. ${where})`);
         }
       }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -29,6 +29,7 @@ import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { CompactionCircuitEvent } from "../plugins/types.js";
+import { isMaxTokensStopReason } from "../providers/stop-reasons.js";
 import { normalizeThinkingConfigForWire } from "../providers/thinking-config.js";
 import type {
   ContentBlock,
@@ -490,19 +491,6 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
  * headroom while still catching pathological alternation between classes.
  */
 const MAX_POST_MODEL_CALL_CONTINUES = 5;
-
-const MAX_TOKENS_STOP_REASONS = new Set([
-  "length",
-  "max_output_tokens",
-  "max_tokens",
-]);
-
-export function isMaxTokensStopReason(
-  stopReason: string | null | undefined,
-): boolean {
-  if (!stopReason) return false;
-  return MAX_TOKENS_STOP_REASONS.has(stopReason.trim().toLowerCase());
-}
 
 /**
  * Concatenate the text of an assistant message's `text` blocks (ignoring

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -147,3 +147,8 @@ export { doesSupportVision } from "./vision-support.js";
 // float the chosen profile above the call-site layers when the plugin must
 // run on a specific profile regardless of workspace tuning.
 export { getConfiguredProvider } from "../providers/provider-send-message.js";
+// Classify a provider stop reason: whether the turn was truncated at the
+// output token cap (vs. a natural stop or a tool call). A `post-model-call`
+// hook reads it off `PostModelCallContext.stopReason` to decide whether to
+// continue a cut-off reply.
+export { isMaxTokensStopReason } from "../providers/stop-reasons.js";

--- a/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
@@ -30,9 +30,12 @@
  *   reject.
  */
 
-import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
+import {
+  type HookFunction,
+  isMaxTokensStopReason,
+  type PostModelCallContext,
+} from "@vellumai/plugin-api";
 
-import { isMaxTokensStopReason } from "../../../../agent/loop.js";
 import {
   consumeMaxTokensContinueBudget,
   hasMaxTokensContinueBudget,

--- a/assistant/src/providers/stop-reasons.ts
+++ b/assistant/src/providers/stop-reasons.ts
@@ -1,0 +1,32 @@
+/**
+ * Provider stop-reason classification.
+ *
+ * Providers report an output-length cutoff under several normalized
+ * finish-reason strings; {@link isMaxTokensStopReason} folds them into a single
+ * "was this turn truncated at the token cap?" predicate.
+ *
+ * Kept dependency-free so it can be re-exported through `@vellumai/plugin-api`
+ * without pulling the agent loop (its other caller) into the plugin API's
+ * module graph.
+ */
+
+/**
+ * Normalized provider stop-reason strings that mean the output hit the token
+ * cap, as opposed to a natural end-of-turn or a tool-call stop.
+ */
+const MAX_TOKENS_STOP_REASONS = new Set([
+  "length",
+  "max_output_tokens",
+  "max_tokens",
+]);
+
+/**
+ * Whether a provider stop reason denotes output truncated at the token cap.
+ * Case- and whitespace-insensitive; a `null`/`undefined`/empty reason is false.
+ */
+export function isMaxTokensStopReason(
+  stopReason: string | null | undefined,
+): boolean {
+  if (!stopReason) return false;
+  return MAX_TOKENS_STOP_REASONS.has(stopReason.trim().toLowerCase());
+}


### PR DESCRIPTION
## Summary

- `max-tokens-continue`'s only reach outside its own directory was `isMaxTokensStopReason` from `agent/loop.ts`. Re-exporting it straight from the loop would create an import cycle (`plugin-api → agent/loop → plugins/* → plugin-api`) and pull the ~2,600-line loop into the thin plugin-api graph — so I extracted the stop-reason classification (`MAX_TOKENS_STOP_REASONS` + `isMaxTokensStopReason`) into a **dependency-free leaf**, `providers/stop-reasons.ts`.
- `@vellumai/plugin-api` now re-exports `isMaxTokensStopReason`; the agent loop, the plugin, and the `agent-loop-exit-reason` test import it from their canonical homes. The truncation-alias Set stays single-source. `max-tokens-continue` is now **fully clean** (plugin-api + its own files only) and is dropped from the guard baseline. No behavior change — `tsc --noEmit` clean, eslint/prettier clean, 16 affected tests pass.
- **Drive-by fix:** removed two stray NUL bytes in `plugin-import-boundary-guard.test.ts` — an accidental map-key delimiter I introduced in #36424 (a `\0` where I meant a space). Every tool tolerated it (which is why it shipped), but it made `grep`/`rg` treat the guard test as a binary file. Replaced with a space.

## Original prompt

Continuing the plugin import-boundary cleanup, leaving the two memory plugins for the in-progress retrieval refactor, `max-tokens-continue` was the next target. Its single escape needed exposing through plugin-api; the open question was avoiding a cycle through the agent loop, which the leaf extraction solves. Opened for review (not auto-merged) because it grows the public plugin-api surface and touches the agent loop.