### PR TITLE
refactor(web): extract shared history-merge helper for acp + background-task stores

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -14,6 +14,10 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
+import {
+  mergeTerminalStatus,
+  seedEntriesFromHistory,
+} from "@/domains/chat/store-helpers/merge-history-entry";
 
 // ---------------------------------------------------------------------------
 // Optimistic-steer marker contract
@@ -284,10 +288,11 @@ function mergeHistoryEntry(
 ): AcpRunEntry {
   const events = mergeEvents(existing.events, incoming.events);
 
-  const status =
-    isActiveAcpStatus(existing.status) || !isActiveAcpStatus(incoming.status)
-      ? incoming.status
-      : existing.status;
+  const status = mergeTerminalStatus(
+    existing.status,
+    incoming.status,
+    isActiveAcpStatus,
+  );
 
   return {
     ...existing,
@@ -562,22 +567,24 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
   seedFromHistory: (entries) => {
     const { byId, orderedIds, byToolUseId, highWaterMark } = get();
 
-    const nextById = { ...byId };
-    const nextOrderedIds = [...orderedIds];
+    // Union live + history events by seq and always merge terminal/status/
+    // usage metadata from history so a live entry can't stay stale. The shared
+    // helper owns the byId/orderedIds insertion; the seq high-water mark and the
+    // tool-use index are acp-specific and folded in from the merged result.
+    const { byId: nextById, orderedIds: nextOrderedIds } = seedEntriesFromHistory(
+      {
+        entries,
+        byId,
+        orderedIds,
+        idOf: (entry) => entry.acpSessionId,
+        merge: mergeHistoryEntry,
+      },
+    );
+
     let nextByToolUseId = byToolUseId;
     let nextHighWaterMark = highWaterMark;
 
     for (const entry of entries) {
-      const existing = nextById[entry.acpSessionId];
-      // Union live + history events by seq and always merge terminal/status/
-      // usage metadata from history so a live entry can't stay stale.
-      const merged = existing ? mergeHistoryEntry(existing, entry) : entry;
-      nextById[entry.acpSessionId] = merged;
-
-      if (!nextOrderedIds.includes(entry.acpSessionId)) {
-        nextOrderedIds.push(entry.acpSessionId);
-      }
-
       if (entry.parentToolUseId) {
         nextByToolUseId = new Map(nextByToolUseId).set(
           entry.parentToolUseId,
@@ -585,7 +592,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         );
       }
 
-      for (const event of merged.events) {
+      for (const event of nextById[entry.acpSessionId].events) {
         if (typeof event.seq !== "number") continue;
         nextHighWaterMark = bumpHighWaterMark(
           nextHighWaterMark,

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -24,6 +24,10 @@ import {
   isActiveBackgroundTaskStatus,
   type BackgroundTaskStatus,
 } from "@/utils/background-task-status";
+import {
+  mergeTerminalStatus,
+  seedEntriesFromHistory,
+} from "@/domains/chat/store-helpers/merge-history-entry";
 
 // ---------------------------------------------------------------------------
 // State
@@ -135,11 +139,11 @@ function mergeHistoryEntry(
   existing: BackgroundTaskEntry,
   incoming: BackgroundTaskEntry,
 ): BackgroundTaskEntry {
-  const status =
-    isActiveBackgroundTaskStatus(existing.status) ||
-    !isActiveBackgroundTaskStatus(incoming.status)
-      ? incoming.status
-      : existing.status;
+  const status = mergeTerminalStatus(
+    existing.status,
+    incoming.status,
+    isActiveBackgroundTaskStatus,
+  );
 
   return {
     ...existing,
@@ -264,18 +268,15 @@ const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => (
 
   seedFromHistory: (entries) => {
     const { byId, orderedIds } = get();
-    const nextById = { ...byId };
-    const nextOrderedIds = [...orderedIds];
-
-    for (const entry of entries) {
-      const existing = nextById[entry.id];
-      nextById[entry.id] = existing
-        ? mergeHistoryEntry(existing, entry)
-        : entry;
-      if (!nextOrderedIds.includes(entry.id)) nextOrderedIds.push(entry.id);
-    }
-
-    set({ byId: nextById, orderedIds: nextOrderedIds });
+    set(
+      seedEntriesFromHistory({
+        entries,
+        byId,
+        orderedIds,
+        idOf: (entry) => entry.id,
+        merge: mergeHistoryEntry,
+      }),
+    );
   },
 
   reset: () => set({ byId: {}, orderedIds: [] }),

--- a/clients/web/src/domains/chat/store-helpers/merge-history-entry.test.ts
+++ b/clients/web/src/domains/chat/store-helpers/merge-history-entry.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import {
+  mergeTerminalStatus,
+  seedEntriesFromHistory,
+} from "@/domains/chat/store-helpers/merge-history-entry";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type Status = "running" | "completed" | "failed" | "cancelled";
+
+const isActive = (status: Status): boolean => status === "running";
+
+interface Entry {
+  id: string;
+  status: Status;
+  output?: string;
+}
+
+const merge = (existing: Entry, incoming: Entry): Entry => ({
+  ...existing,
+  status: mergeTerminalStatus(existing.status, incoming.status, isActive),
+  output: incoming.output ?? existing.output,
+});
+
+// ---------------------------------------------------------------------------
+// mergeTerminalStatus
+// ---------------------------------------------------------------------------
+
+describe("mergeTerminalStatus", () => {
+  it("does not regress a live terminal status to stale active history", () => {
+    // Live entry already settled; a stale snapshot still shows it running.
+    expect(mergeTerminalStatus("completed", "running", isActive)).toBe(
+      "completed",
+    );
+  });
+
+  it("lets a terminal history status win over a live active one", () => {
+    // History knows the process finished; the live entry is still "running".
+    expect(mergeTerminalStatus("running", "completed", isActive)).toBe(
+      "completed",
+    );
+  });
+
+  it("takes the incoming status when both are active", () => {
+    expect(mergeTerminalStatus("running", "running", isActive)).toBe("running");
+  });
+
+  it("takes the incoming status when both are terminal", () => {
+    // A terminal history status replaces a different live terminal one.
+    expect(mergeTerminalStatus("failed", "completed", isActive)).toBe(
+      "completed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedEntriesFromHistory
+// ---------------------------------------------------------------------------
+
+describe("seedEntriesFromHistory", () => {
+  it("inserts unseen entries and appends their ids in order", () => {
+    const result = seedEntriesFromHistory({
+      entries: [
+        { id: "a", status: "running" },
+        { id: "b", status: "completed" },
+      ],
+      byId: {},
+      orderedIds: [],
+      idOf: (e: Entry) => e.id,
+      merge,
+    });
+
+    expect(result.orderedIds).toEqual(["a", "b"]);
+    expect(result.byId.a.status).toBe("running");
+    expect(result.byId.b.status).toBe("completed");
+  });
+
+  it("merges known entries without duplicating ids or reordering", () => {
+    const result = seedEntriesFromHistory({
+      entries: [
+        { id: "b", status: "completed", output: "done" },
+        { id: "c", status: "running" },
+      ],
+      byId: {
+        a: { id: "a", status: "completed" },
+        b: { id: "b", status: "running" },
+      },
+      orderedIds: ["a", "b"],
+      idOf: (e: Entry) => e.id,
+      merge,
+    });
+
+    // Existing ids keep their order; new ids are appended.
+    expect(result.orderedIds).toEqual(["a", "b", "c"]);
+    // Terminal history wins over the live "running" entry, and metadata folds in.
+    expect(result.byId.b.status).toBe("completed");
+    expect(result.byId.b.output).toBe("done");
+  });
+
+  it("does not regress a live terminal entry from stale history", () => {
+    const result = seedEntriesFromHistory({
+      // Stale snapshot still reports the task as running.
+      entries: [{ id: "a", status: "running" }],
+      byId: { a: { id: "a", status: "completed" } },
+      orderedIds: ["a"],
+      idOf: (e: Entry) => e.id,
+      merge,
+    });
+
+    expect(result.byId.a.status).toBe("completed");
+    expect(result.orderedIds).toEqual(["a"]);
+  });
+
+  it("returns fresh byId/orderedIds containers (reference stability)", () => {
+    const byId = { a: { id: "a", status: "running" as Status } };
+    const orderedIds = ["a"];
+
+    const result = seedEntriesFromHistory({
+      entries: [{ id: "a", status: "completed" }],
+      byId,
+      orderedIds,
+      idOf: (e: Entry) => e.id,
+      merge,
+    });
+
+    expect(result.byId).not.toBe(byId);
+    expect(result.orderedIds).not.toBe(orderedIds);
+    // The input containers are not mutated.
+    expect(byId.a.status).toBe("running");
+    expect(orderedIds).toEqual(["a"]);
+  });
+});

--- a/clients/web/src/domains/chat/store-helpers/merge-history-entry.ts
+++ b/clients/web/src/domains/chat/store-helpers/merge-history-entry.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared history-merge primitives for the background-process stores
+ * (`acp-run-store`, `background-task-store`).
+ *
+ * Both stores reconcile a live, streaming entry map against an authoritative
+ * history snapshot with the same two rules:
+ *
+ *   1. Terminal-history-wins: a terminal history status overrides a live
+ *      non-terminal one, so a finished process never stays stuck "running".
+ *   2. Don't-regress-a-live-terminal: a live terminal status is never pushed
+ *      back to a non-terminal history status (stale snapshot can't revive it).
+ *
+ * Each store keeps its own domain entry type and status union; these helpers
+ * are parameterized by an `isTerminal` predicate (or, equivalently, by the
+ * store's `isActive` predicate) and a domain merge callback, so no shared entry
+ * type is introduced.
+ */
+
+/**
+ * Pick the merged status under the terminal-history-wins /
+ * don't-regress-a-live-terminal rule.
+ *
+ * `isActive(status)` reports whether a status is non-terminal (active). The
+ * incoming (history) status wins unless the live entry is already terminal and
+ * the incoming one is not — in which case the live terminal status is kept.
+ *
+ * Equivalent to each store's original inline expression:
+ *   `isActive(existing) || !isActive(incoming) ? incoming : existing`.
+ */
+export function mergeTerminalStatus<S>(
+  existingStatus: S,
+  incomingStatus: S,
+  isActive: (status: S) => boolean,
+): S {
+  return isActive(existingStatus) || !isActive(incomingStatus)
+    ? incomingStatus
+    : existingStatus;
+}
+
+/**
+ * Idempotent merge of history `entries` into a byId/orderedIds pair.
+ *
+ * For each entry: if an entry with the same id already exists, it is replaced
+ * by `merge(existing, incoming)`; otherwise the incoming entry is inserted and
+ * its id appended to `orderedIds`. Ordering of pre-existing ids is preserved and
+ * new ids are appended in `entries` order.
+ *
+ * Reference stability matches the stores' hand-rolled loops: fresh `byId` and
+ * `orderedIds` containers are always returned (callers pass these straight into
+ * `set`). The `idOf` extractor lets each store key on its own id field
+ * (`acpSessionId` vs `id`).
+ *
+ * @returns the next `byId` map and `orderedIds` array.
+ */
+export function seedEntriesFromHistory<E>(params: {
+  entries: E[];
+  byId: Record<string, E>;
+  orderedIds: string[];
+  idOf: (entry: E) => string;
+  merge: (existing: E, incoming: E) => E;
+}): { byId: Record<string, E>; orderedIds: string[] } {
+  const { entries, idOf, merge } = params;
+  const byId = { ...params.byId };
+  const orderedIds = [...params.orderedIds];
+
+  for (const entry of entries) {
+    const id = idOf(entry);
+    const existing = byId[id];
+    byId[id] = existing ? merge(existing, entry) : entry;
+    if (!orderedIds.includes(id)) orderedIds.push(id);
+  }
+
+  return { byId, orderedIds };
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated mergeHistoryEntry/seedFromHistory logic (acp-run + background-task stores) into a shared store-helper parameterized by an isTerminal predicate.
- Adopt in both; no behavior change.

Part of plan: background-process-registry.md (PR 14 of 17)