### PR TITLE
feat(memory-v3): heading-anchored entity lane for named-entity recall

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -25,6 +25,7 @@ describe("MemoryV3ConfigSchema", () => {
       selectorEnabled: false,
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
+      entity: { enabled: true, idfFloor: 4, cap: 8 },
     });
   });
 

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -214,6 +214,41 @@ export const MemoryV3PruneSchema = z
   })
   .describe("Memory v3 prune-valve (resident card footprint) bounds.");
 
+/**
+ * Entity-lane tuning: the heading-anchored named-entity match. A distinctive
+ * token the message shares with a `## ` section heading surfaces that section,
+ * so a named entity (person, place, project, product, bot) the additive needle
+ * buries under a long message's bulk theme is retrieved on the exact-name
+ * signal instead.
+ */
+export const MemoryV3EntitySchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.v3.entity.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the entity lane runs: surface the section whose `## ` heading names a distinctive entity the message mentions. Recall-additive and ~free when the message names no catalogued entity.",
+      ),
+    idfFloor: z
+      .number({ error: "memory.v3.entity.idfFloor must be a number" })
+      .nonnegative("memory.v3.entity.idfFloor must be a non-negative number")
+      .default(4)
+      .describe(
+        'Minimum corpus IDF for a `## ` heading token to become an entity key. Excludes hub tokens (e.g. "vellum") common enough that an exact match cannot disambiguate; those pages ride the core/hot lanes instead.',
+      ),
+    cap: z
+      .number({ error: "memory.v3.entity.cap must be a number" })
+      .int("memory.v3.entity.cap must be an integer")
+      .positive("memory.v3.entity.cap must be a positive integer")
+      .default(8)
+      .describe(
+        "Hard cap on the number of distinct entity-heading articles surfaced per turn.",
+      ),
+  })
+  .describe(
+    "Memory v3 entity-lane (heading-anchored named-entity match) tuning.",
+  );
+
 // NOTE: a retired `workingSet` sub-config (maxPages/evictWindow for the old
 // per-turn carry set) used to live here. Existing user config files may still
 // contain the key; zod default unknown-key stripping accepts and ignores it,
@@ -273,6 +308,7 @@ export const MemoryV3ConfigSchema = z
         "Optional path to a file whose contents replace the bundled per-turn selector system prompt (the instructions that tell the selector which candidate pages to keep). Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The selector prompt takes no placeholders — the candidate pool is supplied separately as the user message — so the file is used verbatim. If the file is missing, unreadable, empty, or over 1 MiB, the bundled prompt is used and a warning is logged.",
       ),
     edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
