### PR TITLE
refactor(assistant): move background-wake startup registration into startScheduler

### DIFF
--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -229,19 +229,25 @@ describe("background wake intent publisher hooks", () => {
     );
   });
 
-  test("daemon lifecycle publishes once after heartbeat and scheduler startup", () => {
+  test("scheduler startup publishes the daemon-startup wake intent", () => {
+    const schedulerSource = readFileSync(
+      new URL("../schedule/scheduler.ts", import.meta.url),
+      "utf-8",
+    );
     const lifecycleSource = readFileSync(
       new URL("../daemon/lifecycle.ts", import.meta.url),
       "utf-8",
     );
 
-    // The wake intent is published once, immediately after the heartbeat is
-    // started (the scheduler is started earlier), so the daemon-startup intent
-    // reflects the live singletons. Tolerant of indentation so the assertion
-    // survives reformatting of lifecycle.ts.
-    expect(lifecycleSource).toMatch(
-      /startHeartbeatService\(\);\n[ \t]*refreshBackgroundWakeIntent\("daemon-startup"\);/,
+    // The daemon-startup intent is published from the end of startScheduler(),
+    // so it lands once the scheduler is live and its schedules are visible to
+    // computeNextBackgroundWakeIntent. Heartbeat startup republishes with the
+    // live heartbeat timing via its own "heartbeat-*" refreshes.
+    expect(schedulerSource).toContain(
+      'refreshBackgroundWakeIntentSoon("daemon-startup")',
     );
+    // Lifecycle no longer publishes the intent directly.
+    expect(lifecycleSource).not.toContain("refreshBackgroundWakeIntent");
   });
 
   test("shutdown paths do not clear background wake intents", () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -2,7 +2,6 @@ import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
 
-import { refreshBackgroundWakeIntent } from "../background-wake/publisher.js";
 import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
 import { setRelayBroadcast } from "../calls/relay-server.js";
@@ -23,7 +22,6 @@ import { startCliIpcServer } from "../ipc/assistant-server.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { startSkillIpcServer } from "../ipc/skill-server.js";
 import { registerMemoryJobHandlers } from "../jobs/register-job-handlers.js";
-import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import {
@@ -65,10 +63,7 @@ import {
 import { startRuntimeHttpServer } from "../runtime/http-server.js";
 import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
-import {
-  publishConfigChanged,
-  publishConversationListChanged,
-} from "../runtime/sync/resource-sync-events.js";
+import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import { rotateToolInvocations } from "../telemetry/tool-usage-store.js";
@@ -860,85 +855,29 @@ export async function runDaemon(): Promise<void> {
     );
   }
 
-  startScheduler(
-    async (conversationId, message, options) => {
-      await processMessage(
-        conversationId,
-        message,
-        options
-          ? {
-              ...(options.trustClass
-                ? {
-                    trustContext: {
-                      sourceChannel: "vellum",
-                      trustClass: options.trustClass,
-                    },
-                  }
-                : {}),
-              ...(options.taskRunId ? { taskRunId: options.taskRunId } : {}),
-              ...(options.overrideProfile
-                ? { overrideProfile: options.overrideProfile }
-                : {}),
-              ...(options.cronRunId ? { cronRunId: options.cronRunId } : {}),
-            }
-          : undefined,
-      );
-    },
-    async (schedule) => {
-      await emitNotificationSignal({
-        sourceEventName: "schedule.notify",
-        sourceChannel: "scheduler",
-        sourceContextId: schedule.id,
-        attentionHints: {
-          requiresAction: true,
-          urgency: "high",
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
-        contextPayload: {
-          scheduleId: schedule.id,
-          label: schedule.label,
-          message: schedule.message,
-        },
-        routingIntent: schedule.routingIntent,
-        routingHints: schedule.routingHints,
-        conversationMetadata: {
-          groupId: "system:scheduled",
-          scheduleJobId: schedule.id,
-          source: "schedule",
-        },
-        dedupeKey: `schedule:notify:${schedule.id}:${Date.now()}`,
-        throwOnError: true,
-      });
-    },
-    (notification) => {
-      void emitNotificationSignal({
-        sourceEventName: "watcher.notification",
-        sourceChannel: "watcher",
-        sourceContextId: `watcher-${Date.now()}`,
-        attentionHints: {
-          requiresAction: false,
-          urgency: "low",
-          isAsyncBackground: true,
-          visibleInSourceNow: false,
-        },
-        contextPayload: {
-          title: notification.title,
-          body: notification.body,
-        },
-        dedupeKey: `watcher:notification:${crypto.randomUUID()}`,
-      });
-    },
-    (info) => {
-      broadcastMessage({
-        type: "schedule_conversation_created",
-        conversationId: info.conversationId,
-        scheduleJobId: info.scheduleJobId,
-        title: info.title,
-      });
-      publishConversationListChanged("created");
-    },
-  );
+  startScheduler(async (conversationId, message, options) => {
+    await processMessage(
+      conversationId,
+      message,
+      options
+        ? {
+            ...(options.trustClass
+              ? {
+                  trustContext: {
+                    sourceChannel: "vellum",
+                    trustClass: options.trustClass,
+                  },
+                }
+              : {}),
+            ...(options.taskRunId ? { taskRunId: options.taskRunId } : {}),
+            ...(options.overrideProfile
+              ? { overrideProfile: options.overrideProfile }
+              : {}),
+            ...(options.cronRunId ? { cronRunId: options.cronRunId } : {}),
+          }
+        : undefined,
+    );
+  });
 
   // Fire-and-forget: Qdrant init and memory worker startup run concurrently
   // with the rest of daemon boot. Must run AFTER `startRuntimeHttpServer()`
@@ -1190,7 +1129,6 @@ export async function runDaemon(): Promise<void> {
   startWorkspaceHeartbeatService();
 
   startHeartbeatService();
-  refreshBackgroundWakeIntent("daemon-startup");
 
   installShutdownHandlers();
 

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -10,7 +10,9 @@ import { bootstrapConversation } from "../persistence/conversation-bootstrap.js"
 import { getConversation } from "../persistence/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { runBackgroundJob } from "../runtime/background-job-runner.js";
+import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import { areCoreToolsInitialized } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -53,6 +55,82 @@ type ScheduleConversationCreatedNotifier = (info: {
   scheduleJobId: string;
   title: string;
 }) => void;
+
+/**
+ * Emit the attention signal for a `notify`-mode schedule firing. The default
+ * `notifyScheduleOneShot` for {@link startScheduler}; tests inject a stub.
+ */
+async function emitScheduleNotifySignal(payload: {
+  id: string;
+  label: string;
+  message: string;
+  routingIntent: RoutingIntent;
+  routingHints: Record<string, unknown>;
+}): Promise<void> {
+  await emitNotificationSignal({
+    sourceEventName: "schedule.notify",
+    sourceChannel: "scheduler",
+    sourceContextId: payload.id,
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      scheduleId: payload.id,
+      label: payload.label,
+      message: payload.message,
+    },
+    routingIntent: payload.routingIntent,
+    routingHints: payload.routingHints,
+    conversationMetadata: {
+      groupId: "system:scheduled",
+      scheduleJobId: payload.id,
+      source: "schedule",
+    },
+    dedupeKey: `schedule:notify:${payload.id}:${Date.now()}`,
+    throwOnError: true,
+  });
+}
+
+/** Emit the attention signal for a watcher notification. */
+function emitWatcherNotifySignal(notification: {
+  title: string;
+  body: string;
+}): void {
+  void emitNotificationSignal({
+    sourceEventName: "watcher.notification",
+    sourceChannel: "watcher",
+    sourceContextId: `watcher-${Date.now()}`,
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      title: notification.title,
+      body: notification.body,
+    },
+    dedupeKey: `watcher:notification:${crypto.randomUUID()}`,
+  });
+}
+
+/** Broadcast + refresh the conversation list when a schedule creates one. */
+function broadcastScheduleConversationCreated(info: {
+  conversationId: string;
+  scheduleJobId: string;
+  title: string;
+}): void {
+  broadcastMessage({
+    type: "schedule_conversation_created",
+    conversationId: info.conversationId,
+    scheduleJobId: info.scheduleJobId,
+    title: info.title,
+  });
+  publishConversationListChanged("created");
+}
 
 export interface SchedulerHandle {
   runOnce(): Promise<number>;
@@ -120,11 +198,26 @@ async function handleExecutionFailure(params: {
 /** The running scheduler, retained so shutdown can stop it. */
 let instance: SchedulerHandle | null = null;
 
+/**
+ * Publish the current background wake intent without statically importing the
+ * publisher — `background-wake/next-wake.js` imports the schedule store, so a
+ * static import here would close an import cycle. Best-effort and fire-and-forget.
+ */
+function refreshBackgroundWakeIntentSoon(reason: string): void {
+  void import("../background-wake/publisher.js")
+    .then(({ refreshBackgroundWakeIntent }) =>
+      refreshBackgroundWakeIntent(reason),
+    )
+    .catch((err) =>
+      log.warn({ err, reason }, "Failed to queue background wake refresh"),
+    );
+}
+
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
-  notifyScheduleOneShot: ScheduleNotifyModeNotifier,
-  watcherNotifier?: WatcherNotifier,
-  onScheduleConversationCreated?: ScheduleConversationCreatedNotifier,
+  notifyScheduleOneShot: ScheduleNotifyModeNotifier = emitScheduleNotifySignal,
+  watcherNotifier: WatcherNotifier = emitWatcherNotifySignal,
+  onScheduleConversationCreated: ScheduleConversationCreatedNotifier = broadcastScheduleConversationCreated,
 ): SchedulerHandle {
   let stopped = false;
   let tickRunning = false;
@@ -177,6 +270,11 @@ export function startScheduler(
       clearInterval(timer);
     },
   };
+
+  // Publish the initial background wake intent now that the scheduler is live
+  // and its schedules are visible to `computeNextBackgroundWakeIntent`.
+  refreshBackgroundWakeIntentSoon("daemon-startup");
+
   return instance;
 }
 


### PR DESCRIPTION
## Why

The daemon-startup background-wake publish lived as a standalone `refreshBackgroundWakeIntent("daemon-startup")` line in `lifecycle.ts`. Since the wake intent is computed from the scheduler's schedules (and, for now, the heartbeat), and heartbeats are slated to fold into the scheduler, the scheduler is the natural owner of that registration.

## What

**1. Wake registration moves into `startScheduler()`.**
- `scheduler.ts` publishes the `"daemon-startup"` intent at the end of `startScheduler()`, once the scheduler is live and its schedules are visible to `computeNextBackgroundWakeIntent`. It uses the same dynamic-import publisher pattern that `schedule-store.ts` and `heartbeat-service.ts` already use, to avoid the `scheduler → background-wake/next-wake → schedule-store` import cycle.
- `lifecycle.ts` drops the standalone call and its import.
- No behavior change: heartbeat startup still republishes with the live heartbeat timing via its own `"heartbeat-*"` refreshes, so the published intent converges the same way it did before.

**2. Three of `startScheduler`'s four injected callbacks are inlined as optional defaults.**
- The notify-mode signal, watcher-notify, and schedule-conversation-created broadcast now have default implementations in `scheduler.ts` (using `emitNotificationSignal` — already imported — plus `broadcastMessage` and `publishConversationListChanged`, both leaf runtime modules). Production calls `startScheduler(processMessage)`; the ~80-line call site in `lifecycle.ts` collapses to one argument.
- The six scheduler test suites keep injecting their mocks positionally (overriding the defaults), so no test rewrites were needed.

**`processMessage` stays injected** — deliberately. `process-message.ts` pulls in the whole conversation/agent pipeline (conversation, host proxies, subagent manager…), and `scheduler-types.ts` exists specifically to keep the scheduler decoupled from it. Folding that import into `scheduler.ts` would fight that decoupling, so it remains the one parameter.

**3. Updated the source-scraping guard test** (`wake-intent-hooks.test.ts`) that pinned the old placement: it now asserts `startScheduler()` contains the `"daemon-startup"` publish and that `lifecycle.ts` no longer references `refreshBackgroundWakeIntent` at all.

## Verification

- `tsc --noEmit`, eslint, prettier all clean.
- All six scheduler suites pass in isolation (`scheduler-recurrence`, `task-scheduler`, `scheduler-wake`, `schedule-retry`, `scheduler-disk-pressure`, `scheduler-reuse-conversation`), plus `next-wake`, `platform-client`, `background-wake-routes`, and the updated `wake-intent-hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_