### PR TITLE
fix(host_bash): cancelled-output parity + bash timeout test

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.test.ts
+++ b/assistant/src/tools/host-terminal/host-shell.test.ts
@@ -297,6 +297,9 @@ describe("host_bash background lifecycle events — proxy path", () => {
     const completed = completedEvents();
     expect(completed).toHaveLength(1);
     expect(completed[0]).toMatchObject({ status: "cancelled" });
+    // Cancellation must surface a cancellation message, not "failed" framing.
+    expect(completed[0]!.output).toContain("cancelled");
+    expect(completed[0]!.output).not.toContain("failed");
   });
 });
 
@@ -386,5 +389,8 @@ describe("host_bash background lifecycle events — direct spawn path", () => {
     const completed = completedEvents();
     expect(completed).toHaveLength(1);
     expect(completed[0]).toMatchObject({ status: "cancelled" });
+    // Cancellation must surface a cancellation message, not "failed" framing.
+    expect(completed[0]!.output).toContain("cancelled");
+    expect(completed[0]!.output).not.toContain("failed");
   });
 });

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -310,14 +310,22 @@ export const hostShellTool = {
               : result.isError
                 ? "failed"
                 : "completed";
-            broadcastMessage({
-              type: "background_tool_completed",
-              id: bgId,
-              conversationId: context.conversationId,
-              status,
-              output: result.content,
-              completedAt: Date.now(),
-            });
+            broadcastMessage(
+              {
+                type: "background_tool_completed",
+                id: bgId,
+                conversationId: context.conversationId,
+                status,
+                // A cancelled command's proxy result carries SIGKILL/"failed"
+                // framing; surface the cancellation instead (see shell.ts).
+                output:
+                  status === "cancelled"
+                    ? `Background host command cancelled (id=${bgId}).`
+                    : result.content,
+                completedAt: Date.now(),
+              },
+              context.conversationId,
+            );
             const framing = result.isError
               ? `Background host command failed (id=${bgId}):`
               : `Background host command completed (id=${bgId}):`;
@@ -335,14 +343,25 @@ export const hostShellTool = {
             });
           })
           .catch((err) => {
-            broadcastMessage({
-              type: "background_tool_completed",
-              id: bgId,
-              conversationId: context.conversationId,
-              status: abortController.signal.aborted ? "cancelled" : "failed",
-              output: err instanceof Error ? err.message : String(err),
-              completedAt: Date.now(),
-            });
+            const status = abortController.signal.aborted
+              ? "cancelled"
+              : "failed";
+            broadcastMessage(
+              {
+                type: "background_tool_completed",
+                id: bgId,
+                conversationId: context.conversationId,
+                status,
+                output:
+                  status === "cancelled"
+                    ? `Background host command cancelled (id=${bgId}).`
+                    : err instanceof Error
+                      ? err.message
+                      : String(err),
+                completedAt: Date.now(),
+              },
+              context.conversationId,
+            );
             void wakeAgentForOpportunity({
               conversationId: context.conversationId,
               hint: `Background host command failed (id=${bgId}): ${err instanceof Error ? err.message : String(err)}`,
@@ -361,14 +380,17 @@ export const hostShellTool = {
           cancel: (reason?: string) => abortController.abort(reason),
         });
 
-        broadcastMessage({
-          type: "background_tool_started",
-          id: bgId,
-          toolName: "host_bash",
-          conversationId: context.conversationId,
-          command,
-          startedAt,
-        });
+        broadcastMessage(
+          {
+            type: "background_tool_started",
+            id: bgId,
+            toolName: "host_bash",
+            conversationId: context.conversationId,
+            command,
+            startedAt,
+          },
+          context.conversationId,
+        );
 
         return {
           content: JSON.stringify({ backgrounded: true, id: bgId }),
@@ -497,15 +519,23 @@ export const hostShellTool = {
           : result.isError
             ? "failed"
             : "completed";
-        broadcastMessage({
-          type: "background_tool_completed",
-          id: bgId,
-          conversationId: context.conversationId,
-          status,
-          exitCode: code,
-          output: result.content,
-          completedAt: Date.now(),
-        });
+        broadcastMessage(
+          {
+            type: "background_tool_completed",
+            id: bgId,
+            conversationId: context.conversationId,
+            status,
+            exitCode: code,
+            // A cancelled command's SIGKILL output is framed as "failed";
+            // surface the cancellation instead (see shell.ts).
+            output:
+              status === "cancelled"
+                ? `Background host command cancelled (id=${bgId}).`
+                : result.content,
+            completedAt: Date.now(),
+          },
+          context.conversationId,
+        );
         const framing = result.isError
           ? `Background host command failed (id=${bgId}):`
           : `Background host command completed (id=${bgId}):`;
@@ -528,14 +558,21 @@ export const hostShellTool = {
         if (completed) return;
         completed = true;
         clearTimeout(timer);
-        broadcastMessage({
-          type: "background_tool_completed",
-          id: bgId,
-          conversationId: context.conversationId,
-          status: aborted ? "cancelled" : "failed",
-          output: err.message,
-          completedAt: Date.now(),
-        });
+        const status = aborted ? "cancelled" : "failed";
+        broadcastMessage(
+          {
+            type: "background_tool_completed",
+            id: bgId,
+            conversationId: context.conversationId,
+            status,
+            output:
+              status === "cancelled"
+                ? `Background host command cancelled (id=${bgId}).`
+                : err.message,
+            completedAt: Date.now(),
+          },
+          context.conversationId,
+        );
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
           hint: `Background host command failed (id=${bgId}): ${err.message}`,
@@ -557,14 +594,17 @@ export const hostShellTool = {
         },
       });
 
-      broadcastMessage({
-        type: "background_tool_started",
-        id: bgId,
-        toolName: "host_bash",
-        conversationId: context.conversationId,
-        command,
-        startedAt,
-      });
+      broadcastMessage(
+        {
+          type: "background_tool_started",
+          id: bgId,
+          toolName: "host_bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt,
+        },
+        context.conversationId,
+      );
 
       return {
         content: JSON.stringify({ backgrounded: true, id: bgId }),

--- a/assistant/src/tools/terminal/shell.test.ts
+++ b/assistant/src/tools/terminal/shell.test.ts
@@ -135,6 +135,30 @@ describe("background bash lifecycle events", () => {
     });
   });
 
+  test("timed-out background command broadcasts completed with status failed", async () => {
+    // A 1s timeout against a long-running command forces the timeout watcher
+    // to SIGKILL the process group (timedOut=true, aborted=false), which must
+    // map to "failed" — distinct from a cancel's "cancelled".
+    const result = await shellTool.execute(
+      {
+        command: "sleep 30",
+        activity: "test",
+        background: true,
+        timeout_seconds: 1,
+      },
+      makeContext(),
+    );
+    const { id } = JSON.parse(result.content) as { id: string };
+
+    await waitFor(() => completedEvents().length > 0);
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({ id, status: "failed" });
+    expect(completed[0]?.exitCode).toBeNull();
+    // A timeout is not a cancel: it must not carry the cancellation message.
+    expect(completed[0]?.output).not.toContain("cancelled");
+  });
+
   test("cancelled background command broadcasts completed with status cancelled", async () => {
     const id = await startBackground("sleep 30");
 


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for bash-bg-task-ui.md:
- host_bash cancelled completions surface a cancellation message (not failed framing), matching local bash
- broadcastMessage call sites in host-shell pass conversationId for symmetry with shell.ts
- add the missing local-bash timeout→failed test