### PR TITLE
test(web): add chat transcript Storybook stories (+ drop dead pagination field)

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -223,7 +223,6 @@ const INITIAL_PAGINATION: Omit<TranscriptPaginationState, "items"> = {
   hasMore: false,
   oldestTimestamp: null,
   isLoadingOlder: false,
-  isPinnedToLatest: true,
 };
 
 function initialState(): ChatSessionState {

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -194,7 +194,6 @@ export function useConversationHistory({
       hasMore: pagination.hasMore,
       oldestTimestamp: pagination.oldestLoadedTimestamp,
       isLoadingOlder: pagination.isFetchingOlderPages,
-      isPinnedToLatest: true,
     });
 
     recordDiagnostic("history_tq_data_apply", {

--- a/clients/web/src/domains/chat/transcript/transcript.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.stories.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useTurnStore } from "@/domains/chat/turn-store";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+import { Transcript, type TranscriptHandle, type TranscriptProps } from "./transcript";
+import type { MessageItem, TranscriptItem } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+//
+// `Transcript` takes a flat `TranscriptItem[]`. A text row is a `MessageItem`
+// wrapping a `DisplayMessage` whose body is three positional arrays kept in
+// lockstep — `textSegments`, `contentOrder`, `contentBlocks` — exactly the
+// shape the ingest boundary materializes for a single text block (the canonical
+// builder is `textBody` in `utils/message-test-helpers.ts`). `message()` is the
+// thin local builder for that shape; `user`/`assistant` name the role.
+// ---------------------------------------------------------------------------
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): MessageItem {
+  const msg: DisplayMessage = {
+    id,
+    role,
+    textSegments: [text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text }],
+  };
+  return { kind: "message", key: id, message: msg };
+}
+const user = (id: string, text: string) => message(id, "user", text);
+const assistant = (id: string, text: string) => message(id, "assistant", text);
+
+const CONVERSATION: TranscriptItem[] = [
+  user("u1", "How do I set up the project locally?"),
+  assistant(
+    "a1",
+    "Clone the repo, run `bun install`, then `bun run dev`. The web client lives in `clients/web` and proxies API calls to the local gateway.",
+  ),
+  user("u2", "What runs in CI on a pull request?"),
+  assistant(
+    "a2",
+    "Three required checks: **Lint**, **Type Check**, and the isolated **Test** runner. Each test file runs in its own subprocess so `mock.module` can't leak between files.",
+  ),
+  user("u3", "How do feature flags work here?"),
+  assistant(
+    "a3",
+    "Flags live in `meta/feature-flags/feature-flag-registry.json` with a matching kebab-case `id` and `key`. A gate function delegates to the resolver; undeclared flags fail closed.",
+  ),
+];
+
+// Enough turns to overflow the viewport so the transcript scrolls.
+const LONG_HISTORY: TranscriptItem[] = Array.from({ length: 24 }, (_, i) => [
+  user(`lu${i}`, `Question ${i + 1}: can you explain part ${i + 1}?`),
+  assistant(
+    `la${i}`,
+    `Answer ${i + 1}. ${"Here is a paragraph that wraps over a couple of lines to give the row some height. ".repeat(2)}`,
+  ),
+]).flat();
+
+// A simple gradient avatar via the real ChatAvatar (production mounts one at
+// the bottom of the latest turn through `renderAvatar`).
+const AVATAR_URL =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='56' height='56'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%237c5cff'/><stop offset='1' stop-color='%23e83f5b'/></linearGradient></defs><rect width='56' height='56' rx='28' fill='url(%23g)'/></svg>`,
+  );
+const renderAvatar = () => (
+  <ChatAvatar
+    components={null}
+    traits={null}
+    customImageUrl={AVATAR_URL}
+    size={48}
+  />
+);
+
+/** A sized chat surface; `Transcript` fills its `h-full` parent. */
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 720,
+        width: 780,
+        overflow: "hidden",
+        borderRadius: 12,
+        border: "1px solid var(--border-base)",
+        background: "var(--surface-base)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Renders the transcript scrolled to the latest message on mount — the resting
+ *  state production lands in when a conversation opens. Isolated from the parent
+ *  scroll coordinator, the bare component would otherwise open at the top. */
+function TranscriptAtLatest(props: TranscriptProps) {
+  const ref = useRef<TranscriptHandle>(null);
+  useLayoutEffect(() => {
+    ref.current?.scrollToLatest({ behavior: "auto" });
+  }, []);
+  return <Transcript ref={ref} {...props} />;
+}
+
+const meta: Meta<typeof Transcript> = {
+  title: "Chat/Transcript",
+  component: Transcript,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "The scrollable chat transcript. It renders a flat `TranscriptItem[]` " +
+          "as a column (oldest first, latest at the bottom) and pins the most " +
+          "recent user message to the top of the viewport while its answer " +
+          "streams into the space below.",
+      },
+    },
+  },
+  args: {
+    conversationId: "demo",
+    onSurfaceAction: () => {},
+    renderAvatar,
+  },
+  decorators: [
+    (Story) => (
+      <Frame>
+        <Story />
+      </Frame>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof Transcript>;
+
+/** A settled conversation, opened at the latest message. */
+export const Conversation: Story = {
+  args: { items: CONVERSATION },
+  render: (args) => <TranscriptAtLatest {...args} />,
+};
+
+/** No messages yet — a fresh conversation renders an empty transcript. */
+export const Empty: Story = {
+  args: { items: [] },
+};
+
+/** A long history that overflows the viewport — opens at the latest turn;
+ *  scroll up to page back through earlier ones. */
+export const LongHistory: Story = {
+  args: { items: LONG_HISTORY },
+  render: (args) => <TranscriptAtLatest {...args} />,
+};
+
+/**
+ * A live turn: the user's question pins to the top of the viewport and the
+ * answer streams into the reserved space below it, one growing assistant bubble
+ * — read long answers top-down, like Claude.ai. The story is self-contained: it
+ * drives the turn store into its `streaming` phase (so the live row shows its
+ * streaming state) and feeds the answer in word by word, returning to `idle`
+ * when it finishes.
+ */
+export const Streaming: Story = {
+  parameters: { controls: { disable: true } },
+  render: function StreamingStory(args) {
+    const ref = useRef<TranscriptHandle>(null);
+    const [answer, setAnswer] = useState("");
+
+    // Land the question at the viewport top once it's mounted. Its min-height
+    // reserve (owned by `Transcript`) makes room below, so scrolling to the
+    // latest message pins the question up and the answer streams into the
+    // reserved space beneath it. rAF lets the reserve settle before we scroll.
+    useLayoutEffect(() => {
+      const raf = requestAnimationFrame(() =>
+        ref.current?.scrollToLatest({ behavior: "auto" }),
+      );
+      return () => cancelAnimationFrame(raf);
+    }, []);
+
+    useEffect(() => {
+      useTurnStore.setState({ phase: "streaming" });
+      const full =
+        "Sure — here's the end-to-end flow. On every PR, CI runs lint, " +
+        "type-check, and the isolated test runner. Merging to `main` triggers " +
+        "the release workflow via GitHub Actions, which builds the web client " +
+        "and the desktop artifacts, uploads them, and tags the version. " +
+        "Feature-flagged work stays dark until the flag is flipped on the " +
+        "platform, and the rollout is reverted by toggling that same flag.";
+      const words = full.split(" ");
+      let count = 0;
+      const id = setInterval(() => {
+        count += 1;
+        setAnswer(words.slice(0, count).join(" "));
+        if (count >= words.length) {
+          clearInterval(id);
+          useTurnStore.setState({ phase: "idle" });
+        }
+      }, 90);
+      return () => {
+        clearInterval(id);
+        useTurnStore.setState({ phase: "idle" });
+      };
+    }, []);
+
+    const items: TranscriptItem[] = [
+      ...CONVERSATION,
+      user("uq", "Walk me through the whole release flow, in detail."),
+      ...(answer ? [assistant("a-stream", answer)] : []),
+    ];
+
+    return <Transcript ref={ref} {...args} items={items} />;
+  },
+};

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -117,5 +117,4 @@ export interface TranscriptPaginationState {
   hasMore: boolean;
   oldestTimestamp: number | null;
   isLoadingOlder: boolean;
-  isPinnedToLatest: boolean;
 }


### PR DESCRIPTION
Two independent, low-risk pieces carved out of the transcript-virtualization exploration (#36217) — worth keeping on their own regardless of whether that refactor lands. Both are off `main` and touch no production render path.

## Storybook stories for `Transcript`

A proper CSF3 story file that renders the **real** `Transcript` component against mocked `TranscriptItem[]` data (no harness shims). Fixtures use the production text-block `DisplayMessage` shape — the lockstep `textSegments` / `contentOrder` / `contentBlocks` the ingest boundary materializes (mirrors `textBody` in `message-test-helpers.ts`).

Stories:
- **Conversation** — a settled conversation, opened at the latest message.
- **Empty** — a fresh conversation renders nothing.
- **LongHistory** — overflows the viewport; opens at the latest turn, scroll up to page back through history.
- **Streaming** — a live turn: the question pins to the top of the viewport while the answer streams word-by-word into the reserved space below it (the read-top-down UX), driving the turn store's `streaming` phase so the live row shows its streaming state.

Settled stories open at the latest message via the component's `scrollToLatest` handle, matching how a conversation opens in production (the bare component, isolated from the parent scroll coordinator, would otherwise open at the top).

## Remove dead `isPinnedToLatest` pagination field

**Dead code.** `TranscriptPaginationState.isPinnedToLatest` is write-only — set to `true` in `INITIAL_PAGINATION` and on every history apply, but never read.

Verified against the repo's full git history (the clone was shallow; deepened to ~5.7k commits to confirm): the field was declared write-only in the original platform→monorepo port (#31101) and has **never** had a reader in this repo. Every `isPinnedToLatest` *read* that has ever existed belonged to the scroll hook's separate internal `useState` — exposed via `latestRef`/`scrollCoordinator`, and removed during the deprecated-scroll cleanup (#32139, #32374, #32399) — not this store field. The debug snapshot's `isPinnedToLatest` is likewise a distinct field, derived from `classification.isPinned`. Dropped the field and its two writes.

## Verification

- Dead-code removal verified across the full git history: no read of the store field exists in any commit (`git log -G "(transcriptPagination|pagination)\.isPinnedToLatest"` is empty), back to the original port #31101.
- `tsc --noEmit` clean on all touched files (the repo's pre-existing `@vellumai/assistant-api` codegen errors are unrelated and present identically on `main`).
- `eslint` clean.
- `bun test` green: `debug-api.test.ts` (54 pass), `transcript.test.tsx` (15 pass).
- Storybook: all four stories verified rendering faithfully in a real browser, including the streaming pin-to-top behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HrngnXzqnk4rUSuyKBVvg