### PR TITLE
feat(web): project backgroundToolCompletions from paginated history

### DIFF
--- a/clients/web/src/domains/chat/api/history.test.ts
+++ b/clients/web/src/domains/chat/api/history.test.ts
@@ -356,6 +356,78 @@ describe("subagent notification extraction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Background-tool completion extraction
+// ---------------------------------------------------------------------------
+
+describe("background-tool completion extraction", () => {
+  test("projects a backgroundToolCompletion row onto backgroundToolCompletions, preserving the id exactly", async () => {
+    /**
+     * A history row that carries a `backgroundToolCompletion` record yields a
+     * `BackgroundTaskEntry` with the wire fields mapped 1:1. The `id` must be
+     * preserved verbatim: web background-card detection keys off the spawning
+     * tool result's `bg-…` id, so the seeded entry's id has to equal it.
+     */
+    nextResponse = makeJsonResponse({
+      messages: [
+        { id: "m1", role: "user", ...textBody("run it") },
+        {
+          id: "m2",
+          role: "assistant",
+          ...textBody("[Background task completed]"),
+          backgroundToolCompletion: {
+            id: "bg-abcd1234",
+            toolName: "bash",
+            conversationId: "conv-xyz",
+            command: "sleep 5 && echo done",
+            startedAt: 1000,
+            status: "completed",
+            exitCode: 0,
+            output: "done\n",
+            completedAt: 6000,
+          },
+        },
+      ],
+      hasMore: false,
+      oldestTimestamp: 0,
+      oldestMessageId: "m1",
+    });
+
+    const result = await fetchLatestHistoryPage("asst-1", "K");
+
+    expect(result.backgroundToolCompletions).toEqual([
+      {
+        id: "bg-abcd1234",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+        command: "sleep 5 && echo done",
+        startedAt: 1000,
+        status: "completed",
+        exitCode: 0,
+        output: "done\n",
+        completedAt: 6000,
+      },
+    ]);
+    expect(result.backgroundToolCompletions![0]!.id).toBe("bg-abcd1234");
+  });
+
+  test("yields an empty array when no row carries a completion", async () => {
+    nextResponse = makeJsonResponse({
+      messages: [
+        { id: "m1", role: "user", ...textBody("hello") },
+        { id: "m2", role: "assistant", ...textBody("hi") },
+      ],
+      hasMore: false,
+      oldestTimestamp: 0,
+      oldestMessageId: "m1",
+    });
+
+    const result = await fetchLatestHistoryPage("asst-1", "K");
+
+    expect(result.backgroundToolCompletions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Error handling
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -21,7 +21,11 @@ import { summarizeDisplayMessages } from "@/domains/chat/utils/diagnostics";
 
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
-import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import {
+  toBackgroundTaskEntryFromCompletion,
+  type RuntimeSubagentNotification,
+} from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 export type { PaginatedHistoryResult };
 
@@ -41,6 +45,8 @@ function parsePaginatedResponse(
   // non-notification assistant message (the message that spawned the
   // subagent). This mirrors macOS HistoryReconstructionService.
   const subagentNotifications: RuntimeSubagentNotification[] = [];
+  // Completion records re-seed completed inline cards across daemon restarts.
+  const backgroundToolCompletions: BackgroundTaskEntry[] = [];
   let lastAssistantMessageId: string | undefined;
   for (let i = 0; i < rows.length; i++) {
     const m = rows[i];
@@ -55,6 +61,11 @@ function parsePaginatedResponse(
         parentMessageId: lastAssistantMessageId,
       });
     }
+    if (m.backgroundToolCompletion) {
+      backgroundToolCompletions.push(
+        toBackgroundTaskEntryFromCompletion(m.backgroundToolCompletion),
+      );
+    }
   }
 
   const hasMore = body?.hasMore ?? false;
@@ -68,6 +79,7 @@ function parsePaginatedResponse(
     oldestTimestamp,
     oldestMessageId,
     seq,
+    backgroundToolCompletions,
     ...(subagentNotifications.length > 0 ? { subagentNotifications } : {}),
   };
 }

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -17,6 +17,7 @@ import type {
 import { parseAttachmentSummariesFromContent } from "@/domains/chat/utils/parse-attachment-summaries";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 import {
   attachmentsPost,
   messagesGet,
@@ -55,6 +56,28 @@ export interface RuntimeSubagentNotification extends ConversationSubagentNotific
   parentMessageStableId?: string;
   /** Daemon UUID of the parent assistant message. Stable across reloads. */
   parentMessageId?: string;
+}
+
+/**
+ * Project a history message's `backgroundToolCompletion` wire record onto the
+ * `BackgroundTaskEntry` the viewer store seeds from. The `id` is preserved
+ * exactly: web background-card detection keys off the spawning tool result's
+ * `bg-…` id, so the seeded entry's id must equal the completion's id.
+ */
+export function toBackgroundTaskEntryFromCompletion(
+  c: NonNullable<ConversationMessage["backgroundToolCompletion"]>,
+): BackgroundTaskEntry {
+  return {
+    id: c.id,
+    toolName: c.toolName,
+    conversationId: c.conversationId,
+    command: c.command,
+    startedAt: c.startedAt,
+    status: c.status,
+    exitCode: c.exitCode,
+    output: c.output,
+    completedAt: c.completedAt,
+  };
 }
 
 export async function pollForResponse(

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -8,6 +8,7 @@ import type {
   Surface,
 } from "@/domains/chat/types/types";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 export type TranscriptItemKind =
   | "message"
@@ -102,6 +103,12 @@ export interface PaginatedHistoryResult {
   oldestMessageId: string | null;
   /** Subagent notifications extracted from history messages for state reconstruction. */
   subagentNotifications?: RuntimeSubagentNotification[];
+  /** Background-task completion records extracted from history messages, used to
+   *  re-seed completed inline cards across daemon restarts. The paginated
+   *  fetchers always populate it (an empty array when no row carried a
+   *  completion); it is optional so other constructors (snapshot spreads, tests)
+   *  need not restate it. */
+  backgroundToolCompletions?: BackgroundTaskEntry[];
   /** Global SSE `seq` this snapshot is durably persisted through for the
    *  conversation, or `null` when the daemon reports no honest position
    *  (cold conversation, post-restart, aged-out map, or an older daemon


### PR DESCRIPTION
## Summary
- Collect backgroundToolCompletion records from history rows into backgroundToolCompletions: BackgroundTaskEntry[] (mapped 1:1), returned on PaginatedHistoryResult.

Part of plan: bg-card-survive-restart.md (PR 5 of 7)