### PR TITLE
feat(daemon): per-conversation enabledPlugins storage column + accessors

### DIFF
--- a/assistant/src/__tests__/conversation-crud-enabled-plugins.test.ts
+++ b/assistant/src/__tests__/conversation-crud-enabled-plugins.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  forkConversation,
+  getConversation,
+  getConversationEnabledPlugins,
+  setConversationEnabledPlugins,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+await initializeDb();
+
+describe("getConversationEnabledPlugins / setConversationEnabledPlugins", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("defaults to null on a fresh conversation", () => {
+    const conv = createConversation("enabled-plugins-default");
+    expect(getConversationEnabledPlugins(conv.id)).toBeNull();
+    expect(getConversation(conv.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("round-trips a plugin list and clears it with null", () => {
+    const conv = createConversation("enabled-plugins-roundtrip");
+
+    setConversationEnabledPlugins(conv.id, ["a", "b"]);
+    expect(getConversationEnabledPlugins(conv.id)).toEqual(["a", "b"]);
+    expect(getConversation(conv.id)?.enabledPlugins).toEqual(["a", "b"]);
+
+    setConversationEnabledPlugins(conv.id, null);
+    expect(getConversationEnabledPlugins(conv.id)).toBeNull();
+    expect(getConversation(conv.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("stores an empty list distinctly from null", () => {
+    const conv = createConversation("enabled-plugins-empty");
+    setConversationEnabledPlugins(conv.id, []);
+    expect(getConversationEnabledPlugins(conv.id)).toEqual([]);
+  });
+
+  test("a forked conversation carries the plugin selection", async () => {
+    const conv = createConversation("enabled-plugins-fork-source");
+    setConversationEnabledPlugins(conv.id, ["x", "y"]);
+    await addMessage(conv.id, "user", "hi");
+
+    const forked = forkConversation({ conversationId: conv.id });
+    expect(getConversationEnabledPlugins(forked.id)).toEqual(["x", "y"]);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -36,7 +36,7 @@ import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
 import { getLogsDbPath } from "../util/logs-db-path.js";
 import { getConversationsDir } from "../util/platform.js";
-import { createRowMapper } from "../util/row-mapper.js";
+import { createRowMapper, parseJsonNullable } from "../util/row-mapper.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   deleteOrphanAttachments,
@@ -282,6 +282,8 @@ export interface ConversationRow {
   archivedAt: number | null;
   surfacedAt: number | null;
   inferenceProfile: string | null;
+  /** Parsed plugin-id list scoping this chat; null = default (all globally-enabled). */
+  enabledPlugins: string[] | null;
   inferenceProfileSessionId: string | null;
   inferenceProfileExpiresAt: number | null;
   lastNotifiedInferenceProfile: string | null;
@@ -318,6 +320,10 @@ export const parseConversation = createRowMapper<
   archivedAt: "archivedAt",
   surfacedAt: "surfacedAt",
   inferenceProfile: "inferenceProfile",
+  enabledPlugins: {
+    from: "enabledPlugins",
+    transform: parseJsonNullable<string[]>(),
+  },
   inferenceProfileSessionId: "inferenceProfileSessionId",
   inferenceProfileExpiresAt: "inferenceProfileExpiresAt",
   lastNotifiedInferenceProfile: "lastNotifiedInferenceProfile",
@@ -940,6 +946,7 @@ export function forkConversation(params: {
           ? sourceHistoryStrippedAt
           : null,
         inferenceProfile: sourceConversation.inferenceProfile,
+        enabledPlugins: encodeEnabledPlugins(sourceConversation.enabledPlugins),
       })
       .where(eq(conversations.id, fc.id))
       .run();
@@ -1317,6 +1324,9 @@ export async function forkConversationForRetrospective(params: {
               ? sourceHistoryStrippedAt
               : null,
             inferenceProfile: sourceConversation.inferenceProfile,
+            enabledPlugins: encodeEnabledPlugins(
+              sourceConversation.enabledPlugins,
+            ),
           })
           .where(eq(conversations.id, fc.id))
           .run();
@@ -2340,6 +2350,51 @@ export function setConversationInferenceProfile(
       inferenceProfile: profile,
       inferenceProfileSessionId: null,
       inferenceProfileExpiresAt: null,
+      updatedAt: Date.now(),
+    })
+    .where(eq(conversations.id, conversationId))
+    .run();
+}
+
+/**
+ * Encode a plugin-id list for the `enabled_plugins` text column. Keeps a true
+ * SQL NULL for `null` (rather than the JSON literal `"null"`) so it reads back
+ * as "no per-chat restriction".
+ */
+function encodeEnabledPlugins(plugins: string[] | null): string | null {
+  return plugins === null ? null : JSON.stringify(plugins);
+}
+
+/**
+ * Read the per-conversation plugin scope. Returns the parsed `string[]` of
+ * plugin ids, or `null` when the column is unset/empty (= no per-chat
+ * restriction). Defensively returns `null` on a JSON parse failure.
+ */
+export function getConversationEnabledPlugins(
+  conversationId: string,
+): string[] | null {
+  const db = getDb();
+  const row = db
+    .select({ enabledPlugins: conversations.enabledPlugins })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .get();
+  return parseJsonNullable<string[]>()(row?.enabledPlugins);
+}
+
+/**
+ * Set or clear the per-conversation plugin scope. Pass a `string[]` to scope
+ * the chat to those plugin ids, or `null` to clear the restriction and fall
+ * back to all globally-enabled plugins.
+ */
+export function setConversationEnabledPlugins(
+  conversationId: string,
+  plugins: string[] | null,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      enabledPlugins: encodeEnabledPlugins(plugins),
       updatedAt: Date.now(),
     })
     .where(eq(conversations.id, conversationId))

--- a/assistant/src/persistence/migrations/311-add-conversation-enabled-plugins.ts
+++ b/assistant/src/persistence/migrations/311-add-conversation-enabled-plugins.ts
@@ -1,0 +1,25 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "enabled_plugins";
+const COLUMN_DEFINITION = "enabled_plugins TEXT";
+
+/**
+ * Add the nullable `enabled_plugins` column to the `conversations` table.
+ *
+ * Stores a JSON-encoded `string[]` of plugin ids scoping the chat, or NULL
+ * (the default) meaning no per-chat restriction — all globally-enabled
+ * plugins apply. No backfill is needed: existing rows default to NULL.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot.
+ */
+export function migrateAddConversationEnabledPlugins(
+  database: DrizzleDb,
+): void {
+  if (tableHasColumn(database, "conversations", COLUMN_NAME)) {
+    return;
+  }
+  database.run(`ALTER TABLE conversations ADD COLUMN ${COLUMN_DEFINITION}`);
+}

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -49,6 +49,8 @@ export const conversations = sqliteTable(
      */
     surfacedAt: integer("surfaced_at"),
     inferenceProfile: text("inference_profile"),
+    // JSON-encoded string[] of plugin ids scoping this chat; null = default (all globally-enabled).
+    enabledPlugins: text("enabled_plugins"),
     inferenceProfileSessionId: text("inference_profile_session_id"),
     inferenceProfileExpiresAt: integer("inference_profile_expires_at"),
     lastNotifiedInferenceProfile: text("last_notified_inference_profile"),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -418,6 +418,7 @@ import { migrateAcpSessionHistoryUsageColumns } from "./migrations/307-acp-sessi
 import { migrateAcpSessionHistoryTokenColumns } from "./migrations/308-acp-session-history-token-columns.js";
 import { migrateDropRedundantIndexes } from "./migrations/309-drop-redundant-indexes.js";
 import { migrateLlmRequestLogLatencyBreakdown } from "./migrations/310-llm-request-log-latency-breakdown.js";
+import { migrateAddConversationEnabledPlugins } from "./migrations/311-add-conversation-enabled-plugins.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1307,4 +1308,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryTokenColumns,
   migrateDropRedundantIndexes,
   migrateLlmRequestLogLatencyBreakdown,
+  migrateAddConversationEnabledPlugins,
 ];

--- a/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
@@ -45,6 +45,7 @@ function makeConversationRow(
     archivedAt: null,
     surfacedAt: null,
     inferenceProfile: null,
+    enabledPlugins: null,
     inferenceProfileSessionId: null,
     inferenceProfileExpiresAt: null,
     lastNotifiedInferenceProfile: null,


### PR DESCRIPTION
## Summary
- Add nullable enabled_plugins column to the conversations schema + Drizzle migration
- Add get/set accessors mirroring inferenceProfile; carry through clone sites

Part of plan: new-chat-plugin-pills.md (PR 1 of 15)