### PR TITLE
feat(web): PluginPill toggle component

### DIFF
--- a/clients/web/src/domains/chat/components/new-chat-plugins/plugin-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/plugin-pill.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for the presentational `PluginPill` toggle button. Rendered to static
+ * markup (no DOM needed) to assert the accessible label, `aria-pressed` state,
+ * and the selected vs unselected token class branches. Click behaviour is
+ * covered by invoking the rendered element's `onClick` directly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PluginPill } from "./plugin-pill";
+
+describe("PluginPill", () => {
+  test("renders the label and an aria-label that offers to enable when unselected", () => {
+    const html = renderToStaticMarkup(
+      <PluginPill name="simple-memory" selected={false} onToggle={() => {}} />,
+    );
+
+    expect(html).toContain("simple-memory");
+    expect(html).toContain('aria-label="Enable simple-memory for this chat"');
+    expect(html).toContain('aria-pressed="false"');
+  });
+
+  test("reflects the selected state in aria-pressed and the disable label", () => {
+    const html = renderToStaticMarkup(
+      <PluginPill name="simple-memory" selected={true} onToggle={() => {}} />,
+    );
+
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('aria-label="Disable simple-memory for this chat"');
+  });
+
+  test("applies the unselected token classes", () => {
+    const html = renderToStaticMarkup(
+      <PluginPill name="simple-memory" selected={false} onToggle={() => {}} />,
+    );
+
+    expect(html).toContain("border-[var(--border-disabled)]");
+    expect(html).toContain("bg-[var(--surface-base)]");
+    expect(html).toContain("text-[var(--content-secondary)]");
+  });
+
+  test("applies the selected token classes", () => {
+    const html = renderToStaticMarkup(
+      <PluginPill name="simple-memory" selected={true} onToggle={() => {}} />,
+    );
+
+    expect(html).toContain("border-[var(--border-active)]");
+    expect(html).toContain("bg-[var(--surface-active)]");
+    expect(html).toContain("text-[var(--content-default)]");
+  });
+
+  test("invokes onToggle when the rendered button is clicked", () => {
+    let toggled = 0;
+    const element = PluginPill({
+      name: "simple-memory",
+      selected: false,
+      onToggle: () => {
+        toggled += 1;
+      },
+    });
+
+    // The hand-rolled button exposes its click handler directly on props.
+    const props = (element as { props: { onClick: () => void } }).props;
+    props.onClick();
+
+    expect(toggled).toBe(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/new-chat-plugins/plugin-pill.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/plugin-pill.tsx
@@ -1,0 +1,26 @@
+import { Plug } from "lucide-react";
+
+interface PluginPillProps {
+  name: string;
+  selected: boolean;
+  onToggle: () => void;
+}
+
+export function PluginPill({ name, selected, onToggle }: PluginPillProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-label={`${selected ? "Disable" : "Enable"} ${name} for this chat`}
+      onClick={onToggle}
+      className={`inline-flex items-center gap-1.5 rounded-full border pl-2.5 pr-3 py-2 text-body-medium-default ${
+        selected
+          ? "border-[var(--border-active)] bg-[var(--surface-active)] text-[var(--content-default)]"
+          : "border-[var(--border-disabled)] bg-[var(--surface-base)] text-[var(--content-secondary)]"
+      }`}
+    >
+      <Plug className="h-4 w-4 shrink-0" aria-hidden />
+      {name}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add hand-rolled aria-pressed PluginPill with token-driven selected/unselected states
- Leading lucide Plug icon; tests via renderToStaticMarkup

Part of plan: new-chat-plugin-pills.md (PR 9 of 15)