### PR TITLE
Make memory v3 defaults lean for TTFT

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -8,23 +8,23 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed).toEqual({
       live: false,
       prune: { maxResidentBytes: 393216, targetResidentBytes: 262144 },
-      hotSet: { k: 40, halfLifeDays: 14 },
-      freshSet: { k: 100 },
+      hotSet: { k: 8, halfLifeDays: 14 },
+      freshSet: { k: 8 },
       learnedEdges: {
         halfLifeDays: 30,
         minCount: 3,
         npmiFloor: 0.2,
         maxPerPage: 6,
         perSeed: 3,
-        cap: 20,
+        cap: 0,
       },
       spotlight: { n: 6, windowTurns: 2 },
-      needleK: 100,
-      denseK: 100,
-      replyQueryK: 12,
-      selectorEnabled: true,
+      needleK: 12,
+      denseK: 0,
+      replyQueryK: 0,
+      selectorEnabled: false,
       selectorPromptPath: null,
-      edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
+      edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
     });
   });
 
@@ -105,9 +105,9 @@ describe("MemoryV3ConfigSchema", () => {
     const parsed = MemoryV3ConfigSchema.parse({ edge: { hubDegree: 10 } });
     expect(parsed.edge).toEqual({
       hubDegree: 10,
-      seedCount: 18,
-      perSeed: 6,
-      cap: 45,
+      seedCount: 6,
+      perSeed: 1,
+      cap: 6,
     });
   });
 

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -18,7 +18,7 @@ export const MemoryV3EdgeSchema = z
       .number({ error: "memory.v3.edge.seedCount must be a number" })
       .int("memory.v3.edge.seedCount must be an integer")
       .positive("memory.v3.edge.seedCount must be a positive integer")
-      .default(18)
+      .default(6)
       .describe(
         "Number of top needle+dense seeds (in rank order) expanded by the edge lane.",
       ),
@@ -26,13 +26,13 @@ export const MemoryV3EdgeSchema = z
       .number({ error: "memory.v3.edge.perSeed must be a number" })
       .int("memory.v3.edge.perSeed must be an integer")
       .positive("memory.v3.edge.perSeed must be a positive integer")
-      .default(6)
+      .default(1)
       .describe("Maximum neighbours surfaced per expanded seed."),
     cap: z
       .number({ error: "memory.v3.edge.cap must be a number" })
       .int("memory.v3.edge.cap must be an integer")
       .positive("memory.v3.edge.cap must be a positive integer")
-      .default(45)
+      .default(6)
       .describe(
         "Hard cap on the total number of distinct articles surfaced by the edge lane.",
       ),
@@ -49,7 +49,7 @@ export const MemoryV3HotSetSchema = z
       .number({ error: "memory.v3.hotSet.k must be a number" })
       .int("memory.v3.hotSet.k must be an integer")
       .nonnegative("memory.v3.hotSet.k must be a non-negative integer")
-      .default(40)
+      .default(8)
       .describe(
         "Number of top frecency-scored pages included in the hot-set lane. 0 disables the lane.",
       ),
@@ -76,7 +76,7 @@ export const MemoryV3FreshSetSchema = z
       .number({ error: "memory.v3.freshSet.k must be a number" })
       .int("memory.v3.freshSet.k must be an integer")
       .nonnegative("memory.v3.freshSet.k must be a non-negative integer")
-      .default(100)
+      .default(8)
       .describe(
         "Number of most-recently-modified pages included in the fresh-set lane (0 disables the lane). Sized to cover roughly the last day or two of page writes — the recency window conversations reference most.",
       ),
@@ -134,7 +134,7 @@ export const MemoryV3LearnedEdgesSchema = z
       .number({ error: "memory.v3.learnedEdges.cap must be a number" })
       .int("memory.v3.learnedEdges.cap must be an integer")
       .nonnegative("memory.v3.learnedEdges.cap must be a non-negative integer")
-      .default(20)
+      .default(0)
       .describe(
         "Hard cap on total learned-lane surfaced articles per turn (0 disables the pass).",
       ),
@@ -239,7 +239,7 @@ export const MemoryV3ConfigSchema = z
       .number({ error: "memory.v3.needleK must be a number" })
       .int("memory.v3.needleK must be an integer")
       .nonnegative("memory.v3.needleK must be a non-negative integer")
-      .default(100)
+      .default(12)
       .describe(
         "Number of section-grain BM25 needle articles folded into the candidate pool each turn. 0 disables the needle lane.",
       ),
