### PR TITLE
feat(daemon): restrict plugin-contributed skills to a conversation's enabledPlugins

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -3008,6 +3008,66 @@ describe("includes metadata does not auto-activate child skill tools", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Per-chat plugin scope — effectiveEnabledPluginSet drops plugin skills
+// ---------------------------------------------------------------------------
+
+describe("projectSkillTools per-chat plugin scope", () => {
+  function makePluginSkill(id: string, pluginId: string): SkillSummary {
+    return {
+      ...makeSkill(id, `/skills/${id}`, "plugin"),
+      owner: { kind: "plugin", id: pluginId },
+    };
+  }
+
+  beforeEach(() => {
+    mockCatalog = [makeSkill("deploy"), makePluginSkill("plug_skill", "b")];
+    mockManifests = {
+      deploy: makeManifest(["deploy_run"]),
+      plug_skill: makeManifest(["plug_action"]),
+    };
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
+    mockRegisterFailures = new Set();
+  });
+
+  test("set excluding the owning plugin drops that plugin's skill tools", () => {
+    const result = projectSkillTools([], {
+      preactivatedSkillIds: ["deploy", "plug_skill"],
+      previouslyActiveSkillIds: new Map<string, string>(),
+      effectiveEnabledPluginSet: new Set(["a"]),
+    });
+
+    expect(result.allowedToolNames.has("deploy_run")).toBe(true);
+    expect(result.allowedToolNames.has("plug_action")).toBe(false);
+  });
+
+  test("null set leaves plugin skill resolution unchanged", () => {
+    const result = projectSkillTools([], {
+      preactivatedSkillIds: ["deploy", "plug_skill"],
+      previouslyActiveSkillIds: new Map<string, string>(),
+      effectiveEnabledPluginSet: null,
+    });
+
+    expect(result.allowedToolNames.has("deploy_run")).toBe(true);
+    expect(result.allowedToolNames.has("plug_action")).toBe(true);
+  });
+
+  test("set including the owning plugin keeps that plugin's skill tools", () => {
+    const result = projectSkillTools([], {
+      preactivatedSkillIds: ["deploy", "plug_skill"],
+      previouslyActiveSkillIds: new Map<string, string>(),
+      effectiveEnabledPluginSet: new Set(["b"]),
+    });
+
+    expect(result.allowedToolNames.has("deploy_run")).toBe(true);
+    expect(result.allowedToolNames.has("plug_action")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Skill load harness — validates shared test helpers
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/config/skills-plugin-filter.test.ts
+++ b/assistant/src/config/skills-plugin-filter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { filterSkillsByEnabledPlugins, type SkillSummary } from "./skills.js";
+
+function makeSkill(
+  id: string,
+  overrides: Partial<SkillSummary> = {},
+): SkillSummary {
+  return {
+    id,
+    name: id,
+    displayName: id,
+    description: `Skill ${id}`,
+    directoryPath: `/skills/${id}`,
+    skillFilePath: `/skills/${id}/SKILL.md`,
+    source: "managed",
+    ...overrides,
+  };
+}
+
+function makePluginSkill(id: string, pluginId: string): SkillSummary {
+  return makeSkill(id, {
+    source: "plugin",
+    owner: { kind: "plugin", id: pluginId },
+  });
+}
+
+describe("filterSkillsByEnabledPlugins", () => {
+  test("null set is a no-op: returns the same array reference unchanged", () => {
+    const skills = [
+      makeSkill("bundled-one", { source: "bundled" }),
+      makePluginSkill("from-a", "a"),
+      makePluginSkill("from-b", "b"),
+    ];
+
+    const result = filterSkillsByEnabledPlugins(skills, null);
+
+    expect(result).toBe(skills);
+    expect(result.map((s) => s.id)).toEqual([
+      "bundled-one",
+      "from-a",
+      "from-b",
+    ]);
+  });
+
+  test("drops plugin skills whose owning plugin is outside the set", () => {
+    const skills = [
+      makeSkill("bundled-one", { source: "bundled" }),
+      makePluginSkill("from-a", "a"),
+      makePluginSkill("from-b", "b"),
+    ];
+
+    const result = filterSkillsByEnabledPlugins(skills, new Set(["a"]));
+
+    expect(result.map((s) => s.id)).toEqual(["bundled-one", "from-a"]);
+  });
+
+  test("retains non-plugin skills even when the set is empty", () => {
+    const skills = [
+      makeSkill("bundled-one", { source: "bundled" }),
+      makeSkill("managed-one", { source: "managed" }),
+      makeSkill("workspace-one", { source: "workspace" }),
+      makePluginSkill("from-a", "a"),
+    ];
+
+    const result = filterSkillsByEnabledPlugins(skills, new Set());
+
+    expect(result.map((s) => s.id)).toEqual([
+      "bundled-one",
+      "managed-one",
+      "workspace-one",
+    ]);
+  });
+
+  test("keeps every plugin skill when all owners are in the set", () => {
+    const skills = [
+      makePluginSkill("from-a", "a"),
+      makePluginSkill("from-b", "b"),
+    ];
+
+    const result = filterSkillsByEnabledPlugins(skills, new Set(["a", "b"]));
+
+    expect(result.map((s) => s.id)).toEqual(["from-a", "from-b"]);
+  });
+
+  test("does not mutate the input array when filtering", () => {
+    const skills = [
+      makePluginSkill("from-a", "a"),
+      makePluginSkill("from-b", "b"),
+    ];
+
+    filterSkillsByEnabledPlugins(skills, new Set(["a"]));
+
+    expect(skills.map((s) => s.id)).toEqual(["from-a", "from-b"]);
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -783,6 +783,32 @@ function discoverPluginResidentSkills(): SkillSummary[] {
 
 // ─── Catalog loading ─────────────────────────────────────────────────────────
 
+/**
+ * Scope a list of skills to a conversation's per-chat plugin selection.
+ *
+ * `effectiveEnabledPluginSet` is the conversation's effective set as produced
+ * by `getEffectiveEnabledPluginSet`: `null` means there is no per-chat
+ * restriction, so the input is returned unchanged (all globally-enabled
+ * plugins apply). When a set is given, a plugin-contributed skill
+ * (`owner.kind === "plugin"`) survives only if its owning plugin id is in the
+ * set; non-plugin skills (bundled/managed/workspace/extra) are always retained.
+ *
+ * Pure: returns the same array reference when there is no restriction, and a
+ * filtered copy otherwise, so callers can pass a cached catalog without
+ * mutating the cache.
+ */
+export function filterSkillsByEnabledPlugins(
+  skills: SkillSummary[],
+  effectiveEnabledPluginSet: Set<string> | null,
+): SkillSummary[] {
+  if (effectiveEnabledPluginSet === null) return skills;
+  return skills.filter((skill) => {
+    const owner = skill.owner;
+    if (owner?.kind !== "plugin") return true;
+    return effectiveEnabledPluginSet.has(owner.id);
+  });
+}
+
 function skillSummaryFromDefinition(
   skill: SkillDefinition,
   source: SkillSource,

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -15,7 +15,10 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
-import { loadSkillCatalog } from "../config/skills.js";
+import {
+  filterSkillsByEnabledPlugins,
+  loadSkillCatalog,
+} from "../config/skills.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
@@ -114,6 +117,14 @@ export interface ProjectSkillToolsOptions {
    * reads across agent turns.
    */
   cache?: SkillProjectionCache;
+  /**
+   * The conversation's effective per-chat plugin scope from
+   * `getEffectiveEnabledPluginSet`. `null`/absent means no per-chat restriction
+   * (all globally-enabled plugins apply). When a set is given, plugin-owned
+   * skills whose owning plugin id is outside it are dropped from this
+   * conversation's resolution; non-plugin skills are unaffected.
+   */
+  effectiveEnabledPluginSet?: Set<string> | null;
   /** Telemetry context for skill_loaded events; absent disables recording. */
   telemetry?: {
     conversationId: string;
@@ -339,8 +350,13 @@ export function projectSkillTools(
   const contextIds = contextEntries.map((e) => e.id);
   const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
 
-  // Load the catalog (cached for conversation lifetime) and index by ID
-  const catalog = getCachedCatalog(options?.cache);
+  // Load the catalog (cached for conversation lifetime), then scope it to the
+  // conversation's per-chat plugin selection so plugin-contributed skills from
+  // unselected plugins are not resolvable for this run (null = no restriction).
+  const catalog = filterSkillsByEnabledPlugins(
+    getCachedCatalog(options?.cache),
+    options?.effectiveEnabledPluginSet ?? null,
+  );
   const catalogById = new Map<string, SkillSummary>();
   for (const skill of catalog) {
     catalogById.set(skill.id, skill);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -441,6 +441,14 @@ export interface SkillProjectionContext {
   /** Per-turn override profile. */
   currentTurnOverrideProfile?: string;
   /**
+   * The conversation's per-chat plugin scope (mirrors
+   * {@link Conversation.enabledPlugins}). `null`/absent means no per-chat
+   * restriction. Read per turn so skill resolution drops plugin-owned skills
+   * outside the conversation's effective set via
+   * {@link getEffectiveEnabledPluginSet}.
+   */
+  readonly enabledPlugins?: string[] | null;
+  /**
    * Conversation id for `skill_loaded` telemetry. Absent (e.g. minimal test
    * contexts) disables telemetry recording in the skill projection.
    */
@@ -788,6 +796,9 @@ export function createResolveToolsCallback(
       preactivatedSkillIds: effectivePreactivated,
       previouslyActiveSkillIds: ctx.skillProjectionState,
       cache: ctx.skillProjectionCache,
+      // Scope plugin-contributed skills to the conversation's per-chat plugin
+      // selection (null = no restriction).
+      effectiveEnabledPluginSet: getEffectiveEnabledPluginSet(ctx),
       // skill_loaded telemetry context — resolved per turn so attribution
       // reflects the call site/profile the current turn actually runs on.
       telemetry:


### PR DESCRIPTION
## Summary
- Per-conversation skill resolution drops plugin-owned skills outside the conversation's effective enabledPlugins set (null = no restriction)

Part of plan: new-chat-plugin-pills.md (PR 6 of 15)