### PR TITLE
refactor(persistence): move conversation migration guards into persistence/

### DIFF
--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -11,8 +11,8 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-import { _resetDisplayOrderMigrationForTests } from "../memory/conversation-display-order-migration.js";
-import { _resetGroupMigrationForTests } from "../memory/conversation-group-migration.js";
+import { _resetDisplayOrderMigrationForTests } from "../persistence/conversation-display-order-migration.js";
+import { _resetGroupMigrationForTests } from "../persistence/conversation-group-migration.js";
 import { getSqliteFrom } from "../persistence/db-connection.js";
 import { migrateAddConversationInferenceProfile } from "../persistence/migrations/227-add-conversation-inference-profile.js";
 import { migrateRenameInferenceProfileSnakeCase } from "../persistence/migrations/228-rename-inference-profile-snake-case.js";

--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -53,8 +53,6 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "memory");
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
     "auto-analysis-constants",
-    "conversation-display-order-migration",
-    "conversation-group-migration",
     "graph/graph-memory-state-store",
     "indexer",
     "memory-retrospective-constants",
@@ -63,15 +61,8 @@ const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
     "v2/activation-store",
     "v2/injected-block-slugs",
   ]),
-  "assistant/src/persistence/conversation-queries.ts": new Set([
-    "conversation-display-order-migration",
-    "conversation-group-migration",
-  ]),
   "assistant/src/persistence/embeddings/embedding-backend.ts": new Set([
     "sparse-tokenize",
-  ]),
-  "assistant/src/persistence/group-crud.ts": new Set([
-    "conversation-group-migration",
   ]),
   "assistant/src/persistence/jobs-worker.ts": new Set([
     "cleanup-schedule-state",

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -30,8 +30,6 @@ import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import { AUTO_ANALYSIS_SOURCE } from "../memory/auto-analysis-constants.js";
-import { ensureDisplayOrderMigration } from "../memory/conversation-display-order-migration.js";
-import { ensureGroupMigration } from "../memory/conversation-group-migration.js";
 import { forkGraphMemoryState } from "../memory/graph/graph-memory-state-store.js";
 import { indexMessageNow } from "../memory/indexer.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "../memory/memory-retrospective-constants.js";
@@ -80,6 +78,8 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "./conversation-disk-view.js";
+import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import {
   type DrizzleDb,

--- a/assistant/src/persistence/conversation-display-order-migration.ts
+++ b/assistant/src/persistence/conversation-display-order-migration.ts
@@ -5,8 +5,8 @@
  * (which needs the migration to run before ORDER BY display_order).
  */
 
-import { rawRun } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
+import { rawRun } from "./raw-query.js";
 const log = getLogger("conversation-store");
 
 function isDuplicateColumnError(err: unknown): boolean {

--- a/assistant/src/persistence/conversation-group-migration.test.ts
+++ b/assistant/src/persistence/conversation-group-migration.test.ts
@@ -1,20 +1,15 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 
-mock.module("../../util/logger.js", () => ({
+mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
 }));
 
-import { initializeDb } from "../../persistence/db-init.js";
-import {
-  rawAll,
-  rawExec,
-  rawGet,
-  rawRun,
-} from "../../persistence/raw-query.js";
-import { ensureGroupMigration } from "../conversation-group-migration.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
+import { initializeDb } from "./db-init.js";
+import { rawAll, rawExec, rawGet, rawRun } from "./raw-query.js";
 await initializeDb();
 
 // Simulate a legacy install that has the `system:reflections` system group

--- a/assistant/src/persistence/conversation-group-migration.ts
+++ b/assistant/src/persistence/conversation-group-migration.ts
@@ -8,9 +8,9 @@
  * than the formal migrations/ pipeline.
  */
 
-import { rawExec, rawGet, rawRun } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { rawExec, rawGet, rawRun } from "./raw-query.js";
 const log = getLogger("conversation-store");
 
 function isDuplicateColumnError(err: unknown): boolean {

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -1,7 +1,5 @@
 import { and, count, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 
-import { ensureDisplayOrderMigration } from "../memory/conversation-display-order-migration.js";
-import { ensureGroupMigration } from "../memory/conversation-group-migration.js";
 import { rawAll } from "../persistence/raw-query.js";
 import {
   parseExternalContentEnvelope,
@@ -12,6 +10,8 @@ import {
 import { getLogger } from "../util/logger.js";
 import type { ConversationRow } from "./conversation-crud.js";
 import { parseConversation } from "./conversation-crud.js";
+import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
 import type { ConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { conversations, messages } from "./schema/index.js";

--- a/assistant/src/persistence/group-crud.ts
+++ b/assistant/src/persistence/group-crud.ts
@@ -7,8 +7,8 @@
 
 import { v4 as uuid } from "uuid";
 
-import { ensureGroupMigration } from "../memory/conversation-group-migration.js";
 import { rawAll, rawExec, rawGet, rawRun } from "../persistence/raw-query.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
 export interface ConversationGroupRow {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Move conversation-group-migration + conversation-display-order-migration (idempotent ensure-guards) from memory/ to persistence/, preserving function names.
- Remove the now-empty conversation-queries + group-crud allowlist entries and the migration specifiers from conversation-crud.
- Behavior byte-identical.

Part of plan: memory-tenant-extraction.md (PR 14 of 19)