### PR TITLE
Stream OpenAI tool call progress

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -400,6 +400,39 @@ describe("OpenAIProvider", () => {
     expect(events[1]).toEqual({ type: "text_delta", text: ", world!" });
   });
 
+  test("fires tool preview and argument progress events while tool calls stream", async () => {
+    fakeChunks = [
+      ...toolCallChunks([
+        {
+          id: "call_write",
+          name: "app_create",
+          args: '{"source_files":[{"path":"src/App.tsx","content":"hello"}]}',
+        },
+      ]),
+      usageChunk(10, 15),
+    ];
+
+    const events: ProviderEvent[] = [];
+    await provider.sendMessage([userMsg("Create an app")], {
+      onEvent: (e) => events.push(e),
+    });
+
+    expect(events.slice(0, 2)).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call_write",
+        toolName: "app_create",
+      },
+      {
+        type: "input_json_delta",
+        toolUseId: "call_write",
+        toolName: "app_create",
+        accumulatedJson:
+          '{"source_files":[{"path":"src/App.tsx","content":"hello"}]}',
+      },
+    ]);
+  });
+
   // -----------------------------------------------------------------------
   // Reasoning content (MiniMax / DeepSeek extension)
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -89,6 +89,10 @@ function textDeltaEvent(delta: string): FakeStreamEvent {
   return { type: "response.output_text.delta", delta };
 }
 
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
 function functionCallAddedEvent(
   callId: string,
   name: string,
@@ -393,6 +397,42 @@ describe("OpenAIResponsesProvider", () => {
       name: "file_read",
       input: { path: "/tmp/test" },
     });
+  });
+
+  test("fires tool preview and argument progress events while tool calls stream", async () => {
+    fakeStreamEvents = [
+      functionCallAddedEvent("call_write", "app_create"),
+      functionCallArgsDeltaEvent(
+        '{"source_files":[{"path":"src/App.tsx","content":"hello"}]}',
+        "call_write",
+      ),
+      functionCallArgsDoneEvent(
+        "call_write",
+        "app_create",
+        '{"source_files":[{"path":"src/App.tsx","content":"hello"}]}',
+      ),
+      completedEvent(10, 15),
+    ];
+
+    const events: ProviderEvent[] = [];
+    await provider.sendMessage([userMsg("Create an app")], {
+      onEvent: (e) => events.push(e),
+    });
+
+    expect(events.slice(0, 2)).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call_write",
+        toolName: "app_create",
+      },
+      {
+        type: "input_json_delta",
+        toolUseId: "call_write",
+        toolName: "app_create",
+        accumulatedJson:
+          '{"source_files":[{"path":"src/App.tsx","content":"hello"}]}',
+      },
+    ]);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -7,6 +7,7 @@ import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { PLACEHOLDER_EMPTY_TURN } from "../placeholder-sentinels.js";
 import { createStreamTimeout } from "../stream-timeout.js";
+import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
   ContentBlock,
   Message,
@@ -462,6 +463,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         number,
         { id: string; name: string; args: string }
       >();
+      const toolProgress = createToolProgressEmitter(onEvent);
       let finishReason = "unknown";
       let responseModel = modelOverride ?? this.model;
       let promptTokens = 0;
@@ -551,7 +553,15 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 const entry = toolCallMap.get(tc.index)!;
                 if (tc.id) entry.id = tc.id;
                 if (tc.function?.name) entry.name += tc.function.name;
-                if (tc.function?.arguments) entry.args += tc.function.arguments;
+                toolProgress.emitPreviewStart(entry.id, entry.name);
+                if (tc.function?.arguments) {
+                  entry.args += tc.function.arguments;
+                  toolProgress.emitInputJsonDelta(
+                    entry.id,
+                    entry.name,
+                    entry.args,
+                  );
+                }
               }
             }
 
