### PR TITLE
feat(daemon): restrict plugin injectors/hooks to a conversation's enabledPlugins

### DIFF
--- a/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
+++ b/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
@@ -310,10 +310,12 @@ describe("handleSendMessage enabledPlugins", () => {
       ["a", "b"],
     );
 
-    // Applied to the live conversation instance.
-    expect(getEffectiveEnabledPluginSet(conversation)).toEqual(
-      new Set(["a", "b"]),
-    );
+    // Applied to the live conversation instance: the user's selection, unioned
+    // with the always-on first-party defaults (which the pills never list).
+    const effective = getEffectiveEnabledPluginSet(conversation);
+    expect(effective?.has("a")).toBe(true);
+    expect(effective?.has("b")).toBe(true);
+    expect(effective?.has("default-memory")).toBe(true);
   });
 
   test("empty array scopes the chat to no plugins", async () => {
@@ -330,7 +332,12 @@ describe("handleSendMessage enabledPlugins", () => {
       "conv-plugins-test",
       [],
     );
-    expect(getEffectiveEnabledPluginSet(conversation)).toEqual(new Set());
+    // No user plugins are in scope, but the always-on first-party defaults are
+    // never filtered out — core runtime infra must keep running.
+    const effective = getEffectiveEnabledPluginSet(conversation);
+    expect(effective).not.toBeNull();
+    expect(effective?.has("default-memory")).toBe(true);
+    expect(effective?.has("a")).toBe(false);
   });
 
   test("explicit null clears to the default (no per-chat restriction)", async () => {

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for per-chat plugin scope (`enabledPlugins`) filtering at the runtime
+ * injector and lifecycle-hook gather sites.
+ *
+ * A conversation may restrict which plugins' capabilities it uses. That scope
+ * is expressed as an effective-enabled-plugin Set (see
+ * `getEffectiveEnabledPluginSet` in `daemon/conversation-tool-setup.ts`): a
+ * non-null Set is an allowlist, `null` means no restriction. This suite locks
+ * the contract that both gather sites honor it:
+ *  - `getRegisteredInjectors(set)` excludes injectors from plugins outside the
+ *    set, and is unchanged for `null`/omitted.
+ *  - `getHooksFor(name, set)` excludes in-process default-plugin hooks outside
+ *    the set, and is unchanged for `null`/omitted.
+ *  - `collectUserHooks(name, dirs, set)` excludes user-land plugin hooks outside
+ *    the set, while standalone workspace hooks (not owned by a plugin) still run.
+ *
+ * The per-chat scope layers on top of (does not replace) the global
+ * `.disabled` sentinel check — a plugin excluded by either is excluded.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { collectUserHooks } from "../hooks/hook-loader.js";
+import { getHooksFor } from "../hooks/registry.js";
+import {
+  clearInjectorRegistry,
+  getRegisteredInjectors,
+  registerPluginInjectors,
+} from "../plugins/injector-registry.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type { HookFunction, Injector, Plugin } from "../plugins/types.js";
+
+// Point the workspace at an empty temp dir so `getHooksFor` -> `getUserHooksFor`
+// finds no user-land plugins; the in-process hook tests then observe only the
+// hooks registered through `registerPlugin`.
+const TEST_WORKSPACE_DIR = join(
+  tmpdir(),
+  `vellum-plugin-effective-set-${process.pid}-${Date.now()}`,
+);
+process.env.VELLUM_WORKSPACE_DIR = TEST_WORKSPACE_DIR;
+
+function injector(name: string, order: number): Injector {
+  return { name, order, produce: () => Promise.resolve(null) };
+}
+
+function buildPlugin(
+  name: string,
+  hooks: Record<string, HookFunction>,
+): Plugin {
+  return { manifest: { name, version: "1.0.0" }, hooks };
+}
+
+describe("getRegisteredInjectors per-chat plugin scope", () => {
+  beforeEach(() => clearInjectorRegistry());
+  afterEach(() => clearInjectorRegistry());
+
+  test("null set runs every globally-enabled plugin's injectors (unchanged)", () => {
+    registerPluginInjectors("plugin-a", [injector("inj-a", 1)]);
+    registerPluginInjectors("plugin-b", [injector("inj-b", 2)]);
+
+    const namesNull = getRegisteredInjectors(null).map((i) => i.name);
+    const namesOmitted = getRegisteredInjectors().map((i) => i.name);
+
+    expect(namesNull).toEqual(["inj-a", "inj-b"]);
+    expect(namesOmitted).toEqual(["inj-a", "inj-b"]);
+  });
+
+  test("a set excluding plugin b drops b's injectors and keeps a's", () => {
+    registerPluginInjectors("plugin-a", [injector("inj-a", 1)]);
+    registerPluginInjectors("plugin-b", [injector("inj-b", 2)]);
+
+    const names = getRegisteredInjectors(new Set(["plugin-a"])).map(
+      (i) => i.name,
+    );
+
+    expect(names).toEqual(["inj-a"]);
+  });
+
+  test("an empty set excludes every plugin's injectors", () => {
+    registerPluginInjectors("plugin-a", [injector("inj-a", 1)]);
+    registerPluginInjectors("plugin-b", [injector("inj-b", 2)]);
+
+    expect(getRegisteredInjectors(new Set<string>())).toEqual([]);
+  });
+});
+
+describe("getHooksFor per-chat plugin scope (in-process default hooks)", () => {
+  beforeEach(() => resetPluginRegistryForTests());
+  afterEach(() => resetPluginRegistryForTests());
+
+  test("null/omitted set runs both plugins' hooks (unchanged)", async () => {
+    registerPlugin(
+      buildPlugin("default-a", {
+        "user-prompt-submit": () => Promise.resolve(),
+      }),
+    );
+    registerPlugin(
+      buildPlugin("default-b", {
+        "user-prompt-submit": () => Promise.resolve(),
+      }),
+    );
+
+    expect(await getHooksFor("user-prompt-submit")).toHaveLength(2);
+    expect(await getHooksFor("user-prompt-submit", null)).toHaveLength(2);
+  });
+
+  test("a set excluding plugin b drops b's hooks and keeps a's", async () => {
+    let aRan = 0;
+    let bRan = 0;
+    registerPlugin(
+      buildPlugin("default-a", {
+        "user-prompt-submit": () => {
+          aRan++;
+          return Promise.resolve();
+        },
+      }),
+    );
+    registerPlugin(
+      buildPlugin("default-b", {
+        "user-prompt-submit": () => {
+          bRan++;
+          return Promise.resolve();
+        },
+      }),
+    );
+
+    const hooks = await getHooksFor(
+      "user-prompt-submit",
+      new Set(["default-a"]),
+    );
+    expect(hooks).toHaveLength(1);
+
+    // The surviving hook is a's, not b's.
+    await hooks[0]!({});
+    expect(aRan).toBe(1);
+    expect(bRan).toBe(0);
+  });
+
+  test("an empty set excludes every plugin's hooks", async () => {
+    registerPlugin(
+      buildPlugin("default-a", {
+        "user-prompt-submit": () => Promise.resolve(),
+      }),
+    );
+    expect(
+      await getHooksFor("user-prompt-submit", new Set<string>()),
+    ).toHaveLength(0);
+  });
+});
+
+describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
+  let root: string;
+  let counter = 0;
+
+  beforeEach(() => {
+    root = join(
+      tmpdir(),
+      `vellum-userhooks-${process.pid}-${Date.now()}-${counter++}`,
+    );
+    mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function pluginDirWithHook(name: string): string {
+    const dir = join(root, name);
+    const hooksDir = join(dir, "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(
+      join(hooksDir, "user-prompt-submit.ts"),
+      "export default () => ({});\n",
+    );
+    return dir;
+  }
+
+  test("null set runs both user plugins' hooks (unchanged)", async () => {
+    const dirs: Array<readonly [string, string]> = [
+      [pluginDirWithHook("uplug-a"), "uplug-a"],
+      [pluginDirWithHook("uplug-b"), "uplug-b"],
+    ];
+
+    expect(await collectUserHooks("user-prompt-submit", dirs)).toHaveLength(2);
+    expect(
+      await collectUserHooks("user-prompt-submit", dirs, null),
+    ).toHaveLength(2);
+  });
+
+  test("a set excluding plugin b drops b's user-land hook", async () => {
+    const dirs: Array<readonly [string, string]> = [
+      [pluginDirWithHook("uplug-a"), "uplug-a"],
+      [pluginDirWithHook("uplug-b"), "uplug-b"],
+    ];
+
+    expect(
+      await collectUserHooks("user-prompt-submit", dirs, new Set(["uplug-a"])),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -763,6 +763,17 @@ export interface AgentLoopConstructorOptions {
    * result-time pass and the post-turn truncation covers the turn instead.
    */
   resolveConversationDir?: () => string | null;
+  /**
+   * Resolve the conversation's per-chat plugin scope as a membership set, read
+   * fresh on each lifecycle-hook gather so a mid-conversation change to the
+   * selection takes effect on the next turn. `null` (or an omitted resolver)
+   * means no per-chat restriction — every globally-enabled plugin's hooks run.
+   * Threaded into each `runHook` call so a deselected plugin's lifecycle hooks
+   * (post-compact, stop, pre/post-model-call, post-tool-use) do not fire for
+   * this conversation. Injected by the conversation wiring, which reads the
+   * live conversation; lightweight loops (workflows) omit it.
+   */
+  resolveEffectiveEnabledPlugins?: () => Set<string> | null;
 }
 
 export class AgentLoop {
@@ -785,6 +796,11 @@ export class AgentLoop {
   /** See {@link AgentLoopConstructorOptions.resolveConversationDir}. */
   private readonly resolveConversationDir: (() => string | null) | null;
 
+  /** See {@link AgentLoopConstructorOptions.resolveEffectiveEnabledPlugins}. */
+  private readonly resolveEffectiveEnabledPlugins:
+    | (() => Set<string> | null)
+    | null;
+
   /**
    * Loop-held compaction circuit breaker. The loop has a 1:1 lifetime with its
    * conversation, so it is the source of truth for the cross-turn failure
@@ -805,6 +821,7 @@ export class AgentLoop {
       isExclusiveTool,
       conversationId,
       resolveConversationDir,
+      resolveEffectiveEnabledPlugins,
     } = options;
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -815,7 +832,14 @@ export class AgentLoop {
     this.isExclusiveTool = isExclusiveTool ?? null;
     this.conversationId = conversationId;
     this.resolveConversationDir = resolveConversationDir ?? null;
+    this.resolveEffectiveEnabledPlugins =
+      resolveEffectiveEnabledPlugins ?? null;
     this.compactionCircuit = new CompactionCircuit(this.conversationId);
+  }
+
+  /** Per-chat plugin scope for the current gather; see the resolver option. */
+  private effectiveEnabledPlugins(): Set<string> | null {
+    return this.resolveEffectiveEnabledPlugins?.() ?? null;
   }
 
   /**
@@ -996,6 +1020,7 @@ export class AgentLoop {
     const finalPostCompactCtx = await runHook(
       HOOKS.POST_COMPACT,
       postCompactCtx,
+      this.effectiveEnabledPlugins(),
     );
     return {
       history: finalPostCompactCtx.history,
@@ -1150,7 +1175,7 @@ export class AgentLoop {
         logger: rlog,
       };
       try {
-        await runHook(HOOKS.STOP, stopCtx);
+        await runHook(HOOKS.STOP, stopCtx, this.effectiveEnabledPlugins());
       } catch (stopHookError) {
         rlog.error(
           { err: stopHookError, exitReason: reason },
@@ -1624,6 +1649,7 @@ export class AgentLoop {
           const finalPreModelCtx = await runHook(
             HOOKS.PRE_MODEL_CALL,
             preModelCtx,
+            this.effectiveEnabledPlugins(),
           );
           // Emit a changed event when the hook mutated the prompt. Compare
           // against the pre-hook value from providerOptions, not
@@ -1790,7 +1816,11 @@ export class AgentLoop {
               decision: "stop",
               logger: rlog,
             };
-            const result = await runHook(HOOKS.POST_MODEL_CALL, ctx);
+            const result = await runHook(
+              HOOKS.POST_MODEL_CALL,
+              ctx,
+              this.effectiveEnabledPlugins(),
+            );
             return {
               finalized: { role: "assistant", content: result.content },
               decision: result.decision,
@@ -2228,7 +2258,11 @@ export class AgentLoop {
             supportsDynamicUi,
             logger: rlog,
           };
-          const finalCtx = await runHook(HOOKS.POST_TOOL_USE, postToolUseCtx);
+          const finalCtx = await runHook(
+            HOOKS.POST_TOOL_USE,
+            postToolUseCtx,
+            this.effectiveEnabledPlugins(),
+          );
           resultBlocks.push(finalCtx.toolResponse);
           if (finalCtx.additionalContext !== null) {
             additionalContextBlocks.push({
@@ -2438,6 +2472,7 @@ export class AgentLoop {
             errorOutcome = await runHook(
               HOOKS.POST_MODEL_CALL,
               errorOutcomeCtx,
+              this.effectiveEnabledPlugins(),
             );
           } catch (postModelCallError) {
             rlog.error(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -113,6 +113,7 @@ import {
   type SlackChronologicalContext,
 } from "./conversation-runtime-assembly.js";
 import { markSurfaceCompleted } from "./conversation-surfaces.js";
+import { getEffectiveEnabledPluginSet } from "./conversation-tool-setup.js";
 import { recordUsage } from "./conversation-usage.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
 import { getDiskPressureStatus } from "./disk-pressure-guard.js";
@@ -912,6 +913,7 @@ export async function runAgentLoopImpl(
     const finalUserPromptCtx = await runHook(
       HOOKS.USER_PROMPT_SUBMIT,
       userPromptCtx,
+      getEffectiveEnabledPluginSet(ctx),
     );
     latencyTracker.mark("prompt_hook_end");
     const runMessages = finalUserPromptCtx.latestMessages;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -71,6 +71,7 @@ import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
+import { getEffectiveEnabledPluginSet } from "./conversation-tool-setup.js";
 import { canonicalizeTimeZone, formatTurnTimestamp } from "./date-context.js";
 import type {
   DynamicPageSurfaceData,
@@ -1592,13 +1593,19 @@ export interface RuntimeInjectionResult {
  * preserves ascending-`order` sort so downstream callers (notably
  * {@link applyRuntimeInjections}) can group blocks by `placement` and apply
  * them declaratively without losing per-injector ordering within each slot.
+ *
+ * `effectiveEnabledPlugins` carries the conversation's per-chat plugin scope:
+ * when non-null, injectors contributed by a plugin outside the set are excluded
+ * for this turn (see {@link getRegisteredInjectors}). `null`/omitted means no
+ * per-chat restriction.
  */
 async function collectInjectorBlocks(
   ctx: TurnContext,
   runMessages?: Message[],
+  effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<InjectionBlock[]> {
   const out: InjectionBlock[] = [];
-  for (const injector of getRegisteredInjectors()) {
+  for (const injector of getRegisteredInjectors(effectiveEnabledPlugins)) {
     const block = await injector.produce(ctx, runMessages);
     if (block) out.push(block);
   }
@@ -1937,6 +1944,14 @@ export async function applyRuntimeInjections(
   // field below from it rather than from orchestrator-computed options.
   const liveConversation = findConversationOrSubagent(conversationId);
 
+  // Per-chat plugin scope for this turn: when the conversation restricts its
+  // plugins (`enabledPlugins` non-null), injectors contributed by a plugin
+  // outside the set are excluded below. `null` (no live conversation, or no
+  // restriction) leaves the injector chain unchanged.
+  const effectiveEnabledPlugins = liveConversation
+    ? getEffectiveEnabledPluginSet(liveConversation)
+    : null;
+
   const channelCapabilities = liveConversation?.channelCapabilities ?? null;
   const slackConversation = channelCapabilities?.channel === "slack";
 
@@ -2088,7 +2103,11 @@ export async function applyRuntimeInjections(
     ...injectionInputs,
   };
 
-  const chainBlocks = await collectInjectorBlocks(turnCtx, runMessages);
+  const chainBlocks = await collectInjectorBlocks(
+    turnCtx,
+    runMessages,
+    effectiveEnabledPlugins,
+  );
 
   // Split the chain output by placement so the downstream assembly can
   // process each slot with the correct ordering rule.

--- a/assistant/src/daemon/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/conversation-tool-setup.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { getAllDefaultPlugins } from "../plugins/defaults/index.js";
 import { getEffectiveEnabledPluginSet } from "./conversation-tool-setup.js";
+
+const DEFAULT_NAMES = getAllDefaultPlugins().map((p) => p.manifest.name);
 
 describe("getEffectiveEnabledPluginSet", () => {
   test("returns null when enabledPlugins is null (no per-chat restriction)", () => {
@@ -11,19 +14,32 @@ describe("getEffectiveEnabledPluginSet", () => {
     expect(getEffectiveEnabledPluginSet({})).toBeNull();
   });
 
-  test("returns a Set of the scoped plugin ids", () => {
-    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["a"] });
-    expect(set).toEqual(new Set(["a"]));
+  test("unions first-party defaults with the selected user plugins", () => {
+    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["user-a"] });
+    expect(set).not.toBeNull();
+    // The explicitly selected user plugin is present...
+    expect(set?.has("user-a")).toBe(true);
+    // ...alongside core default-plugin infrastructure, which the new-chat pills
+    // never list and so must never be filtered out.
+    expect(set?.has("default-memory")).toBe(true);
+    expect(set?.has("default-turn-context")).toBe(true);
+    expect(set?.has("default-workspace")).toBe(true);
+    expect(set?.has("default-session")).toBe(true);
+    expect(set?.has("default-title-generate")).toBe(true);
+    for (const name of DEFAULT_NAMES) {
+      expect(set?.has(name)).toBe(true);
+    }
   });
 
-  test("preserves every scoped plugin id", () => {
-    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["a", "b"] });
-    expect(set).toEqual(new Set(["a", "b"]));
+  test("still excludes a non-selected user plugin", () => {
+    const set = getEffectiveEnabledPluginSet({ enabledPlugins: ["user-a"] });
+    expect(set?.has("user-b")).toBe(false);
   });
 
-  test("returns an empty Set for an explicit empty scope", () => {
+  test("an explicit empty scope still includes the defaults", () => {
     const set = getEffectiveEnabledPluginSet({ enabledPlugins: [] });
     expect(set).not.toBeNull();
-    expect(set?.size).toBe(0);
+    expect(set?.has("default-memory")).toBe(true);
+    expect(set?.size).toBe(DEFAULT_NAMES.length);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -17,6 +17,7 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { getBindingByConversation } from "../persistence/external-conversation-store.js";
+import { DEFAULT_PLUGIN_NAMES } from "../plugins/defaults/default-plugin-names.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -127,11 +128,21 @@ export function resolveConversationAttribution(
  * apply — otherwise a Set of the scoped plugin ids. Later tool/skill/hook
  * filters intersect their candidate set against this; `null` is the no-op
  * sentinel (no intersection).
+ *
+ * The first-party default plugins are ALWAYS unioned into a non-null scope:
+ * they are core runtime infrastructure (memory, turn-context, workspace
+ * grounding, session framing, history repair, title generation, …), not
+ * user-toggleable extensions. The per-chat pills only list user-INSTALLED
+ * plugins (`/v1/plugins` = installed plugins), so without this union,
+ * deselecting any pill would intersect the defaults out and silently disable
+ * core behavior. Unioning here fixes every consumer (tools/skills/injectors/
+ * hooks) at the single chokepoint.
  */
 export function getEffectiveEnabledPluginSet(conv: {
   enabledPlugins?: string[] | null;
 }): Set<string> | null {
-  return conv.enabledPlugins == null ? null : new Set(conv.enabledPlugins);
+  if (conv.enabledPlugins == null) return null;
+  return new Set([...conv.enabledPlugins, ...DEFAULT_PLUGIN_NAMES]);
 }
 
 // ── createToolExecutor ───────────────────────────────────────────────
@@ -415,13 +426,6 @@ export interface SkillProjectionContext {
   /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
   subagentAllowedTools?: Set<string>;
   /**
-   * Per-chat plugin scope. `null`/absent means no per-chat restriction (all
-   * globally-enabled plugins apply); otherwise plugin tools are intersected
-   * with this set via {@link getEffectiveEnabledPluginSet} at per-turn
-   * resolution. Read lazily so a mid-conversation scope change is picked up.
-   */
-  enabledPlugins?: string[] | null;
-  /**
    * How {@link subagentAllowedTools} is enforced — see
    * {@link SubagentToolGateMode}. Absent means `"wire"`.
    */
@@ -451,9 +455,10 @@ export interface SkillProjectionContext {
   /**
    * The conversation's per-chat plugin scope (mirrors
    * {@link Conversation.enabledPlugins}). `null`/absent means no per-chat
-   * restriction. Read per turn so skill resolution drops plugin-owned skills
-   * outside the conversation's effective set via
-   * {@link getEffectiveEnabledPluginSet}.
+   * restriction; otherwise plugin-owned tools and skills are intersected with
+   * the effective set (the scope unioned with the always-on first-party
+   * defaults) via {@link getEffectiveEnabledPluginSet}. Read per turn so a
+   * mid-conversation scope change is picked up.
    */
   readonly enabledPlugins?: string[] | null;
   /**

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -160,6 +160,7 @@ import type {
 import {
   createResolveToolsCallback,
   createToolExecutor,
+  getEffectiveEnabledPluginSet,
 } from "./conversation-tool-setup.js";
 import { canonicalizeTimeZone } from "./date-context.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
@@ -760,6 +761,9 @@ export class Conversation {
           conv.createdAt,
         );
       },
+      // Read the live per-chat plugin scope each gather so a mid-conversation
+      // selection change applies on the next turn's lifecycle hooks.
+      resolveEffectiveEnabledPlugins: () => getEffectiveEnabledPluginSet(this),
     });
     createContextWindowManager({
       provider,

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -144,14 +144,26 @@ async function resolveCachedHook<TCtx>(
  * Added and removed hook files are picked up live (discovery is by directory
  * listing). A content edit to an existing file is only reflected after a
  * process restart, since Bun caches dynamic imports by resolved path.
+ *
+ * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null, a
+ * plugin whose name is not in the set is skipped (its hooks do not run for this
+ * conversation). The standalone workspace hook is not owned by a plugin, so it
+ * always runs. `null`/omitted means no per-chat restriction.
  */
 export async function collectUserHooks<TCtx = unknown>(
   hookName: string,
   pluginDirs: Iterable<readonly [string, string]>,
+  effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookFunction<TCtx>[]> {
   const out: HookFunction<TCtx>[] = [];
 
   for (const [pluginDir, pluginName] of pluginDirs) {
+    if (
+      effectiveEnabledPlugins != null &&
+      !effectiveEnabledPlugins.has(pluginName)
+    ) {
+      continue;
+    }
     const hookFile = listSurfaceDir(join(pluginDir, "hooks")).find(
       (f) => f.name === hookName,
     );

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -89,9 +89,16 @@ export function unregisterPluginHooks(pluginName: string): void {
  * over the concrete context type their hook receives. Hooks that mutate the
  * context in place return `void`; hooks that return a new context replace
  * the threaded value for the next hook in the chain.
+ *
+ * `effectiveEnabledPlugins` layers the per-chat plugin scope on top of the
+ * global disabled check: when non-null, a hook's contributing plugin must also
+ * be a member of the set or the hook is excluded for this turn (applies to both
+ * in-process default plugins and user-land plugins). `null`/omitted means no
+ * per-chat restriction — every globally-enabled plugin's hooks run, unchanged.
  */
 export async function getHooksFor<TCtx = unknown>(
   name: string,
+  effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookFunction<TCtx>[]> {
   // First-party defaults from the hook registry, filtered by the `.disabled`
   // sentinel at read time. This is what makes `assistant plugins disable
@@ -99,13 +106,20 @@ export async function getHooksFor<TCtx = unknown>(
   // registered but are filtered out on the next turn.
   const defaultHooks: HookFunction<TCtx>[] = [];
   for (const entry of hookRegistry.get(name) ?? []) {
-    if (!isPluginDisabled(entry.pluginName)) {
-      defaultHooks.push(entry.fn as HookFunction<TCtx>);
+    if (isPluginDisabled(entry.pluginName)) continue;
+    if (
+      effectiveEnabledPlugins != null &&
+      !effectiveEnabledPlugins.has(entry.pluginName)
+    ) {
+      continue;
     }
+    defaultHooks.push(entry.fn as HookFunction<TCtx>);
   }
 
-  // User-land hooks from the mtime cache (async, may re-import).
-  const userHooks = await getUserHooksFor<TCtx>(name);
+  // User-land hooks from the mtime cache (async, may re-import). The per-chat
+  // scope is threaded through so a deselected user plugin's hooks are excluded
+  // too — standalone workspace hooks (not owned by a plugin) always run.
+  const userHooks = await getUserHooksFor<TCtx>(name, effectiveEnabledPlugins);
 
   return [...defaultHooks, ...userHooks];
 }

--- a/assistant/src/plugins/defaults/default-plugin-names.ts
+++ b/assistant/src/plugins/defaults/default-plugin-names.ts
@@ -1,0 +1,60 @@
+/**
+ * Names of the first-party default plugins, as a leaf module.
+ *
+ * This deliberately imports ONLY each default plugin's `package.json` (pure
+ * JSON data, no code) rather than the `./index.js` barrel. The barrel statically
+ * pulls in every hook/injector implementation (the memory-v3 engine, caption
+ * caches, persistence hooks, …) and reaches back into `daemon/` modules, so
+ * importing it from `daemon/conversation-tool-setup.ts` forms a module-init
+ * cycle. Sourcing the names from this leaf keeps that consumer cycle-free while
+ * staying data-driven (names come from `package.json`, never hand-typed).
+ *
+ * The set is kept in lock-step with the canonical {@link getAllDefaultPlugins}
+ * list by a unit assertion in `daemon/conversation-tool-setup.test.ts`.
+ */
+
+import channelPkg from "./channel/package.json" with { type: "json" };
+import compactionPkg from "./compaction/package.json" with { type: "json" };
+import documentsPkg from "./documents/package.json" with { type: "json" };
+import emptyResponsePkg from "./empty-response/package.json" with { type: "json" };
+import explorationDriftPkg from "./exploration-drift/package.json" with { type: "json" };
+import historyRepairPkg from "./history-repair/package.json" with { type: "json" };
+import imageFallbackPkg from "./image-fallback/package.json" with { type: "json" };
+import imageRecoveryPkg from "./image-recovery/package.json" with { type: "json" };
+import maxTokensContinuePkg from "./max-tokens-continue/package.json" with { type: "json" };
+import memoryPkg from "./memory/package.json" with { type: "json" };
+import sessionPkg from "./session/package.json" with { type: "json" };
+import surfaceCompletionNudgePkg from "./surface-completion-nudge/package.json" with { type: "json" };
+import taskProgressNudgePkg from "./task-progress-nudge/package.json" with { type: "json" };
+import titleGeneratePkg from "./title-generate/package.json" with { type: "json" };
+import toolErrorPkg from "./tool-error/package.json" with { type: "json" };
+import toolResultTruncatePkg from "./tool-result-truncate/package.json" with { type: "json" };
+import turnContextPkg from "./turn-context/package.json" with { type: "json" };
+import workspacePkg from "./workspace/package.json" with { type: "json" };
+
+/**
+ * The set of first-party default plugin names — runtime infrastructure
+ * (memory, turn-context, workspace, session, history repair, title generation,
+ * …), not user-toggleable extensions. Used by per-chat plugin scoping to ensure
+ * these are never filtered out (see `getEffectiveEnabledPluginSet`).
+ */
+export const DEFAULT_PLUGIN_NAMES: ReadonlySet<string> = new Set([
+  memoryPkg.name,
+  turnContextPkg.name,
+  workspacePkg.name,
+  documentsPkg.name,
+  channelPkg.name,
+  sessionPkg.name,
+  imageFallbackPkg.name,
+  toolResultTruncatePkg.name,
+  emptyResponsePkg.name,
+  maxTokensContinuePkg.name,
+  toolErrorPkg.name,
+  explorationDriftPkg.name,
+  taskProgressNudgePkg.name,
+  surfaceCompletionNudgePkg.name,
+  historyRepairPkg.name,
+  imageRecoveryPkg.name,
+  compactionPkg.name,
+  titleGeneratePkg.name,
+]);

--- a/assistant/src/plugins/injector-registry.ts
+++ b/assistant/src/plugins/injector-registry.ts
@@ -96,8 +96,16 @@ export function unregisterPluginInjectors(pluginName: string): void {
  * and tool registries honor. The order-sorted union is memoized across the
  * filter (rebuilt only on a registration change); only the small per-plugin
  * disabled check re-runs each call.
+ *
+ * `effectiveEnabledPlugins` layers the per-chat plugin scope on top of the
+ * global disabled check: when non-null, an injector's contributing plugin must
+ * also be a member of the set or the injector is excluded for this turn. `null`
+ * (or omitted) means no per-chat restriction — every globally-enabled plugin's
+ * injectors run, unchanged.
  */
-export function getRegisteredInjectors(): Injector[] {
+export function getRegisteredInjectors(
+  effectiveEnabledPlugins?: Set<string> | null,
+): Injector[] {
   if (cachedChain === null) {
     const pairs: Array<{ plugin: string; injector: Injector }> = [];
     for (const [plugin, injectors] of injectorsByPlugin) {
@@ -110,7 +118,10 @@ export function getRegisteredInjectors(): Injector[] {
   const isEnabled = (plugin: string): boolean => {
     let enabled = enabledByPlugin.get(plugin);
     if (enabled === undefined) {
-      enabled = !isPluginDisabled(plugin);
+      enabled =
+        !isPluginDisabled(plugin) &&
+        (effectiveEnabledPlugins == null ||
+          effectiveEnabledPlugins.has(plugin));
       enabledByPlugin.set(plugin, enabled);
     }
     return enabled;

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -177,12 +177,21 @@ const disabledPluginDirs = new Set<string>();
  * workspace hooks. Refreshes plugin discovery first, then delegates the actual
  * hook resolution to the hook loader. Plugin hooks run in install-date order,
  * the workspace hook runs last.
+ *
+ * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
+ * user plugins outside the set are skipped (standalone workspace hooks always
+ * run). `null`/omitted means no per-chat restriction.
  */
 export async function getUserHooksFor<TCtx = unknown>(
   hookName: string,
+  effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookFunction<TCtx>[]> {
   await scanPlugins();
-  return collectUserHooks<TCtx>(hookName, discoveredPluginDirs);
+  return collectUserHooks<TCtx>(
+    hookName,
+    discoveredPluginDirs,
+    effectiveEnabledPlugins,
+  );
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -109,16 +109,20 @@ function cloneHookValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
  *
  * @param name        The hook identifier — pick one from {@link HOOKS}.
  * @param initialCtx  Context the first hook receives.
+ * @param effectiveEnabledPlugins  Per-chat plugin scope (see
+ *        {@link getHooksFor}): when non-null, only hooks contributed by a
+ *        plugin in the set run. `null`/omitted means no per-chat restriction.
  * @returns The final context after the chain settles. Same reference as
  *          `initialCtx` when no plugin registers `name`.
  */
 export async function runHook<TCtx>(
   name: HookName,
   initialCtx: TCtx,
+  effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<TCtx> {
   let hooks: HookFunction<TCtx>[];
   try {
-    hooks = await getHooksFor<TCtx>(name);
+    hooks = await getHooksFor<TCtx>(name, effectiveEnabledPlugins);
   } catch (err) {
     log.error(
       { err, hookName: name },


### PR DESCRIPTION
## Summary
- Per-turn injector + lifecycle-hook gather excludes plugins outside the conversation's effective enabledPlugins set (null = no restriction)

Part of plan: new-chat-plugin-pills.md (PR 7 of 15)