### PR TITLE
feat(web): useSupportsNewChatPlugins backwards-compat gate

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import {
+  resolveSupportsNewChatPlugins,
+  supportsNewChatPlugins,
+  useSupportsNewChatPlugins,
+} from "@/lib/backwards-compat/use-supports-new-chat-plugins";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify the boundary on each side of 0.10.4
+// plus the conservative-on-unknown policy and the awaiting send-path
+// variant.
+describe("supportsNewChatPlugins", () => {
+  test("returns false when the version is unknown", () => {
+    setVersion(null);
+    expect(supportsNewChatPlugins()).toBe(false);
+  });
+
+  test("returns false for assistants on 0.10.3 and older", () => {
+    setVersion("0.10.3");
+    expect(supportsNewChatPlugins()).toBe(false);
+    setVersion("0.10.0");
+    expect(supportsNewChatPlugins()).toBe(false);
+    setVersion("0.9.0");
+    expect(supportsNewChatPlugins()).toBe(false);
+  });
+
+  test("returns true for assistants on 0.10.4+", () => {
+    setVersion("0.10.4");
+    expect(supportsNewChatPlugins()).toBe(true);
+    setVersion("0.11.0");
+    expect(supportsNewChatPlugins()).toBe(true);
+    setVersion("1.0.0");
+    expect(supportsNewChatPlugins()).toBe(true);
+  });
+
+  test("returns false for unparseable versions", () => {
+    setVersion("garbage");
+    expect(supportsNewChatPlugins()).toBe(false);
+    setVersion("0.10");
+    expect(supportsNewChatPlugins()).toBe(false);
+  });
+});
+
+describe("useSupportsNewChatPlugins", () => {
+  test("returns false while unresolved and on older daemons", () => {
+    setVersion(null);
+    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
+      false,
+    );
+    setVersion("0.10.3");
+    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
+      false,
+    );
+  });
+
+  test("returns true on supported daemons", () => {
+    setVersion("0.10.4");
+    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
+      true,
+    );
+  });
+});
+
+describe("resolveSupportsNewChatPlugins", () => {
+  test("resolves false for an older daemon once the version is known", async () => {
+    setVersion("0.10.3");
+    expect(await resolveSupportsNewChatPlugins()).toBe(false);
+  });
+
+  test("resolves true for a supported daemon once the version is known", async () => {
+    setVersion("0.10.4");
+    expect(await resolveSupportsNewChatPlugins()).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
@@ -1,0 +1,70 @@
+/**
+ * Backwards-compat gate: per-chat plugin selection.
+ *
+ * Per-chat plugin selection lets a chat carry its own set of enabled
+ * plugins, sent on the write path when starting/continuing a
+ * conversation. The daemon side that accepts and applies that per-chat
+ * plugin set first ships in the assistant version below.
+ *
+ * The web app always serves the latest bundle, but the assistant can be
+ * any locally-installed version. On an older assistant the per-chat
+ * plugin set is silently ignored, so the UI that lets the user pick
+ * plugins for a chat — and the send path that includes them — must stay
+ * gated until the active assistant is known to support it.
+ *
+ * Because this is a write path whose legacy fallback (sending without
+ * the per-chat set) is silently accepted by older daemons, the gate must
+ * be read against a RESOLVED version, never the conservative
+ * `false`-on-unknown default: use {@link resolveSupportsNewChatPlugins}
+ * on the send path so the decision awaits version hydration rather than
+ * optimistically assuming support.
+ *
+ * TODO(version): MIN_VERSION is a near-future placeholder. The current
+ * assistant release is 0.10.3; bump this to the exact release that ships
+ * the daemon side of per-chat plugin selection once it is cut.
+ */
+import {
+  assistantSupports,
+  useAssistantSupports,
+  whenAssistantVersionKnown,
+} from "./utils";
+
+export const MIN_VERSION = "0.10.4";
+
+/**
+ * Returns `true` when the active assistant accepts the per-chat plugin
+ * set. Snapshot variant for non-hook contexts (request builders, event
+ * handlers).
+ *
+ * Returns `false` while the identity store has no version yet, when the
+ * version is unparseable, or when it falls below `MIN_VERSION`. Callers
+ * must omit the per-chat plugin set on the `false` branch.
+ */
+export function supportsNewChatPlugins(): boolean {
+  return assistantSupports(MIN_VERSION);
+}
+
+/**
+ * Hook variant of {@link supportsNewChatPlugins}: subscribes to the
+ * identity store so consumers re-render when the active assistant's
+ * version crosses `MIN_VERSION` (e.g. to show/hide the plugin picker).
+ */
+export function useSupportsNewChatPlugins(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}
+
+/**
+ * Async variant of {@link supportsNewChatPlugins} for the send path:
+ * waits (bounded) for the assistant version to hydrate before reading
+ * the gate.
+ *
+ * The sync snapshot returns `false` until the version resolves, which
+ * would drop the per-chat plugin set on the very first send after a cold
+ * start even against a capable assistant. Awaiting the version first
+ * ensures the decision is made against a resolved version — never an
+ * optimistic `true`, and never the pre-hydration `false`.
+ */
+export async function resolveSupportsNewChatPlugins(): Promise<boolean> {
+  await whenAssistantVersionKnown();
+  return supportsNewChatPlugins();
+}


### PR DESCRIPTION
## Summary
- Add daemon-version capability gate for the per-chat plugins feature, awaiting resolved version

Part of plan: new-chat-plugin-pills.md (PR 10 of 15)