### PR TITLE
fix(assistant): retry mid-turn SQLite writes so a transient lock doesn't kill the turn

### DIFF
--- a/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
+++ b/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression tests for SQLite write-contention resilience in the agent loop.
+ *
+ * When another writer holds the SQLite write lock long enough that
+ * `busy_timeout` elapses, an in-loop content write throws `SQLITE_BUSY`
+ * ("database is locked"). The turn-finalizing write at `message_complete` is on
+ * `dispatchAgentEvent`'s re-throw allowlist, so before this resilience layer a
+ * single transient lock aborted the whole turn and surfaced to the user as
+ * "Processing failed: database is locked".
+ *
+ * These tests pin the two guarantees:
+ *  1. A transient `SQLITE_BUSY` is retried and the row is finalized normally.
+ *  2. A persistent `SQLITE_BUSY` is swallowed (logged) so the turn continues
+ *     instead of throwing — a later write (this turn or the next) overwrites
+ *     the dropped content.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock platform (must precede imports that read it) ─────────────────────────
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ memory: {} }),
+  loadConfig: () => ({}),
+}));
+
+// `updateMessageContent` throws `SQLITE_BUSY` for the first
+// `updateContentFailuresRemaining` calls, then records the content written.
+let updateContentFailuresRemaining = 0;
+const writtenContentById = new Map<string, string>();
+const updateMessageContentMock = mock((id: string, content: string) => {
+  if (updateContentFailuresRemaining > 0) {
+    updateContentFailuresRemaining -= 1;
+    throw Object.assign(new Error("database is locked"), {
+      code: "SQLITE_BUSY",
+    });
+  }
+  writtenContentById.set(id, content);
+});
+
+// Stand-in for the `conversations.seq` column, mirroring the monotonic,
+// ignore-non-positive semantics of the real `recordConversationPersistedSeq`.
+const persistedSeqByConversation = new Map<string, number>();
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getConversation: () => null,
+  getMessageById: () => null,
+  updateMessageContent: updateMessageContentMock,
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: async (_conversationId: string, role: string) => ({
+    id: role === "user" ? "tool-result-row" : "assistant-row",
+  }),
+  recordConversationPersistedSeq: (id: string, seq: number) => {
+    if (!Number.isFinite(seq) || seq <= 0) return;
+    const prev = persistedSeqByConversation.get(id);
+    if (prev == null || prev < seq) persistedSeqByConversation.set(id, seq);
+  },
+  getConversationPersistedSeq: (id: string) =>
+    persistedSeqByConversation.get(id) ?? null,
+}));
+
+mock.module("../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+mock.module("../plugins/defaults/memory/memory-recall-log-store.js", () => ({
+  backfillMemoryRecallLogMessageId: () => {},
+}));
+
+mock.module(
+  "../plugins/defaults/memory/memory-v2-activation-log-store.js",
+  () => ({
+    backfillMemoryV2ActivationMessageId: () => {},
+  }),
+);
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type { AgentEvent } from "../agent/loop.js";
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  handleMessageComplete,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
+
+const CONVERSATION_ID = "test-session-id";
+
+function createMockDeps(): EventHandlerDeps {
+  return {
+    ctx: {
+      conversationId: CONVERSATION_ID,
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (_msg: ServerMessage) => {},
+    reqId: "test-req-id",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+}
+
+const MESSAGE_COMPLETE_EVENT = {
+  type: "message_complete",
+  message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+} as Extract<AgentEvent, { type: "message_complete" }>;
+
+describe("agent loop SQLite write-contention resilience", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+    // A row was reserved at llm_call_started; message_complete finalizes it.
+    state.lastAssistantMessageId = "assistant-row";
+    state.assistantRowAwaitingFinalization = true;
+    state.lastPersistedContentSeq = 5;
+    updateContentFailuresRemaining = 0;
+    writtenContentById.clear();
+    persistedSeqByConversation.clear();
+    updateMessageContentMock.mockClear();
+  });
+
+  test("retries a transient SQLITE_BUSY and finalizes the assistant row", async () => {
+    // GIVEN the finalize write loses the write-lock race twice before winning
+    updateContentFailuresRemaining = 2;
+
+    // WHEN message_complete drains
+    await handleMessageComplete(
+      state,
+      createMockDeps(),
+      MESSAGE_COMPLETE_EVENT,
+    );
+
+    // THEN it retried until the write committed (2 failures + 1 success) ...
+    expect(updateMessageContentMock).toHaveBeenCalledTimes(3);
+    expect(writtenContentById.get("assistant-row")).toContain("done");
+    // ... the finalization completed ...
+    expect(state.assistantRowAwaitingFinalization).toBe(false);
+    // ... and the persisted seq advanced because the content is durable.
+    expect(getConversationPersistedSeq(CONVERSATION_ID)).toBe(5);
+  });
+
+  test("swallows a persistent SQLITE_BUSY without aborting the turn", async () => {
+    // GIVEN every finalize attempt loses the race (lock held past every retry)
+    updateContentFailuresRemaining = Number.POSITIVE_INFINITY;
+
+    // WHEN message_complete drains, it must resolve rather than throw — a thrown
+    // SQLITE_BUSY here is on dispatchAgentEvent's re-throw allowlist and would
+    // kill the turn.
+    await expect(
+      handleMessageComplete(state, createMockDeps(), MESSAGE_COMPLETE_EVENT),
+    ).resolves.toBeUndefined();
+
+    // THEN the write was attempted (initial try + the retries) ...
+    expect(updateMessageContentMock.mock.calls.length).toBeGreaterThan(1);
+    // ... no content landed ...
+    expect(writtenContentById.has("assistant-row")).toBe(false);
+    // ... and the seq was NOT advanced past content that never became durable.
+    expect(getConversationPersistedSeq(CONVERSATION_ID)).toBeNull();
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -74,6 +74,7 @@ import {
 import { ProviderError } from "../util/errors.js";
 import { faviconUrlForDomain } from "../util/favicon.js";
 import { getLogger } from "../util/logger.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
 import {
   cleanAssistantContent,
@@ -538,6 +539,39 @@ function resetPartialPersistAccumulator(state: EventHandlerState): void {
   state.pendingPartialFlushPromise = undefined;
 }
 
+/**
+ * Persist an in-loop message-content write, retrying transient SQLite write
+ * contention (`SQLITE_BUSY`/`SQLITE_IOERR`) and swallowing a final failure so a
+ * lock held by another writer cannot abort the turn. Every in-loop write
+ * rewrites the full content snapshot of its assistant/tool-result row, so a
+ * dropped write is overwritten by a later write in the same turn (the
+ * end-of-turn finalize) or the next turn — missing one is a self-healing
+ * cosmetic gap, not corruption.
+ *
+ * Returns whether the write committed, so callers can gate dependent
+ * bookkeeping (e.g. advancing the persisted seq) on durable content.
+ */
+async function persistLoopMessageContent(
+  messageId: string,
+  contentJson: string,
+  op: string,
+  rlog: pino.Logger,
+): Promise<boolean> {
+  try {
+    await withSqliteRetry(() => updateMessageContent(messageId, contentJson), {
+      op,
+      context: { messageId },
+    });
+    return true;
+  } catch (err) {
+    rlog.error(
+      { err, messageId, op },
+      "in-loop message-content write failed after retries; continuing without interrupting the turn",
+    );
+    return false;
+  }
+}
+
 /** Flush `state.currentMessageContent` to the persisted assistant row. */
 async function flushAccumulatedContent(
   state: EventHandlerState,
@@ -558,18 +592,16 @@ async function flushAccumulatedContent(
   // again, but they are not part of this write.
   const flushedSeq = state.lastPersistedContentSeq;
 
-  try {
-    updateMessageContent(messageId, contentJson);
-    // Record only after the write commits, so the snapshot seq never
-    // claims content that is not yet durable.
-    if (flushedSeq != null) {
-      recordConversationPersistedSeq(deps.ctx.conversationId, flushedSeq);
-    }
-  } catch (err) {
-    deps.rlog.warn(
-      { err, messageId },
-      "partial flush of accumulated assistant content failed; finalize at message_complete will recover",
-    );
+  const persisted = await persistLoopMessageContent(
+    messageId,
+    contentJson,
+    "partial_flush_assistant_content",
+    deps.rlog,
+  );
+  // Record only after the write commits, so the snapshot seq never
+  // claims content that is not yet durable.
+  if (persisted && flushedSeq != null) {
+    recordConversationPersistedSeq(deps.ctx.conversationId, flushedSeq);
   }
 }
 
@@ -1188,11 +1220,15 @@ async function persistPendingToolResultRow(
   );
   // Serialize the content after the reservation resolves so the last of the
   // concurrent writers reflects the fullest batch.
-  updateMessageContent(
+  const persisted = await persistLoopMessageContent(
     rowId,
     JSON.stringify(buildToolResultBlocks(state.pendingToolResults)),
+    "persist_tool_result_row",
+    deps.rlog,
   );
-  recordConversationPersistedSeq(deps.ctx.conversationId, seq);
+  if (persisted) {
+    recordConversationPersistedSeq(deps.ctx.conversationId, seq);
+  }
   const conv = getConversation(deps.ctx.conversationId);
   if (conv != null) {
     syncMessageToDisk(deps.ctx.conversationId, rowId, conv.createdAt);
@@ -1222,7 +1258,12 @@ export async function finalizePendingToolResultRow(
   const contentJson = JSON.stringify(
     buildToolResultBlocks(state.pendingToolResults),
   );
-  updateMessageContent(rowId, contentJson);
+  await persistLoopMessageContent(
+    rowId,
+    contentJson,
+    "finalize_tool_result_row",
+    rlog,
+  );
   // Sync the row to the JSONL disk view so it stays in lockstep with the DB.
   // `getConversation` returns `ConversationRow | null`, so `!= null` gates on a
   // real row (skipping the sync when the conversation was not found rather than
@@ -1520,7 +1561,17 @@ function recordToolStartOnPersistedMessage(
     if (rec.id !== toolUseId) continue;
     if (rec._startedAt === startedAt) return;
     rec._startedAt = startedAt;
-    updateMessageContent(messageId, JSON.stringify(content));
+    // Best-effort early stamp: `annotatePersistedAssistantMessage` re-stamps
+    // once every tool in the turn completes, so a transient `SQLITE_BUSY` here
+    // must not abort the turn — the end-of-turn write recovers it.
+    try {
+      updateMessageContent(messageId, JSON.stringify(content));
+    } catch (err) {
+      log.error(
+        { err, messageId },
+        "stamping tool start time failed; end-of-turn annotation will recover",
+      );
+    }
     return;
   }
 }
@@ -1559,7 +1610,17 @@ function recordToolPreviewStartOnPersistedMessage(
     if (rec.id !== toolUseId) continue;
     if (rec._previewStartedAt === previewStartedAt) return;
     rec._previewStartedAt = previewStartedAt;
-    updateMessageContent(messageId, JSON.stringify(content));
+    // Best-effort early stamp, mirroring `recordToolStartOnPersistedMessage`:
+    // `annotatePersistedAssistantMessage` re-stamps at end of turn, so a
+    // transient `SQLITE_BUSY` here must not abort the turn.
+    try {
+      updateMessageContent(messageId, JSON.stringify(content));
+    } catch (err) {
+      log.error(
+        { err, messageId },
+        "stamping tool preview-start time failed; end-of-turn annotation will recover",
+      );
+    }
     return;
   }
 }
@@ -1680,6 +1741,10 @@ function annotatePersistedAssistantMessage(
   }
 
   if (modified) {
+    // This end-of-turn write is best-effort: the caller wraps it in a
+    // try/catch (and `dispatchAgentEvent` swallows `tool_result` handler
+    // errors), so a transient `SQLITE_BUSY` here is logged and the turn
+    // continues — it never reaches the turn-level catch.
     updateMessageContent(messageId, JSON.stringify(content));
   }
 
@@ -1917,7 +1982,12 @@ export async function handleMessageComplete(
     );
   }
   const contentJson = JSON.stringify(contentForPersistence);
-  updateMessageContent(assistantMessageId, contentJson);
+  const persisted = await persistLoopMessageContent(
+    assistantMessageId,
+    contentJson,
+    "finalize_assistant_message",
+    deps.rlog,
+  );
   state.assistantRowAwaitingFinalization = false;
   // The assistant row now holds the authoritative content (text + thinking +
   // tool_use blocks from `event.message`), and any drained tool-result rows
@@ -1927,8 +1997,9 @@ export async function handleMessageComplete(
   // turn, so this seq already covers it; a call that streams no content (a
   // pure tool call) advances instead via `tool_use_start`.
   // `recordConversationPersistedSeq` clamps monotonically, so a lower value
-  // here never regresses the seq.
-  if (state.lastPersistedContentSeq != null) {
+  // here never regresses the seq. Gate on `persisted` so a swallowed finalize
+  // write never advances the seq past content that is not durable.
+  if (persisted && state.lastPersistedContentSeq != null) {
     recordConversationPersistedSeq(
       deps.ctx.conversationId,
       state.lastPersistedContentSeq,


### PR DESCRIPTION
## Prompt / plan

An assistant hit `Processing failed: database is locked` mid-turn while processing. The DB-lock source is being debugged separately; the ask here was to make the agent loop **resilient** to a transient lock while a turn is in flight: find where the loop fails and stop a brief lock from killing the whole turn.

**Where it failed.** `SQLITE_BUSY` ("database is locked") is thrown by a write when another writer holds the lock past `busy_timeout` (5s). Tracing the surfaced string: an in-loop `updateMessageContent` throws → propagates to `runAgentLoopImpl`'s top-level catch → `classifyConversationError` has no specific classifier for it → the fallback in `classifyByMessage` emits `Processing failed: <first line>` (`CONVERSATION_PROCESSING_FAILED`). The `withSqliteRetry` helper (busy_timeout + jittered backoff) already guarded inserts/forks, but **not** the hot mid/post-turn `updateMessageContent` path. The genuinely turn-killing sites:
- `handleMessageComplete` — finalizes the assistant row; `message_complete` is on `dispatchAgentEvent`'s re-throw allowlist → kills the turn.
- `finalizePendingToolResultRow` — called from the orchestrator *outside* dispatch → propagates to the turn-level catch.
- The partial-flush and on-arrival tool-result writes degraded the turn (dropped emits / floated rejections) even where dispatch swallowed them.

**The fix.** Route the loop's content writes through a shared `persistLoopMessageContent` helper that wraps `updateMessageContent` in `withSqliteRetry` (retries transient `SQLITE_BUSY`/`SQLITE_IOERR`) and, on final failure, **logs and continues** instead of throwing. Each in-loop write rewrites the full content snapshot, so a dropped write is overwritten by a later write this turn or the next — a self-healing gap rather than a dead turn (matches the requested "missing one or two due to contention is fine" tradeoff). Paired `recordConversationPersistedSeq` advances are gated on the write actually committing, so the snapshot seq never claims non-durable content.

The two early tool-timing stamps run inside the **synchronous** `handleToolUse` handler and are superseded by the end-of-turn annotation, so they get a synchronous swallow rather than an async retry (avoids rippling `async` through the sync handler and its sync tests). The end-of-turn annotation write was already double-protected (its caller's try/catch plus dispatch's swallow), so it's left as-is.

## Test plan

- New `assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts`:
  - A transient `SQLITE_BUSY` (2 failures) is retried and the assistant row finalizes normally; the persisted seq advances.
  - A persistent `SQLITE_BUSY` is swallowed — `handleMessageComplete` resolves instead of throwing, no content lands, and the seq is not advanced past non-durable content.
- Existing handler/loop suites pass in isolation (per the repo's per-file test convention): `conversation-agent-loop` (66), `tool-preview-lifecycle` (18), `tool-start-timestamp`, `annotate-activity-metadata`, `annotate-risk-options`, `tool-result-metadata-plumbing`, `db-busy-timeout`, `processing-flag-persist-failure`, `persist-user-message-set-processing-failure`.
- `bunx tsc --noEmit` and `bun run lint` clean (pre-commit hook re-verified format/lint/typecheck).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SYHqq2EbgZVDtdsf21XwWE)_