### PR TITLE
fix(web): stop plugin detail icon vertical shift on load

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -165,7 +165,9 @@ function Header({
 
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
+      {/* Top-align the icon: the description loads asynchronously and grows the
+          text block, so centering would nudge the icon down once it arrives. */}
+      <div className="flex min-w-0 flex-1 items-start gap-3">
         {resolvedExternal === undefined ? (
           <span aria-hidden className="h-8 w-8 shrink-0" />
         ) : (


### PR DESCRIPTION
## Summary
- The detail header centered the icon against a text block that grows when the description loads asynchronously (unlike Skills, which has its data up front), nudging the icon down a few px. Top-align the icon (items-start) so it anchors to the title and stays put.

Part of plan: plugins-tab-match-skills.md (post-review fix)