### PR TITLE
refactor(assistant): extract conversation evictor out of DaemonServer

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -103,7 +103,6 @@ mock.module("../daemon/conversation-store.js", () => ({
   conversationEntries: () => [][Symbol.iterator](),
   conversationIds: () => [][Symbol.iterator](),
   getConversationMap: () => new Map(),
-  initConversationLifecycle: () => {},
   registerConversationFactory: () => {},
   getOrCreateActiveConversation: mockGetOrCreateConversation,
   getConversationOptions: () => undefined,

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -8,10 +8,9 @@
  *
  * The {@link getOrCreateConversation} function owns the full
  * creation/reuse lifecycle — provider wiring, rate limiting, system
- * prompt assembly, and DB hydration. DaemonServer calls
- * {@link initConversationLifecycle} once at construction time to
- * supply the few remaining lifecycle references (evictor, shared
- * rate-limit timestamps, broadcast).
+ * prompt assembly, and DB hydration. The idle-eviction sweep and the
+ * shared rate-limit window also live here; {@link startConversationEvictor}
+ * starts the sweep at daemon startup.
  */
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
@@ -25,7 +24,7 @@ import { getSubagentManager } from "../subagent/index.js";
 import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import { Conversation } from "./conversation.js";
-import type { ConversationEvictor } from "./conversation-evictor.js";
+import { ConversationEvictor } from "./conversation-evictor.js";
 import {
   allConversations,
   clearConversations,
@@ -34,6 +33,7 @@ import {
   conversationIds,
   deleteConversation,
   findConversation,
+  getConversationMap,
   setConversation,
 } from "./conversation-registry.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
@@ -66,20 +66,32 @@ function clearConversationOptions(): void {
 /** Dedup guard: in-flight creation promises keyed by conversation ID. */
 const conversationCreating = new Map<string, Promise<Conversation>>();
 
-/** Lifecycle refs injected once by DaemonServer at construction. */
-let _evictor: ConversationEvictor | null = null;
-let _sharedRequestTimestamps: number[] = [];
-
 /**
- * One-time initialization called by DaemonServer to supply lifecycle
- * references that the conversation creation logic needs.
+ * Cross-conversation rate-limit window, shared between the per-conversation
+ * RateLimitProvider and the subagent manager so subagent requests count
+ * against the same budget.
  */
-export function initConversationLifecycle(refs: {
-  evictor: ConversationEvictor;
-  sharedRequestTimestamps: number[];
-}): void {
-  _evictor = refs.evictor;
-  _sharedRequestTimestamps = refs.sharedRequestTimestamps;
+const sharedRequestTimestamps: number[] = [];
+
+/** Idle/LRU/memory-pressure evictor for the in-memory conversation pool. */
+const evictor = new ConversationEvictor(getConversationMap());
+evictor.onEvict = (conversationId: string) => {
+  getSubagentManager().abortAllForParent(conversationId);
+};
+evictor.shouldProtect = (conversationId: string) => {
+  const children = getSubagentManager().getChildrenOf(conversationId);
+  return children.some((c) => c.status === "running" || c.status === "pending");
+};
+
+/** Start the conversation evictor's periodic sweep at daemon startup. */
+export function startConversationEvictor(): void {
+  getSubagentManager().sharedRequestTimestamps = sharedRequestTimestamps;
+  evictor.start();
+}
+
+/** Stop the conversation evictor during daemon shutdown. */
+export function stopConversationEvictor(): void {
+  evictor.stop();
 }
 
 function applyTransportMetadata(
@@ -97,9 +109,7 @@ function applyTransportMetadata(
  * Get or create an active conversation by ID.
  *
  * Handles provider setup, rate limiting, system prompt, memory policy,
- * and conversation hydration. Caller must have called
- * {@link initConversationLifecycle} first (DaemonServer does this at
- * construction).
+ * and conversation hydration.
  */
 export async function getOrCreateConversation(
   conversationId: string,
@@ -156,7 +166,7 @@ export async function getOrCreateConversation(
         provider = new RateLimitProvider(
           provider,
           rateLimit,
-          _sharedRequestTimestamps,
+          sharedRequestTimestamps,
         );
       }
       const workingDir = getSandboxWorkingDir();
@@ -202,7 +212,7 @@ export async function getOrCreateConversation(
     } finally {
       conversationCreating.delete(conversationId);
     }
-    _evictor?.touch(conversationId);
+    evictor.touch(conversationId);
   } else {
     if (!conversation.isProcessing()) {
       applyTransportMetadata(conversation, options);
@@ -210,7 +220,7 @@ export async function getOrCreateConversation(
         conversation.setTrustContext(options.trustContext);
       }
     }
-    _evictor?.touch(conversationId);
+    evictor.touch(conversationId);
   }
   return conversation;
 }
@@ -220,11 +230,11 @@ export async function getOrCreateConversation(
 // ---------------------------------------------------------------------------
 
 export function touchConversation(conversationId: string): void {
-  _evictor?.touch(conversationId);
+  evictor.touch(conversationId);
 }
 
 function removeFromEvictor(conversationId: string): void {
-  _evictor?.remove(conversationId);
+  evictor.remove(conversationId);
 }
 
 /**

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -93,6 +93,7 @@ import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import { startAppSourceWatcher } from "./app-source-watcher.js";
 import { startConfigWatcher } from "./config-watcher.js";
+import { startConversationEvictor } from "./conversation-store.js";
 import { writePid } from "./daemon-control.js";
 import {
   evaluateDiskPressureNow,
@@ -590,6 +591,10 @@ export async function runDaemon(): Promise<void> {
   const server = new DaemonServer();
   await server.start();
   log.info("Daemon startup: DaemonServer started");
+
+  // Start the idle/LRU/memory-pressure sweep over the in-memory conversation
+  // pool.
+  startConversationEvictor();
 
   // Watch workspace files (config, prompts, skills, sounds, avatar) and react
   // to changes: evict conversations so the next turn rebuilds against the new

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -11,12 +11,7 @@ import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 import { Conversation } from "./conversation.js";
-import { ConversationEvictor } from "./conversation-evictor.js";
-import { getConversationMap } from "./conversation-registry.js";
-import {
-  getOrCreateConversation as getOrCreateActiveConversation,
-  initConversationLifecycle,
-} from "./conversation-store.js";
+import { getOrCreateConversation as getOrCreateActiveConversation } from "./conversation-store.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 
@@ -37,29 +32,6 @@ function readPackageVersion(): string | undefined {
 const daemonVersion = readPackageVersion();
 
 export class DaemonServer {
-  private sharedRequestTimestamps: number[] = [];
-  private evictor: ConversationEvictor;
-
-  constructor() {
-    this.evictor = new ConversationEvictor(getConversationMap());
-    getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
-
-    initConversationLifecycle({
-      evictor: this.evictor,
-      sharedRequestTimestamps: this.sharedRequestTimestamps,
-    });
-
-    this.evictor.onEvict = (conversationId: string) => {
-      getSubagentManager().abortAllForParent(conversationId);
-    };
-    this.evictor.shouldProtect = (conversationId: string) => {
-      const children = getSubagentManager().getChildrenOf(conversationId);
-      return children.some(
-        (c) => c.status === "running" || c.status === "pending",
-      );
-    };
-  }
-
   /** Best-effort sync of the IDENTITY.md name to the platform record. */
   private syncIdentityToPlatform(): void {
     try {
@@ -82,8 +54,6 @@ export class DaemonServer {
     const config = getConfig();
     await initializeProviders(config);
 
-    this.evictor.start();
-
     this.syncIdentityToPlatform();
 
     log.info("DaemonServer started (HTTP-only mode)");
@@ -92,7 +62,6 @@ export class DaemonServer {
   async stop(): Promise<void> {
     getSubagentManager().disposeAll();
     disposeAcpSessionManager();
-    this.evictor.stop();
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -24,7 +24,10 @@ import {
 } from "../workspace/heartbeat-service.js";
 import { stopAppSourceWatcher } from "./app-source-watcher.js";
 import { stopConfigWatcher } from "./config-watcher.js";
-import { stopConversations } from "./conversation-store.js";
+import {
+  stopConversationEvictor,
+  stopConversations,
+} from "./conversation-store.js";
 import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
@@ -99,6 +102,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    stopConversationEvictor();
     stopConfigWatcher();
     stopAppSourceWatcher();
     stopCliIpcServer();


### PR DESCRIPTION
## Prompt / plan

Continuing the bottom-up dissolution of `DaemonServer`. After config-watcher, the evictor is the next (and last big) subsystem `stop()` touches.

## What changed

The `ConversationEvictor` was created and wired entirely in the `DaemonServer` constructor — `onEvict`/`shouldProtect` hooks, the shared rate-limit timestamps array, and injection into `conversation-store` via `initConversationLifecycle` — then started/stopped in `start()`/`stop()`. Since `conversation-store` already held the evictor reference (and the shared timestamps), it now **owns** them directly:

- **`daemon/conversation-store.ts`** — creates the `evictor` (and `sharedRequestTimestamps`) as module singletons, wires the `onEvict`/`shouldProtect` subagent hooks itself, and exposes `startConversationEvictor()` (sets the subagent manager's shared timestamps + starts the sweep) and `stopConversationEvictor()`.
- **`daemon/server.ts`** — dropped the `evictor` + `sharedRequestTimestamps` fields, the whole constructor, and the `evictor.start()`/`stop()` calls. (`DaemonServer` now has no constructor; `start()` does providers + identity sync, `stop()` does subagent/ACP disposal.)
- **`daemon/lifecycle.ts`** / **`daemon/shutdown-handlers.ts`** — call `startConversationEvictor()` after `server.start()` and `stopConversationEvictor()` after `server.stop()` (same relative positions as before).

### Bonus: deleted the `initConversationLifecycle` DI

That injector existed only to hand the evictor + timestamps from `DaemonServer` into `conversation-store`. With `conversation-store` owning them, it's gone. No import cycle (`conversation-evictor` only imports the logger).

## Test plan

- `conversation-store` (28), `conversation-evictor` (9), `btw-routes` (14), `conversation-process-callsite` (5), `subagent-manager-notify` (19) — pass in isolation.
- Pre-commit + pre-push hooks: prettier, eslint, full project typecheck all green.
- No test constructs `DaemonServer`; the evictor/subagent unit tests construct their classes directly and are unaffected. Removed a stale `initConversationLifecycle` key from the `btw-routes` conversation-store mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_