### PR TITLE
fix(web): address Plugins-tab self-review gaps

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -181,6 +181,20 @@ describe("PluginDetailMobile", () => {
     expect(getActionButton("Remove")).toBeTruthy();
   });
 
+  test("origin badge stays hidden until the plugin loads", () => {
+    // While loading there's no `source`, so the badge would mislabel the
+    // plugin as Local. It must not render until the plugin resolves.
+    hookState.plugin = null;
+    hookState.isLoading = true;
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(screen.queryByText("Local")).toBeNull();
+    expect(screen.queryByText("External")).toBeNull();
+  });
+
   test("update available: Upgrade and Remove are both reachable, plus the badge", () => {
     // Regression for Codex P2: an update must not hide the uninstall path. The
     // shared action set renders Upgrade *and* Remove together, so mobile users

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -126,7 +126,7 @@ export function PluginDetailMobile({
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
             {updateAvailable ? <UpdateAvailableBadge /> : null}
-            <PluginOriginBadge external={isExternal} />
+            {plugin ? <PluginOriginBadge external={isExternal} /> : null}
           </div>
         </div>
         {plugin?.description ? (
@@ -160,13 +160,9 @@ export function PluginDetailMobile({
       {(isInstallError || isRemoveError || isUpgradeError) && (
         <div className="mt-3">
           <PluginDetailActionError
-            message={
-              isInstallError
-                ? "Failed to install plugin. Please try again."
-                : isRemoveError
-                  ? "Failed to remove plugin. Please try again."
-                  : "Failed to upgrade plugin. Please try again."
-            }
+            isInstallError={isInstallError}
+            isRemoveError={isRemoveError}
+            isUpgradeError={isUpgradeError}
           />
         </div>
       )}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -9,6 +9,13 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
+import {
+    PLUGIN_INSTALL_ERROR,
+    PLUGIN_REMOVE_ERROR,
+    PLUGIN_UPGRADE_ERROR,
+    pluginRemoveConfirmMessage,
+    pluginRiskyUpgradeConfirmMessage,
+} from "@/domains/intelligence/plugins/constants";
 import { shortSha } from "@/domains/intelligence/plugins/use-plugin-detail";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
@@ -20,13 +27,11 @@ import { Button, ConfirmDialog } from "@vellumai/design-library";
  * metadata table, loading / error states, and the Install / Download / Upgrade
  * / Remove action set don't drift between them. These take props (plugin +
  * drift + callbacks) and render UI only — data fetching stays in the consuming
- * panel/page via `usePluginDetail`.
+ * panel via `usePluginDetail`.
  *
- * Consumers: the desktop in-tab detail (`plugin-detail.tsx`) and the mobile
- * detail overlay (`plugin-detail-mobile.tsx`, on a separate branch). Both place
- * these pieces in their own layout chrome, so the building blocks stay
- * layout-agnostic. (The route page `plugin-detail-page.tsx` is being retired in
- * favor of a redirect.)
+ * The desktop in-tab detail (`plugin-detail.tsx`) and the mobile detail overlay
+ * (`plugin-detail-mobile.tsx`) each place these pieces in their own layout
+ * chrome, so the building blocks stay layout-agnostic.
  */
 
 interface PluginDetailMetadataProps {
@@ -262,7 +267,7 @@ export function PluginDetailActions({
       <ConfirmDialog
         open={confirmingRemove}
         title="Remove plugin"
-        message={`Remove "${plugin.name}" from this assistant?`}
+        message={pluginRemoveConfirmMessage(plugin.name)}
         confirmLabel="Remove"
         destructive
         onConfirm={confirmRemove}
@@ -272,7 +277,7 @@ export function PluginDetailActions({
       <ConfirmDialog
         open={confirmingUpgrade}
         title="Upgrade plugin"
-        message={`"${plugin.name}" has local edits that will be overwritten by the upgrade. Continue?`}
+        message={pluginRiskyUpgradeConfirmMessage(plugin.name)}
         confirmLabel="Upgrade anyway"
         destructive
         onConfirm={confirmUpgrade}
@@ -310,8 +315,30 @@ export function PluginDetailError() {
   );
 }
 
-/** Inline banner for a failed install / remove / upgrade attempt. */
-export function PluginDetailActionError({ message }: { message: string }) {
+/**
+ * Inline banner for a failed install / remove / upgrade attempt. Derives the
+ * message from the three error flags so the desktop and mobile detail surfaces
+ * stay in lockstep. Render it only when one of the flags is set.
+ */
+export function PluginDetailActionError({
+  isInstallError,
+  isRemoveError,
+  isUpgradeError,
+}: {
+  isInstallError: boolean;
+  isRemoveError: boolean;
+  isUpgradeError: boolean;
+}) {
+  const message = isInstallError
+    ? PLUGIN_INSTALL_ERROR
+    : isRemoveError
+      ? PLUGIN_REMOVE_ERROR
+      : isUpgradeError
+        ? PLUGIN_UPGRADE_ERROR
+        : null;
+
+  if (!message) return null;
+
   return (
     <div
       className="mb-3 flex items-center gap-2 rounded px-3 py-2 text-body-small-default"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -4,12 +4,12 @@
  * actions that reflect whether the plugin is installed and whether it has
  * drifted behind the marketplace pin. The back button invokes `onBack`.
  *
- * Unlike the retired route page, `PluginDetail` is callback-driven with no
- * routing, so there's no `MemoryRouter` or identity-store seeding here —
- * just the React Query cache pre-populated so the detail (and, for installed
- * copies, the drift inspect) queries resolve on mount instead of hitting the
- * network. Uses `@testing-library/react` (happy-dom) so the back-button
- * click can be exercised.
+ * `PluginDetail` is callback-driven with no routing, so there's no
+ * `MemoryRouter` or identity-store seeding here — just the React Query cache
+ * pre-populated so the detail (and, for installed copies, the drift inspect)
+ * queries resolve on mount instead of hitting the network. Uses
+ * `@testing-library/react` (happy-dom) so the back-button click can be
+ * exercised.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -25,10 +25,10 @@ interface PluginDetailProps {
 
 /**
  * In-tab detail panel for a single plugin, mirroring the Skills tab's
- * `SkillDetail` chrome (a back-button header + a `Card` body). Unlike the
- * retired `PluginDetailPage`, this is callback-driven with no routing: the
- * parent owns selection and passes `onBack` to close the panel. Removal
- * closes via `usePluginDetail`'s `onRemoved` hook.
+ * `SkillDetail` chrome (a back-button header + a `Card` body). It is
+ * callback-driven with no routing: the parent owns selection and passes
+ * `onBack` to close the panel. Removal closes via `usePluginDetail`'s
+ * `onRemoved` hook.
  *
  * Renders the plugin's README plus the metadata we track (source, homepage,
  * license, contributed surfaces) and Install / Download / Upgrade / Remove
@@ -81,13 +81,9 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
 
       {(isInstallError || isRemoveError || isUpgradeError) && (
         <PluginDetailActionError
-          message={
-            isInstallError
-              ? "Failed to install plugin. Please try again."
-              : isRemoveError
-                ? "Failed to remove plugin. Please try again."
-                : "Failed to upgrade plugin. Please try again."
-          }
+          isInstallError={isInstallError}
+          isRemoveError={isRemoveError}
+          isUpgradeError={isUpgradeError}
         />
       )}
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,7 +1,6 @@
 /**
- * Tests for `PluginIcon`: emoji defaulting by `external`, `emoji`
- * override, and the `sm` / `md` container sizing that matches
- * `SkillIcon`.
+ * Tests for `PluginIcon`: glyph defaulting by `external` and the `sm` / `md`
+ * container sizing that matches `SkillIcon`.
  *
  * Mounted via `@testing-library/react` (happy-dom — see
  * `clients/web/test-setup.ts`).
@@ -29,16 +28,6 @@ describe("PluginIcon", () => {
   test("defaults to 🧩 when not external", () => {
     const { container } = render(<PluginIcon />);
     expect(container.textContent).toBe(PUZZLE);
-  });
-
-  test("emoji prop overrides the external default", () => {
-    const { container } = render(<PluginIcon external emoji="🚀" />);
-    expect(container.textContent).toBe("🚀");
-  });
-
-  test("emoji prop overrides the non-external default", () => {
-    const { container } = render(<PluginIcon emoji="🚀" />);
-    expect(container.textContent).toBe("🚀");
   });
 
   test("sm size renders an h-7 w-7 container", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -2,7 +2,6 @@ import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
-  emoji?: string;
   size?: "sm" | "md";
   className?: string;
 }
@@ -15,17 +14,16 @@ const SIZE_CLASS = {
 /**
  * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
  * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
- * icon-image endpoint, so there is no remote-image branch. The default
+ * icon-image endpoint, so there is no remote-image branch. The glyph
  * follows the existing Plugins convention: 📦 for catalog (external),
- * 🧩 otherwise; a passed `emoji` overrides the default.
+ * 🧩 otherwise.
  */
 export function PluginIcon({
   external = false,
-  emoji,
   size = "sm",
   className,
 }: PluginIconProps) {
-  const glyph = emoji ?? (external ? "\u{1F4E6}" : "\u{1F9E9}");
+  const glyph = external ? "\u{1F4E6}" : "\u{1F9E9}";
 
   return (
     <span

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -144,6 +144,24 @@ describe("PluginListRow", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  test("does not render an origin badge (origin is unknowable from the list)", () => {
+    const onSelect = mock(() => {});
+
+    const { container } = render(
+      <PluginListRow
+        item={makeItem({ status: "installed", external: false })}
+        onSelect={onSelect}
+      />,
+    );
+
+    // The installed-list endpoint carries no source, so the row must not claim
+    // an origin. No Local/External tag and no globe/drive icon.
+    expect(container.querySelector(".lucide-globe")).toBeNull();
+    expect(container.querySelector(".lucide-hard-drive")).toBeNull();
+    expect(container.textContent).not.toContain("Local");
+    expect(container.textContent).not.toContain("External");
+  });
+
   test("upgrade affordance only appears with update-available drift", () => {
     const onSelect = mock(() => {});
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -2,7 +2,6 @@ import { ArrowDownToLine, ArrowUpCircle, Loader2, Trash2 } from "lucide-react";
 import type { KeyboardEvent } from "react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
-import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
@@ -24,11 +23,11 @@ interface PluginListRowProps {
 
 /**
  * Unified row for the Plugins tab, mirroring `SkillRow`: an emoji icon, the
- * name with version + origin/update badges, a description, and a single
- * trailing inline action chosen by status (Install for catalog entries,
- * Upgrade when an installed copy is behind the marketplace pin, otherwise
- * Remove). The whole row is a `role="button"` that fires `onSelect`; the
- * trailing action `stopPropagation`s so it never also selects the row.
+ * name with version + update badge, a description, and a single trailing
+ * inline action chosen by status (Install for catalog entries, Upgrade when an
+ * installed copy is behind the marketplace pin, otherwise Remove). The whole
+ * row is a `role="button"` that fires `onSelect`; the trailing action
+ * `stopPropagation`s so it never also selects the row.
  */
 export function PluginListRow({
   item,
@@ -80,7 +79,9 @@ export function PluginListRow({
                 v{item.version}
               </span>
             ) : null}
-            <PluginOriginBadge external={item.external} sourceHost={item.sourceHost} />
+            {/* No origin badge here: the installed-list endpoint carries no
+                source, so a list row can't tell Local from External. The detail
+                view derives origin from the plugin's own `source` instead. */}
             {updateAvailable ? <UpdateAvailableBadge /> : null}
           </div>
           <p

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
@@ -7,16 +7,12 @@ import { Tag } from "@vellumai/design-library";
  * Origin badge for plugins, mirroring `SkillOriginBadge`. Renders a
  * design-library `Tag` labeled `External` (with a globe icon) when the plugin
  * comes from a remote host, otherwise `Local` (with a drive icon).
- *
- * `sourceHost` is accepted for parity but does not change the label in v1.
  */
 export function PluginOriginBadge({
   external,
-  sourceHost: _sourceHost,
   className,
 }: {
   external: boolean;
-  sourceHost?: string;
   className?: string;
 }) {
   const meta = external

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -14,10 +14,19 @@ import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-d
 import { PluginDetailMobile } from "@/domains/intelligence/components/plugins/plugin-detail-mobile";
 import { FilterBar } from "@/domains/intelligence/components/plugins/plugin-filters";
 import { PluginListRow } from "@/domains/intelligence/components/plugins/plugin-list-row";
+import {
+    PLUGIN_INSTALL_ERROR,
+    PLUGIN_REMOVE_ERROR,
+    PLUGIN_UPGRADE_ERROR,
+    pluginRemoveConfirmMessage,
+    pluginRiskyUpgradeConfirmMessage,
+} from "@/domains/intelligence/plugins/constants";
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import type {
     PluginFilter,
     PluginListItem,
 } from "@/domains/intelligence/plugins/types";
+import { shortSha } from "@/domains/intelligence/plugins/use-plugin-detail";
 import { usePluginsList } from "@/domains/intelligence/plugins/use-plugins-list";
 import {
     filterByStatus,
@@ -29,16 +38,13 @@ import {
     usePluginDrift,
 } from "@/domains/intelligence/use-plugin-drift";
 import {
-    pluginsByNameInspectGetQueryKey,
-    pluginsGetQueryKey,
-    pluginsSearchGetQueryKey,
     usePluginsByNameDeleteMutation,
     usePluginsByNameUpgradePostMutation,
     usePluginsInstallPostMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
-import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+import { Button, Card, ConfirmDialog, toast } from "@vellumai/design-library";
 
 interface PluginsTabProps {
   assistantId: string;
@@ -86,26 +92,15 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
     usePluginsList(assistantId);
 
   const invalidate = useCallback(
-    (name: string) => {
-      void queryClient.invalidateQueries({
-        queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: pluginsSearchGetQueryKey({
-          path: { assistant_id: assistantId },
-        }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: pluginsByNameInspectGetQueryKey({
-          path: { assistant_id: assistantId, name },
-        }),
-      });
-    },
+    (name: string) => invalidatePluginQueries(queryClient, assistantId, name),
     [assistantId, queryClient],
   );
 
   const installMutation = usePluginsInstallPostMutation({
     onMutate: (variables) => setInstallingName(variables.body.name),
+    onSuccess: (_data, variables) =>
+      toast.success(`Installed ${variables.body.name}`),
+    onError: () => toast.error(PLUGIN_INSTALL_ERROR),
     onSettled: (_data, _error, variables) => {
       setInstallingName(null);
       invalidate(variables.body.name);
@@ -114,6 +109,9 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
 
   const removeMutation = usePluginsByNameDeleteMutation({
     onMutate: (variables) => setRemovingName(variables.path.name),
+    onSuccess: (_data, variables) =>
+      toast.success(`Removed ${variables.path.name}`),
+    onError: () => toast.error(PLUGIN_REMOVE_ERROR),
     onSettled: (_data, _error, variables) => {
       setRemovingName(null);
       invalidate(variables.path.name);
@@ -122,6 +120,13 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
 
   const upgradeMutation = usePluginsByNameUpgradePostMutation({
     onMutate: (variables) => setUpgradingName(variables.path.name),
+    onSuccess: (result, variables) =>
+      toast.success(
+        result.outcome === "already-up-to-date"
+          ? `${variables.path.name} is already up to date`
+          : `Upgraded ${variables.path.name} to ${shortSha(result.toCommit)}`,
+      ),
+    onError: () => toast.error(PLUGIN_UPGRADE_ERROR),
     onSettled: (_data, _error, variables) => {
       setUpgradingName(null);
       invalidate(variables.path.name);
@@ -270,9 +275,7 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
         open={pendingRemoval !== null}
         title="Remove plugin"
         message={
-          pendingRemoval
-            ? `Remove "${pendingRemoval.name}" from this assistant?`
-            : ""
+          pendingRemoval ? pluginRemoveConfirmMessage(pendingRemoval.name) : ""
         }
         confirmLabel="Remove"
         destructive
@@ -285,7 +288,7 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
         title="Upgrade plugin"
         message={
           pendingUpgrade
-            ? `"${pendingUpgrade.name}" has local edits that upgrading will overwrite. Continue?`
+            ? pluginRiskyUpgradeConfirmMessage(pendingUpgrade.name)
             : ""
         }
         confirmLabel="Upgrade"

--- a/clients/web/src/domains/intelligence/plugin-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/plugin-detail-page.test.tsx
@@ -1,15 +1,15 @@
 /**
- * Tests for the retired standalone plugin detail route. The page is now a
- * thin redirect shim: detail renders in-tab via the `?plugin=<name>`
- * deep-link, so the old `/assistant/plugins/:name` URL forwards there to
- * preserve the bookmark/deep-link contract.
+ * Tests for the standalone plugin-detail route, a thin redirect shim: detail
+ * renders in-tab via the `?plugin=<name>` deep-link, so the
+ * `/assistant/plugins/:name` URL forwards there to preserve the
+ * bookmark/deep-link contract.
  *
  * Mounted via `@testing-library/react` (happy-dom — see `test-setup.ts`)
  * with sentinel routes at the redirect targets so the test can prove where
  * the shim lands. The active assistant id is stubbed and the identity store
  * is seeded per-test so the backwards-compat gate's branch is deterministic
  * (a plugin-capable version forwards in-tab; a too-old version redirects to
- * Identity, matching the prior route's guard).
+ * Identity).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared user-facing copy for the plugin surfaces (desktop detail, mobile
+ * detail, and the Plugins tab), kept in one place so the confirm dialogs and
+ * failure messages stay in lockstep across them.
+ */
+
+/** Confirm-dialog body for removing an installed plugin. */
+export const pluginRemoveConfirmMessage = (name: string): string =>
+  `Remove "${name}" from this assistant?`;
+
+/** Confirm-dialog body for an upgrade that would clobber local edits. */
+export const pluginRiskyUpgradeConfirmMessage = (name: string): string =>
+  `"${name}" has local edits that will be overwritten by the upgrade. Continue?`;
+
+/** Failure copy for a failed install / remove / upgrade attempt. */
+export const PLUGIN_INSTALL_ERROR =
+  "Failed to install plugin. Please try again.";
+export const PLUGIN_REMOVE_ERROR = "Failed to remove plugin. Please try again.";
+export const PLUGIN_UPGRADE_ERROR =
+  "Failed to upgrade plugin. Please try again.";

--- a/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
+++ b/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
@@ -1,0 +1,40 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import {
+    pluginsByNameGetQueryKey,
+    pluginsByNameInspectGetQueryKey,
+    pluginsGetQueryKey,
+    pluginsSearchGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+
+/**
+ * Invalidate the plugin queries an install / remove / upgrade can stale. The
+ * installed list and catalog search always go stale; the per-plugin detail
+ * read and its drift inspect only when a specific plugin `name` is supplied.
+ */
+export function invalidatePluginQueries(
+  queryClient: QueryClient,
+  assistantId: string,
+  name?: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: pluginsSearchGetQueryKey({
+      path: { assistant_id: assistantId },
+    }),
+  });
+  if (name) {
+    void queryClient.invalidateQueries({
+      queryKey: pluginsByNameGetQueryKey({
+        path: { assistant_id: assistantId, name },
+      }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: pluginsByNameInspectGetQueryKey({
+        path: { assistant_id: assistantId, name },
+      }),
+    });
+  }
+}

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -19,7 +19,6 @@ export interface PluginListItem {
   external: boolean;
   version?: string;
   path?: string;
-  sourceHost?: string;
   issues?: string[];
 }
 

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import {
     hasLocalEdits as computeHasLocalEdits,
     type PluginDrift,
@@ -8,10 +9,6 @@ import {
 } from "@/domains/intelligence/use-plugin-drift";
 import {
     pluginsByNameGetOptions,
-    pluginsByNameGetQueryKey,
-    pluginsByNameInspectGetQueryKey,
-    pluginsGetQueryKey,
-    pluginsSearchGetQueryKey,
     usePluginsByNameDeleteMutation,
     usePluginsByNameUpgradePostMutation,
     usePluginsInstallPostMutation,
@@ -87,28 +84,10 @@ export function usePluginDetail(
   });
   const drift = driftQuery.data;
 
-  const invalidate = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: pluginsSearchGetQueryKey({
-        path: { assistant_id: assistantId },
-      }),
-    });
-    if (name) {
-      void queryClient.invalidateQueries({
-        queryKey: pluginsByNameGetQueryKey({
-          path: { assistant_id: assistantId, name },
-        }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: pluginsByNameInspectGetQueryKey({
-          path: { assistant_id: assistantId, name },
-        }),
-      });
-    }
-  }, [assistantId, name, queryClient]);
+  const invalidate = useCallback(
+    () => invalidatePluginQueries(queryClient, assistantId, name),
+    [assistantId, name, queryClient],
+  );
 
   const installMutation = usePluginsInstallPostMutation({
     onSuccess: () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -60,7 +60,6 @@ describe("mergePlugins", () => {
       description: "B",
       status: "available",
       external: true,
-      sourceHost: "acme/beta",
     });
   });
 

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -35,7 +35,6 @@ export function mergePlugins(
       status: "available",
       external: true,
       path: m.path,
-      sourceHost: m.source.repo,
     }));
 
   return [...installedItems, ...catalogItems];

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -133,7 +133,6 @@ export const routes = {
   },
   identity: r("/assistant/identity"),
   plugins: r("/assistant/plugins"),
-  plugin: (name: string) => dyn(r("/assistant/plugins"), name),
   skills: r("/assistant/skills"),
   workspace: r("/assistant/workspace"),
   library: {


### PR DESCRIPTION
## Summary
- Inline list actions now toast on success/failure (parity with the detail panel).
- List rows no longer show a misleading origin badge for installed plugins (origin is unknowable from the list endpoint); removed dead sourceHost prop.
- Mobile detail origin badge only renders once the plugin loads.
- Removed dead routes.plugin helper; extracted shared plugin query invalidation; hoisted confirm-dialog copy + action-error message into shared constants/component; present-tense docblocks; dropped unused PluginIcon emoji prop.

Part of plan: plugins-tab-match-skills.md (self-review remediation)