### PR TITLE
feat(skills): github-watcher catalog skill (script-mode schedule)

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -271,6 +271,20 @@
       "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
+      "id": "github-watcher",
+      "name": "github-watcher",
+      "description": "Install a recurring GitHub watcher — a scheduled poll of GitHub notifications (review requests, mentions, assignments) that only spends an LLM call when there's something new. Use for ongoing, hands-off GitHub monitoring (e.g. \"keep an eye on my repos\", \"ping me about review requests\", \"watch my GitHub notifications\").",
+      "metadata": {
+        "emoji": "👀",
+        "vellum": {
+          "category": "development",
+          "display-name": "GitHub Watcher"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-06-30T15:29:08.000Z"
+    },
+    {
       "id": "gmail",
       "name": "gmail",
       "description": "Manage Gmail email — drafting, sending, organizing, filters, vacation replies, and inbox analysis",
@@ -781,7 +795,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-01T17:14:52.000Z"
+      "updatedAt": "2026-07-01T19:29:37.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/github-watcher/SKILL.md
+++ b/skills/github-watcher/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-watcher
+description: Install a recurring GitHub watcher — a scheduled poll of GitHub notifications (review requests, mentions, assignments) that only spends an LLM call when there's something new. Use for ongoing, hands-off GitHub monitoring (e.g. "keep an eye on my repos", "ping me about review requests", "watch my GitHub notifications").
+compatibility: Designed for Vellum personal assistants
+metadata:
+  emoji: "👀"
+  vellum:
+    category: development
+    display-name: "GitHub Watcher"
+---
+
+# GitHub Watcher
+
+Polls GitHub notifications on a cron and escalates to your assistant **only when there's new activity** — an empty poll spends zero LLM tokens.
+
+## Prerequisites
+
+- GitHub connected via OAuth. Verify with `assistant oauth status`.
+
+## Setup
+
+```bash
+bun scripts/setup.ts                    # poll every 15 minutes (default)
+bun scripts/setup.ts --cron "*/5 * * * *"
+```
+
+This registers a **script-mode schedule** that runs `scripts/poll.ts` on the cron. On each fire the script polls; it only wakes the assistant when there is new activity.
+
+## How it works
+
+- **Deterministic poll, LLM only on new items.** `scripts/poll.ts` calls `assistant oauth request --provider github /notifications` (the token stays in the daemon — it never enters the script), filters to `review_requested` / `mention` / `assign` / `team_mention`, and dedups against a cursor in the schedule's `state/`. No model call on an empty poll.
+- **Fenced escalation.** When there's new activity it creates a fresh conversation and wakes it with the raw notification payload passed via `--external-content` (fenced as data, never instructions); the trusted framing is in `--hint`.
+- **Self-contained.** Built-ins + the `assistant` CLI only — no dependencies.
+
+## Customizing
+
+By default the schedule runs the shipped `scripts/poll.ts` **in place**, so it picks up skill updates. To customize (e.g. change `ACTION_PROMPT` or the notification filter), copy the script into the schedule's own dir and point the schedule at the copy:
+
+```bash
+cp scripts/poll.ts "$VELLUM_WORKSPACE_DIR/schedules/<id>/poll.ts"
+assistant schedules update <id> --script 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts'
+```
+
+(`setup.ts` prints the `<id>`; or find it with `assistant schedules list`.) The copy is frozen — it won't receive future skill updates.
+
+## Notes
+
+- Cursor state lives at `schedules/<id>/state/` and is gitignored (the script writes a `state/` `.gitignore` on first run); the schedule dir and that `.gitignore` are versioned, the cursor is not.
+- Change the cadence later with `assistant schedules update <id> --expression "<cron>"`; pause with `assistant schedules disable <id>`.

--- a/skills/github-watcher/scripts/poll.ts
+++ b/skills/github-watcher/scripts/poll.ts
@@ -1,0 +1,161 @@
+/**
+ * GitHub watcher (script-mode schedule). Polls notifications via the daemon's
+ * OAuth proxy, keeps a cursor under `./state/`, and wakes a fresh conversation
+ * only when there's new activity — empty polls cost no LLM tokens. Runs with cwd
+ * at the schedule's own dir. Self-contained: built-ins + the `assistant` CLI.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const STATE_DIR = "state";
+const STATE_FILE = "state/state.json";
+
+// TRUSTED framing you authored. Raw GitHub data rides the fenced
+// --external-content channel below, never this line. Edit to taste.
+const ACTION_PROMPT =
+  "New GitHub activity arrived. Summarize what's new — review requests, " +
+  "mentions, assignments — grouped by repo, and flag anything time-sensitive.";
+
+// Notification reasons worth surfacing.
+const RELEVANT_REASONS = new Set([
+  "assign",
+  "mention",
+  "review_requested",
+  "team_mention",
+]);
+const SEEN_CAP = 1000;
+
+interface State {
+  since: string;
+  seen: string[];
+}
+
+interface GhNotification {
+  id: string;
+  reason: string;
+  updated_at: string;
+  subject: { title: string; url: string | null; type: string };
+  repository: { full_name: string; html_url: string };
+}
+
+// Keep runtime state out of git: the schedule dir + this `.gitignore` are
+// versioned, but `state/` is not.
+async function ensureGitignore(): Promise<void> {
+  if (!existsSync(".gitignore")) await writeFile(".gitignore", "state/\n");
+}
+
+async function loadState(): Promise<State> {
+  try {
+    const s = JSON.parse(await Bun.file(STATE_FILE).text());
+    if (typeof s.since === "string") {
+      return { since: s.since, seen: Array.isArray(s.seen) ? s.seen : [] };
+    }
+  } catch {
+    // First run or unreadable: start from "now" so we don't replay the backlog.
+  }
+  return { since: new Date().toISOString(), seen: [] };
+}
+
+async function saveState(state: State): Promise<void> {
+  await mkdir(STATE_DIR, { recursive: true });
+  await Bun.write(STATE_FILE, JSON.stringify(state));
+}
+
+/** Run `assistant <args>` (argv, no shell) and parse its --json stdout. */
+async function cli<T>(args: string[]): Promise<T> {
+  const proc = Bun.spawn(["assistant", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(
+      `assistant ${args.slice(0, 2).join(" ")} exited ${code}: ${err.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(out) as T;
+}
+
+async function fetchNotifications(since: string): Promise<GhNotification[]> {
+  const all: GhNotification[] = [];
+  for (let page = 1; ; page++) {
+    const r = await cli<{ ok: boolean; status: number; body: unknown }>([
+      "oauth", "request", "--provider", "github", "/notifications",
+      "-G",
+      "-d", "all=false",
+      "-d", `since=${since}`,
+      "-d", "per_page=50",
+      "-d", `page=${page}`,
+      "--json",
+    ]);
+    if (!r.ok || r.status >= 400) {
+      throw new Error(`GitHub notifications API status ${r.status}`);
+    }
+    const items = Array.isArray(r.body) ? (r.body as GhNotification[]) : [];
+    all.push(...items);
+    if (items.length < 50) break; // last page
+  }
+  return all;
+}
+
+async function main(): Promise<void> {
+  await ensureGitignore();
+  const state = await loadState();
+  const seen = new Set(state.seen);
+  const fresh = (await fetchNotifications(state.since))
+    .filter((n) => RELEVANT_REASONS.has(n.reason))
+    .filter((n) => !seen.has(n.id));
+
+  // Advance the cursor on every successful poll.
+  const nextSince = new Date().toISOString();
+
+  // No-op tick: nothing new → no conversation, no wake, no LLM call.
+  if (fresh.length === 0) {
+    await saveState({ since: nextSince, seen: state.seen });
+    console.log(JSON.stringify({ ok: true, new: 0 }));
+    return;
+  }
+
+  // Data-only digest — titles/repos/urls, no instructions. Fenced as untrusted.
+  const digest = fresh.map((n) => ({
+    id: n.id,
+    reason: n.reason,
+    type: n.subject.type,
+    title: n.subject.title,
+    repo: n.repository.full_name,
+    url: n.subject.url ?? n.repository.html_url,
+    updated: n.updated_at,
+  }));
+
+  // Fresh conversation per escalation (tagged `scheduled` via __SCHEDULE_RUN_ID).
+  const conv = await cli<{ ok: boolean; id: string }>([
+    "conversations", "new", "GitHub watcher", "--json",
+  ]);
+
+  // Wake it: trusted framing in --hint, untrusted payload fenced in
+  // --external-content (implies --persist). Runs guardian + clientless.
+  await cli<{ ok: boolean; invoked: boolean }>([
+    "conversations", "wake", conv.id,
+    "--source", "github-watcher",
+    "--hint", ACTION_PROMPT,
+    "--external-content", JSON.stringify(digest),
+    "--persist",
+    "--json",
+  ]);
+
+  const nextSeen = [...digest.map((d) => d.id), ...state.seen].slice(0, SEEN_CAP);
+  await saveState({ since: nextSince, seen: nextSeen });
+  console.log(
+    JSON.stringify({ ok: true, new: fresh.length, conversationId: conv.id }),
+  );
+}
+
+main().catch((err) => {
+  console.error(String(err?.message ?? err));
+  process.exit(1);
+});

--- a/skills/github-watcher/scripts/setup.ts
+++ b/skills/github-watcher/scripts/setup.ts
@@ -1,0 +1,55 @@
+/**
+ * Installs the GitHub watcher as a script-mode schedule that runs this skill's
+ * `poll.ts` in place (cwd = the schedule's own dir, so state lives in
+ * `schedules/<id>/state/`). `$__SCHEDULE_ID` resolves at run time, so the saved
+ * command is static.
+ *   bun scripts/setup.ts [--cron "<expr>"]   # default: every 15 minutes
+ */
+
+if (!process.env.VELLUM_WORKSPACE_DIR) {
+  console.error("VELLUM_WORKSPACE_DIR is not set — run inside the assistant.");
+  process.exit(1);
+}
+
+const cronIdx = process.argv.indexOf("--cron");
+const cron = cronIdx >= 0 ? process.argv[cronIdx + 1] : "*/15 * * * *";
+
+const command =
+  'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && ' +
+  'bun "$VELLUM_WORKSPACE_DIR/skills/github-watcher/scripts/poll.ts"';
+
+const proc = Bun.spawn(
+  [
+    "assistant", "schedules", "create", "GitHub watcher",
+    "--mode", "script",
+    "--script", command,
+    "--expression", cron,
+    "--description", "Polls GitHub notifications and escalates new activity",
+    "--timeout-ms", "300000",
+    "--json",
+  ],
+  { stdout: "pipe", stderr: "pipe" },
+);
+const [out, err, code] = await Promise.all([
+  new Response(proc.stdout).text(),
+  new Response(proc.stderr).text(),
+  proc.exited,
+]);
+
+if (code !== 0) {
+  console.error(`schedules create failed (exit ${code}): ${err.trim()}`);
+  process.exit(1);
+}
+
+let id: string | undefined;
+try {
+  id = JSON.parse(out)?.schedule?.id as string | undefined;
+} catch {
+  // Non-JSON stdout; fall back to a bare confirmation.
+}
+console.log(`GitHub watcher scheduled${id ? ` (id ${id})` : ""}, cron ${cron}.`);
+if (id) {
+  console.log(
+    `To customize, copy scripts/poll.ts into schedules/${id}/ (see SKILL.md).`,
+  );
+}


### PR DESCRIPTION
Adds the `github-watcher` catalog skill (`skills/github-watcher`): a script-mode schedule that polls GitHub notifications and wakes a conversation only on new activity (empty polls cost no LLM tokens). `setup.ts` registers the schedule; `poll.ts` polls via `oauth request` (token stays in the daemon) and fences the payload via `--external-content`.

Depends on #36639 (`__SCHEDULE_ID` env) and #36640 (CLI `--mode script`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)