### PR TITLE
JARVIS-1228: prefer the primary channel among duplicate externalChatId rows

### DIFF
--- a/assistant/src/contacts/__tests__/find-contact-by-external-chat-id.test.ts
+++ b/assistant/src/contacts/__tests__/find-contact-by-external-chat-id.test.ts
@@ -1,0 +1,124 @@
+/**
+ * findContactChannel's externalChatId fallback must prefer the primary channel
+ * among duplicate (type, externalChatId) rows. externalChatId has no unique
+ * constraint, so a revoked/blocked duplicate (more recently touched) must not
+ * win over the active/primary one.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import {
+  contactChannels,
+  contacts,
+} from "../../persistence/schema/index.js";
+import { findContactChannel } from "../contact-store.js";
+
+await initializeDb();
+
+const TYPE = "telegram";
+const EXT_CHAT = "shared-chat-123";
+
+function seedContact(id: string, ts: number): void {
+  getDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: id,
+      contactType: "human",
+      createdAt: ts,
+      updatedAt: ts,
+    })
+    .run();
+}
+
+function seedChannel(params: {
+  id: string;
+  contactId: string;
+  address: string;
+  isPrimary: boolean;
+  updatedAt: number;
+  createdAt: number;
+}): void {
+  getDb()
+    .insert(contactChannels)
+    .values({
+      id: params.id,
+      contactId: params.contactId,
+      type: TYPE,
+      address: params.address,
+      isPrimary: params.isPrimary,
+      externalChatId: EXT_CHAT,
+      updatedAt: params.updatedAt,
+      createdAt: params.createdAt,
+    })
+    .run();
+}
+
+describe("findContactChannel — duplicate externalChatId tiebreak", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+  });
+
+  test("prefers the primary channel over a more-recently-updated duplicate", () => {
+    // The non-primary duplicate is updated LATER (a revoke/blocked touch would
+    // bump updatedAt), so pure recency would wrongly pick it.
+    seedContact("c-active", 100);
+    seedContact("c-stale", 100);
+    seedChannel({
+      id: "ch-active",
+      contactId: "c-active",
+      address: "@active",
+      isPrimary: true,
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    seedChannel({
+      id: "ch-stale",
+      contactId: "c-stale",
+      address: "@stale",
+      isPrimary: false,
+      createdAt: 100,
+      updatedAt: 999, // newer
+    });
+
+    const found = findContactChannel({
+      channelType: TYPE,
+      externalChatId: EXT_CHAT,
+    });
+
+    expect(found?.contact.id).toBe("c-active");
+    expect(found?.channel.id).toBe("ch-active");
+  });
+
+  test("falls back to recency when no duplicate is primary", () => {
+    seedContact("c-old", 100);
+    seedContact("c-new", 100);
+    seedChannel({
+      id: "ch-old",
+      contactId: "c-old",
+      address: "@old",
+      isPrimary: false,
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    seedChannel({
+      id: "ch-new",
+      contactId: "c-new",
+      address: "@new",
+      isPrimary: false,
+      createdAt: 100,
+      updatedAt: 500,
+    });
+
+    const found = findContactChannel({
+      channelType: TYPE,
+      externalChatId: EXT_CHAT,
+    });
+
+    expect(found?.contact.id).toBe("c-new");
+  });
+});

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -684,8 +684,10 @@ export function findContactByAddress(
 /**
  * Find a contact by channel external chat ID. Fallback for callers that only
  * have a chat ID (no user-level address) — matches by (type, externalChatId).
- * No unique constraint exists on externalChatId, so ORDER BY is needed for a
- * deterministic pick; channel ranking (status) is owned by the gateway now.
+ * No unique constraint exists on externalChatId, so ORDER BY gives a
+ * deterministic pick: prefer the primary channel, then most-recent. Channel
+ * ACL/status ranking is owned by the gateway; isPrimary is the best local
+ * proxy for "the active row" among duplicates.
  */
 function findContactByChannelExternalChatId(
   channelType: string,
@@ -701,7 +703,11 @@ function findContactByChannelExternalChatId(
         eq(contactChannels.externalChatId, externalChatId),
       ),
     )
-    .orderBy(desc(contactChannels.updatedAt), desc(contactChannels.createdAt))
+    .orderBy(
+      desc(contactChannels.isPrimary),
+      desc(contactChannels.updatedAt),
+      desc(contactChannels.createdAt),
+    )
     .get();
   if (!channel) return null;
   return getContactInternal(channel.contactId);


### PR DESCRIPTION
## Summary
- `findContactByChannelExternalChatId` (`assistant/src/contacts/contact-store.ts`) is the chat-ID fallback lookup. `externalChatId` has no unique constraint, so when multiple `contact_channels` rows share `(type, externalChatId)` it relied on `ORDER BY updatedAt DESC, createdAt DESC` for a deterministic pick — but a revoked/blocked duplicate's `updatedAt` gets bumped by the revoke, so it could win over the active row (feeding e.g. `already_member`/reactivation targeting).
- Adds `isPrimary DESC` as the leading sort key (then recency). `isPrimary` is a kept identity column and the best local proxy for "the active row" now that channel ACL/status is owned by the gateway. The ACL *decision* was already gateway-correct; this only sharpens which duplicate row's id the local lookup returns.
- Display/targeting-only, assistant-only, no new IPC. (Ticket fix option 2.)
- Test: a new real-DB case asserts the primary channel wins over a more-recently-updated non-primary duplicate, and that recency still breaks ties when neither is primary. tsc clean; contacts suite 46/0.

## Original prompt
Last of the cleanly-executable contacts-ACL read-side follow-ups. JARVIS-1228: among duplicate externalChatId rows the local lookup could return a revoked/blocked duplicate over the active one. We chose the ticket's option 2 (assistant-only isPrimary-then-recency tiebreak, no gateway round-trip) since the ACL decision is already gateway-sourced and this is a low-severity targeting refinement.

Closes JARVIS-1228.