### PR TITLE
feat(web): in-tab Plugins master/detail with ?plugin deep-link

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -20,10 +20,8 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router";
-
 import type {
+  PluginsByNameGetResponse,
   PluginsByNameInspectGetResponse,
   PluginsGetResponse,
   PluginsSearchGetResponse,
@@ -74,6 +72,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     data: inspectByName[options.path.name] ?? upToDateInspect(options.path.name),
     ...okResponse,
   })),
+  // Backs the in-tab detail (`usePluginDetail`) once a row is selected.
+  pluginsByNameGet: mock(async (options: { path: { name: string } }) => ({
+    data: pluginDetail(options.path.name),
+    ...okResponse,
+  })),
 }));
 
 const { PluginsTab } = await import("./plugins-tab");
@@ -106,6 +109,22 @@ function upToDateInspect(name: string): PluginsByNameInspectGetResponse {
   };
 }
 
+/** Minimal schema-valid detail response backing the in-tab `PluginDetail`. */
+function pluginDetail(name: string): PluginsByNameGetResponse {
+  return {
+    name,
+    installed: true,
+    description: null,
+    homepage: null,
+    license: null,
+    version: "0.1.0",
+    source: null,
+    readme: null,
+    ref: "main",
+    artifact: null,
+  };
+}
+
 function catalog(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
   return {
     name: "apollo-bot-brain",
@@ -119,22 +138,15 @@ function catalog(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
   };
 }
 
-function renderTab() {
+function renderTab(props: { initialPluginName?: string } = {}) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <Wrapper>
-        <PluginsTab assistantId={ASSISTANT_ID} />
-      </Wrapper>
+      <PluginsTab assistantId={ASSISTANT_ID} {...props} />
     </QueryClientProvider>,
   );
-}
-
-function Wrapper({ children }: { children: ReactNode }) {
-  // Row selection calls `navigate(routes.plugin(name))`, which needs a router.
-  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 /** Click the Status option whose visible label matches (popover portal). */
@@ -244,5 +256,32 @@ describe("PluginsTab", () => {
 
     const { findByText } = renderTab();
     expect(await findByText("Failed to load plugins")).toBeTruthy();
+  });
+
+  test("selecting a row opens the detail in-tab and back returns to the list", async () => {
+    installedPlugins = [installed()];
+
+    const { findByText, findByLabelText, queryByLabelText } = renderTab();
+    // Click the row (the name bubbles up to the row's `onSelect`).
+    fireEvent.click(await findByText("simple-memory"));
+
+    // The detail renders in-tab — its back affordance appears and the list
+    // chrome (the search box) is gone. No route change is involved.
+    const back = await findByLabelText("Back to plugins");
+    expect(queryByLabelText("Search plugins")).toBeNull();
+
+    fireEvent.click(back);
+
+    // Back returns to the list view.
+    expect(await findByLabelText("Search plugins")).toBeTruthy();
+    expect(await findByText("simple-memory")).toBeTruthy();
+  });
+
+  test("initialPluginName deep-links straight into the detail on mount", async () => {
+    installedPlugins = [installed()];
+
+    const { findByLabelText } = renderTab({ initialPluginName: "simple-memory" });
+
+    expect(await findByLabelText("Back to plugins")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -9,8 +9,9 @@ import {
     X,
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
 
+import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-detail";
+import { PluginDetailMobile } from "@/domains/intelligence/components/plugins/plugin-detail-mobile";
 import { FilterBar } from "@/domains/intelligence/components/plugins/plugin-filters";
 import { PluginListRow } from "@/domains/intelligence/components/plugins/plugin-list-row";
 import type {
@@ -35,12 +36,18 @@ import {
     usePluginsByNameUpgradePostMutation,
     usePluginsInstallPostMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
-import { routes } from "@/utils/routes";
 import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
 
 interface PluginsTabProps {
   assistantId: string;
+  /**
+   * Optional plugin name to open in the detail view on first mount. Comes from
+   * the `?plugin=<name>` deep-link. Only seeds the initial state — internal
+   * navigation thereafter is local state.
+   */
+  initialPluginName?: string;
 }
 
 const TIP_STORAGE_KEY = "vellum:plugins:tipDismissed";
@@ -50,14 +57,18 @@ const TIP_STORAGE_KEY = "vellum:plugins:tipDismissed";
  * status-filter bar, and a single installed-first list of `PluginListRow`s.
  * Install / remove / upgrade live here (the rows are presentational) so the
  * tab can gate destructive Remove and local-edit-overwriting Upgrade behind a
- * `ConfirmDialog`. Selecting a row navigates to the existing detail route.
+ * `ConfirmDialog`. Selecting a row opens the detail in-tab (like `SkillsTab`)
+ * via local selection state, seeded once from the `?plugin=` deep-link.
  */
-export function PluginsTab({ assistantId }: PluginsTabProps) {
+export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
+  const isMobile = useIsMobile();
 
   const [searchValue, setSearchValue] = useState("");
   const [filter, setFilter] = useState<PluginFilter>("all");
+  const [selectedPluginName, setSelectedPluginName] = useState<string | null>(
+    initialPluginName ?? null,
+  );
   const [installingName, setInstallingName] = useState<string | null>(null);
   const [removingName, setRemovingName] = useState<string | null>(null);
   const [upgradingName, setUpgradingName] = useState<string | null>(null);
@@ -118,8 +129,8 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   });
 
   const handleSelect = useCallback(
-    (item: PluginListItem) => navigate(routes.plugin(item.name)),
-    [navigate],
+    (item: PluginListItem) => setSelectedPluginName(item.name),
+    [],
   );
 
   const handleInstall = useCallback(
@@ -184,6 +195,19 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   );
 
   const isSearching = isFetching && !isLoading;
+
+  if (selectedPluginName) {
+    const detailProps = {
+      assistantId,
+      name: selectedPluginName,
+      onBack: () => setSelectedPluginName(null),
+    };
+    return isMobile ? (
+      <PluginDetailMobile {...detailProps} />
+    ) : (
+      <PluginDetail {...detailProps} />
+    );
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col gap-4">

--- a/clients/web/src/domains/intelligence/plugins-page.tsx
+++ b/clients/web/src/domains/intelligence/plugins-page.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router";
+import { Navigate, useSearchParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { PluginsTab } from "@/domains/intelligence/components/plugins/plugins-tab";
@@ -20,6 +20,8 @@ export function PluginsPage() {
   const version = useAssistantIdentityStore.use.version();
   const supportsPlugins = useSupportsPluginsSurface();
   const assistantId = useActiveAssistantId();
+  const [searchParams] = useSearchParams();
+  const initialPluginName = searchParams.get("plugin") ?? undefined;
 
   if (version === null) {
     return null;
@@ -29,5 +31,7 @@ export function PluginsPage() {
     return <Navigate to={routes.identity} replace />;
   }
 
-  return <PluginsTab assistantId={assistantId} />;
+  return (
+    <PluginsTab assistantId={assistantId} initialPluginName={initialPluginName} />
+  );
 }


### PR DESCRIPTION
## Summary
- Plugins tab now renders PluginDetail/PluginDetailMobile in-tab via local selection + ?plugin= deep-link (mirrors Skills), instead of navigating to the detail route. Route page untouched (retired in a later PR).

Part of plan: plugins-tab-match-skills.md (PR 12 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)