### PR TITLE
feat(web): flag-gated transcript render from the materialized snapshot (cutover 2a)

### DIFF
--- a/clients/web/src/domains/chat/transcript/use-transcript-messages.test.tsx
+++ b/clients/web/src/domains/chat/transcript/use-transcript-messages.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+
+// Stub the history query so the hook reads a fixed cached-history value, with
+// no QueryClient provider needed.
+const realPaginationModule = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
+let historyMessages: DisplayMessage[] = [];
+mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
+  ...realPaginationModule,
+  useHistoryPagination: () =>
+    ({ messages: historyMessages }) as unknown as HistoryPaginationResult,
+}));
+
+const { useTranscriptMessages } = await import(
+  "@/domains/chat/transcript/use-transcript-messages"
+);
+const { useChatSessionStore } = await import("@/domains/chat/chat-session-store");
+const { useClientFeatureFlagStore } = await import(
+  "@/stores/client-feature-flag-store"
+);
+
+function row(id: string, role: DisplayMessage["role"], text: string): DisplayMessage {
+  return {
+    id,
+    role,
+    textSegments: [text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text }],
+    ...(role === "user" ? { clientMessageId: id } : {}),
+  };
+}
+
+function setFlag(on: boolean) {
+  useClientFeatureFlagStore.getState().setFlag("clientSyncSnapshotRender", on);
+}
+
+beforeEach(() => {
+  historyMessages = [];
+  useChatSessionStore.setState({ liveTurn: [], snapshot: null, optimisticSends: [] });
+  setFlag(false);
+});
+afterEach(() => {
+  cleanup();
+  useChatSessionStore.setState({ liveTurn: [], snapshot: null, optimisticSends: [] });
+  setFlag(false);
+});
+
+const render = () =>
+  renderHook(() => useTranscriptMessages("asst-1", "conv-A")).result;
+
+describe("useTranscriptMessages — render source flag", () => {
+  test("flag off: derives from cached history ⊕ liveTurn", () => {
+    historyMessages = [row("h1", "assistant", "from history")];
+    useChatSessionStore.setState({
+      liveTurn: [row("u1", "user", "from liveTurn")],
+      snapshot: {
+        messages: [row("s1", "assistant", "from snapshot")],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+      optimisticSends: [row("o1", "user", "from optimistic")],
+    });
+
+    expect(render().current.map((m) => m.id)).toEqual(["h1", "u1"]);
+  });
+
+  test("flag on: derives from snapshot ⊕ optimisticSends", () => {
+    historyMessages = [row("h1", "assistant", "from history")];
+    useChatSessionStore.setState({
+      liveTurn: [row("u1", "user", "from liveTurn")],
+      snapshot: {
+        messages: [row("s1", "assistant", "from snapshot")],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+      optimisticSends: [row("o1", "user", "from optimistic")],
+    });
+    setFlag(true);
+
+    expect(render().current.map((m) => m.id)).toEqual(["s1", "o1"]);
+  });
+
+  test("flag on with no snapshot yet: shows just the optimistic sends", () => {
+    useChatSessionStore.setState({
+      snapshot: null,
+      optimisticSends: [row("o1", "user", "queued send")],
+    });
+    setFlag(true);
+
+    expect(render().current.map((m) => m.id)).toEqual(["o1"]);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/use-transcript-messages.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-messages.ts
@@ -19,6 +19,7 @@ import { useMemo } from "react";
 import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
 import { useHistoryPagination } from "@/domains/chat/transcript/use-history-pagination";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { filterDismissedSurfaces } from "@/domains/chat/utils/dismissed-surfaces-storage";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
@@ -32,13 +33,22 @@ export function useTranscriptMessages(
     enabled: !!assistantId && !!conversationId,
   });
   const liveTurn = useChatSessionStore.use.liveTurn();
+  const snapshot = useChatSessionStore.use.snapshot();
+  const optimisticSends = useChatSessionStore.use.optimisticSends();
   const dismissedSurfaceIds = useChatSessionStore.use.dismissedSurfaceIds();
+  // Client-sync cutover: when on, derive from the materialized snapshot
+  // (snapshot ⊕ optimisticSends) instead of cached history ⊕ liveTurn. Off by
+  // default — optimistic-send re-homing, queued messages, and confirmation
+  // patches are still being migrated onto the new homes (slice 2b).
+  const fromSnapshot = useClientFeatureFlagStore.use.clientSyncSnapshotRender();
 
   return useMemo(() => {
+    const base = fromSnapshot ? (snapshot?.messages ?? []) : history;
+    const live = fromSnapshot ? optimisticSends : liveTurn;
     // Dismissed surfaces are client state that hides server-sent surface rows;
-    // apply it to history at read time (returns the same ref when nothing is
+    // apply it to the base at read time (returns the same ref when nothing is
     // dismissed, so the steady-state union stays referentially stable).
-    const visibleHistory = filterDismissedSurfaces(history, dismissedSurfaceIds);
-    return selectTranscriptMessages(visibleHistory, liveTurn);
-  }, [history, liveTurn, dismissedSurfaceIds]);
+    const visibleBase = filterDismissedSurfaces(base, dismissedSurfaceIds);
+    return selectTranscriptMessages(visibleBase, live);
+  }, [fromSnapshot, history, liveTurn, snapshot, optimisticSends, dismissedSurfaceIds]);
 }

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -409,6 +409,14 @@
       "label": "New-thread suggestions library",
       "description": "Replace the empty-state conversation-starter chips with the scrollable, categorized suggestions library and detail drawer (currently mocked data).",
       "defaultEnabled": false
+    },
+    {
+      "id": "client-sync-snapshot-render",
+      "scope": "client",
+      "key": "client-sync-snapshot-render",
+      "label": "Client-sync: render from the materialized snapshot",
+      "description": "Derive the chat transcript from the client-sync rolling snapshot (snapshot ⊕ optimisticSends) instead of cached history ⊕ liveTurn. In-progress cutover — optimistic-send re-homing, queued messages, and confirmation/surface patches are still being migrated, so leave off outside testing.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
The render flip, behind a flag. Adds the `client-sync-snapshot-render` client flag (**default off**) and branches the single transcript read seam (`use-transcript-messages`) on it:

- **off (default):** `cached history ⊕ liveTurn` — byte-identical to today.
- **on:** `snapshot ⊕ optimisticSends` — the rolling snapshot maintained in shadow (#36469), overlaid with optimistic sends.

This is intentionally the *thin* slice that establishes the flag + render seam without touching the entangled hot paths. `liveTurn` turned out to be the shared home for **five** concerns (streaming, optimistic sends, queued messages, confirmation/surface cleanup, the live overlay) with six readers — too much for one safe PR — so the cutover is sliced:

- **2a (this):** flag + gated render seam.
- **2b:** re-home optimistic sends (+ clear on echo), queued messages (fold `message_queued`/`dequeued`/`deleted` into the reducer), and confirmation/surface patches; migrate the secondary readers (`use-chat-ui-state`, `use-auto-greet-gate`, `use-message-reconciliation`).
- **2c:** flip the default, delete `liveTurn` + `setLiveTurn` + the seed-twin overlay + the turn-idle handoff prune, and flip `clients/web/AGENTS.md:30`.

The **flag-on path is WIP** until 2b — optimistic sends, queued messages, and confirmation patches still target `liveTurn`, so leave the flag off outside testing. Off by default ⇒ production is unchanged.

## Test
`use-transcript-messages.test.tsx`: the seam reads `history ⊕ liveTurn` when off and `snapshot ⊕ optimisticSends` when on, and shows just the optimistic sends before the snapshot seeds. Lint + typecheck clean; existing `select-transcript-messages` suite unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfnfDLSWa4M6wbpznZvcTV)_