### PR TITLE
refactor(assistant): extract app source watcher out of DaemonServer into a singleton

### DIFF
--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -11,10 +11,22 @@
 
 import { existsSync, type FSWatcher, watch } from "node:fs";
 
-import { getAppsDir, resolveAppIdByDirName } from "../memory/app-store.js";
+import { compileApp } from "../bundler/app-compiler.js";
+import {
+  getApp,
+  getAppDirPath,
+  getAppsDir,
+  isMultifileApp,
+  resolveAppIdByDirName,
+} from "../memory/app-store.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
+import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import { DebouncerMap } from "../util/debounce.js";
 import { attachFsWatcherErrorHandler } from "../util/fs-watcher-error.js";
 import { getLogger } from "../util/logger.js";
+import { allConversations } from "./conversation-registry.js";
+import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 
 const log = getLogger("app-source-watcher");
 
@@ -22,18 +34,16 @@ const APP_REFRESH_DEBOUNCE_MS = 500;
 
 export type AppSourceChangeCallback = (appId: string) => void;
 
+/** Process-level singleton; created by {@link startAppSourceWatcher}. */
+let instance: AppSourceWatcher | null = null;
+
 /**
- * Module-level callback so tool-side-effects can ensure the watcher starts
- * after the apps directory is created (e.g. on first app_create).
+ * Ensure the watcher is running. Called by tool-side-effects after the apps
+ * directory may have been created (e.g. on first app_create), since the
+ * watcher is skipped at startup when the directory doesn't exist yet.
  */
