### PR TITLE
feat(schedule): run local-principal wakes as non-interactive guardian

### DIFF
--- a/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
+++ b/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
@@ -1,0 +1,33 @@
+/**
+ * `injectLocalActorHeader` resolves the IPC caller's principal type. Routes
+ * that elevate trust gate on `"local"`, so a gateway-proxied remote request
+ * must never resolve to `local` — even when it arrives with no verified
+ * principal header (e.g. `runtimeProxyRequireAuth` disabled). The
+ * `x-vellum-proxy-server: ipc` marker (forwarded by the gateway, never sent by
+ * a direct CLI) distinguishes the two.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { injectLocalActorHeader } from "../assistant-server.js";
+
+describe("injectLocalActorHeader principal resolution", () => {
+  test("a forwarded verified principal wins", () => {
+    const out = injectLocalActorHeader({
+      headers: { "x-vellum-principal-type": "actor" },
+    });
+    expect(out.principalType).toBe("actor");
+  });
+
+  test("gateway-proxied IPC with no principal resolves to svc_gateway, not local", () => {
+    const out = injectLocalActorHeader({
+      headers: { "x-vellum-proxy-server": "ipc" },
+    });
+    expect(out.principalType).toBe("svc_gateway");
+  });
+
+  test("a direct IPC caller (no proxy marker, no principal) defaults to local", () => {
+    const out = injectLocalActorHeader({ headers: {} });
+    expect(out.principalType).toBe("local");
+  });
+});

--- a/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
+++ b/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
@@ -16,18 +16,18 @@ describe("injectLocalActorHeader principal resolution", () => {
     const out = injectLocalActorHeader({
       headers: { "x-vellum-principal-type": "actor" },
     });
-    expect(out.principalType).toBe("actor");
+    expect(out.headers?.["x-vellum-principal-type"]).toBe("actor");
   });
 
   test("gateway-proxied IPC with no principal resolves to svc_gateway, not local", () => {
     const out = injectLocalActorHeader({
       headers: { "x-vellum-proxy-server": "ipc" },
     });
-    expect(out.principalType).toBe("svc_gateway");
+    expect(out.headers?.["x-vellum-principal-type"]).toBe("svc_gateway");
   });
 
   test("a direct IPC caller (no proxy marker, no principal) defaults to local", () => {
     const out = injectLocalActorHeader({ headers: {} });
-    expect(out.principalType).toBe("local");
+    expect(out.headers?.["x-vellum-principal-type"]).toBe("local");
   });
 });

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -630,15 +630,23 @@ export class AssistantIpcServer {
  * request) are preserved — we only fill in the gap for direct CLI/local
  * IPC callers.
  */
