### PR TITLE
feat(skills): category support for scaffold_managed_skill + retrospective authoring

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -192,6 +192,18 @@ describe("buildSkillMarkdown", () => {
     expect(parsed.metadata.vellum.includes).toEqual(["child-a", "child-b"]);
   });
 
+  test("includes optional category in metadata.vellum", () => {
+    const result = buildSkillMarkdown({
+      name: "Categorized Skill",
+      description: "Has a category",
+      bodyMarkdown: "Body.",
+      category: "development",
+    });
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    const parsed = parseYaml(fmMatch![1]);
+    expect(parsed.metadata.vellum.category).toBe("development");
+  });
+
   test("omits metadata when no vellum fields provided", () => {
     const result = buildSkillMarkdown({
       name: "Solo",
@@ -199,6 +211,17 @@ describe("buildSkillMarkdown", () => {
       bodyMarkdown: "Body.",
     });
     expect(result).not.toContain("metadata:");
+  });
+
+  test("omits category when blank or whitespace-only", () => {
+    expect(
+      buildSkillMarkdown({
+        name: "Blank Category",
+        description: "Blank",
+        bodyMarkdown: "Body.",
+        category: "   ",
+      }),
+    ).not.toContain("metadata:");
   });
 
   test("omits metadata when includes is empty array and no other vellum fields", () => {
@@ -291,6 +314,41 @@ describe("createManagedSkill", () => {
     expect(result3.created).toBe(true);
     const content = readFileSync(result3.path, "utf-8");
     expect(content).toContain("Overwritten");
+  });
+
+  test("writes category to frontmatter and round-trips through catalog load", () => {
+    createManagedSkill({
+      id: "categorized-skill",
+      name: "Categorized",
+      description: "Has a category",
+      bodyMarkdown: "Body.",
+      category: "development",
+    });
+
+    const content = readFileSync(
+      join(TEST_DIR, "skills", "categorized-skill", "SKILL.md"),
+      "utf-8",
+    );
+    expect(content).toContain("category: development");
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const skill = catalog.find((s) => s.id === "categorized-skill");
+    expect(skill).toBeDefined();
+    expect(skill!.category).toBe("development");
+  });
+
+  test("leaves category unset when omitted", () => {
+    createManagedSkill({
+      id: "no-category",
+      name: "No Category",
+      description: "Uncategorized",
+      bodyMarkdown: "Body.",
+    });
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const skill = catalog.find((s) => s.id === "no-category");
+    expect(skill).toBeDefined();
+    expect(skill!.category).toBeUndefined();
   });
 
   test("rejects invalid IDs", () => {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -324,6 +324,64 @@ describe("scaffold_managed_skill tool", () => {
     expect(content).not.toContain("includes");
   });
 
+  test("passes category through to the written skill, lowercased and trimmed", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "categorized",
+        name: "Categorized",
+        description: "Has a category",
+        body_markdown: "Body.",
+        category: "  Development  ",
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const content = readFileSync(
+      join(TEST_DIR, "skills", "categorized", "SKILL.md"),
+      "utf-8",
+    );
+    expect(content).toContain("category: development");
+
+    const skill = loadSkillCatalog().find((s) => s.id === "categorized");
+    expect(skill!.category).toBe("development");
+  });
+
+  test("rejects non-string category", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "bad-category",
+        name: "Bad Category",
+        description: "Non-string category",
+        body_markdown: "Body.",
+        category: 42,
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("category must be a string");
+  });
+
+  test("omits category when not provided", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "no-category",
+        name: "No Category",
+        description: "Uncategorized",
+        body_markdown: "Body.",
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const content = readFileSync(
+      join(TEST_DIR, "skills", "no-category", "SKILL.md"),
+      "utf-8",
+    );
+    expect(content).not.toContain("category");
+  });
+
   test("rejects invalid skill_id", async () => {
     const result = await executeScaffoldManagedSkill(
       {

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -31,7 +31,7 @@
           },
           "category": {
             "type": "string",
-            "description": "Optional single lowercase category for grouping the skill in the Skills UI sidebar. Choose the best fit from: browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice. Only coin a new lowercase category if none fit."
+            "description": "Optional single lowercase category for grouping the skill in the Skills UI sidebar. Must be one of the published categories — a value outside this list shows under All with no sidebar bucket, so always pick the closest fit: browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice."
           },
           "overwrite": {
             "type": "boolean",

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -29,6 +29,10 @@
             "type": "string",
             "description": "Optional emoji icon for the skill."
           },
+          "category": {
+            "type": "string",
+            "description": "Optional single lowercase category for grouping the skill in the Skills UI sidebar. Choose the best fit from: browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice. Only coin a new lowercase category if none fit."
+          },
           "overwrite": {
             "type": "boolean",
             "description": "Whether to overwrite an existing skill with the same ID (default: false)."

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -1528,6 +1528,10 @@ describe("memoryRetrospectiveJob", () => {
     expect(instructionText).toContain("references/failure-modes.md");
     expect(instructionText).toContain("`files`");
 
+    // Category directive: pick the best-fitting canonical Skills-UI bucket.
+    expect(instructionText).toContain("`category`");
+    expect(instructionText).toContain("Skills-UI bucket");
+
     // Ownership directive: only overwrite/refine your own skills; skip
     // (don't shadow or duplicate) a match of any other source.
     expect(instructionText).toContain(

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -939,6 +939,8 @@ When you do capture a procedure:
 
 2. Capture procedure-scoped knowledge alongside the body. Failure modes, gotchas, and cached values you observed in the trace (error signatures and how you recovered, preconditions, IDs/paths/endpoints that held steady) belong in companion files passed via \`scaffold_managed_skill\`'s \`files\` input (for example \`references/failure-modes.md\`), and the SKILL.md body should reference them so a future load surfaces them.
 
+3. Set \`category\` to the single best-fitting value from browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice — only invent a new lowercase category if none fit — so the skill lands in the right Skills-UI bucket.
+
 Ordinary facts still go through \`remember\` (unlinked) exactly as above — skills are for executed, reusable procedures, not for facts.
 `;
 }

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -939,7 +939,7 @@ When you do capture a procedure:
 
 2. Capture procedure-scoped knowledge alongside the body. Failure modes, gotchas, and cached values you observed in the trace (error signatures and how you recovered, preconditions, IDs/paths/endpoints that held steady) belong in companion files passed via \`scaffold_managed_skill\`'s \`files\` input (for example \`references/failure-modes.md\`), and the SKILL.md body should reference them so a future load surfaces them.
 
-3. Set \`category\` to the single best-fitting value from browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice — only invent a new lowercase category if none fit — so the skill lands in the right Skills-UI bucket.
+3. Set \`category\` to the single closest-fitting value from this published set (a value outside it gets no Skills-UI bucket, so always pick from the list, never invent one): browsing, calendar, commerce, content, development, email, health, integrations, messaging, productivity, system, voice.
 
 Ordinary facts still go through \`remember\` (unlinked) exactly as above — skills are for executed, reusable procedures, not for facts.
 `;

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -107,6 +107,7 @@ interface BuildSkillMarkdownInput {
   bodyMarkdown: string;
   emoji?: string;
   includes?: string[];
+  category?: string;
 }
 
 export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
@@ -130,6 +131,11 @@ export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
   }
   if (input.includes && input.includes.length > 0) {
     vellum.includes = input.includes;
+  }
+  // The web Skills UI groups skills into a category sidebar by this value;
+  // skip it when blank so an empty bucket assignment never lands in frontmatter.
+  if (input.category?.trim()) {
+    vellum.category = input.category.trim();
   }
 
   if (Object.keys(vellum).length > 0) {
@@ -174,6 +180,7 @@ interface CreateManagedSkillParams {
   emoji?: string;
   overwrite?: boolean;
   includes?: string[];
+  category?: string;
   version?: string;
   contactId?: string;
   author?: "assistant" | "user";
@@ -255,6 +262,7 @@ export function createManagedSkill(
     bodyMarkdown: params.bodyMarkdown,
     emoji: params.emoji,
     includes: params.includes,
+    category: params.category,
   });
 
   mkdirSync(skillDir, { recursive: true });

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -137,6 +137,23 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  // Validate and normalize the optional category (lowercased/trimmed for
+  // consistency with the lowercase Skills-UI sidebar buckets). Blank or
+  // whitespace-only values become undefined so they never land in frontmatter.
+  let category: string | undefined;
+  if (input.category !== undefined) {
+    if (typeof input.category !== "string") {
+      return {
+        content: "Error: category must be a string",
+        isError: true,
+      };
+    }
+    const normalized = input.category.trim().toLowerCase();
+    if (normalized) {
+      category = normalized;
+    }
+  }
+
   const id = skillId.trim();
   const fromRetrospective =
     context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
@@ -194,6 +211,7 @@ export async function executeScaffoldManagedSkill(
         : undefined,
     overwrite: input.overwrite === true,
     includes,
+    category,
     files,
     author,
   });


### PR DESCRIPTION
## Summary
Adds an optional category to scaffold_managed_skill / createManagedSkill (written to metadata.vellum.category) and directs the retrospective to set the best-fitting canonical category (development, productivity, system, …) when authoring a skill — so retrospective-authored skills land in the correct Skills-UI bucket instead of being uncategorized.

Part of plan: procedural-memory-as-skills.md