### PR TITLE
fix(memory): reset v3 section embed high-water when the dense collection is recreated

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -211,12 +211,25 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
+// Records the checkpoint clears `ensureSectionCollection` performs when it
+// (re)creates an empty collection, so tests can assert the embed high-water is
+// reset (which sends the next maintain pass down its full-corpus re-embed path).
+const checkpointState = { deletes: [] as string[] };
+mock.module("../../../../../persistence/checkpoints.js", () => ({
+  getMemoryCheckpoint: () => null,
+  setMemoryCheckpoint: () => undefined,
+  deleteMemoryCheckpoint: (key: string) => {
+    checkpointState.deletes.push(key);
+  },
+}));
+
 const {
   ensureSectionCollection,
   upsertSections,
   deleteSectionsForArticle,
   listSectionArticles,
   SECTION_COLLECTION,
+  MAINTAIN_EMBED_HIGH_WATER_KEY,
   _resetSectionDenseStoreForTests,
 } = await import("../section-dense-store.js");
 
@@ -258,6 +271,7 @@ function resetState(): void {
   embedState.geminiDimensions = undefined;
   cacheState.store.clear();
   cacheState.reads.length = 0;
+  checkpointState.deletes.length = 0;
   _resetSectionDenseStoreForTests();
 }
 
@@ -357,6 +371,39 @@ describe("memory v3 section-dense-store — collection lifecycle", () => {
 
     expect(state.deleteCollectionCalls).toEqual([]);
     expect(state.createCollectionCalls).toBe(0);
+  });
+
+  test("clears the embed high-water when recreating on dimension drift", async () => {
+    state.collectionExists = true;
+    state.getCollectionInfo = {
+      config: { params: { vectors: { size: 384, distance: "Cosine" } } },
+    };
+
+    await ensureSectionCollection(CONFIG);
+
+    // The recreate empties the collection, so the maintain checkpoint is reset:
+    // the next pass re-embeds every page instead of only pages edited since.
+    expect(state.deleteCollectionCalls).toEqual([SECTION_COLLECTION]);
+    expect(checkpointState.deletes).toEqual([MAINTAIN_EMBED_HIGH_WATER_KEY]);
+  });
+
+  test("clears the embed high-water when creating a fresh collection", async () => {
+    state.collectionExists = false;
+
+    await ensureSectionCollection(CONFIG);
+
+    expect(state.createCollectionCalls).toBe(1);
+    expect(checkpointState.deletes).toEqual([MAINTAIN_EMBED_HIGH_WATER_KEY]);
+  });
+
+  test("leaves the embed high-water untouched when the collection is compatible", async () => {
+    state.collectionExists = true;
+    // MATCHING_SECTION_SCHEMA is size 4 === CONFIG, so no recreate happens.
+
+    await ensureSectionCollection(CONFIG);
+
+    expect(state.createCollectionCalls).toBe(0);
+    expect(checkpointState.deletes).toEqual([]);
   });
 
   test("re-running ensure latches readiness (single existence probe)", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
@@ -90,31 +90,12 @@ import {
   deleteSectionsForArticle as realDeleteSectionsForArticle,
   ensureSectionCollection as realEnsureSectionCollection,
   listSectionArticles as realListSectionArticles,
+  MAINTAIN_EMBED_HIGH_WATER_KEY,
   upsertSections as realUpsertSections,
 } from "./section-dense-store.js";
 import { buildSectionIndex as realBuildSectionIndex } from "./sections.js";
 import { invalidateLanes as realInvalidateLanes } from "./shadow-plugin.js";
 import type { Slug } from "./types.js";
-
-/**
- * Durable checkpoint holding the epoch-ms high-water mark of the last successful
- * re-embed pass. Pages whose mtime is past this mark are re-chunked + re-embedded
- * into the section dense store; the mark is advanced only after a pass completes,
- * captured before the pass so a transient embed write does not re-trigger itself.
- *
- * This is a FRESH key, distinct from the tree-era `enriched_through_ms` that the
- * old classify-union maintainer advanced. On upgrade the new key is absent, so
- * `computeChangedPages` sees a high-water of 0 and re-embeds EVERY page on the
- * first run — seeding the otherwise-empty `memory_v3_sections` collection.
- * Reusing the old (already-advanced) key would skip all historical pages and
- * leave dense retrieval blind to existing memory until each page was next edited.
- *
- * Distinct too from `memory_v3_maintain_last_run` (the enqueue-cadence checkpoint
- * in `jobs-worker.ts`), which advances on every backstop enqueue rather than on
- * an actual maintenance run.
- */
-const MAINTAIN_EMBED_HIGH_WATER_KEY =
-  "memory_v3_maintain:sections_embedded_through_ms" as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -25,6 +25,7 @@ import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v5 as uuidv5 } from "uuid";
 
 import type { AssistantConfig } from "../../../../config/types.js";
