### PR TITLE
feat(bash): broadcast background_tool started/completed lifecycle events

### DIFF
--- a/assistant/src/tools/terminal/shell.test.ts
+++ b/assistant/src/tools/terminal/shell.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Singleton mocks — must precede the tool import so bun's module mock applies.
+// ---------------------------------------------------------------------------
+
+// Silence the logger across every module this graph reaches.
+const realLogger = await import("../../util/logger.js");
+mock.module("../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const realLoader = await import("../../config/loader.js");
+mock.module("../../config/loader.js", () => ({
+  ...realLoader,
+  getConfig: () =>
+    ({
+      timeouts: { shellDefaultTimeoutSec: 30, shellMaxTimeoutSec: 60 },
+    }) as unknown as ReturnType<typeof realLoader.getConfig>,
+}));
+
+const realGates = await import("../../credential-execution/feature-gates.js");
+mock.module("../../credential-execution/feature-gates.js", () => ({
+  ...realGates,
+  isCesShellLockdownEnabled: () => false,
+}));
+
+// Capture lifecycle events broadcast by the tool.
+type CapturedEvent = { type: string } & Record<string, unknown>;
+const events: CapturedEvent[] = [];
+
+const realHub = await import("../../runtime/assistant-event-hub.js");
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  ...realHub,
+  broadcastMessage: (msg: unknown) => {
+    events.push(msg as CapturedEvent);
+  },
+}));
+
+// Background completion wakes the agent; that side-effect is out of scope here.
+const realWake = await import("../../runtime/agent-wake.js");
+mock.module("../../runtime/agent-wake.js", () => ({
+  ...realWake,
+  wakeAgentForOpportunity: async () => ({}),
+}));
+
+const { shellTool } = await import("./shell.js");
+const { cancelBackgroundTool, _clearRegistryForTesting } =
+  await import("../background-tool-registry.js");
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: process.cwd(),
+    conversationId: "conv-1",
+    trustClass: "guardian",
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function startBackground(command: string): Promise<string> {
+  const result = await shellTool.execute(
+    { command, activity: "test", background: true },
+    makeContext(),
+  );
+  const parsed = JSON.parse(result.content) as { id: string };
+  return parsed.id;
+}
+
+function completedEvents(): CapturedEvent[] {
+  return events.filter((e) => e.type === "background_tool_completed");
+}
+
+describe("background bash lifecycle events", () => {
+  beforeEach(() => {
+    events.length = 0;
+    _clearRegistryForTesting();
+  });
+
+  afterEach(() => {
+    _clearRegistryForTesting();
+  });
+
+  test("normal exit broadcasts one started then one completed", async () => {
+    const id = await startBackground("exit 0");
+
+    const started = events.filter((e) => e.type === "background_tool_started");
+    expect(started).toHaveLength(1);
+    expect(started[0]).toMatchObject({
+      id,
+      toolName: "bash",
+      conversationId: "conv-1",
+      command: "exit 0",
+    });
+    expect(typeof started[0]?.startedAt).toBe("number");
+
+    await waitFor(() => completedEvents().length > 0);
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      id,
+      conversationId: "conv-1",
+      status: "completed",
+      exitCode: 0,
+    });
+  });
+
+  test("non-zero exit broadcasts completed with status failed", async () => {
+    const id = await startBackground("exit 3");
+
+    await waitFor(() => completedEvents().length > 0);
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      id,
+      status: "failed",
+      exitCode: 3,
+    });
+  });
+
+  test("cancelled background command broadcasts completed with status cancelled", async () => {
+    const id = await startBackground("sleep 30");
+
+    expect(completedEvents()).toHaveLength(0);
+    expect(cancelBackgroundTool(id)).toBe(true);
+
+    await waitFor(() => completedEvents().length > 0);
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({ id, status: "cancelled" });
+    expect(completed[0]?.exitCode).toBeNull();
+  });
+});

--- a/assistant/src/tools/terminal/shell.test.ts
+++ b/assistant/src/tools/terminal/shell.test.ts
@@ -146,5 +146,8 @@ describe("background bash lifecycle events", () => {
     expect(completed).toHaveLength(1);
     expect(completed[0]).toMatchObject({ id, status: "cancelled" });
     expect(completed[0]?.exitCode).toBeNull();
+    // Cancellation must not surface the "failed exit code null" framing.
+    expect(completed[0]?.output).toContain("cancelled");
+    expect(completed[0]?.output).not.toContain("failed");
   });
 });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -3,8 +3,10 @@ import { spawn } from "node:child_process";
 
 import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
+import type { BackgroundToolCompleted } from "../../daemon/message-types/background-tools.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
+import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
@@ -346,6 +348,7 @@ export const shellTool = {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
+      let aborted = false;
       const startedAt = Date.now();
 
       const child = spawn(wrapped.command, wrapped.args, {
@@ -423,6 +426,26 @@ export const shellTool = {
             maxChars: MAX_OUTPUT_LENGTH * 2,
           },
         });
+
+        const status: BackgroundToolCompleted["status"] = aborted
+          ? "cancelled"
+          : timedOut
+            ? "failed"
+            : code === 0
+              ? "completed"
+              : "failed";
+        broadcastMessage(
+          {
+            type: "background_tool_completed",
+            id: bgId,
+            conversationId: context.conversationId,
+            status,
+            exitCode: code ?? null,
+            output: fmtResult.content,
+            completedAt: Date.now(),
+          },
+          context.conversationId,
+        );
       });
 
       child.on("error", (err) => {
@@ -444,12 +467,26 @@ export const shellTool = {
           spawnError: err.message,
         });
 
+        const framing = `Background command failed (id=${bgId}): ${err.message}`;
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
-          hint: `Background command failed (id=${bgId}): ${err.message}`,
+          hint: framing,
           source: "background-tool",
           persistTriggerAsEvent: true,
         });
+
+        broadcastMessage(
+          {
+            type: "background_tool_completed",
+            id: bgId,
+            conversationId: context.conversationId,
+            status: "failed",
+            exitCode: null,
+            output: framing,
+            completedAt: Date.now(),
+          },
+          context.conversationId,
+        );
       });
 
       registerBackgroundTool({
@@ -458,8 +495,23 @@ export const shellTool = {
         conversationId: context.conversationId,
         command,
         startedAt,
-        cancel: () => killTree("abort"),
+        cancel: () => {
+          aborted = true;
+          killTree("abort");
+        },
       });
+
+      broadcastMessage(
+        {
+          type: "background_tool_started",
+          id: bgId,
+          toolName: "bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt,
+        },
+        context.conversationId,
+      );
 
       return {
         content: JSON.stringify({ backgrounded: true, id: bgId }),

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -441,7 +441,12 @@ export const shellTool = {
             conversationId: context.conversationId,
             status,
             exitCode: code ?? null,
-            output: fmtResult.content,
+            // A cancelled command exits with a null code, which formatShellOutput
+            // frames as "failed"; surface the cancellation instead.
+            output:
+              status === "cancelled"
+                ? `Background command cancelled (id=${bgId}).`
+                : fmtResult.content,
             completedAt: Date.now(),
           },
           context.conversationId,


### PR DESCRIPTION
## Summary
- Emit background_tool_started after registering a background bash tool
- Emit background_tool_completed (completed/failed/cancelled) from the close/error handlers

Part of plan: bash-bg-task-ui.md (PR 6 of 13)