### PR TITLE
feat(web): mobile category filter sheet for the Plugins tab

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
@@ -2,18 +2,41 @@
  * Tests for the Plugins `FilterBar`. Mounted via `@testing-library/react`
  * (happy-dom — see `clients/web/test-setup.ts`). The design-library
  * `Popover` is a real Radix portal here; clicking the filter button opens
- * the Status listbox into `document.body`, where we query its options.
+ * the Status listbox into `document.body`, where we query its options. On
+ * mobile the same button opens a `BottomSheet` that also exposes Categories.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 
 import type { PluginFilter } from "@/domains/intelligence/plugins/types.js";
 import { FilterBar } from "@/domains/intelligence/components/plugins/plugin-filters.js";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories.js";
 
 afterEach(() => {
   cleanup();
 });
+
+const CATEGORIES: CategoryInfo[] = [
+  { slug: "email", label: "Email", description: "Email tools", icon: "mail" },
+  { slug: "system", label: "System", description: "System tools", icon: "settings" },
+];
+
+/** Required `FilterBar` props with inert defaults each test can override. */
+function baseProps() {
+  return {
+    search: "",
+    onSearchChange: () => {},
+    filter: "all" as PluginFilter,
+    onFilterChange: () => {},
+    categories: [] as CategoryInfo[],
+    category: null,
+    onCategoryChange: () => {},
+    counts: {} as Record<string, number>,
+    totalCount: 0,
+    showCounts: true,
+  };
+}
 
 /** Click the Status option whose visible label matches. */
 function clickStatusOption(label: string): void {
@@ -32,16 +55,33 @@ function clickStatusOption(label: string): void {
   fireEvent.click(option);
 }
 
+/**
+ * Force `useIsMobile` true so the filter button opens the BottomSheet (the
+ * mobile category surface) instead of the desktop Status popover. Returns a
+ * restore fn the caller invokes once done.
+ */
+function forceMobile(): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 describe("Plugins FilterBar", () => {
   test("typing in the search input reports the new value", () => {
     const onSearchChange = mock((_value: string) => {});
     const { getByLabelText } = render(
-      <FilterBar
-        searchValue=""
-        onSearchChange={onSearchChange}
-        filter="all"
-        onFilterChange={() => {}}
-      />,
+      <FilterBar {...baseProps()} onSearchChange={onSearchChange} />,
     );
 
     fireEvent.change(getByLabelText("Search plugins"), {
@@ -54,17 +94,55 @@ describe("Plugins FilterBar", () => {
   test("opening the filter and choosing Installed switches the filter", () => {
     const onFilterChange = mock((_filter: PluginFilter) => {});
     const { getByLabelText } = render(
-      <FilterBar
-        searchValue=""
-        onSearchChange={() => {}}
-        filter="all"
-        onFilterChange={onFilterChange}
-      />,
+      <FilterBar {...baseProps()} onFilterChange={onFilterChange} />,
     );
 
     fireEvent.click(getByLabelText("Filter plugins"));
     clickStatusOption("Installed");
 
     expect(onFilterChange).toHaveBeenCalledWith("installed");
+  });
+
+  test("the mobile sheet exposes category rows that report the selected slug", async () => {
+    const onCategoryChange = mock((_category: string | null) => {});
+    const restoreMatchMedia = forceMobile();
+    try {
+      const { getByLabelText } = render(
+        <FilterBar
+          {...baseProps()}
+          categories={CATEGORIES}
+          counts={{ email: 2, system: 1 }}
+          totalCount={3}
+          onCategoryChange={onCategoryChange}
+        />,
+      );
+
+      fireEvent.click(getByLabelText("Filter plugins"));
+
+      const sheet = await screen.findByRole("dialog");
+      expect(within(sheet).getByText("Categories")).toBeTruthy();
+      const emailRow = within(sheet).getByText("Email");
+      expect(within(sheet).getByText("System")).toBeTruthy();
+
+      fireEvent.click(emailRow);
+      expect(onCategoryChange).toHaveBeenCalledWith("email");
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
+  test("the mobile sheet omits Categories when no categories are available", async () => {
+    const restoreMatchMedia = forceMobile();
+    try {
+      const { getByLabelText } = render(<FilterBar {...baseProps()} />);
+
+      fireEvent.click(getByLabelText("Filter plugins"));
+
+      const sheet = await screen.findByRole("dialog");
+      expect(within(sheet).getByText("Status")).toBeTruthy();
+      expect(within(sheet).queryByText("Categories")).toBeNull();
+    } finally {
+      restoreMatchMedia();
+    }
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
@@ -10,6 +10,8 @@ import {
 import { type ChangeEvent, type ReactNode, useState } from "react";
 
 import type { PluginFilter } from "@/domains/intelligence/plugins/types";
+import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon-map";
+import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BottomSheet, Button, Input, PanelItem, Popover } from "@vellumai/design-library";
 
@@ -26,19 +28,36 @@ const STATUS_FILTERS: FilterOption[] = [
 ];
 
 interface FilterBarProps {
-  searchValue: string;
+  search: string;
   onSearchChange: (value: string) => void;
   filter: PluginFilter;
   onFilterChange: (f: PluginFilter) => void;
   isSearching?: boolean;
+  /** Available plugin categories — surfaced inside the mobile filter sheet. */
+  categories: CategoryInfo[];
+  /** Currently selected category slug, or `null` for "All". */
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  /** Per-category result counts keyed by slug. */
+  counts: Record<string, number>;
+  /** Total result count across all categories (the "All" row badge). */
+  totalCount: number;
+  /** When false, the per-category count badges are hidden. */
+  showCounts: boolean;
 }
 
 export function FilterBar({
-  searchValue,
+  search,
   onSearchChange,
   filter,
   onFilterChange,
   isSearching = false,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -48,7 +67,7 @@ export function FilterBar({
     <div className="flex items-center gap-3">
       <Input
         type="search"
-        value={searchValue}
+        value={search}
         onChange={handleChange}
         placeholder="Search plugins"
         aria-label="Search plugins"
@@ -62,7 +81,16 @@ export function FilterBar({
         wrapperClassName="flex-1"
       />
 
-      <FilterControl filter={filter} onFilterChange={onFilterChange} />
+      <FilterControl
+        filter={filter}
+        onFilterChange={onFilterChange}
+        categories={categories}
+        category={category}
+        onCategoryChange={onCategoryChange}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts={showCounts}
+      />
     </div>
   );
 }
@@ -70,14 +98,22 @@ export function FilterBar({
 interface FilterControlProps {
   filter: PluginFilter;
   onFilterChange: (v: PluginFilter) => void;
+  categories: CategoryInfo[];
+  category: string | null;
+  onCategoryChange: (category: string | null) => void;
+  counts: Record<string, number>;
+  totalCount: number;
+  showCounts: boolean;
 }
 
 /**
- * Filter affordance for the Plugins page. The outlined button opens a compact
- * Status popover on desktop and a bottom sheet on mobile. Plugins expose no
- * category/source axes (unlike Skills), so Status is the sole filter group.
+ * Filter affordance for the Plugins page. On mobile the outlined button opens a
+ * bottom sheet exposing Status AND Categories (the category sidebar is
+ * desktop-only, so the sheet is mobile's sole category surface). On desktop the
+ * same button opens a compact Status popover; the always-visible sidebar owns
+ * category selection there.
  */
-function FilterControl({ filter, onFilterChange }: FilterControlProps) {
+function FilterControl(props: FilterControlProps) {
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
 
@@ -95,13 +131,7 @@ function FilterControl({ filter, onFilterChange }: FilterControlProps) {
 
   if (isMobile) {
     return (
-      <FilterSheet
-        filter={filter}
-        onFilterChange={onFilterChange}
-        open={open}
-        onOpenChange={setOpen}
-        trigger={trigger}
-      />
+      <FilterSheet {...props} open={open} onOpenChange={setOpen} trigger={trigger} />
     );
   }
 
@@ -117,9 +147,9 @@ function FilterControl({ filter, onFilterChange }: FilterControlProps) {
           <FilterGroup
             label="Status"
             options={STATUS_FILTERS}
-            selected={filter}
+            selected={props.filter}
             onSelect={(v) => {
-              onFilterChange(v);
+              props.onFilterChange(v);
               setOpen(false);
             }}
           />
@@ -135,13 +165,30 @@ interface FilterSheetProps extends FilterControlProps {
   trigger: ReactNode;
 }
 
+/**
+ * Mobile bottom sheet. Status and Categories are independent axes that both
+ * stay applied, so selecting a row updates the results live behind the sheet
+ * without closing it — the user dials in both, then taps Done (or outside) to
+ * dismiss. The Categories section only renders when the daemon exposes the
+ * taxonomy (mirrors the desktop sidebar's capability gate).
+ */
 function FilterSheet({
   filter,
   onFilterChange,
+  categories,
+  category,
+  onCategoryChange,
+  counts,
+  totalCount,
+  showCounts,
   open,
   onOpenChange,
   trigger,
 }: FilterSheetProps) {
+  const sortedCategories = [...categories].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
   return (
     <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
       <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
@@ -165,6 +212,28 @@ function FilterSheet({
               />
             ))}
           </SheetSection>
+
+          {categories.length > 0 && (
+            <SheetSection label="Categories">
+              <FilterRow
+                icon={LayoutGrid}
+                label="All"
+                active={category === null}
+                badge={showCounts ? totalCount : undefined}
+                onSelect={() => onCategoryChange(null)}
+              />
+              {sortedCategories.map((cat) => (
+                <FilterRow
+                  key={cat.slug}
+                  icon={resolveCategoryIcon(cat.icon) ?? LayoutGrid}
+                  label={cat.label}
+                  active={category === cat.slug}
+                  badge={showCounts ? (counts[cat.slug] ?? 0) : undefined}
+                  onSelect={() => onCategoryChange(cat.slug)}
+                />
+              ))}
+            </SheetSection>
+          )}
         </BottomSheet.Body>
         <BottomSheet.Footer>
           <Button
@@ -181,6 +250,7 @@ function FilterSheet({
   );
 }
 
+/** Section grouping inside the mobile filter sheet. */
 function SheetSection({
   label,
   children,
@@ -201,15 +271,22 @@ function SheetSection({
   );
 }
 
+/**
+ * One selectable row inside the filter sheet. `badge` carries a result count
+ * (categories); the trailing check marks the active row on the count-less
+ * Status axis where the branded highlight alone is easy to miss.
+ */
 function FilterRow({
   icon,
   label,
   active,
+  badge,
   onSelect,
 }: {
   icon: typeof LayoutGrid;
   label: string;
   active: boolean;
+  badge?: ReactNode;
   onSelect: () => void;
 }) {
   return (
@@ -218,8 +295,9 @@ function FilterRow({
       label={label}
       active={active}
       activeVariant="branded"
+      badge={badge}
       trailingAction={
-        active ? (
+        active && badge == null ? (
           <Check className="h-4 w-4 text-[var(--primary-base)]" aria-hidden />
         ) : undefined
       }

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -54,6 +54,9 @@ let installedCategoryCounts: Record<string, number> | undefined;
 let catalogMatches: CatalogMatch[];
 let categoryDefs: CategoryInfo[];
 let inspectByName: Record<string, PluginsByNameInspectGetResponse>;
+// When set, the installed read awaits this gate before resolving — lets a test
+// hold a category-filtered installed read pending after the initial load.
+let installedGate: Promise<unknown> | null = null;
 
 const installSpy = mock(async (_options: unknown) => ({
   data: { ok: true },
@@ -77,6 +80,7 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   // Mirrors the daemon: filter installed plugins by the requested category
   // slug, and (when taxonomy-aware) echo the UNFILTERED categoryCounts/total.
   pluginsGet: mock(async (options: { query?: { category?: string } }) => {
+    if (installedGate) await installedGate;
     const selected = options.query?.category;
     const plugins = selected
       ? installedPlugins.filter((p) => (p.category ?? "system") === selected)
@@ -245,6 +249,7 @@ beforeEach(() => {
   catalogMatches = [];
   categoryDefs = CATEGORY_DEFS;
   inspectByName = {};
+  installedGate = null;
   installSpy.mockClear();
   deleteSpy.mockClear();
   upgradeSpy.mockClear();
@@ -563,5 +568,38 @@ describe("PluginsTab", () => {
     expect(
       queryByRole("navigation", { name: "Plugin categories" }),
     ).toBeNull();
+  });
+
+  test("keeps the category rail mounted while a category-filtered read is pending", async () => {
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+      installed({ id: "sysd", name: "sysd", category: "system" }),
+    ];
+    installedCategoryCounts = { email: 1, system: 1 };
+
+    const { findByRole, queryByRole } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // Hold every subsequent installed read pending, then select a category. The
+    // filtered read stays in flight, but the rail must remain mounted so the
+    // user can still switch or clear the category — support derives from the
+    // cached unfiltered read (latched), not the in-flight filtered one.
+    let releaseInstalled: () => void = () => {};
+    installedGate = new Promise<void>((resolve) => {
+      releaseInstalled = resolve;
+    });
+    fireEvent.click(within(nav).getByRole("button", { name: /Email/ }));
+
+    expect(
+      queryByRole("navigation", { name: "Plugin categories" }),
+    ).not.toBeNull();
+
+    // Let the pending read resolve; the rail is still there afterward.
+    releaseInstalled();
+    await waitFor(() =>
+      expect(
+        queryByRole("navigation", { name: "Plugin categories" }),
+      ).not.toBeNull(),
+    );
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -216,6 +216,28 @@ function clickStatusOption(label: string): void {
   fireEvent.click(option);
 }
 
+/**
+ * Force `useIsMobile` true so the filter button opens the BottomSheet (the
+ * mobile category surface) instead of the desktop Status popover. Returns a
+ * restore fn the caller invokes once done.
+ */
+function forceMobile(): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 beforeEach(() => {
   installedPlugins = [];
   installedStatus = 200;
@@ -484,6 +506,50 @@ describe("PluginsTab", () => {
     expect(
       queryByRole("navigation", { name: "Plugin categories" }),
     ).toBeNull();
+  });
+
+  test("the mobile filter sheet surfaces the category taxonomy", async () => {
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+    ];
+    installedCategoryCounts = { email: 1 };
+    catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
+
+    const restoreMatchMedia = forceMobile();
+    try {
+      const { findByLabelText } = renderTab();
+      // The desktop <aside> rail is hidden on mobile; the sheet is the only
+      // category surface. Open it via the filter button.
+      fireEvent.click(await findByLabelText("Filter plugins"));
+
+      const sheet = await screen.findByRole("dialog");
+      // Status stays available alongside the new Categories axis.
+      expect(within(sheet).getByText("Status")).toBeTruthy();
+      expect(within(sheet).getByText("Categories")).toBeTruthy();
+      // "All" + each seeded Skills category renders a selectable row.
+      expect(within(sheet).getByText("Email")).toBeTruthy();
+      expect(within(sheet).getByText("System")).toBeTruthy();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
+  test("the mobile filter sheet omits Categories when the daemon lacks support", async () => {
+    installedPlugins = [installed()];
+    // installedCategoryCounts stays undefined → older daemon, no taxonomy.
+
+    const restoreMatchMedia = forceMobile();
+    try {
+      const { findByLabelText } = renderTab();
+      fireEvent.click(await findByLabelText("Filter plugins"));
+
+      const sheet = await screen.findByRole("dialog");
+      // Status is still offered, but no Categories section is rendered.
+      expect(within(sheet).getByText("Status")).toBeTruthy();
+      expect(within(sheet).queryByText("Categories")).toBeNull();
+    } finally {
+      restoreMatchMedia();
+    }
   });
 
   test("hides the rail when no categories load even if categoryCounts is present", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -320,11 +320,17 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       {!tipDismissed && <TipBanner onDismiss={handleDismissTip} />}
 
       <FilterBar
-        searchValue={searchValue}
+        search={searchValue}
         onSearchChange={setSearchValue}
         filter={filter}
         onFilterChange={setFilter}
         isSearching={isSearching}
+        categories={categoryRailEnabled ? categories : []}
+        category={category}
+        onCategoryChange={setCategory}
+        counts={counts}
+        totalCount={totalCount}
+        showCounts
       />
 
       {catalogError && !isLoading && !isError ? (

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -36,12 +36,16 @@ let catalogResult: PluginsSearchGetResponse | Error;
 // When set, the catalog mock awaits this gate before resolving — lets a test
 // hold the catalog query pending while the installed query resolves.
 let catalogGate: Promise<unknown> | null = null;
+// When set, the installed mock awaits this gate before resolving — lets a test
+// hold a category-filtered installed read pending after the initial load.
+let installedGate: Promise<unknown> | null = null;
 
 const sdkActual = await import("@/generated/daemon/sdk.gen");
 // Mirrors the daemon: an unfiltered read returns `installedResult` as-is; a
 // `?category=` read narrows the installed plugins to that category server-side.
 const pluginsGetSpy = mock(
   async (options: { query?: { category?: string } }) => {
+    if (installedGate) await installedGate;
     const selected = options?.query?.category;
     if (!selected) return installedResult;
     const plugins = (installedResult.data?.plugins ?? []).filter(
@@ -109,6 +113,7 @@ beforeEach(() => {
   installedResult = installedOk([]);
   catalogResult = catalogOk([]);
   catalogGate = null;
+  installedGate = null;
   pluginsGetSpy.mockClear();
   pluginsSearchGetSpy.mockClear();
 });
@@ -242,5 +247,50 @@ describe("usePluginsList", () => {
     // Installed list still renders; the catalog failure is not fatal.
     expect(result.current.items.map((p) => p.name)).toEqual(["alpha"]);
     expect(result.current.isError).toBe(false);
+  });
+
+  test("category support stays true while a category-filtered read is pending", async () => {
+    // The initial unfiltered load is taxonomy-aware (carries categoryCounts),
+    // so support latches true.
+    installedResult = {
+      data: {
+        plugins: [installed({ category: "email" })],
+        categoryCounts: { email: 1 },
+        totalCount: 1,
+      } as PluginsGetResponse,
+      response: { ok: true, status: 200 },
+    };
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client }, children);
+    }
+    const { result, rerender } = renderHook(
+      ({ category }: { category: string | null }) =>
+        usePluginsList(ASSISTANT_ID, category),
+      { wrapper, initialProps: { category: null as string | null } },
+    );
+
+    await waitFor(() => expect(result.current.categorySupported).toBe(true));
+
+    // Hold every subsequent installed read pending, then select a category. The
+    // filtered main read is now in flight (as is any uncached unfiltered
+    // re-read), so the unfiltered source is momentarily undefined — yet support
+    // must NOT regress to false, which would collapse the category rail.
+    let releaseInstalled: () => void = () => {};
+    installedGate = new Promise<void>((resolve) => {
+      releaseInstalled = resolve;
+    });
+    rerender({ category: "email" });
+
+    await waitFor(() => expect(result.current.isFetching).toBe(true));
+    expect(result.current.categorySupported).toBe(true);
+
+    // It stays true once the filtered read finally resolves, too.
+    releaseInstalled();
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.categorySupported).toBe(true);
   });
 });

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type {
     InstalledPlugin,
@@ -44,9 +44,11 @@ export interface UsePluginsListResult {
    */
   catalogError: boolean;
   /**
-   * True once the installed read returns `categoryCounts` — the daemon
-   * understands the Skills category taxonomy. Older daemons omit it; the tab
-   * uses this to gate the category rail (version-skew safeguard).
+   * True once the UNFILTERED installed read returns `categoryCounts` — the
+   * daemon understands the Skills category taxonomy. Latched sticky so it never
+   * regresses while a category-filtered read is pending. Older daemons omit
+   * `categoryCounts`; the tab uses this to gate the category rail (version-skew
+   * safeguard).
    */
   categorySupported: boolean;
   /**
@@ -179,10 +181,28 @@ export function usePluginsList(
     unfilteredInstalledNames,
   ]);
 
-  // Counts come from the unfiltered installed read: the main read while no
-  // category is selected, the parallel read once one is.
-  const countsSource =
+  // The unfiltered installed read backs both the rail counts and category
+  // support: the main read while no category is selected (its key is already
+  // unfiltered), the parallel counts read once one is. Reading the filtered
+  // main read instead would make these go undefined mid-selection while the
+  // filtered request is in flight.
+  const unfilteredInstalledData =
     category !== null ? installedCountsQuery.data : installedQuery.data;
+
+  // Category support is a daemon capability that holds for the session, so latch
+  // it sticky once the unfiltered read first carries `categoryCounts`. The live
+  // OR covers the current render; the latch keeps it true across a category
+  // switch even if the unfiltered source is momentarily uncached and pending, so
+  // the rail (and the mobile sheet's Categories section) never vanishes
+  // mid-filter.
+  const categoryCountsObserved =
+    unfilteredInstalledData?.categoryCounts !== undefined;
+  const [categorySupportedLatched, setCategorySupportedLatched] =
+    useState(false);
+  useEffect(() => {
+    if (categoryCountsObserved) setCategorySupportedLatched(true);
+  }, [categoryCountsObserved]);
+  const categorySupported = categorySupportedLatched || categoryCountsObserved;
 
   return {
     items,
@@ -193,10 +213,10 @@ export function usePluginsList(
     isError: installedQuery.isError,
     isFetching: installedQuery.isFetching || catalogQuery.isFetching,
     catalogError: catalogQuery.isError,
-    categorySupported: installedQuery.data?.categoryCounts !== undefined,
-    installedCategoryCounts: countsSource?.categoryCounts,
-    installedPlugins: countsSource?.plugins ?? EMPTY_INSTALLED,
-    installedTotal: countsSource?.totalCount,
+    categorySupported,
+    installedCategoryCounts: unfilteredInstalledData?.categoryCounts,
+    installedPlugins: unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED,
+    installedTotal: unfilteredInstalledData?.totalCount,
     catalogMatches: catalogQuery.data?.matches ?? EMPTY_MATCHES,
     unfilteredInstalledNames,
   };


### PR DESCRIPTION
## Summary
- Extract the Plugins FilterBar into plugin-filters.tsx and add a mobile BottomSheet 'Categories' surface mirroring Skills
- Desktop keeps the <aside> rail; both drive the same category state
- Filter button hidden when the daemon lacks category support

Part of plan: plugins-tab-category-filter.md (PR 5 of 5)