### PR TITLE
feat(daemon): plugin list category field, ?category= filter, and counts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20581,7 +20581,10 @@ paths:
       description:
         Return one entry per directory under `<workspaceDir>/plugins/`, sorted alphabetically. Matches the CLI's
         `assistant plugins list`. Supports `?q=<text>` for case-insensitive substring matching across plugin id, name,
-        and description.
+        and description. Each entry carries a `category` (marketplace slug from the Skills taxonomy, or `null` for
+        non-marketplace installs); the response also reports `categoryCounts` (per-category totals, computed before the
+        category filter) and `totalCount`. `?category=<slug>` filters the returned plugins by category server-side while
+        leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list.
       tags:
         - plugins
       parameters:
@@ -20591,6 +20594,12 @@ paths:
           schema:
             type: string
           description: Optional substring filter applied to plugin id, name, and description.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter installed plugins by category slug (Skills taxonomy).
       responses:
         "200":
           description: Successful response
@@ -20628,12 +20637,29 @@ paths:
                           type: array
                           items:
                             type: string
+                        category:
+                          description:
+                            Marketplace category slug (Skills taxonomy); null when origin/category is unknown, e.g. non-marketplace
+                            installs.
+                          anyOf:
+                            - type: string
+                            - type: "null"
                       required:
                         - id
                         - name
                         - description
                         - version
                       additionalProperties: false
+                  categoryCounts:
+                    description: Installed plugins per category (before the category filter is applied).
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total installed plugins matching non-category filters.
+                    type: number
                 required:
                   - plugins
                 additionalProperties: false

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -239,7 +239,10 @@ import {
   NotFoundError,
   ServiceUnavailableError,
 } from "../errors.js";
-import { ROUTES as PLUGINS_ROUTES } from "../plugins-routes.js";
+import {
+  loadCategoryMapBounded,
+  ROUTES as PLUGINS_ROUTES,
+} from "../plugins-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
@@ -568,6 +571,57 @@ describe("GET /v1/plugins", () => {
     expect(result.plugins.map((p) => p.category)).toEqual([null, null]);
     expect(result.categoryCounts).toEqual({ system: 2 });
     expect(result.totalCount).toBe(2);
+  });
+
+  // The category lookup is bounded so a slow/hanging marketplace fetch (a cold
+  // cache stuck on GitHub) can't hold up the installed list — it degrades to an
+  // empty map exactly like the rejection path above. `loadCategoryMapBounded`
+  // takes an injectable timeout so we can prove the bound without waiting the
+  // full 1500ms production budget.
+  test("bounds the catalog lookup: a stall past the budget degrades to an empty map", async () => {
+    // GIVEN a catalog fetch that resolves only AFTER the (shortened) budget.
+    getCatalogSpy.mockImplementation(
+      (ref) =>
+        new Promise<PluginCatalog>((resolve) => {
+          setTimeout(
+            () =>
+              resolve(
+                catalog(ref, [
+                  {
+                    name: "alpha",
+                    path: "github:acme/alpha@v1",
+                    category: "productivity",
+                    source: { kind: "github", repo: "acme/alpha", ref: "v1" },
+                  },
+                ]),
+              ),
+            80,
+          );
+        }),
+    );
+
+    // WHEN the bound (10ms) elapses first, the timer wins the race.
+    const map = await loadCategoryMapBounded(10);
+
+    // THEN we fall back to an empty map, so every category resolves to null and
+    // the installed list returns immediately instead of blocking on GitHub.
+    expect(map.size).toBe(0);
+  });
+
+  test("returns the catalog category map when the lookup resolves within the budget", async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "alpha",
+          path: "github:acme/alpha@v1",
+          category: "productivity",
+          source: { kind: "github", repo: "acme/alpha", ref: "v1" },
+        },
+      ]),
+    );
+
+    const map = await loadCategoryMapBounded();
+    expect(map.get("alpha")).toBe("productivity");
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -6,8 +6,12 @@
  *     description, version, path; issues omitted when empty)
  *   - `?q=` substring filter (case-insensitive across id/name/description)
  *   - Trimming + empty-string fallthrough on `?q=`
- *   - Empty install dir → `{ plugins: [] }`
+ *   - Empty install dir → `{ plugins: [], categoryCounts: {}, totalCount: 0 }`
  *   - Issues array surfaced when present
