### PR TITLE
Research-onboarding polish: resume, role input, depth + UI fixes

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -1,14 +1,13 @@
 /**
- * Lightweight autocomplete fields for the research-onboarding form.
+ * Lightweight autocomplete field for the research-onboarding form.
  *
  * SPIKE — research-onboarding flow.
  *
- * The design library has no combobox primitive, so these are purpose-built on
- * top of plain inputs styled to match the design-library `Input` (same
- * `--field-bg` / `--field-border` / focus tokens). Both accept free text — the
+ * The design library has no combobox primitive, so this is purpose-built on
+ * top of a plain input styled to match the design-library `Input` (same
+ * `--field-bg` / `--field-border` / focus tokens). It accepts free text — the
  * suggestion dropdown only exists to make the common cases a single keystroke.
  *
- *   - `AutocompleteInput`   single free-text value + suggestion dropdown (Role)
  *   - `TagAutocompleteInput` multi-select chips + suggestion dropdown (Hobbies)
  *
  * Keyboard: ↑/↓ move the highlight, Enter commits the highlighted suggestion
@@ -153,115 +152,6 @@ function useDismiss(
     document.addEventListener("mousedown", onPointerDown);
     return () => document.removeEventListener("mousedown", onPointerDown);
   }, [ref, close]);
-}
-
-// ---------------------------------------------------------------------------
-// Single-value autocomplete (Role)
-// ---------------------------------------------------------------------------
-
-export interface AutocompleteInputProps {
-  label: string;
-  placeholder?: string;
-  value: string;
-  onChange: (value: string) => void;
-  suggestions: readonly string[];
-  autoFocus?: boolean;
-  required?: boolean;
-}
-
-export function AutocompleteInput({
-  label,
-  placeholder,
-  value,
-  onChange,
-  suggestions,
-  autoFocus,
-  required,
-}: AutocompleteInputProps) {
-  const reactId = useId();
-  const inputId = `ac-${reactId}`;
-  const listId = `ac-list-${reactId}`;
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const [open, setOpen] = useState(false);
-  const [highlighted, setHighlighted] = useState(-1);
-
-  const items = useMemo(
-    () => filterSuggestions(suggestions, value),
-    [suggestions, value],
-  );
-
-  useDismiss(wrapperRef, () => setOpen(false));
-
-  // Keep the highlight in range as the filtered list changes.
-  useEffect(() => {
-    setHighlighted((h) => (h >= items.length ? items.length - 1 : h));
-  }, [items.length]);
-
-  const showList = open && items.length > 0;
-
-  function pick(next: string) {
-    onChange(next);
-    setOpen(false);
-    setHighlighted(-1);
-  }
-
-  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setOpen(true);
-      setHighlighted((h) => Math.min(h + 1, items.length - 1));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setHighlighted((h) => Math.max(h - 1, 0));
-    } else if (e.key === "Enter" && showList && highlighted >= 0) {
-      e.preventDefault();
-      pick(items[highlighted]!);
-    } else if (e.key === "Escape") {
-      setOpen(false);
-    }
-  }
-
-  return (
-    <div ref={wrapperRef} className="relative flex flex-col gap-1.5">
-      <FieldLabel htmlFor={inputId} required={required}>
-        {label}
-      </FieldLabel>
-      <div className={cn(FIELD_BOX, "h-9")}>
-        <input
-          id={inputId}
-          role="combobox"
-          aria-required={required}
-          aria-expanded={showList}
-          aria-controls={listId}
-          aria-autocomplete="list"
-          aria-activedescendant={
-            highlighted >= 0 ? `${listId}-opt-${highlighted}` : undefined
-          }
-          autoComplete="off"
-          autoFocus={autoFocus}
-          className={BARE_INPUT}
-          placeholder={placeholder}
-          value={value}
-          onChange={(e) => {
-            onChange(e.target.value);
-            setOpen(true);
-          }}
-          onFocus={() => setOpen(true)}
-          onKeyDown={handleKeyDown}
-        />
-      </div>
-      {showList && (
-        <SuggestionList
-          id={listId}
-          items={items}
-          highlighted={highlighted}
-          onPick={pick}
-          onHover={setHighlighted}
-        />
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-character-stage.tsx
@@ -39,6 +39,32 @@ function slotRotation(slot: number): number {
 }
 
 /**
+ * Two-plane depth per edge slot — 0 = background, 1 = foreground — shared by both
+ * onboarding screens (the first-screen scatter and this picker) so the cast
+ * layers identically. The one value drives stacking (z-index), opacity, and
+ * size together: background avatars are dimmed, shrunk, and sit behind; the
+ * foreground stays full opacity and on top. No in-between opacities. Slots past
+ * the table default to foreground. The centered (selected) avatar always renders
+ * above every edge.
+ */
+const SLOT_DEPTH = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0];
+const DEPTH_SCALE = [0.72, 1];
+const DEPTH_OPACITY = [0.4, 1];
+const DEPTH_Z = [10, 20];
+/** z-index for the centered avatar — above every edge plane. */
+const CENTER_Z = 50;
+
+export function slotDepthScale(slot: number): number {
+  return DEPTH_SCALE[SLOT_DEPTH[slot] ?? 1] ?? 1;
+}
+export function slotDepthOpacity(slot: number): number {
+  return DEPTH_OPACITY[SLOT_DEPTH[slot] ?? 1] ?? 1;
+}
+export function slotDepthZ(slot: number): number {
+  return DEPTH_Z[SLOT_DEPTH[slot] ?? 1] ?? 20;
+}
+
+/**
  * Edge avatars render at this (large) px box; the center avatar is shown
  * smaller (scaled down) so it sits between the arrows. Both scale with the
  * viewport so the cast is big on desktop and fits on mobile.
@@ -187,17 +213,21 @@ export function OnboardingCharacterStage({
         if (isEntering) {
           const from = slots[entering.fromSlot]!;
           const off = offscreenPoint(from, centerX, centerY, w, h);
+          // Start at the source slot's depth (it may be a dim/shrunk background
+          // slot), then resolve to the full-size, full-opacity centre.
+          const fromScale = slotDepthScale(entering.fromSlot);
+          const fromOpacity = slotDepthOpacity(entering.fromSlot);
           return (
             <motion.div
               key={i}
               className="absolute left-0 top-0"
-              style={{ width: size, height: size }}
+              style={{ width: size, height: size, zIndex: CENTER_Z }}
               initial={false}
               animate={{
                 x: [from.x - half, off.x - half, off.x - half, centerTx, centerTx, centerTx],
                 y: [from.y - half, off.y - half, off.y - half, centerTy, centerTy, centerTy],
-                scale: [1, 1, 1, centerScaleVal * 0.7, centerScaleVal * 1.08, centerScaleVal],
-                opacity: [1, 1, 0, 0, 1, 1],
+                scale: [fromScale, fromScale, fromScale, centerScaleVal * 0.7, centerScaleVal * 1.08, centerScaleVal],
+                opacity: [fromOpacity, fromOpacity, 0, 0, 1, 1],
               }}
               transition={{
                 duration: 0.85,
@@ -220,17 +250,21 @@ export function OnboardingCharacterStage({
           if (slotHidden(exiting.toSlot)) return null;
           const to = slots[exiting.toSlot]!;
           const off = offscreenPoint(to, centerX, centerY, w, h);
+          // Settle into the destination slot's depth (dim/shrunk if it's a
+          // background slot) rather than always full size + opacity.
+          const toScale = slotDepthScale(exiting.toSlot);
+          const toOpacity = slotDepthOpacity(exiting.toSlot);
           return (
             <motion.div
               key={i}
               className="absolute left-0 top-0"
-              style={{ width: size, height: size }}
+              style={{ width: size, height: size, zIndex: slotDepthZ(exiting.toSlot) }}
               initial={false}
               animate={{
                 x: [centerTx, centerTx, off.x - half, off.x - half, to.x - half, to.x - half],
                 y: [centerTy, centerTy, off.y - half, off.y - half, to.y - half, to.y - half],
-                scale: [centerScaleVal, centerScaleVal * 0.6, 1, 1, 1.1, 1],
-                opacity: [1, 0, 0, 1, 1, 1],
+                scale: [centerScaleVal, centerScaleVal * 0.6, toScale, toScale, toScale * 1.1, toScale],
+                opacity: [1, 0, 0, toOpacity, toOpacity, toOpacity],
               }}
               transition={{
                 duration: 0.85,
@@ -262,13 +296,18 @@ export function OnboardingCharacterStage({
             key={i}
             // Edge avatars are clickable to select; the center one isn't.
             className={`absolute left-0 top-0 ${isCenter ? "" : "pointer-events-auto cursor-pointer"}`}
-            style={{ width: size, height: size }}
+            style={{
+              width: size,
+              height: size,
+              zIndex: isCenter ? CENTER_Z : slotDepthZ(charSlot),
+            }}
             initial={false}
             animate={{
               x: point.x - half,
               y: point.y - half,
-              scale: isCenter ? centerScaleVal : 1,
-              opacity: 1,
+              // Background slots sit smaller, dimmer, and behind (see slot depth).
+              scale: isCenter ? centerScaleVal : slotDepthScale(charSlot),
+              opacity: isCenter ? 1 : slotDepthOpacity(charSlot),
             }}
             transition={
               reduce

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -22,19 +22,13 @@ import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import {
   edgeSize,
   edgeSlots,
+  slotDepthOpacity,
+  slotDepthScale,
+  slotDepthZ,
   SLOT_ROTATIONS,
 } from "@/domains/onboarding/components/onboarding-character-stage";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-// Per-slot depth pass, indexed by edge slot (0–10). Size varies so the cast
-// isn't a uniform ring, and opacity is layered (a few near-full, the rest
-// pushed back) so several read as background. Slots 9 & 10 are the bottom-
-// centre pair — kept small and dim so they don't crowd the Continue button.
-// Deterministic by slot — never jumps between renders; slots past the table
-// fall back to full size / full opacity.
-const SLOT_SCALE = [1.12, 0.85, 1.0, 0.9, 1.14, 0.82, 1.06, 0.92, 1.1, 0.62, 0.6];
-const SLOT_OPACITY = [0.9, 0.4, 1, 0.55, 0.85, 0.45, 0.65, 0.5, 0.95, 0.45, 0.4];
 
 function useViewport() {
   const [size, setSize] = useState(() => ({
@@ -87,11 +81,12 @@ export function OnboardingEdgeCharacters() {
         const p = positions[slot];
         if (!p) return null;
         const rotation = SLOT_ROTATIONS[slot % SLOT_ROTATIONS.length] ?? 0;
-        // Depth pass: scale around the slot centre and dim a few so the ring
-        // reads with depth instead of a flat, uniform border.
-        const scale = SLOT_SCALE[slot] ?? 1;
-        const avatarSize = size * scale;
-        const opacity = SLOT_OPACITY[slot] ?? 1;
+        // Depth pass: a single per-slot layer (shared with the picker screen)
+        // drives size, opacity, and stacking so the further-back avatars shrink,
+        // fade, AND sit behind the front ones.
+        const avatarSize = size * slotDepthScale(slot);
+        const opacity = slotDepthOpacity(slot);
+        const zIndex = slotDepthZ(slot);
         return (
           <div
             key={i}
@@ -101,6 +96,7 @@ export function OnboardingEdgeCharacters() {
               top: p.y - avatarSize / 2,
               width: avatarSize,
               height: avatarSize,
+              zIndex,
               animation: reduce
                 ? undefined
                 : `character-pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) ${0.1 + i * 0.05}s both`,

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -27,12 +27,14 @@ import {
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
-// Per-slot depth pass, indexed by edge slot (0–10). A slight size variation so
-// the cast isn't a uniform ring, and reduced opacity on a few so some sit back
-// for depth. Deterministic by slot — never jumps between renders; slots past
-// the table fall back to full size / full opacity.
-const SLOT_SCALE = [1.12, 0.85, 1.0, 0.9, 1.14, 0.82, 1.06, 0.92, 1.1, 0.88, 1.0];
-const SLOT_OPACITY = [1, 0.5, 1, 0.7, 1, 0.55, 0.85, 0.65, 1, 0.75, 0.6];
+// Per-slot depth pass, indexed by edge slot (0–10). Size varies so the cast
+// isn't a uniform ring, and opacity is layered (a few near-full, the rest
+// pushed back) so several read as background. Slots 9 & 10 are the bottom-
+// centre pair — kept small and dim so they don't crowd the Continue button.
+// Deterministic by slot — never jumps between renders; slots past the table
+// fall back to full size / full opacity.
+const SLOT_SCALE = [1.12, 0.85, 1.0, 0.9, 1.14, 0.82, 1.06, 0.92, 1.1, 0.62, 0.6];
+const SLOT_OPACITY = [0.9, 0.4, 1, 0.55, 0.85, 0.45, 0.65, 0.5, 0.95, 0.45, 0.4];
 
 function useViewport() {
   const [size, setSize] = useState(() => ({
@@ -99,13 +101,16 @@ export function OnboardingEdgeCharacters() {
               top: p.y - avatarSize / 2,
               width: avatarSize,
               height: avatarSize,
-              opacity,
               animation: reduce
                 ? undefined
                 : `character-pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) ${0.1 + i * 0.05}s both`,
             }}
           >
-            <div style={{ transform: `rotate(${rotation}deg)` }}>
+            {/* Opacity sits on this inner wrapper, not the animated parent: the
+                `character-pop-in` keyframes animate opacity 0→1 with `both`
+                fill, which would otherwise override an inline opacity on the
+                same element and pin every avatar to full opacity. */}
+            <div style={{ opacity, transform: `rotate(${rotation}deg)` }}>
               <AnimatedAvatar
                 components={components}
                 traits={traits}

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -4,10 +4,13 @@
  *
  * SPIKE — research-onboarding flow.
  *
