### PR TITLE
feat(schedule): inject + require `__SCHEDULE_ID`/`__SCHEDULE_RUN_ID` for script runs

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -903,6 +903,7 @@ async function handleRunScheduleNow(id: string) {
       const result = await runScript(schedule.script, {
         timeoutMs: schedule.timeoutMs ?? undefined,
         scheduleRunId: runId,
+        scheduleId: schedule.id,
       });
       await completeScheduleRun(runId, {
         status: result.exitCode === 0 ? "ok" : "error",

--- a/assistant/src/schedule/__tests__/run-script.test.ts
+++ b/assistant/src/schedule/__tests__/run-script.test.ts
@@ -1,0 +1,21 @@
+/**
+ * `runScript` injects the schedule's ids into the spawned command's env so a
+ * saved command can reference its own dir, e.g.
+ * `cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts`.
+ */
+
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+
+import { runScript } from "../run-script.js";
+
+describe("runScript schedule env injection", () => {
+  test("injects __SCHEDULE_ID and __SCHEDULE_RUN_ID, expanded by the shell", async () => {
+    const result = await runScript(
+      'echo "id=$__SCHEDULE_ID run=$__SCHEDULE_RUN_ID"',
+      { cwd: tmpdir(), scheduleId: "sched-abc", scheduleRunId: "run-xyz" },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("id=sched-abc run=run-xyz");
+  });
+});

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -32,10 +32,15 @@ export interface ScriptResult {
  */
 export async function runScript(
   command: string,
-  options?: { timeoutMs?: number; cwd?: string; scheduleRunId?: string },
+  options: {
+    scheduleRunId: string;
+    scheduleId: string;
+    timeoutMs?: number;
+    cwd?: string;
+  },
 ): Promise<ScriptResult> {
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const cwd = options?.cwd ?? getWorkspaceDir();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const cwd = options.cwd ?? getWorkspaceDir();
 
   log.info({ command, cwd, timeoutMs }, "Running script");
 
@@ -45,9 +50,11 @@ export async function runScript(
     stderr: "pipe",
     env: {
       ...buildSanitizedEnv(),
-      ...(options?.scheduleRunId
-        ? { __SCHEDULE_RUN_ID: options.scheduleRunId }
-        : {}),
+      // __SCHEDULE_ID lets a saved command find its own dir; __SCHEDULE_RUN_ID
+      // is the per-firing id (cost attribution). Required, so a script run is
+      // always attributable and can locate its dir.
+      __SCHEDULE_RUN_ID: options.scheduleRunId,
+      __SCHEDULE_ID: options.scheduleId,
     },
   });
 

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -396,6 +396,7 @@ export async function runScheduleDueWorkOnce(
         const result: ScriptResult = await runScript(job.script, {
           timeoutMs: job.timeoutMs ?? undefined,
           scheduleRunId: runId,
+          scheduleId: job.id,
         });
         await completeScheduleRun(runId, {
           status: result.exitCode === 0 ? "ok" : "error",


### PR DESCRIPTION
ref ATL-911

`runScript` now **requires** `scheduleRunId` + `scheduleId` (previously optional) and injects both into the script's env, so a saved command can find its own dir (`cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID"`) and every run is attributable. Making them required surfaced + fixes a gap: the manual `schedules execute` path injected only the run id, leaving `$__SCHEDULE_ID` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)