### PR TITLE
Rename inkwell to red-pen in marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -126,15 +126,15 @@
       "license": "MIT"
     },
     {
-      "name": "inkwell",
+      "name": "red-pen",
       "source": {
         "source": "github",
-        "repo": "vellum-ai/inkwell",
-        "ref": "e83bd129b221eef8c56048002d60bf80e50c6b29"
+        "repo": "vellum-ai/red-pen",
+        "ref": "67b1ed8e19da4480bb3f8b5d3f1dd22fdefe9324"
       },
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer with Balkan-mom energy.",
       "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/inkwell",
+      "homepage": "https://github.com/vellum-ai/red-pen",
       "license": "MIT"
     }
   ]


### PR DESCRIPTION
Follow-up to #36502. The writing-coach plugin was renamed `inkwell` to `red-pen` (a red pen is what a savage-but-loving editor wields), but the first marketplace entry merged with the old name before the rename push landed.

This updates the catalog entry to the new repo, SHA, and homepage:
- repo: `vellum-ai/red-pen`
- ref: `67b1ed8e19da4480bb3f8b5d3f1dd22fdefe9324`
- homepage: https://github.com/vellum-ai/red-pen

The old `vellum-ai/inkwell` URL auto-redirects, but pinning to the renamed repo keeps the catalog clean.