### PR TITLE
feat(memory): add embedding probe + committed-collection-dimension primitives

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../../../config/types.js";
+
+const CONFIG = {
+  memory: { qdrant: { url: "http://127.0.0.1:6333", vectorSize: 768 } },
+} as unknown as AssistantConfig;
+
+// ── Stub selectEmbeddingBackend + the billing breaker ──────────────
+let backendToReturn: {
+  provider: string;
+  model: string;
+  embed: (inputs: string[]) => Promise<number[][]>;
+} | null = null;
+let breakerOpen = false;
+
+const selectEmbeddingBackendMock = mock(async () => ({
+  backend: backendToReturn,
+  reason: backendToReturn ? null : "no backend",
+}));
+mock.module("../embedding-backend.js", () => ({
+  selectEmbeddingBackend: selectEmbeddingBackendMock,
+}));
+
+mock.module("../embedding-billing-breaker.js", () => ({
+  isEmbeddingBillingBreakerOpen: () => breakerOpen,
+}));
+
+// ── Stub the Qdrant REST client ────────────────────────────────────
+let collectionExistsResult = { exists: true };
+let getCollectionResult: unknown = {
+  config: { params: { vectors: { dense: { size: 768 } } } },
+};
+let collectionExistsThrows = false;
+let getCollectionThrows = false;
+
+const collectionExistsMock = mock(async () => {
+  if (collectionExistsThrows) throw new Error("qdrant down");
+  return collectionExistsResult;
+});
+const getCollectionMock = mock(async () => {
+  if (getCollectionThrows) throw new Error("qdrant probe failed");
+  return getCollectionResult;
+});
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: class {
+    collectionExists = collectionExistsMock;
+    getCollection = getCollectionMock;
+  },
+}));
+
+const { probeBackendDimension, readConceptPageCollectionDim } =
+  await import("../embedding-identity.js");
+
+describe("probeBackendDimension", () => {
+  beforeEach(() => {
+    breakerOpen = false;
+    backendToReturn = {
+      provider: "openai",
+      model: "text-embedding-3-small",
+      embed: async () => [new Array(1536).fill(0)],
+    };
+  });
+  afterEach(() => {
+    selectEmbeddingBackendMock.mockClear();
+  });
+
+  test("returns the measured dimension on success", async () => {
+    const result = await probeBackendDimension(CONFIG);
+    expect(result).toEqual({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dim: 1536,
+    });
+  });
+
+  test("returns null when the billing breaker is open", async () => {
+    breakerOpen = true;
+    expect(await probeBackendDimension(CONFIG)).toBeNull();
+    // Breaker short-circuits before selecting a backend.
+    expect(selectEmbeddingBackendMock).not.toHaveBeenCalled();
+  });
+
+  test("returns null when no backend is selectable", async () => {
+    backendToReturn = null;
+    expect(await probeBackendDimension(CONFIG)).toBeNull();
+  });
+
+  test("returns null when the backend embed call throws", async () => {
+    backendToReturn = {
+      provider: "openai",
+      model: "text-embedding-3-small",
+      embed: async () => {
+        throw new Error("provider unreachable");
+      },
+    };
+    expect(await probeBackendDimension(CONFIG)).toBeNull();
+  });
+});
+
+describe("readConceptPageCollectionDim", () => {
+  beforeEach(() => {
+    collectionExistsResult = { exists: true };
+    getCollectionResult = {
+      config: { params: { vectors: { dense: { size: 768 } } } },
+    };
+    collectionExistsThrows = false;
+    getCollectionThrows = false;
+  });
+
+  test("returns the committed dense vector size", async () => {
+    expect(await readConceptPageCollectionDim(CONFIG)).toBe(768);
+  });
+
+  test("returns null when the collection is absent", async () => {
+    collectionExistsResult = { exists: false };
+    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+  });
+
+  test("returns null when the dense size is unreadable", async () => {
+    getCollectionResult = { config: { params: { vectors: {} } } };
+    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+  });
+
+  test("returns null on probe failure (existence check throws)", async () => {
+    collectionExistsThrows = true;
+    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+  });
+
+  test("returns null on probe failure (getCollection throws)", async () => {
+    getCollectionThrows = true;
+    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+  });
+});

