### PR TITLE
refactor(ces): serialize manage_secure_command_tool operations (multi-client PR 3)

### DIFF
--- a/credential-executor/src/__tests__/command-workspace.test.ts
+++ b/credential-executor/src/__tests__/command-workspace.test.ts
@@ -112,6 +112,30 @@ describe("stageInputs", () => {
     }
   });
 
+  test("concurrent stagings get isolated scratch directories", () => {
+    // run_authenticated_command relies on each invocation getting its own
+    // scratch dir so that interleaved commands cannot read or clobber each
+    // other's staged inputs/outputs. Same config, two stagings → distinct dirs.
+    const config: WorkspaceStageConfig = {
+      workspaceDir,
+      inputs: [{ workspacePath: "input.txt" }],
+      outputs: [],
+      secrets: new Set(),
+    };
+
+    const a = stageInputs(config);
+    const b = stageInputs(config);
+
+    try {
+      expect(a.scratchDir).not.toBe(b.scratchDir);
+      expect(existsSync(a.scratchDir)).toBe(true);
+      expect(existsSync(b.scratchDir)).toBe(true);
+    } finally {
+      cleanupScratchDir(a.scratchDir);
+      cleanupScratchDir(b.scratchDir);
+    }
+  });
+
   test("staged inputs are read-only", () => {
     const config: WorkspaceStageConfig = {
       workspaceDir,

--- a/credential-executor/src/__tests__/manage-secure-command-tool.test.ts
+++ b/credential-executor/src/__tests__/manage-secure-command-tool.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the manage_secure_command_tool handler's operation serialization.
+ *
+ * The register path awaits a bundle download mid-handler. Without
+ * serialization, a concurrent unregister could run its "still in use?" check
+ * and bundle delete during that await — against a registry that doesn't yet
+ * reflect the in-flight registration — transiently deleting a bundle another
+ * caller is publishing or executing. The handler runs operations one-at-a-time
+ * to close that window.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ManageSecureCommandTool } from "@vellumai/service-contracts/credential-rpc";
+
+import {
+  createManageSecureCommandToolHandler,
+  type ManageSecureCommandToolHandlerDeps,
+} from "../server.js";
+
+const CTX = { sessionId: "test-session" };
+
+function registerRequest(toolName: string): ManageSecureCommandTool {
+  return {
+    action: "register",
+    toolName,
+    bundleId: "bundle-1",
+    version: "1.0.0",
+    sourceUrl: "https://example.com/bundle.tgz",
+    sha256: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0",
+    credentialHandle: "local_static:svc/key",
+    description: "a tool",
+    // publishBundle is mocked in these tests, so the manifest contents are
+    // irrelevant — only its presence matters for the required-field check.
+    secureCommandManifest: {} as unknown as ManageSecureCommandTool["secureCommandManifest"],
+  };
+}
+
+function unregisterRequest(toolName: string): ManageSecureCommandTool {
+  return { action: "unregister", toolName };
+}
+
+describe("manage_secure_command_tool serialization", () => {
+  test("a slow register does not let a concurrent unregister interleave", async () => {
+    const events: string[] = [];
+
+    let releaseDownload!: () => void;
+    const downloadGate = new Promise<void>((resolve) => {
+      releaseDownload = resolve;
+    });
+
+    const deps: ManageSecureCommandToolHandlerDeps = {
+      downloadBundle: async () => {
+        events.push("download:start");
+        await downloadGate;
+        events.push("download:end");
+        return Buffer.from("bundle-bytes");
+      },
+      publishBundle: () => {
+        events.push("publish");
+        return { success: true, deduplicated: false, bundlePath: "/tmp/bundle" };
+      },
+      registerTool: () => {
+        events.push("register");
+      },
+      unregisterTool: (toolName: string) => {
+        events.push(`unregister:${toolName}`);
+        return true;
+      },
+    };
+
+    const handler = createManageSecureCommandToolHandler(deps);
+
+    // Fire a register (which blocks in downloadBundle) then an unregister.
+    const registerPromise = handler(registerRequest("tool-a"), CTX);
+    const unregisterPromise = handler(unregisterRequest("tool-b"), CTX);
+
+    // Let the event loop run: the register has reached its download await, and
+    // the unregister must be queued behind it — its delete must not have run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(events).toEqual(["download:start"]);
+
+    // Release the download; both operations complete in order.
+    releaseDownload();
+    const [registerResult, unregisterResult] = await Promise.all([
+      registerPromise,
+      unregisterPromise,
+    ]);
+
+    expect(registerResult.success).toBe(true);
+    expect(unregisterResult.success).toBe(true);
+
+    // The unregister ran only after the register fully completed.
+    expect(events).toEqual([
+      "download:start",
+      "download:end",
+      "publish",
+      "register",
+      "unregister:tool-b",
+    ]);
+  });
+
+  test("a rejected operation does not break serialization for later ones", async () => {
+    const events: string[] = [];
+
+    const deps: ManageSecureCommandToolHandlerDeps = {
+      downloadBundle: async () => {
+        throw new Error("network down");
+      },
+      publishBundle: () => ({
+        success: true,
+        deduplicated: false,
+        bundlePath: "/tmp/bundle",
+      }),
+      registerTool: () => {},
+      unregisterTool: (toolName: string) => {
+        events.push(`unregister:${toolName}`);
+        return true;
+      },
+    };
+
+    const handler = createManageSecureCommandToolHandler(deps);
+
+    // First op fails inside the handler (download error → structured failure),
+    // second op must still run.
+    const first = await handler(registerRequest("tool-a"), CTX);
+    const second = await handler(unregisterRequest("tool-b"), CTX);
+
+    expect(first.success).toBe(false);
+    expect(first.error?.code).toBe("DOWNLOAD_FAILED");
+    expect(second.success).toBe(true);
+    expect(events).toEqual(["unregister:tool-b"]);
+  });
+});

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -678,7 +678,19 @@ export interface ManageSecureCommandToolHandlerDeps {
 export function createManageSecureCommandToolHandler(
   deps: ManageSecureCommandToolHandlerDeps,
 ): RpcMethodHandler<ManageSecureCommandTool, ManageSecureCommandToolResponse> {
-  return async (request) => {
+  // Serialize all manage_secure_command_tool operations. The register path
+  // awaits a bundle download mid-handler; during that await a concurrent
+  // unregister would run its "still in use?" check + bundle delete against a
+  // registry that doesn't yet reflect the in-flight registration — transiently
+  // deleting a bundle another caller is publishing or executing. Running these
+  // operations one-at-a-time closes that window. The registry and toolstore are
+  // process-global, so this single chain serializes tool management across
+  // every connection.
+  let tail: Promise<unknown> = Promise.resolve();
+
+  const handle = async (
+    request: ManageSecureCommandTool,
+  ): Promise<ManageSecureCommandToolResponse> => {
     if (request.action === "unregister") {
       const removed = deps.unregisterTool(request.toolName);
       if (!removed) {
@@ -783,6 +795,18 @@ export function createManageSecureCommandToolHandler(
     });
 
     return { success: true };
+  };
+
+  return (request) => {
+    // Chain each operation onto the previous one so they never interleave.
+    const result = tail.then(() => handle(request));
+    // Keep the chain alive regardless of this op's outcome — a rejection must
+    // not break serialization for subsequent operations.
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   };
 }
 


### PR DESCRIPTION
## Why

**PR 3 of the multi-client series** (follows #36472, #36494). This is the concurrency-hardening step flagged as a follow-up in #36494.

`manage_secure_command_tool`'s **register** path awaits a bundle download mid-handler (`await downloadBundle(...)`). During that await, a concurrent **unregister** — whose "still in use?" check and `deleteBundleFromToolstore` run synchronously — can delete a bundle against a registry state that doesn't yet reflect the in-flight registration. That transiently removes a bundle another caller is publishing or executing (a `run_authenticated_command` resolving the same digest would briefly fail). A single client can already trigger this by pipelining RPCs; multi-connection (a later PR) makes interleaving routine.

## What

- **Serialize** all `manage_secure_command_tool` operations through a per-handler promise chain in `createManageSecureCommandToolHandler`, so register and unregister never interleave. The registry and toolstore are process-global and the handler is built once per process, so this single chain serializes tool management across every connection. A rejected op can't break the chain for later ones.
- **Lock in the staging-isolation invariant** for `run_authenticated_command` with a test. No code change was needed — `createScratchDir` already uses `join(scratchBase, randomUUID())` (and the executor uses per-call `ces-home-<uuid>` / `ces-auth-<uuid>` dirs) — so interleaved commands can't read or clobber each other's staged inputs/outputs. The test pins it.

## Testing

- `tsc` clean, `eslint` clean.
- New tests: serialization (slow register can't let a concurrent unregister interleave; a rejected op doesn't break the chain) + staging isolation (two stagings get distinct scratch dirs).
- `bun test src/`: **569 pass, 2 fail** — the two failures (`managed-integration`, `managed-reconnect`) fail at `socket.listen()` (`Failed to listen at ::`), a sandbox networking limitation that reproduces identically on `main`; unrelated to this change.

## Next in the series

PR 4 = local-mode Unix socket listener (so sibling child processes can reach CES, not just the stdio parent); PR 5 = multi-connection accept loop + `credential-executor/AGENTS.md` "socket possession is authorization" docs; PR 6 = assistant-side per-child connection bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThtowSBkUHK91W6v2xASsR)_