### PR TITLE
fix(memory): add 'local' to embedding provider status enum

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16609,6 +16609,7 @@ paths:
                         anyOf:
                           - type: string
                             enum:
+                              - local
                               - openai
                               - gemini
                               - ollama

--- a/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-worker-routes.test.ts
@@ -79,7 +79,9 @@ mock.module("../../../config/loader.js", () => ({
   },
 }));
 
-const { ROUTES } = await import("../memory-worker-routes.js");
+const { ROUTES, embeddingStatusSchema } = await import(
+  "../memory-worker-routes.js"
+);
 
 function handler(operationId: string) {
   const route = ROUTES.find((r) => r.operationId === operationId);
@@ -239,6 +241,30 @@ describe("memory_worker_status", () => {
     expect(res).toMatchObject({
       embedding: { degraded: false, provider: "gemini" },
     });
+  });
+
+  test("surfaces the local embedding backend (the default non-platform provider)", async () => {
+    workerProbe = { status: "not_running" };
+    configEnabled = false;
+    backendStatus = {
+      enabled: true,
+      degraded: false,
+      provider: "local",
+      model: "Xenova/all-MiniLM-L6-v2",
+      reason: null,
+    };
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toMatchObject({
+      embedding: { degraded: false, provider: "local" },
+    });
+    // The wire value "local" must satisfy the documented response contract.
+    expect(
+      embeddingStatusSchema.safeParse(
+        (res as { embedding: unknown }).embedding,
+      ).success,
+    ).toBe(true);
   });
 
   test("surfaces a degraded embedding backend with a reason when none is configured", async () => {

--- a/assistant/src/runtime/routes/memory-worker-routes.ts
+++ b/assistant/src/runtime/routes/memory-worker-routes.ts
@@ -62,10 +62,10 @@ const stopResponseSchema = z.object({
   workerEnabled: z.literal(false),
 });
 
-const embeddingStatusSchema = z.object({
+export const embeddingStatusSchema = z.object({
   enabled: z.boolean(),
   degraded: z.boolean(),
-  provider: z.enum(["openai", "gemini", "ollama"]).nullable(),
+  provider: z.enum(["local", "openai", "gemini", "ollama"]).nullable(),
   model: z.string().nullable(),
   reason: z.string().nullable(),
 });


### PR DESCRIPTION
## Summary
getMemoryBackendStatus can return provider='local' (the default non-platform backend), but the memory_worker_status schema/OpenAPI enum omitted it. Adds 'local' to the zod enum + regenerated openapi.yaml + test.

Fixes gap from plan review for embedding-dim-reconcile.md (provider enum omits local).