### PR TITLE
feat(daemon): hydrate per-conversation enabledPlugins onto the live conversation

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/conversation-tool-setup.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { getEffectiveEnabledPluginSet } from "./conversation-tool-setup.js";
+
+describe("getEffectiveEnabledPluginSet", () => {
+  test("returns null when enabledPlugins is null (no per-chat restriction)", () => {
+    expect(getEffectiveEnabledPluginSet({ enabledPlugins: null })).toBeNull();
+  });
+
+  test("returns null when enabledPlugins is undefined", () => {
+    expect(getEffectiveEnabledPluginSet({})).toBeNull();
+  });
+
+  test("returns a Set of the scoped plugin ids", () => {
+    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["a"] });
+    expect(set).toEqual(new Set(["a"]));
+  });
+
+  test("preserves every scoped plugin id", () => {
+    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["a", "b"] });
+    expect(set).toEqual(new Set(["a", "b"]));
+  });
+
+  test("returns an empty Set for an explicit empty scope", () => {
+    const set = getEffectiveEnabledPluginSet({ enabledPlugins: [] });
+    expect(set).not.toBeNull();
+    expect(set?.size).toBe(0);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -119,6 +119,20 @@ export function resolveConversationAttribution(
   }
 }
 
+/**
+ * Resolve a conversation's effective per-chat plugin scope as a Set for
+ * membership checks. Returns `null` when there is no per-chat restriction
+ * (`enabledPlugins` null/undefined) — meaning all globally-enabled plugins
+ * apply — otherwise a Set of the scoped plugin ids. Later tool/skill/hook
+ * filters intersect their candidate set against this; `null` is the no-op
+ * sentinel (no intersection).
+ */
+export function getEffectiveEnabledPluginSet(conv: {
+  enabledPlugins?: string[] | null;
+}): Set<string> | null {
+  return conv.enabledPlugins == null ? null : new Set(conv.enabledPlugins);
+}
+
 // ── createToolExecutor ───────────────────────────────────────────────
 
 /**

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -329,6 +329,15 @@ export class Conversation {
   inferenceProfile: string | null = null;
   /** @internal */ inferenceProfileSessionId: string | null = null;
   /** @internal */ inferenceProfileExpiresAt: number | null = null;
+  /**
+   * Per-conversation plugin scope mirrored from the DB row. `null` means no
+   * per-chat restriction (all globally-enabled plugins apply). Hydrated on load
+   * and kept in sync by {@link setEnabledPlugins} so the live instance is the
+   * source of truth; later tool/skill/hook filters intersect their candidate
+   * set against this via `getEffectiveEnabledPluginSet`.
+   * @internal
+   */
+  enabledPlugins: string[] | null = null;
   /** @internal */ currentRequestId?: string;
   /**
    * The {@link LLMCallSite} of the in-flight turn, set at turn start from
@@ -921,6 +930,7 @@ export class Conversation {
     this.inferenceProfile = conv?.inferenceProfile ?? null;
     this.inferenceProfileSessionId = conv?.inferenceProfileSessionId ?? null;
     this.inferenceProfileExpiresAt = conv?.inferenceProfileExpiresAt ?? null;
+    this.enabledPlugins = conv?.enabledPlugins ?? null;
     this.contextCompactedMessageCount = Math.max(
       0,
       conv?.contextCompactedMessageCount ?? 0,
@@ -1322,6 +1332,10 @@ export class Conversation {
 
   setSubagentAllowedTools(tools: Set<string> | undefined): void {
     this.subagentAllowedTools = tools;
+  }
+
+  setEnabledPlugins(plugins: string[] | null): void {
+    this.enabledPlugins = plugins;
   }
 
   setIsSubagent(value: boolean): void {


### PR DESCRIPTION
## Summary
- Hydrate persisted enabledPlugins onto the live conversation + setter (mirrors inferenceProfile/subagentAllowedTools)
- Add getEffectiveEnabledPluginSet helper (null = no restriction)

Part of plan: new-chat-plugin-pills.md (PR 3 of 15)