### PR TITLE
feat(web): add in-tab PluginDetail desktop component

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Focused tests for the presentational `PluginDetailMetadata` building block.
+ * The panel/page tests cover the install/remove/upgrade flow end-to-end; this
+ * pins the metadata table's net-new branch — the contributed-surface counts
+ * (Skills / Hooks / Tools) that only render when an installed copy's drift
+ * inspection supplies them. Presentational, so no QueryClient is needed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { PluginDetailMetadata } from "@/domains/intelligence/components/plugins/plugin-detail-shared";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+
+afterEach(() => {
+  cleanup();
+});
+
+const githubPlugin: PluginsByNameGetResponse = {
+  name: "level-up",
+  installed: true,
+  description: "Surfaces a Level Up diff card.",
+  homepage: "https://example.com/level-up",
+  license: "MIT",
+  version: "0.1.0",
+  source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+  readme: "# Level Up",
+  ref: "main",
+  artifact: null,
+};
+
+describe("PluginDetailMetadata", () => {
+  test("renders source repo link, homepage, and license rows", () => {
+    const { container } = render(<PluginDetailMetadata plugin={githubPlugin} />);
+    const html = container.innerHTML;
+
+    expect(html).toContain("vellum-ai/level-up");
+    expect(html).toContain('href="https://github.com/vellum-ai/level-up"');
+    expect(html).toContain("https://example.com/level-up");
+    expect(html).toContain("MIT");
+    // Without surfaces, no contributed-surface counts appear.
+    expect(html).not.toContain("Skills");
+  });
+
+  test("lists only the non-empty contributed-surface counts", () => {
+    const surfaces: PluginDrift["surfaces"] = {
+      skills: ["a", "b"],
+      hooks: [],
+      tools: ["t"],
+    };
+    const { container } = render(
+      <PluginDetailMetadata plugin={githubPlugin} surfaces={surfaces} />,
+    );
+    const html = container.innerHTML;
+
+    expect(html).toContain("Skills");
+    expect(html).toContain("Tools");
+    // An empty surface list is omitted rather than shown as "0".
+    expect(html).not.toContain("Hooks");
+  });
+
+  test("labels a local plugin source without a repo link", () => {
+    const localPlugin: PluginsByNameGetResponse = {
+      ...githubPlugin,
+      source: null,
+      homepage: null,
+      license: null,
+    };
+    const { container } = render(<PluginDetailMetadata plugin={localPlugin} />);
+    const html = container.innerHTML;
+
+    expect(html).toContain("Local");
+    expect(html).not.toContain("href=\"https://github.com");
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -1,0 +1,328 @@
+import {
+    ArrowDownToLine,
+    ArrowUpCircle,
+    Download,
+    ExternalLink,
+    Loader2,
+    Trash2,
+    TriangleAlert,
+} from "lucide-react";
+import { useState } from "react";
+
+import { shortSha } from "@/domains/intelligence/plugins/use-plugin-detail";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { cn } from "@/utils/misc";
+import { Button, ConfirmDialog } from "@vellumai/design-library";
+
+/**
+ * Presentational building blocks shared by the plugin detail surfaces so the
+ * metadata table, loading / error states, and the Install / Download / Upgrade
+ * / Remove action set don't drift between them. These take props (plugin +
+ * drift + callbacks) and render UI only — data fetching stays in the consuming
+ * panel/page via `usePluginDetail`.
+ *
+ * Consumers: the desktop in-tab detail (`plugin-detail.tsx`) and the mobile
+ * detail overlay (`plugin-detail-mobile.tsx`, on a separate branch). Both place
+ * these pieces in their own layout chrome, so the building blocks stay
+ * layout-agnostic. (The route page `plugin-detail-page.tsx` is being retired in
+ * favor of a redirect.)
+ */
+
+interface PluginDetailMetadataProps {
+  plugin: PluginsByNameGetResponse;
+  /**
+   * Contributed-surface counts for an installed copy (skills / hooks / tools).
+   * Only present once the drift inspection resolves; omit for surfaces we don't
+   * track on this view.
+   */
+  surfaces?: PluginDrift["surfaces"];
+  className?: string;
+}
+
+/**
+ * Metadata table for a plugin: Source (repo link), Homepage, License, and —
+ * when an installed copy's contributed surfaces are known — Skills / Hooks /
+ * Tools counts. Only non-empty rows render.
+ */
+export function PluginDetailMetadata({
+  plugin,
+  surfaces = null,
+  className,
+}: PluginDetailMetadataProps) {
+  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
+  const repoHref =
+    plugin.source?.kind === "github"
+      ? `https://github.com/${plugin.source.repo}`
+      : null;
+
+  const rows: { label: string; value: string; href?: string }[] = [
+    {
+      label: "Source",
+      value: repo,
+      href: repoHref ?? undefined,
+    },
+  ];
+  if (plugin.homepage) {
+    rows.push({
+      label: "Homepage",
+      value: plugin.homepage,
+      href: plugin.homepage,
+    });
+  }
+  if (plugin.license) {
+    rows.push({ label: "License", value: plugin.license });
+  }
+  // Surfaces are only present for an installed copy; list the non-empty
+  // contributions (skills / hooks / tools) so the panel shows what the
+  // plugin actually adds.
+  if (surfaces) {
+    if (surfaces.skills.length > 0) {
+      rows.push({ label: "Skills", value: String(surfaces.skills.length) });
+    }
+    if (surfaces.hooks.length > 0) {
+      rows.push({ label: "Hooks", value: String(surfaces.hooks.length) });
+    }
+    if (surfaces.tools.length > 0) {
+      rows.push({ label: "Tools", value: String(surfaces.tools.length) });
+    }
+  }
+
+  return (
+    <dl
+      className={cn(
+        "mb-5 grid gap-x-6 gap-y-2 border-b pb-5 sm:grid-cols-[max-content_1fr]",
+        className,
+      )}
+      style={{ borderColor: "var(--border-base)" }}
+    >
+      {rows.map((row) => (
+        <div key={row.label} className="contents">
+          <dt
+            className="text-body-small-default"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {row.label}
+          </dt>
+          <dd
+            className="min-w-0 truncate text-body-small-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {row.href ? (
+              <a
+                href={row.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 underline"
+                style={{ color: "var(--primary-base, #60a5fa)" }}
+              >
+                {row.value}
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            ) : (
+              row.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+interface PluginDetailActionsProps {
+  plugin: PluginsByNameGetResponse;
+  drift: PluginDrift | undefined;
+  /** Install the available plugin. */
+  onInstall: () => void;
+  /** Remove the installed plugin (the confirm prompt is wired internally). */
+  onRemove: () => void;
+  /**
+   * Upgrade the installed copy. A locally-edited copy is confirmed first (the
+   * risky-upgrade prompt is wired internally); a clean copy upgrades directly.
+   */
+  onUpgrade: () => void;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  isUpgrading: boolean;
+  /** Gates whether an upgrade prompts before overwriting local edits. */
+  hasLocalEdits: boolean;
+}
+
+/**
+ * Action set for a plugin: Install when available, otherwise Download-artifact
+ * (when one ships), Upgrade (when an installed copy has drifted), and Remove.
+ * Remove always confirms; Upgrade confirms only when the copy has local edits
+ * that the re-install would clobber. The confirm dialogs are portal-rendered,
+ * so callers can place this anywhere without affecting layout.
+ */
+export function PluginDetailActions({
+  plugin,
+  drift,
+  onInstall,
+  onRemove,
+  onUpgrade,
+  isInstalling,
+  isRemoving,
+  isUpgrading,
+  hasLocalEdits,
+}: PluginDetailActionsProps) {
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
+
+  const installed = plugin.installed ?? false;
+  const artifact = plugin.artifact ?? null;
+  const updateAvailable = drift?.status === "update-available";
+  const upgradeTitle = updateAvailable
+    ? `Upgrade ${shortSha(drift?.local?.commit ?? null)} → ${shortSha(
+        drift?.remote?.commit ?? null,
+      )}`
+    : undefined;
+
+  const confirmRemove = () => {
+    setConfirmingRemove(false);
+    onRemove();
+  };
+
+  // Local edits would be clobbered by the re-install, so confirm first;
+  // a clean copy upgrades directly.
+  const handleUpgrade = () => {
+    if (hasLocalEdits) {
+      setConfirmingUpgrade(true);
+      return;
+    }
+    onUpgrade();
+  };
+
+  const confirmUpgrade = () => {
+    setConfirmingUpgrade(false);
+    onUpgrade();
+  };
+
+  return (
+    <>
+      {installed ? (
+        <div className="flex shrink-0 items-center gap-2">
+          {artifact ? (
+            <Button asChild leftIcon={<Download aria-hidden />}>
+              <a href={artifact.url} download>
+                {artifact.label ?? "Download"}
+              </a>
+            </Button>
+          ) : null}
+          {updateAvailable ? (
+            <Button
+              type="button"
+              onClick={handleUpgrade}
+              disabled={isUpgrading}
+              title={upgradeTitle}
+              leftIcon={
+                isUpgrading ? (
+                  <Loader2 className="animate-spin" aria-hidden />
+                ) : (
+                  <ArrowUpCircle aria-hidden />
+                )
+              }
+            >
+              Upgrade
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            variant="dangerOutline"
+            onClick={() => setConfirmingRemove(true)}
+            disabled={isRemoving}
+            leftIcon={
+              isRemoving ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <Trash2 aria-hidden />
+              )
+            }
+          >
+            Remove
+          </Button>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          onClick={onInstall}
+          disabled={isInstalling}
+          leftIcon={
+            isInstalling ? (
+              <Loader2 className="animate-spin" aria-hidden />
+            ) : (
+              <ArrowDownToLine aria-hidden />
+            )
+          }
+        >
+          Install
+        </Button>
+      )}
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove plugin"
+        message={`Remove "${plugin.name}" from this assistant?`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={confirmRemove}
+        onCancel={() => setConfirmingRemove(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmingUpgrade}
+        title="Upgrade plugin"
+        message={`"${plugin.name}" has local edits that will be overwritten by the upgrade. Continue?`}
+        confirmLabel="Upgrade anyway"
+        destructive
+        onConfirm={confirmUpgrade}
+        onCancel={() => setConfirmingUpgrade(false)}
+      />
+    </>
+  );
+}
+
+export function PluginDetailLoading() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2
+        className="h-6 w-6 animate-spin"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    </div>
+  );
+}
+
+export function PluginDetailError() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-12 text-center"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      <TriangleAlert className="h-6 w-6" aria-hidden />
+      <p className="text-body-medium-default">
+        We couldn&apos;t load this plugin.
+      </p>
+      <p className="text-body-small-default">
+        It may not exist, or your assistant may be on an older build.
+      </p>
+    </div>
+  );
+}
+
+/** Inline banner for a failed install / remove / upgrade attempt. */
+export function PluginDetailActionError({ message }: { message: string }) {
+  return (
+    <div
+      className="mb-3 flex items-center gap-2 rounded px-3 py-2 text-body-small-default"
+      style={{
+        backgroundColor: "var(--surface-secondary)",
+        color: "var(--content-warning, var(--content-tertiary))",
+      }}
+      role="alert"
+    >
+      <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
+      {message}
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Tests for the in-tab `PluginDetail` panel: it renders the README, the
+ * tracked metadata (source/homepage/license), and the install/remove/upgrade
+ * actions that reflect whether the plugin is installed and whether it has
+ * drifted behind the marketplace pin. The back button invokes `onBack`.
+ *
+ * Unlike the retired route page, `PluginDetail` is callback-driven with no
+ * routing, so there's no `MemoryRouter` or identity-store seeding here —
+ * just the React Query cache pre-populated so the detail (and, for installed
+ * copies, the drift inspect) queries resolve on mount instead of hitting the
+ * network. Uses `@testing-library/react` (happy-dom) so the back-button
+ * click can be exercised.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import {
+  pluginsByNameGetQueryKey,
+  pluginsByNameInspectGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { Options } from "@/generated/daemon/sdk.gen";
+import type {
+  PluginsByNameGetData,
+  PluginsByNameGetResponse,
+  PluginsByNameInspectGetData,
+  PluginsByNameInspectGetResponse,
+} from "@/generated/daemon/types.gen";
+
+import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-detail";
+
+const ASSISTANT_ID = "asst-1";
+const LOCAL_COMMIT = "60a392b0000000000000000000000000000000aa";
+const REMOTE_COMMIT = "3eae1820000000000000000000000000000000bb";
+
+afterEach(() => {
+  cleanup();
+});
+
+function upToDateInspect(
+  name: string,
+  installed: boolean,
+): PluginsByNameInspectGetResponse {
+  return {
+    name,
+    installed,
+    status: "up-to-date",
+    local: null,
+    remote: null,
+    remoteError: null,
+    surfaces: null,
+  };
+}
+
+function updateAvailableInspect(name: string): PluginsByNameInspectGetResponse {
+  return {
+    name,
+    installed: true,
+    status: "update-available",
+    local: {
+      target: `/ws/plugins/${name}`,
+      commit: LOCAL_COMMIT,
+      committedAt: null,
+      version: "0.1.0",
+      description: null,
+      installedAt: "2026-06-01T00:00:00.000Z",
+      source: {
+        kind: "github",
+        owner: "vellum-ai",
+        repo: "level-up",
+        ref: LOCAL_COMMIT,
+      },
+      localChanges: {
+        modified: [],
+        added: [],
+        removed: [],
+        clean: true,
+      },
+      issues: [],
+    },
+    remote: {
+      repo: "vellum-ai/level-up",
+      path: "",
+      commit: REMOTE_COMMIT,
+      committedAt: null,
+      description: null,
+      homepage: null,
+      license: "MIT",
+      category: null,
+      marketplaceRef: "main",
+    },
+    remoteError: null,
+    surfaces: null,
+  };
+}
+
+function renderDetail(
+  name: string,
+  detail: PluginsByNameGetResponse,
+  inspect: PluginsByNameInspectGetResponse,
+) {
+  const client = new QueryClient({
+    // Infinite stale time keeps the seeded queries from refetching on mount
+    // (a client render runs query effects), so neither the detail read nor
+    // the installed-copy drift inspect touches the network.
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  client.setQueryData(
+    pluginsByNameGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID, name },
+    } as Options<PluginsByNameGetData>),
+    detail,
+  );
+  client.setQueryData(
+    pluginsByNameInspectGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID, name },
+    } as Options<PluginsByNameInspectGetData>),
+    inspect,
+  );
+  const onBack = mock(() => {});
+  const result = render(
+    <QueryClientProvider client={client}>
+      <PluginDetail assistantId={ASSISTANT_ID} name={name} onBack={onBack} />
+    </QueryClientProvider>,
+  );
+  return { ...result, onBack };
+}
+
+describe("PluginDetail", () => {
+  test("renders README, metadata, and an Install button for an available plugin", () => {
+    const { container } = renderDetail(
+      "caveman",
+      {
+        name: "caveman",
+        installed: false,
+        description: "Talk like a caveman.",
+        homepage: "https://example.com/caveman",
+        license: "MIT",
+        version: "1.8.2",
+        source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
+        readme: "# Caveman\n\nMakes the agent speak in grunts.",
+        ref: "v1.8.2",
+        artifact: null,
+      },
+      upToDateInspect("caveman", false),
+    );
+    const html = container.innerHTML;
+
+    // README markdown is rendered.
+    expect(html).toContain("Makes the agent speak in grunts.");
+    // Tracked metadata is surfaced.
+    expect(html).toContain("example-org/caveman");
+    expect(html).toContain("https://example.com/caveman");
+    expect(html).toContain("MIT");
+    // A github-sourced plugin is badged External.
+    expect(html).toContain("External");
+    // An available plugin offers Install, not Remove.
+    expect(html).toContain("Install");
+    expect(html).not.toContain("Remove");
+  });
+
+  test("renders a Remove action when the plugin is already installed", () => {
+    const { container } = renderDetail(
+      "simple-memory",
+      {
+        name: "simple-memory",
+        installed: true,
+        description: null,
+        homepage: null,
+        license: null,
+        version: "0.1.0",
+        source: null,
+        readme: null,
+        ref: "main",
+        artifact: null,
+      },
+      upToDateInspect("simple-memory", true),
+    );
+    const html = container.innerHTML;
+
+    expect(html).toContain("Remove");
+    // A plugin with no marketplace origin isn't badged External.
+    expect(html).not.toContain("External");
+    // No README falls back to an explanatory line.
+    expect(html).toContain("ship a README");
+    // With no artifact descriptor, no download affordance is offered.
+    expect(html).not.toContain("Download");
+  });
+
+  test("offers an Upgrade action and update badge when an installed copy has drifted", () => {
+    const { container } = renderDetail(
+      "level-up",
+      {
+        name: "level-up",
+        installed: true,
+        description: "Surfaces a Level Up diff card.",
+        homepage: null,
+        license: "MIT",
+        version: "0.1.0",
+        source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+        readme: "# Level Up",
+        ref: "main",
+        artifact: null,
+      },
+      updateAvailableInspect("level-up"),
+    );
+    const html = container.innerHTML;
+
+    expect(html).toContain("Update available");
+    expect(html).toContain("Upgrade");
+    // The drifted copy is still installed, so Remove remains available.
+    expect(html).toContain("Remove");
+  });
+
+  test("offers a download linked to the artifact when an installed plugin ships one", () => {
+    const url =
+      "https://github.com/example-org/dynamic-notch/releases/download/v1.0.0/DynamicNotch.dmg";
+    const { container } = renderDetail(
+      "dynamic-notch",
+      {
+        name: "dynamic-notch",
+        installed: true,
+        description: "A dynamic notch companion.",
+        homepage: null,
+        license: "MIT",
+        version: "1.0.0",
+        source: {
+          kind: "github",
+          repo: "example-org/dynamic-notch",
+          ref: "v1.0.0",
+        },
+        readme: "# Dynamic Notch",
+        ref: "v1.0.0",
+        artifact: { url, sha256: "a".repeat(64), label: "Download for macOS" },
+      },
+      upToDateInspect("dynamic-notch", true),
+    );
+    const html = container.innerHTML;
+
+    expect(html).toContain("Download for macOS");
+    expect(html).toContain(`href="${url}"`);
+    expect(html).toContain("Remove");
+  });
+
+  test("invokes onBack when the back button is clicked", () => {
+    const { getByLabelText, onBack } = renderDetail(
+      "caveman",
+      {
+        name: "caveman",
+        installed: false,
+        description: "Talk like a caveman.",
+        homepage: null,
+        license: null,
+        version: "1.8.2",
+        source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
+        readme: "# Caveman",
+        ref: "v1.8.2",
+        artifact: null,
+      },
+      upToDateInspect("caveman", false),
+    );
+
+    fireEvent.click(getByLabelText("Back to plugins"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -1,26 +1,20 @@
-import {
-    ArrowDownToLine,
-    ArrowLeft,
-    ArrowUpCircle,
-    Download,
-    ExternalLink,
-    Loader2,
-    Trash2,
-    TriangleAlert,
-} from "lucide-react";
-import { useState } from "react";
+import { ArrowLeft } from "lucide-react";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
+import {
+    PluginDetailActionError,
+    PluginDetailActions,
+    PluginDetailError,
+    PluginDetailLoading,
+    PluginDetailMetadata,
+} from "@/domains/intelligence/components/plugins/plugin-detail-shared";
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
-import {
-    shortSha,
-    usePluginDetail,
-} from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
-import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailProps {
   assistantId: string;
@@ -38,13 +32,12 @@ interface PluginDetailProps {
  *
  * Renders the plugin's README plus the metadata we track (source, homepage,
  * license, contributed surfaces) and Install / Download / Upgrade / Remove
- * actions. Plugins have no file-list endpoint, so there is no file tree —
+ * actions. The metadata table, state views, and action set come from
+ * `plugin-detail-shared` so they stay in lockstep with the mobile detail.
+ * Plugins have no file-list endpoint, so there is no file tree —
  * README + metadata only.
  */
 export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
-  const [confirmingRemove, setConfirmingRemove] = useState(false);
-  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
-
   const {
     plugin,
     drift,
@@ -62,26 +55,6 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
 
-  const confirmRemove = () => {
-    setConfirmingRemove(false);
-    remove();
-  };
-
-  // Local edits would be clobbered by the re-install, so confirm first;
-  // a clean copy upgrades directly.
-  const handleUpgrade = () => {
-    if (hasLocalEdits) {
-      setConfirmingUpgrade(true);
-      return;
-    }
-    upgrade();
-  };
-
-  const confirmUpgrade = () => {
-    setConfirmingUpgrade(false);
-    upgrade();
-  };
-
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="mb-4 flex items-start gap-3">
@@ -97,16 +70,17 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
           plugin={plugin}
           drift={drift}
           onInstall={install}
-          onRemove={() => setConfirmingRemove(true)}
-          onUpgrade={handleUpgrade}
+          onRemove={remove}
+          onUpgrade={upgrade}
           isInstalling={isInstalling}
           isRemoving={isRemoving}
           isUpgrading={isUpgrading}
+          hasLocalEdits={hasLocalEdits}
         />
       </div>
 
       {(isInstallError || isRemoveError || isUpgradeError) && (
-        <ActionError
+        <PluginDetailActionError
           message={
             isInstallError
               ? "Failed to install plugin. Please try again."
@@ -120,12 +94,15 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
       <Card.Root asChild>
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
           {isLoading ? (
-            <LoadingState />
+            <PluginDetailLoading />
           ) : isError || !plugin ? (
-            <DetailErrorState />
+            <PluginDetailError />
           ) : (
             <>
-              <Metadata plugin={plugin} surfaces={drift?.surfaces ?? null} />
+              <PluginDetailMetadata
+                plugin={plugin}
+                surfaces={drift?.surfaces ?? null}
+              />
               {plugin.readme ? (
                 <FileMarkdown content={plugin.readme} />
               ) : (
@@ -140,26 +117,6 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
           )}
         </div>
       </Card.Root>
-
-      <ConfirmDialog
-        open={confirmingRemove}
-        title="Remove plugin"
-        message={`Remove "${plugin?.name ?? name}" from this assistant?`}
-        confirmLabel="Remove"
-        destructive
-        onConfirm={confirmRemove}
-        onCancel={() => setConfirmingRemove(false)}
-      />
-
-      <ConfirmDialog
-        open={confirmingUpgrade}
-        title="Upgrade plugin"
-        message={`"${plugin?.name ?? name}" has local edits that will be overwritten by the upgrade. Continue?`}
-        confirmLabel="Upgrade anyway"
-        destructive
-        onConfirm={confirmUpgrade}
-        onCancel={() => setConfirmingUpgrade(false)}
-      />
     </div>
   );
 }
@@ -174,6 +131,7 @@ interface HeaderProps {
   isInstalling: boolean;
   isRemoving: boolean;
   isUpgrading: boolean;
+  hasLocalEdits: boolean;
 }
 
 function Header({
@@ -186,16 +144,10 @@ function Header({
   isInstalling,
   isRemoving,
   isUpgrading,
+  hasLocalEdits,
 }: HeaderProps) {
-  const installed = plugin?.installed ?? false;
   const isExternal = plugin?.source?.kind === "github";
-  const artifact = plugin?.artifact ?? null;
   const updateAvailable = drift?.status === "update-available";
-  const upgradeTitle = updateAvailable
-    ? `Upgrade ${shortSha(drift?.local?.commit ?? null)} → ${shortSha(
-        drift?.remote?.commit ?? null,
-      )}`
-    : undefined;
 
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
@@ -232,192 +184,18 @@ function Header({
       </div>
 
       {plugin ? (
-        installed ? (
-          <div className="flex shrink-0 items-center gap-2">
-            {artifact ? (
-              <Button asChild leftIcon={<Download aria-hidden />}>
-                <a href={artifact.url} download>
-                  {artifact.label ?? "Download"}
-                </a>
-              </Button>
-            ) : null}
-            {updateAvailable ? (
-              <Button
-                type="button"
-                onClick={onUpgrade}
-                disabled={isUpgrading}
-                title={upgradeTitle}
-                leftIcon={
-                  isUpgrading ? (
-                    <Loader2 className="animate-spin" aria-hidden />
-                  ) : (
-                    <ArrowUpCircle aria-hidden />
-                  )
-                }
-              >
-                Upgrade
-              </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="dangerOutline"
-              onClick={onRemove}
-              disabled={isRemoving}
-              leftIcon={
-                isRemoving ? (
-                  <Loader2 className="animate-spin" aria-hidden />
-                ) : (
-                  <Trash2 aria-hidden />
-                )
-              }
-            >
-              Remove
-            </Button>
-          </div>
-        ) : (
-          <Button
-            type="button"
-            onClick={onInstall}
-            disabled={isInstalling}
-            leftIcon={
-              isInstalling ? (
-                <Loader2 className="animate-spin" aria-hidden />
-              ) : (
-                <ArrowDownToLine aria-hidden />
-              )
-            }
-          >
-            Install
-          </Button>
-        )
+        <PluginDetailActions
+          plugin={plugin}
+          drift={drift}
+          onInstall={onInstall}
+          onRemove={onRemove}
+          onUpgrade={onUpgrade}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          isUpgrading={isUpgrading}
+          hasLocalEdits={hasLocalEdits}
+        />
       ) : null}
-    </div>
-  );
-}
-
-function Metadata({
-  plugin,
-  surfaces,
-}: {
-  plugin: PluginsByNameGetResponse;
-  surfaces: PluginDrift["surfaces"];
-}) {
-  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
-  const repoHref =
-    plugin.source?.kind === "github"
-      ? `https://github.com/${plugin.source.repo}`
-      : null;
-
-  const rows: { label: string; value: string; href?: string }[] = [
-    {
-      label: "Source",
-      value: repo,
-      href: repoHref ?? undefined,
-    },
-  ];
-  if (plugin.homepage) {
-    rows.push({
-      label: "Homepage",
-      value: plugin.homepage,
-      href: plugin.homepage,
-    });
-  }
-  if (plugin.license) {
-    rows.push({ label: "License", value: plugin.license });
-  }
-  // Surfaces are only present for an installed copy; list the non-empty
-  // contributions (skills / hooks / tools) so the panel shows what the
-  // plugin actually adds.
-  if (surfaces) {
-    if (surfaces.skills.length > 0) {
-      rows.push({ label: "Skills", value: String(surfaces.skills.length) });
-    }
-    if (surfaces.hooks.length > 0) {
-      rows.push({ label: "Hooks", value: String(surfaces.hooks.length) });
-    }
-    if (surfaces.tools.length > 0) {
-      rows.push({ label: "Tools", value: String(surfaces.tools.length) });
-    }
-  }
-
-  return (
-    <dl
-      className="mb-5 grid gap-x-6 gap-y-2 border-b pb-5 sm:grid-cols-[max-content_1fr]"
-      style={{ borderColor: "var(--border-base)" }}
-    >
-      {rows.map((row) => (
-        <div key={row.label} className="contents">
-          <dt
-            className="text-body-small-default"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            {row.label}
-          </dt>
-          <dd
-            className="min-w-0 truncate text-body-small-default"
-            style={{ color: "var(--content-secondary)" }}
-          >
-            {row.href ? (
-              <a
-                href={row.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 underline"
-                style={{ color: "var(--primary-base, #60a5fa)" }}
-              >
-                {row.value}
-                <ExternalLink className="h-3 w-3" aria-hidden />
-              </a>
-            ) : (
-              row.value
-            )}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
-function LoadingState() {
-  return (
-    <div className="flex items-center justify-center py-12">
-      <Loader2
-        className="h-6 w-6 animate-spin"
-        style={{ color: "var(--content-tertiary)" }}
-      />
-    </div>
-  );
-}
-
-function DetailErrorState() {
-  return (
-    <div
-      className="flex flex-col items-center justify-center gap-2 py-12 text-center"
-      style={{ color: "var(--content-tertiary)" }}
-    >
-      <TriangleAlert className="h-6 w-6" aria-hidden />
-      <p className="text-body-medium-default">
-        We couldn&apos;t load this plugin.
-      </p>
-      <p className="text-body-small-default">
-        It may not exist, or your assistant may be on an older build.
-      </p>
-    </div>
-  );
-}
-
-function ActionError({ message }: { message: string }) {
-  return (
-    <div
-      className="mb-3 flex items-center gap-2 rounded px-3 py-2 text-body-small-default"
-      style={{
-        backgroundColor: "var(--surface-secondary)",
-        color: "var(--content-warning, var(--content-tertiary))",
-      }}
-      role="alert"
-    >
-      <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
-      {message}
     </div>
   );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -1,0 +1,423 @@
+import {
+    ArrowDownToLine,
+    ArrowLeft,
+    ArrowUpCircle,
+    Download,
+    ExternalLink,
+    Loader2,
+    Trash2,
+    TriangleAlert,
+} from "lucide-react";
+import { useState } from "react";
+
+import { FileMarkdown } from "@/components/file-markdown";
+import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
+import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
+import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
+import {
+    shortSha,
+    usePluginDetail,
+} from "@/domains/intelligence/plugins/use-plugin-detail";
+import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
+import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+
+interface PluginDetailProps {
+  assistantId: string;
+  name: string;
+  /** Leave the detail view (return to the plugins list). */
+  onBack: () => void;
+}
+
+/**
+ * In-tab detail panel for a single plugin, mirroring the Skills tab's
+ * `SkillDetail` chrome (a back-button header + a `Card` body). Unlike the
+ * retired `PluginDetailPage`, this is callback-driven with no routing: the
+ * parent owns selection and passes `onBack` to close the panel. Removal
+ * closes via `usePluginDetail`'s `onRemoved` hook.
+ *
+ * Renders the plugin's README plus the metadata we track (source, homepage,
+ * license, contributed surfaces) and Install / Download / Upgrade / Remove
+ * actions. Plugins have no file-list endpoint, so there is no file tree —
+ * README + metadata only.
+ */
+export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
+
+  const {
+    plugin,
+    drift,
+    isLoading,
+    isError,
+    install,
+    remove,
+    upgrade,
+    isInstalling,
+    isRemoving,
+    isUpgrading,
+    isInstallError,
+    isRemoveError,
+    isUpgradeError,
+    hasLocalEdits,
+  } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+
+  const confirmRemove = () => {
+    setConfirmingRemove(false);
+    remove();
+  };
+
+  // Local edits would be clobbered by the re-install, so confirm first;
+  // a clean copy upgrades directly.
+  const handleUpgrade = () => {
+    if (hasLocalEdits) {
+      setConfirmingUpgrade(true);
+      return;
+    }
+    upgrade();
+  };
+
+  const confirmUpgrade = () => {
+    setConfirmingUpgrade(false);
+    upgrade();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex items-start gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          iconOnly={<ArrowLeft aria-hidden />}
+          aria-label="Back to plugins"
+          onClick={onBack}
+        />
+        <Header
+          name={name}
+          plugin={plugin}
+          drift={drift}
+          onInstall={install}
+          onRemove={() => setConfirmingRemove(true)}
+          onUpgrade={handleUpgrade}
+          isInstalling={isInstalling}
+          isRemoving={isRemoving}
+          isUpgrading={isUpgrading}
+        />
+      </div>
+
+      {(isInstallError || isRemoveError || isUpgradeError) && (
+        <ActionError
+          message={
+            isInstallError
+              ? "Failed to install plugin. Please try again."
+              : isRemoveError
+                ? "Failed to remove plugin. Please try again."
+                : "Failed to upgrade plugin. Please try again."
+          }
+        />
+      )}
+
+      <Card.Root asChild>
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {isLoading ? (
+            <LoadingState />
+          ) : isError || !plugin ? (
+            <DetailErrorState />
+          ) : (
+            <>
+              <Metadata plugin={plugin} surfaces={drift?.surfaces ?? null} />
+              {plugin.readme ? (
+                <FileMarkdown content={plugin.readme} />
+              ) : (
+                <p
+                  className="text-body-medium-lighter"
+                  style={{ color: "var(--content-tertiary)" }}
+                >
+                  This plugin doesn&apos;t ship a README.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </Card.Root>
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove plugin"
+        message={`Remove "${plugin?.name ?? name}" from this assistant?`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={confirmRemove}
+        onCancel={() => setConfirmingRemove(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmingUpgrade}
+        title="Upgrade plugin"
+        message={`"${plugin?.name ?? name}" has local edits that will be overwritten by the upgrade. Continue?`}
+        confirmLabel="Upgrade anyway"
+        destructive
+        onConfirm={confirmUpgrade}
+        onCancel={() => setConfirmingUpgrade(false)}
+      />
+    </div>
+  );
+}
+
+interface HeaderProps {
+  name: string;
+  plugin: PluginsByNameGetResponse | null;
+  drift: PluginDrift | undefined;
+  onInstall: () => void;
+  onRemove: () => void;
+  onUpgrade: () => void;
+  isInstalling: boolean;
+  isRemoving: boolean;
+  isUpgrading: boolean;
+}
+
+function Header({
+  name,
+  plugin,
+  drift,
+  onInstall,
+  onRemove,
+  onUpgrade,
+  isInstalling,
+  isRemoving,
+  isUpgrading,
+}: HeaderProps) {
+  const installed = plugin?.installed ?? false;
+  const isExternal = plugin?.source?.kind === "github";
+  const artifact = plugin?.artifact ?? null;
+  const updateAvailable = drift?.status === "update-available";
+  const upgradeTitle = updateAvailable
+    ? `Upgrade ${shortSha(drift?.local?.commit ?? null)} → ${shortSha(
+        drift?.remote?.commit ?? null,
+      )}`
+    : undefined;
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <PluginIcon external={isExternal} size="md" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <h2
+              className="text-title-medium"
+              style={{ color: "var(--content-default)" }}
+            >
+              {plugin?.name ?? name}
+            </h2>
+            {plugin?.version ? (
+              <span
+                className="shrink-0 text-body-small-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                v{plugin.version}
+              </span>
+            ) : null}
+            {plugin ? <PluginOriginBadge external={isExternal} /> : null}
+            {updateAvailable ? <UpdateAvailableBadge /> : null}
+          </div>
+          {plugin?.description ? (
+            <p
+              className="mt-0.5 line-clamp-2 text-body-medium-lighter"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              {plugin.description}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {plugin ? (
+        installed ? (
+          <div className="flex shrink-0 items-center gap-2">
+            {artifact ? (
+              <Button asChild leftIcon={<Download aria-hidden />}>
+                <a href={artifact.url} download>
+                  {artifact.label ?? "Download"}
+                </a>
+              </Button>
+            ) : null}
+            {updateAvailable ? (
+              <Button
+                type="button"
+                onClick={onUpgrade}
+                disabled={isUpgrading}
+                title={upgradeTitle}
+                leftIcon={
+                  isUpgrading ? (
+                    <Loader2 className="animate-spin" aria-hidden />
+                  ) : (
+                    <ArrowUpCircle aria-hidden />
+                  )
+                }
+              >
+                Upgrade
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="dangerOutline"
+              onClick={onRemove}
+              disabled={isRemoving}
+              leftIcon={
+                isRemoving ? (
+                  <Loader2 className="animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 aria-hidden />
+                )
+              }
+            >
+              Remove
+            </Button>
+          </div>
+        ) : (
+          <Button
+            type="button"
+            onClick={onInstall}
+            disabled={isInstalling}
+            leftIcon={
+              isInstalling ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <ArrowDownToLine aria-hidden />
+              )
+            }
+          >
+            Install
+          </Button>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function Metadata({
+  plugin,
+  surfaces,
+}: {
+  plugin: PluginsByNameGetResponse;
+  surfaces: PluginDrift["surfaces"];
+}) {
+  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
+  const repoHref =
+    plugin.source?.kind === "github"
+      ? `https://github.com/${plugin.source.repo}`
+      : null;
+
+  const rows: { label: string; value: string; href?: string }[] = [
+    {
+      label: "Source",
+      value: repo,
+      href: repoHref ?? undefined,
+    },
+  ];
+  if (plugin.homepage) {
+    rows.push({
+      label: "Homepage",
+      value: plugin.homepage,
+      href: plugin.homepage,
+    });
+  }
+  if (plugin.license) {
+    rows.push({ label: "License", value: plugin.license });
+  }
+  // Surfaces are only present for an installed copy; list the non-empty
+  // contributions (skills / hooks / tools) so the panel shows what the
+  // plugin actually adds.
+  if (surfaces) {
+    if (surfaces.skills.length > 0) {
+      rows.push({ label: "Skills", value: String(surfaces.skills.length) });
+    }
+    if (surfaces.hooks.length > 0) {
+      rows.push({ label: "Hooks", value: String(surfaces.hooks.length) });
+    }
+    if (surfaces.tools.length > 0) {
+      rows.push({ label: "Tools", value: String(surfaces.tools.length) });
+    }
+  }
+
+  return (
+    <dl
+      className="mb-5 grid gap-x-6 gap-y-2 border-b pb-5 sm:grid-cols-[max-content_1fr]"
+      style={{ borderColor: "var(--border-base)" }}
+    >
+      {rows.map((row) => (
+        <div key={row.label} className="contents">
+          <dt
+            className="text-body-small-default"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {row.label}
+          </dt>
+          <dd
+            className="min-w-0 truncate text-body-small-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {row.href ? (
+              <a
+                href={row.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 underline"
+                style={{ color: "var(--primary-base, #60a5fa)" }}
+              >
+                {row.value}
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            ) : (
+              row.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2
+        className="h-6 w-6 animate-spin"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    </div>
+  );
+}
+
+function DetailErrorState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-12 text-center"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      <TriangleAlert className="h-6 w-6" aria-hidden />
+      <p className="text-body-medium-default">
+        We couldn&apos;t load this plugin.
+      </p>
+      <p className="text-body-small-default">
+        It may not exist, or your assistant may be on an older build.
+      </p>
+    </div>
+  );
+}
+
+function ActionError({ message }: { message: string }) {
+  return (
+    <div
+      className="mb-3 flex items-center gap-2 rounded px-3 py-2 text-body-small-default"
+      style={{
+        backgroundColor: "var(--surface-secondary)",
+        color: "var(--content-warning, var(--content-tertiary))",
+      }}
+      role="alert"
+    >
+      <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds in-tab PluginDetail (desktop): Skills-style header + Card body (metadata + README) via usePluginDetail, callback-driven (onBack), preserving install/remove/upgrade/drift. No route dependency.

Part of plan: plugins-tab-match-skills.md (PR 10 of 13)