+import { deleteMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import {
   embedWithBackend,
@@ -44,6 +45,20 @@ const log = getLogger("memory-v3-section-dense-store");
 
 /** Name of the dedicated Qdrant collection holding section-grain embeddings. */
 export const SECTION_COLLECTION = "memory_v3_sections";
+
+/**
+ * Durable checkpoint key holding the epoch-ms high-water of the last successful
+ * section re-embed pass; read and advanced by the maintain job, which re-embeds
+ * only pages whose mtime is past the mark. When the key is absent the maintainer
+ * re-embeds EVERY page (seeding the otherwise-empty collection on first run), so
+ * {@link ensureSectionCollection} clears it whenever it (re)creates an empty
+ * collection to force a full rebuild. Defined here, beside the collection it
+ * guards, so the store can clear it without importing the maintainer (which
+ * depends on this module). Distinct from the tree-era `enriched_through_ms` and
+ * from `memory_v3_maintain_last_run` (the enqueue-cadence checkpoint).
+ */
+export const MAINTAIN_EMBED_HIGH_WATER_KEY =
+  "memory_v3_maintain:sections_embedded_through_ms";
 
 /**
  * Stable UUIDv5 namespace used to derive a deterministic Qdrant point ID from a
@@ -166,6 +181,14 @@ export async function ensureSectionCollection(
           : undefined;
       if (status !== 409) throw err;
     }
+
+    // A freshly (re)created collection is empty, so the section dense store
+    // must be rebuilt from the whole page corpus, not just pages edited since
+    // the last pass. Clearing the embed high-water sends the next maintain pass
+    // down its absent-key path (re-embed every page); leaving it set would strand
+    // every page older than the checkpoint, invisible to the dense lane until it
+    // is next edited.
+    deleteMemoryCheckpoint(MAINTAIN_EMBED_HIGH_WATER_KEY);
   }
 
   // Always ensure the `article` payload index — on EVERY path (fresh create,


### PR DESCRIPTION
## Summary
- `ensureSectionCollection` recreates the `memory_v3_sections` Qdrant collection on embedding-dimension drift (and creates it fresh when absent), but never reset the `memory_v3_maintain:sections_embedded_through_ms` high-water checkpoint. The incremental maintain pass only re-embeds pages whose mtime is past that mark, so after a recreate the **entire historical corpus is stranded** — invisible to the dense lane until each page is next edited. The designed "absent-key ⇒ full backfill" self-seed never re-fired because the key wasn't absent, and the only full backfill is a manual `POST /v1/memory/v3/backfill-sections` route.
- Now clear the checkpoint whenever `ensureSectionCollection` (re)creates an empty collection, so the next maintain pass re-embeds every page via its existing absent-key path (self-heal). Moved `MAINTAIN_EMBED_HIGH_WATER_KEY` to `section-dense-store.ts` (the store cannot import the maintainer, which depends on it) and imported it into `maintain-job.ts`.
- Added `section-dense-store` tests: a dimension-drift recreate and a fresh create both clear the checkpoint; a dimension-matched existing collection leaves it untouched.

## Original prompt
While diagnosing why a live assistant failed to recall a colleague's identity, we found the memory-v3 dense lane covered only ~35 of ~1500 pages: section embeddings get stranded whenever the Qdrant collection is recreated (e.g. on an embedding model/dimension change) because the high-water checkpoint is never reset — the incremental maintainer then only re-embeds pages edited since, and the historical corpus is never repopulated. This is structural (it affects any assistant whose section collection was recreated, not one instance). This PR makes a recreate self-heal by clearing the checkpoint; a one-time manual backfill was separately run to restore the affected live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)