### PR TITLE
feat(cli): add --json to `conversations new`

### DIFF
--- a/assistant/src/cli/commands/__tests__/conversations-new.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-new.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for `conversations new --json` — the flag emits a machine-readable
+ * result (incl. the new id) so callers can capture it without scraping the log.
+ */
+
+import * as nodeFs from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let lastIpcCall: { method: string; params?: Record<string, unknown> } | null =
+  null;
+const loggerCalls: { level: string; msg: string }[] = [];
+
+// Reassigned per-test so a single mock can stand in for success and failure.
+let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
+  ok: true,
+  result: {
+    id: "conv-new-1",
+    title: "GitHub watcher",
+    conversationKey: "key-1",
+    messagesInserted: 0,
+  },
+};
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+  exitCodeFromIpcResult: (r: { statusCode?: number }) =>
+    r.statusCode === undefined
+      ? 10
+      : r.statusCode >= 500
+        ? 3
+        : r.statusCode >= 400
+          ? 2
+          : 1,
+  exitFromIpcResult: (r: { error?: string }) => {
+    process.exitCode = 1;
+    loggerCalls.push({ level: "error", msg: r.error ?? "Unknown error" });
+  },
+}));
+
+const fakeLogger = {
+  info: (m: unknown) => loggerCalls.push({ level: "info", msg: String(m) }),
+  warn: () => {},
+  error: (m: unknown) => loggerCalls.push({ level: "error", msg: String(m) }),
+  debug: () => {},
+};
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => fakeLogger,
+  getCliLogger: () => fakeLogger,
+  initLogger: () => {},
+  truncateForLog: (v: string) => v,
+  pruneOldLogFiles: () => 0,
+  LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
+  getCurrentLogFilePath: () => "/tmp/test-assistant.log",
+}));
+
+// Full passthrough mock — spreading the real module avoids a hang in the heavy
+// conversations.js import graph that a partial node:fs mock triggered.
+const realFs = { ...nodeFs };
+mock.module("node:fs", () => ({ ...realFs }));
+
+const { registerConversationsCommand } = await import("../conversations.js");
+
+async function runNew(args: string[]): Promise<number> {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+  registerConversationsCommand(program);
+  try {
+    await program.parseAsync(["node", "assistant", "conversations", ...args]);
+  } catch {
+    if (process.exitCode === 0 || process.exitCode === undefined) {
+      process.exitCode = 1;
+    }
+  }
+  const code = Number(process.exitCode ?? 0);
+  process.exitCode = 0;
+  return code;
+}
+
+/** Parse the last info line as JSON (the `--json` path emits one JSON line). */
+function jsonOutput(): Record<string, unknown> {
+  const info = loggerCalls.filter((c) => c.level === "info");
+  const last = info[info.length - 1];
+  if (!last) throw new Error("no info output captured");
+  return JSON.parse(last.msg) as Record<string, unknown>;
+}
+
+let savedRunId: string | undefined;
+
+beforeEach(() => {
+  lastIpcCall = null;
+  loggerCalls.length = 0;
+  process.exitCode = 0;
+  // Clear __SCHEDULE_RUN_ID so it can't leak conversationType into the body.
+  savedRunId = process.env.__SCHEDULE_RUN_ID;
+  delete process.env.__SCHEDULE_RUN_ID;
+});
+
+describe("conversations new --json", () => {
+  test("--json emits a parseable result with the new conversation id", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "conv-new-1",
+        title: "GitHub watcher",
+        conversationKey: "key-1",
+        messagesInserted: 0,
+      },
+    };
+    const code = await runNew(["new", "GitHub watcher", "--json"]);
+    expect(code).toBe(0);
+    expect(lastIpcCall?.method).toBe("conversation_create_cli");
+    expect(jsonOutput()).toMatchObject({
+      ok: true,
+      id: "conv-new-1",
+      conversationKey: "key-1",
+    });
+  });
+
+  test("without --json, prints the human line and not JSON", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "conv-new-2",
+        title: "Notes",
+        conversationKey: "key-2",
+        messagesInserted: 0,
+      },
+    };
+    const code = await runNew(["new", "Notes"]);
+    expect(code).toBe(0);
+    const info = loggerCalls.filter((c) => c.level === "info").map((c) => c.msg);
+    expect(
+      info.some((m) => m.includes("Created conversation: Notes (conv-new-2)")),
+    ).toBe(true);
+    expect(() => JSON.parse(info[info.length - 1]!)).toThrow();
+  });
+
+  test("--json reports failure as { ok: false } and exits non-zero", async () => {
+    mockIpcResult = { ok: false, error: "daemon not running" };
+    const code = await runNew(["new", "X", "--json"]);
+    expect(code).toBe(1);
+    expect(jsonOutput()).toEqual({ ok: false, error: "daemon not running" });
+  });
+
+  test("under a script-mode schedule, creates the conversation as scheduled", async () => {
+    process.env.__SCHEDULE_RUN_ID = "run-9";
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "conv-new-3",
+        title: "GitHub watcher",
+        conversationKey: "key-3",
+        messagesInserted: 0,
+      },
+    };
+    await runNew(["new", "GitHub watcher", "--json"]);
+    const body = (lastIpcCall?.params as { body?: Record<string, unknown> })
+      ?.body;
+    expect(body?.conversationType).toBe("scheduled");
+  });
+});
+
+afterEach(() => {
+  if (savedRunId !== undefined) process.env.__SCHEDULE_RUN_ID = savedRunId;
+  process.exitCode = 0;
+});

--- a/assistant/src/cli/commands/__tests__/conversations-new.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-new.test.ts
@@ -59,8 +59,8 @@ mock.module("../../../util/logger.js", () => ({
   getCurrentLogFilePath: () => "/tmp/test-assistant.log",
 }));
 
