### PR TITLE
feat(web): expose backgroundToolCompletions across paginated history

### DIFF
--- a/clients/web/src/domains/chat/transcript/use-history-pagination.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { aggregateSubagentNotifications } from "@/domains/chat/transcript/use-history-pagination";
+import {
+  aggregateBackgroundToolCompletions,
+  aggregateSubagentNotifications,
+} from "@/domains/chat/transcript/use-history-pagination";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 
 function notif(
@@ -11,8 +15,20 @@ function notif(
   return { subagentId, label: subagentId, status } as RuntimeSubagentNotification;
 }
 
+function completion(id: string): BackgroundTaskEntry {
+  return {
+    id,
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: `echo ${id}`,
+    startedAt: 0,
+    status: "completed",
+  };
+}
+
 function page(
   subagentNotifications?: RuntimeSubagentNotification[],
+  backgroundToolCompletions?: BackgroundTaskEntry[],
 ): PaginatedHistoryResult {
   return {
     messages: [],
@@ -20,6 +36,7 @@ function page(
     oldestTimestamp: null,
     oldestMessageId: null,
     ...(subagentNotifications ? { subagentNotifications } : {}),
+    ...(backgroundToolCompletions ? { backgroundToolCompletions } : {}),
   };
 }
 
@@ -49,6 +66,41 @@ describe("aggregateSubagentNotifications", () => {
     expect(result?.map((n) => n.subagentId)).toEqual([
       "aborted-early",
       "completed-late",
+    ]);
+  });
+});
+
+describe("aggregateBackgroundToolCompletions", () => {
+  test("returns undefined for no pages", () => {
+    expect(aggregateBackgroundToolCompletions(undefined)).toBeUndefined();
+    expect(aggregateBackgroundToolCompletions([])).toBeUndefined();
+  });
+
+  test("returns undefined when no page carries completions", () => {
+    expect(
+      aggregateBackgroundToolCompletions([page(), page()]),
+    ).toBeUndefined();
+  });
+
+  test("returns a single page's completions", () => {
+    const result = aggregateBackgroundToolCompletions([
+      page(undefined, [completion("bg-a")]),
+    ]);
+    expect(result?.map((c) => c.id)).toEqual(["bg-a"]);
+  });
+
+  test("concatenates completions from multiple pages, oldest-first", () => {
+    // pages[0] = latest page, pages[1] = older. Completions from the older
+    // page must come first so first-seen order is preserved for seeding.
+    const pages = [
+      page(undefined, [completion("bg-late"), completion("bg-latest")]),
+      page(undefined, [completion("bg-early")]),
+    ];
+    const result = aggregateBackgroundToolCompletions(pages);
+    expect(result?.map((c) => c.id)).toEqual([
+      "bg-early",
+      "bg-late",
+      "bg-latest",
     ]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.ts
@@ -32,6 +32,7 @@ import { shouldRetryDaemonError } from "@/utils/daemon-errors";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import { mergeAdjacentAssistantMessages } from "@/domains/chat/utils/message-merge";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 // ---------------------------------------------------------------------------
 // Query key
@@ -66,6 +67,23 @@ export function aggregateSubagentNotifications(
   return acc.length > 0 ? acc : undefined;
 }
 
+// Background-task completions across all loaded pages, oldest-first. Seeding
+// reads this rather than only the latest page so a card that completed in an
+// older page still gets re-seeded into the store after a daemon restart.
+// Dedupe is unnecessary — the store's `seedFromHistory` is idempotent — so we
+// just preserve first-seen (oldest-first) order.
+export function aggregateBackgroundToolCompletions(
+  pages: readonly PaginatedHistoryResult[] | undefined,
+): BackgroundTaskEntry[] | undefined {
+  if (!pages?.length) return undefined;
+  const acc: BackgroundTaskEntry[] = [];
+  for (let i = pages.length - 1; i >= 0; i--) {
+    const cs = pages[i]?.backgroundToolCompletions;
+    if (cs?.length) acc.push(...cs);
+  }
+  return acc.length > 0 ? acc : undefined;
+}
+
 /** The shape `useInfiniteQuery` stores under a conversation-history key. */
 export type HistoryCache = InfiniteData<PaginatedHistoryResult>;
 
@@ -88,6 +106,8 @@ export interface HistoryPaginationResult {
   subagentNotifications:
     | NonNullable<PaginatedHistoryResult["subagentNotifications"]>
     | undefined;
+  /** Background-task completions aggregated across all loaded pages, oldest-first. */
+  backgroundToolCompletions: BackgroundTaskEntry[] | undefined;
   /** First-time load with no cached data available. */
   isLoading: boolean;
   /** At least one successful fetch has completed. */
@@ -207,6 +227,11 @@ export function useHistoryPagination({
     [query.data],
   );
 
+  const backgroundToolCompletions = useMemo(
+    () => aggregateBackgroundToolCompletions(query.data?.pages),
+    [query.data],
+  );
+
   const latestPage = query.data?.pages[0];
   const oldestPage = query.data?.pages[query.data.pages.length - 1];
 
@@ -228,6 +253,7 @@ export function useHistoryPagination({
     messages,
     latestPage,
     subagentNotifications,
+    backgroundToolCompletions,
     isLoading: query.isLoading,
     isSuccess: query.isSuccess,
     isError: query.isError,


### PR DESCRIPTION
## Summary
- Aggregate per-page backgroundToolCompletions across all loaded history pages and expose on HistoryPaginationResult (mirrors subagentNotifications).

Part of plan: bg-card-survive-restart.md (PR 6 of 7)