### PR TITLE
feat(memory): add reconcileEmbeddingIdentity orchestrator (probe-gated, confirm-before-destroy)

### DIFF
--- a/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../../config/types.js";
+import type { ReconcileAction } from "../../persistence/embeddings/reconcile-decision.js";
+import {
+  type ReconcileDeps,
+  reconcileEmbeddingIdentity,
+} from "../embedding-reconcile.js";
+
+function fakeConfig(provider = "auto"): AssistantConfig {
+  return {
+    memory: {
+      embeddings: { provider },
+      qdrant: { vectorSize: 384 },
+    },
+  } as unknown as AssistantConfig;
+}
+
+/**
+ * Build a fully-spied dep set. `decision` fixes the action the (otherwise
+ * irrelevant) pure decision returns; the read primitives return the supplied
+ * committed/probe dims so the orchestrator's wiring — not the decision logic,
+ * which has its own unit tests — is what each case exercises.
+ */
+function makeDeps(opts: {
+  decision: ReconcileAction;
+  committedDim?: number | null;
+  probeDim?: number | null;
+}): ReconcileDeps {
+  return {
+    probeBackendDimension: mock(async () =>
+      opts.probeDim == null
+        ? null
+        : { provider: "gemini" as const, model: "m", dim: opts.probeDim },
+    ),
+    readConceptPageCollectionDim: mock(async () => opts.committedDim ?? null),
+    decideEmbeddingReconcile: mock(() => opts.decision),
+    persistVectorSize: mock(() => {}),
+    setInMemoryVectorSize: mock(() => {}),
+    recreateCollectionsAtDim: mock(async () => {}),
+    ensureCollections: mock(async () => {}),
+    enqueueReembed: mock(() => {}),
+  };
+}
+
+describe("reconcileEmbeddingIdentity", () => {
+  test("defer-degraded performs ZERO destructive calls and ZERO config writes", async () => {
+    const deps = makeDeps({
+      decision: { kind: "defer-degraded", reason: "no reachable backend" },
+      committedDim: 384,
+      probeDim: null,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(fakeConfig(), deps);
+
+    expect(outcome).toEqual({
+      action: "defer-degraded",
+      reason: "no reachable backend",
+    });
+    // Core anti-regression: nothing destructive, nothing persisted.
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+  });
+
+  test("migrate recreates collections exactly once and persists the new dim, after a non-null probe", async () => {
+    const deps = makeDeps({
+      decision: { kind: "migrate", fromDim: 384, toDim: 3072 },
+      committedDim: 384,
+      probeDim: 3072,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("gemini"),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "migrate", fromDim: 384, toDim: 3072 });
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(1);
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledWith(3072);
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(1);
+    expect(deps.persistVectorSize).toHaveBeenCalledWith(3072);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledWith(3072);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(1);
+    // Migrate does NOT use the create-if-absent path.
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
+    // Probe was confirmed reachable before any destructive call.
+    expect(deps.probeBackendDimension).toHaveBeenCalledTimes(1);
+  });
+
+  test("commit-fresh persists and ensures-without-destroy, never recreates", async () => {
+    const deps = makeDeps({
+      decision: { kind: "commit-fresh", dim: 3072 },
+      committedDim: null,
+      probeDim: 3072,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("gemini"),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "commit-fresh", dim: 3072 });
+    expect(deps.persistVectorSize).toHaveBeenCalledWith(3072);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledWith(3072);
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(1);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(1);
+    // Commit-fresh must never destroy.
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+  });
+
+  test("noop writes nothing and returns the committed dim", async () => {
+    const deps = makeDeps({
+      decision: { kind: "noop" },
+      committedDim: 384,
+      probeDim: 384,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(fakeConfig(), deps);
+
+    expect(outcome).toEqual({ action: "noop", dim: 384 });
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+  });
+
+  test("passes committed + probe dims and configured provider into the decision", async () => {
+    const deps = makeDeps({
+      decision: { kind: "noop" },
+      committedDim: 384,
+      probeDim: 768,
+    });
+
+    await reconcileEmbeddingIdentity(fakeConfig("voyage"), deps);
+
+    expect(deps.decideEmbeddingReconcile).toHaveBeenCalledWith({
+      committedDim: 384,
+      probeDim: 768,
+      configuredProvider: "voyage",
+    });
+  });
+});

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -1,0 +1,199 @@
+// ---------------------------------------------------------------------------
+// Embedding-identity reconcile orchestrator
+// ---------------------------------------------------------------------------
+//
+// Ties the read primitives (`probeBackendDimension` /
+// `readConceptPageCollectionDim`) and the pure decision (`decideEmbeddingReconcile`)
+// to the side-effecting collaborators that commit a dimension, recreate the
+// Qdrant collections, and enqueue a reembed. The dimension of the embedding
+// collections is a derived, committed property reconciled at startup with
+// confirm-before-destroy: a destructive collection recreate runs only on a
+// `migrate` action, and only after a non-null backend probe.
+//
+// All collaborators are injectable so the decision/write-gating can be tested
+// without Qdrant, a real backend, or config-file I/O.
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../config/loader.js";
+import { isMemoryV3Live } from "../config/memory-v3-gate.js";
+import type { AssistantConfig } from "../config/types.js";
+import {
+  ensureConceptPageCollection,
+  recreateConceptPageCollection,
+} from "../memory/v2/qdrant.js";
+import {
+  probeBackendDimension,
+  readConceptPageCollectionDim,
+} from "../persistence/embeddings/embedding-identity.js";
+import { decideEmbeddingReconcile } from "../persistence/embeddings/reconcile-decision.js";
+import { enqueueMemoryJob } from "../persistence/jobs-store.js";
+import {
+  ensureSectionCollection,
+  recreateSectionCollection,
+} from "../plugins/defaults/memory/v3/section-dense-store.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("embedding-reconcile");
+
+export type ReconcileOutcome =
+  | { action: "noop"; dim: number | null }
+  | { action: "commit-fresh"; dim: number }
+  | { action: "migrate"; fromDim: number; toDim: number }
+  | { action: "defer-degraded"; reason: string };
+
+/**
+ * Injectable collaborators for {@link reconcileEmbeddingIdentity}. Defaults wire
+ * the real read primitives, decision, and side-effecting collaborators; tests
+ * override them with spies to exercise each decision branch and assert which
+ * destructive/write paths run.
+ */
+export interface ReconcileDeps {
+  probeBackendDimension: typeof probeBackendDimension;
+  readConceptPageCollectionDim: typeof readConceptPageCollectionDim;
+  decideEmbeddingReconcile: typeof decideEmbeddingReconcile;
+  /** Commit the reconciled dimension to `memory.qdrant.vectorSize` on disk. */
+  persistVectorSize: (dim: number) => void;
+  /** Make the committed dimension visible to same-process config readers. */
+  setInMemoryVectorSize: (dim: number) => void;
+  /** Destroy + recreate the v2 and v3 collections at `dim` (the only destructive path). */
+  recreateCollectionsAtDim: (dim: number) => Promise<void>;
+  /** Ensure the v2 + v3 collections exist at the committed dim without destroying. */
+  ensureCollections: () => Promise<void>;
+  /** Enqueue the reembed jobs that repopulate the (re)created collections. */
+  enqueueReembed: () => void;
+}
+
+/**
+ * Write ONLY `memory.qdrant.vectorSize` into config.json. Deliberately does not
+ * touch `provider`, `geminiModel`, or `geminiDimensions` — the committed
+ * dimension is derived from the reachable backend's probe, not a provider
+ * choice forced into config. Invalidating the cache makes the next
+ * `getConfig()` observe the new value, so this doubles as the in-process commit.
+ */
+function defaultPersistVectorSize(dim: number): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "memory.qdrant.vectorSize", dim);
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+/**
+ * Default `recreateCollectionsAtDim`: destroy + recreate both the v2
+ * concept-page collection and the v3 section collection at `dim`. Reuses the
+ * recreate helpers each store exports so the named-vector layout and payload
+ * indexes flow through the single creation code path. The `dim` is read from
+ * config (which the caller has already committed via `persistVectorSize` +
+ * cache invalidation) by the underlying `ensure*` calls.
+ */
+async function defaultRecreateCollectionsAtDim(
+  config: AssistantConfig,
+): Promise<void> {
+  await recreateConceptPageCollection();
+  await recreateSectionCollection(config);
+}
+
+/**
+ * Default `enqueueReembed`: enqueue the v2 reembed, plus the v3 maintain job
+ * when v3 is the live injected source for this assistant (its section
+ * collection only carries points under v3-live).
+ */
+function defaultEnqueueReembed(config: AssistantConfig): void {
+  enqueueMemoryJob("memory_v2_reembed", {});
+  if (isMemoryV3Live(config)) {
+    enqueueMemoryJob("memory_v3_maintain", {});
+  }
+}
+
+function defaultDeps(config: AssistantConfig): ReconcileDeps {
+  return {
+    probeBackendDimension,
+    readConceptPageCollectionDim,
+    decideEmbeddingReconcile,
+    persistVectorSize: defaultPersistVectorSize,
+    // The committed dimension becomes visible to same-process readers through
+    // the cache invalidation in `persistVectorSize`; the in-memory commit is an
+    // alias of that write rather than a separate mutation.
+    setInMemoryVectorSize: () => {},
+    recreateCollectionsAtDim: () => defaultRecreateCollectionsAtDim(config),
+    ensureCollections: async () => {
+      await ensureConceptPageCollection();
+      await ensureSectionCollection(config);
+    },
+    enqueueReembed: () => defaultEnqueueReembed(config),
+  };
+}
+
+/**
+ * Reconcile the committed Qdrant collection dimension against a live probe of
+ * the configured embedding backend, then execute the resulting action:
+ *
+ *  - `noop` — committed dimension already matches (or auto-mode declines to
+ *    thrash); no writes, no destructive calls.
+ *  - `commit-fresh` — fresh install adopts the reachable backend's dimension:
+ *    commit the dim, ensure the collections EXIST at it (create-if-absent, never
+ *    destroy), and enqueue a reembed.
+ *  - `migrate` — deliberate provider intent with a confirmed probe: commit the
+ *    new dim, then destroy + recreate the collections (the only destructive
+ *    path) and enqueue a reembed.
+ *  - `defer-degraded` — backend unreachable: no write, no destructive call;
+ *    warn and leave the collections untouched.
+ */
+export async function reconcileEmbeddingIdentity(
+  config: AssistantConfig,
+  deps: ReconcileDeps = defaultDeps(config),
+): Promise<ReconcileOutcome> {
+  const [committedDim, probe] = await Promise.all([
+    deps.readConceptPageCollectionDim(config),
+    deps.probeBackendDimension(config),
+  ]);
+
+  const action = deps.decideEmbeddingReconcile({
+    committedDim,
+    probeDim: probe?.dim ?? null,
+    configuredProvider: config.memory.embeddings.provider,
+  });
+
+  switch (action.kind) {
+    case "noop":
+      return { action: "noop", dim: committedDim };
+
+    case "commit-fresh": {
+      deps.setInMemoryVectorSize(action.dim);
+      deps.persistVectorSize(action.dim);
+      await deps.ensureCollections();
+      deps.enqueueReembed();
+      log.info(
+        { dim: action.dim },
+        "Committed fresh embedding dimension and ensured collections",
+      );
+      return { action: "commit-fresh", dim: action.dim };
+    }
+
+    case "migrate": {
+      deps.setInMemoryVectorSize(action.toDim);
+      deps.persistVectorSize(action.toDim);
+      await deps.recreateCollectionsAtDim(action.toDim);
+      deps.enqueueReembed();
+      log.warn(
+        { fromDim: action.fromDim, toDim: action.toDim },
+        "Migrated embedding dimension: recreated collections and enqueued reembed",
+      );
+      return {
+        action: "migrate",
+        fromDim: action.fromDim,
+        toDim: action.toDim,
+      };
+    }
+
+    case "defer-degraded":
+      log.warn(
+        { reason: action.reason },
+        "Deferring embedding-identity reconcile; backend unavailable — no destructive action taken",
+      );
+      return { action: "defer-degraded", reason: action.reason };
+  }
+}

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -705,6 +705,31 @@ export async function countConceptPagePoints(): Promise<number> {
 }
 
 /**
+ * Destructively delete and recreate the v2 concept-page collection at the
+ * configured `config.memory.qdrant.vectorSize`. Owned by the probe-gated
+ * startup reconcile, which is the only path permitted to make the
+ * destroy-before-confirm decision for a dimension migration (the lazy
+ * `ensureConceptPageCollection` path explicitly defers dimension drift here).
+ *
+ * Resets the in-process readiness latch and delegates creation to
+ * `ensureConceptPageCollection` so the named-vector layout, payload indexes,
+ * and reembed sentinel all flow through the single creation code path.
+ * Idempotent against an absent collection — a missing collection is treated as
+ * "already deleted" and the recreate proceeds.
+ */
+export async function recreateConceptPageCollection(): Promise<void> {
+  const client = getClient();
+  try {
+    await client.deleteCollection(MEMORY_V2_COLLECTION);
+  } catch (err) {
+    if (!isCollectionMissing(err)) throw err;
+  }
+  _collectionReady = false;
+  _collectionReadyPromise = null;
+  await ensureConceptPageCollection();
+}
+
+/**
  * Probe whether the v2 concept-page collection currently exists in Qdrant
  * **without** triggering creation. Read-only diagnostics use this to avoid
  * the side effect of bootstrapping storage just by inspecting it.

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -176,6 +176,28 @@ export async function ensureSectionCollection(
 }
 
 /**
+ * Destructively delete and recreate the section-grain collection at the
+ * configured `config.memory.qdrant.vectorSize`. Owned by the probe-gated
+ * startup reconcile, the only path permitted to make the destroy-before-confirm
+ * decision for a dimension migration (the lazy `ensureSectionCollection` path
+ * explicitly defers dimension drift). Resets the in-process readiness latch and
+ * delegates creation to `ensureSectionCollection` so the vector layout and
+ * payload index flow through the single creation code path. Idempotent against
+ * an absent collection.
+ */
+export async function recreateSectionCollection(
+  config: AssistantConfig,
+): Promise<void> {
+  const client = getSectionDenseClient(config);
+  const exists = await client.collectionExists(SECTION_COLLECTION);
+  if (exists.exists) {
+    await client.deleteCollection(SECTION_COLLECTION);
+  }
+  _collectionReady = false;
+  await ensureSectionCollection(config);
+}
+
+/**
  * `target_type` marker on `memory_embeddings` rows that cache section vectors.
  * Distinct from the v2 `concept_page` rows so the two caches never collide on a
  * shared `(targetType, targetId, provider, model)` key.


### PR DESCRIPTION
## Summary
- Add reconcileEmbeddingIdentity(): probe + decide + execute (commit-fresh / migrate / defer-degraded / noop)
- Only migrate deletes+recreates collections, and only after a confirmed probe
- defer-degraded performs zero destructive calls and zero config writes (tested)

Part of plan: embedding-dim-reconcile.md (PR 5 of 8)