### PR TITLE
feat(web): add terminal icon and use it for bash / host_bash

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.test.tsx
@@ -35,7 +35,7 @@ function bash(
     title: "Working",
     info: command,
     activity,
-    iconName: "code",
+    iconName: "terminal",
     durationLabel: duration,
     toolCallId,
     status,

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -23,6 +23,7 @@ import {
   Pen,
   Plug,
   Sparkles,
+  SquareTerminal,
   UserPlus,
   type LucideIcon,
 } from "lucide-react";
@@ -50,6 +51,7 @@ import type { ToolDetailPayload } from "@/stores/viewer-store";
  */
 const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
+  terminal: SquareTerminal,
   file: FileText,
   globe: Globe,
   pen: Pen,

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -21,7 +21,7 @@ function buildToolCall(
 }
 
 describe("deriveStepLabel", () => {
-  test("bash → Working with truncated command and code icon", () => {
+  test("bash → Working with truncated command and terminal icon", () => {
     const result = deriveStepLabel(
       buildToolCall({
         name: "bash",
@@ -32,7 +32,7 @@ describe("deriveStepLabel", () => {
       title: "Working",
       info: "echo hello world",
       activity: "",
-      iconName: "code",
+      iconName: "terminal",
     });
   });
 
@@ -44,7 +44,7 @@ describe("deriveStepLabel", () => {
         input: { command: longCommand },
       }),
     );
-    expect(result.iconName).toBe("code");
+    expect(result.iconName).toBe("terminal");
     expect(result.title).toBe("Working");
     expect(result.info.length).toBe(80);
     expect(result.info.endsWith("…")).toBe(true);
@@ -265,7 +265,7 @@ describe("deriveStepLabel", () => {
     // Inner tool drives title/info/iconName; outer activity overrides inner.
     expect(result.title).toBe("Working");
     expect(result.info).toBe("echo hi");
-    expect(result.iconName).toBe("code");
+    expect(result.iconName).toBe("terminal");
     expect(result.activity).toBe("outer activity wins");
   });
 });

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -25,6 +25,7 @@ import { truncate } from "@/domains/chat/utils/truncate";
  */
 export type IconName =
   | "code"
+  | "terminal"
   | "file"
   | "pen"
   | "monitor"
@@ -133,7 +134,7 @@ export function deriveStepLabelFromName(
         title: "Working",
         info: truncate(cleaned, INFO_MAX_LENGTH),
         activity,
-        iconName: "code",
+        iconName: "terminal",
       };
     }
 

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.stories.tsx
@@ -18,7 +18,7 @@ function toolStep(overrides: Partial<
     title: "Working",
     info: "date",
     activity: "Checking the current time",
-    iconName: "code",
+    iconName: "terminal",
     toolCallId: `tc-${Math.random().toString(36).slice(2, 8)}`,
     status: "completed",
     ...overrides,

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -41,7 +41,7 @@ function bash(
     title: "Working",
     info: command,
     activity: "",
-    iconName: "code",
+    iconName: "terminal",
     durationLabel: duration,
     toolCallId,
     status,

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -29,6 +29,7 @@ import {
   Pen,
   Plug,
   Sparkles,
+  SquareTerminal,
   UserPlus,
   type LucideIcon,
 } from "lucide-react";
@@ -47,6 +48,7 @@ import { cn } from "@/utils/misc";
 /** Concrete lucide icon for each `IconName` produced by `deriveStepLabel`. */
 export const ICON_MAP: Record<IconName, LucideIcon> = {
   code: Code,
+  terminal: SquareTerminal,
   file: FileText,
   globe: Globe,
   pen: Pen,

--- a/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof ToolStepPill> = {
       control: "select",
       options: [
         "code",
+        "terminal",
         "file",
         "pen",
         "monitor",
@@ -48,7 +49,7 @@ export const Default: Story = {
 
 export const WithRiskLow: Story = {
   args: {
-    iconName: "code",
+    iconName: "terminal",
     label: "bun test",
     riskLevel: "low",
   },
@@ -56,7 +57,7 @@ export const WithRiskLow: Story = {
 
 export const WithRiskHigh: Story = {
   args: {
-    iconName: "code",
+    iconName: "terminal",
     label: "rm -rf build",
     riskLevel: "high",
   },
@@ -187,8 +188,8 @@ export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-2">
       <ToolStepPill iconName="sparkle" label="review-cycle" />
-      <ToolStepPill iconName="code" label="bun test" riskLevel="low" />
-      <ToolStepPill iconName="code" label="rm -rf build" riskLevel="high" />
+      <ToolStepPill iconName="terminal" label="bun test" riskLevel="low" />
+      <ToolStepPill iconName="terminal" label="rm -rf build" riskLevel="high" />
       <ToolStepPill
         iconName="plug"
         label="linear.createIssue"

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -165,7 +165,7 @@ describe("computeSubagentCardData — step mapping", () => {
     // Regression guard: before Fix 1, every tool step in the subagent
     // inline card rendered the bolt icon and a generic "Using <Tool>"
     // title. After Fix 1, `mapToolEventToStep` routes through the shared
-    // `deriveStepLabelFromName` so bash → "Working" / code icon.
+    // `deriveStepLabelFromName` so bash → "Working" / terminal icon.
     const data = computeSubagentCardData(
       makeEntry({
         events: [
@@ -182,7 +182,7 @@ describe("computeSubagentCardData — step mapping", () => {
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
       expect(step.title).toBe("Working");
-      expect(step.iconName).toBe("code");
+      expect(step.iconName).toBe("terminal");
       expect(step.info).toBe("ls -la");
     }
   });
@@ -1063,7 +1063,7 @@ describe("mapToolEventToStep", () => {
     });
     // host_bash routes through `deriveStepLabelFromName`'s bash branch.
     expect(step.title).toBe("Working");
-    expect(step.iconName).toBe("code");
+    expect(step.iconName).toBe("terminal");
     expect(step.info).toBe("summary");
     expect(step.status).toBe("running");
     expect(step.toolCallId).toBe("tu-1");

--- a/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -82,7 +82,7 @@ describe("computeToolCallCardData — step kinds", () => {
       info: "echo hello",
       activity: "",
       riskLevel: undefined,
-      iconName: "code",
+      iconName: "terminal",
       toolCallId: "tc-1",
       status: "completed",
     });


### PR DESCRIPTION
## Summary
- Add a 'terminal' IconName mapped to lucide SquareTerminal in both ICON_MAP copies
- Use the terminal glyph for bash / host_bash steps

Part of plan: bash-bg-task-ui.md (PR 3 of 13)