### PR TITLE
feat(memory): expose embedding-backend degraded status in worker status route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16563,7 +16563,9 @@ paths:
     get:
       operationId: memory_worker_status_get
       summary: Memory worker status
-      description: Reports the memory worker process state, memory.worker.enabled, and the synchronous in-process runner.
+      description:
+        Reports the memory worker process state, memory.worker.enabled, the synchronous in-process runner, and the
+        embedding-backend status (including a degraded flag and reason when no backend resolves).
       tags:
         - system
       responses:
@@ -16596,10 +16598,41 @@ paths:
                     required:
                       - status
                     additionalProperties: false
+                  embedding:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      degraded:
+                        type: boolean
+                      provider:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - openai
+                              - gemini
+                              - ollama
+                          - type: "null"
+                      model:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      reason:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - enabled
+                      - degraded
+                      - provider
+                      - model
+                      - reason
+                    additionalProperties: false
                 required:
                   - status
                   - workerEnabled
                   - syncRunner
+                  - embedding
                 additionalProperties: false
   /v1/memory/worker/stop:
     post:

--- a/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
@@ -30,6 +30,19 @@ let workerProbe: { status: "running" | "not_running"; pid?: number } = {
 };
 let configEnabled = false;
 let memoryEnabled = true;
+let backendStatus: {
+  enabled: boolean;
+  degraded: boolean;
+  provider: string | null;
+  model: string | null;
+  reason: string | null;
+} = {
+  enabled: true,
+  degraded: false,
+  provider: "openai",
+  model: "text-embedding-3-small",
+  reason: null,
+};
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -46,6 +59,10 @@ mock.module("../../../persistence/worker-control.js", () => ({
   },
   stopMemoryWorkerProcess: () => stopImpl(),
   probeMemoryWorker: () => workerProbe,
+}));
+
+mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
+  getMemoryBackendStatus: async () => backendStatus,
 }));
 
 // Spread the real loader so the route-policy import chain keeps every other
@@ -82,6 +99,13 @@ beforeEach(() => {
   workerProbe = { status: "not_running" };
   configEnabled = false;
   memoryEnabled = true;
+  backendStatus = {
+    enabled: true,
+    degraded: false,
+    provider: "openai",
+    model: "text-embedding-3-small",
+    reason: null,
+  };
 });
 
 // ---------------------------------------------------------------------------
@@ -169,6 +193,13 @@ describe("memory_worker_status", () => {
       pid: 321,
       workerEnabled: true,
       syncRunner: { status: "not_running" },
+      embedding: {
+        enabled: true,
+        degraded: false,
+        provider: "openai",
+        model: "text-embedding-3-small",
+        reason: null,
+      },
     });
   });
 
@@ -182,6 +213,55 @@ describe("memory_worker_status", () => {
       status: "not_running",
       workerEnabled: false,
       syncRunner: { status: "running", pid: process.pid },
+      embedding: {
+        enabled: true,
+        degraded: false,
+        provider: "openai",
+        model: "text-embedding-3-small",
+        reason: null,
+      },
+    });
+  });
+
+  test("surfaces a resolved embedding backend", async () => {
+    workerProbe = { status: "not_running" };
+    configEnabled = false;
+    backendStatus = {
+      enabled: true,
+      degraded: false,
+      provider: "gemini",
+      model: "text-embedding-004",
+      reason: null,
+    };
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toMatchObject({
+      embedding: { degraded: false, provider: "gemini" },
+    });
+  });
+
+  test("surfaces a degraded embedding backend with a reason when none is configured", async () => {
+    workerProbe = { status: "not_running" };
+    configEnabled = false;
+    backendStatus = {
+      enabled: true,
+      degraded: true,
+      provider: null,
+      model: null,
+      reason: "No embedding backend configured",
+    };
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toMatchObject({
+      embedding: {
+        enabled: true,
+        degraded: true,
+        provider: null,
+        model: null,
+        reason: "No embedding backend configured",
+      },
     });
   });
 

--- a/assistant/src/runtime/routes/memory-worker-routes.ts
+++ b/assistant/src/runtime/routes/memory-worker-routes.ts
@@ -17,6 +17,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { getMemoryBackendStatus } from "../../persistence/embeddings/embedding-backend.js";
 import {
   MemoryWorkerSpawnError,
   probeMemoryWorker,
@@ -61,11 +62,20 @@ const stopResponseSchema = z.object({
   workerEnabled: z.literal(false),
 });
 
+const embeddingStatusSchema = z.object({
+  enabled: z.boolean(),
+  degraded: z.boolean(),
+  provider: z.enum(["openai", "gemini", "ollama"]).nullable(),
+  model: z.string().nullable(),
+  reason: z.string().nullable(),
+});
+
 const statusResponseSchema = z.object({
   status: z.enum(["running", "not_running"]),
   pid: z.number().optional(),
   workerEnabled: z.boolean(),
   syncRunner: workerStatusSchema,
+  embedding: embeddingStatusSchema,
 });
 
 /**
@@ -141,8 +151,12 @@ function stopMemoryWorker() {
  * This handler runs inside the daemon — the very process that is (or isn't) the
  * synchronous runner — so the runner's state is derived directly from config,
  * with the daemon's own PID, rather than read back from a marker file.
+ *
+ * The `embedding` block reports the resolved embedding backend (or the
+ * degraded state when none resolves), so a silent embedding-backend
+ * degradation — memory enqueues fine but never embeds — is observable.
  */
-function memoryWorkerStatus() {
+async function memoryWorkerStatus() {
   const worker = probeMemoryWorker();
   const config = getConfigReadOnly();
   const workerEnabled = config.memory.worker.enabled;
@@ -153,11 +167,14 @@ function memoryWorkerStatus() {
       ? { status: "running", pid: process.pid }
       : { status: "not_running" };
 
+  const embedding = await getMemoryBackendStatus(config);
+
   return {
     status: worker.status,
     ...(worker.pid != null ? { pid: worker.pid } : {}),
     workerEnabled,
     syncRunner,
+    embedding,
   };
 }
 
@@ -203,7 +220,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: memoryWorkerStatus,
     summary: "Memory worker status",
     description:
-      "Reports the memory worker process state, memory.worker.enabled, and the synchronous in-process runner.",
+      "Reports the memory worker process state, memory.worker.enabled, the synchronous in-process runner, and the embedding-backend status (including a degraded flag and reason when no backend resolves).",
     tags: ["system"],
     responseBody: statusResponseSchema,
   },


### PR DESCRIPTION
## Summary
- Add embedding {enabled,degraded,provider,model,reason} to memory_worker_status
- Surfaces silent embedding-backend degradation to clients

Part of plan: embedding-dim-reconcile.md (PR 3 of 8)