### PR TITLE
feat(web): add additive openProcessDetail/closeActiveDetail facade to viewer-store

### DIFF
--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -401,6 +401,91 @@ describe("closeWorkflowDetail", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Process-detail routing facade
+// ---------------------------------------------------------------------------
+
+describe("openProcessDetail", () => {
+  it("routes 'subagent' to openSubagentDetail", () => {
+    getState().openProcessDetail({ kind: "subagent", id: "sa-1" });
+    const state = getState();
+    expect(state.mainView).toBe("subagent-detail");
+    expect(state.activeSubagentId).toBe("sa-1");
+  });
+
+  it("routes 'workflow' to openWorkflowDetail", () => {
+    getState().openProcessDetail({ kind: "workflow", id: "run-1" });
+    const state = getState();
+    expect(state.mainView).toBe("workflow-detail");
+    expect(state.activeWorkflowRunId).toBe("run-1");
+  });
+
+  it("routes 'acp-run' to openAcpRunDetail", () => {
+    getState().openProcessDetail({ kind: "acp-run", id: "acp-1" });
+    const state = getState();
+    expect(state.mainView).toBe("acp-run-detail");
+    expect(state.activeAcpRunId).toBe("acp-1");
+  });
+
+  it("routes 'background-task' to openBackgroundTaskDetail", () => {
+    getState().openProcessDetail({ kind: "background-task", id: "bg-1" });
+    const state = getState();
+    expect(state.mainView).toBe("background-task-detail");
+    expect(state.activeBackgroundTaskId).toBe("bg-1");
+  });
+});
+
+describe("closeActiveDetail", () => {
+  it("closes an open subagent-detail and restores the prior view", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openProcessDetail({ kind: "subagent", id: "sa-1" });
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeSubagentId).toBeNull();
+  });
+
+  it("closes an open workflow-detail and restores the prior view", () => {
+    getState().openProcessDetail({ kind: "workflow", id: "run-1" });
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeWorkflowRunId).toBeNull();
+  });
+
+  it("closes an open acp-run-detail and restores the prior view", () => {
+    getState().openProcessDetail({ kind: "acp-run", id: "acp-1" });
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeAcpRunId).toBeNull();
+  });
+
+  it("closes an open background-task-detail and restores the prior view", () => {
+    getState().openProcessDetail({ kind: "background-task", id: "bg-1" });
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeBackgroundTaskId).toBeNull();
+  });
+
+  it("is a no-op when no process-detail view is open", () => {
+    useViewerStore.setState({ mainView: "app", activeAppId: "app-1" });
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeAppId).toBe("app-1");
+  });
+
+  it("does not close tool-detail (out of scope for the process facade)", () => {
+    getState().openToolDetail(SAMPLE_TOOL);
+    getState().closeActiveDetail();
+    const state = getState();
+    expect(state.mainView).toBe("tool-detail");
+    expect(state.activeToolDetail).toBe(SAMPLE_TOOL);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tool detail
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -27,6 +27,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { create } from "zustand";
 
 import type { SetupChannelId } from "@/types/channel-types";
+import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
@@ -312,6 +313,27 @@ export interface ViewerActions {
   openBackgroundTaskDetail: (id: string) => void;
   closeBackgroundTaskDetail: () => void;
 
+  // --- Process-detail routing facade ---
+  /**
+   * Forward-compatible entry point for opening any background-process detail
+   * panel by `{ kind, id }`. Delegates to the matching per-kind `openXDetail`
+   * action so new process kinds route through one call site.
+   *
+   * This is purely additive over the per-kind actions: the destructive
+   * `mainView` enum collapse — and absorbing the payload-carrying
+   * `tool-detail` / `document` / `channel-setup` views into this facade — is a
+   * deferred follow-up.
+   */
+  openProcessDetail: (ref: { kind: ProcessKind; id: string }) => void;
+  /**
+   * Close whichever of the four process-detail panels (subagent, workflow,
+   * acp-run, background-task) is currently open, restoring the prior view. A
+   * no-op when none of the four is the active view. Mirrors the existing
+   * Escape behavior for these kinds; does not handle tool-detail, document, or
+   * channel-setup.
+   */
+  closeActiveDetail: () => void;
+
   // --- Tool detail ---
   openToolDetail: (payload: ToolDetailPayload) => void;
   /**
@@ -545,6 +567,48 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       mainView: get().viewBeforeBackgroundTaskDetail,
       activeBackgroundTaskId: null,
     });
+  },
+
+  // --- Process-detail routing facade ---
+
+  openProcessDetail: ({ kind, id }) => {
+    switch (kind) {
+      case "subagent":
+        get().openSubagentDetail(id);
+        return;
+      case "workflow":
+        get().openWorkflowDetail(id);
+        return;
+      case "acp-run":
+        get().openAcpRunDetail(id);
+        return;
+      case "background-task":
+        get().openBackgroundTaskDetail(id);
+        return;
+      default: {
+        const _exhaustive: never = kind;
+        void _exhaustive;
+      }
+    }
+  },
+
+  closeActiveDetail: () => {
+    switch (get().mainView) {
+      case "subagent-detail":
+        get().closeSubagentDetail();
+        return;
+      case "workflow-detail":
+        get().closeWorkflowDetail();
+        return;
+      case "acp-run-detail":
+        get().closeAcpRunDetail();
+        return;
+      case "background-task-detail":
+        get().closeBackgroundTaskDetail();
+        return;
+      default:
+        return;
+    }
   },
 
   // --- Channel setup ---

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -315,14 +315,11 @@ export interface ViewerActions {
 
   // --- Process-detail routing facade ---
   /**
-   * Forward-compatible entry point for opening any background-process detail
-   * panel by `{ kind, id }`. Delegates to the matching per-kind `openXDetail`
-   * action so new process kinds route through one call site.
-   *
-   * This is purely additive over the per-kind actions: the destructive
-   * `mainView` enum collapse — and absorbing the payload-carrying
-   * `tool-detail` / `document` / `channel-setup` views into this facade — is a
-   * deferred follow-up.
+   * Opens any background-process detail panel by `{ kind, id }`, delegating to
+   * the matching per-kind `openXDetail` action so every process kind routes
+   * through one call site. Handles the four process kinds (subagent, workflow,
+   * acp-run, background-task); `tool-detail`, `document`, and `channel-setup`
+   * keep their own dedicated open actions.
    */
   openProcessDetail: (ref: { kind: ProcessKind; id: string }) => void;
   /**


### PR DESCRIPTION
## Summary
- Add additive openProcessDetail({kind,id}) + closeActiveDetail() that delegate to the existing per-kind viewer actions. No removals; enum collapse deferred.

Part of plan: background-process-registry.md (PR 16 of 17)