### PR TITLE
refactor(bg-task): consolidate backgroundToolCompletion shape + validate status

### DIFF
--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -404,6 +404,7 @@ export {
   DictationRequestSchema,
 } from "./requests/dictation.js";
 export {
+  type BackgroundToolCompletion,
   type ConversationAttachmentBlock,
   ConversationAttachmentBlockSchema,
   type ConversationContentBlock,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -134,6 +134,18 @@ const acpNotificationSchema = z.object({
   agent: z.string().optional(),
 });
 
+const backgroundToolCompletionMetadataSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+  status: z.enum(["completed", "failed", "cancelled"]),
+  exitCode: z.number().nullable(),
+  output: z.string(),
+  completedAt: z.number(),
+});
+
 export const messageMetadataSchema = z
   .object({
     userMessageChannel: channelIdSchema.optional(),
@@ -170,19 +182,7 @@ export const messageMetadataSchema = z
      * source="background-tool">` wake so the web can rebuild the inline
      * bash/host_bash card from history after a daemon restart.
      */
-    backgroundToolCompletion: z
-      .object({
-        id: z.string(),
-        toolName: z.string(),
-        conversationId: z.string(),
-        command: z.string(),
-        startedAt: z.number(),
-        status: z.enum(["completed", "failed", "cancelled"]),
-        exitCode: z.number().nullable(),
-        output: z.string(),
-        completedAt: z.number(),
-      })
-      .optional(),
+    backgroundToolCompletion: backgroundToolCompletionMetadataSchema.optional(),
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -11,6 +11,7 @@ import {
   createUserMessage,
 } from "../../agent/message-types.js";
 import {
+  BackgroundToolCompletionSchema,
   type ConversationContentBlock,
   type ConversationMessage,
   ConversationMessageSchema,
@@ -857,25 +858,11 @@ export function handleListMessages({
         // `persistWakeTriggerMessage` stamps the structured completion onto the
         // same wake row, letting the web rebuild a terminal inline card from
         // history after a restart (the in-memory completed ring does not survive).
-        const c = meta.backgroundToolCompletion as
-          | Record<string, unknown>
-          | undefined;
-        if (
-          c &&
-          typeof c.id === "string" &&
-          typeof c.completedAt === "number"
-        ) {
-          backgroundToolCompletion = {
-            id: c.id,
-            toolName: String(c.toolName ?? ""),
-            conversationId: String(c.conversationId ?? ""),
-            command: String(c.command ?? ""),
-            startedAt: Number(c.startedAt ?? 0),
-            status: c.status as "completed" | "failed" | "cancelled",
-            exitCode: (c.exitCode ?? null) as number | null,
-            output: String(c.output ?? ""),
-            completedAt: c.completedAt,
-          };
+        const completionParse = BackgroundToolCompletionSchema.safeParse(
+          meta.backgroundToolCompletion,
+        );
+        if (completionParse.success) {
+          backgroundToolCompletion = completionParse.data;
         }
         if (meta.subagentNotification) {
           const n = meta.subagentNotification;

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -9,6 +9,7 @@
 
 import { captureError } from "@/lib/sentry/capture-error";
 import type {
+  BackgroundToolCompletion,
   ConversationContentBlock,
   ConversationMessage,
   ConversationMessageToolCall,
@@ -65,7 +66,7 @@ export interface RuntimeSubagentNotification extends ConversationSubagentNotific
  * `bg-…` id, so the seeded entry's id must equal the completion's id.
  */
 export function toBackgroundTaskEntryFromCompletion(
-  c: NonNullable<ConversationMessage["backgroundToolCompletion"]>,
+  c: BackgroundToolCompletion,
 ): BackgroundTaskEntry {
   return {
     id: c.id,

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -135,6 +135,10 @@ function mergeHistoryEntry(
   existing: BackgroundTaskEntry,
   incoming: BackgroundTaskEntry,
 ): BackgroundTaskEntry {
+  // When both are terminal, the history-seeded status overwrites the existing
+  // one (unlike completeTask, which keeps an optimistic "cancelled" over a
+  // daemon "failed"); safe because the daemon persists "cancelled" for
+  // user-aborted runs, so history agrees.
   const status =
     isActiveBackgroundTaskStatus(existing.status) ||
     !isActiveBackgroundTaskStatus(incoming.status)


### PR DESCRIPTION
## Summary
Self-review cleanups for the durable bg-card feature:
- History projection now safeParses backgroundToolCompletion via the shared schema (validates the status enum; consumes the previously-dead exported type).
- Persistence inline metadata schema extracted to a named const (matches subagent/acp siblings).
- One-line comment on mergeHistoryEntry's terminal-overwrite behavior.

Fixes gaps identified during plan self-review for bg-card-survive-restart.md.