### PR TITLE
feat(web): add unified Plugins list types and utils

### DIFF
--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -1,0 +1,58 @@
+import type {
+  PluginsGetResponse,
+  PluginsSearchGetResponse,
+} from "@/generated/daemon/types.gen";
+
+export type PluginStatus = "installed" | "available";
+
+export type PluginFilter = "all" | "installed" | "available";
+
+/**
+ * Unified row model for the Plugins tab, populated from two independent
+ * daemon endpoints: the installed list (`pluginsGet`) and the catalog
+ * (`pluginsSearchGet`). Mirrors the Skills domain's `SkillInfo`.
+ */
+export interface PluginListItem {
+  name: string;
+  description?: string;
+  status: PluginStatus;
+  external: boolean;
+  version?: string;
+  path?: string;
+  sourceHost?: string;
+  issues?: string[];
+}
+
+/** Generated element type for an installed plugin (`pluginsGet`). */
+export type InstalledPlugin = PluginsGetResponse["plugins"][number];
+
+/** Generated element type for a catalog match (`pluginsSearchGet`). */
+export type PluginCatalogMatch = PluginsSearchGetResponse["matches"][number];
+
+/**
+ * Compile-time guard: the generated response element types must keep the
+ * source fields `mergePlugins` reads, with compatible shapes. If the daemon
+ * OpenAPI spec renames a field, these lines produce a type error — surfacing
+ * the drift immediately instead of silently at runtime.
+ *
+ * @see ./utils.ts (mergePlugins)
+ */
+type AssertAssignable<_Target, _Source extends _Target> = true;
+
+interface InstalledPluginSource {
+  name: string;
+  description: string | null;
+  version: string | null;
+  path?: string;
+  issues?: string[];
+}
+
+interface CatalogPluginSource {
+  name: string;
+  description?: string;
+  path: string;
+  source: { repo: string };
+}
+
+type _InstalledCompat = AssertAssignable<InstalledPluginSource, InstalledPlugin>;
+type _CatalogCompat = AssertAssignable<CatalogPluginSource, PluginCatalogMatch>;

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  InstalledPlugin,
+  PluginCatalogMatch,
+  PluginListItem,
+} from "./types";
+import {
+  filterByStatus,
+  matchesQuery,
+  mergePlugins,
+  sortPlugins,
+} from "./utils";
+
+function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  return {
+    id: "alpha",
+    name: "alpha",
+    description: null,
+    version: null,
+    ...overrides,
+  };
+}
+
+function catalog(overrides: Partial<PluginCatalogMatch> = {}): PluginCatalogMatch {
+  return {
+    name: "beta",
+    path: "github:acme/beta@main",
+    source: { kind: "github", repo: "acme/beta", ref: "main" },
+    ...overrides,
+  };
+}
+
+function item(overrides: Partial<PluginListItem> = {}): PluginListItem {
+  return {
+    name: "x",
+    status: "available",
+    external: true,
+    ...overrides,
+  };
+}
+
+describe("mergePlugins", () => {
+  test("maps installed and catalog into one list with status/external", () => {
+    const result = mergePlugins(
+      [installed({ name: "alpha", description: "A", version: "1.0.0" })],
+      [catalog({ name: "beta", description: "B" })],
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      name: "alpha",
+      description: "A",
+      status: "installed",
+      external: false,
+      version: "1.0.0",
+    });
+    expect(result[1]).toMatchObject({
+      name: "beta",
+      description: "B",
+      status: "available",
+      external: true,
+      sourceHost: "acme/beta",
+    });
+  });
+
+  test("drops catalog entries already installed (dedup by name)", () => {
+    const result = mergePlugins(
+      [installed({ name: "dup" })],
+      [catalog({ name: "dup" }), catalog({ name: "fresh" })],
+    );
+
+    expect(result.map((p) => p.name)).toEqual(["dup", "fresh"]);
+    expect(result.find((p) => p.name === "dup")?.status).toBe("installed");
+  });
+
+  test("normalizes null description/version to undefined", () => {
+    const [row] = mergePlugins(
+      [installed({ name: "alpha", description: null, version: null })],
+      [],
+    );
+
+    expect(row.description).toBeUndefined();
+    expect(row.version).toBeUndefined();
+  });
+});
+
+describe("matchesQuery", () => {
+  test("empty query matches everything", () => {
+    expect(matchesQuery(item({ name: "anything" }), "")).toBe(true);
+    expect(matchesQuery(item({ name: "anything" }), "   ")).toBe(true);
+  });
+
+  test("matches against name (case-insensitive)", () => {
+    expect(matchesQuery(item({ name: "GitHub" }), "hub")).toBe(true);
+  });
+
+  test("matches against description (case-insensitive)", () => {
+    expect(
+      matchesQuery(item({ name: "x", description: "Linear tickets" }), "linear"),
+    ).toBe(true);
+  });
+
+  test("returns false when neither name nor description matches", () => {
+    expect(
+      matchesQuery(item({ name: "x", description: "nope" }), "zzz"),
+    ).toBe(false);
+  });
+});
+
+describe("sortPlugins", () => {
+  test("installed first, then alphabetical by name", () => {
+    const items = [
+      item({ name: "zeta", status: "available" }),
+      item({ name: "beta", status: "installed" }),
+      item({ name: "alpha", status: "available" }),
+      item({ name: "gamma", status: "installed" }),
+    ];
+
+    expect(sortPlugins(items).map((p) => p.name)).toEqual([
+      "beta",
+      "gamma",
+      "alpha",
+      "zeta",
+    ]);
+  });
+
+  test("does not mutate the input array", () => {
+    const items = [item({ name: "b" }), item({ name: "a" })];
+    const before = items.map((p) => p.name);
+    sortPlugins(items);
+    expect(items.map((p) => p.name)).toEqual(before);
+  });
+});
+
+describe("filterByStatus", () => {
+  const items = [
+    item({ name: "a", status: "installed" }),
+    item({ name: "b", status: "available" }),
+    item({ name: "c", status: "installed" }),
+  ];
+
+  test("all returns everything", () => {
+    expect(filterByStatus(items, "all")).toHaveLength(3);
+  });
+
+  test("installed returns only installed", () => {
+    expect(filterByStatus(items, "installed").map((p) => p.name)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  test("available returns only available", () => {
+    expect(filterByStatus(items, "available").map((p) => p.name)).toEqual(["b"]);
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -1,0 +1,69 @@
+import type {
+  InstalledPlugin,
+  PluginCatalogMatch,
+  PluginFilter,
+  PluginListItem,
+} from "./types";
+
+/**
+ * Consolidate the installed list and the catalog into one row model.
+ * Catalog entries whose name is already installed are dropped — the two
+ * endpoints are independent, so a locally-installed plugin still appears in
+ * the catalog, and suppressing it keeps the "available" set honest.
+ */
+export function mergePlugins(
+  installed: readonly InstalledPlugin[],
+  catalog: readonly PluginCatalogMatch[],
+): PluginListItem[] {
+  const installedItems: PluginListItem[] = installed.map((p) => ({
+    name: p.name,
+    description: p.description ?? undefined,
+    status: "installed",
+    external: false,
+    version: p.version ?? undefined,
+    path: p.path,
+    issues: p.issues,
+  }));
+
+  const installedNames = new Set(installedItems.map((i) => i.name));
+
+  const catalogItems: PluginListItem[] = catalog
+    .filter((m) => !installedNames.has(m.name))
+    .map((m) => ({
+      name: m.name,
+      description: m.description,
+      status: "available",
+      external: true,
+      path: m.path,
+      sourceHost: m.source.repo,
+    }));
+
+  return [...installedItems, ...catalogItems];
+}
+
+/** Case-insensitive substring match against a plugin's name + description. */
+export function matchesQuery(item: PluginListItem, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [item.name, item.description].some((f) =>
+    f?.toLowerCase().includes(q),
+  );
+}
+
+/** Installed first, then alphabetical by name. Mirrors `sortSkills`. */
+export function sortPlugins(items: PluginListItem[]): PluginListItem[] {
+  return [...items].sort((a, b) => {
+    const aInstalled = a.status === "installed";
+    const bInstalled = b.status === "installed";
+    if (aInstalled !== bInstalled) return aInstalled ? -1 : 1;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}
+
+export function filterByStatus(
+  items: PluginListItem[],
+  filter: PluginFilter,
+): PluginListItem[] {
+  if (filter === "all") return items;
+  return items.filter((i) => i.status === filter);
+}


### PR DESCRIPTION
## Summary
- Adds plugins/{types,utils}.ts: PluginListItem unified model + mergePlugins/matchesQuery/sortPlugins/filterByStatus, mirroring the Skills domain. Pure additive logic with unit tests.

Part of plan: plugins-tab-match-skills.md (PR 4 of 13)