### PR TITLE
refactor(persistence): invert conversation-wipe + worker-startup memory cleanup through the seam

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -17,6 +17,7 @@ import {
 import { getDb, getLogsDb, getMemoryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { enqueueMemoryJob } from "../persistence/jobs-store.js";
+import { registerDefaultPluginPersistenceHooks } from "../plugins/defaults/index.js";
 
 // Initialize db once before all tests
 await initializeDb();
@@ -34,6 +35,7 @@ describe("wipeConversation", () => {
     getLogsDb()!.run(`DELETE FROM llm_request_logs`);
     db.run(`DELETE FROM messages`);
     db.run(`DELETE FROM conversations`);
+    registerDefaultPluginPersistenceHooks();
   });
 
   test("wipes conversation and all messages", async () => {

--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -54,13 +54,9 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
     "memory-retrospective-constants",
-    "task-memory-cleanup",
     "v3/ever-injected-store",
   ]),
-  "assistant/src/persistence/jobs-worker.ts": new Set([
-    "memory-retrospective-startup-cleanup",
-    "v2/consolidation-job",
-  ]),
+  "assistant/src/persistence/jobs-worker.ts": new Set(["v2/consolidation-job"]),
   "assistant/src/persistence/steps.ts": new Set(["graph/bootstrap"]),
 };
 

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -266,6 +266,10 @@ describe("per-surface disabled-state filtering", () => {
         calls++;
       },
       onConversationForked() {},
+      onConversationWiped() {
+        return 0;
+      },
+      onWorkerStartup() {},
     });
     const event: MessagePersistedEvent = {
       messageId: "msg-1",
@@ -288,5 +292,32 @@ describe("per-surface disabled-state filtering", () => {
     await removeSentinel("default-memory");
     await guarded.onMessagePersisted(event);
     expect(calls).toBe(2);
+  });
+
+  test("cleanup persistence hooks run even while the memory plugin is disabled", async () => {
+    let wiped = 0;
+    let swept = 0;
+    const guarded = guardPersistenceHooksByDisabledState("default-memory", {
+      onMessagePersisted() {},
+      onConversationForked() {},
+      onConversationWiped() {
+        wiped++;
+        return 7;
+      },
+      onWorkerStartup() {
+        swept++;
+      },
+    });
+
+    await createSentinel("default-memory");
+
+    // Cleanup hooks are NOT gated: they must still run (and return real values)
+    // while disabled, or state created while enabled would be orphaned.
+    expect(guarded.onConversationWiped("conv-1")).toBe(7);
+    guarded.onWorkerStartup();
+    expect(wiped).toBe(1);
+    expect(swept).toBe(1);
+
+    await removeSentinel("default-memory");
   });
 });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -29,7 +29,6 @@ import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "../plugins/defaults/memory/memory-retrospective-constants.js";
