### PR TITLE
feat(web): add SUBAGENT_DESCRIPTOR + CardSummary adapter

### DIFF
--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `SUBAGENT_DESCRIPTOR` — the subagent {@link BackgroundProcessDescriptor}.
+ *
+ * The `useCardSummary` projection is driven against the real `useSubagentStore`
+ * (seeded via `spawnSubagent` / `loadDetail` / `changeStatus`) so it exercises
+ * the same `ToolCallCardData → CardSummary` mapping a consumer would observe.
+ * The static copy/config fields (`kind`, `overlayTitle`, `pill`, aria labels)
+ * are asserted directly.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import {
+  useSubagentStore,
+  type SubagentTimelineEvent,
+} from "@/domains/chat/subagent-store";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+const NOW = 1700000000000;
+
+afterEach(() => {
+  cleanup();
+  useSubagentStore.getState().reset();
+});
+
+/** Spawn a subagent, seed its timeline events, and move it to `status`. */
+function seed(
+  subagentId: string,
+  status: SubagentStatus,
+  events: SubagentTimelineEvent[] = [],
+  label = "Research Agent",
+) {
+  const store = useSubagentStore.getState();
+  store.spawnSubagent({ subagentId, label, objective: "test", timestamp: NOW });
+  if (events.length > 0) store.loadDetail({ subagentId, events });
+  store.changeStatus({ subagentId, status });
+}
+
+describe("SUBAGENT_DESCRIPTOR — static config", () => {
+  test("kind is subagent", () => {
+    expect(SUBAGENT_DESCRIPTOR.kind).toBe("subagent");
+  });
+
+  test("overlayTitle pluralises on count", () => {
+    expect(SUBAGENT_DESCRIPTOR.overlayTitle(1)).toBe("1 Active Subagent");
+    expect(SUBAGENT_DESCRIPTOR.overlayTitle(2)).toBe("2 Active Subagents");
+  });
+
+  test("pill is a stacked variant", () => {
+    expect(SUBAGENT_DESCRIPTOR.pill.variant).toBe("stacked");
+  });
+
+  test("exposes the subagent aria labels", () => {
+    expect(SUBAGENT_DESCRIPTOR.openCardAriaLabel).toBe("Open subagent");
+    expect(SUBAGENT_DESCRIPTOR.pillAriaLabel(3)).toBe("Active subagents");
+  });
+});
+
+describe("SUBAGENT_DESCRIPTOR — useCardSummary projection", () => {
+  test("returns null in the spawn-race window (no entry yet)", () => {
+    const { result } = renderHook(() =>
+      SUBAGENT_DESCRIPTOR.useCardSummary("missing"),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  test("projects a running, no-step subagent's card data", () => {
+    act(() => {
+      seed("sa-1", "running", [], "Find tigers");
+    });
+
+    const { result } = renderHook(() =>
+      SUBAGENT_DESCRIPTOR.useCardSummary("sa-1"),
+    );
+
+    // Mirrors `deriveSubagentCardData` for a running entry with no steps:
+    // state "loading", title "Working", info = label, count "0 steps".
+    expect(result.current).toEqual({
+      state: "loading",
+      title: "Working",
+      info: "Find tigers",
+      count: "0 steps",
+    });
+  });
+
+  test("projects step title/info/count for a subagent mid-tool-call", () => {
+    act(() => {
+      seed("sa-2", "running", [
+        {
+          id: "te-0",
+          type: "tool_call",
+          content: "ls -la",
+          toolName: "bash",
+          toolUseId: "tu-1",
+          timestamp: NOW,
+        },
+      ]);
+    });
+
+    const { result } = renderHook(() =>
+      SUBAGENT_DESCRIPTOR.useCardSummary("sa-2"),
+    );
+
+    expect(result.current).toEqual({
+      state: "loading",
+      title: "Working",
+      info: "ls -la",
+      count: "1 step",
+    });
+  });
+
+  test("projects a terminal (completed) subagent → complete state", () => {
+    act(() => {
+      seed(
+        "sa-3",
+        "completed",
+        [{ id: "te-0", type: "text", content: "Done.", timestamp: NOW }],
+        "Wrap up",
+      );
+    });
+
+    const { result } = renderHook(() =>
+      SUBAGENT_DESCRIPTOR.useCardSummary("sa-3"),
+    );
+
+    expect(result.current).toEqual({
+      state: "complete",
+      title: "Thought",
+      info: "Done.",
+      count: "1 step",
+    });
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
@@ -1,0 +1,96 @@
+/**
+ * The `subagent` {@link BackgroundProcessDescriptor} — the registry entry that
+ * projects the subagent store into the shared inline-card + overlay-pill +
+ * detail-panel surface.
+ *
+ * Behaviour-preserving: every field mirrors what the bespoke subagent surface
+ * already renders (the inline progress card, the active-subagents overlay/pill,
+ * and the subagent detail panel). Nothing consumes this descriptor yet — the
+ * registry + generic surface wiring lands in a later PR.
+ */
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import { SubagentDetailPanel } from "@/domains/chat/components/subagent-detail-panel";
+import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+import type {
+  BackgroundProcessDescriptor,
+  CardSummary,
+} from "@/domains/chat/process-registry/types";
+
+/**
+ * Active subagent ids for the current conversation. The descriptor's
+ * `useActiveIds` contract takes no arguments, so the conversation scoping the
+ * bespoke surface applies (`useActiveSubagentIds(activeConversationId)` in
+ * `chat-route-content`) is resolved here from the conversation store.
+ */
+function useActiveIds(): string[] {
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  return useActiveSubagentIds(activeConversationId);
+}
+
+/**
+ * Project the subagent's `ToolCallCardData` into the shared {@link CardSummary}
+ * shape. Returns `null` in the spawn-race window (no entry yet), preserving the
+ * inline card's short-circuit. The 4-value `ToolCallCardData["state"]` is a
+ * subset of `ToolProgressCardState` (it never emits `warning`/`denied`), so it
+ * passes through unchanged.
+ */
+function useCardSummary(id: string): CardSummary | null {
+  const data = useSubagentCardData(id);
+  if (data === null) return null;
+  return {
+    state: data.state,
+    title: data.currentStepTitle,
+    info: data.currentStepInfo,
+    count: data.stepCount,
+  };
+}
+
+/**
+ * Detail-panel adapter: the shared descriptor renders `DetailPanel` with an
+ * `{ id, onClose }` contract, but `SubagentDetailPanel` reads its `entry` from
+ * the store. Resolve the entry by id here and short-circuit to `null` when it's
+ * absent (spawn race / cleared), matching the inline surface.
+ */
+function SubagentDetailPanelById({
+  id,
+  onClose,
+}: {
+  id: string;
+  onClose: () => void;
+}) {
+  const entry = useSubagentStore((s) => s.byId[id]);
+  if (!entry) return null;
+  return <SubagentDetailPanel entry={entry} onClose={onClose} />;
+}
+
+export const SUBAGENT_DESCRIPTOR: BackgroundProcessDescriptor = {
+  kind: "subagent",
+  useActiveIds,
+  useCardSummary,
+  renderCardLeading: (id) => <SubagentAvatarChip subagentId={id} size={16} />,
+  pill: {
+    variant: "stacked",
+    renderChip: (id) => (
+      <SubagentAvatarChip
+        key={id}
+        subagentId={id}
+        size={16}
+        className="-ml-1 ring-2 ring-[var(--surface-lift)]"
+      />
+    ),
+    max: MAX_VISIBLE_SUBAGENT_AVATARS,
+  },
+  overlayTitle: (n) => `${n} Active Subagent${n === 1 ? "" : "s"}`,
+  pillAriaLabel: () => "Active subagents",
+  openCardAriaLabel: "Open subagent",
+  onOpenDetail: (id) => useViewerStore.getState().openSubagentDetail(id),
+  onStop: (id) => void useSubagentStore.getState().abortSubagent(id),
+  DetailPanel: SubagentDetailPanelById,
+};


### PR DESCRIPTION
## Summary
- Add the subagent BackgroundProcessDescriptor + a useSubagentCardData→CardSummary projection.

Part of plan: background-process-registry.md (PR 5 of 17)