### PR TITLE
feat(inspector): first-token latency waterfall in the LLM call inspector

### DIFF
--- a/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
@@ -106,6 +106,7 @@ describe("ClickHouseLlmRequestLogSource", () => {
       createdAt: 1778465138786,
       agentLoopExitReason: "no_tool_calls",
       callSite: "mainAgent",
+      latencyBreakdown: null,
     });
   });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -647,6 +647,18 @@ export interface AgentLoopRunOptions {
    * persisted mid-turn). Defaults to `null` when omitted.
    */
   modelProfileKey?: string | null;
+  /**
+   * First-token latency instrumentation. Created per turn by the
+   * orchestrator (which stamps the turn-level marks) and threaded here so
+   * the loop can stamp the per-call marks (`tools_resolved`, `request_sent`,
+   * `first_token`, `call_complete`). Structurally typed to keep the loop
+   * decoupled from the daemon's `TurnLatencyTracker`. Absent for callers
+   * that don't instrument (tests, workflows).
+   */
+  latencyTracker?: {
+    mark(name: string): void;
+    markFirstToken(kind: "thinking" | "text"): void;
+  };
 }
 
 /**
@@ -993,6 +1005,7 @@ export class AgentLoop {
       isNonInteractive = false,
       modelProfileKey = null,
       model: runModel,
+      latencyTracker,
     } = options;
     // Snapshot the system prompt once per run. The instance field is mutable
     // (the conversation may update it between turns), but a single run must
@@ -1306,6 +1319,9 @@ export class AgentLoop {
         const resolvedTools = this.resolveTools
           ? this.resolveTools(history)
           : this.tools;
+        // Latency: the budget gate (above) and tool resolution are done; what
+        // follows is per-call request prep before the wire.
+        latencyTracker?.mark("tools_resolved");
 
         // Provider-native web search: append a `web_search`-named tool that the
         // provider substitutes for its server-side search (run inline, no client
@@ -1491,6 +1507,11 @@ export class AgentLoop {
         // the client would otherwise see nothing.
         let streamedVisibleText = false;
 
+        // Latency instrumentation: stamp the first streamed token (thinking or
+        // text) of THIS call exactly once, so each per-call segment carries its
+        // own time-to-first-token. Reset per provider call.
+        let firstTokenMarked = false;
+
         // The `onEvent` wrapping below applies sensitive-output placeholder
         // substitution to streamed text while forwarding every other event
         // type through unchanged.
@@ -1499,6 +1520,15 @@ export class AgentLoop {
           systemPrompt: runSystemPrompt,
           config: providerConfig,
           onEvent: (event) => {
+            if (
+              !firstTokenMarked &&
+              (event.type === "thinking_delta" || event.type === "text_delta")
+            ) {
+              firstTokenMarked = true;
+              latencyTracker?.markFirstToken(
+                event.type === "thinking_delta" ? "thinking" : "text",
+              );
+            }
             if (event.type === "text_delta") {
               // Held when the turn's output is deferred — the final text is
               // emitted once, after the `post-model-call` hook runs.
@@ -1639,6 +1669,9 @@ export class AgentLoop {
         // `llm_request_logs` row, then re-throw so the existing outer catch
         // continues to handle abort sync, Sentry capture, the `error` event,
         // and the loop break unchanged.
+        // Latency: the request is about to leave for the provider. The span
+        // from here to the first streamed token is time-to-first-token.
+        latencyTracker?.mark("request_sent");
         let response: ProviderResponse;
         try {
           response = await this.provider.sendMessage(
@@ -1681,6 +1714,10 @@ export class AgentLoop {
         }
 
         const providerDurationMs = Date.now() - providerStart;
+        // Latency: provider call returned; the span from first token to here is
+        // generation time. Stamped before the `usage` event so the breakdown
+        // serialized in `handleUsage` already sees it.
+        latencyTracker?.mark("call_complete");
 
         onEvent({
           type: "usage",

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -469,6 +469,10 @@ export {
   LlmContextResponseSchema,
 } from "./responses/llm-context-response.js";
 export {
+  type LatencyBreakdown,
+  LatencyBreakdownSchema,
+  type LatencyPhase,
+  LatencyPhaseSchema,
   type LLMCallError,
   LLMCallErrorSchema,
   type LLMCallSummary,

--- a/assistant/src/api/responses/llm-request-log-entry.ts
+++ b/assistant/src/api/responses/llm-request-log-entry.ts
@@ -21,6 +21,40 @@
 import { z } from "zod";
 
 /**
+ * One segment of the turn's first-token latency waterfall. `key` is a
+ * stable machine id (`queue`, `memory_context`, `ttft`, …); `label` is
+ * the human row title; `ms` is the wall-clock duration of that phase.
+ */
+export const LatencyPhaseSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  ms: z.number(),
+});
+
+export type LatencyPhase = z.infer<typeof LatencyPhaseSchema>;
+
+/**
+ * Per-call latency breakdown for a main-agent LLM call, measured by the
+ * daemon and stored on the `llm_request_logs` row. `phases` is the
+ * ordered waterfall from turn receipt to call completion (queue → memory
+ * & context retrieval → setup → request prep → time-to-first-token →
+ * generation); the scalar fields are the headline numbers derived from
+ * it. `totalToFirstTokenMs` is only present on the first call of a turn —
+ * later calls (tool-use loops) carry just their own per-call segment.
+ * `firstTokenKind` records whether the first streamed token was a
+ * thinking or text delta.
+ */
+export const LatencyBreakdownSchema = z.object({
+  phases: z.array(LatencyPhaseSchema),
+  ttftMs: z.number().nullish(),
+  totalToFirstTokenMs: z.number().nullish(),
+  providerDurationMs: z.number().nullish(),
+  firstTokenKind: z.enum(["thinking", "text"]).nullish(),
+});
+
+export type LatencyBreakdown = z.infer<typeof LatencyBreakdownSchema>;
+
+/**
  * Provider-normalized summary attached to each request log. `null` /
  * missing fields are common — formatters fall back to a shared
  * "Unavailable" placeholder.
@@ -117,6 +151,13 @@ export const LLMRequestLogEntrySchema = z.object({
   agentLoopExitReason: z.string().nullish(),
   callSite: z.string().nullish(),
   error: LLMCallErrorSchema.nullish(),
+  /**
+   * Daemon-measured first-token latency waterfall for this call. Present on
+   * main-agent calls recorded after the instrumentation shipped; `null` on
+   * older rows, failed calls, and non-main-agent call sites. Stamped on the
+   * row (like `callSite`), not derived from the request/response payloads.
+   */
+  latency: LatencyBreakdownSchema.nullish(),
 });
 
 export type LLMRequestLogEntry = z.infer<typeof LLMRequestLogEntrySchema>;

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -99,6 +99,7 @@ import type {
   WebSearchMetadata,
   WebSearchResultItem,
 } from "./message-types/web-activity.js";
