### PR TITLE
feat(skills): badge assistant-authored skills as 'Assistant's Memory'

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24181,7 +24181,7 @@ paths:
           required: false
           schema:
             type: string
-          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom', 'assistant-memory').
         - name: kind
           in: query
           required: false
@@ -24474,6 +24474,60 @@ paths:
                             origin:
                               type: string
                               const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - category
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            icon:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            category:
+                              type: string
+                            owner:
+                              type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - skill
+                                    - mcp
+                                    - plugin
+                                    - workspace
+                                id:
+                                  type: string
+                              required:
+                                - kind
+                                - id
+                              additionalProperties: false
+                            origin:
+                              type: string
+                              const: assistant-memory
                           required:
                             - id
                             - name
@@ -24859,6 +24913,60 @@ paths:
                           origin:
                             type: string
                             const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - category
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          icon:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          category:
+                            type: string
+                          owner:
+                            type: object
+                            properties:
+                              kind:
+                                type: string
+                                enum:
+                                  - skill
+                                  - mcp
+                                  - plugin
+                                  - workspace
+                              id:
+                                type: string
+                            required:
+                              - kind
+                              - id
+                            additionalProperties: false
+                          origin:
+                            type: string
+                            const: assistant-memory
                         required:
                           - id
                           - name
@@ -25259,6 +25367,60 @@ paths:
                           origin:
                             type: string
                             const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - category
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          icon:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          category:
+                            type: string
+                          owner:
+                            type: object
+                            properties:
+                              kind:
+                                type: string
+                                enum:
+                                  - skill
+                                  - mcp
+                                  - plugin
+                                  - workspace
+                              id:
+                                type: string
+                            required:
+                              - kind
+                              - id
+                            additionalProperties: false
+                          origin:
+                            type: string
+                            const: assistant-memory
                         required:
                           - id
                           - name
@@ -25846,6 +26008,60 @@ paths:
                             origin:
                               type: string
                               const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - category
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            icon:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            category:
+                              type: string
+                            owner:
+                              type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - skill
+                                    - mcp
+                                    - plugin
+                                    - workspace
+                                id:
+                                  type: string
+                              required:
+                                - kind
+                                - id
+                              additionalProperties: false
+                            origin:
+                              type: string
+                              const: assistant-memory
                           required:
                             - id
                             - name

--- a/assistant/src/__tests__/slim-skill-category.test.ts
+++ b/assistant/src/__tests__/slim-skill-category.test.ts
@@ -7,9 +7,11 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
 import type { CatalogSkill } from "../skills/catalog-install.js";
+import type { SkillInstallMeta } from "../skills/install-meta.js";
 
 let mockSummaries: SkillSummary[] = [];
 let mockCachedCatalog: CatalogSkill[] = [];
+let mockInstallMeta: SkillInstallMeta | null = null;
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared before importing the module under test
@@ -44,7 +46,7 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../skills/install-meta.js", () => ({
-  readInstallMeta: () => null,
+  readInstallMeta: () => mockInstallMeta,
 }));
 
 mock.module("../skills/catalog-cache.js", () => ({
@@ -191,5 +193,35 @@ describe("listSkills — category precedence", () => {
 
     const [skill] = listSkills();
     expect(skill.category).toBe("system");
+  });
+});
+
+describe("listSkills — origin derivation", () => {
+  test("managed skill authored by the assistant reports the assistant-memory origin", () => {
+    mockSummaries = [makeSummary({ id: "retro-note", source: "managed" })];
+    mockCachedCatalog = [];
+    mockInstallMeta = {
+      origin: "custom",
+      installedAt: "2026-01-01T00:00:00.000Z",
+      author: "assistant",
+    };
+
+    const [skill] = listSkills();
+    expect(skill.origin).toBe("assistant-memory");
+    // Stays an installed (managed) skill so it remains deletable.
+    expect(skill.kind).toBe("installed");
+  });
+
+  test("managed skill without an assistant author keeps its custom origin", () => {
+    mockSummaries = [makeSummary({ id: "hand-rolled", source: "managed" })];
+    mockCachedCatalog = [];
+    mockInstallMeta = {
+      origin: "custom",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const [skill] = listSkills();
+    expect(skill.origin).toBe("custom");
+    expect(skill.kind).toBe("installed");
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -334,6 +334,10 @@ function deriveOrigin(
   // null means "already read, nothing found" — don't re-read.
   const meta =
     installMeta !== undefined ? installMeta : readInstallMeta(directoryPath);
+  // Skills authored by the assistant's retrospective report a distinct origin
+  // so the UI badges them as "Assistant's Memory". They stay managed/deletable
+  // because that is driven by `kind === "installed"`, not the origin label.
+  if (meta?.author === "assistant") return "assistant-memory";
   return meta?.origin ?? "custom";
 }
 
@@ -397,6 +401,7 @@ function toSlimSkillResponse(
       };
     }
     case "custom":
+    case "assistant-memory":
       return { ...base, origin };
   }
 }
@@ -472,6 +477,8 @@ function originDisplayLabel(origin: string): string {
       return "skills.sh";
     case "custom":
       return "Custom";
+    case "assistant-memory":
+      return "Assistant's Memory";
     default:
       return origin;
   }

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -128,11 +128,21 @@ interface CustomSlimSkill extends SlimSkillBase {
   origin: "custom";
 }
 
+/**
+ * Managed skill authored by the assistant's retrospective. Identical shape to a
+ * custom skill — it stays managed/deletable — but carries a distinct origin so
+ * the UI badges it as "Assistant's Memory" instead of "Custom".
+ */
+interface AssistantMemorySlimSkill extends SlimSkillBase {
+  origin: "assistant-memory";
+}
+
 export type SlimSkillResponse =
   | VellumSlimSkill
   | ClawhubSlimSkill
   | SkillsshSlimSkill
-  | CustomSlimSkill;
+  | CustomSlimSkill
+  | AssistantMemorySlimSkill;
 
 export interface SkillsListResponse {
   type: "skills_list_response";
@@ -220,11 +230,19 @@ interface CustomSkillDetail extends SkillDetailBase {
   owner?: OwnerInfo;
 }
 
+/** Detail counterpart of {@link AssistantMemorySlimSkill}. */
+interface AssistantMemorySkillDetail extends SkillDetailBase {
+  origin: "assistant-memory";
+  /** See {@link VellumSkillDetail.owner}. */
+  owner?: OwnerInfo;
+}
+
 export type SkillDetailResponse =
   | VellumSkillDetail
   | ClawhubSkillDetail
   | SkillsshSkillDetail
-  | CustomSkillDetail;
+  | CustomSkillDetail
+  | AssistantMemorySkillDetail;
 
 // ─── Single-file content response (HTTP API) ─────────────────────────────
 export interface SkillFileContentResponse {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -83,6 +83,12 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
     audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBaseWithOwner, origin: z.literal("custom") }),
+  // Managed skill authored by the assistant's retrospective. Same shape as
+  // custom; the distinct origin only changes how the UI badges it.
+  z.object({
+    ...slimSkillBaseWithOwner,
+    origin: z.literal("assistant-memory"),
+  }),
 ]);
 
 const skillDetailSchema = z.discriminatedUnion("origin", [
@@ -133,6 +139,10 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
     audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBaseWithOwner, origin: z.literal("custom") }),
+  z.object({
+    ...slimSkillBaseWithOwner,
+    origin: z.literal("assistant-memory"),
+  }),
 ]);
 
 // ---------------------------------------------------------------------------
