### PR TITLE
perf(persistence): shrink conversation-delete batch size to bound FTS lock-hold

### DIFF
--- a/assistant/src/persistence/conversation-row-batch-delete.ts
+++ b/assistant/src/persistence/conversation-row-batch-delete.ts
@@ -49,8 +49,15 @@ import {
  * for a contending foreground write is one short batch, even on a bloated
  * database; per-batch statement overhead stays negligible and delete latency
  * doesn't matter (nobody waits on a background GC).
+ *
+ * Each deleted `messages` row fires the per-row `messages_fts_ad` trigger,
+ * whose `DELETE FROM messages_fts WHERE message_id = old.id` scans the FTS
+ * index (`message_id` is an fts5 `UNINDEXED` column), so a single batch is far
+ * more expensive than its row count suggests. A small batch keeps that
+ * per-batch lock-hold short enough that a contending live user turn isn't
+ * starved.
  */
-export const DEFAULT_DELETE_BATCH_SIZE = 50;
+export const DEFAULT_DELETE_BATCH_SIZE = 5;
 
 /**
  * Pause inserted between batch subprocess calls. Without it the delete releases


### PR DESCRIPTION
## Prompt / plan

The memory-retrospective GC's gentle conversation delete was still too expensive — each batch held the SQLite write lock ~14s, starving live user turns.

### Why a batch is so expensive

Each deleted `messages` row fires the per-row `messages_fts_ad` AFTER DELETE trigger:

```sql
DELETE FROM messages_fts WHERE message_id = old.id;
```

`message_id` is an fts5 **`UNINDEXED`** column, so that lookup is a full scan of the FTS table *per row*. A 50-row batch therefore does ~50 full FTS scans inside one lock-holding transaction, which is far more expensive than the row count suggests.

We explored handling FTS in bulk (pre-deleting the conversation's FTS rows so they'd be their own writes), but with the trigger left on it doesn't help: the trigger still fires once per `messages` row and still does the full-index scan, even when the FTS rows are already gone. Eliminating that scan would require either dropping/recreating the trigger at runtime (schema mutation that belongs in a migration, not in delete logic) or a schema change to key the delete on rowid — both out of scope here. So this PR keeps the change to the one safe lever.

### Change

Drop `DEFAULT_DELETE_BATCH_SIZE` from **50 → 5**. Each batch's lock-hold becomes roughly a tenth of what it was, so contending foreground writes get a chance to acquire the lock between batches (the inter-batch yield already exists). Total background-delete wall time goes up, but nothing waits on a background GC.

## Test plan

- Existing `conversation-row-batch-delete.test.ts` suite passes (8/8) — exercised via the in-process SQLite fallback since the CI host has no `sqlite3` CLI.
- `tsc --noEmit`, `eslint`, and Prettier all clean (enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)