+import type { TurnLatencyTracker } from "./turn-latency-tracker.js";
 
 const log = getLogger("agent-loop-handlers");
 
@@ -310,6 +311,12 @@ export interface EventHandlerState {
    * consumed (deleted) when the end event dispatches.
    */
   readonly compactionStartMessages: Map<string, Message[]>;
+  /**
+   * Cursor into the turn's latency-mark list marking how far prior calls have
+   * already been serialized, so each `usage` event emits only its own call's
+   * latency segment. Advances on every `handleUsage`.
+   */
+  latencyCursor: number;
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -335,6 +342,15 @@ export interface EventHandlerDeps {
     result: ContextWindowResult,
     messages: Message[],
   ) => Promise<void>;
+  /**
+   * Per-turn first-token latency instrumentation. The orchestrator stamps the
+   * turn-level marks; the agent loop stamps the per-call marks. `handleUsage`
+   * serializes the breakdown for each call and persists it on the request log.
+   * Optional: a pure observability hook that the production orchestrator always
+   * supplies, but test fixtures and any future caller may omit — `handleUsage`
+   * degrades gracefully when it's absent.
+   */
+  readonly latencyTracker?: TurnLatencyTracker;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -388,6 +404,7 @@ export function createEventHandlerState(): EventHandlerState {
     currentThinkingTimestamps: [],
     lastPersistedContentSeq: undefined,
     compactionStartMessages: new Map(),
+    latencyCursor: 0,
   };
 }
 
@@ -2119,6 +2136,27 @@ function handleUsage(
     state.exchangeRawResponses.push(event.rawResponse);
   }
 
