### PR TITLE
refactor(assistant): extract conversation disposal loop out of DaemonServer

### DIFF
--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -242,6 +242,19 @@ export function destroyActiveConversation(conversationId: string): void {
 }
 
 /**
+ * Dispose all in-memory conversations and clear the store during daemon
+ * shutdown. Subagent teardown and evictor stop are driven separately by the
+ * shutdown sequence, so this only releases the conversation instances and
+ * resets the registry.
+ */
+export function stopConversations(): void {
+  for (const conversation of allConversations()) {
+    conversation.dispose();
+  }
+  clearConversations();
+}
+
+/**
  * Dispose all in-memory conversations, clear the store, and remove
  * from the evictor. Returns the count of conversations that were cleared.
  */

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -32,7 +32,6 @@ import { Conversation } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import {
   allConversations,
-  clearConversations,
   conversationEntries,
   deleteConversation,
   getConversationMap,
@@ -266,11 +265,6 @@ export class DaemonServer {
       this.unsubscribeContactChange();
       this.unsubscribeContactChange = null;
     }
-
-    for (const conversation of allConversations()) {
-      conversation.dispose();
-    }
-    clearConversations();
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -20,6 +20,7 @@ import {
   commitAllPendingWorkspaceChanges,
   stopWorkspaceHeartbeatService,
 } from "../workspace/heartbeat-service.js";
+import { stopConversations } from "./conversation-store.js";
 import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
@@ -94,6 +95,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    stopConversations();
     await stopCes();
 
     // Final commit sweep: catch any writes that occurred during server.stop()


### PR DESCRIPTION
## Prompt / plan

Continuing the effort to dissolve `DaemonServer` by pulling its embedded singletons out one at a time (bottom-to-top through `stop()`). The CES connection went in #36422/#36430; next up is the conversation disposal loop.

## What changed

The teardown loop at the end of `DaemonServer.stop()`:

```ts
for (const conversation of allConversations()) {
  conversation.dispose();
}
clearConversations();
```

is now a standalone `stopConversations()` in `conversation-store.ts` — the module that already owns the conversation lifecycle (`getOrCreateConversation`, `clearAllActiveConversations`, etc.). The shutdown sequence in `shutdown-handlers.ts` calls it directly, immediately after `await deps.server.stop()`, which preserves the original ordering (the loop was the last thing `stop()` did, and subagent teardown / evictor stop are already handled earlier in the sequence).

- **`daemon/conversation-store.ts`** — add `stopConversations()`.
- **`daemon/server.ts`** — remove the loop from `stop()`; drop the now-unused `clearConversations` import (`allConversations` is still used by `handleAppSourceChange`).
- **`daemon/shutdown-handlers.ts`** — import and call `stopConversations()` after `server.stop()`.

No behavior change — this is a pure relocation of the existing teardown.

## Test plan

- `bun test src/__tests__/conversation-store.test.ts` → 28 pass
- `bun test src/__tests__/conversation-process-callsite.test.ts` → 5 pass
- `bun test src/__tests__/conversation-fork-route.test.ts` → 5 pass
- Pre-commit + pre-push hooks: prettier, eslint, full project typecheck all green
- No test constructs `DaemonServer` directly, so nothing asserted on the in-class disposal loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_