### PR TITLE
feat(web): detect background bash calls and extract their bg id

### DIFF
--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -5,11 +5,13 @@ import type { Surface } from "@/domains/chat/types/types";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import {
   groupContentBlocks,
+  isBackgroundBashCall,
   isRunWorkflowCall,
   isSubagentSpawnCall,
   isSuppressedUiTool,
   isTaskProgressSurface,
 } from "@/domains/chat/transcript/message-content";
+import { extractBgIdFromResult } from "@/domains/chat/transcript/transcript-message-body-shared";
 
 function toolCall(
   overrides: Partial<ChatMessageToolCall> & Pick<ChatMessageToolCall, "id">,
@@ -225,6 +227,79 @@ describe("isRunWorkflowCall", () => {
         toolCall({ id: "x", name: "skill_execute", input: { tool: "other" } }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("isBackgroundBashCall", () => {
+  test("matches bash with input.background === true", () => {
+    expect(
+      isBackgroundBashCall(
+        toolCall({ id: "x", name: "bash", input: { background: true } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches host_bash with input.background === true", () => {
+    expect(
+      isBackgroundBashCall(
+        toolCall({ id: "x", name: "host_bash", input: { background: true } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match bash without the background flag", () => {
+    expect(isBackgroundBashCall(toolCall({ id: "x", name: "bash" }))).toBe(false);
+  });
+
+  test("does not match other tools or non-object input", () => {
+    expect(
+      isBackgroundBashCall(toolCall({ id: "x", name: "subagent_spawn" })),
+    ).toBe(false);
+    expect(
+      isBackgroundBashCall(
+        toolCall({ id: "x", name: "bash", input: null as never }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("extractBgIdFromResult", () => {
+  test("returns the bg id for a backgrounded bash result", () => {
+    expect(
+      extractBgIdFromResult(
+        toolCall({
+          id: "x",
+          name: "bash",
+          input: { background: true },
+          result: JSON.stringify({ backgrounded: true, id: "bg-123" }),
+        }),
+      ),
+    ).toBe("bg-123");
+  });
+
+  test("returns undefined for a foreground (non-backgrounded) result", () => {
+    expect(
+      extractBgIdFromResult(
+        toolCall({
+          id: "x",
+          name: "bash",
+          result: JSON.stringify({ stdout: "ok" }),
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for a non-JSON result", () => {
+    expect(
+      extractBgIdFromResult(
+        toolCall({
+          id: "x",
+          name: "bash",
+          input: { background: true },
+          result: "not json",
+        }),
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -245,6 +245,19 @@ export function isAcpSpawnCall(toolCall: ChatMessageToolCall): boolean {
 }
 
 /**
+ * Detect whether a tool call is a backgrounded `bash`/`host_bash` invocation.
+ * Unlike the subagent/workflow/ACP triad, background bash is not a
+ * `skill_execute` envelope — it's an `input.background === true` flag on the
+ * real `bash`/`host_bash` tool, so we match the raw tool name plus the flag.
+ */
+export function isBackgroundBashCall(toolCall: ChatMessageToolCall): boolean {
+  if (toolCall.name !== "bash" && toolCall.name !== "host_bash") return false;
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") return false;
+  return (input as Record<string, unknown>).background === true;
+}
+
+/**
  * Detect a task-progress card surface — `template === "task_progress"` with a
  * non-empty `steps` array. Used by the activity-summary hoist-detection path.
  */

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -1,5 +1,6 @@
 import {
   isAcpSpawnCall,
+  isBackgroundBashCall,
   isRunWorkflowCall,
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
@@ -315,6 +316,31 @@ function extractAcpSessionIdFromResult(
     return typeof parsed.acpSessionId === "string" ? parsed.acpSessionId : null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Extract the `bg-…` id from a backgrounded `bash`/`host_bash` tool call's
+ * synchronous result. The daemon returns `JSON.stringify({ backgrounded: true,
+ * id })` when the command is launched in the background. Returns `undefined`
+ * for a foreground command or a non-JSON/malformed result so callers can anchor
+ * only on real background runs.
+ */
+export function extractBgIdFromResult(
+  toolCall: ChatMessageToolCall,
+): string | undefined {
+  if (!isBackgroundBashCall(toolCall)) return undefined;
+  if (typeof toolCall.result !== "string" || !toolCall.result) return undefined;
+  try {
+    const parsed = JSON.parse(toolCall.result) as {
+      backgrounded?: unknown;
+      id?: unknown;
+    };
+    return parsed.backgrounded === true && typeof parsed.id === "string"
+      ? parsed.id
+      : undefined;
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add isBackgroundBashCall (name + background:true flag) detection helper
- Add extractBgIdFromResult to parse the bg id from a backgrounded tool result

Part of plan: bash-bg-task-ui.md (PR 4 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)