### PR TITLE
feat(daemon): accept enabledPlugins[] on POST /messages (schema only)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17893,6 +17893,15 @@ paths:
                   anyOf:
                     - type: string
                     - type: "null"
+                enabledPlugins:
+                  description:
+                    Plugin ids to scope this conversation to. Applied when minting a new conversation. null/omitted = default
+                    (all globally-enabled plugins).
+                  anyOf:
+                    - type: array
+                      items:
+                        type: string
+                    - type: "null"
                 riskThreshold:
                   type: string
                   enum:

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2860,6 +2860,13 @@ export const ROUTES: RouteDefinition[] = [
         )
         .optional(),
       inferenceProfile: z.string().nullable().optional(),
+      enabledPlugins: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Plugin ids to scope this conversation to. Applied when minting a new conversation. null/omitted = default (all globally-enabled plugins).",
+        ),
       riskThreshold: z.enum(VALID_RISK_THRESHOLDS).optional(),
       onboarding: z
         .object({


### PR DESCRIPTION
## Summary
- Add optional enabledPlugins[] to the messages_post request schema (inert; handler unchanged)
- Regenerate committed assistant/openapi.yaml

Part of plan: new-chat-plugin-pills.md (PR 2 of 15)