### PR TITLE
refactor(assistant): dissolve DaemonServer.stop() and drop its shutdown dependency

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1185,7 +1185,7 @@ export async function runDaemon(): Promise<void> {
   // (see `maybeEnqueueGraphMaintenanceJobs`).
   startFilingService();
 
-  installShutdownHandlers({ server });
+  installShutdownHandlers();
 
   // The critical startup await-chain has completed and the daemon can serve
   // requests, so latch readiness before logging "Daemon started". Any fatal

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,7 +6,6 @@ import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
-import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 import { Conversation } from "./conversation.js";
@@ -56,12 +55,6 @@ export class DaemonServer {
     this.syncIdentityToPlatform();
 
     log.info("DaemonServer started (HTTP-only mode)");
-  }
-
-  async stop(): Promise<void> {
-    getSubagentManager().disposeAll();
-
-    log.info("Daemon server stopped");
   }
 
   // ── Conversation management ──────────────────────────────────────────────

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -14,6 +14,7 @@ import { stopMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { stopMemoryWorkerProcess } from "../persistence/worker-control.js";
 import { stopRuntimeHttpServer } from "../runtime/http-server.js";
 import { stopScheduler } from "../schedule/scheduler.js";
+import { getSubagentManager } from "../subagent/index.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
@@ -31,7 +32,6 @@ import { cleanupPidFile } from "./daemon-control.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
 import { stopOrphanReaper } from "./orphan-reaper.js";
-import type { DaemonServer } from "./server.js";
 import { runShutdownHooks } from "./shutdown-registry.js";
 
 const log = getLogger("lifecycle");
@@ -49,11 +49,7 @@ function stopBackgroundServicesAndCleanupPidFile(): void {
   cleanupPidFile();
 }
 
-export interface ShutdownDeps {
-  server: DaemonServer;
-}
-
-export function installShutdownHandlers(deps: ShutdownDeps): void {
+export function installShutdownHandlers(): void {
   let shuttingDown = false;
   let exitCode = 0;
 
@@ -100,7 +96,8 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       log.warn({ err, phase: "pre_stop" }, "Shutdown workspace commit failed");
     }
 
-    await deps.server.stop();
+    // Abort all running subagents and tear down conversation-related state.
+    getSubagentManager().disposeAll();
     disposeAcpSessionManager();
     stopConversationEvictor();
     stopConfigWatcher();
@@ -110,8 +107,9 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     stopConversations();
     await stopCes();
 
-    // Final commit sweep: catch any writes that occurred during server.stop()
-    // (e.g. in-flight tool executions completing during drain).
+    // Final commit sweep: catch any writes that occurred during the
+    // subagent/conversation teardown (e.g. in-flight tool executions
+    // completing during drain).
     try {
       log.info({ phase: "post_stop" }, "Final workspace commit sweep");
       await commitAllPendingWorkspaceChanges();


### PR DESCRIPTION
## Why

This is the last step of the bottom-up dissolution of `DaemonServer.stop()`. Each subsystem `stop()` tore down has been relocated to the daemon shutdown sequence; after the ACP change merged, `stop()` was down to a single line:

```ts
async stop(): Promise<void> {
  getSubagentManager().disposeAll();
  log.info("Daemon server stopped");
}
```

That last call belongs in the shutdown sequence like everything else around it, and once it moves there `installShutdownHandlers` no longer has any reason to take a `DaemonServer`.

## What

- **`src/daemon/shutdown-handlers.ts`**: replaced `await deps.server.stop()` with `getSubagentManager().disposeAll()` (same relative position — immediately before `disposeAcpSessionManager()`). Removed the `ShutdownDeps` interface, the `{ server }` parameter, and the now-unused `DaemonServer` type import. `installShutdownHandlers()` now takes no arguments.
- **`src/daemon/server.ts`**: deleted the `stop()` method and the now-unused `getSubagentManager` import.
- **`src/daemon/lifecycle.ts`**: `installShutdownHandlers({ server })` → `installShutdownHandlers()`. The `server` instance is still constructed and used for HTTP request handling (`getConversationForMessages`) and `broadcastStatus()` — only its shutdown coupling is gone.

No behavior change: subagent disposal still runs at the same point in the shutdown order. This just removes the last bit of lifecycle responsibility from the `DaemonServer` object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_