### PR TITLE
fix(assistant): persist clientMessageId on canned wake-up greeting

### DIFF
--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -6,7 +6,9 @@
  *   do NOT trigger the agent loop.
  * - Regular messages pass through to the agent loop unchanged.
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
@@ -302,6 +304,7 @@ function makeConversation() {
     forceCompact,
     setPreactivatedSkillIds,
     drainQueue: async () => {},
+    warmPromptCache: () => {},
     getMessages: () => messages,
     assistantId: "self",
     trustContext: undefined,
@@ -543,5 +546,47 @@ describe("handleSendMessage slash command interception", () => {
     const text = await res.text();
     expect(text).toContain("riskThreshold");
     expect(ipcCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// The first-message wake-up greeting ("Wake up, my friend!") is served as a
+// canned response that skips the agent loop, just like a slash command. Its
+// user row must still carry the client-generated idempotency nonce so the web
+// client can reconcile its optimistic row against the persisted one — otherwise
+// the greeting renders twice (see the "two wakeup messages" staging report).
+describe("handleSendMessage canned wake-up greeting", () => {
+  // `isWakeUpGreeting` resolves BOOTSTRAP.md via getWorkspacePromptPath, which
+  // is rooted at VELLUM_WORKSPACE_DIR (the per-test temp workspace).
+  const bootstrapPath = join(process.env.VELLUM_WORKSPACE_DIR!, "BOOTSTRAP.md");
+
+  beforeEach(() => {
+    addMessageMock.mockClear();
+    // `isWakeUpGreeting` only treats the message as the wake-up greeting when
+    // BOOTSTRAP.md exists at the workspace prompt path (i.e. a first run).
+    writeFileSync(bootstrapPath, "# Bootstrap\n\nFirst run.");
+  });
+
+  afterEach(() => {
+    if (existsSync(bootstrapPath)) rmSync(bootstrapPath, { force: true });
+  });
+
+  test("persists the clientMessageId on the user row", async () => {
+    const { conversation, runAgentLoop } = makeConversation();
+    const res = await callHandler(
+      (args) => handleSendMessage(args, makeDeps(conversation)),
+      makeRequest("Wake up, my friend!", {
+        clientMessageId: "nonce-wake-123",
+      }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    // Canned greeting path: user + assistant rows persisted, agent loop skipped.
+    expect(runAgentLoop).not.toHaveBeenCalled();
+    const userCall = addMessageMock.mock.calls.find((c) => c[1] === "user");
+    expect(userCall).toBeDefined();
+    const options = userCall?.[3] as { clientMessageId?: string } | undefined;
+    expect(options?.clientMessageId).toBe("nonce-wake-123");
   });
 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1738,6 +1738,7 @@ export async function handleSendMessage(
         attachments,
         requestId: crypto.randomUUID(),
         metadata: greetingMeta,
+        clientMessageId,
       });
 
       const conversationId = mapping.conversationId;


### PR DESCRIPTION
## Prompt / plan

Staging report: `[Release] two wakeup messages`. The first-message wake-up greeting ("Wake up, my friend!") rendered twice in the chat transcript.

**Root cause** (confirmed from the attached triage dump): the conversation had two user rows for the greeting — one optimistic client row (`isOptimistic: true`, carrying its `clientMessageId`) and one persisted server row with **no** `clientMessageId`. The web client reconciles its optimistic row against the `/messages` snapshot by `clientMessageId`; with the nonce missing from the persisted row, it couldn't match the two and both rendered.

The wake-up greeting is served by a canned-response branch in `handleSendMessage` that persists the user row via `persistQueuedMessageBody`. Unlike the three sibling persist call sites (normal send, slash commands, compaction) — which all forward `clientMessageId` — this branch omitted it. The `user_message_echo` SSE event already forwarded the nonce, but the snapshot row (the reconciliation source of truth) did not.

**Fix:** forward `clientMessageId` into the canned-greeting `persistQueuedMessageBody` call so the persisted row carries the nonce, matching the other sites and letting the client dedupe. This also lets server-side idempotency dedupe a retried wake-up send.

## Test plan

- Added a regression test in `conversation-routes-slash-commands.test.ts` that drives the canned wake-up greeting through `handleSendMessage` and asserts the persisted user row carries the `clientMessageId` (and that the agent loop is skipped). Verified the test fails when the fix is reverted and passes with it.
- `bun test src/__tests__/conversation-routes-slash-commands.test.ts` → 9 pass / 0 fail.
- Pre-commit hooks pass: Prettier, ESLint, and `tsc` type-check all green.

## CLI verb checklist

No new routes added — this is a one-line change inside the existing `POST /v1/messages` (`handleSendMessage`) handler. No CLI verb needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiNzVKH6fKZzbuUHe1YmYb)_