### PR TITLE
refactor(assistant): move ACP session-manager disposal out of DaemonServer

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { disposeAcpSessionManager } from "../acp/index.js";
 import { getConfig } from "../config/loader.js";
 import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
@@ -61,7 +60,6 @@ export class DaemonServer {
 
   async stop(): Promise<void> {
     getSubagentManager().disposeAll();
-    disposeAcpSessionManager();
 
     log.info("Daemon server stopped");
   }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import { disposeAcpSessionManager } from "../acp/index.js";
 import { stopCes } from "../credential-execution/ces-runtime.js";
 import { stopFilingService } from "../filing/filing-service.js";
 import { stopHeartbeatService } from "../heartbeat/heartbeat-service.js";
@@ -100,6 +101,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     await deps.server.stop();
+    disposeAcpSessionManager();
     stopConversationEvictor();
     stopConfigWatcher();
     stopAppSourceWatcher();


### PR DESCRIPTION
## Why

Continuing the bottom-up dissolution of `DaemonServer.stop()`: each subsystem that `stop()` tears down is being relocated to the daemon shutdown sequence so it manages its own lifecycle and `DaemonServer` no longer owns it.

`disposeAcpSessionManager()` was already a self-managed module singleton in `src/acp/index.ts` — it owns its own `manager` reference, creates it lazily, and nulls it on dispose. `DaemonServer.stop()` was the only caller, which is the last bit of coupling keeping ACP teardown inside the server object.

## What

- **`src/daemon/server.ts`**: removed the `disposeAcpSessionManager()` call from `stop()` and dropped the now-unused `import { disposeAcpSessionManager } from "../acp/index.js"`.
- **`src/daemon/shutdown-handlers.ts`**: added the import and the `disposeAcpSessionManager()` call immediately after `await deps.server.stop()` — the same relative position it held in the old `stop()` body, so the ordering relative to the rest of the shutdown sequence is unchanged.

This is a pure relocation; no behavior change. The ACP singleton itself is untouched.

With this change, `DaemonServer.stop()` is down to just `getSubagentManager().disposeAll()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_