### PR TITLE
feat(web): add background-task Zustand store

### DIFF
--- a/clients/web/src/domains/chat/background-task-store.test.ts
+++ b/clients/web/src/domains/chat/background-task-store.test.ts
@@ -220,6 +220,24 @@ describe("restoreTaskStatus", () => {
     expect(getState().byId["bg-1"]!.status).toBe("completed");
   });
 
+  it("is a no-op when a terminal completion raced in after the optimistic cancel", () => {
+    getState().startTask(startedEvent());
+    getState().cancelTask("bg-1");
+    // A failed terminal races in before the cancel request reports: it settles
+    // the entry (sets completedAt) while preserving the "cancelled" status.
+    getState().completeTask(
+      completedEvent({ status: "failed", exitCode: 143, output: "killed", completedAt: NOW + 2000 }),
+    );
+    expect(getState().byId["bg-1"]!.completedAt).toBe(NOW + 2000);
+
+    // The cancel request later fails — restore must NOT revive the settled task.
+    getState().restoreTaskStatus("bg-1", "running");
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("cancelled");
+    expect(entry.completedAt).toBe(NOW + 2000);
+  });
+
   it("ignores an unknown id", () => {
     getState().restoreTaskStatus("bg-missing", "running");
     expect(getState().byId).toEqual({});
@@ -235,8 +253,9 @@ describe("retireMissing", () => {
     getState().startTask(startedEvent({ id: "bg-1" }));
     getState().startTask(startedEvent({ id: "bg-2" }));
 
-    // Only bg-1 is still active in the snapshot — bg-2 is retired.
-    getState().retireMissing(["bg-1"]);
+    // Both were known when the snapshot was taken; only bg-1 is still active in
+    // it — bg-2 is retired.
+    getState().retireMissing(["bg-1"], ["bg-1", "bg-2"]);
 
     expect(getState().byId["bg-1"]!.status).toBe("running");
     expect(getState().byId["bg-2"]!.status).toBe("cancelled");
@@ -245,7 +264,7 @@ describe("retireMissing", () => {
   it("leaves an already-terminal task untouched", () => {
     getState().startTask(startedEvent());
     getState().completeTask(completedEvent({ status: "completed" }));
-    getState().retireMissing([]);
+    getState().retireMissing([], ["bg-1"]);
 
     expect(getState().byId["bg-1"]!.status).toBe("completed");
   });
@@ -253,8 +272,20 @@ describe("retireMissing", () => {
   it("does not touch state when every running task is still active", () => {
     getState().startTask(startedEvent());
     const before = getState().byId;
-    getState().retireMissing(["bg-1"]);
+    getState().retireMissing(["bg-1"], ["bg-1"]);
     expect(getState().byId).toBe(before);
+  });
+
+  it("leaves a task started after the snapshot (not in knownIds) untouched", () => {
+    getState().startTask(startedEvent({ id: "bg-known" }));
+    getState().startTask(startedEvent({ id: "bg-new" }));
+
+    // Snapshot knew only bg-known; bg-new started while the fetch was in flight.
+    // Neither is in the active set, but only the known one is retired.
+    getState().retireMissing([], ["bg-known"]);
+
+    expect(getState().byId["bg-known"]!.status).toBe("cancelled");
+    expect(getState().byId["bg-new"]!.status).toBe("running");
   });
 });
 

--- a/clients/web/src/domains/chat/background-task-store.test.ts
+++ b/clients/web/src/domains/chat/background-task-store.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type {
+  BackgroundToolCompletedEvent,
+  BackgroundToolStartedEvent,
+} from "@vellumai/assistant-api";
+import {
+  useBackgroundTaskStore,
+  type BackgroundTaskEntry,
+} from "@/domains/chat/background-task-store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getState() {
+  return useBackgroundTaskStore.getState();
+}
+
+const NOW = 1700000000000;
+
+function startedEvent(
+  overrides: Partial<BackgroundToolStartedEvent> = {},
+): BackgroundToolStartedEvent {
+  return {
+    type: "background_tool_started",
+    id: "bg-1",
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: "sleep 10",
+    startedAt: NOW,
+    ...overrides,
+  };
+}
+
+function completedEvent(
+  overrides: Partial<BackgroundToolCompletedEvent> = {},
+): BackgroundToolCompletedEvent {
+  return {
+    type: "background_tool_completed",
+    id: "bg-1",
+    conversationId: "conv-1",
+    status: "completed",
+    exitCode: 0,
+    output: "done",
+    completedAt: NOW + 1000,
+    ...overrides,
+  };
+}
+
+function historyEntry(
+  overrides: Partial<BackgroundTaskEntry> = {},
+): BackgroundTaskEntry {
+  return {
+    id: "bg-1",
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: "sleep 10",
+    startedAt: NOW,
+    status: "completed",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("initial state", () => {
+  it("starts empty", () => {
+    expect(getState().byId).toEqual({});
+    expect(getState().orderedIds).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startTask
+// ---------------------------------------------------------------------------
+
+describe("startTask", () => {
+  it("adds a running entry with the event metadata", () => {
+    getState().startTask(startedEvent({ command: "npm run build" }));
+
+    const entry = getState().byId["bg-1"]!;
+    expect(getState().orderedIds).toEqual(["bg-1"]);
+    expect(entry.toolName).toBe("bash");
+    expect(entry.conversationId).toBe("conv-1");
+    expect(entry.command).toBe("npm run build");
+    expect(entry.startedAt).toBe(NOW);
+    expect(entry.status).toBe("running");
+    expect(entry.exitCode).toBeUndefined();
+    expect(entry.output).toBeUndefined();
+    expect(entry.completedAt).toBeUndefined();
+  });
+
+  it("is idempotent — a replayed start with the same id is ignored", () => {
+    getState().startTask(startedEvent());
+    getState().startTask(
+      startedEvent({ command: "replayed", startedAt: NOW + 5000 }),
+    );
+
+    expect(getState().orderedIds).toEqual(["bg-1"]);
+    expect(getState().byId["bg-1"]!.command).toBe("sleep 10");
+    expect(getState().byId["bg-1"]!.startedAt).toBe(NOW);
+  });
+
+  it("preserves insertion order across multiple starts", () => {
+    getState().startTask(startedEvent({ id: "bg-a" }));
+    getState().startTask(startedEvent({ id: "bg-b" }));
+    getState().startTask(startedEvent({ id: "bg-c" }));
+
+    expect(getState().orderedIds).toEqual(["bg-a", "bg-b", "bg-c"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeTask
+// ---------------------------------------------------------------------------
+
+describe("completeTask", () => {
+  it("settles a running task with status, exit code, output, and time", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(
+      completedEvent({ exitCode: 0, output: "build ok", completedAt: NOW + 1500 }),
+    );
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.exitCode).toBe(0);
+    expect(entry.output).toBe("build ok");
+    expect(entry.completedAt).toBe(NOW + 1500);
+  });
+
+  it("records a failing exit code on a failed task", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(
+      completedEvent({ status: "failed", exitCode: 1, output: "boom" }),
+    );
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("failed");
+    expect(entry.exitCode).toBe(1);
+    expect(entry.output).toBe("boom");
+  });
+
+  it("does not regress an optimistically-cancelled task to failed", () => {
+    getState().startTask(startedEvent());
+    getState().cancelTask("bg-1");
+    expect(getState().byId["bg-1"]!.status).toBe("cancelled");
+
+    // The daemon's cancellation emits a failed terminal — status stays cancelled
+    // but the captured output/exit code still land.
+    getState().completeTask(
+      completedEvent({ status: "failed", exitCode: 143, output: "killed", completedAt: NOW + 2000 }),
+    );
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("cancelled");
+    expect(entry.exitCode).toBe(143);
+    expect(entry.output).toBe("killed");
+    expect(entry.completedAt).toBe(NOW + 2000);
+  });
+
+  it("ignores an unknown id", () => {
+    getState().completeTask(completedEvent({ id: "bg-missing" }));
+    expect(getState().byId).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelTask
+// ---------------------------------------------------------------------------
+
+describe("cancelTask", () => {
+  it("marks a running task cancelled", () => {
+    getState().startTask(startedEvent());
+    getState().cancelTask("bg-1");
+
+    expect(getState().byId["bg-1"]!.status).toBe("cancelled");
+  });
+
+  it("does not regress an already-terminal task", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(completedEvent({ status: "completed" }));
+    getState().cancelTask("bg-1");
+
+    expect(getState().byId["bg-1"]!.status).toBe("completed");
+  });
+
+  it("ignores an unknown id", () => {
+    getState().cancelTask("bg-missing");
+    expect(getState().byId).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// restoreTaskStatus
+// ---------------------------------------------------------------------------
+
+describe("restoreTaskStatus", () => {
+  it("reverts an optimistic cancel to the prior status and clears completedAt", () => {
+    getState().startTask(startedEvent());
+    getState().cancelTask("bg-1");
+    expect(getState().byId["bg-1"]!.status).toBe("cancelled");
+
+    getState().restoreTaskStatus("bg-1", "running");
+
+    expect(getState().byId["bg-1"]!.status).toBe("running");
+    expect(getState().byId["bg-1"]!.completedAt).toBeUndefined();
+  });
+
+  it("is a no-op once a real terminal has landed (never regresses to active)", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(completedEvent({ status: "completed" }));
+    getState().restoreTaskStatus("bg-1", "running");
+
+    expect(getState().byId["bg-1"]!.status).toBe("completed");
+  });
+
+  it("ignores an unknown id", () => {
+    getState().restoreTaskStatus("bg-missing", "running");
+    expect(getState().byId).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retireMissing
+// ---------------------------------------------------------------------------
+
+describe("retireMissing", () => {
+  it("cancels running tasks absent from the active snapshot", () => {
+    getState().startTask(startedEvent({ id: "bg-1" }));
+    getState().startTask(startedEvent({ id: "bg-2" }));
+
+    // Only bg-1 is still active in the snapshot — bg-2 is retired.
+    getState().retireMissing(["bg-1"]);
+
+    expect(getState().byId["bg-1"]!.status).toBe("running");
+    expect(getState().byId["bg-2"]!.status).toBe("cancelled");
+  });
+
+  it("leaves an already-terminal task untouched", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(completedEvent({ status: "completed" }));
+    getState().retireMissing([]);
+
+    expect(getState().byId["bg-1"]!.status).toBe("completed");
+  });
+
+  it("does not touch state when every running task is still active", () => {
+    getState().startTask(startedEvent());
+    const before = getState().byId;
+    getState().retireMissing(["bg-1"]);
+    expect(getState().byId).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedFromHistory
+// ---------------------------------------------------------------------------
+
+describe("seedFromHistory", () => {
+  it("adds new entries and ordered ids", () => {
+    getState().seedFromHistory([
+      historyEntry({ id: "bg-h1", status: "completed", exitCode: 0, output: "ok" }),
+    ]);
+
+    expect(getState().orderedIds).toEqual(["bg-h1"]);
+    const entry = getState().byId["bg-h1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.output).toBe("ok");
+  });
+
+  it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
+    const entry = historyEntry({ id: "bg-h1" });
+    getState().seedFromHistory([entry]);
+    getState().seedFromHistory([entry]);
+
+    expect(getState().orderedIds).toEqual(["bg-h1"]);
+  });
+
+  it("folds a terminal history status onto a live running entry", () => {
+    getState().startTask(startedEvent());
+    expect(getState().byId["bg-1"]!.status).toBe("running");
+
+    getState().seedFromHistory([
+      historyEntry({ status: "completed", exitCode: 0, output: "done", completedAt: NOW + 3000 }),
+    ]);
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.output).toBe("done");
+    expect(entry.completedAt).toBe(NOW + 3000);
+  });
+
+  it("does not regress a live terminal entry with a non-terminal history status", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(
+      completedEvent({ status: "completed", exitCode: 0, output: "done", completedAt: NOW + 1000 }),
+    );
+
+    getState().seedFromHistory([
+      historyEntry({ status: "running", exitCode: undefined, output: undefined }),
+    ]);
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.completedAt).toBe(NOW + 1000);
+    expect(entry.output).toBe("done");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset
+// ---------------------------------------------------------------------------
+
+describe("reset", () => {
+  it("clears all state back to initial", () => {
+    getState().startTask(startedEvent());
+    getState().completeTask(completedEvent());
+
+    getState().reset();
+
+    expect(getState().byId).toEqual({});
+    expect(getState().orderedIds).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -87,10 +87,19 @@ export interface BackgroundTaskActions {
    * Retire running tasks absent from an authoritative active-task snapshot —
    * the daemon restarted and lost the subprocess before persisting a terminal
    * row, so no completion event will ever settle them. Marks each still-running
-   * task "cancelled". No-op for tasks already terminal or present in the
-   * snapshot.
+   * task "cancelled".
+   *
+   * `knownIds` is the snapshot of task ids that existed when the active-task
+   * fetch was issued. A running task is retired only if it IS in `knownIds` AND
+   * NOT in `activeIds`, so a task that started while the fetch was in flight (in
+   * `byId` but absent from both sets) is left untouched. Callers must capture
+   * the id snapshot before issuing the fetch and pass it here. No-op for tasks
+   * already terminal or present in the snapshot.
    */
-  retireMissing: (activeIds: string[]) => void;
+  retireMissing: (
+    activeIds: string[] | Set<string>,
+    knownIds: Iterable<string>,
+  ) => void;
 
   /**
    * Idempotent merge of history entries keyed by id. Adds unseen entries (with
@@ -209,9 +218,18 @@ const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => (
   restoreTaskStatus: (id, prev) => {
     const { byId } = get();
     const existing = byId[id];
-    // Only revert our own optimistic cancel; if a real terminal already landed,
-    // leave it.
-    if (!existing || existing.status !== "cancelled") return;
+    // Only revert our own optimistic cancel. The optimistic `cancelTask` never
+    // sets `completedAt`, so a non-null `completedAt` means a real terminal
+    // already landed — even one that preserved the "cancelled" status (a racing
+    // failed `completeTask`). Reviving it would flash a finished task back to
+    // active.
+    if (
+      !existing ||
+      existing.status !== "cancelled" ||
+      existing.completedAt != null
+    ) {
+      return;
+    }
 
     set({
       byId: {
@@ -221,13 +239,21 @@ const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => (
     });
   },
 
-  retireMissing: (activeIds) => {
+  retireMissing: (activeIds, knownIds) => {
     const { byId } = get();
     const active = new Set(activeIds);
+    const known = new Set(knownIds);
     let changed = false;
     const next = { ...byId };
     for (const entry of Object.values(byId)) {
-      if (!isActiveBackgroundTaskStatus(entry.status) || active.has(entry.id)) {
+      // Retire only tasks known before the snapshot and absent from it; a task
+      // started while the fetch was in flight is in `byId` but not `known`, so
+      // it is left running.
+      if (
+        !isActiveBackgroundTaskStatus(entry.status) ||
+        !known.has(entry.id) ||
+        active.has(entry.id)
+      ) {
         continue;
       }
       next[entry.id] = { ...entry, status: "cancelled" };

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -1,0 +1,258 @@
+/**
+ * Zustand store for background bash/host_bash task lifecycle state.
+ *
+ * Maintains a map of BackgroundTaskEntry records keyed by the `bg-xxxxxxxx`
+ * task id, with an ordered list of ids for stable rendering. Unlike the ACP
+ * run store, there is no streaming event buffer: a background task is just
+ * metadata plus a terminal status/exit-code/output, so the entry settles in a
+ * single `completeTask` instead of accumulating chunks. Anchoring is by the
+ * synchronous result-parsed task id, so no `byToolUseId`/`highWaterMark`/seq
+ * machinery is needed.
+ *
+ * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
+ * @see https://zustand.docs.pmnd.rs/guides/updating-state
+ */
+
+import { create } from "zustand";
+
+import type {
+  BackgroundToolCompletedEvent,
+  BackgroundToolStartedEvent,
+} from "@vellumai/assistant-api";
+import { createSelectors } from "@/utils/create-selectors";
+import {
+  isActiveBackgroundTaskStatus,
+  type BackgroundTaskStatus,
+} from "@/utils/background-task-status";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface BackgroundTaskEntry {
+  id: string;
+  toolName: string;
+  conversationId: string;
+  command: string;
+  startedAt: number;
+  status: BackgroundTaskStatus;
+  exitCode?: number | null;
+  output?: string;
+  completedAt?: number;
+}
+
+export interface BackgroundTaskState {
+  byId: Record<string, BackgroundTaskEntry>;
+  orderedIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export interface BackgroundTaskActions {
+  /**
+   * Record a started background task. Inserts a "running" entry and appends its
+   * id to `orderedIds`. Idempotent — a replayed start for a known id is ignored
+   * so the entry's original metadata and ordering are preserved.
+   */
+  startTask: (event: BackgroundToolStartedEvent) => void;
+
+  /**
+   * Settle a background task from its terminal event — status, exit code,
+   * captured output, and completion time. No-op for an unknown id. Never
+   * regresses an optimistically-cancelled entry to "failed": the daemon's
+   * cancellation still emits a `background_tool_completed` with a non-zero
+   * status, which would otherwise flash the card from "cancelled" to "failed".
+   */
+  completeTask: (event: BackgroundToolCompletedEvent) => void;
+
+  /**
+   * Optimistically mark a running task "cancelled" (user pressed Stop). No-op
+   * for an unknown or already-terminal task so a finished task is never
+   * regressed. The authoritative `completedAt`/`exitCode`/`output` land later
+   * via {@link completeTask}, which preserves this "cancelled" status.
+   */
+  cancelTask: (id: string) => void;
+
+  /**
+   * Roll back an optimistic {@link cancelTask} when the cancel request fails —
+   * restore the prior status and clear `completedAt`. No-op unless the task is
+   * still in the optimistic "cancelled" state, so a real terminal that already
+   * landed is never regressed back to active.
+   */
+  restoreTaskStatus: (id: string, prev: BackgroundTaskStatus) => void;
+
+  /**
+   * Retire running tasks absent from an authoritative active-task snapshot —
+   * the daemon restarted and lost the subprocess before persisting a terminal
+   * row, so no completion event will ever settle them. Marks each still-running
+   * task "cancelled". No-op for tasks already terminal or present in the
+   * snapshot.
+   */
+  retireMissing: (activeIds: string[]) => void;
+
+  /**
+   * Idempotent merge of history entries keyed by id. Adds unseen entries (with
+   * ordering) and folds terminal metadata into known ones via
+   * {@link mergeHistoryEntry}.
+   */
+  seedFromHistory: (entries: BackgroundTaskEntry[]) => void;
+
+  reset: () => void;
+}
+
+export type BackgroundTaskStore = BackgroundTaskState & BackgroundTaskActions;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: BackgroundTaskState = {
+  byId: {},
+  orderedIds: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fold a history entry into an existing one. A terminal history status wins
+ * over a live running one; a live terminal status is not regressed by a
+ * non-terminal history status. Terminal metadata fills in where missing.
+ */
+function mergeHistoryEntry(
+  existing: BackgroundTaskEntry,
+  incoming: BackgroundTaskEntry,
+): BackgroundTaskEntry {
+  const status =
+    isActiveBackgroundTaskStatus(existing.status) ||
+    !isActiveBackgroundTaskStatus(incoming.status)
+      ? incoming.status
+      : existing.status;
+
+  return {
+    ...existing,
+    status,
+    exitCode: incoming.exitCode ?? existing.exitCode,
+    output: incoming.output ?? existing.output,
+    completedAt: incoming.completedAt ?? existing.completedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => ({
+  ...INITIAL_STATE,
+
+  startTask: (event) => {
+    const { byId, orderedIds } = get();
+    if (byId[event.id]) return;
+
+    const entry: BackgroundTaskEntry = {
+      id: event.id,
+      toolName: event.toolName,
+      conversationId: event.conversationId,
+      command: event.command,
+      startedAt: event.startedAt,
+      status: "running",
+    };
+
+    set({
+      byId: { ...byId, [event.id]: entry },
+      orderedIds: [...orderedIds, event.id],
+    });
+  },
+
+  completeTask: (event) => {
+    const { byId } = get();
+    const existing = byId[event.id];
+    if (!existing) return;
+
+    // Preserve an optimistic cancel: the daemon's cancellation reports a
+    // "failed" terminal, which must not regress the user-visible "cancelled".
+    const status =
+      existing.status === "cancelled" && event.status === "failed"
+        ? "cancelled"
+        : event.status;
+
+    set({
+      byId: {
+        ...byId,
+        [event.id]: {
+          ...existing,
+          status,
+          exitCode: event.exitCode,
+          output: event.output,
+          completedAt: event.completedAt,
+        },
+      },
+    });
+  },
+
+  cancelTask: (id) => {
+    const { byId } = get();
+    const existing = byId[id];
+    if (!existing || !isActiveBackgroundTaskStatus(existing.status)) return;
+
+    set({
+      byId: {
+        ...byId,
+        [id]: { ...existing, status: "cancelled" },
+      },
+    });
+  },
+
+  restoreTaskStatus: (id, prev) => {
+    const { byId } = get();
+    const existing = byId[id];
+    // Only revert our own optimistic cancel; if a real terminal already landed,
+    // leave it.
+    if (!existing || existing.status !== "cancelled") return;
+
+    set({
+      byId: {
+        ...byId,
+        [id]: { ...existing, status: prev, completedAt: undefined },
+      },
+    });
+  },
+
+  retireMissing: (activeIds) => {
+    const { byId } = get();
+    const active = new Set(activeIds);
+    let changed = false;
+    const next = { ...byId };
+    for (const entry of Object.values(byId)) {
+      if (!isActiveBackgroundTaskStatus(entry.status) || active.has(entry.id)) {
+        continue;
+      }
+      next[entry.id] = { ...entry, status: "cancelled" };
+      changed = true;
+    }
+    if (changed) set({ byId: next });
+  },
+
+  seedFromHistory: (entries) => {
+    const { byId, orderedIds } = get();
+    const nextById = { ...byId };
+    const nextOrderedIds = [...orderedIds];
+
+    for (const entry of entries) {
+      const existing = nextById[entry.id];
+      nextById[entry.id] = existing
+        ? mergeHistoryEntry(existing, entry)
+        : entry;
+      if (!nextOrderedIds.includes(entry.id)) nextOrderedIds.push(entry.id);
+    }
+
+    set({ byId: nextById, orderedIds: nextOrderedIds });
+  },
+
+  reset: () => set({ byId: {}, orderedIds: [] }),
+}));
+
+export const useBackgroundTaskStore = createSelectors(useBackgroundTaskStoreBase);


### PR DESCRIPTION
## Summary
- Add background-task store (byId + orderedIds) with start/complete/cancel/retire actions
- Mirrors acp-run-store; anchors by result-parsed bg id (no seq/byToolUseId)

Part of plan: bash-bg-task-ui.md (PR 8 of 13)