### PR TITLE
feat(web): NewChatPluginsSection for the empty-state composer

### DIFF
--- a/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.test.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for `NewChatPluginsSection`, the plugin picker under the new-chat
+ * composer. Rendered to static markup (no DOM needed): the installed list is
+ * supplied by seeding the `pluginsGet` React Query cache so `useNewChatPlugins`
+ * resolves synchronously on the first render, mirroring how `plugins-tab.test`
+ * drives the same read. Assertions cover the header, the Manage Plugins link
+ * href, one pill per plugin, the collapsed "Show all (+N)" cap, and the
+ * nothing-installed null render.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { pluginsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { useConversationStore } from "@/stores/conversation-store";
+
+import { NewChatPluginsSection } from "./new-chat-plugins-section";
+
+const ASSISTANT_ID = "asst-1";
+
+type InstalledPlugin = PluginsGetResponse["plugins"][number];
+
+function installed(name: string): InstalledPlugin {
+  return { id: name, name, description: null, version: null };
+}
+
+/**
+ * Render the section to static markup with the installed list pre-seeded in
+ * the query cache so the data hook reports it synchronously.
+ */
+function renderSection(plugins: InstalledPlugin[]): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    pluginsGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID },
+      query: { q: undefined },
+    }),
+    { plugins } as PluginsGetResponse,
+  );
+
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <NewChatPluginsSection
+          assistantId={ASSISTANT_ID}
+          conversationId="draft-1"
+        />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  useConversationStore.getState().reset();
+  useConversationStore.getState().setActiveConversationId("draft-1");
+});
+
+describe("NewChatPluginsSection", () => {
+  test("renders the header, info tooltip, manage link, and one pill per plugin", () => {
+    const html = renderSection([
+      installed("simple-memory"),
+      installed("weather"),
+      installed("calendar"),
+    ]);
+
+    expect(html).toContain("Add plugins for new chat");
+    // The info tooltip trigger renders the lucide Info glyph.
+    expect(html).toContain("lucide-info");
+    // Manage Plugins links to the plugins route.
+    expect(html).toContain("Manage Plugins");
+    expect(html).toContain('href="/assistant/plugins"');
+    // One pill per installed plugin.
+    expect(html).toContain("simple-memory");
+    expect(html).toContain("weather");
+    expect(html).toContain("calendar");
+    // Below the collapse threshold, no expander.
+    expect(html).not.toContain("Show all");
+  });
+
+  test("caps the collapsed view and shows a Show all (+N) affordance", () => {
+    const plugins = Array.from({ length: 14 }, (_, i) =>
+      installed(`plugin-${String(i + 1).padStart(2, "0")}`),
+    );
+
+    const html = renderSection(plugins);
+
+    // First 12 pills render; the overflow is hidden behind the expander.
+    expect(html).toContain("plugin-01");
+    expect(html).toContain("plugin-12");
+    expect(html).not.toContain("plugin-13");
+    expect(html).not.toContain("plugin-14");
+    expect(html).toContain("Show all (+2)");
+  });
+
+  test("renders nothing when no plugins are installed", () => {
+    expect(renderSection([])).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+
+import { ChevronDown, ChevronUp, Info } from "lucide-react";
+import { Link } from "react-router";
+
+import { Tooltip } from "@vellumai/design-library";
+
+import { routes } from "@/utils/routes";
+
+import { PluginPill } from "./plugin-pill";
+import { useNewChatPlugins } from "./use-new-chat-plugins";
+
+/** Pills shown before the "Show all (+N)" expander reveals the rest. */
+const COLLAPSED_PILL_COUNT = 12;
+
+const TOOLTIP_COPY =
+  "Choose which plugins this chat can use. Your selection is applied when you send your first message and stays with this conversation.";
+
+interface NewChatPluginsSectionProps {
+  assistantId: string;
+  /**
+   * The draft conversation the pills belong to. The selection itself is keyed
+   * off the store's active conversation inside `useNewChatPlugins`, so this is
+   * accepted for the composer's API symmetry rather than read directly here.
+   */
+  conversationId: string | undefined;
+}
+
+/**
+ * Plugin picker that sits under the new-chat composer: a labelled header with
+ * an info tooltip and a "Manage Plugins" link, then a wrap of toggleable pills
+ * — one per installed plugin — collapsed to the first {@link COLLAPSED_PILL_COUNT}
+ * behind a "Show all (+N)" expander. Renders nothing when nothing is installed.
+ */
+export function NewChatPluginsSection({
+  assistantId,
+}: NewChatPluginsSectionProps) {
+  const { plugins, isSelected, toggle } = useNewChatPlugins(assistantId);
+  const [expanded, setExpanded] = useState(false);
+
+  if (plugins.length === 0) return null;
+
+  const hiddenCount = plugins.length - COLLAPSED_PILL_COUNT;
+  const hasOverflow = hiddenCount > 0;
+  const visiblePlugins = expanded
+    ? plugins
+    : plugins.slice(0, COLLAPSED_PILL_COUNT);
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)]">
+          <span>Add plugins for new chat</span>
+          <Tooltip content={TOOLTIP_COPY} side="top">
+            <span className="inline-flex cursor-help items-center">
+              <Info
+                className="h-3.5 w-3.5 text-[var(--content-tertiary)]"
+                aria-hidden
+              />
+            </span>
+          </Tooltip>
+        </div>
+        <Link
+          to={routes.plugins}
+          className="text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
+        >
+          Manage Plugins
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {visiblePlugins.map((plugin) => (
+          <PluginPill
+            key={plugin.name}
+            name={plugin.name}
+            selected={isSelected(plugin.name)}
+            onToggle={() => toggle(plugin.name)}
+          />
+        ))}
+      </div>
+
+      {hasOverflow ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex items-center gap-1 self-start text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
+        >
+          {expanded ? (
+            <>
+              Show less
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden />
+            </>
+          ) : (
+            <>
+              {`Show all (+${hiddenCount})`}
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+            </>
+          )}
+        </button>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add NewChatPluginsSection: header + info tooltip + Manage Plugins link + toggleable plugin pills + Show all (+N) expander

Part of plan: new-chat-plugin-pills.md (PR 12 of 15)