### PR TITLE
refactor(assistant): address DaemonServer dissolution review feedback

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -390,6 +390,20 @@ mock.module("../providers/registry.js", () => {
   };
 });
 
+// The voice bridge resolves conversations through conversation-store; tests
+// supply a fake conversation by setting `relayConversationFactory`.
+let relayConversationFactory: ((conversationId: string) => unknown) | null =
+  null;
+
+mock.module("../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async (conversationId: string) => {
+    if (!relayConversationFactory) {
+      throw new Error("relayConversationFactory not set for test");
+    }
+    return relayConversationFactory(conversationId);
+  },
+}));
+
 // ── Import source modules after all mocks ────────────────────────────
 
 import {
@@ -629,25 +643,77 @@ describe("relay-server", () => {
     mockTtsSupportsStreaming = false;
     mockTtsSynthesizeStream = null;
     mockTtsSynthesize = null;
-    setVoiceBridgeDeps({
-      getOrCreateConversation: async (conversationId) => {
-        const session = {
-          callSessionId: undefined as string | undefined,
-          currentRequestId: undefined as string | undefined,
-          memoryPolicy: {
-            scopeId: "default",
-            includeDefaultFallback: false,
+    relayConversationFactory = async (conversationId) => {
+      const session = {
+        callSessionId: undefined as string | undefined,
+        currentRequestId: undefined as string | undefined,
+        memoryPolicy: {
+          scopeId: "default",
+          includeDefaultFallback: false,
+        },
+        isProcessing: () => false,
+        persistUserMessage: async (options: {
+          content: string;
+          requestId?: string;
+        }) => {
+          session.currentRequestId = options.requestId;
+          const message = await addMessage(
+            conversationId,
+            "user",
+            JSON.stringify([{ type: "text", text: options.content }]),
+            {
+              metadata: {
+                userMessageChannel: "phone",
+                assistantMessageChannel: "phone",
+                userMessageInterface: "phone",
+                assistantMessageInterface: "phone",
+              },
+            },
+          );
+          return { id: message.id, deduplicated: false };
+        },
+        setChannelCapabilities: () => {},
+        setAssistantId: () => {},
+        setTrustContext: () => {},
+        setCommandIntent: () => {},
+        setTurnChannelContext: () => {},
+        setVoiceCallControlPrompt: () => {},
+        updateClient: () => {},
+        handleConfirmationResponse: () => {},
+        handleSecretResponse: () => {},
+        abort: () => {},
+        runAgentLoop: async (
+          _content: string,
+          _messageId: string,
+          options?: {
+            onEvent?: (event: {
+              type: string;
+              conversationId?: string;
+              text?: string;
+            }) => void;
           },
-          isProcessing: () => false,
-          persistUserMessage: async (options: {
-            content: string;
-            requestId?: string;
-          }) => {
-            session.currentRequestId = options.requestId;
-            const message = await addMessage(
+        ) => {
+          const onEvent = options?.onEvent ?? (() => {});
+          const tokens: string[] = [];
+          await mockSendMessage([], [], "", {
+            onEvent: (event: { type: string; text?: string }) => {
+              if (event.type !== "text_delta" || typeof event.text !== "string")
+                return;
+              tokens.push(event.text);
+              onEvent({
+                type: "assistant_text_delta",
+                conversationId: conversationId,
+                text: event.text,
+              });
+            },
+          });
+
+          const fullText = tokens.join("");
+          if (fullText.length > 0) {
+            await addMessage(
               conversationId,
-              "user",
-              JSON.stringify([{ type: "text", text: options.content }]),
+              "assistant",
+              JSON.stringify([{ type: "text", text: fullText }]),
               {
                 metadata: {
                   userMessageChannel: "phone",
@@ -657,72 +723,17 @@ describe("relay-server", () => {
                 },
               },
             );
-            return { id: message.id, deduplicated: false };
-          },
-          setChannelCapabilities: () => {},
-          setAssistantId: () => {},
-          setTrustContext: () => {},
-          setCommandIntent: () => {},
-          setTurnChannelContext: () => {},
-          setVoiceCallControlPrompt: () => {},
-          updateClient: () => {},
-          handleConfirmationResponse: () => {},
-          handleSecretResponse: () => {},
-          abort: () => {},
-          runAgentLoop: async (
-            _content: string,
-            _messageId: string,
-            options?: {
-              onEvent?: (event: {
-                type: string;
-                conversationId?: string;
-                text?: string;
-              }) => void;
-            },
-          ) => {
-            const onEvent = options?.onEvent ?? (() => {});
-            const tokens: string[] = [];
-            await mockSendMessage([], [], "", {
-              onEvent: (event: { type: string; text?: string }) => {
-                if (
-                  event.type !== "text_delta" ||
-                  typeof event.text !== "string"
-                )
-                  return;
-                tokens.push(event.text);
-                onEvent({
-                  type: "assistant_text_delta",
-                  conversationId: conversationId,
-                  text: event.text,
-                });
-              },
-            });
+          }
 
-            const fullText = tokens.join("");
-            if (fullText.length > 0) {
-              await addMessage(
-                conversationId,
-                "assistant",
-                JSON.stringify([{ type: "text", text: fullText }]),
-                {
-                  metadata: {
-                    userMessageChannel: "phone",
-                    assistantMessageChannel: "phone",
-                    userMessageInterface: "phone",
-                    assistantMessageInterface: "phone",
-                  },
-                },
-              );
-            }
-
-            onEvent({
-              type: "message_complete",
-              conversationId: conversationId,
-            });
-          },
-        };
-        return session as unknown as import("../daemon/conversation.js").Conversation;
-      },
+          onEvent({
+            type: "message_complete",
+            conversationId: conversationId,
+          });
+        },
+      };
+      return session as unknown as import("../daemon/conversation.js").Conversation;
+    };
+    setVoiceBridgeDeps({
       resolveAttachments: () => [],
     });
   });

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -73,6 +73,19 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   }),
 }));
 
+// ── Conversation store mock (voice bridge resolves conversations here) ──
+
+let scopedGrantConversationFactory: (() => unknown) | null = null;
+
+mock.module("../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async () => {
+    if (!scopedGrantConversationFactory) {
+      throw new Error("scopedGrantConversationFactory not set for test");
+    }
+    return scopedGrantConversationFactory();
+  },
+}));
+
 // ── Import source modules after all mocks are registered ────────────
 
 import { and, eq } from "drizzle-orm";
