### PR TITLE
JARVIS-1230: invalidate daemon guardian-id cache on gateway-side guardian rebinds

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -853,4 +853,43 @@ describe("handleContactPromptSubmit", () => {
     // The rolled-back bind mutated nothing net — no cache-invalidation broadcast.
     expectNoEmit(ipcMock);
   });
+
+  test("guardian bind — existing guardian, read-back miss still emits (committed bind, no rollback)", async () => {
+    // An existing guardian is bound to a NEW channel; the post-bind resolve
+    // misses. rollbackCreatedContact is a no-op (the guardian wasn't created
+    // here), so the committed channel bind persists and the caches MUST be
+    // invalidated despite the 500.
+    seedGuardian();
+    const spy = spyOn(
+      ContactStore.prototype,
+      "getChannelsForContact",
+    ).mockReturnValue([]);
+
+    let res: Response;
+    try {
+      res = await handleContactPromptSubmit(
+        makeRequest({
+          requestId: "req-existing-noresolve",
+          address: "+15557778888",
+          channelType: "phone",
+          role: "guardian",
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(res.status).toBe(500);
+
+    // The existing guardian was NOT rolled back.
+    const gwGuardians = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.role, "guardian"))
+      .all();
+    expect(gwGuardians).toHaveLength(1);
+
+    // Committed bind on an existing guardian — caches invalidated despite 500.
+    expectEmittedContactsChanged(ipcMock);
+  });
 });

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -800,13 +800,14 @@ describe("handleContactPromptSubmit", () => {
     expect(body.accepted).toBe(false);
 
     // Daemon was notified with an error (not a success resolve with empty id).
-    expect(ipcMock).toHaveBeenCalledTimes(1);
     const ipcCall = resolveCall(ipcMock);
     expect(typeof ipcCall.body.error).toBe("string");
     expect(ipcCall.body.channelId).toBeUndefined();
 
-    // Failed resolution mutated nothing — no cache-invalidation broadcast.
-    expectNoEmit(ipcMock);
+    // The non-guardian upsert already committed (no rollback on this path)
+    // before the read-back miss, so the caches are still invalidated — the
+    // emit fires before the channel-id guard.
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("guardian bind — rolls back freshly-created guardian + 500 when channel can't be resolved", async () => {

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -133,6 +133,40 @@ function makeRequest(body: Record<string, unknown>): Request {
 }
 
 // ---------------------------------------------------------------------------
+// IPC call inspectors
+//
+// The handler fires two IPC operations on a successful mutating submit: an
+// `emit_event` { kind: "contacts_changed" } cache-invalidation broadcast plus
+// the `resolve_contact_prompt` that unblocks the CLI. These helpers pick the
+// right call regardless of order.
+// ---------------------------------------------------------------------------
+
+function callsFor(
+  ipc: typeof ipcMock,
+  op: string,
+): { body: Record<string, unknown> }[] {
+  return (ipc.mock.calls as any[][])
+    .filter((c) => c[0] === op)
+    .map((c) => c[1] as { body: Record<string, unknown> });
+}
+
+function resolveCall(ipc: typeof ipcMock): { body: Record<string, unknown> } {
+  const calls = callsFor(ipc, "resolve_contact_prompt");
+  expect(calls).toHaveLength(1);
+  return calls[0];
+}
+
+function expectEmittedContactsChanged(ipc: typeof ipcMock): void {
+  const calls = callsFor(ipc, "emit_event");
+  expect(calls.length).toBeGreaterThanOrEqual(1);
+  expect(calls.some((c) => c.body.kind === "contacts_changed")).toBe(true);
+}
+
+function expectNoEmit(ipc: typeof ipcMock): void {
+  expect(callsFor(ipc, "emit_event")).toHaveLength(0);
+}
+
+// ---------------------------------------------------------------------------
 // Suite setup
 // ---------------------------------------------------------------------------
 
@@ -209,11 +243,12 @@ describe("handleContactPromptSubmit", () => {
     expect(gwGuardian[0].role).toBe("guardian");
 
     // IPC should have been called with the guardian contactId + gateway channel id.
-    expect(ipcMock).toHaveBeenCalledTimes(1);
-
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.contactId).toBe("guardian-1");
     expect(ipcCall.body.channelId).toBe(gwChannels[0].id);
+
+    // A successful guardian bind invalidates the daemon guardian-id cache.
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("guardian prompt — reuses channel already bound to guardian", async () => {
@@ -252,9 +287,9 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].id).toBe("chan-1");
 
-
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.channelId).toBe("chan-1");
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("guardian prompt — 409 when channel already belongs to another contact", async () => {
@@ -310,8 +345,11 @@ describe("handleContactPromptSubmit", () => {
     // IPC should have been called with an error so the CLI doesn't hang.
     expect(ipcMock).toHaveBeenCalledTimes(1);
 
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(typeof ipcCall.body.error).toBe("string");
+
+    // A 409 conflict mutated nothing — no cache-invalidation broadcast.
+    expectNoEmit(ipcMock);
   });
 
   test("guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
@@ -377,9 +415,9 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].contactId).toBe(gwGuardians[0].id);
 
-
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.contactId).toBe(gwGuardians[0].id);
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("non-guardian prompt — creates new contact and channel (gateway-first)", async () => {
@@ -417,10 +455,12 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannelRows[0].isPrimary).toBe(true);
 
     // The channel id handed to resolve_contact_prompt matches the gateway row.
-
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.channelId).toBe(gwChannelRows[0].id);
     expect(ipcCall.body.contactId).toBe(gwContactRows[0].id);
+
+    // A successful non-guardian upsert invalidates the daemon contact caches.
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("non-guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
@@ -505,9 +545,9 @@ describe("handleContactPromptSubmit", () => {
     // display_name not clobbered when displayName omitted from the body.
     expect(gwContactRows[0].displayName).toBe("Alice");
 
-
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as { body: Record<string, unknown> };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.contactId).toBe("contact-1");
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("non-guardian prompt — explicit null displayName is treated as omitted (preserves name, no 500)", async () => {
@@ -633,10 +673,9 @@ describe("handleContactPromptSubmit", () => {
     expect(asChannels).toHaveLength(1);
     expect(asChannels[0].contact_id).toBe("guardian-1");
 
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
-      body: Record<string, unknown>;
-    };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.channelId).toBe("chan-reuse");
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("guardian reuse — mirror-heal upsert throwing is non-fatal (still accepted, reuses channel)", async () => {
@@ -697,11 +736,10 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels[0].contactId).toBe("guardian-1");
 
     // Daemon resolved with the existing channel id (success, not error).
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
-      body: Record<string, unknown>;
-    };
+    const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.channelId).toBe("chan-reuse-fail");
     expect(ipcCall.body.error).toBeUndefined();
+    expectEmittedContactsChanged(ipcMock);
   });
 
   test("guardian bootstrap-create — gateway is authoritative; assistant mirror row exists without ACL role", async () => {
@@ -763,11 +801,12 @@ describe("handleContactPromptSubmit", () => {
 
     // Daemon was notified with an error (not a success resolve with empty id).
     expect(ipcMock).toHaveBeenCalledTimes(1);
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
-      body: Record<string, unknown>;
-    };
+    const ipcCall = resolveCall(ipcMock);
     expect(typeof ipcCall.body.error).toBe("string");
     expect(ipcCall.body.channelId).toBeUndefined();
+
+    // Failed resolution mutated nothing — no cache-invalidation broadcast.
+    expectNoEmit(ipcMock);
   });
 
   test("guardian bind — rolls back freshly-created guardian + 500 when channel can't be resolved", async () => {
@@ -807,9 +846,10 @@ describe("handleContactPromptSubmit", () => {
     expect(gwGuardians).toHaveLength(0);
 
     // Daemon notified with an error.
-    const ipcCall = (ipcMock.mock.calls as any[][])[0][1] as {
-      body: Record<string, unknown>;
-    };
+    const ipcCall = resolveCall(ipcMock);
     expect(typeof ipcCall.body.error).toBe("string");
+
+    // The rolled-back bind mutated nothing net — no cache-invalidation broadcast.
+    expectNoEmit(ipcMock);
   });
 });

--- a/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
@@ -50,6 +50,14 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   },
 }));
 
+// Mock IPC so the post-commit cache-invalidation emit doesn't dial a socket,
+// and so we can assert it fired.
+const ipcMock = mock(async () => ({}));
+
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: ipcMock,
+}));
+
 import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
 import {
   initGatewayDb,
@@ -104,6 +112,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  ipcMock.mockClear();
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
@@ -244,6 +253,25 @@ describe("createGuardianBinding gateway dual-write", () => {
     expect(row.status).toBe("active");
     expect(row.policy).toBe("allow");
     expect(row.contactId).toBe(result.contactId);
+  });
+
+  test("emits contacts_changed to invalidate the daemon guardian-id cache after a successful bind", async () => {
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_EMIT",
+      deliveryChatId: "D_EMIT",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const emitCalls = (ipcMock.mock.calls as any[][]).filter(
+      (c) => c[0] === "emit_event",
+    );
+    expect(emitCalls).toHaveLength(1);
+    expect(
+      (emitCalls[0][1] as { body: Record<string, unknown> }).body.kind,
+    ).toBe("contacts_changed");
   });
 });
 

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -21,6 +21,7 @@ import {
 import { readCredential } from "../credential-reader.js";
 import { credentialKey } from "../credential-key.js";
 import { arePlatformFeaturesEnabled } from "../feature-flag-resolver.js";
+import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { getLogger } from "../logger.js";
 
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
@@ -414,6 +415,12 @@ export async function createGuardianBinding(
     },
     "Created guardian binding",
   );