@@ -606,6 +616,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
         content.push({ type: "text", text: finalContent });
       }
       for (const [, tc] of toolCallMap) {
+        toolProgress.emitInputJsonDelta(tc.id, tc.name, tc.args, {
+          force: true,
+        });
         let input: Record<string, unknown>;
         try {
           input = JSON.parse(tc.args);

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -7,6 +7,7 @@ import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { createStreamTimeout } from "../stream-timeout.js";
+import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
   ContentBlock,
   Message,
@@ -293,6 +294,7 @@ export class OpenAIResponsesProvider implements Provider {
       >();
       // Maps item_id → callId so we can look up tool calls from delta events.
       const itemIdToCallId = new Map<string, string>();
+      const toolProgress = createToolProgressEmitter(onEvent);
       // Track web search call item IDs so we can emit server_tool_complete.
       const webSearchCallIds: string[] = [];
       let finishReason = "unknown";
@@ -348,6 +350,7 @@ export class OpenAIResponsesProvider implements Provider {
                   args: "",
                 });
                 itemIdToCallId.set(itemId, callId);
+                toolProgress.emitPreviewStart(callId, name);
               } else if (item?.type === "web_search_call") {
                 const toolUseId = item.id ?? "";
                 webSearchCallIds.push(toolUseId);
@@ -372,6 +375,11 @@ export class OpenAIResponsesProvider implements Provider {
                   const entry = toolCallMap.get(callId);
                   if (entry) {
                     entry.args += delta;
+                    toolProgress.emitInputJsonDelta(
+                      entry.callId,
+                      entry.name,
+                      entry.args,
+                    );
                   }
                 }
               }
@@ -388,7 +396,14 @@ export class OpenAIResponsesProvider implements Provider {
                 if (callId) {
                   const entry = toolCallMap.get(callId);
                   if (entry) {
+                    if (event.name) entry.name = event.name;
                     entry.args = event.arguments;
+                    toolProgress.emitInputJsonDelta(
+                      entry.callId,
+                      entry.name,
+                      entry.args,
+                      { force: true },
+                    );
                   }
                 }
               }
@@ -462,6 +477,9 @@ export class OpenAIResponsesProvider implements Provider {
         content.push({ type: "text", text: contentText });
       }
       for (const [, tc] of toolCallMap) {
+        toolProgress.emitInputJsonDelta(tc.callId, tc.name, tc.args, {
+          force: true,
+        });
         let input: Record<string, unknown>;
         try {
           input = JSON.parse(tc.args);

--- a/assistant/src/providers/tool-progress-events.test.ts
+++ b/assistant/src/providers/tool-progress-events.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { createToolProgressEmitter } from "./tool-progress-events.js";
+import type { ProviderEvent } from "./types.js";
+
+describe("createToolProgressEmitter", () => {
+  test("flushes the latest throttled argument progress after activity pauses", async () => {
+    const events: ProviderEvent[] = [];
+    const progress = createToolProgressEmitter((event) => events.push(event));
+
+    progress.emitInputJsonDelta("call-1", "app_create", '{"a":1}');
+    progress.emitInputJsonDelta("call-1", "app_create", '{"a":12}');
+
+    expect(events).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call-1",
+        toolName: "app_create",
+      },
+      {
+        type: "input_json_delta",
+        toolUseId: "call-1",
+        toolName: "app_create",
+        accumulatedJson: '{"a":1}',
+      },
+    ]);
+
+    await Bun.sleep(180);
+
+    expect(events).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call-1",
+        toolName: "app_create",
+      },
+      {
+        type: "input_json_delta",
+        toolUseId: "call-1",
+        toolName: "app_create",
+        accumulatedJson: '{"a":1}',
+      },
+      {
+        type: "input_json_delta",
+        toolUseId: "call-1",
+        toolName: "app_create",
+        accumulatedJson: '{"a":12}',
+      },
+    ]);
+  });
+});

