### PR TITLE
feat(web): maintain the materialized snapshot in shadow (client-sync cutover pt1)

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -45,58 +45,58 @@ const store = () => useChatSessionStore.getState();
 beforeEach(() => {
   resetSseDebugStateForTests();
   store().setLiveTurn([]);
-  useChatSessionStore.setState({ base: null, optimisticSends: [] });
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
 });
 afterEach(() => {
   resetSseDebugStateForTests();
-  useChatSessionStore.setState({ base: null, optimisticSends: [] });
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
 });
 
-describe("chat-session-store — base + optimistic", () => {
-  test("seedBase with no buffered tail uses the snapshot as-is", () => {
+describe("chat-session-store — snapshot + optimistic", () => {
+  test("seedSnapshot with no buffered tail uses the snapshot as-is", () => {
     const snap = snapshot([textRow("a1", "persisted")], 5);
-    store().seedBase(CONV, snap);
-    expect(store().base).toBe(snap); // resolveBase returns the snapshot ref
+    store().seedSnapshot(CONV, snap);
+    expect(store().snapshot).toBe(snap); // resolveSnapshot returns the snapshot ref
   });
 
-  test("seedBase replays the buffered tail (events that raced the fetch)", () => {
+  test("seedSnapshot replays the buffered tail (events that raced the fetch)", () => {
     const id = registerSseClient(new AbortController().signal);
     // The ring reaches back to the cursor (oldest retained seq 6 <= snapshot.seq+1).
     pushSseEvent(id, textDelta(6, CONV, "a1", " + live"));
 
-    store().seedBase(CONV, snapshot([textRow("a1", "persisted")], 5));
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "persisted")], 5));
 
-    expect(store().base?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+    expect(store().snapshot?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
       "persisted + live",
     ]);
-    expect(store().base?.seq).toBe(6);
+    expect(store().snapshot?.seq).toBe(6);
   });
 
-  test("seedBase takes the snapshot wholesale when the tail is an eviction gap", () => {
+  test("seedSnapshot takes the snapshot wholesale when the tail is an eviction gap", () => {
     const id = registerSseClient(new AbortController().signal);
     // Oldest retained seq (50) is past snapshot.seq+1 → getSseEnvelopesSince → null.
     pushSseEvent(id, textDelta(50, CONV, "a1", " evicted-gap"));
 
     const snap = snapshot([textRow("a1", "persisted")], 5);
-    store().seedBase(CONV, snap);
-    expect(store().base).toBe(snap); // wholesale, no partial replay
+    store().seedSnapshot(CONV, snap);
+    expect(store().snapshot).toBe(snap); // wholesale, no partial replay
   });
 
-  test("applyEnvelopeToBase folds a live event once seeded; idempotent by seq", () => {
-    store().seedBase(CONV, snapshot([textRow("a1", "persisted")], 5));
-    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", " live"));
-    expect(store().base?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+  test("applyEnvelopeToSnapshot folds a live event once seeded; idempotent by seq", () => {
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "persisted")], 5));
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", " live"));
+    expect(store().snapshot?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
       "persisted live",
     ]);
     // Re-applying seq 6 is a no-op.
-    const before = store().base;
-    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", " live"));
-    expect(store().base).toBe(before);
+    const before = store().snapshot;
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", " live"));
+    expect(store().snapshot).toBe(before);
   });
 
-  test("applyEnvelopeToBase is a no-op before the base is seeded", () => {
-    store().applyEnvelopeToBase(textDelta(6, CONV, "a1", "x"));
-    expect(store().base).toBeNull();
+  test("applyEnvelopeToSnapshot is a no-op before the snapshot is seeded", () => {
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", "x"));
+    expect(store().snapshot).toBeNull();
   });
 
   test("optimistic sends add and clear by clientMessageId", () => {
@@ -107,13 +107,13 @@ describe("chat-session-store — base + optimistic", () => {
     expect(store().optimisticSends).toEqual([]);
   });
 
-  test("switching conversation resets base and optimistic sends", () => {
-    store().seedBase(CONV, snapshot([textRow("a1", "x")], 1));
+  test("switching conversation resets snapshot and optimistic sends", () => {
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "x")], 1));
     store().addOptimisticSend({ ...textRow("u1", "hi"), role: "user", clientMessageId: "n" });
 
     store().switchToConversation({ assistantId: "asst-1", activeConversationId: "conv-B" });
 
-    expect(store().base).toBeNull();
+    expect(store().snapshot).toBeNull();
     expect(store().optimisticSends).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -42,7 +42,7 @@ import type {
   PaginatedHistoryResult,
   TranscriptPaginationState,
 } from "@/domains/chat/transcript/types";
-import { applyEvent, resolveBase } from "@/domains/chat/transcript/rolling-base";
+import { applyEvent, resolveSnapshot } from "@/domains/chat/transcript/rolling-base";
 import { getSseEnvelopesSince } from "@/lib/streaming/stream-debug";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
@@ -59,16 +59,16 @@ export interface ChatSessionState {
   // cached history and this live turn (`selectTranscriptMessages`).
   liveTurn: DisplayMessage[];
 
-  // --- Materialized base (client-sync rolling base) ---
-  // The active conversation's history materialized as the `/messages` page
-  // shape, seeded from the snapshot and advanced by the stream reducer
+  // --- Materialized snapshot (client-sync rolling snapshot) ---
+  // The client's living snapshot of the active conversation, in the `/messages`
+  // page shape: seeded from a server snapshot and advanced by the stream reducer
   // (`applyEvent`). `null` until seeded. Unwired: the rendered transcript still
   // reads cached history ⊕ `liveTurn` today; this is the home the cutover
   // moves it to.
-  base: PaginatedHistoryResult | null;
+  snapshot: PaginatedHistoryResult | null;
   // Optimistic user sends not yet confirmed by their `user_message_echo`.
-  // Held apart from `base` so it's clear they're unconfirmed until an event
-  // clears them; rebased onto a fresh `base` on resync.
+  // Held apart from `snapshot` so it's clear they're unconfirmed until an event
+  // clears them; rebased onto a fresh `snapshot` on resync.
   optimisticSends: DisplayMessage[];
 
   error: ChatError | null;
@@ -133,14 +133,15 @@ export interface ChatSessionActions {
   // --- Setters ---
   setLiveTurn: (updater: DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[])) => void;
 
-  // --- Materialized base ---
-  /** Seed (or resync) the base from a fresh snapshot, replaying the buffered
-   *  event tail with `seq > snapshot.seq` onto it so events that raced the
-   *  fetch aren't lost. A gap (evicted tail) falls back to the snapshot alone. */
-  seedBase: (conversationId: string, snapshot: PaginatedHistoryResult) => void;
-  /** Fold one live stream event into the base (no-op until seeded; the seed's
-   *  replay covers anything that arrived first). Idempotent by `seq`. */
-  applyEnvelopeToBase: (envelope: AssistantEventEnvelope) => void;
+  // --- Materialized snapshot ---
+  /** Seed (or resync) the snapshot from a freshly fetched server snapshot,
+   *  replaying the buffered event tail with `seq > snapshot.seq` onto it so
+   *  events that raced the fetch aren't lost. A gap (evicted tail) falls back
+   *  to the fetched snapshot alone. */
+  seedSnapshot: (conversationId: string, snapshot: PaginatedHistoryResult) => void;
+  /** Fold one live stream event into the snapshot (no-op until seeded; the
+   *  seed's replay covers anything that arrived first). Idempotent by `seq`. */
+  applyEnvelopeToSnapshot: (envelope: AssistantEventEnvelope) => void;
   /** Add an optimistic user send; cleared when its echo lands. */
   addOptimisticSend: (message: DisplayMessage) => void;
   /** Drop the optimistic send correlated by `clientMessageId`. */
@@ -228,7 +229,7 @@ const INITIAL_PAGINATION: Omit<TranscriptPaginationState, "items"> = {
 function initialState(): ChatSessionState {
   return {
     liveTurn: [],
-    base: null,
+    snapshot: null,
     optimisticSends: [],
     error: null,
     notice: null,
@@ -273,13 +274,13 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
   setLiveTurn: (updater) =>
     set((s) => ({ liveTurn: applyUpdater(s.liveTurn, updater) })),
 
-  seedBase: (conversationId, snapshot) => {
+  seedSnapshot: (conversationId, snapshot) => {
     const tail = getSseEnvelopesSince(conversationId, snapshot.seq ?? null);
-    set({ base: resolveBase(snapshot, tail) });
+    set({ snapshot: resolveSnapshot(snapshot, tail) });
   },
 
-  applyEnvelopeToBase: (envelope) =>
-    set((s) => (s.base ? { base: applyEvent(s.base, envelope) } : {})),
+  applyEnvelopeToSnapshot: (envelope) =>
+    set((s) => (s.snapshot ? { snapshot: applyEvent(s.snapshot, envelope) } : {})),
 
   addOptimisticSend: (message) =>
     set((s) => ({ optimisticSends: [...s.optimisticSends, message] })),
@@ -376,7 +377,7 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
     set({
       liveTurn: [],
-      base: null,
+      snapshot: null,
       optimisticSends: [],
       ephemeralMetaResults: [],
       error: shouldSuppressGenericChatErrorNotice(state.error) ? state.error : null,

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -177,6 +177,18 @@ export function useConversationHistory({
     recordLocalSeq(activeConversationId, latestPageSeq);
     anchorColdStartReplay(latestPageSeq);
 
+    // Client-sync cutover (shadow): seed the materialized snapshot from the
+    // committed history, replaying any buffered events that raced the fetch.
+    // Maintained in parallel with the cached-history ⊕ liveTurn render today;
+    // the render flip reads from it next. See `chat-session-store`.
+    useChatSessionStore.getState().seedSnapshot(activeConversationId, {
+      messages: pagination.messages,
+      seq: latestPageSeq,
+      hasMore: pagination.hasMore,
+      oldestTimestamp: pagination.oldestLoadedTimestamp,
+      oldestMessageId: pagination.latestPage?.oldestMessageId ?? null,
+    });
+
     setIsLoadingHistory(false);
     setTranscriptPagination({
       hasMore: pagination.hasMore,

--- a/clients/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/clients/web/src/domains/chat/hooks/use-event-stream.ts
@@ -279,6 +279,17 @@ export function useEventStream({
 
   useBusSubscription("sse.event", (envelope) => {
     consumer?.handleSseEvent(envelope);
+    // Client-sync cutover (shadow): fold the active conversation's events into
+    // the materialized snapshot in parallel with the live render. Idempotent by
+    // seq; a no-op until the snapshot is seeded — the seed replays the ring
+    // tail, so events that arrive first aren't lost. Gated on the same
+    // commit-phase active-conversation ref the consumer's filter uses.
+    if (
+      envelope.conversationId &&
+      envelope.conversationId === activeConversationIdLatestRef.current
+    ) {
+      useChatSessionStore.getState().applyEnvelopeToSnapshot(envelope);
+    }
   });
 
   useBusSubscription("sse.opened", (payload) => {

--- a/clients/web/src/domains/chat/transcript/rolling-base.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   applyEvent,
   applyEventsToHistory,
-  resolveBase,
+  resolveSnapshot,
 } from "@/domains/chat/transcript/rolling-base";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import type { AssistantEvent } from "@/types/event-types";
@@ -189,10 +189,10 @@ describe("rolling-base reducer", () => {
     expect(after.oldestMessageId).toBe("old");
   });
 
-  describe("resolveBase (seed / resync)", () => {
+  describe("resolveSnapshot (seed / resync)", () => {
     test("a null tail (gap / no anchor) leaves the snapshot standing alone", () => {
       const snapshot = applyEventsToHistory(SEED, [textDelta(1, "a1", "persisted")]);
-      expect(resolveBase(snapshot, null)).toBe(snapshot);
+      expect(resolveSnapshot(snapshot, null)).toBe(snapshot);
     });
 
     test("replays the buffered tail onto the snapshot", () => {
@@ -200,7 +200,7 @@ describe("rolling-base reducer", () => {
         userEcho(1, "u1", "hi"),
         textDelta(2, "a1", "persisted"),
       ]);
-      const resolved = resolveBase(snapshot, [textDelta(3, "a1", " + live")]);
+      const resolved = resolveSnapshot(snapshot, [textDelta(3, "a1", " + live")]);
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
         "persisted + live",
       ]);
@@ -210,7 +210,7 @@ describe("rolling-base reducer", () => {
     test("idempotent: tail events already in the snapshot are dropped", () => {
       const snapshot = applyEventsToHistory(SEED, [textDelta(5, "a1", "x")]); // seq 5
       // A stale tail (<= snapshot.seq) folds to nothing.
-      const resolved = resolveBase(snapshot, [textDelta(4, "a1", " stale")]);
+      const resolved = resolveSnapshot(snapshot, [textDelta(4, "a1", " stale")]);
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
     });
   });

--- a/clients/web/src/domains/chat/transcript/rolling-base.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-base.ts
@@ -186,12 +186,13 @@ export function applyEventsToHistory(
 }
 
 /**
- * Resolve the base from a fresh snapshot and the buffered event tail to replay
- * onto it (seed and resync share this). A `null` tail means the buffer can't
- * cover the snapshot's watermark (eviction, or no anchor), so the snapshot
- * stands alone; otherwise the tail's `seq > snapshot.seq` events fold on top.
+ * Resolve the client's current snapshot from a freshly fetched server snapshot
+ * and the buffered event tail to replay onto it (seed and resync share this). A
+ * `null` tail means the buffer can't cover the snapshot's watermark (eviction,
+ * or no anchor), so the fetched snapshot stands alone; otherwise the tail's
+ * `seq > snapshot.seq` events fold on top.
  */
-export function resolveBase(
+export function resolveSnapshot(
   snapshot: PaginatedHistoryResult,
   tail: readonly AssistantEventEnvelope[] | null,
 ): PaginatedHistoryResult {


### PR DESCRIPTION
Cutover **part 1 of 2** — wire the rolling snapshot to live traffic **in parallel** with the existing `cached-history ⊕ liveTurn` render. **No behavior change.** This de-risks the render flip: the snapshot is built and proven against real traffic before anything reads from it, so the flip becomes a small, reviewable render swap.

> ⚠️ Stacks on #36419 (the `base`→`snapshot` rename). Until that merges, the rename commit shows in this diff — review just the second commit (`maintain the materialized snapshot in shadow`).

## What it wires
- **Seed** (`use-conversation-history`): on each committed history snapshot, `seedSnapshot` the store from the merged loaded pages, replaying any buffered events that raced the fetch — so the original seed-race (a delta beating the `/messages` fetch) structurally can't drop the opening of a turn.
- **Fold** (`use-event-stream`): each active-conversation envelope folds into the snapshot via `applyEnvelopeToSnapshot`, gated on the same commit-phase active-conversation ref the consumer's filter uses. Idempotent by `seq`; a no-op until seeded (the seed's ring replay covers anything that arrived first).

Render still reads `cached history ⊕ liveTurn` — the snapshot is maintained but unread.

## Safety
The store actions (`seedSnapshot`/`applyEnvelopeToSnapshot`) and the engine under them are already unit-tested (#36317/#36318/#36341). This PR is the thin wiring that drives them; the existing event-stream / history / store suites stay green (resume-reconcile, conversation-filter, rapid-switch, reconnect-refetch, store + reducer). Lint + typecheck clean.

## Part 2 (the flip — separate PR)
Read the transcript from `snapshot ⊕ optimisticSends`; move message-array folding out of the stream handlers (turn/interaction/subagent side-effects stay); route optimistic sends to `addOptimisticSend` and clear on echo; retire `liveTurn` + the seed-twin overlay; flip the `clients/web/AGENTS.md:30` single-source note. I'll sketch the handler split (e.g. `currentAssistantMessageIdRef` attribution) before building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_