@@ -247,7 +247,7 @@ export const MemoryV3ConfigSchema = z
       .number({ error: "memory.v3.denseK must be a number" })
       .int("memory.v3.denseK must be an integer")
       .nonnegative("memory.v3.denseK must be a non-negative integer")
-      .default(100)
+      .default(0)
       .describe(
         "Number of dense-lane articles folded into the candidate pool each turn after embedding the turn query. 0 disables dense retrieval for both current-message and reply-query passes.",
       ),
@@ -255,13 +255,13 @@ export const MemoryV3ConfigSchema = z
       .number({ error: "memory.v3.replyQueryK must be a number" })
       .int("memory.v3.replyQueryK must be an integer")
       .nonnegative("memory.v3.replyQueryK must be a non-negative integer")
-      .default(12)
+      .default(0)
       .describe(
         "Per-lane article budget for the reply-query finder pass: needle and dense each re-run over the assistant's previous message as separate queries (never concatenated with the user's message). 0 disables the pass. Deliberately small next to needleK/denseK — the pass adds the assistant-side retrieval signal, not a second full sweep.",
       ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })
-      .default(true)
+      .default(false)
       .describe(
         "Whether to run the memory-v3 selector LLM callsite over the candidate pool. When false, every pooled candidate is passed through to injection directly; an empty pool produces no memory block.",
       ),

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -279,7 +279,7 @@ describe("orchestrate — candidate pool composition", () => {
     denseHits = [{ article: "topic-b", section: 0 }];
     providerStub = selectProvider([]); // selection is irrelevant to pool union
 
-    await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
+    await orchestrate(makeTurn(1, "apple"), depsOf(lanes, { denseK: 100 }));
 
     expect(selectCalls).toBe(1);
     expect(new Set(lastPool)).toEqual(
@@ -362,8 +362,9 @@ describe("orchestrate — candidate pool composition", () => {
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "x"), depsOf(lanes, { needle }));
     expect(needleK).toBe(DEFAULT_NEEDLE_K);
-    expect(denseCalls[0]?.k).toBe(DEFAULT_DENSE_K);
-    expect(DEFAULT_DENSE_K).toBe(100);
+    expect(DEFAULT_NEEDLE_K).toBe(12);
+    expect(denseCalls).toEqual([]);
+    expect(DEFAULT_DENSE_K).toBe(0);
   });
 
   test("denseK override controls the embedding-backed candidate budget", async () => {
@@ -396,7 +397,7 @@ describe("orchestrate — candidate pool composition", () => {
 
     const result = await orchestrate(
       makeTurn(1, "apple"),
-      depsOf(lanes, { selectorEnabled: false }),
+      depsOf(lanes, { denseK: 100, selectorEnabled: false }),
     );
 
     expect(selectCalls).toBe(0);
@@ -451,7 +452,11 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
 
     const result = await orchestrate(
       makeTurn(1, "apple"),
-      depsOf(lanes, { coreSlugs: ["topic-c"], hotSlugs: ["topic-d"] }),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        hotSlugs: ["topic-d"],
+        denseK: 100,
+      }),
     );
 
     expect(lastPool).toEqual(["topic-c", "topic-d", "topic-a", "topic-b"]);
@@ -811,7 +816,10 @@ describe("orchestrate — dense liveness filter", () => {
       { article: "gone-page", section: 0 },
     ];
     providerStub = selectProvider([]); // selection irrelevant to pool membership
-    const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100 }),
+    );
 
     // The live dense hit is pooled; the deleted page is dropped entirely.
     expect(lastPool).toContain("topic-b");
@@ -825,7 +833,7 @@ describe("orchestrate — dense liveness filter", () => {
     // text — its finder line falls back to the page's lead-section text.
     denseHits = [{ article: "topic-b", section: 99 }];
     providerStub = selectProvider([]);
-    await orchestrate(makeTurn(1, "zzzz"), depsOf(lanes));
+    await orchestrate(makeTurn(1, "zzzz"), depsOf(lanes, { denseK: 100 }));
 
     const line = lastPoolLines.find((l) => / topic-b — /.test(l));
     expect(line).toContain("lead for topic b");
@@ -845,7 +853,10 @@ describe("orchestrate — finder lane provenance", () => {
     // topic-d (edge). So each lane contributes exactly one distinct slug.
     denseHits = [{ article: "topic-b", section: 0 }];
     providerStub = selectProvider([]); // selection irrelevant to pool provenance
-    const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100 }),
+    );
 
     const laneOf = new Map(result.lanes.finder.map((c) => [c.slug, c.lane]));
     expect(laneOf.get("topic-a")).toBe("needle");
@@ -892,7 +903,7 @@ describe("orchestrate — degradation", () => {
     };
     const result = await orchestrate(
       makeTurn(1, "apple"),
-      depsOf(lanes, { coreSlugs: ["topic-c"] }),
+      depsOf(lanes, { coreSlugs: ["topic-c"], denseK: 100 }),
     );
     expect(new Set(result.selections.map((s) => s.slug))).toEqual(
       new Set(["topic-c", "topic-a", "topic-b", "topic-d"]),

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -56,6 +56,7 @@ const realSectionDenseStore = {
   ...(await import("../section-dense-store.js")),
 };
 const realOrchestrate = { ...(await import("../orchestrate.js")) };
+const realLearnedEdges = { ...(await import("../learned-edges.js")) };
 const realPlatform = { ...(await import("../../../../../util/platform.js")) };
 const realPageStore = {
   ...(await import("../../../../../memory/v2/page-store.js")),
@@ -78,6 +79,7 @@ let shadowMockActive = false;
 
 let liveEnabled = false;
 let memoryEnabled = true;
+let learnedEdgesCap = 0;
 let messages: Array<{ role: string; content: string }> = [];
 
 // A synthetic skill capability slug the page index carries. Its rendered
@@ -127,6 +129,7 @@ const orchestrateSpy = mock(
 let sectionBuilds = 0;
 let needleBuilds = 0;
 let edgeBuilds = 0;
+let learnedGraphBuilds = 0;
 let ensureCollectionCalls = 0;
 let ensureCollectionThrows = false;
 
@@ -183,22 +186,22 @@ mock.module("../../../../../config/loader.js", () => ({
       enabled: memoryEnabled,
       v3: {
         live: liveEnabled,
-        hotSet: { k: 40, halfLifeDays: 14 },
-        freshSet: { k: 50 },
+        hotSet: { k: 8, halfLifeDays: 14 },
+        freshSet: { k: 8 },
         spotlight: { n: 6, windowTurns: 2 },
-        needleK: 100,
-        denseK: 100,
-        replyQueryK: 12,
-        selectorEnabled: true,
+        needleK: 12,
+        denseK: 0,
+        replyQueryK: 0,
+        selectorEnabled: false,
         learnedEdges: {
           halfLifeDays: 30,
           minCount: 3,
           npmiFloor: 0.2,
           maxPerPage: 6,
           perSeed: 3,
-          cap: 20,
+          cap: learnedEdgesCap,
         },
-        edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
+        edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
       },
       qdrant: { vectorSize: 8, onDisk: false },
     },
@@ -353,6 +356,18 @@ mock.module("../edge.js", () => ({
   },
 }));
 
+mock.module("../learned-edges.js", () => ({
+  ...realLearnedEdges,
+  computeLearnedEdgeGraph: (
+    ...args: Parameters<typeof realLearnedEdges.computeLearnedEdgeGraph>
+  ) => {
+    if (!shadowMockActive)
+      return realLearnedEdges.computeLearnedEdgeGraph(...args);
+    learnedGraphBuilds++;
+    return { adjacency: new Map(), hubs: new Set(), slugs: new Set() };
+  },
+}));
+
 mock.module("../section-dense-store.js", () => ({
   ...realSectionDenseStore,
   ensureSectionCollection: async (
@@ -401,6 +416,7 @@ beforeEach(() => {
   shadowMockActive = true;
   liveEnabled = false;
   memoryEnabled = true;
+  learnedEdgesCap = 0;
   messages = [
     {
       role: "user",
@@ -411,6 +427,7 @@ beforeEach(() => {
   sectionBuilds = 0;
   needleBuilds = 0;
   edgeBuilds = 0;
+  learnedGraphBuilds = 0;
   ensureCollectionCalls = 0;
   ensureCollectionThrows = false;
   capturedPageBody = null;
@@ -572,6 +589,36 @@ describe("memory-v3 engine", () => {
     expect(deps.hotSlugs).toEqual([]);
   });
 
+  test("learned-edge graph init is skipped when the configured cap is zero", async () => {
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as {
+      learnedGraph?: unknown;
+      learnedCap?: number;
+    };
+    expect(learnedGraphBuilds).toBe(0);
+    expect(deps.learnedGraph).toBeUndefined();
+    expect(deps.learnedCap).toBe(0);
+  });
+
+  test("learned-edge graph init runs when the configured cap is positive", async () => {
+    learnedEdgesCap = 6;
+
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as {
+      learnedGraph?: unknown;
+      learnedCap?: number;
+    };
+    expect(learnedGraphBuilds).toBe(1);
+    expect(deps.learnedGraph).toBeDefined();
+    expect(deps.learnedCap).toBe(6);
+  });
+
   test("initLanes filters core to existing pages and excludes core from the hot set", async () => {
     // The core file lists a live page and a dangling slug; the hot set returns
     // a live page and a deleted one (selection rows can outlive their pages).
@@ -591,7 +638,7 @@ describe("memory-v3 engine", () => {
     // The hot set was computed with the (filtered) core excluded and the
     // configured k / half-life (14 days, in ms).
     expect(hotSetOpts?.excludeSlugs).toEqual(new Set(["page-1"]));
-    expect(hotSetOpts?.k).toBe(40);
+    expect(hotSetOpts?.k).toBe(8);
     expect(hotSetOpts?.halfLifeMs).toBe(14 * 24 * 60 * 60 * 1000);
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
@@ -116,7 +116,7 @@ describe("computeHotSet", () => {
 describe("MemoryV3ConfigSchema hotSet", () => {
   test("defaults apply when omitted", () => {
     const config = MemoryV3ConfigSchema.parse({});
-    expect(config.hotSet).toEqual({ k: 40, halfLifeDays: 14 });
+    expect(config.hotSet).toEqual({ k: 8, halfLifeDays: 14 });
   });
 
   test("explicit values parse", () => {

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -63,9 +63,9 @@ import type {
 } from "./types.js";
 
 /** Default number of BM25 needle articles to fold into the pool. */
-export const DEFAULT_NEEDLE_K = 100;
+export const DEFAULT_NEEDLE_K = 12;
 /** Default number of dense-lane articles to fold into the pool. */
-export const DEFAULT_DENSE_K = 100;
+export const DEFAULT_DENSE_K = 0;
 
 export interface OrchestrateDeps {
   sectionIndex: SectionIndex;

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -105,8 +105,8 @@ export interface ShadowLanes {
    *  in SKILL.md), existence-filtered and core/hot/fresh-excluded. */
   alwaysCandidateSlugs: string[];
   /** Learned-edge graph: co-selection NPMI associations over the selection
-   *  log, rebuilt with the lanes (the consolidation cadence). */
-  learnedGraph: EdgeGraph;
+   *  log, rebuilt with the lanes when the learned lane is enabled. */
+  learnedGraph?: EdgeGraph;
   /** Pre-rendered FULL cards for the stable-prefix (core+hot+fresh) slugs,
    *  keyed by slug. Frozen at lane build so the selector's stable prefix is
    *  byte-identical across turns until the next invalidation. */
@@ -279,18 +279,21 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   // index membership is the existence filter (capability slugs included —
   // they are first-class pages there).
   const learned = config.memory.v3.learnedEdges;
-  const learnedGraph = computeLearnedEdgeGraph(
-    { db: getDb() },
-    {
-      halfLifeMs: learned.halfLifeDays * DAY_MS,
-      minCount: learned.minCount,
-      npmiFloor: learned.npmiFloor,
-      maxPerPage: learned.maxPerPage,
-      now: Date.now(),
-      windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-      knownSlugs: new Set(sectionIndex.byArticle.keys()),
-    },
-  );
+  const learnedGraph =
+    learned.cap > 0 && learned.maxPerPage > 0
+      ? computeLearnedEdgeGraph(
+          { db: getDb() },
+          {
+            halfLifeMs: learned.halfLifeDays * DAY_MS,
+            minCount: learned.minCount,
+            npmiFloor: learned.npmiFloor,
+            maxPerPage: learned.maxPerPage,
+            now: Date.now(),
+            windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
+            knownSlugs: new Set(sectionIndex.byArticle.keys()),
+          },
+        )
+      : undefined;
   // Ensuring the dense collection is best-effort: the needle + edge lanes and
   // the core/hot prefix are in-memory and independent of Qdrant, so a Qdrant outage
   // must NOT reject lane init (which would return `null` from observeTurn and


### PR DESCRIPTION
## Summary
- Make memory v3 default to the lean TTFT-oriented profile: selector bypass, dense/reply retrieval off, needle 12, hot/fresh 8, edge 6/1/6, learned cap 0.
- Keep dense-specific tests explicit about opting into dense retrieval when they assert dense behavior.
- Skip learned-edge graph construction when learned-edge settings disable that lane.

## Original prompt
Make the hybrid TTFT-focused memory-v3 settings the new defaults in a new PR, keeping the selector LLM off by default without blowing up context.