### PR TITLE
[codex] Virtualize thinking drawer markdown

### DIFF
--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -201,6 +201,19 @@ describe("ToolDetailPanel", () => {
     expect(queryByText("Subagent Spawn")).toBeNull();
   });
 
+  test("thinking variant renders reasoning inside a virtual list", () => {
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thinking",
+      thinkingText: "I should first check the directory listing.",
+    });
+    const { container } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+
+    expect(container.querySelector('[data-slot="virtual-list"]')).not.toBeNull();
+  });
+
   test("thinking variant close button fires onClose", () => {
     const onClose = mock(() => {});
     const detail = makeDetail({

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -30,10 +30,10 @@ import { useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
-import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { DetailShell } from "@/domains/chat/components/detail-shell";
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
+import { VirtualizedThinkingMarkdown } from "@/domains/chat/components/virtualized-thinking-markdown";
 import { useLiveThinkingText } from "@/domains/chat/hooks/use-live-thinking-text";
 import { useLiveToolCall } from "@/domains/chat/hooks/use-live-tool-call";
 import {
@@ -143,12 +143,16 @@ function ThinkingDetailBody({
     detail.thinkingGroupIndex,
     detail.thinkingItemIndex,
   );
+  const content = live ?? detail.thinkingText ?? "";
+
   return (
-    <DetailShell Glyph={Brain} title={detail.title} closeLabel="Close tool details" onClose={onClose}>
-      <ChatMarkdownMessage
-        content={live ?? detail.thinkingText ?? ""}
-        hardLineBreaks
-      />
+    <DetailShell
+      Glyph={Brain}
+      title={detail.title}
+      closeLabel="Close tool details"
+      onClose={onClose}
+    >
+      <VirtualizedThinkingMarkdown content={content} />
     </DetailShell>
   );
 }

--- a/clients/web/src/domains/chat/components/virtualized-thinking-markdown.tsx
+++ b/clients/web/src/domains/chat/components/virtualized-thinking-markdown.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from "react";
+
+import { VirtualList } from "@vellumai/design-library";
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { splitThinkingMarkdownChunks } from "@/domains/chat/utils/thinking-markdown-chunks";
+
+const INITIAL_RENDERED_CHUNKS = 8;
+
+export interface VirtualizedThinkingMarkdownProps {
+  content: string;
+}
+
+export function VirtualizedThinkingMarkdown({
+  content,
+}: VirtualizedThinkingMarkdownProps) {
+  const chunks = useMemo(() => splitThinkingMarkdownChunks(content), [content]);
+  const itemContent = useCallback(
+    (_index: number, chunk: string) => (
+      <div className="pb-3 last:pb-0">
+        <ChatMarkdownMessage content={chunk} hardLineBreaks />
+      </div>
+    ),
+    [],
+  );
+  const computeItemKey = useCallback((index: number) => index, []);
+
+  if (chunks.length === 0) return null;
+
+  return (
+    <VirtualList
+      items={chunks}
+      itemContent={itemContent}
+      computeItemKey={computeItemKey}
+      className="h-full bg-transparent"
+      initialItemCount={Math.min(chunks.length, INITIAL_RENDERED_CHUNKS)}
+      increaseViewportBy={{ top: 400, bottom: 800 }}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/utils/thinking-markdown-chunks.test.ts
+++ b/clients/web/src/domains/chat/utils/thinking-markdown-chunks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { splitThinkingMarkdownChunks } from "@/domains/chat/utils/thinking-markdown-chunks";
+
+describe("splitThinkingMarkdownChunks", () => {
+  test("splits paragraph-style thinking at blank lines", () => {
+    expect(
+      splitThinkingMarkdownChunks("First thought.\n\nSecond thought."),
+    ).toEqual(["First thought.", "Second thought."]);
+  });
+
+  test("chunks long list-style thinking without requiring blank lines", () => {
+    const content = Array.from({ length: 7 }, (_, i) => `- item ${i + 1}`).join(
+      "\n",
+    );
+
+    expect(splitThinkingMarkdownChunks(content, { maxLines: 3 })).toEqual([
+      "- item 1\n- item 2\n- item 3",
+      "- item 4\n- item 5\n- item 6",
+      "- item 7",
+    ]);
+  });
+
+  test("does not split inside fenced code blocks", () => {
+    const content = [
+      "Before.",
+      "",
+      "```ts",
+      "const a = 1;",
+      "",
+      "const b = 2;",
+      "```",
+      "",
+      "After.",
+    ].join("\n");
+
+    expect(splitThinkingMarkdownChunks(content, { maxLines: 2 })).toEqual([
+      "Before.",
+      "```ts\nconst a = 1;\n\nconst b = 2;\n```",
+      "After.",
+    ]);
+  });
+});

--- a/clients/web/src/domains/chat/utils/thinking-markdown-chunks.ts
+++ b/clients/web/src/domains/chat/utils/thinking-markdown-chunks.ts
@@ -1,0 +1,84 @@
+export interface SplitThinkingMarkdownChunksOptions {
+  maxLines?: number;
+  maxChars?: number;
+}
+
+const DEFAULT_MAX_LINES = 24;
+const DEFAULT_MAX_CHARS = 4_000;
+
+interface Fence {
+  marker: "`" | "~";
+  length: number;
+}
+
+function parseFence(line: string): Fence | null {
+  const match = line.match(/^\s*(`{3,}|~{3,})/);
+  if (!match) return null;
+  const fence = match[1]!;
+  return {
+    marker: fence[0] as Fence["marker"],
+    length: fence.length,
+  };
+}
+
+function closesFence(line: string, fence: Fence): boolean {
+  const candidate = parseFence(line);
+  return (
+    candidate?.marker === fence.marker && candidate.length >= fence.length
+  );
+}
+
+/**
+ * Splits long streamed reasoning into markdown chunks that can be windowed by
+ * the thinking drawer. The splitter favors paragraph boundaries, caps long
+ * line-oriented runs, and keeps fenced code blocks intact so partial chunks
+ * do not render as broken markdown.
+ */
+export function splitThinkingMarkdownChunks(
+  content: string,
+  options: SplitThinkingMarkdownChunksOptions = {},
+): string[] {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const chunks: string[] = [];
+  let currentLines: string[] = [];
+  let currentChars = 0;
+  let openFence: Fence | null = null;
+
+  const flush = () => {
+    const chunk = currentLines.join("\n").trimEnd();
+    if (chunk.trim().length > 0) {
+      chunks.push(chunk);
+    }
+    currentLines = [];
+    currentChars = 0;
+  };
+
+  for (const line of content.split("\n")) {
+    const fence = parseFence(line);
+    const closesOpenFence = openFence ? closesFence(line, openFence) : false;
+
+    currentLines.push(line);
+    currentChars += line.length + 1;
+
+    if (openFence && closesOpenFence) {
+      openFence = null;
+    } else if (!openFence && fence) {
+      openFence = fence;
+    }
+
+    if (openFence) continue;
+
+    if (line.trim() === "") {
+      flush();
+      continue;
+    }
+
+    if (currentLines.length >= maxLines || currentChars >= maxChars) {
+      flush();
+    }
+  }
+
+  flush();
+  return chunks;
+}

--- a/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
@@ -95,4 +95,10 @@ describe("VirtualList rendering", () => {
     });
     expect(html).toContain('data-slot="virtual-list"');
   });
+
+  test("renders initial items when initialItemCount is set", () => {
+    const html = render({ initialItemCount: 2 });
+    expect(html).toContain("a");
+    expect(html).toContain("b");
+  });
 });

--- a/packages/design-library/src/components/virtual-list/virtual-list.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.tsx
@@ -61,6 +61,8 @@ export interface VirtualListProps<T> {
 
   // --- Initial position ---
   initialTopMostItemIndex?: number | "LAST";
+  /** Render this many items before the first viewport measurement lands. */
+  initialItemCount?: number;
 
   // --- Layout ---
   overscan?: number;
@@ -122,6 +124,7 @@ export function VirtualList<T>({
   startReached,
   endReached,
   initialTopMostItemIndex,
+  initialItemCount,
   overscan,
   increaseViewportBy,
   className,
@@ -167,7 +170,6 @@ export function VirtualList<T>({
       className={cn("bg-[var(--surface-base)]", className)}
       data={items}
       itemContent={itemContent}
-      computeItemKey={computeItemKey}
       followOutput={resolvedFollowOutput}
       atBottomStateChange={atBottomStateChange}
       atBottomThreshold={atBottomThreshold}
@@ -183,10 +185,12 @@ export function VirtualList<T>({
       // own numeric defaults (e.g. overscan/increaseViewportBy default to 0),
       // which then throws in its viewport math. Only forward these when the
       // consumer actually set them so virtuoso keeps its defaults otherwise.
+      {...(computeItemKey !== undefined ? { computeItemKey } : {})}
       {...(firstItemIndex !== undefined ? { firstItemIndex } : {})}
       {...(resolvedInitialTopMostItemIndex !== undefined
         ? { initialTopMostItemIndex: resolvedInitialTopMostItemIndex }
         : {})}
+      {...(initialItemCount !== undefined ? { initialItemCount } : {})}
       {...(overscan !== undefined ? { overscan } : {})}
       {...(increaseViewportBy !== undefined ? { increaseViewportBy } : {})}
     />


### PR DESCRIPTION
## Summary
- Render the Thinking drawer through a chunked virtual markdown list instead of one ever-growing markdown tree.
- Add markdown chunking that preserves fenced code blocks and caps long line-oriented runs.
- Expose `initialItemCount` on the shared design-library `VirtualList` wrapper and avoid forwarding undefined `computeItemKey`.

## Why
Opening the Thinking drawer while reasoning streams can freeze the browser because the full accumulated reasoning markdown is repeatedly parsed and rendered. Windowing the content bounds the mounted markdown work while preserving the existing live-thinking drawer behavior.

## Validation
- `cd clients/web && bun test src/domains/chat/utils/thinking-markdown-chunks.test.ts src/domains/chat/components/tool-detail-panel.test.tsx`
- `cd packages/design-library && bun test src/components/virtual-list/virtual-list.test.tsx`
- `cd clients/web && bun run lint -- src/domains/chat/components/tool-detail-panel.tsx src/domains/chat/components/tool-detail-panel.test.tsx src/domains/chat/components/virtualized-thinking-markdown.tsx src/domains/chat/utils/thinking-markdown-chunks.ts src/domains/chat/utils/thinking-markdown-chunks.test.ts`
- `cd clients/web && bunx tsc --noEmit`
- `cd packages/design-library && bun run typecheck`