### PR TITLE
fix(web): final Plugins-tab self-review polish

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -83,9 +83,8 @@ mock.module("@/domains/intelligence/plugins/use-plugin-detail", () => ({
     isRemoveError: false,
     isUpgradeError: false,
   }),
-  // The shared `PluginDetailActions` imports `shortSha` from this module for its
-  // upgrade tooltip, so the mock must re-export it.
-  shortSha: (sha: string | null) => (sha ? sha.slice(0, 7) : "unknown"),
+  // `shortSha` is not stubbed: `PluginDetailActions` now imports it from
+  // `plugins/utils`, so the real helper runs.
 }));
 
 const { PluginDetailMobile } = await import(

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -14,9 +14,10 @@ import {
     PLUGIN_REMOVE_ERROR,
     PLUGIN_UPGRADE_ERROR,
     pluginRemoveConfirmMessage,
+    pluginRiskyUpgradeConfirmLabel,
     pluginRiskyUpgradeConfirmMessage,
 } from "@/domains/intelligence/plugins/constants";
-import { shortSha } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { cn } from "@/utils/misc";
@@ -278,7 +279,7 @@ export function PluginDetailActions({
         open={confirmingUpgrade}
         title="Upgrade plugin"
         message={pluginRiskyUpgradeConfirmMessage(plugin.name)}
-        confirmLabel="Upgrade anyway"
+        confirmLabel={pluginRiskyUpgradeConfirmLabel}
         destructive
         onConfirm={confirmUpgrade}
         onCancel={() => setConfirmingUpgrade(false)}

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -20,6 +20,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { PLUGIN_INSTALL_ERROR } from "@/domains/intelligence/plugins/constants";
 import type {
   PluginsByNameGetResponse,
   PluginsByNameInspectGetResponse,
@@ -77,6 +78,21 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     data: pluginDetail(options.path.name),
     ...okResponse,
   })),
+}));
+
+// The tab-level mutations toast on success / error; spy on `toast` while
+// keeping the rest of the design library (Button, Card, ConfirmDialog) real so
+// the list still renders under happy-dom.
+const toastSuccessSpy = mock((_message: string) => {});
+const toastErrorSpy = mock((_message: string) => {});
+const dlActual = await import("@vellumai/design-library");
+mock.module("@vellumai/design-library", () => ({
+  ...dlActual,
+  toast: Object.assign((_message: string) => {}, {
+    success: toastSuccessSpy,
+    error: toastErrorSpy,
+    dismiss: () => {},
+  }),
 }));
 
 const { PluginsTab } = await import("./plugins-tab");
