### PR TITLE
feat(web): add shared StackedChipsPill for active-process overlays

### DIFF
--- a/clients/web/src/domains/chat/process-registry/stacked-chips-pill.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/stacked-chips-pill.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for `StackedChipsPill` — the generic stacked-chip pill body shared by
+ * the subagent / ACP-run / background-task overlays.
+ *
+ * A stub `renderChip` emits a labelled marker per id so we can assert the
+ * visible-chip cap, the "+N" overflow, the chevron direction, the toggle
+ * callback, and the pill's aria contract without pulling in any store.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { StackedChipsPill } from "@/domains/chat/process-registry/stacked-chips-pill";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderChip(id: string) {
+  return <span key={id} data-testid="stacked-chip" data-id={id} />;
+}
+
+function ids(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `id-${i}`);
+}
+
+describe("StackedChipsPill — chips", () => {
+  test("renders all chips and no overflow when ids.length <= max", () => {
+    render(
+      <StackedChipsPill
+        ids={ids(4)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    expect(screen.getAllByTestId("stacked-chip").length).toBe(4);
+    expect(screen.queryByText(/^\+/)).toBeNull();
+  });
+
+  test("renders all chips and no overflow when ids.length === max", () => {
+    render(
+      <StackedChipsPill
+        ids={ids(6)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    expect(screen.getAllByTestId("stacked-chip").length).toBe(6);
+    expect(screen.queryByText(/^\+/)).toBeNull();
+  });
+
+  test("caps visible chips at max and shows +N overflow when ids.length > max", () => {
+    render(
+      <StackedChipsPill
+        ids={ids(8)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    // 8 ids, 6 visible → "+2" overflow.
+    expect(screen.getAllByTestId("stacked-chip").length).toBe(6);
+    expect(screen.getByText("+2")).toBeTruthy();
+  });
+});
+
+describe("StackedChipsPill — chevron", () => {
+  test("shows the down chevron when collapsed and up chevron when expanded", () => {
+    const { rerender, container } = render(
+      <StackedChipsPill
+        ids={ids(2)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    expect(container.querySelector(".lucide-chevron-down")).toBeTruthy();
+    expect(container.querySelector(".lucide-chevron-up")).toBeNull();
+
+    rerender(
+      <StackedChipsPill
+        ids={ids(2)}
+        renderChip={renderChip}
+        max={6}
+        expanded
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    expect(container.querySelector(".lucide-chevron-up")).toBeTruthy();
+    expect(container.querySelector(".lucide-chevron-down")).toBeNull();
+  });
+});
+
+describe("StackedChipsPill — interaction & aria", () => {
+  test("invokes onToggle when the pill is clicked", () => {
+    let toggles = 0;
+    render(
+      <StackedChipsPill
+        ids={ids(2)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {
+          toggles += 1;
+        }}
+        ariaLabel="Active things"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /active things/i }));
+    expect(toggles).toBe(1);
+  });
+
+  test("exposes ariaLabel and reflects expanded via aria-expanded", () => {
+    const { rerender } = render(
+      <StackedChipsPill
+        ids={ids(2)}
+        renderChip={renderChip}
+        max={6}
+        expanded={false}
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+
+    const pill = screen.getByRole("button", { name: /active things/i });
+    expect(pill.getAttribute("aria-label")).toBe("Active things");
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+
+    rerender(
+      <StackedChipsPill
+        ids={ids(2)}
+        renderChip={renderChip}
+        max={6}
+        expanded
+        onToggle={() => {}}
+        ariaLabel="Active things"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /active things/i }).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/stacked-chips-pill.tsx
+++ b/clients/web/src/domains/chat/process-registry/stacked-chips-pill.tsx
@@ -1,0 +1,75 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { ChatPill } from "@/domains/chat/components/chat-pill";
+
+export interface StackedChipsPillProps {
+  /** Ids backing each stacked chip. */
+  ids: string[];
+  /**
+   * Renders a single stacked chip for one id. The chip owns its own visuals
+   * (avatar / icon / glyph) and the stacking offset (`-ml-1 ring-2` for every
+   * chip past the first), mirroring the per-surface pills this generalizes.
+   */
+  renderChip: (id: string) => ReactNode;
+  /** Visible-chip cap before the remainder collapses to a "+N" badge. */
+  max: number;
+  /** Whether the owning overlay is expanded (drives the chevron direction). */
+  expanded: boolean;
+  /** Toggles the owning overlay open/closed. */
+  onToggle: () => void;
+  /** Accessible label for the pill button. */
+  ariaLabel: string;
+}
+
+/**
+ * Shared stacked-chip pill body for chat-overlay "active process" affordances
+ * (subagents, ACP runs, background tasks). Renders up to `max` overlapping
+ * chips, a "+N" overflow badge when there are more, and an expand/collapse
+ * chevron — all inside a single compact `ChatPill` button.
+ *
+ * Pure presentational: chip visuals and store reads live in `renderChip`.
+ */
+export function StackedChipsPill({
+  ids,
+  renderChip,
+  max,
+  expanded,
+  onToggle,
+  ariaLabel,
+}: StackedChipsPillProps) {
+  const visibleIds = ids.slice(0, max);
+  const overflowCount = ids.length - max;
+
+  return (
+    <ChatPill
+      onClick={onToggle}
+      ariaLabel={ariaLabel}
+      ariaExpanded={expanded}
+      size="compact"
+    >
+      {/* pointer-events-none so the ChatPill button owns clicks + cursor —
+          clicking any chip toggles. */}
+      <span className="pointer-events-none inline-flex items-center gap-2">
+        <span className="flex items-center">{visibleIds.map(renderChip)}</span>
+
+        {overflowCount > 0 && (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-emphasised)]"
+          >
+            +{overflowCount}
+          </Typography>
+        )}
+
+        {expanded ? (
+          <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
+        ) : (
+          <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
+        )}
+      </span>
+    </ChatPill>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the stacked avatar/chip/glyph pill body shared by subagent/acp/background-task pills into StackedChipsPill.
- Presentational only; visual/aria parity with existing pills.

Part of plan: background-process-registry.md (PR 3 of 17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)