### PR TITLE
feat(onboarding): "Create my personality" slider step (research onboarding)

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the personality system-message builder — the load-bearing mapping
+ * from the five 0–100 sliders to the nine named trait scores. Must reproduce
+ * the agreed template wording exactly (the assistant parses these lines).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildPersonalityMessage } from "./apply-personality";
+
+describe("buildPersonalityMessage", () => {
+  test("reproduces the template scores from the matching slider values", () => {
+    // Sliders that should yield the reference template (Companion 30/Coworker
+    // 70, Voice 80, Execute 20/Collaborate 80, Playful 100/Serious 0, Polite
+    // 40/Unfiltered 60).
+    const msg = buildPersonalityMessage(
+      {
+        "companion-coworker": 70,
+        "genz-boomer": 80,
+        "execute-collaborate": 80,
+        "playful-serious": 0,
+        "polite-unfiltered": 60,
+      },
+      "Akash",
+    );
+
+    expect(msg).toContain("Akash wants to customize your personality.");
+    expect(msg).toContain("Companion (0-100): 30");
+    expect(msg).toContain("Coworker (0-100): 70");
+    expect(msg).toContain("Voice Style (0 = Gen Z, 100 = Boomer): 80");
+    expect(msg).toContain("Execute Independently (0 - 100): 20");
+    expect(msg).toContain("Collaborative (0 - 100): 80");
+    expect(msg).toContain("Playfulness (0 - 100): 100");
+    expect(msg).toContain("Seriousness (0 - 100): 0");
+    expect(msg).toContain("Politeness (0 - 100): 40");
+    expect(msg).toContain("Unfiltered Rawness/Crassness (0 - 100): 60");
+    expect(msg).toContain("Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md)");
+    expect(msg).toContain("<system-message>");
+    expect(msg).toContain("</system-message>");
+  });
+
+  test("defaults missing sliders to the midpoint and falls back to a generic name", () => {
+    const msg = buildPersonalityMessage({});
+    expect(msg).toContain("The user wants to customize your personality.");
+    // Empty → every slider treated as 50, so both ends read 50.
+    expect(msg).toContain("Companion (0-100): 50");
+    expect(msg).toContain("Coworker (0-100): 50");
+    expect(msg).toContain("Voice Style (0 = Gen Z, 100 = Boomer): 50");
+  });
+
+  test("clamps out-of-range values into 0–100", () => {
+    const msg = buildPersonalityMessage({ "companion-coworker": 140 });
+    expect(msg).toContain("Coworker (0-100): 100");
+    expect(msg).toContain("Companion (0-100): 0");
+  });
+});

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -1,0 +1,192 @@
+/**
+ * Applies the "Create my personality" slider choices to the assistant.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The personality step collects five 0–100 trait sliders. On continue we hand
+ * them to the real hatched assistant as a system-message that asks it to
+ * rewrite its identity files (IDENTITY.md / SOUL.md / users/guardian.md) in a
+ * voice matching the new personality — the durable way to reshape its persona,
+ * since those files feed every future conversation's system prompt.
+ *
+ * Like the research turn (`research-runner.ts`) and the check-in
+ * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
+ * conversation: we await hatch readiness, mint a conversation, post the prompt,
+ * let the rewrite turn settle, then archive it so it never shows in the user's
+ * sidebar. Talks to the daemon through the generated SDK directly
+ * (`@/domains/chat/api/*` is import-banned from onboarding).
+ *
+ * Best-effort and fire-and-forget: a failure here must never block or surface
+ * in the onboarding flow. Every error is swallowed (reported to Sentry).
+ */
+
+import {
+  conversationsByIdArchivePost,
+  conversationsPost,
+  messagesGet,
+  messagesPost,
+} from "@/generated/daemon/sdk.gen";
+import type {
+  MessagesGetResponses,
+  MessagesPostData,
+} from "@/generated/daemon/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+
+/**
+ * Axis ids the personality step keys its slider values by. Mirror
+ * `PERSONALITY_AXES` in `screens/create-personality-step.tsx`; each is 0–100
+ * with 0 = the left label and 100 = the right label.
+ */
+const AXIS = {
+  companionCoworker: "companion-coworker",
+  genzBoomer: "genz-boomer",
+  executeCollaborate: "execute-collaborate",
+  playfulSerious: "playful-serious",
+  politeUnfiltered: "polite-unfiltered",
+} as const;
+
+/** Poll cadence + ceiling while waiting for the rewrite turn to land. */
+const POLL_INTERVAL_MS = 1500;
+const MAX_POLL_MS = 120_000;
+/** Consecutive identical assistant reads that mark the rewrite turn settled. */
+const STABLE_READS_TO_SETTLE = 2;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const clamp = (n: number): number => Math.max(0, Math.min(100, Math.round(n)));
+
+/**
+ * Render the personality system-message from the five slider values. Pure, so
+ * it's unit-testable without the daemon. Each slider's two ends become explicit
+ * 0–100 scores (a slider at 70 toward "Coworker" → Companion 30 / Coworker 70).
+ */
+export function buildPersonalityMessage(
+  values: Record<string, number>,
+  userName?: string,
+): string {
+  const v = (id: string): number => clamp(values[id] ?? 50);
+  const companionCoworker = v(AXIS.companionCoworker); // 100 = Coworker
+  const executeCollaborate = v(AXIS.executeCollaborate); // 100 = Collaborate
+  const playfulSerious = v(AXIS.playfulSerious); // 100 = Serious
+  const politeUnfiltered = v(AXIS.politeUnfiltered); // 100 = Unfiltered
+
+  const who = userName?.trim() || "The user";
+  return `<system-message>
+${who} wants to customize your personality.
+This is what they want you to be:
+Companion (0-100): ${100 - companionCoworker}
+Coworker (0-100): ${companionCoworker}
+Voice Style (0 = Gen Z, 100 = Boomer): ${v(AXIS.genzBoomer)}
+Execute Independently (0 - 100): ${100 - executeCollaborate}
+Collaborative (0 - 100): ${executeCollaborate}
+Playfulness (0 - 100): ${100 - playfulSerious}
+Seriousness (0 - 100): ${playfulSerious}
+Politeness (0 - 100): ${100 - politeUnfiltered}
+Unfiltered Rawness/Crassness (0 - 100): ${politeUnfiltered}
+
+Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality. Write them in first person in a voice and style that matches your new personality.
+</system-message>`;
+}
+
+type GetMessage = MessagesGetResponses[200]["messages"][number];
+
+/** Latest assistant reply text (text blocks, then legacy flat content). */
+function latestAssistantText(messages: GetMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m || m.role !== "assistant") continue;
+    const blocks = m.contentBlocks;
+    if (blocks && blocks.length > 0) {
+      const text = blocks
+        .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
+        .map((b) => b.text)
+        .join("\n")
+        .trim();
+      if (text) return text;
+    }
+    return (m.content ?? "").trim();
+  }
+  return "";
+}
+
+export interface ApplyPersonalityOptions {
+  /** Resolves with the hatched assistant id once it's healthy. */
+  awaitAssistantId: () => Promise<string>;
+  /** The five slider values, keyed by axis id (see `AXIS`). */
+  values: Record<string, number>;
+  /** The user's name, woven into the system-message. */
+  userName?: string;
+}
+
+/**
+ * Apply the personality on a throwaway side conversation. Resolves once the
+ * conversation has been archived (or immediately on any failure); never throws.
+ */
+export async function applyPersonality({
+  awaitAssistantId,
+  values,
+  userName,
+}: ApplyPersonalityOptions): Promise<void> {
+  let assistantId: string | undefined;
+  let conversationId: string | undefined;
+  try {
+    assistantId = await awaitAssistantId();
+
+    const conversation = await conversationsPost({
+      path: { assistant_id: assistantId },
+      body: { conversationType: "standard", title: "Updating personality" },
+      throwOnError: false,
+    });
+    conversationId = conversation.data?.id;
+    if (!conversation.response?.ok || !conversationId) return;
+
+    const body: MessagesPostData["body"] = {
+      conversationId,
+      content: buildPersonalityMessage(values, userName),
+      sourceChannel: "vellum",
+      interface: "vellum",
+      clientMessageId: crypto.randomUUID(),
+    };
+    const posted = await messagesPost({
+      path: { assistant_id: assistantId },
+      body,
+      throwOnError: false,
+    });
+    if (!posted.response?.ok) return;
+
+    // Let the rewrite turn run before hiding the thread — archiving mid-turn
+    // could drop the identity edits. Settle once the reply stops changing.
+    const deadline = Date.now() + MAX_POLL_MS;
+    let lastText = "";
+    let stableReads = 0;
+    while (Date.now() < deadline) {
+      await sleep(POLL_INTERVAL_MS);
+      const listed = await messagesGet({
+        path: { assistant_id: assistantId },
+        query: { conversationId },
+        throwOnError: false,
+      });
+      const text = latestAssistantText(listed.data?.messages ?? []);
+      if (text) {
+        stableReads = text === lastText ? stableReads + 1 : 0;
+        lastText = text;
+        if (stableReads >= STABLE_READS_TO_SETTLE) break;
+      }
+    }
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_personality" });
+  } finally {
+    // Archive the throwaway thread so it never appears in the sidebar.
+    if (assistantId && conversationId) {
+      try {
+        await conversationsByIdArchivePost({
+          path: { assistant_id: assistantId, id: conversationId },
+          throwOnError: false,
+        });
+      } catch (err) {
+        captureError(err, { context: "research_onboarding_personality_archive" });
+      }
+    }
+  }
+}

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -197,7 +197,7 @@ describe("onboarding funnel events", () => {
     expect(secondEvent?.session_id).toBe(firstEvent?.session_id);
     expect(secondEvent).toMatchObject({
       step_name: "research_suggestions",
-      step_index: 9,
+      step_index: 10,
       funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
       outcome: "skipped",
     });
@@ -226,7 +226,7 @@ describe("onboarding funnel events", () => {
     expect(event).toMatchObject({
       type: "onboarding",
       step_name: "research_checkin_open",
-      step_index: 10,
+      step_index: 11,
       user_id: "user-123",
       funnel_version: RESEARCH_ONBOARDING_FUNNEL_VERSION,
       ab_variant: "control",

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -61,12 +61,13 @@ export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
   face: { stepName: "research_face", stepIndex: 1 },
   intro: { stepName: "research_intro", stepIndex: 2 },
   different: { stepName: "research_pitch", stepIndex: 3 },
-  integration: { stepName: "research_integration", stepIndex: 4 },
-  letschat: { stepName: "research_calendar", stepIndex: 5 },
-  meeting: { stepName: "research_meeting", stepIndex: 6 },
-  looking: { stepName: "research_looking", stepIndex: 7 },
-  results: { stepName: "research_results", stepIndex: 8 },
-  suggestions: { stepName: "research_suggestions", stepIndex: 9 },
+  personality: { stepName: "research_personality", stepIndex: 4 },
+  integration: { stepName: "research_integration", stepIndex: 5 },
+  letschat: { stepName: "research_calendar", stepIndex: 6 },
+  meeting: { stepName: "research_meeting", stepIndex: 7 },
+  looking: { stepName: "research_looking", stepIndex: 8 },
+  results: { stepName: "research_results", stepIndex: 9 },
+  suggestions: { stepName: "research_suggestions", stepIndex: 10 },
 } as const satisfies Record<ResearchStep, OnboardingFunnelStepDescriptor>;
 
 export type ResearchOnboardingFunnelStep =
@@ -96,7 +97,7 @@ export const RESEARCH_CHECKIN_CALENDAR_ATTRIBUTION = "research_checkin";
  */
 export const RESEARCH_ONBOARDING_CHECKIN_STEP = {
   stepName: "research_checkin_open",
-  stepIndex: 10,
+  stepIndex: 11,
 } as const satisfies OnboardingFunnelStepDescriptor;
 
 /**

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -173,6 +173,13 @@ export function ResearchOnboardingRoute() {
     null,
   );
   const [faceValues, setFaceValues] = useState<GiveMeAFaceValues | null>(null);
+  // Personality sliders live here (not in the step) so they survive a step-back
+  // and stay shown once locked. `personalityLocked` flips true on the first
+  // continue — the prompt has been sent, so the sliders can't be edited again.
+  const [personalityValues, setPersonalityValues] = useState<
+    Record<string, number>
+  >({});
+  const [personalityLocked, setPersonalityLocked] = useState(false);
   // Id of the behind-the-scenes "research me" conversation. Captured the moment
   // it's minted (and restored from the snapshot on refresh) so a mid-search
   // reload re-attaches to that same thread instead of starting a second search.
@@ -555,16 +562,27 @@ export function ResearchOnboardingRoute() {
         )}
         {step === "personality" && (
           <CreatePersonalityStep
-            onContinue={(personalityValues) => {
-              // Apply the sliders to the assistant's persona on a throwaway side
-              // thread (awaits hatch readiness internally, then archives). Fire-
-              // and-forget — the rewrite turn finishes during the later steps,
-              // well before the chat handoff. Best-effort; never blocks the flow.
-              void applyPersonality({
-                awaitAssistantId: awaitHatchReady,
-                values: personalityValues,
-                userName: formValues?.firstName?.trim() || undefined,
-              });
+            values={personalityValues}
+            onValueChange={(axisId, value) =>
+              setPersonalityValues((prev) => ({ ...prev, [axisId]: value }))
+            }
+            locked={personalityLocked}
+            onContinue={() => {
+              // First continue applies the sliders to the assistant's persona on
+              // a throwaway side thread (awaits hatch readiness internally, then
+              // archives) and locks them — the prompt has been sent, so a later
+              // step-back can't silently diverge. Fire-and-forget: the rewrite
+              // turn finishes during the later steps, well before the chat
+              // handoff. Best-effort; never blocks the flow. A continue while
+              // already locked just advances.
+              if (!personalityLocked) {
+                void applyPersonality({
+                  awaitAssistantId: awaitHatchReady,
+                  values: personalityValues,
+                  userName: formValues?.firstName?.trim() || undefined,
+                });
+                setPersonalityLocked(true);
+              }
               goForwardTo("integration");
             }}
             onBack={() => goBackTo("different")}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -65,6 +65,7 @@ import {
 import { IntroductionScreen } from "@/domains/onboarding/screens/introduction-screen";
 import { PitchStep } from "@/domains/onboarding/screens/intro-pitch-steps";
 import { IntegrationStep } from "@/domains/onboarding/screens/integration-step";
+import { CreatePersonalityStep } from "@/domains/onboarding/screens/create-personality-step";
 import { LetsChatTomorrowStep } from "@/domains/onboarding/screens/lets-chat-tomorrow-step";
 import {
   MeetingCreatedStep,
@@ -511,6 +512,7 @@ export function ResearchOnboardingRoute() {
   // content swaps. Extra edge characters pop in per step to build excitement.
   const tonedSteps = [
     "different",
+    "personality",
     "integration",
     "letschat",
     "meeting",
@@ -545,8 +547,15 @@ export function ResearchOnboardingRoute() {
         />
         {step === "different" && (
           <PitchStep
-            onContinue={() => goForwardTo("integration")}
+            onContinue={() => goForwardTo("personality")}
             onBack={() => goBackTo("intro")}
+            onForward={onForward}
+          />
+        )}
+        {step === "personality" && (
+          <CreatePersonalityStep
+            onContinue={() => goForwardTo("integration")}
+            onBack={() => goBackTo("different")}
             onForward={onForward}
           />
         )}
@@ -554,7 +563,7 @@ export function ResearchOnboardingRoute() {
           <IntegrationStep
             onClaim={() => goForwardTo("letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
-            onBack={() => goBackTo("different")}
+            onBack={() => goBackTo("personality")}
             onForward={onForward}
           />
         )}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -113,6 +113,10 @@ export function ResearchOnboardingRoute() {
   // Belt-and-suspenders gate: the spike lives at a dedicated path AND behind
   // this flag (off by default; enable locally via the feature-flags panel).
   const enabled = useClientFeatureFlagStore.use.researchOnboarding();
+  // Sub-gate for the "Create my personality" step; when off it's skipped
+  // entirely (pitch → integration, with the back nav mirrored).
+  const personalityEnabled =
+    useClientFeatureFlagStore.use.personalityOnboarding();
   const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
 
   // Sub-steps share this route: details form → avatar/name picker →
@@ -555,7 +559,9 @@ export function ResearchOnboardingRoute() {
         />
         {step === "different" && (
           <PitchStep
-            onContinue={() => goForwardTo("personality")}
+            onContinue={() =>
+              goForwardTo(personalityEnabled ? "personality" : "integration")
+            }
             onBack={() => goBackTo("intro")}
             onForward={onForward}
           />
@@ -593,7 +599,9 @@ export function ResearchOnboardingRoute() {
           <IntegrationStep
             onClaim={() => goForwardTo("letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
-            onBack={() => goBackTo("personality")}
+            onBack={() =>
+              goBackTo(personalityEnabled ? "personality" : "different")
+            }
             onForward={onForward}
           />
         )}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -38,6 +38,7 @@ import {
 import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
 import { sendResearchCorrection } from "@/domains/onboarding/send-research-correction";
+import { applyPersonality } from "@/domains/onboarding/apply-personality";
 import {
   clearResearchSnapshot,
   readResearchSnapshot,
@@ -554,7 +555,18 @@ export function ResearchOnboardingRoute() {
         )}
         {step === "personality" && (
           <CreatePersonalityStep
-            onContinue={() => goForwardTo("integration")}
+            onContinue={(personalityValues) => {
+              // Apply the sliders to the assistant's persona on a throwaway side
+              // thread (awaits hatch readiness internally, then archives). Fire-
+              // and-forget — the rewrite turn finishes during the later steps,
+              // well before the chat handoff. Best-effort; never blocks the flow.
+              void applyPersonality({
+                awaitAssistantId: awaitHatchReady,
+                values: personalityValues,
+                userName: formValues?.firstName?.trim() || undefined,
+              });
+              goForwardTo("integration");
+            }}
             onBack={() => goBackTo("different")}
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -40,6 +40,7 @@ export type ResearchStep =
   | "face"
   | "intro"
   | "different"
+  | "personality"
   | "integration"
   | "letschat"
   | "meeting"

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -1,0 +1,160 @@
+/**
+ * "Create my personality" — five trait sliders the user nudges to shape the
+ * assistant's voice, shown between the pitch and the free-credits step.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Frontend-only for now: the slider values are held in local state and aren't
+ * sent anywhere yet (a later PR will wire them to the assistant's persona). The
+ * step is part of the research-onboarding flow (no separate flag). Foreground
+ * content only — the shared toned backdrop (avatar color + bottom eyes) sits
+ * behind.
+ */
+
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+
+interface CreatePersonalityStepProps {
+  onContinue: () => void;
+  onBack: () => void;
+  /** Redo into the next step — only set when the user has stepped back. */
+  onForward?: () => void;
+}
+
+/** The five trait axes, each a 0–100 slider flanked by its end labels. */
+interface PersonalityAxis {
+  id: string;
+  left: string;
+  right: string;
+}
+
+const PERSONALITY_AXES: PersonalityAxis[] = [
+  { id: "companion-coworker", left: "Companion", right: "Coworker" },
+  { id: "genz-boomer", left: "Gen Z", right: "Baby Boomer" },
+  { id: "execute-collaborate", left: "Execute", right: "Collaborate" },
+  { id: "playful-serious", left: "Playful", right: "Serious" },
+  { id: "polite-unfiltered", left: "Polite", right: "Unfiltered" },
+];
+
+/** Sliders start centered — no axis is nudged either way until the user acts. */
+const DEFAULT_VALUE = 50;
+
+/**
+ * Slider styling from Figma (node 6279-576): a thick, uniformly-tinted track
+ * (Surface-Dark/Lift at low opacity, so it darkens whatever avatar color sits
+ * behind it) with a large solid-white thumb (Primary-Dark/Base). Smooth
+ * (continuous) drag, no separate filled-range color — the track reads the same
+ * on both sides of the thumb.
+ */
+const TRACK_COLOR = "rgba(36, 41, 46, 0.2)"; // #24292E @ 20%
+const THUMB_COLOR = "#FDFDFC";
+
+/** One trait row: left label, the tinted track, right label. */
+function PersonalitySlider({
+  axis,
+  value,
+  onValueChange,
+  fg,
+}: {
+  axis: PersonalityAxis;
+  value: number;
+  onValueChange: (next: number) => void;
+  fg: string;
+}) {
+  // Responsive: on mobile the labels sit on one line split to the slider's two
+  // ends (left label hard-left, right label hard-right) above a full-width
+  // track, so it's obvious which end each label belongs to; on >=sm they flank
+  // the track in a single row. Flex `order` + wrap drives the reflow.
+  return (
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 sm:flex-nowrap">
+      <span
+        className="order-1 flex-1 text-left text-body-medium-default sm:w-28 sm:flex-none sm:text-right"
+        style={{ color: fg }}
+      >
+        {axis.left}
+      </span>
+      <span
+        className="order-2 flex-1 text-right text-body-medium-default sm:order-3 sm:w-28 sm:flex-none sm:text-left"
+        style={{ color: fg }}
+      >
+        {axis.right}
+      </span>
+      <SliderPrimitive.Root
+        className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
+        value={[value]}
+        onValueChange={(next) => onValueChange(next[0] ?? DEFAULT_VALUE)}
+        min={0}
+        max={100}
+        step={1}
+        aria-label={`${axis.left} to ${axis.right}`}
+      >
+        <SliderPrimitive.Track
+          className="relative h-3 w-full grow rounded-full"
+          style={{ backgroundColor: TRACK_COLOR }}
+        />
+        <SliderPrimitive.Thumb
+          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70"
+          style={{ backgroundColor: THUMB_COLOR }}
+        />
+      </SliderPrimitive.Root>
+    </div>
+  );
+}
+
+export function CreatePersonalityStep({
+  onContinue,
+  onBack,
+  onForward,
+}: CreatePersonalityStepProps) {
+  const tone = useOnboardingTone();
+  // Frontend-only: keep each axis' value locally; nothing is persisted yet.
+  const [values, setValues] = useState<Record<string, number>>(() =>
+    Object.fromEntries(PERSONALITY_AXES.map((axis) => [axis.id, DEFAULT_VALUE])),
+  );
+
+  return (
+    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
+      <OnboardingTopBar onBack={onBack} onNext={onForward} />
+
+      <div className="absolute left-1/2 top-[14%] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-12 px-6">
+        <h1
+          className="text-center text-[2.6rem] leading-none"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          Create my personality
+        </h1>
+
+        <div className="flex w-full flex-col gap-7">
+          {PERSONALITY_AXES.map((axis) => (
+            <PersonalitySlider
+              key={axis.id}
+              axis={axis}
+              value={values[axis.id] ?? DEFAULT_VALUE}
+              onValueChange={(next) =>
+                setValues((prev) => ({ ...prev, [axis.id]: next }))
+              }
+              fg={tone.fg}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={onContinue}
+          className="mt-4 flex h-11 w-[234px] cursor-pointer items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
+          style={{
+            backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
+            color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
+          }}
+        >
+          Continue
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -120,8 +120,12 @@ const DEFAULT_VALUE = 50;
 const TRACK_COLOR = "rgba(36, 41, 46, 0.2)"; // #24292E @ 20%
 const THUMB_COLOR = "#FDFDFC";
 
-/** Largest fraction of a peeking avatar that pokes past its screen edge. */
-const MAX_PEEK = 0.62;
+/**
+ * Inset (as a fraction of avatar width) from the screen edge at a fully-dragged
+ * slider — at the far end the avatar is entirely on-screen with this much gap
+ * between it and the edge, then it slides back off-screen toward center.
+ */
+const EDGE_GAP = 0.16;
 
 /**
  * Keep an avatar's color off the background. The toned backdrop is painted in
@@ -177,9 +181,10 @@ function EdgePeekAvatar({
   progress: number;
 }) {
   const p = Math.max(0, Math.min(1, progress));
-  // Hidden just past the edge at p=0; up to MAX_PEEK of the body shown at p=1.
-  const shown = MAX_PEEK * p;
-  const tx = side === "left" ? -100 + shown * 100 : 100 - shown * 100;
+  // p=0: fully off-screen just past the edge (-100% of its width). p=1: fully
+  // on-screen, inset EDGE_GAP from the edge. Travel spans (100% + the gap).
+  const travel = 100 + EDGE_GAP * 100;
+  const tx = side === "left" ? -100 + travel * p : 100 - travel * p;
   return (
     <div
       aria-hidden="true"

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -40,7 +40,9 @@ preloadBundledAvatarComponents();
 const DESKTOP_MIN_WIDTH = 640;
 
 interface CreatePersonalityStepProps {
-  onContinue: () => void;
+  /** Continue, reporting the slider values (keyed by axis id) so the route can
+   *  apply them to the assistant's persona. */
+  onContinue: (values: Record<string, number>) => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
@@ -412,7 +414,7 @@ export function CreatePersonalityStep({
 
         <button
           type="button"
-          onClick={onContinue}
+          onClick={() => onContinue(values)}
           className="mt-4 flex h-11 w-[234px] cursor-pointer items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -10,18 +10,20 @@
  * content only — the shared toned backdrop (avatar color + bottom eyes) sits
  * behind.
  *
- * Each slider has a personality avatar peeking in from each screen edge — one
- * per end label (ten in all). Dead-center, both hide; the further the user
- * drags toward an end, the further that end's avatar pokes in from its edge.
- * It makes the abstract trait axes feel like characters reacting to the choice.
+ * On desktop, each slider has a personality avatar peeking in from each screen
+ * edge — one per end label (ten in all). Dead-center, both hide; the further
+ * the user drags toward an end, the further that end's avatar pokes in. It makes
+ * the abstract trait axes feel like characters reacting to the choice. (Hidden
+ * on mobile, where the narrow track leaves no room for them.)
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import {
   preloadBundledAvatarComponents,
@@ -32,6 +34,9 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 // Warm the (~48 kB) bundled-avatar chunk the moment this lazy step's module
 // loads, so the peeking characters are ready by the time it paints.
 preloadBundledAvatarComponents();
+
+/** Below this viewport width the peeking avatars are hidden (Tailwind `sm`). */
+const DESKTOP_MIN_WIDTH = 640;
 
 interface CreatePersonalityStepProps {
   onContinue: () => void;
@@ -109,6 +114,23 @@ const THUMB_COLOR = "#FDFDFC";
 /** Largest fraction of a peeking avatar that pokes past its screen edge. */
 const MAX_PEEK = 0.62;
 
+/**
+ * Keep an avatar's color off the background. The toned backdrop is painted in
+ * the selected avatar's color, so a side avatar sharing it would melt into the
+ * page. When that happens, swap to another palette color (stable per slot via
+ * `seed`); otherwise keep the hand-picked color.
+ */
+function avoidBackgroundColor(
+  preferred: string,
+  selectedColor: string | undefined,
+  palette: string[],
+  seed: number,
+): string {
+  if (!selectedColor || preferred !== selectedColor) return preferred;
+  const options = palette.filter((c) => c !== selectedColor);
+  return options.length > 0 ? (options[seed % options.length] ?? preferred) : preferred;
+}
+
 /** Track a live viewport width so the peeking avatars scale with the screen. */
 function useViewportWidth(): number {
   const [width, setWidth] = useState(() =>
@@ -174,20 +196,25 @@ function EdgePeekAvatar({
   );
 }
 
-/** One trait row: edge avatars, left label, the tinted track, right label. */
+/** One trait row: edge avatars (desktop only), left label, track, right label. */
 function PersonalitySlider({
   axis,
   value,
   onValueChange,
   fg,
   components,
+  leftAvatar,
+  rightAvatar,
   avatarSize,
 }: {
   axis: PersonalityAxis;
   value: number;
   onValueChange: (next: number) => void;
   fg: string;
+  /** Null while loading or on mobile — gates the peeking avatars off. */
   components: CharacterComponents | null;
+  leftAvatar: CharacterTraits;
+  rightAvatar: CharacterTraits;
   avatarSize: number;
 }) {
   // Distance from center toward each end, 0 (centered) → 1 (hard against the
@@ -205,14 +232,14 @@ function PersonalitySlider({
         <>
           <EdgePeekAvatar
             components={components}
-            traits={axis.leftAvatar}
+            traits={leftAvatar}
             side="left"
             size={avatarSize}
             progress={leftProgress}
           />
           <EdgePeekAvatar
             components={components}
-            traits={axis.rightAvatar}
+            traits={rightAvatar}
             side="right"
             size={avatarSize}
             progress={rightProgress}
@@ -220,19 +247,19 @@ function PersonalitySlider({
         </>
       )}
       <span
-        className="relative z-[1] order-1 flex-1 text-left text-base sm:w-32 sm:flex-none sm:text-right sm:text-lg"
+        className="relative z-[1] order-1 flex-1 text-left text-base sm:w-32 sm:flex-none sm:text-right sm:text-[17px]"
         style={{ color: fg }}
       >
         {axis.left}
       </span>
       <span
-        className="relative z-[1] order-2 flex-1 text-right text-base sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-lg"
+        className="relative z-[1] order-2 flex-1 text-right text-base sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-[17px]"
         style={{ color: fg }}
       >
         {axis.right}
       </span>
       <SliderPrimitive.Root
-        className="relative z-[1] order-3 flex h-7 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
+        className="relative z-[1] order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
         value={[value]}
         onValueChange={(next) => onValueChange(next[0] ?? DEFAULT_VALUE)}
         min={0}
@@ -241,11 +268,11 @@ function PersonalitySlider({
         aria-label={`${axis.left} to ${axis.right}`}
       >
         <SliderPrimitive.Track
-          className="relative h-3 w-full grow rounded-full sm:h-4"
+          className="relative h-3 w-full grow rounded-full"
           style={{ backgroundColor: TRACK_COLOR }}
         />
         <SliderPrimitive.Thumb
-          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70 sm:h-7 sm:w-7"
+          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70"
           style={{ backgroundColor: THUMB_COLOR }}
         />
       </SliderPrimitive.Root>
@@ -261,11 +288,32 @@ export function CreatePersonalityStep({
   const tone = useOnboardingTone();
   const components = useBundledAvatarComponents();
   const viewportWidth = useViewportWidth();
-  // Scale the peeking avatars with the viewport: big and bold on desktop,
-  // restrained on phones so they don't swamp the narrow track.
+  const isDesktop = viewportWidth >= DESKTOP_MIN_WIDTH;
+  // The page is painted in the selected avatar's color, so steer the side
+  // avatars clear of it (see `avoidBackgroundColor`).
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
+  const selectedColor = characters[selectedIndex]?.color;
+  // The peeking avatars are desktop-only and a touch bigger than the slider
+  // chrome — scale them with the viewport, with a generous floor and ceiling.
   const avatarSize = Math.round(
-    Math.min(120, Math.max(64, viewportWidth * 0.085)),
+    Math.min(168, Math.max(112, viewportWidth * 0.1)),
   );
+  // Resolve each axis' two avatars once, swapping any color that matches the
+  // background. Stable unless the components or the selected color change.
+  const sideAvatars = useMemo(() => {
+    const palette = components?.colors.map((c) => c.id) ?? [];
+    return PERSONALITY_AXES.map((axis, i) => ({
+      left: {
+        ...axis.leftAvatar,
+        color: avoidBackgroundColor(axis.leftAvatar.color, selectedColor, palette, i * 2),
+      },
+      right: {
+        ...axis.rightAvatar,
+        color: avoidBackgroundColor(axis.rightAvatar.color, selectedColor, palette, i * 2 + 1),
+      },
+    }));
+  }, [components, selectedColor]);
   // Frontend-only: keep each axis' value locally; nothing is persisted yet.
   const [values, setValues] = useState<Record<string, number>>(() =>
     Object.fromEntries(PERSONALITY_AXES.map((axis) => [axis.id, DEFAULT_VALUE])),
@@ -275,7 +323,7 @@ export function CreatePersonalityStep({
     <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[14%] flex w-full max-w-3xl -translate-x-1/2 flex-col items-center gap-12 px-6">
+      <div className="absolute left-1/2 top-[14%] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-10 px-6">
         <h1
           className="text-center text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
@@ -283,8 +331,8 @@ export function CreatePersonalityStep({
           Create my personality
         </h1>
 
-        <div className="flex w-full flex-col gap-11 sm:gap-14">
-          {PERSONALITY_AXES.map((axis) => (
+        <div className="flex w-full flex-col gap-8 sm:gap-11">
+          {PERSONALITY_AXES.map((axis, i) => (
             <PersonalitySlider
               key={axis.id}
               axis={axis}
@@ -293,7 +341,9 @@ export function CreatePersonalityStep({
                 setValues((prev) => ({ ...prev, [axis.id]: next }))
               }
               fg={tone.fg}
-              components={components}
+              components={isDesktop ? components : null}
+              leftAvatar={sideAvatars[i]?.left ?? axis.leftAvatar}
+              rightAvatar={sideAvatars[i]?.right ?? axis.rightAvatar}
               avatarSize={avatarSize}
             />
           ))}

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -128,20 +128,36 @@ const THUMB_COLOR = "#FDFDFC";
 const EDGE_GAP = 0.16;
 
 /**
- * Keep an avatar's color off the background. The toned backdrop is painted in
- * the selected avatar's color, so a side avatar sharing it would melt into the
- * page. When that happens, swap to another palette color (stable per slot via
- * `seed`); otherwise keep the hand-picked color.
+ * Resolve the colors for one side's avatars (top→bottom), keeping the
+ * hand-picked color wherever it's valid and only swapping when it would either
+ * (a) match the background — the backdrop is painted in the selected avatar's
+ * color, so a same-colored avatar melts in — or (b) match the avatar directly
+ * above it, so two same-colored characters never stack on one edge. A
+ * replacement also dodges the next avatar's preferred color where possible, to
+ * avoid forcing a chain of swaps.
  */
-function avoidBackgroundColor(
-  preferred: string,
+function resolveSideColors(
+  preferred: string[],
   selectedColor: string | undefined,
   palette: string[],
-  seed: number,
-): string {
-  if (!selectedColor || preferred !== selectedColor) return preferred;
-  const options = palette.filter((c) => c !== selectedColor);
-  return options.length > 0 ? (options[seed % options.length] ?? preferred) : preferred;
+): string[] {
+  const resolved: string[] = [];
+  for (let i = 0; i < preferred.length; i++) {
+    const prev = resolved[i - 1];
+    const next = preferred[i + 1];
+    const want = preferred[i] ?? "";
+    const bad = (c: string) => c === selectedColor || c === prev;
+    if (!bad(want)) {
+      resolved.push(want);
+      continue;
+    }
+    const alt =
+      palette.find((c) => !bad(c) && c !== next) ??
+      palette.find((c) => !bad(c)) ??
+      want;
+    resolved.push(alt);
+  }
+  return resolved;
 }
 
 /** Track a live viewport width so the peeking avatars scale with the screen. */
@@ -334,19 +350,24 @@ export function CreatePersonalityStep({
   const avatarSize = Math.round(
     Math.min(300, Math.max(160, viewportWidth * 0.16)),
   );
-  // Resolve each axis' two avatars once, swapping any color that matches the
-  // background. Stable unless the components or the selected color change.
+  // Resolve each side's colors top-to-bottom once: keep the hand-picked color,
+  // but swap any that matches the background or the avatar stacked above it.
+  // Stable unless the components or the selected color change.
   const sideAvatars = useMemo(() => {
     const palette = components?.colors.map((c) => c.id) ?? [];
+    const leftColors = resolveSideColors(
+      PERSONALITY_AXES.map((a) => a.leftAvatar.color),
+      selectedColor,
+      palette,
+    );
+    const rightColors = resolveSideColors(
+      PERSONALITY_AXES.map((a) => a.rightAvatar.color),
+      selectedColor,
+      palette,
+    );
     return PERSONALITY_AXES.map((axis, i) => ({
-      left: {
-        ...axis.leftAvatar,
-        color: avoidBackgroundColor(axis.leftAvatar.color, selectedColor, palette, i * 2),
-      },
-      right: {
-        ...axis.rightAvatar,
-        color: avoidBackgroundColor(axis.rightAvatar.color, selectedColor, palette, i * 2 + 1),
-      },
+      left: { ...axis.leftAvatar, color: leftColors[i] ?? axis.leftAvatar.color },
+      right: { ...axis.rightAvatar, color: rightColors[i] ?? axis.rightAvatar.color },
     }));
   }, [components, selectedColor]);
   // Frontend-only: keep each axis' value locally; nothing is persisted yet.

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -294,10 +294,10 @@ export function CreatePersonalityStep({
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const selectedColor = characters[selectedIndex]?.color;
-  // The peeking avatars are desktop-only and a touch bigger than the slider
-  // chrome — scale them with the viewport, with a generous floor and ceiling.
+  // The peeking avatars are desktop-only and big and bold — scale them with the
+  // viewport, with a generous floor and ceiling.
   const avatarSize = Math.round(
-    Math.min(168, Math.max(112, viewportWidth * 0.1)),
+    Math.min(300, Math.max(160, viewportWidth * 0.16)),
   );
   // Resolve each axis' two avatars once, swapping any color that matches the
   // background. Stable unless the components or the selected color change.

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -40,9 +40,18 @@ preloadBundledAvatarComponents();
 const DESKTOP_MIN_WIDTH = 640;
 
 interface CreatePersonalityStepProps {
-  /** Continue, reporting the slider values (keyed by axis id) so the route can
-   *  apply them to the assistant's persona. */
-  onContinue: (values: Record<string, number>) => void;
+  /** Slider values keyed by axis id, owned by the route so they survive a step
+   *  back (and stay shown once locked). Missing keys default to centered. */
+  values: Record<string, number>;
+  /** Report a single slider's new value. */
+  onValueChange: (axisId: string, value: number) => void;
+  /**
+   * Once the user has continued, the personality prompt has already been sent
+   * to the assistant — lock the sliders so a step-back can't silently diverge
+   * from what was applied.
+   */
+  locked: boolean;
+  onContinue: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
@@ -236,11 +245,14 @@ function PersonalitySlider({
   value,
   onValueChange,
   fg,
+  disabled,
 }: {
   axis: PersonalityAxis;
   value: number;
   onValueChange: (next: number) => void;
   fg: string;
+  /** Locked after continue — no drag/keyboard, dimmed grab cursor. */
+  disabled: boolean;
 }) {
   // Responsive: on mobile the labels sit on one line split to the slider's two
   // ends (left label hard-left, right label hard-right) above a full-width
@@ -264,6 +276,7 @@ function PersonalitySlider({
         className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
         value={[value]}
         onValueChange={(next) => onValueChange(next[0] ?? DEFAULT_VALUE)}
+        disabled={disabled}
         min={0}
         max={100}
         step={1}
@@ -274,7 +287,7 @@ function PersonalitySlider({
           style={{ backgroundColor: TRACK_COLOR }}
         />
         <SliderPrimitive.Thumb
-          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70"
+          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70 data-[disabled]:cursor-not-allowed data-[disabled]:active:scale-100"
           style={{ backgroundColor: THUMB_COLOR }}
         />
       </SliderPrimitive.Root>
@@ -334,6 +347,9 @@ function EdgeAvatarLayer({
 }
 
 export function CreatePersonalityStep({
+  values,
+  onValueChange,
+  locked,
   onContinue,
   onBack,
   onForward,
@@ -372,10 +388,6 @@ export function CreatePersonalityStep({
       right: { ...axis.rightAvatar, color: rightColors[i] ?? axis.rightAvatar.color },
     }));
   }, [components, selectedColor]);
-  // Frontend-only: keep each axis' value locally; nothing is persisted yet.
-  const [values, setValues] = useState<Record<string, number>>(() =>
-    Object.fromEntries(PERSONALITY_AXES.map((axis) => [axis.id, DEFAULT_VALUE])),
-  );
 
   return (
     <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
@@ -391,30 +403,40 @@ export function CreatePersonalityStep({
       )}
 
       <div className="absolute left-1/2 top-[14%] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-10 px-6">
-        <h1
-          className="text-center text-[2.6rem] leading-none"
-          style={{ fontFamily: "var(--font-serif)" }}
-        >
-          Create my personality
-        </h1>
+        <div className="flex flex-col items-center gap-2">
+          <h1
+            className="text-center text-[2.6rem] leading-none"
+            style={{ fontFamily: "var(--font-serif)" }}
+          >
+            Create my personality
+          </h1>
+          {locked && (
+            <p className="text-center text-[15px]" style={{ color: tone.fgMuted }}>
+              Personality locked — chat with your assistant to make any more
+              updates
+            </p>
+          )}
+        </div>
 
-        <div className="flex w-full flex-col gap-8 sm:gap-11">
+        <div
+          className="flex w-full flex-col gap-8 sm:gap-11"
+          style={{ opacity: locked ? 0.7 : 1 }}
+        >
           {PERSONALITY_AXES.map((axis) => (
             <PersonalitySlider
               key={axis.id}
               axis={axis}
               value={values[axis.id] ?? DEFAULT_VALUE}
-              onValueChange={(next) =>
-                setValues((prev) => ({ ...prev, [axis.id]: next }))
-              }
+              onValueChange={(next) => onValueChange(axis.id, next)}
               fg={tone.fg}
+              disabled={locked}
             />
           ))}
         </div>
 
         <button
           type="button"
-          onClick={() => onContinue(values)}
+          onClick={onContinue}
           className="mt-4 flex h-11 w-[234px] cursor-pointer items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -12,9 +12,10 @@
  *
  * On desktop, each slider has a personality avatar peeking in from each screen
  * edge — one per end label (ten in all). Dead-center, both hide; the further
- * the user drags toward an end, the further that end's avatar pokes in. It makes
- * the abstract trait axes feel like characters reacting to the choice. (Hidden
- * on mobile, where the narrow track leaves no room for them.)
+ * the user drags toward an end, the further that end's avatar pokes in. They're
+ * scattered down the page edges (NOT aligned to their slider row) so they read
+ * as a loose crowd reacting to the choices. (Hidden on mobile, where the narrow
+ * track leaves no room for them.)
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -98,6 +99,14 @@ const PERSONALITY_AXES: PersonalityAxis[] = [
   },
 ];
 
+/**
+ * Vertical anchor (viewport-height fraction) for each axis' peeking avatars,
+ * scattered down the page rather than pinned to the slider rows — and spaced
+ * far enough apart that several on the same edge don't pile up. The same anchor
+ * serves both ends of an axis: only one side is ever shown at a time.
+ */
+const AVATAR_TOPS = ["9%", "27%", "45%", "62%", "79%"];
+
 /** Sliders start centered — no axis is nudged either way until the user acts. */
 const DEFAULT_VALUE = 50;
 
@@ -146,23 +155,24 @@ function useViewportWidth(): number {
 
 /**
  * One personality avatar peeking in from a screen edge. It's anchored to the
- * true viewport edge via `calc(50% - 50vw)` — the slider column is horizontally
- * centered, so 50% of the (full-width) row sits at screen-center, and pulling
- * back 50vw lands exactly on the edge — no measurement needed. `progress`
- * (0 at center → 1 at the far end) drives how far it slides in, plus a little
- * grow + fade so the entrance feels alive. Sits behind the row's labels/track
- * (`-z-10`) and never intercepts pointer events.
+ * true viewport edge via `calc(50% - 50vw)` — the overlay is full-width, so 50%
+ * is screen-center and pulling back 50vw lands on the edge — and to `top` for
+ * its scattered vertical slot. `progress` (0 at center → 1 at the far end)
+ * drives how far it slides in, plus a little grow + fade so the entrance feels
+ * alive. Never intercepts pointer events.
  */
 function EdgePeekAvatar({
   components,
   traits,
   side,
+  top,
   size,
   progress,
 }: {
   components: CharacterComponents;
   traits: CharacterTraits;
   side: "left" | "right";
+  top: string;
   size: number;
   progress: number;
 }) {
@@ -173,9 +183,10 @@ function EdgePeekAvatar({
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute top-1/2 -z-10"
+      className="pointer-events-none absolute"
       style={{
         [side]: "calc(50% - 50vw)",
+        top,
         width: size,
         height: size,
         opacity: Math.min(1, p * 1.6),
@@ -196,70 +207,38 @@ function EdgePeekAvatar({
   );
 }
 
-/** One trait row: edge avatars (desktop only), left label, track, right label. */
+/** One trait row: left label, the tinted track, right label. */
 function PersonalitySlider({
   axis,
   value,
   onValueChange,
   fg,
-  components,
-  leftAvatar,
-  rightAvatar,
-  avatarSize,
 }: {
   axis: PersonalityAxis;
   value: number;
   onValueChange: (next: number) => void;
   fg: string;
-  /** Null while loading or on mobile — gates the peeking avatars off. */
-  components: CharacterComponents | null;
-  leftAvatar: CharacterTraits;
-  rightAvatar: CharacterTraits;
-  avatarSize: number;
 }) {
-  // Distance from center toward each end, 0 (centered) → 1 (hard against the
-  // end). Only one side is ever non-zero, so the opposite avatar stays hidden.
-  const leftProgress = Math.max(0, (DEFAULT_VALUE - value) / DEFAULT_VALUE);
-  const rightProgress = Math.max(0, (value - DEFAULT_VALUE) / DEFAULT_VALUE);
-
   // Responsive: on mobile the labels sit on one line split to the slider's two
   // ends (left label hard-left, right label hard-right) above a full-width
   // track, so it's obvious which end each label belongs to; on >=sm they flank
   // the track in a single row. Flex `order` + wrap drives the reflow.
   return (
-    <div className="relative flex flex-wrap items-center gap-x-5 gap-y-1.5 sm:flex-nowrap">
-      {components && (
-        <>
-          <EdgePeekAvatar
-            components={components}
-            traits={leftAvatar}
-            side="left"
-            size={avatarSize}
-            progress={leftProgress}
-          />
-          <EdgePeekAvatar
-            components={components}
-            traits={rightAvatar}
-            side="right"
-            size={avatarSize}
-            progress={rightProgress}
-          />
-        </>
-      )}
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 sm:flex-nowrap">
       <span
-        className="relative z-[1] order-1 flex-1 text-left text-base sm:w-32 sm:flex-none sm:text-right sm:text-[17px]"
+        className="order-1 flex-1 text-left text-base sm:w-32 sm:flex-none sm:text-right sm:text-[17px]"
         style={{ color: fg }}
       >
         {axis.left}
       </span>
       <span
-        className="relative z-[1] order-2 flex-1 text-right text-base sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-[17px]"
+        className="order-2 flex-1 text-right text-base sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-[17px]"
         style={{ color: fg }}
       >
         {axis.right}
       </span>
       <SliderPrimitive.Root
-        className="relative z-[1] order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
+        className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
         value={[value]}
         onValueChange={(next) => onValueChange(next[0] ?? DEFAULT_VALUE)}
         min={0}
@@ -276,6 +255,57 @@ function PersonalitySlider({
           style={{ backgroundColor: THUMB_COLOR }}
         />
       </SliderPrimitive.Root>
+    </div>
+  );
+}
+
+/**
+ * Full-bleed layer of the ten peeking avatars, behind the slider column. Each
+ * axis' value drives its two edge avatars: the distance from center toward an
+ * end (0 → 1) is how far that end's avatar pokes in; the opposite side stays
+ * hidden. Scattered down the edges via `AVATAR_TOPS`.
+ */
+function EdgeAvatarLayer({
+  components,
+  values,
+  sideAvatars,
+  size,
+}: {
+  components: CharacterComponents;
+  values: Record<string, number>;
+  sideAvatars: { left: CharacterTraits; right: CharacterTraits }[];
+  size: number;
+}) {
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10">
+      {PERSONALITY_AXES.map((axis, i) => {
+        const value = values[axis.id] ?? DEFAULT_VALUE;
+        const leftProgress = Math.max(0, (DEFAULT_VALUE - value) / DEFAULT_VALUE);
+        const rightProgress = Math.max(0, (value - DEFAULT_VALUE) / DEFAULT_VALUE);
+        const top = AVATAR_TOPS[i] ?? "50%";
+        const pair = sideAvatars[i];
+        if (!pair) return null;
+        return (
+          <div key={axis.id}>
+            <EdgePeekAvatar
+              components={components}
+              traits={pair.left}
+              side="left"
+              top={top}
+              size={size}
+              progress={leftProgress}
+            />
+            <EdgePeekAvatar
+              components={components}
+              traits={pair.right}
+              side="right"
+              top={top}
+              size={size}
+              progress={rightProgress}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -323,6 +353,15 @@ export function CreatePersonalityStep({
     <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
+      {isDesktop && components && (
+        <EdgeAvatarLayer
+          components={components}
+          values={values}
+          sideAvatars={sideAvatars}
+          size={avatarSize}
+        />
+      )}
+
       <div className="absolute left-1/2 top-[14%] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-10 px-6">
         <h1
           className="text-center text-[2.6rem] leading-none"
@@ -332,7 +371,7 @@ export function CreatePersonalityStep({
         </h1>
 
         <div className="flex w-full flex-col gap-8 sm:gap-11">
-          {PERSONALITY_AXES.map((axis, i) => (
+          {PERSONALITY_AXES.map((axis) => (
             <PersonalitySlider
               key={axis.id}
               axis={axis}
@@ -341,10 +380,6 @@ export function CreatePersonalityStep({
                 setValues((prev) => ({ ...prev, [axis.id]: next }))
               }
               fg={tone.fg}
-              components={isDesktop ? components : null}
-              leftAvatar={sideAvatars[i]?.left ?? axis.leftAvatar}
-              rightAvatar={sideAvatars[i]?.right ?? axis.rightAvatar}
-              avatarSize={avatarSize}
             />
           ))}
         </div>

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -9,14 +9,29 @@
  * step is part of the research-onboarding flow (no separate flag). Foreground
  * content only — the shared toned backdrop (avatar color + bottom eyes) sits
  * behind.
+ *
+ * Each slider has a personality avatar peeking in from each screen edge — one
+ * per end label (ten in all). Dead-center, both hide; the further the user
+ * drags toward an end, the further that end's avatar pokes in from its edge.
+ * It makes the abstract trait axes feel like characters reacting to the choice.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import {
+  preloadBundledAvatarComponents,
+  useBundledAvatarComponents,
+} from "@/utils/use-bundled-avatar-components";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+
+// Warm the (~48 kB) bundled-avatar chunk the moment this lazy step's module
+// loads, so the peeking characters are ready by the time it paints.
+preloadBundledAvatarComponents();
 
 interface CreatePersonalityStepProps {
   onContinue: () => void;
@@ -25,19 +40,57 @@ interface CreatePersonalityStepProps {
   onForward?: () => void;
 }
 
-/** The five trait axes, each a 0–100 slider flanked by its end labels. */
+/**
+ * The five trait axes, each a 0–100 slider flanked by its end labels. Each end
+ * carries the avatar that peeks in when the slider is dragged toward it — a
+ * character whose body/eyes/color evoke that end of the trait (e.g. a warm
+ * gentle blob for "Companion", a sharp scowling star for "Execute"). The ten
+ * trait-sets are all visually distinct.
+ */
 interface PersonalityAxis {
   id: string;
   left: string;
   right: string;
+  leftAvatar: CharacterTraits;
+  rightAvatar: CharacterTraits;
 }
 
 const PERSONALITY_AXES: PersonalityAxis[] = [
-  { id: "companion-coworker", left: "Companion", right: "Coworker" },
-  { id: "genz-boomer", left: "Gen Z", right: "Baby Boomer" },
-  { id: "execute-collaborate", left: "Execute", right: "Collaborate" },
-  { id: "playful-serious", left: "Playful", right: "Serious" },
-  { id: "polite-unfiltered", left: "Polite", right: "Unfiltered" },
+  {
+    id: "companion-coworker",
+    left: "Companion",
+    right: "Coworker",
+    leftAvatar: { bodyShape: "blob", eyeStyle: "gentle", color: "pink" },
+    rightAvatar: { bodyShape: "ninja", eyeStyle: "curious", color: "purple" },
+  },
+  {
+    id: "genz-boomer",
+    left: "Gen Z",
+    right: "Baby Boomer",
+    leftAvatar: { bodyShape: "burst", eyeStyle: "quirky", color: "yellow" },
+    rightAvatar: { bodyShape: "cloud", eyeStyle: "dazed", color: "green" },
+  },
+  {
+    id: "execute-collaborate",
+    left: "Execute",
+    right: "Collaborate",
+    leftAvatar: { bodyShape: "star", eyeStyle: "angry", color: "orange" },
+    rightAvatar: { bodyShape: "flower", eyeStyle: "goofy", color: "teal" },
+  },
+  {
+    id: "playful-serious",
+    left: "Playful",
+    right: "Serious",
+    leftAvatar: { bodyShape: "star", eyeStyle: "goofy", color: "yellow" },
+    rightAvatar: { bodyShape: "blob", eyeStyle: "grumpy", color: "purple" },
+  },
+  {
+    id: "polite-unfiltered",
+    left: "Polite",
+    right: "Unfiltered",
+    leftAvatar: { bodyShape: "sprout", eyeStyle: "bashful", color: "green" },
+    rightAvatar: { bodyShape: "urchin", eyeStyle: "surprised", color: "orange" },
+  },
 ];
 
 /** Sliders start centered — no axis is nudged either way until the user acts. */
@@ -53,38 +106,133 @@ const DEFAULT_VALUE = 50;
 const TRACK_COLOR = "rgba(36, 41, 46, 0.2)"; // #24292E @ 20%
 const THUMB_COLOR = "#FDFDFC";
 
-/** One trait row: left label, the tinted track, right label. */
+/** Largest fraction of a peeking avatar that pokes past its screen edge. */
+const MAX_PEEK = 0.62;
+
+/** Track a live viewport width so the peeking avatars scale with the screen. */
+function useViewportWidth(): number {
+  const [width, setWidth] = useState(() =>
+    typeof window === "undefined" ? 1280 : window.innerWidth,
+  );
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}
+
+/**
+ * One personality avatar peeking in from a screen edge. It's anchored to the
+ * true viewport edge via `calc(50% - 50vw)` — the slider column is horizontally
+ * centered, so 50% of the (full-width) row sits at screen-center, and pulling
+ * back 50vw lands exactly on the edge — no measurement needed. `progress`
+ * (0 at center → 1 at the far end) drives how far it slides in, plus a little
+ * grow + fade so the entrance feels alive. Sits behind the row's labels/track
+ * (`-z-10`) and never intercepts pointer events.
+ */
+function EdgePeekAvatar({
+  components,
+  traits,
+  side,
+  size,
+  progress,
+}: {
+  components: CharacterComponents;
+  traits: CharacterTraits;
+  side: "left" | "right";
+  size: number;
+  progress: number;
+}) {
+  const p = Math.max(0, Math.min(1, progress));
+  // Hidden just past the edge at p=0; up to MAX_PEEK of the body shown at p=1.
+  const shown = MAX_PEEK * p;
+  const tx = side === "left" ? -100 + shown * 100 : 100 - shown * 100;
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute top-1/2 -z-10"
+      style={{
+        [side]: "calc(50% - 50vw)",
+        width: size,
+        height: size,
+        opacity: Math.min(1, p * 1.6),
+        transform: `translate(${tx}%, -50%) scale(${0.8 + 0.2 * p})`,
+        transformOrigin: `${side} center`,
+        transition:
+          "transform 0.18s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.18s ease",
+        willChange: "transform, opacity",
+      }}
+    >
+      <AnimatedAvatar
+        components={components}
+        traits={traits}
+        size={size}
+        breathe={false}
+      />
+    </div>
+  );
+}
+
+/** One trait row: edge avatars, left label, the tinted track, right label. */
 function PersonalitySlider({
   axis,
   value,
   onValueChange,
   fg,
+  components,
+  avatarSize,
 }: {
   axis: PersonalityAxis;
   value: number;
   onValueChange: (next: number) => void;
   fg: string;
+  components: CharacterComponents | null;
+  avatarSize: number;
 }) {
+  // Distance from center toward each end, 0 (centered) → 1 (hard against the
+  // end). Only one side is ever non-zero, so the opposite avatar stays hidden.
+  const leftProgress = Math.max(0, (DEFAULT_VALUE - value) / DEFAULT_VALUE);
+  const rightProgress = Math.max(0, (value - DEFAULT_VALUE) / DEFAULT_VALUE);
+
   // Responsive: on mobile the labels sit on one line split to the slider's two
   // ends (left label hard-left, right label hard-right) above a full-width
   // track, so it's obvious which end each label belongs to; on >=sm they flank
   // the track in a single row. Flex `order` + wrap drives the reflow.
   return (
-    <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 sm:flex-nowrap">
+    <div className="relative flex flex-wrap items-center gap-x-5 gap-y-1.5 sm:flex-nowrap">
+      {components && (
+        <>
+          <EdgePeekAvatar
+            components={components}
+            traits={axis.leftAvatar}
+            side="left"
+            size={avatarSize}
+            progress={leftProgress}
+          />
+          <EdgePeekAvatar
+            components={components}
+            traits={axis.rightAvatar}
+            side="right"
+            size={avatarSize}
+            progress={rightProgress}
+          />
+        </>
+      )}
       <span
-        className="order-1 flex-1 text-left text-body-medium-default sm:w-28 sm:flex-none sm:text-right"
+        className="relative z-[1] order-1 flex-1 text-left text-base sm:w-32 sm:flex-none sm:text-right sm:text-lg"
         style={{ color: fg }}
       >
         {axis.left}
       </span>
       <span
-        className="order-2 flex-1 text-right text-body-medium-default sm:order-3 sm:w-28 sm:flex-none sm:text-left"
+        className="relative z-[1] order-2 flex-1 text-right text-base sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-lg"
         style={{ color: fg }}
       >
         {axis.right}
       </span>
       <SliderPrimitive.Root
-        className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
+        className="relative z-[1] order-3 flex h-7 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
         value={[value]}
         onValueChange={(next) => onValueChange(next[0] ?? DEFAULT_VALUE)}
         min={0}
@@ -93,11 +241,11 @@ function PersonalitySlider({
         aria-label={`${axis.left} to ${axis.right}`}
       >
         <SliderPrimitive.Track
-          className="relative h-3 w-full grow rounded-full"
+          className="relative h-3 w-full grow rounded-full sm:h-4"
           style={{ backgroundColor: TRACK_COLOR }}
         />
         <SliderPrimitive.Thumb
-          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70"
+          className="block h-6 w-6 cursor-grab rounded-full shadow-sm transition-transform active:scale-95 active:cursor-grabbing keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-white/70 sm:h-7 sm:w-7"
           style={{ backgroundColor: THUMB_COLOR }}
         />
       </SliderPrimitive.Root>
@@ -111,16 +259,23 @@ export function CreatePersonalityStep({
   onForward,
 }: CreatePersonalityStepProps) {
   const tone = useOnboardingTone();
+  const components = useBundledAvatarComponents();
+  const viewportWidth = useViewportWidth();
+  // Scale the peeking avatars with the viewport: big and bold on desktop,
+  // restrained on phones so they don't swamp the narrow track.
+  const avatarSize = Math.round(
+    Math.min(120, Math.max(64, viewportWidth * 0.085)),
+  );
   // Frontend-only: keep each axis' value locally; nothing is persisted yet.
   const [values, setValues] = useState<Record<string, number>>(() =>
     Object.fromEntries(PERSONALITY_AXES.map((axis) => [axis.id, DEFAULT_VALUE])),
   );
 
   return (
-    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
+    <div className="absolute inset-0 z-10 overflow-hidden" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-[14%] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-12 px-6">
+      <div className="absolute left-1/2 top-[14%] flex w-full max-w-3xl -translate-x-1/2 flex-col items-center gap-12 px-6">
         <h1
           className="text-center text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}
@@ -128,7 +283,7 @@ export function CreatePersonalityStep({
           Create my personality
         </h1>
 
-        <div className="flex w-full flex-col gap-7">
+        <div className="flex w-full flex-col gap-11 sm:gap-14">
           {PERSONALITY_AXES.map((axis) => (
             <PersonalitySlider
               key={axis.id}
@@ -138,6 +293,8 @@ export function CreatePersonalityStep({
                 setValues((prev) => ({ ...prev, [axis.id]: next }))
               }
               fg={tone.fg}
+              components={components}
+              avatarSize={avatarSize}
             />
           ))}
         </div>

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -379,6 +379,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "personality-onboarding",
+      "scope": "client",
+      "key": "personality-onboarding",
+      "label": "Personality onboarding step (spike)",
+      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
+      "defaultEnabled": false
+    },
+    {
       "id": "channel-trust-floors",
       "scope": "assistant",
       "key": "channel-trust-floors",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -379,6 +379,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "personality-onboarding",
+      "scope": "client",
+      "key": "personality-onboarding",
+      "label": "Personality onboarding step (spike)",
+      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
+      "defaultEnabled": false
+    },
+    {
       "id": "channel-trust-floors",
       "scope": "assistant",
       "key": "channel-trust-floors",


### PR DESCRIPTION
## What

Adds a **"Create my personality"** step to the research-onboarding flow, inserted between the pitch and the free-credits step. Five trait sliders the user nudges to shape the assistant's voice:

- Companion ↔ Coworker
- Gen Z ↔ Baby Boomer
- Execute ↔ Collaborate
- Playful ↔ Serious
- Polite ↔ Unfiltered

The step renders over the existing shared toned backdrop (avatar color + bottom eyes), with a centered Continue button and back via the standard top-left chevron.

## Design

Slider matches Figma (node `6279-576`): a thick translucent-dark track (`Surface-Dark/Lift #24292E` @ 20%, so it darkens whatever avatar color sits behind it) with a large solid-white thumb (`Primary-Dark/Base #FDFDFC`). Smooth/continuous drag, single uniform track color.

**Responsive:** on mobile the two end labels split to the slider's far-left / far-right above a full-width track (so it's obvious which end each label belongs to); on `>=sm` they flank the track in a single row.

## Scope

**Frontend-only for now** — slider values live in local component state and aren't sent anywhere yet. A follow-up will wire them to the assistant persona.

## Changes

- **New screen:** `create-personality-step.tsx`
- **Route** (`research-onboarding-route.tsx`): wire `"personality"` between pitch → free credits, share the toned backdrop
- **Persistence:** add `"personality"` to the resume-snapshot `ResearchStep` union
- **Funnel:** add the `research_personality` step (subsequent indices renumbered)

## How to view

Visit `/assistant/onboarding/research` with the `research-onboarding` flag enabled (feature-flags panel, or `VITE_VELLUM_FLAG_RESEARCH_ONBOARDING=true bun run dev`). The step appears right after the intro/pitch, before the free-credits page.

## Checks

Typecheck, lint, and `vite build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)