### PR TITLE
refactor(web): extract optimistic cancel/restore/retire helper

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -14,6 +14,12 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
+import {
+  optimisticCancel,
+  optimisticRestore,
+  optimisticRetire,
+  type OptimisticLifecycleConfig,
+} from "@/domains/chat/store-helpers/optimistic-lifecycle";
 
 // ---------------------------------------------------------------------------
 // Optimistic-steer marker contract
@@ -322,6 +328,34 @@ function bumpHighWaterMark(
   return new Map(highWaterMark).set(acpSessionId, seq);
 }
 
+/**
+ * Build the optimistic cancel/restore/retire config for the acp-run store. An
+ * optimistic cancel stamps `completedAt`; a retire additionally records a stop
+ * reason (e.g. `daemon_restarted`). Restore clears `completedAt`.
+ */
+function acpLifecycleConfig(
+  completedAt?: number,
+  stopReason?: string,
+): OptimisticLifecycleConfig<AcpRunEntry, AcpRunStatus> {
+  return {
+    getStatus: (entry) => entry.status,
+    isActive: isActiveAcpStatus,
+    cancelledStatus: "cancelled",
+    applyCancel: (entry) => ({ ...entry, status: "cancelled", completedAt }),
+    applyRestore: (entry, prev) => ({
+      ...entry,
+      status: prev,
+      completedAt: undefined,
+    }),
+    applyRetire: (entry) => ({
+      ...entry,
+      status: "cancelled",
+      stopReason,
+      completedAt,
+    }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -482,53 +516,36 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
 
   cancelRun: (params) => {
     const { byId } = get();
-    const existing = byId[params.acpSessionId];
-    if (!existing || !isActiveAcpStatus(existing.status)) return;
+    const next = optimisticCancel(
+      byId[params.acpSessionId],
+      acpLifecycleConfig(params.completedAt),
+    );
+    if (!next) return;
 
-    set({
-      byId: {
-        ...byId,
-        [params.acpSessionId]: {
-          ...existing,
-          status: "cancelled",
-          completedAt: params.completedAt,
-        },
-      },
-    });
+    set({ byId: { ...byId, [params.acpSessionId]: next } });
   },
 
   restoreRunStatus: (params) => {
     const { byId } = get();
-    const existing = byId[params.acpSessionId];
-    // Only revert our own optimistic cancel; if a real terminal already landed,
-    // leave it.
-    if (!existing || existing.status !== "cancelled") return;
+    const next = optimisticRestore(
+      byId[params.acpSessionId],
+      params.status,
+      acpLifecycleConfig(),
+    );
+    if (!next) return;
 
-    set({
-      byId: {
-        ...byId,
-        [params.acpSessionId]: {
-          ...existing,
-          status: params.status,
-          completedAt: undefined,
-        },
-      },
-    });
+    set({ byId: { ...byId, [params.acpSessionId]: next } });
   },
 
   retireMissingRuns: (params) => {
     const { byId } = get();
+    const config = acpLifecycleConfig(params.completedAt, "daemon_restarted");
     let changed = false;
     const next = { ...byId };
     for (const id of params.acpSessionIds) {
-      const existing = next[id];
-      if (!existing || !isActiveAcpStatus(existing.status)) continue;
-      next[id] = {
-        ...existing,
-        status: "cancelled",
-        stopReason: "daemon_restarted",
-        completedAt: params.completedAt,
-      };
+      const retired = optimisticRetire(next[id], config);
+      if (!retired) continue;
+      next[id] = retired;
       changed = true;
     }
     if (changed) set({ byId: next });

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -24,6 +24,12 @@ import {
   isActiveBackgroundTaskStatus,
   type BackgroundTaskStatus,
 } from "@/utils/background-task-status";
+import {
+  optimisticCancel,
+  optimisticRestore,
+  optimisticRetire,
+  type OptimisticLifecycleConfig,
+} from "@/domains/chat/store-helpers/optimistic-lifecycle";
 
 // ---------------------------------------------------------------------------
 // State
@@ -150,6 +156,29 @@ function mergeHistoryEntry(
   };
 }
 
+/**
+ * Optimistic cancel/restore/retire config for the background-task store. The
+ * optimistic cancel sets no `completedAt`, so a non-null `completedAt` marks a
+ * settled real terminal that restore must not revive — even one that preserved
+ * the "cancelled" status via a racing failed completion.
+ */
+const LIFECYCLE_CONFIG: OptimisticLifecycleConfig<
+  BackgroundTaskEntry,
+  BackgroundTaskStatus
+> = {
+  getStatus: (entry) => entry.status,
+  isActive: isActiveBackgroundTaskStatus,
+  cancelledStatus: "cancelled",
+  applyCancel: (entry) => ({ ...entry, status: "cancelled" }),
+  applyRestore: (entry, prev) => ({
+    ...entry,
+    status: prev,
+    completedAt: undefined,
+  }),
+  applyRetire: (entry) => ({ ...entry, status: "cancelled" }),
+  isSettled: (entry) => entry.completedAt != null,
+};
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -204,39 +233,18 @@ const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => (
 
   cancelTask: (id) => {
     const { byId } = get();
-    const existing = byId[id];
-    if (!existing || !isActiveBackgroundTaskStatus(existing.status)) return;
+    const next = optimisticCancel(byId[id], LIFECYCLE_CONFIG);
+    if (!next) return;
 
-    set({
-      byId: {
-        ...byId,
-        [id]: { ...existing, status: "cancelled" },
-      },
-    });
+    set({ byId: { ...byId, [id]: next } });
   },
 
   restoreTaskStatus: (id, prev) => {
     const { byId } = get();
-    const existing = byId[id];
-    // Only revert our own optimistic cancel. The optimistic `cancelTask` never
-    // sets `completedAt`, so a non-null `completedAt` means a real terminal
-    // already landed — even one that preserved the "cancelled" status (a racing
-    // failed `completeTask`). Reviving it would flash a finished task back to
-    // active.
-    if (
-      !existing ||
-      existing.status !== "cancelled" ||
-      existing.completedAt != null
-    ) {
-      return;
-    }
+    const next = optimisticRestore(byId[id], prev, LIFECYCLE_CONFIG);
+    if (!next) return;
 
-    set({
-      byId: {
-        ...byId,
-        [id]: { ...existing, status: prev, completedAt: undefined },
-      },
-    });
+    set({ byId: { ...byId, [id]: next } });
   },
 
   retireMissing: (activeIds, knownIds) => {
@@ -248,15 +256,12 @@ const useBackgroundTaskStoreBase = create<BackgroundTaskStore>()((set, get) => (
     for (const entry of Object.values(byId)) {
       // Retire only tasks known before the snapshot and absent from it; a task
       // started while the fetch was in flight is in `byId` but not `known`, so
-      // it is left running.
-      if (
-        !isActiveBackgroundTaskStatus(entry.status) ||
-        !known.has(entry.id) ||
-        active.has(entry.id)
-      ) {
-        continue;
-      }
-      next[entry.id] = { ...entry, status: "cancelled" };
+      // it is left running. The status guard (already-terminal) lives in
+      // `optimisticRetire`.
+      if (!known.has(entry.id) || active.has(entry.id)) continue;
+      const retired = optimisticRetire(entry, LIFECYCLE_CONFIG);
+      if (!retired) continue;
+      next[entry.id] = retired;
       changed = true;
     }
     if (changed) set({ byId: next });

--- a/clients/web/src/domains/chat/store-helpers/optimistic-lifecycle.test.ts
+++ b/clients/web/src/domains/chat/store-helpers/optimistic-lifecycle.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  optimisticCancel,
+  optimisticRestore,
+  optimisticRetire,
+  type OptimisticLifecycleConfig,
+} from "@/domains/chat/store-helpers/optimistic-lifecycle";
+
+// ---------------------------------------------------------------------------
+// Test fixture: a minimal entry/status shape exercising both store variants.
+// `completedAt` lets us cover the `isSettled` guard (background-task style).
+// ---------------------------------------------------------------------------
+
+type Status = "running" | "cancelled" | "completed" | "failed";
+
+interface Entry {
+  id: string;
+  status: Status;
+  completedAt?: number;
+  stopReason?: string;
+}
+
+const NOW = 1700000000000;
+
+function config(
+  overrides: Partial<OptimisticLifecycleConfig<Entry, Status>> = {},
+): OptimisticLifecycleConfig<Entry, Status> {
+  return {
+    getStatus: (entry) => entry.status,
+    isActive: (status) => status === "running",
+    cancelledStatus: "cancelled",
+    applyCancel: (entry) => ({ ...entry, status: "cancelled", completedAt: NOW }),
+    applyRestore: (entry, prev) => ({
+      ...entry,
+      status: prev,
+      completedAt: undefined,
+    }),
+    applyRetire: (entry) => ({
+      ...entry,
+      status: "cancelled",
+      stopReason: "daemon_restarted",
+      completedAt: NOW,
+    }),
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return { id: "e-1", status: "running", ...overrides };
+}
+
+describe("optimisticCancel", () => {
+  it("applies the optimistic transition to an active entry", () => {
+    const next = optimisticCancel(entry(), config());
+    expect(next).toEqual({ id: "e-1", status: "cancelled", completedAt: NOW });
+  });
+
+  it("is a no-op for an unknown entry", () => {
+    expect(optimisticCancel(undefined, config())).toBeNull();
+  });
+
+  it("is a no-op for an already-terminal entry", () => {
+    expect(optimisticCancel(entry({ status: "completed" }), config())).toBeNull();
+    expect(optimisticCancel(entry({ status: "cancelled" }), config())).toBeNull();
+  });
+});
+
+describe("optimisticRestore", () => {
+  it("reverts an optimistically-cancelled entry to the prior status", () => {
+    const cancelled = entry({ status: "cancelled", completedAt: NOW });
+    const next = optimisticRestore(cancelled, "running", config());
+    expect(next).toEqual({ id: "e-1", status: "running", completedAt: undefined });
+  });
+
+  it("is a no-op for an unknown entry", () => {
+    expect(optimisticRestore(undefined, "running", config())).toBeNull();
+  });
+
+  it("is a no-op when the entry is not in the optimistic cancelled state", () => {
+    expect(
+      optimisticRestore(entry({ status: "running" }), "running", config()),
+    ).toBeNull();
+    expect(
+      optimisticRestore(entry({ status: "failed" }), "running", config()),
+    ).toBeNull();
+  });
+
+  it("respects isSettled — a real terminal that landed is not revived", () => {
+    const settled = entry({ status: "cancelled", completedAt: NOW });
+    const next = optimisticRestore(
+      settled,
+      "running",
+      config({ isSettled: (e) => e.completedAt != null }),
+    );
+    expect(next).toBeNull();
+  });
+
+  it("restores when isSettled reports the entry is not yet settled", () => {
+    const cancelled = entry({ status: "cancelled" });
+    const next = optimisticRestore(
+      cancelled,
+      "running",
+      config({ isSettled: (e) => e.completedAt != null }),
+    );
+    expect(next).toEqual({ id: "e-1", status: "running", completedAt: undefined });
+  });
+});
+
+describe("optimisticRetire", () => {
+  it("retires a still-active entry with the store's terminal fields", () => {
+    const next = optimisticRetire(entry({ status: "running" }), config());
+    expect(next).toEqual({
+      id: "e-1",
+      status: "cancelled",
+      stopReason: "daemon_restarted",
+      completedAt: NOW,
+    });
+  });
+
+  it("leaves an already-terminal entry untouched", () => {
+    expect(optimisticRetire(entry({ status: "completed" }), config())).toBeNull();
+    expect(optimisticRetire(entry({ status: "cancelled" }), config())).toBeNull();
+  });
+
+  it("is a no-op for an unknown entry", () => {
+    expect(optimisticRetire(undefined, config())).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/store-helpers/optimistic-lifecycle.ts
+++ b/clients/web/src/domains/chat/store-helpers/optimistic-lifecycle.ts
@@ -1,0 +1,105 @@
+/**
+ * Generic optimistic cancel / restore / retire lifecycle for entry-map stores.
+ *
+ * The acp-run and background-task stores share a byte-parallel trio:
+ *
+ * - **cancel** — optimistically mark an active entry "cancelling/cancelled"
+ *   (user pressed Stop). No-op for unknown or already-terminal entries so a
+ *   finished entry is never regressed.
+ * - **restore** — roll back that optimistic cancel when the cancel request
+ *   fails, reverting to the prior status. No-op unless the entry is still in
+ *   the optimistic cancelled state (and, where applicable, not yet settled by
+ *   a real terminal), so a landed terminal is never regressed back to active.
+ * - **retire** — mark active entries that an authoritative daemon snapshot no
+ *   longer reports as cancelled (the daemon restarted and lost the subprocess
+ *   before persisting a terminal row, so no event will ever settle them).
+ *
+ * These pure transforms are parameterized by the status values each store uses
+ * for the optimistic transition and by its terminal-state predicate. Each store
+ * wraps them in its own zustand setters; entry shapes stay domain-specific.
+ */
+
+/**
+ * Per-store configuration for the optimistic lifecycle transforms.
+ *
+ * @typeParam Entry - the store's entry record.
+ * @typeParam Status - the store's status union.
+ */
+export interface OptimisticLifecycleConfig<Entry, Status> {
+  /** Read an entry's current status. */
+  getStatus: (entry: Entry) => Status;
+  /** Whether a status is active (non-terminal) and thus cancelable. */
+  isActive: (status: Status) => boolean;
+  /** The status an optimistic cancel transitions an active entry to. */
+  cancelledStatus: Status;
+  /**
+   * Apply the cancel mutation, producing the optimistically-cancelled entry.
+   * Stores set their own terminal fields here (e.g. `completedAt`).
+   */
+  applyCancel: (entry: Entry) => Entry;
+  /**
+   * Apply the restore mutation, reverting an optimistically-cancelled entry to
+   * `prev`. Stores clear their own terminal fields here.
+   */
+  applyRestore: (entry: Entry, prev: Status) => Entry;
+  /**
+   * Apply the retire mutation, settling a still-active entry the daemon no
+   * longer reports. Stores set their own terminal fields here (e.g. a
+   * `daemon_restarted` stop reason).
+   */
+  applyRetire: (entry: Entry) => Entry;
+  /**
+   * Whether an entry already settled by a real terminal (so restore must not
+   * revive it) — even one that preserved the cancelled status via a racing
+   * failed completion. Defaults to always-false: stores whose optimistic cancel
+   * is indistinguishable from a settled terminal rely solely on the status
+   * guard.
+   */
+  isSettled?: (entry: Entry) => boolean;
+}
+
+/**
+ * Optimistically cancel an active entry. Returns the cancelled entry, or `null`
+ * when there is no change (unknown or already-terminal entry).
+ */
+export function optimisticCancel<Entry, Status>(
+  entry: Entry | undefined,
+  config: OptimisticLifecycleConfig<Entry, Status>,
+): Entry | null {
+  if (!entry || !config.isActive(config.getStatus(entry))) return null;
+  return config.applyCancel(entry);
+}
+
+/**
+ * Roll back an optimistic cancel, reverting to `prev`. Returns the restored
+ * entry, or `null` when there is no change — unknown entry, not in the
+ * optimistic cancelled state, or already settled by a real terminal.
+ */
+export function optimisticRestore<Entry, Status>(
+  entry: Entry | undefined,
+  prev: Status,
+  config: OptimisticLifecycleConfig<Entry, Status>,
+): Entry | null {
+  if (
+    !entry ||
+    config.getStatus(entry) !== config.cancelledStatus ||
+    config.isSettled?.(entry)
+  ) {
+    return null;
+  }
+  return config.applyRestore(entry, prev);
+}
+
+/**
+ * Retire an active entry the daemon snapshot dropped. Returns the retired
+ * entry, or `null` when there is no change (already-terminal entry). Callers
+ * own the selection of WHICH entries to feed in (e.g. an id list, or filtering
+ * `byId` against an active/known snapshot).
+ */
+export function optimisticRetire<Entry, Status>(
+  entry: Entry | undefined,
+  config: OptimisticLifecycleConfig<Entry, Status>,
+): Entry | null {
+  if (!entry || !config.isActive(config.getStatus(entry))) return null;
+  return config.applyRetire(entry);
+}


### PR DESCRIPTION
## Summary
- Extract the byte-parallel optimistic cancel/restore/retire lifecycle trio (acp-run + background-task stores) into a shared store-helper.
- Adopt in both; no behavior change.

Part of plan: background-process-registry.md (PR 15 of 17)