### PR TITLE
[codex] fix enter send latency

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -280,6 +280,7 @@ export function ActiveChatView() {
     assistantId,
     activeConversationId,
     diskPressureChatBlockReason,
+    uiContextRef,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
     startReconciliationLoop,

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -74,7 +74,9 @@ import {
   parsePendingConfirmationData,
   parsePendingSecretState,
   resolvePostError,
+  shouldCleanupSupersededInteractions,
 } from "@/domains/chat/utils/send-message-utils";
+import type { UIContext } from "@/domains/chat/turn-selectors";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
 import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
@@ -131,6 +133,7 @@ interface UseSendMessageParams {
   assistantId: string | null;
   activeConversationId: string | null;
   diskPressureChatBlockReason: DiskPressureChatBlockReason | null;
+  uiContextRef: MutableRefObject<UIContext | null>;
 
   // Onboarding refs (ChatPage-local, not per-conversation)
   pendingOnboardingContextRef: MutableRefObject<PreChatOnboardingContext | null>;
@@ -151,6 +154,7 @@ export function useSendMessage({
   assistantId,
   activeConversationId,
   diskPressureChatBlockReason,
+  uiContextRef,
   pendingOnboardingContextRef,
   onboardingDraftConversationIdRef,
   startReconciliationLoop,
@@ -680,37 +684,39 @@ export function useSendMessage({
       // clear + dismiss transform is applied to BOTH sources via
       // patchTranscriptMessages (a no-op for rows it doesn't match), and the
       // dismissed-id list that drives the hide set is computed over the union.
-      const cachedHistory =
-        assistantId && activeConversationId
-          ? queryClient.getQueryData<HistoryCache>(
-              conversationHistoryQueryKey(assistantId, activeConversationId),
-            )
-          : undefined;
-      const historyRows = cachedHistory
-        ? [...cachedHistory.pages].reverse().flatMap((page) => page.messages)
-        : [];
-      const transcriptForScan =
-        historyRows.length > 0
-          ? [...historyRows, ...useChatSessionStore.getState().liveTurn]
-          : useChatSessionStore.getState().liveTurn;
+      if (shouldCleanupSupersededInteractions(uiContextRef.current)) {
+        const cachedHistory =
+          assistantId && activeConversationId
+            ? queryClient.getQueryData<HistoryCache>(
+                conversationHistoryQueryKey(assistantId, activeConversationId),
+              )
+            : undefined;
+        const historyRows = cachedHistory
+          ? [...cachedHistory.pages].reverse().flatMap((page) => page.messages)
+          : [];
+        const transcriptForScan =
+          historyRows.length > 0
+            ? [...historyRows, ...useChatSessionStore.getState().liveTurn]
+            : useChatSessionStore.getState().liveTurn;
 
-      patchTranscriptMessages((prev) => {
-        const cleared = clearPendingConfirmationsFromMessages(prev);
-        const { updatedMessages, dismissedIds } = dismissInteractiveSurfaces(
-          cleared,
+        patchTranscriptMessages((prev) => {
+          const cleared = clearPendingConfirmationsFromMessages(prev);
+          const { updatedMessages, dismissedIds } = dismissInteractiveSurfaces(
+            cleared,
+            transcriptForScan,
+          );
+          return dismissedIds.size > 0 ? updatedMessages : cleared;
+        });
+
+        // Persist dismissed surfaces outside the updater (side effect).
+        const { dismissedIds } = dismissInteractiveSurfaces(
+          transcriptForScan,
           transcriptForScan,
         );
-        return dismissedIds.size > 0 ? updatedMessages : cleared;
-      });
-
-      // Persist dismissed surfaces outside the updater (side effect).
-      const { dismissedIds } = dismissInteractiveSurfaces(
-        transcriptForScan,
-        transcriptForScan,
-      );
-      if (dismissedIds.size > 0) {
-        persistDismissedSurfaces(dismissedIds);
-        useTurnStore.getState().dismissSurface();
+        if (dismissedIds.size > 0) {
+          persistDismissedSurfaces(dismissedIds);
+          useTurnStore.getState().dismissSurface();
+        }
       }
 
       const willQueue = isSending(useTurnStore.getState().phase);
@@ -928,6 +934,7 @@ export function useSendMessage({
       activeConversationId,
       assistantId,
       diskPressureChatBlockReason,
+      uiContextRef,
       runLocalMetaCommand,
       sendMessageViaStream,
       refreshConversations,

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -10,6 +10,7 @@ import {
   parsePendingConfirmationData,
   parsePendingSecretState,
   resolvePostError,
+  shouldCleanupSupersededInteractions,
 } from "@/domains/chat/utils/send-message-utils";
 
 // ---------------------------------------------------------------------------
@@ -85,6 +86,34 @@ describe("dismissInteractiveSurfaces", () => {
     );
     expect(dismissedIds.has("s-1")).toBe(true);
     expect(updatedMessages[0]!.surfaces).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldCleanupSupersededInteractions
+// ---------------------------------------------------------------------------
+
+describe("shouldCleanupSupersededInteractions", () => {
+  it("skips cleanup when the rendered UI has no supersedable interaction", () => {
+    expect(
+      shouldCleanupSupersededInteractions({
+        hasPendingConfirmation: false,
+        hasUncompletedVisibleSurface: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("runs cleanup when the rendered UI has an interactive surface", () => {
+    expect(
+      shouldCleanupSupersededInteractions({
+        hasPendingConfirmation: false,
+        hasUncompletedVisibleSurface: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("runs cleanup when there is no rendered UI context", () => {
+    expect(shouldCleanupSupersededInteractions(null)).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -29,9 +29,24 @@ const OPTIMISTIC_COMPLETION_SURFACE_TYPES = [
   "task_preferences",
 ];
 
+interface SupersededInteractionCleanupContext {
+  hasPendingConfirmation: boolean;
+  hasUncompletedVisibleSurface: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Pure updater functions — no React state, fully testable
 // ---------------------------------------------------------------------------
+
+export function shouldCleanupSupersededInteractions(
+  uiContext: SupersededInteractionCleanupContext | null | undefined,
+): boolean {
+  return (
+    uiContext == null ||
+    uiContext.hasPendingConfirmation ||
+    uiContext.hasUncompletedVisibleSurface
+  );
+}
 
 /**
  * Remove `pendingConfirmation` from a specific request ID's tool calls.


### PR DESCRIPTION
solves a noticeable ~1sec lag when i press enter on chat

## Summary

- Avoid the full history + live-turn cleanup scan on the normal chat send path when there is no pending confirmation or visible interactive surface to supersede.
- Thread the already-rendered UI context into `useSendMessage` so the Enter key path can skip that work before inserting the optimistic user message.
- Add focused regression coverage for the cleanup gate.

## Root cause

The single-source history refactor moved superseded-interaction cleanup onto the active send path and made it scan the full rendered transcript before the optimistic message is appended. On longer conversations, that synchronous history traversal could make pressing Enter feel delayed before the message appeared as sent.

## Validation

- `cd clients/web && bun test src/domains/chat/utils/send-message-utils.test.ts`
- `cd clients/web && bunx tsc --noEmit --pretty false`
- `git diff --check HEAD^ HEAD`
