### PR TITLE
[codex] Fix Ollama onboarding profile selection

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4591,6 +4591,162 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  $ref: "#/components/schemas/LLMProvider"
+                model:
+                  type: string
+                  minLength: 1
+                maxTokens:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                effort:
+                  type: string
+                  enum:
+                    - none
+                    - low
+                    - medium
+                    - high
+                    - xhigh
+                    - max
+                speed:
+                  type: string
+                  enum:
+                    - standard
+                    - fast
+                verbosity:
+                  type: string
+                  enum:
+                    - low
+                    - medium
+                    - high
+                temperature:
+                  anyOf:
+                    - type: number
+                      minimum: 0
+                      maximum: 2
+                    - type: "null"
+                topP:
+                  anyOf:
+                    - type: number
+                      minimum: 0
+                      maximum: 1
+                    - type: "null"
+                thinking:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    streamThinking:
+                      type: boolean
+                    level:
+                      type: string
+                      enum:
+                        - minimal
+                        - low
+                        - medium
+                        - high
+                contextWindow:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    maxInputTokens:
+                      type: integer
+                      exclusiveMinimum: 0
+                      maximum: 9007199254740991
+                    targetBudgetRatio:
+                      type: number
+                      exclusiveMinimum: 0
+                      maximum: 1
+                    compactThreshold:
+                      type: number
+                      exclusiveMinimum: 0
+                      maximum: 1
+                    summaryBudgetRatio:
+                      type: number
+                      exclusiveMinimum: 0
+                      maximum: 1
+                    overflowRecovery:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        safetyMarginRatio:
+                          type: number
+                          exclusiveMinimum: 0
+                          exclusiveMaximum: 1
+                        maxAttempts:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                        interactiveLatestTurnCompression:
+                          type: string
+                          enum:
+                            - truncate
+                            - summarize
+                            - drop
+                        nonInteractiveLatestTurnCompression:
+                          type: string
+                          enum:
+                            - truncate
+                            - summarize
+                            - drop
+                openrouter:
+                  type: object
+                  properties:
+                    only:
+                      type: array
+                      items:
+                        type: string
+                        minLength: 1
+                logitBias:
+                  type: string
+                  enum:
+                    - suppress-cjk
+                disableCache:
+                  type: boolean
+                source:
+                  type: string
+                  enum:
+                    - managed
+                    - user
+                label:
+                  anyOf:
+                    - type: string
+                      minLength: 1
+                    - type: "null"
+                description:
+                  type: string
+                provider_connection:
+                  type: string
+                  minLength: 1
+                status:
+                  anyOf:
+                    - $ref: "#/components/schemas/ProfileStatus"
+                    - type: "null"
+                mix:
+                  minItems: 2
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      profile:
+                        type: string
+                        minLength: 1
+                      weight:
+                        type: number
+                        exclusiveMinimum: 0
+                    required:
+                      - profile
+                      - weight
       responses:
         "200":
           description: Successful response

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1596,6 +1596,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Replace the settings-UI-managed leaves of a single llm.profiles entry while preserving non-UI leaves.",
     tags: ["config"],
