### PR TITLE
feat(web): rehydrate running background tasks from the daemon on load

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -22,6 +22,7 @@ import { type Dispatch, type MutableRefObject, type ReactNode, type RefObject, t
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
 import { useAcpRunRehydration } from "@/domains/chat/hooks/use-acp-run-rehydration";
+import { useBackgroundTaskRehydration } from "@/domains/chat/hooks/use-background-task-rehydration";
 import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
@@ -283,6 +284,10 @@ export function ChatMainPanel({
   // Rehydrate ACP runs from the daemon on conversation load so completed and
   // in-progress runs reappear after a refresh / reconnect.
   useAcpRunRehydration(assistantId, activeConversationId);
+
+  // Rehydrate still-running background tasks from the daemon so they reappear
+  // as active entries after a refresh.
+  useBackgroundTaskRehydration(activeConversationId);
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);

--- a/clients/web/src/domains/chat/hooks/use-background-task-rehydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-background-task-rehydration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `fetchBackgroundTasks` + `applyBackgroundTaskSnapshot`. We mock the
+ * generated `backgroundtoolsGet` SDK fn so we can stage `background-tools`
+ * responses and assert the rehydrated entries plus the known-vs-in-flight
+ * retirement logic.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface FakeRequest {
+  path?: Record<string, string>;
+  query?: Record<string, unknown>;
+}
+
+interface FakeResponse {
+  status: number;
+  body?: unknown;
+}
+
+const requests: FakeRequest[] = [];
+let nextResponses: FakeResponse[] = [];
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  backgroundtoolsGet: async ({
+    path,
+    query,
+  }: {
+    path?: Record<string, string>;
+    query?: Record<string, unknown>;
+    throwOnError?: boolean;
+  }) => {
+    requests.push({ path, query });
+    const next = nextResponses.shift();
+    if (!next) throw new Error("No staged response for backgroundtoolsGet");
+    const response = {
+      status: next.status,
+      ok: next.status >= 200 && next.status < 300,
+    };
+    return { data: next.body, response };
+  },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+// Subject imported after mocks.
+import {
+  applyBackgroundTaskSnapshot,
+  fetchBackgroundTasks,
+} from "@/domains/chat/hooks/use-background-task-rehydration";
+import {
+  useBackgroundTaskStore,
+  type BackgroundTaskEntry,
+} from "@/domains/chat/background-task-store";
+
+const NOW = 1700000000000;
+
+function getState() {
+  return useBackgroundTaskStore.getState();
+}
+
+function toolRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "bg-1",
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: "sleep 10",
+    startedAt: NOW,
+    ...overrides,
+  };
+}
+
+function runningEntry(
+  id: string,
+  conversationId = "conv-1",
+): BackgroundTaskEntry {
+  return {
+    id,
+    toolName: "bash",
+    conversationId,
+    command: "sleep 10",
+    startedAt: NOW,
+    status: "running",
+  };
+}
+
+beforeEach(() => {
+  requests.length = 0;
+  nextResponses = [];
+  getState().reset();
+});
+
+afterEach(() => {
+  getState().reset();
+});
+
+describe("fetchBackgroundTasks", () => {
+  test("requests the assistant-scoped route filtered by conversation", async () => {
+    nextResponses = [{ status: 200, body: { tools: [] } }];
+    await fetchBackgroundTasks("asst-1", "conv-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.path).toEqual({ assistant_id: "asst-1" });
+    expect(requests[0]!.query).toEqual({ conversationId: "conv-1" });
+  });
+
+  test("maps returned tools to running entries", async () => {
+    nextResponses = [{ status: 200, body: { tools: [toolRow()] } }];
+    const entries = await fetchBackgroundTasks("asst-1", "conv-1");
+
+    expect(entries).toEqual([
+      {
+        id: "bg-1",
+        toolName: "bash",
+        conversationId: "conv-1",
+        command: "sleep 10",
+        startedAt: NOW,
+        status: "running",
+      },
+    ]);
+  });
+
+  test("returns null on a non-ok response (distinct from an empty snapshot)", async () => {
+    nextResponses = [{ status: 500, body: null }];
+    expect(await fetchBackgroundTasks("asst-1", "conv-1")).toBeNull();
+  });
+});
+
+describe("rehydration", () => {
+  test("a list response seeds running entries", async () => {
+    nextResponses = [{ status: 200, body: { tools: [toolRow()] } }];
+    const entries = await fetchBackgroundTasks("asst-1", "conv-1");
+    applyBackgroundTaskSnapshot(entries, []);
+
+    const entry = getState().byId["bg-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.command).toBe("sleep 10");
+    expect(getState().orderedIds).toContain("bg-1");
+  });
+
+  test("retires a known task absent from the snapshot", () => {
+    getState().seedFromHistory([runningEntry("bg-1")]);
+    // bg-1 existed before the fetch and the daemon no longer reports it.
+    applyBackgroundTaskSnapshot([], ["bg-1"]);
+
+    expect(getState().byId["bg-1"]!.status).toBe("cancelled");
+  });
+
+  test("leaves an in-flight-started (not-known) task running", () => {
+    // bg-2 started after the snapshot was captured: in the store but absent
+    // from `knownIds`, so retirement must skip it.
+    getState().seedFromHistory([runningEntry("bg-2")]);
+    applyBackgroundTaskSnapshot([], []);
+
+    expect(getState().byId["bg-2"]!.status).toBe("running");
+  });
+
+  test("keeps a task still reported by the snapshot running", () => {
+    getState().seedFromHistory([runningEntry("bg-1")]);
+    applyBackgroundTaskSnapshot([runningEntry("bg-1")], ["bg-1"]);
+
+    expect(getState().byId["bg-1"]!.status).toBe("running");
+  });
+
+  test("a null snapshot (failed fetch) reconciles nothing", () => {
+    getState().seedFromHistory([runningEntry("bg-1")]);
+    applyBackgroundTaskSnapshot(null, ["bg-1"]);
+
+    expect(getState().byId["bg-1"]!.status).toBe("running");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-background-task-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-background-task-rehydration.ts
@@ -1,0 +1,111 @@
+/**
+ * Rehydrate in-flight background tasks from the daemon on conversation load.
+ *
+ * On conversation change, fetch the daemon's active `background-tools` list for
+ * the conversation and `seedFromHistory` the background-task store so tasks
+ * still running on the daemon reappear as active entries after a refresh.
+ *
+ * The list route carries no exit/output, so seeded entries are always
+ * "running" until a `background_tool_completed` event settles them.
+ *
+ * An authoritative snapshot also retires tasks the daemon no longer reports —
+ * the daemon restarted and lost the subprocess, so no completion event will
+ * ever land. `knownIds` is captured BEFORE the fetch (scoped to this
+ * conversation) so a task spawned mid-flight — present in the store but absent
+ * from the pre-fetch snapshot — is left running rather than wrongly retired.
+ */
+
+import { useEffect } from "react";
+
+import { backgroundtoolsGet } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+  useBackgroundTaskStore,
+  type BackgroundTaskEntry,
+} from "@/domains/chat/background-task-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+/** A single active-tool row from the daemon list route. */
+type BackgroundToolListItem =
+  NonNullable<
+    Awaited<ReturnType<typeof backgroundtoolsGet>>["data"]
+  >["tools"][number];
+
+function toTaskEntry(tool: BackgroundToolListItem): BackgroundTaskEntry {
+  return {
+    id: tool.id,
+    toolName: tool.toolName,
+    conversationId: tool.conversationId,
+    command: tool.command,
+    startedAt: tool.startedAt,
+    status: "running",
+  };
+}
+
+/**
+ * Fetch the authoritative active-task snapshot for a conversation. Returns
+ * `null` on a failed/non-ok fetch so callers distinguish "couldn't load" from
+ * an authoritative empty snapshot (which must retire stale tasks).
+ */
+export async function fetchBackgroundTasks(
+  assistantId: string,
+  conversationId: string,
+): Promise<BackgroundTaskEntry[] | null> {
+  try {
+    const { data, response } = await backgroundtoolsGet({
+      path: { assistant_id: assistantId },
+      query: { conversationId },
+      throwOnError: false,
+    });
+    if (!response?.ok || !data?.tools) return null;
+    return data.tools.map(toTaskEntry);
+  } catch (err) {
+    captureError(err, { context: "fetchBackgroundTasks" });
+    return null;
+  }
+}
+
+/** Ids of tasks in the store that belong to `conversationId`. */
+function knownTaskIdsFor(conversationId: string): string[] {
+  const { byId } = useBackgroundTaskStore.getState();
+  return Object.keys(byId).filter(
+    (id) => byId[id]?.conversationId === conversationId,
+  );
+}
+
+/**
+ * Apply an authoritative snapshot: seed the reported running tasks and retire
+ * any task known before the fetch that the daemon no longer reports. A `null`
+ * snapshot means the fetch failed, so nothing is reconciled.
+ */
+export function applyBackgroundTaskSnapshot(
+  entries: BackgroundTaskEntry[] | null,
+  knownIds: string[],
+): void {
+  if (entries === null) return;
+  const store = useBackgroundTaskStore.getState();
+  if (entries.length > 0) store.seedFromHistory(entries);
+  store.retireMissing(
+    entries.map((e) => e.id),
+    knownIds,
+  );
+}
+
+export function useBackgroundTaskRehydration(
+  conversationId: string | null,
+): void {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+
+  useEffect(() => {
+    if (!assistantId || !conversationId) return;
+    let cancelled = false;
+    const knownIds = knownTaskIdsFor(conversationId);
+    void fetchBackgroundTasks(assistantId, conversationId).then((entries) => {
+      if (cancelled) return;
+      applyBackgroundTaskSnapshot(entries, knownIds);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantId, conversationId]);
+}


### PR DESCRIPTION
## Summary
- Add use-background-task-rehydration: seed running tasks from background_tool_list on load
- Retire known tasks absent from the snapshot (knownIds-scoped to avoid an in-flight race)

Part of plan: bash-bg-task-ui.md (PR 13 of 13)