### PR TITLE
refactor(web): extract shared byToolUseId index helper

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -15,6 +15,8 @@ import { create } from "zustand";
 import { createSelectors } from "@/utils/create-selectors";
 import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
 
+import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
+
 // ---------------------------------------------------------------------------
 // Optimistic-steer marker contract
 // ---------------------------------------------------------------------------
@@ -349,10 +351,13 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         parentToolUseId: existing.parentToolUseId ?? params.parentToolUseId,
       };
 
-      const nextByToolUseId =
-        params.parentToolUseId && !existing.parentToolUseId
-          ? new Map(byToolUseId).set(params.parentToolUseId, params.acpSessionId)
-          : byToolUseId;
+      const nextByToolUseId = existing.parentToolUseId
+        ? byToolUseId
+        : setToolUseAnchor(
+            byToolUseId,
+            params.parentToolUseId,
+            params.acpSessionId,
+          );
 
       set({
         byId: { ...byId, [params.acpSessionId]: resumed },
@@ -378,9 +383,11 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
 
     // Only clone the tool-use index when this spawn carries a
     // `parentToolUseId`; otherwise keep the reference stable.
-    const nextByToolUseId = params.parentToolUseId
-      ? new Map(byToolUseId).set(params.parentToolUseId, params.acpSessionId)
-      : byToolUseId;
+    const nextByToolUseId = setToolUseAnchor(
+      byToolUseId,
+      params.parentToolUseId,
+      params.acpSessionId,
+    );
 
     set({
       byId: { ...byId, [params.acpSessionId]: entry },
@@ -578,12 +585,11 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         nextOrderedIds.push(entry.acpSessionId);
       }
 
-      if (entry.parentToolUseId) {
-        nextByToolUseId = new Map(nextByToolUseId).set(
-          entry.parentToolUseId,
-          entry.acpSessionId,
-        );
-      }
+      nextByToolUseId = setToolUseAnchor(
+        nextByToolUseId,
+        entry.parentToolUseId,
+        entry.acpSessionId,
+      );
 
       for (const event of merged.events) {
         if (typeof event.seq !== "number") continue;

--- a/clients/web/src/domains/chat/store-helpers/by-tool-use-id-index.test.ts
+++ b/clients/web/src/domains/chat/store-helpers/by-tool-use-id-index.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  clearToolUseAnchor,
+  setToolUseAnchor,
+} from "@/domains/chat/store-helpers/by-tool-use-id-index";
+
+describe("setToolUseAnchor", () => {
+  it("sets a new mapping and returns a new Map", () => {
+    const index = new Map<string, string>();
+    const next = setToolUseAnchor(index, "tu-1", "id-1");
+
+    expect(next).not.toBe(index);
+    expect(next.get("tu-1")).toBe("id-1");
+    // Source map is left untouched (immutable update).
+    expect(index.size).toBe(0);
+  });
+
+  it("preserves existing entries when adding a new one", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = setToolUseAnchor(index, "tu-2", "id-2");
+
+    expect(next.get("tu-1")).toBe("id-1");
+    expect(next.get("tu-2")).toBe("id-2");
+  });
+
+  it("returns the same Map reference when toolUseId is undefined", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = setToolUseAnchor(index, undefined, "id-1");
+
+    expect(next).toBe(index);
+  });
+
+  it("returns the same Map reference when toolUseId is an empty string", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = setToolUseAnchor(index, "", "id-1");
+
+    expect(next).toBe(index);
+  });
+
+  it("returns the same Map reference when the mapping is unchanged (idempotent)", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = setToolUseAnchor(index, "tu-1", "id-1");
+
+    expect(next).toBe(index);
+  });
+
+  it("clones when an existing toolUseId is remapped to a different id", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = setToolUseAnchor(index, "tu-1", "id-2");
+
+    expect(next).not.toBe(index);
+    expect(next.get("tu-1")).toBe("id-2");
+    expect(index.get("tu-1")).toBe("id-1");
+  });
+});
+
+describe("clearToolUseAnchor", () => {
+  it("removes an existing mapping and returns a new Map", () => {
+    const index = new Map([
+      ["tu-1", "id-1"],
+      ["tu-2", "id-2"],
+    ]);
+    const next = clearToolUseAnchor(index, "tu-1");
+
+    expect(next).not.toBe(index);
+    expect(next.has("tu-1")).toBe(false);
+    expect(next.get("tu-2")).toBe("id-2");
+    // Source map is left untouched (immutable update).
+    expect(index.has("tu-1")).toBe(true);
+  });
+
+  it("returns the same Map reference when toolUseId is undefined", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = clearToolUseAnchor(index, undefined);
+
+    expect(next).toBe(index);
+  });
+
+  it("returns the same Map reference when toolUseId is not present", () => {
+    const index = new Map([["tu-1", "id-1"]]);
+    const next = clearToolUseAnchor(index, "tu-missing");
+
+    expect(next).toBe(index);
+  });
+});

