### PR TITLE
refactor(ces): share temporary grants for the process lifetime (multi-client PR 2)

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -122,7 +122,7 @@ function buildHandlers(
   apiKeyRef: ApiKeyRef,
   assistantIdRef: AssistantIdRef,
   secureKeyBackend: SecureKeyBackend,
-): { handlers: RpcHandlerRegistry; temporaryGrantStore: TemporaryGrantStore } {
+): RpcHandlerRegistry {
   // -- Grant stores ----------------------------------------------------------
   const persistentGrantStore = new PersistentGrantStore(
     getCesGrantsDir("managed"),
@@ -411,7 +411,7 @@ function buildHandlers(
     return { results };
   }) as (typeof handlers)[string];
 
-  return { handlers, temporaryGrantStore };
+  return handlers;
 }
 
 // ---------------------------------------------------------------------------
@@ -668,10 +668,12 @@ async function main(): Promise<void> {
   // `unregister` miss a tool registered in an earlier session and orphan its
   // bundle.
   //
-  // The in-memory temporary-grant store is the exception: `allow_once` /
-  // `allow_10m` grants are keyed by proposal hash only (not session), so they
-  // would otherwise leak ephemeral approvals across sessions. It is cleared at
-  // the end of every session below so a reconnecting assistant must re-prompt.
+  // The in-memory temporary-grant store is also process-scoped, and (unlike
+  // before) is NOT cleared between sessions: ephemeral approvals are shared
+  // across all of a daemon's connections for the process lifetime. Its own
+  // semantics keep this safe — `allow_once` is consumed on first use,
+  // `allow_10m` expires by wall-clock TTL, `allow_conversation` is cleared when
+  // its conversation ends (see the serve loop below).
   //
   // The mutable refs carry the handshake-provided API key and assistant ID;
   // handlers read them at call time. These don't vary across a daemon's
@@ -680,7 +682,7 @@ async function main(): Promise<void> {
   // at call time for audit attribution).
   const apiKeyRef: ApiKeyRef = { current: "" };
   const assistantIdRef: AssistantIdRef = { current: "" };
-  const { handlers, temporaryGrantStore } = buildHandlers(
+  const handlers = buildHandlers(
     apiKeyRef,
     assistantIdRef,
     secureKeyBackend,
@@ -780,14 +782,16 @@ async function main(): Promise<void> {
 
     rpcConnected = false;
 
-    // Drop all ephemeral approvals when the session ends. `allow_once` /
-    // `allow_10m` grants are keyed by proposal hash only, so reusing the
-    // store across a reconnect would let a pre-disconnect approval be
-    // consumed by a later session without re-prompting. Clearing here
-    // restores the prior behavior, where the process exited on stream end
-    // and these grants never survived.
-    temporaryGrantStore.clear();
-
+    // Temporary grants are process-shared: they are NOT cleared when a session
+    // ends. CES is moving to a model where the assistant daemon's multiple
+    // processes each hold their own connection, so an ephemeral approval
+    // (`allow_once` / `allow_10m` / `allow_conversation`) granted on one
+    // connection must remain usable by the others rather than being scoped to a
+    // single session. The store's own semantics keep this safe across a
+    // reconnect: `allow_once` is consumed on first use, `allow_10m` is bounded
+    // by its wall-clock TTL, and `allow_conversation` is cleared when its
+    // conversation ends.
+    //
     // A signal-driven end means the process is shutting down; exit the loop.
     // Any other end reason (the assistant disconnected, its stream closed,
     // or the transport errored) means we keep the sidecar up and await a


### PR DESCRIPTION
## Why

**PR 2 of the multi-client series** (follows #36472).

The managed serve loop cleared the in-memory temporary-grant store on every session end (`temporaryGrantStore.clear()`), which scoped ephemeral approvals — `allow_once` / `allow_10m` / `allow_conversation` — to a single connection. As CES moves toward a multiprocess assistant daemon where each process holds its own connection, an approval granted on one connection must remain usable by the others. Per the agreed design decision, temporary grants are now **process-shared**: the store is no longer cleared between sessions.

## Why this is safe across a reconnect

The store's own semantics already bound each grant correctly, so dropping the per-session clear doesn't widen approval scope in time:

- `allow_once` — consumed (deleted) on first use.
- `allow_10m` — bounded by its wall-clock TTL; expired entries are purged on read.
- `allow_conversation` — cleared when its conversation ends (`clearConversation`).

The store is already a single process-global instance reused across reconnects (built once in `buildHandlers`), so this PR only removes the per-session `clear()` and updates the surrounding comments. `buildHandlers` no longer needs to return the store handle (the `clear()` was its only caller-side use), so it returns the registry directly.

## Trade-off

An `allow_10m` (or unused `allow_once`) granted just before a disconnect now survives a reconnect within its lifetime instead of forcing a re-prompt. This is the intended consequence of making approvals connection-independent; `allow_10m` remains TTL-bounded and `allow_once` remains single-use.

## Testing

- `tsc` clean, `eslint` clean.
- `bun test src/`: **566 pass, 2 fail** — the two failures (`managed-integration`, `managed-reconnect`) fail at `socket.listen()` (`Failed to listen at ::`), a sandbox networking limitation that reproduces identically on `main`; not affected by this change.

## Not in this PR

The tool-registry register/unregister path has a narrow, currently-latent race (the "still in use?" check + bundle delete) that only becomes reachable once multiple connections can interleave calls. Since its callbacks are synchronous today, I'll harden it in its own small PR before the multi-connection accept loop lands, rather than bundle speculative locking here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThtowSBkUHK91W6v2xASsR)_