### PR TITLE
feat(memory): add pure embedding-reconcile decision function

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/reconcile-decision.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/reconcile-decision.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decideEmbeddingReconcile,
+  type ReconcileAction,
+} from "../reconcile-decision.js";
+
+describe("decideEmbeddingReconcile", () => {
+  test("fresh install, backend up -> commit-fresh", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: null,
+      probeDim: 3072,
+      configuredProvider: "gemini",
+    });
+    expect(action).toEqual({ kind: "commit-fresh", dim: 3072 });
+  });
+
+  test("fresh install, backend down -> defer-degraded", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: null,
+      probeDim: null,
+      configuredProvider: "auto",
+    });
+    expect(action).toEqual({
+      kind: "defer-degraded",
+      reason: "no reachable embedding backend",
+    });
+  });
+
+  test("committed matches probe -> noop", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 384,
+      probeDim: 384,
+      configuredProvider: "auto",
+    });
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  test("explicit provider, mismatch upward -> migrate", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 384,
+      probeDim: 3072,
+      configuredProvider: "gemini",
+    });
+    expect(action).toEqual({ kind: "migrate", fromDim: 384, toDim: 3072 });
+  });
+
+  test("explicit provider, mismatch downward -> migrate", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 3072,
+      probeDim: 384,
+      configuredProvider: "local",
+    });
+    expect(action).toEqual({ kind: "migrate", fromDim: 3072, toDim: 384 });
+  });
+
+  test("auto provider, mismatch upward -> noop (no thrash)", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 384,
+      probeDim: 3072,
+      configuredProvider: "auto",
+    });
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  test("auto provider, mismatch downward -> noop (no thrash)", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 3072,
+      probeDim: 384,
+      configuredProvider: "auto",
+    });
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  test("existing collection, backend down -> defer-degraded", () => {
+    const action = decideEmbeddingReconcile({
+      committedDim: 3072,
+      probeDim: null,
+      configuredProvider: "gemini",
+    });
+    expect(action).toEqual({
+      kind: "defer-degraded",
+      reason: "no reachable embedding backend",
+    });
+  });
+
+  test("defer-degraded precedes fresh-commit when both committed and probe are null", () => {
+    const action: ReconcileAction = decideEmbeddingReconcile({
+      committedDim: null,
+      probeDim: null,
+      configuredProvider: "gemini",
+    });
+    expect(action.kind).toBe("defer-degraded");
+  });
+});

--- a/assistant/src/persistence/embeddings/reconcile-decision.ts
+++ b/assistant/src/persistence/embeddings/reconcile-decision.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure decision logic for reconciling the committed Qdrant collection
+ * dimension against the dimension reported by a live probe of the configured
+ * embedding backend.
+ *
+ * No-thrash rationale: under `provider: "auto"` the reachable backend can flip
+ * between a small local model (384) and a large managed model (3072) purely on
+ * transient availability, so a per-boot mismatch must NOT trigger a destructive
+ * recreate/migrate. Platform intent to change dimensions is expressed by setting
+ * an explicit provider (a fill-only deployment default supplied in a later PR),
+ * never inferred from which backend happened to answer the probe this boot.
+ *
+ * This module is intentionally dependency-free: it imports neither the config
+ * loader, Qdrant, nor any embedding backend. It maps observed inputs to a
+ * decision; the orchestrator performs the I/O.
+ */
+export type ReconcileAction =
+  | { kind: "noop" }
+  | { kind: "commit-fresh"; dim: number }
+  | { kind: "migrate"; fromDim: number; toDim: number }
+  | { kind: "defer-degraded"; reason: string };
+
+export function decideEmbeddingReconcile(input: {
+  committedDim: number | null;
+  probeDim: number | null;
+  configuredProvider: string;
+}): ReconcileAction {
+  const { committedDim, probeDim, configuredProvider } = input;
+
+  // Never destroy or commit while the backend is down.
+  if (probeDim == null) {
+    return { kind: "defer-degraded", reason: "no reachable embedding backend" };
+  }
+
+  // Fresh install adopts the reachable backend's dimension.
+  if (committedDim == null) {
+    return { kind: "commit-fresh", dim: probeDim };
+  }
+
+  // Reachable backend matches the committed collection.
+  if (committedDim === probeDim) {
+    return { kind: "noop" };
+  }
+
+  // Under auto, stay committed — never thrash 384 <-> 3072 on transient
+  // availability. A genuine upgrade is expressed by setting provider explicitly.
+  if (configuredProvider === "auto") {
+    return { kind: "noop" };
+  }
+
+  // Deliberate provider intent; probe already confirmed the backend is reachable.
+  return { kind: "migrate", fromDim: committedDim, toDim: probeDim };
+}


### PR DESCRIPTION
## Summary
- Add decideEmbeddingReconcile() pure decision: noop / commit-fresh / migrate / defer-degraded
- Never thrash under provider=auto; defer when no backend reachable
- Exhaustive truth-table tests

Part of plan: embedding-dim-reconcile.md (PR 2 of 8)