--- a/clients/web/src/domains/chat/store-helpers/by-tool-use-id-index.ts
+++ b/clients/web/src/domains/chat/store-helpers/by-tool-use-id-index.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared spawn-anchor index helpers.
+ *
+ * Several background-process stores (workflow, subagent, ACP) keep a
+ * `byToolUseId` index — a `Map<toolUseId, entryId>` — so the transcript can
+ * anchor an inline card to the exact tool-use that spawned the run.
+ *
+ * These helpers centralize the immutable-update + reference-stability
+ * discipline those stores rely on: the index is only cloned when its contents
+ * actually change, so selectors subscribed to the index don't churn on
+ * no-op updates.
+ */
+
+/**
+ * Set `toolUseId -> id` in the index.
+ *
+ * Returns the **same** Map reference when nothing would change — i.e. when
+ * `toolUseId` is absent, or when it is already mapped to `id`. Otherwise
+ * returns a new Map with the mapping applied.
+ */
+export function setToolUseAnchor(
+  index: Map<string, string>,
+  toolUseId: string | undefined,
+  id: string,
+): Map<string, string> {
+  if (!toolUseId) return index;
+  if (index.get(toolUseId) === id) return index;
+  return new Map(index).set(toolUseId, id);
+}
+
+/**
+ * Remove `toolUseId` from the index.
+ *
+ * Returns the **same** Map reference when nothing would change — i.e. when
+ * `toolUseId` is absent or not present in the index. Otherwise returns a new
+ * Map with the entry removed.
+ */
+export function clearToolUseAnchor(
+  index: Map<string, string>,
+  toolUseId: string | undefined,
+): Map<string, string> {
+  if (!toolUseId) return index;
+  if (!index.has(toolUseId)) return index;
+  const next = new Map(index);
+  next.delete(toolUseId);
+  return next;
+}

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -21,6 +21,7 @@ import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import { isActiveStatus } from "@/utils/subagent-status";
 import { fetchSubagentDetail } from "./fetch-subagent-detail";
 import { mapDetailEvents } from "./map-detail-events";
+import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
 
 // ---------------------------------------------------------------------------
 // State
@@ -407,10 +408,11 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     // Only clone the tool-use index when this spawn carries a
     // `parentToolUseId`; otherwise keep the existing reference stable so
     // index subscribers don't re-render.
-    const prevByToolUseId = get().byToolUseId;
-    const nextByToolUseId = params.parentToolUseId
-      ? new Map(prevByToolUseId).set(params.parentToolUseId, params.subagentId)
-      : prevByToolUseId;
+    const nextByToolUseId = setToolUseAnchor(
+      get().byToolUseId,
+      params.parentToolUseId,
+      params.subagentId,
+    );
     set({
       byId: nextById,
       orderedIds: [...orderedIds, params.subagentId],

--- a/clients/web/src/domains/chat/workflow-store.ts
+++ b/clients/web/src/domains/chat/workflow-store.ts
@@ -29,6 +29,7 @@ import type {
 
 import { fetchWorkflowJournal } from "./fetch-workflow-journal";
 import { fetchWorkflowRun } from "./fetch-workflow-run";
+import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
 
 // ---------------------------------------------------------------------------
 // State
@@ -318,10 +319,9 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
         label: nextLabel,
         toolUseId: nextToolUseId,
       };
-      const nextByToolUseId =
-        toolUseIdChanged && params.toolUseId
-          ? new Map(byToolUseId).set(params.toolUseId, params.runId)
-          : byToolUseId;
+      const nextByToolUseId = toolUseIdChanged
+        ? setToolUseAnchor(byToolUseId, params.toolUseId, params.runId)
+        : byToolUseId;
       set({
         byId: { ...byId, [params.runId]: updated },
         byToolUseId: nextByToolUseId,
@@ -336,9 +336,11 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
     };
     // Only clone the tool-use index when this start carries a `toolUseId`;
     // otherwise keep the existing reference stable.
-    const nextByToolUseId = params.toolUseId
-      ? new Map(byToolUseId).set(params.toolUseId, params.runId)
-      : byToolUseId;
+    const nextByToolUseId = setToolUseAnchor(
+      byToolUseId,
+      params.toolUseId,
+      params.runId,
+    );
     set({
       byId: { ...byId, [params.runId]: entry },
       orderedIds: [...orderedIds, params.runId],


### PR DESCRIPTION
## Summary
- Extract the spawn-anchor byToolUseId index (hand-rolled in workflow/subagent/acp stores) into a shared store-helper.
- Adopt in all three; reference-stability preserved; no behavior change.

Part of plan: background-process-registry.md (PR 13 of 17)