### PR TITLE
feat(api): add background_tool_started / background_tool_completed SSE events

### DIFF
--- a/assistant/src/api/events/background-tool-completed.test.ts
+++ b/assistant/src/api/events/background-tool-completed.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { BackgroundToolCompletedEventSchema } from "./background-tool-completed.js";
+
+describe("BackgroundToolCompletedEventSchema", () => {
+  test("parses a completed event with exit code and output", () => {
+    const event = {
+      type: "background_tool_completed" as const,
+      id: "bg-1a2b3c4d",
+      conversationId: "conv-abc",
+      status: "completed" as const,
+      exitCode: 0,
+      output: "done\n",
+      completedAt: 1_700_000_001_000,
+    };
+
+    const result = BackgroundToolCompletedEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("parses a completed event without the optional fields", () => {
+    const event = {
+      type: "background_tool_completed" as const,
+      id: "bg-1a2b3c4d",
+      conversationId: "conv-abc",
+      status: "cancelled" as const,
+      completedAt: 1_700_000_001_000,
+    };
+
+    const result = BackgroundToolCompletedEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("rejects an unrecognized field under .strict()", () => {
+    const result = BackgroundToolCompletedEventSchema.safeParse({
+      type: "background_tool_completed",
+      id: "bg-1a2b3c4d",
+      conversationId: "conv-abc",
+      status: "failed",
+      completedAt: 1_700_000_001_000,
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/api/events/background-tool-completed.test.ts
+++ b/assistant/src/api/events/background-tool-completed.test.ts
@@ -35,7 +35,7 @@ describe("BackgroundToolCompletedEventSchema", () => {
     expect(result.success && result.data).toEqual(event);
   });
 
-  test("rejects an unrecognized field under .strict()", () => {
+  test("strips an unrecognized field for forward compatibility", () => {
     const result = BackgroundToolCompletedEventSchema.safeParse({
       type: "background_tool_completed",
       id: "bg-1a2b3c4d",
@@ -45,6 +45,7 @@ describe("BackgroundToolCompletedEventSchema", () => {
       unexpected: true,
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.success && "unexpected" in result.data).toBe(false);
   });
 });

--- a/assistant/src/api/events/background-tool-completed.ts
+++ b/assistant/src/api/events/background-tool-completed.ts
@@ -1,0 +1,29 @@
+/**
+ * `background_tool_completed` SSE event.
+ *
+ * Server → client notification that a background bash/host_bash command
+ * has finished. Carries the background-tool identity (`id`), scoping
+ * (`conversationId`), the terminal `status`, the optional `exitCode` and
+ * captured `output`, and the `completedAt` timestamp.
+ *
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
+ */
+
+import { z } from "zod";
+
+export const BackgroundToolCompletedEventSchema = z
+  .object({
+    type: z.literal("background_tool_completed"),
+    id: z.string(),
+    conversationId: z.string(),
+    status: z.enum(["completed", "failed", "cancelled"]),
+    exitCode: z.number().nullable().optional(),
+    output: z.string().optional(),
+    completedAt: z.number(),
+  })
+  .strict();
+
+export type BackgroundToolCompletedEvent = z.infer<
+  typeof BackgroundToolCompletedEventSchema
+>;

--- a/assistant/src/api/events/background-tool-completed.ts
+++ b/assistant/src/api/events/background-tool-completed.ts
@@ -12,17 +12,17 @@
 
 import { z } from "zod";
 
-export const BackgroundToolCompletedEventSchema = z
-  .object({
-    type: z.literal("background_tool_completed"),
-    id: z.string(),
-    conversationId: z.string(),
-    status: z.enum(["completed", "failed", "cancelled"]),
-    exitCode: z.number().nullable().optional(),
-    output: z.string().optional(),
-    completedAt: z.number(),
-  })
-  .strict();
+// No `.strict()`: unknown server-added fields are stripped, not rejected, so a
+// future field can't make older clients drop the whole lifecycle event.
+export const BackgroundToolCompletedEventSchema = z.object({
+  type: z.literal("background_tool_completed"),
+  id: z.string(),
+  conversationId: z.string(),
+  status: z.enum(["completed", "failed", "cancelled"]),
+  exitCode: z.number().nullable().optional(),
+  output: z.string().optional(),
+  completedAt: z.number(),
+});
 
 export type BackgroundToolCompletedEvent = z.infer<
   typeof BackgroundToolCompletedEventSchema

--- a/assistant/src/api/events/background-tool-started.test.ts
+++ b/assistant/src/api/events/background-tool-started.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { BackgroundToolStartedEventSchema } from "./background-tool-started.js";
+
+describe("BackgroundToolStartedEventSchema", () => {
+  test("parses a started event", () => {
+    const event = {
+      type: "background_tool_started" as const,
+      id: "bg-1a2b3c4d",
+      toolName: "bash",
+      conversationId: "conv-abc",
+      command: "sleep 30 && echo done",
+      startedAt: 1_700_000_000_000,
+    };
+
+    const result = BackgroundToolStartedEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("rejects an unrecognized field under .strict()", () => {
+    const result = BackgroundToolStartedEventSchema.safeParse({
+      type: "background_tool_started",
+      id: "bg-1a2b3c4d",
+      toolName: "bash",
+      conversationId: "conv-abc",
+      command: "echo hi",
+      startedAt: 1_700_000_000_000,
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/api/events/background-tool-started.test.ts
+++ b/assistant/src/api/events/background-tool-started.test.ts
@@ -19,7 +19,7 @@ describe("BackgroundToolStartedEventSchema", () => {
     expect(result.success && result.data).toEqual(event);
   });
 
-  test("rejects an unrecognized field under .strict()", () => {
+  test("strips an unrecognized field for forward compatibility", () => {
     const result = BackgroundToolStartedEventSchema.safeParse({
       type: "background_tool_started",
       id: "bg-1a2b3c4d",
@@ -30,6 +30,7 @@ describe("BackgroundToolStartedEventSchema", () => {
       unexpected: true,
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.success && "unexpected" in result.data).toBe(false);
   });
 });

--- a/assistant/src/api/events/background-tool-started.ts
+++ b/assistant/src/api/events/background-tool-started.ts
@@ -1,0 +1,28 @@
+/**
+ * `background_tool_started` SSE event.
+ *
+ * Server → client notification that a background bash/host_bash command
+ * has started. Carries the background-tool identity (`id`, a `bg-xxxxxxxx`
+ * id), the `toolName`, scoping (`conversationId`), the `command` being run,
+ * and the `startedAt` timestamp.
+ *
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
+ */
+
+import { z } from "zod";
+
+export const BackgroundToolStartedEventSchema = z
+  .object({
+    type: z.literal("background_tool_started"),
+    id: z.string(),
+    toolName: z.string(),
+    conversationId: z.string(),
+    command: z.string(),
+    startedAt: z.number(),
+  })
+  .strict();
+
+export type BackgroundToolStartedEvent = z.infer<
+  typeof BackgroundToolStartedEventSchema
+>;

--- a/assistant/src/api/events/background-tool-started.ts
+++ b/assistant/src/api/events/background-tool-started.ts
@@ -12,16 +12,16 @@
 
 import { z } from "zod";
 
-export const BackgroundToolStartedEventSchema = z
-  .object({
-    type: z.literal("background_tool_started"),
-    id: z.string(),
-    toolName: z.string(),
-    conversationId: z.string(),
-    command: z.string(),
-    startedAt: z.number(),
-  })
-  .strict();
+// No `.strict()`: unknown server-added fields are stripped, not rejected, so a
+// future field can't make older clients drop the whole lifecycle event.
+export const BackgroundToolStartedEventSchema = z.object({
+  type: z.literal("background_tool_started"),
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+});
 
 export type BackgroundToolStartedEvent = z.infer<
   typeof BackgroundToolStartedEventSchema

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -10,6 +10,8 @@ import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js"
 import { AssistantThinkingDeltaEventSchema } from "./events/assistant-thinking-delta.js";
 import { AssistantTurnStartEventSchema } from "./events/assistant-turn-start.js";
 import { AvatarUpdatedEventSchema } from "./events/avatar-updated.js";
+import { BackgroundToolCompletedEventSchema } from "./events/background-tool-completed.js";
+import { BackgroundToolStartedEventSchema } from "./events/background-tool-started.js";
 import { CompactionCircuitClosedEventSchema } from "./events/compaction-circuit-closed.js";
 import { CompactionCircuitOpenEventSchema } from "./events/compaction-circuit-open.js";
 import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js";
@@ -126,6 +128,14 @@ export {
   type AvatarUpdatedEvent,
   AvatarUpdatedEventSchema,
 } from "./events/avatar-updated.js";
+export {
+  type BackgroundToolCompletedEvent,
+  BackgroundToolCompletedEventSchema,
+} from "./events/background-tool-completed.js";
+export {
+  type BackgroundToolStartedEvent,
+  BackgroundToolStartedEventSchema,
+} from "./events/background-tool-started.js";
 export {
   type CompactionCircuitClosedEvent,
   CompactionCircuitClosedEventSchema,
@@ -543,6 +553,8 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   AssistantThinkingDeltaEventSchema,
   AssistantTurnStartEventSchema,
   AvatarUpdatedEventSchema,
+  BackgroundToolCompletedEventSchema,
+  BackgroundToolStartedEventSchema,
   CompactionCircuitClosedEventSchema,
   CompactionCircuitOpenEventSchema,
   ConfirmationRequestEventSchema,

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -15,6 +15,7 @@
 // Re-export domain modules (all individual types remain importable)
 export * from "./message-types/acp.js";
 export * from "./message-types/apps.js";
+export * from "./message-types/background-tools.js";
 export * from "./message-types/bookmarks.js";
 export * from "./message-types/computer-use.js";
 export * from "./message-types/contacts.js";
@@ -56,6 +57,7 @@ import type {
   _AppsClientMessages,
   _AppsServerMessages,
 } from "./message-types/apps.js";
+import type { _BackgroundToolsServerMessages } from "./message-types/background-tools.js";
 import type { _BookmarksServerMessages } from "./message-types/bookmarks.js";
 import type {
   _ComputerUseClientMessages,
@@ -209,6 +211,7 @@ export type ServerMessage =
   | _NotificationsServerMessages
   | _UpgradesServerMessages
   | _AcpServerMessages
+  | _BackgroundToolsServerMessages
   | _BookmarksServerMessages
   | _WorkflowsServerMessages
   | DiskPressureStatusChangedEvent

--- a/assistant/src/daemon/message-types/background-tools.ts
+++ b/assistant/src/daemon/message-types/background-tools.ts
@@ -1,0 +1,28 @@
+// Background bash/host_bash command lifecycle types.
+
+// === Server → Client (streamed via SSE) ===
+
+export interface BackgroundToolStarted {
+  type: "background_tool_started";
+  id: string;
+  toolName: string;
+  conversationId: string;
+  command: string;
+  startedAt: number;
+}
+
+export interface BackgroundToolCompleted {
+  type: "background_tool_completed";
+  id: string;
+  conversationId: string;
+  status: "completed" | "failed" | "cancelled";
+  exitCode?: number | null;
+  output?: string;
+  completedAt: number;
+}
+
+// --- Domain-level union alias (consumed by message-protocol.ts) ---
+
+export type _BackgroundToolsServerMessages =
+  | BackgroundToolStarted
+  | BackgroundToolCompleted;


### PR DESCRIPTION
## Summary
- Add zod schemas for background_tool_started / background_tool_completed and register them in AssistantEventSchema
- Add daemon message-type twins and wire into the ServerMessage union

Part of plan: bash-bg-task-ui.md (PR 1 of 13)