+ *   - `category` resolved from the marketplace catalog (null when unknown)
+ *   - `categoryCounts` / `totalCount` computed before the `?category=` filter
+ *   - `?category=` filters the list while counts stay unfiltered
+ *   - A catalog fetch failure degrades `category` to null without erroring
  *
  * GET /v1/plugins/search (catalog search):
  *   - Forwards `?q=` and `?ref=` to the `searchPlugins` lib
@@ -254,10 +258,16 @@ const versionsHandler = findHandler("plugins_versions");
 const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
 
-function invoke(args: RouteHandlerArgs = {}): {
+async function invoke(args: RouteHandlerArgs = {}): Promise<{
   plugins: Array<Record<string, unknown>>;
-} {
-  return listHandler(args) as { plugins: Array<Record<string, unknown>> };
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}> {
+  return (await listHandler(args)) as {
+    plugins: Array<Record<string, unknown>>;
+    categoryCounts: Record<string, number>;
+    totalCount: number;
+  };
 }
 
 // The route wire shape mirrors the lib match — including `category`.
@@ -289,11 +299,23 @@ beforeEach(() => {
 });
 
 describe("GET /v1/plugins", () => {
-  test("returns { plugins: [] } when nothing is installed", () => {
-    expect(invoke()).toEqual({ plugins: [] });
+  beforeEach(() => {
+    getCatalogSpy.mockClear();
+    // Default to an empty catalog so every installed plugin's category resolves
+    // to `null` (bucketed under "system"). Tests that exercise real categories
+    // override this.
+    getCatalogSpy.mockImplementation(async (ref) => catalog(ref, []));
   });
 
-  test("projects InstalledPluginInfo → response shape with all fields populated", () => {
+  test("returns an empty list (with empty counts) when nothing is installed", async () => {
+    expect(await invoke()).toEqual({
+      plugins: [],
+      categoryCounts: {},
+      totalCount: 0,
+    });
+  });
+
+  test("projects InstalledPluginInfo → response shape with all fields populated", async () => {
     installedFixture = [
       pluginEntry({
         name: "alpha",
@@ -306,20 +328,44 @@ describe("GET /v1/plugins", () => {
       }),
     ];
 
-    const result = invoke();
+    const result = await invoke();
     expect(result.plugins).toHaveLength(1);
+    // No catalog entry for `alpha`, so its category is null.
     expect(result.plugins[0]).toEqual({
       id: "alpha",
       name: "alpha",
       description: "Alpha plugin",
       version: "1.2.3",
       path: "/workspace/plugins/alpha",
+      category: null,
     });
     // `issues` is omitted (not just undefined) when the entry is clean.
     expect("issues" in result.plugins[0]!).toBe(false);
   });
 
-  test("uses directory name for `id` and `name` even when package.json#name is scoped", () => {
+  test("surfaces a marketplace category when the catalog declares one", async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "alpha",
+          path: "github:acme/alpha@v1",
+          category: "productivity",
+          source: { kind: "github", repo: "acme/alpha", ref: "v1" },
+        },
+      ]),
+    );
+    installedFixture = [
+      pluginEntry({
+        name: "alpha",
+        packageJson: { name: "alpha", version: "1.2.3" },
+      }),
+    ];
+
+    const [entry] = (await invoke()).plugins;
+    expect(entry?.category).toBe("productivity");
+  });
+
+  test("uses directory name for `id` and `name` even when package.json#name is scoped", async () => {
     installedFixture = [
       pluginEntry({
         name: "fancy-plugin",
@@ -331,12 +377,12 @@ describe("GET /v1/plugins", () => {
       }),
     ];
 
-    const [entry] = invoke().plugins;
+    const [entry] = (await invoke()).plugins;
     expect(entry?.id).toBe("fancy-plugin");
     expect(entry?.name).toBe("fancy-plugin");
   });
 
-  test("nulls description and version when package.json is missing or partial", () => {
+  test("nulls description and version when package.json is missing or partial", async () => {
     installedFixture = [
       pluginEntry({ name: "no-pkg-json", packageJson: null }),
       pluginEntry({
@@ -345,7 +391,7 @@ describe("GET /v1/plugins", () => {
       }),
     ];
 
-    const [missing, partial] = invoke().plugins;
+    const [missing, partial] = (await invoke()).plugins;
     expect(missing).toMatchObject({
       id: "no-pkg-json",
       description: null,
@@ -358,7 +404,7 @@ describe("GET /v1/plugins", () => {
     });
   });
 
-  test("surfaces non-fatal issues array when present", () => {
+  test("surfaces non-fatal issues array when present", async () => {
     installedFixture = [
       pluginEntry({
         name: "broken",
@@ -367,11 +413,11 @@ describe("GET /v1/plugins", () => {
       }),
     ];
 
-    const [entry] = invoke().plugins;
+    const [entry] = (await invoke()).plugins;
     expect(entry?.issues).toEqual(["missing package.json"]);
   });
 
-  test("?q= filters case-insensitively on id, name, and description", () => {
+  test("?q= filters case-insensitively on id, name, and description", async () => {
     installedFixture = [
       pluginEntry({
         name: "calendar-sync",
@@ -401,48 +447,127 @@ describe("GET /v1/plugins", () => {
 
     // id match
     expect(
-      invoke({ queryParams: { q: "calendar" } }).plugins.map((p) => p.id),
+      (await invoke({ queryParams: { q: "calendar" } })).plugins.map(
+        (p) => p.id,
+      ),
     ).toEqual(["calendar-sync"]);
 
     // description match (case-insensitive)
     expect(
-      invoke({ queryParams: { q: "GOOGLE" } }).plugins.map((p) => p.id),
+      (await invoke({ queryParams: { q: "GOOGLE" } })).plugins.map((p) => p.id),
     ).toEqual(["calendar-sync"]);
 
     // matches multiple
     expect(
-      invoke({ queryParams: { q: "o" } })
-        .plugins.map((p) => p.id)
+      (await invoke({ queryParams: { q: "o" } })).plugins
+        .map((p) => p.id)
         .sort(),
     ).toEqual(["calendar-sync", "todo", "weather"].sort());
 
     // no match
-    expect(invoke({ queryParams: { q: "zzz" } }).plugins).toEqual([]);
+    expect((await invoke({ queryParams: { q: "zzz" } })).plugins).toEqual([]);
   });
 
-  test("?q= is trimmed; whitespace-only treated as no filter", () => {
+  test("?q= is trimmed; whitespace-only treated as no filter", async () => {
     installedFixture = [
       pluginEntry({ name: "alpha" }),
       pluginEntry({ name: "beta" }),
     ];
 
     expect(
-      invoke({ queryParams: { q: "   " } }).plugins.map((p) => p.id),
+      (await invoke({ queryParams: { q: "   " } })).plugins.map((p) => p.id),
     ).toEqual(["alpha", "beta"]);
   });
 
-  test("preserves the order returned by listInstalledPlugins", () => {
+  test("preserves the order returned by listInstalledPlugins", async () => {
     installedFixture = [
       pluginEntry({ name: "alpha" }),
       pluginEntry({ name: "beta" }),
       pluginEntry({ name: "zeta" }),
     ];
 
-    expect(invoke().plugins.map((p) => p.id)).toEqual([
+    expect((await invoke()).plugins.map((p) => p.id)).toEqual([
       "alpha",
       "beta",
       "zeta",
     ]);
+  });
+
+  test('reports categoryCounts + totalCount, bucketing unknown plugins under "system"', async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "calendar-sync",
+          path: "github:acme/calendar-sync@v1",
+          category: "calendar",
+          source: { kind: "github", repo: "acme/calendar-sync", ref: "v1" },
+        },
+      ]),
+    );
+    installedFixture = [
+      pluginEntry({ name: "calendar-sync" }),
+      // Not in the catalog → category null → counted under "system".
+      pluginEntry({ name: "mystery" }),
+    ];
+
+    const result = await invoke();
+    expect(result.totalCount).toBe(2);
+    expect(result.categoryCounts).toEqual({ calendar: 1, system: 1 });
+    expect(result.plugins.find((p) => p.id === "calendar-sync")?.category).toBe(
+      "calendar",
+    );
+    expect(result.plugins.find((p) => p.id === "mystery")?.category).toBeNull();
+  });
+
+  test("?category= filters the list while categoryCounts stays unfiltered", async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "notes",
+          path: "github:acme/notes@v1",
+          category: "productivity",
+          source: { kind: "github", repo: "acme/notes", ref: "v1" },
+        },
+        {
+          name: "inbox",
+          path: "github:acme/inbox@v1",
+          category: "email",
+          source: { kind: "github", repo: "acme/inbox", ref: "v1" },
+        },
+      ]),
+    );
+    installedFixture = [
+      pluginEntry({ name: "notes" }),
+      pluginEntry({ name: "inbox" }),
+      // No catalog entry → "system".
+      pluginEntry({ name: "loose" }),
+    ];
+
+    const result = await invoke({ queryParams: { category: "productivity" } });
+    // The list is filtered to the productivity bucket...
+    expect(result.plugins.map((p) => p.id)).toEqual(["notes"]);
+    // ...but the badge counts reflect the unfiltered totals.
+    expect(result.categoryCounts).toEqual({
+      productivity: 1,
+      email: 1,
+      system: 1,
+    });
+    expect(result.totalCount).toBe(3);
+  });
+
+  test("degrades to category: null without failing when the catalog fetch throws", async () => {
+    getCatalogSpy.mockImplementation(async () => {
+      throw new PluginCatalogUnavailableError("HTTP 403", 403);
+    });
+    installedFixture = [
+      pluginEntry({ name: "alpha" }),
+      pluginEntry({ name: "beta" }),
+    ];
+
+    const result = await invoke();
+    expect(result.plugins.map((p) => p.category)).toEqual([null, null]);
+    expect(result.categoryCounts).toEqual({ system: 2 });
+    expect(result.totalCount).toBe(2);
   });
 });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -113,10 +113,27 @@ const pluginInfoSchema = z.object({
     .describe(
       "Non-fatal issues with this entry (missing `package.json`, malformed JSON, ...). Omitted when clean.",
     ),
+  category: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Marketplace category slug (Skills taxonomy); null when origin/category is unknown, e.g. non-marketplace installs.",
+    ),
 });
 
 const pluginsListResponseSchema = z.object({
   plugins: z.array(pluginInfoSchema),
+  categoryCounts: z
+    .record(z.string(), z.number())
+    .optional()
+    .describe(
+      "Installed plugins per category (before the category filter is applied).",
+    ),
+  totalCount: z
+    .number()
+    .optional()
+    .describe("Total installed plugins matching non-category filters."),
 });
 
 const pluginMatchSourceSchema = z
@@ -621,6 +638,7 @@ interface PluginView {
   version: string | null;
   path: string;
   issues?: string[];
+  category?: string | null;
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -686,14 +704,58 @@ function matchesQuery(plugin: PluginView, needle: string): boolean {
 // Handler — list installed
 // ---------------------------------------------------------------------------
 
-function handleListPlugins({ queryParams = {} }: RouteHandlerArgs): {
+/** Uncategorized fallback bucket — matches the Skills taxonomy default. */
+const UNCATEGORIZED = "system";
+
+async function handleListPlugins({
+  queryParams = {},
+}: RouteHandlerArgs): Promise<{
   plugins: PluginView[];
-} {
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}> {
   const q = queryParams.q?.trim();
+  const category = queryParams.category?.trim();
+
   const installed = listInstalledPlugins();
   const projected = installed.map(projectPlugin);
-  const filtered = q ? projected.filter((p) => matchesQuery(p, q)) : projected;
-  return { plugins: filtered };
+
+  // Categories live only in the catalog. A marketplace outage must never fail
+  // the installed list, so degrade to an empty map (every category becomes
+  // `null`) instead of throwing.
+  let categoryMap: Map<string, string | null>;
+  try {
+    const catalog = await getPluginCatalog(DEFAULT_PLUGIN_REF, {
+      fetch: globalThis.fetch.bind(globalThis),
+    });
+    categoryMap = new Map(catalog.matches.map((m) => [m.name, m.category]));
+  } catch {
+    categoryMap = new Map();
+  }
+
+  // An installed plugin's `id` is its directory name, which is the catalog
+  // match's `name` — so it's the lookup key.
+  const withCategory = projected.map((p) => ({
+    ...p,
+    category: categoryMap.get(p.id) ?? null,
+  }));
+
+  let list = q ? withCategory.filter((p) => matchesQuery(p, q)) : withCategory;
+
+  // Counts are taken BEFORE the category filter so the rail badges stay stable
+  // while a single category is selected.
+  const categoryCounts: Record<string, number> = {};
+  for (const p of list) {
+    const bucket = p.category ?? UNCATEGORIZED;
+    categoryCounts[bucket] = (categoryCounts[bucket] ?? 0) + 1;
+  }
+  const totalCount = list.length;
+
+  if (category) {
+    list = list.filter((p) => (p.category ?? UNCATEGORIZED) === category);
+  }
+
+  return { plugins: list, categoryCounts, totalCount };
 }
 
 // ---------------------------------------------------------------------------
@@ -1096,7 +1158,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "List installed plugins",
     description:
-      "Return one entry per directory under `<workspaceDir>/plugins/`, sorted alphabetically. Matches the CLI's `assistant plugins list`. Supports `?q=<text>` for case-insensitive substring matching across plugin id, name, and description.",
+      "Return one entry per directory under `<workspaceDir>/plugins/`, sorted alphabetically. Matches the CLI's `assistant plugins list`. Supports `?q=<text>` for case-insensitive substring matching across plugin id, name, and description. Each entry carries a `category` (marketplace slug from the Skills taxonomy, or `null` for non-marketplace installs); the response also reports `categoryCounts` (per-category totals, computed before the category filter) and `totalCount`. `?category=<slug>` filters the returned plugins by category server-side while leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list.",
     tags: ["plugins"],
     queryParams: [
       {
@@ -1104,6 +1166,12 @@ export const ROUTES: RouteDefinition[] = [
         schema: { type: "string" },
         description:
           "Optional substring filter applied to plugin id, name, and description.",
+      },
+      {
+        name: "category",
+        schema: { type: "string" },
+        description:
+          "Filter installed plugins by category slug (Skills taxonomy).",
       },
     ],
     responseBody: pluginsListResponseSchema,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -707,6 +707,46 @@ function matchesQuery(plugin: PluginView, needle: string): boolean {
 /** Uncategorized fallback bucket — matches the Skills taxonomy default. */
 const UNCATEGORIZED = "system";
 
+/**
+ * Time budget for the marketplace category lookup on the installed list.
+ * The installed list is a fast local read; the catalog is a remote GitHub
+ * fetch that can hang on a cold cache. Bounding the lookup keeps `GET
+ * /v1/plugins` responsive during a marketplace slowdown.
+ */
+const CATEGORY_LOOKUP_TIMEOUT_MS = 1500;
+
+/**
+ * Resolve the marketplace category map within a bounded time budget.
+ *
+ * Categories live only in the catalog, but the installed list must stay a fast
+ * local path: a marketplace outage (rejection) OR slowdown (a slow/hanging
+ * fetch on a cold cache) must never block it. We race the catalog fetch against
+ * a short timer; if the fetch rejects or does not resolve within
+ * {@link CATEGORY_LOOKUP_TIMEOUT_MS}, we degrade to an empty map so every
+ * `category` becomes `null` and the list returns immediately.
+ *
+ * `timeoutMs` is injectable so tests can exercise the bound without waiting the
+ * full production budget.
+ */
+export async function loadCategoryMapBounded(
+  timeoutMs: number = CATEGORY_LOOKUP_TIMEOUT_MS,
+): Promise<Map<string, string | null>> {
+  try {
+    const catalog = await Promise.race([
+      getPluginCatalog(DEFAULT_PLUGIN_REF, {
+        fetch: globalThis.fetch.bind(globalThis),
+      }),
+      new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), timeoutMs),
+      ),
+    ]);
+    if (!catalog) return new Map();
+    return new Map(catalog.matches.map((m) => [m.name, m.category]));
+  } catch {
+    return new Map();
+  }
+}
+
 async function handleListPlugins({
   queryParams = {},
 }: RouteHandlerArgs): Promise<{
@@ -720,18 +760,10 @@ async function handleListPlugins({
   const installed = listInstalledPlugins();
   const projected = installed.map(projectPlugin);
 
-  // Categories live only in the catalog. A marketplace outage must never fail
-  // the installed list, so degrade to an empty map (every category becomes
-  // `null`) instead of throwing.
-  let categoryMap: Map<string, string | null>;
-  try {
-    const catalog = await getPluginCatalog(DEFAULT_PLUGIN_REF, {
-      fetch: globalThis.fetch.bind(globalThis),
-    });
-    categoryMap = new Map(catalog.matches.map((m) => [m.name, m.category]));
-  } catch {
-    categoryMap = new Map();
-  }
+  // Categories live only in the catalog. A marketplace outage OR slowdown must
+  // never block the installed list, so the lookup is bounded: it degrades to an
+  // empty map (every category becomes `null`) on a rejection or a stall.
+  const categoryMap = await loadCategoryMapBounded();
 
   // An installed plugin's `id` is its directory name, which is the catalog
   // match's `name` — so it's the lookup key.


### PR DESCRIPTION
## Summary
- Add `category` to installed plugin list items (Skills-taxonomy slug or null)
- Add `?category=` server-side filter + stable `categoryCounts`/`totalCount` (system fallback)
- Degrade to `category: null` if the marketplace catalog is unreachable
- Regenerate and commit `assistant/openapi.yaml`

Part of plan: plugins-tab-category-filter.md (PR 3 of 5)