### PR TITLE
fix(onboarding): make research claim removal actually disregard facts in context

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -17,7 +17,7 @@
  * then clicks "Continue" to drop into the full workspace on the same conversation.
  */
 
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -215,6 +215,12 @@ export function ResearchOnboardingRoute() {
   const research = useResearchRunner();
   // Stable across renders (useCallback in the runner); safe as effect deps.
   const { start: startResearch, hydrate: hydrateResearch } = research;
+  // In-flight removal correction (if any), fired from the results step. The
+  // chat handoff awaits it (alongside the plugin installs) so a removed claim is
+  // persisted into the research conversation BEFORE the first real chat is
+  // minted — otherwise the rejected facts could still be pulled into its context.
+  // Resolves immediately when nothing was corrected (never rejects).
+  const researchCorrectionRef = useRef<Promise<void>>(Promise.resolve());
   const researchLoading =
     research.status === "idle" || research.status === "running";
   // The research turn settled with nothing to show — skip the "this is what I
@@ -592,9 +598,10 @@ export function ResearchOnboardingRoute() {
             onContinue={(removed) => {
               // Pruned claims are wrong — tell the assistant to disregard them so
               // they don't leak into the real chat (the research turn taught its
-              // memory these facts). Best-effort; never blocks the handoff.
+              // memory these facts). The chat handoff awaits this promise, so the
+              // correction is persisted before the first conversation is minted.
               if (researchConversationId && hatchedAssistantId && removed.length > 0) {
-                void sendResearchCorrection({
+                researchCorrectionRef.current = sendResearchCorrection({
                   assistantId: hatchedAssistantId,
                   conversationId: researchConversationId,
                   removedClaims: removed,
@@ -607,7 +614,7 @@ export function ResearchOnboardingRoute() {
               // "This is not me" — the search matched someone else. Disown the
               // whole result so none of it carries into the assistant's context.
               if (researchConversationId && hatchedAssistantId) {
-                void sendResearchCorrection({
+                researchCorrectionRef.current = sendResearchCorrection({
                   assistantId: hatchedAssistantId,
                   conversationId: researchConversationId,
                   removedClaims: research.claims.map((c) => c.claim),
@@ -636,8 +643,12 @@ export function ResearchOnboardingRoute() {
               // Wait out any background capability installs so the new chat can
               // discover their skills (else it silently degrades to a generic
               // prompt). Usually instant — installs kicked off while the user
-              // reviewed the results.
-              await research.awaitPluginInstalls();
+              // reviewed the results. Also wait for any removal correction to
+              // persist so rejected claims can't leak into this first chat.
+              await Promise.all([
+                research.awaitPluginInstalls(),
+                researchCorrectionRef.current,
+              ]);
               enterAssistant(formValues, faceValues, suggestion.prompt);
             }}
             onSkip={async () => {
@@ -646,7 +657,10 @@ export function ResearchOnboardingRoute() {
                 RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
                 { userId, outcome: "skipped" },
               );
-              await research.awaitPluginInstalls();
+              await Promise.all([
+                research.awaitPluginInstalls(),
+                researchCorrectionRef.current,
+              ]);
               enterAssistant(formValues, faceValues, undefined, { skip: true });
             }}
             onBack={() => goBackTo(noClaims ? "looking" : "results")}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/domains/onboarding/research-prompt";
 import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
+import { sendResearchCorrection } from "@/domains/onboarding/send-research-correction";
 import {
   clearResearchSnapshot,
   readResearchSnapshot,
@@ -588,7 +589,33 @@ export function ResearchOnboardingRoute() {
           <ResearchResultsStep
             claims={research.claims}
             loading={researchLoading}
-            onContinue={() => goForwardTo("suggestions")}
+            onContinue={(removed) => {
+              // Pruned claims are wrong — tell the assistant to disregard them so
+              // they don't leak into the real chat (the research turn taught its
+              // memory these facts). Best-effort; never blocks the handoff.
+              if (researchConversationId && hatchedAssistantId && removed.length > 0) {
+                void sendResearchCorrection({
+                  assistantId: hatchedAssistantId,
+                  conversationId: researchConversationId,
+                  removedClaims: removed,
+                  rejectedAll: false,
+                });
+              }
+              goForwardTo("suggestions");
+            }}
+            onRejectAll={() => {
+              // "This is not me" — the search matched someone else. Disown the
+              // whole result so none of it carries into the assistant's context.
+              if (researchConversationId && hatchedAssistantId) {
+                void sendResearchCorrection({
+                  assistantId: hatchedAssistantId,
+                  conversationId: researchConversationId,
+                  removedClaims: research.claims.map((c) => c.claim),
+                  rejectedAll: true,
+                });
+              }
+              goForwardTo("suggestions", "skipped");
+            }}
             onBack={() => goBackTo("looking")}
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -301,6 +301,7 @@ export function ResearchResultsStep({
   claims,
   loading,
   onContinue,
+  onRejectAll,
   onBack,
   onForward,
 }: {
@@ -308,7 +309,18 @@ export function ResearchResultsStep({
   claims: ResearchFact[];
   /** True while the research turn is still streaming. */
   loading: boolean;
-  onContinue: () => void;
+  /**
+   * Continue into the suggestions, reporting the claims the user X'd out (their
+   * exact `claim` text) so the assistant can be told to disregard them — pruning
+   * an option here must actually take it out of the assistant's context, not
+   * just hide the row.
+   */
+  onContinue: (removedClaims: string[]) => void;
+  /**
+   * "This is not me" — the whole search matched someone else (a similar-name
+   * mismatch). Discard ALL of the web-research context and continue.
+   */
+  onRejectAll: () => void;
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
@@ -376,9 +388,24 @@ export function ResearchResultsStep({
           </AnimatePresence>
         </div>
 
+        {/* The whole search can land on the wrong person (similar names). Let the
+            user disown it in one click — continue with no web-research context at
+            all, telling the assistant to forget everything it found. Only once
+            there's something to reject and the turn has settled. */}
+        {hasClaims && canContinue && (
+          <button
+            type="button"
+            onClick={onRejectAll}
+            className="mt-5 self-start cursor-pointer text-[14px] underline underline-offset-2 transition-opacity hover:opacity-80"
+            style={{ color: tone.fgMuted }}
+          >
+            This is not me
+          </button>
+        )}
+
         <button
           type="button"
-          onClick={onContinue}
+          onClick={() => onContinue([...removed])}
           disabled={!canContinue}
           className="mt-8 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{

--- a/clients/web/src/domains/onboarding/send-research-correction.test.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the research-correction helper.
+ *
+ * `buildResearchCorrection` is pure and covers the message wording / no-op
+ * cases. `sendResearchCorrection` must post the correction to the research
+ * conversation, then re-archive it, and swallow every failure so the
+ * onboarding handoff is never blocked.
+ *
+ * NOTE: `bun mock.module` can leak across files — run this file singly:
+ *   bun test src/domains/onboarding/send-research-correction.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface PostCall {
+  path: { assistant_id: string };
+  body: { conversationId: string; content: string };
+  throwOnError: false;
+}
+interface ArchiveCall {
+  path: { assistant_id: string; id: string };
+  throwOnError: false;
+}
+
+let postCalls: PostCall[] = [];
+let archiveCalls: ArchiveCall[] = [];
+let postShouldThrow = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  messagesPost: (opts: PostCall) => {
+    postCalls.push(opts);
+    if (postShouldThrow) return Promise.reject(new Error("network blew up"));
+    return Promise.resolve({
+      data: {},
+      error: undefined,
+      response: { ok: true, status: 200 },
+    });
+  },
+  conversationsByIdArchivePost: (opts: ArchiveCall) => {
+    archiveCalls.push(opts);
+    return Promise.resolve({
+      data: {},
+      error: undefined,
+      response: { ok: true, status: 200 },
+    });
+  },
+}));
+
+const { buildResearchCorrection, sendResearchCorrection } = await import(
+  "./send-research-correction"
+);
+
+afterEach(() => {
+  postCalls = [];
+  archiveCalls = [];
+  postShouldThrow = false;
+});
+
+describe("buildResearchCorrection", () => {
+  test("lists the removed claims when some were pruned", () => {
+    const msg = buildResearchCorrection({
+      removedClaims: ["Based in Oakland, CA", "Founded Weird Canada"],
+      rejectedAll: false,
+    });
+    expect(msg).toContain("- Based in Oakland, CA");
+    expect(msg).toContain("- Founded Weird Canada");
+    expect(msg).toContain("disregard");
+  });
+
+  test("returns null when nothing was removed (no correction to send)", () => {
+    expect(
+      buildResearchCorrection({ removedClaims: [], rejectedAll: false }),
+    ).toBeNull();
+    // Blank/whitespace-only entries don't count as removals.
+    expect(
+      buildResearchCorrection({ removedClaims: ["  "], rejectedAll: false }),
+    ).toBeNull();
+  });
+
+  test("disowns the whole search on full rejection, ignoring the list", () => {
+    const msg = buildResearchCorrection({ removedClaims: [], rejectedAll: true });
+    expect(msg).toContain("none of what you found");
+    expect(msg).toContain("similar name");
+  });
+});
+
+describe("sendResearchCorrection", () => {
+  test("posts the correction then re-archives the conversation", async () => {
+    await sendResearchCorrection({
+      assistantId: "a1",
+      conversationId: "c1",
+      removedClaims: ["Based in Oakland, CA"],
+      rejectedAll: false,
+    });
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0]?.path).toEqual({ assistant_id: "a1" });
+    expect(postCalls[0]?.body.conversationId).toBe("c1");
+    expect(postCalls[0]?.throwOnError).toBe(false);
+
+    expect(archiveCalls).toHaveLength(1);
+    expect(archiveCalls[0]?.path).toEqual({ assistant_id: "a1", id: "c1" });
+  });
+
+  test("no-ops (no post, no archive) when there's nothing to correct", async () => {
+    await sendResearchCorrection({
+      assistantId: "a1",
+      conversationId: "c1",
+      removedClaims: [],
+      rejectedAll: false,
+    });
+
+    expect(postCalls).toHaveLength(0);
+    expect(archiveCalls).toHaveLength(0);
+  });
+
+  test("swallows a thrown post and still re-archives", async () => {
+    postShouldThrow = true;
+
+    await expect(
+      sendResearchCorrection({
+        assistantId: "a1",
+        conversationId: "c1",
+        removedClaims: ["x"],
+        rejectedAll: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(archiveCalls).toHaveLength(1);
+  });
+});

--- a/clients/web/src/domains/onboarding/send-research-correction.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.ts
@@ -1,0 +1,110 @@
+/**
+ * Posts a one-shot correction into the research-onboarding side conversation
+ * when the user prunes — or rejects all of — the web-research claims on the
+ * "This is what I found about you" step.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The research turn runs against the REAL hatched assistant, so what it learned
+ * about the user lives in that assistant's memory (shared across all of its
+ * conversations — see `archive-research-conversation.ts` for the side-channel
+ * design). Removing a claim in the UI alone changes nothing: the assistant
+ * still believes it and carries it into the real chat. This fires a
+ * natural-language correction back into the same conversation so the assistant
+ * disregards the wrong claims — or, when the user clicks "This is not me", the
+ * ENTIRE search (a similar-name mismatch, the failure mode the step guards
+ * against) — and doesn't treat any of it as true going forward.
+ *
+ * Best-effort and fire-and-forget, exactly like `archive-research-conversation`
+ * and `checkin-scheduler`: a failure here must never block or surface in the
+ * flow. Talks to the daemon through the generated SDK directly
+ * (`@/domains/chat/api/*` is import-banned from onboarding), mirroring the
+ * research runner that minted this conversation.
+ *
+ * The conversation was archived once research settled; posting a message can
+ * resurface it in the sidebar, so we re-archive afterwards (idempotent,
+ * best-effort) to keep the throwaway side channel hidden.
+ */
+
+import { messagesPost } from "@/generated/daemon/sdk.gen";
+import type { MessagesPostData } from "@/generated/daemon/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
+
+export interface ResearchCorrection {
+  /** The claims the user X'd out (their exact `claim` text). */
+  removedClaims: string[];
+  /**
+   * The user clicked "This is not me" — the whole search matched someone else.
+   * Disregard everything it found, not just the listed claims.
+   */
+  rejectedAll: boolean;
+}
+
+/**
+ * Build the correction message, or `null` when there's nothing to correct (no
+ * claims removed and not a full rejection). Pure so it's unit-testable without
+ * mocking the SDK.
+ */
+export function buildResearchCorrection({
+  removedClaims,
+  rejectedAll,
+}: ResearchCorrection): string | null {
+  if (rejectedAll) {
+    return [
+      "Correction: none of what you found in that web search is actually me —",
+      "it looks like you matched someone else with a similar name. Please",
+      "disregard everything from that search and don't remember any of it as",
+      "true about me. We'll build up what you actually know about me from here,",
+      "as we talk.",
+    ].join(" ");
+  }
+  const cleaned = removedClaims.map((c) => c.trim()).filter(Boolean);
+  if (cleaned.length === 0) return null;
+  return [
+    "Quick correction on what you found about me — these aren't true, so please",
+    "disregard them and don't remember them as facts about me:",
+    "",
+    ...cleaned.map((c) => `- ${c}`),
+  ].join("\n");
+}
+
+export interface SendResearchCorrectionOptions extends ResearchCorrection {
+  assistantId: string;
+  /** The research side conversation the claims came from. */
+  conversationId: string;
+}
+
+/**
+ * Fire the correction into the research conversation. Resolves regardless of
+ * outcome and never throws; a no-op (resolves immediately) when there's nothing
+ * to correct.
+ */
+export async function sendResearchCorrection({
+  assistantId,
+  conversationId,
+  removedClaims,
+  rejectedAll,
+}: SendResearchCorrectionOptions): Promise<void> {
+  const content = buildResearchCorrection({ removedClaims, rejectedAll });
+  if (!content) return;
+  try {
+    const body: MessagesPostData["body"] = {
+      conversationId,
+      content,
+      sourceChannel: "vellum",
+      interface: "vellum",
+      clientMessageId: crypto.randomUUID(),
+    };
+    await messagesPost({
+      path: { assistant_id: assistantId },
+      body,
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_correction" });
+  }
+  // Keep the throwaway side conversation out of the sidebar even if posting
+  // resurfaced it. Best-effort and already-swallowed by the helper.
+  await archiveResearchConversation(assistantId, conversationId);
+}


### PR DESCRIPTION
## Problem

In the research-onboarding "This is what I found about you" step, clicking the **X** to remove a web-research claim did nothing beyond hiding the row. `ResearchResultsStep`'s `onContinue` took no arguments, so the removed claims were never communicated anywhere.

Because the research turn runs against the **real hatched assistant** (in a side conversation that's archived afterward), what it "found" lives in that assistant's memory and carries into the actual chat. So even removed claims — including ones from a **similar-name mismatch where the whole search is about a different person** — kept getting passed into context.

## Changes

- **`screens/research-result-steps.tsx`** — `onContinue(removedClaims: string[])` now reports the exact claim text the user X'd out. Added a **"This is not me"** inline affordance (`onRejectAll`) under the last claim — one click to disown the entire search — shown once the turn settles.
- **`send-research-correction.ts`** (new) — best-effort helper. `buildResearchCorrection` (pure) builds either a "disregard these specific claims" note or, on full rejection, a "none of this is me, you matched a similar name — disregard the whole search" note. `sendResearchCorrection` posts it back into the research conversation so the assistant updates what it knows, then re-archives the throwaway side conversation. Fire-and-forget; swallows all errors, mirroring `archive-research-conversation` / `checkin-scheduler`.
- **`pages/research-onboarding-route.tsx`** — wires `onContinue` (sends only when something was removed) and `onRejectAll` (disowns the full claim list), both guarded on the assistant + conversation ids.
- **`send-research-correction.test.ts`** (new) — covers the builder wording/no-op cases and the post-then-re-archive + error-swallowing contract.

## Notes / follow-ups

- The correction relies on the assistant honoring "forget this" in its memory — the same natural-language mechanism already used by `removal-note-prompt.ts` for the overlay variant. A hard guarantee would need a daemon-side memory-delete API (larger change, not done here).
- After "This is not me", the suggestions step still shows suggestions derived from the wrong person. Left as-is (out of scope); could fall back to generic suggestions on rejection if desired.

## Testing

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean (0 errors)
- `bun test src/domains/onboarding/send-research-correction.test.ts` — 6 pass

Visual QA of the onboarding flow still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)