### PR TITLE
refactor(jobs): extract register-job-handlers out of memory/ into a jobs/ composition root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@
 # Memory system (Sidd)
 assistant/src/memory/ @siddseethepalli
 
+# Background-job worker composition root (Sidd)
+assistant/src/jobs/ @siddseethepalli
+
 # Tool definitions and infrastructure (Sidd)
 assistant/src/tools/ @siddseethepalli
 

--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -110,7 +110,7 @@ mock.module("../persistence/db-maintenance.js", () => ({
   maybeRunDbMaintenance: () => {},
 }));
 
-import { registerMemoryJobHandlers } from "../memory/register-job-handlers.js";
+import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
 import { getMemoryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { _resetQdrantBreaker } from "../persistence/embeddings/qdrant-circuit-breaker.js";

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -23,7 +23,7 @@ import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { startCliIpcServer } from "../ipc/assistant-server.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { startSkillIpcServer } from "../ipc/skill-server.js";
-import { registerMemoryJobHandlers } from "../memory/register-job-handlers.js";
+import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
 import { sweepConceptPageFrontmatter } from "../memory/v2/frontmatter-sweep.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";

--- a/assistant/src/jobs/register-job-handlers.ts
+++ b/assistant/src/jobs/register-job-handlers.ts
@@ -2,6 +2,37 @@ import type { AssistantConfig } from "../config/types.js";
 import { buildConversationSummaryJob } from "../conversations/job-handlers/summarization.js";
 import { generateConversationStartersJob } from "../home/job-handlers/conversation-starters.js";
 import { mediaProcessingJob } from "../media/job-handlers/media-processing.js";
+import { bootstrapFromHistory } from "../memory/graph/bootstrap.js";
+import { runConsolidation } from "../memory/graph/consolidation.js";
+import { runDecayTick } from "../memory/graph/decay.js";
+import { graphExtractJob } from "../memory/graph/extraction-job.js";
+import {
+  embedGraphNodeJob,
+  embedGraphTriggerJob,
+} from "../memory/graph/graph-search.js";
+import { runNarrativeRefinement } from "../memory/graph/narrative.js";
+import { runPatternScan } from "../memory/graph/pattern-scan.js";
+import { backfillJob } from "../memory/job-handlers/backfill.js";
+import {
+  embedAttachmentJob,
+  embedMediaJob,
+  embedSegmentJob,
+  embedSummaryJob,
+} from "../memory/job-handlers/embedding.js";
+import {
+  deleteQdrantVectorsJob,
+  rebuildIndexJob,
+} from "../memory/job-handlers/index-maintenance.js";
+import { embedConceptPageJob } from "../memory/jobs/embed-concept-page.js";
+import { embedPkbFileJob } from "../memory/jobs/embed-pkb-file.js";
+import { memoryRetrospectiveJob } from "../memory/memory-retrospective-job.js";
+import {
+  memoryV2ActivationRecomputeJob,
+  memoryV2MigrateJob,
+  memoryV2ReembedJob,
+} from "../memory/v2/backfill-jobs.js";
+import { memoryV2ConsolidateJob } from "../memory/v2/consolidation-job.js";
+import { memoryV2SweepJob } from "../memory/v2/sweep-job.js";
 import {
   pruneOldConversationsJob,
   pruneOldLlmRequestLogsJob,
@@ -12,37 +43,6 @@ import { registerJobHandler } from "../persistence/jobs-worker.js";
 import { maintainJob as memoryV3MaintainJob } from "../plugins/defaults/memory/v3/maintain-job.js";
 import { conversationAnalyzeJob } from "../runtime/services/conversation-analyze-job.js";
 import { getLogger } from "../util/logger.js";
-import { bootstrapFromHistory } from "./graph/bootstrap.js";
-import { runConsolidation } from "./graph/consolidation.js";
-import { runDecayTick } from "./graph/decay.js";
-import { graphExtractJob } from "./graph/extraction-job.js";
-import {
-  embedGraphNodeJob,
-  embedGraphTriggerJob,
-} from "./graph/graph-search.js";
-import { runNarrativeRefinement } from "./graph/narrative.js";
-import { runPatternScan } from "./graph/pattern-scan.js";
-import { backfillJob } from "./job-handlers/backfill.js";
-import {
-  embedAttachmentJob,
-  embedMediaJob,
-  embedSegmentJob,
-  embedSummaryJob,
-} from "./job-handlers/embedding.js";
-import {
-  deleteQdrantVectorsJob,
-  rebuildIndexJob,
-} from "./job-handlers/index-maintenance.js";
-import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
-import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
-import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
-import {
-  memoryV2ActivationRecomputeJob,
-  memoryV2MigrateJob,
-  memoryV2ReembedJob,
-} from "./v2/backfill-jobs.js";
-import { memoryV2ConsolidateJob } from "./v2/consolidation-job.js";
-import { memoryV2SweepJob } from "./v2/sweep-job.js";
 
 const log = getLogger("memory-jobs-worker");
 

--- a/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
@@ -67,13 +67,13 @@ const tmpWorkspace = mkdtempSync(
 const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
 process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
 
+import { registerMemoryJobHandlers } from "../../jobs/register-job-handlers.js";
 import { getMemoryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { _resetQdrantBreaker } from "../../persistence/embeddings/qdrant-circuit-breaker.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { runMemoryJobsOnce } from "../../persistence/jobs-worker.js";
 import { memoryJobs } from "../../persistence/schema/index.js";
-import { registerMemoryJobHandlers } from "../register-job-handlers.js";
 
 describe("graph_trigger_embed under memory v2", () => {
   beforeAll(async () => {

--- a/assistant/src/memory/worker.ts
+++ b/assistant/src/memory/worker.ts
@@ -13,10 +13,10 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 
 import { getConfig } from "../config/loader.js";
+import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
 import { startInProcessMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryWorkerPidPath } from "../util/platform.js";
-import { registerMemoryJobHandlers } from "./register-job-handlers.js";
 
 const log = getLogger("memory-worker-process");
 


### PR DESCRIPTION
## Summary
Extract the cross-domain job-handler registry (`register-job-handlers.ts`) out of `assistant/src/memory/` into a new `assistant/src/jobs/` composition root. Pure move + import repoint — **behavior byte-identical** (git tracks it as an 87% rename; `registerMemoryJobHandlers()` call sites unchanged).

## Why
`register-job-handlers.ts` is the assistant's **general** background-job wiring: it imports handlers from `conversations/`, `home/`, `media/`, `persistence/`, `runtime/`, `plugins/` **and** `memory/`. It is not memory-feature code — it just lived in `memory/` for historical reasons. It cannot stay inside `memory/` when memory becomes a plugin, because the plugin rule is "import only its own files + `@vellumai/plugin-api`," and a cross-domain composition root violates that. Moving it to a neutral `jobs/` composition root (which is *allowed* to import across domains) unblocks the eventual memory→plugin relocation.

Part of the memory-as-a-plugin effort (Track 2, step 2). Verified against the Track-2 escaping-imports inventory.

## Scope (deliberately narrow)
- **Only `register-job-handlers.ts` moves.** Its intra-`memory/` handler imports (`./graph/*`, `./job-handlers/*`, `./jobs/*`, `./v2/*`, `./memory-retrospective-job`) become `../memory/*`; cross-domain imports were already `../<domain>/` and are unchanged.
- **`worker.ts` stays in `memory/`** with a one-line import fix (`./register-job-handlers.js` → `../jobs/register-job-handlers.js`). Its relocation is deferred to a follow-up: moving the worker entry changes its *diagnostic `/ps` process name* (`memory-worker` → `jobs-worker`, since the name is derived from the script path) and is entangled with the legacy `memory-worker` identity surface (PID file `memory-worker.pid`, HTTP routes `memory/worker/*`). That rename deserves its own behavior-compat PR, not a side effect of a file move.

## Changed
- `git mv memory/register-job-handlers.ts → jobs/register-job-handlers.ts` (+ intra-memory import rewrites).
- Import repoints: `daemon/lifecycle.ts`, `memory/worker.ts`, and two tests.
- `.github/CODEOWNERS`: `assistant/src/jobs/ @siddseethepalli` (preserves ownership — the file was under the Sidd-owned `memory/`).

## Verification
`typecheck:fast` + `lint` + `lint:unused` + `prettier` clean; the two registration tests (`memory/__tests__/jobs-worker-v2-graph-trigger-embed`, `__tests__/memory-jobs-worker-lanes`) pass. No `@vellumai/plugin-api` changes.