+  // Serialize this call's first-token latency segment and advance the cursor
+  // so the next call in the turn serializes only its own marks. Non-fatal: a
+  // tracking hiccup must never escalate into a turn-level throw.
+  let latencyBreakdownJson: string | undefined;
+  let ttftMs: number | undefined;
+  try {
+    const segment = deps.latencyTracker?.serializeSince(state.latencyCursor);
+    if (segment) {
+      state.latencyCursor = segment.cursor;
+      if (segment.breakdown) {
+        latencyBreakdownJson = JSON.stringify(segment.breakdown);
+        ttftMs = segment.breakdown.ttftMs ?? undefined;
+      }
+    }
+  } catch (err) {
+    deps.rlog.warn(
+      { err },
+      "Failed to serialize latency breakdown (non-fatal)",
+    );
+  }
+
   if (event.rawRequest && event.rawResponse) {
     try {
       recordRequestLog(
@@ -2128,6 +2166,7 @@ function handleUsage(
         undefined,
         providerName,
         "mainAgent",
+        latencyBreakdownJson,
       );
     } catch (err) {
       deps.rlog.warn({ err }, "Failed to persist LLM request log (non-fatal)");
@@ -2150,6 +2189,10 @@ function handleUsage(
         inputTokens: event.inputTokens,
         outputTokens: event.outputTokens,
         latencyMs: event.providerDurationMs,
+        // Time-to-first-token for this call (network + provider queue + first
+        // token), so the Logs-tab trace timeline reflects TTFT alongside the
+        // whole-call latency. Omitted when no token streamed (pure tool call).
+        ...(ttftMs != null ? { ttftMs } : {}),
       },
     },
   );

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -124,6 +124,7 @@ import type {
 } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
+import { TurnLatencyTracker } from "./turn-latency-tracker.js";
 
 const log = getLogger("conversation-agent-loop");
 
@@ -317,6 +318,11 @@ export async function runAgentLoopImpl(
 
   const abortController = ctx.abortController;
   const reqId = ctx.currentRequestId ?? uuid();
+  // First-token latency instrumentation for this turn. Stamped here at the
+  // earliest point of turn processing, then through the prompt-submit hook
+  // (memory/context retrieval) and the agent loop's per-call marks.
+  const latencyTracker = new TurnLatencyTracker();
+  latencyTracker.mark("turn_start");
   const rlog = log.child({
     conversationId: ctx.conversationId,
     requestId: reqId,
@@ -888,10 +894,12 @@ export async function runAgentLoopImpl(
       modelProfileKey,
       isNonInteractive,
     };
+    latencyTracker.mark("prompt_hook_start");
     const finalUserPromptCtx = await runHook(
       HOOKS.USER_PROMPT_SUBMIT,
       userPromptCtx,
     );
+    latencyTracker.mark("prompt_hook_end");
     const runMessages = finalUserPromptCtx.latestMessages;
 
     // Reset the manager's turn-scoped overflow-recovery ladder at the turn
@@ -912,6 +920,7 @@ export async function runAgentLoopImpl(
       turnChannelContext: capturedTurnChannelContext,
       turnInterfaceContext: capturedTurnInterfaceContext,
       applyCompaction: applySuccessfulCompaction,
+      latencyTracker,
     };
     const eventHandler = (event: AgentEvent): Promise<void> => {
       if (
@@ -992,6 +1001,7 @@ export async function runAgentLoopImpl(
           compactInPlace,
           isNonInteractive,
           modelProfileKey,
+          latencyTracker,
           ...(ctx.modelOverride ? { model: ctx.modelOverride } : {}),
         }),
         abortController.signal,

--- a/assistant/src/daemon/turn-latency-tracker.test.ts
+++ b/assistant/src/daemon/turn-latency-tracker.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+
+import { TurnLatencyTracker } from "./turn-latency-tracker.js";
+
+// Drive `Date.now()` deterministically so phase durations are exact.
+let clock = 0;
+const nowSpy = spyOn(Date, "now").mockImplementation(() => clock);
+afterAll(() => nowSpy.mockRestore());
+
+function phaseMap(
+  phases: { key: string; ms: number }[],
+): Record<string, number> {
+  return Object.fromEntries(phases.map((p) => [p.key, p.ms]));
+}
+
+describe("TurnLatencyTracker", () => {
+  test("first call serializes the full turn waterfall", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start"); // queue = 10
+    clock = 110;
+    t.mark("prompt_hook_end"); // memory_context = 100
+    clock = 120;
+    t.mark("tools_resolved"); // setup = 10
+    clock = 130;
+    t.mark("request_sent"); // request_prep = 10
+    clock = 430;
+    t.markFirstToken("thinking"); // ttft = 300
+    clock = 700;
+    t.mark("call_complete"); // generation = 270
+
+    const { breakdown, cursor } = t.serializeSince(0);
+    expect(cursor).toBe(7);
+    expect(breakdown).not.toBeNull();
+    expect(phaseMap(breakdown!.phases)).toEqual({
+      queue: 10,
+      memory_context: 100,
+      setup: 10,
+      request_prep: 10,
+      ttft: 300,
+      generation: 270,
+    });
+    expect(breakdown!.ttftMs).toBe(300);
+    expect(breakdown!.totalToFirstTokenMs).toBe(430);
+    expect(breakdown!.providerDurationMs).toBe(570);
+    expect(breakdown!.firstTokenKind).toBe("thinking");
+  });
+
+  test("second call segments only its own marks via the cursor", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start");
+    clock = 110;
+    t.mark("prompt_hook_end");
+    clock = 120;
+    t.mark("tools_resolved");
+    clock = 130;
+    t.mark("request_sent");
+    clock = 430;
+    t.markFirstToken("thinking");
+    clock = 700;
+    t.mark("call_complete");
+    const first = t.serializeSince(0);
+
+    // Tool-use loop: a second provider call after tool execution.
+    clock = 1000;
+    t.mark("tools_resolved"); // tool-exec gap from prev call_complete(700) = 300
+    clock = 1010;
+    t.mark("request_sent"); // request_prep = 10
+    clock = 1200;
+    t.markFirstToken("text"); // ttft = 190
+    clock = 1260;
+    t.mark("call_complete"); // generation = 60
+
+    const { breakdown, cursor } = t.serializeSince(first.cursor);
+    expect(cursor).toBe(11);
+    expect(breakdown!.phases.map((p) => p.key)).toEqual([
+      "setup",
+      "request_prep",
+      "ttft",
+      "generation",
+    ]);
+    expect(phaseMap(breakdown!.phases).setup).toBe(300);
+    expect(breakdown!.ttftMs).toBe(190);
+    // total-to-first-token is first-call-only (no `turn_start` in this segment).
+    expect(breakdown!.totalToFirstTokenMs).toBeUndefined();
+    expect(breakdown!.firstTokenKind).toBe("text");
+  });
+
+  test("tool-only response (no streamed token) omits ttft", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 5;
+    t.mark("prompt_hook_start");
+    clock = 55;
+    t.mark("prompt_hook_end");
+    clock = 60;
+    t.mark("tools_resolved");
+    clock = 65;
+    t.mark("request_sent");
+    clock = 200;
+    t.mark("call_complete"); // no first_token
+
+    const { breakdown } = t.serializeSince(0);
+    expect(breakdown!.ttftMs).toBeUndefined();
+    expect(breakdown!.totalToFirstTokenMs).toBeUndefined();
+    expect(breakdown!.firstTokenKind).toBeUndefined();
+    // generation spans request_sent → call_complete when no token streamed.
+    expect(phaseMap(breakdown!.phases).generation).toBe(135);
+    expect(breakdown!.providerDurationMs).toBe(135);
+  });
+
+  test("no marks serializes to null", () => {
+    const t = new TurnLatencyTracker();
+    expect(t.serializeSince(0).breakdown).toBeNull();
+    expect(t.serializeSince(0).cursor).toBe(0);
+  });
+
+  test("a fully-consumed cursor serializes to null", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("request_sent");
+    clock = 50;
+    t.markFirstToken("thinking");
+    clock = 90;
+    t.mark("call_complete");
+    const { cursor } = t.serializeSince(0);
+    expect(t.serializeSince(cursor).breakdown).toBeNull();
+  });
+});

--- a/assistant/src/daemon/turn-latency-tracker.ts
+++ b/assistant/src/daemon/turn-latency-tracker.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-turn first-token latency instrumentation.
+ *
+ * A single tracker is created at turn start and threaded through both the
+ * orchestrator (`conversation-agent-loop.ts`, which stamps the turn-level
+ * marks: queue + memory/context retrieval) and the agent loop
+ * (`agent/loop.ts`, which stamps the per-call marks: tool resolution →
+ * request sent → first token → call complete). When a call's `usage`
+ * event lands, `handleUsage` serializes the marks for that call into a
+ * {@link LatencyBreakdown} and persists it on the `llm_request_logs` row,
+ * where the inspector renders it.
+ *
+ * A phase is the span between two consecutive marks, labeled by the mark
+ * that *closes* it — so the exact interleaving of work between marks does
+ * not matter, only that the marks land in execution order.
+ */
+
+import type {
+  LatencyBreakdown,
+  LatencyPhase,
+} from "../api/responses/llm-request-log-entry.js";
+
+/** Canonical mark names, in the order they fire on the first call of a turn. */
+export type LatencyMark =
+  | "turn_start"
+  | "prompt_hook_start"
+  | "prompt_hook_end"
+  | "tools_resolved"
+  | "request_sent"
+  | "first_token"
+  | "call_complete";
+
+/**
+ * Phase metadata keyed by the mark that closes the span. A mark with no
+ * entry here (e.g. `turn_start`, which only opens the first phase) emits
+ * no phase of its own.
+ */
+const PHASE_BY_CLOSING_MARK: Record<string, { key: string; label: string }> = {
+  prompt_hook_start: { key: "queue", label: "Queue & turn setup" },
+  prompt_hook_end: {
+    key: "memory_context",
+    label: "Memory & context retrieval",
+  },
+  tools_resolved: { key: "setup", label: "Budget gate & tool resolution" },
+  request_sent: { key: "request_prep", label: "Request prep" },
+  first_token: { key: "ttft", label: "Time to first token" },
+  call_complete: { key: "generation", label: "Generation" },
+};
+
+export class TurnLatencyTracker {
+  private readonly marks: {
+    name: string;
+    at: number;
+    kind?: "thinking" | "text";
+  }[] = [];
+
+  /** Stamp a point-in-time mark. Cheap (`Date.now()`); safe to over-call. */
+  mark(name: LatencyMark): void {
+    this.marks.push({ name, at: Date.now() });
+  }
+
+  /**
+   * Stamp the first streamed token of the current call, carrying its kind on
+   * the mark. The caller fires this once per call (guarded loop-side), so each
+   * per-call segment gets its own `first_token` mark and kind.
+   */
+  markFirstToken(kind: "thinking" | "text"): void {
+    this.marks.push({ name: "first_token", at: Date.now(), kind });
+  }
+
+  /**
+   * Serialize the breakdown for the call segment beginning at `cursor` (an
+   * index into the mark list). Emits one phase per mark from `cursor` to the
+   * end, each measured against its predecessor, and returns the next cursor
+   * (the new mark count) so the following call serializes only its own
+   * segment. Returns a `null` breakdown when there is nothing to report.
+   */
+  serializeSince(cursor: number): {
+    breakdown: LatencyBreakdown | null;
+    cursor: number;
+  } {
+    const end = this.marks.length;
+    if (end === 0 || cursor >= end) return { breakdown: null, cursor: end };
+
+    const phases: LatencyPhase[] = [];
+    // Start at max(cursor, 1): the first mark of the whole turn has no
+    // predecessor to measure against, and a mid-turn segment's first phase
+    // is measured against the previous segment's last mark (index cursor-1).
+    for (let i = Math.max(cursor, 1); i < end; i++) {
+      const meta = PHASE_BY_CLOSING_MARK[this.marks[i]!.name];
+      if (!meta) continue;
+      const ms = this.marks[i]!.at - this.marks[i - 1]!.at;
+      // A non-monotonic clock would yield a negative span; drop it rather
+      // than render misleading noise.
+      if (ms < 0) continue;
+      phases.push({ key: meta.key, label: meta.label, ms });
+    }
+    if (phases.length === 0) return { breakdown: null, cursor: end };
+
+    const breakdown: LatencyBreakdown = { phases };
+    const requestSent = this.findMarkFrom("request_sent", cursor)?.at;
+    const firstTokenMark = this.findMarkFrom("first_token", cursor);
+    const firstToken = firstTokenMark?.at;
+    const callComplete = this.findMarkFrom("call_complete", cursor)?.at;
+    if (requestSent != null && firstToken != null) {
+      breakdown.ttftMs = firstToken - requestSent;
+    }
+    if (requestSent != null && callComplete != null) {
+      breakdown.providerDurationMs = callComplete - requestSent;
+    }
+    // total-to-first-token is only meaningful for the first call of the turn,
+    // the only segment that contains `turn_start`.
+    if (cursor === 0 && firstToken != null) {
+      const turnStart = this.findMarkFrom("turn_start", 0)?.at;
+      if (turnStart != null) {
+        breakdown.totalToFirstTokenMs = firstToken - turnStart;
+      }
+    }
+    // Per-call kind, read off this segment's own `first_token` mark (a pure
+    // tool-call response streams none, leaving it undefined).
+    if (firstTokenMark?.kind) breakdown.firstTokenKind = firstTokenMark.kind;
+    return { breakdown, cursor: end };
+  }
+
+  private findMarkFrom(
+    name: string,
+    from: number,
+  ): { at: number; kind?: "thinking" | "text" } | undefined {
+    for (let i = Math.max(from, 0); i < this.marks.length; i++) {
+      if (this.marks[i]!.name === name) return this.marks[i]!;
+    }
+    return undefined;
+  }
+}

--- a/assistant/src/persistence/llm-request-log-source-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-source-clickhouse.ts
@@ -464,6 +464,10 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
       ...this.toLogMetaRow(row),
       requestPayload: row.request_payload,
       responsePayload: row.response_payload,
+      // The ClickHouse mirror does not replicate `latency_breakdown` yet, so
+      // ClickHouse-sourced rows carry no waterfall — the inspector falls back
+      // to no latency card, exactly as for a pre-instrumentation row.
+      latencyBreakdown: null,
     };
   }
 

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -62,10 +62,24 @@ export type LogRow = {
    * In practice values come from `LLMCallSite` (`config/schemas/llm.ts`).
    */
   callSite: string | null;
+  /**
+   * JSON-serialized {@link LatencyBreakdown} — the daemon-measured
+   * first-token latency waterfall for this main-agent call. NULL on
+   * pre-instrumentation rows, failed calls, and non-main-agent call sites.
+   */
+  latencyBreakdown: string | null;
 };
 
