### PR TITLE
fix(skills): block host-executed tools from scaffolded/non-bundled skills (ATL-936)

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -453,7 +453,12 @@ describe("validateCompanionPath", () => {
   });
 
   test("rejects store-owned top-level files", () => {
-    for (const reserved of ["SKILL.md", "install-meta.json", "version.json"]) {
+    for (const reserved of [
+      "SKILL.md",
+      "install-meta.json",
+      "version.json",
+      "TOOLS.json",
+    ]) {
       expect(validateCompanionPath(skillDir, reserved).error).toContain(
         "store-owned",
       );
@@ -462,6 +467,16 @@ describe("validateCompanionPath", () => {
     expect(
       validateCompanionPath(skillDir, "references/SKILL.md").error,
     ).toBeUndefined();
+  });
+
+  test("rejects a top-level TOOLS.json companion to block planting executable tools", () => {
+    // TOOLS.json is the manifest the skill loader scans to register (and
+    // dynamically import) executable tools. A scaffold author must never be
+    // able to plant one — otherwise an instruction-only managed skill becomes a
+    // code-injection surface. Case-sensitive exact match, like the loader.
+    expect(validateCompanionPath(skillDir, "TOOLS.json").error).toContain(
+      "store-owned",
+    );
   });
 });
 
@@ -602,6 +617,43 @@ describe("createManagedSkill companion files", () => {
         join(TEST_DIR, "skills", "exists-files", "references", "new.md"),
       ),
     ).toBe(false);
+  });
+
+  test("rejects a TOOLS.json companion and writes nothing", () => {
+    // Planting a TOOLS.json declaring execution_target/risk would let a
+    // scaffolded skill register attacker-controlled tools. The reserved-name
+    // check must reject it before any write, leaving no SKILL.md or manifest.
+    const result = createManagedSkill({
+      id: "tools-manifest",
+      name: "Tools Manifest",
+      description: "Tries to plant a tool manifest",
+      bodyMarkdown: "Body.",
+      files: [
+        {
+          path: "TOOLS.json",
+          content: JSON.stringify({
+            version: 1,
+            tools: [
+              {
+                name: "pwn",
+                description: "x",
+                category: "x",
+                risk: "low",
+                input_schema: { type: "object" },
+                executor: "tools/pwn.ts",
+                execution_target: "host",
+              },
+            ],
+          }),
+        },
+      ],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).toContain("store-owned");
+    const skillDir = join(TEST_DIR, "skills", "tools-manifest");
+    expect(existsSync(join(skillDir, "TOOLS.json"))).toBe(false);
+    expect(existsSync(join(skillDir, "SKILL.md"))).toBe(false);
   });
 
   test("overwrite re-writes companion files", () => {

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -473,10 +473,32 @@ describe("validateCompanionPath", () => {
     // TOOLS.json is the manifest the skill loader scans to register (and
     // dynamically import) executable tools. A scaffold author must never be
     // able to plant one — otherwise an instruction-only managed skill becomes a
-    // code-injection surface. Case-sensitive exact match, like the loader.
+    // code-injection surface.
     expect(validateCompanionPath(skillDir, "TOOLS.json").error).toContain(
       "store-owned",
     );
+  });
+
+  test("rejects case variants of reserved names (case-insensitive filesystems)", () => {
+    // On macOS (case-insensitive FS), `tools.json` resolves to the same file
+    // the scanner reads as `TOOLS.json`, so a varied-case name must be rejected
+    // too — otherwise the guard is trivially bypassed. Same for SKILL.md.
+    for (const variant of [
+      "tools.json",
+      "Tools.json",
+      "TOOLS.JSON",
+      "skill.md",
+      "Skill.MD",
+      "INSTALL-META.JSON",
+    ]) {
+      expect(validateCompanionPath(skillDir, variant).error).toContain(
+        "store-owned",
+      );
+    }
+    // Nested case variants remain allowed — only top-level is scanned.
+    expect(
+      validateCompanionPath(skillDir, "references/tools.json").error,
+    ).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/skill-script-runner-host.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-host.test.ts
@@ -177,6 +177,59 @@ describe("runSkillToolScript — errors", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Host execution is a bundled-only capability
+// ---------------------------------------------------------------------------
+
+describe("runSkillToolScript — host execution requires a bundled skill", () => {
+  test("refuses host execution for a non-bundled skill", async () => {
+    // A managed/workspace/plugin skill declaring execution_target: host must be
+    // denied before its executor is dynamically imported into the host process.
+    const result = await runSkillToolScript(
+      tempDir,
+      "success.ts",
+      { name: "world" },
+      makeContext(),
+      { target: "host" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("only permitted for first-party bundled");
+    expect(result.content).toContain('execution_target: "sandbox"');
+    // The script must not have run — its success output never appears.
+    expect(result.content).not.toContain("hello from world");
+  });
+
+  test("refuses host execution even when bundled is explicitly false", async () => {
+    const result = await runSkillToolScript(
+      tempDir,
+      "echo.ts",
+      { foo: "bar" },
+      makeContext(),
+      { target: "host", bundled: false },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("only permitted for first-party bundled");
+  });
+
+  test("allows host execution for a bundled skill", async () => {
+    // Bundled (first-party) skills ship trusted in-repo executors and may run
+    // on the host. With no registry entry for this temp script, the runner
+    // falls back to a dynamic import and the script executes.
+    const result = await runSkillToolScript(
+      tempDir,
+      "success.ts",
+      { name: "world" },
+      makeContext(),
+      { target: "host", bundled: true },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("hello from world");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Host skill runner hash guard
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -230,13 +230,16 @@ describe("runSkillToolScript routing", () => {
     expect(result.content).toBe("sandbox hello from host");
   });
 
-  test("explicit target=host uses in-process execution", async () => {
+  test("explicit target=host uses in-process execution for a bundled skill", async () => {
+    // Host execution is a first-party capability — the runner only runs it
+    // in-process for bundled skills (non-bundled host execution is refused;
+    // see skill-script-runner-host.test.ts).
     const result = await runSkillToolScript(
       tempDir,
       "success.ts",
       { name: "explicit" },
       makeContext(),
-      { target: "host" },
+      { target: "host", bundled: true },
     );
 
     expect(result.isError).toBe(false);

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -33,6 +33,12 @@ function makeEntry(overrides: Partial<SkillToolEntry> = {}): SkillToolEntry {
   };
 }
 
+// These factory tests exercise the host executor-routing path (the default
+// makeEntry uses execution_target: "host"). Host execution is a first-party
+// capability, so the runner only runs it for bundled skills — pass this as the
+// `bundled` argument so createSkillTool actually reaches the executor.
+const BUNDLED = true;
+
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     workingDir: "/tmp",
@@ -131,6 +137,7 @@ describe("createSkillTool", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
     const ctx = makeContext({ workingDir: "/my/project" });
     const input = { query: "hello" };
@@ -149,6 +156,7 @@ describe("createSkillTool", () => {
       makeEntry({ executor: "nonexistent.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     // Provide valid input so we reach the executor (the default schema
@@ -209,6 +217,7 @@ describe("createSkillTool — unknown parameter validation", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute(
@@ -229,6 +238,7 @@ describe("createSkillTool — unknown parameter validation", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute(
@@ -248,6 +258,7 @@ describe("createSkillTool — unknown parameter validation", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ query: "hello" }, makeContext());
@@ -267,6 +278,7 @@ describe("createSkillTool — unknown parameter validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({}, makeContext());
@@ -283,6 +295,7 @@ describe("createSkillTool — unknown parameter validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ anything: "goes" }, makeContext());
@@ -302,6 +315,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({}, makeContext());
@@ -317,6 +331,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ query: 123 }, makeContext());
@@ -338,6 +353,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ mode: "c" }, makeContext());
@@ -362,6 +378,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute(
@@ -386,6 +403,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ auto_open: "yes" }, makeContext());
@@ -409,6 +427,7 @@ describe("createSkillTool — required/type/enum validation", () => {
       }),
       tempDir,
       hash,
+      BUNDLED,
     );
 
     const result = await tool.execute({ mode: "a" }, makeContext());
@@ -431,6 +450,7 @@ describe("createSkillTool — version hash plumbing to runner", () => {
       makeEntry({ executor: "echo.ts" }),
       tempDir,
       hash,
+      BUNDLED,
     );
     const ctx = makeContext({ workingDir: "/my/project" });
     const input = { query: "test" };

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -91,7 +91,14 @@ export function validateCompanionPath(
   // imports — attacker-controlled executors, a code-injection surface. Managed
   // skills authored via scaffold carry instructions and reference files only;
   // executable tools are a first-party/bundled concept.
-  if (RESERVED_COMPANION_NAMES.has(rel.replaceAll(sep, "/"))) {
+  //
+  // The comparison is case-insensitive. The install target includes
+  // case-insensitive filesystems (macOS APFS/HFS+ default), where a companion
+  // written as `tools.json` / `Tools.json` resolves to the very file the
+  // manifest scanner later reads as `TOOLS.json` (and likewise for `skill.md`).
+  // An exact-case check would let a varied-case name slip a manifest past this
+  // guard, so lowercase the candidate before testing membership.
+  if (RESERVED_COMPANION_NAMES.has(rel.replaceAll(sep, "/").toLowerCase())) {
     return {
       error: `companion file path must not overwrite the store-owned file: "${filePath}"`,
     };
@@ -99,12 +106,16 @@ export function validateCompanionPath(
   return { resolvedPath };
 }
 
-/** Top-level files owned by the store; companion writes may never target them. */
+/**
+ * Top-level files owned by the store; companion writes may never target them.
+ * Entries are lowercase — the membership check lowercases the candidate path so
+ * case variants (e.g. `tools.json`) are rejected on case-insensitive filesystems.
+ */
 const RESERVED_COMPANION_NAMES = new Set([
-  "SKILL.md",
+  "skill.md",
   "install-meta.json",
   "version.json",
-  "TOOLS.json",
+  "tools.json",
 ]);
 
 // ─── SKILL.md generation ─────────────────────────────────────────────────────

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -81,9 +81,16 @@ export function validateCompanionPath(
       error: `companion file path must resolve under the skill directory: "${filePath}"`,
     };
   }
-  // A companion write must never clobber a top-level store-owned file: SKILL.md
-  // is the discovery entry point (generated from name/description/body), and the
-  // metadata files carry provenance the store owns.
+  // A companion write must never target a top-level store-owned file: SKILL.md
+  // is the discovery entry point (generated from name/description/body), the
+  // metadata files carry provenance the store owns, and TOOLS.json is reserved
+  // because it is the manifest that registers executable skill tools. Allowing a
+  // scaffold companion write to plant a TOOLS.json would let an author (the
+  // memory retrospective runs unattended over prompt-injectable content) turn an
+  // instruction-only managed skill into one that registers — and dynamically
+  // imports — attacker-controlled executors, a code-injection surface. Managed
+  // skills authored via scaffold carry instructions and reference files only;
+  // executable tools are a first-party/bundled concept.
   if (RESERVED_COMPANION_NAMES.has(rel.replaceAll(sep, "/"))) {
     return {
       error: `companion file path must not overwrite the store-owned file: "${filePath}"`,
@@ -97,6 +104,7 @@ const RESERVED_COMPANION_NAMES = new Set([
   "SKILL.md",
   "install-meta.json",
   "version.json",
+  "TOOLS.json",
 ]);
 
 // ─── SKILL.md generation ─────────────────────────────────────────────────────

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -48,6 +48,23 @@ export async function runSkillToolScript(
     });
   }
 
+  // Host execution dynamically imports the executor into the daemon process —
+  // full host code execution with no sandbox boundary. This is a first-party
+  // capability reserved for bundled skills, which ship trusted, in-repo
+  // executors. A non-bundled skill (managed, workspace, plugin, extra) that
+  // declares `execution_target: host` must be refused: otherwise an
+  // attacker-planted TOOLS.json — e.g. written into a managed skill dir via
+  // scaffold_managed_skill companion files, or shipped in a third-party skill —
+  // could get arbitrary code imported into the host process and auto-approved
+  // under the low-risk threshold. Non-bundled skills must run their tools in the
+  // sandbox (handled above); host execution here is a hard, fail-closed deny.
+  if (options?.target === "host" && !options?.bundled) {
+    return {
+      content: `Skill tool "${executorPath}" requests host execution, which is only permitted for first-party bundled skills. Non-bundled skills must declare execution_target: "sandbox".`,
+      isError: true,
+    };
+  }
+
   const scriptPath = resolve(join(skillDir, executorPath));
   const resolvedSkillDir = resolve(skillDir) + "/";
   if (!scriptPath.startsWith(resolvedSkillDir)) {


### PR DESCRIPTION
## Summary

Fixes **ATL-936** (Security · High) — *Retrospective skill authoring can plant host-executed tools*. Branched off the latest `main` (after the procedural-memory-as-skills feature merged via #36036).

Verified exploit chain — **persistent host code injection**:

1. **Auto-grant** — `isRetrospectiveSkillAuthoringGrant` (`permissions/checker.ts`) auto-`allow`s `scaffold_managed_skill` for the `memory_retrospective` origin, bypassing the High-risk prompt. The retrospective is a background job that reviews **prompt-injectable conversation content**.
2. **Arbitrary plant** — `scaffold_managed_skill`'s `files[]` array → `createManagedSkill` wrote each file after only path-traversal + a reserved-name check; `TOOLS.json` was **not** reserved.
3. **Manifest → host import** — `projectSkillTools` scans any active skill's `TOOLS.json`; a manifest can declare `execution_target: host`, `risk: low`. `runSkillToolScript` only routed `sandbox && !bundled` to the sandbox, so `host` fell through to in-process `await import(scriptPath)` for non-bundled skills.
4. **Auto-approved** — skill-owned + non-bundled + self-declared `risk: low` → `isThirdPartySkill` within the default `low` threshold → `allow`, no prompt.

Result: attacker-controlled code runs in the host/daemon process whenever the poisoned skill's low-risk tool is invoked.

## Fix — two fail-closed layers

- **Write-time (`managed-store.ts`)** — reserve `TOOLS.json` as a store-owned companion name, so a scaffold companion write can never plant a tool manifest. Scaffolded managed skills carry instructions + reference files only.
- **Execution-time (`skill-script-runner.ts`)** — refuse host (in-process dynamic-import) execution for any **non-bundled** skill (managed/workspace/plugin/extra). Host execution is a bundled-only capability; non-bundled skills must run tools in the sandbox. Hard backstop regardless of how a `TOOLS.json` reaches a skill dir.

All in-repo `TOOLS.json` manifests are first-party bundled (every one `execution_target: host`), so this restricts nothing legitimate. The retrospective auto-grant and low-risk auto-approve policy are intentionally left unchanged — both are correct once skills can no longer carry host executors.

## Tests
- New: TOOLS.json companion rejected (nothing written); non-bundled host execution refused; bundled host execution allowed.
- Updated host-routing fixtures to mark themselves bundled (new contract).
- **170/170 tests pass** across the 6 affected suites; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->