### PR TITLE
refactor(web): extract use-plugin-detail hook from detail page

### DIFF
--- a/clients/web/src/domains/intelligence/plugin-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/plugin-detail-page.tsx
@@ -1,4 +1,3 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
     ArrowDownToLine,
     ArrowLeft,
@@ -9,37 +8,22 @@ import {
     Trash2,
     TriangleAlert,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { FileMarkdown } from "@/components/file-markdown";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import {
-    hasLocalEdits,
-    type PluginDrift,
-    usePluginDrift,
-} from "@/domains/intelligence/use-plugin-drift";
-import {
-    pluginsByNameGetOptions,
-    pluginsByNameGetQueryKey,
-    pluginsByNameInspectGetQueryKey,
-    pluginsGetQueryKey,
-    pluginsSearchGetQueryKey,
-    usePluginsByNameDeleteMutation,
-    usePluginsByNameUpgradePostMutation,
-    usePluginsInstallPostMutation,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+    shortSha,
+    usePluginDetail,
+} from "@/domains/intelligence/plugins/use-plugin-detail";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { routes } from "@/utils/routes";
-import { Button, Card, ConfirmDialog, toast } from "@vellumai/design-library";
-
-/** First 7 chars of a commit SHA, matching git's default short form. */
-function shortSha(sha: string | null): string {
-  return sha ? sha.slice(0, 7) : "unknown";
-}
+import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
 
 /**
  * Detail page for a single plugin, reached by clicking a row in the
@@ -61,73 +45,30 @@ export function PluginDetailPage() {
   const assistantId = useActiveAssistantId();
   const { name } = useParams<{ name: string }>();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
 
-  const detailQuery = useQuery({
-    ...pluginsByNameGetOptions({
-      path: { assistant_id: assistantId, name: name ?? "" },
-    }),
-    enabled: Boolean(assistantId) && Boolean(name),
-  });
-
-  const installed = detailQuery.data?.installed ?? false;
-  const driftQuery = usePluginDrift({
-    assistantId,
-    name: name ?? "",
-    enabled: installed,
-  });
-  const drift = driftQuery.data;
-
-  const invalidate = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: pluginsSearchGetQueryKey({
-        path: { assistant_id: assistantId },
-      }),
-    });
-    if (name) {
-      void queryClient.invalidateQueries({
-        queryKey: pluginsByNameGetQueryKey({
-          path: { assistant_id: assistantId, name },
-        }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: pluginsByNameInspectGetQueryKey({
-          path: { assistant_id: assistantId, name },
-        }),
-      });
-    }
-  }, [assistantId, name, queryClient]);
-
-  const installMutation = usePluginsInstallPostMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(`Installed ${name ?? "plugin"}`);
-    },
-  });
-
-  const removeMutation = usePluginsByNameDeleteMutation({
-    onSuccess: () => {
-      invalidate();
+  const {
+    plugin,
+    drift,
+    isLoading,
+    isError,
+    install,
+    remove,
+    upgrade,
+    isInstalling,
+    isRemoving,
+    isUpgrading,
+    isInstallError,
+    isRemoveError,
+    isUpgradeError,
+    hasLocalEdits,
+  } = usePluginDetail(assistantId, name ?? "", {
+    onRemoved: () => {
       // The detail page has nothing left to show once the plugin is gone,
       // so return to the plugins list rather than stranding the user on a
       // "We couldn't load this plugin" error.
       void navigate(routes.plugins);
-    },
-  });
-
-  const upgradeMutation = usePluginsByNameUpgradePostMutation({
-    onSuccess: (result) => {
-      invalidate();
-      toast.success(
-        result.outcome === "already-up-to-date"
-          ? `${name ?? "Plugin"} is already up to date`
-          : `Upgraded ${name ?? "plugin"} to ${shortSha(result.toCommit)}`,
-      );
     },
   });
 
@@ -146,43 +87,25 @@ export function PluginDetailPage() {
     return <Navigate to={routes.plugins} replace />;
   }
 
-  const handleInstall = () => {
-    installMutation.mutate({
-      path: { assistant_id: assistantId },
-      body: { name },
-    });
-  };
-
   const confirmRemove = () => {
     setConfirmingRemove(false);
-    removeMutation.mutate({
-      path: { assistant_id: assistantId, name },
-    });
-  };
-
-  const runUpgrade = () => {
-    upgradeMutation.mutate({
-      path: { assistant_id: assistantId, name },
-      body: {},
-    });
+    remove();
   };
 
   // Local edits would be clobbered by the re-install, so confirm first;
   // a clean copy upgrades directly.
   const handleUpgrade = () => {
-    if (hasLocalEdits(drift)) {
+    if (hasLocalEdits) {
       setConfirmingUpgrade(true);
       return;
     }
-    runUpgrade();
+    upgrade();
   };
 
   const confirmUpgrade = () => {
     setConfirmingUpgrade(false);
-    runUpgrade();
+    upgrade();
   };
-
-  const plugin = detailQuery.data ?? null;
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
@@ -196,23 +119,21 @@ export function PluginDetailPage() {
           name={name}
           plugin={plugin}
           drift={drift}
-          onInstall={handleInstall}
+          onInstall={install}
           onRemove={() => setConfirmingRemove(true)}
           onUpgrade={handleUpgrade}
-          isInstalling={installMutation.isPending}
-          isRemoving={removeMutation.isPending}
-          isUpgrading={upgradeMutation.isPending}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          isUpgrading={isUpgrading}
         />
       </div>
 
-      {(installMutation.isError ||
-        removeMutation.isError ||
-        upgradeMutation.isError) && (
+      {(isInstallError || isRemoveError || isUpgradeError) && (
         <ActionError
           message={
-            installMutation.isError
+            isInstallError
               ? "Failed to install plugin. Please try again."
-              : removeMutation.isError
+              : isRemoveError
                 ? "Failed to remove plugin. Please try again."
                 : "Failed to upgrade plugin. Please try again."
           }
@@ -221,9 +142,9 @@ export function PluginDetailPage() {
 
       <Card.Root asChild>
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-          {detailQuery.isLoading ? (
+          {isLoading ? (
             <LoadingState />
-          ) : detailQuery.isError || !plugin ? (
+          ) : isError || !plugin ? (
             <DetailErrorState />
           ) : (
             <>

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for `usePluginDetail`, the shared data hook backing the plugin detail
+ * surfaces. It owns the single-plugin read, the install/remove/upgrade
+ * mutations (each invalidating the list/search/detail/inspect queries on
+ * success), and the `hasLocalEdits` signal derived from the drift inspection.
+ *
+ * The generated SDK layer is mocked so the mutations resolve locally and we can
+ * assert which endpoint each action hits. The detail + inspect reads are seeded
+ * into the React Query cache (infinite stale time) so the hook resolves on
+ * mount without touching the network, mirroring the detail-page tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { Options } from "@/generated/daemon/sdk.gen";
+import type {
+  PluginsByNameGetData,
+  PluginsByNameGetResponse,
+  PluginsByNameInspectGetData,
+  PluginsByNameInspectGetResponse,
+} from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+const NAME = "level-up";
+const LOCAL_COMMIT = "60a392b0000000000000000000000000000000aa";
+const REMOTE_COMMIT = "3eae1820000000000000000000000000000000bb";
+
+const okResponse = { response: new Response(), error: undefined };
+
+// Spy each mutation endpoint so the actions resolve locally and we can assert
+// the path/body each one is called with.
+const installSpy = mock(async (_options: unknown) => ({
+  data: undefined,
+  ...okResponse,
+}));
+const deleteSpy = mock(async (_options: unknown) => ({
+  data: undefined,
+  ...okResponse,
+}));
+const upgradeSpy = mock(async (_options: unknown) => ({
+  data: {
+    name: NAME,
+    outcome: "upgraded" as const,
+    fromCommit: LOCAL_COMMIT,
+    toCommit: REMOTE_COMMIT,
+    target: `/ws/plugins/${NAME}`,
+    fileCount: 3,
+    dryRun: false,
+    provenanceWasUnknown: false,
+  },
+  ...okResponse,
+}));
+
+// Each success path invalidates the list/search/detail/inspect queries, which
+// refetch on the next tick. Stub those reads so the refetch resolves locally
+// instead of dialing an absent daemon.
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsInstallPost: installSpy,
+  pluginsByNameDelete: deleteSpy,
+  pluginsByNameUpgradePost: upgradeSpy,
+  pluginsGet: mock(async () => ({ data: { plugins: [] }, ...okResponse })),
+  pluginsSearchGet: mock(async () => ({ data: { matches: [] }, ...okResponse })),
+  pluginsByNameGet: mock(async (options: { path: { name: string } }) => ({
+    data: installedDetail(options.path.name),
+    ...okResponse,
+  })),
+  pluginsByNameInspectGet: mock(
+    async (options: { path: { name: string } }) => ({
+      data: inspectResponse(options.path.name, true),
+      ...okResponse,
+    }),
+  ),
+}));
+
+const { pluginsByNameGetQueryKey, pluginsByNameInspectGetQueryKey } =
+  await import("@/generated/daemon/@tanstack/react-query.gen");
+const { usePluginDetail } = await import(
+  "@/domains/intelligence/plugins/use-plugin-detail"
+);
+
+function installedDetail(name: string): PluginsByNameGetResponse {
+  return {
+    name,
+    installed: true,
+    description: "Surfaces a Level Up diff card.",
+    homepage: null,
+    license: "MIT",
+    version: "0.1.0",
+    source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+    readme: "# Level Up",
+    ref: "main",
+    artifact: null,
+  };
+}
+
+function inspectResponse(
+  name: string,
+  localClean: boolean,
+): PluginsByNameInspectGetResponse {
+  return {
+    name,
+    installed: true,
+    status: "up-to-date",
+    local: {
+      target: `/ws/plugins/${name}`,
+      commit: LOCAL_COMMIT,
+      committedAt: null,
+      version: "0.1.0",
+      description: "Surfaces a Level Up diff card.",
+      installedAt: "2026-06-01T00:00:00.000Z",
+      source: {
+        kind: "github",
+        owner: "vellum-ai",
+        repo: "level-up",
+        ref: LOCAL_COMMIT,
+      },
+      localChanges: {
+        modified: localClean ? [] : ["hooks/stop.ts"],
+        added: [],
+        removed: [],
+        clean: localClean,
+      },
+      issues: [],
+    },
+    remote: null,
+    remoteError: null,
+    surfaces: null,
+  };
+}
+
+interface RenderArgs {
+  localClean?: boolean;
+}
+
+function renderPluginDetail({ localClean = true }: RenderArgs = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  client.setQueryData(
+    pluginsByNameGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    } as Options<PluginsByNameGetData>),
+    installedDetail(NAME),
+  );
+  client.setQueryData(
+    pluginsByNameInspectGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    } as Options<PluginsByNameInspectGetData>),
+    inspectResponse(NAME, localClean),
+  );
+  const invalidateSpy = mock(client.invalidateQueries.bind(client));
+  client.invalidateQueries = invalidateSpy;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+
+  const result = renderHook(() => usePluginDetail(ASSISTANT_ID, NAME), {
+    wrapper,
+  });
+  return { ...result, invalidateSpy };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  installSpy.mockClear();
+  deleteSpy.mockClear();
+  upgradeSpy.mockClear();
+});
+
+describe("usePluginDetail", () => {
+  test("resolves the seeded plugin from cache", () => {
+    const { result } = renderPluginDetail();
+
+    expect(result.current.plugin?.name).toBe(NAME);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  test("install hits the install endpoint and invalidates on success", async () => {
+    const { result, invalidateSpy } = renderPluginDetail();
+
+    result.current.install();
+
+    await waitFor(() => expect(installSpy).toHaveBeenCalledTimes(1));
+    expect(installSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID },
+      body: { name: NAME },
+    });
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+  });
+
+  test("remove hits the delete endpoint, invalidates, and fires onRemoved", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+      },
+    });
+    client.setQueryData(
+      pluginsByNameGetQueryKey({
+        path: { assistant_id: ASSISTANT_ID, name: NAME },
+      } as Options<PluginsByNameGetData>),
+      installedDetail(NAME),
+    );
+    const invalidateSpy = mock(client.invalidateQueries.bind(client));
+    client.invalidateQueries = invalidateSpy;
+    const onRemoved = mock(() => {});
+
+    function wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client }, children);
+    }
+
+    const { result } = renderHook(
+      () => usePluginDetail(ASSISTANT_ID, NAME, { onRemoved }),
+      { wrapper },
+    );
+
+    result.current.remove();
+
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledTimes(1));
+    expect(deleteSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    });
+    await waitFor(() => expect(onRemoved).toHaveBeenCalledTimes(1));
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  test("upgrade hits the upgrade endpoint and invalidates on success", async () => {
+    const { result, invalidateSpy } = renderPluginDetail();
+
+    result.current.upgrade();
+
+    await waitFor(() => expect(upgradeSpy).toHaveBeenCalledTimes(1));
+    expect(upgradeSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+      body: {},
+    });
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+  });
+
+  test("hasLocalEdits reflects local.localChanges.clean", () => {
+    const clean = renderPluginDetail({ localClean: true });
+    expect(clean.result.current.hasLocalEdits).toBe(false);
+    clean.unmount();
+
+    const dirty = renderPluginDetail({ localClean: false });
+    expect(dirty.result.current.hasLocalEdits).toBe(true);
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
@@ -1,0 +1,177 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import {
+    hasLocalEdits as computeHasLocalEdits,
+    type PluginDrift,
+    usePluginDrift,
+} from "@/domains/intelligence/use-plugin-drift";
+import {
+    pluginsByNameGetOptions,
+    pluginsByNameGetQueryKey,
+    pluginsByNameInspectGetQueryKey,
+    pluginsGetQueryKey,
+    pluginsSearchGetQueryKey,
+    usePluginsByNameDeleteMutation,
+    usePluginsByNameUpgradePostMutation,
+    usePluginsInstallPostMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { toast } from "@vellumai/design-library";
+
+/** First 7 chars of a commit SHA, matching git's default short form. */
+export function shortSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : "unknown";
+}
+
+interface UsePluginDetailOptions {
+  /**
+   * Invoked after a successful removal. The full-page detail view uses this to
+   * navigate back to the list (nothing is left to render once the plugin is
+   * gone); an in-tab panel can use it to close itself instead.
+   */
+  onRemoved?: () => void;
+}
+
+export interface UsePluginDetailResult {
+  /** The fetched plugin, or `null` until the detail query resolves. */
+  plugin: PluginsByNameGetResponse | null;
+  /** Update-drift signal for the installed copy (`undefined` until resolved). */
+  drift: PluginDrift | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  /** Install the available plugin (no-op gating is the caller's concern). */
+  install: () => void;
+  /** Remove the installed plugin; fires `onRemoved` on success. */
+  remove: () => void;
+  /** Upgrade the installed copy to the marketplace pin. */
+  upgrade: () => void;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  isUpgrading: boolean;
+  isInstallError: boolean;
+  isRemoveError: boolean;
+  isUpgradeError: boolean;
+  /** True when the installed copy has uncommitted local edits vs its baseline. */
+  hasLocalEdits: boolean;
+}
+
+/**
+ * Single source of truth for a single plugin's detail view: the plugin read,
+ * its update-drift inspection, and the install / remove / upgrade mutations
+ * (with their toast + cache-invalidation side effects). Shared by the full-page
+ * detail route and the in-tab detail panel so neither duplicates the wiring.
+ *
+ * Toast and invalidation behavior matches the original detail page exactly:
+ * install and upgrade surface a success toast, all three invalidate the list /
+ * search / detail / inspect queries, and removal defers its post-success
+ * navigation to the caller via `onRemoved`.
+ */
+export function usePluginDetail(
+  assistantId: string,
+  name: string,
+  options?: UsePluginDetailOptions,
+): UsePluginDetailResult {
+  const queryClient = useQueryClient();
+  const onRemoved = options?.onRemoved;
+
+  const detailQuery = useQuery({
+    ...pluginsByNameGetOptions({
+      path: { assistant_id: assistantId, name },
+    }),
+    enabled: Boolean(assistantId) && Boolean(name),
+  });
+
+  const installed = detailQuery.data?.installed ?? false;
+  const driftQuery = usePluginDrift({
+    assistantId,
+    name,
+    enabled: installed,
+  });
+  const drift = driftQuery.data;
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: pluginsSearchGetQueryKey({
+        path: { assistant_id: assistantId },
+      }),
+    });
+    if (name) {
+      void queryClient.invalidateQueries({
+        queryKey: pluginsByNameGetQueryKey({
+          path: { assistant_id: assistantId, name },
+        }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: pluginsByNameInspectGetQueryKey({
+          path: { assistant_id: assistantId, name },
+        }),
+      });
+    }
+  }, [assistantId, name, queryClient]);
+
+  const installMutation = usePluginsInstallPostMutation({
+    onSuccess: () => {
+      invalidate();
+      toast.success(`Installed ${name || "plugin"}`);
+    },
+  });
+
+  const removeMutation = usePluginsByNameDeleteMutation({
+    onSuccess: () => {
+      invalidate();
+      onRemoved?.();
+    },
+  });
+
+  const upgradeMutation = usePluginsByNameUpgradePostMutation({
+    onSuccess: (result) => {
+      invalidate();
+      toast.success(
+        result.outcome === "already-up-to-date"
+          ? `${name || "Plugin"} is already up to date`
+          : `Upgraded ${name || "plugin"} to ${shortSha(result.toCommit)}`,
+      );
+    },
+  });
+
+  const install = () => {
+    installMutation.mutate({
+      path: { assistant_id: assistantId },
+      body: { name },
+    });
+  };
+
+  const remove = () => {
+    removeMutation.mutate({
+      path: { assistant_id: assistantId, name },
+    });
+  };
+
+  const upgrade = () => {
+    upgradeMutation.mutate({
+      path: { assistant_id: assistantId, name },
+      body: {},
+    });
+  };
+
+  return {
+    plugin: detailQuery.data ?? null,
+    drift,
+    isLoading: detailQuery.isLoading,
+    isError: detailQuery.isError,
+    install,
+    remove,
+    upgrade,
+    isInstalling: installMutation.isPending,
+    isRemoving: removeMutation.isPending,
+    isUpgrading: upgradeMutation.isPending,
+    isInstallError: installMutation.isError,
+    isRemoveError: removeMutation.isError,
+    isUpgradeError: upgradeMutation.isError,
+    hasLocalEdits: computeHasLocalEdits(drift),
+  };
+}

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
@@ -26,9 +26,8 @@ export function shortSha(sha: string | null): string {
 
 interface UsePluginDetailOptions {
   /**
-   * Invoked after a successful removal. The full-page detail view uses this to
-   * navigate back to the list (nothing is left to render once the plugin is
-   * gone); an in-tab panel can use it to close itself instead.
+   * Invoked after a successful removal, when the plugin no longer exists to
+   * render. Callers use it to leave the detail view (navigate away or close it).
    */
   onRemoved?: () => void;
 }
@@ -59,13 +58,11 @@ export interface UsePluginDetailResult {
 /**
  * Single source of truth for a single plugin's detail view: the plugin read,
  * its update-drift inspection, and the install / remove / upgrade mutations
- * (with their toast + cache-invalidation side effects). Shared by the full-page
- * detail route and the in-tab detail panel so neither duplicates the wiring.
+ * with their toast + cache-invalidation side effects.
  *
- * Toast and invalidation behavior matches the original detail page exactly:
- * install and upgrade surface a success toast, all three invalidate the list /
- * search / detail / inspect queries, and removal defers its post-success
- * navigation to the caller via `onRemoved`.
+ * Install and upgrade surface a success toast; all three mutations invalidate
+ * the list / search / detail / inspect queries on success. Removal defers its
+ * post-success action to the caller via `onRemoved`.
  */
 export function usePluginDetail(
   assistantId: string,


### PR DESCRIPTION
## Summary
- Extracts single-plugin queries + install/remove/upgrade mutations into usePluginDetail; plugin-detail-page consumes it with no behavior change. Enables in-tab detail reuse.

Part of plan: plugins-tab-match-skills.md (PR 9 of 13)