### PR TITLE
refactor(persistence): add the memory-lifecycle seam, route message indexing through it

### DIFF
--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -54,7 +54,6 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
     "graph/graph-memory-state-store",
-    "indexer",
     "memory-retrospective-constants",
     "memory-retrospective-state",
     "task-memory-cleanup",

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -17,6 +17,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { getHooksFor } from "../hooks/registry.js";
 import { RiskLevel } from "../permissions/types.js";
+import type { MessagePersistedEvent } from "../persistence/memory-lifecycle-hooks.js";
+import { guardPersistenceHooksByDisabledState } from "../plugins/defaults/index.js";
 import {
   clearInjectorRegistry,
   getRegisteredInjectors,
@@ -255,5 +257,35 @@ describe("per-surface disabled-state filtering", () => {
 
     hooks = await getHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(0);
+  });
+
+  test("persistence hooks no-op while the memory plugin is disabled", async () => {
+    let calls = 0;
+    const guarded = guardPersistenceHooksByDisabledState("default-memory", {
+      onMessagePersisted() {
+        calls++;
+      },
+    });
+    const event: MessagePersistedEvent = {
+      messageId: "msg-1",
+      conversationId: "conv-1",
+      role: "user",
+      content: "[]",
+      createdAt: 0,
+    };
+
+    // Enabled: the wrapped handler runs.
+    await guarded.onMessagePersisted(event);
+    expect(calls).toBe(1);
+
+    // Disable via sentinel — checked at call time, no restart needed.
+    await createSentinel("default-memory");
+    await guarded.onMessagePersisted(event);
+    expect(calls).toBe(1);
+
+    // Re-enable.
+    await removeSentinel("default-memory");
+    await guarded.onMessagePersisted(event);
+    expect(calls).toBe(2);
   });
 });

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -178,6 +178,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../persistence/embeddings/embedding-runtime-manager.js",
     "../../../persistence/embeddings/embedding-types.js",
     "../../../persistence/jobs-store.js",
