### PR TITLE
feat(runtime): surface backgroundToolCompletion in GET /messages projection

### DIFF
--- a/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
+++ b/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for handleListMessages background-tool completion projection.
+ *
+ * A backgrounded bash/host_bash run posts a `<background_event
+ * source="background-tool">` wake on completion, stamped with
+ * `metadata.backgroundToolCompletion`. The history projection must surface
+ * that structured record (and the `backgroundToolNotification` flag) so the
+ * web can rebuild a terminal inline card after a daemon restart.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import { ConversationMessageSchema } from "../api/responses/conversation-message.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+interface ProjectedMessage {
+  role: string;
+  backgroundToolNotification?: boolean;
+  backgroundToolCompletion?: Record<string, unknown>;
+}
+
+describe("handleListMessages background-tool completion projection", () => {
+  beforeEach(resetTables);
+
+  test("projects backgroundToolCompletion from the wake row metadata", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "run a long command" }]),
+    );
+
+    const completion = {
+      id: "bg-1",
+      toolName: "bash",
+      conversationId: conv.id,
+      command: "sleep 5 && echo done",
+      startedAt: 1000,
+      status: "completed" as const,
+      exitCode: 0,
+      output: "done\n",
+      completedAt: 2000,
+    };
+    // Mirror persistWakeTriggerMessage: a user-role
+    // `<background_event source="background-tool">` row carrying the structured
+    // completion. Not flagged `hidden`; the client suppresses it from the
+    // transcript via `backgroundToolNotification`.
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        {
+          type: "text",
+          text: '<background_event source="background-tool">Background command completed (id=bg-1, exit=0):</background_event>',
+        },
+      ]),
+      {
+        metadata: {
+          kind: "background-event",
+          backgroundEventSource: "background-tool",
+          automated: true,
+          backgroundToolCompletion: completion,
+        },
+      },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    // Every projected message validates against the wire schema.
+    for (const message of response.messages) {
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+
+    const wakeRow = response.messages.find(
+      (m) => m.backgroundToolCompletion !== undefined,
+    );
+    expect(wakeRow).toBeDefined();
+    expect(wakeRow?.backgroundToolNotification).toBe(true);
+    expect(wakeRow?.backgroundToolCompletion).toEqual(completion);
+  });
+
+  test("omits backgroundToolCompletion when the row carries no completion metadata", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "hello" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "hi there" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    expect(response.messages).toHaveLength(2);
+    for (const message of response.messages) {
+      expect(message.backgroundToolCompletion).toBeUndefined();
+      expect(message.backgroundToolNotification).toBeUndefined();
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+  });
+});

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,6 +12,7 @@ import {
 } from "../../agent/message-types.js";
 import {
   type ConversationContentBlock,
+  type ConversationMessage,
   ConversationMessageSchema,
 } from "../../api/responses/conversation-message.js";
 import {
@@ -840,6 +841,7 @@ export function handleListMessages({
       | undefined;
     let acpNotification: { acpSessionId: string; agent?: string } | undefined;
     let backgroundToolNotification: boolean | undefined;
+    let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
@@ -851,6 +853,29 @@ export function handleListMessages({
         // the status.
         if (meta.backgroundEventSource === "background-tool") {
           backgroundToolNotification = true;
+        }
+        // `persistWakeTriggerMessage` stamps the structured completion onto the
+        // same wake row, letting the web rebuild a terminal inline card from
+        // history after a restart (the in-memory completed ring does not survive).
+        const c = meta.backgroundToolCompletion as
+          | Record<string, unknown>
+          | undefined;
+        if (
+          c &&
+          typeof c.id === "string" &&
+          typeof c.completedAt === "number"
+        ) {
+          backgroundToolCompletion = {
+            id: c.id,
+            toolName: String(c.toolName ?? ""),
+            conversationId: String(c.conversationId ?? ""),
+            command: String(c.command ?? ""),
+            startedAt: Number(c.startedAt ?? 0),
+            status: c.status as "completed" | "failed" | "cancelled",
+            exitCode: (c.exitCode ?? null) as number | null,
+            output: String(c.output ?? ""),
+            completedAt: c.completedAt,
+          };
         }
         if (meta.subagentNotification) {
           const n = meta.subagentNotification;
@@ -905,6 +930,7 @@ export function handleListMessages({
       subagentNotification,
       acpNotification,
       backgroundToolNotification,
+      backgroundToolCompletion,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
     };
@@ -1091,6 +1117,9 @@ export function handleListMessages({
       ...(m.acpNotification ? { acpNotification: m.acpNotification } : {}),
       ...(m.backgroundToolNotification
         ? { backgroundToolNotification: true }
+        : {}),
+      ...(m.backgroundToolCompletion
+        ? { backgroundToolCompletion: m.backgroundToolCompletion }
         : {}),
       ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
     };


### PR DESCRIPTION
## Summary
- Project meta.backgroundToolCompletion onto the history message (both projection sites), mirroring backgroundToolNotification.

Part of plan: bg-card-survive-restart.md (PR 4 of 7)