### PR TITLE
feat(web): ChatBody pluginPillsSlot between composer and starters

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -318,6 +318,34 @@ describe("ChatBody — startersSlot rendering", () => {
 
 });
 
+describe("ChatBody — pluginPillsSlot rendering", () => {
+  test("renders pluginPillsSlot between the composer and the starters", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          pluginPillsSlot: <div data-testid="plugins">PLUGIN_PILLS</div>,
+          startersSlot: <div data-testid="starters">STARTER_CHIPS</div>,
+        })}
+      />,
+    );
+    expect(html).toContain("PLUGIN_PILLS");
+    // Order: composer, then plugin pills, then starters.
+    expect(html.indexOf("COMPOSER")).toBeLessThan(
+      html.indexOf("PLUGIN_PILLS"),
+    );
+    expect(html.indexOf("PLUGIN_PILLS")).toBeLessThan(
+      html.indexOf("STARTER_CHIPS"),
+    );
+  });
+
+  test("omits plugin pills when pluginPillsSlot is undefined", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody {...withEmptyState()} />,
+    );
+    expect(html).not.toContain("PLUGIN_PILLS");
+  });
+});
+
 describe("ChatBody — active subagents overlay slot", () => {
   const activeSubagentsSlot = (
     <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -159,6 +159,15 @@ export interface ChatBodyProps {
   startersSlot?: ReactNode;
 
   /**
+   * Optional per-chat plugin-selection pills rendered inside the max-width
+   * wrapper directly below the composer and above {@link startersSlot}.
+   * Visible only on the empty state; the parent passes `undefined` once
+   * messages arrive. Rendered as a slot (like {@link startersSlot}) so
+   * `ChatBody` stays agnostic of the plugin data model.
+   */
+  pluginPillsSlot?: ReactNode;
+
+  /**
    * Below-the-fold content rendered after the first viewport on the empty
    * state. Only used when {@link dockStartersToBottom} is true (the
    * suggestions-library layout); holds the categorized suggestion groups.
@@ -244,6 +253,7 @@ export function ChatBody({
   channelFooterSlot,
   readonlyBannerSlot,
   startersSlot,
+  pluginPillsSlot,
   belowFoldSlot,
   dockStartersToBottom = false,
   activeSubagentsSlot,
@@ -402,6 +412,7 @@ export function ChatBody({
         ) : (
           composerSlot
         )}
+        {pluginPillsSlot && <div className="mt-4">{pluginPillsSlot}</div>}
         {trailingStarters}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add optional pluginPillsSlot prop to ChatBody, rendered between composer and starters in renderComposerStack

Part of plan: new-chat-plugin-pills.md (PR 13 of 15)