### PR TITLE
fix(web): stop plugin detail icon flicker on load

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -41,6 +41,9 @@ function makePlugin(
 
 const UPDATE_DRIFT = { status: "update-available" } as unknown as PluginDrift;
 
+const PACKAGE = "\u{1F4E6}"; // 📦 — external (catalog) glyph
+const PUZZLE = "\u{1F9E9}"; // 🧩 — local glyph
+
 // Mutable so individual tests can swap the plugin / drift before rendering.
 const hookState: {
   plugin: PluginsByNameGetResponse | null;
@@ -178,6 +181,50 @@ describe("PluginDetailMobile", () => {
     );
 
     expect(getActionButton("Remove")).toBeTruthy();
+  });
+
+  test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {
+    // No resolved plugin and no seeded hint: the header must not flash either
+    // glyph (avoids the 🧩 → 📦 load flicker).
+    hookState.plugin = null;
+    hookState.isLoading = true;
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(document.body.textContent).not.toContain(PUZZLE);
+    expect(document.body.textContent).not.toContain(PACKAGE);
+  });
+
+  test("while loading with externalHint, the header shows the seeded 📦 (not 🧩)", () => {
+    hookState.plugin = null;
+    hookState.isLoading = true;
+
+    render(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+        externalHint
+      />,
+    );
+
+    expect(document.body.textContent).toContain(PACKAGE);
+    expect(document.body.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the external 📦 glyph once a github-sourced plugin has loaded", () => {
+    hookState.plugin = makePlugin({
+      source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+    });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(document.body.textContent).toContain(PACKAGE);
+    expect(document.body.textContent).not.toContain(PUZZLE);
   });
 
   test("origin badge stays hidden until the plugin loads", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -20,6 +20,12 @@ interface PluginDetailMobileProps {
   assistantId: string;
   name: string;
   onBack: () => void;
+  /**
+   * Known external state from the selected list row, used to seed the header
+   * icon before the detail query resolves so click-through shows the right
+   * glyph immediately. `undefined` for deep-links with no matching row.
+   */
+  externalHint?: boolean;
 }
 
 /**
@@ -45,6 +51,7 @@ export function PluginDetailMobile({
   assistantId,
   name,
   onBack,
+  externalHint,
 }: PluginDetailMobileProps) {
   const {
     plugin,
@@ -72,6 +79,10 @@ export function PluginDetailMobile({
   }, []);
 
   const isExternal = plugin?.source?.kind === "github";
+  // Gate the header icon on the loaded plugin, seeding the known external state
+  // from the selected list row, so we never flash a wrong glyph (🧩 → 📦) while
+  // the detail query is still loading. `undefined` until we know either.
+  const resolvedExternal = plugin ? isExternal : externalHint;
   const updateAvailable = drift?.status === "update-available";
   const title = plugin?.name ?? name;
 
@@ -116,7 +127,11 @@ export function PluginDetailMobile({
       <div className="mt-4 flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
-            <PluginIcon external={isExternal} size="md" />
+            {resolvedExternal === undefined ? (
+              <span aria-hidden className="h-8 w-8 shrink-0" />
+            ) : (
+              <PluginIcon external={resolvedExternal} size="md" />
+            )}
             <h2
               className="min-w-0 truncate text-title-medium"
               style={{ color: "var(--content-emphasised)" }}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -34,9 +34,40 @@ const ASSISTANT_ID = "asst-1";
 const LOCAL_COMMIT = "60a392b0000000000000000000000000000000aa";
 const REMOTE_COMMIT = "3eae1820000000000000000000000000000000bb";
 
+const PACKAGE = "\u{1F4E6}"; // 📦 — external (catalog) glyph
+const PUZZLE = "\u{1F9E9}"; // 🧩 — local glyph
+
+const realFetch = globalThis.fetch;
+
 afterEach(() => {
   cleanup();
+  globalThis.fetch = realFetch;
 });
+
+/**
+ * Render `PluginDetail` with no seeded detail data so the query stays in its
+ * loading state, exercising the gated/seeded header icon. `fetch` is stubbed
+ * to never resolve so the detail query never settles mid-assertion.
+ */
+function renderLoadingDetail(externalHint?: boolean) {
+  globalThis.fetch = (() =>
+    new Promise<Response>(() => {})) as unknown as typeof fetch;
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <PluginDetail
+        assistantId={ASSISTANT_ID}
+        name="loading-plugin"
+        onBack={() => {}}
+        externalHint={externalHint}
+      />
+    </QueryClientProvider>,
+  );
+}
 
 function upToDateInspect(
   name: string,
@@ -243,6 +274,44 @@ describe("PluginDetail", () => {
     expect(html).toContain("Download for macOS");
     expect(html).toContain(`href="${url}"`);
     expect(html).toContain("Remove");
+  });
+
+  test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {
+    const { container } = renderLoadingDetail();
+
+    // The detail query hasn't resolved and there's no seeded hint, so the
+    // header must not flash either glyph (avoids the 🧩 → 📦 load flicker).
+    expect(container.textContent).not.toContain(PUZZLE);
+    expect(container.textContent).not.toContain(PACKAGE);
+  });
+
+  test("while loading with externalHint, the header shows the seeded 📦 (not 🧩)", () => {
+    const { container } = renderLoadingDetail(true);
+
+    expect(container.textContent).toContain(PACKAGE);
+    expect(container.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the external 📦 glyph once a github-sourced plugin has loaded", () => {
+    const { container } = renderDetail(
+      "caveman",
+      {
+        name: "caveman",
+        installed: false,
+        description: "Talk like a caveman.",
+        homepage: null,
+        license: null,
+        version: "1.8.2",
+        source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
+        readme: "# Caveman",
+        ref: "v1.8.2",
+        artifact: null,
+      },
+      upToDateInspect("caveman", false),
+    );
+
+    expect(container.textContent).toContain(PACKAGE);
+    expect(container.textContent).not.toContain(PUZZLE);
   });
 
   test("invokes onBack when the back button is clicked", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -21,6 +21,12 @@ interface PluginDetailProps {
   name: string;
   /** Leave the detail view (return to the plugins list). */
   onBack: () => void;
+  /**
+   * Known external state from the selected list row, used to seed the header
+   * icon before the detail query resolves so click-through shows the right
+   * glyph immediately. `undefined` for deep-links with no matching row.
+   */
+  externalHint?: boolean;
 }
 
 /**
@@ -37,7 +43,12 @@ interface PluginDetailProps {
  * Plugins have no file-list endpoint, so there is no file tree —
  * README + metadata only.
  */
-export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
+export function PluginDetail({
+  assistantId,
+  name,
+  onBack,
+  externalHint,
+}: PluginDetailProps) {
   const {
     plugin,
     drift,
@@ -68,6 +79,7 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
         <Header
           name={name}
           plugin={plugin}
+          externalHint={externalHint}
           drift={drift}
           onInstall={install}
           onRemove={remove}
@@ -120,6 +132,7 @@ export function PluginDetail({ assistantId, name, onBack }: PluginDetailProps) {
 interface HeaderProps {
   name: string;
   plugin: PluginsByNameGetResponse | null;
+  externalHint?: boolean;
   drift: PluginDrift | undefined;
   onInstall: () => void;
   onRemove: () => void;
@@ -133,6 +146,7 @@ interface HeaderProps {
 function Header({
   name,
   plugin,
+  externalHint,
   drift,
   onInstall,
   onRemove,
@@ -143,12 +157,20 @@ function Header({
   hasLocalEdits,
 }: HeaderProps) {
   const isExternal = plugin?.source?.kind === "github";
+  // Gate the header icon on the loaded plugin, seeding the known external state
+  // from the selected list row, so we never flash a wrong glyph (🧩 → 📦) while
+  // the detail query is still loading. `undefined` until we know either.
+  const resolvedExternal = plugin ? isExternal : externalHint;
   const updateAvailable = drift?.status === "update-available";
 
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <PluginIcon external={isExternal} size="md" />
+        {resolvedExternal === undefined ? (
+          <span aria-hidden className="h-8 w-8 shrink-0" />
+        ) : (
+          <PluginIcon external={resolvedExternal} size="md" />
+        )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <h2

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -203,9 +203,17 @@ export function PluginsTab({ assistantId, initialPluginName }: PluginsTabProps) 
   const isSearching = isFetching && !isLoading;
 
   if (selectedPluginName) {
+    // Seed the detail header icon from the already-loaded list row so
+    // click-through shows the right glyph immediately (no load-time flash);
+    // `undefined` for a deep-link with no matching row falls back to a
+    // glyph-less placeholder until the detail query resolves.
+    const selectedExternalHint = items.find(
+      (p) => p.name === selectedPluginName,
+    )?.external;
     const detailProps = {
       assistantId,
       name: selectedPluginName,
+      externalHint: selectedExternalHint,
       onBack: () => setSelectedPluginName(null),
     };
     return isMobile ? (


### PR DESCRIPTION
## Summary
- The detail header icon was driven by plugin.source while the detail query was still loading, so uninstalled (catalog) plugins flashed 🧩 then 📦. Gate the icon on the plugin being loaded and seed the known external value from the selected list item, so click-through shows the correct glyph immediately and deep-links show a glyph-less placeholder until loaded.

Part of plan: plugins-tab-match-skills.md (post-review fix)