### PR TITLE
Drop Balkan-mom framing from red-pen marketplace entry

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -130,9 +130,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/red-pen",
-        "ref": "67b1ed8e19da4480bb3f8b5d3f1dd22fdefe9324"
+        "ref": "9e2c59c443f92d7800cbb33521cc166066226355"
       },
-      "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer with Balkan-mom energy.",
+      "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/red-pen",
       "license": "MIT"


### PR DESCRIPTION
Updates the red-pen marketplace entry:

- Removes the "Balkan-mom energy" framing from the description (Marina's call). New copy: "a word count enforcer that guilt-trips you when you skip."
- Repins to the latest red-pen SHA (9e2c59c) which carries the same scrub across the plugin's README and word-count-enforcer skill.

Follow-up to #36503, which merged before this copy change landed.