### PR TITLE
fix(memory): ensure the v3 section collection before selecting maintain deltas

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
@@ -79,6 +79,7 @@ describe("maintainJob", () => {
     };
     const base: MaintainJobDeps = {
       config: CONFIG,
+      ensureSectionCollection: async () => {},
       selectChangedPages: async () => [],
       buildSectionIndex: async (slugs) => {
         calls.built.push(slugs);
@@ -114,6 +115,28 @@ describe("maintainJob", () => {
     };
     return { deps: { ...base, ...overrides }, calls };
   }
+
+  test("ensures the section collection before selecting deltas", async () => {
+    // A drift recreate inside ensureSectionCollection clears the embed
+    // high-water; it must run before selectChangedPages reads the mark, or this
+    // pass re-embeds only recent pages and the end-of-pass commit clobbers the
+    // reset, stranding the rest. Assert the ordering that prevents that.
+    memoryV3LiveSlot = true;
+    const order: string[] = [];
+    const { deps: d } = deps({
+      ensureSectionCollection: async () => {
+        order.push("ensure");
+      },
+      selectChangedPages: async () => {
+        order.push("select");
+        return [];
+      },
+    });
+
+    await maintainJob(JOB, CONFIG, d);
+
+    expect(order).toEqual(["ensure", "select"]);
+  });
 
   test("no-op when v3 is disabled", async () => {
     const { deps: d, calls } = deps({
@@ -797,6 +820,7 @@ describe("maintainJob skill usage-prune", () => {
     const sectionDeletes: string[] = [];
     const d: MaintainJobDeps = {
       config: makeConfig(skillPruneDays),
+      ensureSectionCollection: async () => {},
       selectChangedPages: async () => [],
       buildSectionIndex: async (slugs) => makeIndex(slugs),
       readPageBody: async (s) => `body for ${s}`,

--- a/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
@@ -121,6 +121,13 @@ export interface ChangedPageCandidate {
 /** Injectable collaborators; defaults wire the real implementations. */
 export interface MaintainJobDeps {
   /**
+   * Establish the section collection before delta selection. Recreates it (and
+   * clears the embed high-water) on absence or dimension drift, so a wiped
+   * collection is observed by {@link selectChangedPages} and re-embedded in full
+   * this pass rather than after a clobbered reset.
+   */
+  ensureSectionCollection: typeof realEnsureSectionCollection;
+  /**
    * The slugs whose sections to re-embed this pass: pages new or edited since
    * the last successful pass. See {@link computeChangedPages}.
    */
@@ -375,6 +382,7 @@ async function selectAllPagesFromWorkspace(
 function defaultDeps(config: AssistantConfig): MaintainJobDeps {
   const workspaceDir = getWorkspaceDir();
   return {
+    ensureSectionCollection: realEnsureSectionCollection,
     selectChangedPages: () => selectChangedPagesFromWorkspace(workspaceDir),
     buildSectionIndex: realBuildSectionIndex,
     readPageBody: (slug) => readPageBodyFromWorkspace(workspaceDir, slug),
@@ -823,6 +831,14 @@ export async function maintainJob(
   // does not re-trigger it next pass; advance it only when every page succeeded.
   try {
     const startedAtMs = Date.now();
+    // Establish the collection BEFORE selecting deltas. If it is absent or
+    // dimension-drifted, `ensureSectionCollection` recreates it empty and clears
+    // the embed high-water; selecting deltas first would read the stale mark, so
+    // this pass would re-embed only recent pages and then commit `startedAtMs`,
+    // clobbering the reset and stranding the rest. Ensuring first makes the
+    // cleared mark visible to `selectChangedPages`, turning this pass into the
+    // full-corpus re-embed the recreate requires.
+    await deps.ensureSectionCollection(deps.config);
     const changed = await deps.selectChangedPages();
     const { reembedded, reembedFailures } = await reembedChangedPages(
       changed,


### PR DESCRIPTION
## Summary
- Follow-up to #36578. That PR made `ensureSectionCollection` clear the embed high-water when it (re)creates an empty collection, so the next maintain pass re-embeds the whole corpus. But if the recreate happens *during* a `memory_v3_maintain` re-embed — after `selectChangedPages()` has already read the old high-water — the same pass calls `commitEmbedHighWater(startedAtMs)` and **clobbers the reset**, re-embedding only recent pages and stranding the rest. Especially likely with `denseK=0` (dense queries never call `ensureSectionCollection`, so maintain is the only caller).
- Fix: `maintainJob` now calls `ensureSectionCollection` **before** `selectChangedPages`, so a drift recreate + checkpoint clear is observed by delta selection and the pass performs the intended full-corpus re-embed. Added `ensureSectionCollection` to `MaintainJobDeps`.
- Test: asserts `ensureSectionCollection` runs before `selectChangedPages` in a maintain pass.

## Original prompt
Codex left a P1 review comment on #36578 noting that the checkpoint reset in `ensureSectionCollection` is overwritten when the recreate happens inside a running maintain re-embed (the stage commits the high-water afterward), so the intended full-corpus re-embed never happens. This PR addresses it by ordering the collection-ensure (and its reset) before delta selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)