### PR TITLE
feat(memory): shared withSqliteRetry helper for write contention

### DIFF
--- a/assistant/src/memory/memory-retrospective-state.ts
+++ b/assistant/src/memory/memory-retrospective-state.ts
@@ -24,6 +24,7 @@ import { eq } from "drizzle-orm";
 
 import { type DrizzleDb, getDb } from "../persistence/db-connection.js";
 import { memoryRetrospectiveState } from "../persistence/schema/index.js";
+import { withSqliteRetrySync } from "../util/sqlite-retry.js";
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -122,24 +123,32 @@ export function upsertRetrospectiveState(
     args.rememberedLog === undefined
       ? undefined
       : serializeRememberedLog(args.rememberedLog);
-  db.insert(memoryRetrospectiveState)
-    .values({
-      conversationId: args.conversationId,
-      lastProcessedMessageId: args.lastProcessedMessageId,
-      lastRunAt: args.lastRunAt,
-      rememberedLog: serializedLog ?? null,
-    })
-    .onConflictDoUpdate({
-      target: memoryRetrospectiveState.conversationId,
-      set: {
-        lastProcessedMessageId: args.lastProcessedMessageId,
-        lastRunAt: args.lastRunAt,
-        ...(serializedLog !== undefined
-          ? { rememberedLog: serializedLog }
-          : {}),
-      },
-    })
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .insert(memoryRetrospectiveState)
+        .values({
+          conversationId: args.conversationId,
+          lastProcessedMessageId: args.lastProcessedMessageId,
+          lastRunAt: args.lastRunAt,
+          rememberedLog: serializedLog ?? null,
+        })
+        .onConflictDoUpdate({
+          target: memoryRetrospectiveState.conversationId,
+          set: {
+            lastProcessedMessageId: args.lastProcessedMessageId,
+            lastRunAt: args.lastRunAt,
+            ...(serializedLog !== undefined
+              ? { rememberedLog: serializedLog }
+              : {}),
+          },
+        })
+        .run(),
+    {
+      op: "upsertRetrospectiveState",
+      context: { conversationId: args.conversationId },
+    },
+  );
 }
 
 /**
@@ -231,15 +240,20 @@ export function bumpRetrospectiveLastRunAt(
   lastRunAt: number,
 ): void {
   const db = getDb();
-  db.insert(memoryRetrospectiveState)
-    .values({
-      conversationId,
-      lastProcessedMessageId: "",
-      lastRunAt,
-    })
-    .onConflictDoUpdate({
-      target: memoryRetrospectiveState.conversationId,
-      set: { lastRunAt },
-    })
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .insert(memoryRetrospectiveState)
+        .values({
+          conversationId,
+          lastProcessedMessageId: "",
+          lastRunAt,
+        })
+        .onConflictDoUpdate({
+          target: memoryRetrospectiveState.conversationId,
+          set: { lastRunAt },
+        })
+        .run(),
+    { op: "bumpRetrospectiveLastRunAt", context: { conversationId } },
+  );
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -72,6 +72,7 @@ import { getLogger } from "../util/logger.js";
 import { getLogsDbPath } from "../util/logs-db-path.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
+import { withSqliteRetry, withSqliteRetrySync } from "../util/sqlite-retry.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -457,11 +458,11 @@ async function insertMessageCore(
       ? metadata.userMessageChannel
       : null;
 
-  const MAX_RETRIES = 3;
-  let now!: number;
-  for (let attempt = 0; ; attempt++) {
-    now = monotonicNow();
-    try {
+  // The timestamp is recomputed each attempt so a late retry doesn't persist a
+  // stale `updatedAt`.
+  return withSqliteRetry(
+    (): InsertedMessage => {
+      const now = monotonicNow();
       const values = {
         id: messageId,
         conversationId,
@@ -547,35 +548,20 @@ async function insertMessageCore(
             .run();
         });
       }
-      break;
-    } catch (err) {
-      const errCode = (err as { code?: string }).code ?? "";
-      if (
-        attempt < MAX_RETRIES &&
-        (errCode.startsWith("SQLITE_BUSY") ||
-          errCode.startsWith("SQLITE_IOERR"))
-      ) {
-        log.warn(
-          { attempt, conversationId, code: errCode },
-          "insertMessageCore: transient SQLite error, retrying",
-        );
-        await Bun.sleep(50 * (attempt + 1));
-        continue;
-      }
-      throw err;
-    }
-  }
 
-  return {
-    id: messageId,
-    conversationId,
-    role,
-    content,
-    createdAt: now,
-    ...(metadataStr ? { metadata: metadataStr } : {}),
-    ...(clientMessageId ? { clientMessageId } : {}),
-    deduplicated: false,
-  };
+      return {
+        id: messageId,
+        conversationId,
+        role,
+        content,
+        createdAt: now,
+        ...(metadataStr ? { metadata: metadataStr } : {}),
+        ...(clientMessageId ? { clientMessageId } : {}),
+        deduplicated: false,
+      };
+    },
+    { op: "insertMessageCore", context: { conversationId } },
+  );
 }
 
 export function createConversation(
@@ -652,58 +638,26 @@ export function createConversation(
   // No explicit BEGIN/COMMIT here — callers that need atomicity (e.g.
   // forkConversation) wrap in their own transaction, and nesting raw BEGIN
   // inside Drizzle's db.transaction() would crash SQLite.
-  const MAX_RETRIES = 3;
-  for (let attempt = 0; ; attempt++) {
-    try {
-      db.insert(conversations).values(conversation).run();
-      break;
-    } catch (err) {
-      const code = (err as { code?: string }).code ?? "";
-      if (
-        attempt < MAX_RETRIES &&
-        (code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_IOERR"))
-      ) {
-        log.warn(
-          { attempt, conversationId: id, code },
-          "createConversation: INSERT transient error, retrying",
-        );
-        Bun.sleepSync(50 * (attempt + 1));
-        continue;
-      }
-      throw err;
-    }
-  }
+  withSqliteRetrySync(
+    () => db.insert(conversations).values(conversation).run(),
+    { op: "createConversation.insert", context: { conversationId: id } },
+  );
 
   // group_id is NOT in the Drizzle schema (raw-query-only pattern).
   // Set via raw SQL after the INSERT succeeds.
   // Always set group_id — default to "system:all" when none provided.
   {
     const effectiveGroupId = groupId ?? "system:all";
-    for (let attempt = 0; ; attempt++) {
-      try {
+    withSqliteRetrySync(
+      () =>
         rawRun(
           "UPDATE conversations SET group_id = ?, is_pinned = ? WHERE id = ?",
           effectiveGroupId,
           effectiveGroupId === "system:pinned" ? 1 : 0,
           id,
-        );
-        break;
-      } catch (err) {
-        const code = (err as { code?: string }).code ?? "";
-        if (
-          attempt < MAX_RETRIES &&
-          (code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_IOERR"))
-        ) {
-          log.warn(
-            { attempt, conversationId: id, code },
-            "createConversation: group_id UPDATE transient error, retrying",
-          );
-          Bun.sleepSync(50 * (attempt + 1));
-          continue;
-        }
-        throw err;
-      }
-    }
+        ),
+      { op: "createConversation.groupId", context: { conversationId: id } },
+    );
   }
 
   initConversationDir({ ...conversation, originChannel: null });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -7,6 +7,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
+import { withSqliteRetrySync } from "../util/sqlite-retry.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -216,7 +217,10 @@ export function createSchedule(params: {
     updatedAt: now,
   };
 
-  db.insert(scheduleJobs).values(row).run();
+  withSqliteRetrySync(() => db.insert(scheduleJobs).values(row).run(), {
+    op: "createSchedule",
+    context: { scheduleId: id },
+  });
   notifySchedulesChanged();
   return parseJobRow(row);
 }
@@ -415,7 +419,10 @@ export function updateSchedule(
     set.nextRunAt = newEnabled ? computeNextRunAtEngine(spec) : 0;
   }
 
-  db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run();
+  withSqliteRetrySync(
+    () => db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run(),
+    { op: "updateSchedule", context: { scheduleId: id } },
+  );
   notifySchedulesChanged();
 
   return getSchedule(id);
@@ -423,7 +430,10 @@ export function updateSchedule(
 
 export function deleteSchedule(id: string): boolean {
   const db = getDb();
-  db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run();
+  withSqliteRetrySync(
+    () => db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run(),
+    { op: "deleteSchedule", context: { scheduleId: id } },
+  );
   const deleted = rawChanges() > 0;
   if (deleted) notifySchedulesChanged();
   return deleted;
@@ -495,15 +505,20 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
       updates.nextRunAt = newNextRunAt!;
     }
 
-    db.update(scheduleJobs)
-      .set(updates)
-      .where(
-        and(
-          eq(scheduleJobs.id, row.id),
-          eq(scheduleJobs.nextRunAt, row.nextRunAt),
-        ),
-      )
-      .run();
+    withSqliteRetrySync(
+      () =>
+        db
+          .update(scheduleJobs)
+          .set(updates)
+          .where(
+            and(
+              eq(scheduleJobs.id, row.id),
+              eq(scheduleJobs.nextRunAt, row.nextRunAt),
+            ),
+          )
+          .run(),
+      { op: "claimDueSchedules.recurring", context: { scheduleId: row.id } },
+    );
 
     if (rawChanges() === 0) continue;
 
@@ -534,16 +549,21 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
     .all();
 
   for (const row of oneShotCandidates) {
-    db.update(scheduleJobs)
-      .set({
-        status: "firing",
-        lastRunAt: now,
-        updatedAt: now,
-      })
-      .where(
-        and(eq(scheduleJobs.id, row.id), eq(scheduleJobs.status, "active")),
-      )
-      .run();
+    withSqliteRetrySync(
+      () =>
+        db
+          .update(scheduleJobs)
+          .set({
+            status: "firing",
+            lastRunAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(eq(scheduleJobs.id, row.id), eq(scheduleJobs.status, "active")),
+          )
+          .run(),
+      { op: "claimDueSchedules.oneShot", context: { scheduleId: row.id } },
+    );
 
     if (rawChanges() === 0) continue;
 
@@ -568,14 +588,19 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
 export function completeOneShot(id: string): void {
   const db = getDb();
   const now = Date.now();
-  db.update(scheduleJobs)
-    .set({
-      status: "fired",
-      enabled: false,
-      updatedAt: now,
-    })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "fired",
+          enabled: false,
+          updatedAt: now,
+        })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run(),
+    { op: "completeOneShot", context: { scheduleId: id } },
+  );
   if (rawChanges() > 0) notifySchedulesChanged();
 }
 
@@ -586,13 +611,18 @@ export function completeOneShot(id: string): void {
 export function failOneShot(id: string): void {
   const db = getDb();
   const now = Date.now();
-  db.update(scheduleJobs)
-    .set({
-      status: "active",
-      updatedAt: now,
-    })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "active",
+          updatedAt: now,
+        })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run(),
+    { op: "failOneShot", context: { scheduleId: id } },
+  );
   if (rawChanges() > 0) notifySchedulesChanged();
 }
 
@@ -619,15 +649,20 @@ export function failOneShot(id: string): void {
 export function deferClaimedSchedule(id: string): void {
   const db = getDb();
   const now = Date.now();
-  db.update(scheduleJobs)
-    .set({
-      status: "active",
-      enabled: true,
-      nextRunAt: now,
-      updatedAt: now,
-    })
-    .where(eq(scheduleJobs.id, id))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "active",
+          enabled: true,
+          nextRunAt: now,
+          updatedAt: now,
+        })
+        .where(eq(scheduleJobs.id, id))
+        .run(),
+    { op: "deferClaimedSchedule", context: { scheduleId: id } },
+  );
   if (rawChanges() > 0) notifySchedulesChanged();
 }
 
@@ -640,14 +675,19 @@ export function retryOneShot(id: string): void {
   const db = getDb();
   const now = Date.now();
   let changed = false;
-  db.update(scheduleJobs)
-    .set({
-      status: "active",
-      retryCount: sql`${scheduleJobs.retryCount} + 1`,
-      updatedAt: now,
-    })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "active",
+          retryCount: sql`${scheduleJobs.retryCount} + 1`,
+          updatedAt: now,
+        })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run(),
+    { op: "retryOneShot", context: { scheduleId: id } },
+  );
   changed = rawChanges() > 0;
   if (changed) notifySchedulesChanged();
 }
@@ -660,15 +700,20 @@ export function retryOneShot(id: string): void {
 export function failOneShotPermanently(id: string): void {
   const db = getDb();
   const now = Date.now();
-  db.update(scheduleJobs)
-    .set({
-      status: "cancelled",
-      enabled: false,
-      lastStatus: "error",
-      updatedAt: now,
-    })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "cancelled",
+          enabled: false,
+          lastStatus: "error",
+          updatedAt: now,
+        })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run(),
+    { op: "failOneShotPermanently", context: { scheduleId: id } },
+  );
   if (rawChanges() > 0) notifySchedulesChanged();
 }
 
@@ -679,14 +724,19 @@ export function failOneShotPermanently(id: string): void {
 export function cancelSchedule(id: string): boolean {
   const db = getDb();
   const now = Date.now();
-  db.update(scheduleJobs)
-    .set({
-      status: "cancelled",
-      enabled: false,
-      updatedAt: now,
-    })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "active")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({
+          status: "cancelled",
+          enabled: false,
+          updatedAt: now,
+        })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "active")))
+        .run(),
+    { op: "cancelSchedule", context: { scheduleId: id } },
+  );
   const cancelled = rawChanges() > 0;
   if (cancelled) notifySchedulesChanged();
   return cancelled;
@@ -699,20 +749,25 @@ export function createScheduleRun(
   const db = getDb();
   const id = uuid();
   const now = Date.now();
-  db.insert(scheduleRuns)
-    .values({
-      id,
-      jobId,
-      status: "running",
-      startedAt: now,
-      finishedAt: null,
-      durationMs: null,
-      output: null,
-      error: null,
-      conversationId,
-      createdAt: now,
-    })
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .insert(scheduleRuns)
+        .values({
+          id,
+          jobId,
+          status: "running",
+          startedAt: now,
+          finishedAt: null,
+          durationMs: null,
+          output: null,
+          error: null,
+          conversationId,
+          createdAt: now,
+        })
+        .run(),
+    { op: "createScheduleRun", context: { scheduleId: jobId, runId: id } },
+  );
   return id;
 }
 
@@ -721,10 +776,15 @@ export function setScheduleRunConversationId(
   conversationId: string,
 ): void {
   const db = getDb();
-  db.update(scheduleRuns)
-    .set({ conversationId })
-    .where(eq(scheduleRuns.id, runId))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleRuns)
+        .set({ conversationId })
+        .where(eq(scheduleRuns.id, runId))
+        .run(),
+    { op: "setScheduleRunConversationId", context: { runId } },
+  );
 }
 
 export function completeScheduleRun(
@@ -743,16 +803,21 @@ export function completeScheduleRun(
 
   const durationMs = now - run.startedAt;
 
-  db.update(scheduleRuns)
-    .set({
-      status: result.status,
-      finishedAt: now,
-      durationMs,
-      output: result.output?.slice(0, 10_000) ?? null,
-      error: result.error?.slice(0, 2000) ?? null,
-    })
-    .where(eq(scheduleRuns.id, runId))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleRuns)
+        .set({
+          status: result.status,
+          finishedAt: now,
+          durationMs,
+          output: result.output?.slice(0, 10_000) ?? null,
+          error: result.error?.slice(0, 2000) ?? null,
+        })
+        .where(eq(scheduleRuns.id, runId))
+        .run(),
+    { op: "completeScheduleRun.run", context: { runId } },
+  );
 
   // Update the parent job's lastStatus and retryCount
   if (result.status === "error") {
@@ -763,21 +828,34 @@ export function completeScheduleRun(
       .where(eq(scheduleJobs.id, run.jobId))
       .get();
     if (job) {
-      db.update(scheduleJobs)
-        .set({
-          lastStatus: "error",
-          retryCount: job.retryCount + 1,
-          updatedAt: now,
-        })
-        .where(eq(scheduleJobs.id, run.jobId))
-        .run();
+      withSqliteRetrySync(
+        () =>
+          db
+            .update(scheduleJobs)
+            .set({
+              lastStatus: "error",
+              retryCount: job.retryCount + 1,
+              updatedAt: now,
+            })
+            .where(eq(scheduleJobs.id, run.jobId))
+            .run(),
+        {
+          op: "completeScheduleRun.jobError",
+          context: { scheduleId: run.jobId },
+        },
+      );
       if (rawChanges() > 0) notifySchedulesChanged();
     }
   } else {
-    db.update(scheduleJobs)
-      .set({ lastStatus: "ok", retryCount: 0, updatedAt: now })
-      .where(eq(scheduleJobs.id, run.jobId))
-      .run();
+    withSqliteRetrySync(
+      () =>
+        db
+          .update(scheduleJobs)
+          .set({ lastStatus: "ok", retryCount: 0, updatedAt: now })
+          .where(eq(scheduleJobs.id, run.jobId))
+          .run(),
+      { op: "completeScheduleRun.jobOk", context: { scheduleId: run.jobId } },
+    );
     if (rawChanges() > 0) notifySchedulesChanged();
   }
 }
@@ -1032,17 +1110,27 @@ export function scheduleRetry(id: string, nextRetryAt: number): void {
   const db = getDb();
   const now = Date.now();
   let changed = false;
-  db.update(scheduleJobs)
-    .set({ nextRunAt: nextRetryAt, updatedAt: now })
-    .where(eq(scheduleJobs.id, id))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({ nextRunAt: nextRetryAt, updatedAt: now })
+        .where(eq(scheduleJobs.id, id))
+        .run(),
+    { op: "scheduleRetry.nextRunAt", context: { scheduleId: id } },
+  );
   changed = rawChanges() > 0;
   // Revert one-shot status from "firing" to "active" so the scheduler
   // will claim it again when nextRetryAt arrives. No-op for recurring.
-  db.update(scheduleJobs)
-    .set({ status: "active", updatedAt: now })
-    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({ status: "active", updatedAt: now })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run(),
+    { op: "scheduleRetry.revertStatus", context: { scheduleId: id } },
+  );
   changed = rawChanges() > 0 || changed;
   if (changed) notifySchedulesChanged();
 }
@@ -1052,10 +1140,15 @@ export function scheduleRetry(id: string, nextRetryAt: number): void {
  */
 export function resetRetryCount(id: string): void {
   const db = getDb();
-  db.update(scheduleJobs)
-    .set({ retryCount: 0, updatedAt: Date.now() })
-    .where(eq(scheduleJobs.id, id))
-    .run();
+  withSqliteRetrySync(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({ retryCount: 0, updatedAt: Date.now() })
+        .where(eq(scheduleJobs.id, id))
+        .run(),
+    { op: "resetRetryCount", context: { scheduleId: id } },
+  );
   if (rawChanges() > 0) notifySchedulesChanged();
 }
 