-/** `LogRow` without the payload columns — for reads that only need metadata. */
-export type LogMetaRow = Omit<LogRow, "requestPayload" | "responsePayload">;
+/**
+ * `LogRow` without the heavy payload columns — for reads that only need
+ * metadata (conversation scoping, `createdAt` anchoring). `latencyBreakdown`
+ * is likewise excluded: it's per-call detail the metadata/compaction-trail
+ * consumers don't surface.
+ */
+export type LogMetaRow = Omit<
+  LogRow,
+  "requestPayload" | "responsePayload" | "latencyBreakdown"
+>;
 
 /**
  * Compaction-trail row: metadata plus the (small) summarizer response
@@ -149,6 +163,7 @@ export function recordRequestLog(
   messageId?: string,
   provider?: string,
   callSite?: LLMCallSite,
+  latencyBreakdown?: string,
 ): string {
   const db = logsDb();
   const id = uuid();
@@ -168,6 +183,9 @@ export function recordRequestLog(
       // a caller hasn't been updated yet — preserves backward compat
       // while we plumb call sites through one site at a time.
       callSite: callSite ?? null,
+      // JSON first-token latency waterfall, supplied by `handleUsage` for
+      // main-agent calls. NULL for failed/non-instrumented call paths.
+      latencyBreakdown: latencyBreakdown ?? null,
     })
     .run();
   return id;
@@ -337,6 +355,7 @@ function selectLogsByMessageIds(messageIds: string[]): LogRow[] {
       createdAt: llmRequestLogs.createdAt,
       agentLoopExitReason: llmRequestLogs.agentLoopExitReason,
       callSite: llmRequestLogs.callSite,
+      latencyBreakdown: llmRequestLogs.latencyBreakdown,
     })
     .from(llmRequestLogs)
     .where(inArray(llmRequestLogs.messageId, messageIds))
@@ -365,6 +384,7 @@ export function getRequestLogsByConversationId(
       createdAt: llmRequestLogs.createdAt,
       agentLoopExitReason: llmRequestLogs.agentLoopExitReason,
       callSite: llmRequestLogs.callSite,
+      latencyBreakdown: llmRequestLogs.latencyBreakdown,
     })
     .from(llmRequestLogs)
     .where(eq(llmRequestLogs.conversationId, conversationId))
@@ -402,6 +422,7 @@ function selectOrphanedLogsInRange(
       createdAt: llmRequestLogs.createdAt,
       agentLoopExitReason: llmRequestLogs.agentLoopExitReason,
       callSite: llmRequestLogs.callSite,
+      latencyBreakdown: llmRequestLogs.latencyBreakdown,
     })
     .from(llmRequestLogs)
     .where(
@@ -458,6 +479,7 @@ function selectUnlinkedLogsInRange(
       createdAt: llmRequestLogs.createdAt,
       agentLoopExitReason: llmRequestLogs.agentLoopExitReason,
       callSite: llmRequestLogs.callSite,
+      latencyBreakdown: llmRequestLogs.latencyBreakdown,
     })
     .from(llmRequestLogs)
     .where(
@@ -613,6 +635,7 @@ export function getRequestLogById(logId: string): LogRow | null {
         createdAt: llmRequestLogs.createdAt,
         agentLoopExitReason: llmRequestLogs.agentLoopExitReason,
         callSite: llmRequestLogs.callSite,
+        latencyBreakdown: llmRequestLogs.latencyBreakdown,
       })
       .from(llmRequestLogs)
       .where(eq(llmRequestLogs.id, logId))

--- a/assistant/src/persistence/migrations/310-llm-request-log-latency-breakdown.ts
+++ b/assistant/src/persistence/migrations/310-llm-request-log-latency-breakdown.ts
@@ -1,0 +1,37 @@
+import { getLogsSqlite } from "../db-connection.js";
+
+/**
+ * Adds `latency_breakdown` (nullable TEXT) to the `llm_request_logs` table in
+ * the logs database (`assistant-logs.db`, where migration 297 relocated the
+ * table).
+ *
+ * Stores the daemon-measured first-token latency waterfall as JSON
+ * (`LatencyBreakdown` in `api/responses/llm-request-log-entry.ts`): queue →
+ * memory/context retrieval → setup → request prep → time-to-first-token →
+ * generation. Lets the LLM call inspector show where a turn's
+ * time-to-first-token went. No backfill — historical rows stay NULL; new
+ * main-agent rows are stamped at insertion time by `recordRequestLog`.
+ *
+ * Idempotent (`PRAGMA table_info` guard). Throws when the logs DB cannot be
+ * opened so the runner records the step as failed and retries on a later boot,
+ * rather than marking it applied without ever adding the column. Modeled on
+ * migration 264 (`llm-request-log-call-site`), targeting the logs connection
+ * like migration 297.
+ */
+export function migrateLlmRequestLogLatencyBreakdown(): void {
+  const raw = getLogsSqlite();
+  if (!raw) {
+    throw new Error(
+      "logs database unavailable — deferring llm_request_logs latency_breakdown column add",
+    );
+  }
+
+  const columns = raw
+    .query(`PRAGMA table_info(llm_request_logs)`)
+    .all() as Array<{ name: string }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  if (!columnNames.has("latency_breakdown")) {
+    raw.exec(`ALTER TABLE llm_request_logs ADD COLUMN latency_breakdown TEXT`);
+  }
+}

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -155,6 +155,14 @@ export const llmRequestLogs = sqliteTable(
      * rather than guessing `mainAgent`.
      */
     callSite: text("call_site"),
+    /**
+     * JSON-serialized first-token latency waterfall measured by the daemon
+     * (`LatencyBreakdown` in `api/responses/llm-request-log-entry.ts`):
+     * queue → memory/context retrieval → setup → request prep →
+     * time-to-first-token → generation. NULL on pre-instrumentation rows,
+     * failed calls, and non-main-agent call sites.
+     */
+    latencyBreakdown: text("latency_breakdown"),
   },
   (table) => [
     index("idx_llm_request_logs_message_id").on(table.messageId),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -417,6 +417,7 @@ import { migrateRewriteFrontierProfilePins } from "./migrations/306-rewrite-fron
 import { migrateAcpSessionHistoryUsageColumns } from "./migrations/307-acp-session-history-usage-columns.js";
 import { migrateAcpSessionHistoryTokenColumns } from "./migrations/308-acp-session-history-token-columns.js";
 import { migrateDropRedundantIndexes } from "./migrations/309-drop-redundant-indexes.js";
+import { migrateLlmRequestLogLatencyBreakdown } from "./migrations/310-llm-request-log-latency-breakdown.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1305,4 +1306,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryUsageColumns,
   migrateAcpSessionHistoryTokenColumns,
   migrateDropRedundantIndexes,
+  migrateLlmRequestLogLatencyBreakdown,
 ];

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -22,7 +22,11 @@
 import { z } from "zod";
 
 import { LlmContextResponseSchema } from "../../api/responses/llm-context-response.js";
