### PR TITLE
feat(web): add background-task-detail view to the viewer store

### DIFF
--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -285,6 +285,64 @@ describe("closeAcpRunDetail", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Background task detail
+// ---------------------------------------------------------------------------
+
+describe("openBackgroundTaskDetail", () => {
+  it("saves current view and switches to background-task-detail", () => {
+    getState().openBackgroundTaskDetail("bg-x");
+    const state = getState();
+    expect(state.mainView).toBe("background-task-detail");
+    expect(state.activeBackgroundTaskId).toBe("bg-x");
+    expect(state.viewBeforeBackgroundTaskDetail).toBe("chat");
+  });
+
+  it("preserves existing viewBeforeBackgroundTaskDetail when already in background-task-detail", () => {
+    useViewerStore.setState({
+      mainView: "background-task-detail",
+      viewBeforeBackgroundTaskDetail: "app",
+      activeBackgroundTaskId: "bg-1",
+    });
+    getState().openBackgroundTaskDetail("bg-2");
+    const state = getState();
+    expect(state.viewBeforeBackgroundTaskDetail).toBe("app");
+    expect(state.activeBackgroundTaskId).toBe("bg-2");
+  });
+
+  it("saves non-chat view correctly", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openBackgroundTaskDetail("bg-1");
+    expect(getState().viewBeforeBackgroundTaskDetail).toBe("app");
+  });
+});
+
+describe("closeBackgroundTaskDetail", () => {
+  it("restores viewBeforeBackgroundTaskDetail and clears activeBackgroundTaskId", () => {
+    useViewerStore.setState({
+      mainView: "background-task-detail",
+      viewBeforeBackgroundTaskDetail: "chat",
+      activeBackgroundTaskId: "bg-1",
+    });
+    getState().closeBackgroundTaskDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeBackgroundTaskId).toBeNull();
+  });
+
+  it("restores a non-chat view", () => {
+    useViewerStore.setState({
+      mainView: "background-task-detail",
+      viewBeforeBackgroundTaskDetail: "app",
+      activeBackgroundTaskId: "bg-1",
+    });
+    getState().closeBackgroundTaskDetail();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeBackgroundTaskId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Workflow detail
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -16,6 +16,7 @@
  * - `activeToolDetail` — tool-call detail drawer payload
  * - `activeWorkflowRunId` — workflow detail panel
  * - `activeAcpRunId` — ACP run detail panel
+ * - `activeBackgroundTaskId` — background-task detail panel
  *
  * App share/deploy lifecycle lives in `domains/chat/deploy-store.ts`.
  *
@@ -37,7 +38,8 @@ type OverlayView =
   | "subagent-detail"
   | "tool-detail"
   | "workflow-detail"
-  | "acp-run-detail";
+  | "acp-run-detail"
+  | "background-task-detail";
 
 /**
  * Resolve the "view before" value for overlay navigation.
@@ -98,7 +100,8 @@ function resolveViewBefore(
     | "viewBeforeSubagentDetail"
     | "viewBeforeToolDetail"
     | "viewBeforeWorkflowDetail"
-    | "viewBeforeAcpRunDetail",
+    | "viewBeforeAcpRunDetail"
+    | "viewBeforeBackgroundTaskDetail",
 ): Exclude<MainView, OverlayView> {
   const mv = state.mainView;
   if (
@@ -106,7 +109,8 @@ function resolveViewBefore(
     mv === "subagent-detail" ||
     mv === "tool-detail" ||
     mv === "workflow-detail" ||
-    mv === "acp-run-detail"
+    mv === "acp-run-detail" ||
+    mv === "background-task-detail"
   ) {
     return state[field];
   }
@@ -125,7 +129,8 @@ export type MainView =
   | "subagent-detail"
   | "tool-detail"
   | "workflow-detail"
-  | "acp-run-detail";
+  | "acp-run-detail"
+  | "background-task-detail";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
 
@@ -249,6 +254,8 @@ export interface ViewerState {
   viewBeforeWorkflowDetail: Exclude<MainView, OverlayView>;
   activeAcpRunId: string | null;
   viewBeforeAcpRunDetail: Exclude<MainView, OverlayView>;
+  activeBackgroundTaskId: string | null;
+  viewBeforeBackgroundTaskDetail: Exclude<MainView, OverlayView>;
   /**
    * Monotonic counter bumped when a viewer (e.g. the mobile tool-detail
    * overlay, which lives in a separate portal subtree) asks to open the trust
@@ -285,6 +292,10 @@ export interface ViewerActions {
   // --- ACP run detail ---
   openAcpRunDetail: (acpSessionId: string) => void;
   closeAcpRunDetail: () => void;
+
+  // --- Background task detail ---
+  openBackgroundTaskDetail: (id: string) => void;
+  closeBackgroundTaskDetail: () => void;
 
   // --- Tool detail ---
   openToolDetail: (payload: ToolDetailPayload) => void;
@@ -337,6 +348,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeWorkflowDetail: "chat",
   activeAcpRunId: null,
   viewBeforeAcpRunDetail: "chat",
+  activeBackgroundTaskId: null,
+  viewBeforeBackgroundTaskDetail: "chat",
   ruleEditorRequestSeq: 0,
 };
 
@@ -493,6 +506,23 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeAcpRunDetail,
       activeAcpRunId: null,
+    });
+  },
+
+  // --- Background task detail ---
+
+  openBackgroundTaskDetail: (id) => {
+    set({
+      mainView: "background-task-detail",
+      activeBackgroundTaskId: id,
+      viewBeforeBackgroundTaskDetail: resolveViewBefore(get(), "viewBeforeBackgroundTaskDetail"),
+    });
+  },
+
+  closeBackgroundTaskDetail: () => {
+    set({
+      mainView: get().viewBeforeBackgroundTaskDetail,
+      activeBackgroundTaskId: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Extend OverlayView/MainView with background-task-detail
- Add activeBackgroundTaskId + open/close actions mirroring ACP run detail

Part of plan: bash-bg-task-ui.md (PR 5 of 13)