### PR TITLE
fix(memory): degrade v2 dense read cleanly on committed-dimension mismatch

### DIFF
--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -54,6 +54,7 @@ mock.module("../../../persistence/embeddings/qdrant-client.js", () => ({
 const state = {
   embedCalls: [] as Array<{ inputs: unknown[] }>,
   embedReturn: [[0.1, 0.2, 0.3]] as number[][],
+  dimensionAvailable: true,
   /**
    * Programmable Qdrant query response queues — one per channel. Each test
    * stages whatever ordered hits it needs and lets `simBatch` /
@@ -79,6 +80,7 @@ const realEmbeddingBackend =
   await import("../../../persistence/embeddings/embedding-backend.js");
 mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   ...realEmbeddingBackend,
+  isEmbeddingDimensionAvailable: async () => state.dimensionAvailable,
   embedWithBackend: async (_config: AssistantConfig, inputs: unknown[]) => {
     state.embedCalls.push({ inputs });
     return {
@@ -173,6 +175,7 @@ const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
 function resetState(): void {
   state.embedCalls.length = 0;
   state.embedReturn = [[0.1, 0.2, 0.3]];
+  state.dimensionAvailable = true;
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   state.queryCalls.length = 0;
@@ -376,6 +379,44 @@ describe("selectCandidates", () => {
     // Source-set membership matches each slug's actual provenance.
     expect(out.fromPrior).toEqual(new Set(["alice-vscode", "carol-jazz"]));
     expect(out.fromAnn).toEqual(new Set(["alice-vscode", "delta-recipe"]));
+  });
+
+  test("committed-dimension/reachable-backend mismatch skips the dense embed and runs the ANN scan sparse-only", async () => {
+    // Simulates a 3072-dim collection committed while only a 384-dim backend
+    // is reachable: the ANN candidate scan skips the dense embed (no
+    // `embedWithBackend` throw) and runs BM25-only via the empty dense vector,
+    // so prior-state survivors and sparse ANN hits still populate candidates.
+    state.dimensionAvailable = false;
+    stageHybridResponse([
+      { slug: "delta-recipe", sparseScore: 1 /* denseScore omitted */ },
+    ]);
+
+    const out = await selectCandidates({
+      priorState: {
+        messageId: "msg-1",
+        state: { "alice-vscode": 0.5 },
+        everInjected: [],
+        currentTurn: 1,
+        updatedAt: 1,
+      },
+      userText: "user said hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig(),
+    });
+
+    // No dense embed round-trip was paid.
+    expect(state.embedCalls).toHaveLength(0);
+    // Only the two sparse channels hit Qdrant; the dense channels were skipped
+    // (empty dense vector → sparse-only query).
+    expect(state.queryCalls.map((c) => c.using).sort()).toEqual([
+      "sparse",
+      "summary_sparse",
+    ]);
+    // Prior survivor + sparse ANN hit both land in the candidate set.
+    expect(out.fromPrior).toEqual(new Set(["alice-vscode"]));
+    expect(out.fromAnn).toEqual(new Set(["delta-recipe"]));
+    expect(out.candidates).toEqual(new Set(["alice-vscode", "delta-recipe"]));
   });
 
   test("ANN candidate query honors `config.memory.v2.ann_candidate_limit` and runs without slug restriction", async () => {

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -61,6 +61,7 @@ const state = {
   embedCalls: [] as Array<{ inputs: unknown[] }>,
   sparseCalls: [] as string[],
   embedReturn: [[0.1, 0.2, 0.3]] as number[][],
+  dimensionAvailable: true,
   // Programmable Qdrant query response — one entry per `using` channel,
   // shifted in order so each test can stage dense + sparse results.
   queryResponses: {
@@ -87,6 +88,7 @@ const realEmbeddingBackend =
   await import("../../../persistence/embeddings/embedding-backend.js");
 mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   ...realEmbeddingBackend,
+  isEmbeddingDimensionAvailable: async () => state.dimensionAvailable,
   embedWithBackend: async (_config: AssistantConfig, inputs: unknown[]) => {
     state.embedCalls.push({ inputs });
     return {
@@ -162,6 +164,7 @@ function resetState(): void {
   state.embedCalls.length = 0;
   state.sparseCalls.length = 0;
   state.embedReturn = [[0.1, 0.2, 0.3]];
+  state.dimensionAvailable = true;
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   state.queryCalls.length = 0;
@@ -513,6 +516,32 @@ describe("simBatch", () => {
         must: [{ key: "slug", match: { any: ["alice", "bob", "carol"] } }],
       });
     }
+  });
+
+  test("committed-dimension/reachable-backend mismatch skips the dense embed and degrades to sparse-only", async () => {
+    // Simulates a 3072-dim collection committed while only a 384-dim backend
+    // is reachable: the dense embed is skipped (no `embedWithBackend` throw),
+    // and `hybridQueryConceptPages` runs sparse-only via the empty dense vector
+    // so BM25 still scores the candidate.
+    state.dimensionAvailable = false;
+    const config = configWithWeights(0.0, 1.0);
+    stageHybridResponse([
+      { slug: "sparse-only-page", sparseScore: 7.5 /* denseScore omitted */ },
+    ]);
+
+    const out = await simBatch("query", ["sparse-only-page"], config);
+
+    // No dense embed round-trip was paid.
+    expect(state.embedCalls).toHaveLength(0);
+    // Sparse channels still ran; the dense channels were skipped (empty dense
+    // vector), so only the two sparse `using` channels hit Qdrant.
+    expect(state.queryCalls.map((c) => c.using).sort()).toEqual([
+      "sparse",
+      "summary_sparse",
+    ]);
+    // BM25 still produced a score for the candidate: sparse normalized to 1.0
+    // (single hit), sparse_weight 1.0 → fused 1.0.
+    expect(out.get("sparse-only-page")).toBeCloseTo(1.0, 6);
   });
 
   test("embeds the query text exactly once via dense + sparse backends", async () => {

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -35,7 +35,10 @@
 //     for the next turn and drop below `epsilon` if no longer relevant.
 
 import type { AssistantConfig } from "../../config/types.js";
-import { embedWithBackend } from "../../persistence/embeddings/embedding-backend.js";
+import {
+  embedWithBackend,
+  isEmbeddingDimensionAvailable,
+} from "../../persistence/embeddings/embedding-backend.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { clampUnitInterval } from "../validation.js";
 import type { EdgeIndex } from "./edge-index.js";
@@ -130,15 +133,24 @@ export async function selectCandidates(
     .join("\n");
 
   if (annQueryText.trim().length > 0) {
-    throwIfAborted(signal);
-    const denseResult = await embedWithBackend(config, [annQueryText], {
-      signal,
-    });
-    const dense = await applyCorrectionIfCalibrated(
-      denseResult.vectors[0],
-      denseResult.provider,
-      denseResult.model,
-    );
+    // Dense short-circuit: when the reachable backend can't produce vectors of
+    // the committed collection dimension (degraded backend or dimension
+    // mismatch), skip the embed round-trip that `embedWithBackend` would only
+    // reject on its dimension assertion every turn. `hybridQueryConceptPages`
+    // treats an empty dense vector as sparse-only, so the ANN candidate scan
+    // still runs on BM25 — the dense channel just contributes nothing.
+    let dense: number[] = [];
+    if (await isEmbeddingDimensionAvailable(config)) {
+      throwIfAborted(signal);
+      const denseResult = await embedWithBackend(config, [annQueryText], {
+        signal,
+      });
+      dense = await applyCorrectionIfCalibrated(
+        denseResult.vectors[0],
+        denseResult.provider,
+        denseResult.model,
+      );
+    }
     throwIfAborted(signal);
     const sparse = generateBm25QueryEmbedding(annQueryText);
     const limit =

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -33,7 +33,10 @@
 //   across turns.
 
 import type { AssistantConfig } from "../../config/types.js";
-import { embedWithBackend } from "../../persistence/embeddings/embedding-backend.js";
+import {
+  embedWithBackend,
+  isEmbeddingDimensionAvailable,
+} from "../../persistence/embeddings/embedding-backend.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { clampUnitInterval } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
@@ -166,18 +169,29 @@ export async function simBatch(
     return new Map();
   }
 
+  // Dense short-circuit: when the reachable backend can't produce vectors of
+  // the committed collection dimension (degraded backend or dimension
+  // mismatch), skip the embed round-trip that `embedWithBackend` would only
+  // reject on its dimension assertion every turn. `hybridQueryConceptPages`
+  // treats an empty dense vector as sparse-only, so BM25 still scores the
+  // candidates — the dense channel just contributes nothing this turn.
+  const denseAvailable = await isEmbeddingDimensionAvailable(config);
+
   // Sparse uses BM25: the query side encodes binary occurrences per token,
   // and the stored doc vectors carry the IDF · TF-saturated weights — Qdrant
   // dot product then yields the BM25 score directly.
-  throwIfAborted(options?.signal);
-  const denseResult = await embedWithBackend(config, [text], {
-    signal: options?.signal,
-  });
-  const denseVector = await applyCorrectionIfCalibrated(
-    denseResult.vectors[0],
-    denseResult.provider,
-    denseResult.model,
-  );
+  let denseVector: number[] = [];
+  if (denseAvailable) {
+    throwIfAborted(options?.signal);
+    const denseResult = await embedWithBackend(config, [text], {
+      signal: options?.signal,
+    });
+    denseVector = await applyCorrectionIfCalibrated(
+      denseResult.vectors[0],
+      denseResult.provider,
+      denseResult.model,
+    );
+  }
   throwIfAborted(options?.signal);
   const sparseVector = generateBm25QueryEmbedding(text);
 


### PR DESCRIPTION
## Summary
Extends PR7's clean-degrade guard to the v2 concept-page read lanes (the plan's core scenario): short-circuits dense retrieval via isEmbeddingDimensionAvailable instead of throwing + retrying per turn.

Fixes gap from plan review for embedding-dim-reconcile.md (v2 read-lane guard).