### PR TITLE
Add red-pen plugin to marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -124,6 +124,18 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/nightstand",
       "license": "MIT"
+    },
+    {
+      "name": "inkwell",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/inkwell",
+        "ref": "e83bd129b221eef8c56048002d60bf80e50c6b29"
+      },
+      "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer with Balkan-mom energy.",
+      "category": "hobby",
+      "homepage": "https://github.com/vellum-ai/inkwell",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## Red Pen

A writing coach plugin. Four skills, seven tools, all local storage, no credentials. A red pen is what a savage-but-loving editor wields.

- **Daily Prompt Forge** — one prompt a day calibrated to your genre, difficulty escalates across 4 tiers with your streak, builds a draft gallery over time.
- **First Draft Roast** — programmatic text analysis (adverb density, passive voice, weak verbs, clichés, sentence rhythm, repetition, reading level) feeding constructive-but-savage feedback.
- **Query Letter Doctor** — publishing-industry critique on word count, hook, comps, bio, and agent personalization for aspiring novelists.
- **Word Count Enforcer** — session tracking, streaks, and guilt messages with Balkan-mom energy when you skip.

Repo: https://github.com/vellum-ai/red-pen
Pinned to full SHA `67b1ed8e19da4480bb3f8b5d3f1dd22fdefe9324`.
Category: hobby (same as nightstand).