### PR TITLE
JARVIS-1217: restore member + timezone trust fields on channel retry replay

### DIFF
--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -251,6 +251,51 @@ describe("channel-retry-sweep", () => {
     }
   });
 
+  test("restores member-grounding + timezone trust fields on replay", async () => {
+    const eventId = seedFailedEventWithTrustClass("trusted_contact", {
+      requesterContactId: "contact-77",
+      memberStatus: "active",
+      memberPolicy: "allow",
+      requesterTimezone: "America/New_York",
+      requesterTimezoneLabel: "EST",
+      requesterTimezoneOffsetSeconds: -18000,
+    });
+
+    let capturedTrust: Record<string, unknown> | undefined;
+    await sweepFailedEvents(async (conversationId, _content, options) => {
+      capturedTrust = (options as { trustContext?: Record<string, unknown> })
+        .trustContext;
+      const messageId = "message-grounding";
+      getDb()
+        .insert(messages)
+        .values({
+          id: messageId,
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: "retry me" }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId };
+    });
+
+    // The newer member/timezone fields survive the store→replay round-trip
+    // instead of being dropped (which degraded the turn's member grounding).
+    expect(capturedTrust?.requesterContactId).toBe("contact-77");
+    expect(capturedTrust?.memberStatus).toBe("active");
+    expect(capturedTrust?.memberPolicy).toBe("allow");
+    expect(capturedTrust?.requesterTimezone).toBe("America/New_York");
+    expect(capturedTrust?.requesterTimezoneLabel).toBe("EST");
+    expect(capturedTrust?.requesterTimezoneOffsetSeconds).toBe(-18000);
+
+    const eventRow = getDb()
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.id, eventId))
+      .get();
+    expect(eventRow?.processingStatus).toBe("processed");
+  });
+
   test("marks legacy payloads with only actorRole (no trustClass) as failed", async () => {
     const actorRoles: Array<
       "guardian" | "non-guardian" | "unverified_channel"

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -279,8 +279,8 @@ describe("channel-retry-sweep", () => {
       return { messageId };
     });
 
-    // The newer member/timezone fields survive the store→replay round-trip
-    // instead of being dropped (which degraded the turn's member grounding).
+    // Member-grounding + timezone fields survive the store→replay round-trip,
+    // so the replayed turn keeps its member grounding.
     expect(capturedTrust?.requesterContactId).toBe("contact-77");
     expect(capturedTrust?.memberStatus).toBe("active");
     expect(capturedTrust?.memberPolicy).toBe("allow");

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -98,6 +98,26 @@ function parseTrustRuntimeContext(value: unknown): TrustContext | undefined {
         : undefined,
     requesterChatId:
       typeof raw.requesterChatId === "string" ? raw.requesterChatId : undefined,
+    requesterContactId:
+      typeof raw.requesterContactId === "string"
+        ? raw.requesterContactId
+        : undefined,
+    memberStatus:
+      typeof raw.memberStatus === "string" ? raw.memberStatus : undefined,
+    memberPolicy:
+      typeof raw.memberPolicy === "string" ? raw.memberPolicy : undefined,
+    requesterTimezone:
+      typeof raw.requesterTimezone === "string"
+        ? raw.requesterTimezone
+        : undefined,
+    requesterTimezoneLabel:
+      typeof raw.requesterTimezoneLabel === "string"
+        ? raw.requesterTimezoneLabel
+        : undefined,
+    requesterTimezoneOffsetSeconds:
+      typeof raw.requesterTimezoneOffsetSeconds === "number"
+        ? raw.requesterTimezoneOffsetSeconds
+        : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- `parseTrustRuntimeContext` (`assistant/src/runtime/channel-retry-sweep.ts`) rebuilds a `TrustContext` from a stored inbound payload on retry/replay, but only restored a subset of fields. It dropped `requesterContactId`, `memberStatus`, `memberPolicy`, `requesterTimezone`, `requesterTimezoneLabel`, and `requesterTimezoneOffsetSeconds` — so a replayed turn lost its member grounding (degraded gracefully, guarded by `if (trustContext.requesterContactId)` downstream) and timezone.
- The producer (`secret-ingress-check` → `storePayload`) already persists the **full** `trustCtx` via `JSON.stringify`, so these fields are present in storage; this is a read-side-only fix. Restores all six (string fields via `typeof === "string"`, the offset via `typeof === "number"`), matching the existing per-field guard style.
- No trust-classification logic changes; `trustClass` parsing and the privilege-escalation guards are untouched.
- Test: a new round-trip case seeds a payload carrying the six fields and asserts they reach the replayed `processMessage` call's `trustContext`. tsc clean; channel-retry-sweep suite 11/0.

## Original prompt
Continuing the contacts-ACL read-side follow-ups, picked up JARVIS-1217: the channel-retry-sweep replay path reconstructed a TrustContext that silently omitted the newer member-grounding (`requesterContactId`, `memberStatus`, `memberPolicy`) and timezone fields, so retried/replayed turns lost that grounding. The fix is to persist/restore those fields through the stored snapshot — here, purely restoring them on read since the writer already stores the full context.

Closes JARVIS-1217.