### PR TITLE
fix(memory): non-persistent platform default, defer on read failure, gate on memory.enabled

### DIFF
--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -150,6 +150,39 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     expect(qdrantRaw.vectorSize).toBeUndefined();
   });
 
+  test("first launch (no config.json) does not persist deployment-context fills", () => {
+    // No config.json on disk: this is the first-launch SEED path that writes a
+    // default config so the file exists for users to edit.
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    process.env.IS_PLATFORM = "true";
+
+    const config = loadConfig();
+
+    // In-memory effective config still reflects the platform intent.
+    expect(config.memory.embeddings.provider).toBe("gemini");
+
+    // But the seeded config.json on disk records user intent (schema defaults
+    // only) — the platform fills are applied in-memory on every load and are
+    // intentionally NOT persisted. The embedding provider reflects the schema
+    // default ("auto"), never the platform "gemini", and the managed service
+    // modes are absent so a later non-platform run is not overridden by them.
+    const raw = readConfig();
+    const memoryRaw = (raw.memory ?? {}) as Record<string, unknown>;
+    const embeddingsRaw = (memoryRaw.embeddings ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(embeddingsRaw.provider).not.toBe("gemini");
+    expect(embeddingsRaw.provider ?? "auto").toBe("auto");
+
+    const servicesRaw = (raw.services ?? {}) as Record<string, unknown>;
+    const webSearchRaw = (servicesRaw["web-search"] ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(webSearchRaw.mode).not.toBe("managed");
+  });
+
   test("IS_PLATFORM='1' also fills provider=gemini in memory", () => {
     writeConfig({});
     process.env.IS_PLATFORM = "1";

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -725,6 +725,14 @@ export function loadConfig(): AssistantConfig {
     // Validate and apply defaults via Zod schema
     const config = validateWithSchema(fileConfig);
 
+    // Snapshot the schema-defaulted config BEFORE deployment-context fills are
+    // layered on — but only when the first-launch seed below will actually
+    // persist it. Disk records user intent (schema defaults only), while the
+    // in-memory `config` returned below carries the deployment-context fills as
+    // this run's effective values.
+    const willSeed = !configFileExisted && suppressConfigDiskWritesDepth === 0;
+    const firstLaunchSeed = willSeed ? structuredClone(config) : null;
+
     // Layer deployment-context defaults (e.g. IS_PLATFORM=true → all service
     // modes = "managed") onto the in-memory config for any leaves that aren't
     // explicitly set in `fileConfig`. This runs on every load — not just the
@@ -745,28 +753,29 @@ export function loadConfig(): AssistantConfig {
     }
 
     // First-launch seed only: when config.json does not exist, write the full
-    // schema defaults (with any deployment-context overrides already applied
-    // above) to disk so users can discover and edit all available options.
+    // schema defaults to disk so users can discover and edit all available
+    // options. Deployment-context defaults are deliberately excluded from the
+    // persisted seed — they are applied in-memory on every load (above) and are
+    // intentionally NOT persisted, so disk records user intent (schema defaults
+    // only) while the in-memory cache holds the effective values. Persisting the
+    // platform fills (e.g. IS_PLATFORM=true → provider "gemini", managed service
+    // modes) would make them sticky and able to override a later non-platform
+    // run of the same workspace.
+    //
     // When the file already exists, leave it alone — disk represents user
     // intent, while the in-memory `cached: AssistantConfig` (above) has all
     // schema defaults applied via `applyNestedDefaults`/`validateWithSchema`,
     // so consumers calling `getConfig().memory.v2.bm25_b` continue to receive
-    // the schema default whenever the field is absent on disk.
-    //
-    // The previous behavior — eagerly merging missing keys back into the file
-    // on every load — silently baked stale defaults into existing users'
-    // config.json. Once a default landed in the file, future schema-default
-    // changes were inert because the merge only filled absent keys and never
-    // reconciled existing values. Contract: disk = user intent, in-memory
-    // cache = effective values.
-    if (!configFileExisted && suppressConfigDiskWritesDepth === 0) {
+    // the schema default whenever the field is absent on disk. Contract: disk =
+    // user intent, in-memory cache = effective values.
+    if (willSeed && firstLaunchSeed) {
       try {
         const dir = dirname(configPath);
         if (!existsSync(dir)) {
           mkdirSync(dir, { recursive: true });
         }
         // Strip dataDir (runtime-derived) from the persisted config
-        const { dataDir: _, ...persistable } = config;
+        const { dataDir: _, ...persistable } = firstLaunchSeed;
         writeFileSync(configPath, JSON.stringify(persistable, null, 2) + "\n");
         log.info("Wrote default config to %s", configPath);
       } catch (err) {

--- a/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
@@ -7,9 +7,13 @@ import {
   reconcileEmbeddingIdentity,
 } from "../embedding-reconcile.js";
 
-function fakeConfig(provider = "auto"): AssistantConfig {
+function fakeConfig(
+  provider = "auto",
+  opts: { enabled?: boolean } = {},
+): AssistantConfig {
   return {
     memory: {
+      enabled: opts.enabled ?? true,
       embeddings: { provider },
       qdrant: { vectorSize: 384 },
     },
@@ -26,6 +30,8 @@ function makeDeps(opts: {
   decision: ReconcileAction;
   committedDim?: number | null;
   probeDim?: number | null;
+  /** When set, `readConceptPageCollectionDim` rejects instead of resolving. */
+  committedDimError?: Error;
 }): ReconcileDeps {
   return {
     probeBackendDimension: mock(async () =>
@@ -33,7 +39,10 @@ function makeDeps(opts: {
         ? null
         : { provider: "gemini" as const, model: "m", dim: opts.probeDim },
     ),
-    readConceptPageCollectionDim: mock(async () => opts.committedDim ?? null),
+    readConceptPageCollectionDim: mock(async () => {
+      if (opts.committedDimError) throw opts.committedDimError;
+      return opts.committedDim ?? null;
+    }),
     decideEmbeddingReconcile: mock(() => opts.decision),
     persistVectorSize: mock(() => {}),
     setInMemoryVectorSize: mock(() => {}),
@@ -61,6 +70,60 @@ describe("reconcileEmbeddingIdentity", () => {
     expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
     expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
     expect(deps.setInMemoryVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+  });
+
+  test("memory disabled short-circuits to noop with ZERO side effects", async () => {
+    const deps = makeDeps({
+      // The decision is irrelevant — the disabled gate returns before it runs.
+      decision: { kind: "commit-fresh", dim: 3072 },
+      committedDim: null,
+      probeDim: 3072,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("gemini", { enabled: false }),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "noop", dim: null });
+    // Nothing is read, probed, persisted, recreated, ensured, or enqueued.
+    expect(deps.probeBackendDimension).toHaveBeenCalledTimes(0);
+    expect(deps.readConceptPageCollectionDim).toHaveBeenCalledTimes(0);
+    expect(deps.decideEmbeddingReconcile).toHaveBeenCalledTimes(0);
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+    expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+  });
+
+  test("a committed-dim read failure defers (degraded), never treated as fresh", async () => {
+    const deps = makeDeps({
+      // Even though the decision would be commit-fresh on a null committed dim,
+      // the read throws first, so we must defer WITHOUT persisting/recreating.
+      decision: { kind: "commit-fresh", dim: 3072 },
+      committedDimError: new Error("qdrant down"),
+      probeDim: 3072,
+    });
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("gemini"),
+      deps,
+    );
+
+    expect(outcome).toEqual({
+      action: "defer-degraded",
+      reason: "could not read committed collection dimension",
+    });
+    // The throw short-circuits before probing and before the decision runs, so
+    // nothing is persisted, recreated, ensured, or enqueued.
+    expect(deps.probeBackendDimension).toHaveBeenCalledTimes(0);
+    expect(deps.decideEmbeddingReconcile).toHaveBeenCalledTimes(0);
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.setInMemoryVectorSize).toHaveBeenCalledTimes(0);
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
     expect(deps.ensureCollections).toHaveBeenCalledTimes(0);
     expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
   });

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -186,24 +186,56 @@ export function defaultDeps(config: AssistantConfig): ReconcileDeps {
  * the configured embedding backend, then execute the resulting action:
  *
  *  - `noop` — committed dimension already matches (or auto-mode declines to
- *    thrash); no writes, no destructive calls.
+ *    thrash); no writes, no destructive calls. Also returned immediately when
+ *    `memory.enabled === false`, before any probe/read/persist/enqueue.
  *  - `commit-fresh` — fresh install adopts the reachable backend's dimension:
  *    commit the dim, ensure the collections EXIST at it (create-if-absent, never
  *    destroy), and enqueue a reembed.
  *  - `migrate` — deliberate provider intent with a confirmed probe: commit the
  *    new dim, then destroy + recreate the collections (the only destructive
  *    path) and enqueue a reembed.
- *  - `defer-degraded` — backend unreachable: no write, no destructive call;
- *    warn and leave the collections untouched.
+ *  - `defer-degraded` — backend unreachable, OR the committed dimension could
+ *    not be read (Qdrant unreachable / existing collection unreadable): no
+ *    write, no destructive call; warn and leave the collections untouched.
  */
 export async function reconcileEmbeddingIdentity(
   config: AssistantConfig,
   deps: ReconcileDeps = defaultDeps(config),
 ): Promise<ReconcileOutcome> {
-  const [committedDim, probe] = await Promise.all([
-    deps.readConceptPageCollectionDim(config),
-    deps.probeBackendDimension(config),
-  ]);
+  // Memory disabled: the user has opted out, so incur none of the reconcile's
+  // cost — no probe (a provider embed call), no committed-dim read, no
+  // persist/recreate/enqueue. `memory.enabled` defaults to true; gate strictly
+  // on the explicit `false`. This gate covers both the lifecycle startup call
+  // and the credential-arrival retry call.
+  if (config.memory.enabled === false) {
+    log.info("Memory disabled — skipping embedding-identity reconcile");
+    return { action: "noop", dim: null };
+  }
+
+  // Read the committed dimension first, isolated in its own try/catch. A thrown
+  // error means Qdrant was unreachable or the existing collection's dimension
+  // was unreadable — distinct from a confirmed-absent collection (which returns
+  // `null`). Treating "unreadable" as a fresh install would commit the probed
+  // dimension while the old collection still exists at the old size, so we
+  // defer (degraded) WITHOUT probing, persisting, recreating, or enqueuing.
+  // Reading before probing (rather than in a single `Promise.all`) keeps the
+  // throw from discarding a successful probe; this is startup, not latency-
+  // critical.
+  let committedDim: number | null;
+  try {
+    committedDim = await deps.readConceptPageCollectionDim(config);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Could not read committed embedding-collection dimension — deferring reconcile; no destructive action taken",
+    );
+    return {
+      action: "defer-degraded",
+      reason: "could not read committed collection dimension",
+    };
+  }
+
+  const probe = await deps.probeBackendDimension(config);
 
   const action = deps.decideEmbeddingReconcile({
     committedDim,

--- a/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
@@ -126,23 +126,31 @@ describe("readConceptPageCollectionDim", () => {
     expect(await readConceptPageCollectionDim(CONFIG)).toBe(768);
   });
 
-  test("returns null when the collection is absent", async () => {
+  test("returns null only when the collection is confirmed absent", async () => {
     collectionExistsResult = { exists: false };
     expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
   });
 
-  test("returns null when the dense size is unreadable", async () => {
+  test("throws when an existing collection's dense size is unreadable", async () => {
+    // Collection exists but the dense vector size is missing: "unknown" must
+    // not be reported as "absent" (which the reconcile reads as a fresh
+    // install), so this is an error.
     getCollectionResult = { config: { params: { vectors: {} } } };
-    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+    expect(readConceptPageCollectionDim(CONFIG)).rejects.toThrow();
   });
 
-  test("returns null on probe failure (existence check throws)", async () => {
+  test("propagates a Qdrant read failure (existence check throws)", async () => {
+    // A transient Qdrant outage must propagate rather than be misread as a
+    // confirmed-absent collection, so the reconcile defers instead of committing
+    // a new dimension while the old collection still exists.
     collectionExistsThrows = true;
-    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+    expect(readConceptPageCollectionDim(CONFIG)).rejects.toThrow("qdrant down");
   });
 
-  test("returns null on probe failure (getCollection throws)", async () => {
+  test("propagates a Qdrant read failure (getCollection throws)", async () => {
     getCollectionThrows = true;
-    expect(await readConceptPageCollectionDim(CONFIG)).toBeNull();
+    expect(readConceptPageCollectionDim(CONFIG)).rejects.toThrow(
+      "qdrant probe failed",
+    );
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-identity.ts
+++ b/assistant/src/persistence/embeddings/embedding-identity.ts
@@ -1,7 +1,6 @@
 import { QdrantClient } from "@qdrant/js-client-rest";
 
 import type { AssistantConfig } from "../../config/types.js";
-import { getLogger } from "../../util/logger.js";
 import {
   resolveBackendDimension,
   selectEmbeddingBackend,
@@ -9,8 +8,6 @@ import {
 import { isEmbeddingBillingBreakerOpen } from "./embedding-billing-breaker.js";
 import type { EmbeddingProviderName } from "./embedding-types.js";
 import { resolveQdrantUrl } from "./qdrant-client.js";
-
-const log = getLogger("embedding-identity");
 
 // Inlined rather than imported from `memory/v2/qdrant.ts`: the persistence
 // layer must not import from the memory feature layer (enforced by
@@ -54,32 +51,38 @@ export async function probeBackendDimension(
 /**
  * Read the committed dense-vector dimension of the v2 concept-page collection.
  *
- * Returns `null` — never throws — when the collection is absent or its schema
- * cannot be read, mirroring the "assume unknown on probe failure" posture in
- * `assistant/src/memory/v2/qdrant.ts`.
+ * Returns `null` ONLY for a CONFIRMED-absent collection (a fresh install). Any
+ * other inability to read the committed dimension THROWS rather than returning
+ * `null`:
+ *   - a transient Qdrant failure (`collectionExists`/`getCollection` rejects)
+ *     propagates, so a brief outage is not misread as "no collection";
+ *   - an existing collection whose dense-vector size cannot be read is an error
+ *     too, so "unknown" never masquerades as "fresh".
+ *
+ * The reconcile treats `null` as a fresh install (→ commit the probed dim), so
+ * conflating "unreachable" with "absent" would persist a new dimension while the
+ * old collection still exists at the old size. The reconcile catches the throw
+ * and defers instead.
  */
 export async function readConceptPageCollectionDim(
   config: AssistantConfig,
 ): Promise<number | null> {
-  try {
-    const client = new QdrantClient({
-      url: resolveQdrantUrl(config),
-      checkCompatibility: false,
-    });
-    const exists = await client.collectionExists(MEMORY_V2_COLLECTION);
-    if (!exists.exists) return null;
+  const client = new QdrantClient({
+    url: resolveQdrantUrl(config),
+    checkCompatibility: false,
+  });
+  const exists = await client.collectionExists(MEMORY_V2_COLLECTION);
+  if (!exists.exists) return null;
 
-    const info = await client.getCollection(MEMORY_V2_COLLECTION);
-    const vectors = info.config?.params?.vectors as
-      | Record<string, { size?: number } | undefined>
-      | undefined;
-    const size = vectors?.dense?.size;
-    return typeof size === "number" ? size : null;
-  } catch (err) {
-    log.warn(
-      { err, collection: MEMORY_V2_COLLECTION },
-      "Failed to read v2 concept-page collection dimension; treating as unknown",
+  const info = await client.getCollection(MEMORY_V2_COLLECTION);
+  const vectors = info.config?.params?.vectors as
+    | Record<string, { size?: number } | undefined>
+    | undefined;
+  const size = vectors?.dense?.size;
+  if (typeof size !== "number") {
+    throw new Error(
+      `v2 concept-page collection "${MEMORY_V2_COLLECTION}" exists but its dense-vector size is unreadable`,
     );
-    return null;
   }
+  return size;
 }


### PR DESCRIPTION
## Summary
- loader: first-launch seed no longer persists deployment-context defaults (platform provider=gemini stays in-memory only)
- reconcile: a Qdrant committed-dimension read failure defers instead of being treated as a fresh install (no dim persist without recreate)
- reconcile: short-circuits to noop when memory.enabled is false (no probe/persist/enqueue)

Addresses Codex review findings on PR #36557.