### PR TITLE
refactor(assistant): remove scheduler DI params, inline processMessage, hoist wake import

### DIFF
--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -43,6 +43,27 @@ mock.module("../runtime/background-job-runner.js", () => ({
   },
 }));
 
+// The scheduler's conversation-reuse path dispatches through `processMessage`;
+// route it to the same per-test delegate the runner mock uses.
+let processMessageImpl: (
+  conversationId: string,
+  message: string,
+) => Promise<unknown> = async () => {};
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: (conversationId: string, message: string) =>
+    processMessageImpl(conversationId, message),
+}));
+
+// Notify-mode firings dispatch through `emitNotificationSignal`; a per-test
+// delegate lets a scenario make the notification throw to drive failure paths.
+let emitNotificationSignalImpl: (
+  payload: unknown,
+) => Promise<unknown> = async () => {};
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (payload: unknown) =>
+    emitNotificationSignalImpl(payload),
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { applyRetryDecision, decideRetry } from "../schedule/retry-policy.js";
@@ -62,24 +83,23 @@ import { startScheduler as startSchedulerReal } from "../schedule/scheduler.js";
 import type { ScheduleMessageProcessor } from "../schedule/scheduler-types.js";
 
 /**
- * Wrap `startScheduler` so the same `processMessage` the scheduler holds for
- * its conversation-reuse path is also handed to the mocked
- * `runBackgroundJob` for the fresh-bootstrap path. The two paths in scheduler
- * production code dispatch through different mechanisms; tests exercise both
- * deterministically through this single callback.
+ * Wrap `startScheduler` so a single per-test `processMessage` callback drives
+ * both scheduler dispatch paths: the conversation-reuse path (which calls the
+ * mocked `daemon/process-message`) and the fresh-bootstrap path (which calls
+ * the mocked `runBackgroundJob`). Tests exercise both deterministically through
+ * this one callback.
  */
 function startScheduler(
   processMessage: ScheduleMessageProcessor,
-  notifyScheduleOneShot: Parameters<typeof startSchedulerReal>[1],
-  options?: Parameters<typeof startSchedulerReal>[2],
+  _notifyScheduleOneShot?: unknown,
+  _options?: unknown,
 ): SchedulerHandle {
-  injectedProcessMessageForRunner = async (
-    conversationId: string,
-    message: string,
-  ) => {
+  const dispatch = async (conversationId: string, message: string) => {
     await processMessage(conversationId, message, { trustClass: "guardian" });
   };
-  return startSchedulerReal(processMessage, notifyScheduleOneShot, options);
+  processMessageImpl = dispatch;
+  injectedProcessMessageForRunner = dispatch;
+  return startSchedulerReal();
 }
 
 await initializeDb();
@@ -102,6 +122,7 @@ function forceScheduleDue(scheduleId: string): void {
 
 describe("schedule retry store", () => {
   beforeEach(() => {
+    emitNotificationSignalImpl = async () => {};
     const db = getDb();
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");
@@ -203,6 +224,7 @@ describe("scheduler retry integration", () => {
   let scheduler: SchedulerHandle;
 
   beforeEach(() => {
+    emitNotificationSignalImpl = async () => {};
     const db = getDb();
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");
@@ -389,11 +411,11 @@ describe("scheduler retry integration", () => {
       maxRetries: 2,
     });
 
-    const notifyScheduleOneShot = async () => {
+    emitNotificationSignalImpl = async () => {
       throw new Error("notify failed");
     };
 
-    scheduler = startScheduler(async () => {}, notifyScheduleOneShot);
+    scheduler = startScheduler(async () => {});
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -439,6 +461,7 @@ describe("scheduler retry integration", () => {
 
 describe("crash recovery", () => {
   beforeEach(() => {
+    emitNotificationSignalImpl = async () => {};
     const db = getDb();
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");
@@ -574,6 +597,7 @@ describe("scheduler-recovery equivalence", () => {
   let scheduler: SchedulerHandle;
 
   beforeEach(() => {
+    emitNotificationSignalImpl = async () => {};
     const db = getDb();
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");

--- a/assistant/src/__tests__/scheduler-disk-pressure.test.ts
+++ b/assistant/src/__tests__/scheduler-disk-pressure.test.ts
@@ -89,6 +89,18 @@ mock.module("../daemon/disk-pressure-background-gate.js", () => ({
   shouldLogDiskPressureBackgroundSkip: () => true,
 }));
 
+const mockProcessMessage = mock((..._args: unknown[]) => Promise.resolve());
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: mockProcessMessage,
+}));
+
+const mockEmitNotificationSignal = mock((..._args: unknown[]) =>
+  Promise.resolve(),
+);
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: mockEmitNotificationSignal,
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
@@ -104,6 +116,8 @@ function rawDb(): import("bun:sqlite").Database {
 describe("scheduler disk pressure gate", () => {
   beforeEach(() => {
     locked = true;
+    mockProcessMessage.mockClear();
+    mockEmitNotificationSignal.mockClear();
     const db = getDb();
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");
@@ -122,14 +136,11 @@ describe("scheduler disk pressure gate", () => {
       nextRunAt: dueAt,
     });
 
-    const processMessage = mock(() => Promise.resolve());
-    const notify = mock(() => Promise.resolve());
-
-    const processed = await runScheduleOnce(processMessage, notify);
+    const processed = await runScheduleOnce();
 
     expect(processed).toBe(0);
-    expect(processMessage).not.toHaveBeenCalled();
-    expect(notify).not.toHaveBeenCalled();
+    expect(mockProcessMessage).not.toHaveBeenCalled();
+    expect(mockEmitNotificationSignal).not.toHaveBeenCalled();
 
     const row = rawDb()
       .query("SELECT status, next_run_at FROM cron_jobs WHERE id = ?")

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -50,6 +50,25 @@ mock.module("../runtime/background-job-runner.js", () => ({
   },
 }));
 
+// The scheduler dispatches reuse/task-path messages through `processMessage`;
+// route them to a per-test delegate so tests can capture those calls.
+let processMessageImpl: (
+  conversationId: string,
+  message: string,
+) => Promise<void> = async () => {};
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: (conversationId: string, message: string) =>
+    processMessageImpl(conversationId, message),
+}));
+
+// Notify-mode firings go through `emitNotificationSignal`; capture them.
+const notifySignalCalls: Array<Record<string, unknown>> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (payload: Record<string, unknown>) => {
+    notifySignalCalls.push(payload);
+  },
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -138,6 +157,8 @@ describe("scheduler RRULE execution", () => {
     db.run("DELETE FROM conversations");
     onRunBackgroundJobPrompt = null;
     runBackgroundJobShouldFail = false;
+    processMessageImpl = async () => {};
+    notifySignalCalls.length = 0;
   });
 
   test("RRULE schedule fires and creates cron_runs entry", async () => {
@@ -163,10 +184,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -201,12 +219,12 @@ describe("scheduler RRULE execution", () => {
     const directCalls: { conversationId: string; message: string }[] = [];
     let onMessage: (() => void) | undefined;
     const messageReceived = new Promise<void>((r) => (onMessage = r));
-    const processMessage = async (conversationId: string, message: string) => {
+    processMessageImpl = async (conversationId, message) => {
       directCalls.push({ conversationId, message });
       onMessage?.();
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     // The run_task path involves a dynamic import which can take >50ms in CI,
     // exceeding the patched setTimeout delay. Await the actual callback instead
     // of relying on a fixed timeout.
@@ -271,10 +289,7 @@ describe("scheduler RRULE execution", () => {
     };
 
     // First tick: the expired schedule should fire its final due run
-    const scheduler1 = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -294,10 +309,7 @@ describe("scheduler RRULE execution", () => {
 
     // Second tick: the disabled schedule must NOT fire again
     processedMessages.length = 0;
-    const scheduler2 = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -327,10 +339,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -385,10 +394,7 @@ describe("scheduler RRULE execution", () => {
     // Force the schedule to be due
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -437,10 +443,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push(prompt);
     };
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -516,10 +519,7 @@ describe("scheduler RRULE execution", () => {
         processedMessages.push(prompt);
       };
 
-      const scheduler = startScheduler(
-        async () => {},
-        () => {},
-      );
+      const scheduler = startScheduler();
       await new Promise((resolve) => setTimeout(resolve, 500));
       scheduler.stop();
 
@@ -557,8 +557,7 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
     const forcedDueAt = getSchedule(schedule.id)!.nextRunAt;
 
-    const processMessage = async () => {};
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -589,10 +588,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -623,32 +619,19 @@ describe("scheduler RRULE execution", () => {
 
     expect(getSchedule(schedule.id)!.status).toBe("active");
 
-    const notifyCalls: Array<{
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }> = [];
-    const notifyScheduleOneShot = (payload: {
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }) => {
-      notifyCalls.push(payload);
-    };
-
-    const scheduler = startScheduler(async () => {}, notifyScheduleOneShot);
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    expect(notifyCalls).toHaveLength(1);
-    expect(notifyCalls[0]).toEqual({
-      id: schedule.id,
-      label: "One-shot notify",
-      message: "Notify about this",
+    expect(notifySignalCalls).toHaveLength(1);
+    expect(notifySignalCalls[0]).toMatchObject({
+      sourceEventName: "schedule.notify",
+      sourceContextId: schedule.id,
+      contextPayload: {
+        scheduleId: schedule.id,
+        label: "One-shot notify",
+        message: "Notify about this",
+      },
       routingIntent: "multi_channel",
       routingHints: { channel: "slack" },
     });
@@ -671,10 +654,7 @@ describe("scheduler RRULE execution", () => {
 
     runBackgroundJobShouldFail = true;
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -699,32 +679,19 @@ describe("scheduler RRULE execution", () => {
 
     forceScheduleDue(schedule.id);
 
-    const notifyCalls: Array<{
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }> = [];
-    const notifyScheduleOneShot = (payload: {
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }) => {
-      notifyCalls.push(payload);
-    };
-
-    const scheduler = startScheduler(async () => {}, notifyScheduleOneShot);
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    expect(notifyCalls).toHaveLength(1);
-    expect(notifyCalls[0]).toEqual({
-      id: schedule.id,
-      label: "Recurring notify",
-      message: "Recurring notification",
+    expect(notifySignalCalls).toHaveLength(1);
+    expect(notifySignalCalls[0]).toMatchObject({
+      sourceEventName: "schedule.notify",
+      sourceContextId: schedule.id,
+      contextPayload: {
+        scheduleId: schedule.id,
+        label: "Recurring notify",
+        message: "Recurring notification",
+      },
       routingIntent: "single_channel",
       routingHints: { preferred: "email" },
     });
@@ -752,30 +719,13 @@ describe("scheduler RRULE execution", () => {
       },
     });
 
-    const notifyCalls: Array<{
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }> = [];
-    const notifyScheduleOneShot = (payload: {
-      id: string;
-      label: string;
-      message: string;
-      routingIntent: string;
-      routingHints: Record<string, unknown>;
-    }) => {
-      notifyCalls.push(payload);
-    };
-
-    const scheduler = startScheduler(async () => {}, notifyScheduleOneShot);
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    expect(notifyCalls).toHaveLength(1);
-    expect(notifyCalls[0].routingIntent).toBe("all_channels");
-    expect(notifyCalls[0].routingHints).toEqual({
+    expect(notifySignalCalls).toHaveLength(1);
+    expect(notifySignalCalls[0].routingIntent).toBe("all_channels");
+    expect(notifySignalCalls[0].routingHints).toEqual({
       requestedByUser: true,
       channelMentions: ["telegram", "slack"],
       priority: "high",

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -86,9 +86,28 @@ mock.module("../runtime/background-job-runner.js", () => ({
   },
 }));
 
+// The scheduler's reuse path dispatches into the existing conversation through
+// `processMessage`; capture those calls into the same shared log as the
+// fresh-bootstrap runner so assertions don't need to know which path ran.
+const captureProcessedMessage = async (
+  conversationId: string,
+  message: string,
+): Promise<void> => {
+  processedMessages.push({ conversationId, message });
+};
+let processMessageImpl: (
+  conversationId: string,
+  message: string,
+) => Promise<void> = captureProcessedMessage;
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: (conversationId: string, message: string) =>
+    processMessageImpl(conversationId, message),
+}));
+
 import { deleteConversation } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { createSchedule, getScheduleRuns } from "../schedule/schedule-store.js";
 import { startScheduler } from "../schedule/scheduler.js";
 
@@ -148,6 +167,7 @@ describe("scheduler conversation reuse", () => {
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     processedMessages.length = 0;
+    processMessageImpl = captureProcessedMessage;
     runBackgroundJobOptions.length = 0;
     runBackgroundJobShouldFail = false;
     runBackgroundJobBootstrapFails = false;
@@ -173,11 +193,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
-    };
-
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -196,7 +212,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -233,11 +249,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
-    };
-
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -249,7 +261,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -277,11 +289,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
-    };
-
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -292,7 +300,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -320,11 +328,7 @@ describe("scheduler conversation reuse", () => {
 
     forceScheduleDue(schedule.id);
 
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
-    };
-
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -338,7 +342,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -364,11 +368,7 @@ describe("scheduler conversation reuse", () => {
     });
 
     // WHEN the schedule fires
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
-    };
-
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -403,12 +403,12 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
 
     let shouldFail = false;
-    const processMessage = async (conversationId: string, message: string) => {
+    processMessageImpl = async (conversationId, message) => {
       processedMessages.push({ conversationId, message });
       if (shouldFail) throw new Error("Simulated failure");
     };
 
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -420,7 +420,7 @@ describe("scheduler conversation reuse", () => {
     processedMessages.length = 0;
     shouldFail = true;
 
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -434,7 +434,7 @@ describe("scheduler conversation reuse", () => {
     processedMessages.length = 0;
     shouldFail = false;
 
-    const scheduler3 = startScheduler(processMessage, () => {});
+    const scheduler3 = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler3.stop();
 
@@ -453,6 +453,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     processedMessages.length = 0;
+    processMessageImpl = captureProcessedMessage;
     runBackgroundJobOptions.length = 0;
     runBackgroundJobShouldFail = false;
     runBackgroundJobBootstrapFails = false;
@@ -470,8 +471,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const processMessage = async () => {};
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -495,8 +495,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const processMessage = async () => {};
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -524,8 +523,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     forceScheduleDue(schedule.id);
     runBackgroundJobBootstrapFails = true;
 
-    const processMessage = async () => {};
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -554,15 +552,22 @@ describe("scheduler talk-mode runner option propagation", () => {
       scheduleJobId: string;
       title: string;
     }> = [];
-    const processMessage = async () => {};
-    const scheduler = startScheduler(
-      processMessage,
-      () => {},
-      undefined,
-      (info) => sseCalls.push(info),
-    );
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        if (event.message.type === "schedule_conversation_created") {
+          sseCalls.push({
+            conversationId: event.message.conversationId,
+            scheduleJobId: event.message.scheduleJobId,
+            title: event.message.title,
+          });
+        }
+      },
+    });
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
+    subscription.dispose();
 
     expect(sseCalls).toHaveLength(1);
     expect(sseCalls[0]).toMatchObject({

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -27,6 +27,11 @@ mock.module("../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: mockWakeAgentForOpportunity,
 }));
 
+const mockProcessMessage = mock((..._args: unknown[]) => Promise.resolve());
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: mockProcessMessage,
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
@@ -77,6 +82,7 @@ describe("scheduler wake mode", () => {
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     mockWakeAgentForOpportunity.mockClear();
+    mockProcessMessage.mockClear();
   });
 
   test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
@@ -90,10 +96,8 @@ describe("scheduler wake mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const processMessage = mock(() => Promise.resolve());
-
     // WHEN the scheduler fires
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -107,7 +111,7 @@ describe("scheduler wake mode", () => {
     });
 
     // AND processMessage is never called (wake mode doesn't use it)
-    expect(processMessage).not.toHaveBeenCalled();
+    expect(mockProcessMessage).not.toHaveBeenCalled();
   });
 
   test("missing wakeConversationId logs warning and completes (not fails)", async () => {
@@ -127,10 +131,8 @@ describe("scheduler wake mode", () => {
     );
     forceScheduleDue(schedule.id);
 
-    const processMessage = mock(() => Promise.resolve());
-
     // WHEN the scheduler fires
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -161,10 +163,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -189,10 +188,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -225,10 +221,7 @@ describe("scheduler wake mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
+    const scheduler = startScheduler();
 
     // WHEN the first tick runs (fires immediately from startScheduler)
     await new Promise((resolve) => origSetTimeout(resolve, 600));
@@ -277,10 +270,7 @@ describe("scheduler wake mode", () => {
     ]);
 
     // WHEN the scheduler fires (first tick runs immediately from startScheduler)
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
+    const scheduler = startScheduler();
     await new Promise((resolve) => origSetTimeout(resolve, 600));
     scheduler.stop();
 

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -85,6 +85,23 @@ mock.module("../tools/registry.js", () => ({
   areCoreToolsInitialized: () => coreToolsReady,
 }));
 
+// The scheduler dispatches task/reuse-path messages through `processMessage`;
+// route them to a per-test delegate so tests can capture those calls. The
+// delegate receives the daemon-shaped options (trustContext, taskRunId, …)
+// that the scheduler maps from the schedule's trustClass.
+let processMessageImpl: (
+  conversationId: string,
+  message: string,
+  options?: unknown,
+) => Promise<unknown> = async () => {};
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: (
+    conversationId: string,
+    message: string,
+    options?: unknown,
+  ) => processMessageImpl(conversationId, message, options),
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
@@ -198,6 +215,7 @@ describe("scheduler run_task detection", () => {
     db.run("DELETE FROM conversations");
     onRunBackgroundJobCall = null;
     emitNotificationCalls.length = 0;
+    processMessageImpl = async () => {};
   });
 
   test("run_task:<id> messages trigger runTask instead of processMessage", async () => {
@@ -219,17 +237,20 @@ describe("scheduler run_task detection", () => {
     const directCalls: Array<{
       conversationId: string;
       message: string;
-      options?: { trustClass?: string; taskRunId?: string };
+      options?: {
+        trustContext?: { sourceChannel?: string; trustClass?: string };
+        taskRunId?: string;
+      };
     }> = [];
-    const processMessage = async (
-      conversationId: string,
-      message: string,
-      options?: { trustClass?: string; taskRunId?: string },
-    ) => {
-      directCalls.push({ conversationId, message, options });
+    processMessageImpl = async (conversationId, message, options) => {
+      directCalls.push({
+        conversationId,
+        message,
+        options: options as (typeof directCalls)[number]["options"],
+      });
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
 
     // Wait for the initial tick to complete
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -246,7 +267,7 @@ describe("scheduler run_task detection", () => {
     expect(runTaskCalls.length).toBe(1);
     // The scheduler should NOT pass the raw run_task: message to processMessage
     expect(rawCalls.length).toBe(0);
-    expect(runTaskCalls[0].options?.trustClass).toBe("guardian");
+    expect(runTaskCalls[0].options?.trustContext?.trustClass).toBe("guardian");
     expect(typeof runTaskCalls[0].options?.taskRunId).toBe("string");
   });
 
@@ -270,10 +291,7 @@ describe("scheduler run_task detection", () => {
       runnerCalls.push(info);
     };
 
-    const scheduler = startScheduler(
-      async () => {},
-      () => {},
-    );
+    const scheduler = startScheduler();
 
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
@@ -300,12 +318,7 @@ describe("scheduler run_task detection", () => {
 
     forceScheduleDue(schedule.id);
 
-    const processMessage = async (
-      _conversationId: string,
-      _message: string,
-    ) => {};
-
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler();
 
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
@@ -350,32 +363,30 @@ describe("scheduler run_task detection", () => {
     let usageEventCreatedAt: number | null = null;
     let runsDuringProcessing: ReturnType<typeof getScheduleRuns> = [];
 
-    const result = await runScheduleDueWorkOnce(
-      async (conversationId) => {
-        processingConversationId = conversationId;
-        runsDuringProcessing = getScheduleRuns(schedule.id);
-        const event = recordUsageEvent(
-          {
-            conversationId,
-            runId: null,
-            requestId: "req-scheduled-task-usage",
-            actor: "main_agent",
-            callSite: "mainAgent",
-            inferenceProfile: "balanced",
-            provider: "anthropic",
-            model: "claude-sonnet-4-20250514",
-            inputTokens: 100,
-            outputTokens: 50,
-            cacheCreationInputTokens: 0,
-            cacheReadInputTokens: 0,
-            rawUsage: null,
-          },
-          { estimatedCostUsd: 0.25, pricingStatus: "priced" },
-        );
-        usageEventCreatedAt = event.createdAt;
-      },
-      () => {},
-    );
+    processMessageImpl = async (conversationId) => {
+      processingConversationId = conversationId;
+      runsDuringProcessing = getScheduleRuns(schedule.id);
+      const event = recordUsageEvent(
+        {
+          conversationId,
+          runId: null,
+          requestId: "req-scheduled-task-usage",
+          actor: "main_agent",
+          callSite: "mainAgent",
+          inferenceProfile: "balanced",
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          rawUsage: null,
+        },
+        { estimatedCostUsd: 0.25, pricingStatus: "priced" },
+      );
+      usageEventCreatedAt = event.createdAt;
+    };
+    const result = await runScheduleDueWorkOnce();
     const to = Date.now() + 1000;
 
     expect(result.completed).toBe(1);
@@ -447,10 +458,7 @@ describe("scheduler run_task detection", () => {
       usageEventCreatedAt = event.createdAt;
     };
 
-    const result = await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    const result = await runScheduleDueWorkOnce();
     const to = Date.now() + 1000;
 
     expect(result.completed).toBe(1);
@@ -500,6 +508,7 @@ describe("scheduler workflow mode", () => {
       return { runId: "wf-run-1" };
     };
     coreToolsReady = true;
+    processMessageImpl = async () => {};
   });
 
   test("a due workflow-mode job triggers the run manager with name/args", async () => {
@@ -515,10 +524,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const result = await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    const result = await runScheduleDueWorkOnce();
 
     expect(result.completed).toBe(1);
     expect(result.failed).toBe(0);
@@ -551,10 +557,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
 
     expect(workflowStartCalls).toHaveLength(1);
     expect(workflowStartCalls[0]).toMatchObject({
@@ -578,10 +581,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
 
     expect(workflowStartCalls).toHaveLength(1);
     expect(workflowStartCalls[0]).toMatchObject({
@@ -604,10 +604,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
 
     expect(workflowStartCalls).toHaveLength(1);
     expect(workflowStartCalls[0]).toMatchObject({
@@ -628,10 +625,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
 
     expect(workflowStartCalls[0]).toMatchObject({
       conversationId: "conv-wake",
@@ -649,10 +643,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
 
     expect(workflowStartCalls).toHaveLength(1);
     expect(workflowStartCalls[0].args).toEqual({});
@@ -672,10 +663,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const result = await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    const result = await runScheduleDueWorkOnce();
 
     expect(result.failed).toBe(1);
     const runs = getScheduleRuns(schedule.id);
@@ -693,10 +681,7 @@ describe("scheduler workflow mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const result = await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    const result = await runScheduleDueWorkOnce();
 
     expect(result.skipped).toBe(1);
     expect(workflowStartCalls).toHaveLength(0);
@@ -716,10 +701,7 @@ describe("scheduler workflow mode", () => {
 
     // Tools not yet registered: the run must be deferred, not launched with an
     // empty baseline. No run-manager start, no run record, marked skipped.
-    const result = await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    const result = await runScheduleDueWorkOnce();
     expect(workflowStartCalls).toHaveLength(0);
     expect(result.skipped).toBe(1);
     expect(getScheduleRuns(schedule.id)).toHaveLength(0);
@@ -727,10 +709,7 @@ describe("scheduler workflow mode", () => {
     // Re-armed to due (not consumed): once tools are ready, a later tick fires
     // it with the full baseline.
     coreToolsReady = true;
-    await runScheduleDueWorkOnce(
-      async () => {},
-      () => {},
-    );
+    await runScheduleDueWorkOnce();
     expect(workflowStartCalls).toHaveLength(1);
     expect(workflowStartCalls[0]).toMatchObject({ name: "triage-inbox" });
   });

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -244,7 +244,7 @@ describe("background wake intent publisher hooks", () => {
     // computeNextBackgroundWakeIntent. Heartbeat startup republishes with the
     // live heartbeat timing via its own "heartbeat-*" refreshes.
     expect(schedulerSource).toContain(
-      'refreshBackgroundWakeIntentSoon("daemon-startup")',
+      'refreshBackgroundWakeIntent("daemon-startup")',
     );
     // Lifecycle no longer publishes the intent directly.
     expect(lifecycleSource).not.toContain("refreshBackgroundWakeIntent");

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -109,7 +109,6 @@ import {
 } from "./memory-v2-startup.js";
 import { startOrphanReaper } from "./orphan-reaper.js";
 import { elevatePointerConversationToGuardian } from "./pointer-conversation-trust.js";
-import { processMessage } from "./process-message.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
 import {
   initializeProvidersAndTools,
@@ -855,29 +854,7 @@ export async function runDaemon(): Promise<void> {
     );
   }
 
-  startScheduler(async (conversationId, message, options) => {
-    await processMessage(
-      conversationId,
-      message,
-      options
-        ? {
-            ...(options.trustClass
-              ? {
-                  trustContext: {
-                    sourceChannel: "vellum",
-                    trustClass: options.trustClass,
-                  },
-                }
-              : {}),
-            ...(options.taskRunId ? { taskRunId: options.taskRunId } : {}),
-            ...(options.overrideProfile
-              ? { overrideProfile: options.overrideProfile }
-              : {}),
-            ...(options.cronRunId ? { cronRunId: options.cronRunId } : {}),
-          }
-        : undefined,
-    );
-  });
+  startScheduler();
 
   // Fire-and-forget: Qdrant init and memory worker startup run concurrently
   // with the rest of daemon boot. Must run AFTER `startRuntimeHttpServer()`

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,9 +1,11 @@
+import { refreshBackgroundWakeIntent } from "../background-wake/publisher.js";
 import { getConfig } from "../config/loader.js";
 import {
   checkDiskPressureBackgroundGate,
   diskPressureBackgroundSkipLogFields,
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
+import { processMessage } from "../daemon/process-message.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
@@ -16,7 +18,7 @@ import { publishConversationListChanged } from "../runtime/sync/resource-sync-ev
 import { runSequencesOnce } from "../sequence/engine.js";
 import { areCoreToolsInitialized } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
-import { runWatchersOnce, type WatcherNotifier } from "../watcher/engine.js";
+import { runWatchersOnce } from "../watcher/engine.js";
 import { normalizeCapabilityManifest } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { hasSetConstructs } from "./recurrence-engine.js";
@@ -41,25 +43,41 @@ import {
 
 const log = getLogger("scheduler");
 
-import type { ScheduleMessageProcessor } from "./scheduler-types.js";
-type ScheduleNotifyModeNotifier = (payload: {
-  id: string;
-  label: string;
-  message: string;
-  routingIntent: RoutingIntent;
-  routingHints: Record<string, unknown>;
-}) => void | Promise<void>;
-
-type ScheduleConversationCreatedNotifier = (info: {
-  conversationId: string;
-  scheduleJobId: string;
-  title: string;
-}) => void;
+import type { ScheduleMessageOptions } from "./scheduler-types.js";
 
 /**
- * Emit the attention signal for a `notify`-mode schedule firing. The default
- * `notifyScheduleOneShot` for {@link startScheduler}; tests inject a stub.
+ * Run a scheduled message through the daemon's agent pipeline, translating the
+ * schedule's `trustClass` into the trust context `processMessage` expects.
  */
+async function dispatchScheduleMessage(
+  conversationId: string,
+  message: string,
+  options?: ScheduleMessageOptions,
+): Promise<void> {
+  await processMessage(
+    conversationId,
+    message,
+    options
+      ? {
+          ...(options.trustClass
+            ? {
+                trustContext: {
+                  sourceChannel: "vellum",
+                  trustClass: options.trustClass,
+                },
+              }
+            : {}),
+          ...(options.taskRunId ? { taskRunId: options.taskRunId } : {}),
+          ...(options.overrideProfile
+            ? { overrideProfile: options.overrideProfile }
+            : {}),
+          ...(options.cronRunId ? { cronRunId: options.cronRunId } : {}),
+        }
+      : undefined,
+  );
+}
+
+/** Emit the attention signal for a `notify`-mode schedule firing. */
 async function emitScheduleNotifySignal(payload: {
   id: string;
   label: string;
@@ -198,27 +216,7 @@ async function handleExecutionFailure(params: {
 /** The running scheduler, retained so shutdown can stop it. */
 let instance: SchedulerHandle | null = null;
 
-/**
- * Publish the current background wake intent without statically importing the
- * publisher — `background-wake/next-wake.js` imports the schedule store, so a
- * static import here would close an import cycle. Best-effort and fire-and-forget.
- */
-function refreshBackgroundWakeIntentSoon(reason: string): void {
-  void import("../background-wake/publisher.js")
-    .then(({ refreshBackgroundWakeIntent }) =>
-      refreshBackgroundWakeIntent(reason),
-    )
-    .catch((err) =>
-      log.warn({ err, reason }, "Failed to queue background wake refresh"),
-    );
-}
-
-export function startScheduler(
-  processMessage: ScheduleMessageProcessor,
-  notifyScheduleOneShot: ScheduleNotifyModeNotifier = emitScheduleNotifySignal,
-  watcherNotifier: WatcherNotifier = emitWatcherNotifySignal,
-  onScheduleConversationCreated: ScheduleConversationCreatedNotifier = broadcastScheduleConversationCreated,
-): SchedulerHandle {
+export function startScheduler(): SchedulerHandle {
   let stopped = false;
   let tickRunning = false;
 
@@ -226,12 +224,7 @@ export function startScheduler(
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runScheduleOnce(
-        processMessage,
-        notifyScheduleOneShot,
-        watcherNotifier,
-        onScheduleConversationCreated,
-      );
+      await runScheduleOnce();
     } catch (err) {
       log.error({ err }, "Schedule tick failed");
     } finally {
@@ -247,23 +240,12 @@ export function startScheduler(
 
   instance = {
     async runOnce(): Promise<number> {
-      return runScheduleOnce(
-        processMessage,
-        notifyScheduleOneShot,
-        watcherNotifier,
-        onScheduleConversationCreated,
-      );
+      return runScheduleOnce();
     },
     async runDueWorkOnce(
       options?: SchedulerRunDueWorkOptions,
     ): Promise<SchedulerDueWorkResult> {
-      return runScheduleDueWorkOnce(
-        processMessage,
-        notifyScheduleOneShot,
-        watcherNotifier,
-        onScheduleConversationCreated,
-        options,
-      );
+      return runScheduleDueWorkOnce(options);
     },
     stop(): void {
       stopped = true;
@@ -273,7 +255,7 @@ export function startScheduler(
 
   // Publish the initial background wake intent now that the scheduler is live
   // and its schedules are visible to `computeNextBackgroundWakeIntent`.
-  refreshBackgroundWakeIntentSoon("daemon-startup");
+  refreshBackgroundWakeIntent("daemon-startup");
 
   return instance;
 }
@@ -290,26 +272,12 @@ export function getScheduler(): SchedulerHandle | null {
   return instance;
 }
 
-export async function runScheduleOnce(
-  processMessage: ScheduleMessageProcessor,
-  notifyScheduleOneShot: ScheduleNotifyModeNotifier,
-  watcherNotifier?: WatcherNotifier,
-  onScheduleConversationCreated?: ScheduleConversationCreatedNotifier,
-): Promise<number> {
-  const result = await runScheduleDueWorkOnce(
-    processMessage,
-    notifyScheduleOneShot,
-    watcherNotifier,
-    onScheduleConversationCreated,
-  );
+export async function runScheduleOnce(): Promise<number> {
+  const result = await runScheduleDueWorkOnce();
   return result.completed + result.failed + result.skipped;
 }
 
 export async function runScheduleDueWorkOnce(
-  processMessage: ScheduleMessageProcessor,
-  notifyScheduleOneShot: ScheduleNotifyModeNotifier,
-  watcherNotifier?: WatcherNotifier,
-  onScheduleConversationCreated?: ScheduleConversationCreatedNotifier,
   options: SchedulerRunDueWorkOptions = {},
 ): Promise<SchedulerDueWorkResult> {
   const now = options.now ?? Date.now();
@@ -367,7 +335,7 @@ export async function runScheduleDueWorkOnce(
           { jobId: job.id, name: job.name, isOneShot },
           "Firing schedule notification",
         );
-        await notifyScheduleOneShot({
+        await emitScheduleNotifySignal({
           id: job.id,
           label: job.name,
           message: job.message,
@@ -675,7 +643,7 @@ export async function runScheduleDueWorkOnce(
             scheduleJobId: job.id,
           },
           async (conversationId, message, taskRunId) => {
-            await processMessage(conversationId, message, {
+            await dispatchScheduleMessage(conversationId, message, {
               trustClass: "guardian",
               taskRunId,
               cronRunId: runId,
@@ -687,7 +655,7 @@ export async function runScheduleDueWorkOnce(
         );
 
         await setScheduleRunConversationId(runId, result.conversationId);
-        onScheduleConversationCreated?.({
+        broadcastScheduleConversationCreated({
           conversationId: result.conversationId,
           scheduleJobId: job.id,
           title: result.status === "failed" ? `${job.name}: Error` : job.name,
@@ -738,7 +706,7 @@ export async function runScheduleDueWorkOnce(
           origin: "schedule",
           systemHint: `Schedule: ${job.name}`,
         });
-        onScheduleConversationCreated?.({
+        broadcastScheduleConversationCreated({
           conversationId: fallbackConversation.id,
           scheduleJobId: job.id,
           title: `${job.name}: Error`,
@@ -801,18 +769,18 @@ export async function runScheduleDueWorkOnce(
     const runId = await createScheduleRun(job.id, reusedConversationId);
 
     if (reusedConversationId) {
-      // Reuse path: keep using the injected `processMessage` callback so the
-      // existing conversation is continued in place. `runBackgroundJob`
-      // unconditionally bootstraps a new conversation and is therefore not a
-      // drop-in replacement for the reuse semantics.
+      // Reuse path: dispatch the message into the existing conversation so it
+      // is continued in place. `runBackgroundJob` unconditionally bootstraps a
+      // new conversation and is therefore not a drop-in replacement for the
+      // reuse semantics.
       conversationId = reusedConversationId;
-      onScheduleConversationCreated?.({
+      broadcastScheduleConversationCreated({
         conversationId,
         scheduleJobId: job.id,
         title: job.name,
       });
       try {
-        await processMessage(conversationId, job.message, {
+        await dispatchScheduleMessage(conversationId, job.message, {
           trustClass: "guardian",
           cronRunId: runId,
           ...(job.inferenceProfile
@@ -854,7 +822,7 @@ export async function runScheduleDueWorkOnce(
         onConversationCreated: async (newConversationId) => {
           runConversationId = newConversationId;
           await setScheduleRunConversationId(runId, newConversationId);
-          onScheduleConversationCreated?.({
+          broadcastScheduleConversationCreated({
             conversationId: newConversationId,
             scheduleJobId: job.id,
             title: job.name,
@@ -924,13 +892,11 @@ export async function runScheduleDueWorkOnce(
   }
 
   // ── Watchers (event-driven polling) ────────────────────────────────
-  if (watcherNotifier) {
-    try {
-      const watcherProcessed = await runWatchersOnce(watcherNotifier);
-      result.completed += watcherProcessed;
-    } catch (err) {
-      log.error({ err }, "Watcher tick failed");
-    }
+  try {
+    const watcherProcessed = await runWatchersOnce(emitWatcherNotifySignal);
+    result.completed += watcherProcessed;
+  } catch (err) {
+    log.error({ err }, "Watcher tick failed");
   }
 
   // ── Sequences (multi-step outreach) ──────────────────────────────


### PR DESCRIPTION
## Why

Follow-up to the review on #36594. Three pieces of feedback:

1. **Inline `processMessage`** — the prior "keep the scheduler decoupled from the message pipeline" rationale was rejected: executing agent loops in the background is a core scheduler feature, so depending on `daemon/process-message` is correct.
2. **Hoist the dynamic import** — solve import cycles by isolating modules, not with inline `import()`.
3. **Remove the params entirely** — no defaults either.

## What

**Production (`scheduler.ts`, `lifecycle.ts`):**
- `startScheduler()`, `runScheduleOnce()`, and `runScheduleDueWorkOnce(options?)` no longer take any callback parameters. The four former injection points are now called directly inside the scheduler: a new `dispatchScheduleMessage()` (imports `processMessage` and maps `trustClass` → trust context), `emitScheduleNotifySignal`, `emitWatcherNotifySignal`, and `broadcastScheduleConversationCreated`. `lifecycle.ts` now just calls `startScheduler()` (its ~50-line callback block is gone, along with the `processMessage`/`emitNotificationSignal`/`publishConversationListChanged` imports it no longer needs).
- The background-wake publish is a **static** import now. There is no cycle to avoid: `background-wake/next-wake` imports the schedule store and heartbeat service, and **neither imports the scheduler**, so `scheduler → publisher → next-wake → …` has no back-edge. The dynamic `import()` (and its `refreshBackgroundWakeIntentSoon` helper) is removed.

**Tests:** The six scheduler suites no longer inject callbacks. They `mock.module` the real seams — `daemon/process-message` (a per-test delegate) and `notifications/emit-signal` — instead. The SSE-timing case subscribes to the real `assistantEventHub` rather than mocking the widely-imported hub module. Notify-mode assertions now check the `emitNotificationSignal` payload shape, and the one task-path test that inspected options checks `trustContext.trustClass` (the mapped shape) instead of `trustClass`.

## Verification

- `tsc --noEmit`, eslint, prettier all clean.
- All six scheduler suites pass in isolation: `scheduler-disk-pressure` (1), `scheduler-wake` (6), `scheduler-reuse-conversation` (10), `scheduler-recurrence` (13), `schedule-retry` (19), `task-scheduler` (18) — plus `background-wake-routes` (21) and the updated `wake-intent-hooks` (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_