### PR TITLE
feat(web): add background-task status enum + helpers

### DIFF
--- a/clients/web/src/utils/background-task-status.test.ts
+++ b/clients/web/src/utils/background-task-status.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  type BackgroundTaskStatus,
+  backgroundTaskStatusColor,
+  backgroundTaskStatusLabel,
+  isActiveBackgroundTaskStatus,
+} from "./background-task-status";
+
+describe("isActiveBackgroundTaskStatus", () => {
+  it("is active only while running", () => {
+    expect(isActiveBackgroundTaskStatus("running")).toBe(true);
+  });
+
+  it("is inactive for terminal states", () => {
+    const terminal: BackgroundTaskStatus[] = [
+      "completed",
+      "failed",
+      "cancelled",
+    ];
+    for (const status of terminal) {
+      expect(isActiveBackgroundTaskStatus(status)).toBe(false);
+    }
+  });
+});
+
+describe("backgroundTaskStatusColor", () => {
+  it("maps each status to its semantic color token", () => {
+    expect(backgroundTaskStatusColor("running")).toBe("var(--primary-base)");
+    expect(backgroundTaskStatusColor("completed")).toBe(
+      "var(--system-positive-strong)",
+    );
+    expect(backgroundTaskStatusColor("failed")).toBe(
+      "var(--system-negative-strong)",
+    );
+    expect(backgroundTaskStatusColor("cancelled")).toBe("var(--text-muted)");
+  });
+});
+
+describe("backgroundTaskStatusLabel", () => {
+  it("returns a human-readable label for each status", () => {
+    expect(backgroundTaskStatusLabel("running")).toBe("Running");
+    expect(backgroundTaskStatusLabel("completed")).toBe("Completed");
+    expect(backgroundTaskStatusLabel("failed")).toBe("Failed");
+    expect(backgroundTaskStatusLabel("cancelled")).toBe("Cancelled");
+  });
+});

--- a/clients/web/src/utils/background-task-status.ts
+++ b/clients/web/src/utils/background-task-status.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure status-display helpers for background task entries.
+ *
+ * Shared by the viewer store and the background-task overlay.
+ */
+
+export type BackgroundTaskStatus =
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** Whether the task is in an active (non-terminal) state. */
+export function isActiveBackgroundTaskStatus(
+  status: BackgroundTaskStatus,
+): boolean {
+  return status === "running";
+}
+
+/** Map a BackgroundTaskStatus to a semantic color token. */
+export function backgroundTaskStatusColor(status: BackgroundTaskStatus): string {
+  switch (status) {
+    case "completed":
+      return "var(--system-positive-strong)";
+    case "failed":
+      return "var(--system-negative-strong)";
+    case "cancelled":
+      return "var(--text-muted)";
+    default:
+      return "var(--primary-base)";
+  }
+}
+
+/** Human-readable label for the status badge. */
+export function backgroundTaskStatusLabel(status: BackgroundTaskStatus): string {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Unknown";
+  }
+}


### PR DESCRIPTION
## Summary
- Add BackgroundTaskStatus type + isActive/color/label helpers, mirroring acp-run-status

Part of plan: bash-bg-task-ui.md (PR 2 of 13)