### PR TITLE
feat(web): pendingDraftPlugins ephemeral selection in conversation-store

### DIFF
--- a/clients/web/src/stores/conversation-store.test.ts
+++ b/clients/web/src/stores/conversation-store.test.ts
@@ -147,12 +147,14 @@ describe("useConversationStore", () => {
     getState().addProcessingConversationId("k1");
     getState().addAttentionConversationId("a1");
     getState().setPendingDraftProfile("draft-a", "smart");
+    getState().togglePendingDraftPlugin("draft-a", "plugin-1");
     getState().reset();
     expect(getState().activeConversationId).toBeNull();
     expect(getState().editingConversationId).toBeNull();
     expect(getState().processingConversationIds.size).toBe(0);
     expect(getState().attentionConversationIds.size).toBe(0);
     expect(getState().pendingDraftProfiles.size).toBe(0);
+    expect(getState().pendingDraftPlugins.size).toBe(0);
   });
 
   // ---------------------------------------------------------------------------
@@ -195,6 +197,55 @@ describe("useConversationStore", () => {
       const before = getState().pendingDraftProfiles;
       getState().clearPendingDraftProfile("draft-z");
       expect(getState().pendingDraftProfiles).toBe(before);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pending draft plugins
+  // ---------------------------------------------------------------------------
+
+  describe("pendingDraftPlugins", () => {
+    it("toggle adds then removes a name for a conversation id", () => {
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-1")).toBe(true);
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-1")).toBe(false);
+    });
+
+    it("toggle accumulates multiple names for one conversation id", () => {
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      getState().togglePendingDraftPlugin("draft-a", "plugin-2");
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-1")).toBe(true);
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-2")).toBe(true);
+    });
+
+    it("keeps independent selections for different conversation ids", () => {
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      getState().togglePendingDraftPlugin("draft-b", "plugin-2");
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-1")).toBe(true);
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-2")).toBe(false);
+      expect(getState().pendingDraftPlugins.get("draft-b")?.has("plugin-2")).toBe(true);
+    });
+
+    it("sets a selection set keyed by conversation id", () => {
+      getState().setPendingDraftPlugins("draft-a", new Set(["plugin-1", "plugin-2"]));
+      expect(getState().pendingDraftPlugins.get("draft-a")?.size).toBe(2);
+      expect(getState().pendingDraftPlugins.get("draft-a")?.has("plugin-1")).toBe(true);
+    });
+
+    it("clears only the named id, leaving other drafts intact", () => {
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      getState().togglePendingDraftPlugin("draft-b", "plugin-2");
+      getState().clearPendingDraftPlugins("draft-a");
+      expect(getState().pendingDraftPlugins.has("draft-a")).toBe(false);
+      expect(getState().pendingDraftPlugins.get("draft-b")?.has("plugin-2")).toBe(true);
+    });
+
+    it("clear is a no-op (same reference) when the id is absent", () => {
+      getState().togglePendingDraftPlugin("draft-a", "plugin-1");
+      const before = getState().pendingDraftPlugins;
+      getState().clearPendingDraftPlugins("draft-z");
+      expect(getState().pendingDraftPlugins).toBe(before);
     });
   });
 });

--- a/clients/web/src/stores/conversation-store.ts
+++ b/clients/web/src/stores/conversation-store.ts
@@ -25,6 +25,9 @@
  * - `pendingDraftProfiles` — model profiles picked in the composer for
  *   conversations whose row isn't loaded yet (drafts, or URL-opened
  *   conversations mid-load), keyed by conversation id (see field doc below)
+ * - `pendingDraftPlugins` — plugins picked in the composer for the same
+ *   not-yet-loaded conversations, keyed by conversation id → selected plugin
+ *   ids (see field doc below)
  *
  * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
  * @see @/hooks/conversation-queries.ts for the server-state half
