### PR TITLE
fix(memory): reconcile ordering, reembed dedup, and v3 collection gating

### DIFF
--- a/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
@@ -144,3 +144,171 @@ describe("reconcileEmbeddingIdentity", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Default side-effecting deps: v2-reembed dedup + v3 section-collection gating
+// ---------------------------------------------------------------------------
+//
+// These build the real `defaultDeps` and override ONLY the read primitives +
+// decision so the production side-effecting wiring (config write, collection
+// ensure/recreate, reembed enqueue) runs against mocked collaborator modules —
+// asserting the enqueue dedup and the `isMemoryV3Live` gate on the v3
+// section-collection lifecycle without touching Qdrant, a backend, or config I/O.
+
+/**
+ * Reset and re-install the mocks for the collaborator modules `defaultDeps`
+ * pulls in, then re-import the module under test so its default deps close over
+ * the freshly-mocked collaborators. Returns the spies plus a `defaultDeps`
+ * factory bound to the re-imported module.
+ */
+async function withDefaultDepsMocks(opts: {
+  v3Live: boolean;
+  pendingTypes?: ReadonlyArray<string>;
+}) {
+  const pending = new Set(opts.pendingTypes ?? []);
+  const spies = {
+    enqueueMemoryJob: mock(() => "job-id"),
+    hasActiveJobOfType: mock((type: string) => pending.has(type)),
+    ensureSectionCollection: mock(async () => {}),
+    recreateSectionCollection: mock(async () => {}),
+    ensureConceptPageCollection: mock(async () => ({ migrated: false })),
+    recreateConceptPageCollection: mock(async () => {}),
+  };
+
+  mock.module("../../persistence/jobs-store.js", () => ({
+    enqueueMemoryJob: spies.enqueueMemoryJob,
+    hasActiveJobOfType: spies.hasActiveJobOfType,
+  }));
+  mock.module("../../config/memory-v3-gate.js", () => ({
+    isMemoryV3Live: () => opts.v3Live,
+  }));
+  mock.module("../../memory/v2/qdrant.js", () => ({
+    ensureConceptPageCollection: spies.ensureConceptPageCollection,
+    recreateConceptPageCollection: spies.recreateConceptPageCollection,
+  }));
+  mock.module("../../config/loader.js", () => ({
+    loadRawConfig: () => ({}),
+    saveRawConfig: () => {},
+    setNestedValue: () => {},
+    invalidateConfigCache: () => {},
+  }));
+  mock.module(
+    "../../plugins/defaults/memory/v3/section-dense-store.js",
+    () => ({
+      ensureSectionCollection: spies.ensureSectionCollection,
+      recreateSectionCollection: spies.recreateSectionCollection,
+    }),
+  );
+
+  const mod = await import("../embedding-reconcile.js");
+  return {
+    spies,
+    reconcile: mod.reconcileEmbeddingIdentity,
+    defaultDeps: mod.defaultDeps,
+  };
+}
+
+/** Read-primitive + decision overrides that drive a chosen branch. */
+function driveBranch(
+  decision: ReconcileAction,
+  committedDim: number | null,
+): Partial<ReconcileDeps> {
+  return {
+    probeBackendDimension: mock(async () => ({
+      provider: "gemini" as const,
+      model: "m",
+      dim: 3072,
+    })),
+    readConceptPageCollectionDim: mock(async () => committedDim),
+    decideEmbeddingReconcile: mock(() => decision),
+  };
+}
+
+describe("reconcileEmbeddingIdentity default side-effecting deps", () => {
+  test("v2 reembed enqueue dedups against an already-pending reembed", async () => {
+    const config = fakeConfig("gemini");
+
+    // No pending reembed: enqueues exactly once.
+    const first = await withDefaultDepsMocks({ v3Live: false });
+    await first.reconcile(config, {
+      ...first.defaultDeps(config),
+      ...driveBranch({ kind: "commit-fresh", dim: 3072 }, null),
+    });
+    expect(first.spies.enqueueMemoryJob).toHaveBeenCalledTimes(1);
+    expect(first.spies.enqueueMemoryJob).toHaveBeenCalledWith(
+      "memory_v2_reembed",
+      {},
+    );
+
+    // A reembed is already pending: a second reconcile must not enqueue again.
+    const second = await withDefaultDepsMocks({
+      v3Live: false,
+      pendingTypes: ["memory_v2_reembed"],
+    });
+    await second.reconcile(config, {
+      ...second.defaultDeps(config),
+      ...driveBranch({ kind: "commit-fresh", dim: 3072 }, null),
+    });
+    expect(second.spies.enqueueMemoryJob).toHaveBeenCalledTimes(0);
+  });
+
+  test("commit-fresh skips the v3 section ensure when v3 is not live", async () => {
+    const config = fakeConfig("gemini");
+    const { spies, reconcile, defaultDeps } = await withDefaultDepsMocks({
+      v3Live: false,
+    });
+
+    await reconcile(config, {
+      ...defaultDeps(config),
+      ...driveBranch({ kind: "commit-fresh", dim: 3072 }, null),
+    });
+
+    expect(spies.ensureConceptPageCollection).toHaveBeenCalledTimes(1);
+    expect(spies.ensureSectionCollection).toHaveBeenCalledTimes(0);
+  });
+
+  test("commit-fresh ensures the v3 section collection when v3 is live", async () => {
+    const config = fakeConfig("gemini");
+    const { spies, reconcile, defaultDeps } = await withDefaultDepsMocks({
+      v3Live: true,
+    });
+
+    await reconcile(config, {
+      ...defaultDeps(config),
+      ...driveBranch({ kind: "commit-fresh", dim: 3072 }, null),
+    });
+
+    expect(spies.ensureConceptPageCollection).toHaveBeenCalledTimes(1);
+    expect(spies.ensureSectionCollection).toHaveBeenCalledTimes(1);
+  });
+
+  test("migrate skips the v3 section recreate when v3 is not live", async () => {
+    const config = fakeConfig("gemini");
+    const { spies, reconcile, defaultDeps } = await withDefaultDepsMocks({
+      v3Live: false,
+    });
+
+    await reconcile(config, {
+      ...defaultDeps(config),
+      ...driveBranch({ kind: "migrate", fromDim: 384, toDim: 3072 }, 384),
+    });
+
+    expect(spies.recreateConceptPageCollection).toHaveBeenCalledTimes(1);
+    expect(spies.recreateSectionCollection).toHaveBeenCalledTimes(0);
+  });
+
+  test("migrate recreates the v3 section collection when v3 is live", async () => {
+    const config = fakeConfig("gemini");
+    const { spies, reconcile, defaultDeps } = await withDefaultDepsMocks({
+      v3Live: true,
+    });
+
+    await reconcile(config, {
+      ...defaultDeps(config),
+      ...driveBranch({ kind: "migrate", fromDim: 384, toDim: 3072 }, 384),
+    });
+
+    expect(spies.recreateConceptPageCollection).toHaveBeenCalledTimes(1);
+    expect(spies.recreateSectionCollection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -30,7 +30,10 @@ import {
   readConceptPageCollectionDim,
 } from "../persistence/embeddings/embedding-identity.js";
 import { decideEmbeddingReconcile } from "../persistence/embeddings/reconcile-decision.js";
-import { enqueueMemoryJob } from "../persistence/jobs-store.js";
+import {
+  enqueueMemoryJob,
+  hasActiveJobOfType,
+} from "../persistence/jobs-store.js";
 import {
   ensureSectionCollection,
   recreateSectionCollection,
@@ -82,33 +85,52 @@ function defaultPersistVectorSize(dim: number): void {
 }
 
 /**
- * Default `recreateCollectionsAtDim`: destroy + recreate both the v2
- * concept-page collection and the v3 section collection at `dim`. Reuses the
- * recreate helpers each store exports so the named-vector layout and payload
- * indexes flow through the single creation code path. The `dim` is read from
- * config (which the caller has already committed via `persistVectorSize` +
- * cache invalidation) by the underlying `ensure*` calls.
+ * Default `recreateCollectionsAtDim`: destroy + recreate the v2 concept-page
+ * collection at `dim`, plus the v3 section collection when v3 is the live
+ * injected source. Reuses the recreate helpers each store exports so the
+ * named-vector layout and payload indexes flow through the single creation code
+ * path. The `dim` is read from config (which the caller has already committed
+ * via `persistVectorSize` + cache invalidation) by the underlying `ensure*`
+ * calls. The v3 section collection's lifecycle is gated on `isMemoryV3Live` to
+ * match its population gate — a v2-only install never populates it, so it must
+ * not be created.
  */
 async function defaultRecreateCollectionsAtDim(
   config: AssistantConfig,
 ): Promise<void> {
   await recreateConceptPageCollection();
-  await recreateSectionCollection(config);
+  if (isMemoryV3Live(config)) {
+    await recreateSectionCollection(config);
+  }
 }
 
 /**
  * Default `enqueueReembed`: enqueue the v2 reembed, plus the v3 maintain job
  * when v3 is the live injected source for this assistant (its section
  * collection only carries points under v3-live).
+ *
+ * Both enqueues dedup against an already-in-flight (pending or running) job of
+ * the same type: on the lifecycle startup path the reconcile runs immediately
+ * before `maybeRebuildMemoryV2Concepts`, which also enqueues `memory_v2_reembed`
+ * when it finds the just-(re)created collection empty — without the guard the
+ * corpus would re-embed twice.
  */
 function defaultEnqueueReembed(config: AssistantConfig): void {
-  enqueueMemoryJob("memory_v2_reembed", {});
-  if (isMemoryV3Live(config)) {
+  if (!hasActiveJobOfType("memory_v2_reembed")) {
+    enqueueMemoryJob("memory_v2_reembed", {});
+  }
+  if (isMemoryV3Live(config) && !hasActiveJobOfType("memory_v3_maintain")) {
     enqueueMemoryJob("memory_v3_maintain", {});
   }
 }
 
-function defaultDeps(config: AssistantConfig): ReconcileDeps {
+/**
+ * Build the production collaborator set: real read primitives + decision wired
+ * to the side-effecting defaults (config write, collection ensure/recreate,
+ * reembed enqueue). Exported so tests can take the real side-effecting deps and
+ * override only the read primitives + decision to drive a specific branch.
+ */
+export function defaultDeps(config: AssistantConfig): ReconcileDeps {
   return {
     probeBackendDimension,
     readConceptPageCollectionDim,
@@ -121,7 +143,11 @@ function defaultDeps(config: AssistantConfig): ReconcileDeps {
     recreateCollectionsAtDim: () => defaultRecreateCollectionsAtDim(config),
     ensureCollections: async () => {
       await ensureConceptPageCollection();
-      await ensureSectionCollection(config);
+      // The v3 section collection's lifecycle matches its population gate: a
+      // v2-only install never writes to it, so it must not be created.
+      if (isMemoryV3Live(config)) {
+        await ensureSectionCollection(config);
+      }
     },
     enqueueReembed: () => defaultEnqueueReembed(config),
   };

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -137,6 +137,28 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
     await import("../providers/platform-proxy/context.js");
   if (!(await hasManagedProxyPrereqs())) return;
 
+  // The managed credential has just landed, so the embedding backend is now
+  // reachable. Retry the embedding-identity reconcile to close the
+  // fresh-platform-install-booted-with-Gemini-down case: the first boot defers
+  // (degraded) because the backend probe returns null, and this credential-
+  // arrival retry commits the collection dimension once the backend answers.
+  // Run to COMPLETION before launching the reseeds below: the reconcile's
+  // commit-fresh/migrate may create or destroy+recreate the concept-page
+  // collection, and the reseeds embed + upsert into it — settling the
+  // collection dimension first stops a recreate from wiping freshly-seeded
+  // points or upserting at a stale dimension. Contained so a reconcile failure
+  // never rejects the detached caller.
+  try {
+    const { reconcileEmbeddingIdentity } =
+      await import("./embedding-reconcile.js");
+    await reconcileEmbeddingIdentity(config);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Embedding-identity reconcile after managed proxy credential update threw — continuing",
+    );
+  }
+
   // Skills and CLI commands are independent catalogs sharing the unified
   // collection — reseed in parallel, each contained so one catalog's embed
   // failure does not abort the other or reject the detached caller.
@@ -175,23 +197,6 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
         ),
     ),
   );
-
-  // The managed credential has just landed, so the embedding backend is now
-  // reachable. Retry the embedding-identity reconcile to close the
-  // fresh-platform-install-booted-with-Gemini-down case: the first boot defers
-  // (degraded) because the backend probe returns null, and this credential-
-  // arrival retry commits the collection dimension once the backend answers.
-  // Contained so a reconcile failure never rejects the detached caller.
-  try {
-    const { reconcileEmbeddingIdentity } =
-      await import("./embedding-reconcile.js");
-    await reconcileEmbeddingIdentity(config);
-  } catch (err) {
-    log.warn(
-      { err },
-      "Embedding-identity reconcile after managed proxy credential update threw — continuing",
-    );
-  }
 
   // When v3 is live, a maintain pass embeds the freshly-seeded capability rows
   // into `memory_v3_sections` and invalidates the lanes so v3 surfaces the


### PR DESCRIPTION
## Summary
- Run reconcileEmbeddingIdentity to completion before the detached capability reseeds (avoid recreate-wipes-reseed race)
- Dedup memory_v2_reembed enqueue so reconcile + maybeRebuildMemoryV2Concepts don't double-enqueue a full reembed
- Gate v3 memory_v3_sections ensure/recreate on isMemoryV3Live (match the population gate)

Fixes gaps from plan review for embedding-dim-reconcile.md (reconcile race / double-enqueue / v3 gating).