### PR TITLE
feat(web): add unified PluginListRow with inline install/remove/upgrade

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -106,6 +106,25 @@ describe("PluginListRow", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  test("Enter on a focused inline action does not also select the row", () => {
+    const onSelect = mock(() => {});
+    const onRemove = mock(() => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        onSelect={onSelect}
+        onRemove={onRemove}
+      />,
+    );
+
+    // Key events originating on the action button must not bubble into the
+    // row's keydown handler and trigger selection.
+    fireEvent.keyDown(getButton("Remove plugin"), { key: "Enter" });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   test("update-available drift: upgrade control upgrades without selecting", () => {
     const onSelect = mock(() => {});
     const onUpgrade = mock(() => {});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for `PluginListRow` action controls.
+ *
+ * The row is a `role="button"` whose primary click fires `onSelect`. The
+ * trailing icon-only action button (install for catalog entries, upgrade
+ * when an installed copy is behind the marketplace pin, otherwise remove)
+ * must:
+ *   - expose the correct `aria-label`
+ *   - fire its own handler (`onInstall` / `onUpgrade` / `onRemove`)
+ *   - NOT also bubble up to `onSelect` (stopPropagation)
+ *
+ * The Upgrade affordance is gated on `update-available` drift, so it only
+ * appears when that signal is passed in.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see
+ * `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { PluginListRow } from "@/domains/intelligence/components/plugins/plugin-list-row.js";
+import type { PluginListItem } from "@/domains/intelligence/plugins/types.js";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeItem(overrides: Partial<PluginListItem> = {}): PluginListItem {
+  return {
+    name: "Test Plugin",
+    description: "A plugin used in tests",
+    status: "installed",
+    external: false,
+    version: "0.1",
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal drift stand-in. The row only reads `status`, so the rest of the
+ * inspect shape is irrelevant to these assertions.
+ */
+function makeDrift(status: PluginDrift["status"]): PluginDrift {
+  return { status } as PluginDrift;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("PluginListRow", () => {
+  test("clicking the row fires onSelect", () => {
+    const onSelect = mock(() => {});
+
+    const { getByText } = render(
+      <PluginListRow item={makeItem()} onSelect={onSelect} />,
+    );
+
+    fireEvent.click(getByText("Test Plugin"));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("installed plugin: trash control removes without selecting", () => {
+    const onSelect = mock(() => {});
+    const onRemove = mock(() => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        onSelect={onSelect}
+        onRemove={onRemove}
+      />,
+    );
+
+    fireEvent.click(getButton("Remove plugin"));
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("catalog plugin: install control installs without selecting", () => {
+    const onSelect = mock(() => {});
+    const onInstall = mock(() => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "available" })}
+        onSelect={onSelect}
+        onInstall={onInstall}
+      />,
+    );
+
+    fireEvent.click(getButton("Install plugin"));
+
+    expect(onInstall).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("update-available drift: upgrade control upgrades without selecting", () => {
+    const onSelect = mock(() => {});
+    const onUpgrade = mock(() => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        drift={makeDrift("update-available")}
+        onSelect={onSelect}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    fireEvent.click(getButton("Upgrade plugin"));
+
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("upgrade affordance only appears with update-available drift", () => {
+    const onSelect = mock(() => {});
+
+    // Up-to-date installed plugin shows Remove, not Upgrade.
+    const { rerender } = render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        drift={makeDrift("up-to-date")}
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(
+      document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).not.toBeNull();
+
+    // Same plugin with drift now exposes Upgrade.
+    rerender(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        drift={makeDrift("update-available")}
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(
+      document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -45,6 +45,9 @@ export function PluginListRow({
   const updateAvailable = drift?.status === "update-available";
 
   const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    // Ignore key events bubbling up from a focused inline action button —
+    // otherwise Enter/Space on Install/Remove/Upgrade would also select the row.
+    if (e.target !== e.currentTarget) return;
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       onSelect();

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -1,0 +1,166 @@
+import { ArrowDownToLine, ArrowUpCircle, Loader2, Trash2 } from "lucide-react";
+import type { KeyboardEvent } from "react";
+
+import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
+import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
+import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
+import type { PluginListItem } from "@/domains/intelligence/plugins/types";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
+import { Button, Card } from "@vellumai/design-library";
+
+interface PluginListRowProps {
+  item: PluginListItem;
+  /** Inspect result for the installed copy; owned by the tab, passed in so
+   *  the row stays presentational. Gates the upgrade affordance. */
+  drift?: PluginDrift;
+  onSelect: () => void;
+  onInstall?: () => void;
+  onRemove?: () => void;
+  onUpgrade?: () => void;
+  isInstalling?: boolean;
+  isRemoving?: boolean;
+  isUpgrading?: boolean;
+}
+
+/**
+ * Unified row for the Plugins tab, mirroring `SkillRow`: an emoji icon, the
+ * name with version + origin/update badges, a description, and a single
+ * trailing inline action chosen by status (Install for catalog entries,
+ * Upgrade when an installed copy is behind the marketplace pin, otherwise
+ * Remove). The whole row is a `role="button"` that fires `onSelect`; the
+ * trailing action `stopPropagation`s so it never also selects the row.
+ */
+export function PluginListRow({
+  item,
+  drift,
+  onSelect,
+  onInstall,
+  onRemove,
+  onUpgrade,
+  isInstalling = false,
+  isRemoving = false,
+  isUpgrading = false,
+}: PluginListRowProps) {
+  const available = item.status === "available";
+  const updateAvailable = drift?.status === "update-available";
+
+  const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect();
+    }
+  };
+
+  return (
+    <Card.Root asChild>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={handleRowKeyDown}
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        <PluginIcon size="sm" external={item.external} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="truncate text-body-medium-default"
+              style={{ color: "var(--content-emphasised)" }}
+            >
+              {item.name}
+            </span>
+            {item.version ? (
+              <span
+                className="shrink-0 text-body-small-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                v{item.version}
+              </span>
+            ) : null}
+            <PluginOriginBadge external={item.external} sourceHost={item.sourceHost} />
+            {updateAvailable ? <UpdateAvailableBadge /> : null}
+          </div>
+          <p
+            className="mt-1 truncate text-body-medium-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {item.description ?? "No description provided."}
+          </p>
+          {item.issues && item.issues.length > 0 ? (
+            <p
+              className="mt-1 truncate text-body-small-default"
+              style={{ color: "var(--content-warning, var(--content-tertiary))" }}
+              title={item.issues.join("; ")}
+            >
+              {item.issues[0]}
+              {item.issues.length > 1
+                ? ` (+${item.issues.length - 1} more)`
+                : ""}
+            </p>
+          ) : null}
+        </div>
+
+        {available ? (
+          isInstalling ? (
+            <Button
+              type="button"
+              iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+              disabled
+              aria-label="Installing"
+              expandOnMobile={false}
+            />
+          ) : (
+            <Button
+              type="button"
+              iconOnly={<ArrowDownToLine aria-hidden />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onInstall?.();
+              }}
+              disabled={!onInstall}
+              aria-label="Install plugin"
+              expandOnMobile={false}
+            />
+          )
+        ) : updateAvailable ? (
+          <Button
+            type="button"
+            iconOnly={
+              isUpgrading ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <ArrowUpCircle aria-hidden />
+              )
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              onUpgrade?.();
+            }}
+            disabled={isUpgrading || !onUpgrade}
+            aria-label="Upgrade plugin"
+            expandOnMobile={false}
+          />
+        ) : (
+          <Button
+            type="button"
+            variant="dangerOutline"
+            iconOnly={
+              isRemoving ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <Trash2 aria-hidden />
+              )
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove?.();
+            }}
+            disabled={isRemoving || !onRemove}
+            aria-label="Remove plugin"
+            expandOnMobile={false}
+          />
+        )}
+      </div>
+    </Card.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds PluginListRow: a button-row (icon + name/version + origin/update badges + description + inline Install/Remove/Upgrade actions) mirroring SkillRow. Additive; wired in by a later PR.

Part of plan: plugins-tab-match-skills.md (PR 7 of 13)