-function injectLocalActorHeader(
+export function injectLocalActorHeader(
   params: Record<string, unknown> | undefined,
 ): RouteHandlerArgs {
   const args = (params ?? {}) as RouteHandlerArgs;
   const existingHeaders = args.headers;
+  const forwardedPrincipal = existingHeaders?.["x-vellum-principal-type"] as
+    | PrincipalType
+    | undefined;
+  // A gateway-proxied request carries `x-vellum-proxy-server: ipc` (forwarded
+  // as an `x-vellum-*` header); a direct CLI on the local IPC socket never
+  // sends it. Default to `local` ONLY for genuinely-direct callers — a proxied
+  // request with no verified principal (e.g. `runtimeProxyRequireAuth`
+  // disabled) is remote: it resolves to `svc_gateway` (matching the gateway's
+  // HTTP proxy path), never `local`.
+  const isGatewayProxied = existingHeaders?.["x-vellum-proxy-server"] === "ipc";
   const principalType: PrincipalType =
-    (existingHeaders?.["x-vellum-principal-type"] as
-      | PrincipalType
-      | undefined) ?? "local";
+    forwardedPrincipal ?? (isGatewayProxied ? "svc_gateway" : "local");
 
   if (existingHeaders?.["x-vellum-actor-principal-id"]) {
     return { ...args, principalType };

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -33,6 +33,7 @@ import { createServer, type Server, type Socket } from "node:net";
 
 import { ensureSocketDir, SocketWatchdog } from "@vellumai/ipc-server-utils";
 
+import type { PrincipalType } from "../runtime/auth/types.js";
 import { findLocalGuardianPrincipalIdFromStore } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/index.js";
@@ -608,14 +609,21 @@ export class AssistantIpcServer {
 // ---------------------------------------------------------------------------
 
 /**
- * Inject a synthetic `x-vellum-actor-principal-id` header from the local
- * guardian principal when the caller hasn't already provided one.
+ * Resolve the caller's principal identity for an IPC request: the verified
+ * principal type and a synthetic `x-vellum-actor-principal-id` header from the
+ * local guardian when the caller hasn't already provided one.
  *
  * Local IPC is intra-process and owned by the same user as the daemon, so
  * routes that consume `headers["x-vellum-actor-principal-id"]` (e.g. the
  * same-user filter on `GET /v1/clients`) need an actor identity to function
  * over IPC. The HTTP adapter does this from the verified `AuthContext`
  * (`http-adapter.ts`); this helper mirrors that convention for IPC.
+ *
+ * `principalType` comes from the gateway-forwarded `x-vellum-principal-type`
+ * (the gateway IPC proxy sets it from the verified JWT), defaulting to
+ * `"local"` for direct CLI/local IPC callers. Routes that elevate trust gate
+ * on `"local"`, so a gateway-proxied remote `actor` must never be mistaken
+ * for a local caller.
  *
  * Existing headers from the caller (e.g. the gateway's IPC runtime proxy,
  * which forwards real `x-vellum-*` headers from the authenticated HTTP
@@ -627,8 +635,13 @@ function injectLocalActorHeader(
 ): RouteHandlerArgs {
   const args = (params ?? {}) as RouteHandlerArgs;
   const existingHeaders = args.headers;
+  const principalType: PrincipalType =
+    (existingHeaders?.["x-vellum-principal-type"] as
+      | PrincipalType
+      | undefined) ?? "local";
+
   if (existingHeaders?.["x-vellum-actor-principal-id"]) {
-    return args;
+    return { ...args, principalType };
   }
 
   // Defensive: the guardian lookup queries the contacts table, which may
@@ -643,12 +656,13 @@ function injectLocalActorHeader(
       { err },
       "failed to resolve local actor principal for IPC header injection",
     );
-    return args;
+    return { ...args, principalType };
   }
-  if (!localActor) return args;
+  if (!localActor) return { ...args, principalType };
 
   return {
     ...args,
+    principalType,
     headers: {
       ...existingHeaders,
       "x-vellum-actor-principal-id": localActor,

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -609,26 +609,17 @@ export class AssistantIpcServer {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the caller's principal identity for an IPC request: the verified
- * principal type and a synthetic `x-vellum-actor-principal-id` header from the
- * local guardian when the caller hasn't already provided one.
+ * Resolve an IPC caller's identity headers, mirroring what the HTTP adapter
+ * derives from the verified `AuthContext`: `x-vellum-principal-type` and a
+ * synthetic `x-vellum-actor-principal-id` for the local guardian. Handlers read
+ * the resolved identity from `headers` (the single source of truth across both
+ * transports); they never trust the request body.
  *
- * Local IPC is intra-process and owned by the same user as the daemon, so
- * routes that consume `headers["x-vellum-actor-principal-id"]` (e.g. the
- * same-user filter on `GET /v1/clients`) need an actor identity to function
- * over IPC. The HTTP adapter does this from the verified `AuthContext`
- * (`http-adapter.ts`); this helper mirrors that convention for IPC.
- *
- * `principalType` comes from the gateway-forwarded `x-vellum-principal-type`
- * (the gateway IPC proxy sets it from the verified JWT), defaulting to
- * `"local"` for direct CLI/local IPC callers. Routes that elevate trust gate
- * on `"local"`, so a gateway-proxied remote `actor` must never be mistaken
- * for a local caller.
- *
- * Existing headers from the caller (e.g. the gateway's IPC runtime proxy,
- * which forwards real `x-vellum-*` headers from the authenticated HTTP
- * request) are preserved — we only fill in the gap for direct CLI/local
- * IPC callers.
+ * Principal type comes from the gateway-forwarded `x-vellum-principal-type`,
+ * else `svc_gateway` for a gateway-proxied request (marked by
+ * `x-vellum-proxy-server: ipc`, which a direct CLI never sends), else `local`.
+ * Routes that elevate trust gate on `local`, so a remote caller arriving with
+ * no verified principal must resolve to `svc_gateway`, never `local`.
  */
 export function injectLocalActorHeader(
   params: Record<string, unknown> | undefined,
@@ -638,44 +629,30 @@ export function injectLocalActorHeader(
   const forwardedPrincipal = existingHeaders?.["x-vellum-principal-type"] as
     | PrincipalType
     | undefined;
-  // A gateway-proxied request carries `x-vellum-proxy-server: ipc` (forwarded
-  // as an `x-vellum-*` header); a direct CLI on the local IPC socket never
-  // sends it. Default to `local` ONLY for genuinely-direct callers — a proxied
-  // request with no verified principal (e.g. `runtimeProxyRequireAuth`
-  // disabled) is remote: it resolves to `svc_gateway` (matching the gateway's
-  // HTTP proxy path), never `local`.
   const isGatewayProxied = existingHeaders?.["x-vellum-proxy-server"] === "ipc";
-  const principalType: PrincipalType =
-    forwardedPrincipal ?? (isGatewayProxied ? "svc_gateway" : "local");
-
-  if (existingHeaders?.["x-vellum-actor-principal-id"]) {
-    return { ...args, principalType };
-  }
-
-  // Defensive: the guardian lookup queries the contacts table, which may
-  // not yet exist on a very early boot path or in test fixtures that don't
-  // initialize the DB. A failure here must not block IPC dispatch — routes
-  // that require the header will fail-closed on their own.
-  let localActor: string | undefined;
-  try {
-    localActor = findLocalGuardianPrincipalIdFromStore();
-  } catch (err) {
-    log.debug(
-      { err },
-      "failed to resolve local actor principal for IPC header injection",
-    );
-    return { ...args, principalType };
-  }
-  if (!localActor) return { ...args, principalType };
-
-  return {
-    ...args,
-    principalType,
-    headers: {
-      ...existingHeaders,
-      "x-vellum-actor-principal-id": localActor,
-    },
+  const headers: Record<string, string> = {
+    ...existingHeaders,
+    "x-vellum-principal-type":
+      forwardedPrincipal ?? (isGatewayProxied ? "svc_gateway" : "local"),
   };
+
+  // Fill the local guardian's actor id for direct callers that lack one.
+  // Defensive: the lookup queries the contacts table, which may not exist on a
+  // very early boot path or in test fixtures without a DB — a failure must not
+  // block dispatch, so routes requiring the header fail-closed on their own.
+  if (!headers["x-vellum-actor-principal-id"]) {
+    try {
+      const localActor = findLocalGuardianPrincipalIdFromStore();
+      if (localActor) headers["x-vellum-actor-principal-id"] = localActor;
+    } catch (err) {
+      log.debug(
+        { err },
+        "failed to resolve local actor principal for IPC header injection",
+      );
+    }
+  }
+
+  return { ...args, headers };
 }
 
 // ── Process-level singleton ───────────────────────────────────────────────

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -715,6 +715,57 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.personaOverrideSets).toEqual([override, undefined]);
   });
 
+  test("trustContext elevation is applied for the run and restored after", async () => {
+    const conversation = makeWakeConversation({
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "reviewed." }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "scheduled triage",
+        source: "schedule",
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result.invoked).toBe(true);
+    const ctxs = conversation.setTrustContextCalls.map((c) => c.ctx);
+    // Elevated for the turn …
+    expect(ctxs).toContainEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    // … then restored to the prior value (unset → null) as the LAST write, so
+    // a later wake reusing this cached conversation can't inherit guardian.
+    expect(ctxs[ctxs.length - 1]).toBeNull();
+  });
+
+  test("trustContext elevation is restored even when the agent loop throws", async () => {
+    const conversation = makeWakeConversation({
+      runImpl: async () => {
+        throw new Error("loop exploded");
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "scheduled triage",
+        source: "schedule",
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    const ctxs = conversation.setTrustContextCalls.map((c) => c.ctx);
+    expect(ctxs[ctxs.length - 1]).toBeNull();
+  });
+
   test("personaOverride is cleared even when the agent loop throws", async () => {
     const conversation = makeWakeConversation({
       runImpl: async () => {
@@ -1432,11 +1483,14 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(conversation.setTrustContextCalls).toHaveLength(1);
+    // Two writes: the elevation (before the run) and the turn-scoped restore
+    // (after), so the guardian trust never lingers on the cached conversation.
+    expect(conversation.setTrustContextCalls).toHaveLength(2);
     expect(conversation.setTrustContextCalls[0]!.ctx).toEqual({
       sourceChannel: "vellum",
       trustClass: "guardian",
     });
+    expect(conversation.setTrustContextCalls[1]!.ctx).toBeNull();
     // setTrustContext fired strictly before agentLoop.run.
     expect(conversation.runCalls).toHaveLength(1);
     expect(conversation.setTrustContextCalls[0]!.order).toBeLessThan(

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -6,9 +6,9 @@
  * yields a live `Conversation`. These tests build a lightweight structural
  * double typed as `Conversation` (`makeWakeConversation`) that stubs only the
  * handful of members the wake touches — `getMessages`, `messages.push`,
- * `isProcessing`/`setProcessing`, `setTrustContext`, `setSubagentAllowedTools`,
- * `drainQueue`, `maybeCompact`, `contextWindowManager.estimateInputTokens`,
- * and a scripted `agentLoop.run()`.
+ * `isProcessing`/`setProcessing`, `currentTurnTrustContext`,
+ * `setSubagentAllowedTools`, `drainQueue`, `maybeCompact`,
+ * `contextWindowManager.estimateInputTokens`, and a scripted `agentLoop.run()`.
  *
  * The wake's side effects flow through the daemon boundary, so the
  * instrumentation is captured at that boundary: event emission and the
@@ -81,8 +81,12 @@ interface WakeConversationProbe {
    * scope. `undefined` means unrestricted.
    */
   allowedToolSnapshots: Array<string[] | undefined>;
-  /** `setTrustContext` calls, with the value and a monotonic order tag. */
-  setTrustContextCalls: Array<{ ctx: unknown; order: number }>;
+  /**
+   * Assignments to `conversation.currentTurnTrustContext`, with the value and
+   * a monotonic order tag. The wake elevates the turn's trust here (not via the
+   * persistent `setTrustContext`) and restores the prior value in its finally.
+   */
+  turnTrustContextSets: Array<{ ctx: unknown; order: number }>;
   /**
    * Every assignment to `conversation.wakePersonaOverride`, in order. A
    * wake that applies an override records `[override, undefined]` — the
@@ -392,7 +396,7 @@ function makeWakeConversation(options: {
     callSequence: [],
     processingDuringDrain: [],
     allowedToolSnapshots: [],
-    setTrustContextCalls: [],
+    turnTrustContextSets: [],
     personaOverrideSets: [],
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
@@ -404,6 +408,7 @@ function makeWakeConversation(options: {
   let order = 0;
   let activeAllowedTools = options.initialAllowedTools;
   let wakePersonaOverride: unknown;
+  let currentTurnTrustContext: unknown;
   const snapshotAllowedTools = (): string[] | undefined =>
     activeAllowedTools ? [...activeAllowedTools].sort() : undefined;
 
@@ -495,8 +500,12 @@ function makeWakeConversation(options: {
       probe.processingToggles.push(on);
       probe.callSequence.push(on ? "processing:true" : "processing:false");
     },
-    setTrustContext: (ctx: unknown) => {
-      probe.setTrustContextCalls.push({ ctx, order: order++ });
+    get currentTurnTrustContext() {
+      return currentTurnTrustContext;
+    },
+    set currentTurnTrustContext(value: unknown) {
+      currentTurnTrustContext = value;
+      probe.turnTrustContextSets.push({ ctx: value, order: order++ });
     },
     // Pre-run auto-compaction gate. The double only records the call (and
     // the sizing argument) — compaction side effects are exercised in the
@@ -734,15 +743,15 @@ describe("wakeAgentForOpportunity", () => {
     );
 
     expect(result.invoked).toBe(true);
-    const ctxs = conversation.setTrustContextCalls.map((c) => c.ctx);
+    const ctxs = conversation.turnTrustContextSets.map((c) => c.ctx);
     // Elevated for the turn …
     expect(ctxs).toContainEqual({
       sourceChannel: "vellum",
       trustClass: "guardian",
     });
-    // … then restored to the prior value (unset → null) as the LAST write, so
-    // a later wake reusing this cached conversation can't inherit guardian.
-    expect(ctxs[ctxs.length - 1]).toBeNull();
+    // … then restored to the prior value (unset → undefined) as the LAST write,
+    // so a later wake reusing this cached conversation can't inherit guardian.
+    expect(ctxs[ctxs.length - 1]).toBeUndefined();
   });
 
   test("trustContext elevation is restored even when the agent loop throws", async () => {
@@ -762,8 +771,8 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    const ctxs = conversation.setTrustContextCalls.map((c) => c.ctx);
-    expect(ctxs[ctxs.length - 1]).toBeNull();
+    const ctxs = conversation.turnTrustContextSets.map((c) => c.ctx);
+    expect(ctxs[ctxs.length - 1]).toBeUndefined();
   });
 
   test("personaOverride is cleared even when the agent loop throws", async () => {
@@ -1464,11 +1473,11 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.isProcessing()).toBe(false);
   });
 
-  test("applies caller-supplied trustContext to the target before the agent loop runs", async () => {
-    // Background system jobs (e.g. memory consolidation) need
-    // guardian trust to clear the side-effect approval gate. The wake must
-    // call setTrustContext BEFORE agentLoop.run so the per-turn snapshot
-    // captures the elevated trust.
+  test("elevates the turn's trust context before the agent loop runs", async () => {
+    // Background system jobs (e.g. memory consolidation) need guardian trust to
+    // clear the side-effect approval gate. The wake must set
+    // `currentTurnTrustContext` BEFORE agentLoop.run so the per-turn approval
+    // check sees the elevated trust.
     const conversation = makeWakeConversation({
       conversationId: "conv-trust",
     });
@@ -1485,20 +1494,20 @@ describe("wakeAgentForOpportunity", () => {
 
     // Two writes: the elevation (before the run) and the turn-scoped restore
     // (after), so the guardian trust never lingers on the cached conversation.
-    expect(conversation.setTrustContextCalls).toHaveLength(2);
-    expect(conversation.setTrustContextCalls[0]!.ctx).toEqual({
+    expect(conversation.turnTrustContextSets).toHaveLength(2);
+    expect(conversation.turnTrustContextSets[0]!.ctx).toEqual({
       sourceChannel: "vellum",
       trustClass: "guardian",
     });
-    expect(conversation.setTrustContextCalls[1]!.ctx).toBeNull();
-    // setTrustContext fired strictly before agentLoop.run.
+    expect(conversation.turnTrustContextSets[1]!.ctx).toBeUndefined();
+    // The elevation fired strictly before agentLoop.run.
     expect(conversation.runCalls).toHaveLength(1);
-    expect(conversation.setTrustContextCalls[0]!.order).toBeLessThan(
+    expect(conversation.turnTrustContextSets[0]!.order).toBeLessThan(
       conversation.runCalls[0]!.order,
     );
   });
 
-  test("does not call setTrustContext when no trustContext is supplied", async () => {
+  test("does not elevate the turn's trust when no trustContext is supplied", async () => {
     const conversation = makeWakeConversation({
       conversationId: "conv-no-trust",
     });
@@ -1513,9 +1522,13 @@ describe("wakeAgentForOpportunity", () => {
     );
 
     // Inbound-message conversations populate trust via processMessage().
-    // Without an explicit opt-in from the caller, the wake must not
-    // overwrite whatever the conversation already holds.
-    expect(conversation.setTrustContextCalls).toHaveLength(0);
+    // Without an explicit opt-in from the caller, the wake never elevates the
+    // turn's trust — it only ever restores the prior value (here, unset), so it
+    // can't overwrite whatever the conversation already holds.
+    expect(
+      conversation.turnTrustContextSets.filter((s) => s.ctx != null),
+    ).toHaveLength(0);
+    expect(conversation.currentTurnTrustContext).toBeUndefined();
   });
 
   test("two concurrent wakes on the same conversation are serialized", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -665,6 +665,12 @@ export async function wakeAgentForOpportunity(
     // Apply caller-supplied trust before the agent loop reads its per-turn
     // snapshot. Background jobs without an inbound message use this to
     // declare guardian trust so side-effect tools clear the approval gate.
+    // Scoped to this wake's turn: capture the prior value and restore it in
+    // both cleanup paths below (mirroring the guardian-elevation restore in
+    // daemon/handlers/conversations.ts), so the elevation never lingers on the
+    // cached conversation — a later wake on the same conversation (e.g. a
+    // remote `actor`) must not inherit this turn's guardian trust.
+    const priorTrustContext = conversation.trustContext;
     if (opts.trustContext) {
       conversation.setTrustContext(opts.trustContext);
     }
@@ -1372,6 +1378,9 @@ export async function wakeAgentForOpportunity(
       // error/early-return paths where no tail was produced.
       restoreWakeAllowedTools();
       clearWakePersonaOverride();
+      if (opts.trustContext) {
+        conversation.setTrustContext(priorTrustContext ?? null);
+      }
       try {
         conversation.setProcessing(false);
       } catch (err) {
@@ -1400,6 +1409,9 @@ export async function wakeAgentForOpportunity(
       if (!drainedInTry) {
         restoreWakeAllowedTools();
         clearWakePersonaOverride();
+        if (opts.trustContext) {
+          conversation.setTrustContext(priorTrustContext ?? null);
+        }
         try {
           conversation.setProcessing(false);
         } catch (err) {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -325,6 +325,17 @@ export interface WakeOptions {
    * woken turn's cost is attributed to that firing.
    */
   cronRunId?: string;
+  /**
+   * Run the woken turn clientless: pin `hasNoClient = true` for the duration of
+   * the agent-loop run (restored after). Wakes bypass the orchestrator's
+   * turn-start interactivity setup, so a wake on a conversation with no client
+   * attached otherwise derives `isInteractive: true` (the default
+   * `hasNoClient = false`). Pinning it makes `conversation-tool-setup` derive
+   * `isInteractive: false`, which `policy-context` maps to `background`
+   * (guardian) / `headless` (unknown) — so a side-effecting tool that would
+   * prompt is denied instead of stalling on a client that isn't there.
+   */
+  clientless?: boolean;
 }
 
 /**
@@ -1236,8 +1247,10 @@ export async function wakeAgentForOpportunity(
       // user turn or a later background read never inherits the wake's stamps.
       const priorCallSite = conversation.currentCallSite;
       const priorTurnOverrideProfile = conversation.currentTurnOverrideProfile;
+      const priorHasNoClient = conversation.hasNoClient;
       conversation.currentCallSite = callSite;
       conversation.currentTurnOverrideProfile = overrideProfile;
+      if (opts.clientless) conversation.hasNoClient = true;
 
       let updatedHistory: Message[];
       try {
@@ -1298,6 +1311,7 @@ export async function wakeAgentForOpportunity(
         // at the start of the next normal turn regardless.)
         conversation.currentCallSite = priorCallSite;
         conversation.currentTurnOverrideProfile = priorTurnOverrideProfile;
+        conversation.hasNoClient = priorHasNoClient;
       }
 
       // The loop swallows provider rejections into a graceful no-output

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -662,18 +662,8 @@ export async function wakeAgentForOpportunity(
       return { invoked: false, producedToolCalls: false, reason: "timeout" };
     }
 
-    // Apply caller-supplied trust before the agent loop reads its per-turn
-    // snapshot. Background jobs without an inbound message use this to
-    // declare guardian trust so side-effect tools clear the approval gate.
-    // Scoped to this wake's turn: capture the prior value and restore it in
-    // both cleanup paths below (mirroring the guardian-elevation restore in
-    // daemon/handlers/conversations.ts), so the elevation never lingers on the
-    // cached conversation — a later wake on the same conversation (e.g. a
-    // remote `actor`) must not inherit this turn's guardian trust.
-    const priorTrustContext = conversation.trustContext;
-    if (opts.trustContext) {
-      conversation.setTrustContext(opts.trustContext);
-    }
+    // Trust elevation is applied per-turn via `currentTurnTrustContext` right
+    // before the run (see below) — not on the persistent conversation trust.
 
     // Honor the conversation's pinned inference-profile override (if any).
     // Without this, scheduled-task wakes and other opportunity wakes bypass
@@ -1254,9 +1244,15 @@ export async function wakeAgentForOpportunity(
       const priorCallSite = conversation.currentCallSite;
       const priorTurnOverrideProfile = conversation.currentTurnOverrideProfile;
       const priorHasNoClient = conversation.hasNoClient;
+      const priorTurnTrust = conversation.currentTurnTrustContext;
       conversation.currentCallSite = callSite;
       conversation.currentTurnOverrideProfile = overrideProfile;
       if (opts.clientless) conversation.hasNoClient = true;
+      // Per-turn guardian elevation for the wake's tools, set after the pre-run
+      // reads so a pre-run failure can't leak it; restored in the finally.
+      if (opts.trustContext) {
+        conversation.currentTurnTrustContext = opts.trustContext;
+      }
 
       let updatedHistory: Message[];
       try {
@@ -1318,6 +1314,7 @@ export async function wakeAgentForOpportunity(
         conversation.currentCallSite = priorCallSite;
         conversation.currentTurnOverrideProfile = priorTurnOverrideProfile;
         conversation.hasNoClient = priorHasNoClient;
+        conversation.currentTurnTrustContext = priorTurnTrust;
       }
 
       // The loop swallows provider rejections into a graceful no-output
@@ -1378,9 +1375,6 @@ export async function wakeAgentForOpportunity(
       // error/early-return paths where no tail was produced.
       restoreWakeAllowedTools();
       clearWakePersonaOverride();
-      if (opts.trustContext) {
-        conversation.setTrustContext(priorTrustContext ?? null);
-      }
       try {
         conversation.setProcessing(false);
       } catch (err) {
@@ -1409,9 +1403,6 @@ export async function wakeAgentForOpportunity(
       if (!drainedInTry) {
         restoreWakeAllowedTools();
         clearWakePersonaOverride();
-        if (opts.trustContext) {
-          conversation.setTrustContext(priorTrustContext ?? null);
-        }
         try {
           conversation.setProcessing(false);
         } catch (err) {

--- a/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
@@ -52,7 +52,7 @@ describe("wake_conversation principal-gated elevation", () => {
     const conversationId = makeConversation();
     const result = await handler({
       body: { conversationId, hint: "poll result", cronRunId: "run-1" },
-      principalType: "local",
+      headers: { "x-vellum-principal-type": "local" },
     });
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
     expect(wakeCalls).toHaveLength(1);
@@ -69,7 +69,7 @@ describe("wake_conversation principal-gated elevation", () => {
     const conversationId = makeConversation();
     await handler({
       body: { conversationId, hint: "poll result", cronRunId: "attacker-run" },
-      principalType: "actor",
+      headers: { "x-vellum-principal-type": "actor" },
     });
     expect(wakeCalls[0].trustContext).toBeUndefined();
     expect(wakeCalls[0].clientless).toBeUndefined();

--- a/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Asserts the `wake_conversation` route elevates trust from the caller's
+ * verified principal type, never the request body: a `local` (CLI/IPC) caller
+ * runs the woken turn as a non-interactive guardian (clientless + guardian
+ * trustContext) and may attribute cost to a body-supplied `cronRunId`; a remote
+ * `actor` stays `unknown`/interactive and its body `cronRunId` is ignored.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+interface CapturedWake {
+  conversationId: string;
+  hint: string;
+  trustContext?: { sourceChannel: string; trustClass: string };
+  cronRunId?: string;
+  clientless?: boolean;
+}
+const wakeCalls: CapturedWake[] = [];
+mock.module("../../agent-wake.js", () => ({
+  wakeAgentForOpportunity: (opts: CapturedWake) => {
+    wakeCalls.push(opts);
+    return { invoked: true, producedToolCalls: false };
+  },
+}));
+
+import { createConversation } from "../../../persistence/conversation-crud.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { ROUTES } from "../wake-conversation-routes.js";
+
+await initializeDb();
+
+const handler = (() => {
+  const route = ROUTES.find((r) => r.operationId === "wake_conversation");
+  if (!route) throw new Error("wake_conversation route not found");
+  return route.handler;
+})();
+
+function makeConversation(): string {
+  return createConversation({ conversationType: "scheduled" }).id;
+}
+
+describe("wake_conversation principal-gated elevation", () => {
+  test("local principal → non-interactive guardian, honors body cronRunId", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    const result = await handler({
+      body: { conversationId, hint: "poll result", cronRunId: "run-1" },
+      principalType: "local",
+    });
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0].trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    expect(wakeCalls[0].clientless).toBe(true);
+    expect(wakeCalls[0].cronRunId).toBe("run-1");
+  });
+
+  test("actor principal → interactive, no elevation, ignores body cronRunId", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    await handler({
+      body: { conversationId, hint: "poll result", cronRunId: "attacker-run" },
+      principalType: "actor",
+    });
+    expect(wakeCalls[0].trustContext).toBeUndefined();
+    expect(wakeCalls[0].clientless).toBeUndefined();
+    expect(wakeCalls[0].cronRunId).toBeUndefined();
+  });
+
+  test("missing principal type defaults to no elevation (fail-safe)", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    await handler({
+      body: { conversationId, hint: "poll", cronRunId: "ignored-run" },
+    });
+    expect(wakeCalls[0].trustContext).toBeUndefined();
+    expect(wakeCalls[0].clientless).toBeUndefined();
+    expect(wakeCalls[0].cronRunId).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -126,7 +126,6 @@ export function routeDefinitionsToHTTPRoutes(
           body,
           rawBody,
           headers,
-          principalType: authContext?.principalType,
           abortSignal: req.signal,
         });
 

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -126,6 +126,7 @@ export function routeDefinitionsToHTTPRoutes(
           body,
           rawBody,
           headers,
+          principalType: authContext?.principalType,
           abortSignal: req.signal,
         });
 

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -5,6 +5,7 @@
 import type { z } from "zod";
 
 import type { RoutePolicy } from "../auth/route-policy.js";
+import type { PrincipalType } from "../auth/types.js";
 
 export interface RouteQueryParam {
   name: string;
@@ -101,6 +102,14 @@ export interface RouteHandlerArgs {
   body?: Record<string, unknown>;
   rawBody?: Uint8Array;
   headers?: Record<string, string>;
+  /**
+   * Verified principal type of the caller. On HTTP it is the JWT's
+   * `authCtx.principalType`; on IPC it is the gateway-forwarded
+   * `x-vellum-principal-type`, defaulting to `"local"` for direct
+   * CLI/IPC callers. Handlers that elevate trust must gate on
+   * `"local"` — never on the unverified body.
+   */
+  principalType?: PrincipalType;
   /**
    * Abort signal tied to the client connection. Fired when the client
    * disconnects (e.g. SSE stream closed). The IPC adapter may pass

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -5,7 +5,6 @@
 import type { z } from "zod";
 
 import type { RoutePolicy } from "../auth/route-policy.js";
-import type { PrincipalType } from "../auth/types.js";
 
 export interface RouteQueryParam {
   name: string;
@@ -101,15 +100,14 @@ export interface RouteHandlerArgs {
   queryParams?: Record<string, string>;
   body?: Record<string, unknown>;
   rawBody?: Uint8Array;
-  headers?: Record<string, string>;
   /**
-   * Verified principal type of the caller. On HTTP it is the JWT's
-   * `authCtx.principalType`; on IPC it is the gateway-forwarded
-   * `x-vellum-principal-type`, defaulting to `"local"` for direct
-   * CLI/IPC callers. Handlers that elevate trust must gate on
-   * `"local"` — never on the unverified body.
+   * Caller identity headers, including `x-vellum-principal-type` (the verified
+   * principal type) and `x-vellum-actor-principal-id`. Both adapters derive
+   * these from a trusted source — HTTP from the verified `AuthContext`, IPC
+   * from `injectLocalActorHeader` — never from caller-supplied values, so
+   * handlers that elevate trust can gate on the header (e.g. `"local"`).
    */
-  principalType?: PrincipalType;
+  headers?: Record<string, string>;
   /**
    * Abort signal tied to the client connection. Fired when the client
    * disconnects (e.g. SSE stream closed). The IPC adapter may pass

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -41,7 +41,7 @@ export const ROUTES: RouteDefinition[] = [
       producedToolCalls: z.boolean(),
       reason: z.string().optional(),
     }),
-    handler: async ({ body, principalType }) => {
+    handler: async ({ body, headers }) => {
       const { conversationId, hint, source, cronRunId } =
         WakeConversationBody.parse(body);
 
@@ -58,7 +58,7 @@ export const ROUTES: RouteDefinition[] = [
       // client. A remote `actor` (reachable via the gateway) stays
       // `unknown`/interactive. The body's `cronRunId` is trusted only from a
       // local caller.
-      const isLocal = principalType === "local";
+      const isLocal = headers?.["x-vellum-principal-type"] === "local";
 
       return wakeAgentForOpportunity({
         conversationId,

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
 import { wakeAgentForOpportunity } from "../agent-wake.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -16,6 +17,8 @@ const WakeConversationBody = z.object({
   conversationId: z.string().min(1),
   hint: z.string().min(1),
   source: z.string().default("cli"),
+  // Honored only for a `local` caller (see handler) — a remote `actor` could
+  // otherwise attribute its wake's cost to an arbitrary firing.
   cronRunId: z.string().min(1).optional(),
 });
 
@@ -38,7 +41,7 @@ export const ROUTES: RouteDefinition[] = [
       producedToolCalls: z.boolean(),
       reason: z.string().optional(),
     }),
-    handler: async ({ body }) => {
+    handler: async ({ body, principalType }) => {
       const { conversationId, hint, source, cronRunId } =
         WakeConversationBody.parse(body);
 
@@ -47,11 +50,24 @@ export const ROUTES: RouteDefinition[] = [
         throw new NotFoundError(`Conversation not found: ${conversationId}`);
       }
 
+      // A local IPC caller is already guardian-capable, so its wake runs as a
+      // non-interactive guardian: `clientless` makes the turn derive
+      // `isInteractive: false` (mapped to the `background` policy context), so
+      // read-only/reasoning tools stay available while side-effecting tools are
+      // denied at the default threshold rather than stalling on an absent
+      // client. A remote `actor` (reachable via the gateway) stays
+      // `unknown`/interactive. The body's `cronRunId` is trusted only from a
+      // local caller.
+      const isLocal = principalType === "local";
+
       return wakeAgentForOpportunity({
         conversationId,
         hint,
         source,
-        cronRunId,
+        ...(isLocal
+          ? { trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT, clientless: true }
+          : {}),
+        ...(isLocal && cronRunId ? { cronRunId } : {}),
       });
     },
   },


### PR DESCRIPTION
ref ATL-911

A script-mode schedule's `wake` runs as `unknown` trust today and can take no action. Elevate it to guardian — but **only for `local` (IPC) callers**: a local caller is already guardian-capable (`credentials reveal` / `oauth request` are `LOCAL_PRINCIPALS`), so this grants nothing it couldn't already do, while a remote `actor` (chat.write via the gateway) stays `unknown` so it can't be elevated. Trust comes from the caller's principal — no token or `trust_level` column.

Supersedes #36246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)