### PR TITLE
refactor(daemon): Phase 4 — inline consent-cache teardown off the shutdown registry

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -45,10 +45,7 @@ import {
   isMemoryEnabled,
 } from "../persistence/jobs-store.js";
 import { startMemoryJobsWorker } from "../persistence/jobs-worker.js";
-import {
-  startConsentRefresh,
-  stopConsentRefresh,
-} from "../platform/consent-cache.js";
+import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { sweepConceptPageFrontmatter } from "../plugins/defaults/memory/v2/frontmatter-sweep.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -114,7 +111,6 @@ import {
   registerWatcherProviders,
 } from "./providers-setup.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
-import { registerShutdownHook } from "./shutdown-registry.js";
 import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 import { broadcastDaemonStatus } from "./status.js";
 
@@ -585,7 +581,6 @@ export async function runDaemon(): Promise<void> {
   // platform. Fire-and-forget: startConsentRefresh() runs an immediate
   // non-blocking refresh, so the startup hot path is never blocked.
   startConsentRefresh();
-  registerShutdownHook("consent-cache", () => stopConsentRefresh());
 
   // Bring up the daemon's CES connection (process + handshake + reconnect
   // wiring). Blocks up to a 20s timeout so credential reads route through CES

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -10,6 +10,7 @@ import { getSqlite, resetDb } from "../persistence/db-connection.js";
 import { stopQdrantManager } from "../persistence/embeddings/qdrant-manager.js";
 import { stopMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { stopMemoryWorkerProcess } from "../persistence/worker-control.js";
+import { stopConsentRefresh } from "../platform/consent-cache.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import { runHook } from "../plugins/pipeline.js";
 import { stopRuntimeHttpServer } from "../runtime/http-server.js";
@@ -81,9 +82,12 @@ async function shutdown(): Promise<void> {
   await stopWorkspaceHeartbeatService();
   await stopHeartbeatService();
 
-  // Run registered shutdown-registry hooks (skill teardown like meet-join, plus
-  // daemon singletons such as the consent-cache refresh) before stopping the
-  // server so any HTTP round-trips and SSE emissions still have live transports.
+  // Stop the periodic consent-cache refresh (a daemon-owned interval).
+  await stopConsentRefresh();
+
+  // Run registered shutdown-registry hooks (skill teardown like meet-join)
+  // before stopping the server so any HTTP round-trips and SSE emissions still
+  // have live transports.
   try {
     await runShutdownHooks("daemon-shutdown");
   } catch (err) {


### PR DESCRIPTION
## Prompt / plan

Part of removing `shutdown-registry.ts` so all shutdown goes through `runHook(HOOKS.SHUTDOWN)` (Phase 1 already migrated the plugin layer). Phases:

1. ✅ Plugin/user/workspace shutdown via `runHook` (merged).
2. Skill host removal.
3. meet-join → plugin (handled separately).
4. **(this PR)** Inline daemon singletons.
5. Delete `shutdown-registry.ts`.

Re-inventoried the registry's `registerShutdownHook` consumers on current `main`: the only daemon singleton left is the consent-cache refresh (filing/memory teardown already ride the pipeline as a default-plugin `shutdown` hook). The registry only ever existed to decouple *skills* from the daemon — a daemon singleton calling another daemon singleton needs no indirection.

### What changed
- `shutdown-handlers.ts` calls `await stopConsentRefresh()` directly during the shutdown sequence (right after the heartbeat stops).
- `lifecycle.ts` drops the `registerShutdownHook("consent-cache", …)` registration and its now-unused `registerShutdownHook` / `stopConsentRefresh` imports.

After the skill host (Phase 2) and meet-join (Phase 3) come off the registry, it can be deleted (Phase 5).

## Test plan
- `tsc --noEmit`: 0 errors; `eslint` + `prettier --check` clean on both files (pre-commit hook verified).
- `consent-cache.test.ts` green (20 tests) — `stopConsentRefresh` is unchanged and still tested directly.
- No test asserts the consent-cache shutdown registration (only `daemon-skill-host.test.ts` references `registerShutdownHook`, and that's the skill-host facet, untouched here).
- Module-load smoke test of `shutdown-handlers` + `lifecycle` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1HBsQzMdfT45G8DfzNbk)_