### PR TITLE
feat(schedule): support script mode in the create CLI/route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22474,7 +22474,7 @@ paths:
     post:
       operationId: schedules_post
       summary: Create schedule
-      description: Create a new recurring schedule. Currently restricted to mode='execute'.
+      description: Create a new recurring schedule (execute, script, or workflow mode).
       tags:
         - schedules
       requestBody:
@@ -22508,12 +22508,20 @@ paths:
                   description: Whether the schedule starts active (default true)
                 mode:
                   type: string
-                  description: "'execute' (default) or 'workflow' (flag-gated)"
+                  description: "'execute' (default), 'script', or 'workflow' (flag-gated)"
                 workflowName:
                   type: string
                   description: Saved workflow to trigger (required for workflow mode)
                 workflowArgs:
                   description: Args passed to the workflow run (workflow mode)
+                script:
+                  type: string
+                  description: Shell command run on each fire (required for script mode)
+                timeoutMs:
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                  description: Script execution timeout override in ms (script mode)
                 inferenceProfile:
                   anyOf:
                     - type: string

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1241,7 +1241,7 @@ describe("POST /schedules — create", () => {
     expect(job.description).toBe("Description fallback");
   });
 
-  test("rejects modes other than execute/workflow", async () => {
+  test("rejects modes other than execute/workflow/script", async () => {
     await expect(
       postCreate({
         name: "x",
@@ -1250,7 +1250,9 @@ describe("POST /schedules — create", () => {
         message: "hi",
         mode: "notify",
       }),
-    ).rejects.toThrow("Only 'execute' and 'workflow' modes are supported");
+    ).rejects.toThrow(
+      "Only 'execute', 'script', and 'workflow' modes are supported",
+    );
   });
 
   test("rejects an unparseable expression", async () => {

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -748,6 +748,58 @@ describe("schedules create", () => {
     expect(exitFromIpcResultCalls).toEqual([mockIpcResult]);
     expect(errorLines).toEqual([]);
   });
+
+  test("creates a script-mode schedule with --mode script --script", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "GitHub watcher",
+      "--mode",
+      "script",
+      "--script",
+      'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
+      "--expression",
+      "*/15 * * * *",
+      "--description",
+      "Polls GitHub notifications",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "createSchedule",
+        params: {
+          body: {
+            name: "GitHub watcher",
+            expression: "*/15 * * * *",
+            description: "Polls GitHub notifications",
+            enabled: true,
+            mode: "script",
+            script:
+              'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
+          },
+        },
+      },
+    ]);
+  });
+
+  test("exits 1 when --mode script is missing --script", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Broken",
+      "--mode",
+      "script",
+      "--expression",
+      "*/15 * * * *",
+      "--description",
+      "no script",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe("schedules update", () => {

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -416,9 +416,21 @@ Examples:
           "-d, --description <text>",
           "Authored description explaining what the schedule is for",
         )
-        .requiredOption(
+        .option(
           "-m, --message <text>",
-          "Message body sent to the assistant on each fire",
+          "Message body sent to the assistant on each fire (required for execute mode)",
+        )
+        .option(
+          "--mode <mode>",
+          "Schedule mode: 'execute' (default), 'script', or 'workflow'",
+        )
+        .option(
+          "--script <command>",
+          "Shell command to run on each fire (required for --mode script)",
+        )
+        .option(
+          "--timeout-ms <ms>",
+          "Script execution timeout override in ms (--mode script)",
         )
         .option(
           "-t, --timezone <tz>",
@@ -436,7 +448,10 @@ Examples:
 Options:
   -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
   -d, --description <text>  Authored description explaining what the schedule is for.
-  -m, --message <text>      Message body sent on each fire.
+  -m, --message <text>      Message body sent on each fire (execute mode).
+  --mode <mode>             execute (default), script, or workflow.
+  --script <command>        Shell command for --mode script.
+  --timeout-ms <ms>         Script timeout override in ms (--mode script).
   -t, --timezone <tz>       IANA timezone applied to the expression.
   --profile <name>          Inference profile (llm.profiles key) the schedule's
                             runs use. When omitted, runs use the default —
@@ -448,11 +463,17 @@ Arguments:
   <name>   Display name for the schedule.
 
 Behavior:
-  Creates a recurring schedule in 'execute' mode. The IPC endpoint is
-  currently locked to execute mode; notify/script/wake schedules remain
-  reachable only through the in-assistant schedule_create LLM tool.
+  Defaults to 'execute' mode (requires --message). Pass --mode script with
+  --script to run a shell command on each fire with no LLM call; the script's
+  env includes $VELLUM_WORKSPACE_DIR and $__SCHEDULE_ID (this schedule's id).
+  notify/wake schedules remain reachable only through the schedule_create tool.
 
 Examples:
+  $ assistant schedules create "GitHub watcher" \\
+      --mode script \\
+      --script 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts' \\
+      --expression '*/15 * * * *' \\
+      --description 'Polls GitHub notifications' --json
   $ assistant schedules create "Heartbeat" \\
       --expression '*/30 * * * *' \\
       --description 'Checks service heartbeat every 30 minutes' \\
@@ -474,7 +495,10 @@ Examples:
             opts: {
               expression: string;
               description: string;
-              message: string;
+              message?: string;
+              mode?: string;
+              script?: string;
+              timeoutMs?: string;
               timezone?: string;
               profile?: string;
               enabled: boolean;
@@ -506,13 +530,33 @@ Examples:
               return;
             }
 
+            const mode = opts.mode ?? "execute";
+            if (mode === "script" && !opts.script) {
+              const error = "--script is required for --mode script";
+              if (opts.json) writeOutput(cmd, { ok: false, error });
+              else log.error(error);
+              process.exitCode = 1;
+              return;
+            }
+            if (mode === "execute" && !opts.message) {
+              const error = "--message is required for execute mode";
+              if (opts.json) writeOutput(cmd, { ok: false, error });
+              else log.error(error);
+              process.exitCode = 1;
+              return;
+            }
+
             const body: Record<string, unknown> = {
               name: scheduleName,
               expression: opts.expression,
               description,
-              message: opts.message,
               enabled: opts.enabled,
             };
+            // Omit mode for the default; the route treats absent as 'execute'.
+            if (mode !== "execute") body.mode = mode;
+            if (opts.message != null) body.message = opts.message;
+            if (opts.script != null) body.script = opts.script;
+            if (opts.timeoutMs != null) body.timeoutMs = Number(opts.timeoutMs);
             if (opts.timezone != null) body.timezone = opts.timezone;
             if (opts.profile != null) body.inferenceProfile = opts.profile;
 

--- a/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The `createSchedule` route accepts `script` mode (not just execute/workflow),
+ * so a catalog skill's `setup.ts` can register a script-mode schedule via the
+ * CLI/HTTP path instead of the in-assistant `schedule_create` tool.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../../../persistence/db-init.js";
+import { ROUTES } from "../schedule-routes.js";
+
+await initializeDb();
+
+const createHandler = (() => {
+  const route = ROUTES.find((r) => r.operationId === "createSchedule");
+  if (!route) throw new Error("createSchedule route not found");
+  return route.handler;
+})();
+
+interface ListResult {
+  schedules: Array<{
+    name: string;
+    mode: string;
+    script: string | null;
+    timeoutMs: number | null;
+  }>;
+}
+
+async function create(body: Record<string, unknown>): Promise<ListResult> {
+  return (await createHandler({ body })) as ListResult;
+}
+
+describe("createSchedule route — script mode", () => {
+  test("creates a script-mode schedule with its command + timeout", async () => {
+    const res = await create({
+      name: "wt-script-create",
+      mode: "script",
+      script: 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
+      expression: "*/15 * * * *",
+      description: "polls github",
+      timeoutMs: 120000,
+    });
+    const job = res.schedules.find((s) => s.name === "wt-script-create");
+    expect(job?.mode).toBe("script");
+    expect(job?.script).toContain("bun poll.ts");
+    expect(job?.timeoutMs).toBe(120000);
+  });
+
+  test("script mode does not require a message", async () => {
+    const res = await create({
+      name: "wt-script-nomsg",
+      mode: "script",
+      script: "echo hi",
+      expression: "0 * * * *",
+      description: "d",
+    });
+    expect(
+      res.schedules.find((s) => s.name === "wt-script-nomsg")?.mode,
+    ).toBe("script");
+  });
+
+  test("rejects script mode without a script", async () => {
+    await expect(
+      create({
+        name: "wt-script-missing",
+        mode: "script",
+        expression: "* * * * *",
+        description: "d",
+      }),
+    ).rejects.toThrow(/script is required/);
+  });
+});

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -273,7 +273,7 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
   // entirely (see the workflow branch below), so only require a message for the
   // execute path. Requiring it for workflow mode would force API/UI callers to
   // pass an unused dummy string.
-  if (mode !== "workflow" && !message) {
+  if (mode !== "workflow" && mode !== "script" && !message) {
     throw new BadRequestError("message is required");
   }
   if (description === "") {
@@ -283,9 +283,9 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
   // The settings UI only exposes execute mode; `workflow` mode is reachable
   // here (flag-gated) and via the schedule_create LLM tool. All other modes
   // remain tool-only.
-  if (mode !== "execute" && mode !== "workflow") {
+  if (mode !== "execute" && mode !== "workflow" && mode !== "script") {
     throw new BadRequestError(
-      "Only 'execute' and 'workflow' modes are supported by this endpoint",
+      "Only 'execute', 'script', and 'workflow' modes are supported by this endpoint",
     );
   }
 
@@ -321,6 +321,37 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
         { id: job.id, name: job.name, workflowName },
         "Workflow schedule created",
       );
+    } catch (err) {
+      if (err instanceof Error) throw new BadRequestError(err.message);
+      throw err;
+    }
+    return handleListSchedules({});
+  }
+
+  if (mode === "script") {
+    const script = typeof body.script === "string" ? body.script.trim() : "";
+    if (!script) {
+      throw new BadRequestError("script is required for script-mode schedules");
+    }
+    const timeoutMs = body.timeoutMs == null ? null : Number(body.timeoutMs);
+    if (timeoutMs !== null) {
+      const timeoutError = validateScriptTimeoutMs(timeoutMs);
+      if (timeoutError) throw new BadRequestError(timeoutError);
+    }
+    try {
+      const job = await createSchedule({
+        name,
+        description,
+        message,
+        mode: "script",
+        script,
+        enabled,
+        timezone,
+        expression: normalized.expression,
+        syntax: normalized.syntax,
+        timeoutMs,
+      });
+      log.info({ id: job.id, name: job.name }, "Script schedule created");
     } catch (err) {
       if (err instanceof Error) throw new BadRequestError(err.message);
       throw err;
@@ -675,7 +706,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Create schedule",
     description:
-      "Create a new recurring schedule. Currently restricted to mode='execute'.",
+      "Create a new recurring schedule (execute, script, or workflow mode).",
     tags: ["schedules"],
     requestBody: z.object({
       name: z.string().describe("Display name"),
@@ -703,7 +734,7 @@ export const ROUTES: RouteDefinition[] = [
         .optional(),
       mode: z
         .string()
-        .describe("'execute' (default) or 'workflow' (flag-gated)")
+        .describe("'execute' (default), 'script', or 'workflow' (flag-gated)")
         .optional(),
       workflowName: z
         .string()
@@ -712,6 +743,15 @@ export const ROUTES: RouteDefinition[] = [
       workflowArgs: z
         .unknown()
         .describe("Args passed to the workflow run (workflow mode)")
+        .optional(),
+      script: z
+        .string()
+        .describe("Shell command run on each fire (required for script mode)")
+        .optional(),
+      timeoutMs: z
+        .number()
+        .nullable()
+        .describe("Script execution timeout override in ms (script mode)")
         .optional(),
       inferenceProfile: z
         .string()

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -1075,6 +1075,15 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("high");
   });
 
+  test("assistant schedules create --mode script → high (persists a shell payload)", async () => {
+    const result = await classifier.classify({
+      command:
+        "assistant schedules create Watcher --mode script --script 'bun poll.ts' --expression '*/15 * * * *' --description watch",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
   test("assistant bash ls → high", async () => {
     const result = await classifier.classify({
       command: "assistant bash ls",

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -633,6 +633,23 @@ describe("command-registry", () => {
       expect(modeRule).toBeDefined();
       expect(modeRule!.risk).toBe("high");
     });
+
+    test("assistant schedules create escalates to high for script payloads", () => {
+      const createSpec = getAssistantPath("schedules create");
+      expect(createSpec.argRules).toBeDefined();
+
+      const scriptRule = createSpec.argRules!.find((r) =>
+        r.flags?.includes("--script"),
+      );
+      expect(scriptRule).toBeDefined();
+      expect(scriptRule!.risk).toBe("high");
+
+      const modeRule = createSpec.argRules!.find(
+        (r) => r.flags?.includes("--mode") && r.valuePattern === "^script$",
+      );
+      expect(modeRule).toBeDefined();
+      expect(modeRule!.risk).toBe("high");
+    });
   });
 
   // ── sandboxAutoApprove allowlist guard ───────────────────────────────────

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -724,4 +724,28 @@ scheduleUpdateNode.argRules = scheduleUpdateArgRules;
 // arg parser pairs `--mode script` / `--script <cmd>` correctly.
 scheduleUpdateNode.argSchema = { valueFlags: ["--mode", "--script"] };
 
+// `schedules create` mirrors `schedules update`: a create that installs a
+// script payload persists host shell execution for a later fire — high like
+// `bash`.
+const scheduleCreateArgRules: ArgRule[] = [
+  {
+    id: "assistant-schedules-create:script",
+    flags: ["--script"],
+    risk: "high",
+    reason:
+      "Persists an arbitrary shell command that the schedule executes on fire",
+  },
+  {
+    id: "assistant-schedules-create:mode-script",
+    flags: ["--mode"],
+    valuePattern: "^script$",
+    risk: "high",
+    reason:
+      "Switches the schedule to script mode (host shell execution on fire)",
+  },
+];
+const scheduleCreateNode = getExistingPath(spec, "schedules create");
+scheduleCreateNode.argRules = scheduleCreateArgRules;
+scheduleCreateNode.argSchema = { valueFlags: ["--mode", "--script"] };
+
 export default spec;


### PR DESCRIPTION
ref ATL-911

Opens `schedules create` (CLI + the `createSchedule` route) to `--mode script` with `--script` / `--timeout-ms`, so a script-mode schedule can be created via the CLI instead of only the in-assistant `schedule_create` tool. Script mode doesn't require `--message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)