### PR TITLE
refactor(jobs): move the standalone worker entry out of memory/ into jobs/

### DIFF
--- a/assistant/src/jobs/worker.ts
+++ b/assistant/src/jobs/worker.ts
@@ -13,10 +13,10 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 
 import { getConfig } from "../config/loader.js";
-import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
 import { startInProcessMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryWorkerPidPath } from "../util/platform.js";
+import { registerMemoryJobHandlers } from "./register-job-handlers.js";
 
 const log = getLogger("memory-worker-process");
 

--- a/assistant/src/persistence/worker-control.ts
+++ b/assistant/src/persistence/worker-control.ts
@@ -194,7 +194,7 @@ export async function spawnMemoryWorkerProcess(
   }
 
   const pidPath = getMemoryWorkerPidPath();
-  const entry = new URL("../memory/worker.ts", import.meta.url);
+  const entry = new URL("../jobs/worker.ts", import.meta.url);
 
   // Pipe the worker's stderr into the same daily log file the daemon
   // writes to. The worker's pino logger already writes there directly,

--- a/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
@@ -26,8 +26,8 @@ mock.module("../../../util/process-tree.js", () => ({
       { pid: 200, name: "qdrant", command: "qdrant", children: [] },
       {
         pid: 300,
-        name: "memory-worker",
-        command: "bun run /app/memory/worker.ts",
+        name: "jobs-worker",
+        command: "bun run /app/jobs/worker.ts",
         children: [
           {
             pid: 400,
@@ -78,7 +78,7 @@ describe("ps route handler", () => {
     const { processes } = await getHandler()();
     const names = JSON.stringify(processes);
 
-    expect(names).toContain("memory-worker");
+    expect(names).toContain("jobs-worker");
     expect(names).toContain("embed-helper");
   });
 

--- a/assistant/src/util/__tests__/process-tree.test.ts
+++ b/assistant/src/util/__tests__/process-tree.test.ts
@@ -20,8 +20,8 @@ describe("deriveName", () => {
   });
 
   test("summarizes the script path as <parent>-<file> for interpreter invocations", () => {
-    expect(deriveName("bun run /home/u/app/memory/worker.ts")).toBe(
-      "memory-worker",
+    expect(deriveName("bun run /home/u/app/jobs/worker.ts")).toBe(
+      "jobs-worker",
     );
     expect(deriveName("bun run /home/u/app/daemon/main.ts")).toBe(
       "daemon-main",
@@ -53,7 +53,7 @@ describe("buildProcessTree", () => {
   const procs: ProcInfo[] = [
     { pid: 100, ppid: 1, command: "bun run /app/daemon/main.ts" },
     { pid: 200, ppid: 100, command: "/usr/bin/qdrant" },
-    { pid: 300, ppid: 100, command: "bun run /app/memory/worker.ts" },
+    { pid: 300, ppid: 100, command: "bun run /app/jobs/worker.ts" },
     { pid: 400, ppid: 300, command: "/usr/bin/embed-helper" },
     { pid: 999, ppid: 1, command: "unrelated" },
   ];
@@ -70,7 +70,7 @@ describe("buildProcessTree", () => {
     const tree = buildProcessTree(procs, 100);
     const worker = tree.children.find((c) => c.pid === 300)!;
 
-    expect(worker.name).toBe("memory-worker");
+    expect(worker.name).toBe("jobs-worker");
     expect(worker.children.map((c) => c.pid)).toEqual([400]);
     expect(worker.children[0].name).toBe("embed-helper");
   });

--- a/assistant/src/util/process-tree.ts
+++ b/assistant/src/util/process-tree.ts
@@ -49,7 +49,7 @@ const SCRIPT_EXT_RE = /\.(ts|js|mjs|cjs|py)$/;
 
 /**
  * Summarize a script path as `<parent-dir>-<filename-without-ext>` so the worker
- * at `…/memory/worker.ts` reads as `memory-worker` and the daemon entry
+ * at `…/jobs/worker.ts` reads as `jobs-worker` and the daemon entry
  * `…/daemon/main.ts` as `daemon-main`. Falls back to the bare extensionless
  * filename when the script sits at the filesystem root.
  */
@@ -62,9 +62,9 @@ function scriptName(scriptPath: string): string {
 
 /**
  * Derive a readable name from a command line. For interpreter invocations
- * (`bun run /…/memory/worker.ts`) the script path is far more useful than the
+ * (`bun run /…/jobs/worker.ts`) the script path is far more useful than the
  * interpreter name, so prefer the first script-looking argument and summarize it
- * as `<parent-dir>-<filename>` (e.g. `memory-worker`). Plain binaries
+ * as `<parent-dir>-<filename>` (e.g. `jobs-worker`). Plain binaries
  * (`/…/vellum-qdrant`) keep their bare executable name.
  */
 export function deriveName(command: string): string {


### PR DESCRIPTION
## Summary

Move `memory/worker.ts` (the standalone background-jobs worker entry) to `jobs/worker.ts`, alongside the `register-job-handlers` composition root from PR #36486. It's general job-worker infra, not memory-feature code (imports nothing from the feature). With the memory feature relocated into the plugin (#36584), this was the **last file in `memory/`** — moving it **empties and removes `assistant/src/memory/`**, completing the relocate.

## Identity: functional kept byte-identical, only the cosmetic `/ps` label follows

The worker's **functional identity is unchanged**, so the live worker's lifecycle is byte-identical:
- PID file: `memory-worker.pid` (unchanged)
- HTTP/IPC routes: `memory/worker/{start,stop,status}` (unchanged)
- Logger names: `memory-worker-process` / `memory-worker-routes` (unchanged)

Detection is PID-based, so `vellum sleep`/`wake`/`ps` lifecycle is unaffected.

The **only visible change** is the `vellum ps` display label. `deriveName` auto-summarizes a script path as `<parent>-<file>`, so the worker now reads **`jobs-worker`** instead of `memory-worker`. That label is cosmetic (nothing functional keys on it), and `jobs-worker` is the more accurate name for a general jobs worker. Pinning it would mean a misleading special-case in a generic util (labeling a `jobs/worker.ts` file `memory-worker`), so the label follows the file. The `/ps`-modeling comments + test fixtures are updated to match.

## Changes
- `git mv memory/worker.ts → jobs/worker.ts`; worker's `register-job-handlers` import becomes same-directory.
- Spawn path updated: `persistence/worker-control.ts` `new URL("../jobs/worker.ts")`.
- `util/process-tree.ts` doc comments + `process-tree.test.ts` / `ps-routes.test.ts` fixtures/assertions updated to `jobs-worker`.

## Validation
typecheck, eslint, prettier, knip, OpenAPI no-op; worker-control / ps-routes / process-tree / cli-worker / memory-worker-routes tests all pass. No external (Docker/build/package.json) references to the old path. Zero `@vellumai/plugin-api` changes.

Closes the physical relocation arc (Track 2): the memory feature + its worker now live in their proper homes; `memory/` is gone.