### PR TITLE
test(assistant): fix flaky attachment-upload-trusted-source hook timeout

### DIFF
--- a/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
+++ b/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
@@ -55,9 +55,11 @@ function makeUploadArgs(
 }
 
 describe("attachment upload — trustedSource flag", () => {
+  // initializeDb runs the full migration chain (hundreds of steps); under
+  // parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(() => {
     // Each test uploads a fresh attachment with unique filename; no per-test


### PR DESCRIPTION
## Summary
- `attachment-upload-trusted-source.test.ts`'s `beforeAll` runs `initializeDb()` — the full 248-step migration chain. Under parallel CI load this can exceed bun's **default 5s hook timeout**; the Test job in run 28348751719 failed at 5148.99ms with `a beforeEach/afterEach hook timed out for this test`.
- Pass an explicit `30_000`ms timeout to the hook, matching the repo convention for migration-heavy hooks (e.g. `migration-import-from-gcs.test.ts`) and staying well under the 120s per-process cap in `scripts/test.sh`.

## Original prompt
Fix the specific CI failure in the "Test" job of run 28348751719 (CI Main Assistant Checks, on main): `attachment-upload-trusted-source.test.ts` failed because its `initializeDb()` `beforeAll` hook timed out under CI load. The ask was to scope the fix to that one failing job only.