### PR TITLE
fix(memory-tenant-extraction): self-review remediations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,8 +79,8 @@ assistant/src/tools/tool-approval-handler.ts @noanflaherty
 assistant/src/security/tool-approval-digest.ts @noanflaherty
 assistant/src/permissions/ @noanflaherty
 assistant/src/memory/guardian-* @noanflaherty
-assistant/src/memory/scoped-approval-grants.ts @noanflaherty
-assistant/src/memory/canonical-guardian-store.ts @noanflaherty
+assistant/src/approvals/scoped-approval-grants.ts @noanflaherty
+assistant/src/contacts/canonical-guardian-store.ts @noanflaherty
 assistant/src/calls/guardian-*.ts @noanflaherty
 assistant/src/config/bundled-skills/guardian-verify-setup/ @noanflaherty
 assistant/src/config/bundled-skills/contacts/ @noanflaherty

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -99,7 +99,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/guardian/init` (initial JWT issuance)                                               |
 | `src/runtime/routes/guardian-refresh-routes.ts`   | `POST /v1/guardian/refresh` (token rotation)                                                  |
 | `src/runtime/local-actor-identity.ts`             | `resolveLocalGuardianContext` — deterministic local identity                                  |
-| `src/memory/channel-verification-sessions.ts`     | Guardian binding types, verification session management                                       |
+| `src/channels/channel-verification-sessions.ts`   | Guardian binding types, verification session management                                       |
 
 ### Channel-Agnostic Scoped Approval Grants
 
@@ -178,7 +178,7 @@ The canonical guardian request system provides a channel-agnostic, unified domai
 
 **Architecture layers:**
 
-1. **Canonical domain (single source of truth):** All guardian requests — tool approvals, pending questions, access requests — are persisted in the `canonical_guardian_requests` table (`src/memory/canonical-guardian-store.js`). Each request has a unique ID, a short human-readable request code, and a status that follows a CAS (compare-and-swap) lifecycle: `pending` -> `approved` | `denied` | `expired` | `cancelled`. Deliveries (notifications sent to guardians) are tracked in `canonical_guardian_deliveries`.
+1. **Canonical domain (single source of truth):** All guardian requests — tool approvals, pending questions, access requests — are persisted in the `canonical_guardian_requests` table (`src/contacts/canonical-guardian-store.js`). Each request has a unique ID, a short human-readable request code, and a status that follows a CAS (compare-and-swap) lifecycle: `pending` -> `approved` | `denied` | `expired` | `cancelled`. Deliveries (notifications sent to guardians) are tracked in `canonical_guardian_deliveries`.
 
 2. **Unified apply primitive (single write path):** `applyCanonicalGuardianDecision()` in `src/approvals/guardian-decision-primitive.ts` is the single write path for all guardian decisions. It enforces identity validation, expiry checks, CAS resolution, `approve_always` downgrade (guardian-on-behalf invariant), kind-specific resolver dispatch via the resolver registry, and scoped grant minting. All callers — HTTP API, inbound channel router, desktop session — route decisions through this function.
 
@@ -200,7 +200,7 @@ The canonical guardian request system provides a channel-agnostic, unified domai
 
 | File                                                    | Purpose                                                                               |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `src/memory/canonical-guardian-store.ts`                | Canonical request and delivery persistence (CRUD, CAS resolve, list with filters)     |
+| `src/contacts/canonical-guardian-store.ts`              | Canonical request and delivery persistence (CRUD, CAS resolve, list with filters)     |
 | `src/approvals/guardian-decision-primitive.ts`          | Canonical decision primitive: `applyCanonicalGuardianDecision` + scoped grant minting |
 | `src/approvals/guardian-request-resolvers.ts`           | Resolver registry: kind-specific side-effect dispatch after CAS resolution            |
 | `src/runtime/guardian-reply-router.ts`                  | Shared inbound router: callback -> code -> NL classification pipeline                 |
@@ -434,7 +434,7 @@ External users who are not the guardian can gain access to the assistant through
 | `src/runtime/invite-service.ts`                        | Business logic for invite operations                                          |
 | `src/contacts/contact-store.ts`                        | Contact read queries — lookup, search, list, and channel operations           |
 | `src/memory/guardian-approvals.ts`                     | Approval request persistence                                                  |
-| `src/memory/channel-verification-sessions.ts`          | Verification challenge persistence                                            |
+| `src/channels/channel-verification-sessions.ts`        | Verification challenge persistence                                            |
 | `src/config/bundled-skills/contacts/SKILL.md`          | Unified skill for contact management, access control, and invite links        |
 
 ### Guardian-Initiated Invite Links
@@ -594,7 +594,7 @@ All guardian decisions for voice access requests flow through:
 | `src/approvals/guardian-decision-primitive.ts` | `applyCanonicalGuardianDecision` — unified decision primitive                          |
 | `src/approvals/guardian-request-resolvers.ts`  | `access_request` resolver — voice direct activation, text-channel verification session |
 | `src/runtime/actor-trust-resolver.ts`          | `resolveActorTrust` — caller trust classification                                      |
-| `src/memory/canonical-guardian-store.ts`       | Canonical request persistence and CAS resolution                                       |
+| `src/contacts/canonical-guardian-store.ts`     | Canonical request persistence and CAS resolution                                       |
 
 ### Speech-to-Text (STT) Boundaries
 
@@ -2152,7 +2152,7 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 
 **Explicit trust gates:** `trustClass` is a **required** field in `ToolContext` (in `src/tools/types.ts`). Every tool execution must carry a trust classification — the field is not optional. This ensures trust-gated tool policies (guardian control-plane restrictions, host-tool blocking for untrusted actors) cannot be bypassed by omitting the classification.
 
-**Guardian bindings** (in `src/memory/channel-verification-sessions.ts`) always carry `guardianPrincipalId: string` as a required, non-null field. A binding without a principal ID is invalid and cannot be created.
+**Guardian bindings** (in `src/channels/channel-verification-sessions.ts`) always carry `guardianPrincipalId: string` as a required, non-null field. A binding without a principal ID is invalid and cannot be created.
 
 **Strict retry sweep parsing:** The channel retry sweep (`src/runtime/channel-retry-sweep.ts`) uses `parseTrustRuntimeContext()` which validates `trustClass` against the canonical three-value set. There is no fallback to a legacy `actorRole` field — stored payloads that lack a valid `trustClass` are rejected deterministically to prevent silent privilege escalation. When `trustCtx` is entirely absent from a stored payload (pre-guardian events), the sweep synthesizes an explicit `trustClass: 'unknown'` context so that replay never proceeds without a trust classification.
 
@@ -2160,13 +2160,13 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 
 **Key files:**
 
-| File                                          | Purpose                                               |
-| --------------------------------------------- | ----------------------------------------------------- |
-| `src/daemon/conversation-runtime-assembly.ts` | `TrustContext` type definition                        |
-| `src/tools/types.ts`                          | `ToolContext.trustClass` (required trust gate)        |
-| `src/runtime/channel-retry-sweep.ts`          | Strict `trustClass` parser for retry sweep            |
-| `src/memory/channel-verification-sessions.ts` | `GuardianBinding` with required `guardianPrincipalId` |
-| `src/__tests__/trust-context-guards.test.ts`  | Guard tests enforcing trust-context type invariants   |
+| File                                            | Purpose                                               |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `src/daemon/conversation-runtime-assembly.ts`   | `TrustContext` type definition                        |
+| `src/tools/types.ts`                            | `ToolContext.trustClass` (required trust gate)        |
+| `src/runtime/channel-retry-sweep.ts`            | Strict `trustClass` parser for retry sweep            |
+| `src/channels/channel-verification-sessions.ts` | `GuardianBinding` with required `guardianPrincipalId` |
+| `src/__tests__/trust-context-guards.test.ts`    | Guard tests enforcing trust-context type invariants   |
 
 ### TTS Provider Abstraction (`services.tts`)
 

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -1,10 +1,10 @@
 import { readSlackMetadata } from "../../../messaging/providers/slack/message-metadata.js";
+import { AUTO_ANALYSIS_SOURCE } from "../../../persistence/auto-analysis-constants.js";
 import {
   buildFtsMatchQuery,
   buildRecallEvidenceExcerpt,
 } from "../../../persistence/conversation-queries.js";
 import { rawAll } from "../../../persistence/raw-query.js";
-import { AUTO_ANALYSIS_SOURCE } from "../../../runtime/services/auto-analysis-guard.js";
 import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,

--- a/assistant/src/runtime/services/__tests__/auto-analysis-guard.test.ts
+++ b/assistant/src/runtime/services/__tests__/auto-analysis-guard.test.ts
@@ -7,14 +7,14 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
-import { createConversation } from "../../../persistence/conversation-crud.js";
-import { getDb } from "../../../persistence/db-connection.js";
-import { initializeDb } from "../../../persistence/db-init.js";
 import {
   AUTO_ANALYSIS_GROUP_ID,
   AUTO_ANALYSIS_SOURCE,
-  isAutoAnalysisConversation,
-} from "../auto-analysis-guard.js";
+} from "../../../persistence/auto-analysis-constants.js";
+import { createConversation } from "../../../persistence/conversation-crud.js";
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { isAutoAnalysisConversation } from "../auto-analysis-guard.js";
 await initializeDb();
 
 function resetTables(): void {

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -23,6 +23,10 @@
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { isMemoryRetrospectiveSource } from "../../memory/memory-retrospective-constants.js";
 import {
+  AUTO_ANALYSIS_GROUP_ID,
+  AUTO_ANALYSIS_SOURCE,
+} from "../../persistence/auto-analysis-constants.js";
+import {
   addMessage,
   createConversation,
   findAnalysisConversationFor,
@@ -33,10 +37,6 @@ import {
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
-import {
-  AUTO_ANALYSIS_GROUP_ID,
-  AUTO_ANALYSIS_SOURCE,
-} from "./auto-analysis-guard.js";
 import {
   buildAutoAnalysisPrompt,
   neutralizeTranscriptSentinel,

--- a/assistant/src/runtime/services/auto-analysis-guard.ts
+++ b/assistant/src/runtime/services/auto-analysis-guard.ts
@@ -1,9 +1,5 @@
 import { AUTO_ANALYSIS_SOURCE } from "../../persistence/auto-analysis-constants.js";
 import { getConversationSource } from "../../persistence/conversation-crud.js";
-export {
-  AUTO_ANALYSIS_GROUP_ID,
-  AUTO_ANALYSIS_SOURCE,
-} from "../../persistence/auto-analysis-constants.js";
 
 /**
  * Returns true if the conversation's `source` column is `"auto-analysis"`,


### PR DESCRIPTION
## Summary
Addresses the 3 self-review findings on the feature branch:
- **CODEOWNERS**: repoint scoped-approval-grants → approvals/ and canonical-guardian-store → contacts/ (the moves silently dropped a code owner).
- **ARCHITECTURE.md**: update stale src/memory/ paths for canonical-guardian-store (→contacts/) and channel-verification-sessions (→channels/).
- **auto-analysis-guard.ts**: delete the now-unnecessary re-export of the AUTO_ANALYSIS_* constants and repoint its 3 remaining consumers at persistence/auto-analysis-constants — completing the de-shim the constants move started.

Part of plan: memory-tenant-extraction.md (self-review fix)