### PR TITLE
feat(ces): local CES serves over a Unix socket and runs as a standalone sibling (sibling-process step 1)

### DIFF
--- a/credential-executor/src/__tests__/local-socket.test.ts
+++ b/credential-executor/src/__tests__/local-socket.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the local-mode CES Unix socket server.
+ *
+ * Covers:
+ * - `getLocalSocketPath` resolution (env override + default).
+ * - `socketToStreams` wrapping (no socket / listen required).
+ * - End-to-end multi-accept over a real Unix socket: two concurrent
+ *   connections each complete a handshake and an RPC. The socket `listen`
+ *   requires a sandbox that permits binding, mirroring the existing
+ *   managed-integration tests.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createConnection, type Socket } from "node:net";
+
+import {
+  CES_PROTOCOL_VERSION,
+  CesRpcMethod,
+  type HandshakeAck,
+  type ListGrantsResponse,
+  type RpcEnvelope,
+} from "@vellumai/service-contracts/credential-rpc";
+
+import { getLocalSocketPath } from "../paths.js";
+import {
+  socketToStreams,
+  startLocalSocketServer,
+} from "../local-socket.js";
+import { PersistentGrantStore } from "../grants/persistent-store.js";
+import { createListGrantsHandler } from "../grants/rpc-handlers.js";
+import type { RpcHandlerRegistry } from "../server.js";
+
+// ---------------------------------------------------------------------------
+// getLocalSocketPath
+// ---------------------------------------------------------------------------
+
+describe("getLocalSocketPath", () => {
+  test("honors the CES_LOCAL_SOCKET override", () => {
+    const prev = process.env["CES_LOCAL_SOCKET"];
+    process.env["CES_LOCAL_SOCKET"] = "/tmp/custom/ces.sock";
+    try {
+      expect(getLocalSocketPath()).toBe("/tmp/custom/ces.sock");
+    } finally {
+      if (prev === undefined) delete process.env["CES_LOCAL_SOCKET"];
+      else process.env["CES_LOCAL_SOCKET"] = prev;
+    }
+  });
+
+  test("defaults to ces.sock under the local data root", () => {
+    const prev = process.env["CES_LOCAL_SOCKET"];
+    delete process.env["CES_LOCAL_SOCKET"];
+    try {
+      expect(getLocalSocketPath().endsWith("/ces.sock")).toBe(true);
+    } finally {
+      if (prev !== undefined) process.env["CES_LOCAL_SOCKET"] = prev;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// socketToStreams (no real socket required)
+// ---------------------------------------------------------------------------
+
+/** Minimal Socket-like stub: emits data/end/error and records writes. */
+class FakeSocket extends EventEmitter {
+  writable = true;
+  readonly writes: string[] = [];
+  write(chunk: Buffer | string, cb?: (err?: Error | null) => void): boolean {
+    this.writes.push(chunk.toString());
+    cb?.(null);
+    return true;
+  }
+}
+
+describe("socketToStreams", () => {
+  test("pushes socket data onto the readable and forwards writes to the socket", async () => {
+    const socket = new FakeSocket();
+    const { readable, writable } = socketToStreams(socket as unknown as Socket);
+
+    const received: string[] = [];
+    readable.on("data", (chunk: Buffer) => received.push(chunk.toString()));
+
+    socket.emit("data", Buffer.from("hello\n"));
+    writable.write("world\n");
+
+    // Let the stream 'data' event flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(received.join("")).toBe("hello\n");
+    expect(socket.writes.join("")).toBe("world\n");
+  });
+
+  test("ends the readable when the socket ends", async () => {
+    const socket = new FakeSocket();
+    const { readable } = socketToStreams(socket as unknown as Socket);
+
+    let ended = false;
+    readable.on("end", () => {
+      ended = true;
+    });
+    // A readable only emits 'end' once it's flowing and drained.
+    readable.on("data", () => {});
+
+    socket.emit("end");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ended).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end multi-accept over a real Unix socket
+// ---------------------------------------------------------------------------
+
+function buildGrantsHandlers(dataDir: string): RpcHandlerRegistry {
+  const grantsDir = join(dataDir, "grants");
+  mkdirSync(grantsDir, { recursive: true });
+  const persistentGrantStore = new PersistentGrantStore(grantsDir);
+  persistentGrantStore.init();
+
+  const handlers: RpcHandlerRegistry = {};
+  handlers[CesRpcMethod.ListGrants] = createListGrantsHandler({
+    persistentGrantStore,
+  }) as RpcHandlerRegistry[string];
+  return handlers;
+}
+
+function connectToSocket(
+  socketPath: string,
+  { maxRetries = 20, baseDelayMs = 10 } = {},
+): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    const tryConnect = () => {
+      const sock = createConnection(socketPath, () => {
+        sock.removeAllListeners("error");
+        resolve(sock);
+      });
+      sock.on("error", (err: NodeJS.ErrnoException) => {
+        sock.destroy();
+        attempt++;
+        if (
+          attempt < maxRetries &&
+          (err.code === "ENOENT" || err.code === "ECONNREFUSED")
+        ) {
+          setTimeout(tryConnect, baseDelayMs * Math.pow(2, Math.min(attempt, 6)));
+        } else {
+          reject(err);
+        }
+      });
+    };
+    tryConnect();
+  });
+}
+
+function readMessages(
+  sock: Socket,
+  expectedCount: number,
+  timeoutMs = 3000,
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const messages: unknown[] = [];
+    let buffer = "";
+    const timer = setTimeout(() => {
+      sock.removeAllListeners("data");
+      resolve(messages);
+    }, timeoutMs);
+
+    sock.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf-8");
+      let idx: number;
+      while ((idx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (line.length === 0) continue;
+        try {
+          messages.push(JSON.parse(line));
+        } catch {
+          // skip malformed
+        }
+        if (messages.length >= expectedCount) {
+          clearTimeout(timer);
+          sock.removeAllListeners("data");
+          resolve(messages);
+          return;
+        }
+      }
+    });
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function sendMessage(sock: Socket, msg: unknown): void {
+  sock.write(JSON.stringify(msg) + "\n");
+}
+
+async function handshakeAndListGrants(
+  socketPath: string,
+  sessionId: string,
+): Promise<{ ack: HandshakeAck; grants: ListGrantsResponse }> {
+  const sock = await connectToSocket(socketPath);
+  try {
+    sendMessage(sock, {
+      type: "handshake_request",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId,
+    });
+    const [ackMsg] = await readMessages(sock, 1);
+    const ack = ackMsg as HandshakeAck;
+
+    sendMessage(sock, {
+      type: "rpc",
+      id: `${sessionId}-rpc-1`,
+      kind: "request",
+      method: CesRpcMethod.ListGrants,
+      payload: {},
+      timestamp: new Date().toISOString(),
+    });
+    const [rpcMsg] = await readMessages(sock, 1);
+    const grants = (rpcMsg as RpcEnvelope & { type: "rpc" })
+      .payload as ListGrantsResponse;
+
+    return { ack, grants };
+  } finally {
+    sock.end();
+  }
+}
+
+describe("local CES socket server (real Unix socket)", () => {
+  let tmpDir: string;
+  let controller: AbortController | undefined;
+
+  afterEach(() => {
+    controller?.abort();
+    controller = undefined;
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  test("accepts multiple concurrent connections on one bound socket", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ces-local-socket-"));
+    const socketPath = join(tmpDir, "ces.sock");
+    const handlers = buildGrantsHandlers(tmpDir);
+
+    controller = new AbortController();
+    startLocalSocketServer({
+      socketPath,
+      handlers,
+      signal: controller.signal,
+      logger: { log: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    // Two siblings connect concurrently to the same bound socket — the socket
+    // is NOT unlinked after the first accept (multi-accept).
+    const [a, b] = await Promise.all([
+      handshakeAndListGrants(socketPath, "sibling-a"),
+      handshakeAndListGrants(socketPath, "sibling-b"),
+    ]);
+
+    expect(a.ack.accepted).toBe(true);
+    expect(b.ack.accepted).toBe(true);
+    expect(a.grants.grants).toEqual([]);
+    expect(b.grants.grants).toEqual([]);
+  });
+});

--- a/credential-executor/src/__tests__/local-standalone.test.ts
+++ b/credential-executor/src/__tests__/local-standalone.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Local CES standalone-lifecycle test (real entrypoint subprocess).
+ *
+ * Spawns the actual `main.ts` entrypoint with **stdin closed** — simulating a
+ * standalone sibling launched without a stdio parent — and verifies that CES:
+ *
+ *   1. stays up and binds its Unix socket despite the immediate stdin EOF
+ *      (the lifecycle is anchored to SIGTERM, not stdin), and
+ *   2. survives a client disconnecting (multi-accept socket), and
+ *   3. shuts down on SIGTERM.
+ *
+ * This guards the core property that local CES can run as an independent
+ * sibling process, the direction it is converging on. There is no TCP health
+ * server in local mode, so this runs without binding a TCP port.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createConnection, type Socket } from "node:net";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  CES_PROTOCOL_VERSION,
+  CesRpcMethod,
+  type HandshakeAck,
+  type RpcEnvelope,
+  type ListCredentialsResponse,
+} from "@vellumai/service-contracts/credential-rpc";
+
+import type { Subprocess } from "bun";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForSocket(socketPath: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(socketPath)) return;
+    await delay(50);
+  }
+  throw new Error(`Local CES socket did not appear within ${timeoutMs}ms`);
+}
+
+function connectToSocket(
+  socketPath: string,
+  { maxRetries = 40, baseDelayMs = 25 } = {},
+): Promise<Socket> {
+  return new Promise((resolveConn, reject) => {
+    let attempt = 0;
+    const tryConnect = () => {
+      const sock = createConnection(socketPath, () => {
+        sock.removeAllListeners("error");
+        resolveConn(sock);
+      });
+      sock.on("error", (err: NodeJS.ErrnoException) => {
+        sock.destroy();
+        attempt++;
+        if (
+          attempt < maxRetries &&
+          (err.code === "ENOENT" || err.code === "ECONNREFUSED")
+        ) {
+          setTimeout(tryConnect, baseDelayMs);
+        } else {
+          reject(err);
+        }
+      });
+    };
+    tryConnect();
+  });
+}
+
+/** Read one newline-delimited JSON message from the socket. */
+function readOne<T>(sock: Socket, timeoutMs = 5_000): Promise<T> {
+  return new Promise((resolveMsg, reject) => {
+    let buffer = "";
+    const timer = setTimeout(() => {
+      sock.removeAllListeners("data");
+      reject(new Error("Timed out waiting for a message"));
+    }, timeoutMs);
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString("utf-8");
+      const idx = buffer.indexOf("\n");
+      if (idx === -1) return;
+      clearTimeout(timer);
+      sock.removeListener("data", onData);
+      try {
+        resolveMsg(JSON.parse(buffer.slice(0, idx).trim()) as T);
+      } catch (err) {
+        reject(err as Error);
+      }
+    };
+    sock.on("data", onData);
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function handshake(sock: Socket, sessionId: string): Promise<HandshakeAck> {
+  sock.write(
+    JSON.stringify({
+      type: "handshake_request",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId,
+    }) + "\n",
+  );
+  return readOne<HandshakeAck>(sock);
+}
+
+let tmpDir: string | undefined;
+let proc: Subprocess | undefined;
+
+afterEach(async () => {
+  if (proc) {
+    proc.kill("SIGTERM");
+    await Promise.race([proc.exited, delay(3_000)]);
+    proc = undefined;
+  }
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ok */
+    }
+    tmpDir = undefined;
+  }
+});
+
+describe("local CES standalone lifecycle (real entrypoint)", () => {
+  test("runs without a stdio parent, survives a disconnect, exits on SIGTERM", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ces-local-standalone-"));
+    const socketPath = join(tmpDir, "ces.sock");
+    const securityDir = join(tmpDir, "protected");
+    const workspaceDir = join(tmpDir, "workspace");
+    mkdirSync(securityDir, { recursive: true });
+    mkdirSync(workspaceDir, { recursive: true });
+
+    const localMain = resolve(__dirname, "..", "main.ts");
+
+    // stdin: "ignore" gives the child an empty stdin that EOFs immediately —
+    // the standalone condition. With a stdin-anchored lifecycle CES would exit
+    // here; with the SIGTERM-anchored lifecycle it stays up and binds the socket.
+    proc = Bun.spawn({
+      cmd: [process.execPath, localMain],
+      env: {
+        ...process.env,
+        CES_LOCAL_SOCKET: socketPath,
+        CREDENTIAL_SECURITY_DIR: securityDir,
+        VELLUM_WORKSPACE_DIR: workspaceDir,
+      },
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    // The socket appears only if CES did NOT exit on the immediate stdin EOF.
+    await waitForSocket(socketPath);
+    expect(proc.killed).toBe(false);
+
+    // A first client connects, handshakes, and makes a real RPC call.
+    const first = await connectToSocket(socketPath);
+    const ack1 = await handshake(first, "sibling-1");
+    expect(ack1.accepted).toBe(true);
+
+    first.write(
+      JSON.stringify({
+        type: "rpc",
+        id: "rpc-1",
+        kind: "request",
+        method: CesRpcMethod.ListCredentials,
+        payload: {},
+        timestamp: new Date().toISOString(),
+      }) + "\n",
+    );
+    const rpcResp = await readOne<RpcEnvelope & { type: "rpc" }>(first);
+    expect((rpcResp.payload as ListCredentialsResponse).accounts).toEqual([]);
+
+    // The client disconnects — CES must stay up (multi-accept, not anchored to
+    // any single connection).
+    first.destroy();
+    await delay(200);
+    expect(proc.killed).toBe(false);
+
+    // A second client connects and handshakes, proving CES survived.
+    const second = await connectToSocket(socketPath);
+    const ack2 = await handshake(second, "sibling-2");
+    expect(ack2.accepted).toBe(true);
+    second.destroy();
+
+    // SIGTERM shuts it down.
+    proc.kill("SIGTERM");
+    const exited = await Promise.race([
+      proc.exited.then(() => true),
+      delay(5_000).then(() => false),
+    ]);
+    expect(exited).toBe(true);
+  }, 30_000);
+});

--- a/credential-executor/src/local-socket.ts
+++ b/credential-executor/src/local-socket.ts
@@ -1,0 +1,145 @@
+/**
+ * Local-mode CES Unix socket server.
+ *
+ * In local mode CES is spawned by the assistant and serves the spawning parent
+ * over stdio. To support a multiprocess assistant daemon — where sibling
+ * processes also need to reach CES — local mode additionally listens on a Unix
+ * socket. The socket stays bound and accepts connections concurrently; each
+ * connection is served by its own `CesRpcServer` over the shared (and
+ * connection-safe) handler registry.
+ *
+ * Trust model: possession of the socket is the authorization boundary. Any
+ * process able to open the socket is treated as one of the assistant's own
+ * processes. The socket lives under the CES-private local data directory, whose
+ * filesystem permissions gate access — CES performs no per-connection
+ * authentication. (The normative statement of this boundary lives in
+ * `credential-executor/AGENTS.md`.)
+ */
+
+import { mkdirSync, unlinkSync } from "node:fs";
+import { createServer as createNetServer, type Socket } from "node:net";
+import { dirname } from "node:path";
+import { Readable, Writable } from "node:stream";
+
+import { CesRpcServer, type RpcHandlerRegistry } from "./server.js";
+
+/**
+ * Wrap an accepted Unix socket as the readable/writable stream pair the
+ * `CesRpcServer` consumes. Mirrors the wrapping used by the managed sidecar.
+ */
+export function socketToStreams(socket: Socket): {
+  readable: Readable;
+  writable: Writable;
+} {
+  const readable = new Readable({
+    read() {
+      // Data is pushed from the socket's "data" events.
+    },
+  });
+
+  const writable = new Writable({
+    write(chunk, _encoding, callback) {
+      if (socket.writable) {
+        socket.write(chunk, callback);
+      } else {
+        callback(new Error("Socket no longer writable"));
+      }
+    },
+  });
+
+  socket.on("data", (chunk) => {
+    readable.push(chunk);
+  });
+  socket.on("end", () => {
+    readable.push(null);
+  });
+  socket.on("error", (err) => {
+    readable.destroy(err);
+    writable.destroy(err);
+  });
+
+  return { readable, writable };
+}
+
+export interface LocalSocketServerOptions {
+  /** Filesystem path to bind the Unix socket at. */
+  socketPath: string;
+  /** Shared RPC handler registry (connection-safe; reused per connection). */
+  handlers: RpcHandlerRegistry;
+  /** Abort signal — closes the listener and tears down live connections. */
+  signal: AbortSignal;
+  /** Logger for per-connection RPC servers. Defaults to console. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+  /** Invoked once the socket is listening. */
+  onListening?: (socketPath: string) => void;
+  /** Invoked when the listener (not a single connection) errors. */
+  onServerError?: (err: unknown) => void;
+}
+
+/**
+ * Bind a Unix socket and serve every accepted connection with its own
+ * `CesRpcServer`. The socket stays bound for the process lifetime (multi
+ * accept); it is unlinked on startup (to clear a stale path) and again when the
+ * signal aborts.
+ *
+ * Returns synchronously after starting the listen; serving happens via event
+ * callbacks. A transport error on one connection is isolated and never affects
+ * the others or the process.
+ */
+export function startLocalSocketServer(opts: LocalSocketServerOptions): void {
+  const { socketPath, handlers, signal, logger, onListening, onServerError } =
+    opts;
+
+  mkdirSync(dirname(socketPath), { recursive: true });
+  // Clear any stale socket file from a previous run.
+  try {
+    unlinkSync(socketPath);
+  } catch {
+    // File may not exist — that's fine.
+  }
+
+  const netServer = createNetServer();
+
+  netServer.on("error", (err) => {
+    onServerError?.(err);
+  });
+
+  netServer.on("connection", (socket: Socket) => {
+    const { readable, writable } = socketToStreams(socket);
+    const server = new CesRpcServer({
+      input: readable,
+      output: writable,
+      handlers,
+      logger,
+      signal,
+      // Local mode reads API keys from env/store directly — no-op so
+      // update_managed_credential is still registered and returns success.
+      onApiKeyUpdate: () => {},
+    });
+
+    // Each connection serves independently. serve() rejects on a transport
+    // error (e.g. the peer crashes); contain it so one connection's failure
+    // doesn't take down the listener or the process.
+    void server.serve().catch((err) => {
+      server.close();
+      onServerError?.(err);
+    });
+  });
+
+  netServer.listen(socketPath, () => {
+    onListening?.(socketPath);
+  });
+
+  signal.addEventListener(
+    "abort",
+    () => {
+      netServer.close();
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Already removed.
+      }
+    },
+    { once: true },
+  );
+}

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -6,17 +6,17 @@
  * over stdin/stdout using newline-delimited JSON. This entrypoint:
  *
  * 1. Ensures the CES-private data directories exist.
- * 2. Starts the RPC server on process.stdin / process.stdout.
- * 3. Shuts down cleanly when stdin closes (parent exit) or SIGTERM arrives.
+ * 2. Starts the RPC server on process.stdin / process.stdout (the spawning
+ *    parent's transport, and the process lifecycle anchor).
+ * 3. Additionally listens on a Unix socket under the CES-private data dir so
+ *    the daemon's sibling processes can reach CES (see `local-socket.ts`).
+ * 4. Shuts down cleanly when stdin closes (parent exit) or SIGTERM arrives,
+ *    tearing down the socket listener with it.
  *
- * Local mode never opens a TCP listener or Unix socket. All communication
- * flows through the inherited stdio file descriptors, which are automatically
- * closed when the parent process exits.
- *
- * The stdio transport ensures that shell subprocesses spawned by CES
- * (e.g. for `run_authenticated_command`) do not accidentally inherit the
- * command channel — Bun's `Bun.spawn` defaults to "pipe" for stdio on
- * child processes, so CES's own stdin/stdout are not leaked to subprocesses.
+ * Local mode never opens a TCP listener. The stdio transport is never inherited
+ * by shell subprocesses spawned by CES (e.g. for `run_authenticated_command`):
+ * Bun's `Bun.spawn` defaults to "pipe" for stdio, and the Unix socket's
+ * listening fd is likewise not passed to those subprocesses.
  */
 
 import { mkdirSync } from "node:fs";
@@ -52,7 +52,9 @@ import {
   getCesGrantsDir,
   getCesLogDir,
   getCesToolStoreDir,
+  getLocalSocketPath,
 } from "./paths.js";
+import { startLocalSocketServer } from "./local-socket.js";
 import {
   buildHandlersWithHttp,
   CesRpcServer,
@@ -357,7 +359,7 @@ async function main(): Promise<void> {
   const log = getLogger("main");
 
   log.info(
-    `Starting CES v${CES_PROTOCOL_VERSION} (local mode, stdio transport)`,
+    `Starting CES v${CES_PROTOCOL_VERSION} (local mode, stdio + socket transport)`,
   );
 
   const controller = new AbortController();
@@ -390,22 +392,45 @@ async function main(): Promise<void> {
   const handlers = buildHandlers(secureKeyBackend);
 
   const rpcLog = getLogger("rpc");
-  const server = new CesRpcServer({
+  const rpcLogger = {
+    log: (msg: string, ...args: unknown[]) => rpcLog.info({ args }, msg),
+    warn: (msg: string, ...args: unknown[]) => rpcLog.warn({ args }, msg),
+    error: (msg: string, ...args: unknown[]) => rpcLog.error({ args }, msg),
+  };
+
+  // Serve the spawning parent over stdio. This is the lifecycle anchor: when
+  // the parent exits, stdin closes and serve() resolves, and we tear down.
+  const stdioServer = new CesRpcServer({
     input: process.stdin,
     output: process.stdout,
     handlers,
-    logger: {
-      log: (msg: string, ...args: unknown[]) => rpcLog.info({ args }, msg),
-      warn: (msg: string, ...args: unknown[]) => rpcLog.warn({ args }, msg),
-      error: (msg: string, ...args: unknown[]) => rpcLog.error({ args }, msg),
-    },
+    logger: rpcLogger,
     signal: controller.signal,
     // Local mode reads API keys from env/store directly — no-op handler so
     // update_managed_credential is still registered and returns success.
     onApiKeyUpdate: () => {},
   });
 
-  await server.serve();
+  // Additionally listen on a Unix socket so the daemon's sibling processes can
+  // reach CES (the spawning parent keeps using stdio). Possession of the socket
+  // is the authorization boundary — it lives under the CES-private data dir —
+  // and each accepted connection is served by its own server over the shared,
+  // connection-safe handler registry.
+  const socketPath = getLocalSocketPath();
+  startLocalSocketServer({
+    socketPath,
+    handlers,
+    signal: controller.signal,
+    logger: rpcLogger,
+    onListening: (p) => log.info(`Local CES socket listening at ${p}`),
+    onServerError: (err) =>
+      rpcLog.warn({ err }, "Local CES socket server error"),
+  });
+
+  await stdioServer.serve();
+  // The parent disconnected (or a shutdown signal fired). Abort so the socket
+  // listener and any live socket connections are torn down too.
+  controller.abort();
   log.info("Server stopped.");
 }
 

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -2,21 +2,22 @@
 /**
  * Local CES entrypoint.
  *
- * In local mode the assistant spawns CES as a child process and communicates
- * over stdin/stdout using newline-delimited JSON. This entrypoint:
+ * Local CES is converging on the same shape the managed sidecar already uses:
+ * an independent, socket-serving process. This entrypoint:
  *
  * 1. Ensures the CES-private data directories exist.
- * 2. Starts the RPC server on process.stdin / process.stdout (the spawning
- *    parent's transport, and the process lifecycle anchor).
- * 3. Additionally listens on a Unix socket under the CES-private data dir so
- *    the daemon's sibling processes can reach CES (see `local-socket.ts`).
- * 4. Shuts down cleanly when stdin closes (parent exit) or SIGTERM arrives,
- *    tearing down the socket listener with it.
+ * 2. Listens on a Unix socket under the CES-private data dir — the transport
+ *    for sibling/standalone use (see `local-socket.ts`).
+ * 3. Also serves the spawning parent over stdin/stdout (transitional: today the
+ *    assistant still spawns CES and talks over stdio).
+ * 4. Runs until SIGTERM/SIGINT — NOT until stdin closes — so it can run as a
+ *    standalone sibling launched without a stdio parent. On shutdown the socket
+ *    listener and any live connections are torn down with it.
  *
- * Local mode never opens a TCP listener. The stdio transport is never inherited
- * by shell subprocesses spawned by CES (e.g. for `run_authenticated_command`):
- * Bun's `Bun.spawn` defaults to "pipe" for stdio, and the Unix socket's
- * listening fd is likewise not passed to those subprocesses.
+ * Local mode never opens a TCP listener. Neither the stdio transport nor the
+ * Unix socket's listening fd is inherited by shell subprocesses spawned by CES
+ * (e.g. for `run_authenticated_command`): Bun's `Bun.spawn` defaults to "pipe"
+ * for stdio, and the listening socket is not passed to those subprocesses.
  */
 
 import { mkdirSync } from "node:fs";
@@ -398,23 +399,10 @@ async function main(): Promise<void> {
     error: (msg: string, ...args: unknown[]) => rpcLog.error({ args }, msg),
   };
 
-  // Serve the spawning parent over stdio. This is the lifecycle anchor: when
-  // the parent exits, stdin closes and serve() resolves, and we tear down.
-  const stdioServer = new CesRpcServer({
-    input: process.stdin,
-    output: process.stdout,
-    handlers,
-    logger: rpcLogger,
-    signal: controller.signal,
-    // Local mode reads API keys from env/store directly — no-op handler so
-    // update_managed_credential is still registered and returns success.
-    onApiKeyUpdate: () => {},
-  });
-
-  // Additionally listen on a Unix socket so the daemon's sibling processes can
-  // reach CES (the spawning parent keeps using stdio). Possession of the socket
-  // is the authorization boundary — it lives under the CES-private data dir —
-  // and each accepted connection is served by its own server over the shared,
+  // Listen on a Unix socket — the transport for sibling/standalone use, and
+  // the direction local CES is converging on. Possession of the socket is the
+  // authorization boundary (it lives under the CES-private data dir); each
+  // accepted connection is served by its own server over the shared,
   // connection-safe handler registry.
   const socketPath = getLocalSocketPath();
   startLocalSocketServer({
@@ -427,10 +415,38 @@ async function main(): Promise<void> {
       rpcLog.warn({ err }, "Local CES socket server error"),
   });
 
-  await stdioServer.serve();
-  // The parent disconnected (or a shutdown signal fired). Abort so the socket
-  // listener and any live socket connections are torn down too.
-  controller.abort();
+  // Also serve the spawning parent over stdio (transitional: today the
+  // assistant still spawns CES and talks to it over stdio). This is no longer
+  // the lifecycle anchor — see below — so stdin EOF alone does not shut CES
+  // down. It is run in the background and its end is not awaited.
+  const stdioServer = new CesRpcServer({
+    input: process.stdin,
+    output: process.stdout,
+    handlers,
+    logger: rpcLogger,
+    signal: controller.signal,
+    // Local mode reads API keys from env/store directly — no-op handler so
+    // update_managed_credential is still registered and returns success.
+    onApiKeyUpdate: () => {},
+  });
+  void stdioServer.serve().catch((err) => {
+    rpcLog.warn({ err }, "CES stdio server ended with a transport error");
+  });
+
+  // Run until a shutdown signal (SIGTERM/SIGINT) aborts the controller — NOT
+  // until stdin closes. This lets CES run as a standalone sibling launched
+  // without a stdio parent (its stdin is empty and would EOF immediately),
+  // while an assistant that still spawns CES tears it down with an explicit
+  // SIGTERM on shutdown.
+  await new Promise<void>((resolve) => {
+    if (controller.signal.aborted) {
+      resolve();
+      return;
+    }
+    controller.signal.addEventListener("abort", () => resolve(), {
+      once: true,
+    });
+  });
   log.info("Server stopped.");
 }
 

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -141,6 +141,32 @@ export function getBootstrapSocketPath(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Local-mode command socket
+// ---------------------------------------------------------------------------
+
+/** Default local-mode CES socket filename (under the local data root). */
+const LOCAL_SOCKET_NAME = "ces.sock";
+
+/**
+ * Return the path to the local-mode CES Unix socket.
+ *
+ * In local mode CES serves the spawning parent over stdio AND listens on this
+ * Unix socket so other same-host processes — the assistant daemon's sibling
+ * processes — can reach it. The socket lives under the CES-private local data
+ * root, whose directory permissions are the access boundary.
+ *
+ * Priority:
+ * 1. `CES_LOCAL_SOCKET` env var (full file path override, e.g. for tests).
+ * 2. Default: `<localDataRoot>/ces.sock`.
+ */
+export function getLocalSocketPath(): string {
+  return (
+    process.env["CES_LOCAL_SOCKET"] ??
+    join(getCesDataRoot("local"), LOCAL_SOCKET_NAME)
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Health port (managed mode only)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

**Step 1 of converging local CES onto the managed sidecar shape** — an independent, socket-serving process — and away from the assistant-spawned stdio child. This is the workstream that replaces the earlier "multi-client local socket" direction (this PR was paused as that draft and re-scoped).

Today CES runs as a sibling everywhere *except* the non-containerized native daemon: the CES `Dockerfile` runs `managed-main.ts` (`CES_MODE=managed`) over a socket, and `statefulset.ts` registers a `credential-executor-sidecar` for both Docker and k8s. Only the native path has the assistant spawn CES as a stdio child (`process-manager.startLocalProcess`). The gateway, by contrast, is *already* a CLI-launched sibling in that same native path — CES is the odd one out. The goal is to make CES a sibling there too.

This PR is the CES-side enabler. It does **not** change who launches CES or how the assistant connects — those are later steps (CLI launches CES; assistant connects over the socket and stops spawning it).

## What

- **Local CES listens on a Unix socket** (`local-socket.ts`, `getLocalSocketPath()`), accepting connections concurrently — each served by its own server over the now connection-safe handler registry (per-connection `SessionContext`, process-shared grants, serialized tool management from the merged PR1–3).
- **Lifecycle anchored to SIGTERM/SIGINT, not stdin EOF.** Previously `await stdioServer.serve()` made stdin EOF the shutdown trigger, so a process launched without a stdio parent (e.g. the CLI launching CES like it launches the gateway) would exit immediately. It now runs until a signal — the same anchor the managed sidecar and the gateway use.
- **stdio still served, transitionally**, for an assistant that still spawns CES. stdin EOF no longer shuts CES down.

## Behavior / risk

- **Containerized paths untouched** (`managed-main.ts` unchanged) — zero platform risk.
- The only behavioral change to the native path: a CES whose parent crashes *without* signalling now lingers until the next launch, instead of dying on the parent's stdin close. That's the same "no crash supervision" gap the gateway already has, and it disappears once the assistant stops spawning CES (a later step). An assistant that shuts down gracefully already `SIGTERM`s/`SIGKILL`s CES, so the common path is unchanged.
- Credential model is unchanged — `CES_MODE=local` still uses the shared-FS / `local_static` backend. This workstream moves transport/lifecycle only.

## Testing

- `tsc` clean, `eslint` clean.
- **New `local-standalone.test.ts`**: spawns the real `main.ts` with **stdin closed** and verifies CES binds its socket (i.e. did *not* exit on the immediate stdin EOF), serves a real RPC, survives a client disconnect (multi-accept), and exits on SIGTERM. Runs green in-sandbox (Unix-domain binds work here; only TCP binds don't).
- Plus `local-socket.test.ts` (path resolution, `socketToStreams`, two-connection multi-accept).
- `bun test src/`: **575 pass, 2 fail** — the two failures (`managed-integration`, `managed-reconnect`) bind a **TCP** health port (`Failed to listen at ::`) and fail identically on `main`; unrelated to this change.

## Next in the workstream

Step 2 — CLI launches CES as a sibling (`.vellum/ces.pid`, started by `wake`, stopped by `sleep`/`retire`), like the gateway. Step 3 — assistant connects over the socket and stops spawning CES (reconnect just re-dials; `stopCes` no longer kills CES). Step 4 — delete the stdio transport and the assistant's spawn/discovery code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)