### PR TITLE
feat(web): add desktop category filter rail to the Plugins tab

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-category-sidebar.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-category-sidebar.tsx
@@ -1,0 +1,105 @@
+import { LayoutGrid } from "lucide-react";
+
+import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon-map";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
+import { Button } from "@vellumai/design-library";
+
+interface PluginCategorySidebarProps {
+  selected: string | null;
+  onSelect: (slug: string | null) => void;
+  counts: Record<string, number>;
+  totalCount: number;
+  showCounts: boolean;
+  categories: CategoryInfo[];
+}
+
+/**
+ * Desktop category rail for the Plugins tab. Categories are the SHARED Skills
+ * taxonomy (same hook, same icon map) — uncategorized plugins bucket into the
+ * real `"system"` category row, so there is no free-form merge here.
+ */
+export function PluginCategorySidebar({
+  selected,
+  onSelect,
+  counts,
+  totalCount,
+  showCounts,
+  categories,
+}: PluginCategorySidebarProps) {
+  const sortedCategories = [...categories].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
+  return (
+    <nav className="flex flex-col gap-1" aria-label="Plugin categories">
+      <CategoryRow
+        icon={LayoutGrid}
+        label="All"
+        count={totalCount}
+        isActive={selected === null}
+        showCount={showCounts}
+        onClick={() => onSelect(null)}
+      />
+      {sortedCategories.map((cat) => {
+        const Icon = resolveCategoryIcon(cat.icon) ?? LayoutGrid;
+        return (
+          <CategoryRow
+            key={cat.slug}
+            icon={Icon}
+            label={cat.label}
+            count={counts[cat.slug] ?? 0}
+            isActive={selected === cat.slug}
+            showCount={showCounts}
+            onClick={() => onSelect(cat.slug)}
+          />
+        );
+      })}
+    </nav>
+  );
+}
+
+interface CategoryRowProps {
+  icon: typeof LayoutGrid;
+  label: string;
+  count: number;
+  isActive: boolean;
+  showCount: boolean;
+  onClick: () => void;
+}
+
+function CategoryRow({
+  icon: Icon,
+  label,
+  count,
+  isActive,
+  showCount,
+  onClick,
+}: CategoryRowProps) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={onClick}
+      aria-pressed={isActive}
+      className="h-auto justify-between gap-3 rounded-lg border-0 bg-transparent px-3 py-2 text-left hover:bg-[var(--ghost-hover)]"
+      style={{
+        backgroundColor: isActive ? "var(--surface-active)" : undefined,
+        color: isActive
+          ? "var(--content-default)"
+          : "var(--content-secondary)",
+      }}
+    >
+      <span className="flex items-center gap-2.5">
+        <Icon className="h-4 w-4 shrink-0" aria-hidden />
+        <span className="text-body-medium-default">{label}</span>
+      </span>
+      {showCount && (
+        <span
+          className="text-body-small-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {count}
+        </span>
+      )}
+    </Button>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -19,9 +19,11 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { PLUGIN_INSTALL_ERROR } from "@/domains/intelligence/plugins/constants";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
 import type {
   PluginsByNameGetResponse,
   PluginsByNameInspectGetResponse,
@@ -32,14 +34,25 @@ import type {
 const ASSISTANT_ID = "asst-1";
 const okResponse = { response: new Response(), error: undefined };
 
+// The shared Skills taxonomy the rail renders from. Seeded by default so the
+// rail gate hinges solely on whether the installed read carries categoryCounts.
+const CATEGORY_DEFS: CategoryInfo[] = [
+  { slug: "email", label: "Email", description: "Email tools", icon: "mail" },
+  { slug: "system", label: "System", description: "System tools", icon: "settings" },
+];
+
 type InstalledPlugin = PluginsGetResponse["plugins"][number];
 type CatalogMatch = PluginsSearchGetResponse["matches"][number];
 
 // Per-test holders the SDK mocks read. `installedStatus` lets a case force the
 // installed read into its failure branch (a non-ok, non-404 response).
+// `installedCategoryCounts` (when set) makes the installed read taxonomy-aware,
+// which is what gates the category rail.
 let installedPlugins: InstalledPlugin[];
 let installedStatus: number;
+let installedCategoryCounts: Record<string, number> | undefined;
 let catalogMatches: CatalogMatch[];
+let categoryDefs: CategoryInfo[];
 let inspectByName: Record<string, PluginsByNameInspectGetResponse>;
 
 const installSpy = mock(async (_options: unknown) => ({
@@ -61,13 +74,33 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   pluginsInstallPost: installSpy,
   pluginsByNameDelete: deleteSpy,
   pluginsByNameUpgradePost: upgradeSpy,
-  pluginsGet: mock(async () => ({
-    data: { plugins: installedPlugins } as PluginsGetResponse,
-    response: new Response(null, { status: installedStatus }),
-    error: undefined,
-  })),
+  // Mirrors the daemon: filter installed plugins by the requested category
+  // slug, and (when taxonomy-aware) echo the UNFILTERED categoryCounts/total.
+  pluginsGet: mock(async (options: { query?: { category?: string } }) => {
+    const selected = options.query?.category;
+    const plugins = selected
+      ? installedPlugins.filter((p) => (p.category ?? "system") === selected)
+      : installedPlugins;
+    const body = installedCategoryCounts
+      ? ({
+          plugins,
+          categoryCounts: installedCategoryCounts,
+          totalCount: installedPlugins.length,
+        } as PluginsGetResponse)
+      : ({ plugins } as PluginsGetResponse);
+    return {
+      data: body,
+      response: new Response(null, { status: installedStatus }),
+      error: undefined,
+    };
+  }),
   pluginsSearchGet: mock(async () => ({
     data: { query: "", ref: "main", matches: catalogMatches } as PluginsSearchGetResponse,
+    ...okResponse,
+  })),
+  // Backs the shared Skills category taxonomy the rail renders from.
+  skillsCategoriesGet: mock(async () => ({
+    data: { categories: categoryDefs },
     ...okResponse,
   })),
   pluginsByNameInspectGet: mock(async (options: { path: { name: string } }) => ({
@@ -146,6 +179,7 @@ function catalog(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
   return {
     name: "apollo-bot-brain",
     path: "github:acme/apollo-bot-brain@1111111111111111111111111111111111111111",
+    category: null,
     source: {
       kind: "github",
       repo: "acme/apollo-bot-brain",
@@ -185,7 +219,9 @@ function clickStatusOption(label: string): void {
 beforeEach(() => {
   installedPlugins = [];
   installedStatus = 200;
+  installedCategoryCounts = undefined;
   catalogMatches = [];
+  categoryDefs = CATEGORY_DEFS;
   inspectByName = {};
   installSpy.mockClear();
   deleteSpy.mockClear();
@@ -335,5 +371,79 @@ describe("PluginsTab", () => {
     const { findByLabelText } = renderTab({ plugin: "simple-memory" });
 
     expect(await findByLabelText("Back to plugins")).toBeTruthy();
+  });
+
+  test("renders the category rail with counts when the daemon supports categories", async () => {
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+    ];
+    installedCategoryCounts = { email: 1 };
+    catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
+
+    const { findByRole } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // "All" + each seeded Skills category renders a row.
+    expect(within(nav).getByRole("button", { name: /All/ })).toBeTruthy();
+    const emailRow = within(nav).getByRole("button", { name: /Email/ });
+    const systemRow = within(nav).getByRole("button", { name: /System/ });
+    // Email: 1 installed + 0 catalog. System: 0 installed + 1 catalog.
+    expect(emailRow.textContent).toContain("1");
+    expect(systemRow.textContent).toContain("1");
+  });
+
+  test("selecting a category filters both installed and available", async () => {
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+      installed({ id: "sysd", name: "sysd", category: "system" }),
+    ];
+    installedCategoryCounts = { email: 1, system: 1 };
+    catalogMatches = [
+      catalog({ name: "email-cat", category: "email" }),
+      catalog({ name: "sys-cat", category: "system" }),
+    ];
+
+    const { findByRole, findByText, queryByText } = renderTab();
+
+    // Everything shows under the default "All" selection.
+    await findByText("mailer");
+    expect(queryByText("sysd")).toBeTruthy();
+    expect(queryByText("email-cat")).toBeTruthy();
+    expect(queryByText("sys-cat")).toBeTruthy();
+
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+    fireEvent.click(within(nav).getByRole("button", { name: /Email/ }));
+
+    // Installed filters server-side (?category=); available filters client-side.
+    await waitFor(() => expect(queryByText("sysd")).toBeNull());
+    expect(queryByText("sys-cat")).toBeNull();
+    expect(queryByText("mailer")).toBeTruthy();
+    expect(queryByText("email-cat")).toBeTruthy();
+  });
+
+  test("falls back to a single column when the daemon omits categoryCounts", async () => {
+    installedPlugins = [installed()];
+    catalogMatches = [catalog()];
+    // installedCategoryCounts stays undefined → older daemon, no rail.
+
+    const { findByText, queryByRole } = renderTab();
+    await findByText("simple-memory");
+
+    expect(
+      queryByRole("navigation", { name: "Plugin categories" }),
+    ).toBeNull();
+  });
+
+  test("hides the rail when no categories load even if categoryCounts is present", async () => {
+    installedPlugins = [installed({ category: "email" })];
+    installedCategoryCounts = { email: 1 };
+    categoryDefs = [];
+
+    const { findByText, queryByRole } = renderTab();
+    await findByText("simple-memory");
+
+    expect(
+      queryByRole("navigation", { name: "Plugin categories" }),
+    ).toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -421,6 +421,58 @@ describe("PluginsTab", () => {
     expect(queryByText("email-cat")).toBeTruthy();
   });
 
+  test("a plugin both installed and in the catalog is deduped from rows and counts", async () => {
+    // `mailer` is installed AND surfaces in the catalog (the two reads are
+    // independent). It must render once (installed) and count once, not twice.
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+    ];
+    installedCategoryCounts = { email: 1 };
+    catalogMatches = [
+      catalog({ name: "mailer", category: "email" }),
+      catalog({ name: "apollo-bot-brain", category: "email" }),
+    ];
+
+    const { findByRole, findByText, queryAllByText } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // The fresh catalog plugin is Available; `mailer` renders once, never as a
+    // second "Available" row alongside its installed row.
+    await findByText("apollo-bot-brain");
+    expect(queryAllByText("mailer")).toHaveLength(1);
+
+    // Email: 1 installed + 1 deduped catalog (apollo) = 2 — NOT 3 (no double
+    // count of the installed `mailer`). "All" mirrors the deduped union total.
+    const allRow = within(nav).getByRole("button", { name: /All/ });
+    const emailRow = within(nav).getByRole("button", { name: /Email/ });
+    expect(allRow.textContent).toContain("2");
+    expect(emailRow.textContent).toContain("2");
+  });
+
+  test("an installed plugin is not Available even when its catalog category differs", async () => {
+    // Installed under "system" (e.g. the marketplace lookup degraded the
+    // category), but its catalog entry is "email". Selecting Email must NOT
+    // surface it as Available — dedup is against the UNFILTERED installed names.
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "system" }),
+    ];
+    installedCategoryCounts = { system: 1 };
+    catalogMatches = [
+      catalog({ name: "mailer", category: "email" }),
+      catalog({ name: "apollo-bot-brain", category: "email" }),
+    ];
+
+    const { findByRole, findByText, queryByText } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    fireEvent.click(within(nav).getByRole("button", { name: /Email/ }));
+
+    // `apollo` is the only Available row under Email; the installed `mailer`
+    // (bucketed under system) is suppressed despite its email catalog entry.
+    await findByText("apollo-bot-brain");
+    await waitFor(() => expect(queryByText("mailer")).toBeNull());
+  });
+
   test("falls back to a single column when the daemon omits categoryCounts", async () => {
     installedPlugins = [installed()];
     catalogMatches = [catalog()];

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -105,6 +105,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     installedPlugins,
     installedTotal,
     catalogMatches,
+    unfilteredInstalledNames,
   } = usePluginsList(assistantId, category);
 
   const { counts, totalCount } = useMergedPluginCounts(
@@ -112,6 +113,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     installedPlugins,
     installedTotal,
     catalogMatches,
+    unfilteredInstalledNames,
   );
 
   // Two-pane rail only when the daemon understands the category taxonomy AND
@@ -379,15 +381,19 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
 /**
  * Rail counts merge the two independent sources: the installed `categoryCounts`
  * (server) — or a client bucketing of installed plugins when the server omits
- * them — plus a client bucketing of the full catalog. `totalCount` is the
- * installed total + the catalog total. All inputs are unfiltered, so badges
- * stay stable while a category is selected. Mirrors skills' `useDerivedCounts`.
+ * them — plus a client bucketing of the catalog. Catalog matches already in the
+ * unfiltered installed set are skipped so an installed marketplace plugin counts
+ * once (under installed), never twice. `totalCount` is the installed total + the
+ * deduped catalog total, matching the deduped union of visible rows. All inputs
+ * are unfiltered, so badges stay stable while a category is selected. Mirrors
+ * skills' `useDerivedCounts`.
  */
 function useMergedPluginCounts(
   installedCategoryCounts: Record<string, number> | undefined,
   installedPlugins: InstalledPlugin[],
   installedTotal: number | undefined,
   catalogMatches: PluginCatalogMatch[],
+  unfilteredInstalledNames: Set<string>,
 ): { counts: Record<string, number>; totalCount: number } {
   return useMemo(() => {
     const counts: Record<string, number> = {};
@@ -402,13 +408,25 @@ function useMergedPluginCounts(
         counts[cat] = (counts[cat] ?? 0) + 1;
       }
     }
+    let catalogTotal = 0;
     for (const match of catalogMatches) {
+      // An installed marketplace plugin also appears in the catalog; counting it
+      // here would double it against the installed counts, so dedup against the
+      // unfiltered installed names — it already counts under installed.
+      if (unfilteredInstalledNames.has(match.name)) continue;
       const cat = match.category ?? "system";
       counts[cat] = (counts[cat] ?? 0) + 1;
+      catalogTotal += 1;
     }
     const installedTotalResolved = installedTotal ?? installedPlugins.length;
-    return { counts, totalCount: installedTotalResolved + catalogMatches.length };
-  }, [installedCategoryCounts, installedPlugins, installedTotal, catalogMatches]);
+    return { counts, totalCount: installedTotalResolved + catalogTotal };
+  }, [
+    installedCategoryCounts,
+    installedPlugins,
+    installedTotal,
+    catalogMatches,
+    unfilteredInstalledNames,
+  ]);
 }
 
 interface InstalledPluginRowProps {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
     CheckCircle,
     CloudOff,
+    LayoutGrid,
     Loader2,
     Puzzle,
     Sparkles,
@@ -11,6 +12,7 @@ import {
 import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 
+import { PluginCategorySidebar } from "@/domains/intelligence/components/plugins/plugin-category-sidebar";
 import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-detail";
 import { PluginDetailMobile } from "@/domains/intelligence/components/plugins/plugin-detail-mobile";
 import { FilterBar } from "@/domains/intelligence/components/plugins/plugin-filters";
@@ -25,6 +27,8 @@ import {
 } from "@/domains/intelligence/plugins/constants";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import type {
+    InstalledPlugin,
+    PluginCatalogMatch,
     PluginFilter,
     PluginListItem,
 } from "@/domains/intelligence/plugins/types";
@@ -34,6 +38,8 @@ import {
     matchesQuery,
     shortSha,
 } from "@/domains/intelligence/plugins/utils";
+// Plugin categories reuse the SHARED Skills taxonomy (same hook + icon map).
+import { useSkillCategories } from "@/domains/intelligence/skills/use-skill-categories";
 import {
     hasLocalEdits,
     type PluginDrift,
@@ -71,6 +77,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
 
   const [searchValue, setSearchValue] = useState("");
   const [filter, setFilter] = useState<PluginFilter>("all");
+  const [category, setCategory] = useState<string | null>(null);
   const [installingName, setInstallingName] = useState<string | null>(null);
   const [removingName, setRemovingName] = useState<string | null>(null);
   const [upgradingName, setUpgradingName] = useState<string | null>(null);
@@ -84,8 +91,32 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     getLocalBool(TIP_STORAGE_KEY, false),
   );
 
-  const { items, isLoading, catalogLoading, isError, isFetching, catalogError } =
-    usePluginsList(assistantId);
+  const { data: categories = [] } = useSkillCategories(assistantId);
+
+  const {
+    items,
+    isLoading,
+    catalogLoading,
+    isError,
+    isFetching,
+    catalogError,
+    categorySupported,
+    installedCategoryCounts,
+    installedPlugins,
+    installedTotal,
+    catalogMatches,
+  } = usePluginsList(assistantId, category);
+
+  const { counts, totalCount } = useMergedPluginCounts(
+    installedCategoryCounts,
+    installedPlugins,
+    installedTotal,
+    catalogMatches,
+  );
+
+  // Two-pane rail only when the daemon understands the category taxonomy AND
+  // categories loaded — otherwise fall back to today's single-column layout.
+  const categoryRailEnabled = categorySupported && categories.length > 0;
 
   const invalidate = useCallback(
     (name: string) => invalidatePluginQueries(queryClient, assistantId, name),
@@ -239,6 +270,49 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     );
   }
 
+  const listColumn = (
+    <div className="min-w-0 flex-1 overflow-y-auto">
+      {isLoading ? (
+        <LoadingState />
+      ) : isError ? (
+        <ErrorState />
+      ) : visibleItems.length === 0 ? (
+        // Don't flash an "empty" state for available plugins while the
+        // catalog is still loading (installed plugins already render above).
+        catalogLoading && filter !== "installed" ? (
+          <LoadingState />
+        ) : (
+          <EmptyState filter={filter} category={category} />
+        )
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {visibleItems.map((item) => (
+            <li key={item.name}>
+              {item.status === "installed" ? (
+                <InstalledPluginRow
+                  assistantId={assistantId}
+                  item={item}
+                  onSelect={() => handleSelect(item)}
+                  onRemove={() => setPendingRemoval(item)}
+                  onUpgrade={(drift) => handleUpgrade(item, drift)}
+                  isRemoving={removingName === item.name}
+                  isUpgrading={upgradingName === item.name}
+                />
+              ) : (
+                <PluginListRow
+                  item={item}
+                  onSelect={() => handleSelect(item)}
+                  onInstall={() => handleInstall(item)}
+                  isInstalling={installingName === item.name}
+                />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col gap-4">
       {!tipDismissed && <TipBanner onDismiss={handleDismissTip} />}
@@ -255,46 +329,23 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         <CatalogUnavailableNotice />
       ) : null}
 
-      <div className="min-w-0 flex-1 overflow-y-auto">
-        {isLoading ? (
-          <LoadingState />
-        ) : isError ? (
-          <ErrorState />
-        ) : visibleItems.length === 0 ? (
-          // Don't flash an "empty" state for available plugins while the
-          // catalog is still loading (installed plugins already render above).
-          catalogLoading && filter !== "installed" ? (
-            <LoadingState />
-          ) : (
-            <EmptyState filter={filter} />
-          )
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {visibleItems.map((item) => (
-              <li key={item.name}>
-                {item.status === "installed" ? (
-                  <InstalledPluginRow
-                    assistantId={assistantId}
-                    item={item}
-                    onSelect={() => handleSelect(item)}
-                    onRemove={() => setPendingRemoval(item)}
-                    onUpgrade={(drift) => handleUpgrade(item, drift)}
-                    isRemoving={removingName === item.name}
-                    isUpgrading={upgradingName === item.name}
-                  />
-                ) : (
-                  <PluginListRow
-                    item={item}
-                    onSelect={() => handleSelect(item)}
-                    onInstall={() => handleInstall(item)}
-                    isInstalling={installingName === item.name}
-                  />
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      {categoryRailEnabled ? (
+        <div className="flex min-h-0 flex-1 gap-6">
+          <aside className="hidden w-56 shrink-0 overflow-y-auto sm:block">
+            <PluginCategorySidebar
+              selected={category}
+              onSelect={setCategory}
+              counts={counts}
+              totalCount={totalCount}
+              showCounts
+              categories={categories}
+            />
+          </aside>
+          {listColumn}
+        </div>
+      ) : (
+        listColumn
+      )}
 
       <ConfirmDialog
         open={pendingRemoval !== null}
@@ -323,6 +374,41 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       />
     </div>
   );
+}
+
+/**
+ * Rail counts merge the two independent sources: the installed `categoryCounts`
+ * (server) — or a client bucketing of installed plugins when the server omits
+ * them — plus a client bucketing of the full catalog. `totalCount` is the
+ * installed total + the catalog total. All inputs are unfiltered, so badges
+ * stay stable while a category is selected. Mirrors skills' `useDerivedCounts`.
+ */
+function useMergedPluginCounts(
+  installedCategoryCounts: Record<string, number> | undefined,
+  installedPlugins: InstalledPlugin[],
+  installedTotal: number | undefined,
+  catalogMatches: PluginCatalogMatch[],
+): { counts: Record<string, number>; totalCount: number } {
+  return useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (
+      installedCategoryCounts &&
+      Object.keys(installedCategoryCounts).length > 0
+    ) {
+      Object.assign(counts, installedCategoryCounts);
+    } else {
+      for (const plugin of installedPlugins) {
+        const cat = plugin.category ?? "system";
+        counts[cat] = (counts[cat] ?? 0) + 1;
+      }
+    }
+    for (const match of catalogMatches) {
+      const cat = match.category ?? "system";
+      counts[cat] = (counts[cat] ?? 0) + 1;
+    }
+    const installedTotalResolved = installedTotal ?? installedPlugins.length;
+    return { counts, totalCount: installedTotalResolved + catalogMatches.length };
+  }, [installedCategoryCounts, installedPlugins, installedTotal, catalogMatches]);
 }
 
 interface InstalledPluginRowProps {
@@ -455,8 +541,14 @@ function ErrorState() {
   );
 }
 
-function EmptyState({ filter }: { filter: PluginFilter }) {
-  const { title, subtitle, Icon } = getEmptyStateCopy(filter);
+function EmptyState({
+  filter,
+  category,
+}: {
+  filter: PluginFilter;
+  category: string | null;
+}) {
+  const { title, subtitle, Icon } = getEmptyStateCopy(filter, category);
   return (
     <Card.Root>
       <Card.Body className="flex flex-col items-center justify-center py-16 text-center">
@@ -482,11 +574,21 @@ function EmptyState({ filter }: { filter: PluginFilter }) {
   );
 }
 
-function getEmptyStateCopy(filter: PluginFilter): {
+function getEmptyStateCopy(
+  filter: PluginFilter,
+  category: string | null,
+): {
   title: string;
   subtitle: string;
   Icon: typeof Puzzle;
 } {
+  if (category) {
+    return {
+      title: "No plugins in this category",
+      subtitle: "Try selecting a different category or clearing the filter.",
+      Icon: LayoutGrid,
+    };
+  }
   switch (filter) {
     case "installed":
       return {

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -68,6 +68,7 @@ function match(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
   return {
     name: "beta",
     path: "github:acme/beta@main",
+    category: null,
     source: { kind: "github", repo: "acme/beta", ref: "main" },
     ...overrides,
   };

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -38,7 +38,18 @@ let catalogResult: PluginsSearchGetResponse | Error;
 let catalogGate: Promise<unknown> | null = null;
 
 const sdkActual = await import("@/generated/daemon/sdk.gen");
-const pluginsGetSpy = mock(async () => installedResult);
+// Mirrors the daemon: an unfiltered read returns `installedResult` as-is; a
+// `?category=` read narrows the installed plugins to that category server-side.
+const pluginsGetSpy = mock(
+  async (options: { query?: { category?: string } }) => {
+    const selected = options?.query?.category;
+    if (!selected) return installedResult;
+    const plugins = (installedResult.data?.plugins ?? []).filter(
+      (p) => (p.category ?? "system") === selected,
+    );
+    return { ...installedResult, data: { ...installedResult.data, plugins } };
+  },
+);
 const pluginsSearchGetSpy = mock(async () => {
   if (catalogGate) await catalogGate;
   if (catalogResult instanceof Error) throw catalogResult;
@@ -82,7 +93,7 @@ function catalogOk(matches: CatalogMatch[]): PluginsSearchGetResponse {
   return { query: "", ref: "main", matches };
 }
 
-function renderPluginsList() {
+function renderPluginsList(category: string | null = null) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -91,7 +102,7 @@ function renderPluginsList() {
     return createElement(QueryClientProvider, { client }, children);
   }
 
-  return renderHook(() => usePluginsList(ASSISTANT_ID), { wrapper });
+  return renderHook(() => usePluginsList(ASSISTANT_ID, category), { wrapper });
 }
 
 beforeEach(() => {
@@ -150,6 +161,27 @@ describe("usePluginsList", () => {
     expect(result.current.items.find((p) => p.name === "dup")?.status).toBe(
       "installed",
     );
+  });
+
+  test("dedups catalog rows against installed in another category (unfiltered)", async () => {
+    // `dup` is installed under category "a", but its catalog entry is "b".
+    installedResult = installedOk([
+      installed({ id: "dup", name: "dup", category: "a" }),
+    ]);
+    catalogResult = catalogOk([
+      match({ name: "dup", category: "b" }),
+      match({ name: "fresh", category: "b" }),
+    ]);
+
+    // Selecting "b": the installed read is server-filtered to "b" (empty, since
+    // `dup` is in "a"), yet `dup` must still be deduped against the UNFILTERED
+    // installed set and never appear as Available.
+    const { result } = renderPluginsList("b");
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(result.current.items.map((p) => p.name)).toEqual(["fresh"]);
+    expect(result.current.items[0]?.status).toBe("available");
+    expect(result.current.unfilteredInstalledNames.has("dup")).toBe(true);
   });
 
   test("installed 404 degrades to an empty installed list, not an error", async () => {

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -60,6 +60,14 @@ export interface UsePluginsListResult {
   installedTotal: number | undefined;
   /** Full, unfiltered catalog matches (carry `category`) for rail counts. */
   catalogMatches: PluginCatalogMatch[];
+  /**
+   * Names of ALL installed plugins, unfiltered by category. Catalog rows and
+   * rail counts dedup against this so an installed plugin is never surfaced as
+   * "Available" (nor double-counted) regardless of its category bucket — even
+   * when its catalog category sits in a different bucket or degraded to
+   * null/system.
+   */
+  unfilteredInstalledNames: Set<string>;
 }
 
 /** Installed read with the older-daemon 404 → empty degradation. */
@@ -135,17 +143,41 @@ export function usePluginsList(
     staleTime: CATALOG_STALE_TIME_MS,
   });
 
+  // Names of every installed plugin, unfiltered by category. While no category
+  // is selected the main read is itself unfiltered; once one is, the parallel
+  // counts read backs the set, falling back to the (filtered) main read until
+  // it resolves so we never crash — we only briefly under-suppress.
+  const unfilteredInstalledNames = useMemo(() => {
+    const source =
+      category !== null
+        ? (installedCountsQuery.data?.plugins ?? installedQuery.data?.plugins)
+        : installedQuery.data?.plugins;
+    return new Set((source ?? EMPTY_INSTALLED).map((p) => p.name));
+  }, [
+    category,
+    installedCountsQuery.data?.plugins,
+    installedQuery.data?.plugins,
+  ]);
+
   const items = useMemo(() => {
     const installed = installedQuery.data?.plugins ?? EMPTY_INSTALLED;
     const matches = catalogQuery.data?.matches ?? EMPTY_MATCHES;
     // Installed is filtered server-side; filter the catalog client-side so the
-    // "available" section honors the same category.
-    const filteredMatches =
+    // "available" section honors the same category. Then drop any match already
+    // installed under ANY category (unfiltered) so an installed plugin bucketed
+    // elsewhere — or with a null/system category — is never shown as Available.
+    const availableMatches = (
       category === null
         ? matches
-        : matches.filter((m) => (m.category ?? "system") === category);
-    return sortPlugins(mergePlugins(installed, filteredMatches));
-  }, [installedQuery.data?.plugins, catalogQuery.data?.matches, category]);
+        : matches.filter((m) => (m.category ?? "system") === category)
+    ).filter((m) => !unfilteredInstalledNames.has(m.name));
+    return sortPlugins(mergePlugins(installed, availableMatches));
+  }, [
+    installedQuery.data?.plugins,
+    catalogQuery.data?.matches,
+    category,
+    unfilteredInstalledNames,
+  ]);
 
   // Counts come from the unfiltered installed read: the main read while no
   // category is selected, the parallel read once one is.
@@ -166,5 +198,6 @@ export function usePluginsList(
     installedPlugins: countsSource?.plugins ?? EMPTY_INSTALLED,
     installedTotal: countsSource?.totalCount,
     catalogMatches: catalogQuery.data?.matches ?? EMPTY_MATCHES,
+    unfilteredInstalledNames,
   };
 }

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -1,7 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import type { PluginListItem } from "@/domains/intelligence/plugins/types";
+import type {
+    InstalledPlugin,
+    PluginCatalogMatch,
+    PluginListItem,
+} from "@/domains/intelligence/plugins/types";
 import { mergePlugins, sortPlugins } from "@/domains/intelligence/plugins/utils";
 import {
     pluginsGetQueryKey,
@@ -14,6 +18,11 @@ import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
 // cached, rate-limited GitHub listing) both change rarely, so `staleTime`
 // keeps each warm across tab switches and revisiting doesn't refetch.
 const CATALOG_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
+
+// Stable empty references so consumers' `useMemo`s don't recompute while a
+// query is still pending (`?? []` would mint a new array each render).
+const EMPTY_INSTALLED: InstalledPlugin[] = [];
+const EMPTY_MATCHES: PluginCatalogMatch[] = [];
 
 export interface UsePluginsListResult {
   /** Installed + catalog merged into one deduped, sorted list. */
@@ -34,6 +43,43 @@ export interface UsePluginsListResult {
    * installed plugins; the view surfaces this as a degraded "installed only".
    */
   catalogError: boolean;
+  /**
+   * True once the installed read returns `categoryCounts` — the daemon
+   * understands the Skills category taxonomy. Older daemons omit it; the tab
+   * uses this to gate the category rail (version-skew safeguard).
+   */
+  categorySupported: boolean;
+  /**
+   * Unfiltered installed category counts from the server (before the category
+   * filter is applied). Undefined on daemons without taxonomy support.
+   */
+  installedCategoryCounts: Record<string, number> | undefined;
+  /** Unfiltered installed plugins — the client-side fallback for rail counts. */
+  installedPlugins: InstalledPlugin[];
+  /** Unfiltered installed total, the rail's installed baseline. */
+  installedTotal: number | undefined;
+  /** Full, unfiltered catalog matches (carry `category`) for rail counts. */
+  catalogMatches: PluginCatalogMatch[];
+}
+
+/** Installed read with the older-daemon 404 → empty degradation. */
+async function fetchInstalled(
+  assistantId: string,
+  category: string | undefined,
+  signal: AbortSignal,
+): Promise<PluginsGetResponse> {
+  const result = await pluginsGet({
+    path: { assistant_id: assistantId },
+    query: { q: undefined, category },
+    signal,
+    throwOnError: false,
+  });
+  const status = result.response?.status;
+  // Older daemons return 404 when the list endpoint isn't implemented yet —
+  // degrade to an empty installed list.
+  if (status === 404) return { plugins: [] } as PluginsGetResponse;
+  if (!result.response?.ok) throw new Error("Failed to load plugins");
+  return result.data ?? ({ plugins: [] } as PluginsGetResponse);
 }
 
 /**
@@ -45,28 +91,38 @@ export interface UsePluginsListResult {
  * The installed list is fatal — its failure surfaces as `isError`. The
  * catalog is best-effort: a failure degrades to "installed only" and is
  * exposed via `catalogError` rather than failing the whole list.
+ *
+ * When a `category` slug is passed, the installed list is filtered server-side
+ * (`?category=`) while the catalog stays full and is filtered client-side, so
+ * both sections honor the selected category. A parallel unfiltered installed
+ * read backs the rail badges so they stay stable across category changes.
  */
-export function usePluginsList(assistantId: string): UsePluginsListResult {
+export function usePluginsList(
+  assistantId: string,
+  category: string | null = null,
+): UsePluginsListResult {
+  const categoryParam = category ?? undefined;
+
   const installedQuery = useQuery({
+    queryKey: pluginsGetQueryKey({
+      path: { assistant_id: assistantId },
+      query: { q: undefined, category: categoryParam },
+    }),
+    queryFn: ({ signal }) => fetchInstalled(assistantId, categoryParam, signal),
+    enabled: Boolean(assistantId),
+    staleTime: CATALOG_STALE_TIME_MS,
+  });
+
+  // Unfiltered installed read so the rail badges reflect totals across every
+  // category while one is selected. Disabled until a category is chosen — when
+  // none is, the main read above is already unfiltered (same query key).
+  const installedCountsQuery = useQuery({
     queryKey: pluginsGetQueryKey({
       path: { assistant_id: assistantId },
       query: { q: undefined },
     }),
-    queryFn: async ({ signal }) => {
-      const result = await pluginsGet({
-        path: { assistant_id: assistantId },
-        query: { q: undefined },
-        signal,
-        throwOnError: false,
-      });
-      const status = result.response?.status;
-      // Older daemons return 404 when the list endpoint isn't
-      // implemented yet — degrade to an empty installed list.
-      if (status === 404) return { plugins: [] } as PluginsGetResponse;
-      if (!result.response?.ok) throw new Error("Failed to load plugins");
-      return result.data ?? ({ plugins: [] } as PluginsGetResponse);
-    },
-    enabled: Boolean(assistantId),
+    queryFn: ({ signal }) => fetchInstalled(assistantId, undefined, signal),
+    enabled: Boolean(assistantId) && category !== null,
     staleTime: CATALOG_STALE_TIME_MS,
   });
 
@@ -79,16 +135,22 @@ export function usePluginsList(assistantId: string): UsePluginsListResult {
     staleTime: CATALOG_STALE_TIME_MS,
   });
 
-  const items = useMemo(
-    () =>
-      sortPlugins(
-        mergePlugins(
-          installedQuery.data?.plugins ?? [],
-          catalogQuery.data?.matches ?? [],
-        ),
-      ),
-    [installedQuery.data?.plugins, catalogQuery.data?.matches],
-  );
+  const items = useMemo(() => {
+    const installed = installedQuery.data?.plugins ?? EMPTY_INSTALLED;
+    const matches = catalogQuery.data?.matches ?? EMPTY_MATCHES;
+    // Installed is filtered server-side; filter the catalog client-side so the
+    // "available" section honors the same category.
+    const filteredMatches =
+      category === null
+        ? matches
+        : matches.filter((m) => (m.category ?? "system") === category);
+    return sortPlugins(mergePlugins(installed, filteredMatches));
+  }, [installedQuery.data?.plugins, catalogQuery.data?.matches, category]);
+
+  // Counts come from the unfiltered installed read: the main read while no
+  // category is selected, the parallel read once one is.
+  const countsSource =
+    category !== null ? installedCountsQuery.data : installedQuery.data;
 
   return {
     items,
@@ -99,5 +161,10 @@ export function usePluginsList(assistantId: string): UsePluginsListResult {
     isError: installedQuery.isError,
     isFetching: installedQuery.isFetching || catalogQuery.isFetching,
     catalogError: catalogQuery.isError,
+    categorySupported: installedQuery.data?.categoryCounts !== undefined,
+    installedCategoryCounts: countsSource?.categoryCounts,
+    installedPlugins: countsSource?.plugins ?? EMPTY_INSTALLED,
+    installedTotal: countsSource?.totalCount,
+    catalogMatches: catalogQuery.data?.matches ?? EMPTY_MATCHES,
   };
 }

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -27,6 +27,7 @@ function catalog(overrides: Partial<PluginCatalogMatch> = {}): PluginCatalogMatc
   return {
     name: "beta",
     path: "github:acme/beta@main",
+    category: null,
     source: { kind: "github", repo: "acme/beta", ref: "main" },
     ...overrides,
   };

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -26,6 +26,7 @@ function match(
   return {
     name,
     path: `github:${repo}@abc123`,
+    category: null,
     ...(description ? { description } : {}),
     source: { kind: "github", repo, ref: "abc123" },
   };


### PR DESCRIPTION
## Summary
- Two-pane Plugins tab with a left category rail reusing the Skills categories + icons
- Installed section filters server-side via `?category=`; Available filters client-side
- Falls back to today's single-column layout when the daemon lacks category support

Part of plan: plugins-tab-category-filter.md (PR 4 of 5)