- * Uses the exact same edge slots, sizing, and rotations as the picker step
+ * Uses the same edge slots and rotations as the picker step
  * (`OnboardingCharacterStage`) so the arrangement matches between the two
- * screens. Pool index 0 is the picker's centered avatar, so it's omitted here
- * (the form sits in the center); indices 1–9 fill edge slots 0–8.
+ * screens, but adds a per-slot depth pass — a slight size variation and reduced
+ * opacity on a few of the cast — so the first screen's ring reads with depth
+ * rather than a flat, uniform border. Pool index 0 is the picker's centered
+ * avatar, so it's omitted here (the form sits in the center); indices 1–9 fill
+ * edge slots 0–8.
  *
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe.
  */
@@ -23,6 +26,13 @@ import {
 } from "@/domains/onboarding/components/onboarding-character-stage";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+// Per-slot depth pass, indexed by edge slot (0–10). A slight size variation so
+// the cast isn't a uniform ring, and reduced opacity on a few so some sit back
+// for depth. Deterministic by slot — never jumps between renders; slots past
+// the table fall back to full size / full opacity.
+const SLOT_SCALE = [1.12, 0.85, 1.0, 0.9, 1.14, 0.82, 1.06, 0.92, 1.1, 0.88, 1.0];
+const SLOT_OPACITY = [1, 0.5, 1, 0.7, 1, 0.55, 0.85, 0.65, 1, 0.75, 0.6];
 
 function useViewport() {
   const [size, setSize] = useState(() => ({
@@ -75,15 +85,21 @@ export function OnboardingEdgeCharacters() {
         const p = positions[slot];
         if (!p) return null;
         const rotation = SLOT_ROTATIONS[slot % SLOT_ROTATIONS.length] ?? 0;
+        // Depth pass: scale around the slot centre and dim a few so the ring
+        // reads with depth instead of a flat, uniform border.
+        const scale = SLOT_SCALE[slot] ?? 1;
+        const avatarSize = size * scale;
+        const opacity = SLOT_OPACITY[slot] ?? 1;
         return (
           <div
             key={i}
             className="absolute"
             style={{
-              left: p.x - size / 2,
-              top: p.y - size / 2,
-              width: size,
-              height: size,
+              left: p.x - avatarSize / 2,
+              top: p.y - avatarSize / 2,
+              width: avatarSize,
+              height: avatarSize,
+              opacity,
               animation: reduce
                 ? undefined
                 : `character-pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) ${0.1 + i * 0.05}s both`,
@@ -93,7 +109,7 @@ export function OnboardingEdgeCharacters() {
               <AnimatedAvatar
                 components={components}
                 traits={traits}
-                size={size}
+                size={avatarSize}
                 breathe={false}
               />
             </div>

--- a/clients/web/src/domains/onboarding/components/onboarding-top-bar.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-top-bar.tsx
@@ -43,7 +43,7 @@ export function OnboardingTopBar({
         type="button"
         onClick={onBack}
         aria-label="Back"
-        className="flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-150"
+        className="flex cursor-pointer h-8 w-8 items-center justify-center rounded-md transition-colors duration-150"
         style={{ color: fg }}
         onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = hoverBg)}
         onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "transparent")}
@@ -56,7 +56,7 @@ export function OnboardingTopBar({
           type="button"
           onClick={onNext}
           aria-label="Forward"
-          className="flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-150"
+          className="flex cursor-pointer h-8 w-8 items-center justify-center rounded-md transition-colors duration-150"
           style={{ color: fg }}
           onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = hoverBg)}
           onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "transparent")}

--- a/clients/web/src/domains/onboarding/onboarding-suggestions.ts
+++ b/clients/web/src/domains/onboarding/onboarding-suggestions.ts
@@ -1,57 +1,14 @@
 /**
- * Prefill suggestion lists for the research-onboarding form's role and hobbies
- * autocompletes.
+ * Prefill suggestion list for the research-onboarding form's hobbies
+ * autocomplete.
  *
  * SPIKE — research-onboarding flow.
  *
- * These are convenience prefills only: both fields accept free text, so the
- * lists just need to cover the common cases well enough that most people can
- * pick rather than type. Kept deliberately broad and alphabetized-by-frequency
- * rather than exhaustive.
+ * Convenience prefills only: the field accepts free text, so the list just
+ * needs to cover the common cases well enough that most people can pick rather
+ * than type. Kept deliberately broad and alphabetized-by-frequency rather than
+ * exhaustive.
  */
-
-/** Common roles / occupations, ordered roughly by how often we expect them. */
-export const ROLE_SUGGESTIONS: readonly string[] = [
-  "Software Engineer",
-  "Product Manager",
-  "Product Designer",
-  "Founder / CEO",
-  "Engineering Manager",
-  "Data Scientist",
-  "Marketing Manager",
-  "Growth Marketer",
-  "Content Writer",
-  "Sales Representative",
-  "Account Executive",
-  "Customer Success Manager",
-  "Operations Manager",
-  "Project Manager",
-  "Program Manager",
-  "Business Analyst",
-  "Data Engineer",
-  "Machine Learning Engineer",
-  "DevOps Engineer",
-  "Solutions Architect",
-  "UX Researcher",
-  "Graphic Designer",
-  "Recruiter",
-  "HR Manager",
-  "Financial Analyst",
-  "Accountant",
-  "Consultant",
-  "Investor / VC",
-  "Lawyer",
-  "Teacher",
-  "Professor",
-  "Researcher",
-  "Doctor / Physician",
-  "Nurse",
-  "Real Estate Agent",
-  "Executive Assistant",
-  "Entrepreneur",
-  "Freelancer",
-  "Student",
-];
 
 /** Common hobbies / interests for the multi-select chips field. */
 export const HOBBY_SUGGESTIONS: readonly string[] = [

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -24,6 +24,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { routes } from "@/utils/routes";
+import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
 import {
   setPendingAssistantName,
@@ -91,6 +92,10 @@ function researchTitleFor(values: ResearchOnboardingValues): string {
   const first = values.firstName.trim();
   return first ? `Getting to know ${first}` : "Getting to know you";
 }
+
+// Warm the (~48 kB) bundled-avatar chunk the instant this lazy route loads, so
+// the edge cast is ready as the form paints instead of popping in a beat later.
+preloadBundledAvatarComponents();
 
 export function ResearchOnboardingRoute() {
   const navigate = useNavigate();

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -165,6 +165,12 @@ export function ResearchOnboardingRoute() {
     null,
   );
   const [faceValues, setFaceValues] = useState<GiveMeAFaceValues | null>(null);
+  // Id of the behind-the-scenes "research me" conversation. Captured the moment
+  // it's minted (and restored from the snapshot on refresh) so a mid-search
+  // reload re-attaches to that same thread instead of starting a second search.
+  const [researchConversationId, setResearchConversationId] = useState<
+    string | null
+  >(null);
   // Formatted booked check-in time ("2:30 PM"), set when scheduleCheckin lands;
   // null until then (or if booking failed) → confirmation shows generic copy.
   const [checkinTime, setCheckinTime] = useState<string | null>(null);
@@ -243,6 +249,7 @@ export function ResearchOnboardingRoute() {
       setFaceValues(snapshot.faceValues);
       setCheckinTime(snapshot.checkinTime);
       setCheckinBooked(snapshot.checkinBooked);
+      setResearchConversationId(snapshot.researchConversationId ?? null);
       // Re-enqueue the named plugin installs against the re-hatched assistant so
       // a suggestion click awaits real (idempotent) installs, not an empty map.
       if (snapshot.research) hydrateResearch(snapshot.research, awaitHatchReady);
@@ -274,6 +281,9 @@ export function ResearchOnboardingRoute() {
               installedPlugins: research.installedPlugins,
             }
           : null,
+      ...(researchConversationId
+        ? { researchConversationId }
+        : {}),
     });
   }, [
     restored,
@@ -283,6 +293,7 @@ export function ResearchOnboardingRoute() {
     faceValues,
     checkinTime,
     checkinBooked,
+    researchConversationId,
     research.status,
     research.claims,
     research.suggestions,
@@ -290,12 +301,15 @@ export function ResearchOnboardingRoute() {
   ]);
 
   // Mid-flow resume: we restored a journey whose research turn hadn't settled.
-  // The in-flight client turn is gone, so re-fire it once from the restored
-  // subject. Only fires when results are absent (status "idle") — a fresh visit
-  // has no `formValues` until the form is submitted (which fires the search
-  // itself), and a completed resume hydrates the status to "done". The meeting
-  // is never re-booked here: that only fires from the calendar step, which a
-  // resume skips past.
+  // Resume it once from the restored subject. When the prior session got far
+  // enough to mint the research conversation, re-attach to that SAME thread
+  // (`resumeConversationId`) — the turn keeps generating server-side across the
+  // reload, so we poll it instead of running a second search; only if it's gone
+  // (or was never minted) does the runner fall back to a fresh run. Only fires
+  // when results are absent (status "idle") — a fresh visit has no `formValues`
+  // until the form is submitted (which fires the search itself), and a completed
+  // resume hydrates the status to "done". The meeting is never re-booked here:
+  // that only fires from the calendar step, which a resume skips past.
   useEffect(() => {
     if (!restored || !enabled || !flagsHydrated) return;
     if (!formValues || research.status !== "idle") return;
@@ -303,12 +317,17 @@ export function ResearchOnboardingRoute() {
       awaitAssistantId: awaitHatchReady,
       subject: researchSubjectFrom(formValues),
       conversationTitle: researchTitleFor(formValues),
+      ...(researchConversationId
+        ? { resumeConversationId: researchConversationId }
+        : {}),
+      onConversationCreated: setResearchConversationId,
     });
   }, [
     restored,
     enabled,
     flagsHydrated,
     formValues,
+    researchConversationId,
     research.status,
     startResearch,
     awaitHatchReady,
@@ -414,6 +433,7 @@ export function ResearchOnboardingRoute() {
       awaitAssistantId: awaitHatchReady,
       subject: researchSubjectFrom(values),
       conversationTitle: researchTitleFor(values),
+      onConversationCreated: setResearchConversationId,
     });
     goForwardTo("face");
   }

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
@@ -37,11 +37,11 @@ function baseSnapshot(
 }
 
 beforeEach(() => {
-  sessionStorage.clear();
+  localStorage.clear();
 });
 
 afterEach(() => {
-  sessionStorage.clear();
+  localStorage.clear();
 });
 
 describe("read/write/clear round-trip", () => {
@@ -73,8 +73,14 @@ describe("read/write/clear round-trip", () => {
   });
 
   test("malformed stored JSON reads as null rather than throwing", () => {
-    sessionStorage.setItem(`research_onboarding:${USER}`, "{not json");
+    localStorage.setItem(`research_onboarding:${USER}`, "{not json");
     expect(readResearchSnapshot(USER)).toBeNull();
+  });
+
+  test("round-trips the research conversation id for mid-search resume", () => {
+    const snapshot = baseSnapshot({ researchConversationId: "conv-abc" });
+    writeResearchSnapshot(USER, snapshot);
+    expect(readResearchSnapshot(USER)?.researchConversationId).toBe("conv-abc");
   });
 });
 

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -6,19 +6,22 @@
  * The flow keeps its whole journey in React state, so a page refresh used to
  * remount at the form, re-fire the (expensive) "research me" background turn,
  * and risk re-booking the day-2 check-in. We snapshot the journey to
- * `sessionStorage` (per-tab, cleared on tab close) keyed by user so a refresh
- * resumes where the user left off:
+ * `localStorage` keyed by user (persists across reloads — and tab closes —
+ * until onboarding completes and the snapshot is cleared) so a refresh resumes
+ * where the user left off:
  *   - the collected details (form + avatar/name) are restored, so the early
  *     steps aren't re-asked;
  *   - the COMPLETED research output ({ claims, suggestions, installedPlugins })
  *     is restored, so the background search is NOT re-run and we land straight
  *     on the suggestions;
- *   - mid-flow (research not yet settled) resumes on the right step and lets the
- *     route re-fire the search once — the in-flight client turn can't survive a
- *     reload, so there's nothing to recover, but the meeting is never re-booked
- *     because the booking step is never replayed.
+ *   - mid-flow (research not yet settled) resumes on the right step and re-
+ *     attaches to the SAME research conversation via `researchConversationId`
+ *     rather than minting a second one: the prior turn keeps generating server-
+ *     side after the reload, so the route resumes polling it (and only re-posts
+ *     the prompt if it never landed) instead of running a fresh search. The
+ *     meeting is never re-booked because the booking step is never replayed.
  *
- * Best-effort: `sessionStorage` can throw under privacy modes / quota, so every
+ * Best-effort: `localStorage` can throw under privacy modes / quota, so every
  * access is guarded and a failure just degrades to the old restart-at-form
  * behavior.
  */
@@ -67,6 +70,14 @@ export interface ResearchOnboardingSnapshot {
   checkinBooked: boolean;
   /** Completed research output; null until the turn settles with results. */
   research: PersistedResearchResults | null;
+  /**
+   * Id of the behind-the-scenes "research me" conversation, saved as soon as it
+   * is minted so a refresh mid-search can re-attach to (resume) that same thread
+   * instead of starting a second search. Cleared implicitly with the snapshot
+   * once onboarding completes. Absent on older snapshots / before the turn
+   * starts.
+   */
+  researchConversationId?: string;
 }
 
 function storageKey(userId: string | null): string | null {
@@ -79,7 +90,7 @@ export function readResearchSnapshot(
   const key = storageKey(userId);
   if (!key) return null;
   try {
-    const raw = sessionStorage.getItem(key);
+    const raw = localStorage.getItem(key);
     if (!raw) return null;
     return JSON.parse(raw) as ResearchOnboardingSnapshot;
   } catch {
@@ -95,9 +106,9 @@ export function writeResearchSnapshot(
   const key = storageKey(userId);
   if (!key) return;
   try {
-    sessionStorage.setItem(key, JSON.stringify(snapshot));
+    localStorage.setItem(key, JSON.stringify(snapshot));
   } catch {
-    // sessionStorage can throw under privacy modes / quota — best-effort.
+    // localStorage can throw under privacy modes / quota — best-effort.
   }
 }
 
@@ -105,7 +116,7 @@ export function clearResearchSnapshot(userId: string | null): void {
   const key = storageKey(userId);
   if (!key) return;
   try {
-    sessionStorage.removeItem(key);
+    localStorage.removeItem(key);
   } catch {
     // Best-effort.
   }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -216,6 +216,21 @@ export interface StartResearchOptions {
   subject: ResearchSubject;
   /** Friendly title for the behind-the-scenes research conversation. */
   conversationTitle?: string;
+  /**
+   * Resume a research conversation a prior session minted (a refresh mid-search)
+   * instead of creating a fresh one. The prior turn keeps generating server-side
+   * across the reload, so we re-attach and poll it — re-posting the prompt only
+   * if it never landed before the refresh — so the search is never run twice. If
+   * the conversation is gone (e.g. it completed and was archived), falls back to
+   * a fresh run so the user still gets results.
+   */
+  resumeConversationId?: string;
+  /**
+   * Invoked with the conversation id the moment a FRESH research conversation is
+   * minted (not on resume), so the caller can persist it and resume this exact
+   * thread if the page is refreshed mid-search.
+   */
+  onConversationCreated?: (conversationId: string) => void;
 }
 
 export interface UseResearchRunner extends ResearchRunnerState {
@@ -320,7 +335,13 @@ export function useResearchRunner(): UseResearchRunner {
   const queryClient = useQueryClient();
 
   const start = useCallback(
-    ({ awaitAssistantId, subject, conversationTitle }: StartResearchOptions) => {
+    ({
+      awaitAssistantId,
+      subject,
+      conversationTitle,
+      resumeConversationId,
+      onConversationCreated,
+    }: StartResearchOptions) => {
       const subjectKey = JSON.stringify(subject);
       if (subjectKeyRef.current === subjectKey) return;
       subjectKeyRef.current = subjectKey;
@@ -386,49 +407,99 @@ export function useResearchRunner(): UseResearchRunner {
             setState((s) => ({ ...s, installedPlugins: deterministicPlugins }));
           }
 
-          const conversation = await conversationsPost({
-            path: { assistant_id: assistantId },
-            body: {
-              conversationType: "standard",
-              ...(conversationTitle ? { title: conversationTitle } : {}),
-            },
-            throwOnError: false,
-          });
-          // Capture the created conversation id before the stale check. The
-          // finally block archives it only after a complete payload settles.
-          createdConversationId = conversation.data?.id;
-          if (isStale()) return;
-          const conversationId = conversation.data?.id;
-          if (!conversation.response?.ok || !conversationId) {
-            setState((s) => ({ ...s, status: "error" }));
-            return;
-          }
-
-          const body: MessagesPostData["body"] = {
-            conversationId,
-            content: buildResearchPrompt(subject, capabilities),
-            sourceChannel: "vellum",
-            interface: "vellum",
-            clientMessageId: crypto.randomUUID(),
+          // Post the research prompt onto a conversation. Returns false on a
+          // failed POST so the caller can settle "error".
+          const postResearchPrompt = async (cid: string): Promise<boolean> => {
+            const body: MessagesPostData["body"] = {
+              conversationId: cid,
+              content: buildResearchPrompt(subject, capabilities),
+              sourceChannel: "vellum",
+              interface: "vellum",
+              clientMessageId: crypto.randomUUID(),
+            };
+            // Carry the browser timezone so any time-relative reasoning resolves
+            // to the user's local clock. Mirrors `checkin-scheduler.ts`.
+            try {
+              const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+              if (tz) body.clientTimezone = tz;
+            } catch {
+              // Intl unavailable — daemon falls back to its own cascade.
+            }
+            const posted = await messagesPost({
+              path: { assistant_id: assistantId },
+              body,
+              throwOnError: false,
+            });
+            return Boolean(posted.response?.ok);
           };
-          // Carry the browser timezone so any time-relative reasoning resolves
-          // to the user's local clock. Mirrors `checkin-scheduler.ts`.
-          try {
-            const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            if (tz) body.clientTimezone = tz;
-          } catch {
-            // Intl unavailable — daemon falls back to its own cascade.
+
+          // Mint a fresh research conversation + fire the prompt. Used for the
+          // initial run and as the resume fallback when the prior conversation
+          // is gone.
+          const startFreshConversation = async (): Promise<
+            string | undefined
+          > => {
+            const conversation = await conversationsPost({
+              path: { assistant_id: assistantId },
+              body: {
+                conversationType: "standard",
+                ...(conversationTitle ? { title: conversationTitle } : {}),
+              },
+              throwOnError: false,
+            });
+            // Capture before the stale check so the finally block can archive it
+            // once a complete payload settles.
+            createdConversationId = conversation.data?.id;
+            const id = conversation.data?.id;
+            if (!conversation.response?.ok || !id) return undefined;
+            // Surface the new id immediately so the caller can persist it and
+            // resume this exact thread across a refresh.
+            onConversationCreated?.(id);
+            return id;
+          };
+
+          let conversationId: string | undefined;
+          if (resumeConversationId) {
+            // Resume the prior session's research conversation rather than
+            // running a second search. The turn keeps generating server-side
+            // across the reload, so re-attach and poll it; only re-post the
+            // prompt if it never landed before the refresh (no user message).
+            const existing = await messagesGet({
+              path: { assistant_id: assistantId },
+              query: { conversationId: resumeConversationId },
+              throwOnError: false,
+            });
+            if (isStale()) return;
+            if (existing.response?.ok) {
+              conversationId = resumeConversationId;
+              createdConversationId = resumeConversationId;
+              const turnAlreadyStarted = (existing.data?.messages ?? []).some(
+                (m) => m.role === "user",
+              );
+              if (!turnAlreadyStarted) {
+                if (!(await postResearchPrompt(conversationId))) {
+                  setState((s) => ({ ...s, status: "error" }));
+                  return;
+                }
+                if (isStale()) return;
+              }
+            }
+            // Not ok → conversation gone (e.g. completed + archived); fall
+            // through to a fresh run below.
           }
 
-          const posted = await messagesPost({
-            path: { assistant_id: assistantId },
-            body,
-            throwOnError: false,
-          });
-          if (isStale()) return;
-          if (!posted.response?.ok) {
-            setState((s) => ({ ...s, status: "error" }));
-            return;
+          if (!conversationId) {
+            conversationId = await startFreshConversation();
+            if (isStale()) return;
+            if (!conversationId) {
+              setState((s) => ({ ...s, status: "error" }));
+              return;
+            }
+            if (!(await postResearchPrompt(conversationId))) {
+              setState((s) => ({ ...s, status: "error" }));
+              return;
+            }
+            if (isStale()) return;
           }
 
           // Poll the conversation, parsing the (possibly partial) reply each

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, ArrowRight, Pencil } from "lucide-react";
+import { ArrowLeft, ArrowRight, Dices, Pencil } from "lucide-react";
 
 import { OnboardingCharacterStage } from "@/domains/onboarding/components/onboarding-character-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
@@ -152,8 +152,20 @@ export function GiveMeAFaceScreen({
     if (centeredTraits) onContinue({ traits: centeredTraits, name: name.trim() });
   }
 
+  // Roll a random name from the pool (different from the current one). Counts as
+  // a deliberate pick, so — like editing — it sticks across avatar cycling
+  // instead of being re-prefilled from the centered avatar.
+  function randomizeName() {
+    nameCustomized.current = true;
+    setName((current) => {
+      const options = ASSISTANT_NAMES.filter((candidate) => candidate !== current);
+      const pool = options.length > 0 ? options : ASSISTANT_NAMES;
+      return pool[Math.floor(Math.random() * pool.length)]!;
+    });
+  }
+
   const arrowClass =
-    "pointer-events-auto z-10 flex h-10 w-10 items-center justify-center rounded-full " +
+    "pointer-events-auto z-10 flex cursor-pointer h-10 w-10 items-center justify-center rounded-full " +
     "bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] text-[var(--content-default)] " +
     "transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_18%,transparent)]";
 
@@ -239,19 +251,30 @@ export function GiveMeAFaceScreen({
             className="w-[234px] rounded-2xl border border-[var(--border-element)] bg-transparent px-4 py-2.5 text-center text-lg text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-colors duration-150 focus:border-[var(--border-active)]"
           />
         ) : (
-          <button
-            type="button"
-            onClick={() => setEditingName(true)}
-            aria-label="Edit name"
-            className="flex items-center gap-2.5"
-          >
-            <span
-              className={`text-3xl font-medium ${name ? "text-[var(--content-default)]" : "text-[var(--content-tertiary)]"}`}
+          <div className="flex items-center gap-2.5">
+            <button
+              type="button"
+              onClick={() => setEditingName(true)}
+              aria-label="Edit name"
+              className="flex cursor-pointer items-center gap-2.5"
             >
-              {name || "Name your assistant"}
-            </span>
-            <Pencil className="h-5 w-5 text-[var(--content-tertiary)]" />
-          </button>
+              <span
+                className={`text-3xl font-medium ${name ? "text-[var(--content-default)]" : "text-[var(--content-tertiary)]"}`}
+              >
+                {name || "Name your assistant"}
+              </span>
+              <Pencil className="h-5 w-5 text-[var(--content-tertiary)]" />
+            </button>
+            <button
+              type="button"
+              onClick={randomizeName}
+              aria-label="Shuffle name"
+              title="Shuffle name"
+              className="cursor-pointer text-[var(--content-tertiary)] transition-[transform,color] duration-300 hover:rotate-180 hover:text-[var(--content-default)]"
+            >
+              <Dices className="h-5 w-5" />
+            </button>
+          </div>
         )}
 
         <Button

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -102,7 +102,7 @@ export function IntegrationStep({
           <button
             type="button"
             onClick={handleClaim}
-            className="mt-6 flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
+            className="mt-6 flex cursor-pointer h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
             style={{
               backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
               color: tone.isLight ? "#FFFFFF" : "#1A1A1A",

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -27,6 +27,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 
+import { Button } from "@vellumai/design-library/components/button";
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import {
   MotionEyes,
@@ -479,17 +480,22 @@ export function PitchStep({
         </div>
 
         {landed && (
-          <motion.button
-            type="button"
-            onClick={onContinue}
-            className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
+          <motion.div
             initial={reduce ? false : { opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={reduce ? { duration: 0 } : { duration: 0.4 }}
           >
-            Continue
-            <ArrowRight className="h-4 w-4" />
-          </motion.button>
+            <Button
+              type="button"
+              variant="primary"
+              size="regular"
+              rightIcon={<ArrowRight size={16} />}
+              onClick={onContinue}
+              className="h-11 w-[234px] text-base"
+            >
+              Continue
+            </Button>
+          </motion.div>
         )}
       </div>
     </div>

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -14,6 +14,7 @@
 import { useMemo } from "react";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
+import { Button } from "@vellumai/design-library/components/button";
 
 import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
@@ -168,17 +169,22 @@ export function IntroductionScreen({
           </span>
         </motion.h1>
 
-        <motion.button
-          type="button"
-          onClick={onContinue}
-          className="flex h-11 w-[234px] items-center justify-center gap-2 rounded-[10px] bg-black text-body-medium-default text-white transition-transform duration-150 active:scale-[0.97]"
+        <motion.div
           initial={reduce ? false : { opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 1.15 }}
         >
-          Continue
-          <ArrowRight className="h-4 w-4" />
-        </motion.button>
+          <Button
+            type="button"
+            variant="primary"
+            size="regular"
+            rightIcon={<ArrowRight size={16} />}
+            onClick={onContinue}
+            className="h-11 w-[234px] text-base"
+          >
+            Continue
+          </Button>
+        </motion.div>
       </div>
       </OnboardingStageSizeProvider>
     </div>

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -97,7 +97,7 @@ export function LetsChatTomorrowStep({
             type="button"
             onClick={handleConnectClick}
             disabled={connectDisabled}
-            className="flex h-11 w-full items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+            className="flex cursor-pointer h-11 w-full items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
             style={{
               backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
               color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
@@ -124,7 +124,7 @@ export function LetsChatTomorrowStep({
             type="button"
             onClick={onSkip}
             disabled={oauthInProgress}
-            className="text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
+            className="cursor-pointer text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
             style={{ color: tone.fgMuted }}
           >
             Skip for now

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -13,14 +13,8 @@ import { ArrowRight } from "lucide-react";
 
 import { OnboardingEdgeCharacters } from "@/domains/onboarding/components/onboarding-edge-characters";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import {
-  AutocompleteInput,
-  TagAutocompleteInput,
-} from "@/domains/onboarding/components/onboarding-autocomplete";
-import {
-  HOBBY_SUGGESTIONS,
-  ROLE_SUGGESTIONS,
-} from "@/domains/onboarding/onboarding-suggestions";
+import { TagAutocompleteInput } from "@/domains/onboarding/components/onboarding-autocomplete";
+import { HOBBY_SUGGESTIONS } from "@/domains/onboarding/onboarding-suggestions";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
@@ -132,13 +126,13 @@ export function ResearchOnboardingScreen({
           </div>
 
           <div style={riseIn(0.34, 20)}>
-            <AutocompleteInput
+            <Input
               label="Your role"
               placeholder="What do you do for work?"
               value={role}
-              onChange={setRole}
-              suggestions={ROLE_SUGGESTIONS}
+              onChange={(e) => setRole(e.target.value)}
               required
+              fullWidth
             />
           </div>
 

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -366,7 +366,7 @@ export function ResearchResultsStep({
                   onClick={() =>
                     setRemoved((prev) => new Set(prev).add(fact.claim))
                   }
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-100"
+                  className="flex cursor-pointer h-6 w-6 shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-100"
                   style={{ color: tone.fgMuted }}
                 >
                   <X className="h-4 w-4" />
@@ -380,7 +380,7 @@ export function ResearchResultsStep({
           type="button"
           onClick={onContinue}
           disabled={!canContinue}
-          className="mt-8 flex h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+          className="mt-8 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
@@ -683,7 +683,7 @@ export function SuggestionsStep({
               <button
                 type="button"
                 onClick={onSkip}
-                className="underline underline-offset-2 transition-opacity hover:opacity-80"
+                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
                 style={{ color: tone.fg }}
               >
                 Skip to Chat
@@ -705,7 +705,7 @@ export function SuggestionsStep({
               transition={
                 reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
               }
-              className="rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
+              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
               style={{
                 backgroundColor: tone.isLight
                   ? "rgba(0,0,0,0.06)"

--- a/clients/web/src/utils/use-bundled-avatar-components.ts
+++ b/clients/web/src/utils/use-bundled-avatar-components.ts
@@ -57,6 +57,19 @@ function loadBundledComponents(): Promise<CharacterComponents> {
 }
 
 /**
+ * Eagerly kick off the bundled-avatar import without mounting a consumer, so
+ * the (~48 kB) chunk is already in flight — or resolved — by the time the
+ * avatars first render. Safe to call repeatedly: it no-ops once cached / in
+ * flight. Call it as early as a screen full of avatars is known to be coming
+ * (e.g. at the onboarding route's module scope) to cut the blank-then-pop gap.
+ */
+export function preloadBundledAvatarComponents(): void {
+  void loadBundledComponents().catch(() => {
+    // Best-effort warm-up; the hook's own retry path handles real failures.
+  });
+}
+
+/**
  * Lazily loads the bundled avatar character-components data (~48 kB of
  * inline SVG paths) on first mount of any consumer. Returns `null` until
  * the chunk resolves; the caller renders a placeholder of the same size so


### PR DESCRIPTION
## Summary
A batch of polish for the **research-onboarding** flow. Entirely behind the existing `research-onboarding` client feature flag (`defaultEnabled: false`) — the route bounces flag-off visitors, so none of this affects users until the flag is enabled.

- **Refresh resilience**: the journey snapshot moves from `sessionStorage` to `localStorage` and now stores the research conversation id. A mid-search refresh **resumes that same "research me" thread** (re-attach + poll the existing conversation; re-post the prompt only if it never landed) instead of running a second web search. Completed results are still reused; only a vanished conversation falls back to a fresh run.
- **Role field**: replaced the search-select autocomplete with a plain `Input`; removed the now-dead `AutocompleteInput` component and `ROLE_SUGGESTIONS`.
- **Name step**: added a dice button beside the edit pencil to shuffle the assistant name to a random pick (sticks across avatar cycling).
- **First screen**: per-slot size + opacity variation on the edge avatars for depth.
- **Buttons**: the always-black Continue buttons (intro + pitch steps) now use the design-library `Button` (`variant="primary"`), wrapped to preserve their entrance animation.
- **Cursor**: `cursor-pointer` added to clickable elements across the flow.

## Feature flag
All changes live inside the `research-onboarding`-gated route (default off). No new flag needed.

## Tests
- `research-onboarding-persistence.test.ts` — switched to localStorage, added a conversation-id round-trip (11 pass).
- `research-runner.test.ts` — 13 pass (resume options are backward compatible).
- eslint + onboarding typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)