### PR TITLE
refactor(assistant): consolidate CES connection ownership into ces-runtime singleton

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -215,7 +215,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/conversation-process.ts", // masked provider key display
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
-      "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
+      "credential-execution/ces-runtime.ts", // CES runtime owns the daemon CES connection (setCesClient/onCesClientChanged/reconnect wiring at startup)
       "daemon/daemon-skill-host.ts", // SkillHost secureKeys facet adapter (delegates to getProviderKeyAsync)
       "runtime/routes/credential-prompt-routes.ts", // Route for secure credential prompt (stores secret via setSecureKeyAsync)
       "runtime/routes/credential-routes.ts", // CLI credential management routes (CLI-migrated to IPC)

--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -178,7 +178,6 @@ describe("secret routes managed proxy registry sync", () => {
     platformBaseUrlOverride = undefined;
     providerRefreshCalls = 0;
     registerSecretsDeps({
-      getCesClient: () => undefined,
       onProviderCredentialsChanged: () => {
         providerRefreshCalls++;
       },

--- a/assistant/src/credential-execution/ces-runtime.ts
+++ b/assistant/src/credential-execution/ces-runtime.ts
@@ -1,11 +1,32 @@
-import type { CesClient } from "./client.js";
-import type { CesProcessManager } from "./process-manager.js";
+import { getPlatformAssistantId } from "../config/env.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
+import {
+  getCesClient as getSecureKeysCesClient,
+  onCesClientChanged,
+  setCesClient,
+  setCesReconnect,
+} from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import { type CesClient, createCesClient } from "./client.js";
+import {
+  type CesProcessManager,
+  CesUnavailableError,
+  createCesProcessManager,
+} from "./process-manager.js";
+import {
+  awaitCesClientWithTimeout,
+  DEFAULT_CES_STARTUP_TIMEOUT_MS,
+  injectCesClientWhenReady,
+} from "./startup-timeout.js";
+
+const log = getLogger("ces-runtime");
 
 /**
- * Process-level singleton holding the daemon's live CES (Credential Execution
- * Service) connection. The startup flow is driven by `startCesProcess()` in
- * lifecycle.ts, which hands the result here via `setCes()`; shutdown tears it
- * down via `stopCes()`.
+ * Process-level singleton owning the daemon's live CES (Credential Execution
+ * Service) connection. `startCes()` performs the full handshake + reconnect
+ * wiring at daemon startup; `getCesClient()` exposes the live client to routes;
+ * `stopCes()` tears it down at shutdown.
  */
 
 let processManager: CesProcessManager | undefined;
@@ -15,25 +36,101 @@ let clientRef: CesClient | undefined;
 /** Monotonically increasing counter to detect stale client updates. */
 let clientGeneration = 0;
 
-/**
- * Inject the CES client and process manager produced during startup. Must be
- * called before any consumer reads the client via `getCesClient()`.
- */
-export function setCes(result: {
+interface CesStartupResult {
   client: CesClient | undefined;
   processManager: CesProcessManager | undefined;
   clientPromise: Promise<CesClient | undefined> | undefined;
   abortController: AbortController | undefined;
-}): void {
+}
+
+/**
+ * Start the CES process and perform the RPC handshake. Returns immediately with
+ * handles to the in-flight initialization — callers don't need to await this
+ * for startup to continue.
+ *
+ * The managed sidecar accepts exactly one bootstrap connection, so this must be
+ * called at the process level (not per-conversation).
+ */
+function startCesProcess(config: AssistantConfig): CesStartupResult {
+  const pm = createCesProcessManager({ assistantConfig: config });
+  const abortController = new AbortController();
+  let currentClient: CesClient | undefined;
+
+  const handshakePromise = (async (): Promise<CesClient | undefined> => {
+    try {
+      const transport = await pm.start();
+      if (abortController.signal.aborted) {
+        throw new Error("CES initialization aborted during shutdown");
+      }
+      const client = createCesClient(transport);
+      currentClient = client;
+      // Resolve the assistant API key so CES can use it for platform
+      // credential materialisation. In managed mode the key is provisioned
+      // after hatch and stored in the credential store — CES can't read
+      // the env var, so we pass it via the handshake.
+      const proxyCtx = await resolveManagedProxyContext();
+      const assistantId = getPlatformAssistantId();
+      const { accepted, reason } = await client.handshake({
+        ...(proxyCtx.assistantApiKey
+          ? { assistantApiKey: proxyCtx.assistantApiKey }
+          : {}),
+        ...(assistantId ? { assistantId } : {}),
+      });
+      if (abortController.signal.aborted) {
+        client.close();
+        throw new Error("CES initialization aborted during shutdown");
+      }
+      if (accepted) {
+        log.info(
+          "CES client initialized and handshake accepted (server-level)",
+        );
+        return client;
+      }
+      log.warn(
+        { reason },
+        "CES handshake rejected — CES tools will be unavailable",
+      );
+      client.close();
+      currentClient = undefined;
+      await pm.stop();
+      return undefined;
+    } catch (err) {
+      if (err instanceof CesUnavailableError) {
+        log.info(
+          { reason: err.message },
+          "CES is not available — CES tools will be unavailable",
+        );
+      } else {
+        log.warn(
+          { error: err instanceof Error ? err.message : String(err) },
+          "Failed to initialize CES client — CES tools will be unavailable",
+        );
+      }
+      await pm.stop().catch(() => {});
+      currentClient = undefined;
+      return undefined;
+    }
+  })();
+
+  return {
+    get client() {
+      return currentClient;
+    },
+    processManager: pm,
+    clientPromise: handshakePromise,
+    abortController,
+  };
+}
+
+/** Store the startup handles so getCesClient()/stopCes() can reach them. */
+function applyCesResult(result: CesStartupResult): void {
   clientRef = result.client;
   processManager = result.processManager;
   initAbortController = result.abortController;
 
-  // Wrap the external promise so that clientRef stays in sync once the
-  // handshake completes — the async work runs in lifecycle.ts but consumers
-  // need the resolved client reference for getCesClient(). Use a generation
-  // snapshot so a late-resolving promise doesn't overwrite a newer client set
-  // by updateCesClient().
+  // Wrap the handshake promise so clientRef stays in sync once it resolves.
+  // Use a generation snapshot so a late-resolving promise doesn't overwrite a
+  // newer client set by a reconnection.
   if (result.clientPromise) {
     const gen = clientGeneration;
     clientPromise = result.clientPromise.then((client) => {
@@ -46,22 +143,116 @@ export function setCes(result: {
 }
 
 /**
+ * Update the client reference after a reconnection (fired via the
+ * `onCesClientChanged` listener). Bumps the generation counter so any pending
+ * handshake-promise callback won't overwrite this newer client.
+ */
+function updateClientRef(client: CesClient | undefined): void {
+  clientGeneration++;
+  clientRef = client;
+}
+
+/**
+ * Bring up the daemon's CES connection: start the process, run the handshake
+ * (blocking up to a 20s timeout so credential reads can route through CES
+ * before provider init), register the reconnection callback, and keep the live
+ * client reference in sync. Non-fatal — on failure the daemon falls back to the
+ * direct credential store.
+ */
+export async function startCes(config: AssistantConfig): Promise<void> {
+  const cesResult = startCesProcess(config);
+
+  // The handshake runs inside clientPromise. Await it (with a 20s timeout) so
+  // the CES client is available before provider initialization; fall back to
+  // the direct credential store on timeout.
+  if (cesResult.clientPromise) {
+    const client = await awaitCesClientWithTimeout(cesResult.clientPromise, {
+      timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
+      onTimeout: () => {
+        log.warn(
+          "CES handshake timed out after 20s — falling back to direct credential store",
+        );
+      },
+    });
+    if (client) {
+      setCesClient(client);
+    } else {
+      // The handshake lost the startup race, so provider init proceeds on the
+      // direct credential store. Still inject the CES client into the resolver
+      // once the handshake completes, so CES tools and the approval bridge
+      // route through CES rather than reporting it unavailable for the rest of
+      // the process.
+      injectCesClientWhenReady(cesResult.clientPromise, {
+        getCesClient: getSecureKeysCesClient,
+        setCesClient,
+      });
+    }
+  }
+
+  // Register CES reconnection callback so the credential layer can re-establish
+  // the connection when the transport dies, instead of falling back to the
+  // encrypted file store.
+  if (cesResult.processManager) {
+    const pm = cesResult.processManager;
+
+    // Snapshot the managed-proxy context and assistant ID at CES startup so the
+    // reconnect closure below never calls back into `resolveManagedProxyContext()`.
+    // That function reads the assistant API key via `getSecureKeyAsync()`, which
+    // — once `setCesClient()` has resolved the backend to CES RPC — routes the
+    // read through CES itself. During a reconnect the old transport is dead and
+    // a new one is being set up by this very closure, so the nested credential
+    // read recursively awaits its own in-flight reconnection and deadlocks until
+    // `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That 45-second stall delays every
+    // CES restart and causes dependent credential reads (e.g. Meet's STT
+    // provider resolution) to return `undefined` during the window. API key
+    // rotation uses the `updateAssistantApiKey` RPC on the live client, not a
+    // reconnect, so caching at startup is safe.
+    const startupProxyCtx = await resolveManagedProxyContext();
+    const startupAssistantId = getPlatformAssistantId();
+
+    setCesReconnect(async () => {
+      try {
+        await pm.stop();
+        const transport = await pm.start();
+        const newClient = createCesClient(transport);
+        const { accepted, reason } = await newClient.handshake({
+          ...(startupProxyCtx.assistantApiKey
+            ? { assistantApiKey: startupProxyCtx.assistantApiKey }
+            : {}),
+          ...(startupAssistantId ? { assistantId: startupAssistantId } : {}),
+        });
+        if (accepted) {
+          log.info("CES reconnection handshake accepted");
+          return newClient;
+        }
+        log.warn({ reason }, "CES reconnection handshake rejected");
+        newClient.close();
+        await pm.stop().catch(() => {});
+        return undefined;
+      } catch (err) {
+        log.warn(
+          { error: err instanceof Error ? err.message : String(err) },
+          "CES reconnection attempt failed",
+        );
+        await pm.stop().catch(() => {});
+        return undefined;
+      }
+    });
+  }
+
+  applyCesResult(cesResult);
+
+  // Keep the client ref in sync after reconnection so that secret routes and
+  // new conversations use the fresh client.
+  onCesClientChanged(updateClientRef);
+}
+
+/**
  * Return the CES client reference (if available). Used by routes that need to
  * push updates to CES (e.g. secret-routes).
  */
 export function getCesClient(): CesClient | undefined {
   return clientRef;
-}
-
-/**
- * Update the CES client reference after a successful reconnection. Called via
- * the `onCesClientChanged` listener registered in lifecycle.ts. Bumps the
- * generation counter so any pending setCes() promise callback won't overwrite
- * this newer client.
- */
-export function updateCesClient(client: CesClient | undefined): void {
-  clientGeneration++;
-  clientRef = client;
 }
 
 /** Tear down the CES connection during daemon shutdown. */

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -9,33 +9,12 @@ import { setRelayBroadcast } from "../calls/relay-server.js";
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
-import {
-  getPlatformAssistantId,
-  setIngressPublicBaseUrl,
-  validateEnv,
-} from "../config/env.js";
+import { setIngressPublicBaseUrl, validateEnv } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
-import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
-import {
-  getCesClient as getActiveCesClient,
-  setCes,
-  updateCesClient,
-} from "../credential-execution/ces-runtime.js";
-import type { CesClient } from "../credential-execution/client.js";
-import { createCesClient } from "../credential-execution/client.js";
+import { startCes } from "../credential-execution/ces-runtime.js";
 import { refreshManagedConnectionCache } from "../credential-execution/managed-catalog.js";
-import {
-  type CesProcessManager,
-  CesUnavailableError,
-  createCesProcessManager,
-} from "../credential-execution/process-manager.js";
-import {
-  awaitCesClientWithTimeout,
-  DEFAULT_CES_STARTUP_TIMEOUT_MS,
-  injectCesClientWhenReady,
-} from "../credential-execution/startup-timeout.js";
 import { startFilingService } from "../filing/filing-service.js";
 import { startHeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
@@ -69,7 +48,6 @@ import {
 } from "../platform/consent-cache.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
-import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import {
   initAuthSigningKey,
@@ -85,12 +63,6 @@ import {
 } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
-import {
-  getCesClient,
-  onCesClientChanged,
-  setCesClient,
-  setCesReconnect,
-} from "../security/secure-keys.js";
 import { startUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
@@ -189,95 +161,6 @@ export function stopDiskPressureGuardForLifecycle(): void {
     diskPressureStartupSampleTimer = null;
   }
   stopDiskPressureGuard();
-}
-
-export interface CesStartupResult {
-  client: CesClient | undefined;
-  processManager: CesProcessManager | undefined;
-  clientPromise: Promise<CesClient | undefined> | undefined;
-  abortController: AbortController | undefined;
-}
-
-/**
- * Start the CES (Credential Execution Service) process and perform the RPC
- * handshake. Returns a promise that resolves with the CES client and process
- * manager. Callers can fire-and-forget — the daemon does not need to await
- * this for startup to continue.
- *
- * The managed sidecar accepts exactly one bootstrap connection, so this must
- * be called at the process level (not per-conversation).
- */
-async function startCesProcess(
-  config: AssistantConfig,
-): Promise<CesStartupResult> {
-  const pm = createCesProcessManager({ assistantConfig: config });
-  const abortController = new AbortController();
-  let clientRef: CesClient | undefined;
-
-  const clientPromise = (async (): Promise<CesClient | undefined> => {
-    try {
-      const transport = await pm.start();
-      if (abortController.signal.aborted) {
-        throw new Error("CES initialization aborted during shutdown");
-      }
-      const client = createCesClient(transport);
-      clientRef = client;
-      // Resolve the assistant API key so CES can use it for platform
-      // credential materialisation. In managed mode the key is provisioned
-      // after hatch and stored in the credential store — CES can't read
-      // the env var, so we pass it via the handshake.
-      const proxyCtx = await resolveManagedProxyContext();
-      const assistantId = getPlatformAssistantId();
-      const { accepted, reason } = await client.handshake({
-        ...(proxyCtx.assistantApiKey
-          ? { assistantApiKey: proxyCtx.assistantApiKey }
-          : {}),
-        ...(assistantId ? { assistantId } : {}),
-      });
-      if (abortController.signal.aborted) {
-        client.close();
-        throw new Error("CES initialization aborted during shutdown");
-      }
-      if (accepted) {
-        log.info(
-          "CES client initialized and handshake accepted (server-level)",
-        );
-        return client;
-      }
-      log.warn(
-        { reason },
-        "CES handshake rejected — CES tools will be unavailable",
-      );
-      client.close();
-      clientRef = undefined;
-      await pm.stop();
-      return undefined;
-    } catch (err) {
-      if (err instanceof CesUnavailableError) {
-        log.info(
-          { reason: err.message },
-          "CES is not available — CES tools will be unavailable",
-        );
-      } else {
-        log.warn(
-          { error: err instanceof Error ? err.message : String(err) },
-          "Failed to initialize CES client — CES tools will be unavailable",
-        );
-      }
-      await pm.stop().catch(() => {});
-      clientRef = undefined;
-      return undefined;
-    }
-  })();
-
-  return {
-    get client() {
-      return clientRef;
-    },
-    processManager: pm,
-    clientPromise,
-    abortController,
-  };
 }
 
 // Entry point for the daemon process itself
@@ -677,94 +560,12 @@ export async function runDaemon(): Promise<void> {
   startConsentRefresh();
   registerShutdownHook("consent-cache", () => stopConsentRefresh());
 
-  // CES lifecycle — kick off early so CES handshake runs concurrently with
-  // provider/tool initialization. The CES sidecar accepts exactly one
-  // bootstrap connection, so startup must happen at the process level.
-  const cesStartupPromise = startCesProcess(config);
-
-  // CES startup must complete BEFORE provider initialization so credential
-  // reads can go through CES. Block with a 20-second timeout — fall back to
-  // direct credential store on timeout.
-  const cesResult = await cesStartupPromise;
-  // startCesProcess() returns immediately — the actual handshake runs
-  // inside clientPromise. Await it (with a 20s timeout) so the CES client
-  // is available before provider initialization.
-  if (cesResult.clientPromise) {
-    const client = await awaitCesClientWithTimeout(cesResult.clientPromise, {
-      timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
-      onTimeout: () => {
-        log.warn(
-          "CES handshake timed out after 20s — falling back to direct credential store",
-        );
-      },
-    });
-    if (client) {
-      setCesClient(client);
-    } else {
-      // The handshake lost the startup race, so provider init proceeds on
-      // the direct credential store. Still inject the CES client into the
-      // resolver once the handshake completes, so CES tools and the
-      // approval bridge route through CES rather than reporting it
-      // unavailable for the rest of the process.
-      injectCesClientWhenReady(cesResult.clientPromise, {
-        getCesClient,
-        setCesClient,
-      });
-    }
-  }
-
-  // Register CES reconnection callback so the credential layer can
-  // re-establish the connection when the transport dies, instead of
-  // falling back to the encrypted file store.
-  if (cesResult.processManager) {
-    const pm = cesResult.processManager;
-
-    // Snapshot the managed-proxy context and assistant ID at CES startup
-    // so the reconnect closure below never calls back into
-    // `resolveManagedProxyContext()`. That function reads the assistant
-    // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
-    // has resolved the backend to CES RPC — routes the read through CES
-    // itself. During a reconnect the old transport is dead and a new
-    // one is being set up by this very closure, so the nested credential
-    // read recursively awaits its own in-flight reconnection and
-    // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
-    // 45-second stall delays every CES restart and causes dependent
-    // credential reads (e.g. Meet's STT provider resolution) to return
-    // `undefined` during the window. API key rotation uses the
-    // `updateAssistantApiKey` RPC on the live client, not a reconnect,
-    // so caching at startup is safe.
-    const startupProxyCtx = await resolveManagedProxyContext();
-    const startupAssistantId = getPlatformAssistantId();
-
-    setCesReconnect(async () => {
-      try {
-        await pm.stop();
-        const transport = await pm.start();
-        const newClient = createCesClient(transport);
-        const { accepted, reason } = await newClient.handshake({
-          ...(startupProxyCtx.assistantApiKey
-            ? { assistantApiKey: startupProxyCtx.assistantApiKey }
-            : {}),
-          ...(startupAssistantId ? { assistantId: startupAssistantId } : {}),
-        });
-        if (accepted) {
-          log.info("CES reconnection handshake accepted");
-          return newClient;
-        }
-        log.warn({ reason }, "CES reconnection handshake rejected");
-        newClient.close();
-        await pm.stop().catch(() => {});
-        return undefined;
-      } catch (err) {
-        log.warn(
-          { error: err instanceof Error ? err.message : String(err) },
-          "CES reconnection attempt failed",
-        );
-        await pm.stop().catch(() => {});
-        return undefined;
-      }
-    });
-  }
+  // Bring up the daemon's CES connection (process + handshake + reconnect
+  // wiring). Blocks up to a 20s timeout so credential reads route through CES
+  // before provider init; non-fatal — falls back to the direct credential store
+  // on failure. The sidecar accepts exactly one bootstrap connection, so this
+  // happens at the process level.
+  await startCes(config);
 
   // Bring up the plugin layer: install the runtime bridge, register the
   // first-party defaults, load user plugins, and run every plugin's
@@ -777,12 +578,6 @@ export async function runDaemon(): Promise<void> {
   // routes can begin accepting requests while Qdrant initializes.
   log.info("Daemon startup: starting DaemonServer");
   const server = new DaemonServer();
-  setCes(await cesStartupPromise);
-
-  // Keep the CES client ref in sync after reconnection so that secret routes
-  // and new conversations use the fresh client.
-  onCesClientChanged(updateCesClient);
-
   await server.start();
   log.info("Daemon startup: DaemonServer started");
 
@@ -1080,7 +875,6 @@ export async function runDaemon(): Promise<void> {
   // the running routes. They're module-level state, so they're effective
   // even when the HTTP server failed to bind (IPC clients still work).
   registerSecretsDeps({
-    getCesClient: getActiveCesClient,
     onProviderCredentialsChanged: () =>
       server.refreshConversationsForProviderChange(),
   });

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -21,6 +21,7 @@ import {
   getConfig,
   invalidateConfigCache,
 } from "../../config/loader.js";
+import { getCesClient } from "../../credential-execution/ces-runtime.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { maybeReseedCapabilitiesAfterManagedCredential } from "../../daemon/memory-v2-startup.js";
 import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
@@ -303,8 +304,7 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
         void maybeReseedCapabilitiesAfterManagedCredential(getConfig());
         if (service === "vellum" && field === "assistant_api_key") {
           const generation = ++apiKeyGeneration;
-          const deps = getSecretsDeps();
-          const cesClient = deps?.getCesClient?.();
+          const cesClient = getCesClient();
           if (cesClient) {
             if (cesClient.isReady()) {
               try {

--- a/assistant/src/runtime/routes/secrets-deps.ts
+++ b/assistant/src/runtime/routes/secrets-deps.ts
@@ -1,15 +1,12 @@
 /**
  * Module-level singleton for secrets route dependencies.
  *
- * The daemon server registers its CES client accessor and provider-reload
- * callback at startup via {@link registerSecretsDeps}. Route handlers import
- * {@link getSecretsDeps} to access them without DI.
+ * The daemon registers its provider-reload callback at startup via
+ * {@link registerSecretsDeps}. Route handlers import {@link getSecretsDeps} to
+ * access it without DI.
  */
 
-import type { CesClient } from "../../credential-execution/client.js";
-
 export interface SecretsDeps {
-  getCesClient: () => CesClient | undefined;
   onProviderCredentialsChanged: () => void | Promise<void>;
 }
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to #36422 addressing the two review comments left on that PR:

1. The `setCes`/`updateCesClient` setters on `lifecycle.ts` were redundant — the logic should live in the singleton file and the setters removed outright.
2. `registerSecretsDeps` should not need a `getCesClient` param — routes can import the singleton directly.

This completes the CES singleton consolidation so `lifecycle.ts` no longer touches `secure-keys` or any CES internals.

## What changed

- **`credential-execution/ces-runtime.ts`** now owns the full CES startup orchestration via `startCes(config)`: process start, RPC handshake, the 20s startup-timeout fallback, reconnect-callback wiring (with the snapshot-at-startup deadlock guard preserved), and live client-ref tracking with the generation-guard against stale updates. `getCesClient()`/`stopCes()` remain the singleton's read/teardown surface. The old `setCes`/`updateCesClient` setters are gone — their bodies are now internal `applyCesResult`/`updateClientRef` helpers.
- **`daemon/lifecycle.ts`** drops the inline `startCesProcess`, the `CesStartupResult` interface, the post-construction `setCes(...)`/`onCesClientChanged(...)` calls, and all CES + `secure-keys` imports. CES startup is now a single `await startCes(config)`.
- **`runtime/routes/secrets-deps.ts`** drops the `getCesClient` field from `SecretsDeps` (now just `onProviderCredentialsChanged`).
- **`runtime/routes/secret-routes.ts`** imports `getCesClient` directly from `ces-runtime` instead of pulling it through the secrets-deps DI shim.
- **Tests**: added `credential-execution/ces-runtime.ts` to the `secure-keys` importer allowlist (and removed the now-stale `daemon/lifecycle.ts` entry) in `credential-security-invariants.test.ts`; removed the obsolete `getCesClient: () => undefined` from `registerSecretsDeps` in `secret-routes-platform-proxy.test.ts`.

## Test plan

- `bun test src/__tests__/credential-security-invariants.test.ts` → 29 pass
- `bun test src/__tests__/ces-startup-timeout.test.ts` → 7 pass
- `bun test src/__tests__/credential-execution-tools.test.ts` → 16 pass
- Pre-commit + pre-push hooks: prettier, eslint (incl. import-sort), full typecheck all green
- Note: 3 tests in `secret-routes-platform-proxy.test.ts` fail in this sandbox due to pre-existing provider-registry state pollution — they fail identically on `origin/main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_