### PR TITLE
refactor(assistant): move scoped-approval-grants out of memory/ into approvals/

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -210,7 +210,7 @@ mock.module("../calls/call-speech-output.js", () => ({
 }));
 
 // Mock scoped approval grants (used in handleTransportClosed and early teardown)
-mock.module("../memory/scoped-approval-grants.js", () => ({
+mock.module("../approvals/scoped-approval-grants.js", () => ({
   revokeScopedApprovalGrantsForContext: jest.fn(),
 }));
 

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -13,7 +13,7 @@ import {
   type CreateScopedApprovalGrantParams,
   expireScopedApprovalGrants,
   revokeScopedApprovalGrantsForContext,
-} from "../memory/scoped-approval-grants.js";
+} from "../approvals/scoped-approval-grants.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";

--- a/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
+++ b/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
@@ -36,7 +36,7 @@ mock.module("../util/logger.js", () => ({
 import {
   _internal,
   type CreateScopedApprovalGrantParams,
-} from "../memory/scoped-approval-grants.js";
+} from "../approvals/scoped-approval-grants.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -78,15 +78,15 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
 import { and, eq } from "drizzle-orm";
 
 import {
+  _internal,
+  type CreateScopedApprovalGrantParams,
+  revokeScopedApprovalGrantsForContext,
+} from "../approvals/scoped-approval-grants.js";
+import {
   setVoiceBridgeDeps,
   startVoiceTurn,
 } from "../calls/voice-session-bridge.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import {
-  _internal,
-  type CreateScopedApprovalGrantParams,
-  revokeScopedApprovalGrantsForContext,
-} from "../memory/scoped-approval-grants.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -16,7 +16,7 @@ import {
   type ConsumeByRequestIdResult,
   type ConsumeByToolSignatureResult,
   type ScopedApprovalGrant,
-} from "../memory/scoped-approval-grants.js";
+} from "./scoped-approval-grants.js";
 
 const {
   createScopedApprovalGrant,

--- a/assistant/src/approvals/scoped-approval-grants.ts
+++ b/assistant/src/approvals/scoped-approval-grants.ts
@@ -14,10 +14,10 @@
 import { and, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { rawChanges } from "../memory/raw-query.js";
 import { getDb } from "../persistence/db-connection.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";
 import { getLogger } from "../util/logger.js";
-import { rawChanges } from "./raw-query.js";
 
 const log = getLogger("scoped-approval-grants");
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -8,6 +8,7 @@
  * barge-in, state machine, guardian verification).
  */
 
+import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { loadConfig } from "../config/loader.js";
 import {
   expireCanonicalGuardianRequest,
@@ -18,7 +19,6 @@ import {
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
-import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -5,6 +5,7 @@
  * to these functions so business logic lives in one place.
  */
 
+import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { loadConfig } from "../config/loader.js";
 import { VALID_CALLER_IDENTITY_MODES } from "../config/schema.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -15,7 +16,6 @@ import {
 } from "../inbound/public-ingress-urls.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { queueGenerateConversationTitle } from "../memory/conversation-title-service.js";
-import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { upsertBinding } from "../persistence/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -33,7 +33,7 @@
 
 import type { ServerWebSocket } from "bun";
 
-import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
+import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { toTrustContext } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -11,6 +11,7 @@ import { randomInt } from "node:crypto";
 import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
+import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { getCanonicalGuardianRequest } from "../contacts/canonical-guardian-store.js";
 import {
   getGuardianDelivery,
@@ -20,7 +21,6 @@ import {
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
-import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";


### PR DESCRIPTION
## Summary
- Move scoped-approval-grants from memory/ to approvals/. Pure dirname-swap; behavior byte-identical.

Part of plan: memory-tenant-extraction.md (PR 5 of 19)