### PR TITLE
feat(daemon): restrict plugin tools to a conversation's enabledPlugins

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the per-chat plugin scope applied inside
+ * `createResolveToolsCallback`. When a conversation has an `enabledPlugins`
+ * set, only tools whose owning plugin id is in that set appear in the resolved
+ * per-turn tool list; core tools are unaffected. `null` (no per-chat
+ * restriction) leaves the list unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as configLoader from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/schema.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import {
+  __clearRegistryForTesting,
+  registerPluginTools,
+} from "../../tools/registry.js";
+import type { Tool } from "../../tools/types.js";
+import { createResolveToolsCallback } from "../conversation-tool-setup.js";
+
+type SkillProjectionContext =
+  import("../conversation-tool-setup.js").SkillProjectionContext;
+type SkillProjectionCache =
+  import("../conversation-skill-tools.js").SkillProjectionCache;
+
+function def(name: string): ToolDefinition {
+  return { name, description: name, input_schema: { type: "object" } };
+}
+
+function pluginTool(name: string): Tool {
+  return {
+    name,
+    description: name,
+    input_schema: def(name).input_schema,
+  } as unknown as Tool;
+}
+
+function makeCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
+    coreToolNames: new Set<string>(),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+let getConfigSpy: ReturnType<typeof spyOn> | undefined;
+
+beforeEach(() => {
+  __clearRegistryForTesting();
+  // Resolver reads getConfig().tools.exclude; stub to an empty exclude so the
+  // test isolates the plugin-scope filter.
+  const stub: Partial<AssistantConfig> = { tools: { exclude: [] } };
+  getConfigSpy = spyOn(configLoader, "getConfig").mockReturnValue(
+    stub as AssistantConfig,
+  );
+});
+
+afterEach(() => {
+  getConfigSpy?.mockRestore();
+  getConfigSpy = undefined;
+  __clearRegistryForTesting();
+});
+
+describe("createResolveToolsCallback — per-chat plugin scope", () => {
+  test("set {a} keeps plugin a's tools and core tools, drops plugin b's", () => {
+    registerPluginTools("a", [pluginTool("a_tool")]);
+    registerPluginTools("b", [pluginTool("b_tool")]);
+
+    const resolver = createResolveToolsCallback(
+      [def("file_read")],
+      makeCtx({ enabledPlugins: ["a"] }),
+    );
+    const names = resolver!([]).map((d) => d.name);
+
+    expect(names).toContain("a_tool");
+    expect(names).toContain("file_read");
+    expect(names).not.toContain("b_tool");
+  });
+
+  test("null scope leaves all plugin tools in the resolved list", () => {
+    registerPluginTools("a", [pluginTool("a_tool")]);
+    registerPluginTools("b", [pluginTool("b_tool")]);
+
+    const resolver = createResolveToolsCallback(
+      [def("file_read")],
+      makeCtx({ enabledPlugins: null }),
+    );
+    const names = resolver!([]).map((d) => d.name);
+
+    expect(names).toContain("a_tool");
+    expect(names).toContain("b_tool");
+    expect(names).toContain("file_read");
+  });
+
+  test("absent enabledPlugins behaves like null (no restriction)", () => {
+    registerPluginTools("a", [pluginTool("a_tool")]);
+    registerPluginTools("b", [pluginTool("b_tool")]);
+
+    const resolver = createResolveToolsCallback([def("file_read")], makeCtx());
+    const names = resolver!([]).map((d) => d.name);
+
+    expect(names).toContain("a_tool");
+    expect(names).toContain("b_tool");
+  });
+
+  test("empty scope drops every plugin tool but keeps core tools", () => {
+    registerPluginTools("a", [pluginTool("a_tool")]);
+
+    const resolver = createResolveToolsCallback(
+      [def("file_read")],
+      makeCtx({ enabledPlugins: [] }),
+    );
+    const names = resolver!([]).map((d) => d.name);
+
+    expect(names).not.toContain("a_tool");
+    expect(names).toContain("file_read");
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -25,6 +25,7 @@ import {
   getMcpToolDefinitions,
   getPluginToolDefinitions,
   getTool,
+  getToolOwner,
   getWorkspaceToolDefinitions,
   getWorkspaceToolNames,
 } from "../tools/registry.js";
@@ -414,6 +415,13 @@ export interface SkillProjectionContext {
   /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
   subagentAllowedTools?: Set<string>;
   /**
+   * Per-chat plugin scope. `null`/absent means no per-chat restriction (all
+   * globally-enabled plugins apply); otherwise plugin tools are intersected
+   * with this set via {@link getEffectiveEnabledPluginSet} at per-turn
+   * resolution. Read lazily so a mid-conversation scope change is picked up.
+   */
+  enabledPlugins?: string[] | null;
+  /**
    * How {@link subagentAllowedTools} is enforced — see
    * {@link SubagentToolGateMode}. Absent means `"wire"`.
    */
@@ -731,10 +739,24 @@ export function createResolveToolsCallback(
     // so combine them with the core snapshot before filtering.
     const currentPluginDefs = getPluginToolDefinitions();
 
+    // Scope plugin tools to the conversation's per-chat plugin set. `null`
+    // leaves the list unchanged (no per-chat restriction); otherwise keep only
+    // tools whose owning plugin id is in the set, mirroring the
+    // `subagentAllowedTools` intersection below. Ownership lives in the registry
+    // (queried via getToolOwner), not on the Tool object.
+    const enabledPlugins = getEffectiveEnabledPluginSet(ctx);
+    const scopedPluginDefs =
+      enabledPlugins === null
+        ? currentPluginDefs
+        : currentPluginDefs.filter((d) => {
+            const ownerId = getToolOwner(d.name)?.id;
+            return ownerId !== undefined && enabledPlugins.has(ownerId);
+          });
+
     // Filter core + plugin tools based on current conversation context so that
     // tools irrelevant to this turn (e.g. UI tools when no client is connected)
     // are omitted from the definitions sent to the provider.
-    const filteredCoreDefs = [...coreToolDefs, ...currentPluginDefs].filter(
+    const filteredCoreDefs = [...coreToolDefs, ...scopedPluginDefs].filter(
       (d) => isToolActiveForContext(d.name, ctx),
     );
 


### PR DESCRIPTION
## Summary
- Per-turn tool resolution intersects plugin tools with the conversation's effective enabledPlugins set (null = no restriction), mirroring subagentAllowedTools

Part of plan: new-chat-plugin-pills.md (PR 5 of 15)