### PR TITLE
fix(memory): restore v1 collection dimension-drift recreate

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -104,7 +104,7 @@ beforeEach(() => {
 });
 
 describe("Qdrant collection migration", () => {
-  test("leaves collection intact on pure dimension mismatch (defers to startup reconcile)", async () => {
+  test("deletes and recreates collection on pure dimension mismatch", async () => {
     mockCollectionExists = true;
     mockUseNamedVectors = true;
     mockCollectionSize = 384; // Current collection has 384-dim vectors
@@ -120,11 +120,12 @@ describe("Qdrant collection migration", () => {
 
     const result = await client.ensureCollection();
 
-    // The lazy ensure cannot run an embed probe, so it must not destroy the
-    // populated collection on dimension drift; the startup reconcile owns that.
-    expect(callLog.deleteCollection).toBe(0);
-    expect(callLog.createCollection).toBe(0);
-    expect(result.migrated).toBe(false);
+    // The v1 collection is not managed by the startup embedding reconcile, so
+    // dimension drift is repaired here: delete + recreate, then rebuild_index
+    // re-embeds from the SQLite cache via the lifecycle hook.
+    expect(callLog.deleteCollection).toBe(1);
+    expect(callLog.createCollection).toBe(1);
+    expect(result.migrated).toBe(true);
   });
 
   test("deletes and recreates collection on model-only mismatch", async () => {

--- a/assistant/src/persistence/embeddings/qdrant-client.ts
+++ b/assistant/src/persistence/embeddings/qdrant-client.ts
@@ -189,35 +189,28 @@ export class VellumQdrantClient {
             await this.client.deleteCollection(this.collection);
             migrated = true;
             // Fall through to collection creation below
-          } else if (modelMismatch) {
+          } else if (dimMismatch || modelMismatch) {
+            // The v1 collection (config.memory.qdrant.collection) is not managed
+            // by the startup embedding reconcile — that reconcile owns only the
+            // v2 (memory_v2_concept_pages) and v3 (memory_v3_sections)
+            // collections. Dimension drift on v1 is therefore repaired here:
+            // delete and recreate, and the lifecycle hook re-embeds from the
+            // SQLite cache via rebuild_index when ensureCollection reports
+            // migrated and v2 is disabled.
             log.warn(
               {
                 collection: this.collection,
                 currentSize,
                 expectedSize: this.vectorSize,
+                dimMismatch,
                 modelMismatch,
               },
-              "Qdrant collection incompatible (model change) — deleting and recreating. Embeddings will be regenerated on demand.",
+              "Qdrant collection incompatible (dimension/model change) — deleting and recreating. Embeddings will be regenerated on demand.",
             );
             await this.client.deleteCollection(this.collection);
             migrated = true;
             // Fall through to collection creation below
           } else {
-            if (dimMismatch) {
-              // Pure dimension drift (no model change). This lazy path runs on
-              // hot upsert/query calls and cannot run an embed probe to confirm
-              // the new dimension, so it must not make the destroy-before-confirm
-              // decision. Destructive dimension migration is owned by the
-              // probe-gated startup reconcile; treat the collection as ready.
-              log.warn(
-                {
-                  collection: this.collection,
-                  currentSize,
-                  expectedSize: this.vectorSize,
-                },
-                "Qdrant collection dimension drift — deferring to startup reconcile; not recreating in the request path",
-              );
-            }
             if (await this.ensurePayloadIndexesSafe()) {
               this.collectionReady = true;
             }


### PR DESCRIPTION
## Summary
The startup embedding reconcile owns only the v2/v3 collections. Restores the v1 VellumQdrantClient's destroy-on-dimension-drift so a v1-only install isn't left stuck at the wrong size; v1 re-embeds via the existing rebuild_index lifecycle hook.

Fixes gap from plan review for embedding-dim-reconcile.md (v1 orphaned dimension drift).