+
+  // Invalidate the daemon guardian-id/role caches after a gateway-owned
+  // guardian rebind.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
 
   return {
     contactId,

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -193,6 +193,14 @@ export async function handleContactPromptSubmit(
         ],
       });
       contactId = contact.id;
+
+      // Invalidate the daemon guardian-id/role caches after the committed
+      // gateway contact write — before the read-back guard, so a
+      // resolveChannelId miss still drops the stale caches.
+      void ipcCallAssistant("emit_event", {
+        body: { kind: "contacts_changed" },
+      } as unknown as Record<string, unknown>).catch(() => {});
+
       channelId = resolveChannelId(contactId, channelType, normalizedAddress);
 
       log.info(
@@ -207,12 +215,6 @@ export async function handleContactPromptSubmit(
         );
         return await channelResolutionError(requestId);
       }
-
-      // Invalidate the daemon guardian-id/role caches after a gateway-owned
-      // contact write.
-      void ipcCallAssistant("emit_event", {
-        body: { kind: "contacts_changed" },
-      } as unknown as Record<string, unknown>).catch(() => {});
 
       // Non-guardian is fully resolved by upsertContact; skip the guardian-only
       // Phase 2 channel-creation block below and go straight to resolve.

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -208,6 +208,12 @@ export async function handleContactPromptSubmit(
         return await channelResolutionError(requestId);
       }
 
