### PR TITLE
feat(daemon): carry background-tool completion onto the wake message metadata

### DIFF
--- a/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
+++ b/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// persistWakeTriggerMessage syncs each row to the disk view and publishes a
+// sync invalidation; stub both so this unit test stays a pure DB round-trip
+// without touching the filesystem or the event hub.
+mock.module("../../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+mock.module("../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
+}));
+
+import {
+  createConversation,
+  getMessages,
+} from "../../persistence/conversation-crud.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import type { Message } from "../../providers/types.js";
+import type { CompletedBackgroundTool } from "../../tools/background-tool-registry.js";
+import type { Conversation } from "../conversation.js";
+import { persistWakeTriggerMessage } from "../wake-conversation-ops.js";
+
+await initializeDb();
+
+/** Minimal Conversation stub exercising only the fields the function reads. */
+function makeConversationStub(conversationId: string): Conversation {
+  return {
+    conversationId,
+    trustContext: undefined,
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+  } as unknown as Conversation;
+}
+
+function triggerMessage(): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: '<background_event source="background-tool">Background command completed (id=bg-1, exit=0):</background_event>',
+      },
+    ],
+  };
+}
+
+function readMetadata(conversationId: string): Record<string, unknown> {
+  const rows = getMessages(conversationId);
+  expect(rows.length).toBe(1);
+  const raw = rows[0]?.metadata;
+  expect(raw).toBeTruthy();
+  return JSON.parse(raw as string) as Record<string, unknown>;
+}
+
+describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
+  let conversationId: string;
+
+  beforeEach(() => {
+    conversationId = createConversation("wake-completion-test").id;
+  });
+
+  test("round-trips a completion onto the persisted metadata", async () => {
+    const completion: CompletedBackgroundTool = {
+      id: "bg-1",
+      toolName: "bash",
+      conversationId,
+      command: "sleep 1 && echo done",
+      startedAt: 1_700_000_000_000,
+      status: "completed",
+      exitCode: 0,
+      output: "done\n",
+      completedAt: 1_700_000_001_000,
+    };
+
+    await persistWakeTriggerMessage(
+      makeConversationStub(conversationId),
+      triggerMessage(),
+      "background-tool",
+      completion,
+    );
+
+    const metadata = readMetadata(conversationId);
+    expect(metadata.backgroundToolCompletion).toEqual(completion);
+    // Existing wake-trigger metadata is unaffected.
+    expect(metadata.kind).toBe("background-event");
+    expect(metadata.backgroundEventSource).toBe("background-tool");
+    expect(metadata.automated).toBe(true);
+  });
+
+  test("omits the key entirely when no completion is passed", async () => {
+    await persistWakeTriggerMessage(
+      makeConversationStub(conversationId),
+      triggerMessage(),
+      "background-tool",
+    );
+
+    const metadata = readMetadata(conversationId);
+    expect("backgroundToolCompletion" in metadata).toBe(false);
+    expect(metadata.kind).toBe("background-event");
+  });
+});

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -23,6 +23,7 @@ import { backfillMessageIdOnLogs } from "../persistence/llm-request-log-store.js
 import type { Message } from "../providers/types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import type { ServerMessage } from "./message-protocol.js";
@@ -273,6 +274,7 @@ export async function persistWakeTriggerMessage(
   conversation: Conversation,
   message: Message,
   source: string,
+  completion?: CompletedBackgroundTool,
 ): Promise<void> {
   const turnChannelCtx = conversation.getTurnChannelContext();
   const turnInterfaceCtx = conversation.getTurnInterfaceContext();
@@ -287,6 +289,7 @@ export async function persistWakeTriggerMessage(
     kind: "background-event",
     backgroundEventSource: source,
     automated: true,
+    ...(completion ? { backgroundToolCompletion: completion } : {}),
   };
   const persisted = await addMessage(
     conversation.conversationId,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -165,6 +165,24 @@ export const messageMetadataSchema = z
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
     automated: z.boolean().optional(),
+    /**
+     * Structured terminal record stamped onto a `<background_event
+     * source="background-tool">` wake so the web can rebuild the inline
+     * bash/host_bash card from history after a daemon restart.
+     */
+    backgroundToolCompletion: z
+      .object({
+        id: z.string(),
+        toolName: z.string(),
+        conversationId: z.string(),
+        command: z.string(),
+        startedAt: z.number(),
+        status: z.enum(["completed", "failed", "cancelled"]),
+        exitCode: z.number().nullable(),
+        output: z.string(),
+        completedAt: z.number(),
+      })
+      .optional(),
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -108,6 +108,7 @@ import {
   type UntrustedContentSource,
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");
@@ -323,6 +324,12 @@ export interface WakeOptions {
    * framing outside the fence.
    */
   untrustedOutput?: WakeUntrustedOutput;
+  /**
+   * Structured terminal record for a backgrounded bash/host_bash run, stamped
+   * onto the persisted background-event wake so the web can rebuild the inline
+   * card from history after a daemon restart.
+   */
+  backgroundToolCompletion?: CompletedBackgroundTool;
   /**
    * Schedule-run id to stamp on the usage rows this wake records. Set when the
    * wake is triggered by a script-mode schedule (the firing's run id), so the
@@ -784,7 +791,12 @@ export async function wakeAgentForOpportunity(
       };
       conversation.messages.push(triggerMessage);
       try {
-        await persistWakeTriggerMessage(conversation, triggerMessage, source);
+        await persistWakeTriggerMessage(
+          conversation,
+          triggerMessage,
+          source,
+          opts.backgroundToolCompletion,
+        );
       } catch (err) {
         log.warn(
           { conversationId, source, err },


### PR DESCRIPTION
## Summary
- Thread an optional CompletedBackgroundTool through WakeOptions -> persistWakeTriggerMessage -> wake message metadata.
- Add a typed backgroundToolCompletion field to messageMetadataSchema.
- No caller passes it yet (PR 3 wires the shell sites); deploy-safe no-op.

Part of plan: bg-card-survive-restart.md (PR 2 of 7)