### PR TITLE
feat(plugins): host-computed needsFirmerSteering signal on PostToolUseContext

### DIFF
--- a/assistant/src/__tests__/exploration-drift-hook.test.ts
+++ b/assistant/src/__tests__/exploration-drift-hook.test.ts
@@ -122,6 +122,7 @@ function makeCtx(
     messages,
     additionalContext: null,
     model,
+    needsFirmerSteering: false,
     maxInputTokens: 10_000,
     logger: noopLogger,
   };

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -151,7 +151,6 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "task-progress-nudge": [
     "../../../../daemon/conversation-registry.js",
-    "../../../../providers/weak-open-model.js",
     "../../../../subagent/index.js",
   ],
   "title-generate": [
@@ -346,7 +345,7 @@ describe("plugin import boundary", () => {
 
     const exampleFile = new Map<string, string>();
     for (const e of escapes) {
-      exampleFile.set(`${e.plugin} ${e.specifier}`, e.relPath);
+      exampleFile.set(`${e.plugin} ${e.specifier}`, e.relPath);
     }
 
     const plugins = new Set([...byPlugin.keys(), ...Object.keys(BASELINE)]);
@@ -357,7 +356,7 @@ describe("plugin import boundary", () => {
       const allowed = new Set(BASELINE[plugin] ?? []);
       for (const spec of [...found].sort()) {
         if (!allowed.has(spec)) {
-          const where = exampleFile.get(`${plugin} ${spec}`);
+          const where = exampleFile.get(`${plugin} ${spec}`);
           added.push(`  - ${plugin}: "${spec}"  (e.g. ${where})`);
         }
       }

--- a/assistant/src/__tests__/task-progress-nudge-hook.test.ts
+++ b/assistant/src/__tests__/task-progress-nudge-hook.test.ts
@@ -7,9 +7,9 @@
  * - Never nudges when a task_progress card was already shown this turn.
  * - Fires at most once per turn (dedupes parallel results / further rounds).
  * - Resets across turns so a later multi-step turn can nudge again.
- * - Gating: fires only for weak models (Kimi/DeepSeek/MiniMax) and skips
- *   capable models, non-mainAgent call sites, surface-incapable clients, and
- *   subagent conversations.
+ * - Gating: fires only when the host flags needsFirmerSteering, and skips
+ *   non-mainAgent call sites, surface-incapable clients, and subagent
+ *   conversations.
  * - Appends to (not overwrites) `additionalContext` set by an earlier hook.
  * - The nudge leaves the tool result's `content` untouched.
  */
@@ -104,21 +104,22 @@ function currentResponse(toolUseId: string): ToolResultContent {
   };
 }
 
-/** A weak-model id that matches WEAK_OPEN_MODEL_PATTERN (the gated population). */
+/** Realistic weak-model id for the ctx's `model` field (gating is via needsFirmerSteering). */
 const WEAK_MODEL = "minimax/minimax-m3";
 
 function makeCtx(
   conversationId: string,
   toolResponse: ToolResultContent,
   messages: Message[],
-  model: string = WEAK_MODEL,
+  needsFirmerSteering: boolean = true,
 ): PostToolUseContext {
   return {
     conversationId,
     toolResponse,
     messages,
     additionalContext: null,
-    model,
+    model: WEAK_MODEL,
+    needsFirmerSteering,
     maxInputTokens: 10_000,
     logger: noopLogger,
   };
@@ -264,40 +265,18 @@ describe("task-progress-nudge post-tool-use hook", () => {
     expect(ctx3.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
   });
 
-  test("fires for weak models (Kimi, DeepSeek, MiniMax)", async () => {
-    for (const model of [
-      "moonshotai/kimi-k2.6",
-      "deepseek/deepseek-chat",
-      "accounts/fireworks/models/minimax-m3",
-    ]) {
-      const { messages, currentToolUseId } = turnWithRounds(
-        TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
-      );
-      const ctx = makeCtx(
-        freshConversationId(),
-        currentResponse(currentToolUseId),
-        messages,
-        model,
-      );
-      await postToolUse(ctx);
-      expect(ctx.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
-    }
-  });
-
-  test("skips capable models (not in the weak-model set)", async () => {
-    for (const model of ["claude-opus-4-8", "gpt-5.5"]) {
-      const { messages, currentToolUseId } = turnWithRounds(
-        TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 2,
-      );
-      const ctx = makeCtx(
-        freshConversationId(),
-        currentResponse(currentToolUseId),
-        messages,
-        model,
-      );
-      await postToolUse(ctx);
-      expect(ctx.additionalContext).toBeNull();
-    }
+  test("stays silent when the host has not flagged firmer steering", async () => {
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 2,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+      false, // needsFirmerSteering — host judged the model follows the prompt
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
   });
 
   test("skips non-mainAgent call sites", async () => {

--- a/assistant/src/__tests__/tool-error-hook.test.ts
+++ b/assistant/src/__tests__/tool-error-hook.test.ts
@@ -80,6 +80,7 @@ function makeCtx(
     messages,
     additionalContext: null,
     model: "claude-test-model",
+    needsFirmerSteering: false,
     maxInputTokens: 10_000,
     logger: noopLogger,
   };

--- a/assistant/src/__tests__/tool-result-truncate-hook.test.ts
+++ b/assistant/src/__tests__/tool-result-truncate-hook.test.ts
@@ -49,6 +49,7 @@ function makeCtx(content: string): PostToolUseContext {
     messages: [],
     additionalContext: null,
     model: "claude-test-model",
+    needsFirmerSteering: false,
     maxInputTokens: MAX_INPUT_TOKENS,
     logger: noopLogger,
   };

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -41,6 +41,7 @@ import type {
   ToolResultContent,
 } from "../providers/types.js";
 import { isContextOverflowError } from "../providers/types.js";
+import { isWeakOpenModel } from "../providers/weak-open-model.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
   applyStreamingSubstitution,
@@ -2161,6 +2162,7 @@ export class AgentLoop {
             messages: history,
             additionalContext: null,
             model: response.model,
+            needsFirmerSteering: isWeakOpenModel(response.model),
             maxInputTokens: contextWindowTokens,
             logger: rlog,
           };

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -354,10 +354,19 @@ export interface PostToolUseContext {
   /**
    * Model id reported by the provider for the assistant turn that issued
    * this tool call (e.g. `claude-opus-4-8`,
-   * `accounts/fireworks/models/kimi-k2p6`). Hooks use it to vary coaching by
-   * model family — some models need earlier or firmer steering than others.
+   * `accounts/fireworks/models/kimi-k2p6`). A hook needing a finer-grained
+   * model-family signal than {@link needsFirmerSteering} — e.g. matching a
+   * specific loop-prone family — reads it directly.
    */
   readonly model: string;
+  /**
+   * Host's assessment that this turn's model needs firmer mid-turn steering
+   * than the static prompt provides — `true` for weaker open-weight families
+   * that disregard prompt-level coaching, `false` for models that follow it.
+   * Hooks gate aggressive nudges on this boolean instead of re-deriving the
+   * model taxonomy themselves.
+   */
+  readonly needsFirmerSteering: boolean;
   /**
    * The model's context-window size in tokens. Plugins derive their own
    * character budget from this (e.g. a share of the window) rather than

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -15,10 +15,10 @@
  *   a card unnecessary.
  * - A failed or ignored card never blocks the turn.
  *
- * It is scoped to weaker open models (Kimi, DeepSeek, MiniMax) that disregard
- * the static progress-card instruction; capable models follow the prompt and
- * never need the reminder. It also self-targets: a model that already showed a
- * card this turn is never nudged.
+ * It is scoped to turns the host flags as needing firmer steering (weaker
+ * open-weight families that disregard the static progress-card instruction);
+ * models that follow the prompt are never reminded. It also self-targets: a
+ * model that already showed a card this turn is never nudged.
  *
  * The turn state is derived from conversation history on every call (mirroring
  * the tool-error and exploration-drift plugins) so the signal survives
@@ -28,15 +28,15 @@
  * `ui_show` task_progress card was issued.
  *
  * Gating:
- * - weaker open models only (Kimi, DeepSeek, MiniMax) — checked first on the
- *   hot path so capable-model turns short-circuit immediately.
+ * - host-flagged {@link PostToolUseContext.needsFirmerSteering} only — checked
+ *   first on the hot path so capable-model turns short-circuit immediately.
  * - mainAgent call site only — background turns (wake, title-gen, memory) and
  *   subagents have no live user watching, so a progress card is pointless.
  * - the client must support dynamic UI — otherwise `ui_show` is blocked
  *   client-side and the nudge would only provoke a wasted, erroring call.
  *
  * The call-site, capability, and subagent gates are resolved lazily on the
- * would-nudge path; the model gate is a cheap regex test run up front.
+ * would-nudge path; the firmer-steering gate is a cheap boolean read up front.
  *
  * Dedup uses a per-conversation high-water mark of the round count at the last
  * nudge: a non-zero mark means "already nudged this turn", which also dedupes
@@ -51,8 +51,6 @@ import type {
   Message,
   PostToolUseContext,
 } from "@vellumai/plugin-api";
-
-import { isWeakOpenModel } from "../../../../providers/weak-open-model.js";
 
 /**
  * Canonical nudge notice. Module-level constant so tests and wrapping plugins
@@ -139,7 +137,7 @@ function scanTurn(messages: ReadonlyArray<Message>): {
 }
 
 const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
-  if (!isWeakOpenModel(ctx.model)) return;
+  if (!ctx.needsFirmerSteering) return;
 
   const { rounds, taskProgressShown } = scanTurn(ctx.messages);
 


### PR DESCRIPTION
## Summary
- Adds a host-computed `readonly needsFirmerSteering: boolean` to `PostToolUseContext`. The agent loop sets it to `isWeakOpenModel(model)`; `task-progress-nudge` now gates its nudge on `ctx.needsFirmerSteering` instead of calling `isWeakOpenModel(ctx.model)` itself. **Behavior-preserving** — `needsFirmerSteering === isWeakOpenModel(model)`.
- Moves the model-family taxonomy out of the plugin (and off the public predicate surface). A plain boolean fact about the turn is a cleaner contract than a re-exported `isWeakOpenModel` predicate, and it removes `task-progress-nudge`'s deep import of the host provider module (one fewer guard-baseline escape).
- De-NULs the import-boundary guard test: its Map-key delimiter was a literal NUL byte that made the file register as binary to git/grep (which would have hidden the baseline change behind "Binary files differ"). Replaced with a space; the file diffs as text now.

## Relationship to #36432
#36432 (PostToolUseContext enrichment, in review) switches `task-progress-nudge` to import `isWeakOpenModel` from `@vellumai/plugin-api`, which required re-exporting the predicate. With this change the plugin reads `ctx.needsFirmerSteering` instead, so **once this lands and #36432 rebases, #36432 no longer needs the `isWeakOpenModel` re-export** — shrinking its public-surface delta. `task-progress-nudge` is touched by both PRs; I'll own the rebase.

## Original prompt
#36432 is blocked on external review. Rather than stall the related improvement, split the host-computed steering signal into its own focused, behavior-preserving PR that can be reviewed and merged independently, then rebase #36432 onto it to drop the `isWeakOpenModel` re-export. Scope confirmed task-progress-only — exploration-drift keeps its narrow inline loop-prone regex (no behavior change there).