### PR TITLE
feat(web): add generic InlineProcessCard + shared InlineCardStatusIcon

### DIFF
--- a/clients/web/src/domains/chat/process-registry/inline-card-status-icon.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-card-status-icon.tsx
@@ -1,0 +1,69 @@
+import { AlertCircle, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+
+/**
+ * The byte-identical "local copy" of the shell's StatusIndicator that the four
+ * background-process inline cards each re-declared. Extracted here so the
+ * generic {@link InlineProcessCard} and the per-surface cards share one
+ * implementation.
+ *
+ * Renders the full five-state mapping (the ACP card carried the richest set,
+ * which is the superset of the others):
+ *   - `loading`  → pulsing {@link ThreeDotIndicator} (no `data-state`)
+ *   - `complete` → green {@link CheckCircle2}
+ *   - `warning`  → amber {@link AlertTriangle} (e.g. a cancelled-but-completed
+ *     run = partial work — distinct from a red error)
+ *   - `denied` / `error` → red {@link AlertCircle}
+ *
+ * Terminal icons carry `data-state` so the detail panel and tests can read the
+ * settled state; the running indicator has none. Icons are `aria-hidden` — the
+ * card's open affordance owns the accessible label.
+ */
+export const INLINE_CARD_STATUS_TESTID = "inline-card-status-indicator";
+
+export function InlineCardStatusIcon({
+  state,
+}: {
+  state: ToolProgressCardState;
+}) {
+  switch (state) {
+    case "loading":
+      return (
+        <ThreeDotIndicator
+          data-testid={INLINE_CARD_STATUS_TESTID}
+          className="shrink-0"
+        />
+      );
+    case "complete":
+      return (
+        <CheckCircle2
+          data-testid={INLINE_CARD_STATUS_TESTID}
+          aria-hidden="true"
+          data-state="complete"
+          className="h-[14px] w-[14px] shrink-0 text-[var(--system-positive-strong)]"
+        />
+      );
+    case "warning":
+      return (
+        <AlertTriangle
+          data-testid={INLINE_CARD_STATUS_TESTID}
+          aria-hidden="true"
+          data-state="warning"
+          className="h-[14px] w-[14px] shrink-0 text-[var(--system-mid-strong)]"
+        />
+      );
+    case "denied":
+    case "error":
+    default:
+      return (
+        <AlertCircle
+          data-testid={INLINE_CARD_STATUS_TESTID}
+          aria-hidden="true"
+          data-state={state}
+          className="h-[14px] w-[14px] shrink-0 text-[var(--system-negative-strong)]"
+        />
+      );
+  }
+}

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Tests for `InlineProcessCard` — the generic inline progress row shared by the
+ * four background-process surfaces. A stub `summary` + `leadingIcon` exercise
+ * the body without pulling in any store.
+ *
+ *  - Each of the five states renders the correct status icon (`data-state`).
+ *  - The count is hidden for "0 …"/"1 …" rows and shown for "2 …".
+ *  - `onOpen` fires on click + Enter; the leading cluster is inert (no
+ *    role=button) when omitted.
+ *  - The stop button is hidden without `onStop`; clicking it calls `onStop` and
+ *    NOT `onOpen` (stopPropagation).
+ *  - `testId`, `openAriaLabel`, and `stopAriaLabel` are emitted.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { InlineProcessCard } from "@/domains/chat/process-registry/inline-process-card";
+import { INLINE_CARD_STATUS_TESTID } from "@/domains/chat/process-registry/inline-card-status-icon";
+import type { CardSummary } from "@/domains/chat/process-registry/types";
+import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+
+afterEach(() => {
+  cleanup();
+});
+
+function summary(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    state: "loading",
+    title: "Some process",
+    info: "doing something",
+    ...overrides,
+  };
+}
+
+const leadingIcon = <span data-testid="leading-icon" />;
+
+describe("InlineProcessCard — status icon", () => {
+  test("loading renders the three-dot indicator (no data-state)", () => {
+    render(
+      <InlineProcessCard
+        summary={summary({ state: "loading" })}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(
+      screen.getByTestId(INLINE_CARD_STATUS_TESTID).getAttribute("data-state"),
+    ).toBeNull();
+  });
+
+  test.each<[ToolProgressCardState, string]>([
+    ["complete", "complete"],
+    ["warning", "warning"],
+    ["denied", "denied"],
+    ["error", "error"],
+  ])("%s renders the %s status icon", (state, expected) => {
+    render(
+      <InlineProcessCard
+        summary={summary({ state })}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(
+      screen.getByTestId(INLINE_CARD_STATUS_TESTID).getAttribute("data-state"),
+    ).toBe(expected);
+  });
+});
+
+describe("InlineProcessCard — count", () => {
+  test("hides the count for a 0-count row", () => {
+    render(
+      <InlineProcessCard
+        summary={summary({ count: "0 agents" })}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.queryByTestId("inline-process-card-count")).toBeNull();
+  });
+
+  test("hides the count for a 1-count row", () => {
+    render(
+      <InlineProcessCard
+        summary={summary({ count: "1 agent" })}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.queryByTestId("inline-process-card-count")).toBeNull();
+  });
+
+  test("shows the count for a 2-count row", () => {
+    render(
+      <InlineProcessCard
+        summary={summary({ count: "2 agents" })}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.getByTestId("inline-process-card-count").textContent).toBe(
+      "2 agents",
+    );
+  });
+
+  test("hides the count when summary.count is unset", () => {
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.queryByTestId("inline-process-card-count")).toBeNull();
+  });
+});
+
+describe("InlineProcessCard — open affordance", () => {
+  test("fires onOpen on click", () => {
+    let opens = 0;
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+        onOpen={() => {
+          opens += 1;
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open thing/i }));
+    expect(opens).toBe(1);
+  });
+
+  test("fires onOpen on Enter", () => {
+    let opens = 0;
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+        onOpen={() => {
+          opens += 1;
+        }}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("button", { name: /open thing/i }), {
+      key: "Enter",
+    });
+    expect(opens).toBe(1);
+  });
+
+  test("has no role=button (inert) when onOpen is omitted", () => {
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /open thing/i })).toBeNull();
+  });
+});
+
+describe("InlineProcessCard — stop button", () => {
+  test("is hidden when onStop is omitted", () => {
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+      />,
+    );
+    expect(screen.queryByTestId("inline-process-card-stop")).toBeNull();
+  });
+
+  test("clicking stop calls onStop and NOT onOpen (stopPropagation)", () => {
+    let opens = 0;
+    let stops = 0;
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+        onOpen={() => {
+          opens += 1;
+        }}
+        onStop={() => {
+          stops += 1;
+        }}
+        stopAriaLabel="Stop thing"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("inline-process-card-stop"));
+    expect(stops).toBe(1);
+    expect(opens).toBe(0);
+  });
+
+  test("defaults the stop aria-label to 'Stop' and honours an override", () => {
+    const { rerender } = render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+        onStop={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("inline-process-card-stop").getAttribute("aria-label"),
+    ).toBe("Stop");
+
+    rerender(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open thing"
+        onStop={() => {}}
+        stopAriaLabel="Stop thing"
+      />,
+    );
+    expect(
+      screen.getByTestId("inline-process-card-stop").getAttribute("aria-label"),
+    ).toBe("Stop thing");
+  });
+});
+
+describe("InlineProcessCard — testid & aria", () => {
+  test("emits the root testId and the openAriaLabel", () => {
+    render(
+      <InlineProcessCard
+        summary={summary()}
+        leadingIcon={leadingIcon}
+        openAriaLabel="Open workflow"
+        onOpen={() => {}}
+        testId="my-inline-card"
+      />,
+    );
+    expect(screen.getByTestId("my-inline-card")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /open workflow/i })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
@@ -175,6 +175,24 @@ describe("InlineProcessCard — stop button", () => {
     expect(screen.queryByTestId("inline-process-card-stop")).toBeNull();
   });
 
+  test("is hidden for a terminal summary even when onStop is supplied", () => {
+    // Parity with the four existing inline cards, which gate the stop control
+    // on the running (loading) state; terminal rows must not surface a stale
+    // destructive action that dispatches an unnecessary cancellation.
+    for (const state of ["complete", "warning", "denied", "error"] as const) {
+      const { unmount } = render(
+        <InlineProcessCard
+          summary={summary({ state })}
+          leadingIcon={leadingIcon}
+          openAriaLabel="Open thing"
+          onStop={() => {}}
+        />,
+      );
+      expect(screen.queryByTestId("inline-process-card-stop")).toBeNull();
+      unmount();
+    }
+  });
+
   test("clicking stop calls onStop and NOT onOpen (stopPropagation)", () => {
     let opens = 0;
     let stops = 0;

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -110,7 +110,7 @@ export function InlineProcessCard({
             {count}
           </Typography>
         ) : null}
-        {onStop ? (
+        {onStop && summary.state === "loading" ? (
           <Button
             variant="dangerGhost"
             size="compact"

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -1,0 +1,126 @@
+// Generic inline progress row shared by the four background-process surfaces
+// (subagent / workflow / ACP run / background task). Reproduces the body those
+// cards each re-declared, byte-for-byte: status indicator → leading icon →
+// Title | detail carousel → "X agents" count → stop, on the transparent chat
+// background with a full-row --surface-active hover (no boxed surface). The
+// leading cluster is the open affordance (role="button"); the stop button stays
+// a separate sibling so it isn't nested inside an interactive element.
+//
+// Pure presentational: callers project their store state into a `CardSummary`
+// and supply the per-surface leading icon + handlers. No store reads here.
+
+import { Square } from "lucide-react";
+import {
+  useCallback,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+import { HeaderStepCarousel } from "@/domains/chat/components/tool-progress-card/header-step-carousel";
+import { InlineCardStatusIcon } from "@/domains/chat/process-registry/inline-card-status-icon";
+import type { CardSummary } from "@/domains/chat/process-registry/types";
+
+export interface InlineProcessCardProps {
+  /** Pre-projected summary driving the status icon, title, info, and count. */
+  summary: CardSummary;
+  /** Per-surface leading glyph/avatar rendered after the status icon. */
+  leadingIcon: ReactNode;
+  /** Static accessible label for the open affordance, e.g. `"Open workflow"`. */
+  openAriaLabel: string;
+  /** Opens the process's detail panel; omit to make the leading cluster inert. */
+  onOpen?: () => void;
+  /** Stops the in-flight process; omit to hide the stop button. */
+  onStop?: () => void;
+  /** Accessible label for the stop button; defaults to `"Stop"`. */
+  stopAriaLabel?: string;
+  /** `data-testid` for the root row. */
+  testId?: string;
+}
+
+export function InlineProcessCard({
+  summary,
+  leadingIcon,
+  openAriaLabel,
+  onOpen,
+  onStop,
+  stopAriaLabel,
+  testId,
+}: InlineProcessCardProps) {
+  const handleOpenKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ignore keydowns bubbled from children (e.g. the stop button).
+      if (e.target !== e.currentTarget) return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onOpen?.();
+      }
+    },
+    [onOpen],
+  );
+
+  const handleStop = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onStop?.();
+    },
+    [onStop],
+  );
+
+  // Hidden for 0/1-count rows where the carousel detail already says it.
+  const { count } = summary;
+  const showCount =
+    !!count && !count.startsWith("0 ") && !count.startsWith("1 ");
+
+  // Without a click handler the leading cluster is inert (not a button).
+  const canOpen = !!onOpen;
+
+  return (
+    <div
+      data-testid={testId}
+      className="group flex w-full items-center justify-between gap-2 rounded-md p-2 text-left hover:bg-[var(--surface-active)]"
+    >
+      <span
+        role={canOpen ? "button" : undefined}
+        tabIndex={canOpen ? 0 : undefined}
+        aria-label={canOpen ? openAriaLabel : undefined}
+        onClick={canOpen ? onOpen : undefined}
+        onKeyDown={canOpen ? handleOpenKeyDown : undefined}
+        className={`flex min-w-0 flex-1 items-center gap-1 text-left${
+          canOpen ? " cursor-pointer" : ""
+        }`}
+      >
+        <InlineCardStatusIcon state={summary.state} />
+        <span className="mx-1 flex shrink-0 items-center">{leadingIcon}</span>
+        <HeaderStepCarousel
+          currentStepTitle={summary.title}
+          currentStepInfo={summary.info}
+          bypassDwell={summary.state !== "loading"}
+        />
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        {showCount ? (
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+            data-testid="inline-process-card-count"
+          >
+            {count}
+          </Typography>
+        ) : null}
+        {onStop ? (
+          <Button
+            variant="dangerGhost"
+            size="compact"
+            iconOnly={<Square fill="currentColor" />}
+            aria-label={stopAriaLabel ?? "Stop"}
+            data-testid="inline-process-card-stop"
+            onClick={handleStop}
+          />
+        ) : null}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add InlineProcessCard consuming CardSummary + descriptor-supplied leadingIcon/handlers.
- Extract the 5-state InlineCardStatusIcon shared by the four inline cards.
- Visual/aria/testid parity; no consumers yet.

Part of plan: background-process-registry.md (PR 2 of 17)