### PR TITLE
refactor(persistence): move findMostRecentRetrospectiveFor into the memory plugin

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -99,12 +99,6 @@ mock.module("../daemon/process-message.js", () => ({
 }));
 
 const createdConversations: Array<{ conversationType: string }> = [];
-mock.module(
-  "../plugins/defaults/memory/find-most-recent-retrospective-for.js",
-  () => ({
-    findMostRecentRetrospectiveFor: mock(() => null),
-  }),
-);
 mock.module("../persistence/conversation-crud.js", () => ({
   setConversationProcessingStartedAt: () => {},
   isConversationProcessing: () => false,

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -99,6 +99,12 @@ mock.module("../daemon/process-message.js", () => ({
 }));
 
 const createdConversations: Array<{ conversationType: string }> = [];
+mock.module(
+  "../plugins/defaults/memory/find-most-recent-retrospective-for.js",
+  () => ({
+    findMostRecentRetrospectiveFor: mock(() => null),
+  }),
+);
 mock.module("../persistence/conversation-crud.js", () => ({
   setConversationProcessingStartedAt: () => {},
   isConversationProcessing: () => false,
@@ -122,7 +128,6 @@ mock.module("../persistence/conversation-crud.js", () => ({
   })),
   deleteLastExchange: mock(() => 0),
   findAnalysisConversationFor: mock(() => null),
-  findMostRecentRetrospectiveFor: mock(() => null),
   forkConversation: mock(() => ({ id: "conv-fork" })),
   forkConversationForRetrospective: mock(async () => ({ id: "conv-fork" })),
   getConversationOverrideProfile: () => undefined,

--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -52,9 +52,6 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
  * guard is to ratchet this set down to empty, never up.
  */
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
-  "assistant/src/persistence/conversation-crud.ts": new Set([
-    "memory-retrospective-constants",
-  ]),
   "assistant/src/persistence/jobs-worker.ts": new Set(["v2/consolidation-job"]),
   "assistant/src/persistence/steps.ts": new Set(["graph/bootstrap"]),
 };

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -28,7 +28,6 @@ import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
-import { MEMORY_RETROSPECTIVE_SOURCES } from "../plugins/defaults/memory/memory-retrospective-constants.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { UserError } from "../util/errors.js";
@@ -688,67 +687,6 @@ export function findAnalysisConversationFor(
     .limit(1)
     .get();
   return row ? { id: row.id } : null;
-}
-
-/**
- * Find the most recent memory-retrospective background conversation rooted
- * at `parentConversationId`. Used by the memory-retrospective job handler
- * to load the prior retrospective's `remember` calls into the new run's
- * `<already_remembered>` block — bounded source-of-truth for "what the
- * prior pass already saved" that scales as the source conversation grows.
- *
- * Walks up `forkParentConversationId` when no retrospective exists at the
- * current level. This lets a forked conversation inherit dedup context from
- * its source's most recent retro on the fork's *first* retrospective —
- * otherwise the fork would re-save every fact the source already retro'd.
- * Once the fork accumulates its own retros, those are found at the first
- * iteration and we never walk up.
- *
- * The returned `forkParentConversationId` is the conversation the
- * retrospective row is rooted at — `parentConversationId` itself when it has
- * its own retros, or an ancestor when the chain walk found the row higher
- * up. Callers that mutate the prior (e.g. GC of superseded runs) must check
- * it against the source conversation: an ancestor's row is that ancestor's
- * dedup baseline, not the caller's to delete.
- *
- * Returns `null` when no prior retrospective exists anywhere in the fork
- * chain (true first-run case).
- *
- * Hits `idx_conversations_fork_parent_conversation_id` for the
- * `forkParentConversationId` lookup.
- */
-const MAX_FORK_CHAIN_DEPTH = 16;
-
-export function findMostRecentRetrospectiveFor(
-  parentConversationId: string,
-): { id: string; forkParentConversationId: string } | null {
-  const db = getDb();
-  let currentId: string | null = parentConversationId;
-  for (let depth = 0; depth < MAX_FORK_CHAIN_DEPTH && currentId; depth++) {
-    const row = db
-      .select({ id: conversations.id })
-      .from(conversations)
-      .where(
-        and(
-          inArray(conversations.source, MEMORY_RETROSPECTIVE_SOURCES),
-          eq(conversations.forkParentConversationId, currentId),
-        ),
-      )
-      .orderBy(desc(conversations.createdAt))
-      .limit(1)
-      .get();
-    if (row) return { id: row.id, forkParentConversationId: currentId };
-
-    const parent = db
-      .select({
-        forkParentConversationId: conversations.forkParentConversationId,
-      })
-      .from(conversations)
-      .where(eq(conversations.id, currentId))
-      .get();
-    currentId = parent?.forkParentConversationId ?? null;
-  }
-  return null;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/__tests__/find-most-recent-retrospective-for.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/find-most-recent-retrospective-for.test.ts
@@ -9,13 +9,11 @@ mock.module("../../../../util/logger.js", () => ({
     }),
 }));
 
-import {
-  createConversation,
-  findMostRecentRetrospectiveFor,
-} from "../../../../persistence/conversation-crud.js";
+import { createConversation } from "../../../../persistence/conversation-crud.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 import { conversations } from "../../../../persistence/schema/index.js";
+import { findMostRecentRetrospectiveFor } from "../find-most-recent-retrospective-for.js";
 import { MEMORY_RETROSPECTIVE_SOURCE } from "../memory-retrospective-constants.js";
 
 await initializeDb();

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -130,6 +130,13 @@ mock.module("../memory-retrospective-state.js", () => ({
   ],
 }));
 
+mock.module("../find-most-recent-retrospective-for.js", () => ({
+  findMostRecentRetrospectiveFor: (_id: string) =>
+    priorRetroId
+      ? { id: priorRetroId, forkParentConversationId: priorRetroOwnerId }
+      : null,
+}));
+
 mock.module("../../../../persistence/conversation-crud.js", () => ({
   getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
   getMessages: (id: string) => {
@@ -137,10 +144,6 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
     if (id === priorRetroId) return priorRetroMessages;
     return [];
   },
-  findMostRecentRetrospectiveFor: (_id: string) =>
-    priorRetroId
-      ? { id: priorRetroId, forkParentConversationId: priorRetroOwnerId }
-      : null,
   // The handler calls `getConversation(sourceConversationId)` to read the
   // source's title for the fork title. `collectPriorRetrospectiveRemembers`
   // also calls it with the prior retro id to discriminate legacy vs fork

--- a/assistant/src/plugins/defaults/memory/find-most-recent-retrospective-for.ts
+++ b/assistant/src/plugins/defaults/memory/find-most-recent-retrospective-for.ts
@@ -1,0 +1,66 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { conversations } from "../../../persistence/schema/index.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+
+const MAX_FORK_CHAIN_DEPTH = 16;
+
+/**
+ * Find the most recent memory-retrospective background conversation rooted
+ * at `parentConversationId`. Used by the memory-retrospective job handler
+ * to load the prior retrospective's `remember` calls into the new run's
+ * `<already_remembered>` block — bounded source-of-truth for "what the
+ * prior pass already saved" that scales as the source conversation grows.
+ *
+ * Walks up `forkParentConversationId` when no retrospective exists at the
+ * current level. This lets a forked conversation inherit dedup context from
+ * its source's most recent retro on the fork's *first* retrospective —
+ * otherwise the fork would re-save every fact the source already retro'd.
+ * Once the fork accumulates its own retros, those are found at the first
+ * iteration and we never walk up.
+ *
+ * The returned `forkParentConversationId` is the conversation the
+ * retrospective row is rooted at — `parentConversationId` itself when it has
+ * its own retros, or an ancestor when the chain walk found the row higher
+ * up. Callers that mutate the prior (e.g. GC of superseded runs) must check
+ * it against the source conversation: an ancestor's row is that ancestor's
+ * dedup baseline, not the caller's to delete.
+ *
+ * Returns `null` when no prior retrospective exists anywhere in the fork
+ * chain (true first-run case).
+ *
+ * Hits `idx_conversations_fork_parent_conversation_id` for the
+ * `forkParentConversationId` lookup.
+ */
+export function findMostRecentRetrospectiveFor(
+  parentConversationId: string,
+): { id: string; forkParentConversationId: string } | null {
+  const db = getDb();
+  let currentId: string | null = parentConversationId;
+  for (let depth = 0; depth < MAX_FORK_CHAIN_DEPTH && currentId; depth++) {
+    const row = db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(
+        and(
+          inArray(conversations.source, MEMORY_RETROSPECTIVE_SOURCES),
+          eq(conversations.forkParentConversationId, currentId),
+        ),
+      )
+      .orderBy(desc(conversations.createdAt))
+      .limit(1)
+      .get();
+    if (row) return { id: row.id, forkParentConversationId: currentId };
+
+    const parent = db
+      .select({
+        forkParentConversationId: conversations.forkParentConversationId,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, currentId))
+      .get();
+    currentId = parent?.forkParentConversationId ?? null;
+  }
+  return null;
+}

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -57,7 +57,6 @@ import {
   type ConversationRow,
   deleteConversation,
   deleteConversationGently,
-  findMostRecentRetrospectiveFor,
   forkConversationForRetrospective,
   getConversation,
   getMessagesAfter,
@@ -73,6 +72,7 @@ import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
 import { wakeAgentForOpportunity } from "../../../runtime/agent-wake.js";
 import { getLogger } from "../../../util/logger.js";
+import { findMostRecentRetrospectiveFor } from "./find-most-recent-retrospective-for.js";
 import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,


### PR DESCRIPTION
## Summary
- Moves `findMostRecentRetrospectiveFor` (the fork-chain walk that finds a conversation's most recent memory-retrospective) out of `conversation-crud.ts` into the memory plugin (`plugins/defaults/memory/find-most-recent-retrospective-for.ts`). It's a memory-domain query — only the memory-retrospective job + tests call it — and the only reason `conversation-crud` imported `MEMORY_RETROSPECTIVE_SOURCES`.
- **conversation-crud now imports ZERO memory modules.** Its `PERSISTENCE_TO_MEMORY_ALLOWLIST` entry is removed entirely (the allowlist is down to jobs-worker + steps.ts).
- **Behavior byte-identical** (verbatim move; the function + `MAX_FORK_CHAIN_DEPTH` carried together). The query reads the `conversations` table via persistence helpers (memory → persistence, the allowed direction).

## Notes for review
- The co-located test `find-most-recent-retrospective-for.test.ts` already lived in `memory/__tests__` — it now imports the function from its sibling.
- Two tests `mock.module("conversation-crud")` and stubbed `findMostRecentRetrospectiveFor`; those stubs moved to `mock.module(".../find-most-recent-retrospective-for.js")` (verified each in isolation — the mock.module footgun).
- Boundary baseline unchanged: depth-3 memory files already import `persistence/db-connection` + `schema`.
- Completes the **conversation-crud decoupling** for Track 2 Step C. Zero `@vellumai/plugin-api`. Risk: low (verbatim move, memory-only-called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)