### PR TITLE
feat(memory): degrade cleanly when the committed embedding backend is unavailable

### DIFF
--- a/assistant/src/persistence/embeddings/embedding-backend.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.test.ts
@@ -4,6 +4,7 @@ import type { AssistantConfig } from "../../config/types.js";
 import {
   clearEmbeddingBackendCache,
   embedWithBackend,
+  isEmbeddingDimensionAvailable,
   resetLocalEmbeddingFailureState,
   selectEmbeddingBackend,
 } from "./embedding-backend.js";
@@ -92,6 +93,87 @@ describe("embedding backend cache invalidation", () => {
 
     const secondSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
     expect(secondSelection.backend).toBe(firstSelection.backend);
+  });
+});
+
+describe("isEmbeddingDimensionAvailable", () => {
+  afterEach(() => {
+    clearEmbeddingBackendCache();
+  });
+
+  function localConfigWithVectorSize(vectorSize: number): AssistantConfig {
+    return {
+      memory: {
+        enabled: true,
+        embeddings: {
+          provider: "local",
+          localModel: "BAAI/bge-small-en-v1.5",
+          required: false,
+        },
+        qdrant: { vectorSize },
+      },
+    } as unknown as AssistantConfig;
+  }
+
+  /** Stub the selected backend's `embed` so the dimension probe is deterministic. */
+  async function stubSelectedBackendProbeDim(
+    config: AssistantConfig,
+    dim: number,
+  ): Promise<ReturnType<typeof mock>> {
+    const { backend } = await selectEmbeddingBackend(config);
+    if (!backend) throw new Error("expected a backend to be selected");
+    const embedMock = mock(async () => [new Array(dim).fill(0)]);
+    (backend as { embed: typeof backend.embed }).embed =
+      embedMock as unknown as typeof backend.embed;
+    return embedMock;
+  }
+
+  test("returns true when the reachable backend matches the committed dimension", async () => {
+    const config = localConfigWithVectorSize(384);
+    await stubSelectedBackendProbeDim(config, 384);
+
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(true);
+  });
+
+  test("returns false when the reachable backend's dimension differs from the committed one", async () => {
+    // 3072-dim collection committed, but only a 384-dim backend is reachable.
+    const config = localConfigWithVectorSize(3072);
+    await stubSelectedBackendProbeDim(config, 384);
+
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(false);
+  });
+
+  test("returns false when the backend probe throws (unreachable)", async () => {
+    const config = localConfigWithVectorSize(384);
+    const { backend } = await selectEmbeddingBackend(config);
+    if (!backend) throw new Error("expected a backend to be selected");
+    (backend as { embed: typeof backend.embed }).embed = (async () => {
+      throw new Error("backend unreachable");
+    }) as unknown as typeof backend.embed;
+
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(false);
+  });
+
+  test("memoizes the probe so repeated calls embed only once", async () => {
+    const config = localConfigWithVectorSize(384);
+    const embedMock = await stubSelectedBackendProbeDim(config, 384);
+
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(true);
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(true);
+
+    expect(embedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns false when memory is disabled", async () => {
+    const config = {
+      memory: {
+        enabled: false,
+        embeddings: { provider: "local", localModel: "m", required: false },
+        qdrant: { vectorSize: 384 },
+      },
+    } as unknown as AssistantConfig;
+
+    expect(await isEmbeddingDimensionAvailable(config)).toBe(false);
   });
 });
 

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -23,6 +23,7 @@ import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
 import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
 import {
+  EMBEDDING_DIMENSION_PROBE_TEXT,
   type EmbeddingBackend,
   type EmbeddingInput,
   embeddingInputContentHash,
@@ -216,6 +217,7 @@ export function clearEmbeddingBackendCache(): void {
   backendCache.clear();
   vectorCache.clear();
   vectorCacheBytes = 0;
+  backendDimCache.clear();
   localBackendBroken = false;
 }
 
@@ -506,6 +508,77 @@ export async function getMemoryBackendStatus(config: AssistantConfig): Promise<{
     model: selection.backend.model,
     reason: null,
   };
+}
+
+/**
+ * Memoized output dimension per "provider:model". A backend's vector dimension
+ * is fixed for the life of a (provider, model) pair, so a single probe answers
+ * every subsequent {@link isEmbeddingDimensionAvailable} call without another
+ * backend round-trip. Cleared alongside the backend cache so a credential
+ * change or explicit reset re-probes the (possibly different) backend.
+ */
+const backendDimCache = new Map<string, number>();
+
+/**
+ * Whether the currently-reachable embedding backend can produce vectors of the
+ * committed Qdrant collection dimension (`config.memory.qdrant.vectorSize`).
+ *
+ * Read lanes call this BEFORE embedding a query for a dense Qdrant search so a
+ * known mismatch (e.g. a 3072-dim collection committed to Gemini, but only a
+ * 384-dim local backend reachable while Gemini is down) short-circuits to a
+ * clean degraded outcome instead of paying for an embed round-trip that
+ * {@link embedWithBackend} would only reject on its dimension assertion. The
+ * write path keeps that assertion as the correctness backstop.
+ *
+ * Returns `false` when memory is degraded for any of these reasons:
+ *   - no backend is configured/selectable (`getMemoryBackendStatus().degraded`);
+ *   - the selected backend is unreachable (its probe `embed` throws);
+ *   - the selected backend's output dimension differs from the committed one.
+ *
+ * The selected backend's output dimension is not statically known from
+ * provider/model alone, so it is measured with a fixed-string probe and
+ * memoized per (provider, model) — steady-state calls resolve from
+ * {@link backendDimCache} without a backend round-trip.
+ */
+export async function isEmbeddingDimensionAvailable(
+  config: AssistantConfig,
+): Promise<boolean> {
+  const status = await getMemoryBackendStatus(config);
+  if (status.degraded || !status.provider) return false;
+
+  const { backend } = await selectEmbeddingBackend(config);
+  if (!backend) return false;
+
+  const dim = await resolveBackendDimension(backend);
+  if (dim == null) return false;
+  return dim === config.memory.qdrant.vectorSize;
+}
+
+/**
+ * Resolve a backend's output dimension, probing once and memoizing the result.
+ * Returns `null` when the probe fails (backend unreachable) so the caller can
+ * treat the lane as degraded.
+ */
+async function resolveBackendDimension(
+  backend: EmbeddingBackend,
+): Promise<number | null> {
+  const key = `${backend.provider}:${backend.model}`;
+  const cached = backendDimCache.get(key);
+  if (cached != null) return cached;
+
+  try {
+    const [vector] = await backend.embed([EMBEDDING_DIMENSION_PROBE_TEXT]);
+    const dim = vector?.length;
+    if (dim == null) return null;
+    backendDimCache.set(key, dim);
+    return dim;
+  } catch (err) {
+    log.warn(
+      { err, provider: backend.provider, model: backend.model },
+      "Embedding-dimension availability probe failed; treating as degraded",
+    );
+    return null;
+  }
 }
 
 /**

--- a/assistant/src/persistence/embeddings/embedding-identity.ts
+++ b/assistant/src/persistence/embeddings/embedding-identity.ts
@@ -4,7 +4,10 @@ import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { selectEmbeddingBackend } from "./embedding-backend.js";
 import { isEmbeddingBillingBreakerOpen } from "./embedding-billing-breaker.js";
-import type { EmbeddingProviderName } from "./embedding-types.js";
+import {
+  EMBEDDING_DIMENSION_PROBE_TEXT,
+  type EmbeddingProviderName,
+} from "./embedding-types.js";
 import { resolveQdrantUrl } from "./qdrant-client.js";
 
 const log = getLogger("embedding-identity");
@@ -41,7 +44,7 @@ export async function probeBackendDimension(
   if (!backend) return null;
 
   try {
-    const vectors = await backend.embed(["embedding dimension probe"]);
+    const vectors = await backend.embed([EMBEDDING_DIMENSION_PROBE_TEXT]);
     const dim = vectors[0]?.length;
     if (dim == null) return null;
     return { provider: backend.provider, model: backend.model, dim };

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -88,3 +88,10 @@ export interface EmbeddingBackend {
   ): Promise<number[][]>;
   dispose?(): void;
 }
+
+/**
+ * Fixed text embedded to measure a backend's output dimension. Shared so the
+ * startup reconcile probe and the per-query availability check agree on the
+ * input (and therefore the in-memory vector cache identity).
+ */
+export const EMBEDDING_DIMENSION_PROBE_TEXT = "embedding dimension probe";

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -27,11 +27,13 @@ const realEmbeddingBackend =
 const embedState = {
   calls: [] as string[][],
   throws: null as Error | null,
+  dimensionAvailable: true,
 };
 mock.module(
   "../../../../../persistence/embeddings/embedding-backend.js",
   () => ({
     ...realEmbeddingBackend,
+    isEmbeddingDimensionAvailable: async () => embedState.dimensionAvailable,
     embedWithBackend: async (_config: unknown, inputs: string[]) => {
       embedState.calls.push(inputs);
       if (embedState.throws) throw embedState.throws;
@@ -94,6 +96,7 @@ function point(article: string, ordinal: number, score: number): MockPoint {
 function resetState(): void {
   embedState.calls.length = 0;
   embedState.throws = null;
+  embedState.dimensionAvailable = true;
   state.points = [];
   state.queryThrows = null;
   state.queryCalls.length = 0;
@@ -174,6 +177,18 @@ describe("memory v3 dense lane", () => {
     const hits = await denseLane(CONFIG, "query", 5);
 
     expect(hits).toEqual([]);
+  });
+
+  test("a committed-dimension/reachable-backend mismatch degrades to [] without embedding", async () => {
+    // Simulates a 3072-dim collection committed while only a 384-dim backend is
+    // reachable: the read lane short-circuits before paying for an embed.
+    embedState.dimensionAvailable = false;
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
   });
 
   test("a failed embedding degrades to []", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -16,7 +16,10 @@
 // forward regardless, so a dense outage narrows recall but never breaks a turn.
 
 import type { AssistantConfig } from "../../../../config/types.js";
-import { embedWithBackend } from "../../../../persistence/embeddings/embedding-backend.js";
+import {
+  embedWithBackend,
+  isEmbeddingDimensionAvailable,
+} from "../../../../persistence/embeddings/embedding-backend.js";
 import { getLogger } from "../../../../util/logger.js";
 import {
   getSectionDenseClient,
@@ -46,7 +49,11 @@ export interface DenseHit {
  * Qdrant in descending score order, so the first time an article is seen is its
  * best section; subsequent sections of the same article are ignored.
  *
- * Returns `[]` on any embedding or Qdrant failure (logged at warn level).
+ * Returns `[]` on any embedding or Qdrant failure (logged at warn level), and
+ * short-circuits to `[]` when the reachable backend cannot produce vectors of
+ * the committed collection dimension (degraded backend or dimension mismatch) —
+ * so a 3072-dim collection committed while only a 384-dim backend is reachable
+ * narrows recall cleanly rather than failing the dimension assertion every turn.
  */
 export async function denseLane(
   config: AssistantConfig,
@@ -54,6 +61,10 @@ export async function denseLane(
   k: number,
 ): Promise<DenseHit[]> {
   if (k <= 0) return [];
+
+  if (!(await isEmbeddingDimensionAvailable(config))) {
+    return [];
+  }
 
   let points: Array<{ payload?: unknown; score?: number }>;
   try {


### PR DESCRIPTION
## Summary
- Read lane returns empty/degraded instead of throwing a dimension-mismatch when the committed backend is down
- embedWithBackend write-path dimension assertion unchanged (correctness backstop)

Part of plan: embedding-dim-reconcile.md (PR 7 of 8)