### PR TITLE
refactor(persistence): inline the v3 injected-block metadata key in the message schema

### DIFF
--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -54,7 +54,6 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
     "memory-retrospective-constants",
-    "v3/ever-injected-store",
   ]),
   "assistant/src/persistence/jobs-worker.ts": new Set(["v2/consolidation-job"]),
   "assistant/src/persistence/steps.ts": new Set(["graph/bootstrap"]),

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -29,7 +29,6 @@ import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "../plugins/defaults/memory/memory-retrospective-constants.js";
-import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../plugins/defaults/memory/v3/ever-injected-store.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { UserError } from "../util/errors.js";
@@ -171,8 +170,11 @@ export const messageMetadataSchema = z
     imageSourcePaths: z.record(z.string(), z.string()).optional(),
     memoryInjectedBlock: z.string().optional(),
     /** Memory-v3 frozen net-new card block (unwrapped) — the v3 counterpart
-     *  of `memoryInjectedBlock`. A row carries at most one of the two. */
-    [MEMORY_V3_INJECTED_BLOCK_METADATA_KEY]: z.string().optional(),
+     *  of `memoryInjectedBlock`. A row carries at most one of the two. The key
+     *  matches the memory plugin's `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`, kept
+     *  as a literal here (like `memoryInjectedBlock`) so the storage schema does
+     *  not import the memory feature. */
+    memoryV3InjectedBlock: z.string().optional(),
     turnContextBlock: z.string().optional(),
     pkbSystemReminderBlock: z.string().optional(),
     workspaceBlock: z.string().optional(),


### PR DESCRIPTION
## Summary
- `messageMetadataSchema` declared the memory-v3 injected-block field via the imported `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY` constant (a computed key). Inlines it as the literal `memoryV3InjectedBlock` — matching how the v2 sibling `memoryInjectedBlock` is **already** declared — so the storage schema no longer imports the memory feature.
- **Byte-identical**: the literal equals the constant's value (`"memoryV3InjectedBlock"`), an immutable persisted-metadata key. Nothing reads the field typed (the `.memoryV3InjectedBlock` reads elsewhere are a different `blocks` object — the v3 injector output), and the schema `.passthrough()`es regardless.
- Removes the `v3/ever-injected-store` entry from `PERSISTENCE_TO_MEMORY_ALLOWLIST` (conversation-crud now has **1** residual entry — `memory-retrospective-constants` — cleared in the next PR by moving `findMostRecentRetrospectiveFor` into memory).

Part of **Track 2 Step C**. Zero `@vellumai/plugin-api`. Risk: low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)