### PR TITLE
chore(skills): add SKILL.md ↔ public-docs drift tripwire

### DIFF
--- a/assistant/src/__tests__/skill-docs-sync-guard.test.ts
+++ b/assistant/src/__tests__/skill-docs-sync-guard.test.ts
@@ -1,0 +1,34 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Guard for skill ↔ public-docs drift. A bundled skill's SKILL.md is the
+ * behavioral source of truth; its public reference page lives in a separate
+ * repo (vellum-assistant-platform, https://www.vellum.ai/docs/skills-reference).
+ * `scripts/check-skill-docs-sync.ts` fingerprints each documented SKILL.md so a
+ * behavior change can't land without the author reconciling the docs page and
+ * re-recording the fingerprint.
+ *
+ * This guard runs that check. On failure, the script's output names the skills
+ * whose SKILL.md drifted and the docs page to update — read it, fix the docs,
+ * then run `bun run scripts/check-skill-docs-sync.ts --write`.
+ */
+describe("skill ↔ public-docs sync", () => {
+  test("documented SKILL.md files match their recorded fingerprint", () => {
+    const repoRoot = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../..",
+    );
+    const result = spawnSync(
+      process.execPath,
+      ["run", "scripts/check-skill-docs-sync.ts"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(output, output).not.toBe("");
+    expect(result.status, output).toBe(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/AGENTS.md
+++ b/assistant/src/config/bundled-skills/AGENTS.md
@@ -32,3 +32,14 @@ You can regenerate the full registry with:
 ```sh
 bun run scripts/generate-bundled-tool-registry.ts
 ```
+
+## Keeping public docs in sync
+
+A bundled skill's `SKILL.md` is its behavioral source of truth. Skills with a public reference page (`https://www.vellum.ai/docs/skills-reference/<slug>`, authored in the **vellum-assistant-platform** repo) are fingerprinted in `scripts/skill-docs-sync.manifest.json` and enforced by `skill-docs-sync-guard.test.ts`.
+
+When you change a documented skill's `SKILL.md`, the guard fails until you reconcile it:
+
+1. Review the named docs page and update it if the behavior changed.
+2. Re-record the fingerprint to acknowledge it: `bun run scripts/check-skill-docs-sync.ts --write`.
+
+The fingerprint bump is the acknowledgement — even a trivial wording edit requires one. When a bundled skill **gains** a public docs page, add an entry to the manifest.

--- a/scripts/check-skill-docs-sync.ts
+++ b/scripts/check-skill-docs-sync.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * Skill ↔ public-docs drift tripwire.
+ *
+ * The behavioral source of truth for a bundled skill is its SKILL.md
+ * (assistant/src/config/bundled-skills/<skill>/SKILL.md). The public reference
+ * page for that skill lives in a *separate* repo (vellum-assistant-platform,
+ * served at https://www.vellum.ai/docs/skills-reference/<slug>). The two are
+ * authored by hand and drift silently.
+ *
+ * This check records a content fingerprint of each documented skill's SKILL.md
+ * in scripts/skill-docs-sync.manifest.json. When a SKILL.md changes, the
+ * recorded fingerprint no longer matches and the check fails, naming the public
+ * page that may now be stale.
+ *
+ * It cannot prove the cross-repo docs page was updated — it forces a human to
+ * confront the question. The workflow is: change a SKILL.md → review the public
+ * page → re-record the fingerprint with `--write`. The fingerprint bump is the
+ * acknowledgement, and it leaves a reviewable trail in the diff. A trivial
+ * wording edit still requires a bump; that friction is the point.
+ *
+ * Usage:
+ *   bun run scripts/check-skill-docs-sync.ts            # check (CI / guard test)
+ *   bun run scripts/check-skill-docs-sync.ts --write    # re-record fingerprints
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const MANIFEST_PATH = join(SCRIPT_DIR, "skill-docs-sync.manifest.json");
+const BUNDLED_SKILLS_DIR = join(
+  REPO_ROOT,
+  "assistant",
+  "src",
+  "config",
+  "bundled-skills",
+);
+const DOCS_BASE_URL = "https://www.vellum.ai/docs/skills-reference";
+
+interface SkillEntry {
+  /** Slug of the public docs page (path segment under /skills-reference/). */
+  docsSlug: string;
+  /** sha256 of the normalized SKILL.md, recorded at last docs reconciliation. */
+  sha256: string;
+}
+
+interface Manifest {
+  note: string;
+  skills: Record<string, SkillEntry>;
+}
+
+/**
+ * Normalize SKILL.md before hashing so the fingerprint only moves on meaningful
+ * content changes, not line-ending or trailing-whitespace churn: LF endings,
+ * per-line trailing whitespace stripped, exactly one trailing newline.
+ */
+function normalize(content: string): string {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  return (
+    lines
+      .map((line) => line.replace(/[ \t]+$/g, ""))
+      .join("\n")
+      .replace(/\n+$/g, "") + "\n"
+  );
+}
+
+function fingerprint(skillDir: string): { hash: string } | { missing: true } {
+  const path = join(BUNDLED_SKILLS_DIR, skillDir, "SKILL.md");
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return { missing: true };
+  }
+  return {
+    hash: createHash("sha256").update(normalize(content)).digest("hex"),
+  };
+}
+
+function loadManifest(): Manifest {
+  return JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as Manifest;
+}
+
+function saveManifest(manifest: Manifest): void {
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
+}
+
+function docsUrl(slug: string): string {
+  return `${DOCS_BASE_URL}/${slug}`;
+}
+
+function main(): void {
+  const write =
+    process.argv.includes("--write") || process.argv.includes("--update");
+  const manifest = loadManifest();
+  const skillDirs = Object.keys(manifest.skills).sort();
+
+  if (write) {
+    let changed = 0;
+    for (const skillDir of skillDirs) {
+      const fp = fingerprint(skillDir);
+      if ("missing" in fp) {
+        console.error(
+          `✖ ${skillDir}: SKILL.md not found at assistant/src/config/bundled-skills/${skillDir}/SKILL.md`,
+        );
+        process.exit(1);
+      }
+      if (manifest.skills[skillDir].sha256 !== fp.hash) changed++;
+      manifest.skills[skillDir].sha256 = fp.hash;
+    }
+    saveManifest(manifest);
+    console.log(
+      `Recorded fingerprints for ${skillDirs.length} skill(s); ${changed} updated.`,
+    );
+    return;
+  }
+
+  const missing: string[] = [];
+  const drifted: { skillDir: string; slug: string }[] = [];
+
+  for (const skillDir of skillDirs) {
+    const entry = manifest.skills[skillDir];
+    const fp = fingerprint(skillDir);
+    if ("missing" in fp) {
+      missing.push(skillDir);
+      continue;
+    }
+    if (!entry.sha256 || entry.sha256 !== fp.hash) {
+      drifted.push({ skillDir, slug: entry.docsSlug });
+    }
+  }
+
+  if (missing.length === 0 && drifted.length === 0) {
+    console.log(
+      `✓ All ${skillDirs.length} documented skill(s) match their recorded fingerprint.`,
+    );
+    return;
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      "✖ SKILL.md missing for manifest entries (renamed or removed?):",
+    );
+    for (const skillDir of missing) console.error(`    - ${skillDir}`);
+    console.error(
+      "  Update scripts/skill-docs-sync.manifest.json to match the new skill name.\n",
+    );
+  }
+
+  if (drifted.length > 0) {
+    console.error(
+      "✖ SKILL.md changed since the public docs were last reconciled:\n",
+    );
+    for (const { skillDir, slug } of drifted) {
+      console.error(`    - ${skillDir}  →  ${docsUrl(slug)}`);
+    }
+    console.error(
+      [
+        "",
+        "  These skills' behavior may have changed without their public reference page.",
+        "  For each one:",
+        "    1. Review the docs page above (it lives in vellum-assistant-platform:",
+        "       web/src/app/(marketing)/docs/_components/skills-reference-<slug>-content.tsx)",
+        "       and update it if the behavior changed.",
+        "    2. Re-record the fingerprint to acknowledge it is reconciled:",
+        "         bun run scripts/check-skill-docs-sync.ts --write",
+        "",
+      ].join("\n"),
+    );
+  }
+
+  process.exit(1);
+}
+
+main();

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -1,0 +1,65 @@
+{
+  "note": "Maps each bundled skill with a public reference page (https://www.vellum.ai/docs/skills-reference/<docsSlug>, authored in the vellum-assistant-platform repo) to a fingerprint of its SKILL.md. Enforced by scripts/check-skill-docs-sync.ts and assistant/src/__tests__/skill-docs-sync-guard.test.ts. When a SKILL.md changes, review its docs page, then run `bun run scripts/check-skill-docs-sync.ts --write` to re-record the fingerprint. Add an entry here when a bundled skill gains a public docs page.",
+  "skills": {
+    "acp": {
+      "docsSlug": "acp",
+      "sha256": "f3ee44f955e71f33f53f596e3fef194576d37f638949d7dbfffd07f9edcc3e3a"
+    },
+    "app-builder": {
+      "docsSlug": "app-builder",
+      "sha256": "331201817b38c36275faeb3a21545e6a6c0861ddfacd56481e9b28f9ab4ffcea"
+    },
+    "computer-use": {
+      "docsSlug": "computer-use",
+      "sha256": "648ad44fd3c3d052893aaa2b71b8478c73b1c786993aa3ede2aa6298b3a3cf5e"
+    },
+    "contacts": {
+      "docsSlug": "contacts",
+      "sha256": "41289fd9467deafe39eecf1a5484799642755332f3ff1fb963aa51b8983bb2bf"
+    },
+    "document-editor": {
+      "docsSlug": "document",
+      "sha256": "95f34b03900851215b2bc153d5e6c92e382476fa361147f31b28d4757ed6c4d3"
+    },
+    "followups": {
+      "docsSlug": "followups",
+      "sha256": "d34b30de6ec6bd57916f3e7a9b3ee8136809609b9f145009aeecd5dee549b3bb"
+    },
+    "image-studio": {
+      "docsSlug": "image-studio",
+      "sha256": "7a122d409ca7146fcaac4452d8f8dcd11b4f1e702f5079cd0472da992211a1c5"
+    },
+    "media-processing": {
+      "docsSlug": "media-processing",
+      "sha256": "4c93682daa54a9f74ccb12306e82409ae5417fcae253b26f8364bdd28f90a3d4"
+    },
+    "messaging": {
+      "docsSlug": "messaging",
+      "sha256": "bbe48449dc1d19d176ba0bf16988107a8b92eea74dac37e9d05e433947727315"
+    },
+    "phone-calls": {
+      "docsSlug": "phone-calls",
+      "sha256": "9342a16afba60f162b9f9b31333fa50dd808b5445ab6ea1991ed9a46615f1a7e"
+    },
+    "playbooks": {
+      "docsSlug": "playbooks",
+      "sha256": "651bdbdee8719763cc7492b3800134c2e9ac4a88d97ea58e8a8144fcc78ae441"
+    },
+    "schedule": {
+      "docsSlug": "schedule",
+      "sha256": "4e82f6b9add84d81feaf10569f95024e9f54a60b9be13d05be85163cd6e51ee3"
+    },
+    "skill-management": {
+      "docsSlug": "skill-management",
+      "sha256": "eab58d56f6ad533e5644f2e6f857779e21a043334bdf59da4f7179b0e3f4fdea"
+    },
+    "subagent": {
+      "docsSlug": "subagent",
+      "sha256": "c0bb5268d5dc18b38375f2db4e379a941c4ab5082c1375720fcb8949e3f7e09e"
+    },
+    "transcribe": {
+      "docsSlug": "transcribe",
+      "sha256": "8e50033d564e9751f6db6ad75d6604df23b321722a93d402579185cbbdf7ede0"
+    }
+  }
+}


### PR DESCRIPTION
## Why

A bundled skill's `SKILL.md` is its behavioral source of truth, but the public reference page (`vellum.ai/docs/skills-reference/<slug>`) is authored by hand in the **vellum-assistant-platform** repo. The two drift silently — the subagent page had fallen behind and contained an outright-wrong claim ("no shared context", which isn't true for forks). This adds a tripwire so behavior changes can't land without the docs question being confronted.

## What it does

- **`scripts/check-skill-docs-sync.ts`** records a normalized sha256 of each documented skill's `SKILL.md` in **`scripts/skill-docs-sync.manifest.json`** (15 bundled skills that currently have a public page).
- **`skill-docs-sync-guard.test.ts`** runs the check in CI (the assistant test suite already globs `src/**/*.test.ts`).
- When a documented `SKILL.md` changes, the recorded fingerprint no longer matches and the guard **fails**, naming the exact public page that may be stale and how to resolve:
  1. Review the named docs page and update it if the behavior changed.
  2. Re-record the fingerprint: `bun run scripts/check-skill-docs-sync.ts --write`.

The fingerprint bump is the acknowledgement and leaves a reviewable trail in the diff. A trivial wording edit still requires a bump — that friction is the point.

## Honest limitation

The docs page lives in another repo, so this **cannot prove** the page was updated — it forces a human to confront the question and records the decision. I put the check here (not in the platform repo) because the `SKILL.md` source lives here and the check stays self-contained (no cross-repo network/tokens), firing in the PR that actually changes behavior.

## Scope / follow-ups

- Governs the 15 bundled skills with a 1:1 public page (manifest is the explicit allowlist; `document-editor` → `document` slug handled). Bundled skills without a public page (e.g. `workflows`, `settings`) are intentionally excluded.
- Not covered (possible follow-ups): docs pages whose source isn't a bundled `SKILL.md` (integrations like `gmail`/`slack`); a coverage check that flags a *new* documented skill missing from the manifest.

## Verification

Seeded fingerprints, confirmed the check passes, perturbed a `SKILL.md` and confirmed it fails with the remediation message, restored and confirmed green. `eslint` + `prettier` + `tsc` clean; guard test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)