@@ -163,7 +173,7 @@ export const ROUTES: RouteDefinition[] = [
         name: "origin",
         schema: { type: "string" },
         description:
-          "Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').",
+          "Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom', 'assistant-memory').",
       },
       {
         name: "kind",

--- a/clients/web/src/domains/intelligence/components/skills/skill-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-filters.tsx
@@ -1,6 +1,7 @@
 import {
     ArrowDownToLine,
     Box,
+    Brain,
     Check,
     CheckCircle,
     Filter,
@@ -44,6 +45,7 @@ const ORIGIN_FILTERS: FilterOption[] = [
   { value: "clawhub", label: "Clawhub", icon: Globe },
   { value: "skillssh", label: "skills.sh", icon: Terminal },
   { value: "custom", label: "Custom", icon: User },
+  { value: "assistant-memory", label: "Assistant's Memory", icon: Brain },
 ];
 
 interface FilterBarProps {

--- a/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
@@ -1,4 +1,4 @@
-import { Box, Globe, Puzzle, Terminal, User } from "lucide-react";
+import { Box, Brain, Globe, Puzzle, Terminal, User } from "lucide-react";
 import { createElement } from "react";
 
 import type { SkillOrigin } from "@/domains/intelligence/skills/types";
@@ -9,6 +9,7 @@ const ORIGIN_META: Record<SkillOrigin, { label: string; icon: typeof Globe }> = 
   clawhub: { label: "Clawhub", icon: Globe },
   skillssh: { label: "skills.sh", icon: Terminal },
   custom: { label: "Custom", icon: User },
+  "assistant-memory": { label: "Assistant's Memory", icon: Brain },
 };
 
 export function SkillOriginBadge({ origin }: { origin: SkillOrigin | string }) {

--- a/clients/web/src/domains/intelligence/skills/types.ts
+++ b/clients/web/src/domains/intelligence/skills/types.ts
@@ -3,7 +3,12 @@ import type {
   SkillsGetResponses,
 } from "@/generated/daemon/types.gen";
 
-export type SkillOrigin = "vellum" | "clawhub" | "skillssh" | "custom";
+export type SkillOrigin =
+  | "vellum"
+  | "clawhub"
+  | "skillssh"
+  | "custom"
+  | "assistant-memory";
 
 export type SkillKind = "bundled" | "installed" | "catalog";
 

--- a/clients/web/src/domains/intelligence/skills/utils.ts
+++ b/clients/web/src/domains/intelligence/skills/utils.ts
@@ -13,6 +13,7 @@ export function resolveFilterParams(filter: SkillFilter): {
     case "clawhub":
     case "skillssh":
     case "custom":
+    case "assistant-memory":
       return { origin: filter };
     default:
       return {};


### PR DESCRIPTION
## Summary
Skills authored by the retrospective (managed skills with install-meta author='assistant') now show an 'Assistant's Memory' origin badge instead of 'Custom'. Backend reports a distinct 'assistant-memory' origin for these; web adds the badge label/icon + filter. They remain managed/deletable.

Part of plan: procedural-memory-as-skills.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->