@@ -190,13 +203,8 @@ function createMockSession(opts?: {
 function setupBridgeDeps(
   sessionFactory: () => ReturnType<typeof createMockSession>["session"],
 ) {
-  let currentSession: ReturnType<typeof createMockSession>["session"] | null =
-    null;
+  scopedGrantConversationFactory = () => sessionFactory();
   setVoiceBridgeDeps({
-    getOrCreateConversation: async () => {
-      currentSession = sessionFactory();
-      return currentSession as any;
-    },
     resolveAttachments: () => [],
   });
 }

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -34,6 +34,17 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => mockedConfig,
 }));
 
+let voiceConversationFactory: (() => Conversation) | null = null;
+
+mock.module("../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async () => {
+    if (!voiceConversationFactory) {
+      throw new Error("voiceConversationFactory not set for test");
+    }
+    return voiceConversationFactory();
+  },
+}));
+
 import {
   setVoiceBridgeDeps,
   startVoiceTurn,
@@ -168,8 +179,8 @@ function parsePersistedMetadata(
  * Helper to inject voice bridge deps with a given conversation factory.
  */
 function injectDeps(conversationFactory: () => Conversation): void {
+  voiceConversationFactory = conversationFactory;
   setVoiceBridgeDeps({
-    getOrCreateConversation: async () => conversationFactory(),
     resolveAttachments: () => [],
   });
 }
@@ -499,7 +510,6 @@ describe("voice-session-bridge", () => {
       },
     ];
 
-    let capturedTransport: { channelId: string } | undefined;
     let capturedVoiceSessionId: string | undefined;
     const capturedPrompts: Array<string | null> = [];
     const session = makePersistingStreamingSession(conversation.id, events);
@@ -507,11 +517,8 @@ describe("voice-session-bridge", () => {
       capturedPrompts.push(prompt);
     };
 
+    voiceConversationFactory = () => session;
     setVoiceBridgeDeps({
-      getOrCreateConversation: async (_conversationId, transport) => {
-        capturedTransport = transport;
-        return session;
-      },
       resolveAttachments: () => [],
     });
 
@@ -546,7 +553,6 @@ describe("voice-session-bridge", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(capturedTransport).toEqual({ channelId: "vellum" });
     expect(capturedVoiceSessionId).toBe("local-live-voice-session-1");
     expect(capturedPrompts[0]).toBe(
       "You are speaking in a local live voice session. Keep replies brief and conversational.",

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -18,8 +18,8 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
-import type { Conversation } from "../daemon/conversation.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
+import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -40,14 +40,6 @@ const log = getLogger("voice-session-bridge");
 // ---------------------------------------------------------------------------
 
 export interface VoiceBridgeDeps {
-  getOrCreateConversation: (
-    conversationId: string,
-    transport?: {
-      channelId: ChannelId;
-      hints?: string[];
-      uxBrief?: string;
-    },
-  ) => Promise<Conversation>;
   resolveAttachments: (attachmentIds: string[]) => Array<{
     id: string;
     filename: string;
@@ -363,13 +355,7 @@ export async function startVoiceTurn(
       : opts.voiceControlPrompt;
 
   // Get or create the conversation
-  const transport = {
-    channelId: turnChannelContext.userMessageChannel,
-  };
-  const conversation = await deps.getOrCreateConversation(
-    opts.conversationId,
-    transport,
-  );
+  const conversation = await getOrCreateConversation(opts.conversationId);
 
   if (conversation.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait briefly for the

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -99,7 +99,6 @@ import { startConversationEvictor } from "./conversation-evictor.js";
 import { getOrCreateConversation } from "./conversation-store.js";
 import { writePid } from "./daemon-control.js";
 import { setDbReady, setStartupComplete } from "./daemon-readiness.js";
-import { broadcastDaemonStatus } from "./daemon-status.js";
 import {
   evaluateDiskPressureNow,
   startDiskPressureGuard,
@@ -125,6 +124,7 @@ import {
 import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { registerShutdownHook } from "./shutdown-registry.js";
 import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
+import { broadcastDaemonStatus } from "./status.js";
 
 const log = getLogger("lifecycle");
 let diskPressureStartupSampleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -612,10 +612,8 @@ export async function runDaemon(): Promise<void> {
   // Initialize providers before Qdrant so HTTP routes can begin accepting
   // requests while Qdrant initializes, then best-effort sync the workspace
   // identity name to the platform record.
-  log.info("Daemon startup: initializing providers");
   await initializeProviders(config);
   syncWorkspaceIdentityToPlatform();
-  log.info("Daemon startup: providers initialized");
 
   // Start the idle/LRU/memory-pressure sweep over the in-memory conversation
   // pool.
@@ -938,12 +936,10 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, "Background Qdrant init failed"),
   );
 
-  // Inject voice bridge deps so route handlers + the relay pipeline can
-  // resolve a conversation by ID once a call lands. Module-level state,
-  // so available even when the HTTP server failed to bind.
+  // Inject voice bridge deps so the relay pipeline can resolve attachments
+  // once a call lands. Module-level state, so available even when the HTTP
+  // server failed to bind.
   setVoiceBridgeDeps({
-    getOrCreateConversation: (conversationId, _transport) =>
-      getOrCreateConversation(conversationId),
     resolveAttachments: (attachmentIds) => {
       const resolved = getAttachmentsByIds(attachmentIds, {
         hydrateFileData: true,

--- a/assistant/src/daemon/status.ts
+++ b/assistant/src/daemon/status.ts
@@ -1,22 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
-
-function readPackageVersion(): string | undefined {
-  try {
-    const pkgPath = join(import.meta.dir, "../../package.json");
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
-      version?: string;
-    };
-    return pkg.version;
-  } catch {
-    return undefined;
-  }
-}
-
-const daemonVersion = readPackageVersion();
+import { APP_VERSION } from "../version.js";
 
 /**
  * Broadcast the daemon's current version and signing-key fingerprint to all
@@ -25,7 +9,7 @@ const daemonVersion = readPackageVersion();
 export function broadcastDaemonStatus(): void {
   broadcastMessage({
     type: "assistant_status",
-    version: daemonVersion,
+    version: APP_VERSION,
     keyFingerprint: getSigningKeyFingerprint(),
   });
 }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -234,6 +234,8 @@ export async function initializeProviders(
     );
     routingSources.set(entry.id, source);
   }
+
+  log.info({ providerCount: providers.size }, "Providers initialized");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Follow-up to #36492 (DaemonServer dissolution), addressing the four review comments left on that PR.

## What

1. **Rename `daemon/daemon-status.ts` → `daemon/status.ts`** — the `daemon-` prefix was redundant inside the `daemon/` directory.

2. **Reuse `APP_VERSION` instead of a private package.json read** — `status.ts` had its own `readPackageVersion()`/`daemonVersion`, duplicating `version.ts`, which already resolves the version (with the `APP_VERSION` env override). Deleted the duplicate and broadcast `APP_VERSION` directly.

3. **Drop the `getOrCreateConversation` dependency injection in the voice bridge** — `voice-session-bridge.ts` now imports `getOrCreateConversation` from `conversation-store` directly instead of receiving it through `VoiceBridgeDeps`/`setVoiceBridgeDeps`. The injected `transport` argument was already discarded by the lifecycle wiring, so dropping it is behavior-preserving. Removed the prop from the `VoiceBridgeDeps` interface and the lifecycle wiring, and the now-unused `Conversation` type import. The three tests that injected a fake conversation through this prop now mock `conversation-store` instead (one obsolete `transport` assertion removed).

4. **Move the provider-init logging into `initializeProviders`** — the `log.info` bracketing the startup `initializeProviders` call lived in `lifecycle.ts`. `initializeProviders` had no completion log of its own and is called from ~6 sites (startup, config reload, secret routes, lazy init). Replaced the startup-only wrapper pair with a single `"Providers initialized"` log (including a provider count) inside `initializeProviders`, so every caller gets it.

No behavior change beyond logging: same status broadcast, same conversation resolution, same provider init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_