-import { cancelPendingJobsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
 import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../plugins/defaults/memory/v3/ever-injected-store.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
@@ -1575,8 +1574,9 @@ export function wipeConversation(id: string): WipeConversationResult {
   const deletedSummaryIds: string[] = [];
 
   // Step A — Cancel pending memory jobs (before deleting messages, since
-  // the cancellation queries join on `messages`).
-  const cancelledJobCount = cancelPendingJobsForConversation(id);
+  // the cancellation queries join on `messages`). Cleanup runs even while the
+  // memory plugin is disabled; returns 0 when memory is not present.
+  const cancelledJobCount = getMemoryPersistenceHooks().onConversationWiped(id);
 
   // Step C — Delete conversation-scoped memory summaries and their embeddings.
   const summaryRows = db

--- a/assistant/src/persistence/jobs-worker.ts
+++ b/assistant/src/persistence/jobs-worker.ts
@@ -8,7 +8,6 @@ import {
   diskPressureBackgroundSkipLogFields,
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
-import { sweepOrphanMemoryRetrospectiveConversations } from "../plugins/defaults/memory/memory-retrospective-startup-cleanup.js";
 import { countBufferLines } from "../plugins/defaults/memory/v2/consolidation-job.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -48,6 +47,7 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "./jobs-store.js";
+import { getMemoryPersistenceHooks } from "./memory-lifecycle-hooks.js";
 import { spawnMemoryWorkerProcess } from "./worker-control.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -237,7 +237,7 @@ export function startInProcessMemoryJobsWorker(
   // left behind by daemon crashes mid-job. Best-effort — never block worker
   // startup on cleanup failures.
   try {
-    sweepOrphanMemoryRetrospectiveConversations();
+    getMemoryPersistenceHooks().onWorkerStartup();
   } catch (err) {
     log.warn(
       { err },

--- a/assistant/src/persistence/memory-lifecycle-hooks.test.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.test.ts
@@ -20,6 +20,10 @@ const event: MessagePersistedEvent = {
 const baseHooks: MemoryPersistenceHooks = {
   onMessagePersisted() {},
   onConversationForked() {},
+  onConversationWiped() {
+    return 0;
+  },
+  onWorkerStartup() {},
 };
 
 describe("memory persistence-lifecycle seam", () => {

--- a/assistant/src/persistence/memory-lifecycle-hooks.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.ts
@@ -73,11 +73,31 @@ export interface MemoryPersistenceHooks {
    * transaction with the live `db` handle.
    */
   onConversationForked(event: ConversationForkedEvent): void;
+
+  /**
+   * A conversation is being wiped. The memory feature cancels its pending jobs
+   * for that conversation; returns the number cancelled (0 when memory is not
+   * present). Runs before the conversation's message rows are deleted, since
+   * the cancellation queries join on `messages`. Cleanup — runs even while the
+   * plugin is disabled, so jobs created while it was enabled are not orphaned.
+   */
+  onConversationWiped(conversationId: string): number;
+
+  /**
+   * The background-job worker is starting. The memory feature sweeps orphan
+   * retrospective conversations left by a crash mid-job. Best-effort; the caller
+   * wraps it in try/catch. Cleanup — runs even while the plugin is disabled.
+   */
+  onWorkerStartup(): void;
 }
 
 const NOOP: MemoryPersistenceHooks = {
   onMessagePersisted() {},
   onConversationForked() {},
+  onConversationWiped() {
+    return 0;
+  },
+  onWorkerStartup() {},
 };
 
 let current: MemoryPersistenceHooks = NOOP;

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -506,11 +506,13 @@ export function registerDefaultPluginJobHandlers(): void {
 }
 
 /**
- * Wrap a plugin's persistence hooks so each call no-ops while that plugin is
- * disabled (`assistant plugins disable <name>`), mirroring the read-time
- * disabled-state filtering the injector/hook/job-handler/tool surfaces apply.
- * The sentinel is checked per call, so enable/disable takes effect on the next
- * write without a daemon restart.
+ * Wrap a plugin's persistence hooks so its ACTIVE side-effect hooks no-op while
+ * that plugin is disabled (`assistant plugins disable <name>`), mirroring the
+ * read-time disabled-state filtering the injector/hook/job-handler/tool surfaces
+ * apply. The sentinel is checked per call, so enable/disable takes effect on the
+ * next write without a daemon restart. CLEANUP hooks (`onConversationWiped`,
+ * `onWorkerStartup`) are intentionally NOT gated — they must run even when the
+ * plugin is disabled so state created while it was enabled is not orphaned.
  */
 export function guardPersistenceHooksByDisabledState(
   pluginName: string,
@@ -524,6 +526,15 @@ export function guardPersistenceHooksByDisabledState(
     onConversationForked(event) {
       if (isPluginDisabled(pluginName)) return;
       return hooks.onConversationForked(event);
+    },
+    // Cleanup hooks are NOT gated on disabled-state: they must run even while
+    // the plugin is disabled, or jobs/conversations created while it was
+    // enabled would be orphaned.
+    onConversationWiped(conversationId) {
+      return hooks.onConversationWiped(conversationId);
+    },
+    onWorkerStartup() {
+      return hooks.onWorkerStartup();
     },
   };
 }

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -6,7 +6,9 @@ import type {
 } from "../../../persistence/memory-lifecycle-hooks.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
+import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
+import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 import {
   forkActivationState,
   seedForkActivationState,
@@ -105,5 +107,13 @@ export const memoryPersistenceHooks: MemoryPersistenceHooks = {
       forkedMessageIds,
       lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
     });
+  },
+
+  onConversationWiped(conversationId: string): number {
+    return cancelPendingJobsForConversation(conversationId);
+  },
+
+  onWorkerStartup(): void {
+    sweepOrphanMemoryRetrospectiveConversations();
   },
 };


### PR DESCRIPTION
## Summary
- Inverts the last two memory side-effects in the persistence write/startup paths through the `MemoryPersistenceHooks` seam:
  - `wipeConversation`'s `cancelPendingJobsForConversation` → `onConversationWiped(conversationId): number` (returns the cancelled count; still runs **before** message-delete, since the cancellation joins on `messages`).
  - the worker startup orphan-sweep (`sweepOrphanMemoryRetrospectiveConversations`) → `onWorkerStartup()`.
- `PERSISTENCE_TO_MEMORY_ALLOWLIST` drops 2 entries — `task-memory-cleanup` (conversation-crud) and `memory-retrospective-startup-cleanup` (jobs-worker). conversation-crud's set is now **2** (both constants — cleared next PR); jobs-worker's is **1**.
- **Per-method disabled-state rule:** these are CLEANUP hooks, so the guard wrapper passes them through **UNGATED** — they must run even while the plugin is disabled, or jobs/conversations created while it was enabled would be orphaned (contrast `onMessagePersisted`/`onConversationForked`, which are gated). New `plugin-disabled-state.test.ts` case locks this.

## Notes for review
- Both call sites are reached by the **standalone worker** too; the seam is registered there via `registerMemoryJobHandlers()` (added in the prior PR). **Verified the startup-sweep ordering holds in both processes** — daemon: `initializePlugins()` (bootstrap registers the seam) → `registerMemoryJobHandlers()` → `startMemoryJobsWorker()`; standalone: `registerMemoryJobHandlers()` → `startInProcessMemoryJobsWorker()`. So `onWorkerStartup` is never the no-op when the sweep fires.
- `onConversationWiped` returns the cancelled-job count (NOOP returns 0), so `WipeConversationResult.cancelledJobCount` is unchanged.
- Test wiring: `conversation-wipe.test.ts` registers the default persistence hooks in `beforeEach` (the cancellation now flows through the seam).
- Part of **Track 2 Step C**. Zero `@vellumai/plugin-api`. Behavior byte-identical. Risk: low-medium (cleanup paths, guarded, ordering verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)