### PR TITLE
feat(web): inline progress card for background bash tasks

### DIFF
--- a/clients/web/src/domains/chat/components/background-task-inline-card/background-task-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/background-task-inline-card/background-task-inline-progress-card.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for `BackgroundTaskInlineProgressCard` and its supporting id resolver.
+ *
+ *  - Card renders running / complete / cancelled / failed states from a seeded
+ *    background-task store, plus the start-race `null` fallback and the
+ *    header-click + stop callbacks.
+ *  - `resolveBackgroundTaskIds` resolves via the result-parse, dedupes through
+ *    the caller-owned `claimed` Set, and skips foreground / result-less calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// The card cancels the task via `stopBackgroundTask`. Mock the action so the
+// self-contained path is observable without hitting the daemon client.
+const stopBackgroundTaskCalls: string[] = [];
+mock.module("@/domains/chat/utils/background-task-actions", () => ({
+  stopBackgroundTask: async (id: string) => {
+    stopBackgroundTaskCalls.push(id);
+  },
+}));
+
+import { BackgroundTaskInlineProgressCard } from "@/domains/chat/components/background-task-inline-card/background-task-inline-progress-card";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import { resolveBackgroundTaskIds } from "@/domains/chat/transcript/transcript-message-body-shared";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+const NOW = 1700000000000;
+const STATUS_TESTID = "background-task-inline-card-status-indicator";
+const STOP_TESTID = "background-task-inline-card-stop";
+
+beforeEach(() => {
+  useBackgroundTaskStore.getState().reset();
+  stopBackgroundTaskCalls.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Store seeding helpers
+// ---------------------------------------------------------------------------
+
+function start(id: string, command = "ls -la") {
+  useBackgroundTaskStore.getState().startTask({
+    type: "background_tool_started",
+    id,
+    toolName: "bash",
+    conversationId: "conv-1",
+    command,
+    startedAt: NOW,
+  });
+}
+
+function complete(
+  id: string,
+  status: "completed" | "failed" | "cancelled",
+  exitCode: number | null = 0,
+): void {
+  useBackgroundTaskStore.getState().completeTask({
+    type: "background_tool_completed",
+    id,
+    conversationId: "conv-1",
+    status,
+    exitCode,
+    completedAt: NOW + 1000,
+  });
+}
+
+function toolCall(overrides: Partial<ChatMessageToolCall>): ChatMessageToolCall {
+  return {
+    id: "tc-1",
+    name: "bash",
+    input: { background: true },
+    ...overrides,
+  } as ChatMessageToolCall;
+}
+
+// ---------------------------------------------------------------------------
+// Card render
+// ---------------------------------------------------------------------------
+
+describe("BackgroundTaskInlineProgressCard — start race", () => {
+  test("renders null when no entry exists in the store yet", () => {
+    const { container } = render(
+      <BackgroundTaskInlineProgressCard id="missing" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("BackgroundTaskInlineProgressCard — states", () => {
+  test("running task shows the three-dot loading indicator and stop button", () => {
+    act(() => start("bg-run"));
+
+    const { getByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-run" />,
+    );
+
+    const indicator = getByTestId(STATUS_TESTID);
+    // The loading indicator is the ThreeDotIndicator span (no `data-state`).
+    expect(indicator.getAttribute("data-state")).toBeNull();
+    expect(getByTestId(STOP_TESTID)).toBeDefined();
+  });
+
+  test("renders the command as the header info", () => {
+    act(() => start("bg-cmd", "npm run build"));
+
+    const { getAllByText } = render(
+      <BackgroundTaskInlineProgressCard id="bg-cmd" />,
+    );
+    expect(getAllByText("npm run build").length).toBeGreaterThan(0);
+  });
+
+  test("completed task renders the complete status icon and no stop button", () => {
+    act(() => {
+      start("bg-done");
+      complete("bg-done", "completed");
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-done" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe(
+      "complete",
+    );
+    expect(queryByTestId(STOP_TESTID)).toBeNull();
+  });
+
+  test("cancelled task renders the warning icon", () => {
+    act(() => {
+      start("bg-cancel");
+      useBackgroundTaskStore.getState().cancelTask("bg-cancel");
+    });
+
+    const { getByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-cancel" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe(
+      "warning",
+    );
+  });
+
+  test("failed task renders the error icon", () => {
+    act(() => {
+      start("bg-fail");
+      complete("bg-fail", "failed", 1);
+    });
+
+    const { getByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-fail" />,
+    );
+    expect(getByTestId(STATUS_TESTID).getAttribute("data-state")).toBe("error");
+  });
+});
+
+describe("BackgroundTaskInlineProgressCard — interaction", () => {
+  test("clicking the header row invokes onClick with the task id", () => {
+    act(() => start("bg-open"));
+    const seen: string[] = [];
+    const { getByRole } = render(
+      <BackgroundTaskInlineProgressCard
+        id="bg-open"
+        onClick={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: /open command/i }));
+    expect(seen).toEqual(["bg-open"]);
+  });
+
+  test("stop button cancels via stopBackgroundTask and disables after click", () => {
+    act(() => start("bg-stop"));
+    const { getByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-stop" />,
+    );
+    const button = getByTestId(STOP_TESTID);
+    fireEvent.click(button);
+    expect(stopBackgroundTaskCalls).toEqual(["bg-stop"]);
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  test("stop button disappears once the task reaches a terminal status", () => {
+    act(() => start("bg-terminal"));
+    const { getByTestId, queryByTestId } = render(
+      <BackgroundTaskInlineProgressCard id="bg-terminal" />,
+    );
+    fireEvent.click(getByTestId(STOP_TESTID));
+    expect(stopBackgroundTaskCalls).toEqual(["bg-terminal"]);
+
+    act(() => complete("bg-terminal", "cancelled"));
+    expect(queryByTestId(STOP_TESTID)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBackgroundTaskIds
+// ---------------------------------------------------------------------------
+
+describe("resolveBackgroundTaskIds", () => {
+  test("resolves the bg id from a backgrounded call's result", () => {
+    const tc = toolCall({
+      result: JSON.stringify({ backgrounded: true, id: "bg-1" }),
+    });
+    expect(resolveBackgroundTaskIds([tc], new Set())).toEqual(["bg-1"]);
+  });
+
+  test("skips a foreground bash call", () => {
+    const tc = toolCall({
+      input: { background: false },
+      result: JSON.stringify({ backgrounded: true, id: "bg-2" }),
+    });
+    expect(resolveBackgroundTaskIds([tc], new Set())).toEqual([]);
+  });
+
+  test("skips a backgrounded call whose result hasn't landed", () => {
+    expect(resolveBackgroundTaskIds([toolCall({})], new Set())).toEqual([]);
+  });
+
+  test("claimed set prevents two calls anchoring the same id", () => {
+    const calls = [
+      toolCall({
+        id: "tc-1",
+        result: JSON.stringify({ backgrounded: true, id: "bg-shared" }),
+      }),
+      toolCall({
+        id: "tc-2",
+        result: JSON.stringify({ backgrounded: true, id: "bg-shared" }),
+      }),
+    ];
+    expect(resolveBackgroundTaskIds(calls, new Set())).toEqual(["bg-shared"]);
+  });
+});

--- a/clients/web/src/domains/chat/components/background-task-inline-card/background-task-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/background-task-inline-card/background-task-inline-progress-card.tsx
@@ -1,0 +1,101 @@
+/**
+ * Inline background-task progress card rendered per backgrounded `bash` /
+ * `host_bash` run in the assistant transcript. Built on `ToolProgressCardShell`
+ * with a `SquareTerminal` glyph slotted into the leading-icon slot.
+ *
+ * Subscribes to the background task store via `useBackgroundTaskCardData(id)`,
+ * which returns `null` until the task's entry lands — the window where the
+ * assistant message containing the inline card mounts a hair before the
+ * `background_tool_started` event. The card renders `null` in that window so the
+ * transcript layout doesn't jiggle.
+ *
+ * Interaction model mirrors the ACP / subagent / workflow inline cards:
+ *   - Clicking anywhere on the header row opens the task's detail panel via
+ *     `onClick`. There is no inline expand — the panel is the detail view.
+ *   - Stop cancels the task via `stopBackgroundTask` while it is running. The
+ *     button disables after a click to avoid a double-cancel.
+ */
+
+import { Square, SquareTerminal } from "lucide-react";
+import { useCallback, useState, type MouseEvent } from "react";
+
+import { Button } from "@vellumai/design-library";
+
+import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { useBackgroundTaskCardData } from "@/domains/chat/components/background-task-inline-card/use-background-task-card-data";
+import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
+import { captureError } from "@/lib/sentry/capture-error";
+
+export interface BackgroundTaskInlineProgressCardProps {
+  id: string;
+  /** Open the task's detail panel (header-row activation, not the stop button). */
+  onClick?: (id: string) => void;
+}
+
+export function BackgroundTaskInlineProgressCard({
+  id,
+  onClick,
+}: BackgroundTaskInlineProgressCardProps) {
+  const data = useBackgroundTaskCardData(id);
+  // The shell's `loading` state is the live window where stopping the task is a
+  // meaningful action (see `deriveCardState`).
+  const isRunning = data?.state === "loading";
+  const [stopping, setStopping] = useState(false);
+
+  const handleHeaderClick = useCallback(() => {
+    onClick?.(id);
+  }, [onClick, id]);
+
+  const handleStop = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      setStopping(true);
+      void stopBackgroundTask(id).catch((err) => {
+        setStopping(false);
+        captureError(err, { context: "BackgroundTaskInlineProgressCard.stop" });
+      });
+    },
+    [id],
+  );
+
+  // Start race: no entry yet (see header).
+  if (!data) return null;
+
+  const leadingIcon = <SquareTerminal size={20} aria-hidden />;
+
+  const actionSlot = isRunning ? (
+    <Button
+      variant="dangerGhost"
+      size="compact"
+      iconOnly={<Square fill="currentColor" />}
+      aria-label="Stop command"
+      data-testid="background-task-inline-card-stop"
+      disabled={stopping}
+      onClick={handleStop}
+    />
+  ) : undefined;
+
+  return (
+    <div className="w-full" data-testid="background-task-inline-progress-card">
+      <ToolProgressCardShell
+        data-testid="background-task-inline-card-shell"
+        statusIndicatorTestId="background-task-inline-card-status-indicator"
+        state={data.state}
+        leadingIcon={leadingIcon}
+        currentStepTitle={data.title}
+        currentStepInfo={data.info}
+        // Background tasks have no discrete steps, so the count pill stays empty.
+        stepCount=""
+        // No inline timeline to reveal — the detail panel is the only detail
+        // view, so the expanded body stays disabled.
+        disableExpand
+        headerActionSlot={actionSlot}
+        onHeaderClick={onClick ? handleHeaderClick : undefined}
+        headerAriaLabel={onClick ? "Open command" : undefined}
+      >
+        {/* Children unused — `disableExpand` suppresses the body region. */}
+        <span className="hidden" />
+      </ToolProgressCardShell>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/background-task-inline-card/use-background-task-card-data.ts
+++ b/clients/web/src/domains/chat/components/background-task-inline-card/use-background-task-card-data.ts
@@ -1,0 +1,79 @@
+/**
+ * Builds the props for `BackgroundTaskInlineProgressCard` from a single
+ * background task's store entry. Maps the task status to the shared
+ * tool-progress card props — the same shape the workflow, subagent, and ACP
+ * inline cards feed their shells.
+ *
+ * Returns `null` when no entry exists for the given id yet — the window where
+ * the assistant message containing the inline card mounts a hair before the
+ * `background_tool_started` event lands. The card renders `null` in that window
+ * so the transcript layout doesn't jiggle, mirroring `useAcpRunCardData`.
+ *
+ * Visual-state and copy mapping live in `deriveCardState` / `deriveTitle`.
+ */
+
+import { useMemo } from "react";
+
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import type { BackgroundTaskStatus } from "@/utils/background-task-status";
+
+export interface BackgroundTaskCardData {
+  state: ToolProgressCardState;
+  /** Header headline, keyed off the task status. */
+  title: string;
+  /** Secondary descriptor — the command being run. */
+  info: string;
+}
+
+/**
+ * Translate the task status to a shell-compatible visual state. A `cancelled`
+ * task reads as a `warning` (user-stopped, partial work); a `failed` one as an
+ * `error`.
+ */
+function deriveCardState(status: BackgroundTaskStatus): ToolProgressCardState {
+  switch (status) {
+    case "running":
+      return "loading";
+    case "completed":
+      return "complete";
+    case "cancelled":
+      return "warning";
+    case "failed":
+      return "error";
+  }
+}
+
+/** Header headline for each task status. */
+function deriveTitle(status: BackgroundTaskStatus): string {
+  switch (status) {
+    case "running":
+      return "Running command";
+    case "completed":
+      return "Command finished";
+    case "cancelled":
+      return "Command cancelled";
+    case "failed":
+      return "Command failed";
+  }
+}
+
+/**
+ * React hook: subscribe to the background task store entry for `id` and project
+ * it into card props. Returns `null` when no entry exists yet so callers can
+ * short-circuit rendering.
+ */
+export function useBackgroundTaskCardData(
+  id: string,
+): BackgroundTaskCardData | null {
+  const entry = useBackgroundTaskStore((s) => s.byId[id]);
+
+  return useMemo(() => {
+    if (!entry) return null;
+    return {
+      state: deriveCardState(entry.status),
+      title: deriveTitle(entry.status),
+      info: entry.command,
+    };
+  }, [entry]);
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -345,6 +345,35 @@ export function extractBgIdFromResult(
 }
 
 /**
+ * Resolve the `bg-…` id for each backgrounded `bash`/`host_bash` tool call in
+ * `toolCalls`. Unlike the subagent/workflow/ACP triad there is no `byToolUseId`
+ * anchor — the id is carried only on the call's synchronous result, so each id
+ * resolves via {@link extractBgIdFromResult}. A foreground command or a call
+ * whose result hasn't landed resolves to nothing and is skipped.
+ *
+ * The caller owns the `claimed` Set so it persists across every invocation
+ * within a single message, stopping two non-consecutive background tool-call
+ * groups from both anchoring the same task id.
+ */
+export function resolveBackgroundTaskIds(
+  toolCalls: ChatMessageToolCall[],
+  claimed: Set<string>,
+): string[] {
+  const ids: string[] = [];
+
+  for (const tc of toolCalls) {
+    if (!isBackgroundBashCall(tc)) continue;
+    const id = extractBgIdFromResult(tc);
+    if (id && !claimed.has(id)) {
+      ids.push(id);
+      claimed.add(id);
+    }
+  }
+
+  return ids;
+}
+
+/**
  * The `acpSessionId` a single `acp_spawn` tool call resolves to — its
  * `byToolUseId` anchor (from the `acp_session_spawned` event), else the id
  * encoded in its result — or `null` when none is available (e.g. the call

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -18,6 +18,7 @@ import { MessageHoverActions } from "@/domains/chat/components/message-hover-act
 import { SubagentSpawnGroup } from "@/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group";
 import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
+import { BackgroundTaskInlineProgressCard } from "@/domains/chat/components/background-task-inline-card/background-task-inline-progress-card";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import { SingleActivity } from "@/domains/chat/components/single-activity/single-activity";
 import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
@@ -38,15 +39,18 @@ import { isPointerCoarse } from "@/utils/pointer";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
 import {
   computeCardBackedWorkflowRunIds,
+  extractBgIdFromResult,
   isInteractiveClickTarget,
   lookupSubagentEntriesForMessage,
   acpRunIdForCall,
   resolveAcpRunIds,
+  resolveBackgroundTaskIds,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -216,10 +220,34 @@ export function TranscriptMessageBody({
     () => new Set(cardBackedAcpKey ? cardBackedAcpKey.split("|") : []),
     [cardBackedAcpKey],
   );
+  // The background-task ids in THIS message whose `bash`/`host_bash` chip is
+  // suppressed in favor of an inline card ("card-backed"). Mirrors the ACP gate:
+  // a bg id is card-backed only when an entry exists in the store, so a
+  // backgrounded call whose start event hasn't landed (or whose store wiring
+  // isn't present yet) keeps rendering its tool result instead of vanishing
+  // behind a card with nothing to show.
+  const cardBackedBgKey = useBackgroundTaskStore(
+    useCallback(
+      (s) => {
+        const ids: string[] = [];
+        for (const tc of message.toolCalls ?? []) {
+          const id = extractBgIdFromResult(tc);
+          if (id !== undefined && s.byId[id] !== undefined) ids.push(id);
+        }
+        return ids.join("|");
+      },
+      [message.toolCalls],
+    ),
+  );
+  const cardBackedBackgroundTaskIds = useMemo(
+    () => new Set(cardBackedBgKey ? cardBackedBgKey.split("|") : []),
+    [cardBackedBgKey],
+  );
 
   const claimedSpawnIds = new Set<string>();
   const claimedWorkflowIds = new Set<string>();
   const claimedAcpIds = new Set<string>();
+  const claimedBackgroundTaskIds = new Set<string>();
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -228,8 +256,17 @@ export function TranscriptMessageBody({
     const id = acpRunIdForCall(tc, byToolUseIdAcp);
     return id !== null && cardBackedAcpRunIds.has(id) ? id : null;
   };
+  const cardBackedBackgroundTaskId = (
+    tc: ChatMessageToolCall,
+  ): string | null => {
+    const id = extractBgIdFromResult(tc);
+    return id !== undefined && cardBackedBackgroundTaskIds.has(id) ? id : null;
+  };
   const handleAcpRunClick = useCallback((acpSessionId: string) => {
     useViewerStore.getState().openAcpRunDetail(acpSessionId);
+  }, []);
+  const handleBackgroundTaskClick = useCallback((id: string) => {
+    useViewerStore.getState().openBackgroundTaskDetail(id);
   }, []);
 
   const handleVellumLinkClick = useCallback(
@@ -346,6 +383,24 @@ export function TranscriptMessageBody({
     );
   };
 
+  const renderInlineBackgroundTaskCards = (
+    toolCalls: ChatMessageToolCall[],
+  ) => {
+    const taskIds = resolveBackgroundTaskIds(toolCalls, claimedBackgroundTaskIds);
+    if (taskIds.length === 0) return null;
+    return (
+      <div className="flex w-full flex-col gap-1.5">
+        {taskIds.map((id) => (
+          <BackgroundTaskInlineProgressCard
+            key={id}
+            id={id}
+            onClick={handleBackgroundTaskClick}
+          />
+        ))}
+      </div>
+    );
+  };
+
   const renderToolResultImages = (toolCalls: ChatMessageToolCall[]) => {
     if (hasAttachments) return null;
     const images = toolCalls.flatMap((tc) => {
@@ -418,14 +473,16 @@ export function TranscriptMessageBody({
       }
     }
     const renderableToolCalls = groupToolCalls.filter(
-      // Suppress the raw chip only for a card-backed run_workflow / acp_spawn
-      // call (see cardBackedWorkflowRunId / cardBackedAcpRunId). A failed call
-      // (no id) or a run with no store entry is not card-backed, so it renders
-      // its tool result instead of vanishing.
+      // Suppress the raw chip only for a card-backed run_workflow / acp_spawn /
+      // background bash call (see cardBackedWorkflowRunId / cardBackedAcpRunId /
+      // cardBackedBackgroundTaskId). A failed call (no id) or a run with no
+      // store entry is not card-backed, so it renders its tool result instead
+      // of vanishing.
       (tc) =>
         !isSubagentSpawnCall(tc) &&
         cardBackedWorkflowRunId(tc) === null &&
-        cardBackedAcpRunId(tc) === null,
+        cardBackedAcpRunId(tc) === null &&
+        cardBackedBackgroundTaskId(tc) === null,
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -443,6 +500,7 @@ export function TranscriptMessageBody({
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
           {renderInlineAcpRunCards(groupToolCalls)}
+          {renderInlineBackgroundTaskCards(groupToolCalls)}
         </Fragment>
       );
     }
@@ -457,7 +515,8 @@ export function TranscriptMessageBody({
           .filter(
             (tc) =>
               cardBackedWorkflowRunId(tc) !== null ||
-              cardBackedAcpRunId(tc) !== null,
+              cardBackedAcpRunId(tc) !== null ||
+              cardBackedBackgroundTaskId(tc) !== null,
           )
           .map((tc) => tc.id),
       );
@@ -492,6 +551,7 @@ export function TranscriptMessageBody({
           {renderInlineSubagentCards(groupToolCalls)}
           {renderInlineWorkflowCards(groupToolCalls)}
           {renderInlineAcpRunCards(groupToolCalls)}
+          {renderInlineBackgroundTaskCards(groupToolCalls)}
         </Fragment>
       );
     }
@@ -515,6 +575,7 @@ export function TranscriptMessageBody({
         {renderInlineSubagentCards(groupToolCalls)}
         {renderInlineWorkflowCards(groupToolCalls)}
         {renderInlineAcpRunCards(groupToolCalls)}
+        {renderInlineBackgroundTaskCards(groupToolCalls)}
       </Fragment>
     );
   };

--- a/clients/web/src/domains/chat/utils/background-task-actions.ts
+++ b/clients/web/src/domains/chat/utils/background-task-actions.ts
@@ -1,0 +1,48 @@
+/**
+ * Imperative actions for background bash/host_bash tasks: stop (cancel).
+ *
+ * Unlike the ACP routes, the daemon's `background-tools/cancel` endpoint IS in
+ * the generated web SDK, so this calls the generated `backgroundtoolsCancelPost`
+ * directly. The gateway proxies it via `/v1/assistants/{id}/background-tools/...`.
+ */
+
+import { backgroundtoolsCancelPost } from "@/generated/daemon/sdk.gen";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+function activeAssistantId(): string {
+  const id = useResolvedAssistantsStore.getState().activeAssistantId;
+  if (!id) throw new Error("No active assistant");
+  return id;
+}
+
+/**
+ * Cancel a running background task. Optimistically marks the task cancelled so
+ * the live card reflects the user's intent immediately; rolls the status back
+ * if the cancel request fails so the Stop control reappears.
+ */
+export async function stopBackgroundTask(id: string): Promise<void> {
+  // Resolve preconditions BEFORE the optimistic write so a missing active
+  // assistant can't leave the task stuck `cancelled` with no way back.
+  const assistantId = activeAssistantId();
+  const store = useBackgroundTaskStore.getState();
+  const prevStatus = store.byId[id]?.status;
+  store.cancelTask(id);
+  try {
+    const { response } = await backgroundtoolsCancelPost({
+      path: { assistant_id: assistantId },
+      body: { id },
+      throwOnError: false,
+    });
+    if (!response?.ok) {
+      throw new Error(`Failed to stop background task: ${response?.status}`);
+    }
+  } catch (err) {
+    // The cancel didn't land — roll back the optimistic `cancelled` so the task
+    // and its Stop control reappear.
+    if (prevStatus !== undefined) {
+      useBackgroundTaskStore.getState().restoreTaskStatus(id, prevStatus);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- Add background-task inline progress card + card-data hook (terminal glyph, stop button)
- Render it from the transcript and suppress the raw tool chip for card-backed background calls

Part of plan: bash-bg-task-ui.md (PR 10 of 13)