### PR TITLE
refactor(memory): single async withSqliteRetry, drop sync variant

### DIFF
--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -69,8 +69,8 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     getRawDb().run("DELETE FROM conversations");
   });
 
-  test("deleting a conversation with a scheduleJobId removes the schedule", () => {
-    const schedule = createSchedule({
+  test("deleting a conversation with a scheduleJobId removes the schedule", async () => {
+    const schedule = await createSchedule({
       name: "Daily standup",
       expression: "0 9 * * 1-5",
       message: "Time for standup!",
@@ -83,7 +83,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
 
     expect(getSchedule(schedule.id)).not.toBeNull();
 
-    deleteRoute.handler({
+    await deleteRoute.handler({
       pathParams: { id: conv.id },
       body: {},
       headers: {},
@@ -93,8 +93,8 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     expect(getConversation(conv.id)).toBeNull();
   });
 
-  test("deleting a conversation without a scheduleJobId does not affect schedules", () => {
-    const schedule = createSchedule({
+  test("deleting a conversation without a scheduleJobId does not affect schedules", async () => {
+    const schedule = await createSchedule({
       name: "Unrelated schedule",
       expression: "0 12 * * *",
       message: "Noon check",
@@ -102,7 +102,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
 
     const conv = createConversation("no-schedule-conv");
 
-    deleteRoute.handler({
+    await deleteRoute.handler({
       pathParams: { id: conv.id },
       body: {},
       headers: {},
@@ -112,8 +112,8 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     expect(getConversation(conv.id)).toBeNull();
   });
 
-  test("deleting a conversation with a schedule also removes its cron_runs", () => {
-    const schedule = createSchedule({
+  test("deleting a conversation with a schedule also removes its cron_runs", async () => {
+    const schedule = await createSchedule({
       name: "Recurring job",
       expression: "0 9 * * *",
       message: "Daily task",
@@ -137,7 +137,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       .get();
     expect(runBefore).not.toBeNull();
 
-    deleteRoute.handler({
+    await deleteRoute.handler({
       pathParams: { id: conv.id },
       body: {},
       headers: {},
@@ -150,8 +150,8 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     expect(runAfter).toBeNull();
   });
 
-  test("deleting one of multiple conversations sharing a schedule preserves the schedule", () => {
-    const schedule = createSchedule({
+  test("deleting one of multiple conversations sharing a schedule preserves the schedule", async () => {
+    const schedule = await createSchedule({
       name: "Recurring daily",
       expression: "0 9 * * *",
       message: "Daily task",
@@ -166,7 +166,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       scheduleJobId: schedule.id,
     });
 
-    deleteRoute.handler({
+    await deleteRoute.handler({
       pathParams: { id: conv1.id },
       body: {},
       headers: {},
@@ -175,13 +175,13 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     expect(getSchedule(schedule.id)).not.toBeNull();
   });
 
-  test("deleting one scheduled conversation does not affect other schedules", () => {
-    const scheduleA = createSchedule({
+  test("deleting one scheduled conversation does not affect other schedules", async () => {
+    const scheduleA = await createSchedule({
       name: "Schedule A",
       expression: "0 9 * * *",
       message: "Task A",
     });
-    const scheduleB = createSchedule({
+    const scheduleB = await createSchedule({
       name: "Schedule B",
       expression: "0 17 * * *",
       message: "Task B",
@@ -196,7 +196,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       scheduleJobId: scheduleB.id,
     });
 
-    deleteRoute.handler({
+    await deleteRoute.handler({
       pathParams: { id: convA.id },
       body: {},
       headers: {},
@@ -222,8 +222,8 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
     getRawDb().run("DELETE FROM conversations");
   });
 
-  test("wiping a conversation with a scheduleJobId removes the schedule", () => {
-    const schedule = createSchedule({
+  test("wiping a conversation with a scheduleJobId removes the schedule", async () => {
+    const schedule = await createSchedule({
       name: "Wipe-test schedule",
       expression: "0 9 * * 1-5",
       message: "Time for standup!",
@@ -236,7 +236,7 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
 
     expect(getSchedule(schedule.id)).not.toBeNull();
 
-    wipeRoute.handler({
+    await wipeRoute.handler({
       pathParams: { id: conv.id },
       body: {},
       headers: {},
@@ -245,8 +245,8 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
     expect(getSchedule(schedule.id)).toBeNull();
   });
 
-  test("wiping a conversation without a scheduleJobId does not affect schedules", () => {
-    const schedule = createSchedule({
+  test("wiping a conversation without a scheduleJobId does not affect schedules", async () => {
+    const schedule = await createSchedule({
       name: "Unrelated schedule",
       expression: "0 12 * * *",
       message: "Noon check",
@@ -254,7 +254,7 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
 
     const conv = createConversation("no-schedule-wipe");
 
-    wipeRoute.handler({
+    await wipeRoute.handler({
       pathParams: { id: conv.id },
       body: {},
       headers: {},

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -107,8 +107,8 @@ describe("schedule retry store", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("scheduleRetry reverts one-shot from firing to active with future nextRunAt", () => {
-    const schedule = createSchedule({
+  test("scheduleRetry reverts one-shot from firing to active with future nextRunAt", async () => {
+    const schedule = await createSchedule({
       name: "One-shot retry",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -122,15 +122,15 @@ describe("schedule retry store", () => {
     ]);
 
     const futureTime = Date.now() + 120_000;
-    scheduleRetry(schedule.id, futureTime);
+    await scheduleRetry(schedule.id, futureTime);
 
     const updated = getSchedule(schedule.id)!;
     expect(updated.status).toBe("active");
     expect(updated.nextRunAt).toBe(futureTime);
   });
 
-  test("scheduleRetry sets nextRunAt for recurring schedule without changing status", () => {
-    const schedule = createSchedule({
+  test("scheduleRetry sets nextRunAt for recurring schedule without changing status", async () => {
+    const schedule = await createSchedule({
       name: "Recurring retry",
       cronExpression: "0 * * * *",
       message: "test",
@@ -139,7 +139,7 @@ describe("schedule retry store", () => {
 
     const originalStatus = getSchedule(schedule.id)!.status;
     const futureTime = Date.now() + 120_000;
-    scheduleRetry(schedule.id, futureTime);
+    await scheduleRetry(schedule.id, futureTime);
 
     const updated = getSchedule(schedule.id)!;
     expect(updated.nextRunAt).toBe(futureTime);
@@ -147,8 +147,8 @@ describe("schedule retry store", () => {
     expect(updated.status).toBe(originalStatus);
   });
 
-  test("resetRetryCount resets retryCount to 0 after error", () => {
-    const schedule = createSchedule({
+  test("resetRetryCount resets retryCount to 0 after error", async () => {
+    const schedule = await createSchedule({
       name: "Reset test",
       cronExpression: "0 * * * *",
       message: "test",
@@ -156,20 +156,20 @@ describe("schedule retry store", () => {
     });
 
     // Simulate an error run which increments retryCount
-    const runId = createScheduleRun(schedule.id, "test-conv");
-    completeScheduleRun(runId, { status: "error", error: "boom" });
+    const runId = await createScheduleRun(schedule.id, "test-conv");
+    await completeScheduleRun(runId, { status: "error", error: "boom" });
 
     const afterError = getSchedule(schedule.id)!;
     expect(afterError.retryCount).toBe(1);
 
-    resetRetryCount(schedule.id);
+    await resetRetryCount(schedule.id);
 
     const afterReset = getSchedule(schedule.id)!;
     expect(afterReset.retryCount).toBe(0);
   });
 
-  test("createSchedule with custom maxRetries and retryBackoffMs", () => {
-    const schedule = createSchedule({
+  test("createSchedule with custom maxRetries and retryBackoffMs", async () => {
+    const schedule = await createSchedule({
       name: "Custom retry config",
       cronExpression: "0 * * * *",
       message: "test",
@@ -183,8 +183,8 @@ describe("schedule retry store", () => {
     expect(retrieved.retryBackoffMs).toBe(30000);
   });
 
-  test("createSchedule with defaults has maxRetries=3 and retryBackoffMs=60000", () => {
-    const schedule = createSchedule({
+  test("createSchedule with defaults has maxRetries=3 and retryBackoffMs=60000", async () => {
+    const schedule = await createSchedule({
       name: "Default retry config",
       cronExpression: "0 * * * *",
       message: "test",
@@ -213,7 +213,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("execute mode failure retries with backoff", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Failing hourly",
       cronExpression: "0 * * * *",
       message: "do work",
@@ -249,7 +249,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("execute mode retry success resets retryCount", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Flaky hourly",
       cronExpression: "0 * * * *",
       message: "do work",
@@ -283,7 +283,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("execute mode exhaustion resets retryCount and resumes cadence", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Exhaust hourly",
       cronExpression: "0 * * * *",
       message: "do work",
@@ -320,7 +320,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("one-shot failure retries with backoff", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot failing",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -347,7 +347,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("one-shot exhaustion permanently cancels", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot exhaust",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -379,7 +379,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("notify one-shot failure creates schedule run", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Notify one-shot",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -406,7 +406,7 @@ describe("scheduler retry integration", () => {
   });
 
   test("recurring schedule retry blocks normal cadence", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Cadence blocking",
       cronExpression: "0 * * * *",
       message: "do work",
@@ -444,8 +444,8 @@ describe("crash recovery", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("recovers stale firing one-shot", () => {
-    const schedule = createSchedule({
+  test("recovers stale firing one-shot", async () => {
+    const schedule = await createSchedule({
       name: "Stale one-shot",
       expression: null,
       nextRunAt: Date.now() - 60_000,
@@ -460,7 +460,7 @@ describe("crash recovery", () => {
       [Date.now() - 60_000, schedule.id],
     );
 
-    const recovered = recoverStaleSchedules();
+    const recovered = await recoverStaleSchedules();
     expect(recovered).toBe(1);
 
     // A schedule run should be created with error
@@ -476,8 +476,8 @@ describe("crash recovery", () => {
     expect(updated.nextRunAt).toBeGreaterThan(Date.now() - 5000);
   });
 
-  test("recovers stale running cron_run", () => {
-    const schedule = createSchedule({
+  test("recovers stale running cron_run", async () => {
+    const schedule = await createSchedule({
       name: "Stale run",
       cronExpression: "0 * * * *",
       message: "test",
@@ -485,10 +485,10 @@ describe("crash recovery", () => {
     });
 
     // Create a "running" schedule run to simulate crash
-    const runId = createScheduleRun(schedule.id, "stale-conv");
+    const runId = await createScheduleRun(schedule.id, "stale-conv");
     // The run is now in "running" status by default
 
-    const recovered = recoverStaleSchedules();
+    const recovered = await recoverStaleSchedules();
     expect(recovered).toBe(1);
 
     const runs = getScheduleRuns(schedule.id);
@@ -498,8 +498,8 @@ describe("crash recovery", () => {
     expect(recoveredRun!.error).toContain("recovered on restart");
   });
 
-  test("respects maxRetries on recovery - cancels exhausted one-shot", () => {
-    const schedule = createSchedule({
+  test("respects maxRetries on recovery - cancels exhausted one-shot", async () => {
+    const schedule = await createSchedule({
       name: "Exhausted one-shot",
       expression: null,
       nextRunAt: Date.now() - 60_000,
@@ -514,15 +514,15 @@ describe("crash recovery", () => {
       [3, Date.now() - 60_000, schedule.id],
     );
 
-    recoverStaleSchedules();
+    await recoverStaleSchedules();
 
     const updated = getSchedule(schedule.id)!;
     expect(updated.status).toBe("cancelled");
     expect(updated.enabled).toBe(false);
   });
 
-  test("idempotent - second call returns 0", () => {
-    const schedule = createSchedule({
+  test("idempotent - second call returns 0", async () => {
+    const schedule = await createSchedule({
       name: "Idempotent test",
       expression: null,
       nextRunAt: Date.now() - 60_000,
@@ -535,15 +535,15 @@ describe("crash recovery", () => {
       [Date.now() - 60_000, schedule.id],
     );
 
-    const first = recoverStaleSchedules();
+    const first = await recoverStaleSchedules();
     expect(first).toBe(1);
 
-    const second = recoverStaleSchedules();
+    const second = await recoverStaleSchedules();
     expect(second).toBe(0);
   });
 
-  test("age threshold filters recent in-flight jobs", () => {
-    const schedule = createSchedule({
+  test("age threshold filters recent in-flight jobs", async () => {
+    const schedule = await createSchedule({
       name: "Recent firing",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -585,7 +585,7 @@ describe("scheduler-recovery equivalence", () => {
 
   test("same retry state for identical recurring job inputs", async () => {
     // Create two identical recurring schedules
-    const scheduleA = createSchedule({
+    const scheduleA = await createSchedule({
       name: "Equiv A",
       cronExpression: "0 * * * *",
       message: "test",
@@ -594,7 +594,7 @@ describe("scheduler-recovery equivalence", () => {
       retryBackoffMs: 60000,
     });
 
-    const scheduleB = createSchedule({
+    const scheduleB = await createSchedule({
       name: "Equiv B",
       cronExpression: "0 * * * *",
       message: "test",
@@ -620,8 +620,8 @@ describe("scheduler-recovery equivalence", () => {
       scheduleB.id,
     ]);
     // Create a run and complete it with error (same as what scheduler does)
-    const runId = createScheduleRun(scheduleB.id, "recovery-conv");
-    completeScheduleRun(runId, {
+    const runId = await createScheduleRun(scheduleB.id, "recovery-conv");
+    await completeScheduleRun(runId, {
       status: "error",
       error: "Process terminated during execution (recovered on restart)",
     });
@@ -631,7 +631,7 @@ describe("scheduler-recovery equivalence", () => {
     const noopLogger = new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     });
-    applyRetryDecision({
+    await applyRetryDecision({
       job: jobB,
       isOneShot: false,
       errorMsg: "fail",
@@ -659,7 +659,7 @@ describe("scheduler-recovery equivalence", () => {
 
   test("same exhaust state for identical one-shot inputs", async () => {
     // Create two identical one-shot schedules at max retries
-    const scheduleA = createSchedule({
+    const scheduleA = await createSchedule({
       name: "Exhaust A",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -669,7 +669,7 @@ describe("scheduler-recovery equivalence", () => {
       retryBackoffMs: 1000,
     });
 
-    const scheduleB = createSchedule({
+    const scheduleB = await createSchedule({
       name: "Exhaust B",
       expression: null,
       nextRunAt: Date.now() - 1000,
@@ -703,15 +703,15 @@ describe("scheduler-recovery equivalence", () => {
       "UPDATE cron_jobs SET status = 'firing', last_run_at = ? WHERE id = ?",
       [Date.now() - 60_000, scheduleB.id],
     );
-    const runB1 = createScheduleRun(scheduleB.id, "recovery-conv-1");
-    completeScheduleRun(runB1, { status: "error", error: "fail" });
+    const runB1 = await createScheduleRun(scheduleB.id, "recovery-conv-1");
+    await completeScheduleRun(runB1, { status: "error", error: "fail" });
     // decideRetry + apply for first failure
     const jobB1 = getSchedule(scheduleB.id)!;
     const decision1 = decideRetry(jobB1);
     const noopLogger = new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     });
-    applyRetryDecision({
+    await applyRetryDecision({
       job: jobB1,
       isOneShot: true,
       errorMsg: "fail",
@@ -734,11 +734,11 @@ describe("scheduler-recovery equivalence", () => {
       "UPDATE cron_jobs SET status = 'firing', last_run_at = ? WHERE id = ?",
       [Date.now() - 60_000, scheduleB.id],
     );
-    const runB2 = createScheduleRun(scheduleB.id, "recovery-conv-2");
-    completeScheduleRun(runB2, { status: "error", error: "fail" });
+    const runB2 = await createScheduleRun(scheduleB.id, "recovery-conv-2");
+    await completeScheduleRun(runB2, { status: "error", error: "fail" });
     const jobB2 = getSchedule(scheduleB.id)!;
     const decision2 = decideRetry(jobB2);
-    applyRetryDecision({
+    await applyRetryDecision({
       job: jobB2,
       isOneShot: true,
       errorMsg: "fail",

--- a/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
+++ b/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
@@ -9,7 +9,11 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../config/loader.js", () => ({
-  getConfig: () => ({}),
+  getConfig: () => ({
+    migrations: { worker: { enabled: false } },
+    llm: { pricingOverrides: {} },
+    timeouts: { scheduleTurnTimeoutSec: 600 },
+  }),
   invalidateConfigCache: () => {},
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
@@ -86,48 +90,48 @@ function runNowRoute(): RouteDefinition {
 describe("PATCH /schedules/:id — workflow-mode name validation", () => {
   beforeEach(clearTables);
 
-  test("rejects switching mode to workflow without a workflowName (flag on)", () => {
-    const schedule = createSchedule({
+  test("rejects switching mode to workflow without a workflowName (flag on)", async () => {
+    const schedule = await createSchedule({
       name: "Plain execute",
       cronExpression: "0 9 * * *",
       message: "hi",
       syntax: "cron",
     });
 
-    expect(() =>
+    await expect(
       patchRoute().handler({
         pathParams: { id: schedule.id },
         body: { mode: "workflow" },
       }),
-    ).toThrow("workflowName is required");
+    ).rejects.toThrow("workflowName is required");
 
     // The schedule must stay in its prior mode — the wedge-prone nameless
     // workflow row was never persisted.
     expect(listSchedules()[0].mode).toBe("execute");
   });
 
-  test("rejects switching to workflow with a blank/whitespace workflowName", () => {
-    const schedule = createSchedule({
+  test("rejects switching to workflow with a blank/whitespace workflowName", async () => {
+    const schedule = await createSchedule({
       name: "Plain execute",
       cronExpression: "0 9 * * *",
       message: "hi",
       syntax: "cron",
     });
 
-    expect(() =>
+    await expect(
       patchRoute().handler({
         pathParams: { id: schedule.id },
         body: { mode: "workflow", workflowName: "   " },
       }),
-    ).toThrow("workflowName is required");
+    ).rejects.toThrow("workflowName is required");
     expect(listSchedules()[0].mode).toBe("execute");
   });
 
-  test("rejects clearing the workflowName on an already-workflow schedule", () => {
+  test("rejects clearing the workflowName on an already-workflow schedule", async () => {
     // An existing workflow-mode schedule (created via the store, which is not
     // flag-gated). PATCH does not touch `mode`, so the resulting mode is still
     // `workflow` and a cleared name must be rejected.
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Workflow schedule",
       cronExpression: "0 9 * * *",
       message: "trigger",
@@ -136,61 +140,61 @@ describe("PATCH /schedules/:id — workflow-mode name validation", () => {
       workflowName: "triage-inbox",
     });
 
-    expect(() =>
+    await expect(
       patchRoute().handler({
         pathParams: { id: schedule.id },
         body: { workflowName: "" },
       }),
-    ).toThrow("workflowName is required");
+    ).rejects.toThrow("workflowName is required");
 
     // Null clears the name too — same rejection.
-    expect(() =>
+    await expect(
       patchRoute().handler({
         pathParams: { id: schedule.id },
         body: { workflowName: null },
       }),
-    ).toThrow("workflowName is required");
+    ).rejects.toThrow("workflowName is required");
 
     // The original name is intact (neither PATCH was applied).
     expect(listSchedules()[0].workflowName).toBe("triage-inbox");
   });
 
-  test("rejects with a BadRequestError instance (400 shape, matching create)", () => {
-    const schedule = createSchedule({
+  test("rejects with a BadRequestError instance (400 shape, matching create)", async () => {
+    const schedule = await createSchedule({
       name: "Plain execute",
       cronExpression: "0 9 * * *",
       message: "hi",
       syntax: "cron",
     });
 
-    expect(() =>
+    await expect(
       patchRoute().handler({
         pathParams: { id: schedule.id },
         body: { mode: "workflow" },
       }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  test("allows switching to workflow mode WITH a valid workflowName", () => {
-    const schedule = createSchedule({
+  test("allows switching to workflow mode WITH a valid workflowName", async () => {
+    const schedule = await createSchedule({
       name: "Plain execute",
       cronExpression: "0 9 * * *",
       message: "hi",
       syntax: "cron",
     });
 
-    const result = patchRoute().handler({
+    const result = (await patchRoute().handler({
       pathParams: { id: schedule.id },
       body: { mode: "workflow", workflowName: "triage-inbox" },
-    }) as { schedules: Array<{ id: string; mode: string }> };
+    })) as { schedules: Array<{ id: string; mode: string }> };
 
     const updated = result.schedules.find((s) => s.id === schedule.id);
     expect(updated?.mode).toBe("workflow");
     expect(listSchedules()[0].workflowName).toBe("triage-inbox");
   });
 
-  test("allows an unrelated PATCH on a workflow schedule (name untouched)", () => {
-    const schedule = createSchedule({
+  test("allows an unrelated PATCH on a workflow schedule (name untouched)", async () => {
+    const schedule = await createSchedule({
       name: "Workflow schedule",
       cronExpression: "0 9 * * *",
       message: "trigger",
@@ -201,10 +205,10 @@ describe("PATCH /schedules/:id — workflow-mode name validation", () => {
 
     // Patching only the message leaves mode=workflow and the name in place, so
     // the validation passes (it reads the persisted name).
-    const result = patchRoute().handler({
+    const result = (await patchRoute().handler({
       pathParams: { id: schedule.id },
       body: { message: "trigger now" },
-    }) as { schedules: Array<{ id: string; workflowName: string | null }> };
+    })) as { schedules: Array<{ id: string; workflowName: string | null }> };
 
     expect(result.schedules[0].workflowName).toBe("triage-inbox");
   });
@@ -213,10 +217,10 @@ describe("PATCH /schedules/:id — workflow-mode name validation", () => {
 describe("POST /schedules — workflow mode does not require a message", () => {
   beforeEach(clearTables);
 
-  test("creates a workflow schedule with no message field", () => {
+  test("creates a workflow schedule with no message field", async () => {
     // Workflow runs trigger workflowName/workflowArgs and ignore job.message,
     // so the endpoint must not force a dummy message for workflow mode.
-    const result = createRoute().handler({
+    const result = (await createRoute().handler({
       body: {
         name: "Nightly triage",
         description: "Run the triage workflow",
@@ -225,14 +229,14 @@ describe("POST /schedules — workflow mode does not require a message", () => {
         workflowName: "triage-inbox",
         // no `message`
       },
-    }) as { schedules: Array<{ mode: string; workflowName: string | null }> };
+    })) as { schedules: Array<{ mode: string; workflowName: string | null }> };
 
     const created = result.schedules.find((s) => s.mode === "workflow");
     expect(created?.workflowName).toBe("triage-inbox");
   });
 
-  test("still rejects a workflow schedule with no workflowName", () => {
-    expect(() =>
+  test("still rejects a workflow schedule with no workflowName", async () => {
+    await expect(
       createRoute().handler({
         body: {
           name: "Nightly triage",
@@ -241,11 +245,11 @@ describe("POST /schedules — workflow mode does not require a message", () => {
           mode: "workflow",
         },
       }),
-    ).toThrow("workflowName is required");
+    ).rejects.toThrow("workflowName is required");
   });
 
-  test("execute mode still requires a message", () => {
-    expect(() =>
+  test("execute mode still requires a message", async () => {
+    await expect(
       createRoute().handler({
         body: {
           name: "Plain execute",
@@ -255,7 +259,7 @@ describe("POST /schedules — workflow mode does not require a message", () => {
           // no `message`
         },
       }),
-    ).toThrow("message is required");
+    ).rejects.toThrow("message is required");
   });
 });
 
@@ -267,7 +271,7 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
   });
 
   test("starts the saved workflow instead of running a message turn", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Nightly triage",
       cronExpression: "0 9 * * *",
       message: "", // workflow mode carries no message
@@ -311,7 +315,7 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
   });
 
   test("fires with the schedule's stored side-effecting manifest", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Side-effecting workflow",
       cronExpression: "0 9 * * *",
       message: "",
@@ -336,7 +340,7 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
   });
 
   test("a legacy schedule (null capabilities) fires with the read-only baseline", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Legacy workflow",
       cronExpression: "0 9 * * *",
       message: "",
@@ -360,7 +364,7 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
     // Defensive guard mirroring the scheduler's automatic firing path; a
     // nameless workflow schedule cannot be created via the routes, but the store
     // does not enforce it, so run-now must fail fast rather than fall through.
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Nameless workflow",
       cronExpression: "0 9 * * *",
       message: "",
@@ -380,7 +384,7 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
     // can't defer to a later tick, so it fails fast with a retryable 503 and
     // never calls start().
     coreToolsReady = false;
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Nightly triage",
       cronExpression: "0 9 * * *",
       message: "",

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -17,6 +17,9 @@ mock.module("../config/loader.js", () => ({
       cronExpression: null,
       timezone: null,
     },
+    migrations: { worker: { enabled: false } },
+    llm: { pricingOverrides: {} },
+    timeouts: { scheduleTurnTimeoutSec: 600 },
   }),
   getConfigReadOnly: () => ({
     llm: {
@@ -197,7 +200,7 @@ describe("schedule run-now trust propagation", () => {
   });
 
   test("manual run-now executes plain schedules with guardian trust", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Direct schedule",
       cronExpression: "* * * * *",
       message: "scan my inbox",
@@ -226,7 +229,7 @@ describe("schedule run-now trust propagation", () => {
       title: "Email triage",
       template: "triage inbox in background",
     });
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Scheduled task",
       cronExpression: "* * * * *",
@@ -265,7 +268,7 @@ describe("schedule run-now trust propagation", () => {
       title: "Manual Usage Task",
       template: "spend tokens manually",
     });
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Manual scheduled task",
       cronExpression: "* * * * *",
@@ -312,9 +315,9 @@ describe("schedule run-now trust propagation", () => {
     expect(runs[0].finishedAt!).toBeGreaterThanOrEqual(usageEventCreatedAt!);
 
     const summaryRoute = findRoute("schedules/usage-summary", "GET");
-    const summaryResult = summaryRoute.handler({
+    const summaryResult = (await summaryRoute.handler({
       queryParams: { from: String(from), to: String(to) },
-    }) as {
+    })) as {
       summaries: Array<{
         scheduleId: string;
         runCount: number;
@@ -340,14 +343,14 @@ describe("GET /schedules — default defer exclusion", () => {
     clearTables();
   });
 
-  test("excludes deferred wakes by default", () => {
-    createSchedule({
+  test("excludes deferred wakes by default", async () => {
+    await createSchedule({
       name: "Agent schedule",
       cronExpression: "* * * * *",
       message: "hello",
       syntax: "cron",
     });
-    const deferred = createSchedule({
+    const deferred = await createSchedule({
       name: "Deferred wake",
       cronExpression: "0 9 * * *",
       message: "wake up",
@@ -356,21 +359,21 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{ id: string }>;
     };
     expect(result.schedules).toHaveLength(1);
     expect(result.schedules.every((s) => s.id !== deferred.id)).toBe(true);
   });
 
-  test("returns all schedules when include_all=true", () => {
-    createSchedule({
+  test("returns all schedules when include_all=true", async () => {
+    await createSchedule({
       name: "Agent schedule",
       cronExpression: "* * * * *",
       message: "hello",
       syntax: "cron",
     });
-    createSchedule({
+    await createSchedule({
       name: "Deferred wake",
       cronExpression: "0 9 * * *",
       message: "wake up",
@@ -379,39 +382,39 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       queryParams: { include_all: "true" },
-    }) as { schedules: Array<{ id: string }> };
+    })) as { schedules: Array<{ id: string }> };
     expect(result.schedules).toHaveLength(2);
   });
 
-  test("includes source conversation availability metadata", () => {
+  test("includes source conversation availability metadata", async () => {
     const activeSource = createConversation("Active schedule source");
     const archivedSource = createConversation("Archived schedule source");
     expect(archiveConversation(archivedSource.id)).toBe(true);
 
-    createSchedule({
+    await createSchedule({
       name: "Active source schedule",
       cronExpression: "* * * * *",
       message: "active source",
       syntax: "cron",
       createdFromConversationId: activeSource.id,
     });
-    createSchedule({
+    await createSchedule({
       name: "Archived source schedule",
       cronExpression: "0 9 * * *",
       message: "archived source",
       syntax: "cron",
       createdFromConversationId: archivedSource.id,
     });
-    createSchedule({
+    await createSchedule({
       name: "Missing source schedule",
       cronExpression: "0 10 * * *",
       message: "missing source",
       syntax: "cron",
       createdFromConversationId: "conv-missing",
     });
-    createSchedule({
+    await createSchedule({
       name: "No source schedule",
       cronExpression: "0 11 * * *",
       message: "no source",
@@ -419,7 +422,7 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{
         name: string;
         createdFromConversationId: string | null;
@@ -449,8 +452,8 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(noSource.createdFromConversationArchivedAt).toBeNull();
   });
 
-  test("returns authored descriptions separately from cadence descriptions", () => {
-    createSchedule({
+  test("returns authored descriptions separately from cadence descriptions", async () => {
+    await createSchedule({
       name: "Described schedule",
       description: "Review the morning queue",
       cronExpression: "0 9 * * *",
@@ -459,7 +462,7 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{
         name: string;
         description: string;
@@ -475,8 +478,8 @@ describe("GET /schedules — default defer exclusion", () => {
     });
   });
 
-  test("returns One-time as the cadence description for one-shot schedules", () => {
-    createSchedule({
+  test("returns One-time as the cadence description for one-shot schedules", async () => {
+    await createSchedule({
       name: "One-shot schedule",
       description: "Send a one-time reminder",
       cronExpression: null,
@@ -485,7 +488,7 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{
         name: string;
         description: string;
@@ -500,14 +503,14 @@ describe("GET /schedules — default defer exclusion", () => {
     });
   });
 
-  test("humanizes rrule cadences and flags single-fire rrules as one-shot", () => {
-    createSchedule({
+  test("humanizes rrule cadences and flags single-fire rrules as one-shot", async () => {
+    await createSchedule({
       name: "RRule single fire",
       cronExpression: "DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=1",
       syntax: "rrule",
       message: "brush teeth",
     });
-    createSchedule({
+    await createSchedule({
       name: "RRule weekly",
       cronExpression: "DTSTART:20990612T080000\nRRULE:FREQ=WEEKLY;BYDAY=MO,WE",
       syntax: "rrule",
@@ -515,7 +518,7 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{
         name: string;
         cadenceDescription: string;
@@ -534,14 +537,14 @@ describe("GET /schedules — default defer exclusion", () => {
     });
   });
 
-  test("mutation responses also exclude deferred wakes", () => {
-    createSchedule({
+  test("mutation responses also exclude deferred wakes", async () => {
+    await createSchedule({
       name: "Agent schedule",
       cronExpression: "* * * * *",
       message: "hello",
       syntax: "cron",
     });
-    createSchedule({
+    await createSchedule({
       name: "Deferred wake",
       cronExpression: "0 9 * * *",
       message: "wake up",
@@ -551,10 +554,10 @@ describe("GET /schedules — default defer exclusion", () => {
 
     const route = findRoute("schedules/:id/toggle", "POST");
     const agent = listSchedules().find((j) => j.createdBy === "agent")!;
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: agent.id },
       body: { enabled: false },
-    }) as { schedules: Array<{ id: string }> };
+    })) as { schedules: Array<{ id: string }> };
     expect(result.schedules).toHaveLength(1);
     expect(result.schedules[0].id).toBe(agent.id);
   });
@@ -569,7 +572,7 @@ describe("GET /schedules — default defer exclusion", () => {
     });
 
     try {
-      const agent = createSchedule({
+      const agent = await createSchedule({
         name: "Agent schedule",
         cronExpression: "* * * * *",
         message: "hello",
@@ -579,7 +582,7 @@ describe("GET /schedules — default defer exclusion", () => {
       received.length = 0;
 
       const route = findRoute("schedules/:id/toggle", "POST");
-      route.handler({
+      await route.handler({
         pathParams: { id: agent.id },
         body: { enabled: false },
       });
@@ -602,9 +605,9 @@ describe("GET /schedules/:id", () => {
     clearTables();
   });
 
-  test("returns the full schedule by ID", () => {
+  test("returns the full schedule by ID", async () => {
     const source = createConversation("Schedule source");
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Single schedule",
       description: "Fetch me by ID",
       cronExpression: "0 9 * * *",
@@ -614,7 +617,9 @@ describe("GET /schedules/:id", () => {
     });
 
     const route = findRoute("schedules/:id", "GET");
-    const result = route.handler({ pathParams: { id: schedule.id } }) as {
+    const result = (await route.handler({
+      pathParams: { id: schedule.id },
+    })) as {
       schedule: Record<string, unknown>;
     };
 
@@ -633,8 +638,8 @@ describe("GET /schedules/:id", () => {
     });
   });
 
-  test("returns deferred schedules that the list hides by default", () => {
-    const deferred = createSchedule({
+  test("returns deferred schedules that the list hides by default", async () => {
+    const deferred = await createSchedule({
       name: "Deferred wake",
       cronExpression: "0 9 * * *",
       message: "wake up",
@@ -643,7 +648,9 @@ describe("GET /schedules/:id", () => {
     });
 
     const route = findRoute("schedules/:id", "GET");
-    const result = route.handler({ pathParams: { id: deferred.id } }) as {
+    const result = (await route.handler({
+      pathParams: { id: deferred.id },
+    })) as {
       schedule: { id: string };
     };
     expect(result.schedule.id).toBe(deferred.id);
@@ -667,109 +674,109 @@ describe("schedule runs list — limit handling", () => {
     clearTables();
   });
 
-  test("returns with default limit when no param is provided", () => {
-    const job = createSchedule({
+  test("returns with default limit when no param is provided", async () => {
+    const job = await createSchedule({
       name: "runs default",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
     for (let i = 0; i < 3; i += 1) {
-      createScheduleRun(job.id, `conv-${i}`);
+      await createScheduleRun(job.id, `conv-${i}`);
     }
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({ pathParams: { id: job.id } }) as {
+    const result = (await route.handler({ pathParams: { id: job.id } })) as {
       runs: unknown[];
     };
     expect(Array.isArray(result.runs)).toBe(true);
     expect(result.runs).toHaveLength(3);
   });
 
-  test("non-numeric limit falls back to default", () => {
-    const job = createSchedule({
+  test("non-numeric limit falls back to default", async () => {
+    const job = await createSchedule({
       name: "runs nan",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
-    createScheduleRun(job.id, "conv");
+    await createScheduleRun(job.id, "conv");
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: job.id },
       queryParams: { limit: "abc" },
-    }) as { runs: unknown[] };
+    })) as { runs: unknown[] };
     expect(Array.isArray(result.runs)).toBe(true);
   });
 
-  test("negative limit is clamped to 1", () => {
-    const job = createSchedule({
+  test("negative limit is clamped to 1", async () => {
+    const job = await createSchedule({
       name: "runs negative",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
     for (let i = 0; i < 5; i += 1) {
-      createScheduleRun(job.id, `conv-${i}`);
+      await createScheduleRun(job.id, `conv-${i}`);
     }
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: job.id },
       queryParams: { limit: "-5" },
-    }) as { runs: unknown[] };
+    })) as { runs: unknown[] };
     expect(result.runs).toHaveLength(1);
   });
 
-  test("zero limit is clamped to 1", () => {
-    const job = createSchedule({
+  test("zero limit is clamped to 1", async () => {
+    const job = await createSchedule({
       name: "runs zero",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
     for (let i = 0; i < 3; i += 1) {
-      createScheduleRun(job.id, `conv-${i}`);
+      await createScheduleRun(job.id, `conv-${i}`);
     }
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: job.id },
       queryParams: { limit: "0" },
-    }) as { runs: unknown[] };
+    })) as { runs: unknown[] };
     expect(result.runs).toHaveLength(1);
   });
 
-  test("limit above 100 is capped at 100", () => {
-    const job = createSchedule({
+  test("limit above 100 is capped at 100", async () => {
+    const job = await createSchedule({
       name: "runs huge",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
     for (let i = 0; i < 5; i += 1) {
-      createScheduleRun(job.id, `conv-${i}`);
+      await createScheduleRun(job.id, `conv-${i}`);
     }
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: job.id },
       queryParams: { limit: "9999" },
-    }) as { runs: unknown[] };
+    })) as { runs: unknown[] };
     expect(result.runs).toHaveLength(5);
   });
 
-  test("fractional limit is floored", () => {
-    const job = createSchedule({
+  test("fractional limit is floored", async () => {
+    const job = await createSchedule({
       name: "runs frac",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
     for (let i = 0; i < 5; i += 1) {
-      createScheduleRun(job.id, `conv-${i}`);
+      await createScheduleRun(job.id, `conv-${i}`);
     }
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: job.id },
       queryParams: { limit: "2.7" },
-    }) as { runs: unknown[] };
+    })) as { runs: unknown[] };
     expect(result.runs).toHaveLength(2);
   });
 });
@@ -781,8 +788,8 @@ describe("schedule and heartbeat run metadata", () => {
     clearTables();
   });
 
-  test("schedule runs expose conversation availability and cost by run window", () => {
-    const job = createSchedule({
+  test("schedule runs expose conversation availability and cost by run window", async () => {
+    const job = await createSchedule({
       name: "windowed run",
       cronExpression: "* * * * *",
       message: "hi",
@@ -794,8 +801,8 @@ describe("schedule and heartbeat run metadata", () => {
       source: "schedule",
       scheduleJobId: job.id,
     });
-    const runId = createScheduleRun(job.id, conversation.id);
-    completeScheduleRun(runId, { status: "ok" });
+    const runId = await createScheduleRun(job.id, conversation.id);
+    await completeScheduleRun(runId, { status: "ok" });
     rawRun(
       "UPDATE cron_runs SET started_at = ?, finished_at = ?, duration_ms = ?, created_at = ? WHERE id = ?",
       1000,
@@ -812,7 +819,7 @@ describe("schedule and heartbeat run metadata", () => {
     recordUsageCostAt(conversation.id, "req-after-run", 2500, 0.75);
 
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({ pathParams: { id: job.id } }) as {
+    const result = (await route.handler({ pathParams: { id: job.id } })) as {
       runs: Array<{
         conversationId: string | null;
         conversationExists: boolean;
@@ -828,8 +835,8 @@ describe("schedule and heartbeat run metadata", () => {
     expect(result.runs[0].estimatedCostUsd).toBeCloseTo(0.06);
   });
 
-  test("schedule runs keep archived conversations distinguishable from missing ones", () => {
-    const job = createSchedule({
+  test("schedule runs keep archived conversations distinguishable from missing ones", async () => {
+    const job = await createSchedule({
       name: "archived conversation",
       cronExpression: "* * * * *",
       message: "hi",
@@ -846,11 +853,11 @@ describe("schedule and heartbeat run metadata", () => {
       archivedAt,
       conversation.id,
     );
-    const runId = createScheduleRun(job.id, conversation.id);
-    completeScheduleRun(runId, { status: "ok" });
+    const runId = await createScheduleRun(job.id, conversation.id);
+    await completeScheduleRun(runId, { status: "ok" });
 
     const route = findRoute("schedules/:id/runs", "GET");
-    const result = route.handler({ pathParams: { id: job.id } }) as {
+    const result = (await route.handler({ pathParams: { id: job.id } })) as {
       runs: Array<{
         conversationExists: boolean;
         conversationArchivedAt: number | null;
@@ -861,17 +868,17 @@ describe("schedule and heartbeat run metadata", () => {
     expect(result.runs[0].conversationArchivedAt).toBe(archivedAt);
   });
 
-  test("schedule runs keep missing and synthetic conversation ids non-clickable", () => {
-    const missingJob = createSchedule({
+  test("schedule runs keep missing and synthetic conversation ids non-clickable", async () => {
+    const missingJob = await createSchedule({
       name: "missing conversation",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
-    const missingRunId = createScheduleRun(missingJob.id, "conv-missing");
-    completeScheduleRun(missingRunId, { status: "ok" });
+    const missingRunId = await createScheduleRun(missingJob.id, "conv-missing");
+    await completeScheduleRun(missingRunId, { status: "ok" });
 
-    const scriptJob = createSchedule({
+    const scriptJob = await createSchedule({
       name: "script schedule",
       cronExpression: "* * * * *",
       message: "",
@@ -880,22 +887,22 @@ describe("schedule and heartbeat run metadata", () => {
       syntax: "cron",
     });
     const syntheticId = `script:${scriptJob.id}`;
-    const scriptRunId = createScheduleRun(scriptJob.id, syntheticId);
-    completeScheduleRun(scriptRunId, { status: "ok" });
+    const scriptRunId = await createScheduleRun(scriptJob.id, syntheticId);
+    await completeScheduleRun(scriptRunId, { status: "ok" });
 
     const route = findRoute("schedules/:id/runs", "GET");
-    const missingResult = route.handler({
+    const missingResult = (await route.handler({
       pathParams: { id: missingJob.id },
-    }) as {
+    })) as {
       runs: Array<{
         conversationId: string | null;
         conversationExists: boolean;
         conversationArchivedAt: number | null;
       }>;
     };
-    const scriptResult = route.handler({
+    const scriptResult = (await route.handler({
       pathParams: { id: scriptJob.id },
-    }) as {
+    })) as {
       runs: Array<{
         conversationId: string | null;
         conversationExists: boolean;
@@ -1002,14 +1009,14 @@ describe("GET /schedules/usage-summary", () => {
     expect(result.summaries).toEqual([]);
   });
 
-  test("includes active and inactive schedules with zero activity", () => {
-    const active = createSchedule({
+  test("includes active and inactive schedules with zero activity", async () => {
+    const active = await createSchedule({
       name: "Active summary schedule",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
-    const inactive = createSchedule({
+    const inactive = await createSchedule({
       name: "Inactive summary schedule",
       cronExpression: "0 9 * * *",
       message: "hi",
@@ -1036,18 +1043,18 @@ describe("GET /schedules/usage-summary", () => {
     });
   });
 
-  test("counts runs by started_at in the inclusive range regardless of status", () => {
-    const schedule = createSchedule({
+  test("counts runs by started_at in the inclusive range regardless of status", async () => {
+    const schedule = await createSchedule({
       name: "Run count schedule",
       cronExpression: "* * * * *",
       message: "hi",
       syntax: "cron",
     });
-    const beforeRun = createScheduleRun(schedule.id, "conv-runs");
-    const startRun = createScheduleRun(schedule.id, "conv-runs");
-    const errorRun = createScheduleRun(schedule.id, "conv-runs");
-    const runningRun = createScheduleRun(schedule.id, "conv-runs");
-    const afterRun = createScheduleRun(schedule.id, "conv-runs");
+    const beforeRun = await createScheduleRun(schedule.id, "conv-runs");
+    const startRun = await createScheduleRun(schedule.id, "conv-runs");
+    const errorRun = await createScheduleRun(schedule.id, "conv-runs");
+    const runningRun = await createScheduleRun(schedule.id, "conv-runs");
+    const afterRun = await createScheduleRun(schedule.id, "conv-runs");
 
     setScheduleRunWindow({
       runId: beforeRun,
@@ -1083,8 +1090,8 @@ describe("GET /schedules/usage-summary", () => {
     expect(result.summaries[0].runCount).toBe(3);
   });
 
-  test("sums usage by schedule run windows and excludes reused-conversation usage outside those windows", () => {
-    const schedule = createSchedule({
+  test("sums usage by schedule run windows and excludes reused-conversation usage outside those windows", async () => {
+    const schedule = await createSchedule({
       name: "Usage attribution schedule",
       cronExpression: "* * * * *",
       message: "hi",
@@ -1096,8 +1103,11 @@ describe("GET /schedules/usage-summary", () => {
       source: "schedule",
       scheduleJobId: schedule.id,
     });
-    const includedRun = createScheduleRun(schedule.id, conversation.id);
-    const outsideRangeRun = createScheduleRun(schedule.id, conversation.id);
+    const includedRun = await createScheduleRun(schedule.id, conversation.id);
+    const outsideRangeRun = await createScheduleRun(
+      schedule.id,
+      conversation.id,
+    );
 
     setScheduleRunWindow({
       runId: includedRun,
@@ -1147,15 +1157,15 @@ describe("POST /schedules — create", () => {
     clearTables();
   });
 
-  function postCreate(body: Record<string, unknown>) {
+  async function postCreate(body: Record<string, unknown>) {
     const route = findRoute("schedules", "POST");
-    return route.handler({ body }) as {
+    return (await route.handler({ body })) as {
       schedules: Array<{ id: string; inferenceProfile: string | null }>;
     };
   }
 
-  test("creates a recurring execute schedule with defaults", () => {
-    const result = postCreate({
+  test("creates a recurring execute schedule with defaults", async () => {
+    const result = await postCreate({
       name: "Morning ping",
       description: "Start the morning workflow",
       expression: "0 9 * * *",
@@ -1172,8 +1182,8 @@ describe("POST /schedules — create", () => {
     expect(job.timezone).toBeNull();
   });
 
-  test("trims whitespace and accepts an explicit timezone", () => {
-    postCreate({
+  test("trims whitespace and accepts an explicit timezone", async () => {
+    await postCreate({
       name: "  Trimmed  ",
       description: "  Trimmed description  ",
       expression: "  0 9 * * *  ",
@@ -1187,9 +1197,9 @@ describe("POST /schedules — create", () => {
     expect(job.timezone).toBe("America/New_York");
   });
 
-  test("accepts an rrule expression and detects syntax", () => {
+  test("accepts an rrule expression and detects syntax", async () => {
     const expression = "DTSTART:20260101T000000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO";
-    postCreate({
+    await postCreate({
       name: "Weekly",
       description: "Weekly wake",
       expression,
@@ -1200,28 +1210,28 @@ describe("POST /schedules — create", () => {
     expect(job.expression).toBe(expression);
   });
 
-  test("rejects missing required fields", () => {
-    expect(() =>
+  test("rejects missing required fields", async () => {
+    await expect(
       postCreate({ expression: "* * * * *", message: "hi" }),
-    ).toThrow("name is required");
-    expect(() => postCreate({ name: "x", message: "hi" })).toThrow(
+    ).rejects.toThrow("name is required");
+    await expect(postCreate({ name: "x", message: "hi" })).rejects.toThrow(
       "expression is required",
     );
-    expect(() => postCreate({ name: "x", expression: "* * * * *" })).toThrow(
-      "message is required",
-    );
-    expect(() =>
+    await expect(
+      postCreate({ name: "x", expression: "* * * * *" }),
+    ).rejects.toThrow("message is required");
+    await expect(
       postCreate({
         name: "x",
         description: "   ",
         expression: "* * * * *",
         message: "hi",
       }),
-    ).toThrow("description is required");
+    ).rejects.toThrow("description is required");
   });
 
-  test("defaults omitted create descriptions for backward compatibility", () => {
-    postCreate({
+  test("defaults omitted create descriptions for backward compatibility", async () => {
+    await postCreate({
       name: "Description fallback",
       expression: "0 9 * * *",
       message: "hi",
@@ -1231,8 +1241,8 @@ describe("POST /schedules — create", () => {
     expect(job.description).toBe("Description fallback");
   });
 
-  test("rejects modes other than execute/workflow", () => {
-    expect(() =>
+  test("rejects modes other than execute/workflow", async () => {
+    await expect(
       postCreate({
         name: "x",
         description: "Run the thing",
@@ -1240,35 +1250,35 @@ describe("POST /schedules — create", () => {
         message: "hi",
         mode: "notify",
       }),
-    ).toThrow("Only 'execute' and 'workflow' modes are supported");
+    ).rejects.toThrow("Only 'execute' and 'workflow' modes are supported");
   });
 
-  test("rejects an unparseable expression", () => {
-    expect(() =>
+  test("rejects an unparseable expression", async () => {
+    await expect(
       postCreate({
         name: "x",
         description: "Run the thing",
         expression: "not-a-cron",
         message: "hi",
       }),
-    ).toThrow("could not be parsed");
+    ).rejects.toThrow("could not be parsed");
   });
 
-  test("surfaces invalid-cron errors from the store as 400s", () => {
-    expect(() =>
+  test("surfaces invalid-cron errors from the store as 400s", async () => {
+    await expect(
       postCreate({
         name: "x",
         description: "Run the thing",
         expression: "99 99 99 99 99",
         message: "hi",
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
-  test("persists and round-trips workflowName/workflowArgs in the list response", () => {
+  test("persists and round-trips workflowName/workflowArgs in the list response", async () => {
     // Store-level round trip: the create route is flag-gated (and the mocked
     // config disables it), so exercise persistence directly via the store.
-    createSchedule({
+    await createSchedule({
       name: "Workflow schedule",
       cronExpression: "0 9 * * *",
       message: "trigger",
@@ -1279,7 +1289,7 @@ describe("POST /schedules — create", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{
         name: string;
         mode: string;
@@ -1297,8 +1307,8 @@ describe("POST /schedules — create", () => {
     expect(stored.workflowArgs).toEqual({ folder: "primary", limit: 10 });
   });
 
-  test("respects enabled=false", () => {
-    postCreate({
+  test("respects enabled=false", async () => {
+    await postCreate({
       name: "Off",
       description: "Disabled schedule",
       expression: "0 9 * * *",
@@ -1309,8 +1319,8 @@ describe("POST /schedules — create", () => {
     expect(job.enabled).toBe(false);
   });
 
-  test("persists a valid inferenceProfile and serializes it", () => {
-    const result = postCreate({
+  test("persists a valid inferenceProfile and serializes it", async () => {
+    const result = await postCreate({
       name: "Cheap digest",
       description: "High-frequency digest on a cheap model",
       expression: "0 * * * *",
@@ -1321,8 +1331,8 @@ describe("POST /schedules — create", () => {
     expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 
-  test("defaults inferenceProfile to null when omitted", () => {
-    const result = postCreate({
+  test("defaults inferenceProfile to null when omitted", async () => {
+    const result = await postCreate({
       name: "Default profile",
       description: "Runs on the main-agent selection",
       expression: "0 9 * * *",
@@ -1331,8 +1341,8 @@ describe("POST /schedules — create", () => {
     expect(result.schedules[0].inferenceProfile).toBeNull();
   });
 
-  test("rejects an unknown inferenceProfile", () => {
-    expect(() =>
+  test("rejects an unknown inferenceProfile", async () => {
+    await expect(
       postCreate({
         name: "Bad profile",
         description: "Unknown profile",
@@ -1340,11 +1350,11 @@ describe("POST /schedules — create", () => {
         message: "hi",
         inferenceProfile: "does-not-exist",
       }),
-    ).toThrow('Inference profile "does-not-exist" is not defined');
+    ).rejects.toThrow('Inference profile "does-not-exist" is not defined');
   });
 
-  test("rejects a non-string inferenceProfile", () => {
-    expect(() =>
+  test("rejects a non-string inferenceProfile", async () => {
+    await expect(
       postCreate({
         name: "Bad profile type",
         description: "Wrong type",
@@ -1352,7 +1362,7 @@ describe("POST /schedules — create", () => {
         message: "hi",
         inferenceProfile: 42,
       }),
-    ).toThrow("inferenceProfile must be a string or null");
+    ).rejects.toThrow("inferenceProfile must be a string or null");
   });
 });
 
@@ -1363,8 +1373,8 @@ describe("PATCH /schedules/:id — description", () => {
     clearTables();
   });
 
-  test("updates authored descriptions", () => {
-    const schedule = createSchedule({
+  test("updates authored descriptions", async () => {
+    const schedule = await createSchedule({
       name: "Description update",
       description: "Original description",
       cronExpression: "0 9 * * *",
@@ -1373,10 +1383,10 @@ describe("PATCH /schedules/:id — description", () => {
     });
 
     const route = findRoute("schedules/:id", "PATCH");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: schedule.id },
       body: { description: "Updated description" },
-    }) as {
+    })) as {
       schedules: Array<{ id: string; description: string }>;
     };
 
@@ -1387,8 +1397,8 @@ describe("PATCH /schedules/:id — description", () => {
     expect(listSchedules()[0].description).toBe("Updated description");
   });
 
-  test("sets, validates, and clears inferenceProfile", () => {
-    const schedule = createSchedule({
+  test("sets, validates, and clears inferenceProfile", async () => {
+    const schedule = await createSchedule({
       name: "Profile pin",
       description: "Pinned profile schedule",
       cronExpression: "0 9 * * *",
@@ -1397,29 +1407,29 @@ describe("PATCH /schedules/:id — description", () => {
     });
     const route = findRoute("schedules/:id", "PATCH");
 
-    route.handler({
+    await route.handler({
       pathParams: { id: schedule.id },
       body: { inferenceProfile: "balanced" },
     });
     expect(listSchedules()[0].inferenceProfile).toBe("balanced");
 
-    expect(() =>
+    await expect(
       route.handler({
         pathParams: { id: schedule.id },
         body: { inferenceProfile: "does-not-exist" },
       }),
-    ).toThrow('Inference profile "does-not-exist" is not defined');
+    ).rejects.toThrow('Inference profile "does-not-exist" is not defined');
     expect(listSchedules()[0].inferenceProfile).toBe("balanced");
 
-    route.handler({
+    await route.handler({
       pathParams: { id: schedule.id },
       body: { inferenceProfile: null },
     });
     expect(listSchedules()[0].inferenceProfile).toBeNull();
   });
 
-  test("re-derives syntax when the expression switches cron to rrule", () => {
-    const schedule = createSchedule({
+  test("re-derives syntax when the expression switches cron to rrule", async () => {
+    const schedule = await createSchedule({
       name: "Syntax switch",
       description: "Cron schedule",
       cronExpression: "0 9 * * *",
@@ -1429,7 +1439,7 @@ describe("PATCH /schedules/:id — description", () => {
 
     const route = findRoute("schedules/:id", "PATCH");
     const rrule = "DTSTART:20260101T000000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO";
-    route.handler({
+    await route.handler({
       pathParams: { id: schedule.id },
       body: { expression: rrule },
     });
@@ -1439,8 +1449,8 @@ describe("PATCH /schedules/:id — description", () => {
     expect(updated.cronExpression).toBe(rrule);
   });
 
-  test("rejects an expression that parses as neither cron nor rrule", () => {
-    const schedule = createSchedule({
+  test("rejects an expression that parses as neither cron nor rrule", async () => {
+    const schedule = await createSchedule({
       name: "Bad expression",
       description: "Cron schedule",
       cronExpression: "0 9 * * *",
@@ -1449,12 +1459,12 @@ describe("PATCH /schedules/:id — description", () => {
     });
 
     const route = findRoute("schedules/:id", "PATCH");
-    expect(() =>
+    await expect(
       route.handler({
         pathParams: { id: schedule.id },
         body: { expression: "not a schedule" },
       }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 });
 
@@ -1465,8 +1475,8 @@ describe("wake mode in schedule routes", () => {
     clearTables();
   });
 
-  test("PATCH accepts 'wake' as a valid mode", () => {
-    const schedule = createSchedule({
+  test("PATCH accepts 'wake' as a valid mode", async () => {
+    const schedule = await createSchedule({
       name: "Wake test",
       cronExpression: "* * * * *",
       message: "check deferred",
@@ -1474,10 +1484,10 @@ describe("wake mode in schedule routes", () => {
     });
 
     const route = findRoute("schedules/:id", "PATCH");
-    const result = route.handler({
+    const result = (await route.handler({
       pathParams: { id: schedule.id },
       body: { mode: "wake", wakeConversationId: "conv-xyz" },
-    }) as {
+    })) as {
       schedules: Array<{
         id: string;
         mode: string;
@@ -1490,8 +1500,8 @@ describe("wake mode in schedule routes", () => {
     expect(updated!.wakeConversationId).toBe("conv-xyz");
   });
 
-  test("list schedules includes wakeConversationId", () => {
-    createSchedule({
+  test("list schedules includes wakeConversationId", async () => {
+    await createSchedule({
       name: "Wake schedule",
       cronExpression: "0 9 * * *",
       message: "morning wake",
@@ -1501,7 +1511,7 @@ describe("wake mode in schedule routes", () => {
     });
 
     const route = findRoute("schedules", "GET");
-    const result = route.handler({}) as {
+    const result = (await route.handler({})) as {
       schedules: Array<{ name: string; wakeConversationId: string | null }>;
     };
     const wakeSchedule = result.schedules.find(
@@ -1525,9 +1535,9 @@ describe("PATCH /schedules/:id — timeout override", () => {
     return result.schedules[0];
   }
 
-  test("sets and clears the script timeout, exposing it in the list", () => {
+  test("sets and clears the script timeout, exposing it in the list", async () => {
     // GIVEN a script schedule with no timeout override
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Script job",
       cronExpression: "0 9 * * *",
       message: "",
@@ -1540,7 +1550,7 @@ describe("PATCH /schedules/:id — timeout override", () => {
     const patch = findRoute("schedules/:id", "PATCH");
 
     // WHEN the guardian sets a custom timeout
-    patch.handler({
+    await patch.handler({
       pathParams: { id: schedule.id },
       body: { timeoutMs: 5000 },
     });
@@ -1549,7 +1559,7 @@ describe("PATCH /schedules/:id — timeout override", () => {
     expect(listOne().timeoutMs).toBe(5000);
 
     // AND WHEN the guardian clears it
-    patch.handler({
+    await patch.handler({
       pathParams: { id: schedule.id },
       body: { timeoutMs: null },
     });
@@ -1558,9 +1568,9 @@ describe("PATCH /schedules/:id — timeout override", () => {
     expect(listOne().timeoutMs).toBeNull();
   });
 
-  test("rejects an out-of-range timeout", () => {
+  test("rejects an out-of-range timeout", async () => {
     // GIVEN a script schedule
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Guarded job",
       cronExpression: "0 9 * * *",
       message: "",
@@ -1572,12 +1582,12 @@ describe("PATCH /schedules/:id — timeout override", () => {
     const patch = findRoute("schedules/:id", "PATCH");
 
     // WHEN/THEN patching with a below-minimum timeout throws a RouteError
-    expect(() =>
+    await expect(
       patch.handler({
         pathParams: { id: schedule.id },
         body: { timeoutMs: 10 },
       }),
-    ).toThrow("timeout_ms must be between");
+    ).rejects.toThrow("timeout_ms must be between");
     expect(listOne().timeoutMs).toBeNull();
   });
 });

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -100,7 +100,7 @@ describe("schedule sync invalidation", () => {
     });
 
     try {
-      const job = createSchedule({
+      const job = await createSchedule({
         name: "Sync test",
         cronExpression: "* * * * *",
         message: "sync me",
@@ -108,31 +108,31 @@ describe("schedule sync invalidation", () => {
       });
       await expectScheduleSyncEvent(received);
 
-      updateSchedule(job.id, { name: "Updated sync test" });
+      await updateSchedule(job.id, { name: "Updated sync test" });
       await expectScheduleSyncEvent(received);
 
       getRawDb().run("UPDATE cron_jobs SET next_run_at = ? WHERE id = ?", [
         Date.now() - 1000,
         job.id,
       ]);
-      expect(claimDueSchedules(Date.now())).toHaveLength(1);
+      expect(await claimDueSchedules(Date.now())).toHaveLength(1);
       await expectScheduleSyncEvent(received);
 
-      const runId = createScheduleRun(job.id, "conv-123");
-      completeScheduleRun(runId, { status: "ok" });
+      const runId = await createScheduleRun(job.id, "conv-123");
+      await completeScheduleRun(runId, { status: "ok" });
       await expectScheduleSyncEvent(received);
 
-      const oneShot = createSchedule({
+      const oneShot = await createSchedule({
         name: "One-shot sync test",
         message: "cancel me",
         nextRunAt: Date.now() + 60_000,
       });
       await expectScheduleSyncEvent(received);
 
-      expect(cancelSchedule(oneShot.id)).toBe(true);
+      expect(await cancelSchedule(oneShot.id)).toBe(true);
       await expectScheduleSyncEvent(received);
 
-      expect(deleteSchedule(job.id)).toBe(true);
+      expect(await deleteSchedule(job.id)).toBe(true);
       await expectScheduleSyncEvent(received);
     } finally {
       subscription.dispose();
@@ -149,8 +149,8 @@ describe("createSchedule (cron)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("creates a cron schedule using only cronExpression", () => {
-    const job = createSchedule({
+  test("creates a cron schedule using only cronExpression", async () => {
+    const job = await createSchedule({
       name: "Morning ping",
       cronExpression: "0 9 * * *",
       message: "good morning",
@@ -165,8 +165,8 @@ describe("createSchedule (cron)", () => {
     expect(job.enabled).toBe(true);
   });
 
-  test("persisted cron schedule is retrievable with new fields", () => {
-    const job = createSchedule({
+  test("persisted cron schedule is retrievable with new fields", async () => {
+    const job = await createSchedule({
       name: "Hourly",
       description: "Check the hourly status report",
       cronExpression: "0 * * * *",
@@ -182,8 +182,8 @@ describe("createSchedule (cron)", () => {
     expect(retrieved!.description).toBe("Check the hourly status report");
   });
 
-  test("normalizes schedule descriptions on create and update", () => {
-    const job = createSchedule({
+  test("normalizes schedule descriptions on create and update", async () => {
+    const job = await createSchedule({
       name: "Description normalization",
       description: "  Daily executive summary  ",
       cronExpression: "0 8 * * *",
@@ -198,7 +198,7 @@ describe("createSchedule (cron)", () => {
       .get(job.id) as { description: string };
     expect(raw.description).toBe("Daily executive summary");
 
-    const updated = updateSchedule(job.id, {
+    const updated = await updateSchedule(job.id, {
       description: "  Updated summary prompt  ",
     });
     expect(updated).not.toBeNull();
@@ -207,8 +207,8 @@ describe("createSchedule (cron)", () => {
     expect(listSchedules()[0].description).toBe("Updated summary prompt");
   });
 
-  test("defaults source conversation metadata to null", () => {
-    const job = createSchedule({
+  test("defaults source conversation metadata to null", async () => {
+    const job = await createSchedule({
       name: "No source conversation",
       cronExpression: "0 9 * * *",
       message: "daily check",
@@ -224,8 +224,8 @@ describe("createSchedule (cron)", () => {
     expect(raw.created_from_conversation_id).toBeNull();
   });
 
-  test("persists source conversation metadata through create, list, and update", () => {
-    const job = createSchedule({
+  test("persists source conversation metadata through create, list, and update", async () => {
+    const job = await createSchedule({
       name: "With source conversation",
       cronExpression: "0 9 * * *",
       message: "daily check",
@@ -237,19 +237,19 @@ describe("createSchedule (cron)", () => {
     expect(getSchedule(job.id)!.createdFromConversationId).toBe("conv-source");
     expect(listSchedules()[0].createdFromConversationId).toBe("conv-source");
 
-    const updated = updateSchedule(job.id, {
+    const updated = await updateSchedule(job.id, {
       createdFromConversationId: "conv-updated",
     });
     expect(updated!.createdFromConversationId).toBe("conv-updated");
 
-    const cleared = updateSchedule(job.id, {
+    const cleared = await updateSchedule(job.id, {
       createdFromConversationId: null,
     });
     expect(cleared!.createdFromConversationId).toBeNull();
   });
 
-  test("stores schedule_syntax in the DB row", () => {
-    const job = createSchedule({
+  test("stores schedule_syntax in the DB row", async () => {
+    const job = await createSchedule({
       name: "Syntax check",
       cronExpression: "*/5 * * * *",
       message: "test",
@@ -263,15 +263,15 @@ describe("createSchedule (cron)", () => {
     expect(raw!.schedule_syntax).toBe("cron");
   });
 
-  test("rejects invalid cron expression", () => {
-    expect(() =>
+  test("rejects invalid cron expression", async () => {
+    await expect(
       createSchedule({
         name: "Bad cron",
         cronExpression: "not-a-cron",
         message: "fail",
         syntax: "cron",
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });
 
@@ -284,9 +284,9 @@ describe("createSchedule (RRULE)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("creates an RRULE schedule with syntax + expression", () => {
+  test("creates an RRULE schedule with syntax + expression", async () => {
     const rrule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;INTERVAL=1";
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Daily RRULE",
       cronExpression: rrule,
       message: "rrule test",
@@ -300,9 +300,9 @@ describe("createSchedule (RRULE)", () => {
     expect(job.nextRunAt).toBeGreaterThan(0);
   });
 
-  test("stores rrule syntax in DB", () => {
+  test("stores rrule syntax in DB", async () => {
     const rrule = "DTSTART:20260101T090000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO";
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Weekly RRULE",
       cronExpression: rrule,
       message: "weekly",
@@ -323,8 +323,8 @@ describe("createSchedule (RRULE)", () => {
     expect(raw!.cron_expression).toBe(rrule);
   });
 
-  test("rejects RRULE without DTSTART", () => {
-    expect(() =>
+  test("rejects RRULE without DTSTART", async () => {
+    await expect(
       createSchedule({
         name: "No dtstart",
         cronExpression: "RRULE:FREQ=DAILY",
@@ -332,7 +332,7 @@ describe("createSchedule (RRULE)", () => {
         syntax: "rrule",
         expression: "RRULE:FREQ=DAILY",
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });
 
@@ -345,14 +345,14 @@ describe("createSchedule (RRULE set)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("creates schedule with RRULE + EXDATE set expression", () => {
+  test("creates schedule with RRULE + EXDATE set expression", async () => {
     const expression = [
       "DTSTART:20250101T090000Z",
       "RRULE:FREQ=DAILY;INTERVAL=1",
       "EXDATE:20250102T090000Z",
     ].join("\n");
 
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Daily with exclusion",
       cronExpression: expression,
       message: "set test",
@@ -365,14 +365,14 @@ describe("createSchedule (RRULE set)", () => {
     expect(job.nextRunAt).toBeGreaterThan(0);
   });
 
-  test("creates schedule with RRULE + RDATE set expression", () => {
+  test("creates schedule with RRULE + RDATE set expression", async () => {
     const expression = [
       "DTSTART:20250101T090000Z",
       "RRULE:FREQ=WEEKLY;BYDAY=MO",
       "RDATE:20250115T090000Z",
     ].join("\n");
 
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Weekly with extra dates",
       cronExpression: expression,
       message: "rdate test",
@@ -384,7 +384,7 @@ describe("createSchedule (RRULE set)", () => {
     expect(job.expression).toContain("RDATE");
   });
 
-  test("preserves full set expression text in DB without collapsing", () => {
+  test("preserves full set expression text in DB without collapsing", async () => {
     const expression = [
       "DTSTART:20250101T090000Z",
       "RRULE:FREQ=DAILY;INTERVAL=1",
@@ -392,7 +392,7 @@ describe("createSchedule (RRULE set)", () => {
       "EXDATE:20250103T090000Z",
     ].join("\n");
 
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Multi-EXDATE",
       cronExpression: expression,
       message: "preserve test",
@@ -408,14 +408,14 @@ describe("createSchedule (RRULE set)", () => {
     expect(raw.cron_expression).toContain("EXDATE:20250103T090000Z");
   });
 
-  test("retrieved set schedule matches what was stored", () => {
+  test("retrieved set schedule matches what was stored", async () => {
     const expression = [
       "DTSTART:20250101T090000Z",
       "RRULE:FREQ=DAILY;INTERVAL=1",
       "EXDATE:20250105T090000Z",
     ].join("\n");
 
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Retrieve set",
       cronExpression: expression,
       message: "retrieve test",
@@ -440,7 +440,7 @@ describe("claimDueSchedules (RRULE set)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("claims RRULE set schedule and correctly advances nextRunAt past exclusions", () => {
+  test("claims RRULE set schedule and correctly advances nextRunAt past exclusions", async () => {
     // Use a recent DTSTART (1 hour ago) so rrule doesn't iterate through hundreds of
     // thousands of occurrences when computing the next run.
     const pastDate = new Date(Date.now() - 3_600_000);
@@ -463,7 +463,7 @@ describe("claimDueSchedules (RRULE set)", () => {
       `EXDATE:${exDs}`,
     ].join("\n");
 
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Claim set test",
       cronExpression: expression,
       message: "claim set",
@@ -478,7 +478,7 @@ describe("claimDueSchedules (RRULE set)", () => {
     ]);
 
     const now = Date.now();
-    const claimed = claimDueSchedules(now);
+    const claimed = await claimDueSchedules(now);
     expect(claimed.length).toBe(1);
     expect(claimed[0].syntax).toBe("rrule");
     // nextRunAt should advance to a future time
@@ -495,15 +495,17 @@ describe("updateSchedule", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("updating cronExpression (legacy path) still works", () => {
-    const job = createSchedule({
+  test("updating cronExpression (legacy path) still works", async () => {
+    const job = await createSchedule({
       name: "Update test",
       cronExpression: "0 9 * * *",
       message: "update me",
       syntax: "cron",
     });
 
-    const updated = updateSchedule(job.id, { cronExpression: "0 10 * * *" });
+    const updated = await updateSchedule(job.id, {
+      cronExpression: "0 10 * * *",
+    });
     expect(updated).not.toBeNull();
     expect(updated!.cronExpression).toBe("0 10 * * *");
     expect(updated!.expression).toBe("0 10 * * *");
@@ -512,8 +514,8 @@ describe("updateSchedule", () => {
     expect(updated!.nextRunAt).not.toBe(job.nextRunAt);
   });
 
-  test("updating syntax + expression switches to RRULE", () => {
-    const job = createSchedule({
+  test("updating syntax + expression switches to RRULE", async () => {
+    const job = await createSchedule({
       name: "Switch to RRULE",
       cronExpression: "0 9 * * *",
       message: "switching",
@@ -521,7 +523,7 @@ describe("updateSchedule", () => {
     });
 
     const rrule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;INTERVAL=2";
-    const updated = updateSchedule(job.id, {
+    const updated = await updateSchedule(job.id, {
       syntax: "rrule",
       expression: rrule,
     });
@@ -539,8 +541,8 @@ describe("updateSchedule", () => {
     expect(raw!.schedule_syntax).toBe("rrule");
   });
 
-  test("updating to RRULE set expression preserves full text", () => {
-    const job = createSchedule({
+  test("updating to RRULE set expression preserves full text", async () => {
+    const job = await createSchedule({
       name: "Update to set",
       cronExpression: "0 9 * * *",
       message: "update to set",
@@ -553,7 +555,7 @@ describe("updateSchedule", () => {
       "EXDATE:20250102T090000Z",
     ].join("\n");
 
-    const updated = updateSchedule(job.id, {
+    const updated = await updateSchedule(job.id, {
       syntax: "rrule",
       expression: setExpr,
     });
@@ -565,20 +567,20 @@ describe("updateSchedule", () => {
     expect(updated!.nextRunAt).toBeGreaterThan(0);
   });
 
-  test("rejects invalid expression on update", () => {
-    const job = createSchedule({
+  test("rejects invalid expression on update", async () => {
+    const job = await createSchedule({
       name: "Reject bad update",
       cronExpression: "0 9 * * *",
       message: "nope",
       syntax: "cron",
     });
 
-    expect(() =>
+    await expect(
       updateSchedule(job.id, {
         syntax: "rrule",
         expression: "RRULE:FREQ=DAILY",
       }),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });
 
@@ -591,8 +593,8 @@ describe("claimDueSchedules", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("claims due cron schedules and advances nextRunAt", () => {
-    const job = createSchedule({
+  test("claims due cron schedules and advances nextRunAt", async () => {
+    const job = await createSchedule({
       name: "Claim cron",
       cronExpression: "* * * * *",
       message: "cron claim test",
@@ -605,14 +607,14 @@ describe("claimDueSchedules", () => {
       job.id,
     ]);
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(1);
     expect(claimed[0].id).toBe(job.id);
     expect(claimed[0].syntax).toBe("cron");
     expect(claimed[0].nextRunAt).toBeGreaterThan(Date.now() - 1000);
   });
 
-  test("claims due RRULE schedules and advances nextRunAt", () => {
+  test("claims due RRULE schedules and advances nextRunAt", async () => {
     // Use a recent DTSTART (1 hour ago) so rrule doesn't iterate through
     // hundreds of thousands of occurrences when computing the next run.
     const pastDate = new Date(Date.now() - 3_600_000);
@@ -623,7 +625,7 @@ describe("claimDueSchedules", () => {
       pastDate.getUTCMinutes(),
     )}${pad(pastDate.getUTCSeconds())}Z`;
     const rrule = `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1`;
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Claim RRULE",
       cronExpression: rrule,
       message: "rrule claim test",
@@ -639,7 +641,7 @@ describe("claimDueSchedules", () => {
     ]);
 
     const now = Date.now();
-    const claimed = claimDueSchedules(now);
+    const claimed = await claimDueSchedules(now);
     expect(claimed.length).toBe(1);
     expect(claimed[0].id).toBe(job.id);
     expect(claimed[0].syntax).toBe("rrule");
@@ -647,19 +649,19 @@ describe("claimDueSchedules", () => {
     expect(claimed[0].nextRunAt).toBeGreaterThanOrEqual(now);
   });
 
-  test("does not claim schedules that are not yet due", () => {
-    createSchedule({
+  test("does not claim schedules that are not yet due", async () => {
+    await createSchedule({
       name: "Not due yet",
       cronExpression: "0 9 * * *",
       message: "future schedule",
       syntax: "cron",
     });
 
-    const claimed = claimDueSchedules(0); // timestamp 0 means nothing is due
+    const claimed = await claimDueSchedules(0); // timestamp 0 means nothing is due
     expect(claimed.length).toBe(0);
   });
 
-  test("claims exhausted RRULE schedule and disables it", () => {
+  test("claims exhausted RRULE schedule and disables it", async () => {
     // COUNT=1 with a past DTSTART means the single occurrence has already
     // passed, so computeNextRunAt returns null — triggering the exhaustion path.
     // We insert directly via SQL because createSchedule validates that at least
@@ -690,7 +692,7 @@ describe("claimDueSchedules", () => {
       ],
     );
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(1);
     expect(claimed[0].id).toBe(id);
     expect(claimed[0].enabled).toBe(false);
@@ -701,12 +703,12 @@ describe("claimDueSchedules", () => {
     expect(persisted!.enabled).toBe(false);
 
     // A subsequent claim should not pick it up
-    const again = claimDueSchedules(Date.now());
+    const again = await claimDueSchedules(Date.now());
     expect(again.length).toBe(0);
   });
 
-  test("optimistic lock prevents double-claiming", () => {
-    const job = createSchedule({
+  test("optimistic lock prevents double-claiming", async () => {
+    const job = await createSchedule({
       name: "Double claim",
       cronExpression: "* * * * *",
       message: "no double",
@@ -718,11 +720,11 @@ describe("claimDueSchedules", () => {
       job.id,
     ]);
 
-    const first = claimDueSchedules(Date.now());
+    const first = await claimDueSchedules(Date.now());
     expect(first.length).toBe(1);
 
     // Second claim should find nothing since nextRunAt was advanced
-    const second = claimDueSchedules(Date.now() - 500);
+    const second = await claimDueSchedules(Date.now() - 500);
     expect(second.length).toBe(0);
   });
 });
@@ -736,9 +738,9 @@ describe("createSchedule (one-shot)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("creates a one-shot schedule with no expression", () => {
+  test("creates a one-shot schedule with no expression", async () => {
     const fireAt = Date.now() + 60_000;
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Remind me",
       message: "take out the trash",
       nextRunAt: fireAt,
@@ -754,10 +756,10 @@ describe("createSchedule (one-shot)", () => {
     expect(job.routingHints).toEqual({});
   });
 
-  test("creates a one-shot schedule with notify mode and routing", () => {
+  test("creates a one-shot schedule with notify mode and routing", async () => {
     const fireAt = Date.now() + 60_000;
     const hints = { preferredChannel: "slack", threadId: "abc123" };
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Notify me",
       message: "meeting in 5",
       nextRunAt: fireAt,
@@ -773,19 +775,19 @@ describe("createSchedule (one-shot)", () => {
     expect(job.status).toBe("active");
   });
 
-  test("rejects one-shot schedule without nextRunAt", () => {
-    expect(() =>
+  test("rejects one-shot schedule without nextRunAt", async () => {
+    await expect(
       createSchedule({
         name: "Bad one-shot",
         message: "no time",
       }),
-    ).toThrow("One-shot schedules (no expression) require nextRunAt");
+    ).rejects.toThrow("One-shot schedules (no expression) require nextRunAt");
   });
 
-  test("one-shot schedule persists and round-trips correctly", () => {
+  test("one-shot schedule persists and round-trips correctly", async () => {
     const fireAt = Date.now() + 120_000;
     const hints = { channel: "telegram" };
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Persist test",
       message: "round trip",
       nextRunAt: fireAt,
@@ -815,48 +817,48 @@ describe("claimDueSchedules (one-shot)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("claims one-shot schedules whose nextRunAt <= now", () => {
-    const job = createSchedule({
+  test("claims one-shot schedules whose nextRunAt <= now", async () => {
+    const job = await createSchedule({
       name: "Due one-shot",
       message: "fire now",
       nextRunAt: Date.now() - 1000,
     });
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(1);
     expect(claimed[0].id).toBe(job.id);
     expect(claimed[0].expression).toBeNull();
     expect(claimed[0].status).toBe("firing");
   });
 
-  test("does not claim one-shot schedules that are not yet due", () => {
-    createSchedule({
+  test("does not claim one-shot schedules that are not yet due", async () => {
+    await createSchedule({
       name: "Future one-shot",
       message: "not yet",
       nextRunAt: Date.now() + 60_000,
     });
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(0);
   });
 
-  test("does not double-claim one-shot schedules", () => {
-    createSchedule({
+  test("does not double-claim one-shot schedules", async () => {
+    await createSchedule({
       name: "Once only",
       message: "no double",
       nextRunAt: Date.now() - 1000,
     });
 
-    const first = claimDueSchedules(Date.now());
+    const first = await claimDueSchedules(Date.now());
     expect(first.length).toBe(1);
 
     // Second claim should find nothing since status is now 'firing'
-    const second = claimDueSchedules(Date.now());
+    const second = await claimDueSchedules(Date.now());
     expect(second.length).toBe(0);
   });
 
-  test("claims both recurring and one-shot schedules in the same tick", () => {
-    const recurring = createSchedule({
+  test("claims both recurring and one-shot schedules in the same tick", async () => {
+    const recurring = await createSchedule({
       name: "Recurring",
       cronExpression: "* * * * *",
       message: "recurring",
@@ -867,13 +869,13 @@ describe("claimDueSchedules (one-shot)", () => {
       recurring.id,
     ]);
 
-    createSchedule({
+    await createSchedule({
       name: "One-shot",
       message: "one-shot",
       nextRunAt: Date.now() - 1000,
     });
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(2);
     const expressions = claimed.map((c) => c.expression);
     expect(expressions).toContain(null); // one-shot
@@ -890,31 +892,31 @@ describe("completeOneShot", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("transitions firing -> fired", () => {
-    const job = createSchedule({
+  test("transitions firing -> fired", async () => {
+    const job = await createSchedule({
       name: "Complete me",
       message: "done",
       nextRunAt: Date.now() - 1000,
     });
 
     // Claim first to get to 'firing' state
-    claimDueSchedules(Date.now());
+    await claimDueSchedules(Date.now());
 
-    completeOneShot(job.id);
+    await completeOneShot(job.id);
 
     const retrieved = getSchedule(job.id);
     expect(retrieved!.status).toBe("fired");
     expect(retrieved!.enabled).toBe(false);
   });
 
-  test("does not transition if not in firing state", () => {
-    const job = createSchedule({
+  test("does not transition if not in firing state", async () => {
+    const job = await createSchedule({
       name: "Not firing",
       message: "still active",
       nextRunAt: Date.now() + 60_000,
     });
 
-    completeOneShot(job.id);
+    await completeOneShot(job.id);
 
     const retrieved = getSchedule(job.id);
     expect(retrieved!.status).toBe("active"); // unchanged
@@ -929,35 +931,35 @@ describe("failOneShot", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("transitions firing -> active for retry", () => {
-    const job = createSchedule({
+  test("transitions firing -> active for retry", async () => {
+    const job = await createSchedule({
       name: "Fail me",
       message: "retry",
       nextRunAt: Date.now() - 1000,
     });
 
     // Claim to get to 'firing'
-    claimDueSchedules(Date.now());
+    await claimDueSchedules(Date.now());
 
-    failOneShot(job.id);
+    await failOneShot(job.id);
 
     const retrieved = getSchedule(job.id);
     expect(retrieved!.status).toBe("active");
     expect(retrieved!.enabled).toBe(true); // still enabled for retry
   });
 
-  test("can be re-claimed after failing", () => {
-    const job = createSchedule({
+  test("can be re-claimed after failing", async () => {
+    const job = await createSchedule({
       name: "Retry",
       message: "try again",
       nextRunAt: Date.now() - 1000,
     });
 
-    claimDueSchedules(Date.now());
-    failOneShot(job.id);
+    await claimDueSchedules(Date.now());
+    await failOneShot(job.id);
 
     // Should be claimable again
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(1);
     expect(claimed[0].id).toBe(job.id);
   });
@@ -970,14 +972,14 @@ describe("cancelSchedule", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("cancels an active one-shot schedule", () => {
-    const job = createSchedule({
+  test("cancels an active one-shot schedule", async () => {
+    const job = await createSchedule({
       name: "Cancel me",
       message: "never fire",
       nextRunAt: Date.now() + 60_000,
     });
 
-    const result = cancelSchedule(job.id);
+    const result = await cancelSchedule(job.id);
     expect(result).toBe(true);
 
     const retrieved = getSchedule(job.id);
@@ -985,31 +987,31 @@ describe("cancelSchedule", () => {
     expect(retrieved!.enabled).toBe(false);
   });
 
-  test("returns false for non-active schedule", () => {
-    const job = createSchedule({
+  test("returns false for non-active schedule", async () => {
+    const job = await createSchedule({
       name: "Already done",
       message: "completed",
       nextRunAt: Date.now() - 1000,
     });
 
     // Claim and complete it
-    claimDueSchedules(Date.now());
-    completeOneShot(job.id);
+    await claimDueSchedules(Date.now());
+    await completeOneShot(job.id);
 
-    const result = cancelSchedule(job.id);
+    const result = await cancelSchedule(job.id);
     expect(result).toBe(false);
   });
 
-  test("cancelled schedule is not claimable", () => {
-    const job = createSchedule({
+  test("cancelled schedule is not claimable", async () => {
+    const job = await createSchedule({
       name: "Cancelled",
       message: "should not fire",
       nextRunAt: Date.now() - 1000,
     });
 
-    cancelSchedule(job.id);
+    await cancelSchedule(job.id);
 
-    const claimed = claimDueSchedules(Date.now());
+    const claimed = await claimDueSchedules(Date.now());
     expect(claimed.length).toBe(0);
   });
 });
@@ -1023,8 +1025,8 @@ describe("routing and mode fields", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("recurring schedule defaults to execute mode and all_channels", () => {
-    const job = createSchedule({
+  test("recurring schedule defaults to execute mode and all_channels", async () => {
+    const job = await createSchedule({
       name: "Defaults",
       cronExpression: "0 9 * * *",
       message: "check defaults",
@@ -1037,9 +1039,9 @@ describe("routing and mode fields", () => {
     expect(job.status).toBe("active");
   });
 
-  test("routing hints round-trip through create/read", () => {
+  test("routing hints round-trip through create/read", async () => {
     const hints = { channels: ["slack", "discord"], priority: 1 };
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Routed",
       cronExpression: "0 9 * * *",
       message: "routed msg",
@@ -1055,9 +1057,9 @@ describe("routing and mode fields", () => {
     expect(retrieved!.mode).toBe("notify");
   });
 
-  test("routing hints round-trip through DB raw query", () => {
+  test("routing hints round-trip through DB raw query", async () => {
     const hints = { target: "telegram" };
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Raw round-trip",
       message: "check raw",
       nextRunAt: Date.now() + 60_000,
@@ -1082,15 +1084,15 @@ describe("routing and mode fields", () => {
     expect(raw!.status).toBe("active");
   });
 
-  test("updateSchedule updates mode and routing fields", () => {
-    const job = createSchedule({
+  test("updateSchedule updates mode and routing fields", async () => {
+    const job = await createSchedule({
       name: "Update routing",
       cronExpression: "0 9 * * *",
       message: "update routing",
       syntax: "cron",
     });
 
-    const updated = updateSchedule(job.id, {
+    const updated = await updateSchedule(job.id, {
       mode: "notify",
       routingIntent: "single_channel",
       routingHints: { channel: "telegram" },
@@ -1112,9 +1114,9 @@ describe("script timeout override", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("defaults timeoutMs to null when not provided", () => {
+  test("defaults timeoutMs to null when not provided", async () => {
     // GIVEN a schedule created without a timeout override
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "No timeout",
       cronExpression: "0 9 * * *",
       message: "no timeout",
@@ -1126,9 +1128,9 @@ describe("script timeout override", () => {
     expect(getSchedule(job.id)!.timeoutMs).toBeNull();
   });
 
-  test("persists a timeoutMs override through create/read", () => {
+  test("persists a timeoutMs override through create/read", async () => {
     // GIVEN a script schedule created with a custom timeout
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Slow script",
       cronExpression: "0 9 * * *",
       message: "",
@@ -1143,9 +1145,9 @@ describe("script timeout override", () => {
     expect(getSchedule(job.id)!.timeoutMs).toBe(120_000);
   });
 
-  test("updateSchedule sets and clears the timeout override", () => {
+  test("updateSchedule sets and clears the timeout override", async () => {
     // GIVEN a schedule with a custom timeout
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Adjust timeout",
       cronExpression: "0 9 * * *",
       message: "",
@@ -1156,13 +1158,13 @@ describe("script timeout override", () => {
     });
 
     // WHEN the timeout is changed
-    const updated = updateSchedule(job.id, { timeoutMs: 5_000 });
+    const updated = await updateSchedule(job.id, { timeoutMs: 5_000 });
 
     // THEN the new value is stored
     expect(updated!.timeoutMs).toBe(5_000);
 
     // AND WHEN the timeout is cleared back to the default
-    const cleared = updateSchedule(job.id, { timeoutMs: null });
+    const cleared = await updateSchedule(job.id, { timeoutMs: null });
 
     // THEN it reverts to null
     expect(cleared!.timeoutMs).toBeNull();
@@ -1185,8 +1187,8 @@ describe("capability manifest", () => {
     persona: false,
   };
 
-  test("persists a capability manifest through create/read", () => {
-    const job = createSchedule({
+  test("persists a capability manifest through create/read", async () => {
+    const job = await createSchedule({
       name: "Capable schedule",
       cronExpression: "0 9 * * *",
       message: "do scoped work",
@@ -1198,8 +1200,8 @@ describe("capability manifest", () => {
     expect(getSchedule(job.id)!.capabilities).toEqual(manifest);
   });
 
-  test("defaults capabilities to null when not provided", () => {
-    const job = createSchedule({
+  test("defaults capabilities to null when not provided", async () => {
+    const job = await createSchedule({
       name: "No manifest",
       cronExpression: "0 9 * * *",
       message: "unconstrained",
@@ -1210,8 +1212,8 @@ describe("capability manifest", () => {
     expect(getSchedule(job.id)!.capabilities).toBeNull();
   });
 
-  test("updateSchedule sets and clears the capability manifest", () => {
-    const job = createSchedule({
+  test("updateSchedule sets and clears the capability manifest", async () => {
+    const job = await createSchedule({
       name: "Update manifest",
       cronExpression: "0 9 * * *",
       message: "update manifest",
@@ -1220,11 +1222,11 @@ describe("capability manifest", () => {
 
     expect(job.capabilities).toBeNull();
 
-    const updated = updateSchedule(job.id, { capabilities: manifest });
+    const updated = await updateSchedule(job.id, { capabilities: manifest });
     expect(updated!.capabilities).toEqual(manifest);
     expect(getSchedule(job.id)!.capabilities).toEqual(manifest);
 
-    const cleared = updateSchedule(job.id, { capabilities: null });
+    const cleared = await updateSchedule(job.id, { capabilities: null });
     expect(cleared!.capabilities).toBeNull();
     expect(getSchedule(job.id)!.capabilities).toBeNull();
   });
@@ -1239,14 +1241,14 @@ describe("listSchedules filters", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("oneShotOnly filter returns only one-shot schedules", () => {
-    createSchedule({
+  test("oneShotOnly filter returns only one-shot schedules", async () => {
+    await createSchedule({
       name: "Recurring",
       cronExpression: "0 9 * * *",
       message: "recurring",
       syntax: "cron",
     });
-    createSchedule({
+    await createSchedule({
       name: "One-shot",
       message: "one-shot",
       nextRunAt: Date.now() + 60_000,
@@ -1258,14 +1260,14 @@ describe("listSchedules filters", () => {
     expect(oneShots[0].expression).toBeNull();
   });
 
-  test("recurringOnly filter returns only recurring schedules", () => {
-    createSchedule({
+  test("recurringOnly filter returns only recurring schedules", async () => {
+    await createSchedule({
       name: "Recurring",
       cronExpression: "0 9 * * *",
       message: "recurring",
       syntax: "cron",
     });
-    createSchedule({
+    await createSchedule({
       name: "One-shot",
       message: "one-shot",
       nextRunAt: Date.now() + 60_000,
@@ -1287,8 +1289,8 @@ describe("createSchedule (wake mode)", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("creates a wake schedule with wakeConversationId", () => {
-    const job = createSchedule({
+  test("creates a wake schedule with wakeConversationId", async () => {
+    const job = await createSchedule({
       name: "Wake conv",
       message: "resume conversation",
       nextRunAt: Date.now() + 60_000,
@@ -1305,15 +1307,15 @@ describe("createSchedule (wake mode)", () => {
     expect(retrieved!.wakeConversationId).toBe("conv-123");
   });
 
-  test("throws when creating wake schedule without wakeConversationId", () => {
-    expect(() =>
+  test("throws when creating wake schedule without wakeConversationId", async () => {
+    await expect(
       createSchedule({
         name: "Bad wake",
         message: "no conv id",
         nextRunAt: Date.now() + 60_000,
         mode: "wake",
       }),
-    ).toThrow("Wake schedules require wakeConversationId");
+    ).rejects.toThrow("Wake schedules require wakeConversationId");
   });
 });
 
@@ -1326,14 +1328,14 @@ describe("listSchedules new filters", () => {
     db.run("DELETE FROM cron_jobs");
   });
 
-  test("mode filter returns only schedules with matching mode", () => {
-    createSchedule({
+  test("mode filter returns only schedules with matching mode", async () => {
+    await createSchedule({
       name: "Execute schedule",
       message: "execute",
       nextRunAt: Date.now() + 60_000,
       mode: "execute",
     });
-    createSchedule({
+    await createSchedule({
       name: "Wake schedule",
       message: "wake",
       nextRunAt: Date.now() + 60_000,
@@ -1347,14 +1349,14 @@ describe("listSchedules new filters", () => {
     expect(wakeOnly[0].mode).toBe("wake");
   });
 
-  test("createdBy filter returns only schedules with matching creator", () => {
-    createSchedule({
+  test("createdBy filter returns only schedules with matching creator", async () => {
+    await createSchedule({
       name: "Agent schedule",
       message: "by agent",
       nextRunAt: Date.now() + 60_000,
       createdBy: "agent",
     });
-    createSchedule({
+    await createSchedule({
       name: "Defer schedule",
       message: "by defer",
       nextRunAt: Date.now() + 60_000,
@@ -1367,22 +1369,22 @@ describe("listSchedules new filters", () => {
     expect(deferOnly[0].createdBy).toBe("defer");
   });
 
-  test("conversationId filter returns only wakes targeting that conversation", () => {
-    createSchedule({
+  test("conversationId filter returns only wakes targeting that conversation", async () => {
+    await createSchedule({
       name: "Wake for conv-123",
       message: "wake conv-123",
       nextRunAt: Date.now() + 60_000,
       mode: "wake",
       wakeConversationId: "conv-123",
     });
-    createSchedule({
+    await createSchedule({
       name: "Wake for conv-456",
       message: "wake conv-456",
       nextRunAt: Date.now() + 60_000,
       mode: "wake",
       wakeConversationId: "conv-456",
     });
-    createSchedule({
+    await createSchedule({
       name: "Regular schedule",
       message: "no wake",
       nextRunAt: Date.now() + 60_000,

--- a/assistant/src/__tests__/scheduler-disk-pressure.test.ts
+++ b/assistant/src/__tests__/scheduler-disk-pressure.test.ts
@@ -115,7 +115,7 @@ describe("scheduler disk pressure gate", () => {
 
   test("skips before claiming due schedules while disk pressure is locked", async () => {
     const dueAt = Date.now() - 10_000;
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Due reminder",
       message: "Do not fire while locked",
       mode: "notify",

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -142,7 +142,7 @@ describe("scheduler RRULE execution", () => {
 
   test("RRULE schedule fires and creates cron_runs entry", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "RRULE Test",
       cronExpression: rruleExpr,
       message: "Hello from RRULE",
@@ -188,7 +188,7 @@ describe("scheduler RRULE execution", () => {
     });
 
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "RRULE Task Schedule",
       cronExpression: rruleExpr,
       message: `run_task:${task.id}`,
@@ -308,7 +308,7 @@ describe("scheduler RRULE execution", () => {
   });
 
   test("existing cron schedule behavior is unchanged", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Cron Schedule",
       cronExpression: "* * * * *",
       message: "Cron message",
@@ -374,7 +374,7 @@ describe("scheduler RRULE execution", () => {
 
     const expression = `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1\nEXDATE:${exDate}`;
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "RRULE set EXDATE test",
       cronExpression: expression,
       message: "Set exclusion test",
@@ -422,7 +422,7 @@ describe("scheduler RRULE execution", () => {
       `EXDATE:${exDs}`,
     ].join("\n");
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Set schedule fire test",
       cronExpression: expression,
       message: "Set fire test",
@@ -501,7 +501,7 @@ describe("scheduler RRULE execution", () => {
       // Sanity: the without-EXRULE occurrence must be even (would be excluded)
       expect(offsetWithout % 2).toBe(0);
 
-      const schedule = createSchedule({
+      const schedule = await createSchedule({
         name: "EXRULE scheduler test",
         cronExpression: expression,
         message: "EXRULE scheduler fire",
@@ -545,7 +545,7 @@ describe("scheduler RRULE execution", () => {
 
   test("RRULE schedule advances nextRunAt after firing", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Advancing RRULE",
       cronExpression: rruleExpr,
       message: "Advance test",
@@ -574,7 +574,7 @@ describe("scheduler RRULE execution", () => {
   // ── One-shot schedule tests ───────────────────────────────────────
 
   test("one-shot execute mode fires and marks schedule as fired", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot execute",
       message: "Execute this once",
       mode: "execute",
@@ -612,7 +612,7 @@ describe("scheduler RRULE execution", () => {
   });
 
   test("one-shot notify mode emits notification and marks schedule as fired", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot notify",
       message: "Notify about this",
       mode: "notify",
@@ -660,7 +660,7 @@ describe("scheduler RRULE execution", () => {
   });
 
   test("one-shot failure reverts to active for retry", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot fail",
       message: "This will fail",
       mode: "execute",
@@ -686,7 +686,7 @@ describe("scheduler RRULE execution", () => {
 
   test("recurring + notify mode emits notification and continues recurring", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Recurring notify",
       cronExpression: rruleExpr,
       message: "Recurring notification",
@@ -739,7 +739,7 @@ describe("scheduler RRULE execution", () => {
   });
 
   test("one-shot notify mode passes routing intent and hints to notifier", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Routing test",
       message: "Check routing",
       mode: "notify",

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -161,7 +161,7 @@ describe("scheduler conversation reuse", () => {
 
     // GIVEN a recurring schedule with reuseConversation enabled
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Reuse Test",
       cronExpression: rruleExpr,
       message: "Reuse conversation message",
@@ -221,7 +221,7 @@ describe("scheduler conversation reuse", () => {
 
     // GIVEN a recurring schedule with no explicit reuseConversation
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Default Reuse Test",
       cronExpression: rruleExpr,
       message: "Default reuse message",
@@ -265,7 +265,7 @@ describe("scheduler conversation reuse", () => {
 
     // GIVEN a recurring schedule with reuseConversation explicitly disabled
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "No Reuse Test",
       cronExpression: rruleExpr,
       message: "New conv each run",
@@ -309,7 +309,7 @@ describe("scheduler conversation reuse", () => {
 
     // GIVEN a recurring schedule with reuseConversation enabled that has already run once
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Deleted Conv Test",
       cronExpression: rruleExpr,
       message: "Handle deleted conv",
@@ -354,7 +354,7 @@ describe("scheduler conversation reuse", () => {
      */
 
     // GIVEN a one-shot schedule with reuseConversation enabled
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "One-shot Reuse Ignored",
       message: "One-shot with reuse flag",
       mode: "execute",
@@ -390,7 +390,7 @@ describe("scheduler conversation reuse", () => {
 
     // GIVEN a recurring schedule with reuseConversation enabled
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Most Recent Success Test",
       cronExpression: rruleExpr,
       message: "Pick latest success",
@@ -460,7 +460,7 @@ describe("scheduler talk-mode runner option propagation", () => {
 
   test("talk-mode propagates conversationType=scheduled, scheduleJobId, and quiet=>suppressFailureNotifications", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Quiet Talk Mode",
       cronExpression: rruleExpr,
       message: "Background work",
@@ -485,7 +485,7 @@ describe("scheduler talk-mode runner option propagation", () => {
 
   test("talk-mode without quiet leaves suppressFailureNotifications=false", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Loud Talk Mode",
       cronExpression: rruleExpr,
       message: "Background work",
@@ -514,7 +514,7 @@ describe("scheduler talk-mode runner option propagation", () => {
      * Guard ensures we substitute a recognizable sentinel.
      */
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Bootstrap Failure",
       cronExpression: rruleExpr,
       message: "x",
@@ -540,7 +540,7 @@ describe("scheduler talk-mode runner option propagation", () => {
 
   test("talk-mode fires onScheduleConversationCreated synchronously via runner callback (BEFORE the runner returns)", async () => {
     const rruleExpr = buildEveryMinuteRrule();
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "SSE timing",
       cronExpression: rruleExpr,
       message: "x",

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -81,7 +81,7 @@ describe("scheduler wake mode", () => {
 
   test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
     // GIVEN a one-shot wake schedule with a conversation ID
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake Test",
       message: "Check back on this",
       mode: "wake",
@@ -114,7 +114,7 @@ describe("scheduler wake mode", () => {
     // GIVEN a one-shot wake schedule WITHOUT a conversation ID
     // We need to create it with a wakeConversationId first (validation requires it),
     // then clear it at the DB level to simulate a missing value at runtime.
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake No Conv",
       message: "Missing conv",
       mode: "wake",
@@ -151,7 +151,7 @@ describe("scheduler wake mode", () => {
       producedToolCalls: false,
     });
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake Complete",
       message: "Should complete",
       mode: "wake",
@@ -179,7 +179,7 @@ describe("scheduler wake mode", () => {
     // GIVEN a one-shot wake schedule where wakeAgentForOpportunity throws
     mockWakeAgentForOpportunity.mockRejectedValueOnce(new Error("Wake failed"));
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake Fail",
       message: "Should fail",
       mode: "wake",
@@ -216,7 +216,7 @@ describe("scheduler wake mode", () => {
         producedToolCalls: false,
       });
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake Retry",
       message: "Retry after timeout",
       mode: "wake",
@@ -262,7 +262,7 @@ describe("scheduler wake mode", () => {
       reason: "timeout",
     });
 
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Wake Max Retry",
       message: "Always busy",
       mode: "wake",

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -129,13 +129,13 @@ describe("scheduleTask", () => {
     db.run("DELETE FROM tasks");
   });
 
-  test("creates a schedule with run_task:<taskId> message format", () => {
+  test("creates a schedule with run_task:<taskId> message format", async () => {
     const task = createTask({
       title: "Daily Report",
       template: "Generate the daily report",
     });
 
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Daily Report Schedule",
       cronExpression: "0 9 * * *",
@@ -149,13 +149,13 @@ describe("scheduleTask", () => {
     expect(schedule.enabled).toBe(true);
   });
 
-  test("creates a schedule without timezone", () => {
+  test("creates a schedule without timezone", async () => {
     const task = createTask({
       title: "Hourly Check",
       template: "Check status",
     });
 
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Hourly Check",
       cronExpression: "0 * * * *",
@@ -165,13 +165,13 @@ describe("scheduleTask", () => {
     expect(schedule.timezone).toBeNull();
   });
 
-  test("schedule is persisted and retrievable", () => {
+  test("schedule is persisted and retrievable", async () => {
     const task = createTask({
       title: "Persisted Task",
       template: "Do something",
     });
 
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Persisted Schedule",
       cronExpression: "*/5 * * * *",
@@ -207,7 +207,7 @@ describe("scheduler run_task detection", () => {
     });
 
     // Create a schedule with run_task: message
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Task Schedule",
       cronExpression: "* * * * *",
@@ -252,7 +252,7 @@ describe("scheduler run_task detection", () => {
 
   test("regular messages route through the runBackgroundJob runner", async () => {
     // Create a regular schedule (no run_task: prefix)
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Regular Schedule",
       cronExpression: "* * * * *",
       message: "Do something normal",
@@ -291,7 +291,7 @@ describe("scheduler run_task detection", () => {
 
   test("handles task not found gracefully", async () => {
     // Create a schedule pointing to a nonexistent task
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Bad Task Schedule",
       cronExpression: "* * * * *",
       message: "run_task:nonexistent-task-id",
@@ -338,7 +338,7 @@ describe("scheduler run_task detection", () => {
       title: "Usage Attribution Task",
       template: "Spend scheduled tokens",
     });
-    const schedule = scheduleTask({
+    const schedule = await scheduleTask({
       taskId: task.id,
       name: "Usage Attribution Schedule",
       cronExpression: "* * * * *",
@@ -410,7 +410,7 @@ describe("scheduler run_task detection", () => {
   });
 
   test("opens a normal execute schedule run before fresh background processing and records the conversation id", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Usage Attribution Message Schedule",
       cronExpression: "* * * * *",
       message: "Spend scheduled message tokens",
@@ -503,7 +503,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("a due workflow-mode job triggers the run manager with name/args", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Triage inbox",
       cronExpression: "0 9 * * *",
       message: "triage",
@@ -536,7 +536,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("fires with the schedule's stored side-effecting manifest", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Side-effecting workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -567,7 +567,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("a legacy schedule (null capabilities) fires with the read-only baseline", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Legacy workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -593,7 +593,7 @@ describe("scheduler workflow mode", () => {
     // Workflow schedules created via schedule_create store the originating
     // conversation as createdFromConversationId and leave wakeConversationId
     // unset; without the fallback the completion summary lands nowhere.
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Morning digest",
       cronExpression: "0 9 * * *",
       message: "",
@@ -616,7 +616,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("prefers an explicit wakeConversationId over createdFromConversationId", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Both set",
       cronExpression: "0 9 * * *",
       message: "",
@@ -639,7 +639,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("defaults workflowArgs to {} when unset", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "No-args workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -662,7 +662,7 @@ describe("scheduler workflow mode", () => {
     workflowStartImpl = () => {
       throw new Error("workflows disabled");
     };
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Failing workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -684,7 +684,7 @@ describe("scheduler workflow mode", () => {
   });
 
   test("skips a workflow-mode job with no workflowName", async () => {
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Nameless workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -704,7 +704,7 @@ describe("scheduler workflow mode", () => {
 
   test("defers a due workflow job until tools are registered, then fires it", async () => {
     coreToolsReady = false;
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Boot workflow",
       cronExpression: "0 9 * * *",
       message: "go",
@@ -740,7 +740,7 @@ describe("scheduler workflow mode", () => {
     // (one-shot / exhausted finite RRULE). The due-claim query requires
     // enabled=true, so a deferred final occurrence must be re-enabled or it is
     // never re-claimed. Simulate that disabled-on-claim state, then defer.
-    const schedule = createSchedule({
+    const schedule = await createSchedule({
       name: "Final workflow occurrence",
       cronExpression: "0 9 * * *",
       message: "",
@@ -751,7 +751,7 @@ describe("scheduler workflow mode", () => {
     });
     expect(getSchedule(schedule.id)?.enabled).toBe(false);
 
-    deferClaimedSchedule(schedule.id);
+    await deferClaimedSchedule(schedule.id);
 
     const after = getSchedule(schedule.id);
     expect(after?.enabled).toBe(true);

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -188,7 +188,7 @@ describe("background wake intent publisher hooks", () => {
   });
 
   test("schedule create, update, and delete mutations refresh the wake intent", async () => {
-    const job = createSchedule({
+    const job = await createSchedule({
       name: "Wake hook",
       cronExpression: "* * * * *",
       message: "wake",
@@ -197,11 +197,11 @@ describe("background wake intent publisher hooks", () => {
     await flushQueuedWakeRefresh();
     expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(1);
 
-    updateSchedule(job.id, { name: "Wake hook updated" });
+    await updateSchedule(job.id, { name: "Wake hook updated" });
     await flushQueuedWakeRefresh();
     expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(2);
 
-    expect(deleteSchedule(job.id)).toBe(true);
+    expect(await deleteSchedule(job.id)).toBe(true);
     await flushQueuedWakeRefresh();
     expect(mockPublishBackgroundWakeIntent).toHaveBeenCalledTimes(3);
   });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -819,7 +819,7 @@ export async function runDaemon(): Promise<void> {
   registerMessagingProviders();
 
   try {
-    recoverStaleSchedules();
+    await recoverStaleSchedules();
   } catch (err) {
     log.error({ err }, "Schedule recovery failed — continuing startup");
   }

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -159,7 +159,7 @@ export async function runForkBasedRetrospective(
   // nothing is lost. Returning (not throwing) keeps the jobs-worker from
   // retry-with-backoff.
   if (isConversationProcessing(sourceConversationId)) {
-    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
     log.info(
       { sourceConversationId },
       "memory-retrospective (fork): source conversation is mid-turn; skipping",
@@ -237,7 +237,7 @@ export async function runForkBasedRetrospective(
       groupId: MEMORY_RETROSPECTIVE_GROUP_ID,
     });
   } catch (err) {
-    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
     log.error(
       { err, sourceConversationId },
       "memory-retrospective (fork): forkConversationForRetrospective failed",
@@ -269,7 +269,7 @@ export async function runForkBasedRetrospective(
       "memory-retrospective (fork): failed to persist instruction message",
     );
     safeDeleteRetrospectiveConversation(forkId, FORK_DELETE_FAILURE_WARNING);
-    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
     throw err;
   }
 
@@ -380,7 +380,7 @@ export async function runForkBasedRetrospective(
   // Wake failed. Bump `lastRunAt` only so the cooldown gate applies, leave
   // `lastProcessedMessageId` alone so the next attempt re-processes the
   // same messages. Then clean up the orphan fork.
-  bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+  await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
   safeDeleteRetrospectiveConversation(forkId, FORK_DELETE_FAILURE_WARNING);
 
   if (threw !== undefined) {
@@ -594,7 +594,7 @@ async function finalizeSuccessfulRetrospective(args: {
   const runRemembers = extractRetrospectiveRunRemembers(
     retrospectiveConversationId,
   );
-  upsertRetrospectiveState({
+  await upsertRetrospectiveState({
     conversationId: sourceConversationId,
     lastProcessedMessageId: cutoffMessageId,
     lastRunAt: Date.now(),

--- a/assistant/src/memory/memory-retrospective-state.ts
+++ b/assistant/src/memory/memory-retrospective-state.ts
@@ -24,7 +24,7 @@ import { eq } from "drizzle-orm";
 
 import { type DrizzleDb, getDb } from "../persistence/db-connection.js";
 import { memoryRetrospectiveState } from "../persistence/schema/index.js";
-import { withSqliteRetrySync } from "../util/sqlite-retry.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -113,17 +113,17 @@ export function getRetrospectiveState(
  * against. When omitted, the stored log is left untouched (and seeded NULL on
  * first insert).
  */
-export function upsertRetrospectiveState(
+export async function upsertRetrospectiveState(
   args: Omit<MemoryRetrospectiveState, "rememberedLog"> & {
     rememberedLog?: string[];
   },
-): void {
+): Promise<void> {
   const db = getDb();
   const serializedLog =
     args.rememberedLog === undefined
       ? undefined
       : serializeRememberedLog(args.rememberedLog);
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () =>
       db
         .insert(memoryRetrospectiveState)
@@ -235,12 +235,12 @@ export function forkRetrospectiveState(args: {
  * `getMessagesSince(...)` queries treat the same as a missing row. An
  * existing row's `rememberedLog` is left untouched.
  */
-export function bumpRetrospectiveLastRunAt(
+export async function bumpRetrospectiveLastRunAt(
   conversationId: string,
   lastRunAt: number,
-): void {
+): Promise<void> {
   const db = getDb();
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () =>
       db
         .insert(memoryRetrospectiveState)

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -31,6 +31,7 @@ import {
   upsertOutboundBinding,
 } from "../persistence/external-conversation-store.js";
 import { getLogger } from "../util/logger.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   composeConversationSeed,
   isConversationSeedSane,
@@ -214,13 +215,17 @@ export async function pairDeliveryWithConversation(
         "Conversation reuse target invalid — falling back to new conversation",
       );
 
-      const conversation = createConversation({
-        title,
-        conversationType,
-        source: signal.conversationMetadata?.source ?? "notification",
-        groupId: signal.conversationMetadata?.groupId,
-        scheduleJobId: signal.conversationMetadata?.scheduleJobId,
-      });
+      const conversation = await withSqliteRetry(
+        () =>
+          createConversation({
+            title,
+            conversationType,
+            source: signal.conversationMetadata?.source ?? "notification",
+            groupId: signal.conversationMetadata?.groupId,
+            scheduleJobId: signal.conversationMetadata?.scheduleJobId,
+          }),
+        { op: "conversationPairing.reuseFallback" },
+      );
 
       const message = await addMessage(
         conversation.id,
@@ -380,13 +385,17 @@ export async function pairDeliveryWithConversation(
     // Default path: create a new conversation
     // Memory indexing is skipped on the seed message below to prevent
     // notification copy from polluting conversational recall.
-    const conversation = createConversation({
-      title,
-      conversationType,
-      source: signal.conversationMetadata?.source ?? "notification",
-      groupId: signal.conversationMetadata?.groupId,
-      scheduleJobId: signal.conversationMetadata?.scheduleJobId,
-    });
+    const conversation = await withSqliteRetry(
+      () =>
+        createConversation({
+          title,
+          conversationType,
+          source: signal.conversationMetadata?.source ?? "notification",
+          groupId: signal.conversationMetadata?.groupId,
+          scheduleJobId: signal.conversationMetadata?.scheduleJobId,
+        }),
+      { op: "conversationPairing.default" },
+    );
 
     // Skip memory indexing — notification audit messages are not conversational
     // memory and should not pollute recall or incur embedding/extraction overhead.

--- a/assistant/src/persistence/conversation-bootstrap.ts
+++ b/assistant/src/persistence/conversation-bootstrap.ts
@@ -1,3 +1,4 @@
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import { createConversation } from "./conversation-crud.js";
 import {
   AUTO_TITLE_DETERMINISTIC,
@@ -32,19 +33,27 @@ export interface BootstrapConversationOptions {
  * hook upgrades it to an LLM title (see
  * `plugins/defaults/title-generate/hooks/user-prompt-submit.ts`).
  */
-export function bootstrapConversation(opts: BootstrapConversationOptions) {
-  return createConversation({
-    title: deriveDeterministicTitle({
-      origin: opts.origin,
-      systemHint: opts.systemHint,
-    }),
-    isAutoTitle: AUTO_TITLE_DETERMINISTIC,
-    ...(opts.conversationType && { conversationType: opts.conversationType }),
-    ...(opts.source && { source: opts.source }),
-    ...(opts.scheduleJobId && { scheduleJobId: opts.scheduleJobId }),
-    ...(opts.groupId && { groupId: opts.groupId }),
-    ...(opts.forkParentConversationId && {
-      forkParentConversationId: opts.forkParentConversationId,
-    }),
-  });
+export async function bootstrapConversation(
+  opts: BootstrapConversationOptions,
+) {
+  return withSqliteRetry(
+    () =>
+      createConversation({
+        title: deriveDeterministicTitle({
+          origin: opts.origin,
+          systemHint: opts.systemHint,
+        }),
+        isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+        ...(opts.conversationType && {
+          conversationType: opts.conversationType,
+        }),
+        ...(opts.source && { source: opts.source }),
+        ...(opts.scheduleJobId && { scheduleJobId: opts.scheduleJobId }),
+        ...(opts.groupId && { groupId: opts.groupId }),
+        ...(opts.forkParentConversationId && {
+          forkParentConversationId: opts.forkParentConversationId,
+        }),
+      }),
+    { op: "bootstrapConversation" },
+  );
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -72,7 +72,7 @@ import { getLogger } from "../util/logger.js";
 import { getLogsDbPath } from "../util/logs-db-path.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
-import { withSqliteRetry, withSqliteRetrySync } from "../util/sqlite-retry.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -630,33 +630,24 @@ export function createConversation(
     seq: initialSeq > 0 ? initialSeq : null,
   };
 
-  // Retry on SQLITE_BUSY and SQLITE_IOERR — transient disk I/O errors or WAL
-  // contention can cause the first attempt to fail even under normal load.
-  // INSERT and group_id UPDATE are retried independently so a transient failure
-  // on the UPDATE doesn't re-execute the already-succeeded INSERT (which would
-  // hit a unique constraint violation).
-  // No explicit BEGIN/COMMIT here — callers that need atomicity (e.g.
-  // forkConversation) wrap in their own transaction, and nesting raw BEGIN
-  // inside Drizzle's db.transaction() would crash SQLite.
-  withSqliteRetrySync(
-    () => db.insert(conversations).values(conversation).run(),
-    { op: "createConversation.insert", context: { conversationId: id } },
-  );
+  // Synchronous primitive: it runs inside synchronous bun:sqlite transactions
+  // (the fork paths below), so it cannot itself await a retry. It does NOT
+  // retry on contention — callers on write-contended paths wrap the call (or
+  // their enclosing transaction) in `withSqliteRetry`. No explicit BEGIN/COMMIT
+  // here: callers that need atomicity wrap in their own transaction, and
+  // nesting raw BEGIN inside Drizzle's db.transaction() would crash SQLite.
+  db.insert(conversations).values(conversation).run();
 
   // group_id is NOT in the Drizzle schema (raw-query-only pattern).
   // Set via raw SQL after the INSERT succeeds.
   // Always set group_id — default to "system:all" when none provided.
   {
     const effectiveGroupId = groupId ?? "system:all";
-    withSqliteRetrySync(
-      () =>
-        rawRun(
-          "UPDATE conversations SET group_id = ?, is_pinned = ? WHERE id = ?",
-          effectiveGroupId,
-          effectiveGroupId === "system:pinned" ? 1 : 0,
-          id,
-        ),
-      { op: "createConversation.groupId", context: { conversationId: id } },
+    rawRun(
+      "UPDATE conversations SET group_id = ?, is_pinned = ? WHERE id = ?",
+      effectiveGroupId,
+      effectiveGroupId === "system:pinned" ? 1 : 0,
+      id,
     );
   }
 
@@ -1366,37 +1357,43 @@ export async function forkConversationForRetrospective(params: {
   );
 
   // Phase 1 (in-process, tiny): create the fork conversation row + lineage so
-  // the subprocess connection sees it before inserting messages.
-  const fork = db.transaction(() => {
-    const fc = createConversation({
-      title: forkTitle,
-      conversationType: params.conversationType ?? "standard",
-      groupId: params.groupId ?? parentGroupId ?? "system:all",
-      ...(params.source != null ? { source: params.source } : {}),
-    });
-    db.update(conversations)
-      .set({
-        forkParentConversationId: sourceConversation.id,
-        forkParentMessageId,
-        contextSummary: inheritedCompaction?.summary ?? null,
-        contextCompactedMessageCount:
-          inheritedCompaction?.compactedMessageCount ?? 0,
-        contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
-        slackContextCompactionWatermarkTs: inheritsLatestCompaction
-          ? sourceConversation.slackContextCompactionWatermarkTs
-          : null,
-        slackContextCompactionWatermarkAt: inheritsLatestCompaction
-          ? sourceConversation.slackContextCompactionWatermarkAt
-          : null,
-        historyStrippedAt: inheritsHistoryStrippedAt
-          ? sourceHistoryStrippedAt
-          : null,
-        inferenceProfile: sourceConversation.inferenceProfile,
-      })
-      .where(eq(conversations.id, fc.id))
-      .run();
-    return fc;
-  });
+  // the subprocess connection sees it before inserting messages. The whole
+  // transaction is the retry unit — it rolls back atomically on contention, so
+  // re-running it (with a fresh conversation id) is safe.
+  const fork = await withSqliteRetry(
+    () =>
+      db.transaction(() => {
+        const fc = createConversation({
+          title: forkTitle,
+          conversationType: params.conversationType ?? "standard",
+          groupId: params.groupId ?? parentGroupId ?? "system:all",
+          ...(params.source != null ? { source: params.source } : {}),
+        });
+        db.update(conversations)
+          .set({
+            forkParentConversationId: sourceConversation.id,
+            forkParentMessageId,
+            contextSummary: inheritedCompaction?.summary ?? null,
+            contextCompactedMessageCount:
+              inheritedCompaction?.compactedMessageCount ?? 0,
+            contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
+            slackContextCompactionWatermarkTs: inheritsLatestCompaction
+              ? sourceConversation.slackContextCompactionWatermarkTs
+              : null,
+            slackContextCompactionWatermarkAt: inheritsLatestCompaction
+              ? sourceConversation.slackContextCompactionWatermarkAt
+              : null,
+            historyStrippedAt: inheritsHistoryStrippedAt
+              ? sourceHistoryStrippedAt
+              : null,
+            inferenceProfile: sourceConversation.inferenceProfile,
+          })
+          .where(eq(conversations.id, fc.id))
+          .run();
+        return fc;
+      }),
+    { op: "forkConversationForRetrospective.create" },
+  );
 
   try {
     // Phase 2 (off the event loop): copy the message rows in a sqlite3

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -630,25 +630,31 @@ export function createConversation(
     seq: initialSeq > 0 ? initialSeq : null,
   };
 
-  // Synchronous primitive: it runs inside synchronous bun:sqlite transactions
-  // (the fork paths below), so it cannot itself await a retry. It does NOT
-  // retry on contention — callers on write-contended paths wrap the call (or
-  // their enclosing transaction) in `withSqliteRetry`. No explicit BEGIN/COMMIT
-  // here: callers that need atomicity wrap in their own transaction, and
-  // nesting raw BEGIN inside Drizzle's db.transaction() would crash SQLite.
-  db.insert(conversations).values(conversation).run();
-
-  // group_id is NOT in the Drizzle schema (raw-query-only pattern).
-  // Set via raw SQL after the INSERT succeeds.
-  // Always set group_id — default to "system:all" when none provided.
-  {
-    const effectiveGroupId = groupId ?? "system:all";
+  // Insert the row and set its group_id (raw-SQL-only, not in the Drizzle
+  // schema, so it's a second statement) atomically. A SAVEPOINT — not
+  // `db.transaction()` — because createConversation also runs INSIDE the fork
+  // paths' transactions, where a nested `BEGIN` would error; a savepoint nests
+  // cleanly and is still atomic at the top level. createConversation is a
+  // synchronous primitive and does not retry on contention: callers on
+  // write-contended paths wrap the call in `withSqliteRetry`, and because the
+  // insert+update are atomic here, such a retry re-runs the whole thing cleanly
+  // (a failed attempt rolls back, so no half-written row is ever left behind).
+  const effectiveGroupId = groupId ?? "system:all";
+  const raw = getSqliteFrom(db);
+  raw.exec("SAVEPOINT create_conv");
+  try {
+    db.insert(conversations).values(conversation).run();
     rawRun(
       "UPDATE conversations SET group_id = ?, is_pinned = ? WHERE id = ?",
       effectiveGroupId,
       effectiveGroupId === "system:pinned" ? 1 : 0,
       id,
     );
+    raw.exec("RELEASE create_conv");
+  } catch (err) {
+    raw.exec("ROLLBACK TO create_conv");
+    raw.exec("RELEASE create_conv");
+    throw err;
   }
 
   initConversationDir({ ...conversation, originChannel: null });

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -101,15 +101,15 @@ export interface RunBackgroundJobOptions {
    */
   scheduleJobId?: string;
   /**
-   * Fires synchronously after `bootstrapConversation` returns and BEFORE
+   * Fires (and is awaited) after `bootstrapConversation` returns and BEFORE
    * `processMessage` starts. Use this to populate the macOS sidebar entry
    * immediately (the SSE event fires when the job starts) rather than after
    * the job finishes (which can be up to `timeoutMs` later for long jobs).
    *
-   * Wrapped in try/catch internally — a callback throw is logged and
-   * swallowed so it cannot kill the job runner.
+   * Wrapped in try/catch internally — a callback throw (or rejection) is
+   * logged and swallowed so it cannot kill the job runner.
    */
-  onConversationCreated?: (conversationId: string) => void;
+  onConversationCreated?: (conversationId: string) => void | Promise<void>;
   /**
    * Opt out of the "skip until first user message" gate. Defaults to
    * `false` (gate active). Set to `true` ONLY for jobs that genuinely need
@@ -211,14 +211,16 @@ export async function runBackgroundJob(
     };
   }
 
-  let conversation: ReturnType<typeof bootstrapConversation> | undefined;
+  let conversation:
+    | Awaited<ReturnType<typeof bootstrapConversation>>
+    | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     // Bootstrap inside the try so that a `createConversation` /
     // `queueGenerateConversationTitle` failure is caught and surfaced as a
     // structured `{ ok: false }` result rather than re-thrown to the caller —
     // the documented contract of this runner.
-    conversation = bootstrapConversation({
+    conversation = await bootstrapConversation({
       conversationType: opts.conversationType ?? "background",
       source: opts.source,
       origin: opts.origin,
@@ -237,7 +239,7 @@ export async function runBackgroundJob(
     // callback throw cannot abort the job.
     if (opts.onConversationCreated) {
       try {
-        opts.onConversationCreated(conversation.id);
+        await opts.onConversationCreated(conversation.id);
       } catch (cbErr) {
         log.warn(
           {

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -25,6 +25,7 @@ import { setConversationKey } from "../../persistence/conversation-key-store.js"
 import { listConversations } from "../../persistence/conversation-queries.js";
 import { getBindingByConversation } from "../../persistence/external-conversation-store.js";
 import { getLogger } from "../../util/logger.js";
+import { withSqliteRetry } from "../../util/sqlite-retry.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadGatewayError, BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -102,7 +103,10 @@ async function handleCreateCli({ body = {} }: RouteHandlerArgs) {
     conversationType = parsed.data;
   }
 
-  const conversation = createConversation({ title, conversationType });
+  const conversation = await withSqliteRetry(
+    () => createConversation({ title, conversationType }),
+    { op: "createConversationCli" },
+  );
   const conversationKey = uuid();
   setConversationKey(conversationKey, conversation.id);
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -77,13 +77,13 @@ function resolveOrThrow(rawId: string): string {
   return id;
 }
 
-function cancelScheduleIfLast(conversationId: string): void {
+async function cancelScheduleIfLast(conversationId: string): Promise<void> {
   const conv = getConversation(conversationId);
   if (
     conv?.scheduleJobId &&
     countConversationsByScheduleJobId(conv.scheduleJobId) <= 1
   ) {
-    deleteSchedule(conv.scheduleJobId);
+    await deleteSchedule(conv.scheduleJobId);
   }
 }
 
@@ -264,13 +264,13 @@ async function handleClearAllConversations({ headers = {} }: RouteHandlerArgs) {
   return undefined;
 }
 
-function handleWipeConversation({
+async function handleWipeConversation({
   pathParams = {},
   headers,
 }: RouteHandlerArgs) {
   const resolvedId = resolveOrThrow(pathParams.id!);
 
-  cancelScheduleIfLast(resolvedId);
+  await cancelScheduleIfLast(resolvedId);
 
   destroyActiveConversation(resolvedId);
   const result = wipeConversation(resolvedId);
@@ -310,13 +310,13 @@ function handleWipeConversation({
   };
 }
 
-function handleDeleteConversation({
+async function handleDeleteConversation({
   pathParams = {},
   headers,
 }: RouteHandlerArgs) {
   const resolvedId = resolveOrThrow(pathParams.id!);
 
-  cancelScheduleIfLast(resolvedId);
+  await cancelScheduleIfLast(resolvedId);
 
   destroyActiveConversation(resolvedId);
   const deleted = deleteConversation(resolvedId);

--- a/assistant/src/runtime/routes/conversations-import-routes.ts
+++ b/assistant/src/runtime/routes/conversations-import-routes.ts
@@ -18,6 +18,7 @@ import {
   messages as messagesTable,
 } from "../../persistence/schema/index.js";
 import { getLogger } from "../../util/logger.js";
+import { withSqliteRetry } from "../../util/sqlite-retry.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -119,7 +120,10 @@ async function handleConversationsImport({ body }: RouteHandlerArgs) {
       const { convCreatedAt, convUpdatedAt, messageTimestamps } =
         resolveTimestamps(conv, messages);
 
-      const conversation = createConversation(conv.title);
+      const conversation = await withSqliteRetry(
+        () => createConversation(conv.title),
+        { op: "conversationsImport.createConversation" },
+      );
 
       for (const msg of messages) {
         const contentStr =

--- a/assistant/src/runtime/routes/defer-routes.ts
+++ b/assistant/src/runtime/routes/defer-routes.ts
@@ -94,7 +94,7 @@ async function handleDeferCreate({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const job = createSchedule({
+  const job = await createSchedule({
     name: name ?? "Deferred wake",
     message: hint,
     mode: "wake",
@@ -145,7 +145,7 @@ async function handleDeferCancel({ body = {} }: RouteHandlerArgs) {
     if (!job || job.mode !== "wake" || job.createdBy !== "defer") {
       return { cancelled: 0, error: "Not a deferred wake" };
     }
-    const ok = cancelSchedule(id);
+    const ok = await cancelSchedule(id);
     return { cancelled: ok ? 1 : 0 };
   }
 
@@ -159,7 +159,7 @@ async function handleDeferCancel({ body = {} }: RouteHandlerArgs) {
     let count = 0;
     for (const j of jobs) {
       if (j.status === "active" || j.status === "firing") {
-        if (cancelSchedule(j.id)) count++;
+        if (await cancelSchedule(j.id)) count++;
       }
     }
     return { cancelled: count };

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -38,6 +38,7 @@ import {
   createConversation,
 } from "../../persistence/conversation-crud.js";
 import { getLogger } from "../../util/logger.js";
+import { withSqliteRetry } from "../../util/sqlite-retry.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -321,10 +322,14 @@ export async function handlePostFeedAction({
   }
 
   try {
-    const conversation = createConversation({
-      title: action.label,
-      source: "home-feed",
-    });
+    const conversation = await withSqliteRetry(
+      () =>
+        createConversation({
+          title: action.label,
+          source: "home-feed",
+        }),
+      { op: "homeFeed.createConversation" },
+    );
     await addMessage(
       conversation.id,
       "user",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -240,7 +240,7 @@ function handleGetSchedule(id: string) {
   return { schedule: serializeSchedule(job, new Map()) };
 }
 
-function handleCreateSchedule(body: Record<string, unknown>) {
+async function handleCreateSchedule(body: Record<string, unknown>) {
   const name = typeof body.name === "string" ? body.name.trim() : "";
   const expression =
     typeof body.expression === "string" ? body.expression.trim() : "";
@@ -305,7 +305,7 @@ function handleCreateSchedule(body: Record<string, unknown>) {
       );
     }
     try {
-      const job = createSchedule({
+      const job = await createSchedule({
         name,
         description,
         message,
@@ -329,7 +329,7 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   }
 
   try {
-    const job = createSchedule({
+    const job = await createSchedule({
       name,
       description,
       message,
@@ -348,13 +348,13 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   return handleListSchedules({});
 }
 
-function handleToggleSchedule(id: string, body: Record<string, unknown>) {
+async function handleToggleSchedule(id: string, body: Record<string, unknown>) {
   const enabled = body.enabled;
   if (typeof enabled !== "boolean") {
     throw new BadRequestError("enabled is required");
   }
 
-  const updated = updateSchedule(id, { enabled });
+  const updated = await updateSchedule(id, { enabled });
   if (!updated) {
     throw new NotFoundError("Schedule not found");
   }
@@ -362,8 +362,8 @@ function handleToggleSchedule(id: string, body: Record<string, unknown>) {
   return handleListSchedules({});
 }
 
-function handleDeleteSchedule(id: string) {
-  const removed = deleteSchedule(id);
+async function handleDeleteSchedule(id: string) {
+  const removed = await deleteSchedule(id);
   if (!removed) {
     throw new NotFoundError("Schedule not found");
   }
@@ -371,8 +371,8 @@ function handleDeleteSchedule(id: string) {
   return handleListSchedules({});
 }
 
-function handleCancelSchedule(id: string) {
-  const cancelled = cancelSchedule(id);
+async function handleCancelSchedule(id: string) {
+  const cancelled = await cancelSchedule(id);
   if (!cancelled) {
     throw new NotFoundError("Schedule not found or not cancellable");
   }
@@ -393,7 +393,7 @@ const VALID_ROUTING_INTENTS = [
   "all_channels",
 ] as const;
 
-function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
+async function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
   if (
     "mode" in body &&
     !VALID_MODES.includes(body.mode as (typeof VALID_MODES)[number])
@@ -511,7 +511,7 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
   }
 
   try {
-    const updated = updateSchedule(id, updates);
+    const updated = await updateSchedule(id, updates);
     if (!updated) {
       throw new NotFoundError("Schedule not found");
     }
@@ -894,7 +894,7 @@ async function handleRunScheduleNow(id: string) {
     if (!schedule.script) {
       throw new BadRequestError("Script schedule has no script command");
     }
-    const runId = createScheduleRun(schedule.id, `script:${schedule.id}`);
+    const runId = await createScheduleRun(schedule.id, `script:${schedule.id}`);
     try {
       log.info(
         { jobId: schedule.id, name: schedule.name },
@@ -904,7 +904,7 @@ async function handleRunScheduleNow(id: string) {
         timeoutMs: schedule.timeoutMs ?? undefined,
         scheduleRunId: runId,
       });
-      completeScheduleRun(runId, {
+      await completeScheduleRun(runId, {
         status: result.exitCode === 0 ? "ok" : "error",
         output: result.stdout || undefined,
         error: result.stderr || undefined,
@@ -915,7 +915,7 @@ async function handleRunScheduleNow(id: string) {
         { err, jobId: schedule.id, name: schedule.name },
         "Manual script schedule execution failed",
       );
-      completeScheduleRun(runId, { status: "error", error: errorMsg });
+      await completeScheduleRun(runId, { status: "error", error: errorMsg });
     }
     return handleListSchedules({});
   }
@@ -943,7 +943,10 @@ async function handleRunScheduleNow(id: string) {
           "Try running this workflow again in a moment.",
       );
     }
-    const runId = createScheduleRun(schedule.id, `workflow:${schedule.id}`);
+    const runId = await createScheduleRun(
+      schedule.id,
+      `workflow:${schedule.id}`,
+    );
     try {
       log.info(
         {
@@ -973,7 +976,7 @@ async function handleRunScheduleNow(id: string) {
       // `start` launches the run fire-and-forget and returns synchronously;
       // a successful trigger is recorded as ok. Completion/failure is surfaced
       // out-of-band via workflow events and the completion wake.
-      completeScheduleRun(runId, {
+      await completeScheduleRun(runId, {
         status: "ok",
         output: `workflow run ${workflowRunId} started`,
       });
@@ -983,7 +986,7 @@ async function handleRunScheduleNow(id: string) {
         { err, jobId: schedule.id, name: schedule.name },
         "Manual workflow schedule execution failed",
       );
-      completeScheduleRun(runId, { status: "error", error: errorMsg });
+      await completeScheduleRun(runId, { status: "error", error: errorMsg });
     }
     return handleListSchedules({});
   }
@@ -992,7 +995,7 @@ async function handleRunScheduleNow(id: string) {
   const taskMatch = schedule.message.match(/^run_task:(\S+)$/);
   if (taskMatch) {
     const taskId = taskMatch[1];
-    const runId = createScheduleRun(schedule.id, null);
+    const runId = await createScheduleRun(schedule.id, null);
     try {
       log.info(
         { jobId: schedule.id, name: schedule.name, taskId },
@@ -1022,14 +1025,14 @@ async function handleRunScheduleNow(id: string) {
         },
       );
 
-      setScheduleRunConversationId(runId, result.conversationId);
+      await setScheduleRunConversationId(runId, result.conversationId);
       if (result.status === "failed") {
-        completeScheduleRun(runId, {
+        await completeScheduleRun(runId, {
           status: "error",
           error: result.error ?? "Task run failed",
         });
       } else {
-        completeScheduleRun(runId, { status: "ok" });
+        await completeScheduleRun(runId, { status: "ok" });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -1037,14 +1040,14 @@ async function handleRunScheduleNow(id: string) {
         { err, jobId: schedule.id, name: schedule.name, taskId },
         "Manual scheduled task execution failed",
       );
-      const fallbackConversation = bootstrapConversation({
+      const fallbackConversation = await bootstrapConversation({
         source: "schedule",
         groupId: "system:scheduled",
         origin: "schedule",
         systemHint: `Schedule (manual): ${schedule.name}`,
       });
-      setScheduleRunConversationId(runId, fallbackConversation.id);
-      completeScheduleRun(runId, { status: "error", error: message });
+      await setScheduleRunConversationId(runId, fallbackConversation.id);
+      await completeScheduleRun(runId, { status: "error", error: message });
     }
     return handleListSchedules({});
   }
@@ -1084,7 +1087,7 @@ async function handleRunScheduleNow(id: string) {
     }
   }
   if (!conversationId) {
-    const conversation = bootstrapConversation({
+    const conversation = await bootstrapConversation({
       source: "schedule",
       groupId: "system:scheduled",
       origin: "schedule",
@@ -1092,7 +1095,7 @@ async function handleRunScheduleNow(id: string) {
     });
     conversationId = conversation.id;
   }
-  const runId = createScheduleRun(schedule.id, conversationId);
+  const runId = await createScheduleRun(schedule.id, conversationId);
 
   try {
     log.info(
@@ -1116,14 +1119,14 @@ async function handleRunScheduleNow(id: string) {
         ? { overrideProfile: schedule.inferenceProfile }
         : {}),
     });
-    completeScheduleRun(runId, { status: "ok" });
+    await completeScheduleRun(runId, { status: "ok" });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn(
       { err, jobId: schedule.id, name: schedule.name },
       "Manual schedule execution failed",
     );
-    completeScheduleRun(runId, { status: "error", error: message });
+    await completeScheduleRun(runId, { status: "error", error: message });
   }
   return handleListSchedules({});
 }

--- a/assistant/src/runtime/routes/wipe-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wipe-conversation-routes.ts
@@ -37,7 +37,7 @@ async function handleWipeConversation({ body = {} }: RouteHandlerArgs) {
     conv.scheduleJobId &&
     countConversationsByScheduleJobId(conv.scheduleJobId) <= 1
   ) {
-    deleteSchedule(conv.scheduleJobId);
+    await deleteSchedule(conv.scheduleJobId);
   }
 
   destroyActiveConversation(conversationId);

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -36,6 +36,7 @@ import {
 } from "../../persistence/conversation-crud.js";
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
+import { withSqliteRetry } from "../../util/sqlite-retry.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import {
   buildAutoAnalysisPrompt,
@@ -162,9 +163,13 @@ export async function analyzeConversation(
   let stripTools: boolean;
 
   if (opts.trigger === "manual") {
-    const newConv = createConversation({
-      title: `Analysis: ${conversation.title ?? "Untitled"}`,
-    });
+    const newConv = await withSqliteRetry(
+      () =>
+        createConversation({
+          title: `Analysis: ${conversation.title ?? "Untitled"}`,
+        }),
+      { op: "analyzeConversation.manual" },
+    );
     analysisConversationId = newConv.id;
     prompt = buildManualAnalysisPrompt(transcript);
     trustClass = "unknown";
@@ -179,12 +184,16 @@ export async function analyzeConversation(
       // do not appear in the default `system:all` list rendered by clients
       // that don't filter on `source` (CLI, gateway, web). Existing rolling
       // conversations stay where they were — no migration needed.
-      const newConv = createConversation({
-        title: `Analysis: ${conversation.title ?? "Untitled"}`,
-        source: AUTO_ANALYSIS_SOURCE,
-        groupId: AUTO_ANALYSIS_GROUP_ID,
-        forkParentConversationId: resolvedId,
-      });
+      const newConv = await withSqliteRetry(
+        () =>
+          createConversation({
+            title: `Analysis: ${conversation.title ?? "Untitled"}`,
+            source: AUTO_ANALYSIS_SOURCE,
+            groupId: AUTO_ANALYSIS_GROUP_ID,
+            forkParentConversationId: resolvedId,
+          }),
+        { op: "analyzeConversation.auto" },
+      );
       analysisConversationId = newConv.id;
     }
     prompt = buildAutoAnalysisPrompt(transcript);

--- a/assistant/src/schedule/retry-policy.ts
+++ b/assistant/src/schedule/retry-policy.ts
@@ -38,21 +38,21 @@ export function decideRetry(
  * Calls the provided store operations so this module stays decoupled
  * from direct DB imports.
  */
-export function applyRetryDecision(params: {
+export async function applyRetryDecision(params: {
   job: RetryPolicyJob;
   isOneShot: boolean;
   errorMsg: string;
   decision: RetryDecision;
-  scheduleRetry: (id: string, nextRetryAt: number) => void;
-  failOneShotPermanently: (id: string) => void;
-  resetRetryCount: (id: string) => void;
+  scheduleRetry: (id: string, nextRetryAt: number) => void | Promise<void>;
+  failOneShotPermanently: (id: string) => void | Promise<void>;
+  resetRetryCount: (id: string) => void | Promise<void>;
   emitAlert: (title: string, summary: string, dedupKey: string) => void;
   log: Logger;
-}): void {
+}): Promise<void> {
   const { job, isOneShot, errorMsg, decision } = params;
 
   if (decision.action === "retry") {
-    params.scheduleRetry(job.id, decision.nextRetryAt);
+    await params.scheduleRetry(job.id, decision.nextRetryAt);
     params.log.info(
       {
         jobId: job.id,
@@ -65,9 +65,9 @@ export function applyRetryDecision(params: {
     );
   } else {
     if (isOneShot) {
-      params.failOneShotPermanently(job.id);
+      await params.failOneShotPermanently(job.id);
     } else {
-      params.resetRetryCount(job.id);
+      await params.resetRetryCount(job.id);
     }
     params.emitAlert(
       `${job.name}: Retries exhausted`,

--- a/assistant/src/schedule/schedule-recovery.ts
+++ b/assistant/src/schedule/schedule-recovery.ts
@@ -17,7 +17,7 @@ const log = getLogger("schedule-recovery");
  * Called once at daemon startup, before the scheduler tick loop starts,
  * so all "firing" / "running" rows are definitively stale.
  */
-export function recoverStaleSchedules(): number {
+export async function recoverStaleSchedules(): Promise<number> {
   const stale = findStaleInFlightJobs(0);
   if (stale.length === 0) return 0;
 
@@ -33,16 +33,19 @@ export function recoverStaleSchedules(): number {
         "Process terminated during execution (recovered on restart)";
 
       if (staleRunId) {
-        completeScheduleRun(staleRunId, { status: "error", error: errorMsg });
+        await completeScheduleRun(staleRunId, {
+          status: "error",
+          error: errorMsg,
+        });
       } else {
-        const runId = createScheduleRun(jobId, `recovery:${jobId}`);
-        completeScheduleRun(runId, { status: "error", error: errorMsg });
+        const runId = await createScheduleRun(jobId, `recovery:${jobId}`);
+        await completeScheduleRun(runId, { status: "error", error: errorMsg });
       }
 
       // Use the same retry-or-exhaust path as the scheduler
       const isOneShot = job.expression == null;
       const decision = decideRetry(job);
-      applyRetryDecision({
+      await applyRetryDecision({
         job,
         isOneShot,
         errorMsg,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -7,7 +7,7 @@ import { rawChanges } from "../persistence/raw-query.js";
 import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
-import { withSqliteRetrySync } from "../util/sqlite-retry.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -101,7 +101,7 @@ export function isValidCronExpression(expr: string): boolean {
   }
 }
 
-export function createSchedule(params: {
+export async function createSchedule(params: {
   name: string;
   description?: string;
   cronExpression?: string | null;
@@ -127,7 +127,7 @@ export function createSchedule(params: {
   timeoutMs?: number | null;
   inferenceProfile?: string | null;
   createdFromConversationId?: string | null;
-}): ScheduleJob {
+}): Promise<ScheduleJob> {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
   const syntax = params.syntax ?? "cron";
@@ -217,7 +217,7 @@ export function createSchedule(params: {
     updatedAt: now,
   };
 
-  withSqliteRetrySync(() => db.insert(scheduleJobs).values(row).run(), {
+  await withSqliteRetry(() => db.insert(scheduleJobs).values(row).run(), {
     op: "createSchedule",
     context: { scheduleId: id },
   });
@@ -288,7 +288,7 @@ export function listSchedules(options?: {
   return rows.map(parseJobRow);
 }
 
-export function updateSchedule(
+export async function updateSchedule(
   id: string,
   updates: {
     name?: string;
@@ -315,7 +315,7 @@ export function updateSchedule(
     inferenceProfile?: string | null;
     createdFromConversationId?: string | null;
   },
-): ScheduleJob | null {
+): Promise<ScheduleJob | null> {
   const db = getDb();
   const existing = db
     .select()
@@ -419,7 +419,7 @@ export function updateSchedule(
     set.nextRunAt = newEnabled ? computeNextRunAtEngine(spec) : 0;
   }
 
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () => db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run(),
     { op: "updateSchedule", context: { scheduleId: id } },
   );
@@ -428,13 +428,17 @@ export function updateSchedule(
   return getSchedule(id);
 }
 
-export function deleteSchedule(id: string): boolean {
+export async function deleteSchedule(id: string): Promise<boolean> {
   const db = getDb();
-  withSqliteRetrySync(
-    () => db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run(),
+  // Capture rawChanges() inside the awaited closure: reading it after the
+  // await would race other async DB work on the shared connection.
+  const deleted = await withSqliteRetry(
+    () => {
+      db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run();
+      return rawChanges() > 0;
+    },
     { op: "deleteSchedule", context: { scheduleId: id } },
   );
-  const deleted = rawChanges() > 0;
   if (deleted) notifySchedulesChanged();
   return deleted;
 }
@@ -449,7 +453,7 @@ export function deleteSchedule(id: string): boolean {
  * For one-shot schedules: transition status from 'active' to 'firing' where
  * next_run_at <= now and enabled = true and cron_expression IS NULL.
  */
-export function claimDueSchedules(now: number): ScheduleJob[] {
+export async function claimDueSchedules(now: number): Promise<ScheduleJob[]> {
   const db = getDb();
   const claimed: ScheduleJob[] = [];
 
@@ -505,10 +509,9 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
       updates.nextRunAt = newNextRunAt!;
     }
 
-    withSqliteRetrySync(
-      () =>
-        db
-          .update(scheduleJobs)
+    const recurringClaimed = await withSqliteRetry(
+      () => {
+        db.update(scheduleJobs)
           .set(updates)
           .where(
             and(
@@ -516,11 +519,13 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
               eq(scheduleJobs.nextRunAt, row.nextRunAt),
             ),
           )
-          .run(),
+          .run();
+        return rawChanges() > 0;
+      },
       { op: "claimDueSchedules.recurring", context: { scheduleId: row.id } },
     );
 
-    if (rawChanges() === 0) continue;
+    if (!recurringClaimed) continue;
 
     claimed.push(
       parseJobRow({
@@ -549,10 +554,9 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
     .all();
 
   for (const row of oneShotCandidates) {
-    withSqliteRetrySync(
-      () =>
-        db
-          .update(scheduleJobs)
+    const oneShotClaimed = await withSqliteRetry(
+      () => {
+        db.update(scheduleJobs)
           .set({
             status: "firing",
             lastRunAt: now,
@@ -561,11 +565,13 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
           .where(
             and(eq(scheduleJobs.id, row.id), eq(scheduleJobs.status, "active")),
           )
-          .run(),
+          .run();
+        return rawChanges() > 0;
+      },
       { op: "claimDueSchedules.oneShot", context: { scheduleId: row.id } },
     );
 
-    if (rawChanges() === 0) continue;
+    if (!oneShotClaimed) continue;
 
     claimed.push(
       parseJobRow({
@@ -585,45 +591,47 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
  * Complete a one-shot schedule after successful execution.
  * Transitions status from 'firing' to 'fired' and disables the schedule.
  */
-export function completeOneShot(id: string): void {
+export async function completeOneShot(id: string): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "fired",
           enabled: false,
           updatedAt: now,
         })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "completeOneShot", context: { scheduleId: id } },
   );
-  if (rawChanges() > 0) notifySchedulesChanged();
+  if (changed) notifySchedulesChanged();
 }
 
 /**
  * Revert a one-shot schedule from 'firing' back to 'active' on failure.
  * Allows the schedule to be retried on the next tick.
  */
-export function failOneShot(id: string): void {
+export async function failOneShot(id: string): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "active",
           updatedAt: now,
         })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "failOneShot", context: { scheduleId: id } },
   );
-  if (rawChanges() > 0) notifySchedulesChanged();
+  if (changed) notifySchedulesChanged();
 }
 
 /**
@@ -646,13 +654,12 @@ export function failOneShot(id: string): void {
  * The deferred occurrence has not actually run yet, so re-enabling is correct;
  * when it later fires, the claim path re-applies the right `enabled` state.
  */
-export function deferClaimedSchedule(id: string): void {
+export async function deferClaimedSchedule(id: string): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "active",
           enabled: true,
@@ -660,10 +667,12 @@ export function deferClaimedSchedule(id: string): void {
           updatedAt: now,
         })
         .where(eq(scheduleJobs.id, id))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "deferClaimedSchedule", context: { scheduleId: id } },
   );
-  if (rawChanges() > 0) notifySchedulesChanged();
+  if (changed) notifySchedulesChanged();
 }
 
 /**
@@ -671,24 +680,23 @@ export function deferClaimedSchedule(id: string): void {
  * retry count. Used when a wake times out waiting for an idle conversation
  * — the job should be retried on the next scheduler tick.
  */
-export function retryOneShot(id: string): void {
+export async function retryOneShot(id: string): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  let changed = false;
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "active",
           retryCount: sql`${scheduleJobs.retryCount} + 1`,
           updatedAt: now,
         })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "retryOneShot", context: { scheduleId: id } },
   );
-  changed = rawChanges() > 0;
   if (changed) notifySchedulesChanged();
 }
 
@@ -697,13 +705,12 @@ export function retryOneShot(id: string): void {
  * disabled. Used when a wake has exceeded its retry cap and should not
  * be retried further.
  */
-export function failOneShotPermanently(id: string): void {
+export async function failOneShotPermanently(id: string): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "cancelled",
           enabled: false,
@@ -711,45 +718,47 @@ export function failOneShotPermanently(id: string): void {
           updatedAt: now,
         })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "failOneShotPermanently", context: { scheduleId: id } },
   );
-  if (rawChanges() > 0) notifySchedulesChanged();
+  if (changed) notifySchedulesChanged();
 }
 
 /**
  * Cancel a one-shot schedule. Sets status to 'cancelled' and disables it.
  * Returns true if a row was actually updated (i.e., it was in 'active' status).
  */
-export function cancelSchedule(id: string): boolean {
+export async function cancelSchedule(id: string): Promise<boolean> {
   const db = getDb();
   const now = Date.now();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const cancelled = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({
           status: "cancelled",
           enabled: false,
           updatedAt: now,
         })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "active")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "cancelSchedule", context: { scheduleId: id } },
   );
-  const cancelled = rawChanges() > 0;
   if (cancelled) notifySchedulesChanged();
   return cancelled;
 }
 
-export function createScheduleRun(
+export async function createScheduleRun(
   jobId: string,
   conversationId: string | null,
-): string {
+): Promise<string> {
   const db = getDb();
   const id = uuid();
   const now = Date.now();
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () =>
       db
         .insert(scheduleRuns)
@@ -771,12 +780,12 @@ export function createScheduleRun(
   return id;
 }
 
-export function setScheduleRunConversationId(
+export async function setScheduleRunConversationId(
   runId: string,
   conversationId: string,
-): void {
+): Promise<void> {
   const db = getDb();
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () =>
       db
         .update(scheduleRuns)
@@ -787,10 +796,10 @@ export function setScheduleRunConversationId(
   );
 }
 
-export function completeScheduleRun(
+export async function completeScheduleRun(
   runId: string,
   result: { status: "ok" | "error"; output?: string; error?: string },
-): void {
+): Promise<void> {
   const db = getDb();
   const now = Date.now();
 
@@ -803,7 +812,7 @@ export function completeScheduleRun(
 
   const durationMs = now - run.startedAt;
 
-  withSqliteRetrySync(
+  await withSqliteRetry(
     () =>
       db
         .update(scheduleRuns)
@@ -828,35 +837,37 @@ export function completeScheduleRun(
       .where(eq(scheduleJobs.id, run.jobId))
       .get();
     if (job) {
-      withSqliteRetrySync(
-        () =>
-          db
-            .update(scheduleJobs)
+      const changed = await withSqliteRetry(
+        () => {
+          db.update(scheduleJobs)
             .set({
               lastStatus: "error",
               retryCount: job.retryCount + 1,
               updatedAt: now,
             })
             .where(eq(scheduleJobs.id, run.jobId))
-            .run(),
+            .run();
+          return rawChanges() > 0;
+        },
         {
           op: "completeScheduleRun.jobError",
           context: { scheduleId: run.jobId },
         },
       );
-      if (rawChanges() > 0) notifySchedulesChanged();
+      if (changed) notifySchedulesChanged();
     }
   } else {
-    withSqliteRetrySync(
-      () =>
-        db
-          .update(scheduleJobs)
+    const changed = await withSqliteRetry(
+      () => {
+        db.update(scheduleJobs)
           .set({ lastStatus: "ok", retryCount: 0, updatedAt: now })
           .where(eq(scheduleJobs.id, run.jobId))
-          .run(),
+          .run();
+        return rawChanges() > 0;
+      },
       { op: "completeScheduleRun.jobOk", context: { scheduleId: run.jobId } },
     );
-    if (rawChanges() > 0) notifySchedulesChanged();
+    if (changed) notifySchedulesChanged();
   }
 }
 
@@ -1106,50 +1117,54 @@ export function describeCronExpression(expr: string | null): string {
  * "firing" to "active" so the scheduler will claim it again when nextRetryAt
  * arrives. No-op for recurring schedules (they stay in their current status).
  */
-export function scheduleRetry(id: string, nextRetryAt: number): void {
+export async function scheduleRetry(
+  id: string,
+  nextRetryAt: number,
+): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  let changed = false;
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  let changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({ nextRunAt: nextRetryAt, updatedAt: now })
         .where(eq(scheduleJobs.id, id))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "scheduleRetry.nextRunAt", context: { scheduleId: id } },
   );
-  changed = rawChanges() > 0;
   // Revert one-shot status from "firing" to "active" so the scheduler
   // will claim it again when nextRetryAt arrives. No-op for recurring.
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const reverted = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({ status: "active", updatedAt: now })
         .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "scheduleRetry.revertStatus", context: { scheduleId: id } },
   );
-  changed = rawChanges() > 0 || changed;
+  changed = reverted || changed;
   if (changed) notifySchedulesChanged();
 }
 
 /**
  * Reset the retry count for a schedule back to zero (e.g. after a successful run).
  */
-export function resetRetryCount(id: string): void {
+export async function resetRetryCount(id: string): Promise<void> {
   const db = getDb();
-  withSqliteRetrySync(
-    () =>
-      db
-        .update(scheduleJobs)
+  const changed = await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
         .set({ retryCount: 0, updatedAt: Date.now() })
         .where(eq(scheduleJobs.id, id))
-        .run(),
+        .run();
+      return rawChanges() > 0;
+    },
     { op: "resetRetryCount", context: { scheduleId: id } },
   );
-  if (rawChanges() > 0) notifySchedulesChanged();
+  if (changed) notifySchedulesChanged();
 }
 
 /**

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -92,13 +92,13 @@ const WAKE_MAX_RETRIES = 20;
  * fires an `activity.failed` notification so the user sees that a job
  * permanently failed rather than just silently disappearing.
  */
-function handleExecutionFailure(params: {
+async function handleExecutionFailure(params: {
   job: ScheduleJob;
   errorMsg: string;
   isOneShot: boolean;
-}): void {
+}): Promise<void> {
   const decision = decideRetry(params.job);
-  applyRetryDecision({
+  await applyRetryDecision({
     job: params.job,
     isOneShot: params.isOneShot,
     errorMsg: params.errorMsg,
@@ -256,7 +256,7 @@ export async function runScheduleDueWorkOnce(
   }
 
   // ── Schedules (recurring cron/RRULE + one-shot) ─────────────────────
-  const jobs = claimDueSchedules(now);
+  const jobs = await claimDueSchedules(now);
   result.claimed = jobs.length;
   for (const job of jobs) {
     const isOneShot = job.expression == null;
@@ -277,14 +277,17 @@ export async function runScheduleDueWorkOnce(
           routingHints: job.routingHints,
         });
         if (isOneShot) {
-          const successRunId = createScheduleRun(job.id, `notify-ok:${job.id}`);
-          completeScheduleRun(successRunId, { status: "ok" });
-          completeOneShot(job.id);
+          const successRunId = await createScheduleRun(
+            job.id,
+            `notify-ok:${job.id}`,
+          );
+          await completeScheduleRun(successRunId, { status: "ok" });
+          await completeOneShot(job.id);
         } else {
           // Track recurring notify-mode success so lastStatus resets to ok
           // and retryCount clears after a transient failure.
-          const runId = createScheduleRun(job.id, `notify-ok:${job.id}`);
-          completeScheduleRun(runId, { status: "ok" });
+          const runId = await createScheduleRun(job.id, `notify-ok:${job.id}`);
+          await completeScheduleRun(runId, { status: "ok" });
         }
       } catch (err) {
         log.warn(
@@ -292,9 +295,15 @@ export async function runScheduleDueWorkOnce(
           "Schedule notification failed",
         );
         const errorMsg = err instanceof Error ? err.message : String(err);
-        const errorRunId = createScheduleRun(job.id, `notify-error:${job.id}`);
-        completeScheduleRun(errorRunId, { status: "error", error: errorMsg });
-        handleExecutionFailure({ job, errorMsg, isOneShot });
+        const errorRunId = await createScheduleRun(
+          job.id,
+          `notify-error:${job.id}`,
+        );
+        await completeScheduleRun(errorRunId, {
+          status: "error",
+          error: errorMsg,
+        });
+        await handleExecutionFailure({ job, errorMsg, isOneShot });
         failed = true;
       }
       mark(failed ? "failed" : "completed");
@@ -311,7 +320,7 @@ export async function runScheduleDueWorkOnce(
         mark("skipped");
         continue;
       }
-      const runId = createScheduleRun(job.id, `script:${job.id}`);
+      const runId = await createScheduleRun(job.id, `script:${job.id}`);
       let failed = false;
       try {
         log.info(
@@ -322,17 +331,17 @@ export async function runScheduleDueWorkOnce(
           timeoutMs: job.timeoutMs ?? undefined,
           scheduleRunId: runId,
         });
-        completeScheduleRun(runId, {
+        await completeScheduleRun(runId, {
           status: result.exitCode === 0 ? "ok" : "error",
           output: result.stdout || undefined,
           error: result.stderr || undefined,
         });
         if (result.exitCode === 0) {
-          if (isOneShot) completeOneShot(job.id);
+          if (isOneShot) await completeOneShot(job.id);
         } else {
           const errorMsg =
             result.stderr || "Script exited with non-zero status";
-          handleExecutionFailure({ job, errorMsg, isOneShot });
+          await handleExecutionFailure({ job, errorMsg, isOneShot });
           failed = true;
         }
       } catch (err) {
@@ -341,8 +350,8 @@ export async function runScheduleDueWorkOnce(
           { err, jobId: job.id, name: job.name, isOneShot },
           "Script schedule execution failed",
         );
-        completeScheduleRun(runId, { status: "error", error: errorMsg });
-        handleExecutionFailure({ job, errorMsg, isOneShot });
+        await completeScheduleRun(runId, { status: "error", error: errorMsg });
+        await handleExecutionFailure({ job, errorMsg, isOneShot });
         failed = true;
       }
       mark(failed ? "failed" : "completed");
@@ -357,7 +366,7 @@ export async function runScheduleDueWorkOnce(
           { jobId: job.id, name: job.name },
           "Wake schedule missing wakeConversationId — completing as no-op",
         );
-        if (isOneShot) completeOneShot(job.id);
+        if (isOneShot) await completeOneShot(job.id);
         mark("skipped");
         continue;
       }
@@ -391,7 +400,7 @@ export async function runScheduleDueWorkOnce(
               },
               "Wake timed out and exceeded max retries — permanently failing",
             );
-            failOneShotPermanently(job.id);
+            await failOneShotPermanently(job.id);
           } else {
             log.warn(
               {
@@ -402,7 +411,7 @@ export async function runScheduleDueWorkOnce(
               },
               "Wake timed out waiting for idle conversation — will retry on next tick",
             );
-            retryOneShot(job.id);
+            await retryOneShot(job.id);
           }
           mark("skipped");
           continue;
@@ -421,15 +430,18 @@ export async function runScheduleDueWorkOnce(
             },
             "Wake not invoked; skipping feed event",
           );
-          if (isOneShot) completeOneShot(job.id);
+          if (isOneShot) await completeOneShot(job.id);
           mark("skipped");
           continue;
         }
 
         if (isOneShot) {
-          const successRunId = createScheduleRun(job.id, `wake-ok:${job.id}`);
-          completeScheduleRun(successRunId, { status: "ok" });
-          completeOneShot(job.id);
+          const successRunId = await createScheduleRun(
+            job.id,
+            `wake-ok:${job.id}`,
+          );
+          await completeScheduleRun(successRunId, { status: "ok" });
+          await completeOneShot(job.id);
         }
       } catch (err) {
         log.warn(
@@ -437,15 +449,15 @@ export async function runScheduleDueWorkOnce(
           "Wake schedule execution failed",
         );
         const errorMsg = err instanceof Error ? err.message : String(err);
-        const wakeErrorRunId = createScheduleRun(
+        const wakeErrorRunId = await createScheduleRun(
           job.id,
           `wake-error:${job.id}`,
         );
-        completeScheduleRun(wakeErrorRunId, {
+        await completeScheduleRun(wakeErrorRunId, {
           status: "error",
           error: errorMsg,
         });
-        handleExecutionFailure({ job, errorMsg, isOneShot });
+        await handleExecutionFailure({ job, errorMsg, isOneShot });
         failed = true;
       }
       mark(failed ? "failed" : "completed");
@@ -474,11 +486,11 @@ export async function runScheduleDueWorkOnce(
           { jobId: job.id, name: job.name, workflowName: job.workflowName },
           "Deferring workflow schedule until tools are registered",
         );
-        deferClaimedSchedule(job.id);
+        await deferClaimedSchedule(job.id);
         mark("skipped");
         continue;
       }
-      const runId = createScheduleRun(job.id, `workflow:${job.id}`);
+      const runId = await createScheduleRun(job.id, `workflow:${job.id}`);
       let failed = false;
       try {
         log.info(
@@ -512,19 +524,19 @@ export async function runScheduleDueWorkOnce(
         // `start` launches the run fire-and-forget and returns synchronously;
         // a successful trigger is recorded as ok. Workflow completion/failure
         // is surfaced out-of-band via workflow events and the completion wake.
-        completeScheduleRun(runId, {
+        await completeScheduleRun(runId, {
           status: "ok",
           output: `workflow run ${workflowRunId} started`,
         });
-        if (isOneShot) completeOneShot(job.id);
+        if (isOneShot) await completeOneShot(job.id);
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         log.warn(
           { err, jobId: job.id, name: job.name, isOneShot },
           "Workflow schedule trigger failed",
         );
-        completeScheduleRun(runId, { status: "error", error: errorMsg });
-        handleExecutionFailure({ job, errorMsg, isOneShot });
+        await completeScheduleRun(runId, { status: "error", error: errorMsg });
+        await handleExecutionFailure({ job, errorMsg, isOneShot });
         failed = true;
       }
       mark(failed ? "failed" : "completed");
@@ -541,7 +553,7 @@ export async function runScheduleDueWorkOnce(
         job.syntax === "rrule" &&
         job.expression != null &&
         hasSetConstructs(job.expression);
-      const runId = createScheduleRun(job.id, null);
+      const runId = await createScheduleRun(job.id, null);
       let failed = false;
       try {
         log.info(
@@ -576,7 +588,7 @@ export async function runScheduleDueWorkOnce(
           },
         );
 
-        setScheduleRunConversationId(runId, result.conversationId);
+        await setScheduleRunConversationId(runId, result.conversationId);
         onScheduleConversationCreated?.({
           conversationId: result.conversationId,
           scheduleJobId: job.id,
@@ -585,7 +597,7 @@ export async function runScheduleDueWorkOnce(
 
         if (result.status === "failed") {
           const errorMessage = result.error ?? "Task run failed";
-          completeScheduleRun(runId, {
+          await completeScheduleRun(runId, {
             status: "error",
             error: errorMessage,
           });
@@ -594,15 +606,15 @@ export async function runScheduleDueWorkOnce(
             conversationId: result.conversationId,
             errorMessage,
           });
-          handleExecutionFailure({
+          await handleExecutionFailure({
             job,
             errorMsg: errorMessage,
             isOneShot,
           });
           failed = true;
         } else {
-          completeScheduleRun(runId, { status: "ok" });
-          if (isOneShot) completeOneShot(job.id);
+          await completeScheduleRun(runId, { status: "ok" });
+          if (isOneShot) await completeOneShot(job.id);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -620,7 +632,7 @@ export async function runScheduleDueWorkOnce(
           "Scheduled task execution failed",
         );
         // Create a fallback conversation for the schedule run record
-        const fallbackConversation = bootstrapConversation({
+        const fallbackConversation = await bootstrapConversation({
           conversationType: "scheduled",
           source: "schedule",
           scheduleJobId: job.id,
@@ -633,14 +645,14 @@ export async function runScheduleDueWorkOnce(
           scheduleJobId: job.id,
           title: `${job.name}: Error`,
         });
-        setScheduleRunConversationId(runId, fallbackConversation.id);
-        completeScheduleRun(runId, { status: "error", error: message });
+        await setScheduleRunConversationId(runId, fallbackConversation.id);
+        await completeScheduleRun(runId, { status: "error", error: message });
         emitTaskActivityFailed({
           taskId,
           conversationId: fallbackConversation.id,
           errorMessage: message,
         });
-        handleExecutionFailure({
+        await handleExecutionFailure({
           job,
           errorMsg: message,
           isOneShot,
@@ -688,7 +700,7 @@ export async function runScheduleDueWorkOnce(
     let errorMsg: string | undefined;
     const conversationReused = reusedConversationId != null;
     let runConversationId = reusedConversationId;
-    const runId = createScheduleRun(job.id, reusedConversationId);
+    const runId = await createScheduleRun(job.id, reusedConversationId);
 
     if (reusedConversationId) {
       // Reuse path: keep using the injected `processMessage` callback so the
@@ -741,9 +753,9 @@ export async function runScheduleDueWorkOnce(
         conversationType: "scheduled",
         scheduleJobId: job.id,
         suppressFailureNotifications: job.quiet === true,
-        onConversationCreated: (newConversationId) => {
+        onConversationCreated: async (newConversationId) => {
           runConversationId = newConversationId;
-          setScheduleRunConversationId(runId, newConversationId);
+          await setScheduleRunConversationId(runId, newConversationId);
           onScheduleConversationCreated?.({
             conversationId: newConversationId,
             scheduleJobId: job.id,
@@ -762,15 +774,15 @@ export async function runScheduleDueWorkOnce(
           : result.conversationId;
       if (runConversationId !== conversationId) {
         runConversationId = conversationId;
-        setScheduleRunConversationId(runId, conversationId);
+        await setScheduleRunConversationId(runId, conversationId);
       }
       ok = result.ok;
       errorMsg = result.error?.message;
     }
 
     if (ok) {
-      completeScheduleRun(runId, { status: "ok" });
-      if (isOneShot) completeOneShot(job.id);
+      await completeScheduleRun(runId, { status: "ok" });
+      if (isOneShot) await completeOneShot(job.id);
       mark("completed");
     } else {
       log.warn(
@@ -787,8 +799,8 @@ export async function runScheduleDueWorkOnce(
           ? "One-shot schedule execution failed"
           : "Schedule execution failed",
       );
-      completeScheduleRun(runId, { status: "error", error: errorMsg });
-      handleExecutionFailure({
+      await completeScheduleRun(runId, { status: "error", error: errorMsg });
+      await handleExecutionFailure({
         job,
         errorMsg: errorMsg ?? "Schedule run failed",
         isOneShot,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -269,7 +269,7 @@ export class SubagentManager {
 
     // ── Create conversation ─────────────────────────────────────────
     const subagentId = uuid();
-    const conversationRecord = bootstrapConversation({
+    const conversationRecord = await bootstrapConversation({
       conversationType: "background",
       source: "subagent",
       origin: "subagent",

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -52,7 +52,7 @@ export async function runTask(
   }
 
   const run = createTaskRun(task.id);
-  const conversation = bootstrapConversation({
+  const conversation = await bootstrapConversation({
     // Schedule-triggered tasks use "scheduled" so they don't crowd out
     // interactive conversations in the main list; non-schedule tasks use
     // "background" to stay out of the list entirely.

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -195,7 +195,7 @@ export async function executeScheduleCreate(
     }
 
     try {
-      const job = createSchedule({
+      const job = await createSchedule({
         name,
         description,
         cronExpression: null,
@@ -287,7 +287,7 @@ export async function executeScheduleCreate(
   }
 
   try {
-    const job = createSchedule({
+    const job = await createSchedule({
       name,
       description,
       cronExpression: resolved.expression,

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -16,7 +16,7 @@ export async function executeScheduleDelete(
     return { content: `Error: Schedule not found: ${jobId}`, isError: true };
   }
 
-  const deleted = deleteSchedule(jobId);
+  const deleted = await deleteSchedule(jobId);
   if (!deleted) {
     return {
       content: `Error: Failed to delete schedule: ${jobId}`,

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -251,7 +251,7 @@ export async function executeScheduleUpdate(
   }
 
   try {
-    const job = updateSchedule(
+    const job = await updateSchedule(
       jobId,
       updates as {
         name?: string;

--- a/assistant/src/util/sqlite-retry.ts
+++ b/assistant/src/util/sqlite-retry.ts
@@ -1,5 +1,5 @@
 /**
- * Retry helpers for transient SQLite write contention.
+ * Retry helper for transient SQLite write contention.
  *
  * SQLite serializes writers at the database level: only one connection holds
  * the write lock at a time. `PRAGMA busy_timeout` makes a contending writer
@@ -9,13 +9,13 @@
  * errors surface as `SQLITE_IOERR`. The only correct recovery for either is to
  * re-run the whole operation, so write paths that several processes contend on
  * (the conversation loop, the scheduler, the memory worker) wrap their writes
- * in one of the helpers below.
+ * in {@link withSqliteRetry}.
  *
- * Both helpers retry on `SQLITE_BUSY*` / `SQLITE_IOERR*` with jittered backoff;
- * the jitter decorrelates retries across the now-separate worker processes so
- * they don't collide in lockstep. Pick the variant that matches the call site:
- * {@link withSqliteRetrySync} for `bun:sqlite`'s synchronous statements,
- * {@link withSqliteRetry} when the body is (or contains) an `await`.
+ * It retries on `SQLITE_BUSY*` / `SQLITE_IOERR*` with jittered backoff; the
+ * jitter decorrelates retries across the now-separate worker processes so they
+ * don't collide in lockstep. The wrapped function may be sync (a `bun:sqlite`
+ * statement) or async — it is always awaited, so the single async signature is
+ * the one boundary to port if the storage layer ever moves to an async driver.
  *
  * The wrapped function must be safe to re-run: either a single statement, or a
  * sequence guarded so re-execution is idempotent (e.g. an optimistic-lock
@@ -59,40 +59,7 @@ export function isRetryableSqliteError(err: unknown): boolean {
 }
 
 /**
- * Run a synchronous `bun:sqlite` write with retry on transient contention.
- * Returns the function's value so single-statement callers can read it inline.
- */
-export function withSqliteRetrySync<T>(
-  fn: () => T,
-  options: SqliteRetryOptions,
-): T {
-  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
-  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return fn();
-    } catch (err) {
-      if (attempt < maxRetries && isRetryableSqliteError(err)) {
-        log.warn(
-          {
-            ...options.context,
-            op: options.op,
-            attempt,
-            code: sqliteErrorCode(err),
-          },
-          "withSqliteRetrySync: transient SQLite error, retrying",
-        );
-        Bun.sleepSync(computeRetryDelay(attempt, baseDelayMs));
-        continue;
-      }
-      throw err;
-    }
-  }
-}
-
-/**
- * Run an async (or sync) SQLite write with retry on transient contention.
- * Use when the wrapped body awaits; otherwise prefer {@link withSqliteRetrySync}.
+ * Run a SQLite write (sync or async) with retry on transient contention.
  */
 export async function withSqliteRetry<T>(
   fn: () => T | Promise<T>,


### PR DESCRIPTION
## Prompt / plan

Follow-up to #36429 addressing the review comment on `withSqliteRetry`:

> "I'd rather only have this variant and delete `withSqliteRetrySync`. Makes it easier to one day port over to actual async sql drivers in the future if we ever chose to do so"

So: keep only the async `withSqliteRetry`, delete the sync variant, and propagate `async` through the call sites. Split into its own PR because it ripples `async` widely.

### What changed
- **Deleted `withSqliteRetrySync`.** `withSqliteRetry` (which awaits a sync-or-async fn) is the only variant — one signature to port if storage ever moves to an async driver.
- **`schedule-store.ts`** — all 15 write functions are now `async`. Where a write was followed by `rawChanges()`, the change count is now captured **inside** the awaited closure: reading it after the `await` would race other async work on the shared `bun:sqlite` connection.
- **`memory-retrospective-state.ts`** — `upsertRetrospectiveState` / `bumpRetrospectiveLastRunAt` are now `async`.
- **`createConversation` stays synchronous.** It runs inside synchronous `bun:sqlite` transactions (the fork paths), so it can't `await`. Instead of retrying internally it now defers retry to its boundaries:
  - standalone callers wrap the call in `await withSqliteRetry(...)` (bootstrap, pairing, analyze-conversation, the cli/home-feed/import routes);
  - the retrospective fork wraps its **whole Phase‑1 transaction** in `withSqliteRetry` — the correct retry granularity, since the transaction rolls back atomically on contention.
- **Async propagation through callers:** scheduler tick + run-lifecycle, schedule routes/tools, defer routes, `background-job-runner` (`onConversationCreated` is now awaited — its type widened to `=> void | Promise<void>`), `retry-policy` `applyRetryDecision` → `handleExecutionFailure`, `schedule-recovery`, the memory retrospective job, and the conversation delete/wipe routes.
- **Tests** updated to `await` the now-async store functions and route handlers.

### Note on the `createConversation` decision
The reviewer's "one async variant" goal can't make `createConversation` itself async (sync-transaction usage), so retry moved to its boundaries rather than living inside it. Net effect is the same coverage with a single async retry primitive.

## Test plan
- `bunx tsc --noEmit`, `eslint`, `prettier --check` — clean across all 35 changed files (pre-commit hooks pass).
- Ran every affected test file **individually** (matching CI, which runs one process per file via `xargs -P`): all green — `schedule-store`, `schedule-routes`, `schedule-routes-workflow-validation`, `schedule-retry`, `task-scheduler`, `scheduler-recurrence`, `scheduler-reuse-conversation`, `scheduler-wake`, `scheduler-disk-pressure`, `conversation-delete-schedule-cleanup`, `wake-intent-hooks`, `conversation-fork-retrospective`, `memory-retrospective-state`, `conversation-fork-crud`, plus the `background-job-runner`, `conversation-pairing`, `subagent-*`, and `conversation-routes-*` suites.
- Caught and fixed two classes of bug that `tsc` could not see: route-handler calls in tests cast with `as { … }` (hiding the `Promise`), and fire-and-forget production calls (`deleteSchedule`, `recoverStaleSchedules`, retrospective-state writes) — both now awaited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015UNuD3sKuRtPxqGJnpHXEY)_