### PR TITLE
feat(web): attach enabledPlugins to first message + clear on send

### DIFF
--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -139,6 +139,69 @@ describe("postChatMessage — clientMessageId wire format", () => {
   });
 });
 
+describe("postChatMessage — enabledPlugins wire format", () => {
+  test("includes an explicit plugin selection verbatim", async () => {
+    await postChatMessage(
+      "assistant-1",
+      "conv-key",
+      "Hello",
+      [],
+      undefined,
+      undefined,
+      undefined,
+      ["alpha", "zeta"],
+    );
+
+    expect(
+      (capturedBody as Record<string, unknown>).enabledPlugins,
+    ).toEqual(["alpha", "zeta"]);
+  });
+
+  test("includes an explicit empty selection (user disabled every plugin)", async () => {
+    await postChatMessage(
+      "assistant-1",
+      "conv-key",
+      "Hello",
+      [],
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+
+    // An empty array is a genuine "no plugins for this chat" selection, not a
+    // missing one — it must reach the daemon, unlike the omitted-default case.
+    expect((capturedBody as Record<string, unknown>).enabledPlugins).toEqual(
+      [],
+    );
+  });
+
+  test("omits enabledPlugins when undefined (untouched default)", async () => {
+    await postChatMessage("assistant-1", "conv-key", "Hello");
+
+    expect(
+      (capturedBody as Record<string, unknown>).enabledPlugins,
+    ).toBeUndefined();
+  });
+
+  test("omits enabledPlugins when null", async () => {
+    await postChatMessage(
+      "assistant-1",
+      "conv-key",
+      "Hello",
+      [],
+      undefined,
+      undefined,
+      undefined,
+      null,
+    );
+
+    expect(
+      (capturedBody as Record<string, unknown>).enabledPlugins,
+    ).toBeUndefined();
+  });
+});
+
 describe("normalizeContentOrder", () => {
   test("converts string-format entries to objects", () => {
     const result = normalizeContentOrder(["text:0", "tool:1", "surface:2"]);

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -454,6 +454,7 @@ export async function postChatMessage(
   onboarding?: PreChatOnboardingContext,
   clientMessageId?: string,
   inferenceProfile?: string | null,
+  enabledPlugins?: string[] | null,
 ): Promise<PostMessageResult> {
   // Wire-field selection picks exactly one of `conversationId` (0.8.6+
   // strict internal-id lookup) or `conversationKey` (legacy
@@ -511,6 +512,15 @@ export async function postChatMessage(
   // otherwise so the conversation inherits the global default profile.
   if (inferenceProfile) {
     body.inferenceProfile = inferenceProfile;
+  }
+  // Per-chat plugin selection for the conversation this message mints — the
+  // user picked an explicit plugin set in the composer before sending. The
+  // daemon persists it as the conversation's enabled-plugin set. Omitted when
+  // `null`/`undefined` so the conversation inherits the default set. The caller
+  // gates attachment on daemon support + an explicit selection (see
+  // `use-send-message.ts`); an empty array is a valid "no plugins" selection.
+  if (enabledPlugins != null) {
+    body.enabledPlugins = enabledPlugins;
   }
   const normalizedOnboarding = onboarding
     ? normalizePreChatOnboardingContext(onboarding)

--- a/clients/web/src/domains/chat/hooks/use-send-message.plugins.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message.plugins.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Send-path wiring for per-chat plugin selection (PR 14).
+ *
+ * Mirrors the `inferenceProfile` stash lifecycle: an EXPLICIT plugin
+ * selection stashed for a draft conversation rides along on the first
+ * `POST /messages`, sorted to a stable array, gated on resolved daemon
+ * support, and cleared from the stash once the send succeeds.
+ *
+ * The hook is driven end-to-end against a spied daemon client (no
+ * `mock.module`, so the module registry stays clean for sibling test
+ * files). The scope check intentionally fails — the active assistant /
+ * conversation are left unset — so `sendMessageViaStream` returns right
+ * after the attach + clear, skipping the stream/poll machinery this PR
+ * does not touch.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { useSendMessage } from "@/domains/chat/hooks/use-send-message";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useTurnStore, INITIAL_TURN_STATE } from "@/domains/chat/turn-store";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
+
+const DRAFT_ID = "draft-1";
+
+let capturedBody: Record<string, unknown> | null = null;
+const originalPost = daemonClient.post;
+
+const queryClient = new QueryClient();
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function baseProps() {
+  return {
+    assistantId: "assistant-1",
+    activeConversationId: DRAFT_ID,
+    diskPressureChatBlockReason: null,
+    uiContextRef: { current: null },
+    pendingOnboardingContextRef: { current: null },
+    onboardingDraftConversationIdRef: { current: null },
+    startReconciliationLoop: () => {},
+    cancelReconciliation: () => {},
+    refreshConversations: async () => {},
+  };
+}
+
+async function send(version: string) {
+  useAssistantIdentityStore.getState().setIdentity("Assistant", version);
+  const props = baseProps();
+  const { result } = renderHook(() => useSendMessage(props), {
+    wrapper: Wrapper,
+  });
+  await act(async () => {
+    await result.current.sendMessage("hi");
+  });
+}
+
+beforeEach(() => {
+  capturedBody = null;
+  queryClient.clear();
+  useConversationStore.getState().reset();
+  useTurnStore.setState(INITIAL_TURN_STATE);
+  useChatSessionStore.getState().setOptimisticSends([]);
+  useChatSessionStore.getState().setError(null);
+  // Leave the active assistant/conversation unset so the post-send scope
+  // check returns false and the hook stops right after attach + clear.
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+
+  daemonClient.post = mock(
+    async (options: { body?: Record<string, unknown> }) => {
+      capturedBody = options.body ?? null;
+      return {
+        data: { accepted: true, conversationId: "conv-real", messageId: "m1" },
+        error: null,
+        response: new Response(null, { status: 200 }),
+      };
+    },
+  ) as typeof daemonClient.post;
+});
+
+afterEach(() => {
+  daemonClient.post = originalPost;
+  cleanup();
+});
+
+describe("useSendMessage — enabledPlugins send wiring", () => {
+  test("attaches the sorted explicit selection and clears the stash on success", async () => {
+    useConversationStore
+      .getState()
+      .setPendingDraftPlugins(DRAFT_ID, new Set(["zeta", "alpha"]));
+
+    await send(MIN_VERSION);
+
+    expect((capturedBody as Record<string, unknown>).enabledPlugins).toEqual([
+      "alpha",
+      "zeta",
+    ]);
+    expect(
+      useConversationStore.getState().pendingDraftPlugins.has(DRAFT_ID),
+    ).toBe(false);
+  });
+
+  test("omits enabledPlugins when no explicit selection exists (untouched default)", async () => {
+    await send(MIN_VERSION);
+
+    expect(
+      (capturedBody as Record<string, unknown>).enabledPlugins,
+    ).toBeUndefined();
+  });
+
+  test("never attaches on an unsupported daemon but still clears the stash", async () => {
+    useConversationStore
+      .getState()
+      .setPendingDraftPlugins(DRAFT_ID, new Set(["alpha"]));
+
+    // 0.10.3 is below MIN_VERSION (0.10.4) — the daemon would silently drop
+    // the field, so the gate must omit it. The stash is still cleared because
+    // the conversation was created.
+    await send("0.10.3");
+
+    expect(
+      (capturedBody as Record<string, unknown>).enabledPlugins,
+    ).toBeUndefined();
+    expect(
+      useConversationStore.getState().pendingDraftPlugins.has(DRAFT_ID),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -88,6 +88,7 @@ import {
 } from "@/domains/chat/api/messages";
 import { surfaceConversation } from "@/domains/chat/api/conversations";
 import { supportsServerMintedConversation } from "@/lib/backwards-compat/server-minted-conversation";
+import { resolveSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import {
   ConversationNotFoundError,
   fetchConversationDetail,
@@ -316,6 +317,20 @@ export function useSendMessage({
       const inferenceProfileForSend = useConversationStore
         .getState()
         .pendingDraftProfiles.get(requestConversationId);
+      // A per-chat plugin set the user picked in the composer before this
+      // conversation's row existed — mirrors `inferenceProfileForSend`. Only an
+      // EXPLICIT selection (an entry in the map, including an empty set) is
+      // forwarded; an untouched default has no entry and sends `undefined`.
+      // Gated on resolved daemon support — older daemons silently drop the
+      // field, so the version must hydrate before deciding (see
+      // `use-supports-new-chat-plugins`).
+      const draftPlugins = useConversationStore
+        .getState()
+        .pendingDraftPlugins.get(requestConversationId);
+      const enabledPluginsForSend =
+        draftPlugins && (await resolveSupportsNewChatPlugins())
+          ? [...draftPlugins].sort()
+          : undefined;
       const postResult = await postChatMessage(
         requestAssistantId,
         useServerMint ? null : requestConversationId,
@@ -324,6 +339,7 @@ export function useSendMessage({
         onboardingContext ?? undefined,
         clientMessageId,
         inferenceProfileForSend,
+        enabledPluginsForSend,
       );
       if (
         useServerMint &&
@@ -368,6 +384,15 @@ export function useSendMessage({
         useConversationStore
           .getState()
           .clearPendingDraftProfile(requestConversationId);
+      }
+      // Same lifecycle as the profile stash: the draft's plugin selection has
+      // now been persisted on the minted conversation, so drop this draft's
+      // entry. Cleared only on success — a failed send keeps the stash so a
+      // retry still carries the chosen plugins.
+      if (draftPlugins) {
+        useConversationStore
+          .getState()
+          .clearPendingDraftPlugins(requestConversationId);
       }
       if (onboardingDraftConversationIdRef.current === activeConversationId) {
         onboardingDraftConversationIdRef.current = null;


### PR DESCRIPTION
## Summary
- Thread the per-draft plugin selection onto the first POST /messages body (gated on daemon support + explicit selection)
- Clear the stash on successful send

Part of plan: new-chat-plugin-pills.md (PR 14 of 15)