### PR TITLE
feat(web): add BACKGROUND_TASK_DESCRIPTOR + CardSummary adapter

### DIFF
--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.test.ts
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for `BACKGROUND_TASK_DESCRIPTOR` — the count-less background-process
+ * descriptor for bash / host_bash tasks.
+ *
+ * Drives the real background-task store and asserts:
+ *  - `useCardSummary` projects a seeded entry into `{ state, title, info }`
+ *    with NO `count` (the defining trait of this kind), and passes `null`
+ *    through when the entry is missing (the start race).
+ *  - the static metadata (kind, pill variant, overlay/aria copy) matches the
+ *    existing background-task overlay surface.
+ *
+ * `background-task-actions` is mocked so importing the descriptor (which wires
+ * `onStop` to `stopBackgroundTask`) doesn't pull in the daemon SDK.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+mock.module("@/domains/chat/utils/background-task-actions", () => ({
+  stopBackgroundTask: async () => {},
+}));
+
+import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+
+const NOW = 1700000000000;
+
+function start(id: string, command = "ls -la"): void {
+  useBackgroundTaskStore.getState().startTask({
+    type: "background_tool_started",
+    id,
+    toolName: "bash",
+    conversationId: "conv-1",
+    command,
+    startedAt: NOW,
+  });
+}
+
+beforeEach(() => {
+  useBackgroundTaskStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BACKGROUND_TASK_DESCRIPTOR — useCardSummary", () => {
+  test("projects a running task into a count-less CardSummary", () => {
+    start("bg-1", "npm run build");
+
+    const { result } = renderHook(() =>
+      BACKGROUND_TASK_DESCRIPTOR.useCardSummary("bg-1"),
+    );
+
+    expect(result.current).toEqual({
+      state: "loading",
+      title: "Running command",
+      info: "npm run build",
+    });
+    // The defining trait of this kind: no unit count.
+    expect(result.current?.count).toBeUndefined();
+  });
+
+  test("passes null through when no entry exists yet (start race)", () => {
+    const { result } = renderHook(() =>
+      BACKGROUND_TASK_DESCRIPTOR.useCardSummary("missing"),
+    );
+
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("BACKGROUND_TASK_DESCRIPTOR — metadata", () => {
+  test("is the background-task kind", () => {
+    expect(BACKGROUND_TASK_DESCRIPTOR.kind).toBe("background-task");
+  });
+
+  test("uses a stacked pill (terminal glyphs, no count chip)", () => {
+    expect(BACKGROUND_TASK_DESCRIPTOR.pill.variant).toBe("stacked");
+  });
+
+  test("formats the overlay title with command pluralization", () => {
+    expect(BACKGROUND_TASK_DESCRIPTOR.overlayTitle(1)).toBe("1 Active Command");
+    expect(BACKGROUND_TASK_DESCRIPTOR.overlayTitle(3)).toBe(
+      "3 Active Commands",
+    );
+  });
+
+  test("exposes the active-commands aria labels", () => {
+    expect(BACKGROUND_TASK_DESCRIPTOR.pillAriaLabel(2)).toBe("Active commands");
+    expect(BACKGROUND_TASK_DESCRIPTOR.openCardAriaLabel).toBe("Open command");
+  });
+
+  test("supports stopping a task", () => {
+    expect(typeof BACKGROUND_TASK_DESCRIPTOR.onStop).toBe("function");
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
@@ -1,0 +1,116 @@
+/**
+ * Background-process descriptor for bash / host_bash background tasks.
+ *
+ * This is the count-less kind: unlike subagents ("3 agents") or workflows
+ * ("5 steps"), a background task has no meaningful unit count, so its
+ * {@link CardSummary} omits `count` and the inline card leads with a
+ * tool-keyed terminal glyph (`bash` → square-terminal, `host_bash` →
+ * file-terminal) instead of an avatar.
+ *
+ * Behavior-preserving: every projection here mirrors the existing
+ * `useBackgroundTaskCardData`, `ActiveBackgroundTasksPill`, and
+ * `BackgroundTaskDetailPanel` surfaces — see the per-field notes below.
+ */
+
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import { BackgroundTaskGlyph } from "@/domains/chat/components/background-task-glyph";
+import { BackgroundTaskDetailPanel } from "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel";
+import { useBackgroundTaskCardData } from "@/domains/chat/components/background-task-inline-card/use-background-task-card-data";
+import { useActiveBackgroundTaskIds } from "@/domains/chat/hooks/use-active-background-task-ids";
+import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
+import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Cap on stacked terminal glyphs before the overlay pill collapses the
+ * remainder to "+N". Mirrors the local cap in `ActiveBackgroundTasksPill`,
+ * which is file-private there.
+ */
+const MAX_VISIBLE_BACKGROUND_TASK_GLYPHS = 6;
+
+/**
+ * Active background-task ids for the currently-selected conversation.
+ *
+ * The descriptor contract's `useActiveIds` is zero-arg, but
+ * `useActiveBackgroundTaskIds` is conversation-scoped (the store is global
+ * across conversations). Bind it to the active conversation id here so the
+ * registry sees only the tasks for the conversation on screen — exactly what
+ * `ChatRouteContent` does today.
+ */
+function useActiveIds(): string[] {
+  const conversationId = useConversationStore((s) => s.activeConversationId);
+  return useActiveBackgroundTaskIds(conversationId);
+}
+
+/**
+ * Leading slot of the inline card: a tool-keyed terminal glyph. Subscribes
+ * reactively to just this task's `toolName` so the glyph swaps if the entry
+ * lands after the card mounts (the start race). Falls back to `bash` when the
+ * entry isn't present yet, matching the overlay pill's fallback.
+ */
+function BackgroundTaskCardLeading({ id }: { id: string }) {
+  const toolName = useBackgroundTaskStore((s) => s.byId[id]?.toolName);
+  return <BackgroundTaskGlyph toolName={toolName ?? "bash"} />;
+}
+
+/**
+ * One stacked chip for the overlay pill. The chip owns its own stacking offset
+ * (`-ml-1 ring-2` for every chip past the first) since `StackedChipsPill`
+ * passes only `id`, not an index — mirroring the original pill's per-glyph
+ * offset.
+ */
+function BackgroundTaskChip({ id }: { id: string }) {
+  const toolName = useBackgroundTaskStore((s) => s.byId[id]?.toolName);
+  return (
+    <span className="flex h-4 w-4 items-center justify-center rounded bg-[var(--surface-lift)] [&:not(:first-child)]:-ml-1 [&:not(:first-child)]:ring-2 [&:not(:first-child)]:ring-[var(--surface-lift)]">
+      <BackgroundTaskGlyph
+        toolName={toolName ?? "bash"}
+        className="h-3.5 w-3.5 text-[var(--content-emphasised)]"
+      />
+    </span>
+  );
+}
+
+/**
+ * Adapter from the registry's `{ id; onClose }` detail-panel contract to
+ * `BackgroundTaskDetailPanel`'s `{ entry; onClose }` shape. Resolves the live
+ * store entry by id; renders `null` when no entry exists (e.g. the panel was
+ * opened for a task that has since been cleared), matching how the existing
+ * call sites guard on the resolved entry being present.
+ */
+function BackgroundTaskDetailPanelAdapter({
+  id,
+  onClose,
+}: {
+  id: string;
+  onClose: () => void;
+}) {
+  const entry = useBackgroundTaskStore((s) => s.byId[id]);
+  if (!entry) return null;
+  return <BackgroundTaskDetailPanel entry={entry} onClose={onClose} />;
+}
+
+export const BACKGROUND_TASK_DESCRIPTOR: BackgroundProcessDescriptor = {
+  kind: "background-task",
+  useActiveIds,
+  useCardSummary: (id) => {
+    const data = useBackgroundTaskCardData(id);
+    if (!data) return null;
+    // No `count`: a background task has no meaningful unit count. `toolName`
+    // drives `renderCardLeading`, not the summary.
+    return { state: data.state, title: data.title, info: data.info };
+  },
+  renderCardLeading: (id) => <BackgroundTaskCardLeading id={id} />,
+  pill: {
+    variant: "stacked",
+    renderChip: (id) => <BackgroundTaskChip key={id} id={id} />,
+    max: MAX_VISIBLE_BACKGROUND_TASK_GLYPHS,
+  },
+  overlayTitle: (count) => `${count} Active Command${count === 1 ? "" : "s"}`,
+  pillAriaLabel: () => "Active commands",
+  openCardAriaLabel: "Open command",
+  onOpenDetail: (id) => useViewerStore.getState().openBackgroundTaskDetail(id),
+  onStop: (id) => void stopBackgroundTask(id),
+  DetailPanel: BackgroundTaskDetailPanelAdapter,
+};


### PR DESCRIPTION
## Summary
- Add the background-task BackgroundProcessDescriptor (terminal-glyph leading, no count) + useBackgroundTaskCardData→CardSummary projection.

Part of plan: background-process-registry.md (PR 8 of 17)