### PR TITLE
Clarify assistant CLI top-level description

### DIFF
--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -79,7 +79,7 @@ export function buildCliProgramTree(): Command {
 
   program
     .name("assistant")
-    .description("Local AI assistant")
+    .description("Utilities for navigating and managing your own workspace")
     .version(APP_VERSION)
     .allowExcessArguments(true);
 


### PR DESCRIPTION
## Why

The top-level `assistant` command described itself as **"Local AI assistant"** — vague and uninformative. It doesn't tell a reader (human or AI agent) what the CLI is actually *for*.

Per `assistant/src/cli/AGENTS.md`, every command in `assistant/src/cli/` operates on a **single running assistant's own local state** — config, memory, contacts, conversations, autonomy, etc. — all scoped to the assistant's workspace. The description should reflect that.

## What

Reframed the one-liner so it implies the set of utilities the assistant uses to navigate and manage its own workspace:

```diff
- .description("Local AI assistant")
+ .description("Utilities for navigating and managing your own workspace")
```

This surfaces in `assistant --help` and is written for the assistant ("you") reading its own help docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFNnbV6oAQ5X7SxnvTVR5y)_