@@ -168,6 +184,8 @@ beforeEach(() => {
   installSpy.mockClear();
   deleteSpy.mockClear();
   upgradeSpy.mockClear();
+  toastSuccessSpy.mockClear();
+  toastErrorSpy.mockClear();
 });
 
 afterEach(() => {
@@ -231,6 +249,34 @@ describe("PluginsTab", () => {
       path: { assistant_id: ASSISTANT_ID },
       body: { name: "apollo-bot-brain" },
     });
+  });
+
+  test("a successful inline install fires a success toast", async () => {
+    catalogMatches = [catalog()];
+
+    const { findByLabelText } = renderTab();
+    fireEvent.click(await findByLabelText("Install plugin"));
+
+    await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledTimes(1));
+    expect(toastSuccessSpy.mock.calls[0]?.[0]).toContain("apollo-bot-brain");
+    expect(toastErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test("a failed inline install surfaces an error toast", async () => {
+    catalogMatches = [catalog()];
+    // Force the next install into the mutation's error branch (the SDK throws
+    // because the generated mutationFn passes `throwOnError: true`).
+    installSpy.mockImplementationOnce(async () => {
+      throw new Error("install failed");
+    });
+
+    const { findByLabelText } = renderTab();
+    fireEvent.click(await findByLabelText("Install plugin"));
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(PLUGIN_INSTALL_ERROR),
+    );
+    expect(toastSuccessSpy).not.toHaveBeenCalled();
   });
 
   test("inline Remove opens the confirm dialog without deleting yet", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -19,6 +19,7 @@ import {
     PLUGIN_REMOVE_ERROR,
     PLUGIN_UPGRADE_ERROR,
     pluginRemoveConfirmMessage,
+    pluginRiskyUpgradeConfirmLabel,
     pluginRiskyUpgradeConfirmMessage,
 } from "@/domains/intelligence/plugins/constants";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
@@ -26,11 +27,11 @@ import type {
     PluginFilter,
     PluginListItem,
 } from "@/domains/intelligence/plugins/types";
-import { shortSha } from "@/domains/intelligence/plugins/use-plugin-detail";
 import { usePluginsList } from "@/domains/intelligence/plugins/use-plugins-list";
 import {
     filterByStatus,
     matchesQuery,
+    shortSha,
 } from "@/domains/intelligence/plugins/utils";
 import {
     hasLocalEdits,
@@ -291,7 +292,7 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
             ? pluginRiskyUpgradeConfirmMessage(pendingUpgrade.name)
             : ""
         }
-        confirmLabel="Upgrade"
+        confirmLabel={pluginRiskyUpgradeConfirmLabel}
         destructive
         onConfirm={confirmUpgrade}
         onCancel={() => setPendingUpgrade(null)}

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -12,6 +12,9 @@ export const pluginRemoveConfirmMessage = (name: string): string =>
 export const pluginRiskyUpgradeConfirmMessage = (name: string): string =>
   `"${name}" has local edits that will be overwritten by the upgrade. Continue?`;
 
+/** Confirm-dialog button label for the risky (local-edit-overwriting) upgrade. */
+export const pluginRiskyUpgradeConfirmLabel = "Upgrade anyway";
+
 /** Failure copy for a failed install / remove / upgrade attempt. */
 export const PLUGIN_INSTALL_ERROR =
   "Failed to install plugin. Please try again.";

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
@@ -16,10 +16,11 @@ import {
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { toast } from "@vellumai/design-library";
 
-/** First 7 chars of a commit SHA, matching git's default short form. */
-export function shortSha(sha: string | null): string {
-  return sha ? sha.slice(0, 7) : "unknown";
-}
+import { shortSha } from "./utils";
+
+// Re-export so existing importers/mocks that pull `shortSha` from this hook
+// module keep working now that the helper lives in `./utils`.
+export { shortSha };
 
 interface UsePluginDetailOptions {
   /**

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -9,6 +9,7 @@ import {
   filterByStatus,
   matchesQuery,
   mergePlugins,
+  shortSha,
   sortPlugins,
 } from "./utils";
 
@@ -152,5 +153,15 @@ describe("filterByStatus", () => {
 
   test("available returns only available", () => {
     expect(filterByStatus(items, "available").map((p) => p.name)).toEqual(["b"]);
+  });
+});
+
+describe("shortSha", () => {
+  test("truncates a commit SHA to its first 7 chars", () => {
+    expect(shortSha("1234567890abcdef1234567890abcdef12345678")).toBe("1234567");
+  });
+
+  test("returns 'unknown' for a null SHA", () => {
+    expect(shortSha(null)).toBe("unknown");
   });
 });

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -66,3 +66,8 @@ export function filterByStatus(
   if (filter === "all") return items;
   return items.filter((i) => i.status === filter);
 }
+
+/** First 7 chars of a commit SHA, matching git's default short form. */
+export function shortSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : "unknown";
+}


### PR DESCRIPTION
## Summary
- Unify the risky-upgrade confirm button label across tab + detail via a shared constant.
- Move the pure shortSha helper from the use-plugin-detail hook module to plugins/utils (re-exported for compat); decouple presentational consumers.
- Add a regression test for the tab-level action success/error toasts.

Part of plan: plugins-tab-match-skills.md (self-review remediation r2)