+    requestBody: ProfileEntry,
     handler: handleReplaceInferenceProfile,
   },
   {

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -3,14 +3,15 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import {
-    DEFAULT_ONBOARDING_PROVIDER,
-    ONBOARDING_PROVIDERS,
-    onboardingProvider,
-    type OnboardingProviderId,
+  DEFAULT_ONBOARDING_PROVIDER,
+  ONBOARDING_PROVIDERS,
+  defaultModelForOnboardingProvider,
+  onboardingProvider,
+  type OnboardingProviderId,
 } from "@/domains/onboarding/provider-catalog";
 import {
-    peekPendingProviderKey,
-    setPendingProviderKey,
+  peekPendingProviderKey,
+  setPendingProviderKey,
 } from "@/domains/onboarding/provider-key";
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
@@ -23,23 +24,37 @@ export function ApiKeyScreen() {
   const [searchParams] = useSearchParams();
   const hosting = searchParams.get("hosting");
   const electron = isElectron();
+  const pendingProviderKey = peekPendingProviderKey();
 
   const [provider, setProvider] = useState<OnboardingProviderId>(
-    () => peekPendingProviderKey()?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
+    () => pendingProviderKey?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
   );
-  const [apiKey, setApiKey] = useState(
-    () => peekPendingProviderKey()?.key ?? "",
+  const [apiKey, setApiKey] = useState(() => pendingProviderKey?.key ?? "");
+  const [model, setModel] = useState(
+    () =>
+      pendingProviderKey?.model ??
+      defaultModelForOnboardingProvider(
+        pendingProviderKey?.provider ?? DEFAULT_ONBOARDING_PROVIDER.id,
+      ) ??
+      "",
   );
 
   const entry = onboardingProvider(provider) ?? DEFAULT_ONBOARDING_PROVIDER;
+  const models = entry.models ?? [];
   const requiresKey = entry.requiresKey;
-  const canContinue = !requiresKey || apiKey.trim().length > 0;
+  const requiresModel = models.length > 0;
+  const canContinue =
+    (!requiresKey || apiKey.trim().length > 0) &&
+    (!requiresModel || model.trim().length > 0);
 
   const onContinue = () => {
     if (!canContinue) return;
+    const selectedModel =
+      model.trim() || defaultModelForOnboardingProvider(provider);
     setPendingProviderKey({
       provider,
       key: requiresKey ? apiKey.trim() : "",
+      ...(selectedModel ? { model: selectedModel } : {}),
     });
     void navigate(
       hosting
@@ -54,9 +69,15 @@ export function ApiKeyScreen() {
 
   return (
     <OnboardingLayout>
-      <div className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}>
+      <div
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
+      >
         <h1
-          className={electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}
+          className={
+            electron
+              ? "text-title-large"
+              : "text-3xl font-semibold tracking-tight"
+          }
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
           Connect a Model Provider
@@ -65,7 +86,7 @@ export function ApiKeyScreen() {
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Enter an API key to connect your model provider.
+          Choose the model provider your assistant should use.
         </p>
 
         <div
@@ -84,6 +105,7 @@ export function ApiKeyScreen() {
                 if (match) {
                   setProvider(match.id);
                   setApiKey("");
+                  setModel(defaultModelForOnboardingProvider(match.id) ?? "");
                 }
               }}
               options={ONBOARDING_PROVIDERS.map((p) => ({
@@ -92,6 +114,23 @@ export function ApiKeyScreen() {
               }))}
             />
           </div>
+
+          {models.length > 0 && (
+            <div className={`flex flex-col ${electron ? "gap-2" : "gap-1"}`}>
+              <label className="text-body-small-default text-[var(--content-tertiary)]">
+                Model
+              </label>
+              <Dropdown
+                aria-label="Model"
+                value={model}
+                onChange={setModel}
+                options={models.map((option) => ({
+                  value: option.id,
+                  label: option.displayName,
+                }))}
+              />
+            </div>
+          )}
 
           {requiresKey && (
             <div className="flex flex-col gap-3">

--- a/clients/web/src/domains/onboarding/provider-catalog.ts
+++ b/clients/web/src/domains/onboarding/provider-catalog.ts
@@ -21,6 +21,16 @@ export interface OnboardingProvider {
   readonly docsUrl: string | null;
   /** Whether an API key is required before the user can continue. */
   readonly requiresKey: boolean;
+  /** Balanced model used for the initial local assistant profile. */
+  readonly defaultModel?: string;
+  readonly models?: readonly OnboardingModel[];
+}
+
+export interface OnboardingModel {
+  readonly id: string;
+  readonly displayName: string;
+  readonly contextWindowTokens?: number;
+  readonly maxOutputTokens?: number;
 }
 
 export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
@@ -30,6 +40,7 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: "sk-ant-api03-...",
     docsUrl: "https://console.anthropic.com/settings/keys",
     requiresKey: true,
+    defaultModel: "claude-sonnet-4-6",
   },
   {
     id: "openai",
@@ -37,6 +48,7 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: "sk-proj-...",
     docsUrl: "https://platform.openai.com/api-keys",
     requiresKey: true,
+    defaultModel: "gpt-5.4-mini",
   },
   {
     id: "gemini",
@@ -44,6 +56,7 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: "AIza...",
     docsUrl: "https://aistudio.google.com/apikey",
     requiresKey: true,
+    defaultModel: "gemini-3-flash-preview",
   },
   {
     id: "ollama",
@@ -51,6 +64,21 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: null,
     docsUrl: "https://ollama.com/download",
     requiresKey: false,
+    defaultModel: "llama3.2",
+    models: [
+      {
+        id: "llama3.2",
+        displayName: "Llama 3.2",
+        contextWindowTokens: 128_000,
+        maxOutputTokens: 4_096,
+      },
+      {
+        id: "mistral",
+        displayName: "Mistral",
+        contextWindowTokens: 32_768,
+        maxOutputTokens: 4_096,
+      },
+    ],
   },
   {
     id: "fireworks",
@@ -58,6 +86,7 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: "fw_...",
     docsUrl: "https://fireworks.ai/account/api-keys",
     requiresKey: true,
+    defaultModel: "accounts/fireworks/models/minimax-m3",
   },
   {
     id: "openrouter",
@@ -65,6 +94,7 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     apiKeyPlaceholder: "sk-or-v1-...",
     docsUrl: "https://openrouter.ai/keys",
     requiresKey: true,
+    defaultModel: "anthropic/claude-sonnet-4.6",
   },
   {
     id: "openai-compatible",
@@ -77,8 +107,13 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
 
 export const DEFAULT_ONBOARDING_PROVIDER = ONBOARDING_PROVIDERS[0];
 
-export function onboardingProvider(
-  id: string,
-): OnboardingProvider | undefined {
+export function onboardingProvider(id: string): OnboardingProvider | undefined {
   return ONBOARDING_PROVIDERS.find((p) => p.id === id);
+}
+
+export function defaultModelForOnboardingProvider(
+  id: OnboardingProviderId,
+): string | undefined {
+  const provider = onboardingProvider(id);
+  return provider?.defaultModel ?? provider?.models?.[0]?.id;
 }

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -1,13 +1,38 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
+const secretsPostMock = mock(async () => ({
+  response: { ok: true, status: 200 },
+}));
+const inferenceProviderconnectionsPostMock = mock(async () => ({
+  response: { ok: true, status: 201 },
+}));
+const configLlmProfilesByNamePutMock = mock(async () => ({
+  response: { ok: true, status: 200 },
+}));
+const configPatchMock = mock(async () => ({
+  response: { ok: true, status: 200 },
+}));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  secretsPost: secretsPostMock,
+  inferenceProviderconnectionsPost: inferenceProviderconnectionsPostMock,
+  configLlmProfilesByNamePut: configLlmProfilesByNamePutMock,
+  configPatch: configPatchMock,
+}));
+
+const {
+  applyPendingProviderKey,
   consumePendingProviderKey,
   peekPendingProviderKey,
   setPendingProviderKey,
-} from "@/domains/onboarding/provider-key";
+} = await import("@/domains/onboarding/provider-key");
 
 beforeEach(() => {
   sessionStorage.clear();
+  secretsPostMock.mockClear();
+  inferenceProviderconnectionsPostMock.mockClear();
+  configLlmProfilesByNamePutMock.mockClear();
+  configPatchMock.mockClear();
 });
 
 describe("pending provider key", () => {
@@ -39,7 +64,50 @@ describe("pending provider key", () => {
   });
 
   test("keyless providers store an empty key", () => {
-    setPendingProviderKey({ provider: "ollama", key: "" });
-    expect(consumePendingProviderKey()).toEqual({ provider: "ollama", key: "" });
+    setPendingProviderKey({ provider: "ollama", key: "", model: "llama3.2" });
+    expect(consumePendingProviderKey()).toEqual({
+      provider: "ollama",
+      key: "",
+      model: "llama3.2",
+    });
+  });
+
+  test("applies an Ollama provider connection and activates the selected model profile", async () => {
+    setPendingProviderKey({ provider: "ollama", key: "", model: "mistral" });
+
+    await applyPendingProviderKey("local-1");
+
+    expect(secretsPostMock).not.toHaveBeenCalled();
+    expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-1" },
+      body: {
+        name: "ollama",
+        provider: "ollama",
+        auth: { type: "none" },
+      },
+      throwOnError: false,
+    });
+    expect(configLlmProfilesByNamePutMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-1", name: "custom-balanced" },
+      body: {
+        provider: "ollama",
+        model: "mistral",
+        provider_connection: "ollama",
+        source: "user",
+        label: "Balanced",
+        description: "Good balance of quality, cost, and speed",
+        maxTokens: 4096,
+        contextWindow: { maxInputTokens: 32768 },
+        effort: "none",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      throwOnError: false,
+    });
+    expect(configPatchMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-1" },
+      body: { llm: { activeProfile: "custom-balanced" } },
+      throwOnError: false,
+    });
+    expect(peekPendingProviderKey()).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/provider-key.ts
+++ b/clients/web/src/domains/onboarding/provider-key.ts
@@ -1,8 +1,15 @@
 import {
+  configLlmProfilesByNamePut,
+  configPatch,
   inferenceProviderconnectionsPost,
   secretsPost,
 } from "@/generated/daemon/sdk.gen";
-import type { OnboardingProviderId } from "@/domains/onboarding/provider-catalog";
+import {
+  defaultModelForOnboardingProvider,
+  onboardingProvider,
+  type OnboardingProviderId,
+} from "@/domains/onboarding/provider-catalog";
+import type { ProfileEntry } from "@/generated/daemon/types.gen";
 
 // Model-provider API key collected during onboarding. Held in sessionStorage
 // (consume-once) between the API-key step and the post-hatch application, then
@@ -10,11 +17,15 @@ import type { OnboardingProviderId } from "@/domains/onboarding/provider-catalog
 // holds the key in-memory and POSTs it to the daemon once the assistant is up.
 
 const PENDING_KEY_STORAGE = "onboarding.providerKey";
+const ONBOARDING_ACTIVE_PROFILE = "custom-balanced";
+const DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS = 200_000;
 
 export interface PendingProviderKey {
   provider: OnboardingProviderId;
   /** Empty for keyless providers (e.g. Ollama). */
   key: string;
+  /** Selected model for the initial local assistant profile. */
+  model?: string;
 }
 
 export function setPendingProviderKey(value: PendingProviderKey | null): void {
@@ -36,7 +47,8 @@ function isPendingProviderKey(value: unknown): value is PendingProviderKey {
     "provider" in value &&
     typeof value.provider === "string" &&
     "key" in value &&
-    typeof value.key === "string"
+    typeof value.key === "string" &&
+    (!("model" in value) || typeof value.model === "string")
   );
 }
 
@@ -94,18 +106,79 @@ async function createProviderConnection(
     body: { name: provider, provider, auth },
     throwOnError: false,
   });
-  if (!response?.ok) {
+  if (!response?.ok && response?.status !== 409) {
     throw Object.assign(new Error("Failed to create provider connection"), {
       status: response?.status,
     });
   }
 }
 
+function buildOnboardingProfile(
+  provider: OnboardingProviderId,
+  model: string,
+): ProfileEntry {
+  const providerEntry = onboardingProvider(provider);
+  const modelEntry = providerEntry?.models?.find((entry) => entry.id === model);
+  const profile: ProfileEntry = {
+    provider,
+    model,
+    provider_connection: provider,
+    source: "user",
+    label: "Balanced",
+    description: "Good balance of quality, cost, and speed",
+    maxTokens: modelEntry?.maxOutputTokens ?? 16_000,
+    contextWindow: {
+      maxInputTokens:
+        modelEntry?.contextWindowTokens ??
+        DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  };
+
+  if (provider === "ollama") {
+    profile.effort = "none";
+    profile.thinking = { enabled: false, streamThinking: false };
+  } else {
+    profile.effort = "high";
+    profile.thinking = { enabled: true, streamThinking: true };
+  }
+
+  return profile;
+}
+
+async function replaceOnboardingProfile(
+  assistantId: string,
+  provider: OnboardingProviderId,
+  model: string,
+): Promise<void> {
+  const { response } = await configLlmProfilesByNamePut({
+    path: { assistant_id: assistantId, name: ONBOARDING_ACTIVE_PROFILE },
+    body: buildOnboardingProfile(provider, model),
+    throwOnError: false,
+  });
+  if (!response?.ok) {
+    throw Object.assign(new Error("Failed to set provider profile"), {
+      status: response?.status,
+    });
+  }
+}
+
+async function activateOnboardingProfile(assistantId: string): Promise<void> {
+  const { response } = await configPatch({
+    path: { assistant_id: assistantId },
+    body: { llm: { activeProfile: ONBOARDING_ACTIVE_PROFILE } },
+    throwOnError: false,
+  });
+  if (!response?.ok) {
+    throw Object.assign(new Error("Failed to activate provider profile"), {
+      status: response?.status,
+    });
+  }
+}
+
 /**
- * Apply the API key collected during onboarding to the freshly hatched local
- * assistant: store the secret (when a key was entered) and create the provider
- * connection so the daemon can use it. Consumes the pending key; no-op when
- * nothing was collected (e.g. Vellum Cloud, which skips the API-key step).
+ * Apply the model-provider selection collected during onboarding to the
+ * freshly hatched local assistant. Consumes the pending key; no-op when nothing
+ * was collected (e.g. Vellum Cloud, which skips the API-key step).
  */
 export async function applyPendingProviderKey(
   assistantId: string,
@@ -118,4 +191,11 @@ export async function applyPendingProviderKey(
     await writeApiKeySecret(assistantId, pending.provider, trimmed);
   }
   await createProviderConnection(assistantId, pending.provider, hasKey);
+  const selectedModel = pending.model?.trim();
+  const model =
+    selectedModel || defaultModelForOnboardingProvider(pending.provider);
+  if (model) {
+    await replaceOnboardingProfile(assistantId, pending.provider, model);
+    await activateOnboardingProfile(assistantId);
+  }
 }


### PR DESCRIPTION
## Summary

- persist the onboarding provider model choice, including a static Ollama model picker for llama3.2 and mistral
- after local hatch, create/reuse the provider connection, replace custom-balanced with the selected provider/model, and set it active
- advertise the existing profile-replacement route request body in OpenAPI so the web SDK can call it typed

## Root Cause

The onboarding flow created the selected provider connection after hatch, but it never updated llm.activeProfile or the active custom profile. Fresh local assistants could therefore keep using the seeded Anthropic profile even after the user selected Ollama.

## Testing

- cd clients/web && bun test src/domains/onboarding/provider-key.test.ts
- cd assistant && bun test src/runtime/routes/__tests__/conversation-query-routes.test.ts --grep "PUT /v1/config/llm/profiles"
- cd clients/web && bunx tsc --noEmit
- cd assistant && bun run typecheck:fast
- git diff --check
