### PR TITLE
refactor(web): UpdateAvailableBadge uses design-library Tag

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/update-available-badge.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/update-available-badge.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Tests for `UpdateAvailableBadge`.
+ *
+ * The badge renders the "Update available" label inside the design-library
+ * `Tag` primitive (which exposes `data-slot="tag"`) rather than a bare span,
+ * so the affordance matches the Skills tab styling.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UpdateAvailableBadge", () => {
+  test("renders the 'Update available' label inside a Tag", () => {
+    const { getByText } = render(<UpdateAvailableBadge />);
+
+    const label = getByText("Update available");
+    const tag = label.closest('[data-slot="tag"]');
+
+    expect(tag).not.toBeNull();
+    expect(tag?.tagName.toLowerCase()).toBe("span");
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
@@ -3,16 +3,15 @@
  * pin. Shared by the plugins list row and the plugin detail header so the
  * "update available" affordance reads identically on both surfaces.
  */
+import { ArrowUpCircle } from "lucide-react";
+import { createElement } from "react";
+
+import { Tag } from "@vellumai/design-library";
+
 export function UpdateAvailableBadge() {
   return (
-    <span
-      className="shrink-0 rounded px-1.5 py-0.5 text-body-small-default"
-      style={{
-        backgroundColor: "var(--surface-info, var(--surface-secondary))",
-        color: "var(--content-info, var(--primary-base, #60a5fa))",
-      }}
-    >
+    <Tag tone="warning" leftIcon={createElement(ArrowUpCircle)} className="shrink-0">
       Update available
-    </span>
+    </Tag>
   );
 }


### PR DESCRIPTION
## Summary
- Restyles UpdateAvailableBadge from a raw span to the design-library Tag; public API unchanged so existing callers compile.

Part of plan: plugins-tab-match-skills.md (PR 3 of 13)