### PR TITLE
feat(web): background-task detail side panel (desktop + mobile)

### DIFF
--- a/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for `BackgroundTaskDetailPanel` — the side-drawer body for a background
+ * bash/host_bash task. Asserts it renders the command, status, and (for a
+ * terminal task) the captured output, and wires the close handler through.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+import { BackgroundTaskDetailPanel } from "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel";
+
+const noop = () => {};
+
+function makeEntry(
+  overrides: Partial<BackgroundTaskEntry> = {},
+): BackgroundTaskEntry {
+  return {
+    id: "bg-abc12345",
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: "npm run build",
+    startedAt: 0,
+    status: "completed",
+    exitCode: 0,
+    output: "Build succeeded in 4.2s",
+    completedAt: 1,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("BackgroundTaskDetailPanel", () => {
+  test("renders command, status, and output for a terminal task", () => {
+    render(<BackgroundTaskDetailPanel entry={makeEntry()} onClose={noop} />);
+    // Command appears in both the header title and the command code block.
+    expect(screen.getAllByText("npm run build").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Completed")).toBeDefined();
+    expect(screen.getByText("Build succeeded in 4.2s")).toBeDefined();
+  });
+
+  test("hides the output section while the task is still running", () => {
+    render(
+      <BackgroundTaskDetailPanel
+        entry={makeEntry({ status: "running", output: undefined })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("Running")).toBeDefined();
+    expect(screen.queryByText("Output")).toBeNull();
+  });
+
+  test("close button fires onClose", () => {
+    let closed = 0;
+    render(
+      <BackgroundTaskDetailPanel
+        entry={makeEntry()}
+        onClose={() => {
+          closed += 1;
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Close task detail"));
+    expect(closed).toBe(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
@@ -1,0 +1,91 @@
+/**
+ * Side-drawer detail panel for a background bash/host_bash task — a terminal
+ * glyph + the command as title, a status badge, and the command / captured
+ * output as code blocks.
+ *
+ * Thin like `AcpRunDetailPanel`: reuses `DetailShell` + the shared `CodeBlock`
+ * rather than inventing new output rendering.
+ */
+
+import { SquareTerminal } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { DetailShell } from "@/domains/chat/components/detail-shell";
+import { CodeBlock } from "@/domains/chat/components/tool-detail-panel";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+import {
+  backgroundTaskStatusColor,
+  backgroundTaskStatusLabel,
+  isActiveBackgroundTaskStatus,
+} from "@/utils/background-task-status";
+
+export interface BackgroundTaskDetailPanelProps {
+  entry: BackgroundTaskEntry;
+  onClose: () => void;
+}
+
+/** Uppercase section label in `--content-tertiary`. */
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Typography
+      variant="label-small-default"
+      as="div"
+      className="mb-1.5 uppercase tracking-wider text-[var(--content-tertiary)]"
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/** Status pill — dot + label tinted by the task's semantic status color. */
+function StatusBadge({ status }: { status: BackgroundTaskEntry["status"] }) {
+  const color = backgroundTaskStatusColor(status);
+  return (
+    <div
+      className="mb-4 inline-flex items-center gap-1.5 text-label-small-default"
+      style={{ color }}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      {backgroundTaskStatusLabel(status)}
+    </div>
+  );
+}
+
+export function BackgroundTaskDetailPanel({
+  entry,
+  onClose,
+}: BackgroundTaskDetailPanelProps) {
+  // Output is only meaningful once the task has settled (terminal status).
+  const showOutput =
+    !isActiveBackgroundTaskStatus(entry.status) &&
+    entry.output !== undefined &&
+    entry.output !== "";
+
+  return (
+    <DetailShell
+      Glyph={SquareTerminal}
+      title={entry.command}
+      closeLabel="Close task detail"
+      onClose={onClose}
+    >
+      <StatusBadge status={entry.status} />
+
+      <div>
+        <SectionLabel>Command</SectionLabel>
+        <CodeBlock text={entry.command} />
+      </div>
+
+      {showOutput && (
+        <div className="mt-5">
+          <SectionLabel>Output</SectionLabel>
+          <CodeBlock text={entry.output as string} />
+        </div>
+      )}
+    </DetailShell>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -27,6 +27,7 @@ import { useViewerStore } from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useEditApp } from "@/hooks/use-edit-app";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
@@ -42,6 +43,10 @@ const importAcpRunDetailPanel = () =>
   import("@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel");
 const importWorkflowDetailPanel = () =>
   import("@/domains/chat/components/workflow-detail-panel");
+const importBackgroundTaskDetailPanel = () =>
+  import(
+    "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel"
+  );
 
 const SubagentDetailPanel = lazy(() =>
   importSubagentDetailPanel().then((m) => ({ default: m.SubagentDetailPanel })),
@@ -54,6 +59,11 @@ const WorkflowDetailPanel = lazy(() =>
 );
 const ToolDetailPanel = lazy(() =>
   importToolDetailPanel().then((m) => ({ default: m.ToolDetailPanel })),
+);
+const BackgroundTaskDetailPanel = lazy(() =>
+  importBackgroundTaskDetailPanel().then((m) => ({
+    default: m.BackgroundTaskDetailPanel,
+  })),
 );
 
 // ---------------------------------------------------------------------------
@@ -80,6 +90,11 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   // Active run's entry only — same narrow selector as the subagent entry above.
   const activeAcpRunEntry = useAcpRunStore((s) =>
     activeAcpRunId ? s.byId[activeAcpRunId] : undefined,
+  );
+  const activeBackgroundTaskId = useViewerStore.use.activeBackgroundTaskId();
+  // Active task's entry only — same narrow selector as the entries above.
+  const activeBackgroundTaskEntry = useBackgroundTaskStore((s) =>
+    activeBackgroundTaskId ? s.byId[activeBackgroundTaskId] : undefined,
   );
 
   const isSharing = useDeployStore.use.isSharing();
@@ -165,6 +180,10 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     useViewerStore.getState().closeAcpRunDetail();
   }, []);
 
+  const onCloseBackgroundTaskDetail = useCallback(() => {
+    useViewerStore.getState().closeBackgroundTaskDetail();
+  }, []);
+
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
   // thought process, subagent detail, workflow detail, acp run detail,
@@ -201,6 +220,9 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
         case "acp-run-detail":
           viewer.closeAcpRunDetail();
           break;
+        case "background-task-detail":
+          viewer.closeBackgroundTaskDetail();
+          break;
         case "document":
           viewer.closeDocument();
           break;
@@ -224,6 +246,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       importToolDetailPanel().catch(() => {});
       importAcpRunDetailPanel().catch(() => {});
       importWorkflowDetailPanel().catch(() => {});
+      importBackgroundTaskDetailPanel().catch(() => {});
     };
     if (typeof window.requestIdleCallback === "function") {
       const id = window.requestIdleCallback(run);
@@ -366,6 +389,19 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           <AcpRunDetailPanel
             entry={activeAcpRunEntry}
             onClose={onCloseAcpRunDetail}
+          />
+        </LazyBoundary>
+      );
+    } else if (
+      mainView === "background-task-detail" &&
+      activeBackgroundTaskId &&
+      activeBackgroundTaskEntry
+    ) {
+      rightPanel = (
+        <LazyBoundary>
+          <BackgroundTaskDetailPanel
+            entry={activeBackgroundTaskEntry}
+            onClose={onCloseBackgroundTaskDetail}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/mobile-background-task-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-background-task-detail-overlay.tsx
@@ -1,0 +1,46 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+
+const BackgroundTaskDetailPanel = lazy(() =>
+  import(
+    "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel"
+  ).then((m) => ({ default: m.BackgroundTaskDetailPanel })),
+);
+
+interface MobileBackgroundTaskDetailOverlayProps {
+  entry: BackgroundTaskEntry | null;
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the background-task detail panel.
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ */
+export function MobileBackgroundTaskDetailOverlay({
+  entry,
+  onClose,
+}: MobileBackgroundTaskDetailOverlayProps) {
+  if (!entry) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+    >
+      <LazyBoundary>
+        <BackgroundTaskDetailPanel entry={entry} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -15,6 +15,7 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -22,6 +23,7 @@ import { routes } from "@/utils/routes";
 
 import { MobileAcpRunDetailOverlay } from "@/domains/chat/components/mobile-acp-run-detail-overlay";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
+import { MobileBackgroundTaskDetailOverlay } from "@/domains/chat/components/mobile-background-task-detail-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
 import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
@@ -42,9 +44,11 @@ export function MobileChatOverlays() {
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const activeAcpRunId = useViewerStore.use.activeAcpRunId();
+  const activeBackgroundTaskId = useViewerStore.use.activeBackgroundTaskId();
   const subagentById = useSubagentStore.use.byId();
   const workflowById = useWorkflowStore.use.byId();
   const acpRunById = useAcpRunStore.use.byId();
+  const backgroundTaskById = useBackgroundTaskStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
   const handleCloseApp = useCallback(() => {
@@ -117,6 +121,10 @@ export function MobileChatOverlays() {
     useViewerStore.getState().closeAcpRunDetail();
   }, []);
 
+  const handleCloseBackgroundTaskDetail = useCallback(() => {
+    useViewerStore.getState().closeBackgroundTaskDetail();
+  }, []);
+
   const handleCloseToolDetail = useCallback(() => {
     useViewerStore.getState().closeToolDetail();
   }, []);
@@ -176,6 +184,14 @@ export function MobileChatOverlays() {
             : null
         }
         onClose={handleCloseAcpRunDetail}
+      />
+      <MobileBackgroundTaskDetailOverlay
+        entry={
+          mainView === "background-task-detail" && activeBackgroundTaskId
+            ? backgroundTaskById[activeBackgroundTaskId] ?? null
+            : null
+        }
+        onClose={handleCloseBackgroundTaskDetail}
       />
       <MobileToolDetailOverlay
         detail={mainView === "tool-detail" ? activeToolDetail : null}


### PR DESCRIPTION
## Summary
- Add background-task detail panel (command + output + status) wired into the right drawer
- Add the mobile full-screen overlay variant

Part of plan: bash-bg-task-ui.md (PR 11 of 13)