### PR TITLE
Use host install id for local web registration

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8527,6 +8527,49 @@ paths:
                                     - type: "null"
                               additionalProperties: false
                             - type: "null"
+                        latency:
+                          anyOf:
+                            - type: object
+                              properties:
+                                phases:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      label:
+                                        type: string
+                                      ms:
+                                        type: number
+                                    required:
+                                      - key
+                                      - label
+                                      - ms
+                                    additionalProperties: false
+                                ttftMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                totalToFirstTokenMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                providerDurationMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                firstTokenKind:
+                                  anyOf:
+                                    - type: string
+                                      enum:
+                                        - thinking
+                                        - text
+                                    - type: "null"
+                              required:
+                                - phases
+                              additionalProperties: false
+                            - type: "null"
                       required:
                         - id
                         - createdAt
@@ -15521,6 +15564,49 @@ paths:
                               - type: "null"
                         additionalProperties: false
                       - type: "null"
+                  latency:
+                    anyOf:
+                      - type: object
+                        properties:
+                          phases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                label:
+                                  type: string
+                                ms:
+                                  type: number
+                              required:
+                                - key
+                                - label
+                                - ms
+                              additionalProperties: false
+                          ttftMs:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          totalToFirstTokenMs:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          providerDurationMs:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          firstTokenKind:
+                            anyOf:
+                              - type: string
+                                enum:
+                                  - thinking
+                                  - text
+                              - type: "null"
+                        required:
+                          - phases
+                        additionalProperties: false
+                      - type: "null"
                 required:
                   - id
                   - createdAt
@@ -18145,6 +18231,49 @@ paths:
                                     - type: "null"
                               additionalProperties: false
                             - type: "null"
+                        latency:
+                          anyOf:
+                            - type: object
+                              properties:
+                                phases:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      label:
+                                        type: string
+                                      ms:
+                                        type: number
+                                    required:
+                                      - key
+                                      - label
+                                      - ms
+                                    additionalProperties: false
+                                ttftMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                totalToFirstTokenMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                providerDurationMs:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                firstTokenKind:
+                                  anyOf:
+                                    - type: string
+                                      enum:
+                                        - thinking
+                                        - text
+                                    - type: "null"
+                              required:
+                                - phases
+                              additionalProperties: false
+                            - type: "null"
                       required:
                         - id
                         - createdAt
@@ -20315,6 +20444,10 @@ paths:
                     type: boolean
                   hasWebhookSecret:
                     type: boolean
+                  clientInstallationId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
                   available:
                     type: boolean
                   organizationId:
@@ -20346,6 +20479,7 @@ paths:
                   - assistantId
                   - hasAssistantApiKey
                   - hasWebhookSecret
+                  - clientInstallationId
                   - available
                   - organizationId
                   - userId

--- a/assistant/src/__tests__/device-id.test.ts
+++ b/assistant/src/__tests__/device-id.test.ts
@@ -19,7 +19,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { getDeviceId, resetDeviceIdCache } from "../util/device-id.js";
+import {
+  getDeviceId,
+  getExistingDeviceId,
+  resetDeviceIdCache,
+} from "../util/device-id.js";
 
 const originalVellumEnvironment = process.env.VELLUM_ENVIRONMENT;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
@@ -177,5 +181,38 @@ describe("getDeviceId VELLUM_DEVICE_ID precedence", () => {
 
     resetDeviceIdCache();
     expect(getDeviceId()).not.toBe("env-id");
+  });
+});
+
+describe("getExistingDeviceId", () => {
+  beforeEach(() => {
+    delete process.env.IS_CONTAINERIZED;
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  test("returns null without creating device.json when no id exists", () => {
+    const expectedPath = join(tempDir, "vellum-dev", "device.json");
+
+    expect(getExistingDeviceId()).toBeNull();
+    expect(existsSync(expectedPath)).toBe(false);
+  });
+
+  test("reads an existing device.json id", () => {
+    const dir = join(tempDir, "vellum-dev");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "device.json"),
+      JSON.stringify({ deviceId: "file-id" }),
+    );
+
+    expect(getExistingDeviceId()).toBe("file-id");
+  });
+
+  test("returns the env override without writing device.json", () => {
+    process.env.VELLUM_DEVICE_ID = "env-id";
+
+    expect(getExistingDeviceId()).toBe("env-id");
+    expect(readdirSync(tempDir)).toEqual([]);
   });
 });

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -27,6 +27,7 @@ import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
 } from "../../security/secure-keys.js";
