### PR TITLE
feat(bg-task): stamp completion records from the bash/host_bash background paths

### DIFF
--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -189,6 +189,10 @@ describe("bash tool background mode", () => {
     // Command stdout is fenced as untrusted output, not inlined in the hint.
     expect(wakeCall.untrustedOutput?.content).toContain("bg_output_12345");
     expect(wakeCall.untrustedOutput?.source).toBe("tool_result");
+    // Durable completion record stamped onto the persisted wake.
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("completed");
+    expect(wakeCall.backgroundToolCompletion?.exitCode).toBe(0);
   });
 
   test("failing background process delivers an error hint via wake", async () => {
@@ -210,6 +214,9 @@ describe("bash tool background mode", () => {
     expect(wakeCall.hint).toContain("bg-test1234");
     // The command fails with exit code 1, so the hint should reflect failure
     expect(wakeCall.hint).toContain("exit=1");
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("failed");
+    expect(wakeCall.backgroundToolCompletion?.exitCode).toBe(1);
   });
 
   test("cancelled background process wakes with the cancellation, not a completed result", async () => {
@@ -234,6 +241,8 @@ describe("bash tool background mode", () => {
     expect(wakeCall.hint).toContain("cancelled");
     expect(wakeCall.hint).not.toContain("completed");
     expect(wakeCall.untrustedOutput?.content).toContain("cancelled");
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("cancelled");
   });
 
   test("foreground mode still works when background is not set", async () => {

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -118,6 +118,7 @@ mock.module("../daemon/host-bash-proxy.js", () => ({
 // Import under test — MUST come after mock.module calls.
 // ---------------------------------------------------------------------------
 
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { hostShellTool } from "../tools/host-terminal/host-shell.js";
 import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 
@@ -258,6 +259,11 @@ describe("host_bash background mode — proxy path", () => {
       maxChars: 40_000,
     });
     expect(wakeCall.source).toBe("background-tool");
+    const completion =
+      wakeCall.backgroundToolCompletion as CompletedBackgroundTool;
+    expect(completion.id).toBe("bg-test-0001");
+    expect(completion.status).toBe("completed");
+    expect(completion.exitCode).toBeNull();
   });
 
   test("calls wakeAgentForOpportunity on proxy error result", async () => {
@@ -398,6 +404,11 @@ describe("host_bash background mode — direct execution path", () => {
     expect((wakeCall.untrustedOutput as { content: string }).content).toContain(
       "hello world",
     );
+    const completion =
+      wakeCall.backgroundToolCompletion as CompletedBackgroundTool;
+    expect(completion.id).toBe("bg-test-0001");
+    expect(completion.status).toBe("completed");
+    expect(completion.exitCode).toBe(0);
   });
 
   test("calls wakeAgentForOpportunity with error hint on non-zero exit", async () => {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -31,6 +31,7 @@ import {
 import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
+import type { CompletedBackgroundTool } from "../background-tool-registry.js";
 import {
   generateBackgroundToolId,
   isBackgroundToolLimitReached,
@@ -318,7 +319,7 @@ export const hostShellTool = {
                 ? `Background host command cancelled (id=${bgId}).`
                 : result.content;
             const completedAt = Date.now();
-            recordCompletedBackgroundTool({
+            const completion: CompletedBackgroundTool = {
               id: bgId,
               toolName: "host_bash",
               conversationId: context.conversationId,
@@ -328,7 +329,8 @@ export const hostShellTool = {
               exitCode: null,
               output,
               completedAt,
-            });
+            };
+            recordCompletedBackgroundTool(completion);
             broadcastMessage(
               {
                 type: "background_tool_completed",
@@ -351,6 +353,7 @@ export const hostShellTool = {
               hint: framing,
               source: "background-tool",
               persistTriggerAsEvent: true,
+              backgroundToolCompletion: completion,
               untrustedOutput: {
                 content: output || "(no output)",
                 source: "tool_result",
@@ -370,7 +373,7 @@ export const hostShellTool = {
                   ? err.message
                   : String(err);
             const completedAt = Date.now();
-            recordCompletedBackgroundTool({
+            const completion: CompletedBackgroundTool = {
               id: bgId,
               toolName: "host_bash",
               conversationId: context.conversationId,
@@ -380,7 +383,8 @@ export const hostShellTool = {
               exitCode: null,
               output,
               completedAt,
-            });
+            };
+            recordCompletedBackgroundTool(completion);
             broadcastMessage(
               {
                 type: "background_tool_completed",
@@ -400,6 +404,7 @@ export const hostShellTool = {
                   : `Background host command failed (id=${bgId}): ${err instanceof Error ? err.message : String(err)}`,
               source: "background-tool",
               persistTriggerAsEvent: true,
+              backgroundToolCompletion: completion,
             });
           })
           .finally(() => removeBackgroundTool(bgId));
@@ -559,7 +564,7 @@ export const hostShellTool = {
             ? `Background host command cancelled (id=${bgId}).`
             : result.content;
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "host_bash",
           conversationId: context.conversationId,
@@ -569,7 +574,8 @@ export const hostShellTool = {
           exitCode: code ?? null,
           output,
           completedAt,
-        });
+        };
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -593,6 +599,7 @@ export const hostShellTool = {
           hint: framing,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
           untrustedOutput: {
             content: output || "(no output)",
             source: "tool_result",
@@ -613,7 +620,7 @@ export const hostShellTool = {
             ? `Background host command cancelled (id=${bgId}).`
             : err.message;
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "host_bash",
           conversationId: context.conversationId,
@@ -623,7 +630,8 @@ export const hostShellTool = {
           exitCode: null,
           output,
           completedAt,
-        });
+        };
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -643,6 +651,7 @@ export const hostShellTool = {
               : `Background host command failed (id=${bgId}): ${err.message}`,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
         });
         removeBackgroundTool(bgId);
       });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -11,6 +11,7 @@ import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabili
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
+import type { CompletedBackgroundTool } from "../background-tool-registry.js";
 import {
   generateBackgroundToolId,
   isBackgroundToolLimitReached,
@@ -427,6 +428,17 @@ export const shellTool = {
             ? `Background command cancelled (id=${bgId}).`
             : fmtResult.content;
         const completedAt = Date.now();
+        const completion: CompletedBackgroundTool = {
+          id: bgId,
+          toolName: "bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt,
+          status,
+          exitCode: code ?? null,
+          output,
+          completedAt,
+        };
 
         // Wake AFTER the terminal status is known so a user-cancelled run wakes
         // the assistant with the cancellation — not the SIGKILL-framed "completed"
@@ -440,6 +452,7 @@ export const shellTool = {
           hint: framing,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
           untrustedOutput: {
             content: output,
             source: "tool_result",
@@ -448,17 +461,7 @@ export const shellTool = {
             maxChars: MAX_OUTPUT_LENGTH * 2,
           },
         });
-        recordCompletedBackgroundTool({
-          id: bgId,
-          toolName: "bash",
-          conversationId: context.conversationId,
-          command,
-          startedAt,
-          status,
-          exitCode: code ?? null,
-          output,
-          completedAt,
-        });
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -493,15 +496,8 @@ export const shellTool = {
         });
 
         const framing = `Background command failed (id=${bgId}): ${err.message}`;
-        void wakeAgentForOpportunity({
-          conversationId: context.conversationId,
-          hint: framing,
-          source: "background-tool",
-          persistTriggerAsEvent: true,
-        });
-
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "bash",
           conversationId: context.conversationId,
@@ -511,7 +507,16 @@ export const shellTool = {
           exitCode: null,
           output: framing,
           completedAt,
+        };
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint: framing,
+          source: "background-tool",
+          persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
         });
+
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",


### PR DESCRIPTION
## Summary
- Pass the CompletedBackgroundTool object to wakeAgentForOpportunity (backgroundToolCompletion) at all 6 background completion sites, so the persisted wake carries durable completion metadata.

Part of plan: bg-card-survive-restart.md (PR 3 of 7)