### PR TITLE
feat(memory): remove procedural-memory-as-skills feature flag (ship on v3-live)

### DIFF
--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -54,13 +54,12 @@ mock.module("../plugins/defaults/memory-retrieval/injector-chain.js", () => ({
 
 // `applyRuntimeInjections` reads the v3-live gate (`config.memory.v3.live`)
 // via `isMemoryV3Live`; drive it directly through this slot per-test. The
-// import graph also pulls `isProcToSkillsActive`/`isProcToSkillsEnabled` (the
-// permission policy-context precomputes the proc-to-skills gate), so the
-// wholesale mock must expose them — keyed off the same v3-live slot, flag off.
+// import graph also pulls `isProcToSkillsActive` (the permission policy-context
+// precomputes the proc-to-skills gate), so the wholesale mock must expose it —
+// keyed off the same v3-live slot.
 let memoryV3LiveSlot = false;
 mock.module("../config/memory-v3-gate.js", () => ({
   isMemoryV3Live: () => memoryV3LiveSlot,
-  isProcToSkillsEnabled: () => false,
   isProcToSkillsActive: () => false,
 }));
 

--- a/assistant/src/config/__tests__/proc-to-skills.test.ts
+++ b/assistant/src/config/__tests__/proc-to-skills.test.ts
@@ -1,50 +1,21 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
-import {
-  isProcToSkillsActive,
-  isProcToSkillsEnabled,
-} from "../memory-v3-gate.js";
+import { isProcToSkillsActive } from "../memory-v3-gate.js";
 import type { AssistantConfig } from "../schema.js";
 
-const PROC_TO_SKILLS_FLAG = "procedural-memory-as-skills";
-
-beforeEach(() => {
-  setOverridesForTesting({});
-});
-
-afterEach(() => {
-  setOverridesForTesting({});
-});
-
-describe("isProcToSkillsEnabled", () => {
-  const config = {} as AssistantConfig;
-
-  test("returns false by default (flag off)", () => {
-    expect(isProcToSkillsEnabled(config)).toBe(false);
-  });
-
-  test("returns true when the flag is enabled", () => {
-    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
-    expect(isProcToSkillsEnabled(config)).toBe(true);
-  });
-});
-
-describe("isProcToSkillsActive (flag AND v3-live)", () => {
+describe("isProcToSkillsActive (v3-live)", () => {
   const v3Live = { memory: { v3: { live: true } } } as AssistantConfig;
   const v3NotLive = { memory: { v3: { live: false } } } as AssistantConfig;
 
-  test("false when the flag is off, even with v3 live", () => {
-    expect(isProcToSkillsActive(v3Live)).toBe(false);
-  });
-
-  test("false when the flag is on but v3 is not live", () => {
-    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
+  test("false when v3 is not live", () => {
     expect(isProcToSkillsActive(v3NotLive)).toBe(false);
   });
 
-  test("true only when the flag is on AND v3 is live", () => {
-    setOverridesForTesting({ [PROC_TO_SKILLS_FLAG]: true });
+  test("false by default (no v3 config)", () => {
+    expect(isProcToSkillsActive({} as AssistantConfig)).toBe(false);
+  });
+
+  test("true when v3 is live", () => {
     expect(isProcToSkillsActive(v3Live)).toBe(true);
   });
 });

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -13,10 +13,13 @@ export function isMemoryV3Live(config: AssistantConfig): boolean {
 /**
  * Whether procedural-memory-as-skills is ACTIVE: it is active whenever
  * memory-v3 is the live injected source. The feature is scoped to v3-live
- * assistants because the usage-prune backstop — which retires stale
- * assistant-authored skills — runs only in the v3 maintain job, and skill
- * retrieval rides the v3 lanes. Gating the whole feature (the retrospective
- * skill-authoring step and its skill-authoring permission grant) on this named
+ * assistants because skill retrieval rides the v3 lanes and the usage-prune
+ * stage lives in the v3 maintain job. That prune ships observe-first: with
+ * `memory.maintenance.skillPruneDays` at its default (`null`) it reports stale
+ * assistant-authored skills (`prunableSkills`) but deletes none — so a v3-live
+ * assistant authors skills without an automatic retirement bound until a
+ * positive `skillPruneDays` is configured. Gating the whole feature (the
+ * retrospective skill-authoring step and its permission grant) on this named
  * predicate keeps it coherently inert on non-v3 assistants.
  */
 export function isProcToSkillsActive(config: AssistantConfig): boolean {

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -1,4 +1,3 @@
-import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig } from "./schema.js";
 
 /**
@@ -12,26 +11,14 @@ export function isMemoryV3Live(config: AssistantConfig): boolean {
 }
 
 /**
- * Whether the procedural-memory-as-skills behavior is enabled. Gated by the
- * `procedural-memory-as-skills` assistant feature flag (default off). When on,
- * the retrospective background task may author and update managed skills (with
- * procedure-scoped companion files), and the observe-first usage-prune stage may
- * retire assistant-authored skills that have gone stale.
- */
-export function isProcToSkillsEnabled(config: AssistantConfig): boolean {
-  return isAssistantFeatureFlagEnabled("procedural-memory-as-skills", config);
-}
-
-/**
- * Whether procedural-memory-as-skills is ACTIVE: the flag is on AND memory-v3 is
- * the live injected source. The feature requires v3-live because the
- * usage-prune backstop — which retires stale assistant-authored skills — runs
- * only in the v3 maintain job. Enabling eager retrospective authoring without
- * that backstop would let assistant-authored skills accumulate unbounded, so
- * the feature is scoped to v3-live assistants. Gating the whole feature (the
- * retrospective skill-authoring step and its skill-authoring permission grant)
- * on this combined predicate keeps it coherently inert unless both are on.
+ * Whether procedural-memory-as-skills is ACTIVE: it is active whenever
+ * memory-v3 is the live injected source. The feature is scoped to v3-live
+ * assistants because the usage-prune backstop — which retires stale
+ * assistant-authored skills — runs only in the v3 maintain job, and skill
+ * retrieval rides the v3 lanes. Gating the whole feature (the retrospective
+ * skill-authoring step and its skill-authoring permission grant) on this named
+ * predicate keeps it coherently inert on non-v3 assistants.
  */
 export function isProcToSkillsActive(config: AssistantConfig): boolean {
-  return isProcToSkillsEnabled(config) && isMemoryV3Live(config);
+  return isMemoryV3Live(config);
 }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -261,7 +261,6 @@ mock.module("../jobs-store.js", () => ({
 let mockProcToSkillsActive = false;
 mock.module("../../config/memory-v3-gate.js", () => ({
   isProcToSkillsActive: () => mockProcToSkillsActive,
-  isProcToSkillsEnabled: () => mockProcToSkillsActive,
   isMemoryV3Live: () => mockProcToSkillsActive,
 }));
 

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -859,7 +859,7 @@ interface ForkInstructionArgs {
   /** True when this is the first retrospective pass over the source conversation. */
   isFirstPass: boolean;
   /**
-   * Whether procedural-memory-as-skills is active (flag on AND memory-v3 live).
+   * Whether procedural-memory-as-skills is active (memory-v3 live).
    * Gates the skill-authoring section of the instruction: when false the pass
    * keeps its remember-only behavior, matching the permission checker's grant
    * gate so the directives never appear when the tools would be denied anyway.

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -122,20 +122,13 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
 // driving live through `flagStates["memory-v3-live"]` (and `v3FlagOn` toggles
 // it alongside shadow for the existing on/off tests).
 const procToSkillsLive = () => flagStates["memory-v3-live"] ?? v3FlagOn;
-const procToSkillsFlagOn = () =>
-  flagStates["procedural-memory-as-skills"] ?? false;
 mock.module("../../../config/memory-v3-gate.js", () => ({
   isMemoryV3Live: () => procToSkillsLive(),
-  // Proc-to-skills is gated by the `procedural-memory-as-skills` assistant flag
-  // (default off). Drive it through `flagStates` so suites can flip it the same
-  // way they flip the other gates, while existing cases keep the default-off
-  // shape.
-  isProcToSkillsEnabled: () => procToSkillsFlagOn(),
-  // Active = flag on AND v3 live. The retrospective skill-authoring step and its
-  // skill-authoring grant gate on this combined predicate, so drive it from the
-  // same flag slots. (The v2 consolidation job itself only reads
-  // `isMemoryV3Live`; these are mocked to satisfy the module shape.)
-  isProcToSkillsActive: () => procToSkillsFlagOn() && procToSkillsLive(),
+  // Active whenever v3 is live. The retrospective skill-authoring step and its
+  // skill-authoring grant gate on this predicate. (The v2 consolidation job
+  // itself only reads `isMemoryV3Live`; this is mocked to satisfy the module
+  // shape.)
+  isProcToSkillsActive: () => procToSkillsLive(),
 }));
 
 // ── Workspace pin ───────────────────────────────────────────────────

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -42,7 +42,6 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 let mockProcToSkillsActive = true;
 mock.module("../config/memory-v3-gate.js", () => ({
   isProcToSkillsActive: () => mockProcToSkillsActive,
-  isProcToSkillsEnabled: () => mockProcToSkillsActive,
   isMemoryV3Live: () => mockProcToSkillsActive,
 }));
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -681,14 +681,14 @@ export async function classifyRisk(
 // prompt. The grant resolves these tools to ALLOW non-interactively, and ONLY
 // when all of these hold:
 //   - procedural-memory-as-skills is active (`policyContext.procToSkillsActive`,
-//     precomputed by buildPolicyContext: the flag is on AND memory-v3 is live),
+//     precomputed by buildPolicyContext: memory-v3 is live),
 //   - the turn is the retrospective background source — guardian trust, `vellum`
 //     source channel, `memory_retrospective` origin (set in
 //     memory-retrospective-job.ts).
 //
 // The grant is intentionally narrow: it matches exactly these tools AND the
-// retrospective origin under the active flag, so no interactive session, other
-// origin, or feature-off install is affected.
+// retrospective origin on a v3-live assistant, so no interactive session, other
+// origin, or non-v3-live install is affected.
 const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
 
 function isRetrospectiveSkillAuthoringGrant(

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -88,11 +88,11 @@ export interface PolicyContext {
   /** Source channel the turn arrived on (e.g. "vellum" for internal jobs). */
   sourceChannel?: string;
   /**
-   * Whether procedural-memory-as-skills is active for this assistant (the
-   * `procedural-memory-as-skills` flag is on AND memory-v3 is live). Precomputed
-   * in {@link buildPolicyContext} so the checker can gate the memory-retrospective
-   * skill-authoring auto-grant on the feature without reading config itself.
-   * Undefined/false when the feature is inactive — the grant then never fires.
+   * Whether procedural-memory-as-skills is active for this assistant (memory-v3
+   * is live). Precomputed in {@link buildPolicyContext} so the checker can gate
+   * the memory-retrospective skill-authoring auto-grant on the feature without
+   * reading config itself. Undefined/false when the feature is inactive — the
+   * grant then never fires.
    */
   procToSkillsActive?: boolean;
 }

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -371,14 +371,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "procedural-memory-as-skills",
-      "scope": "assistant",
-      "key": "procedural-memory-as-skills",
-      "label": "Procedural Memory as Skills",
-      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Requires memory-v3-live to take effect (the candidate-note routing lives only in the v3 consolidation prompt); with v3 not live the feature is inert. Off by default.",
-      "defaultEnabled": false
-    },
-    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -371,14 +371,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "procedural-memory-as-skills",
-      "scope": "assistant",
-      "key": "procedural-memory-as-skills",
-      "label": "Procedural Memory as Skills",
-      "description": "When on, consolidation routes procedures to candidate notes and procedural knowledge to skill-linked facts, and a recurrence-gated follow-up distills a recurring procedure into a managed skill. Requires memory-v3-live to take effect (the candidate-note routing lives only in the v3 consolidation prompt); with v3 not live the feature is inert. Off by default.",
-      "defaultEnabled": false
-    },
-    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",


### PR DESCRIPTION
## Summary
Removes the `procedural-memory-as-skills` feature flag and ships the feature directly: it is now active for every v3-live assistant. `isProcToSkillsActive` reduces to `isMemoryV3Live` (the prune stage runs only in the v3 maintain job, so the feature stays scoped to v3-live). Deletes the flag from the server + web flag registries and updates gate/tests/comments.

Part of plan: procedural-memory-as-skills.md