### PR TITLE
refactor(assistant): move config watcher wiring out of DaemonServer

### DIFF
--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -30,6 +30,7 @@ import {
   allConversations,
   clearConversations,
   conversationCount,
+  conversationEntries,
   conversationIds,
   deleteConversation,
   findConversation,
@@ -271,4 +272,24 @@ export function clearAllActiveConversations(): number {
   clearConversations();
   clearConversationOptions();
   return count;
+}
+
+/**
+ * Evict in-memory conversations after a config/prompt/skills reload so the next
+ * turn rebuilds them against the new config. Idle conversations are disposed and
+ * dropped; busy ones are marked stale so they're rebuilt once their current turn
+ * finishes. Also used when provider credentials change.
+ */
+export function evictConversationsForReload(): void {
+  const subagentManager = getSubagentManager();
+  for (const [id, conversation] of conversationEntries()) {
+    if (!conversation.isProcessing()) {
+      subagentManager.abortAllForParent(id);
+      conversation.dispose();
+      deleteConversation(id);
+      removeFromEvictor(id);
+    } else {
+      conversation.markStale();
+    }
+  }
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
@@ -10,7 +11,11 @@ import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import { setIngressPublicBaseUrl, validateEnv } from "../config/env.js";
-import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
+import {
+  getConfig,
+  loadConfig,
+  mergeDefaultWorkspaceConfig,
+} from "../config/loader.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { startCes } from "../credential-execution/ces-runtime.js";
@@ -55,6 +60,7 @@ import {
   startConsentRefresh,
   stopConsentRefresh,
 } from "../platform/consent-cache.js";
+import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -67,8 +73,11 @@ import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
 import {
+  publishAvatarChanged,
   publishConfigChanged,
   publishConversationListChanged,
+  publishIdentityChanged,
+  publishSoundsConfigUpdated,
 } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
@@ -81,6 +90,7 @@ import {
   ensureDataDir,
   getDotEnvPath,
   getWorkspaceDir,
+  getWorkspacePromptPath,
 } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 import {
@@ -93,6 +103,8 @@ import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.j
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import { startAppSourceWatcher } from "./app-source-watcher.js";
+import { getConfigWatcher } from "./config-watcher.js";
+import { evictConversationsForReload } from "./conversation-store.js";
 import { writePid } from "./daemon-control.js";
 import {
   evaluateDiskPressureNow,
@@ -102,6 +114,7 @@ import {
 import { startEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
+import { parseIdentityFields } from "./handlers/identity.js";
 import { installAssistantSymlink } from "./install-symlink.js";
 import {
   maybeRebuildMemoryV2Concepts,
@@ -171,6 +184,27 @@ export function stopDiskPressureGuardForLifecycle(): void {
     diskPressureStartupSampleTimer = null;
   }
   stopDiskPressureGuard();
+}
+
+/**
+ * Re-read IDENTITY.md and broadcast the parsed fields to clients, best-effort
+ * syncing the assistant name to the platform record. Wired as the config
+ * watcher's IDENTITY.md-change reaction.
+ */
+function broadcastIdentityChange(): void {
+  try {
+    const identityPath = getWorkspacePromptPath("IDENTITY.md");
+    const content = existsSync(identityPath)
+      ? readFileSync(identityPath, "utf-8")
+      : "";
+    const fields = parseIdentityFields(content);
+    publishIdentityChanged(fields);
+    if (fields.name) {
+      syncIdentityNameToPlatform(fields.name);
+    }
+  } catch (err) {
+    log.error({ err }, "Failed to broadcast identity change");
+  }
 }
 
 // Entry point for the daemon process itself
@@ -591,6 +625,20 @@ export async function runDaemon(): Promise<void> {
   await server.start();
   log.info("Daemon startup: DaemonServer started");
 
+  // Watch workspace files (config, prompts, skills, sounds, avatar) for changes
+  // and react: evict conversations so the next turn rebuilds against the new
+  // config, and broadcast the relevant resource-changed events to clients.
+  const configWatcher = getConfigWatcher();
+  configWatcher.initFingerprint(getConfig());
+  configWatcher.start(
+    evictConversationsForReload,
+    broadcastIdentityChange,
+    publishSoundsConfigUpdated,
+    publishAvatarChanged,
+    publishConfigChanged,
+    () => refreshSkillCapabilityMemories(getConfig()),
+  );
+
   // Watch app source directories so edits recompile + refresh surfaces across
   // all conversations.
   startAppSourceWatcher();
@@ -900,8 +948,7 @@ export async function runDaemon(): Promise<void> {
   // the running routes. They're module-level state, so they're effective
   // even when the HTTP server failed to bind (IPC clients still work).
   registerSecretsDeps({
-    onProviderCredentialsChanged: () =>
-      server.refreshConversationsForProviderChange(),
+    onProviderCredentialsChanged: () => evictConversationsForReload(),
   });
 
   // Fire-and-forget: Qdrant init and memory worker startup run concurrently

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -7,30 +7,18 @@ import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
-import {
-  publishAvatarChanged,
-  publishConfigChanged,
-  publishIdentityChanged,
-  publishSoundsConfigUpdated,
-} from "../runtime/sync/resource-sync-events.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
-import { getConfigWatcher } from "./config-watcher.js";
 import { Conversation } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
-import {
-  conversationEntries,
-  deleteConversation,
-  getConversationMap,
-} from "./conversation-registry.js";
+import { getConversationMap } from "./conversation-registry.js";
 import {
   getOrCreateConversation as getOrCreateActiveConversation,
   initConversationLifecycle,
 } from "./conversation-store.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
-import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 
 const log = getLogger("server");
 
@@ -52,9 +40,6 @@ export class DaemonServer {
   private sharedRequestTimestamps: number[] = [];
   private evictor: ConversationEvictor;
 
-  // Composed subsystems
-  private configWatcher = getConfigWatcher();
-
   constructor() {
     this.evictor = new ConversationEvictor(getConversationMap());
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
@@ -75,24 +60,6 @@ export class DaemonServer {
     };
   }
 
-  private broadcastIdentityChanged(): void {
-    try {
-      const identityPath = getWorkspacePromptPath("IDENTITY.md");
-      const content = existsSync(identityPath)
-        ? readFileSync(identityPath, "utf-8")
-        : "";
-      const fields = parseIdentityFields(content);
-      publishIdentityChanged(fields);
-
-      // Best-effort sync of the assistant name to the platform record.
-      if (fields.name) {
-        syncIdentityNameToPlatform(fields.name);
-      }
-    } catch (err) {
-      log.error({ err }, "Failed to broadcast identity change");
-    }
-  }
-
   /** Best-effort sync of the IDENTITY.md name to the platform record. */
   private syncIdentityToPlatform(): void {
     try {
@@ -109,35 +76,13 @@ export class DaemonServer {
     }
   }
 
-  private broadcastConfigChanged(): void {
-    publishConfigChanged();
-  }
-
-  private broadcastSoundsConfigUpdated(): void {
-    publishSoundsConfigUpdated();
-  }
-
-  private broadcastAvatarUpdated(): void {
-    publishAvatarChanged();
-  }
-
   // ── Server lifecycle ────────────────────────────────────────────────
 
   async start(): Promise<void> {
     const config = getConfig();
     await initializeProviders(config);
-    this.configWatcher.initFingerprint(config);
 
     this.evictor.start();
-
-    this.configWatcher.start(
-      () => this.evictConversationsForReload(),
-      () => this.broadcastIdentityChanged(),
-      () => this.broadcastSoundsConfigUpdated(),
-      () => this.broadcastAvatarUpdated(),
-      () => this.broadcastConfigChanged(),
-      () => refreshSkillCapabilityMemories(getConfig()),
-    );
 
     this.syncIdentityToPlatform();
 
@@ -148,7 +93,6 @@ export class DaemonServer {
     getSubagentManager().disposeAll();
     disposeAcpSessionManager();
     this.evictor.stop();
-    this.configWatcher.stop();
 
     log.info("Daemon server stopped");
   }
@@ -161,42 +105,6 @@ export class DaemonServer {
       version: daemonVersion,
       keyFingerprint: getSigningKeyFingerprint(),
     });
-  }
-
-  private evictConversationsForReload(): void {
-    const subagentManager = getSubagentManager();
-    for (const [id, conversation] of conversationEntries()) {
-      if (!conversation.isProcessing()) {
-        subagentManager.abortAllForParent(id);
-        conversation.dispose();
-        deleteConversation(id);
-        this.evictor.remove(id);
-      } else {
-        conversation.markStale();
-      }
-    }
-  }
-
-  get lastConfigFingerprint(): string {
-    return this.configWatcher.lastFingerprint;
-  }
-
-  set lastConfigFingerprint(value: string) {
-    this.configWatcher.lastFingerprint = value;
-  }
-
-  async refreshConfigFromSources(): Promise<boolean> {
-    const changed = await this.configWatcher.refreshConfigFromSources();
-    if (changed) this.evictConversationsForReload();
-    return changed;
-  }
-
-  /**
-   * Provider instances are captured when conversations are created, so a key
-   * change must evict or mark them stale before the next turn.
-   */
-  refreshConversationsForProviderChange(): void {
-    this.evictConversationsForReload();
   }
 
   /**

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -23,6 +23,7 @@ import {
   stopWorkspaceHeartbeatService,
 } from "../workspace/heartbeat-service.js";
 import { stopAppSourceWatcher } from "./app-source-watcher.js";
+import { getConfigWatcher } from "./config-watcher.js";
 import { stopConversations } from "./conversation-store.js";
 import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
@@ -98,6 +99,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    getConfigWatcher().stop();
     stopAppSourceWatcher();
     stopCliIpcServer();
     stopSkillIpcServer();


### PR DESCRIPTION
## Prompt / plan

Continuing the bottom-up dissolution of `DaemonServer`. `configWatcher` is the next subsystem in `start()`/`stop()`. Unlike the IPC servers/app watcher, `ConfigWatcher` is *already* a module singleton (`getConfigWatcher()`); `DaemonServer` was just wiring it. So this PR relocates the wiring rather than introducing a new singleton — and `ConfigWatcher`'s own API is left **completely unchanged** (its tests stay green).

## What changed

- **`daemon/conversation-store.ts`** — added `evictConversationsForReload()` (moved from `DaemonServer`). It's conversation-domain logic and was already reused on provider-credential change; it reuses the module's existing evictor ref.
- **`daemon/lifecycle.ts`** — wires the watcher after `server.start()`: `getConfigWatcher().initFingerprint(getConfig())` + `.start(...)` with the six reload reactions. The IDENTITY.md reaction (`broadcastIdentityChange`) is defined here (composition root); the sounds/avatar/config reactions are passed straight through as the `publish*` functions; eviction and skill-memory-refresh are passed directly. Also repoints the `registerSecretsDeps` provider-change callback to `evictConversationsForReload()`.
- **`daemon/shutdown-handlers.ts`** — calls `getConfigWatcher().stop()` after `server.stop()` (preserving the original teardown position).
- **`daemon/server.ts`** — dropped the `configWatcher` field, the four `broadcast*` reaction methods, `evictConversationsForReload`, the `start()`/`stop()` wiring, and the imports they used. Also removed **dead API**: `lastConfigFingerprint` getter/setter and `refreshConfigFromSources()` (zero callers), plus `refreshConversationsForProviderChange` (its one caller now calls `evictConversationsForReload` directly).

### Why the wiring lives in lifecycle, not inside ConfigWatcher

Passing the reload reactions as callbacks from the composition root keeps `ConfigWatcher` decoupled from the conversation/runtime layers (and leaves its existing callback-based tests untouched). `broadcastIdentityChange` is defined in `lifecycle` rather than `handlers/identity.ts` on purpose — that module is intentionally dependency-free (pure parsing, fast unit test), and pulling the `runtime/sync` chain into it would compromise that.

## Test plan

- `config-watcher` (20), `config-watcher-cleanup-throttle` (15), `conversation-store` (28), `conversation-process-callsite` (5) — pass in isolation.
- Pre-commit + pre-push hooks: prettier, eslint, full project typecheck all green.
- Confirmed no remaining references to the removed `DaemonServer` config API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_