### PR TITLE
fix(test): unblock main CI — v3 shadow dense lane + app-builder fingerprint

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -302,6 +302,9 @@ async function runTurn(
     lanes: Awaited<ReturnType<typeof buildLanes>>;
     core?: Slug[];
     hot?: Slug[];
+    /** Dense-lane budget. Omitted → orchestrate's lean `DEFAULT_DENSE_K` (dense
+     *  off by default); set positive to exercise the stubbed dense hits. */
+    denseK?: number;
   },
 ): Promise<OrchestrateResult> {
   providerStub = selectProvider(keep, pin);
@@ -310,6 +313,7 @@ async function runTurn(
     sectionIndex: deps.lanes.sectionIndex,
     needle: deps.lanes.needle,
     denseConfig: config,
+    denseK: deps.denseK,
     edgeGraph: deps.lanes.edgeGraph,
     coreSlugs: deps.core ?? [],
     hotSlugs: deps.hot ?? [],
@@ -346,11 +350,12 @@ afterAll(() => {
 describe("memory-v3 integration — candidate pool", () => {
   test("pool unions needle ∪ dense ∪ edge; one select per turn", async () => {
     const lanes = await buildLanes();
-    // "apple" hits page-a (needle). Dense returns page-b. page-a links to
-    // topic-x (edge). "apple" does NOT match the capability page, so it is not
-    // pooled this turn — capability pages are lane-ranked, not always-added.
+    // "apple" hits page-a (needle). Dense returns page-b (denseK enables the
+    // lane — it is off by default). page-a links to topic-x (edge). "apple"
+    // does NOT match the capability page, so it is not pooled this turn —
+    // capability pages are lane-ranked, not always-added.
     denseHits = [{ article: "page-b", section: 0 }];
-    await runTurn(1, "apple", [], [], { lanes });
+    await runTurn(1, "apple", [], [], { lanes, denseK: 100 });
 
     expect(selectCalls).toBe(1);
     expect(new Set(lastPool)).toEqual(new Set(["page-a", "page-b", "topic-x"]));
@@ -449,9 +454,14 @@ describe("memory-v3 integration — selection-log readout", () => {
 
     // Turn 1: needle selects page-a (matched "apple"), plus the hot topic-x.
     await runTurn(1, "apple", ["page-a", "topic-x"], [], { lanes, ...prefix });
-    // Turn 2: needle selects page-b (matched "banana").
+    // Turn 2: needle selects page-b (matched "banana"); dense also surfaces it
+    // (denseK enables the lane), but needle precedence wins the attribution.
     denseHits = [{ article: "page-b", section: 0 }];
-    await runTurn(2, "banana", ["page-b"], [], { lanes, ...prefix });
+    await runTurn(2, "banana", ["page-b"], [], {
+      lanes,
+      ...prefix,
+      denseK: 100,
+    });
     // Turn 3: needle selects the capability page (matched "durian" in its
     // content).
     denseHits = [];

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -7,7 +7,7 @@
     },
     "app-builder": {
       "docsSlug": "app-builder",
-      "sha256": "331201817b38c36275faeb3a21545e6a6c0861ddfacd56481e9b28f9ab4ffcea"
+      "sha256": "2ac20d056a1d8420f61d99bb0b0f56113e8fecc62b5f86fbb19efd60e6df790f"
     },
     "computer-use": {
       "docsSlug": "computer-use",


### PR DESCRIPTION
## Summary

- **Restores green `main`.** The `CI Main / Test` job was failing on two deterministic tests, each a missed-update side effect of a PR that landed:
  - `skill-docs-sync-guard.test.ts` — #36568 edited `app-builder/SKILL.md` (a model-discipline clarification: "actually write the files") but didn't re-record its fingerprint. Re-recorded via `bun run scripts/check-skill-docs-sync.ts --write` (only `app-builder` moved). The edit is an internal prompt nuance, not an end-user behavior change, so the public docs page needs no update.
  - `shadow-integration.test.ts:356` — #36571 made the v3 defaults lean (`denseK` default `100 → 0`, dense off by default) and updated four sibling tests with explicit `{ denseK: 100 }`, but missed this one. With dense disabled, the stubbed `page-b` dense hit no longer pooled, so `pool unions needle ∪ dense ∪ edge` lost `page-b`.
- **Faithful fix, not a weakened assertion.** Threads an optional `denseK` through the test's `runTurn` helper and sets `denseK: 100` in the two dense-exercising tests (the failing pool test, and the summarize test whose `denseHits` assignment was otherwise dead under the lean default). This keeps the tests exercising the dense lane as documented, mirroring the exact pattern #36571 used elsewhere.

## Original prompt

Fix the specific CI failure in the `Test` job of run 28412296361 — and only that job. Investigation showed two deterministic failures both caused by recently-merged PRs that updated source but missed a companion update (a fingerprint re-record and a sibling test), leaving `main` red. The fix re-records the `app-builder` skill-docs fingerprint and adapts the v3 shadow-integration test to the new lean dense default, restoring the job to green.