--- a/assistant/src/persistence/embeddings/embedding-identity.ts
+++ b/assistant/src/persistence/embeddings/embedding-identity.ts
@@ -1,0 +1,88 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+import type { AssistantConfig } from "../../config/types.js";
+import { getLogger } from "../../util/logger.js";
+import { selectEmbeddingBackend } from "./embedding-backend.js";
+import { isEmbeddingBillingBreakerOpen } from "./embedding-billing-breaker.js";
+import type { EmbeddingProviderName } from "./embedding-types.js";
+import { resolveQdrantUrl } from "./qdrant-client.js";
+
+const log = getLogger("embedding-identity");
+
+const MEMORY_V2_COLLECTION = "memory_v2_concept_pages";
+
+export interface BackendDimensionProbe {
+  provider: EmbeddingProviderName;
+  model: string;
+  dim: number;
+}
+
+/**
+ * Measure the output dimension of the currently selected embedding backend by
+ * embedding a fixed probe string.
+ *
+ * Returns `null` — never throws — when the backend is unavailable, so the
+ * reconcile defers rather than committing on a measurement it could not take:
+ *   - the billing breaker is open (treated as "backend down");
+ *   - no backend is configured/selectable;
+ *   - the backend's `embed` call throws (provider unreachable).
+ *
+ * Calls `backend.embed` directly rather than `embedWithBackend`, which asserts
+ * `config.memory.qdrant.vectorSize` and would throw on exactly the dimension
+ * mismatch this probe is meant to measure. Calling the backend directly also
+ * bypasses the in-memory vector cache, which this probe does not populate.
+ */
+export async function probeBackendDimension(
+  config: AssistantConfig,
+): Promise<BackendDimensionProbe | null> {
+  if (isEmbeddingBillingBreakerOpen()) return null;
+
+  const { backend } = await selectEmbeddingBackend(config);
+  if (!backend) return null;
+
+  try {
+    const vectors = await backend.embed(["embedding dimension probe"]);
+    const dim = vectors[0]?.length;
+    if (dim == null) return null;
+    return { provider: backend.provider, model: backend.model, dim };
+  } catch (err) {
+    log.warn(
+      { err },
+      "Backend dimension probe failed; treating as unavailable",
+    );
+    return null;
+  }
+}
+
+/**
+ * Read the committed dense-vector dimension of the v2 concept-page collection.
+ *
+ * Returns `null` — never throws — when the collection is absent or its schema
+ * cannot be read, mirroring the "assume unknown on probe failure" posture in
+ * `assistant/src/memory/v2/qdrant.ts`.
+ */
+export async function readConceptPageCollectionDim(
+  config: AssistantConfig,
+): Promise<number | null> {
+  try {
+    const client = new QdrantClient({
+      url: resolveQdrantUrl(config),
+      checkCompatibility: false,
+    });
+    const exists = await client.collectionExists(MEMORY_V2_COLLECTION);
+    if (!exists.exists) return null;
+
+    const info = await client.getCollection(MEMORY_V2_COLLECTION);
+    const vectors = info.config?.params?.vectors as
+      | Record<string, { size?: number } | undefined>
+      | undefined;
+    const size = vectors?.dense?.size;
+    return typeof size === "number" ? size : null;
+  } catch (err) {
+    log.warn(
+      { err, collection: MEMORY_V2_COLLECTION },
+      "Failed to read v2 concept-page collection dimension; treating as unknown",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add probeBackendDimension() measuring the selected backend's output dim without the config-dim assertion
- Add readConceptPageCollectionDim() reading the committed v2 collection dimension
- Both return null (never throw) on backend/Qdrant unavailability

Part of plan: embedding-dim-reconcile.md (PR 1 of 8)