### PR TITLE
refactor(assistant): extract CLI IPC server out of DaemonServer into a singleton

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -19,6 +19,7 @@ import { startFilingService } from "../filing/filing-service.js";
 import { startHeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
+import { startCliIpcServer } from "../ipc/assistant-server.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { startSkillIpcServer } from "../ipc/skill-server.js";
 import { expireAllPendingCanonicalRequests } from "../memory/canonical-guardian-store.js";
@@ -588,6 +589,11 @@ export async function runDaemon(): Promise<void> {
   const server = new DaemonServer();
   await server.start();
   log.info("Daemon startup: DaemonServer started");
+
+  // Start the CLI IPC server. Throws on EADDRINUSE to abort startup when another
+  // daemon already holds the socket, so this process never runs background jobs
+  // against the shared database as an unmanageable duplicate.
+  await startCliIpcServer();
 
   // Start the skill IPC server so first-party skill processes can connect for
   // host capabilities. The meet-host supervisor reads the live server from the

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { disposeAcpSessionManager } from "../acp/index.js";
 import { compileApp } from "../bundler/app-compiler.js";
 import { getConfig } from "../config/loader.js";
-import { AssistantIpcServer } from "../ipc/assistant-server.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
@@ -45,15 +44,6 @@ import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 
 const log = getLogger("server");
 
-function isEaddrInUse(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as NodeJS.ErrnoException).code === "EADDRINUSE"
-  );
-}
-
 function readPackageVersion(): string | undefined {
   try {
     const pkgPath = join(import.meta.dir, "../../package.json");
@@ -75,7 +65,6 @@ export class DaemonServer {
   // Composed subsystems
   private configWatcher = getConfigWatcher();
   private appSourceWatcher = new AppSourceWatcher();
-  private cliIpc = new AssistantIpcServer();
 
   constructor() {
     this.evictor = new ConversationEvictor(getConversationMap());
@@ -192,22 +181,6 @@ export class DaemonServer {
 
     this.evictor.start();
 
-    try {
-      await this.cliIpc.start();
-    } catch (err) {
-      if (isEaddrInUse(err)) {
-        log.error(
-          { err },
-          "CLI IPC socket already in use by another daemon — aborting startup to prevent duplicate processing",
-        );
-        throw err;
-      }
-      log.warn(
-        { err },
-        "CLI IPC server failed to start — continuing startup with degraded CLI connectivity",
-      );
-    }
-
     this.configWatcher.start(
       () => this.evictConversationsForReload(),
       () => this.broadcastIdentityChanged(),
@@ -230,7 +203,6 @@ export class DaemonServer {
     this.evictor.stop();
     this.configWatcher.stop();
     this.appSourceWatcher.stop();
-    this.cliIpc.stop();
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/node";
 import { stopCes } from "../credential-execution/ces-runtime.js";
 import { stopFilingService } from "../filing/filing-service.js";
 import { stopHeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { stopCliIpcServer } from "../ipc/assistant-server.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopSkillIpcServer } from "../ipc/skill-server.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
@@ -96,6 +97,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    stopCliIpcServer();
     stopSkillIpcServer();
     stopConversations();
     await stopCes();

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -655,3 +655,50 @@ function injectLocalActorHeader(
     },
   };
 }
+
+// ── Process-level singleton ───────────────────────────────────────────────
+
+let instance: AssistantIpcServer | null = null;
+
+function isEaddrInUse(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "EADDRINUSE"
+  );
+}
+
+/**
+ * Start the daemon's CLI IPC server.
+ *
+ * Throws on EADDRINUSE: another daemon already holds the socket, so this
+ * process must abort startup rather than run as an unmanageable duplicate
+ * (invisible to health checks, unreachable by stop commands) while its
+ * background jobs hit the shared database. Any other bind failure is non-fatal
+ * — startup continues with degraded CLI connectivity.
+ */
+export async function startCliIpcServer(): Promise<void> {
+  instance = new AssistantIpcServer();
+  try {
+    await instance.start();
+  } catch (err) {
+    if (isEaddrInUse(err)) {
+      log.error(
+        { err },
+        "CLI IPC socket already in use by another daemon — aborting startup to prevent duplicate processing",
+      );
+      throw err;
+    }
+    log.warn(
+      { err },
+      "CLI IPC server failed to start — continuing startup with degraded CLI connectivity",
+    );
+  }
+}
+
+/** Stop the CLI IPC server during daemon shutdown. */
+export function stopCliIpcServer(): void {
+  instance?.stop();
+  instance = null;
+}


### PR DESCRIPTION
## Prompt / plan

Continuing the bottom-up dissolution of `DaemonServer`. With the skill IPC server gone (#36464), the last line of `stop()` is `this.cliIpc.stop()`, so the `AssistantIpcServer` (CLI IPC) is the next singleton to pull out.

## What changed

`AssistantIpcServer` was a `DaemonServer` instance field, started in `start()` and stopped in `stop()`. Moved into a module singleton:

- **`ipc/assistant-server.ts`** — added `startCliIpcServer()` / `stopCliIpcServer()`, and moved the `isEaddrInUse` helper here. `startCliIpcServer()` preserves the existing semantics: **re-throw on `EADDRINUSE`** to abort startup (the duplicate-daemon guard — another daemon holds the socket, so this process must not run background jobs against the shared DB as an unmanageable duplicate), and warn-and-continue on any other bind failure.
- **`daemon/server.ts`** — dropped the `cliIpc` field, the `start()` try/catch block, the `stop()` call, the `isEaddrInUse` helper, and the `AssistantIpcServer` import.
- **`daemon/lifecycle.ts`** — calls `await startCliIpcServer()` right after `server.start()` (before the skill IPC server, preserving the original cliIpc-before-skillIpc order). It is intentionally **not** wrapped in try/catch so an `EADDRINUSE` abort propagates out of `runDaemon` exactly as before.
- **`daemon/shutdown-handlers.ts`** — calls `stopCliIpcServer()` after `server.stop()` and before `stopSkillIpcServer()`, matching the original teardown order.

No behavior change beyond relocation; the duplicate-daemon abort path is preserved.

## Test plan

- `cli-ipc` (8), `route-error-envelope` (4), `clients-list-ipc` (4), `streaming-client` (8) — pass in isolation.
- Pre-commit + pre-push hooks: prettier, eslint, full project typecheck all green.
- No test constructs `DaemonServer`; existing tests construct `AssistantIpcServer` directly and are unaffected by the added singleton wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_