### PR TITLE
fix(web): background-task detail/stop/status cleanups

### DIFF
--- a/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.test.tsx
@@ -32,15 +32,26 @@ function makeEntry(
 afterEach(cleanup);
 
 describe("BackgroundTaskDetailPanel", () => {
-  test("renders command, status, and output for a terminal task", () => {
+  test("renders command, status, exit code, and output for a terminal task", () => {
     render(<BackgroundTaskDetailPanel entry={makeEntry()} onClose={noop} />);
     // Command appears in both the header title and the command code block.
     expect(screen.getAllByText("npm run build").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Completed")).toBeDefined();
+    expect(screen.getByText("Exit code: 0")).toBeDefined();
     expect(screen.getByText("Build succeeded in 4.2s")).toBeDefined();
   });
 
-  test("hides the output section while the task is still running", () => {
+  test("renders a non-zero exit code for a failed task", () => {
+    render(
+      <BackgroundTaskDetailPanel
+        entry={makeEntry({ status: "failed", exitCode: 1 })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByText("Exit code: 1")).toBeDefined();
+  });
+
+  test("hides the output and exit-code sections while the task is still running", () => {
     render(
       <BackgroundTaskDetailPanel
         entry={makeEntry({ status: "running", output: undefined })}
@@ -49,6 +60,17 @@ describe("BackgroundTaskDetailPanel", () => {
     );
     expect(screen.getByText("Running")).toBeDefined();
     expect(screen.queryByText("Output")).toBeNull();
+    expect(screen.queryByText(/Exit code:/)).toBeNull();
+  });
+
+  test("omits the exit-code line when none was captured", () => {
+    render(
+      <BackgroundTaskDetailPanel
+        entry={makeEntry({ status: "cancelled", exitCode: null })}
+        onClose={noop}
+      />,
+    );
+    expect(screen.queryByText(/Exit code:/)).toBeNull();
   });
 
   test("close button fires onClose", () => {

--- a/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
@@ -11,60 +11,29 @@ import { SquareTerminal } from "lucide-react";
 
 import { Typography } from "@vellumai/design-library";
 
+import { BackgroundTaskStatusBadge } from "@/domains/chat/components/background-task-status-badge";
 import { DetailShell } from "@/domains/chat/components/detail-shell";
-import { CodeBlock } from "@/domains/chat/components/tool-detail-panel";
-import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 import {
-  backgroundTaskStatusColor,
-  backgroundTaskStatusLabel,
-  isActiveBackgroundTaskStatus,
-} from "@/utils/background-task-status";
+  CodeBlock,
+  SectionLabel,
+} from "@/domains/chat/components/tool-detail-panel";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+import { isActiveBackgroundTaskStatus } from "@/utils/background-task-status";
 
 export interface BackgroundTaskDetailPanelProps {
   entry: BackgroundTaskEntry;
   onClose: () => void;
 }
 
-/** Uppercase section label in `--content-tertiary`. */
-function SectionLabel({ children }: { children: string }) {
-  return (
-    <Typography
-      variant="label-small-default"
-      as="div"
-      className="mb-1.5 uppercase tracking-wider text-[var(--content-tertiary)]"
-    >
-      {children}
-    </Typography>
-  );
-}
-
-/** Status pill — dot + label tinted by the task's semantic status color. */
-function StatusBadge({ status }: { status: BackgroundTaskEntry["status"] }) {
-  const color = backgroundTaskStatusColor(status);
-  return (
-    <div
-      className="mb-4 inline-flex items-center gap-1.5 text-label-small-default"
-      style={{ color }}
-    >
-      <span
-        className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: color }}
-        aria-hidden
-      />
-      {backgroundTaskStatusLabel(status)}
-    </div>
-  );
-}
-
 export function BackgroundTaskDetailPanel({
   entry,
   onClose,
 }: BackgroundTaskDetailPanelProps) {
-  // Output is only meaningful once the task has settled (terminal status).
+  const isTerminal = !isActiveBackgroundTaskStatus(entry.status);
+  // Output and exit code are only meaningful once the task has settled.
   const showOutput =
-    !isActiveBackgroundTaskStatus(entry.status) &&
-    entry.output !== undefined &&
-    entry.output !== "";
+    isTerminal && entry.output !== undefined && entry.output !== "";
+  const showExitCode = isTerminal && entry.exitCode != null;
 
   return (
     <DetailShell
@@ -73,7 +42,18 @@ export function BackgroundTaskDetailPanel({
       closeLabel="Close task detail"
       onClose={onClose}
     >
-      <StatusBadge status={entry.status} />
+      <div className="mb-4 flex items-center gap-2">
+        <BackgroundTaskStatusBadge status={entry.status} />
+        {showExitCode && (
+          <Typography
+            variant="body-small-default"
+            as="span"
+            className="text-[var(--content-tertiary)]"
+          >
+            Exit code: {entry.exitCode}
+          </Typography>
+        )}
+      </div>
 
       <div>
         <SectionLabel>Command</SectionLabel>

--- a/clients/web/src/domains/chat/components/background-task-status-badge.tsx
+++ b/clients/web/src/domains/chat/components/background-task-status-badge.tsx
@@ -1,0 +1,19 @@
+import {
+  backgroundTaskStatusColor,
+  backgroundTaskStatusLabel,
+  type BackgroundTaskStatus,
+} from "@/utils/background-task-status";
+import { StatusBadgePill } from "@/domains/chat/components/status-badge-pill";
+
+export function BackgroundTaskStatusBadge({
+  status,
+}: {
+  status: BackgroundTaskStatus;
+}) {
+  return (
+    <StatusBadgePill
+      color={backgroundTaskStatusColor(status)}
+      label={backgroundTaskStatusLabel(status)}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -112,7 +112,7 @@ export function CodeBlock({ text }: { text: string }) {
 }
 
 /** Uppercase section label in `--content-tertiary`. */
-function SectionLabel({ children }: { children: string }) {
+export function SectionLabel({ children }: { children: string }) {
   return (
     <Typography
       variant="label-small-default"

--- a/clients/web/src/domains/chat/utils/background-task-actions.test.ts
+++ b/clients/web/src/domains/chat/utils/background-task-actions.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the background-task actions (stop).
+ *
+ * `stopBackgroundTask` calls the generated `backgroundtoolsCancelPost`, which
+ * answers 200 with `{ cancelled: boolean }`. Mock the SDK to stage that body and
+ * assert the optimistic-cancel / rollback behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+
+interface CancelCall {
+  path?: Record<string, string>;
+  body?: Record<string, unknown>;
+}
+
+const calls: CancelCall[] = [];
+let nextData: { cancelled: boolean } | undefined = { cancelled: true };
+let nextOk = true;
+let nextStatus = 200;
+
+// Stub the generated cancel SDK to stage the `{ cancelled }` body. Tests run one
+// file per subprocess (`test:ci` / `run-tests.ts`) so this module replacement is
+// isolated, matching `acp-run-actions.test.ts`.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  backgroundtoolsCancelPost: async (options: CancelCall) => {
+    calls.push(options);
+    return { data: nextData, response: { ok: nextOk, status: nextStatus } };
+  },
+}));
+
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
+const { useBackgroundTaskStore } = await import(
+  "@/domains/chat/background-task-store"
+);
+const { stopBackgroundTask } = await import(
+  "@/domains/chat/utils/background-task-actions"
+);
+
+function seedRunning(id = "bg-1"): void {
+  const entry: BackgroundTaskEntry = {
+    id,
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: "npm run build",
+    startedAt: 1,
+    status: "running",
+  };
+  useBackgroundTaskStore.getState().reset();
+  useBackgroundTaskStore.getState().seedFromHistory([entry]);
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  nextData = { cancelled: true };
+  nextOk = true;
+  nextStatus = 200;
+  useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useBackgroundTaskStore.getState().reset();
+});
+
+describe("stopBackgroundTask", () => {
+  test("POSTs the cancel route with the assistant + task id", async () => {
+    seedRunning();
+    await stopBackgroundTask("bg-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.path).toEqual({ assistant_id: "asst-1" });
+    expect(calls[0]!.body).toEqual({ id: "bg-1" });
+  });
+
+  test("optimistically marks the active task cancelled", async () => {
+    seedRunning();
+    await stopBackgroundTask("bg-1");
+    expect(useBackgroundTaskStore.getState().byId["bg-1"]!.status).toBe(
+      "cancelled",
+    );
+  });
+
+  test("rolls back the optimistic cancel when the daemon reports cancelled:false", async () => {
+    seedRunning();
+    nextData = { cancelled: false };
+
+    await expect(stopBackgroundTask("bg-1")).rejects.toThrow();
+
+    // The task was already gone — restored to running so the Stop control
+    // reappears, not left stuck cancelled.
+    const entry = useBackgroundTaskStore.getState().byId["bg-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.completedAt).toBeUndefined();
+  });
+
+  test("rolls back the optimistic cancel when the request fails", async () => {
+    seedRunning();
+    nextOk = false;
+    nextStatus = 500;
+
+    await expect(stopBackgroundTask("bg-1")).rejects.toThrow();
+
+    expect(useBackgroundTaskStore.getState().byId["bg-1"]!.status).toBe(
+      "running",
+    );
+  });
+
+  test("does not optimistically cancel when there is no active assistant", async () => {
+    seedRunning();
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+
+    await expect(stopBackgroundTask("bg-1")).rejects.toThrow(
+      "No active assistant",
+    );
+
+    expect(useBackgroundTaskStore.getState().byId["bg-1"]!.status).toBe(
+      "running",
+    );
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/chat/utils/background-task-actions.ts
+++ b/clients/web/src/domains/chat/utils/background-task-actions.ts
@@ -29,13 +29,18 @@ export async function stopBackgroundTask(id: string): Promise<void> {
   const prevStatus = store.byId[id]?.status;
   store.cancelTask(id);
   try {
-    const { response } = await backgroundtoolsCancelPost({
+    const { data, response } = await backgroundtoolsCancelPost({
       path: { assistant_id: assistantId },
       body: { id },
       throwOnError: false,
     });
-    if (!response?.ok) {
-      throw new Error(`Failed to stop background task: ${response?.status}`);
+    // The route answers 200 with `{ cancelled: false }` when the task was
+    // already gone — nothing was stopped, so treat it like a failed request and
+    // roll back the optimistic cancel below.
+    if (!response?.ok || data?.cancelled === false) {
+      throw new Error(
+        `Failed to stop background task: ${response?.status} (cancelled=${data?.cancelled})`,
+      );
     }
   } catch (err) {
     // The cancel didn't land — roll back the optimistic `cancelled` so the task

--- a/clients/web/src/utils/background-task-status.test.ts
+++ b/clients/web/src/utils/background-task-status.test.ts
@@ -33,7 +33,9 @@ describe("backgroundTaskStatusColor", () => {
     expect(backgroundTaskStatusColor("failed")).toBe(
       "var(--system-negative-strong)",
     );
-    expect(backgroundTaskStatusColor("cancelled")).toBe("var(--text-muted)");
+    expect(backgroundTaskStatusColor("cancelled")).toBe(
+      "var(--system-negative-strong)",
+    );
   });
 });
 

--- a/clients/web/src/utils/background-task-status.ts
+++ b/clients/web/src/utils/background-task-status.ts
@@ -23,9 +23,8 @@ export function backgroundTaskStatusColor(status: BackgroundTaskStatus): string 
     case "completed":
       return "var(--system-positive-strong)";
     case "failed":
-      return "var(--system-negative-strong)";
     case "cancelled":
-      return "var(--text-muted)";
+      return "var(--system-negative-strong)";
     default:
       return "var(--primary-base)";
   }


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for bash-bg-task-ui.md:
- stopBackgroundTask rolls back when the daemon reports cancelled:false
- cancelled status uses a real design token (was non-existent --text-muted)
- detail panel uses the shared StatusBadgePill and renders exitCode
- reuse SectionLabel from tool-detail-panel instead of duplicating it