--- a/assistant/src/providers/tool-progress-events.ts
+++ b/assistant/src/providers/tool-progress-events.ts
@@ -1,0 +1,58 @@
+import type { ProviderEvent } from "./types.js";
+
+const INPUT_JSON_DELTA_EMIT_INTERVAL_MS = 150;
+
+export function createToolProgressEmitter(
+  onEvent: ((event: ProviderEvent) => void) | undefined,
+): {
+  emitPreviewStart: (toolUseId: string, toolName: string) => void;
+  emitInputJsonDelta: (
+    toolUseId: string,
+    toolName: string,
+    accumulatedJson: string,
+    opts?: { force?: boolean },
+  ) => void;
+} {
+  const previewedToolUseIds = new Set<string>();
+  const lastInputEmitByToolUseId = new Map<
+    string,
+    { emittedAt: number; accumulatedJson: string }
+  >();
+
+  const emitPreviewStart = (toolUseId: string, toolName: string): void => {
+    if (!onEvent || !toolUseId || !toolName) return;
+    if (previewedToolUseIds.has(toolUseId)) return;
+    previewedToolUseIds.add(toolUseId);
+    onEvent({ type: "tool_use_preview_start", toolUseId, toolName });
+  };
+
+  const emitInputJsonDelta = (
+    toolUseId: string,
+    toolName: string,
+    accumulatedJson: string,
+    opts?: { force?: boolean },
+  ): void => {
+    if (!onEvent || !toolUseId || !toolName || !accumulatedJson) return;
+    emitPreviewStart(toolUseId, toolName);
+
+    const last = lastInputEmitByToolUseId.get(toolUseId);
+    if (last?.accumulatedJson === accumulatedJson) return;
+
+    const now = Date.now();
+    if (
+      !opts?.force &&
+      last &&
+      now - last.emittedAt < INPUT_JSON_DELTA_EMIT_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    lastInputEmitByToolUseId.set(toolUseId, {
+      emittedAt: now,
+      accumulatedJson,
+    });
+    onEvent({ type: "input_json_delta", toolName, toolUseId, accumulatedJson });
+  };
+
+  return { emitPreviewStart, emitInputJsonDelta };
+}

--- a/assistant/src/providers/tool-progress-events.ts
+++ b/assistant/src/providers/tool-progress-events.ts
@@ -18,6 +18,14 @@ export function createToolProgressEmitter(
     string,
     { emittedAt: number; accumulatedJson: string }
   >();
+  const pendingInputEmitByToolUseId = new Map<
+    string,
+    {
+      timeout: ReturnType<typeof setTimeout>;
+      toolName: string;
+      accumulatedJson: string;
+    }
+  >();
 
   const emitPreviewStart = (toolUseId: string, toolName: string): void => {
     if (!onEvent || !toolUseId || !toolName) return;
@@ -44,9 +52,42 @@ export function createToolProgressEmitter(
       last &&
       now - last.emittedAt < INPUT_JSON_DELTA_EMIT_INTERVAL_MS
     ) {
+      const pending = pendingInputEmitByToolUseId.get(toolUseId);
+      if (pending) {
+        pending.toolName = toolName;
+        pending.accumulatedJson = accumulatedJson;
+        return;
+      }
+      const delay = INPUT_JSON_DELTA_EMIT_INTERVAL_MS - (now - last.emittedAt);
+      const timeout = setTimeout(() => {
+        const latest = pendingInputEmitByToolUseId.get(toolUseId);
+        if (!latest) return;
+        pendingInputEmitByToolUseId.delete(toolUseId);
+        lastInputEmitByToolUseId.set(toolUseId, {
+          emittedAt: Date.now(),
+          accumulatedJson: latest.accumulatedJson,
+        });
+        onEvent({
+          type: "input_json_delta",
+          toolName: latest.toolName,
+          toolUseId,
+          accumulatedJson: latest.accumulatedJson,
+        });
+      }, delay);
+      timeout.unref?.();
+      pendingInputEmitByToolUseId.set(toolUseId, {
+        timeout,
+        toolName,
+        accumulatedJson,
+      });
       return;
     }
 
+    const pending = pendingInputEmitByToolUseId.get(toolUseId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      pendingInputEmitByToolUseId.delete(toolUseId);
+    }
     lastInputEmitByToolUseId.set(toolUseId, {
       emittedAt: now,
       accumulatedJson,


### PR DESCRIPTION
## Summary
- Emit `tool_use_preview_start` as soon as OpenAI Chat Completions or Responses streams identify a function/tool call.
- Emit throttled, deduped `input_json_delta` progress while tool-call arguments stream so existing app-tool previews can update before execution starts.
- Cover both OpenAI provider paths with regression tests for preview-before-arguments ordering.

## Original prompt
The user asked for a PR that improves frontend usability when long tool calls are being generated, so the UI shows that a tool call is being made and streams additional meaningful information as soon as available instead of appearing idle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->