@@ -51,6 +54,13 @@ function removeFromSet<T>(prev: Set<T>, key: T): Set<T> {
   if (!prev.has(key)) return prev;
   const next = new Set(prev);
   next.delete(key);
+  return next;
+}
+
+function addOrRemoveFromSet<T>(prev: Set<T> | undefined, key: T): Set<T> {
+  const next = new Set(prev);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
   return next;
 }
 
@@ -98,6 +108,16 @@ export interface ConversationListState {
    * each one's selection; entries are removed once applied and on reset.
    */
   pendingDraftProfiles: Map<string, string>;
+  /**
+   * Plugins picked in the composer for conversations that have no server row
+   * loaded yet, keyed by conversation id → the set of selected plugin ids.
+   * Mirrors `pendingDraftProfiles`: the composer's `conversationId` prop is
+   * undefined until a row materializes, so an in-draft plugin selection is
+   * stashed here (keyed by id, a Map of Sets, so several unsent drafts each
+   * keep their own selection) and attached to the first message. Entries are
+   * removed once applied and on reset.
+   */
+  pendingDraftPlugins: Map<string, Set<string>>;
 }
 
 export interface ConversationListActions {
@@ -139,6 +159,13 @@ export interface ConversationListActions {
   /** Remove the stash for a single conversation id (no-op when absent). */
   clearPendingDraftProfile: (conversationId: string) => void;
 
+  // --- Pending draft plugins ---
+  setPendingDraftPlugins: (conversationId: string, plugins: Set<string>) => void;
+  /** Add/remove a plugin id from the draft's set, creating it if absent. */
+  togglePendingDraftPlugin: (conversationId: string, name: string) => void;
+  /** Remove the stash for a single conversation id (no-op when absent). */
+  clearPendingDraftPlugins: (conversationId: string) => void;
+
   // --- Compound ---
   graduateProcessingConversationId: (
     conversationId: string,
@@ -158,6 +185,7 @@ const INITIAL_STATE: ConversationListState = {
   processingSnapshots: new Map(),
   attentionConversationIds: new Set(),
   pendingDraftProfiles: new Map(),
+  pendingDraftPlugins: new Map(),
 };
 
 // ---------------------------------------------------------------------------
@@ -276,6 +304,32 @@ export const useConversationStore = createSelectors(
       set({ pendingDraftProfiles: next });
     },
 
+    // --- Pending draft plugins ---
+
+    setPendingDraftPlugins: (conversationId, plugins) => {
+      set({
+        pendingDraftPlugins: new Map(get().pendingDraftPlugins).set(conversationId, plugins),
+      });
+    },
+
+    togglePendingDraftPlugin: (conversationId, name) => {
+      const current = get().pendingDraftPlugins;
+      const next = new Map(current);
+      next.set(conversationId, addOrRemoveFromSet(current.get(conversationId), name));
+      set({ pendingDraftPlugins: next });
+    },
+
+    clearPendingDraftPlugins: (conversationId) => {
+      const current = get().pendingDraftPlugins;
+      // No-op when absent so subscribers don't re-render needlessly. Scoped to
+      // a single id so a send that resolves after the user moved to another
+      // draft can't wipe the newer draft's selection.
+      if (!current.has(conversationId)) return;
+      const next = new Map(current);
+      next.delete(conversationId);
+      set({ pendingDraftPlugins: next });
+    },
+
     // --- Compound ---
 
     graduateProcessingConversationId: (conversationId, hasPendingInteraction) => {
@@ -300,6 +354,7 @@ export const useConversationStore = createSelectors(
         processingSnapshots: new Map(),
         attentionConversationIds: new Set(),
         pendingDraftProfiles: new Map(),
+        pendingDraftPlugins: new Map(),
       });
     },
   })),


### PR DESCRIPTION
## Summary
- Add pendingDraftPlugins Map slice + set/toggle/clear actions mirroring pendingDraftProfiles
- Reset wipes the map

Part of plan: new-chat-plugin-pills.md (PR 8 of 15)