--- a/assistant/src/util/sqlite-retry.ts
+++ b/assistant/src/util/sqlite-retry.ts
@@ -1,0 +1,123 @@
+/**
+ * Retry helpers for transient SQLite write contention.
+ *
+ * SQLite serializes writers at the database level: only one connection holds
+ * the write lock at a time. `PRAGMA busy_timeout` makes a contending writer
+ * *wait* for the lock, but it cannot rescue a statement that still loses the
+ * race (the wait elapses) or a transaction that begins as a reader and then
+ * fails to upgrade to a writer — both surface as `SQLITE_BUSY`. Transient disk
+ * errors surface as `SQLITE_IOERR`. The only correct recovery for either is to
+ * re-run the whole operation, so write paths that several processes contend on
+ * (the conversation loop, the scheduler, the memory worker) wrap their writes
+ * in one of the helpers below.
+ *
+ * Both helpers retry on `SQLITE_BUSY*` / `SQLITE_IOERR*` with jittered backoff;
+ * the jitter decorrelates retries across the now-separate worker processes so
+ * they don't collide in lockstep. Pick the variant that matches the call site:
+ * {@link withSqliteRetrySync} for `bun:sqlite`'s synchronous statements,
+ * {@link withSqliteRetry} when the body is (or contains) an `await`.
+ *
+ * The wrapped function must be safe to re-run: either a single statement, or a
+ * sequence guarded so re-execution is idempotent (e.g. an optimistic-lock
+ * `WHERE` clause, or a full `db.transaction(...)` that rolls back atomically on
+ * failure). Do not wrap a partial sequence whose earlier statements already
+ * committed — a retry would double-apply them.
+ */
+
+import { getLogger } from "./logger.js";
+import { computeRetryDelay } from "./retry.js";
+
+const log = getLogger("sqlite-retry");
+
+const DEFAULT_MAX_RETRIES = 3;
+/** Base for the jittered backoff; busy_timeout absorbs the bulk of the wait. */
+const DEFAULT_BASE_DELAY_MS = 50;
+
+export interface SqliteRetryOptions {
+  /** Short identifier for the wrapped operation, used in retry logs. */
+  op: string;
+  /** Maximum retry attempts after the initial try (default 3). */
+  maxRetries?: number;
+  /** Base delay in ms for the jittered backoff (default 50). */
+  baseDelayMs?: number;
+  /** Extra structured fields to include in retry warnings (e.g. an id). */
+  context?: Record<string, unknown>;
+}
+
+function sqliteErrorCode(err: unknown): string {
+  return (err as { code?: string } | null)?.code ?? "";
+}
+
+/**
+ * Whether an error is a transient SQLite contention/IO error worth retrying.
+ * Matches the `SQLITE_BUSY` and `SQLITE_IOERR` families (including their
+ * extended-result-code suffixes like `SQLITE_BUSY_SNAPSHOT`).
+ */
+export function isRetryableSqliteError(err: unknown): boolean {
+  const code = sqliteErrorCode(err);
+  return code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_IOERR");
+}
+
+/**
+ * Run a synchronous `bun:sqlite` write with retry on transient contention.
+ * Returns the function's value so single-statement callers can read it inline.
+ */
+export function withSqliteRetrySync<T>(
+  fn: () => T,
+  options: SqliteRetryOptions,
+): T {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      if (attempt < maxRetries && isRetryableSqliteError(err)) {
+        log.warn(
+          {
+            ...options.context,
+            op: options.op,
+            attempt,
+            code: sqliteErrorCode(err),
+          },
+          "withSqliteRetrySync: transient SQLite error, retrying",
+        );
+        Bun.sleepSync(computeRetryDelay(attempt, baseDelayMs));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Run an async (or sync) SQLite write with retry on transient contention.
+ * Use when the wrapped body awaits; otherwise prefer {@link withSqliteRetrySync}.
+ */
+export async function withSqliteRetry<T>(
+  fn: () => T | Promise<T>,
+  options: SqliteRetryOptions,
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt < maxRetries && isRetryableSqliteError(err)) {
+        log.warn(
+          {
+            ...options.context,
+            op: options.op,
+            attempt,
+            code: sqliteErrorCode(err),
+          },
+          "withSqliteRetry: transient SQLite error, retrying",
+        );
+        await Bun.sleep(computeRetryDelay(attempt, baseDelayMs));
+        continue;
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
## Prompt / plan

We're seeing `SQLITE_BUSY` under write contention and are about to move the memory-jobs worker and scheduler into separate background processes — which turns in-process writers into multiple OS processes all contending for the single SQLite write lock. Retry-on-`SQLITE_BUSY` existed in only two places (`insertMessageCore`, `createConversation`); the scheduler and memory-worker write paths had none.

This PR adds one shared retry helper and applies it to the existing two sites plus the previously-unprotected hot paths that are moving out-of-process.

### What changed
- **New `assistant/src/util/sqlite-retry.ts`** — `withSqliteRetry` (async) and `withSqliteRetrySync` (sync) that retry on the `SQLITE_BUSY*` / `SQLITE_IOERR*` families with jittered exponential backoff (base 50ms). The jitter decorrelates retries across the now-separate worker processes so they don't collide in lockstep. Reuses the existing `computeRetryDelay` from `util/retry.ts`.
- **Consolidated** the two existing inlined retry loops (`insertMessageCore`, `createConversation` INSERT + group_id UPDATE) onto the helper. Behavior preserved, including per-operation independent retry and per-attempt timestamp recompute.
- **Wrapped** the previously-unprotected writes:
  - `schedule/schedule-store.ts` — all writes: `claimDueSchedules` (per-row, optimistic-lock guarded), run-lifecycle transitions (`completeOneShot`, `failOneShot`, `deferClaimedSchedule`, `retryOneShot`, `failOneShotPermanently`, `cancelSchedule`, `createScheduleRun`, `setScheduleRunConversationId`, `completeScheduleRun`, `scheduleRetry`, `resetRetryCount`), and CRUD (`createSchedule`, `updateSchedule`, `deleteSchedule`).
  - `memory/memory-retrospective-state.ts` — `upsertRetrospectiveState`, `bumpRetrospectiveLastRunAt`.

### Design notes
- Writes are wrapped per-statement (not whole-function) so the write lock is held briefly — better foreground fairness under multiple writers. Each wrapped op is safe to re-run: a single statement, or guarded by an optimistic-lock `WHERE` clause. `forkRetrospectiveState` is intentionally left unwrapped — it runs inside the fork transaction, which should be retried at the transaction boundary.
- `busy_timeout` is unchanged; the helper is the application-level backstop for the cases `busy_timeout` can't cover (wait elapses, or a deferred read→write upgrade returns `SQLITE_BUSY` immediately).

## Test plan
- `bunx tsc --noEmit` — no new type errors in the changed files (pre-commit typecheck hook passed).
- `eslint` + `prettier --check` — clean (pre-commit hooks passed).
- `bun test` on the affected suites, all green:
  - `schedule-store.test.ts` (59), `schedule-retry.test.ts` (19)
  - `memory-retrospective-state.test.ts`, `conversation-crud-inference-profile.test.ts`, `conversation-fork-retrospective.test.ts` (21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015UNuD3sKuRtPxqGJnpHXEY)_