### PR TITLE
feat(web): add PluginDetailMobile full-screen overlay

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -6,8 +6,10 @@
  * plugin plus drift state without touching React Query or the daemon client. A
  * mutable `hookState` lets individual tests swap the plugin (installed vs not)
  * and drift (update available or not). We verify the back wiring, the header
- * content (title + full description), and that the install / remove / upgrade
- * action surfaces per state.
+ * content (title + full description), and that the shared Install / Remove /
+ * Upgrade action set surfaces per state — including that Remove stays reachable
+ * alongside Upgrade when an update is available (the action set now comes from
+ * `plugin-detail-shared`, which renders both together).
  *
  * Mounted via `@testing-library/react` (happy-dom — see `clients/web/test-setup.ts`).
  */
@@ -81,6 +83,9 @@ mock.module("@/domains/intelligence/plugins/use-plugin-detail", () => ({
     isRemoveError: false,
     isUpgradeError: false,
   }),
+  // The shared `PluginDetailActions` imports `shortSha` from this module for its
+  // upgrade tooltip, so the mock must re-export it.
+  shortSha: (sha: string | null) => (sha ? sha.slice(0, 7) : "unknown"),
 }));
 
 const { PluginDetailMobile } = await import(
@@ -100,6 +105,18 @@ function getButton(label: string): HTMLButtonElement {
     throw new Error(`expected a button with aria-label="${label}"`);
   }
   return match;
+}
+
+/**
+ * The shared `PluginDetailActions` labels its buttons with text (not
+ * aria-label), so match by accessible name.
+ */
+function getActionButton(name: string): HTMLButtonElement {
+  return screen.getByRole("button", { name }) as HTMLButtonElement;
+}
+
+function queryActionButton(name: string): HTMLButtonElement | null {
+  return screen.queryByRole("button", { name }) as HTMLButtonElement | null;
 }
 
 describe("PluginDetailMobile", () => {
@@ -149,7 +166,9 @@ describe("PluginDetailMobile", () => {
       <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
     );
 
-    expect(getButton("Install plugin")).toBeTruthy();
+    expect(getActionButton("Install")).toBeTruthy();
+    // An available plugin offers Install, not Remove.
+    expect(queryActionButton("Remove")).toBeNull();
   });
 
   test("installed plugin: remove action appears", () => {
@@ -159,10 +178,13 @@ describe("PluginDetailMobile", () => {
       <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
     );
 
-    expect(getButton("Remove plugin")).toBeTruthy();
+    expect(getActionButton("Remove")).toBeTruthy();
   });
 
-  test("update available: upgrade action and badge appear", () => {
+  test("update available: Upgrade and Remove are both reachable, plus the badge", () => {
+    // Regression for Codex P2: an update must not hide the uninstall path. The
+    // shared action set renders Upgrade *and* Remove together, so mobile users
+    // can still remove a plugin when an upgrade is offered.
     hookState.plugin = makePlugin({ installed: true });
     hookState.drift = UPDATE_DRIFT;
 
@@ -170,7 +192,8 @@ describe("PluginDetailMobile", () => {
       <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
     );
 
-    expect(getButton("Upgrade plugin")).toBeTruthy();
+    expect(getActionButton("Upgrade")).toBeTruthy();
+    expect(getActionButton("Remove")).toBeTruthy();
     expect(screen.getByText("Update available")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Tests for `PluginDetailMobile` — the single-column phone plugin-detail
+ * overlay.
+ *
+ * The data hook (`usePluginDetail`) is mocked so the component renders a fixed
+ * plugin plus drift state without touching React Query or the daemon client. A
+ * mutable `hookState` lets individual tests swap the plugin (installed vs not)
+ * and drift (update available or not). We verify the back wiring, the header
+ * content (title + full description), and that the install / remove / upgrade
+ * action surfaces per state.
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen.js";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift.js";
+
+function makePlugin(
+  overrides: Partial<PluginsByNameGetResponse> = {},
+): PluginsByNameGetResponse {
+  return {
+    name: "test-plugin",
+    installed: true,
+    description: "A plugin used in mobile detail tests",
+    homepage: null,
+    license: null,
+    version: "1.0.0",
+    source: null,
+    readme: "# Readme heading",
+    ref: "main",
+    artifact: null,
+    ...overrides,
+  };
+}
+
+const UPDATE_DRIFT = { status: "update-available" } as unknown as PluginDrift;
+
+// Mutable so individual tests can swap the plugin / drift before rendering.
+const hookState: {
+  plugin: PluginsByNameGetResponse | null;
+  drift: PluginDrift | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  isUpgrading: boolean;
+  hasLocalEdits: boolean;
+} = {
+  plugin: makePlugin(),
+  drift: undefined,
+  isLoading: false,
+  isError: false,
+  isInstalling: false,
+  isRemoving: false,
+  isUpgrading: false,
+  hasLocalEdits: false,
+};
+
+function resetHookState(): void {
+  hookState.plugin = makePlugin();
+  hookState.drift = undefined;
+  hookState.isLoading = false;
+  hookState.isError = false;
+  hookState.isInstalling = false;
+  hookState.isRemoving = false;
+  hookState.isUpgrading = false;
+  hookState.hasLocalEdits = false;
+}
+
+mock.module("@/domains/intelligence/plugins/use-plugin-detail", () => ({
+  usePluginDetail: () => ({
+    ...hookState,
+    install: () => {},
+    remove: () => {},
+    upgrade: () => {},
+    isInstallError: false,
+    isRemoveError: false,
+    isUpgradeError: false,
+  }),
+}));
+
+const { PluginDetailMobile } = await import(
+  "@/domains/intelligence/components/plugins/plugin-detail-mobile.js"
+);
+
+afterEach(() => {
+  cleanup();
+  resetHookState();
+});
+
+function getButton(label: string): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  if (!match) {
+    throw new Error(`expected a button with aria-label="${label}"`);
+  }
+  return match;
+}
+
+describe("PluginDetailMobile", () => {
+  test("back button calls onBack", () => {
+    const onBack = mock(() => {});
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={onBack} />,
+    );
+
+    fireEvent.click(getButton("Back to plugins"));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the title and full description", () => {
+    hookState.plugin = makePlugin({
+      name: "My Plugin",
+      description: "A long description that should not be clamped.",
+    });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="My Plugin" onBack={() => {}} />,
+    );
+
+    // Title appears both in the action bar and the header block.
+    expect(screen.getAllByText("My Plugin").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("A long description that should not be clamped."),
+    ).toBeTruthy();
+  });
+
+  test("renders the README markdown", () => {
+    hookState.plugin = makePlugin({ readme: "# Readme heading" });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(screen.getByText("Readme heading")).toBeTruthy();
+  });
+
+  test("uninstalled plugin: install action appears", () => {
+    hookState.plugin = makePlugin({ installed: false });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(getButton("Install plugin")).toBeTruthy();
+  });
+
+  test("installed plugin: remove action appears", () => {
+    hookState.plugin = makePlugin({ installed: true });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(getButton("Remove plugin")).toBeTruthy();
+  });
+
+  test("update available: upgrade action and badge appear", () => {
+    hookState.plugin = makePlugin({ installed: true });
+    hookState.drift = UPDATE_DRIFT;
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(getButton("Upgrade plugin")).toBeTruthy();
+    expect(screen.getByText("Update available")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -1,22 +1,20 @@
-import {
-    ArrowDownToLine,
-    ArrowLeft,
-    ArrowUpCircle,
-    ExternalLink,
-    Loader2,
-    Trash2,
-    TriangleAlert,
-} from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
+import {
+    PluginDetailActionError,
+    PluginDetailActions,
+    PluginDetailError,
+    PluginDetailLoading,
+    PluginDetailMetadata,
+} from "@/domains/intelligence/components/plugins/plugin-detail-shared";
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
-import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
-import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailMobileProps {
   assistantId: string;
@@ -28,16 +26,20 @@ interface PluginDetailMobileProps {
  * Single-column phone layout for viewing a plugin's details.
  *
  * Renders as a full-screen overlay that takes over the whole viewport — its own
- * back · title · action bar replaces the app's mobile chrome and the
- * Intelligence tab row, mirroring `SkillDetailMobile`. The overlay is portaled
- * into `RootLayout`'s `#viewport-overlays` container so a transformed layout
- * ancestor can't scope its `position: fixed`; when the target isn't resolved
- * yet (first paint / tests) it falls back to rendering inline.
+ * back · title action bar replaces the app's mobile chrome and the Intelligence
+ * tab row, mirroring `SkillDetailMobile`. The overlay is portaled into
+ * `RootLayout`'s `#viewport-overlays` container so a transformed layout ancestor
+ * can't scope its `position: fixed`; when the target isn't resolved yet (first
+ * paint / tests) it falls back to rendering inline.
  *
  * Unlike skills, plugins expose no file endpoints, so the content card is just
- * the tracked metadata plus the README. Owns the install / remove / upgrade
- * flow via `usePluginDetail`, returning to the list (`onBack`) once the plugin
- * is removed. Removing — and upgrading a locally-edited copy — confirm first.
+ * the tracked metadata plus the README. The metadata table, loading / error
+ * states, and the Install / Download / Upgrade / Remove action set all come from
+ * `plugin-detail-shared` so they stay in lockstep with the desktop detail. The
+ * shared action set renders Upgrade *and* Remove together when an update is
+ * available, so an update never hides the uninstall path on mobile. Owns the
+ * install / remove / upgrade flow via `usePluginDetail`, returning to the list
+ * (`onBack`) once the plugin is removed.
  */
 export function PluginDetailMobile({
   assistantId,
@@ -55,11 +57,11 @@ export function PluginDetailMobile({
     isInstalling,
     isRemoving,
     isUpgrading,
+    isInstallError,
+    isRemoveError,
+    isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
-
-  const [confirmingRemove, setConfirmingRemove] = useState(false);
-  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
 
   // Resolve the full-screen portal target after commit (SSR-safe; the element
   // is mounted by RootLayout). Falls back to inline when absent (tests, first
@@ -70,29 +72,8 @@ export function PluginDetailMobile({
   }, []);
 
   const isExternal = plugin?.source?.kind === "github";
-  const installed = plugin?.installed ?? false;
   const updateAvailable = drift?.status === "update-available";
   const title = plugin?.name ?? name;
-
-  const confirmRemove = () => {
-    setConfirmingRemove(false);
-    remove();
-  };
-
-  // Local edits would be clobbered by the re-install, so confirm first; a clean
-  // copy upgrades directly.
-  const handleUpgrade = () => {
-    if (hasLocalEdits) {
-      setConfirmingUpgrade(true);
-      return;
-    }
-    upgrade();
-  };
-
-  const confirmUpgrade = () => {
-    setConfirmingUpgrade(false);
-    upgrade();
-  };
 
   const overlay = (
     <div
@@ -108,7 +89,8 @@ export function PluginDetailMobile({
           "calc(12px + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
       }}
     >
-      {/* Action bar */}
+      {/* Action bar — back + centered title. The trailing spacer mirrors the
+          back button's footprint so the title stays optically centered. */}
       <div className="flex items-center justify-between">
         <Button
           variant="ghost"
@@ -124,16 +106,9 @@ export function PluginDetailMobile({
         >
           {title}
         </span>
-        <RightAction
-          hasPlugin={plugin !== null}
-          installed={installed}
-          updateAvailable={updateAvailable}
-          isInstalling={isInstalling}
-          isRemoving={isRemoving}
-          isUpgrading={isUpgrading}
-          onInstall={install}
-          onRemove={() => setConfirmingRemove(true)}
-          onUpgrade={handleUpgrade}
+        <span
+          aria-hidden
+          className="h-8 w-8 shrink-0 touch-mobile:h-10 touch-mobile:w-10"
         />
       </div>
 
@@ -164,7 +139,39 @@ export function PluginDetailMobile({
         ) : null}
       </div>
 
-      {/* Content card — 24px below the description */}
+      {/* Action set — the full Install / Download / Upgrade / Remove set, so
+          Remove stays reachable even when an update is available. */}
+      {plugin ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <PluginDetailActions
+            plugin={plugin}
+            drift={drift}
+            onInstall={install}
+            onRemove={remove}
+            onUpgrade={upgrade}
+            isInstalling={isInstalling}
+            isRemoving={isRemoving}
+            isUpgrading={isUpgrading}
+            hasLocalEdits={hasLocalEdits}
+          />
+        </div>
+      ) : null}
+
+      {(isInstallError || isRemoveError || isUpgradeError) && (
+        <div className="mt-3">
+          <PluginDetailActionError
+            message={
+              isInstallError
+                ? "Failed to install plugin. Please try again."
+                : isRemoveError
+                  ? "Failed to remove plugin. Please try again."
+                  : "Failed to upgrade plugin. Please try again."
+            }
+          />
+        </div>
+      )}
+
+      {/* Content card — 24px below the action set */}
       <Card.Root asChild noPadding>
         <div
           className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
@@ -172,12 +179,15 @@ export function PluginDetailMobile({
         >
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
             {isLoading ? (
-              <LoadingState />
+              <PluginDetailLoading />
             ) : isError || !plugin ? (
-              <DetailErrorState />
+              <PluginDetailError />
             ) : (
               <>
-                <Metadata plugin={plugin} />
+                <PluginDetailMetadata
+                  plugin={plugin}
+                  surfaces={drift?.surfaces ?? null}
+                />
                 {plugin.readme ? (
                   <FileMarkdown content={plugin.readme} />
                 ) : (
@@ -193,190 +203,8 @@ export function PluginDetailMobile({
           </div>
         </div>
       </Card.Root>
-
-      <ConfirmDialog
-        open={confirmingRemove}
-        title="Remove plugin"
-        message={`Remove "${title}" from this assistant?`}
-        confirmLabel="Remove"
-        destructive
-        onConfirm={confirmRemove}
-        onCancel={() => setConfirmingRemove(false)}
-      />
-
-      <ConfirmDialog
-        open={confirmingUpgrade}
-        title="Upgrade plugin"
-        message={`"${title}" has local edits that will be overwritten by the upgrade. Continue?`}
-        confirmLabel="Upgrade anyway"
-        destructive
-        onConfirm={confirmUpgrade}
-        onCancel={() => setConfirmingUpgrade(false)}
-      />
     </div>
   );
 
   return overlayTarget ? createPortal(overlay, overlayTarget) : overlay;
-}
-
-function RightAction({
-  hasPlugin,
-  installed,
-  updateAvailable,
-  isInstalling,
-  isRemoving,
-  isUpgrading,
-  onInstall,
-  onRemove,
-  onUpgrade,
-}: {
-  hasPlugin: boolean;
-  installed: boolean;
-  updateAvailable: boolean;
-  isInstalling: boolean;
-  isRemoving: boolean;
-  isUpgrading: boolean;
-  onInstall: () => void;
-  onRemove: () => void;
-  onUpgrade: () => void;
-}) {
-  if (!hasPlugin) {
-    return null;
-  }
-
-  if (isInstalling || isRemoving || isUpgrading) {
-    return (
-      <Button
-        variant="ghost"
-        iconOnly={<Loader2 className="animate-spin" aria-hidden />}
-        expandOnMobile
-        disabled
-        aria-label="Pending"
-        className="max-md:bg-[var(--surface-active)]"
-      />
-    );
-  }
-
-  if (!installed) {
-    return (
-      <Button
-        variant="ghost"
-        iconOnly={<ArrowDownToLine aria-hidden />}
-        expandOnMobile
-        aria-label="Install plugin"
-        onClick={onInstall}
-        className="max-md:bg-[var(--surface-active)]"
-      />
-    );
-  }
-
-  if (updateAvailable) {
-    return (
-      <Button
-        variant="ghost"
-        iconOnly={<ArrowUpCircle aria-hidden />}
-        expandOnMobile
-        aria-label="Upgrade plugin"
-        onClick={onUpgrade}
-        className="max-md:bg-[var(--surface-active)]"
-      />
-    );
-  }
-
-  return (
-    <Button
-      variant="dangerGhost"
-      iconOnly={<Trash2 aria-hidden />}
-      expandOnMobile
-      aria-label="Remove plugin"
-      onClick={onRemove}
-      className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
-    />
-  );
-}
-
-function Metadata({ plugin }: { plugin: PluginsByNameGetResponse }) {
-  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
-  const repoHref =
-    plugin.source?.kind === "github"
-      ? `https://github.com/${plugin.source.repo}`
-      : null;
-
-  const rows: { label: string; value: string; href?: string }[] = [
-    { label: "Source", value: repo, href: repoHref ?? undefined },
-  ];
-  if (plugin.version) {
-    rows.push({ label: "Version", value: `v${plugin.version}` });
-  }
-  if (plugin.homepage) {
-    rows.push({ label: "Homepage", value: plugin.homepage, href: plugin.homepage });
-  }
-  if (plugin.license) {
-    rows.push({ label: "License", value: plugin.license });
-  }
-
-  return (
-    <dl
-      className="mb-5 grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 border-b pb-5"
-      style={{ borderColor: "var(--border-base)" }}
-    >
-      {rows.map((row) => (
-        <div key={row.label} className="contents">
-          <dt
-            className="text-body-small-default"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            {row.label}
-          </dt>
-          <dd
-            className="min-w-0 truncate text-body-small-default"
-            style={{ color: "var(--content-secondary)" }}
-          >
-            {row.href ? (
-              <a
-                href={row.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 underline"
-                style={{ color: "var(--primary-base, #60a5fa)" }}
-              >
-                {row.value}
-                <ExternalLink className="h-3 w-3" aria-hidden />
-              </a>
-            ) : (
-              row.value
-            )}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
-function LoadingState() {
-  return (
-    <div className="flex items-center justify-center py-12">
-      <Loader2
-        className="h-6 w-6 animate-spin"
-        style={{ color: "var(--content-tertiary)" }}
-      />
-    </div>
-  );
-}
-
-function DetailErrorState() {
-  return (
-    <div
-      className="flex flex-col items-center justify-center gap-2 py-12 text-center"
-      style={{ color: "var(--content-tertiary)" }}
-    >
-      <TriangleAlert className="h-6 w-6" aria-hidden />
-      <p className="text-body-medium-default">
-        We couldn&apos;t load this plugin.
-      </p>
-      <p className="text-body-small-default">
-        It may not exist, or your assistant may be on an older build.
-      </p>
-    </div>
-  );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -1,0 +1,382 @@
+import {
+    ArrowDownToLine,
+    ArrowLeft,
+    ArrowUpCircle,
+    ExternalLink,
+    Loader2,
+    Trash2,
+    TriangleAlert,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { FileMarkdown } from "@/components/file-markdown";
+import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
+import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
+import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
+import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+
+interface PluginDetailMobileProps {
+  assistantId: string;
+  name: string;
+  onBack: () => void;
+}
+
+/**
+ * Single-column phone layout for viewing a plugin's details.
+ *
+ * Renders as a full-screen overlay that takes over the whole viewport — its own
+ * back · title · action bar replaces the app's mobile chrome and the
+ * Intelligence tab row, mirroring `SkillDetailMobile`. The overlay is portaled
+ * into `RootLayout`'s `#viewport-overlays` container so a transformed layout
+ * ancestor can't scope its `position: fixed`; when the target isn't resolved
+ * yet (first paint / tests) it falls back to rendering inline.
+ *
+ * Unlike skills, plugins expose no file endpoints, so the content card is just
+ * the tracked metadata plus the README. Owns the install / remove / upgrade
+ * flow via `usePluginDetail`, returning to the list (`onBack`) once the plugin
+ * is removed. Removing — and upgrading a locally-edited copy — confirm first.
+ */
+export function PluginDetailMobile({
+  assistantId,
+  name,
+  onBack,
+}: PluginDetailMobileProps) {
+  const {
+    plugin,
+    drift,
+    isLoading,
+    isError,
+    install,
+    remove,
+    upgrade,
+    isInstalling,
+    isRemoving,
+    isUpgrading,
+    hasLocalEdits,
+  } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
+
+  // Resolve the full-screen portal target after commit (SSR-safe; the element
+  // is mounted by RootLayout). Falls back to inline when absent (tests, first
+  // paint).
+  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setOverlayTarget(document.getElementById("viewport-overlays"));
+  }, []);
+
+  const isExternal = plugin?.source?.kind === "github";
+  const installed = plugin?.installed ?? false;
+  const updateAvailable = drift?.status === "update-available";
+  const title = plugin?.name ?? name;
+
+  const confirmRemove = () => {
+    setConfirmingRemove(false);
+    remove();
+  };
+
+  // Local edits would be clobbered by the re-install, so confirm first; a clean
+  // copy upgrades directly.
+  const handleUpgrade = () => {
+    if (hasLocalEdits) {
+      setConfirmingUpgrade(true);
+      return;
+    }
+    upgrade();
+  };
+
+  const confirmUpgrade = () => {
+    setConfirmingUpgrade(false);
+    upgrade();
+  };
+
+  const overlay = (
+    <div
+      className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-[var(--surface-overlay)]"
+      style={{
+        paddingTop:
+          "calc(8px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+        paddingBottom:
+          "calc(8px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
+        paddingLeft:
+          "calc(12px + var(--safe-area-inset-left, env(safe-area-inset-left, 0px)))",
+        paddingRight:
+          "calc(12px + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
+      }}
+    >
+      {/* Action bar */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="ghost"
+          iconOnly={<ArrowLeft aria-hidden />}
+          expandOnMobile
+          aria-label="Back to plugins"
+          onClick={onBack}
+          className="max-md:bg-[var(--surface-active)]"
+        />
+        <span
+          className="min-w-0 flex-1 truncate px-2 text-center text-body-medium-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {title}
+        </span>
+        <RightAction
+          hasPlugin={plugin !== null}
+          installed={installed}
+          updateAvailable={updateAvailable}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          isUpgrading={isUpgrading}
+          onInstall={install}
+          onRemove={() => setConfirmingRemove(true)}
+          onUpgrade={handleUpgrade}
+        />
+      </div>
+
+      {/* Header block — 16px below the action bar */}
+      <div className="mt-4 flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <PluginIcon external={isExternal} size="md" />
+            <h2
+              className="min-w-0 truncate text-title-medium"
+              style={{ color: "var(--content-emphasised)" }}
+            >
+              {title}
+            </h2>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {updateAvailable ? <UpdateAvailableBadge /> : null}
+            <PluginOriginBadge external={isExternal} />
+          </div>
+        </div>
+        {plugin?.description ? (
+          <p
+            className="text-body-medium-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {plugin.description}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Content card — 24px below the description */}
+      <Card.Root asChild noPadding>
+        <div
+          className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-[var(--surface-lift)]"
+          style={{ borderColor: "var(--border-hover)" }}
+        >
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+            {isLoading ? (
+              <LoadingState />
+            ) : isError || !plugin ? (
+              <DetailErrorState />
+            ) : (
+              <>
+                <Metadata plugin={plugin} />
+                {plugin.readme ? (
+                  <FileMarkdown content={plugin.readme} />
+                ) : (
+                  <p
+                    className="text-body-medium-lighter"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    This plugin doesn&apos;t ship a README.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </Card.Root>
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove plugin"
+        message={`Remove "${title}" from this assistant?`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={confirmRemove}
+        onCancel={() => setConfirmingRemove(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmingUpgrade}
+        title="Upgrade plugin"
+        message={`"${title}" has local edits that will be overwritten by the upgrade. Continue?`}
+        confirmLabel="Upgrade anyway"
+        destructive
+        onConfirm={confirmUpgrade}
+        onCancel={() => setConfirmingUpgrade(false)}
+      />
+    </div>
+  );
+
+  return overlayTarget ? createPortal(overlay, overlayTarget) : overlay;
+}
+
+function RightAction({
+  hasPlugin,
+  installed,
+  updateAvailable,
+  isInstalling,
+  isRemoving,
+  isUpgrading,
+  onInstall,
+  onRemove,
+  onUpgrade,
+}: {
+  hasPlugin: boolean;
+  installed: boolean;
+  updateAvailable: boolean;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  isUpgrading: boolean;
+  onInstall: () => void;
+  onRemove: () => void;
+  onUpgrade: () => void;
+}) {
+  if (!hasPlugin) {
+    return null;
+  }
+
+  if (isInstalling || isRemoving || isUpgrading) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<Loader2 className="animate-spin" aria-hidden />}
+        expandOnMobile
+        disabled
+        aria-label="Pending"
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (!installed) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<ArrowDownToLine aria-hidden />}
+        expandOnMobile
+        aria-label="Install plugin"
+        onClick={onInstall}
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  if (updateAvailable) {
+    return (
+      <Button
+        variant="ghost"
+        iconOnly={<ArrowUpCircle aria-hidden />}
+        expandOnMobile
+        aria-label="Upgrade plugin"
+        onClick={onUpgrade}
+        className="max-md:bg-[var(--surface-active)]"
+      />
+    );
+  }
+
+  return (
+    <Button
+      variant="dangerGhost"
+      iconOnly={<Trash2 aria-hidden />}
+      expandOnMobile
+      aria-label="Remove plugin"
+      onClick={onRemove}
+      className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
+    />
+  );
+}
+
+function Metadata({ plugin }: { plugin: PluginsByNameGetResponse }) {
+  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
+  const repoHref =
+    plugin.source?.kind === "github"
+      ? `https://github.com/${plugin.source.repo}`
+      : null;
+
+  const rows: { label: string; value: string; href?: string }[] = [
+    { label: "Source", value: repo, href: repoHref ?? undefined },
+  ];
+  if (plugin.version) {
+    rows.push({ label: "Version", value: `v${plugin.version}` });
+  }
+  if (plugin.homepage) {
+    rows.push({ label: "Homepage", value: plugin.homepage, href: plugin.homepage });
+  }
+  if (plugin.license) {
+    rows.push({ label: "License", value: plugin.license });
+  }
+
+  return (
+    <dl
+      className="mb-5 grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 border-b pb-5"
+      style={{ borderColor: "var(--border-base)" }}
+    >
+      {rows.map((row) => (
+        <div key={row.label} className="contents">
+          <dt
+            className="text-body-small-default"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {row.label}
+          </dt>
+          <dd
+            className="min-w-0 truncate text-body-small-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {row.href ? (
+              <a
+                href={row.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 underline"
+                style={{ color: "var(--primary-base, #60a5fa)" }}
+              >
+                {row.value}
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            ) : (
+              row.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2
+        className="h-6 w-6 animate-spin"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    </div>
+  );
+}
+
+function DetailErrorState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-12 text-center"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      <TriangleAlert className="h-6 w-6" aria-hidden />
+      <p className="text-body-medium-default">
+        We couldn&apos;t load this plugin.
+      </p>
+      <p className="text-body-small-default">
+        It may not exist, or your assistant may be on an older build.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds PluginDetailMobile: full-screen overlay (action bar + header + metadata/README card) via usePluginDetail, mirroring SkillDetailMobile. Callback-driven (onBack).

Part of plan: plugins-tab-match-skills.md (PR 11 of 13)