### PR TITLE
fix(slack): remove numbered prefixes from SlackSetupWizard step tabs

### DIFF
--- a/clients/web/src/domains/contacts/components/slack-setup-wizard.tsx
+++ b/clients/web/src/domains/contacts/components/slack-setup-wizard.tsx
@@ -12,10 +12,10 @@ const WIZARD_STEP_IDS = ["create-app", "app-token", "install-app", "bot-token"] 
 type WizardStepId = (typeof WIZARD_STEP_IDS)[number];
 
 const WIZARD_STEPS: StepperStep[] = [
-  { id: "create-app", label: "1. Create App" },
-  { id: "app-token", label: "2. Generate App Token" },
-  { id: "install-app", label: "3. Install App" },
-  { id: "bot-token", label: "4. Add Bot Token" },
+  { id: "create-app", label: "Create App" },
+  { id: "app-token", label: "Generate App Token" },
+  { id: "install-app", label: "Install App" },
+  { id: "bot-token", label: "Add Bot Token" },
 ];
 
 export interface SlackSetupWizardProps {


### PR DESCRIPTION
## Prompt / plan
Bug fix: the SlackSetupWizard tab labels showed numeric prefixes (`1. Create App`, `2. Generate App Token`, etc.). The tabs shouldn't be numbered. Removed the numeric prefixes from the `WIZARD_STEPS` label definitions in `clients/web/src/domains/contacts/components/slack-setup-wizard.tsx` so the labels read just "Create App", "Generate App Token", "Install App", "Add Bot Token".

## Test plan
- `bunx tsc --noEmit` / lint pass (no logic changed — labels are display-only string literals).
- Manual: open Slack setup wizard and confirm the stepper tabs render without numeric prefixes.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Ci5k7z6DiCkKXTGdHwVK1)_