### PR TITLE
feat(daemon): carry plugin category through the marketplace catalog cache

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
@@ -56,6 +56,7 @@ function catalog(ref: string, names: string[]): PluginCatalog {
     matches: names.map((name) => ({
       name,
       path: `github:acme/${name}@${"0".repeat(40)}`,
+      category: null,
       source: {
         kind: "github" as const,
         repo: `acme/${name}`,

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -30,6 +30,7 @@ interface ManifestPlugin {
   name: string;
   source: { source: "github"; repo: string; path?: string; ref: string };
   description?: string;
+  category?: string;
 }
 
 /** Serve `plugins` as the raw marketplace manifest at the manifest URL. */
@@ -51,7 +52,7 @@ function entry(
   name: string,
   repo: string,
   ref: string,
-  extra?: { path?: string; description?: string },
+  extra?: { path?: string; description?: string; category?: string },
 ): ManifestPlugin {
   return {
     name,
@@ -62,6 +63,7 @@ function entry(
       ref,
     },
     ...(extra?.description ? { description: extra.description } : {}),
+    ...(extra?.category ? { category: extra.category } : {}),
   };
 }
 
@@ -151,6 +153,7 @@ describe("searchPlugins", () => {
         name: "nested",
         path: `github:acme/monorepo/packages/nested@${SHA_B}`,
         description: "A nested plugin.",
+        category: null,
         source: {
           kind: "github",
           repo: "acme/monorepo",
@@ -158,6 +161,30 @@ describe("searchPlugins", () => {
           ref: SHA_B,
         },
       },
+    ]);
+  });
+
+  test("carries the marketplace entry category, defaulting to null", async () => {
+    // GIVEN one entry that declares a category and one that does not
+    // WHEN we search
+    const result = await searchPlugins(
+      { query: "" },
+      {
+        fetch: manifestFetch([
+          entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+            category: "calendar",
+          }),
+          entry("plain-plugin", "acme/plain-plugin", SHA_B),
+        ]),
+      },
+    );
+
+    // THEN the declared category flows through and a missing one is null
+    expect(
+      result.matches.map((m) => ({ name: m.name, category: m.category })),
+    ).toEqual([
+      { name: "calendar-sync", category: "calendar" },
+      { name: "plain-plugin", category: null },
     ]);
   });
 
@@ -335,6 +362,7 @@ describe("searchPlugins", () => {
       {
         name: "caveman",
         path: `github:JuliusBrussee/caveman@${SHA_A}`,
+        category: null,
         source: {
           kind: "github",
           repo: "JuliusBrussee/caveman",

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -67,6 +67,11 @@ export interface PluginSearchMatch {
   readonly path: string;
   /** Short description, when known (external entries only today). */
   readonly description?: string;
+  /**
+   * Free-form grouping hint from the curated marketplace entry (e.g.
+   * `productivity`), or `null` when the entry declares none.
+   */
+  readonly category: string | null;
   /** Discriminated origin, so callers can render/install accordingly. */
   readonly source: PluginMatchSource;
 }
@@ -199,6 +204,7 @@ function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     name: entry.name,
     path: locator,
     description: entry.description,
+    category: entry.category ?? null,
     source: { kind: "github", repo, path, ref },
   };
 }

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -260,15 +260,19 @@ function invoke(args: RouteHandlerArgs = {}): {
   return listHandler(args) as { plugins: Array<Record<string, unknown>> };
 }
 
+// The route response strips `category` (added to the lib match shape but not
+// yet to the wire schema), so the wire matches are `PluginSearchMatch` minus it.
+type PluginMatchWire = Omit<PluginSearchMatch, "category">;
+
 async function invokeSearch(args: RouteHandlerArgs = {}): Promise<{
   query: string;
   ref: string;
-  matches: PluginSearchMatch[];
+  matches: PluginMatchWire[];
 }> {
   return (await searchHandler(args)) as {
     query: string;
     ref: string;
-    matches: PluginSearchMatch[];
+    matches: PluginMatchWire[];
   };
 }
 
@@ -469,6 +473,7 @@ describe("GET /v1/plugins/search", () => {
         {
           name: "simple-memory",
           path: "github:vellum-ai/simple-memory@ed09a4c01bf18e4ac8859faee94cb65c7cbd1ca3",
+          category: null,
           source: {
             kind: "github",
             repo: "vellum-ai/simple-memory",
@@ -479,6 +484,7 @@ describe("GET /v1/plugins/search", () => {
           name: "caveman",
           path: "github:JuliusBrussee/caveman@v1.8.2",
           description: "Ultra-compressed communication mode.",
+          category: null,
           source: {
             kind: "github",
             repo: "JuliusBrussee/caveman",
@@ -522,6 +528,7 @@ describe("GET /v1/plugins/search", () => {
         {
           name: "caveman",
           path: "github:JuliusBrussee/caveman@v1.8.2",
+          category: null,
           source: {
             kind: "github",
             repo: "JuliusBrussee/caveman",
@@ -597,6 +604,7 @@ describe("GET /v1/plugins/search", () => {
       Object.freeze({
         name: "a",
         path: "github:acme/a@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        category: null,
         source: {
           kind: "github",
           repo: "acme/a",


### PR DESCRIPTION
## Summary
- Add `category: string | null` to `PluginSearchMatch`, populated from the marketplace entry
- Field now flows through the cached plugin catalog (no extra network round-trip)

Part of plan: plugins-tab-category-filter.md (PR 1 of 5)