+    "../../../persistence/memory-lifecycle-hooks.js",
     "../../../persistence/message-content.js",
     "../../../persistence/raw-query.js",
     "../../../persistence/schema/index.js",

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -65,6 +65,7 @@ import {
   getAllDefaultPlugins,
   registerDefaultPluginInjectors,
   registerDefaultPluginJobHandlers,
+  registerDefaultPluginPersistenceHooks,
   registerDefaultPlugins,
 } from "../plugins/defaults/index.js";
 import {
@@ -227,6 +228,12 @@ export async function bootstrapPlugins(): Promise<void> {
   // worker dispatch table; pre-registering here keeps the daemon path symmetric
   // with tools/routes/injectors (the standalone worker self-registers instead).
   registerDefaultPluginJobHandlers();
+
+  // Install the memory feature's persistence-lifecycle handlers into the
+  // persistence seam up front, so the layer below memory can drive memory
+  // side effects (message indexing) without importing memory internals.
+  // Symmetric with the injector/job-handler registration above.
+  registerDefaultPluginPersistenceHooks();
 
   // Combine the canonical default plugins with any plugins registered via
   // `registerPlugin` (test fixtures). In production, `getRegisteredPlugins`

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -23,14 +23,12 @@ import { z } from "zod";
 import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
-import { getConfig } from "../config/loader.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import { forkGraphMemoryState } from "../plugins/defaults/memory/graph/graph-memory-state-store.js";
-import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "../plugins/defaults/memory/memory-retrospective-constants.js";
 import { forkRetrospectiveState } from "../plugins/defaults/memory/memory-retrospective-state.js";
 import { cancelPendingJobsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
@@ -87,6 +85,7 @@ import {
   copyForkMessagesViaSubprocess,
   type ForkIdPair,
 } from "./fork-message-copy.js";
+import { getMemoryPersistenceHooks } from "./memory-lifecycle-hooks.js";
 import {
   rawExec,
   rawGet,
@@ -1743,7 +1742,6 @@ export async function addMessage(
 
   if (!skipIndexing) {
     try {
-      const config = getConfig();
       const parsed = metadata
         ? messageMetadataSchema.safeParse(metadata)
         : null;
@@ -1751,19 +1749,15 @@ export async function addMessage(
         ? parsed.data.provenanceTrustClass
         : undefined;
       const automated = parsed?.success ? parsed.data.automated : undefined;
-      await indexMessageNow(
-        {
-          messageId: message.id,
-          conversationId: message.conversationId,
-          role: message.role,
-          content: message.content,
-          createdAt: message.createdAt,
-          scopeId: "default",
-          provenanceTrustClass,
-          automated,
-        },
-        config.memory,
-      );
+      await getMemoryPersistenceHooks().onMessagePersisted({
+        messageId: message.id,
+        conversationId: message.conversationId,
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt,
+        provenanceTrustClass,
+        automated,
+      });
     } catch (err) {
       log.warn(
         { err, conversationId, messageId: message.id },

--- a/assistant/src/persistence/memory-lifecycle-hooks.test.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getMemoryPersistenceHooks,
+  type MessagePersistedEvent,
+  registerMemoryPersistenceHooks,
+  resetMemoryPersistenceHooksForTests,
+} from "./memory-lifecycle-hooks.js";
+
+const event: MessagePersistedEvent = {
+  messageId: "msg-1",
+  conversationId: "conv-1",
+  role: "user",
+  content: "[]",
+  createdAt: 0,
+};
+
+describe("memory persistence-lifecycle seam", () => {
+  afterEach(() => resetMemoryPersistenceHooksForTests());
+
+  test("defaults to a no-op when no implementation is registered", async () => {
+    // Resolves without throwing — the "memory not present" path.
+    await getMemoryPersistenceHooks().onMessagePersisted(event);
+  });
+
+  test("getMemoryPersistenceHooks returns the registered implementation", async () => {
+    const seen: MessagePersistedEvent[] = [];
+    registerMemoryPersistenceHooks({
+      onMessagePersisted(ev) {
+        seen.push(ev);
+      },
+    });
+    await getMemoryPersistenceHooks().onMessagePersisted(event);
+    expect(seen).toEqual([event]);
+  });
+
+  test("registration replaces the prior implementation", async () => {
+    let aCalls = 0;
+    let bCalls = 0;
+    registerMemoryPersistenceHooks({
+      onMessagePersisted() {
+        aCalls++;
+      },
+    });
+    registerMemoryPersistenceHooks({
+      onMessagePersisted() {
+        bCalls++;
+      },
+    });
+    await getMemoryPersistenceHooks().onMessagePersisted(event);
+    expect(aCalls).toBe(0);
+    expect(bCalls).toBe(1);
+  });
+
+  test("resetMemoryPersistenceHooksForTests restores the no-op", async () => {
+    let calls = 0;
+    registerMemoryPersistenceHooks({
+      onMessagePersisted() {
+        calls++;
+      },
+    });
+    resetMemoryPersistenceHooksForTests();
+    await getMemoryPersistenceHooks().onMessagePersisted(event);
+    expect(calls).toBe(0);
+  });
+});

--- a/assistant/src/persistence/memory-lifecycle-hooks.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.ts
@@ -1,0 +1,71 @@
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+
+/**
+ * Seam for the memory feature to react to persistence-layer lifecycle events.
+ *
+ * Persistence is a layer below the memory plugin, so it cannot import memory
+ * internals directly. Instead it calls into this registered-handler seam: the
+ * memory plugin installs an implementation at bootstrap
+ * (`registerMemoryPersistenceHooks`), and persistence invokes the current
+ * implementation (`getMemoryPersistenceHooks`) at the relevant call sites. When
+ * no implementation is registered — memory absent, disabled before bootstrap,
+ * or a unit test that skips plugin bootstrap — the calls fall through to a
+ * no-op, which is the correct "memory is not present" behaviour.
+ *
+ * The seam is a single registered handler (not a multi-subscriber event bus)
+ * because the persistence call sites run synchronously inside their write paths
+ * and there is exactly one subscriber (the memory plugin). Handler methods are
+ * registered as a unit, mirroring how plugins contribute injectors and
+ * job-handlers up-front at bootstrap.
+ *
+ * Payload types reference only persistence/host primitives so no memory type
+ * leaks into this layer.
+ */
+
+/** A message that was just persisted to a conversation. */
+export interface MessagePersistedEvent {
+  messageId: string;
+  conversationId: string;
+  role: string;
+  /** Stored message content (JSON content-block array, serialized). */
+  content: string;
+  createdAt: number;
+  /** Trust class of the actor who produced the message, captured at persist time. */
+  provenanceTrustClass?: TrustClass;
+  /** True when the message was auto-sent by the client (e.g. a wake-up greeting). */
+  automated?: boolean;
+}
+
+/** Handlers the memory feature registers to observe persistence lifecycle events. */
+export interface MemoryPersistenceHooks {
+  /**
+   * A message was persisted (and not deduplicated). The memory feature indexes
+   * it. Awaited inside the write path; the caller wraps the call in try/catch
+   * and logs failures without failing the write, so a throwing implementation
+   * is tolerated.
+   */
+  onMessagePersisted(event: MessagePersistedEvent): Promise<void> | void;
+}
+
+const NOOP: MemoryPersistenceHooks = {
+  onMessagePersisted() {},
+};
+
+let current: MemoryPersistenceHooks = NOOP;
+
+/** Install the memory feature's persistence-lifecycle handlers. Idempotent: replaces any prior registration. */
+export function registerMemoryPersistenceHooks(
+  hooks: MemoryPersistenceHooks,
+): void {
+  current = hooks;
+}
+
+/** The currently-registered handlers, or a no-op set when memory is not present. */
+export function getMemoryPersistenceHooks(): MemoryPersistenceHooks {
+  return current;
+}
+
+/** Test-only: restore the no-op default so a test starts from a clean seam. */
+export function resetMemoryPersistenceHooksForTests(): void {
+  current = NOOP;
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -24,6 +24,7 @@
  * {@link registerDefaultPlugins} at call time.
  */
 
+import { registerMemoryPersistenceHooks } from "../../persistence/memory-lifecycle-hooks.js";
 import {
   clearInjectorRegistry,
   registerPluginInjectors,
@@ -69,6 +70,7 @@ import memoryUserPromptSubmit from "./memory/hooks/user-prompt-submit.js";
 import { memoryInjectors } from "./memory/injectors.js";
 import { memoryJobHandlers } from "./memory/job-handlers.js";
 import memoryPkg from "./memory/package.json" with { type: "json" };
+import { memoryPersistenceHooks } from "./memory/persistence-hooks.js";
 import {
   memoryV3Injector,
   memoryV3SpotlightInjector,
@@ -496,6 +498,19 @@ export function registerDefaultPluginJobHandlers(): void {
 }
 
 /**
+ * Install the memory feature's persistence-lifecycle handlers into the
+ * persistence seam — the persistence-hooks analog of
+ * {@link registerDefaultPluginJobHandlers}. `bootstrapPlugins` calls this
+ * before the per-plugin init loop so the seam is wired regardless of the
+ * memory plugin's disabled-state (a disabled memory plugin's indexer no-ops
+ * via its own config gate). The seam holds a single handler set, so this
+ * replaces any prior registration.
+ */
+export function registerDefaultPluginPersistenceHooks(): void {
+  registerMemoryPersistenceHooks(memoryPersistenceHooks);
+}
+
+/**
  * Test-only helper: clear the hook registry and re-register every default
  * so integration tests that exercise the full agent loop have a
  * production-parity plugin stack. Use this in `beforeEach` of tests that
@@ -520,4 +535,5 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   registerDefaultPluginInjectors();
   clearJobHandlerRegistry();
   registerDefaultPluginJobHandlers();
+  registerDefaultPluginPersistenceHooks();
 }

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -24,7 +24,11 @@
  * {@link registerDefaultPlugins} at call time.
  */
 
-import { registerMemoryPersistenceHooks } from "../../persistence/memory-lifecycle-hooks.js";
+import {
+  type MemoryPersistenceHooks,
+  registerMemoryPersistenceHooks,
+} from "../../persistence/memory-lifecycle-hooks.js";
+import { isPluginDisabled } from "../disabled-state.js";
 import {
   clearInjectorRegistry,
   registerPluginInjectors,
@@ -498,16 +502,41 @@ export function registerDefaultPluginJobHandlers(): void {
 }
 
 /**
+ * Wrap a plugin's persistence hooks so each call no-ops while that plugin is
+ * disabled (`assistant plugins disable <name>`), mirroring the read-time
+ * disabled-state filtering the injector/hook/job-handler/tool surfaces apply.
+ * The sentinel is checked per call, so enable/disable takes effect on the next
+ * write without a daemon restart.
+ */
+export function guardPersistenceHooksByDisabledState(
+  pluginName: string,
+  hooks: MemoryPersistenceHooks,
+): MemoryPersistenceHooks {
+  return {
+    onMessagePersisted(event) {
+      if (isPluginDisabled(pluginName)) return;
+      return hooks.onMessagePersisted(event);
+    },
+  };
+}
+
+/**
  * Install the memory feature's persistence-lifecycle handlers into the
  * persistence seam — the persistence-hooks analog of
  * {@link registerDefaultPluginJobHandlers}. `bootstrapPlugins` calls this
- * before the per-plugin init loop so the seam is wired regardless of the
- * memory plugin's disabled-state (a disabled memory plugin's indexer no-ops
- * via its own config gate). The seam holds a single handler set, so this
+ * before the per-plugin init loop so the seam is wired up front; the handlers
+ * are guarded by {@link guardPersistenceHooksByDisabledState} so a disabled
+ * memory plugin drives no persistence side effects and re-enabling it takes
+ * effect on the next write. The seam holds a single handler set, so this
  * replaces any prior registration.
  */
 export function registerDefaultPluginPersistenceHooks(): void {
-  registerMemoryPersistenceHooks(memoryPersistenceHooks);
+  registerMemoryPersistenceHooks(
+    guardPersistenceHooksByDisabledState(
+      memoryPkg.name,
+      memoryPersistenceHooks,
+    ),
+  );
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,0 +1,18 @@
+import { getConfig } from "../../../config/loader.js";
+import type {
+  MemoryPersistenceHooks,
+  MessagePersistedEvent,
+} from "../../../persistence/memory-lifecycle-hooks.js";
+import { indexMessageNow } from "./indexer.js";
+
+/**
+ * The memory feature's implementation of the persistence lifecycle seam
+ * (`MemoryPersistenceHooks`). Registered into the seam at plugin bootstrap so
+ * the persistence layer can drive memory side effects without importing memory
+ * internals.
+ */
+export const memoryPersistenceHooks: MemoryPersistenceHooks = {
+  async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
+    await indexMessageNow({ ...event, scopeId: "default" }, getConfig().memory);
+  },
+};


### PR DESCRIPTION
## Summary
- Introduces `persistence/memory-lifecycle-hooks.ts` — a registered-handler seam (`MemoryPersistenceHooks`) the persistence layer calls into, so persistence can drive memory side effects **without importing memory internals**. The memory plugin installs its implementation (`plugins/defaults/memory/persistence-hooks.ts`) up-front at bootstrap via `registerDefaultPluginPersistenceHooks()`, symmetric with how it contributes injectors/job-handlers. With no implementation registered (memory absent/disabled, or a unit test that skips bootstrap) the calls fall through to a **no-op** — the correct "memory not present" behaviour.
- **Inverts the first lifecycle back-import.** `addMessage` (in `conversation-crud.ts`) no longer imports `indexMessageNow` from the memory plugin — it calls `getMemoryPersistenceHooks().onMessagePersisted(...)`. The `indexer` entry is removed from `PERSISTENCE_TO_MEMORY_ALLOWLIST` (conversation-crud: 8 → 7).
- **Behavior-identical**: same fields, same `await` inside the same best-effort try/catch + log, same config (`getConfig().memory`, now read inside the handler), `scopeId: "default"` applied by the handler.

## Why a registered handler (not an event bus)
Subsequent Step-C inversions (fork, wipe) run **synchronously inside the write path** — fork must complete before `forkConversation` returns and carries the live `db` handle; wipe must run before message rows are deleted — and there is exactly **one** subscriber (the memory plugin). A single registered handler supports that; a fire-and-forget bus does not. Payloads carry only persistence/host primitives (`TrustClass` is a host type), so no memory type leaks into the layer.

## Notes for review
- Keystone of **Track 2 Step C** (decouple `persistence/ → memory/`). Later PRs invert fork/wipe/worker-startup through the same seam; constants relocate after.
- Seam lives **in `persistence/`** (the lower layer owns it); memory → persistence is already the direction 22 memory files import, so the layering guard is trivially satisfied.
- Test wiring: `resetPluginRegistryAndRegisterDefaults()` also registers the persistence hooks, so integration tests driving `addMessage` keep their indexing behaviour. Verified no test asserts `addMessage`→index without bootstrapping.
- Risk: medium — touches the message-persist write path + bootstrap, but behaviour-identical and best-effort. Zero `@vellumai/plugin-api` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)