### PR TITLE
fix(memory): guard maybeRebuildMemoryV2Concepts reembed enqueue against in-flight job

### DIFF
--- a/assistant/src/daemon/__tests__/memory-v2-startup.test.ts
+++ b/assistant/src/daemon/__tests__/memory-v2-startup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../../config/schema.js";
+
+function fakeConfig(): AssistantConfig {
+  return {
+    memory: { v2: { enabled: true } },
+  } as unknown as AssistantConfig;
+}
+
+/**
+ * Reset and re-install the mocks for the collaborator modules
+ * `maybeRebuildMemoryV2Concepts` pulls in, then re-import the module under test
+ * so its dynamic imports resolve to the freshly-mocked collaborators. Returns
+ * the spies plus the re-imported function.
+ *
+ * Drives the empty-after-create branch (collection not migrated, zero points,
+ * pages on disk) so the reembed enqueue decision is reached, and lets the test
+ * choose whether a `memory_v2_reembed` job is already in-flight.
+ */
+async function withMocks(opts: { reembedInFlight: boolean }) {
+  const spies = {
+    enqueueMemoryJob: mock(() => "job-id"),
+    hasActiveJobOfType: mock(
+      (type: string) => opts.reembedInFlight && type === "memory_v2_reembed",
+    ),
+    ensureConceptPageCollection: mock(async () => ({ migrated: false })),
+    countConceptPagePoints: mock(async () => 0),
+    clearReembedSentinel: mock(async () => {}),
+    hasConceptPages: mock(async () => true),
+  };
+
+  mock.module("../../persistence/jobs-store.js", () => ({
+    enqueueMemoryJob: spies.enqueueMemoryJob,
+    hasActiveJobOfType: spies.hasActiveJobOfType,
+  }));
+  mock.module("../../memory/v2/qdrant.js", () => ({
+    ensureConceptPageCollection: spies.ensureConceptPageCollection,
+    countConceptPagePoints: spies.countConceptPagePoints,
+    clearReembedSentinel: spies.clearReembedSentinel,
+  }));
+  mock.module("../../memory/v2/page-store.js", () => ({
+    hasConceptPages: spies.hasConceptPages,
+  }));
+  const realPlatform = await import("../../util/platform.js");
+  mock.module("../../util/platform.js", () => ({
+    ...realPlatform,
+    getWorkspaceDir: () => "/tmp/workspace",
+  }));
+
+  const mod = await import("../memory-v2-startup.js");
+  return {
+    spies,
+    maybeRebuildMemoryV2Concepts: mod.maybeRebuildMemoryV2Concepts,
+  };
+}
+
+describe("maybeRebuildMemoryV2Concepts reembed dedup", () => {
+  test("does NOT enqueue a second reembed when one is already in-flight", async () => {
+    const { spies, maybeRebuildMemoryV2Concepts } = await withMocks({
+      reembedInFlight: true,
+    });
+
+    await maybeRebuildMemoryV2Concepts(fakeConfig());
+
+    expect(spies.hasActiveJobOfType).toHaveBeenCalledWith("memory_v2_reembed");
+    expect(spies.enqueueMemoryJob).toHaveBeenCalledTimes(0);
+    // The sentinel is still retired even when the enqueue is skipped.
+    expect(spies.clearReembedSentinel).toHaveBeenCalledTimes(1);
+  });
+
+  test("enqueues the reembed when none is in-flight", async () => {
+    const { spies, maybeRebuildMemoryV2Concepts } = await withMocks({
+      reembedInFlight: false,
+    });
+
+    await maybeRebuildMemoryV2Concepts(fakeConfig());
+
+    expect(spies.enqueueMemoryJob).toHaveBeenCalledTimes(1);
+    expect(spies.enqueueMemoryJob).toHaveBeenCalledWith(
+      "memory_v2_reembed",
+      {},
+    );
+    expect(spies.clearReembedSentinel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -110,10 +110,12 @@ async function defaultRecreateCollectionsAtDim(
  * collection only carries points under v3-live).
  *
  * Both enqueues dedup against an already-in-flight (pending or running) job of
- * the same type: on the lifecycle startup path the reconcile runs immediately
- * before `maybeRebuildMemoryV2Concepts`, which also enqueues `memory_v2_reembed`
- * when it finds the just-(re)created collection empty — without the guard the
- * corpus would re-embed twice.
+ * the same type. `memory_v2_reembed` can be enqueued from two startup sites that
+ * both guard on this in-flight check: the credential-arrival reconcile retry
+ * (reconcile-vs-reconcile), and the lifecycle reconcile-then-rebuild interleaving
+ * where `maybeRebuildMemoryV2Concepts` also enqueues a reembed when it finds the
+ * just-(re)created collection empty. The guard keeps the corpus re-embed to a
+ * single round-trip across either path.
  */
 function defaultEnqueueReembed(config: AssistantConfig): void {
   if (!hasActiveJobOfType("memory_v2_reembed")) {

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -335,7 +335,8 @@ export async function maybeRebuildMemoryV2Concepts(
       clearReembedSentinel,
     } = await import("../memory/v2/qdrant.js");
     const { hasConceptPages } = await import("../memory/v2/page-store.js");
-    const { enqueueMemoryJob } = await import("../persistence/jobs-store.js");
+    const { enqueueMemoryJob, hasActiveJobOfType } =
+      await import("../persistence/jobs-store.js");
 
     const { migrated } = await ensureConceptPageCollection();
 
@@ -348,6 +349,17 @@ export async function maybeRebuildMemoryV2Concepts(
     }
 
     if (shouldReembed) {
+      // The lifecycle startup path runs `reconcileEmbeddingIdentity` immediately
+      // before this, and on a commit-fresh/migrate action that reconcile already
+      // enqueues `memory_v2_reembed`. Dedup against the in-flight job so the
+      // reconcile-then-rebuild interleaving re-embeds the corpus once, not twice.
+      if (hasActiveJobOfType("memory_v2_reembed")) {
+        log.info(
+          "Memory v2 reembed already queued — skipping duplicate enqueue",
+        );
+        await clearReembedSentinel();
+        return;
+      }
       const jobId = enqueueMemoryJob("memory_v2_reembed", {});
       log.info(
         { jobId, collectionMigrated: migrated },


### PR DESCRIPTION
## Summary
Adds the in-flight hasActiveJobOfType guard to maybeRebuildMemoryV2Concepts so a commit-fresh/migrate reconcile followed by the empty-after-create rebuild enqueues memory_v2_reembed exactly once (was double-enqueuing a full corpus re-embed on startup).

Fixes the remaining gap from plan re-review for embedding-dim-reconcile.md.