+import { getExistingDeviceId } from "../../util/device-id.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
@@ -64,6 +65,7 @@ const PlatformStatusResponseSchema = z.object({
   assistantId: z.string(),
   hasAssistantApiKey: z.boolean(),
   hasWebhookSecret: z.boolean(),
+  clientInstallationId: z.string().nullable(),
   available: z.boolean(),
   organizationId: z.string().nullable(),
   userId: z.string().nullable(),
@@ -154,6 +156,7 @@ async function handlePlatformStatus(
     assistantId: context.assistantId,
     hasAssistantApiKey: context.hasAssistantApiKey,
     hasWebhookSecret,
+    clientInstallationId: getExistingDeviceId(),
     available: context.enabled,
     organizationId: organizationId || null,
     userId: userId || null,

--- a/assistant/src/util/device-id.ts
+++ b/assistant/src/util/device-id.ts
@@ -67,6 +67,53 @@ function resolveDeviceIdPaths(): { dir: string; file: string } {
   return { dir, file: join(dir, "device.json") };
 }
 
+function readDeviceIdFromFile(filePath: string): string | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+  if (
+    raw &&
+    typeof raw === "object" &&
+    typeof raw.deviceId === "string" &&
+    raw.deviceId.length > 0
+  ) {
+    return raw.deviceId as string;
+  }
+  return null;
+}
+
+/**
+ * Read the current stable device ID without creating or writing device.json.
+ */
+export function getExistingDeviceId(): string | null {
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const fromEnv = getDeviceIdOverride();
+  if (fromEnv) {
+    cached = fromEnv;
+    log.info({ deviceId: cached }, "Resolved device ID from VELLUM_DEVICE_ID");
+    return cached;
+  }
+
+  const { file: filePath } = resolveDeviceIdPaths();
+  try {
+    const existing = readDeviceIdFromFile(filePath);
+    if (existing) {
+      cached = existing;
+      log.info({ deviceId: cached }, "Resolved device ID from device.json");
+      return cached;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 /**
  * Get the stable device ID for this machine.
  *
@@ -95,18 +142,11 @@ export function getDeviceId(): string {
   const generated = randomUUID();
 
   try {
-    if (existsSync(filePath)) {
-      const raw = JSON.parse(readFileSync(filePath, "utf-8"));
-      if (
-        raw &&
-        typeof raw === "object" &&
-        typeof raw.deviceId === "string" &&
-        raw.deviceId.length > 0
-      ) {
-        cached = raw.deviceId as string;
-        log.info({ deviceId: cached }, "Resolved device ID from device.json");
-        return cached;
-      }
+    const existing = readDeviceIdFromFile(filePath);
+    if (existing) {
+      cached = existing;
+      log.info({ deviceId: cached }, "Resolved device ID from device.json");
+      return cached;
     }
   } catch (err) {
     log.warn({ err }, "Failed to read device.json — generating new device ID");

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -5,6 +5,7 @@ const PLATFORM_ASSISTANT_ID = "019ed7d1-e995-71cc-9859-c54f422ace3c";
 const OTHER_PLATFORM_ASSISTANT_ID = "019ed7d1-e995-71cc-9859-c54f422ace3d";
 const ORGANIZATION_ID = "019ed7d1-e995-71cc-9859-c54f422ace3e";
 const GATEWAY_URL = "http://localhost:5173/assistant/__gateway/20101";
+const HOST_INSTALLATION_ID = "host-installation-1";
 
 type RecordedRequest = {
   pathname: string;
@@ -22,6 +23,7 @@ let isPlatformDisabledValue = false;
 let isRemoteGatewayModeValue = false;
 let selfHostedIngressUrl: string | null = GATEWAY_URL;
 let selfHostedActorToken: string | null = "actor-token";
+let browserDeviceId: string | null = null;
 let statusBody: unknown;
 let ensureRegistrationBody: unknown;
 let reprovisionApiKeyBody: unknown;
@@ -62,7 +64,7 @@ mock.module("@/lib/self-hosted/connection", () => ({
 }));
 
 mock.module("@/runtime/device-id", () => ({
-  getDeviceId: () => "device-1",
+  getDeviceId: () => browserDeviceId,
 }));
 
 mock.module("@/runtime/is-electron", () => ({
@@ -124,10 +126,12 @@ beforeEach(() => {
   isRemoteGatewayModeValue = false;
   selfHostedIngressUrl = GATEWAY_URL;
   selfHostedActorToken = "actor-token";
+  browserDeviceId = null;
   statusBody = {
     assistant_id: PLATFORM_ASSISTANT_ID,
     organization_id: ORGANIZATION_ID,
     has_assistant_api_key: true,
+    client_installation_id: HOST_INSTALLATION_ID,
   };
   ensureRegistrationBody = {
     assistant: { id: PLATFORM_ASSISTANT_ID },
@@ -200,6 +204,7 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       assistant_id: PLATFORM_ASSISTANT_ID,
       organization_id: ORGANIZATION_ID,
       has_assistant_api_key: false,
+      client_installation_id: HOST_INSTALLATION_ID,
     };
     ensureRegistrationBody = {
       assistant: { id: OTHER_PLATFORM_ASSISTANT_ID },
@@ -219,6 +224,24 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       "secrets",
       "secrets",
     ]);
+    expect(
+      requests.find((request) =>
+        request.pathname.endsWith("/ensure-registration/"),
+      )?.body,
+    ).toEqual({
+      client_installation_id: HOST_INSTALLATION_ID,
+      runtime_assistant_id: RUNTIME_ASSISTANT_ID,
+      client_platform: "web",
+    });
+    expect(
+      requests.find((request) =>
+        request.pathname.endsWith("/reprovision-api-key/"),
+      )?.body,
+    ).toEqual({
+      client_installation_id: HOST_INSTALLATION_ID,
+      runtime_assistant_id: RUNTIME_ASSISTANT_ID,
+      client_platform: "web",
+    });
 
     const injectedSecrets = requests
       .filter((request) => request.pathname.endsWith("/v1/secrets"))

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -34,12 +34,15 @@ type PlatformStatusBody = {
   organization_id?: unknown;
   hasAssistantApiKey?: unknown;
   has_assistant_api_key?: unknown;
+  clientInstallationId?: unknown;
+  client_installation_id?: unknown;
 };
 
 type LocalPlatformStatus = {
   assistantId: string | null;
   organizationId: string | null;
   hasAssistantApiKey: boolean | null;
+  clientInstallationId: string | null;
 };
 
 type EnsureRegistrationResponse = {
@@ -164,7 +167,19 @@ async function ensureLocalAssistantPlatformIdentity(
     throw new Error("Sign in to Vellum and select an organization to register this local assistant.");
   }
 
-  const registration = await ensureRegistration(assistant, organizationId);
+  const clientInstallationId =
+    status?.clientInstallationId ?? getDeviceId() ?? null;
+  if (!clientInstallationId) {
+    throw new Error(
+      "Unable to identify this local assistant host for platform registration.",
+    );
+  }
+
+  const registration = await ensureRegistration(
+    assistant,
+    organizationId,
+    clientInstallationId,
+  );
   const registrationPlatformAssistantId = firstString(
     registration.assistant?.id,
     registration.assistant_id,
@@ -180,7 +195,11 @@ async function ensureLocalAssistantPlatformIdentity(
 
   let assistantApiKey = stringValue(registration.assistant_api_key);
   if (!assistantApiKey && status?.hasAssistantApiKey !== true) {
-    assistantApiKey = await reprovisionApiKey(assistant, organizationId);
+    assistantApiKey = await reprovisionApiKey(
+      assistant,
+      organizationId,
+      clientInstallationId,
+    );
   }
 
   await injectPlatformCredentials(gateway, {
@@ -245,6 +264,10 @@ async function fetchPlatformStatus(
       body?.hasAssistantApiKey,
       body?.has_assistant_api_key,
     ),
+    clientInstallationId: firstString(
+      body?.clientInstallationId,
+      body?.client_installation_id,
+    ),
   };
 }
 
@@ -268,11 +291,13 @@ async function resolveOrganizationId(
 async function ensureRegistration(
   assistant: LockfileAssistant,
   organizationId: string,
+  clientInstallationId: string,
 ): Promise<EnsureRegistrationResponse> {
   const body = await platformPost<EnsureRegistrationResponse>(
     "/v1/assistants/self-hosted-local/ensure-registration/",
     assistant,
     organizationId,
+    clientInstallationId,
   );
   return body;
 }
@@ -280,11 +305,13 @@ async function ensureRegistration(
 async function reprovisionApiKey(
   assistant: LockfileAssistant,
   organizationId: string,
+  clientInstallationId: string,
 ): Promise<string | null> {
   const body = await platformPost<ReprovisionApiKeyResponse>(
     "/v1/assistants/self-hosted-local/reprovision-api-key/",
     assistant,
     organizationId,
+    clientInstallationId,
   );
   return stringValue(body.provisioning?.assistant_api_key);
 }
@@ -293,12 +320,8 @@ async function platformPost<T>(
   path: string,
   assistant: LockfileAssistant,
   organizationId: string,
+  clientInstallationId: string,
 ): Promise<T> {
-  const deviceId = getDeviceId();
-  if (!deviceId) {
-    throw new Error("Unable to identify this device for local assistant platform registration.");
-  }
-
   const headers = new Headers({
     ...(await buildVellumMutatingHeaders(
       {
@@ -328,9 +351,9 @@ async function platformPost<T>(
     headers,
     credentials: isElectron() ? "omit" : "same-origin",
     body: JSON.stringify({
-      client_installation_id: deviceId,
+      client_installation_id: clientInstallationId,
       runtime_assistant_id: assistant.assistantId,
-      client_platform: "macos",
+      client_platform: isElectron() ? "macos" : "web",
     }),
   }).catch((error: unknown) => {
     throw new Error(


### PR DESCRIPTION
## Summary
- Expose clientInstallationId on assistant GET /platform/status using a read-only existing device-id lookup, so the status route does not create device.json.
- Make web local-assistant registration prefer the host-provided install id and use client_platform: web outside Electron.
- Regenerate the assistant OpenAPI spec for the new nullable status field.

## Verification
- bun test src/__tests__/device-id.test.ts
- bun run typecheck:fast
- bun test src/lib/local-platform-identity.test.ts
- bun run generate:openapi
- bun run openapi-ts
- bun run typecheck in clients/web fails on existing generated-type mismatches in chat/ACP: missing LatencyBreakdown/latency, acpNotification, rawInput, and rawOutput.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->