### PR TITLE
fix(memory-tenant-extraction): repoint path-keyed guards at moved files

### DIFF
--- a/assistant/src/__tests__/app-dir-path-guard.test.ts
+++ b/assistant/src/__tests__/app-dir-path-guard.test.ts
@@ -16,8 +16,8 @@ import { describe, expect, test } from "bun:test";
 
 /** Files that are permitted to import getAppsDir. */
 const ALLOWLIST = new Set([
-  "assistant/src/memory/app-store.ts", // defines getAppsDir
-  "assistant/src/memory/app-git-service.ts", // uses getAppsDir for git repo root, not per-app paths
+  "assistant/src/apps/app-store.ts", // defines getAppsDir
+  "assistant/src/apps/app-git-service.ts", // uses getAppsDir for git repo root, not per-app paths
   "assistant/src/daemon/app-source-watcher.ts", // uses getAppsDir for recursive fs.watch root, not per-app paths
   "assistant/src/tools/filesystem/write.ts", // uses getAppsDir as an exemption root for the artifact-HTML guard, not per-app paths
 ]);

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -7,7 +7,7 @@
  * maybeEnqueueScheduledCleanupJobs (in jobs-worker) early-returns while
  * the throttle is still within its window.
  *
- * The shared throttle state lives in memory/cleanup-schedule-state.ts so
+ * The shared throttle state lives in persistence/cleanup-schedule-state.ts so
  * that config-watcher can reset it without pulling jobs-worker's large
  * transitive import graph into test modules. This test stubs the
  * schedule-state module so calls from config-watcher can be counted

--- a/assistant/src/__tests__/trust-context-guards.test.ts
+++ b/assistant/src/__tests__/trust-context-guards.test.ts
@@ -168,7 +168,7 @@ describe("trust-context guards", () => {
 
   it("guardianPrincipalId is typed as string (non-null) in GuardianBinding", () => {
     const source = readFileSync(
-      join(srcDir, "memory", "channel-verification-sessions.ts"),
+      join(srcDir, "channels", "channel-verification-sessions.ts"),
       "utf-8",
     );
 

--- a/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
@@ -8,7 +8,7 @@
  * recent messages. This hook is the trigger — it retries placeholder titles
  * after successful turns and fires the second-pass regeneration when the
  * conversation reaches its third user turn. The service
- * (`memory/conversation-title-service.ts`) re-checks that the title is still
+ * (`persistence/conversation-title-service.ts`) re-checks that the title is still
  * auto-generated, resolves the title provider, persists, and broadcasts the
  * `conversation_title_updated` / `sync_changed` events.
  *

--- a/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
@@ -7,7 +7,7 @@
  * threaded through the agent loop. The hook is a pure trigger — it schedules
  * the work and returns; persistence and the resulting
  * `conversation_title_updated` / `sync_changed` broadcast are owned by the
- * title service (see `memory/conversation-title-service.ts`).
+ * title service (see `persistence/conversation-title-service.ts`).
  */
 
 import type {


### PR DESCRIPTION
Integrated-CI Test job caught two path-keyed guards referencing moved files by string path (the .js-anchored codemod never touched .ts path literals):
- `app-dir-path-guard.test.ts` getAppsDir allowlist: app-store + app-git-service → `apps/`.
- `trust-context-guards.test.ts` GuardianBinding source path: channel-verification-sessions → `channels/`.
Plus 3 stale doc comments (conversation-title-service, cleanup-schedule-state → persistence/). Both guard tests now pass (6/6).

Part of plan: memory-tenant-extraction.md (CI fix)