### PR TITLE
feat(assistant): run audit-log rotation as a periodic cleanup job

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -186,6 +186,7 @@ mock.module("../persistence/jobs-store.js", () => ({
   enqueuePruneOldConversationsJob: mock(() => "job-prune-conv"),
   enqueuePruneOldLlmRequestLogsJob: mock(() => "job-prune-llm"),
   enqueuePruneOldTraceEventsJob: mock(() => "job-prune-trace"),
+  enqueuePruneOldToolInvocationsJob: mock(() => "job-prune-tool"),
   failMemoryJob: mock(() => {}),
   failStalledJobs: mockFailStalledJobs,
   getMemoryJobCounts: mock(() => ({})),

--- a/assistant/src/__tests__/job-handler-registry-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registry-guard.test.ts
@@ -53,6 +53,7 @@ const NON_PLUGIN_JOB_TYPES = [
   "prune_old_conversations",
   "prune_old_llm_request_logs",
   "prune_old_trace_events",
+  "prune_old_tool_invocations",
   "build_conversation_summary",
   "media_processing",
   "conversation_analyze",

--- a/assistant/src/__tests__/prune-old-tool-invocations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-tool-invocations-job.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { AssistantConfig } from "../config/schema.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { pruneOldToolInvocationsJob } from "../persistence/job-handlers/cleanup.js";
+import type { MemoryJob } from "../persistence/jobs-store.js";
+import { conversations, toolInvocations } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+const DAY_MS = 86_400_000;
+
+function seedInvocation(id: string, createdAt: number): void {
+  getDb()
+    .insert(toolInvocations)
+    .values({
+      id,
+      conversationId: "conv-1",
+      toolName: "bash",
+      input: "{}",
+      result: "{}",
+      decision: "allow",
+      riskLevel: "low",
+      durationMs: 5,
+      createdAt,
+    })
+    .run();
+}
+
+function remainingIds(): string[] {
+  return getDb()
+    .select()
+    .from(toolInvocations)
+    .all()
+    .map((r) => r.id)
+    .sort();
+}
+
+function job(payload: Record<string, unknown> = {}): MemoryJob {
+  return { payload } as unknown as MemoryJob;
+}
+
+function config(retentionDays: number): AssistantConfig {
+  return { auditLog: { retentionDays } } as unknown as AssistantConfig;
+}
+
+describe("pruneOldToolInvocationsJob", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.delete(toolInvocations).run();
+    db.delete(conversations).run();
+    // tool_invocations.conversation_id is an FK into conversations.
+    db.insert(conversations)
+      .values({
+        id: "conv-1",
+        title: "test",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .run();
+  });
+
+  test("deletes audit rows older than auditLog.retentionDays, keeps recent ones", async () => {
+    seedInvocation("old", Date.now() - 60 * DAY_MS);
+    seedInvocation("fresh", Date.now());
+
+    await pruneOldToolInvocationsJob(job(), config(30));
+
+    expect(remainingIds()).toEqual(["fresh"]);
+  });
+
+  test("payload retentionDays overrides the config window", async () => {
+    seedInvocation("ten-days", Date.now() - 10 * DAY_MS);
+
+    // Config would keep it (30d), but the payload tightens to 7d.
+    await pruneOldToolInvocationsJob(job({ retentionDays: 7 }), config(30));
+
+    expect(remainingIds()).toEqual([]);
+  });
+
+  test("retentionDays of 0 is a no-op (keep forever)", async () => {
+    seedInvocation("ancient", Date.now() - 999 * DAY_MS);
+
+    await pruneOldToolInvocationsJob(job(), config(0));
+
+    expect(remainingIds()).toEqual(["ancient"]);
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -65,7 +65,6 @@ import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streamin
 import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
-import { rotateToolInvocations } from "../telemetry/tool-usage-store.js";
 import { startUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
@@ -1090,12 +1089,6 @@ export async function runDaemon(): Promise<void> {
       );
     }
   })();
-
-  if (config.auditLog.retentionDays > 0) {
-    void rotateToolInvocations(config.auditLog.retentionDays).catch((err) => {
-      log.warn({ err }, "Audit log rotation failed");
-    });
-  }
 
   startWorkspaceHeartbeatService();
 

--- a/assistant/src/jobs/register-job-handlers.ts
+++ b/assistant/src/jobs/register-job-handlers.ts
@@ -4,6 +4,7 @@ import { mediaProcessingJob } from "../media/job-handlers/media-processing.js";
 import {
   pruneOldConversationsJob,
   pruneOldLlmRequestLogsJob,
+  pruneOldToolInvocationsJob,
   pruneOldTraceEventsJob,
 } from "../persistence/job-handlers/cleanup.js";
 import { registerJobHandler } from "../persistence/jobs-worker.js";
@@ -55,6 +56,9 @@ export function registerMemoryJobHandlers(): void {
   );
   registerJobHandler("prune_old_trace_events", (job, config) =>
     pruneOldTraceEventsJob(job, config),
+  );
+  registerJobHandler("prune_old_tool_invocations", (job, config) =>
+    pruneOldToolInvocationsJob(job, config),
   );
   registerJobHandler("build_conversation_summary", async (job, config) => {
     // Stale rows enqueued before v2 was enabled must not consume the

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -1,4 +1,5 @@
 import type { AssistantConfig } from "../../config/types.js";
+import { rotateToolInvocations } from "../../telemetry/tool-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { getLogsDbPath } from "../../util/logs-db-path.js";
 import { runAsyncSqlite } from "../db-async-query.js";
@@ -137,6 +138,32 @@ SELECT changes();`,
     },
     "Pruned old trace events",
   );
+}
+
+/**
+ * Delete audit-log (`tool_invocations`) entries older than the configured
+ * retention window. Retention comes from `auditLog.retentionDays` (0 = keep
+ * forever). The DELETE itself lives in {@link rotateToolInvocations}; this
+ * handler just resolves the window and dispatches, mirroring the other
+ * scheduled cleanup jobs.
+ */
+export async function pruneOldToolInvocationsJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const rawRetention = job.payload.retentionDays;
+  const retentionDays =
+    typeof rawRetention === "number" &&
+    Number.isFinite(rawRetention) &&
+    rawRetention >= 0
+      ? rawRetention
+      : config.auditLog.retentionDays;
+
+  // 0 means disabled. rotateToolInvocations no-ops on this too, but
+  // short-circuit so we don't dispatch a pointless async query.
+  if (!retentionDays) return;
+
+  await rotateToolInvocations(retentionDays);
 }
 
 /**

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -36,6 +36,7 @@ export type MemoryJobType =
   | "prune_old_conversations"
   | "prune_old_llm_request_logs"
   | "prune_old_trace_events"
+  | "prune_old_tool_invocations"
   | "build_conversation_summary"
   | "conversation_analyze"
   | "backfill"
@@ -499,6 +500,55 @@ export function enqueuePruneOldTraceEventsJob(retentionDays?: number): string {
       ? { retentionDays }
       : {};
   return enqueueMemoryJob("prune_old_trace_events", payload);
+}
+
+export function enqueuePruneOldToolInvocationsJob(
+  retentionDays?: number,
+): string {
+  const db = memoryDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "prune_old_tool_invocations"),
+        inArray(memoryJobs.status, ["pending", "running"]),
+      ),
+    )
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) {
+    if (
+      existing.status === "pending" &&
+      typeof retentionDays === "number" &&
+      Number.isFinite(retentionDays) &&
+      retentionDays >= 0
+    ) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.retentionDays !== retentionDays) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, retentionDays }),
+            updatedAt: Date.now(),
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+  const payload =
+    typeof retentionDays === "number" &&
+    Number.isFinite(retentionDays) &&
+    retentionDays >= 0
+      ? { retentionDays }
+      : {};
+  return enqueueMemoryJob("prune_old_tool_invocations", payload);
 }
 
 export interface LaneBudgets {

--- a/assistant/src/persistence/jobs-worker.ts
+++ b/assistant/src/persistence/jobs-worker.ts
@@ -37,6 +37,7 @@ import {
   enqueueMemoryJob,
   enqueuePruneOldConversationsJob,
   enqueuePruneOldLlmRequestLogsJob,
+  enqueuePruneOldToolInvocationsJob,
   enqueuePruneOldTraceEventsJob,
   failMemoryJob,
   failStalledJobs,
@@ -650,16 +651,24 @@ function maybeEnqueueScheduledCleanupJobs(
     cleanup.traceEventRetentionDays > 0
       ? enqueuePruneOldTraceEventsJob(cleanup.traceEventRetentionDays)
       : null;
+  // Audit-log (tool_invocations) retention is configured separately under
+  // `auditLog.retentionDays`, but rides this same cleanup cadence for now.
+  const pruneToolInvocationsJobId =
+    config.auditLog.retentionDays > 0
+      ? enqueuePruneOldToolInvocationsJob(config.auditLog.retentionDays)
+      : null;
   markScheduledCleanupEnqueued(nowMs);
   log.debug(
     {
       pruneConversationsJobId,
       pruneLlmRequestLogsJobId,
       pruneTraceEventsJobId,
+      pruneToolInvocationsJobId,
       enqueueIntervalMs: cleanup.enqueueIntervalMs,
       conversationRetentionDays: cleanup.conversationRetentionDays,
       llmRequestLogRetentionMs: cleanup.llmRequestLogRetentionMs,
       traceEventRetentionDays: cleanup.traceEventRetentionDays,
+      auditLogRetentionDays: config.auditLog.retentionDays,
     },
     "Enqueued scheduled memory cleanup jobs",
   );


### PR DESCRIPTION
## Why

Audit-log (`tool_invocations`) rotation ran **once per daemon startup** and nowhere else, so a long-lived daemon never enforced `auditLog.retentionDays` until its next restart. The audit log — one row per tool call, with full input/result payloads — is the table most likely to balloon, so the retention policy silently wasn't being honored on long-running instances. The sibling retention prunes (conversations, llm request logs, trace events) already run on a cadence via the memory jobs worker; audit rotation was the odd one out.

## What

Move audit rotation alongside the other three retention jobs:

- **`jobs-store.ts`** — new `prune_old_tool_invocations` job type + `enqueuePruneOldToolInvocationsJob(retentionDays?)`, mirroring `enqueuePruneOldConversationsJob` (same pending/running dedup + payload-update behavior).
- **`job-handlers/cleanup.ts`** — new `pruneOldToolInvocationsJob(job, config)` handler. It resolves the window from `job.payload.retentionDays` (falling back to `config.auditLog.retentionDays`) and delegates the delete to the existing `rotateToolInvocations` — no duplicated SQL.
- **`register-job-handlers.ts`** — register the handler.
- **`jobs-worker.ts`** — enqueue it from `maybeEnqueueScheduledCleanupJobs`, driven by `config.auditLog.retentionDays > 0`.
- **`lifecycle.ts`** — drop the one-shot startup `rotateToolInvocations` call (and its import). `rotateToolInvocations` itself is unchanged and still the actual delete.

## Behavior change to note

Audit rotation now rides the **memory-cleanup cadence and gating** (`config.memory.cleanup` `enabled` / `enqueueIntervalMs`) instead of running unconditionally at startup. So with `memory.cleanup.enabled = false`, audit rotation no longer runs — the same coupling the other three retention jobs already have. This is the intended interim arrangement; per discussion these retention jobs will move to the scheduler once it's backgrounded, at which point the audit/memory-cleanup config coupling can be undone.

## Tests

- New `prune-old-tool-invocations-job.test.ts`: deletes rows older than `auditLog.retentionDays`, payload window overrides config, and `0` is a no-op (keep forever).
- Updated the job-handler-registry guard to expect the new `prune_old_tool_invocations` type.
- `tsc --noEmit`, eslint, prettier all clean; `audit-log-rotation`, `prune-old-conversations-job`, `memory-jobs-worker-backoff`, and the registry guard pass. (One pre-existing `audit-log-rotation` "anti-block" case fails identically on clean `main` in this sandbox — it needs the `sqlite3` CLI to exercise the non-blocking subprocess path — and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_