### PR TITLE
refactor(persistence): invert the conversation-fork memory carry through the lifecycle seam

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -55,6 +55,7 @@ import {
   memoryRetrospectiveState,
   toolInvocations,
 } from "../persistence/schema/index.js";
+import { registerDefaultPluginPersistenceHooks } from "../plugins/defaults/index.js";
 import {
   loadGraphMemoryState,
   saveGraphMemoryState,
@@ -100,6 +101,7 @@ function parseMetadata(metadata: string | null): unknown {
 describe("forkConversation", () => {
   beforeEach(() => {
     resetTables();
+    registerDefaultPluginPersistenceHooks();
   });
 
   test("forks a full transcript with copied history and lineage", async () => {
@@ -1391,6 +1393,7 @@ describe("forkConversation", () => {
 describe("forkConversation + memory_retrospective_state", () => {
   beforeEach(() => {
     resetTables();
+    registerDefaultPluginPersistenceHooks();
   });
 
   test("does not seed state when the source has none", async () => {

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -50,6 +50,7 @@ import {
   memoryRetrospectiveState,
   toolInvocations,
 } from "../persistence/schema/index.js";
+import { registerDefaultPluginPersistenceHooks } from "../plugins/defaults/index.js";
 import {
   loadGraphMemoryState,
   saveGraphMemoryState,
@@ -110,6 +111,7 @@ async function seedSource(title: string): Promise<{ id: string }> {
 describe("forkConversationForRetrospective", () => {
   beforeEach(() => {
     resetTables();
+    registerDefaultPluginPersistenceHooks();
   });
 
   test("full fork is row-identical to the synchronous fork", async () => {

--- a/assistant/src/__tests__/job-handler-registry-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registry-guard.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
 import * as jobsWorker from "../persistence/jobs-worker.js";
+import {
+  getMemoryPersistenceHooks,
+  resetMemoryPersistenceHooksForTests,
+} from "../persistence/memory-lifecycle-hooks.js";
 import { registerDefaultPluginJobHandlers } from "../plugins/defaults/index.js";
 import {
   clearJobHandlerRegistry,
@@ -61,6 +65,7 @@ describe("job-handler registry — memory plugin contribution", () => {
   });
   afterEach(() => {
     clearJobHandlerRegistry();
+    resetMemoryPersistenceHooksForTests();
   });
 
   it("default-memory contributes exactly the memory job types", () => {
@@ -89,6 +94,22 @@ describe("job-handler registry — memory plugin contribution", () => {
     expect(captured.slice().sort()).toEqual(expected);
     // Each type registered exactly once — no plugin/non-plugin overlap, no drop.
     expect(new Set(captured).size).toBe(captured.length);
+  });
+
+  it("registerMemoryJobHandlers also wires the persistence-lifecycle seam (the standalone worker has no bootstrap)", () => {
+    resetMemoryPersistenceHooksForTests();
+    const before = getMemoryPersistenceHooks();
+    const spy = spyOn(jobsWorker, "registerJobHandler").mockImplementation(
+      () => {},
+    );
+    try {
+      registerMemoryJobHandlers();
+    } finally {
+      spy.mockRestore();
+    }
+    // The seam must move off the no-op default — otherwise the standalone
+    // worker's fork-based retrospectives silently drop carried memory state.
+    expect(getMemoryPersistenceHooks()).not.toBe(before);
   });
 
   it("rejects a duplicate job-handler type across plugins", () => {

--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -53,12 +53,8 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
  */
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
-    "graph/graph-memory-state-store",
     "memory-retrospective-constants",
-    "memory-retrospective-state",
     "task-memory-cleanup",
-    "v2/activation-store",
-    "v2/injected-block-slugs",
     "v3/ever-injected-store",
   ]),
   "assistant/src/persistence/jobs-worker.ts": new Set([

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -265,6 +265,7 @@ describe("per-surface disabled-state filtering", () => {
       onMessagePersisted() {
         calls++;
       },
+      onConversationForked() {},
     });
     const event: MessagePersistedEvent = {
       messageId: "msg-1",

--- a/assistant/src/jobs/register-job-handlers.ts
+++ b/assistant/src/jobs/register-job-handlers.ts
@@ -7,7 +7,10 @@ import {
   pruneOldTraceEventsJob,
 } from "../persistence/job-handlers/cleanup.js";
 import { registerJobHandler } from "../persistence/jobs-worker.js";
-import { registerDefaultPluginJobHandlers } from "../plugins/defaults/index.js";
+import {
+  registerDefaultPluginJobHandlers,
+  registerDefaultPluginPersistenceHooks,
+} from "../plugins/defaults/index.js";
 import { getRegisteredJobHandlers } from "../plugins/job-handler-registry.js";
 import { conversationAnalyzeJob } from "../runtime/services/conversation-analyze-job.js";
 
@@ -31,6 +34,12 @@ export function registerMemoryJobHandlers(): void {
   // here. Idempotent — on the daemon path bootstrap has already registered them
   // (plus any user plugins, which this union also picks up).
   registerDefaultPluginJobHandlers();
+  // The standalone worker runs fork-based memory retrospectives, which carry
+  // per-conversation memory state through the persistence-lifecycle seam. The
+  // daemon wires that seam at bootstrap; the worker must self-register it here
+  // too, or `onConversationForked` is the no-op and the retrospective fork
+  // silently drops the carried activation/injection/graph/retrospective state.
+  registerDefaultPluginPersistenceHooks();
   for (const { type, handler } of getRegisteredJobHandlers()) {
     registerJobHandler(type, handler);
   }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -28,20 +28,9 @@ import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
-import { forkGraphMemoryState } from "../plugins/defaults/memory/graph/graph-memory-state-store.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "../plugins/defaults/memory/memory-retrospective-constants.js";
-import { forkRetrospectiveState } from "../plugins/defaults/memory/memory-retrospective-state.js";
 import { cancelPendingJobsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
-import {
-  forkActivationState,
-  seedForkActivationState,
-} from "../plugins/defaults/memory/v2/activation-store.js";
-import { extractInjectedConceptSlugs } from "../plugins/defaults/memory/v2/injected-block-slugs.js";
-import {
-  forkEverInjected,
-  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
-  seedEverInjectedFromSlugs,
-} from "../plugins/defaults/memory/v3/ever-injected-store.js";
+import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../plugins/defaults/memory/v3/ever-injected-store.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { UserError } from "../util/errors.js";
@@ -227,30 +216,6 @@ function cloneForkMessageMetadata(
   }
 
   return JSON.stringify({ forkSourceMessageId: sourceMessageId });
-}
-
-/**
- * Read a persisted memory-injection block off a message's metadata JSON, or
- * `null` when absent/malformed. `key` selects the injection layer: v2's
- * `memoryInjectedBlock` or memory-v3's card block
- * (`MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`). The block is what the request
- * builder re-attaches as the message's `<memory>` content each turn.
- */
-function readInjectedBlock(
-  metadata: string | null,
-  key: string,
-): string | null {
-  if (!metadata) return null;
-  try {
-    const parsed: unknown = JSON.parse(metadata);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const block = (parsed as Record<string, unknown>)[key];
-      if (typeof block === "string") return block;
-    }
-  } catch {
-    // Malformed metadata — treat as no block.
-  }
-  return null;
 }
 
 /**
@@ -1173,64 +1138,17 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     latestAssistantMessageAt: latestForkedAssistant?.messageAt ?? null,
   });
 
-  // Carry the parent's per-conversation memory state into the child so the
-  // forked thread resumes with the same activation/injection log and
-  // in-context tracker the parent had at fork time. Only valid for
-  // full-history forks: a truncated fork would inherit activation/tracker
-  // entries for turns the child does not actually contain.
-  if (isFullHistoryFork) {
-    forkActivationState(db, sourceConversationId, fork.id);
-    forkEverInjected(db, sourceConversationId, fork.id);
-    forkGraphMemoryState(sourceConversationId, fork.id);
-  } else {
-    // Truncated fork: the wholesale copy above would over-claim, but
-    // seeding nothing makes the child re-select and re-attach every page
-    // whose `<memory>` attachment it already inherited (observed in
-    // production: 89 duplicate page injections on one fork). Derive
-    // `everInjected` from the inherited attachments themselves — scoped to
-    // the child's visible window, since attachments behind an inherited
-    // compaction boundary are not rendered and must stay re-injectable.
-    // The v2 and v3 layers persist under separate metadata keys with the
-    // same `# memory/concepts/<slug>.md` header convention, so each seeds
-    // its own dedup record from its own blocks.
-    const visibleStartIndex = Math.min(
-      inheritedCompactedMessageCount,
-      messagesToCopy.length,
-    );
-    const inheritedSlugs = new Set<string>();
-    const inheritedV3Slugs = new Set<string>();
-    for (const message of messagesToCopy.slice(visibleStartIndex)) {
-      const block = readInjectedBlock(message.metadata, "memoryInjectedBlock");
-      if (block) {
-        for (const slug of extractInjectedConceptSlugs(block)) {
-          inheritedSlugs.add(slug);
-        }
-      }
-      const v3Block = readInjectedBlock(
-        message.metadata,
-        MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
-      );
-      if (v3Block) {
-        for (const slug of extractInjectedConceptSlugs(v3Block)) {
-          inheritedV3Slugs.add(slug);
-        }
-      }
-    }
-    seedForkActivationState(db, fork.id, [...inheritedSlugs]);
-    seedEverInjectedFromSlugs(
-      db,
-      sourceConversationId,
-      fork.id,
-      [...inheritedV3Slugs],
-      Date.now(),
-    );
-  }
-  forkRetrospectiveState({
-    database: db,
+  // Carry the parent's per-conversation memory state into the child (activation
+  // and injection logs, graph state, retrospective state). Runs synchronously
+  // inside the fork transaction; a no-op when memory is absent or disabled.
+  getMemoryPersistenceHooks().onConversationForked({
+    db,
     sourceConversationId,
-    forkedConversationId: fork.id,
+    forkId: fork.id,
+    isFullHistoryFork,
+    messagesToCopy,
     forkedMessageIds,
-    lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
+    inheritedCompactedMessageCount,
   });
 
   // Carry the source's compaction events that predate the fork boundary so the

--- a/assistant/src/persistence/memory-lifecycle-hooks.test.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   getMemoryPersistenceHooks,
+  type MemoryPersistenceHooks,
   type MessagePersistedEvent,
   registerMemoryPersistenceHooks,
   resetMemoryPersistenceHooksForTests,
@@ -15,6 +16,12 @@ const event: MessagePersistedEvent = {
   createdAt: 0,
 };
 
+/** No-op base so each stub only overrides the method it exercises. */
+const baseHooks: MemoryPersistenceHooks = {
+  onMessagePersisted() {},
+  onConversationForked() {},
+};
+
 describe("memory persistence-lifecycle seam", () => {
   afterEach(() => resetMemoryPersistenceHooksForTests());
 
@@ -26,6 +33,7 @@ describe("memory persistence-lifecycle seam", () => {
   test("getMemoryPersistenceHooks returns the registered implementation", async () => {
     const seen: MessagePersistedEvent[] = [];
     registerMemoryPersistenceHooks({
+      ...baseHooks,
       onMessagePersisted(ev) {
         seen.push(ev);
       },
@@ -38,11 +46,13 @@ describe("memory persistence-lifecycle seam", () => {
     let aCalls = 0;
     let bCalls = 0;
     registerMemoryPersistenceHooks({
+      ...baseHooks,
       onMessagePersisted() {
         aCalls++;
       },
     });
     registerMemoryPersistenceHooks({
+      ...baseHooks,
       onMessagePersisted() {
         bCalls++;
       },
@@ -55,6 +65,7 @@ describe("memory persistence-lifecycle seam", () => {
   test("resetMemoryPersistenceHooksForTests restores the no-op", async () => {
     let calls = 0;
     registerMemoryPersistenceHooks({
+      ...baseHooks,
       onMessagePersisted() {
         calls++;
       },

--- a/assistant/src/persistence/memory-lifecycle-hooks.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.ts
@@ -1,4 +1,5 @@
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import type { DrizzleDb } from "./db-connection.js";
 
 /**
  * Seam for the memory feature to react to persistence-layer lifecycle events.
@@ -36,6 +37,25 @@ export interface MessagePersistedEvent {
   automated?: boolean;
 }
 
+/** A conversation was forked; the memory feature carries per-conversation state into the child. */
+export interface ConversationForkedEvent {
+  db: DrizzleDb;
+  sourceConversationId: string;
+  forkId: string;
+  /**
+   * Full-history fork (the child contains every source message). When false the
+   * fork is truncated and per-conversation memory state is re-derived from the
+   * child's visible window instead of copied wholesale.
+   */
+  isFullHistoryFork: boolean;
+  /** The copied messages, in order. Only `id` and `metadata` are read. */
+  messagesToCopy: ReadonlyArray<{ id: string; metadata: string | null }>;
+  /** Map of source message id → forked message id. */
+  forkedMessageIds: Map<string, string>;
+  /** Count of inherited messages behind the fork's compaction boundary. */
+  inheritedCompactedMessageCount: number;
+}
+
 /** Handlers the memory feature registers to observe persistence lifecycle events. */
 export interface MemoryPersistenceHooks {
   /**
@@ -45,10 +65,19 @@ export interface MemoryPersistenceHooks {
    * is tolerated.
    */
   onMessagePersisted(event: MessagePersistedEvent): Promise<void> | void;
+
+  /**
+   * A conversation was forked. The memory feature carries the parent's
+   * per-conversation memory state (activation/injection logs, graph state,
+   * retrospective state) into the child. Runs synchronously inside the fork's
+   * transaction with the live `db` handle.
+   */
+  onConversationForked(event: ConversationForkedEvent): void;
 }
 
 const NOOP: MemoryPersistenceHooks = {
   onMessagePersisted() {},
+  onConversationForked() {},
 };
 
 let current: MemoryPersistenceHooks = NOOP;

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -517,6 +517,10 @@ export function guardPersistenceHooksByDisabledState(
       if (isPluginDisabled(pluginName)) return;
       return hooks.onMessagePersisted(event);
     },
+    onConversationForked(event) {
+      if (isPluginDisabled(pluginName)) return;
+      return hooks.onConversationForked(event);
+    },
   };
 }
 

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,9 +1,25 @@
 import { getConfig } from "../../../config/loader.js";
 import type {
+  ConversationForkedEvent,
   MemoryPersistenceHooks,
   MessagePersistedEvent,
 } from "../../../persistence/memory-lifecycle-hooks.js";
+import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
+import { forkRetrospectiveState } from "./memory-retrospective-state.js";
+import {
+  forkActivationState,
+  seedForkActivationState,
+} from "./v2/activation-store.js";
+import {
+  extractInjectedConceptSlugs,
+  readInjectedBlock,
+} from "./v2/injected-block-slugs.js";
+import {
+  forkEverInjected,
+  MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+  seedEverInjectedFromSlugs,
+} from "./v3/ever-injected-store.js";
 
 /**
  * The memory feature's implementation of the persistence lifecycle seam
@@ -14,5 +30,80 @@ import { indexMessageNow } from "./indexer.js";
 export const memoryPersistenceHooks: MemoryPersistenceHooks = {
   async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
     await indexMessageNow({ ...event, scopeId: "default" }, getConfig().memory);
+  },
+
+  onConversationForked(event: ConversationForkedEvent): void {
+    const {
+      db,
+      sourceConversationId,
+      forkId,
+      isFullHistoryFork,
+      messagesToCopy,
+      forkedMessageIds,
+      inheritedCompactedMessageCount,
+    } = event;
+
+    // Carry the parent's per-conversation memory state into the child so the
+    // forked thread resumes with the same activation/injection log and
+    // in-context tracker the parent had at fork time. Only valid for
+    // full-history forks: a truncated fork would inherit activation/tracker
+    // entries for turns the child does not actually contain.
+    if (isFullHistoryFork) {
+      forkActivationState(db, sourceConversationId, forkId);
+      forkEverInjected(db, sourceConversationId, forkId);
+      forkGraphMemoryState(sourceConversationId, forkId);
+    } else {
+      // Truncated fork: the wholesale copy above would over-claim, but
+      // seeding nothing makes the child re-select and re-attach every page
+      // whose `<memory>` attachment it already inherited (observed in
+      // production: 89 duplicate page injections on one fork). Derive
+      // `everInjected` from the inherited attachments themselves — scoped to
+      // the child's visible window, since attachments behind an inherited
+      // compaction boundary are not rendered and must stay re-injectable.
+      // The v2 and v3 layers persist under separate metadata keys with the
+      // same `# memory/concepts/<slug>.md` header convention, so each seeds
+      // its own dedup record from its own blocks.
+      const visibleStartIndex = Math.min(
+        inheritedCompactedMessageCount,
+        messagesToCopy.length,
+      );
+      const inheritedSlugs = new Set<string>();
+      const inheritedV3Slugs = new Set<string>();
+      for (const message of messagesToCopy.slice(visibleStartIndex)) {
+        const block = readInjectedBlock(
+          message.metadata,
+          "memoryInjectedBlock",
+        );
+        if (block) {
+          for (const slug of extractInjectedConceptSlugs(block)) {
+            inheritedSlugs.add(slug);
+          }
+        }
+        const v3Block = readInjectedBlock(
+          message.metadata,
+          MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
+        );
+        if (v3Block) {
+          for (const slug of extractInjectedConceptSlugs(v3Block)) {
+            inheritedV3Slugs.add(slug);
+          }
+        }
+      }
+      seedForkActivationState(db, forkId, [...inheritedSlugs]);
+      seedEverInjectedFromSlugs(
+        db,
+        sourceConversationId,
+        forkId,
+        [...inheritedV3Slugs],
+        Date.now(),
+      );
+    }
+    forkRetrospectiveState({
+      database: db,
+      sourceConversationId,
+      forkedConversationId: forkId,
+      forkedMessageIds,
+      lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
+    });
   },
 };


### PR DESCRIPTION
## Summary
- Moves the conversation-fork memory-state carry (v2 activation, v3 ever-injected, v1 graph, retrospective state, + the truncated-fork slug re-derivation) out of `conversation-crud.ts`'s `populateForkContentsInProcess` into the memory plugin's `onConversationForked` handler, behind the `MemoryPersistenceHooks` seam (#36588).
- conversation-crud no longer imports the 7 memory fork functions; `PERSISTENCE_TO_MEMORY_ALLOWLIST` drops 4 entries (graph-memory-state-store, memory-retrospective-state, v2/activation-store, v2/injected-block-slugs) — conversation-crud's set **7 → 3**.
- **Single-source-of-truth win**: deletes conversation-crud's duplicate `readInjectedBlock` — the memory plugin already exports its own (`v2/injected-block-slugs.ts`), which the moved handler uses. Net **−82 lines** in conversation-crud.
- **Behavior byte-identical**: the moved block is the same logic (same branches, same comments), reading from a `ConversationForkedEvent` payload of persistence/host primitives (the `db` handle, ids, `MessageRow`-shaped rows). The disabled-state guard extends to `onConversationForked` (active side effect — gated, per the per-method rule).

## Notes for review
- The fork carry runs **synchronously inside the fork transaction** with the live `db` handle — the reason the seam is a registered handler, not an event bus.
- Test wiring: the two fork tests asserting carried memory state register the default persistence hooks in `beforeEach`, since the carry now flows through the seam.
- ⚠️ **Pre-existing local flake (NOT from this PR):** `conversation-fork-crud.test.ts`'s "forks from the compacted-away prefix…" test fails on fast machines (same-millisecond `Date.now()` message timestamps) when run whole-file. **Verified it fails identically on `main` at the pre-C1 commit `9e242d108b`**, and CI (which runs each file standalone) is green on main. Out of scope here.
- Part of **Track 2 Step C** (decouple persistence → memory). Zero `@vellumai/plugin-api` changes. Risk: medium (core fork write path, behavior-identical + guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)