### PR TITLE
feat(web): add usePluginsList hook merging installed + catalog

### DIFF
--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for `usePluginsList`, the shared data hook backing the Plugins tab
+ * list. It owns the installed read (`pluginsGet`, with an older-daemon
+ * 404 → empty degradation) and the catalog read (`pluginsSearchGet`), merged
+ * and sorted into one `PluginListItem[]`.
+ *
+ * The generated SDK layer is mocked so both reads resolve locally. Per-test
+ * fixtures are assigned to module-level holders the mocks read, letting each
+ * case drive the installed/catalog payloads (or force a catalog failure).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type {
+  PluginsGetResponse,
+  PluginsSearchGetResponse,
+} from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+
+type InstalledPlugin = PluginsGetResponse["plugins"][number];
+type CatalogMatch = PluginsSearchGetResponse["matches"][number];
+
+interface InstalledResult {
+  data?: PluginsGetResponse;
+  response: { ok: boolean; status: number };
+}
+
+// Per-test holders the SDK mocks read. `catalogResult` may be an Error to
+// drive the catalog query into its failure (degrade-to-installed) branch.
+let installedResult: InstalledResult;
+let catalogResult: PluginsSearchGetResponse | Error;
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+const pluginsGetSpy = mock(async () => installedResult);
+const pluginsSearchGetSpy = mock(async () => {
+  if (catalogResult instanceof Error) throw catalogResult;
+  return { data: catalogResult };
+});
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsGet: pluginsGetSpy,
+  pluginsSearchGet: pluginsSearchGetSpy,
+}));
+
+const { usePluginsList } = await import(
+  "@/domains/intelligence/plugins/use-plugins-list"
+);
+
+function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  return {
+    id: "alpha",
+    name: "alpha",
+    description: null,
+    version: null,
+    ...overrides,
+  };
+}
+
+function match(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
+  return {
+    name: "beta",
+    path: "github:acme/beta@main",
+    source: { kind: "github", repo: "acme/beta", ref: "main" },
+    ...overrides,
+  };
+}
+
+function installedOk(plugins: InstalledPlugin[]): InstalledResult {
+  return { data: { plugins }, response: { ok: true, status: 200 } };
+}
+
+function catalogOk(matches: CatalogMatch[]): PluginsSearchGetResponse {
+  return { query: "", ref: "main", matches };
+}
+
+function renderPluginsList() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+
+  return renderHook(() => usePluginsList(ASSISTANT_ID), { wrapper });
+}
+
+beforeEach(() => {
+  installedResult = installedOk([]);
+  catalogResult = catalogOk([]);
+  pluginsGetSpy.mockClear();
+  pluginsSearchGetSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePluginsList", () => {
+  test("merges installed + catalog into one sorted list", async () => {
+    installedResult = installedOk([
+      installed({ id: "delta", name: "delta", description: "D" }),
+      installed({ id: "bravo", name: "bravo" }),
+    ]);
+    catalogResult = catalogOk([
+      match({ name: "echo", description: "E" }),
+      match({ name: "alpha", description: "A" }),
+    ]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Installed first (alphabetical), then available (alphabetical).
+    expect(result.current.items.map((p) => p.name)).toEqual([
+      "bravo",
+      "delta",
+      "alpha",
+      "echo",
+    ]);
+    expect(result.current.items.map((p) => p.status)).toEqual([
+      "installed",
+      "installed",
+      "available",
+      "available",
+    ]);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.catalogError).toBe(false);
+  });
+
+  test("dedups catalog entries already installed (by name)", async () => {
+    installedResult = installedOk([installed({ id: "dup", name: "dup" })]);
+    catalogResult = catalogOk([match({ name: "dup" }), match({ name: "fresh" })]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items.map((p) => p.name)).toEqual(["dup", "fresh"]);
+    expect(result.current.items.find((p) => p.name === "dup")?.status).toBe(
+      "installed",
+    );
+  });
+
+  test("installed 404 degrades to an empty installed list, not an error", async () => {
+    installedResult = { data: undefined, response: { ok: false, status: 404 } };
+    catalogResult = catalogOk([match({ name: "alpha" })]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Only the catalog entry survives; installed is empty, not errored.
+    expect(result.current.items.map((p) => p.name)).toEqual(["alpha"]);
+    expect(result.current.items[0]?.status).toBe("available");
+    expect(result.current.isError).toBe(false);
+    expect(result.current.catalogError).toBe(false);
+  });
+
+  test("non-404 installed failure is fatal (isError)", async () => {
+    installedResult = { data: undefined, response: { ok: false, status: 500 } };
+    catalogResult = catalogOk([match({ name: "alpha" })]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  test("catalog failure degrades to installed-only via catalogError", async () => {
+    installedResult = installedOk([installed({ id: "alpha", name: "alpha" })]);
+    catalogResult = new Error("catalog down");
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.catalogError).toBe(true));
+
+    // Installed list still renders; the catalog failure is not fatal.
+    expect(result.current.items.map((p) => p.name)).toEqual(["alpha"]);
+    expect(result.current.isError).toBe(false);
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -1,0 +1,96 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import type { PluginListItem } from "@/domains/intelligence/plugins/types";
+import { mergePlugins, sortPlugins } from "@/domains/intelligence/plugins/utils";
+import {
+    pluginsGetQueryKey,
+    pluginsSearchGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { pluginsGet } from "@/generated/daemon/sdk.gen";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+
+// The installed list (local filesystem) and the catalog (the daemon's
+// cached, rate-limited GitHub listing) both change rarely, so `staleTime`
+// keeps each warm across tab switches and revisiting doesn't refetch.
+const CATALOG_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface UsePluginsListResult {
+  /** Installed + catalog merged into one deduped, sorted list. */
+  items: PluginListItem[];
+  /** True until both underlying queries have first resolved. */
+  isLoading: boolean;
+  /** Fatal: the installed list failed to load. Catalog failures degrade. */
+  isError: boolean;
+  /** True while either underlying query is fetching (incl. background). */
+  isFetching: boolean;
+  /**
+   * Non-fatal: the catalog failed to load. The list still renders the
+   * installed plugins; the view surfaces this as a degraded "installed only".
+   */
+  catalogError: boolean;
+}
+
+/**
+ * Single source of truth for the Plugins tab list: the installed read
+ * (`pluginsGet`, with an older-daemon 404 → empty degradation) and the
+ * catalog (`pluginsSearchGet`), merged via `mergePlugins` and `sortPlugins`
+ * into one `PluginListItem[]`.
+ *
+ * The installed list is fatal — its failure surfaces as `isError`. The
+ * catalog is best-effort: a failure degrades to "installed only" and is
+ * exposed via `catalogError` rather than failing the whole list.
+ */
+export function usePluginsList(assistantId: string): UsePluginsListResult {
+  const installedQuery = useQuery({
+    queryKey: pluginsGetQueryKey({
+      path: { assistant_id: assistantId },
+      query: { q: undefined },
+    }),
+    queryFn: async ({ signal }) => {
+      const result = await pluginsGet({
+        path: { assistant_id: assistantId },
+        query: { q: undefined },
+        signal,
+        throwOnError: false,
+      });
+      const status = result.response?.status;
+      // Older daemons return 404 when the list endpoint isn't
+      // implemented yet — degrade to an empty installed list.
+      if (status === 404) return { plugins: [] } as PluginsGetResponse;
+      if (!result.response?.ok) throw new Error("Failed to load plugins");
+      return result.data ?? ({ plugins: [] } as PluginsGetResponse);
+    },
+    enabled: Boolean(assistantId),
+    staleTime: CATALOG_STALE_TIME_MS,
+  });
+
+  const catalogQuery = useQuery({
+    ...pluginsSearchGetOptions({
+      path: { assistant_id: assistantId },
+      query: { q: undefined },
+    }),
+    enabled: Boolean(assistantId),
+    staleTime: CATALOG_STALE_TIME_MS,
+  });
+
+  const items = useMemo(
+    () =>
+      sortPlugins(
+        mergePlugins(
+          installedQuery.data?.plugins ?? [],
+          catalogQuery.data?.matches ?? [],
+        ),
+      ),
+    [installedQuery.data?.plugins, catalogQuery.data?.matches],
+  );
+
+  return {
+    items,
+    isLoading: installedQuery.isLoading || catalogQuery.isLoading,
+    // Only the installed failure is fatal; a catalog failure degrades.
+    isError: installedQuery.isError,
+    isFetching: installedQuery.isFetching || catalogQuery.isFetching,
+    catalogError: catalogQuery.isError,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds usePluginsList: merges installed (pluginsGet, 404->empty) + catalog (pluginsSearchGet) into one sorted PluginListItem[] via mergePlugins/sortPlugins, exposing catalogError degradation.

Part of plan: plugins-tab-match-skills.md (PR 5 of 13)