-import { LLMRequestLogEntrySchema } from "../../api/responses/llm-request-log-entry.js";
+import {
+  type LatencyBreakdown,
+  LatencyBreakdownSchema,
+  LLMRequestLogEntrySchema,
+} from "../../api/responses/llm-request-log-entry.js";
 import {
   deepMergeOverwrite,
   fillContextDefaultsForMissingKeys,
@@ -272,6 +276,21 @@ function resolveLlmContextView(view: string | undefined): LlmContextView {
   );
 }
 
+/**
+ * Parse the stored `latency_breakdown` JSON into a validated
+ * {@link LatencyBreakdown}. Returns `null` for the common no-data case and
+ * for malformed/legacy rows — a bad blob must never break the inspector.
+ */
+function parseLatencyBreakdown(raw: string | null): LatencyBreakdown | null {
+  if (!raw) return null;
+  try {
+    const parsed = LatencyBreakdownSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
 function normalizeLlmContextLog(
   log: LogRow,
   view: LlmContextView = "full",
@@ -282,6 +301,7 @@ function normalizeLlmContextLog(
   createdAt: number;
   agentLoopExitReason: string | null;
   callSite: string | null;
+  latency: LatencyBreakdown | null;
 } {
   let requestPayload: unknown;
   try {
@@ -321,6 +341,9 @@ function normalizeLlmContextLog(
     // other fields — the frontend branches on this value alone, and the
     // existing `agent_loop_exit_reason` column tells it WHICH error fired.
     callSite: log.callSite ?? null,
+    // Daemon-measured first-token latency waterfall, stamped on the row at
+    // record time (like `callSite`) rather than derived from the payloads.
+    latency: parseLatencyBreakdown(log.latencyBreakdown),
     ...result,
     ...(view === "summary"
       ? { requestSections: undefined, responseSections: undefined }

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/domains/chat/inspector/inspector-formatters";
 import { LlmCallErrorCard } from "@/domains/chat/inspector/components/llm-call-error-card";
 import type {
+  LatencyBreakdown,
   LLMCallSummary,
   LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
@@ -40,6 +41,15 @@ export function OverviewTab({
   const summary = entry.summary;
   const error = entry.error ?? null;
   const hasError = error != null;
+  const latency = entry.latency ?? null;
+  const latencyCard =
+    latency && latency.phases.length > 0 ? (
+      <MetadataCard
+        title="First-token latency"
+        subtitle="Where this turn's time-to-first-token went, measured by the assistant."
+        rows={buildLatencyRows(latency)}
+      />
+    ) : null;
   // A failed call gets a dedicated banner; only show the generic
   // "summary unavailable" fallback when the call didn't fail.
   const showFallback =
@@ -89,8 +99,39 @@ export function OverviewTab({
           />
         </>
       )}
+      {latencyCard}
     </div>
   );
+}
+
+function formatMs(ms: number): string {
+  return `${formatCount(Math.round(ms))} ms`;
+}
+
+/**
+ * Build the first-token latency waterfall rows: the total-to-first-token
+ * headline (first call of a turn only), then one row per phase
+ * (queue → memory/context → setup → request prep → time-to-first-token →
+ * generation), and the streamed first-token kind when known.
+ */
+function buildLatencyRows(latency: LatencyBreakdown): MetadataRow[] {
+  const rows: MetadataRow[] = [];
+  if (
+    latency.totalToFirstTokenMs != null &&
+    Number.isFinite(latency.totalToFirstTokenMs)
+  ) {
+    rows.push({
+      label: "Total to first token",
+      value: formatMs(latency.totalToFirstTokenMs),
+    });
+  }
+  for (const phase of latency.phases) {
+    rows.push({ label: phase.label, value: formatMs(phase.ms) });
+  }
+  if (latency.firstTokenKind) {
+    rows.push({ label: "First token kind", value: latency.firstTokenKind });
+  }
+  return rows;
 }
 
 function renderConversationTotalsCard(


### PR DESCRIPTION
## Summary
- Adds a per-turn `TurnLatencyTracker` that measures where the delay between a user message and the first thinking token goes, as a full waterfall: queue & turn setup → memory & context retrieval (the `USER_PROMPT_SUBMIT` hook: memory-v3 + injectors) → budget gate & tool resolution → request prep → time-to-first-token → generation. It threads turn-level marks from `conversation-agent-loop.ts` and per-call marks from `agent/loop.ts` (all guarded `latencyTracker?.` calls — zero behavior change).
- Persists the breakdown as JSON on a new `llm_request_logs.latency_breakdown` column (logs DB; migration `310`, modeled on `264`/`297`) per main-agent call, surfaces it top-level on the `LLMRequestLogEntry` wire type (like `callSite`), and renders it as a **First-token latency** card in the inspector's Overview tab. Also adds `ttftMs` to the `llm_call_finished` trace so the Logs-tab timeline reflects TTFT too.
- Diagnostic intent: see at a glance whether a slow first token is *our* pre-work (memory/context retrieval) or the *provider's* time-to-first-token.

## Notes
- **System-prompt assembly is intentionally not a separate per-turn phase.** It's built at conversation construction / cache-warm (`conversation.ts`) and cached on the loop — re-resolving per turn would bust the provider prefix cache — so it isn't on the per-turn critical path. The waterfall reflects the real per-turn path.
- `latencyTracker` is an optional `EventHandlerDeps`/`AgentLoopRunOptions` field: the production orchestrator always supplies it; tests and other callers may omit it and `handleUsage` degrades gracefully (the whole serialize/persist path is already non-fatal).
- The ClickHouse log mirror doesn't replicate the new column yet, so ClickHouse-sourced rows carry `latency: null` and fall back to no card (same as a pre-instrumentation row).
- Unit-tested the tracker's waterfall, cursor segmentation across a tool-use loop, and the no-first-token (pure tool call) case.

## Original prompt
We were seeing a high delay between submitting a user message and getting the first thinking token back from the main-agent model, and wanted instrumentation to break that latency down — ideally visible in the LLM call inspector. The ask was to see whether the delay is our pre-work or the provider's time-to-first-token; we chose a full per-phase waterfall surfaced as rows in the inspector's Overview tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)