+    entity: MemoryV3EntitySchema.default(MemoryV3EntitySchema.parse({})),
   })
   .describe("Memory v3 — section-grain lane retrieval");
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -358,6 +358,7 @@ describe("orchestrate — candidate pool composition", () => {
         return [];
       },
       bestSection: () => -1,
+      idf: () => 0,
     };
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "x"), depsOf(lanes, { needle }));
@@ -888,7 +889,9 @@ describe("orchestrate — degradation", () => {
     providerStub = selectProvider([]);
     const result = await orchestrate(
       makeTurn(1, "zzzzz no-match"),
-      depsOf(lanes, { needle: { query: () => [], bestSection: () => -1 } }),
+      depsOf(lanes, {
+        needle: { query: () => [], bestSection: () => -1, idf: () => 0 },
+      }),
     );
     expect(result.selections).toEqual([]);
     expect(result.lanes.finder).toEqual([]);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -913,3 +913,68 @@ describe("orchestrate — degradation", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Entity lane: the heading section is the identity the lane exists to surface,
+// so it overrides a bulk-theme section a prior lane already recorded for the
+// same page, and surfaces a heading-named page no other lane found.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — entity lane", () => {
+  test("overrides the matched section + descriptor to the heading when another lane already surfaced the page", async () => {
+    const lanes = await buildLanes();
+    const { sectionIndex } = lanes;
+    // topic-a sections: [leadDoc] = lead (bulk), [headingDoc] = "## Details".
+    const [leadDoc, headingDoc] = sectionIndex.byArticle.get("topic-a")!;
+    const lead = sectionIndex.sections[leadDoc!]!;
+    const heading = sectionIndex.sections[headingDoc!]!;
+
+    // needle surfaces topic-a for its BULK lead section; the entity catalog
+    // maps a message token to topic-a's HEADING section.
+    const needle = {
+      query: () => [{ article: "topic-a", section: leadDoc! }],
+      bestSection: () => leadDoc!,
+      idf: () => 0,
+    };
+    const entityIndex = new Map<string, number[]>([["widget", [headingDoc!]]]);
+
+    const result = await orchestrate(
+      makeTurn(1, "tell me about the widget"),
+      depsOf(lanes, { needle, entityIndex, selectorEnabled: false }),
+    );
+
+    // The page is surfaced once and keeps the needle's first-lane attribution…
+    const hits = result.lanes.finder.filter((c) => c.slug === "topic-a");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.lane).toBe("needle");
+    // …but its matched section and pool descriptor are the HEADING, not the
+    // bulk lead the needle recorded.
+    expect(result.matchedSections.get("topic-a")).toBe(heading);
+    expect(result.matchedSections.get("topic-a")).not.toBe(lead);
+    expect(hits[0]!.descriptor).toBe(heading.text);
+  });
+
+  test("surfaces a heading-named page no other lane found, tagged `entity`", async () => {
+    const lanes = await buildLanes();
+    const { sectionIndex } = lanes;
+    const [, headingDoc] = sectionIndex.byArticle.get("topic-c")!;
+    const heading = sectionIndex.sections[headingDoc!]!;
+    const needle = {
+      query: () => [] as { article: Slug; section: number }[],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    const entityIndex = new Map<string, number[]>([["gadget", [headingDoc!]]]);
+
+    const result = await orchestrate(
+      makeTurn(1, "what about the gadget"),
+      depsOf(lanes, { needle, entityIndex, selectorEnabled: false }),
+    );
+
+    const hits = result.lanes.finder.filter((c) => c.slug === "topic-c");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.lane).toBe("entity");
+    expect(result.matchedSections.get("topic-c")).toBe(heading);
+    expect(result.selections.map((s) => s.slug)).toContain("topic-c");
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -378,6 +378,7 @@ describe("summarizeSelections", () => {
       edge: 2,
       reply: 0,
       learned: 0,
+      entity: 0,
     });
     expect(summary.turns).toBe(2);
     // page-1 and page-2 — distinct across the two turns.
@@ -395,6 +396,7 @@ describe("summarizeSelections", () => {
         edge: 0,
         reply: 0,
         learned: 0,
+        entity: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -496,6 +496,7 @@ describe("memory-v3 integration — selection-log readout", () => {
         edge: 0,
         reply: 0,
         learned: 0,
+        entity: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -202,6 +202,7 @@ mock.module("../../../../../config/loader.js", () => ({
           cap: learnedEdgesCap,
         },
         edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
+        entity: { enabled: true, idfFloor: 4, cap: 8 },
       },
       qdrant: { vectorSize: 8, onDisk: false },
     },

--- a/assistant/src/plugins/defaults/memory/v3/entity-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/entity-lane.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildEntityIndex, entityLane } from "./entity-lane.js";
+import type { Section, SectionIndex } from "./types.js";
+
+/** Build a minimal {@link SectionIndex} from `(article, title)` pairs. */
+function mkIndex(
+  pairs: Array<{ article: string; title: string }>,
+): SectionIndex {
+  const sections: Section[] = pairs.map((p, i) => ({
+    article: p.article,
+    title: p.title,
+    text: `${p.title}\nbody`,
+    ordinal: i,
+  }));
+  const byArticle = new Map<string, number[]>();
+  sections.forEach((s, i) => {
+    const list = byArticle.get(s.article) ?? [];
+    list.push(i);
+    byArticle.set(s.article, list);
+  });
+  return { sections, byArticle };
+}
+
+/** Stub `isDistinctive`: only the listed tokens count as entity keys. */
+const distinctive =
+  (...tokens: string[]) =>
+  (token: string) =>
+    tokens.includes(token);
+
+describe("buildEntityIndex", () => {
+  test("indexes distinctive heading tokens to their sections", () => {
+    const index = mkIndex([
+      { article: "team-roster", title: "Alice Chen" },
+      { article: "team-roster", title: "Bob" },
+      { article: "places", title: "The Acme room" },
+    ]);
+    const entity = buildEntityIndex(
+      index,
+      distinctive("alice", "chen", "bob", "acme"),
+    );
+    expect(entity.get("alice")).toEqual([0]);
+    expect(entity.get("chen")).toEqual([0]);
+    expect(entity.get("bob")).toEqual([1]);
+    expect(entity.get("acme")).toEqual([2]);
+    // "the"/"room" are not distinctive → not keys.
+    expect(entity.has("the")).toBe(false);
+    expect(entity.has("room")).toBe(false);
+  });
+
+  test("skips lead sections (no heading) and hub tokens", () => {
+    const index = mkIndex([
+      { article: "company", title: "" }, // lead — no heading
+      { article: "company", title: "the team" }, // hub words only
+    ]);
+    const entity = buildEntityIndex(index, distinctive("alice")); // nothing distinctive here
+    expect(entity.size).toBe(0);
+  });
+
+  test("a token in several headings maps to all of them in section order", () => {
+    const index = mkIndex([
+      { article: "a", title: "Alice Chen" },
+      { article: "b", title: "Alice's desk" },
+    ]);
+    const entity = buildEntityIndex(index, distinctive("alice"));
+    expect(entity.get("alice")).toEqual([0, 1]);
+  });
+});
+
+describe("entityLane", () => {
+  const index = mkIndex([
+    { article: "team-roster", title: "Alice Chen" },
+    { article: "side-notes", title: "the weekly bet" }, // names alice in body, not heading
+    { article: "places", title: "The Acme room" },
+  ]);
+  const entity = buildEntityIndex(index, distinctive("alice", "chen", "acme"));
+
+  test("surfaces the heading section for a named entity", () => {
+    expect(entityLane(entity, index, "what's up with alice", 8)).toEqual([
+      { article: "team-roster", section: 0 },
+    ]);
+  });
+
+  test("matches a multi-word heading on either distinctive token", () => {
+    expect(entityLane(entity, index, "ask chen", 8)).toEqual([
+      { article: "team-roster", section: 0 },
+    ]);
+  });
+
+  test("ignores message words that are not entity headings", () => {
+    expect(
+      entityLane(entity, index, "we might do a sale, so annoying", 8),
+    ).toEqual([]);
+  });
+
+  test("dedups to distinct articles and respects the cap", () => {
+    const hits = entityLane(entity, index, "alice and the acme room", 1);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.article).toBe("team-roster");
+  });
+
+  test("cap <= 0 disables the lane", () => {
+    expect(entityLane(entity, index, "alice", 0)).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/entity-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/entity-lane.test.ts
@@ -102,4 +102,23 @@ describe("entityLane", () => {
   test("cap <= 0 disables the lane", () => {
     expect(entityLane(entity, index, "alice", 0)).toEqual([]);
   });
+
+  test("ranks multi-token headings first so a common first name can't starve the exact page", () => {
+    // The exact "Alice Chen" page is LAST in section order; many "Alice …" pages
+    // precede it. Section-order truncation would drop it at a small cap — overlap
+    // ranking keeps it because its heading matches both "alice" and "chen".
+    const roster = mkIndex([
+      { article: "alice-smith", title: "Alice Smith" },
+      { article: "alice-jones", title: "Alice Jones" },
+      { article: "alice-park", title: "Alice Park" },
+      { article: "alice-chen", title: "Alice Chen" },
+    ]);
+    const cat = buildEntityIndex(
+      roster,
+      distinctive("alice", "smith", "jones", "park", "chen"),
+    );
+    expect(entityLane(cat, roster, "any update from alice chen?", 1)).toEqual([
+      { article: "alice-chen", section: 3 },
+    ]);
+  });
 });

--- a/assistant/src/plugins/defaults/memory/v3/entity-lane.ts
+++ b/assistant/src/plugins/defaults/memory/v3/entity-lane.ts
@@ -61,11 +61,14 @@ export function buildEntityIndex(
 }
 
 /**
- * For each distinctive entity token the message names, surface the matching
- * heading section(s), deduped to distinct articles and capped at `cap`. A
- * message word that is not an entity heading (e.g. "sale", "glad") yields
- * nothing, so the lane stays precise where a raw rare-term sweep would inject
- * noise. Each hit carries its heading section index (into
+ * Surface the heading sections the message's distinctive tokens name, ranked by
+ * how many of those tokens a heading contains, deduped to distinct articles and
+ * truncated to `cap`. Ranking before truncation is what makes multi-token names
+ * work: for "Alice Chen", the `## Alice Chen` heading (two matched tokens)
+ * outranks the many `## Alice …` pages (one token each), so the exact page is
+ * never starved out of the cap by a common first name — and a message word that
+ * is not an entity heading (e.g. "sale", "glad") still yields nothing, keeping
+ * the lane precise. Each hit carries its heading section index (into
  * `SectionIndex.sections`) so the caller renders the matched section.
  */
 export function entityLane(
@@ -75,18 +78,36 @@ export function entityLane(
   cap: number,
 ): { article: Slug; section: number }[] {
   if (cap <= 0) return [];
-  const out: { article: Slug; section: number }[] = [];
-  const seen = new Set<Slug>();
+
+  // Per heading section hit by ≥1 message token, count how many DISTINCT message
+  // tokens its heading contains (the entity index maps token → sections whose
+  // heading holds it, so the per-section hit count IS that heading-overlap).
+  const sectionScore = new Map<number, number>();
   for (const token of new Set(tokenize(message))) {
-    const docs = entity.get(token);
-    if (!docs) continue;
-    for (const doc of docs) {
-      const article = index.sections[doc]!.article;
-      if (seen.has(article)) continue;
-      seen.add(article);
-      out.push({ article, section: doc });
-      if (out.length >= cap) return out;
+    for (const doc of entity.get(token) ?? []) {
+      sectionScore.set(doc, (sectionScore.get(doc) ?? 0) + 1);
     }
   }
-  return out;
+
+  // Collapse to one representative section per article: the highest-overlap
+  // heading (ties → lowest section index, for determinism).
+  const best = new Map<Slug, { section: number; score: number }>();
+  for (const [doc, score] of sectionScore) {
+    const article = index.sections[doc]!.article;
+    const cur = best.get(article);
+    if (
+      !cur ||
+      score > cur.score ||
+      (score === cur.score && doc < cur.section)
+    ) {
+      best.set(article, { section: doc, score });
+    }
+  }
+
+  // Rank articles by descending overlap (multi-token names first), tie-broken by
+  // section index, then take the top `cap`.
+  return [...best.entries()]
+    .sort((a, c) => c[1].score - a[1].score || a[1].section - c[1].section)
+    .slice(0, cap)
+    .map(([article, { section }]) => ({ article, section }));
 }

--- a/assistant/src/plugins/defaults/memory/v3/entity-lane.ts
+++ b/assistant/src/plugins/defaults/memory/v3/entity-lane.ts
@@ -1,0 +1,92 @@
+import type { SectionIndex, Slug } from "./types.js";
+
+/**
+ * Entity lane: surface the section whose `## ` HEADING names an entity the
+ * turn's message mentions.
+ *
+ * The needle ranks a section by how much of the WHOLE message it explains —
+ * additive BM25, which a long, multi-topic message dilutes so a single named
+ * entity drowns under the bulk theme (e.g. "who is Alice again?" buried in a
+ * message mostly about a funding fight). The entity lane keys on the corpus's own
+ * heading vocabulary instead: a distinctive token that appears BOTH in the
+ * message AND in a section heading is a strong "the user named this thing"
+ * signal, independent of how much else the message is about. The catalog spans
+ * every heading, so it covers people, places, projects, products, and bots
+ * alike — every entity the corpus has a section about — with no curated name
+ * list and no model call.
+ */
+
+/** Lowercase, split on non-alphanumeric, drop one-character tokens. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 1);
+}
+
+/**
+ * Distinctive heading token → the indices (into `SectionIndex.sections`) of the
+ * sections whose heading contains it, in section order so a lookup is
+ * deterministic.
+ */
+export type EntityIndex = Map<string, number[]>;
+
+/**
+ * Build the entity catalog over section headings. `isDistinctive` gates out hub
+ * tokens — words common enough across the corpus that an exact match cannot
+ * disambiguate (e.g. "vellum", "the", "people"); such pages ride the core/hot
+ * lanes instead. The needle's corpus IDF is the natural source: a token is
+ * distinctive when its IDF clears a floor. Lead sections (no heading, empty
+ * title) contribute nothing.
+ */
+export function buildEntityIndex(
+  index: SectionIndex,
+  isDistinctive: (token: string) => boolean,
+): EntityIndex {
+  const byToken: EntityIndex = new Map();
+  for (let doc = 0; doc < index.sections.length; doc++) {
+    const title = index.sections[doc]!.title;
+    if (title.length === 0) continue;
+    for (const token of new Set(tokenize(title))) {
+      if (!isDistinctive(token)) continue;
+      let docs = byToken.get(token);
+      if (!docs) {
+        docs = [];
+        byToken.set(token, docs);
+      }
+      docs.push(doc);
+    }
+  }
+  return byToken;
+}
+
+/**
+ * For each distinctive entity token the message names, surface the matching
+ * heading section(s), deduped to distinct articles and capped at `cap`. A
+ * message word that is not an entity heading (e.g. "sale", "glad") yields
+ * nothing, so the lane stays precise where a raw rare-term sweep would inject
+ * noise. Each hit carries its heading section index (into
+ * `SectionIndex.sections`) so the caller renders the matched section.
+ */
+export function entityLane(
+  entity: EntityIndex,
+  index: SectionIndex,
+  message: string,
+  cap: number,
+): { article: Slug; section: number }[] {
+  if (cap <= 0) return [];
+  const out: { article: Slug; section: number }[] = [];
+  const seen = new Set<Slug>();
+  for (const token of new Set(tokenize(message))) {
+    const docs = entity.get(token);
+    if (!docs) continue;
+    for (const doc of docs) {
+      const article = index.sections[doc]!.article;
+      if (seen.has(article)) continue;
+      seen.add(article);
+      out.push({ article, section: doc });
+      if (out.length >= cap) return out;
+    }
+  }
+  return out;
+}

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -50,6 +50,8 @@ import type { AssistantConfig } from "../../../../config/schema.js";
 import { denseLane } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
+import type { EntityIndex } from "./entity-lane.js";
+import { entityLane } from "./entity-lane.js";
 import type { PoolCandidate, StableCandidate } from "./pool-select.js";
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
@@ -66,10 +68,16 @@ import type {
 export const DEFAULT_NEEDLE_K = 12;
 /** Default number of dense-lane articles to fold into the pool. */
 export const DEFAULT_DENSE_K = 0;
+/** Default hard cap on entity-lane articles folded into the pool per turn. */
+export const DEFAULT_ENTITY_CAP = 8;
 
 export interface OrchestrateDeps {
   sectionIndex: SectionIndex;
   needle: SectionNeedle;
+  /** Heading-anchored entity catalog (distinctive `## ` heading tokens → their
+   *  sections), built at lane init when the entity lane is enabled. Omitted
+   *  disables the lane. */
+  entityIndex?: EntityIndex;
   /** Config the dense lane needs to embed the query + search the section
    *  collection. */
   denseConfig: AssistantConfig;
@@ -97,6 +105,9 @@ export interface OrchestrateDeps {
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
   denseK?: number;
+  /** Hard cap on entity-lane articles. Defaults to {@link DEFAULT_ENTITY_CAP}.
+   *  Ignored when `entityIndex` is omitted (the lane is off). */
+  entityCap?: number;
   /** Per-lane article budget for the reply-query pass (needle + dense re-run
    *  over `turn.previousAssistantMessage` as separate queries). `0` or
    *  omitted disables the pass (canonical value: `memory.v3.replyQueryK`). */
@@ -292,6 +303,25 @@ export async function orchestrate(
       undefined,
       "reply",
     );
+  }
+
+  // Step 1b'': entity lane — sections whose `## ` heading NAMES a distinctive
+  // entity the message mentions. Additive BM25 buries a single named entity
+  // under a long, multi-topic message's bulk theme; this keys on the heading
+  // vocabulary so the page the user named surfaces regardless of the bulk
+  // theme. The hit carries its heading section, so injection renders it. Runs
+  // before edge expansion so an entity hit joins `finderSeen` (edge won't
+  // re-surface it section-less); it is NOT added to the edge seeds, so it only
+  // contributes its own page.
+  if (deps.entityIndex) {
+    for (const hit of entityLane(
+      deps.entityIndex,
+      deps.sectionIndex,
+      turn.currentMessage,
+      deps.entityCap ?? DEFAULT_ENTITY_CAP,
+    )) {
+      addFinder(hit.article, sections[hit.section], undefined, "entity");
+    }
   }
 
   // Step 1c: edge expansion over the top needle+dense article seeds. `alive`

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -309,10 +309,17 @@ export async function orchestrate(
   // entity the message mentions. Additive BM25 buries a single named entity
   // under a long, multi-topic message's bulk theme; this keys on the heading
   // vocabulary so the page the user named surfaces regardless of the bulk
-  // theme. The hit carries its heading section, so injection renders it. Runs
-  // before edge expansion so an entity hit joins `finderSeen` (edge won't
-  // re-surface it section-less); it is NOT added to the edge seeds, so it only
-  // contributes its own page.
+  // theme. Runs before edge expansion so an entity hit joins `finderSeen` (edge
+  // won't re-surface it section-less); it is NOT added to the edge seeds, so it
+  // only contributes its own page.
+  //
+  // The heading section IS the identity this lane exists to surface, so it
+  // takes precedence over any bulk-theme section a prior lane (needle / dense /
+  // reply) already recorded for the SAME page: `addFinder` keeps the first
+  // matched section and skips duplicate slugs, so override the matched section
+  // and the existing finder descriptor here before delegating, ensuring
+  // injection, the spotlight, and the selector snippet all render the heading
+  // rather than the earlier non-entity match.
   if (deps.entityIndex) {
     for (const hit of entityLane(
       deps.entityIndex,
@@ -320,7 +327,13 @@ export async function orchestrate(
       turn.currentMessage,
       deps.entityCap ?? DEFAULT_ENTITY_CAP,
     )) {
-      addFinder(hit.article, sections[hit.section], undefined, "entity");
+      const section = sections[hit.section];
+      if (section) {
+        matchedSections.set(hit.article, section);
+        const existing = finder.find((c) => c.slug === hit.article);
+        if (existing) existing.descriptor = section.text;
+      }
+      addFinder(hit.article, section, undefined, "entity");
     }
   }
 

--- a/assistant/src/plugins/defaults/memory/v3/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-needle.ts
@@ -39,6 +39,13 @@ export interface SectionNeedle {
    * attach a matched-section descriptor to an article they surface.
    */
   bestSection(article: Slug, queryText: string): number;
+  /**
+   * Corpus IDF of `term` over the section index (its head+body postings): higher
+   * means the term occurs in fewer sections. The entity lane gates heading
+   * tokens by this so only terms distinctive enough to disambiguate become
+   * entity keys (hub words like "vellum" fall below the floor).
+   */
+  idf(term: string): number;
 }
 
 /** Lowercase, split on non-alphanumeric, drop empties. */
@@ -112,6 +119,16 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
 
   const avgDocLength = docCount > 0 ? totalLength / docCount : 0;
 
+  /** Okapi IDF from a document frequency: higher for rarer terms. */
+  function idfFromDf(df: number): number {
+    return Math.log(1 + (docCount - df + 0.5) / (df + 0.5));
+  }
+
+  /** Corpus IDF of `term`; an unseen term gets the maximum (df 0) IDF. */
+  function idf(term: string): number {
+    return idfFromDf(postings.get(term)?.length ?? 0);
+  }
+
   /** BM25F score per section for the given query terms. */
   function scoreSections(queryTerms: Set<string>): Map<number, number> {
     const scores = new Map<number, number>();
@@ -121,15 +138,13 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
       const list = postings.get(term);
       if (!list) continue;
 
-      const idf = Math.log(
-        1 + (docCount - list.length + 0.5) / (list.length + 0.5),
-      );
+      const termIdf = idfFromDf(list.length);
 
       for (const { doc, weightedTf } of list) {
         const norm = weightedTf * (k1 + 1);
         const denom =
           weightedTf + k1 * (1 - b + b * (docLengths[doc]! / avgDocLength));
-        scores.set(doc, (scores.get(doc) ?? 0) + idf * (norm / denom));
+        scores.set(doc, (scores.get(doc) ?? 0) + termIdf * (norm / denom));
       }
     }
 
@@ -196,5 +211,5 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return best;
   }
 
-  return { query, bestSection };
+  return { query, bestSection, idf };
 }

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -44,6 +44,8 @@ import { renderCard } from "./card.js";
 import { loadCoreSet } from "./core-set.js";
 import type { EdgeGraph } from "./edge.js";
 import { buildEdgeGraph } from "./edge.js";
+import type { EntityIndex } from "./entity-lane.js";
+import { buildEntityIndex } from "./entity-lane.js";
 import { computeFreshSet } from "./fresh-set.js";
 import { computeHotSet } from "./hot-set.js";
 import { computeLearnedEdgeGraph } from "./learned-edges.js";
@@ -89,6 +91,9 @@ const LEARNED_EDGES_WINDOW_DAYS = 90;
 export interface ShadowLanes {
   sectionIndex: SectionIndex;
   needle: SectionNeedle;
+  /** Heading-anchored entity catalog, built at lane init when the entity lane
+   *  is enabled (`memory.v3.entity.enabled`). Omitted disables the lane. */
+  entityIndex?: EntityIndex;
   /** Config the dense lane needs to embed the query + search the section
    *  collection. */
   denseConfig: AssistantConfig;
@@ -181,6 +186,18 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
 
   const sectionIndex = await buildSectionIndex(slugs, pageBody);
   const needle = buildSectionNeedle(sectionIndex);
+
+  // The entity lane's heading catalog: distinctive `## ` heading tokens → the
+  // sections they head, so a named entity in the turn message surfaces its page
+  // even when additive BM25 buries it under the message's bulk theme. Gated by
+  // the needle's corpus IDF so hub tokens (e.g. "vellum") never become keys.
+  const entityCfg = config.memory.v3.entity;
+  const entityIndex = entityCfg.enabled
+    ? buildEntityIndex(
+        sectionIndex,
+        (token) => needle.idf(token) >= entityCfg.idfFloor,
+      )
+    : undefined;
 
   // The stable-prefix lanes. Core is the maintainer-curated file (file order
   // preserved — it is the prefix's stable sort), filtered to pages that exist
@@ -313,6 +330,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   return {
     sectionIndex,
     needle,
+    entityIndex,
     denseConfig: config,
     edgeGraph,
     learnedGraph,
@@ -557,6 +575,7 @@ export async function observeTurn(
     const result = await orchestrate(turn, {
       sectionIndex: lanes.sectionIndex,
       needle: lanes.needle,
+      entityIndex: lanes.entityIndex,
       denseConfig: lanes.denseConfig,
       edgeGraph: lanes.edgeGraph,
       coreSlugs: lanes.coreSlugs,
@@ -566,6 +585,7 @@ export async function observeTurn(
       prefixCards: lanes.prefixCards,
       needleK: v3.needleK,
       denseK: v3.denseK,
+      entityCap: v3.entity.cap,
       replyQueryK: v3.replyQueryK,
       edgeSeeds: v3.edge.seedCount,
       edgePerSeed: v3.edge.perSeed,

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -97,7 +97,9 @@ export interface MemoryRoutingTurn {
  * `edge` are the per-turn finder lanes over the user's message; `reply` marks
  * finder candidates first surfaced by the reply-query pass (needle + dense
  * re-run over the assistant's previous message); `learned` marks candidates
- * surfaced by the co-selection NPMI association graph.
+ * surfaced by the co-selection NPMI association graph; `entity` marks
+ * candidates surfaced because the message named an entity that titles a section
+ * heading (the heading-anchored entity lane).
  *
  * The `memory_v3_selections.source` column is free-text, so tightening this set
  * needs no migration: any historical rows with retired labels (e.g. the old
@@ -113,6 +115,7 @@ export const SELECTION_SOURCES = [
   "edge",
   "reply",
   "learned",
+  "entity",
 ] as const;
 
 export type SelectionSource = (typeof SELECTION_SOURCES)[number];


### PR DESCRIPTION
## Problem

The v3 needle ranks each section by how much of the **whole** turn message it explains (additive BM25F over the message's terms). When a message is long and multi-topic, a single named entity mentioned in passing — e.g. *"how's Alice doing? anyway, back to the funding fight…"* — contributes one faint term among ~100, so the section that actually **identifies** that entity ranks far below the bulk-theme sections and never enters the candidate pool. The assistant is left not knowing who the user just named.

Measured on a real long message against a 1,502-page corpus: the section identifying the named person ranked **#446**; even a generous `needleK=100` reached only a tangential page (#96), never the identity section. Sweeping `k1` / `b` / head-weight across their full ranges moved it by ~100–200 ranks but **never into contention** — the dilution is **query-side** (a long query drowns one rare term), not a mis-set BM25 parameter. Rare-term/IDF boosting and query-pruning helped (~#446 → #24–39) but still didn't reliably surface the identity page, since lexically the entity is no more salient than the rest of the message.

## Fix

A **heading-anchored entity lane**. It keys on the corpus's own heading vocabulary: a distinctive token shared between the message and a `## ` section heading surfaces that section directly, independent of the message's bulk theme.

- **Spans all entities, not a curated name list** — the catalog is every section heading, so it covers people, places, projects, products, bots: anything the corpus has a section about.
- **Gated by corpus IDF** — hub tokens common enough that an exact match can't disambiguate (e.g. the product name itself) are excluded; those pages already ride the core/hot lanes.
- **No model call, no maintained index** — the catalog rebuilds with the lanes from headings already on disk.
- **Recall-safe & ~free** — only ADDS candidates, and does nothing when the message names no catalogued entity.

On the measured case the lane surfaces the identity section deterministically (rank-independent), with zero false positives on that message.

## Changes
- `entity-lane.ts`: `buildEntityIndex` + `entityLane` (+ unit tests)
- expose `idf()` on `SectionNeedle` (single-sourced via `idfFromDf`)
- `memory.v3.entity` config: `{ enabled (default true), idfFloor: 4, cap: 8 }`
- add `"entity"` to `SELECTION_SOURCES` for per-lane telemetry
- wire into `orchestrate` (runs before edge so an entity hit joins `finderSeen`) and the `shadow-plugin` lane init

## Review focus / decision
- **`entity.enabled` defaults to `true`** — turns the lane on for all assistants. It's recall-additive and cheap, but it does add up to `cap` (8) candidates on turns that name entities. Flip to `false` if opt-in is preferred.
- `idfFloor: 4` is the distinctiveness threshold that excludes hub tokens — tunable.
- The lane matches on `##` headings only; an entity that exists solely in prose / a roster line (no heading of its own) is not yet catalogued (noted as a follow-up boundary).

## Test plan
- `entity-lane.test.ts` (8 tests): catalog build, lead/hub exclusion, multi-heading, lane dedup/cap/disable
- updated existing fixtures for the new `entity` source + `idf()` method
- `bun test` on all affected v3 + config suites: **73 pass**
- `typecheck:fast` clean, `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
