### PR TITLE
Unregister self-hosted platform record on local retire

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -17,6 +17,7 @@ import {
   removeAssistantEntry,
   loadAllAssistants,
   saveAssistantEntry,
+  saveAssistantPlatformRegistration,
   getActiveAssistant,
   migrateLegacyEntry,
   type AssistantEntry,
@@ -80,6 +81,25 @@ describe("assistant-config", () => {
     const all = loadAllAssistants();
     expect(all).toHaveLength(1);
     expect(all[0].assistantId).toBe("test-1");
+  });
+
+  test("saveAssistantPlatformRegistration stores durable platform metadata", () => {
+    saveAssistantEntry(makeEntry("test-1"));
+
+    saveAssistantPlatformRegistration("test-1", {
+      platformAssistantId: "platform-asst-1",
+      platformBaseUrl: "https://platform.example.com",
+      platformOrganizationId: "org_1",
+    });
+
+    expect(loadAllAssistants()[0]).toEqual(
+      expect.objectContaining({
+        assistantId: "test-1",
+        platformAssistantId: "platform-asst-1",
+        platformBaseUrl: "https://platform.example.com",
+        platformOrganizationId: "org_1",
+      }),
+    );
   });
 
   test("findAssistantByName returns matching entry", () => {

--- a/cli/src/__tests__/retire.test.ts
+++ b/cli/src/__tests__/retire.test.ts
@@ -307,6 +307,45 @@ describe("vellum retire", () => {
     expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
   });
 
+  test("local retire uses stored platform registration when the gateway is unreachable", async () => {
+    const entry = makeEntry("assistant-1", {
+      name: "Example Assistant",
+      platformAssistantId: "platform-assistant-1",
+      platformBaseUrl: "https://platform.example.test",
+      platformOrganizationId: "org-123",
+    });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: null, unreachable: true };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      entry.runtimeUrl,
+      "vellum:platform_assistant_id",
+      entry.bearerToken,
+    );
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
   test("local retire aborts when self-hosted platform unregister fails", async () => {
     const entry = makeEntry("assistant-1", { name: "Example Assistant" });
     writeLockfile([entry]);

--- a/cli/src/__tests__/retire.test.ts
+++ b/cli/src/__tests__/retire.test.ts
@@ -34,10 +34,48 @@ const originalStdoutWrite = process.stdout.write;
 const realRetireLocalModule = { ...retireLocalModule };
 
 const retireLocalMock = mock(async () => {});
+const readPlatformTokenMock = mock((): string | null => null);
+const authHeadersMock = mock(async () => ({
+  "Content-Type": "application/json",
+  "X-Session-Token": "session-token",
+}));
+const authHeadersForOrganizationMock = mock(
+  (token: string, organizationId: string) => ({
+    "Content-Type": "application/json",
+    "X-Session-Token": token,
+    "Vellum-Organization-Id": organizationId,
+  }),
+);
+const getPlatformUrlMock = mock(() => "https://platform.example.com");
+const readGatewayCredentialMock = mock(
+  async (
+    _gatewayUrl: string,
+    _name: string,
+    _bearerToken?: string,
+  ): Promise<{ value: string | null; unreachable: boolean }> => ({
+    value: null,
+    unreachable: false,
+  }),
+);
+const loopbackSafeFetchMock = mock(
+  async (): Promise<Response> => new Response(null, { status: 204 }),
+);
 
 mock.module("../lib/retire-local.js", () => ({
   ...realRetireLocalModule,
   retireLocal: retireLocalMock,
+}));
+
+mock.module("../lib/platform-client.js", () => ({
+  authHeaders: authHeadersMock,
+  authHeadersForOrganization: authHeadersForOrganizationMock,
+  getPlatformUrl: getPlatformUrlMock,
+  readGatewayCredential: readGatewayCredentialMock,
+  readPlatformToken: readPlatformTokenMock,
+}));
+
+mock.module("../lib/loopback-fetch.js", () => ({
+  loopbackSafeFetch: loopbackSafeFetchMock,
 }));
 
 import { retire } from "../commands/retire.js";
@@ -130,6 +168,32 @@ describe("vellum retire", () => {
     }) as typeof process.exit;
     retireLocalMock.mockReset();
     retireLocalMock.mockResolvedValue(undefined);
+    readPlatformTokenMock.mockReset();
+    readPlatformTokenMock.mockReturnValue(null);
+    authHeadersMock.mockReset();
+    authHeadersMock.mockResolvedValue({
+      "Content-Type": "application/json",
+      "X-Session-Token": "session-token",
+    });
+    authHeadersForOrganizationMock.mockReset();
+    authHeadersForOrganizationMock.mockImplementation(
+      (token: string, organizationId: string) => ({
+        "Content-Type": "application/json",
+        "X-Session-Token": token,
+        "Vellum-Organization-Id": organizationId,
+      }),
+    );
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.example.com");
+    readGatewayCredentialMock.mockReset();
+    readGatewayCredentialMock.mockResolvedValue({
+      value: null,
+      unreachable: false,
+    });
+    loopbackSafeFetchMock.mockReset();
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
     setTerminalMode(false);
     consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
@@ -167,6 +231,75 @@ describe("vellum retire", () => {
     expect(output).toContain("ID: assistant-1");
     expect(output).toContain(
       "Removed Example Assistant (assistant-1) from config.",
+    );
+  });
+
+  test("local retire unregisters the self-hosted platform record first", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      entry.runtimeUrl,
+      "vellum:platform_assistant_id",
+      entry.bearerToken,
+    );
+    expect(authHeadersForOrganizationMock).toHaveBeenCalledWith(
+      "session-token",
+      "org-123",
+    );
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
+  test("local retire aborts when self-hosted platform unregister fails", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    const before = readLockfile();
+    readPlatformTokenMock.mockReturnValue("session-token");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response("platform unavailable", { status: 503 }),
+    );
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await expect(retire()).rejects.toThrow("process.exit:1");
+
+    expect(retireLocalMock).not.toHaveBeenCalled();
+    expect(readLockfile()).toBe(before);
+    expect(consoleErrorSpy.mock.calls.flat().join("\n")).toContain(
+      "Platform self-hosted unregister failed (503): platform unavailable",
     );
   });
 

--- a/cli/src/__tests__/retire.test.ts
+++ b/cli/src/__tests__/retire.test.ts
@@ -20,18 +20,23 @@ import { join } from "node:path";
 
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import { loadAllAssistants } from "../lib/assistant-config.js";
+import * as loopbackFetchModule from "../lib/loopback-fetch.js";
+import * as platformClientModule from "../lib/platform-client.js";
 import * as retireLocalModule from "../lib/retire-local.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-retire-test-"));
 const originalArgv = [...process.argv];
 const originalExit = process.exit;
 const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+const originalPlatformToken = process.env.VELLUM_PLATFORM_TOKEN;
 const originalStdinIsTTY = process.stdin.isTTY;
 const originalStdoutIsTTY = process.stdout.isTTY;
 const originalStdinIsRaw = process.stdin.isRaw;
 const originalSetRawMode = process.stdin.setRawMode;
 const originalStdoutWrite = process.stdout.write;
 const realRetireLocalModule = { ...retireLocalModule };
+const realPlatformClientModule = { ...platformClientModule };
+const realLoopbackFetchModule = { ...loopbackFetchModule };
 
 const retireLocalMock = mock(async () => {});
 const readPlatformTokenMock = mock((): string | null => null);
@@ -39,13 +44,6 @@ const authHeadersMock = mock(async () => ({
   "Content-Type": "application/json",
   "X-Session-Token": "session-token",
 }));
-const authHeadersForOrganizationMock = mock(
-  (token: string, organizationId: string) => ({
-    "Content-Type": "application/json",
-    "X-Session-Token": token,
-    "Vellum-Organization-Id": organizationId,
-  }),
-);
 const getPlatformUrlMock = mock(() => "https://platform.example.com");
 const readGatewayCredentialMock = mock(
   async (
@@ -68,7 +66,6 @@ mock.module("../lib/retire-local.js", () => ({
 
 mock.module("../lib/platform-client.js", () => ({
   authHeaders: authHeadersMock,
-  authHeadersForOrganization: authHeadersForOrganizationMock,
   getPlatformUrl: getPlatformUrlMock,
   readGatewayCredential: readGatewayCredentialMock,
   readPlatformToken: readPlatformTokenMock,
@@ -161,6 +158,7 @@ function restoreTerminal(): void {
 describe("vellum retire", () => {
   beforeEach(() => {
     process.env.VELLUM_LOCKFILE_DIR = testDir;
+    delete process.env.VELLUM_PLATFORM_TOKEN;
     rmSync(join(testDir, ".vellum.lock.json"), { force: true });
     process.argv = ["bun", "vellum", "retire"];
     process.exit = ((code?: number) => {
@@ -175,14 +173,6 @@ describe("vellum retire", () => {
       "Content-Type": "application/json",
       "X-Session-Token": "session-token",
     });
-    authHeadersForOrganizationMock.mockReset();
-    authHeadersForOrganizationMock.mockImplementation(
-      (token: string, organizationId: string) => ({
-        "Content-Type": "application/json",
-        "X-Session-Token": token,
-        "Vellum-Organization-Id": organizationId,
-      }),
-    );
     getPlatformUrlMock.mockReset();
     getPlatformUrlMock.mockReturnValue("https://platform.example.com");
     readGatewayCredentialMock.mockReset();
@@ -209,10 +199,17 @@ describe("vellum retire", () => {
 
   afterAll(() => {
     mock.module("../lib/retire-local.js", () => realRetireLocalModule);
+    mock.module("../lib/platform-client.js", () => realPlatformClientModule);
+    mock.module("../lib/loopback-fetch.js", () => realLoopbackFetchModule);
     if (originalLockfileDir === undefined) {
       delete process.env.VELLUM_LOCKFILE_DIR;
     } else {
       process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+    }
+    if (originalPlatformToken === undefined) {
+      delete process.env.VELLUM_PLATFORM_TOKEN;
+    } else {
+      process.env.VELLUM_PLATFORM_TOKEN = originalPlatformToken;
     }
     rmSync(testDir, { recursive: true, force: true });
   });
@@ -259,10 +256,7 @@ describe("vellum retire", () => {
       "vellum:platform_assistant_id",
       entry.bearerToken,
     );
-    expect(authHeadersForOrganizationMock).toHaveBeenCalledWith(
-      "session-token",
-      "org-123",
-    );
+    expect(authHeadersMock).not.toHaveBeenCalled();
     expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
       "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
       {
@@ -276,6 +270,41 @@ describe("vellum retire", () => {
     );
     expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
     expect(loadAllAssistants()).toEqual([]);
+  });
+
+  test("local retire uses injected platform token from the app host", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    process.env.VELLUM_PLATFORM_TOKEN = "host-session-token";
+    readPlatformTokenMock.mockReturnValue(null);
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "host-session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
   });
 
   test("local retire aborts when self-hosted platform unregister fails", async () => {

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -54,6 +54,9 @@ const findAssistantByNameMock = mock<
 const saveAssistantEntryMock = mock<typeof assistantConfig.saveAssistantEntry>(
   () => {},
 );
+const saveAssistantPlatformRegistrationMock = mock<
+  typeof assistantConfig.saveAssistantPlatformRegistration
+>(() => {});
 const loadAllAssistantsMock = mock<typeof assistantConfig.loadAllAssistants>(
   () => [],
 );
@@ -65,6 +68,7 @@ mock.module("../lib/assistant-config.js", () => ({
   ...realAssistantConfig,
   findAssistantByName: findAssistantByNameMock,
   saveAssistantEntry: saveAssistantEntryMock,
+  saveAssistantPlatformRegistration: saveAssistantPlatformRegistrationMock,
   loadAllAssistants: loadAllAssistantsMock,
   removeAssistantEntry: removeAssistantEntryMock,
 }));
@@ -396,6 +400,8 @@ beforeEach(() => {
   findAssistantByNameMock.mockReturnValue(null);
   saveAssistantEntryMock.mockReset();
   saveAssistantEntryMock.mockImplementation(() => {});
+  saveAssistantPlatformRegistrationMock.mockReset();
+  saveAssistantPlatformRegistrationMock.mockImplementation(() => {});
   loadAllAssistantsMock.mockReset();
   loadAllAssistantsMock.mockReturnValue([]);
   removeAssistantEntryMock.mockReset();
@@ -2255,6 +2261,14 @@ describe("platform credential injection", () => {
         undefined, // assistantVersion (gateway unreachable in test)
         expect.any(String), // platformUrl from getPlatformUrl()
         undefined, // ingressUrl (gateway unreachable in test)
+      );
+      expect(saveAssistantPlatformRegistrationMock).toHaveBeenCalledWith(
+        "my-local",
+        {
+          platformAssistantId: "platform-assistant-1",
+          platformBaseUrl: "https://platform.vellum.ai",
+          platformOrganizationId: "org-1",
+        },
       );
       expect(injectCredentialsIntoAssistantMock).toHaveBeenCalledWith({
         gatewayUrl: "http://localhost:7821",

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -626,7 +626,9 @@ async function handleLocalEndpoints(
       );
     }
 
-    const result = await runRetire(invocation, assistantId);
+    const result = await runRetire(invocation, assistantId, {
+      platformToken: currentPlatformToken() ?? undefined,
+    });
     if (result.ok) {
       return Response.json({ ok: true });
     }

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -7,6 +7,7 @@ import {
   loadAllAssistants,
   removeAssistantEntry,
   resolveAssistant,
+  saveAssistantPlatformRegistration,
   setActiveAssistant,
 } from "../lib/assistant-config";
 import { computeDeviceId } from "../lib/guardian-token";
@@ -396,6 +397,11 @@ export async function login(): Promise<void> {
         console.log(
           `Registered assistant: ${registration.assistant.name} (${registration.assistant.id})`,
         );
+        saveAssistantPlatformRegistration(entry.assistantId, {
+          platformAssistantId: registration.assistant.id,
+          platformBaseUrl: getPlatformUrl(),
+          platformOrganizationId: orgId,
+        });
 
         // Resolve the API key to inject, mirroring the macOS app's
         // LocalAssistantBootstrapService 3-step flow:

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -49,6 +49,10 @@ interface RetireArgs {
 const VAK_PREFIX = "vak_";
 const PLATFORM_TOKEN_ENV = "VELLUM_PLATFORM_TOKEN";
 
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 function readPlatformRetireToken(): string | null {
   const envToken = process.env[PLATFORM_TOKEN_ENV]?.trim();
   if (envToken) return envToken;
@@ -113,18 +117,37 @@ async function unregisterSelfHostedLocalPlatformRecord(
   const token = readPlatformRetireToken();
   if (!token) return;
 
+  const storedPlatformAssistantId = nonEmptyString(entry.platformAssistantId);
+  const storedPlatformBaseUrl = nonEmptyString(entry.platformBaseUrl);
+  const storedPlatformOrganizationId = nonEmptyString(
+    entry.platformOrganizationId,
+  );
   const platformAssistant = await readGatewayCredential(
     entry.runtimeUrl,
     "vellum:platform_assistant_id",
     entry.bearerToken,
   );
   if (platformAssistant.unreachable) {
-    console.warn(
-      "\u26a0\ufe0f  Could not read platform registration from the local assistant; skipping platform unregister.",
-    );
+    if (!storedPlatformAssistantId) {
+      console.warn(
+        "\u26a0\ufe0f  Could not read platform registration from the local assistant; skipping platform unregister.",
+      );
+      return;
+    }
+    await deletePlatformAssistant(storedPlatformAssistantId, {
+      token,
+      platformUrl: storedPlatformBaseUrl ?? undefined,
+      organizationId: storedPlatformOrganizationId ?? undefined,
+      label: "Platform self-hosted unregister",
+      successMessage: "\u2705 Platform self-hosted registration unregistered.",
+      alreadyGoneMessage:
+        "\u2705 Platform self-hosted registration already unregistered (404).",
+    });
     return;
   }
-  if (!platformAssistant.value) return;
+  const platformAssistantId =
+    platformAssistant.value ?? storedPlatformAssistantId;
+  if (!platformAssistantId) return;
 
   const [platformBaseUrl, organizationId] = await Promise.all([
     readGatewayCredential(
@@ -139,10 +162,11 @@ async function unregisterSelfHostedLocalPlatformRecord(
     ),
   ]);
 
-  await deletePlatformAssistant(platformAssistant.value, {
+  await deletePlatformAssistant(platformAssistantId, {
     token,
-    platformUrl: platformBaseUrl.value ?? undefined,
-    organizationId: organizationId.value ?? undefined,
+    platformUrl: platformBaseUrl.value ?? storedPlatformBaseUrl ?? undefined,
+    organizationId:
+      organizationId.value ?? storedPlatformOrganizationId ?? undefined,
     label: "Platform self-hosted unregister",
     successMessage: "\u2705 Platform self-hosted registration unregistered.",
     alreadyGoneMessage:

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -20,7 +20,9 @@ import { getConfigDir } from "../lib/environments/paths.js";
 import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 import {
   authHeaders,
+  authHeadersForOrganization,
   getPlatformUrl,
+  readGatewayCredential,
   readPlatformToken,
 } from "../lib/platform-client.js";
 import { retireInstance as retireAwsInstance } from "../lib/aws.js";
@@ -43,6 +45,83 @@ interface RetireArgs {
   name?: string;
   source?: string;
   yes: boolean;
+}
+
+async function deletePlatformAssistant(
+  assistantId: string,
+  options: {
+    token: string;
+    platformUrl?: string;
+    organizationId?: string;
+    label: string;
+    successMessage: string;
+    alreadyGoneMessage: string;
+  },
+): Promise<void> {
+  const platformUrl = options.platformUrl || getPlatformUrl();
+  const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
+  const headers = options.organizationId
+    ? authHeadersForOrganization(options.token, options.organizationId)
+    : await authHeaders(options.token, platformUrl);
+
+  const response = await loopbackSafeFetch(url, {
+    method: "DELETE",
+    headers,
+  });
+
+  if (!response.ok && response.status !== 404) {
+    const body = await response.text();
+    throw new Error(`${options.label} failed (${response.status}): ${body}`);
+  }
+
+  if (response.status === 404) {
+    console.log(options.alreadyGoneMessage);
+  } else {
+    console.log(options.successMessage);
+  }
+}
+
+async function unregisterSelfHostedLocalPlatformRecord(
+  entry: AssistantEntry,
+): Promise<void> {
+  const token = readPlatformToken();
+  if (!token) return;
+
+  const platformAssistant = await readGatewayCredential(
+    entry.runtimeUrl,
+    "vellum:platform_assistant_id",
+    entry.bearerToken,
+  );
+  if (platformAssistant.unreachable) {
+    console.warn(
+      "\u26a0\ufe0f  Could not read platform registration from the local assistant; skipping platform unregister.",
+    );
+    return;
+  }
+  if (!platformAssistant.value) return;
+
+  const [platformBaseUrl, organizationId] = await Promise.all([
+    readGatewayCredential(
+      entry.runtimeUrl,
+      "vellum:platform_base_url",
+      entry.bearerToken,
+    ),
+    readGatewayCredential(
+      entry.runtimeUrl,
+      "vellum:platform_organization_id",
+      entry.bearerToken,
+    ),
+  ]);
+
+  await deletePlatformAssistant(platformAssistant.value, {
+    token,
+    platformUrl: platformBaseUrl.value ?? undefined,
+    organizationId: organizationId.value ?? undefined,
+    label: "Platform self-hosted unregister",
+    successMessage: "\u2705 Platform self-hosted registration unregistered.",
+    alreadyGoneMessage:
+      "\u2705 Platform self-hosted registration already unregistered (404).",
+  });
 }
 
 async function retireCustom(entry: AssistantEntry): Promise<void> {
@@ -94,32 +173,25 @@ async function retireVellum(
     process.exit(1);
   }
 
-  const platformUrl = runtimeUrl || getPlatformUrl();
-  const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
-  const response = await loopbackSafeFetch(url, {
-    method: "DELETE",
-    headers: await authHeaders(token, runtimeUrl),
-  });
-
   // Treat 404 as success: the assistant is already gone from the platform
   // (previously retired, deleted from the web UI, or retired from another
   // device) so the caller's job is done. Falling through to the lockfile
   // cleanup avoids leaving a stale entry that would otherwise wedge the
   // macOS app in a permanent health-check loop.
-  if (!response.ok && response.status !== 404) {
-    const body = await response.text();
+  try {
+    await deletePlatformAssistant(assistantId, {
+      token,
+      platformUrl: runtimeUrl,
+      label: "Platform retire",
+      successMessage: "\u2705 Platform-hosted instance retired.",
+      alreadyGoneMessage:
+        "\u2705 Platform-hosted instance already retired (404) \u2014 cleaning up local state.",
+    });
+  } catch (error) {
     console.error(
-      `Error: Platform retire failed (${response.status}): ${body}`,
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
     );
     process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.log(
-      "\u2705 Platform-hosted instance already retired (404) — cleaning up local state.",
-    );
-  } else {
-    console.log("\u2705 Platform-hosted instance retired.");
   }
 }
 
@@ -303,6 +375,14 @@ async function retireInner(): Promise<void> {
   } else if (cloud === "docker") {
     await retireDocker(assistantId);
   } else if (cloud === "local") {
+    try {
+      await unregisterSelfHostedLocalPlatformRecord(entry);
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    }
     await retireLocal(assistantId, entry);
   } else if (cloud === "custom") {
     await retireCustom(entry);

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -20,7 +20,6 @@ import { getConfigDir } from "../lib/environments/paths.js";
 import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 import {
   authHeaders,
-  authHeadersForOrganization,
   getPlatformUrl,
   readGatewayCredential,
   readPlatformToken,
@@ -47,6 +46,33 @@ interface RetireArgs {
   yes: boolean;
 }
 
+const VAK_PREFIX = "vak_";
+const PLATFORM_TOKEN_ENV = "VELLUM_PLATFORM_TOKEN";
+
+function readPlatformRetireToken(): string | null {
+  const envToken = process.env[PLATFORM_TOKEN_ENV]?.trim();
+  if (envToken) return envToken;
+  return readPlatformToken();
+}
+
+function authHeadersWithKnownOrganization(
+  token: string,
+  organizationId: string,
+): Record<string, string> {
+  if (token.startsWith(VAK_PREFIX)) {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  return {
+    "Content-Type": "application/json",
+    "X-Session-Token": token,
+    "Vellum-Organization-Id": organizationId,
+  };
+}
+
 async function deletePlatformAssistant(
   assistantId: string,
   options: {
@@ -61,7 +87,7 @@ async function deletePlatformAssistant(
   const platformUrl = options.platformUrl || getPlatformUrl();
   const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
   const headers = options.organizationId
-    ? authHeadersForOrganization(options.token, options.organizationId)
+    ? authHeadersWithKnownOrganization(options.token, options.organizationId)
     : await authHeaders(options.token, platformUrl);
 
   const response = await loopbackSafeFetch(url, {
@@ -84,7 +110,7 @@ async function deletePlatformAssistant(
 async function unregisterSelfHostedLocalPlatformRecord(
   entry: AssistantEntry,
 ): Promise<void> {
-  const token = readPlatformToken();
+  const token = readPlatformRetireToken();
   if (!token) return;
 
   const platformAssistant = await readGatewayCredential(
@@ -165,7 +191,7 @@ async function retireVellum(
 ): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Retiring platform-hosted instance...\n");
 
-  const token = readPlatformToken();
+  const token = readPlatformRetireToken();
   if (!token) {
     console.error(
       "Error: Not logged in. Run `vellum login --token <token>` first.",

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -4,6 +4,7 @@ import {
   getDaemonPidPath,
   removeAssistantEntry,
   saveAssistantEntry,
+  saveAssistantPlatformRegistration,
   setActiveAssistant,
   type AssistantEntry,
 } from "../lib/assistant-config.js";
@@ -1133,6 +1134,11 @@ async function tryInjectPlatformCredentials(
       getPlatformUrl(),
       ingressUrl,
     );
+    saveAssistantPlatformRegistration(entry.assistantId, {
+      platformAssistantId: registration.assistant.id,
+      platformBaseUrl: getPlatformUrl(),
+      platformOrganizationId: orgId,
+    });
 
     // Resolve the API key: 1) fresh from registration, 2) existing from
     // daemon credential store, 3) reprovision as last resort (revokes old key).

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -608,6 +608,19 @@ export function saveAssistantEntry(entry: AssistantEntry): void {
   writeAssistants(entries);
 }
 
+export function saveAssistantPlatformRegistration(
+  assistantId: string,
+  metadata: {
+    platformAssistantId: string;
+    platformBaseUrl: string;
+    platformOrganizationId: string;
+  },
+): void {
+  const entry = findAssistantByName(assistantId);
+  if (!entry) return;
+  saveAssistantEntry({ ...entry, ...metadata });
+}
+
 /**
  * Scan upward from `basePort` to find an available port. A port is considered
  * available when `probePort()` returns false (nothing listening). Scans up to

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -85,9 +85,8 @@ const VAK_PREFIX = "vak_";
 /**
  * Sync helper – returns only the token-based auth header.
  *
- * Used internally by {@link fetchOrganizationId} (which cannot call the
- * async {@link authHeaders} without creating a cycle) and by functions
- * that already have an org ID in hand.
+ * Used internally by {@link fetchOrganizationId}, which cannot call the
+ * async {@link authHeaders} without creating a cycle.
  */
 function tokenAuthHeader(token: string): Record<string, string> {
   if (token.startsWith(VAK_PREFIX)) {
@@ -171,22 +170,6 @@ export async function authHeaders(
     }
     throw new Error(`Failed to fetch organization: ${msg}`);
   }
-}
-
-export function authHeadersForOrganization(
-  token: string,
-  organizationId: string,
-): Record<string, string> {
-  const base: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...tokenAuthHeader(token),
-  };
-
-  if (token.startsWith(VAK_PREFIX)) {
-    return base;
-  }
-
-  return { ...base, "Vellum-Organization-Id": organizationId };
 }
 
 export interface HatchedAssistant {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -173,6 +173,22 @@ export async function authHeaders(
   }
 }
 
+export function authHeadersForOrganization(
+  token: string,
+  organizationId: string,
+): Record<string, string> {
+  const base: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...tokenAuthHeader(token),
+  };
+
+  if (token.startsWith(VAK_PREFIX)) {
+    return base;
+  }
+
+  return { ...base, "Vellum-Organization-Id": organizationId };
+}
+
 export interface HatchedAssistant {
   id: string;
   name: string;

--- a/clients/macos/src/main/bundle-flow.test.ts
+++ b/clients/macos/src/main/bundle-flow.test.ts
@@ -26,7 +26,9 @@ mock.module("electron", () => ({
 }));
 
 const getLockfileDataMock = mock(
-  (_paths: string[]): { ok: true; data: unknown } | { ok: false; status: number } => ({
+  (
+    _paths: string[],
+  ): { ok: true; data: unknown } | { ok: false; status: number } => ({
     ok: false as const,
     status: 500,
   }),
@@ -35,9 +37,10 @@ const resolveLockfilePathsMock = mock((_env: NodeJS.ProcessEnv) => [
   "/fake/lockfile",
 ]);
 const resolveConfigDirMock = mock((_env: NodeJS.ProcessEnv) => "/fake/config");
-const getGuardianAccessTokenMock = mock(
-  async () => ({ ok: true as const, accessToken: "fake-token" }),
-);
+const getGuardianAccessTokenMock = mock(async () => ({
+  ok: true as const,
+  accessToken: "fake-token",
+}));
 
 // Full `@vellumai/local-mode` surface so the real `./local-mode` (imported by
 // bundle-flow for resolveCliInvocation) links cleanly.
@@ -67,9 +70,11 @@ mock.module("./cli-installer", () => ({
   ensureCliInstalled: ensureCliInstalledMock,
 }));
 
-const openBundleConfirmationMock = mock(
-  async (_data: BundleScanData) => true,
-);
+mock.module("./session-token-store", () => ({
+  getSessionToken: () => null,
+}));
+
+const openBundleConfirmationMock = mock(async (_data: BundleScanData) => true);
 const installBundleConfirmationMock = mock(() => undefined);
 
 mock.module("./bundle-confirmation", () => ({
@@ -283,7 +288,9 @@ describe("handleBundleFile", () => {
 
     expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
     expect(showErrorBoxMock.mock.calls[0]?.[0]).toBe("Bundle blocked");
-    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain("Detected malicious script");
+    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain(
+      "Detected malicious script",
+    );
     expect(openBundleConfirmationMock).not.toHaveBeenCalled();
   });
 

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -32,7 +32,10 @@ mock.module("electron", () => ({
     getAppPath: () => appState.appPath,
   },
   ipcMain: {
-    handle: (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+    handle: (
+      channel: string,
+      handler: (event: unknown, ...args: unknown[]) => unknown,
+    ) => {
       handlers[channel] = handler;
     },
   },
@@ -42,8 +45,10 @@ import { FakeChild } from "./test-helpers";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[]]> = [];
-const spawnMock = mock((command: string, args: string[]) => {
+const spawnOptions: unknown[] = [];
+const spawnMock = mock((command: string, args: string[], options?: unknown) => {
   spawnArgs.push([command, args]);
+  spawnOptions.push(options);
   lastChild = new FakeChild();
   return lastChild;
 });
@@ -95,6 +100,11 @@ process.env.VELLUM_ENVIRONMENT = "production";
 process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
 process.env.XDG_CONFIG_HOME = configHomeDir;
 const lockfilePath = path.join(lockfileDir, ".vellum.lock.json");
+
+let mockSessionToken: string | null = null;
+mock.module("./session-token-store", () => ({
+  getSessionToken: () => mockSessionToken,
+}));
 
 const { installLocalMode } = await import("./local-mode");
 const { resolveAllowedOrigin } = await import("./app-origin");
@@ -151,10 +161,12 @@ afterEach(() => {
   appState.isPackaged = false;
   appState.appPath = "/repo/clients/macos";
   spawnArgs.length = 0;
+  spawnOptions.length = 0;
   spawnMock.mockClear();
   ensureCliInstalledMock.mockClear();
   cliInstallerState.isInstalled = false;
   cliInstallerState.installError = null;
+  mockSessionToken = null;
   delete process.env.VELLUM_CLI_PATH;
   for (const key of Object.keys(existsSyncOverrides)) {
     delete existsSyncOverrides[key];
@@ -277,7 +289,10 @@ describe("vellum:localMode:hatch handler", () => {
     lastChild.stderr.emit("data", Buffer.from("daemon already running"));
     lastChild.emit("close", 1);
 
-    expect(await pending).toEqual({ ok: false, error: "daemon already running" });
+    expect(await pending).toEqual({
+      ok: false,
+      error: "daemon already running",
+    });
   });
 
   test("a non-zero exit with no output carries a descriptive fallback error", async () => {
@@ -353,7 +368,10 @@ const replacePlatformAssistants = (platformAssistants: unknown): WriteResult =>
     platformAssistants,
   ) as WriteResult;
 const retire = (assistantId?: unknown): Promise<unknown> =>
-  handlers["vellum:localMode:retire"](allowedEvent, assistantId) as Promise<unknown>;
+  handlers["vellum:localMode:retire"](
+    allowedEvent,
+    assistantId,
+  ) as Promise<unknown>;
 const wake = (assistantId?: unknown, options?: unknown): Promise<unknown> =>
   handlers["vellum:localMode:wake"](
     allowedEvent,
@@ -415,7 +433,11 @@ describe("lockfile IPC handlers", () => {
     if (!result.ok) return;
     expect(result.lockfile.activeAssistant).toBe("asst-1");
     expect(result.lockfile.assistants).toEqual([
-      { assistantId: "asst-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "asst-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
     ]);
 
     const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
@@ -440,7 +462,11 @@ describe("lockfile IPC handlers", () => {
 
   test("replacePlatformAssistants swaps platform entries while preserving local ones", () => {
     saveLockfileAssistant(
-      { assistantId: "local-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "local-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
       "local-1",
     );
     saveLockfileAssistant(
@@ -454,15 +480,19 @@ describe("lockfile IPC handlers", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const ids = (result.lockfile.assistants as Array<{ assistantId: string }>).map(
-      (a) => a.assistantId,
-    );
+    const ids = (
+      result.lockfile.assistants as Array<{ assistantId: string }>
+    ).map((a) => a.assistantId);
     expect(ids).toEqual(["local-1", "new-platform"]);
   });
 
   test("replacePlatformAssistants rejects a non-array argument without touching disk", () => {
     saveLockfileAssistant(
-      { assistantId: "local-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "local-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
       "local-1",
     );
 
@@ -505,8 +535,35 @@ describe("vellum:localMode:retire handler", () => {
     expect(await pending).toEqual({ ok: false, error: "no such assistant" });
   });
 
+  test("passes the current session token through the shared retire invocation", async () => {
+    mockSessionToken = "tok-electron";
+    const previousPlatformToken = process.env.VELLUM_PLATFORM_TOKEN;
+    process.env.VELLUM_PLATFORM_TOKEN = "parent-token";
+    try {
+      const pending = retire("asst-1");
+      await tick();
+      lastChild.emit("close", 0);
+
+      expect(await pending).toEqual({ ok: true });
+      expect(
+        (spawnOptions[0] as { env?: NodeJS.ProcessEnv }).env
+          ?.VELLUM_PLATFORM_TOKEN,
+      ).toBe("tok-electron");
+      expect(process.env.VELLUM_PLATFORM_TOKEN).toBe("parent-token");
+    } finally {
+      if (previousPlatformToken === undefined) {
+        delete process.env.VELLUM_PLATFORM_TOKEN;
+      } else {
+        process.env.VELLUM_PLATFORM_TOKEN = previousPlatformToken;
+      }
+    }
+  });
+
   test("rejects a missing assistant id without spawning", async () => {
-    expect(await retire("")).toEqual({ ok: false, error: "Missing assistantId" });
+    expect(await retire("")).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
     expect(await retire(undefined)).toEqual({
       ok: false,
       error: "Missing assistantId",

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -31,6 +31,7 @@ import {
   getBundledBunPath,
   getCliBinPath,
 } from "./cli-installer";
+import { getSessionToken } from "./session-token-store";
 
 /**
  * Local-mode host bridge: provisions and retires local assistants and reads
@@ -130,7 +131,9 @@ async function retire(assistantId: string): Promise<RetireResult> {
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runRetire(invocation, assistantId);
+  const result = await runRetire(invocation, assistantId, {
+    platformToken: getSessionToken() ?? undefined,
+  });
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
@@ -294,7 +297,11 @@ export const installLocalMode = (): void => {
     "vellum:localMode:replacePlatformAssistants",
     z.tuple([z.array(assistantRecord), z.string().optional()]),
     ([list, organizationId]): LockfileWriteResult => {
-      const result = replacePlatformAssistants(lockfilePaths, list, organizationId);
+      const result = replacePlatformAssistants(
+        lockfilePaths,
+        list,
+        organizationId,
+      );
       return result.ok
         ? { ok: true, lockfile: result.lockfile }
         : { ok: false, error: result.error };

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -18,9 +18,20 @@ const loadLockfileHost = mock(async () => {
   throw new Error("host down");
 });
 
+const saveLockfileAssistantHost = mock(
+  async (
+    _entry: Record<string, unknown>,
+    _activeAssistant: string | undefined,
+  ) => ({
+    ok: true as const,
+    lockfile: { assistants: [localA], activeAssistant: "local-a" },
+  }),
+);
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
+  saveLockfileAssistantHost,
   loadLockfileHost,
 }));
 
@@ -39,6 +50,7 @@ import {
   primeLocalGatewayConnection,
   reconcileSelectedAssistant,
   syncPlatformAssistantsToLockfile,
+  updateLockfileAssistant,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
@@ -85,6 +97,7 @@ afterEach(() => {
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
+  saveLockfileAssistantHost.mockClear();
 });
 
 describe("remote gateway mode", () => {
@@ -160,6 +173,41 @@ describe("syncPlatformAssistantsToLockfile", () => {
     expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile).toBeNull();
     expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("updateLockfileAssistant", () => {
+  test("patches an existing entry without changing the active assistant", async () => {
+    setLockfile({ assistants: [localA], activeAssistant: "local-a" });
+    saveLockfileAssistantHost.mockImplementationOnce(async (entry) => ({
+      ok: true as const,
+      lockfile: {
+        assistants: [entry as LockfileAssistant],
+        activeAssistant: "local-a",
+      },
+    }));
+
+    await updateLockfileAssistant("local-a", {
+      platformAssistantId: "platform-asst-1",
+      platformBaseUrl: "https://platform.example.com",
+      platformOrganizationId: "org_1",
+    });
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledWith(
+      {
+        ...localA,
+        platformAssistantId: "platform-asst-1",
+        platformBaseUrl: "https://platform.example.com",
+        platformOrganizationId: "org_1",
+      },
+      undefined,
+    );
+    expect(getLockfile().activeAssistant).toBe("local-a");
+    expect(getLockfile().assistants[0]).toEqual(
+      expect.objectContaining({
+        platformAssistantId: "platform-asst-1",
+      }),
+    );
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -205,10 +205,36 @@ export async function saveLockfileAssistant(assistant: {
   runtimeUrl: string;
   hatchedAt: string;
   organizationId?: string;
+  platformAssistantId?: string;
+  platformBaseUrl?: string;
+  platformOrganizationId?: string;
 }): Promise<void> {
   const result = await saveLockfileAssistantHost(
     assistant,
     assistant.assistantId,
+  );
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
+}
+
+/**
+ * Update an existing lockfile entry without changing the active assistant.
+ */
+export async function updateLockfileAssistant(
+  assistantId: string,
+  patch: Partial<LockfileAssistant>,
+): Promise<void> {
+  if (isRemoteGatewayMode()) return;
+
+  const entry = getLockfile().assistants.find(
+    (assistant) => assistant.assistantId === assistantId,
+  );
+  if (!entry) return;
+
+  const result = await saveLockfileAssistantHost(
+    { ...entry, ...patch, assistantId },
+    undefined,
   );
   if (result.ok) {
     commitLockfile(result.lockfile);

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -38,6 +38,9 @@ const buildVellumMutatingHeadersMock = mock(
 );
 const primeLocalGatewayConnectionWithRepairMock = mock(async () => {});
 const fetchOrganizationsMock = mock(async () => {});
+const updateLockfileAssistantMock = mock(
+  async (_assistantId: string, _patch: Record<string, unknown>) => {},
+);
 
 mock.module("@/lib/auth/request-headers", () => ({
   buildVellumMutatingHeaders: buildVellumMutatingHeadersMock,
@@ -48,12 +51,14 @@ mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => "/assistant/__gateway/20101",
   getPlatformRuntimeUrl: () => "http://localhost:8000",
   getSelectedAssistant: () => activeAssistant,
-  isLocalAssistant: (assistant: { cloud?: string }) => assistant?.cloud === "local",
+  isLocalAssistant: (assistant: { cloud?: string }) =>
+    assistant?.cloud === "local",
   isLocalMode: () => isLocalModeValue,
   isPlatformDisabled: () => isPlatformDisabledValue,
   isRemoteGatewayMode: () => isRemoteGatewayModeValue,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
+  updateLockfileAssistant: updateLockfileAssistantMock,
 }));
 
 mock.module("@/lib/self-hosted/connection", () => ({
@@ -140,6 +145,7 @@ beforeEach(() => {
   buildVellumMutatingHeadersMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   fetchOrganizationsMock.mockClear();
+  updateLockfileAssistantMock.mockClear();
   resetLocalPlatformIdentityCacheForTesting();
 
   globalThis.fetch = mock(
@@ -162,14 +168,12 @@ beforeEach(() => {
         return jsonResponse(statusBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/ensure-registration/"
+        url.pathname === "/v1/assistants/self-hosted-local/ensure-registration/"
       ) {
         return jsonResponse(ensureRegistrationBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/reprovision-api-key/"
+        url.pathname === "/v1/assistants/self-hosted-local/reprovision-api-key/"
       ) {
         return jsonResponse(reprovisionApiKeyBody);
       }
@@ -193,6 +197,14 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(requestNames()).toEqual(["status"]);
+    expect(updateLockfileAssistantMock).toHaveBeenCalledWith(
+      RUNTIME_ASSISTANT_ID,
+      {
+        platformAssistantId: PLATFORM_ASSISTANT_ID,
+        platformBaseUrl: "http://localhost:8000",
+        platformOrganizationId: ORGANIZATION_ID,
+      },
+    );
   });
 
   test("repairs a stored platform id when the local assistant is missing its API key", async () => {
@@ -210,6 +222,14 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(updateLockfileAssistantMock).toHaveBeenCalledWith(
+      RUNTIME_ASSISTANT_ID,
+      {
+        platformAssistantId: PLATFORM_ASSISTANT_ID,
+        platformBaseUrl: "http://localhost:8000",
+        platformOrganizationId: ORGANIZATION_ID,
+      },
+    );
     expect(requestNames()).toEqual([
       "status",
       "ensure-registration",
@@ -238,10 +258,12 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
   test("repairs gateway access by default for blocking platform identity resolution", async () => {
     selfHostedIngressUrl = null;
     selfHostedActorToken = null;
-    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(async () => {
-      selfHostedIngressUrl = GATEWAY_URL;
-      selfHostedActorToken = "actor-token";
-    });
+    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(
+      async () => {
+        selfHostedIngressUrl = GATEWAY_URL;
+        selfHostedActorToken = "actor-token";
+      },
+    );
 
     const platformAssistantId =
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -9,6 +9,7 @@ import {
   isPlatformDisabled,
   isRemoteGatewayMode,
   primeLocalGatewayConnectionWithRepair,
+  updateLockfileAssistant,
   type LockfileAssistant,
 } from "@/lib/local-mode";
 import {
@@ -148,20 +149,33 @@ async function ensureLocalAssistantPlatformIdentity(
 ): Promise<string> {
   const gateway = await ensureGatewayAccess(assistant, options);
   const status = await fetchPlatformStatus(gateway, assistant.assistantId);
+  const statusOrganizationId = status?.organizationId ?? null;
   const statusPlatformAssistantId =
     status?.assistantId && isUuid(status.assistantId)
       ? status.assistantId
       : null;
   if (statusPlatformAssistantId && status?.hasAssistantApiKey !== false) {
+    const platformOrganizationId =
+      statusOrganizationId ??
+      getActiveOrganizationIdForRequests() ??
+      assistant.organizationId ??
+      null;
+    await persistPlatformRegistrationMetadata(assistant, {
+      platformAssistantId: statusPlatformAssistantId,
+      platformBaseUrl: getPlatformRuntimeUrl(),
+      ...(platformOrganizationId ? { platformOrganizationId } : {}),
+    });
     return statusPlatformAssistantId;
   }
 
   const organizationId = await resolveOrganizationId(
-    status?.organizationId ?? null,
+    statusOrganizationId,
     assistant,
   );
   if (!organizationId) {
-    throw new Error("Sign in to Vellum and select an organization to register this local assistant.");
+    throw new Error(
+      "Sign in to Vellum and select an organization to register this local assistant.",
+    );
   }
 
   const registration = await ensureRegistration(assistant, organizationId);
@@ -183,15 +197,35 @@ async function ensureLocalAssistantPlatformIdentity(
     assistantApiKey = await reprovisionApiKey(assistant, organizationId);
   }
 
+  const platformBaseUrl = getPlatformRuntimeUrl();
+  await persistPlatformRegistrationMetadata(assistant, {
+    platformAssistantId,
+    platformBaseUrl,
+    platformOrganizationId: organizationId,
+  });
+
   await injectPlatformCredentials(gateway, {
     assistantApiKey,
     platformAssistantId,
-    platformBaseUrl: getPlatformRuntimeUrl(),
+    platformBaseUrl,
     organizationId,
     webhookSecret: stringValue(registration.webhook_secret),
   });
 
   return platformAssistantId;
+}
+
+async function persistPlatformRegistrationMetadata(
+  assistant: LockfileAssistant,
+  metadata: {
+    platformAssistantId: string;
+    platformBaseUrl: string;
+    platformOrganizationId?: string;
+  },
+): Promise<void> {
+  await updateLockfileAssistant(assistant.assistantId, metadata).catch(
+    () => {},
+  );
 }
 
 async function ensureGatewayAccess(
@@ -215,7 +249,9 @@ async function ensureGatewayAccess(
   }
 
   if (!gatewayUrl || !actorToken) {
-    throw new Error("Unable to reach the local assistant for platform identity setup.");
+    throw new Error(
+      "Unable to reach the local assistant for platform identity setup.",
+    );
   }
 
   return { gatewayUrl, actorToken };
@@ -225,7 +261,10 @@ async function fetchPlatformStatus(
   gateway: { gatewayUrl: string; actorToken: string },
   runtimeAssistantId: string,
 ): Promise<LocalPlatformStatus | null> {
-  const url = gatewayUrl(gateway.gatewayUrl, `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`);
+  const url = gatewayUrl(
+    gateway.gatewayUrl,
+    `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`,
+  );
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
@@ -235,9 +274,9 @@ async function fetchPlatformStatus(
   }).catch(() => null);
   if (!response?.ok) return null;
 
-  const body = (await response.json().catch(() => null)) as
-    | PlatformStatusBody
-    | null;
+  const body = (await response
+    .json()
+    .catch(() => null)) as PlatformStatusBody | null;
   return {
     assistantId: firstString(body?.assistantId, body?.assistant_id),
     organizationId: firstString(body?.organizationId, body?.organization_id),
@@ -259,7 +298,10 @@ async function resolveOrganizationId(
     null;
   if (existing) return existing;
 
-  await useOrganizationStore.getState().fetchOrganizations().catch(() => {});
+  await useOrganizationStore
+    .getState()
+    .fetchOrganizations()
+    .catch(() => {});
   return (
     getActiveOrganizationIdForRequests() ?? assistant.organizationId ?? null
   );
@@ -296,7 +338,9 @@ async function platformPost<T>(
 ): Promise<T> {
   const deviceId = getDeviceId();
   if (!deviceId) {
-    throw new Error("Unable to identify this device for local assistant platform registration.");
+    throw new Error(
+      "Unable to identify this device for local assistant platform registration.",
+    );
   }
 
   const headers = new Headers({
@@ -323,16 +367,19 @@ async function platformPost<T>(
     );
   }
 
-  const response = await fetch(new URL(path, window.location.origin).toString(), {
-    method: "POST",
-    headers,
-    credentials: isElectron() ? "omit" : "same-origin",
-    body: JSON.stringify({
-      client_installation_id: deviceId,
-      runtime_assistant_id: assistant.assistantId,
-      client_platform: "macos",
-    }),
-  }).catch((error: unknown) => {
+  const response = await fetch(
+    new URL(path, window.location.origin).toString(),
+    {
+      method: "POST",
+      headers,
+      credentials: isElectron() ? "omit" : "same-origin",
+      body: JSON.stringify({
+        client_installation_id: deviceId,
+        runtime_assistant_id: assistant.assistantId,
+        client_platform: "macos",
+      }),
+    },
+  ).catch((error: unknown) => {
     throw new Error(
       `Unable to reach the platform registration endpoint: ${errorMessage(error)}`,
     );

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -422,7 +422,9 @@ function retireMiddleware(
         return;
       }
 
-      runRetire(invocation, assistantId).then((result) => {
+      runRetire(invocation, assistantId, {
+        platformToken: getDevPlatformToken() ?? undefined,
+      }).then((result) => {
         res.statusCode = result.ok ? 200 : result.status;
         res.setHeader("Content-Type", "application/json");
         res.end(

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import type { CliInvocation } from "../util";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+let lastChild: FakeChild;
+const spawnArgs: Array<
+  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }]
+> = [];
+const spawnMock = mock(
+  (
+    command: string,
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+  ) => {
+    spawnArgs.push([command, args, options]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+);
+
+mock.module("node:child_process", () => ({ spawn: spawnMock }));
+
+let runRetire: typeof import("../retire").runRetire;
+
+beforeAll(async () => {
+  ({ runRetire } = await import("../retire"));
+});
+
+afterEach(() => {
+  spawnArgs.length = 0;
+  spawnMock.mockClear();
+  delete process.env.VELLUM_PLATFORM_TOKEN;
+});
+
+const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
+
+describe("runRetire", () => {
+  test("spawns the CLI retire command", async () => {
+    const pending = runRetire(invocation, "asst-42");
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "retire", "asst-42", "--yes"],
+      { env: process.env, stdio: ["ignore", "pipe", "pipe"] },
+    ]);
+  });
+
+  test("passes a host platform token to the CLI subprocess", async () => {
+    const pending = runRetire(invocation, "asst-42", {
+      platformToken: "session-token",
+    });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]?.[2].env?.VELLUM_PLATFORM_TOKEN).toBe("session-token");
+    expect(process.env.VELLUM_PLATFORM_TOKEN).toBeUndefined();
+  });
+
+  test("a non-zero exit resolves to a failure carrying the CLI output", async () => {
+    const pending = runRetire(invocation, "asst-42");
+    lastChild.stderr.emit("data", Buffer.from("retire failed"));
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "retire failed",
+    });
+  });
+});

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -21,6 +21,9 @@ describe("parseLockfile", () => {
           species: "vellum",
           hatchedAt: "2026-01-01T00:00:00.000Z",
           organizationId: "org_1",
+          platformAssistantId: "platform-asst-1",
+          platformBaseUrl: "https://platform.example.com",
+          platformOrganizationId: "org_1",
           resources: { gatewayPort: 7777, daemonPort: 7778 },
         },
       ],
@@ -183,6 +186,38 @@ describe("parseLockfile", () => {
     ]);
   });
 
+  test("keeps local platform registration metadata and drops mistyped values", () => {
+    const raw = {
+      assistants: [
+        {
+          assistantId: "asst_1",
+          cloud: "local",
+          platformAssistantId: "platform-asst-1",
+          platformBaseUrl: "https://platform.example.com",
+          platformOrganizationId: "org_1",
+        },
+        {
+          assistantId: "asst_2",
+          cloud: "local",
+          platformAssistantId: 7,
+          platformBaseUrl: false,
+          platformOrganizationId: { id: "org_1" },
+        },
+      ],
+      activeAssistant: null,
+    };
+    expect(parseLockfile(raw).assistants).toEqual([
+      {
+        assistantId: "asst_1",
+        cloud: "local",
+        platformAssistantId: "platform-asst-1",
+        platformBaseUrl: "https://platform.example.com",
+        platformOrganizationId: "org_1",
+      },
+      { assistantId: "asst_2", cloud: "local" },
+    ]);
+  });
+
   test("drops a resources object missing its numeric ports", () => {
     const raw = {
       assistants: [
@@ -274,13 +309,19 @@ describe("parseLockfile", () => {
     expect(parseLockfile(raw).assistants).toEqual([
       { assistantId: "gcp_1", cloud: "gcp", runtimeUrl: "https://a" },
       { assistantId: "ssh_1", cloud: "custom", runtimeUrl: "https://b" },
-      { assistantId: "local_1", cloud: "local", runtimeUrl: "http://localhost:7830" },
+      {
+        assistantId: "local_1",
+        cloud: "local",
+        runtimeUrl: "http://localhost:7830",
+      },
     ]);
   });
 
   test("prefers an explicit cloud over legacy remote markers", () => {
     const raw = {
-      assistants: [{ assistantId: "a", cloud: "vellum", project: "stale-proj" }],
+      assistants: [
+        { assistantId: "a", cloud: "vellum", project: "stale-proj" },
+      ],
       activeAssistant: null,
     };
     expect(parseLockfile(raw).assistants).toEqual([

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -109,6 +109,10 @@ export const LockfileAssistantSchema = z.object({
   hatchedAt: z.string().optional(),
   /** Owning org for platform assistants; absent for local ones. */
   organizationId: z.string().optional(),
+  /** Platform self-hosted registration metadata for local assistants. */
+  platformAssistantId: z.string().optional(),
+  platformBaseUrl: z.string().optional(),
+  platformOrganizationId: z.string().optional(),
   resources: LocalAssistantResourcesSchema.optional(),
 });
 
@@ -134,8 +138,7 @@ export interface Lockfile {
  * surfaces failures by message alone.
  */
 export type LockfileWriteResult =
-  | { ok: true; lockfile: Lockfile }
-  | { ok: false; error: string };
+  { ok: true; lockfile: Lockfile } | { ok: false; error: string };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/local-mode/src/retire.ts
+++ b/packages/local-mode/src/retire.ts
@@ -5,18 +5,25 @@ import type { CliInvocation } from "./util";
 const RETIRE_TIMEOUT_MS = 60_000;
 
 export type RetireResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
+  { ok: true } | { ok: false; status: number; error: string };
+
+export interface RetireOptions {
+  platformToken?: string;
+}
 
 export function runRetire(
   invocation: CliInvocation,
   assistantId: string,
+  options: RetireOptions = {},
 ): Promise<RetireResult> {
   return new Promise((resolve) => {
+    const env = options.platformToken
+      ? { ...process.env, VELLUM_PLATFORM_TOKEN: options.platformToken }
+      : process.env;
     const child = spawn(
       invocation.command,
       [...invocation.baseArgs, "retire", assistantId, "--yes"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { env, stdio: ["ignore", "pipe", "pipe"] },
     );
 
     let stdout = "";
@@ -32,7 +39,11 @@ export function runRetire(
 
     const timeout = setTimeout(() => {
       child.kill("SIGTERM");
-      finish({ ok: false, status: 500, error: "Retire timed out after 60 seconds" });
+      finish({
+        ok: false,
+        status: 500,
+        error: "Retire timed out after 60 seconds",
+      });
     }, RETIRE_TIMEOUT_MS);
 
     child.stdout.on("data", (data: Buffer) => {
@@ -52,7 +63,11 @@ export function runRetire(
     });
 
     child.on("error", (err) => {
-      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+      finish({
+        ok: false,
+        status: 500,
+        error: `Failed to spawn CLI: ${err.message}`,
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- Unregisters a local assistant's self-hosted platform record before local teardown when platform auth is available.
- Keeps retire behavior in the shared CLI retire path used by terminal CLI, locally hosted web, and Electron retire flows.
- Persists self-hosted platform registration metadata (`platformAssistantId`, platform base URL, organization ID) in the local lockfile when registration succeeds from CLI login, teleport, or web/Electron bootstrap.
- Falls back to that durable lockfile metadata when the local gateway is unreachable during retire, so platform cleanup does not depend on the assistant still being healthy enough to serve its injected credentials.
- Passes the web dev server or Electron session token into the shared local-mode retire subprocess via `VELLUM_PLATFORM_TOKEN`, while terminal CLI usage still falls back to the saved CLI platform token.
- Adds focused CLI, local-mode, web, and macOS retire/lockfile tests for successful unregister, abort-on-unregister-failure, host-token propagation, durable metadata persistence, and offline unregister fallback.

## Verification
- `cd packages/local-mode && bun test src/lockfile-contract.test.ts src/lockfile.test.ts`
- `cd packages/local-mode && bun run typecheck`
- `cd clients/web && bun test src/lib/local-platform-identity.test.ts src/lib/local-mode.test.ts`
- `cd clients/web && bun run lint -- src/lib/local-platform-identity.ts src/lib/local-platform-identity.test.ts src/lib/local-mode.ts src/lib/local-mode.test.ts`
- `cd clients/web && bunx tsc --noEmit`
- `cd cli && bun test src/__tests__/retire.test.ts src/__tests__/assistant-config.test.ts src/__tests__/teleport.test.ts`
- `cd cli && bun run lint -- src/commands/retire.ts src/commands/login.ts src/commands/teleport.ts src/lib/assistant-config.ts src/__tests__/retire.test.ts src/__tests__/assistant-config.test.ts src/__tests__/teleport.test.ts`
- `cd clients/macos && bunx tsc --noEmit`
- `cd clients/macos && bun test src/main/local-mode.test.ts`
- `cd clients/macos && bun test src/main/bundle-flow.test.ts`
- `cd clients/macos && bun run test:ci` (outside sandbox; loopback bind tests need host networking)

Local note: full `cd cli && bun run typecheck` is blocked in this workspace by unrelated untracked `cli/src/lib/gateway-auth.ts` importing a non-existent `resolveGuardianAccessToken`. The touched CLI files pass focused lint/tests.

## Original prompt
The local retire flow should remove the self-hosted assistant record on the platform side when a logged-in local assistant is retired from the web or Electron app.
