### PR TITLE
feat(web): add WORKFLOW_DESCRIPTOR + CardSummary adapter

### DIFF
--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for {@link WORKFLOW_DESCRIPTOR} — the count-variant background-process
+ * descriptor.
+ *
+ * The `useCardSummary` projection is exercised against the real
+ * `useWorkflowStore` (seeded via `startRun` / `applyProgress`) so the
+ * `WorkflowEntry → CardSummary` mapping is observed exactly as a consumer
+ * would. The remaining assertions pin the static descriptor metadata that the
+ * shared overlay/pill chrome depends on.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+
+afterEach(() => {
+  cleanup();
+  useWorkflowStore.getState().reset();
+});
+
+describe("WORKFLOW_DESCRIPTOR — useCardSummary projection", () => {
+  test("projects a running run into the shared CardSummary shape", () => {
+    // GIVEN a running workflow with a label, live phase, and spawned agents
+    act(() => {
+      const store = useWorkflowStore.getState();
+      store.startRun({ runId: "wf-1", label: "Research", timestamp: 1 });
+      store.applyProgress({
+        runId: "wf-1",
+        agentsSpawned: 3,
+        phase: "Synthesizing",
+      });
+    });
+
+    // WHEN the descriptor's card-summary hook renders
+    const { result } = renderHook(() =>
+      WORKFLOW_DESCRIPTOR.useCardSummary("wf-1"),
+    );
+
+    // THEN the projected summary mirrors the workflow card data
+    expect(result.current).toEqual({
+      state: "loading",
+      title: "Research",
+      info: "Synthesizing",
+      // `stepCount` is a pre-formatted noun string, passed through to `count`.
+      count: "3 agents",
+    });
+  });
+
+  test("singularizes the count noun for a single spawned agent", () => {
+    act(() => {
+      const store = useWorkflowStore.getState();
+      store.startRun({ runId: "wf-solo", label: "Solo", timestamp: 1 });
+      store.applyProgress({ runId: "wf-solo", agentsSpawned: 1 });
+    });
+
+    const { result } = renderHook(() =>
+      WORKFLOW_DESCRIPTOR.useCardSummary("wf-solo"),
+    );
+
+    expect(result.current?.count).toBe("1 agent");
+  });
+
+  test("returns null for an unknown run id", () => {
+    const { result } = renderHook(() =>
+      WORKFLOW_DESCRIPTOR.useCardSummary("missing"),
+    );
+
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("WORKFLOW_DESCRIPTOR — static metadata", () => {
+  test("identifies as the workflow kind", () => {
+    expect(WORKFLOW_DESCRIPTOR.kind).toBe("workflow");
+  });
+
+  test("is the count-variant pill (single glyph, not stacked chips)", () => {
+    expect(WORKFLOW_DESCRIPTOR.pill.variant).toBe("count");
+  });
+
+  test("pluralizes the overlay title by count", () => {
+    expect(WORKFLOW_DESCRIPTOR.overlayTitle(1)).toBe("1 Active Workflow");
+    expect(WORKFLOW_DESCRIPTOR.overlayTitle(3)).toBe("3 Active Workflows");
+  });
+
+  test("pluralizes the pill aria label by count", () => {
+    expect(WORKFLOW_DESCRIPTOR.pillAriaLabel(1)).toBe("1 active workflow");
+    expect(WORKFLOW_DESCRIPTOR.pillAriaLabel(3)).toBe("3 active workflows");
+  });
+
+  test("exposes a stop action", () => {
+    expect(WORKFLOW_DESCRIPTOR.onStop).toBeDefined();
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
@@ -1,0 +1,98 @@
+/**
+ * Background-process descriptor for the **workflow** kind.
+ *
+ * Workflow is the lone count-variant surface: its overlay pill renders a single
+ * static {@link Workflow} glyph next to the active count (see
+ * `active-workflows-pill.tsx`), not a stack of per-process chips. The card,
+ * detail panel, and copy mirror the existing workflow UI exactly — this
+ * descriptor is a behavior-preserving adapter onto the shared
+ * {@link BackgroundProcessDescriptor} contract.
+ */
+
+import { Workflow } from "lucide-react";
+
+import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
+import { useWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
+import type {
+  BackgroundProcessDescriptor,
+  CardSummary,
+} from "@/domains/chat/process-registry/types";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { WorkflowDetailPanel } from "@/domains/chat/components/workflow-detail-panel";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Adapts the `{ id; onClose }` descriptor contract onto
+ * {@link WorkflowDetailPanel}, which keys on a resolved `WorkflowEntry` rather
+ * than a run id. Subscribes to the workflow store entry for `id` and wires the
+ * panel's stop + journal callbacks to the store the same way the existing
+ * chat-content-layout host does (`abortRun` / `fetchJournalIfNeeded`). Renders
+ * `null` until an entry exists, matching the host's `workflowById[id]` guard.
+ */
+function WorkflowDetailPanelAdapter({
+  id,
+  onClose,
+}: {
+  id: string;
+  onClose: () => void;
+}) {
+  const entry = useWorkflowStore((s) => s.byId[id]);
+  if (!entry) return null;
+  return (
+    <WorkflowDetailPanel
+      entry={entry}
+      onClose={onClose}
+      onStop={(runId) => void useWorkflowStore.getState().abortRun(runId)}
+      onRequestJournal={(runId) => {
+        const assistantId =
+          useResolvedAssistantsStore.getState().activeAssistantId;
+        if (!assistantId) return;
+        void useWorkflowStore
+          .getState()
+          .fetchJournalIfNeeded(assistantId, runId);
+      }}
+    />
+  );
+}
+
+/**
+ * Projects a single run's {@link useWorkflowCardData} into the shared
+ * {@link CardSummary} shape. The card data's `stepCount` is already a
+ * pre-formatted noun string (e.g. `"3 agents"`), so it maps directly to
+ * `count`. Passes `null` through when the run has no card-worthy state yet.
+ */
+function useWorkflowCardSummary(id: string): CardSummary | null {
+  const data = useWorkflowCardData(id);
+  if (!data) return null;
+  return {
+    state: data.state,
+    title: data.currentStepTitle,
+    info: data.currentStepInfo,
+    count: data.stepCount,
+  };
+}
+
+export const WORKFLOW_DESCRIPTOR: BackgroundProcessDescriptor = {
+  kind: "workflow",
+  useActiveIds: useActiveWorkflowRunIds,
+  useCardSummary: useWorkflowCardSummary,
+  renderCardLeading: () => (
+    <Workflow className="h-4 w-4 text-[var(--content-secondary)]" aria-hidden />
+  ),
+  pill: {
+    variant: "count",
+    glyph: (
+      <Workflow
+        className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
+        aria-hidden
+      />
+    ),
+  },
+  overlayTitle: (n) => `${n} Active Workflow${n === 1 ? "" : "s"}`,
+  pillAriaLabel: (n) => `${n} active workflow${n === 1 ? "" : "s"}`,
+  openCardAriaLabel: "Open workflow",
+  onOpenDetail: (id) => useViewerStore.getState().openWorkflowDetail(id),
+  onStop: (id) => void useWorkflowStore.getState().abortRun(id),
+  DetailPanel: WorkflowDetailPanelAdapter,
+};


### PR DESCRIPTION
## Summary
- Add the workflow BackgroundProcessDescriptor with the count-variant pill (the outlier) + useWorkflowCardData→CardSummary projection.

Part of plan: background-process-registry.md (PR 7 of 17)