-// Full passthrough mock — spreading the real module avoids a hang in the heavy
-// conversations.js import graph that a partial node:fs mock triggered.
+// node:fs must stay fully functional for conversations.js's heavy import graph
+// — a partial mock deadlocks it — so spread the real module.
 const realFs = { ...nodeFs };
 mock.module("node:fs", () => ({ ...realFs }));
 
@@ -147,6 +147,19 @@ describe("conversations new --json", () => {
     const code = await runNew(["new", "X", "--json"]);
     expect(code).toBe(1);
     expect(jsonOutput()).toEqual({ ok: false, error: "daemon not running" });
+  });
+
+  test("--json reports a seed-file error as { ok: false } before any IPC", async () => {
+    const code = await runNew([
+      "new",
+      "X",
+      "--content-file",
+      "/no/such/seed-file.json",
+      "--json",
+    ]);
+    expect(code).toBe(1);
+    expect(lastIpcCall).toBeNull(); // validation fails before any IPC call
+    expect(jsonOutput()).toMatchObject({ ok: false });
   });
 
   test("under a script-mode schedule, creates the conversation as scheduled", async () => {

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -36,31 +36,30 @@ function outputSlackDetachError(message: string, json?: boolean): void {
   process.exitCode = 1;
 }
 
-function readSeedMessages(
-  contentFile?: string,
-): ConversationSeedMessage[] | undefined {
-  if (!contentFile) return undefined;
+// Returns the parsed seed messages (or `undefined` when no file is given), or a
+// validation error for the caller to surface — human or `--json`. The caller
+// owns output/exit so the error shape matches the rest of the command.
+type SeedResult =
+  | { messages: ConversationSeedMessage[] | undefined }
+  | { error: string };
+
+function readSeedMessages(contentFile?: string): SeedResult {
+  if (!contentFile) return { messages: undefined };
   if (!existsSync(contentFile)) {
-    log.error(`Error: content file not found: ${contentFile}`);
-    process.exitCode = 1;
-    return undefined;
+    return { error: `content file not found: ${contentFile}` };
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(contentFile, "utf-8"));
   } catch (err) {
-    log.error(
-      `Error: failed to read content file: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    process.exitCode = 1;
-    return undefined;
+    return {
+      error: `failed to read content file: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 
   if (!Array.isArray(parsed)) {
-    log.error("Error: content file must contain an array of messages");
-    process.exitCode = 1;
-    return undefined;
+    return { error: "content file must contain an array of messages" };
   }
 
   const messages: ConversationSeedMessage[] = [];
@@ -71,9 +70,7 @@ function readSeedMessages(
       !("role" in value) ||
       !("content" in value)
     ) {
-      log.error(`Error: message ${index} must include role and content`);
-      process.exitCode = 1;
-      return undefined;
+      return { error: `message ${index} must include role and content` };
     }
     const role = (value as { role?: unknown }).role;
     const content = (value as { content?: unknown }).content;
@@ -81,24 +78,32 @@ function readSeedMessages(
       (role !== "user" && role !== "assistant") ||
       typeof content !== "string"
     ) {
-      log.error(
-        `Error: message ${index} must have role user|assistant and string content`,
-      );
-      process.exitCode = 1;
-      return undefined;
+      return {
+        error: `message ${index} must have role user|assistant and string content`,
+      };
     }
     messages.push({ role, content });
   }
 
-  return messages;
+  return { messages };
 }
 
 async function createConversationCli(
   title: string | undefined,
   opts?: { contentFile?: string; json?: boolean },
 ): Promise<void> {
-  const messages = readSeedMessages(opts?.contentFile);
-  if (process.exitCode) return;
+  // Seed-file errors happen before any IPC — surface them in JSON mode too.
+  const seed = readSeedMessages(opts?.contentFile);
+  if ("error" in seed) {
+    if (opts?.json) {
+      log.info(JSON.stringify({ ok: false, error: seed.error }));
+    } else {
+      log.error(`Error: ${seed.error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+  const messages = seed.messages;
 
   // A script-mode schedule injects __SCHEDULE_RUN_ID into its env (see
   // schedule/run-script.ts). When set, create the conversation as `scheduled`

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -95,7 +95,7 @@ function readSeedMessages(
 
 async function createConversationCli(
   title: string | undefined,
-  opts?: { contentFile?: string },
+  opts?: { contentFile?: string; json?: boolean },
 ): Promise<void> {
   const messages = readSeedMessages(opts?.contentFile);
   if (process.exitCode) return;
@@ -119,9 +119,21 @@ async function createConversationCli(
     },
   });
 
-  if (!result.ok) return exitFromIpcResult(result);
+  if (!result.ok) {
+    if (opts?.json) {
+      log.info(JSON.stringify({ ok: false, error: result.error }));
+      process.exitCode = 1;
+      return;
+    }
+    return exitFromIpcResult(result);
+  }
 
   const conversation = result.result!;
+  // JSON output so callers can capture the new id programmatically.
+  if (opts?.json) {
+    log.info(JSON.stringify({ ok: true, ...conversation }));
+    return;
+  }
   const seedSuffix = conversation.messagesInserted
     ? `, seeded ${conversation.messagesInserted} messages`
     : "";
@@ -218,6 +230,7 @@ Examples:
         .command("new [title]")
         .description("Create a new conversation")
         .option("--content-file <path>", "Seed messages from a JSON file")
+        .option("--json", "Output result as JSON")
         .addHelpText(
           "after",
           `


### PR DESCRIPTION
ref ATL-911

Adds `--json` to `conversations new` so callers can capture the new conversation id (and key) programmatically instead of scraping the human log line — needed by script-mode schedules that wake a fresh conversation per run. Mirrors the existing `--json` handling on `conversations wake`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)