### PR TITLE
test(assistant): raise initializeDb hook timeouts in migration-heavy memory tests

### DIFF
--- a/assistant/src/__tests__/audit-log-rotation.test.ts
+++ b/assistant/src/__tests__/audit-log-rotation.test.ts
@@ -56,6 +56,8 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 // ---------------------------------------------------------------------------
 
 describe("audit log rotation", () => {
+  // initializeDb runs the full migration chain (hundreds of steps); under
+  // parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
   beforeAll(async () => {
     resetDbForTesting();
     await initializeDb();
@@ -63,7 +65,7 @@ describe("audit log rotation", () => {
     getSqlite().run(
       `INSERT INTO conversations (id, title, created_at, updated_at) VALUES ('conv-1', 'test', ${Date.now()}, ${Date.now()})`,
     );
-  });
+  }, 30_000);
 
   beforeEach(() => {
     clearTable();

--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -66,9 +66,11 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
   const convId = "conv-task-cleanup";
   const otherConvId = "conv-other";
 
+  // initializeDb runs the full migration chain (hundreds of steps); under
+  // parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(() => {
     const db = getDb();

--- a/assistant/src/memory/graph/bootstrap.test.ts
+++ b/assistant/src/memory/graph/bootstrap.test.ts
@@ -16,9 +16,11 @@ const MIGRATE_ITEMS_CHECKPOINT = "graph_bootstrap:migrated_tool_items";
 // Setup
 // ---------------------------------------------------------------------------
 
+// initializeDb runs the full migration chain (hundreds of steps); under
+// parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
 beforeAll(async () => {
   await initializeDb();
-});
+}, 30_000);
 
 beforeEach(() => {
   // Clear graph nodes and checkpoints between tests so each test starts clean.

--- a/assistant/src/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/memory/job-handlers/embedding.test.ts
@@ -61,15 +61,17 @@ const TEST_CONFIG: AssistantConfig = {
 };
 
 describe("embedMediaJob", () => {
+  // initializeDb runs the full migration chain (hundreds of steps); under
+  // parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(async () => {
     embedAndUpsertCalls.length = 0;
     resetDbForTesting();
     await initializeDb();
-  });
+  }, 30_000);
 
   function makeJob(payload: Record<string, unknown>): MemoryJob {
     return {

--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -225,7 +225,9 @@ beforeEach(async () => {
   providerCalls.length = 0;
   providerStub = null;
   emitCalls.length = 0;
-});
+  // initializeDb runs the full migration chain (hundreds of steps); under
+  // parallel CI load it can exceed bun's default 5s hook timeout, so allow more.
+}, 30_000);
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Five memory/db test files run the full 248-step `initializeDb()` migration chain in a `beforeAll`/`beforeEach` hook with no explicit timeout, so under parallel CI load they exceed bun's default 5s hook timeout and fail with "a beforeEach/afterEach hook timed out" — the cause of the red Test job on main (run 28354995153).
- Give each affected hook an explicit `30_000`ms timeout, matching the convention established in #36434 (well under the 120s per-process cap). Test-only change; no production code touched.
- Files: `sweep-job.test.ts` (beforeEach), `audit-log-rotation.test.ts` (beforeAll), `task-memory-cleanup.test.ts` (beforeAll), `bootstrap.test.ts` (beforeAll), `embedding.test.ts` (beforeAll + beforeEach).

## Original prompt
Fix the specific CI failure in the Main Assistant Checks "Test" job (run 28354995153), which went red on main when five memory/db test files timed out in their `initializeDb()` setup hooks under parallel load. Scope limited to that one job; apply the same per-hook timeout fix used in #36434.