### PR TITLE
feat(web): add PluginOriginBadge using design-library Tag

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Tests for `PluginOriginBadge`. Asserts the label + leading lucide icon
+ * switch on the `external` prop. Mounted via `@testing-library/react`
+ * (happy-dom — see `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PluginOriginBadge", () => {
+  test("external plugin: shows External label with globe icon", () => {
+    const { container, getByText } = render(<PluginOriginBadge external />);
+
+    expect(getByText("External")).toBeTruthy();
+    expect(container.querySelector(".lucide-globe")).toBeTruthy();
+    expect(container.querySelector(".lucide-hard-drive")).toBeNull();
+  });
+
+  test("local plugin: shows Local label with drive icon", () => {
+    const { container, getByText } = render(
+      <PluginOriginBadge external={false} />,
+    );
+
+    expect(getByText("Local")).toBeTruthy();
+    expect(container.querySelector(".lucide-hard-drive")).toBeTruthy();
+    expect(container.querySelector(".lucide-globe")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
@@ -1,0 +1,31 @@
+import { Globe, HardDrive } from "lucide-react";
+import { createElement } from "react";
+
+import { Tag } from "@vellumai/design-library";
+
+/**
+ * Origin badge for plugins, mirroring `SkillOriginBadge`. Renders a
+ * design-library `Tag` labeled `External` (with a globe icon) when the plugin
+ * comes from a remote host, otherwise `Local` (with a drive icon).
+ *
+ * `sourceHost` is accepted for parity but does not change the label in v1.
+ */
+export function PluginOriginBadge({
+  external,
+  sourceHost: _sourceHost,
+  className,
+}: {
+  external: boolean;
+  sourceHost?: string;
+  className?: string;
+}) {
+  const meta = external
+    ? { label: "External", icon: Globe }
+    : { label: "Local", icon: HardDrive };
+
+  return (
+    <Tag tone="neutral" leftIcon={createElement(meta.icon)} className={className}>
+      {meta.label}
+    </Tag>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds PluginOriginBadge (design-library Tag) showing External/Local, mirroring SkillOriginBadge; replaces the raw-span pill pattern.

Part of plan: plugins-tab-match-skills.md (PR 2 of 13)