### PR TITLE
feat(web): add PluginIcon component for Plugins tab parity

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tests for `PluginIcon`: emoji defaulting by `external`, `emoji`
+ * override, and the `sm` / `md` container sizing that matches
+ * `SkillIcon`.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const PACKAGE = "\u{1F4E6}"; // 📦
+const PUZZLE = "\u{1F9E9}"; // 🧩
+
+describe("PluginIcon", () => {
+  test("defaults to 📦 when external", () => {
+    const { container } = render(<PluginIcon external />);
+    expect(container.textContent).toBe(PACKAGE);
+  });
+
+  test("defaults to 🧩 when not external", () => {
+    const { container } = render(<PluginIcon />);
+    expect(container.textContent).toBe(PUZZLE);
+  });
+
+  test("emoji prop overrides the external default", () => {
+    const { container } = render(<PluginIcon external emoji="🚀" />);
+    expect(container.textContent).toBe("🚀");
+  });
+
+  test("emoji prop overrides the non-external default", () => {
+    const { container } = render(<PluginIcon emoji="🚀" />);
+    expect(container.textContent).toBe("🚀");
+  });
+
+  test("sm size renders an h-7 w-7 container", () => {
+    const { container } = render(<PluginIcon size="sm" />);
+    const span = container.querySelector("span");
+    expect(span?.className).toContain("h-7");
+    expect(span?.className).toContain("w-7");
+  });
+
+  test("md size renders an h-8 w-8 container", () => {
+    const { container } = render(<PluginIcon size="md" />);
+    const span = container.querySelector("span");
+    expect(span?.className).toContain("h-8");
+    expect(span?.className).toContain("w-8");
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/utils/misc";
+
+interface PluginIconProps {
+  external?: boolean;
+  emoji?: string;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const SIZE_CLASS = {
+  sm: "h-7 w-7",
+  md: "h-8 w-8 text-3xl",
+} as const;
+
+/**
+ * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
+ * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
+ * icon-image endpoint, so there is no remote-image branch. The default
+ * follows the existing Plugins convention: 📦 for catalog (external),
+ * 🧩 otherwise; a passed `emoji` overrides the default.
+ */
+export function PluginIcon({
+  external = false,
+  emoji,
+  size = "sm",
+  className,
+}: PluginIconProps) {
+  const glyph = emoji ?? (external ? "\u{1F4E6}" : "\u{1F9E9}");
+
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center",
+        SIZE_CLASS[size],
+        className,
+      )}
+    >
+      {glyph}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds PluginIcon visual primitive (emoji, sm/md sizes) mirroring SkillIcon for Plugins-tab/Skills-tab parity.

Part of plan: plugins-tab-match-skills.md (PR 1 of 13)