### PR TITLE
feat(web): add ACP_RUN_DESCRIPTOR + CardSummary adapter

### DIFF
--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for `ACP_RUN_DESCRIPTOR` — the registry projection of the ACP-run
+ * surface. Asserts the static descriptor metadata and the `useCardSummary`
+ * field rename, including the `warning` state a cancelled-completed run maps to
+ * (parity with the inline card).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+
+afterEach(() => {
+  cleanup();
+  useAcpRunStore.getState().reset();
+});
+
+/** Spawn an active ("running") run, then optionally settle it terminal. */
+function seedRun(acpSessionId: string) {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId,
+    agent: "claude",
+    parentConversationId: "conv-1",
+    startedAt: 0,
+  });
+}
+
+describe("ACP_RUN_DESCRIPTOR — static metadata", () => {
+  test("kind discriminates as acp-run", () => {
+    expect(ACP_RUN_DESCRIPTOR.kind).toBe("acp-run");
+  });
+
+  test("overlayTitle pluralizes on count", () => {
+    expect(ACP_RUN_DESCRIPTOR.overlayTitle(1)).toBe("1 Active Run");
+    expect(ACP_RUN_DESCRIPTOR.overlayTitle(3)).toBe("3 Active Runs");
+  });
+
+  test("pill is stacked with the agent-mark cap", () => {
+    expect(ACP_RUN_DESCRIPTOR.pill.variant).toBe("stacked");
+    if (ACP_RUN_DESCRIPTOR.pill.variant === "stacked") {
+      expect(ACP_RUN_DESCRIPTOR.pill.max).toBe(6);
+    }
+  });
+
+  test("aria copy", () => {
+    expect(ACP_RUN_DESCRIPTOR.openCardAriaLabel).toBe("Open run");
+    expect(ACP_RUN_DESCRIPTOR.pillAriaLabel(3)).toBe("Active runs");
+  });
+
+  test("exposes a stop action", () => {
+    expect(typeof ACP_RUN_DESCRIPTOR.onStop).toBe("function");
+  });
+});
+
+describe("ACP_RUN_DESCRIPTOR — useCardSummary", () => {
+  test("renames the card-data fields", () => {
+    act(() => {
+      seedRun("run-1");
+    });
+
+    const { result } = renderHook(() =>
+      ACP_RUN_DESCRIPTOR.useCardSummary("run-1"),
+    );
+
+    // A freshly-spawned (running) run is `loading` with the default title.
+    expect(result.current).toEqual({
+      state: "loading",
+      title: "Working",
+      info: "",
+      count: "0 steps",
+    });
+  });
+
+  test("returns null for an unknown run (spawn race)", () => {
+    const { result } = renderHook(() =>
+      ACP_RUN_DESCRIPTOR.useCardSummary("missing"),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  test("a cancelled-completed run maps to the warning state", () => {
+    act(() => {
+      seedRun("run-1");
+      // A `completed` run whose stop reason is `cancelled` reads as partial
+      // work — `warning` — not `complete`.
+      useAcpRunStore.getState().setTerminal({
+        acpSessionId: "run-1",
+        status: "completed",
+        stopReason: "cancelled",
+        completedAt: 1,
+      });
+    });
+
+    const { result } = renderHook(() =>
+      ACP_RUN_DESCRIPTOR.useCardSummary("run-1"),
+    );
+
+    expect(result.current?.state).toBe("warning");
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
@@ -1,0 +1,115 @@
+/**
+ * `BackgroundProcessDescriptor` for ACP runs — the registry projection of the
+ * existing acp-run inline-card / detail-panel / overlay-pill surface.
+ *
+ * Behavior-preserving: every axis maps onto a symbol the current ACP UI
+ * already uses, so the generic registry renders the same agent-glyph leading
+ * mark, the same stacked `AcpAgentChip` pill, and the same `warning` state for
+ * a cancelled-completed run.
+ */
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { AcpAgentIcon } from "@/domains/chat/components/acp-run-inline-card/acp-agent-icon";
+import { useAcpRunCardData } from "@/domains/chat/components/acp-run-inline-card/use-acp-run-card-data";
+import { AcpRunDetailPanel } from "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel";
+import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
+import type {
+  BackgroundProcessDescriptor,
+  CardSummary,
+} from "@/domains/chat/process-registry/types";
+import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+// Visible agent-mark cap before the "+N" overflow. Mirrors the literal in
+// `active-acp-runs-pill.tsx` (and the subagents pill) so the registry pill caps
+// at the same count as the surface it generalizes.
+const MAX_VISIBLE_ACP_AGENTS = 6;
+
+/**
+ * No-arg active-id hook for the descriptor. `useActiveAcpRunIds` is scoped to a
+ * conversation (the store is global across conversations), so resolve the
+ * currently-selected conversation reactively here and feed it in — the
+ * descriptor contract is `() => Id[]`, with no place to thread an argument.
+ */
+function useActiveIds(): string[] {
+  const conversationId = useConversationStore.use.activeConversationId();
+  return useActiveAcpRunIds(conversationId);
+}
+
+/**
+ * Project the ACP run's card data into the shared {@link CardSummary} shape.
+ * `useAcpRunCardData` already emits the `ToolProgressCardState` (including
+ * `warning` for a cancelled-completed run); this only renames its fields.
+ */
+function useCardSummary(id: string): CardSummary | null {
+  const data = useAcpRunCardData(id);
+  if (!data) return null;
+  return {
+    state: data.state,
+    title: data.currentStepTitle,
+    info: data.currentStepInfo,
+    count: data.stepCount,
+  };
+}
+
+/**
+ * Leading glyph for the inline card — the run's backing agent brand mark.
+ * Subscribes reactively to the run's `agent` (no `getState()`) so the glyph
+ * updates if the agent string changes mid-run.
+ */
+function AcpRunCardLeading({ id }: { id: string }) {
+  const agent = useAcpRunStore((s) => s.byId[id]?.agent);
+  return <AcpAgentIcon agent={agent} />;
+}
+
+/**
+ * One stacked brand mark for the overlay pill, keyed off the run's backing
+ * agent. Owns its own stacking offset via `:not(:first-child)` so the generic
+ * `StackedChipsPill` (which maps over ids without an index) reproduces the
+ * overlapping-marks layout of the original `ActiveAcpRunsPill` chip exactly.
+ */
+function AcpAgentChip({ id }: { id: string }) {
+  const agent = useAcpRunStore((s) => s.byId[id]?.agent);
+  return (
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-[var(--surface-base)] [&:not(:first-child)]:-ml-1 [&:not(:first-child)]:ring-2 [&:not(:first-child)]:ring-[var(--surface-lift)]">
+      <AcpAgentIcon agent={agent} className="h-3 w-3" />
+    </span>
+  );
+}
+
+/**
+ * Adapter to the descriptor's `{ id; onClose }` detail-panel contract.
+ * `AcpRunDetailPanel` takes the full store entry, so resolve it by id here and
+ * short-circuit to `null` for an unknown run (the entry is gone / not yet
+ * spawned).
+ */
+function AcpRunDetailPanelById({
+  id,
+  onClose,
+}: {
+  id: string;
+  onClose: () => void;
+}) {
+  const entry = useAcpRunStore((s) => s.byId[id]);
+  if (!entry) return null;
+  return <AcpRunDetailPanel entry={entry} onClose={onClose} />;
+}
+
+export const ACP_RUN_DESCRIPTOR: BackgroundProcessDescriptor = {
+  kind: "acp-run",
+  useActiveIds,
+  useCardSummary,
+  renderCardLeading: (id) => <AcpRunCardLeading id={id} />,
+  pill: {
+    variant: "stacked",
+    renderChip: (id) => <AcpAgentChip key={id} id={id} />,
+    max: MAX_VISIBLE_ACP_AGENTS,
+  },
+  overlayTitle: (n) => `${n} Active Run${n === 1 ? "" : "s"}`,
+  pillAriaLabel: () => "Active runs",
+  openCardAriaLabel: "Open run",
+  onOpenDetail: (id) => useViewerStore.getState().openAcpRunDetail(id),
+  onStop: (id) => void stopAcpRun(id),
+  DetailPanel: AcpRunDetailPanelById,
+};


### PR DESCRIPTION
## Summary
- Add the acp-run BackgroundProcessDescriptor (agent-glyph leading, stacked AcpAgentChip pill) + useAcpRunCardData→CardSummary rename.

Part of plan: background-process-registry.md (PR 6 of 17)