-let ensureWatcherStarted: (() => void) | null = null;
-
-export function setEnsureAppSourceWatcher(fn: () => void): void {
-  ensureWatcherStarted = fn;
-}
-
 export function ensureAppSourceWatcher(): void {
-  ensureWatcherStarted?.();
+  instance?.ensureStarted();
 }
 
 /**
@@ -138,4 +148,55 @@ export class AppSourceWatcher {
       this.watcher = null;
     }
   }
+}
+
+/**
+ * Handle a detected app source file change. Recompiles multifile apps and
+ * refreshes surfaces across ALL conversations.
+ */
+function handleAppSourceChange(appId: string): void {
+  const app = getApp(appId);
+  if (!app) return;
+
+  const doRefresh = () => {
+    for (const conversation of allConversations()) {
+      refreshSurfacesForApp(conversation, appId, { fileChange: true });
+    }
+    broadcastMessage({ type: "app_files_changed", appId });
+    publishAppsChanged();
+    void updatePublishedAppDeployment(appId);
+  };
+
+  if (isMultifileApp(app)) {
+    const appDir = getAppDirPath(appId);
+    void compileApp(appDir)
+      .then((result) => {
+        if (!result.ok) {
+          log.warn(
+            { appId, errors: result.errors },
+            "Recompile failed on app source change",
+          );
+        }
+        doRefresh();
+      })
+      .catch((err) => {
+        log.warn({ appId, err }, "Recompile threw on app source change");
+        doRefresh();
+      });
+    return;
+  }
+
+  doRefresh();
+}
+
+/** Start watching app source directories for the life of the daemon. */
+export function startAppSourceWatcher(): void {
+  instance = new AppSourceWatcher();
+  instance.start(handleAppSourceChange);
+}
+
+/** Stop the app source watcher during daemon shutdown. */
+export function stopAppSourceWatcher(): void {
+  instance?.stop();
+  instance = null;
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -92,6 +92,7 @@ import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-t
 import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
+import { startAppSourceWatcher } from "./app-source-watcher.js";
 import { writePid } from "./daemon-control.js";
 import {
   evaluateDiskPressureNow,
@@ -589,6 +590,10 @@ export async function runDaemon(): Promise<void> {
   const server = new DaemonServer();
   await server.start();
   log.info("Daemon startup: DaemonServer started");
+
+  // Watch app source directories so edits recompile + refresh surfaces across
+  // all conversations.
+  startAppSourceWatcher();
 
   // Start the CLI IPC server. Throws on EADDRINUSE to abort startup when another
   // daemon already holds the socket, so this process never runs background jobs

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -2,33 +2,24 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { disposeAcpSessionManager } from "../acp/index.js";
-import { compileApp } from "../bundler/app-compiler.js";
 import { getConfig } from "../config/loader.js";
-import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import {
-  publishAppsChanged,
   publishAvatarChanged,
   publishConfigChanged,
   publishIdentityChanged,
   publishSoundsConfigUpdated,
 } from "../runtime/sync/resource-sync-events.js";
-import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
-import {
-  AppSourceWatcher,
-  setEnsureAppSourceWatcher,
-} from "./app-source-watcher.js";
 import { getConfigWatcher } from "./config-watcher.js";
 import { Conversation } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import {
-  allConversations,
   conversationEntries,
   deleteConversation,
   getConversationMap,
@@ -37,7 +28,6 @@ import {
   getOrCreateConversation as getOrCreateActiveConversation,
   initConversationLifecycle,
 } from "./conversation-store.js";
-import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
@@ -64,7 +54,6 @@ export class DaemonServer {
 
   // Composed subsystems
   private configWatcher = getConfigWatcher();
-  private appSourceWatcher = new AppSourceWatcher();
 
   constructor() {
     this.evictor = new ConversationEvictor(getConversationMap());
@@ -75,7 +64,6 @@ export class DaemonServer {
       sharedRequestTimestamps: this.sharedRequestTimestamps,
     });
 
-    setEnsureAppSourceWatcher(() => this.appSourceWatcher.ensureStarted());
     this.evictor.onEvict = (conversationId: string) => {
       getSubagentManager().abortAllForParent(conversationId);
     };
@@ -133,45 +121,6 @@ export class DaemonServer {
     publishAvatarChanged();
   }
 
-  /**
-   * Handle a detected app source file change from the filesystem watcher.
-   * Recompiles multifile apps and refreshes surfaces across ALL conversations.
-   */
-  private handleAppSourceChange(appId: string): void {
-    const app = getApp(appId);
-    if (!app) return;
-
-    const doRefresh = () => {
-      for (const conversation of allConversations()) {
-        refreshSurfacesForApp(conversation, appId, { fileChange: true });
-      }
-      broadcastMessage({ type: "app_files_changed", appId });
-      publishAppsChanged();
-      void updatePublishedAppDeployment(appId);
-    };
-
-    if (isMultifileApp(app)) {
-      const appDir = getAppDirPath(appId);
-      void compileApp(appDir)
-        .then((result) => {
-          if (!result.ok) {
-            log.warn(
-              { appId, errors: result.errors },
-              "Recompile failed on app source change",
-            );
-          }
-          doRefresh();
-        })
-        .catch((err) => {
-          log.warn({ appId, err }, "Recompile threw on app source change");
-          doRefresh();
-        });
-      return;
-    }
-
-    doRefresh();
-  }
-
   // ── Server lifecycle ────────────────────────────────────────────────
 
   async start(): Promise<void> {
@@ -192,8 +141,6 @@ export class DaemonServer {
 
     this.syncIdentityToPlatform();
 
-    this.appSourceWatcher.start((appId) => this.handleAppSourceChange(appId));
-
     log.info("DaemonServer started (HTTP-only mode)");
   }
 
@@ -202,7 +149,6 @@ export class DaemonServer {
     disposeAcpSessionManager();
     this.evictor.stop();
     this.configWatcher.stop();
-    this.appSourceWatcher.stop();
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -22,6 +22,7 @@ import {
   commitAllPendingWorkspaceChanges,
   stopWorkspaceHeartbeatService,
 } from "../workspace/heartbeat-service.js";
+import { stopAppSourceWatcher } from "./app-source-watcher.js";
 import { stopConversations } from "./conversation-store.js";
 import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
@@ -97,6 +98,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    stopAppSourceWatcher();
     stopCliIpcServer();
     stopSkillIpcServer();
     stopConversations();


### PR DESCRIPTION
## Prompt / plan

Continuing the bottom-up dissolution of `DaemonServer`. With the IPC servers gone, `appSourceWatcher` is the next subsystem in `start()`/`stop()`.

## What changed

`AppSourceWatcher` was a `DaemonServer` instance field, with the change handler (`handleAppSourceChange`) as a private method and a `setEnsureAppSourceWatcher` DI callback wired in the constructor. Moved the whole thing into the `app-source-watcher` module:

- **`daemon/app-source-watcher.ts`** — added a module singleton with `startAppSourceWatcher()` / `stopAppSourceWatcher()`, and co-located the `handleAppSourceChange` handler (recompile multifile apps + refresh surfaces across all conversations + broadcast). `ensureAppSourceWatcher()` (called by `tool-side-effects` on first app create) now drives the singleton directly.
- **`daemon/server.ts`** — dropped the field, the constructor `setEnsureAppSourceWatcher` wiring, the `handleAppSourceChange` method, the `start()`/`stop()` calls, and the imports that only the handler used (`compileApp`, `getApp`/`getAppDirPath`/`isMultifileApp`, `publishAppsChanged`, `updatePublishedAppDeployment`, `refreshSurfacesForApp`, `allConversations`).
- **`daemon/lifecycle.ts`** — calls `startAppSourceWatcher()` after `server.start()` (preserving its original position as the last server bring-up step, before the IPC servers).
- **`daemon/shutdown-handlers.ts`** — calls `stopAppSourceWatcher()` after `server.stop()`, before the IPC stops (matching the original teardown order).

### Bonus: removed the `setEnsureAppSourceWatcher` DI

That setter existed only because the watcher instance lived in `DaemonServer` while `ensureAppSourceWatcher()` lived in the watcher module. With the singleton now in the watcher module, `ensureAppSourceWatcher()` calls `instance?.ensureStarted()` directly and the setter/`ensureWatcherStarted` callback are gone. No import cycle — the handler's dependencies don't import the watcher module.

## Test plan

- `app-source-watcher` (13), `conversation-tool-setup-app-refresh` (18), `app-dir-path-guard` (1) — pass in isolation.
- Pre-commit + pre-push hooks: prettier, eslint, full project typecheck all green.
- `AppSourceWatcher` class stays exported (its tests construct it directly); no test referenced the removed `setEnsureAppSourceWatcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_