+      // Invalidate the daemon guardian-id/role caches after a gateway-owned
+      // contact write.
+      void ipcCallAssistant("emit_event", {
+        body: { kind: "contacts_changed" },
+      } as unknown as Record<string, unknown>).catch(() => {});
+
       // Non-guardian is fully resolved by upsertContact; skip the guardian-only
       // Phase 2 channel-creation block below and go straight to resolve.
       return await resolveContactPrompt({
@@ -363,6 +369,12 @@ export async function handleContactPromptSubmit(
       { status: 500 },
     );
   }
+
+  // Invalidate the daemon guardian-id/role caches after a gateway-owned
+  // guardian bind/rebind/reuse.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
 
   return await resolveContactPrompt({
     requestId,

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -355,6 +355,14 @@ export async function handleContactPromptSubmit(
           "contact-prompt-submit: channel resolution failed after guardian bind, rolling back contact",
         );
         await rollbackCreatedContact();
+        // A freshly-created guardian was just rolled back (net no change). An
+        // existing guardian's channel bind committed and is NOT rolled back, so
+        // invalidate the daemon caches even though the read-back missed.
+        if (!createdNewContact) {
+          void ipcCallAssistant("emit_event", {
+            body: { kind: "contacts_changed" },
+          } as unknown as Record<string, unknown>).catch(() => {});
+        }
         return await channelResolutionError(requestId);
       }
 


### PR DESCRIPTION
## Summary
- The daemon caches the gateway guardian-contact id set (`getGuardianContactIds()`, 30s TTL), invalidated when the gateway fires the existing `emit_event` / `contacts_changed` IPC. The two gateway-side guardian bind/rebind paths wrote the gateway DB **without** emitting it, so daemon-native search / contactType-filtered reads stamped role from a stale set for up to 30s (a just-rebound guardian could render as a contact, or vice versa).
- Fires the same best-effort, fire-and-forget `contacts_changed` emit (matching the ~9 existing sites in the contacts proxy) after a successful guardian/contact write in `contact-prompt.ts` (non-guardian upsert + guardian bind/rebind/reuse) and `guardian-bootstrap.ts` (`createGuardianBinding`, after the binding commits). No mint/binding logic, transactions, TTLs, or response shapes are touched — purely an added notification.
- **Display-only**, no security impact (trust/authz reads the gateway TrustVerdict, not this cache). Emits are non-blocking (`void … .catch(() => {})`) so a failed/blocked emit never fails or delays a guardian bind.
- Tests: success paths (guardian bind/reuse/bootstrap-create, non-guardian create/reuse) assert `emit_event`+`contacts_changed` fires; error paths (409 conflict, 500 rollback, validation) assert it does NOT. `createGuardianBinding` test asserts a successful bind emits once. tsc clean.

## Original prompt
Continuing the contacts-ACL read-side cleanup after JARVIS-1229 merged, we picked up JARVIS-1230: gateway-side guardian rebinds (`contact-prompt` submit, `guardian-bootstrap.createGuardianBinding`) didn't signal the assistant, leaving the daemon's 30s guardian-id cache stale on daemon-native filtered reads. The agreed fix is the ticket's option 1 — fire the existing `contacts_changed` emit after the gateway-owned guardian write — without touching the sensitive mint logic. Gateway package only; display-only correctness fix.

Closes JARVIS-1230.