### PR TITLE
Durable background-task cards: rehydrate completed bash/host_bash runs from history

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17760,6 +17760,44 @@ paths:
                           additionalProperties: false
                         backgroundToolNotification:
                           type: boolean
+                        backgroundToolCompletion:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            toolName:
+                              type: string
+                            conversationId:
+                              type: string
+                            command:
+                              type: string
+                            startedAt:
+                              type: number
+                            status:
+                              type: string
+                              enum:
+                                - completed
+                                - failed
+                                - cancelled
+                            exitCode:
+                              anyOf:
+                                - type: number
+                                - type: "null"
+                            output:
+                              type: string
+                            completedAt:
+                              type: number
+                          required:
+                            - id
+                            - toolName
+                            - conversationId
+                            - command
+                            - startedAt
+                            - status
+                            - exitCode
+                            - output
+                            - completedAt
+                          additionalProperties: false
                         slackMessage:
                           type: object
                           properties:

--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -189,6 +189,10 @@ describe("bash tool background mode", () => {
     // Command stdout is fenced as untrusted output, not inlined in the hint.
     expect(wakeCall.untrustedOutput?.content).toContain("bg_output_12345");
     expect(wakeCall.untrustedOutput?.source).toBe("tool_result");
+    // Durable completion record stamped onto the persisted wake.
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("completed");
+    expect(wakeCall.backgroundToolCompletion?.exitCode).toBe(0);
   });
 
   test("failing background process delivers an error hint via wake", async () => {
@@ -210,6 +214,9 @@ describe("bash tool background mode", () => {
     expect(wakeCall.hint).toContain("bg-test1234");
     // The command fails with exit code 1, so the hint should reflect failure
     expect(wakeCall.hint).toContain("exit=1");
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("failed");
+    expect(wakeCall.backgroundToolCompletion?.exitCode).toBe(1);
   });
 
   test("cancelled background process wakes with the cancellation, not a completed result", async () => {
@@ -234,6 +241,8 @@ describe("bash tool background mode", () => {
     expect(wakeCall.hint).toContain("cancelled");
     expect(wakeCall.hint).not.toContain("completed");
     expect(wakeCall.untrustedOutput?.content).toContain("cancelled");
+    expect(wakeCall.backgroundToolCompletion?.id).toBe("bg-test1234");
+    expect(wakeCall.backgroundToolCompletion?.status).toBe("cancelled");
   });
 
   test("foreground mode still works when background is not set", async () => {

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -118,6 +118,7 @@ mock.module("../daemon/host-bash-proxy.js", () => ({
 // Import under test — MUST come after mock.module calls.
 // ---------------------------------------------------------------------------
 
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { hostShellTool } from "../tools/host-terminal/host-shell.js";
 import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 
@@ -258,6 +259,11 @@ describe("host_bash background mode — proxy path", () => {
       maxChars: 40_000,
     });
     expect(wakeCall.source).toBe("background-tool");
+    const completion =
+      wakeCall.backgroundToolCompletion as CompletedBackgroundTool;
+    expect(completion.id).toBe("bg-test-0001");
+    expect(completion.status).toBe("completed");
+    expect(completion.exitCode).toBeNull();
   });
 
   test("calls wakeAgentForOpportunity on proxy error result", async () => {
@@ -398,6 +404,11 @@ describe("host_bash background mode — direct execution path", () => {
     expect((wakeCall.untrustedOutput as { content: string }).content).toContain(
       "hello world",
     );
+    const completion =
+      wakeCall.backgroundToolCompletion as CompletedBackgroundTool;
+    expect(completion.id).toBe("bg-test-0001");
+    expect(completion.status).toBe("completed");
+    expect(completion.exitCode).toBe(0);
   });
 
   test("calls wakeAgentForOpportunity with error hint on non-zero exit", async () => {

--- a/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
+++ b/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for handleListMessages background-tool completion projection.
+ *
+ * A backgrounded bash/host_bash run posts a `<background_event
+ * source="background-tool">` wake on completion, stamped with
+ * `metadata.backgroundToolCompletion`. The history projection must surface
+ * that structured record (and the `backgroundToolNotification` flag) so the
+ * web can rebuild a terminal inline card after a daemon restart.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import { ConversationMessageSchema } from "../api/responses/conversation-message.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+interface ProjectedMessage {
+  role: string;
+  backgroundToolNotification?: boolean;
+  backgroundToolCompletion?: Record<string, unknown>;
+}
+
+describe("handleListMessages background-tool completion projection", () => {
+  beforeEach(resetTables);
+
+  test("projects backgroundToolCompletion from the wake row metadata", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "run a long command" }]),
+    );
+
+    const completion = {
+      id: "bg-1",
+      toolName: "bash",
+      conversationId: conv.id,
+      command: "sleep 5 && echo done",
+      startedAt: 1000,
+      status: "completed" as const,
+      exitCode: 0,
+      output: "done\n",
+      completedAt: 2000,
+    };
+    // Mirror persistWakeTriggerMessage: a user-role
+    // `<background_event source="background-tool">` row carrying the structured
+    // completion. Not flagged `hidden`; the client suppresses it from the
+    // transcript via `backgroundToolNotification`.
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        {
+          type: "text",
+          text: '<background_event source="background-tool">Background command completed (id=bg-1, exit=0):</background_event>',
+        },
+      ]),
+      {
+        metadata: {
+          kind: "background-event",
+          backgroundEventSource: "background-tool",
+          automated: true,
+          backgroundToolCompletion: completion,
+        },
+      },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    // Every projected message validates against the wire schema.
+    for (const message of response.messages) {
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+
+    const wakeRow = response.messages.find(
+      (m) => m.backgroundToolCompletion !== undefined,
+    );
+    expect(wakeRow).toBeDefined();
+    expect(wakeRow?.backgroundToolNotification).toBe(true);
+    expect(wakeRow?.backgroundToolCompletion).toEqual(completion);
+  });
+
+  test("omits backgroundToolCompletion when the row carries no completion metadata", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "hello" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "hi there" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    expect(response.messages).toHaveLength(2);
+    for (const message of response.messages) {
+      expect(message.backgroundToolCompletion).toBeUndefined();
+      expect(message.backgroundToolNotification).toBeUndefined();
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+  });
+});

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -404,6 +404,7 @@ export {
   DictationRequestSchema,
 } from "./requests/dictation.js";
 export {
+  type BackgroundToolCompletion,
   type ConversationAttachmentBlock,
   ConversationAttachmentBlockSchema,
   type ConversationContentBlock,

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -297,6 +297,29 @@ export type ConversationAcpNotification = z.infer<
 >;
 
 // ---------------------------------------------------------------------------
+// Background-tool completion
+// ---------------------------------------------------------------------------
+
+/** Structured terminal record of a backgrounded bash/host_bash run, carrying
+ *  everything a web `BackgroundTaskEntry` needs to rebuild a completed inline
+ *  card from history. Mirrors the `background_tool_completed` SSE event plus
+ *  the registry fields (`toolName`, `command`, `startedAt`). */
+export const BackgroundToolCompletionSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+  status: z.enum(["completed", "failed", "cancelled"]),
+  exitCode: z.number().nullable(),
+  output: z.string(),
+  completedAt: z.number(),
+});
+export type BackgroundToolCompletion = z.infer<
+  typeof BackgroundToolCompletionSchema
+>;
+
+// ---------------------------------------------------------------------------
 // Slack message envelope
 // ---------------------------------------------------------------------------
 
@@ -549,6 +572,12 @@ export const ConversationMessageSchema = z.object({
    *  notifications, the row stays in state (the LLM reads it) but is filtered
    *  from the rendered transcript — the inline card carries the status. */
   backgroundToolNotification: z.boolean().optional(),
+  /** Structured completion of a backgrounded bash/host_bash run, stamped on the
+   *  same persisted background-event wake row as `backgroundToolNotification`.
+   *  Lets the web reconstruct a terminal inline card after a daemon restart
+   *  (the in-memory completed ring does not survive restarts). `id` equals the
+   *  spawning tool call's `{backgrounded,id}` id. */
+  backgroundToolCompletion: BackgroundToolCompletionSchema.optional(),
   slackMessage: ConversationSlackMessageSchema.optional(),
   /**
    * Queue state for a user message that is still waiting in the daemon's

--- a/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
+++ b/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// persistWakeTriggerMessage syncs each row to the disk view and publishes a
+// sync invalidation; stub both so this unit test stays a pure DB round-trip
+// without touching the filesystem or the event hub.
+mock.module("../../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+mock.module("../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
+}));
+
+import {
+  createConversation,
+  getMessages,
+} from "../../persistence/conversation-crud.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import type { Message } from "../../providers/types.js";
+import type { CompletedBackgroundTool } from "../../tools/background-tool-registry.js";
+import type { Conversation } from "../conversation.js";
+import { persistWakeTriggerMessage } from "../wake-conversation-ops.js";
+
+await initializeDb();
+
+/** Minimal Conversation stub exercising only the fields the function reads. */
+function makeConversationStub(conversationId: string): Conversation {
+  return {
+    conversationId,
+    trustContext: undefined,
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+  } as unknown as Conversation;
+}
+
+function triggerMessage(): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: '<background_event source="background-tool">Background command completed (id=bg-1, exit=0):</background_event>',
+      },
+    ],
+  };
+}
+
+function readMetadata(conversationId: string): Record<string, unknown> {
+  const rows = getMessages(conversationId);
+  expect(rows.length).toBe(1);
+  const raw = rows[0]?.metadata;
+  expect(raw).toBeTruthy();
+  return JSON.parse(raw as string) as Record<string, unknown>;
+}
+
+describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
+  let conversationId: string;
+
+  beforeEach(() => {
+    conversationId = createConversation("wake-completion-test").id;
+  });
+
+  test("round-trips a completion onto the persisted metadata", async () => {
+    const completion: CompletedBackgroundTool = {
+      id: "bg-1",
+      toolName: "bash",
+      conversationId,
+      command: "sleep 1 && echo done",
+      startedAt: 1_700_000_000_000,
+      status: "completed",
+      exitCode: 0,
+      output: "done\n",
+      completedAt: 1_700_000_001_000,
+    };
+
+    await persistWakeTriggerMessage(
+      makeConversationStub(conversationId),
+      triggerMessage(),
+      "background-tool",
+      completion,
+    );
+
+    const metadata = readMetadata(conversationId);
+    expect(metadata.backgroundToolCompletion).toEqual(completion);
+    // Existing wake-trigger metadata is unaffected.
+    expect(metadata.kind).toBe("background-event");
+    expect(metadata.backgroundEventSource).toBe("background-tool");
+    expect(metadata.automated).toBe(true);
+  });
+
+  test("omits the key entirely when no completion is passed", async () => {
+    await persistWakeTriggerMessage(
+      makeConversationStub(conversationId),
+      triggerMessage(),
+      "background-tool",
+    );
+
+    const metadata = readMetadata(conversationId);
+    expect("backgroundToolCompletion" in metadata).toBe(false);
+    expect(metadata.kind).toBe("background-event");
+  });
+});

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -23,6 +23,7 @@ import { backfillMessageIdOnLogs } from "../persistence/llm-request-log-store.js
 import type { Message } from "../providers/types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import type { ServerMessage } from "./message-protocol.js";
@@ -273,6 +274,7 @@ export async function persistWakeTriggerMessage(
   conversation: Conversation,
   message: Message,
   source: string,
+  completion?: CompletedBackgroundTool,
 ): Promise<void> {
   const turnChannelCtx = conversation.getTurnChannelContext();
   const turnInterfaceCtx = conversation.getTurnInterfaceContext();
@@ -287,6 +289,7 @@ export async function persistWakeTriggerMessage(
     kind: "background-event",
     backgroundEventSource: source,
     automated: true,
+    ...(completion ? { backgroundToolCompletion: completion } : {}),
   };
   const persisted = await addMessage(
     conversation.conversationId,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -134,6 +134,18 @@ const acpNotificationSchema = z.object({
   agent: z.string().optional(),
 });
 
+const backgroundToolCompletionMetadataSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+  status: z.enum(["completed", "failed", "cancelled"]),
+  exitCode: z.number().nullable(),
+  output: z.string(),
+  completedAt: z.number(),
+});
+
 export const messageMetadataSchema = z
   .object({
     userMessageChannel: channelIdSchema.optional(),
@@ -170,19 +182,7 @@ export const messageMetadataSchema = z
      * source="background-tool">` wake so the web can rebuild the inline
      * bash/host_bash card from history after a daemon restart.
      */
-    backgroundToolCompletion: z
-      .object({
-        id: z.string(),
-        toolName: z.string(),
-        conversationId: z.string(),
-        command: z.string(),
-        startedAt: z.number(),
-        status: z.enum(["completed", "failed", "cancelled"]),
-        exitCode: z.number().nullable(),
-        output: z.string(),
-        completedAt: z.number(),
-      })
-      .optional(),
+    backgroundToolCompletion: backgroundToolCompletionMetadataSchema.optional(),
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -165,6 +165,24 @@ export const messageMetadataSchema = z
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
     automated: z.boolean().optional(),
+    /**
+     * Structured terminal record stamped onto a `<background_event
+     * source="background-tool">` wake so the web can rebuild the inline
+     * bash/host_bash card from history after a daemon restart.
+     */
+    backgroundToolCompletion: z
+      .object({
+        id: z.string(),
+        toolName: z.string(),
+        conversationId: z.string(),
+        command: z.string(),
+        startedAt: z.number(),
+        status: z.enum(["completed", "failed", "cancelled"]),
+        exitCode: z.number().nullable(),
+        output: z.string(),
+        completedAt: z.number(),
+      })
+      .optional(),
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -108,6 +108,7 @@ import {
   type UntrustedContentSource,
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
+import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");
@@ -323,6 +324,12 @@ export interface WakeOptions {
    * framing outside the fence.
    */
   untrustedOutput?: WakeUntrustedOutput;
+  /**
+   * Structured terminal record for a backgrounded bash/host_bash run, stamped
+   * onto the persisted background-event wake so the web can rebuild the inline
+   * card from history after a daemon restart.
+   */
+  backgroundToolCompletion?: CompletedBackgroundTool;
   /**
    * Schedule-run id to stamp on the usage rows this wake records. Set when the
    * wake is triggered by a script-mode schedule (the firing's run id), so the
@@ -784,7 +791,12 @@ export async function wakeAgentForOpportunity(
       };
       conversation.messages.push(triggerMessage);
       try {
-        await persistWakeTriggerMessage(conversation, triggerMessage, source);
+        await persistWakeTriggerMessage(
+          conversation,
+          triggerMessage,
+          source,
+          opts.backgroundToolCompletion,
+        );
       } catch (err) {
         log.warn(
           { conversationId, source, err },

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,6 +12,7 @@ import {
 } from "../../agent/message-types.js";
 import {
   type ConversationContentBlock,
+  type ConversationMessage,
   ConversationMessageSchema,
 } from "../../api/responses/conversation-message.js";
 import {
@@ -840,6 +841,7 @@ export function handleListMessages({
       | undefined;
     let acpNotification: { acpSessionId: string; agent?: string } | undefined;
     let backgroundToolNotification: boolean | undefined;
+    let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
@@ -851,6 +853,29 @@ export function handleListMessages({
         // the status.
         if (meta.backgroundEventSource === "background-tool") {
           backgroundToolNotification = true;
+        }
+        // `persistWakeTriggerMessage` stamps the structured completion onto the
+        // same wake row, letting the web rebuild a terminal inline card from
+        // history after a restart (the in-memory completed ring does not survive).
+        const c = meta.backgroundToolCompletion as
+          | Record<string, unknown>
+          | undefined;
+        if (
+          c &&
+          typeof c.id === "string" &&
+          typeof c.completedAt === "number"
+        ) {
+          backgroundToolCompletion = {
+            id: c.id,
+            toolName: String(c.toolName ?? ""),
+            conversationId: String(c.conversationId ?? ""),
+            command: String(c.command ?? ""),
+            startedAt: Number(c.startedAt ?? 0),
+            status: c.status as "completed" | "failed" | "cancelled",
+            exitCode: (c.exitCode ?? null) as number | null,
+            output: String(c.output ?? ""),
+            completedAt: c.completedAt,
+          };
         }
         if (meta.subagentNotification) {
           const n = meta.subagentNotification;
@@ -905,6 +930,7 @@ export function handleListMessages({
       subagentNotification,
       acpNotification,
       backgroundToolNotification,
+      backgroundToolCompletion,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
     };
@@ -1091,6 +1117,9 @@ export function handleListMessages({
       ...(m.acpNotification ? { acpNotification: m.acpNotification } : {}),
       ...(m.backgroundToolNotification
         ? { backgroundToolNotification: true }
+        : {}),
+      ...(m.backgroundToolCompletion
+        ? { backgroundToolCompletion: m.backgroundToolCompletion }
         : {}),
       ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
     };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -11,6 +11,7 @@ import {
   createUserMessage,
 } from "../../agent/message-types.js";
 import {
+  BackgroundToolCompletionSchema,
   type ConversationContentBlock,
   type ConversationMessage,
   ConversationMessageSchema,
@@ -857,25 +858,11 @@ export function handleListMessages({
         // `persistWakeTriggerMessage` stamps the structured completion onto the
         // same wake row, letting the web rebuild a terminal inline card from
         // history after a restart (the in-memory completed ring does not survive).
-        const c = meta.backgroundToolCompletion as
-          | Record<string, unknown>
-          | undefined;
-        if (
-          c &&
-          typeof c.id === "string" &&
-          typeof c.completedAt === "number"
-        ) {
-          backgroundToolCompletion = {
-            id: c.id,
-            toolName: String(c.toolName ?? ""),
-            conversationId: String(c.conversationId ?? ""),
-            command: String(c.command ?? ""),
-            startedAt: Number(c.startedAt ?? 0),
-            status: c.status as "completed" | "failed" | "cancelled",
-            exitCode: (c.exitCode ?? null) as number | null,
-            output: String(c.output ?? ""),
-            completedAt: c.completedAt,
-          };
+        const completionParse = BackgroundToolCompletionSchema.safeParse(
+          meta.backgroundToolCompletion,
+        );
+        if (completionParse.success) {
+          backgroundToolCompletion = completionParse.data;
         }
         if (meta.subagentNotification) {
           const n = meta.subagentNotification;

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -31,6 +31,7 @@ import {
 import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
+import type { CompletedBackgroundTool } from "../background-tool-registry.js";
 import {
   generateBackgroundToolId,
   isBackgroundToolLimitReached,
@@ -318,7 +319,7 @@ export const hostShellTool = {
                 ? `Background host command cancelled (id=${bgId}).`
                 : result.content;
             const completedAt = Date.now();
-            recordCompletedBackgroundTool({
+            const completion: CompletedBackgroundTool = {
               id: bgId,
               toolName: "host_bash",
               conversationId: context.conversationId,
@@ -328,7 +329,8 @@ export const hostShellTool = {
               exitCode: null,
               output,
               completedAt,
-            });
+            };
+            recordCompletedBackgroundTool(completion);
             broadcastMessage(
               {
                 type: "background_tool_completed",
@@ -351,6 +353,7 @@ export const hostShellTool = {
               hint: framing,
               source: "background-tool",
               persistTriggerAsEvent: true,
+              backgroundToolCompletion: completion,
               untrustedOutput: {
                 content: output || "(no output)",
                 source: "tool_result",
@@ -370,7 +373,7 @@ export const hostShellTool = {
                   ? err.message
                   : String(err);
             const completedAt = Date.now();
-            recordCompletedBackgroundTool({
+            const completion: CompletedBackgroundTool = {
               id: bgId,
               toolName: "host_bash",
               conversationId: context.conversationId,
@@ -380,7 +383,8 @@ export const hostShellTool = {
               exitCode: null,
               output,
               completedAt,
-            });
+            };
+            recordCompletedBackgroundTool(completion);
             broadcastMessage(
               {
                 type: "background_tool_completed",
@@ -400,6 +404,7 @@ export const hostShellTool = {
                   : `Background host command failed (id=${bgId}): ${err instanceof Error ? err.message : String(err)}`,
               source: "background-tool",
               persistTriggerAsEvent: true,
+              backgroundToolCompletion: completion,
             });
           })
           .finally(() => removeBackgroundTool(bgId));
@@ -559,7 +564,7 @@ export const hostShellTool = {
             ? `Background host command cancelled (id=${bgId}).`
             : result.content;
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "host_bash",
           conversationId: context.conversationId,
@@ -569,7 +574,8 @@ export const hostShellTool = {
           exitCode: code ?? null,
           output,
           completedAt,
-        });
+        };
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -593,6 +599,7 @@ export const hostShellTool = {
           hint: framing,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
           untrustedOutput: {
             content: output || "(no output)",
             source: "tool_result",
@@ -613,7 +620,7 @@ export const hostShellTool = {
             ? `Background host command cancelled (id=${bgId}).`
             : err.message;
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "host_bash",
           conversationId: context.conversationId,
@@ -623,7 +630,8 @@ export const hostShellTool = {
           exitCode: null,
           output,
           completedAt,
-        });
+        };
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -643,6 +651,7 @@ export const hostShellTool = {
               : `Background host command failed (id=${bgId}): ${err.message}`,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
         });
         removeBackgroundTool(bgId);
       });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -11,6 +11,7 @@ import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabili
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
+import type { CompletedBackgroundTool } from "../background-tool-registry.js";
 import {
   generateBackgroundToolId,
   isBackgroundToolLimitReached,
@@ -427,6 +428,17 @@ export const shellTool = {
             ? `Background command cancelled (id=${bgId}).`
             : fmtResult.content;
         const completedAt = Date.now();
+        const completion: CompletedBackgroundTool = {
+          id: bgId,
+          toolName: "bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt,
+          status,
+          exitCode: code ?? null,
+          output,
+          completedAt,
+        };
 
         // Wake AFTER the terminal status is known so a user-cancelled run wakes
         // the assistant with the cancellation — not the SIGKILL-framed "completed"
@@ -440,6 +452,7 @@ export const shellTool = {
           hint: framing,
           source: "background-tool",
           persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
           untrustedOutput: {
             content: output,
             source: "tool_result",
@@ -448,17 +461,7 @@ export const shellTool = {
             maxChars: MAX_OUTPUT_LENGTH * 2,
           },
         });
-        recordCompletedBackgroundTool({
-          id: bgId,
-          toolName: "bash",
-          conversationId: context.conversationId,
-          command,
-          startedAt,
-          status,
-          exitCode: code ?? null,
-          output,
-          completedAt,
-        });
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",
@@ -493,15 +496,8 @@ export const shellTool = {
         });
 
         const framing = `Background command failed (id=${bgId}): ${err.message}`;
-        void wakeAgentForOpportunity({
-          conversationId: context.conversationId,
-          hint: framing,
-          source: "background-tool",
-          persistTriggerAsEvent: true,
-        });
-
         const completedAt = Date.now();
-        recordCompletedBackgroundTool({
+        const completion: CompletedBackgroundTool = {
           id: bgId,
           toolName: "bash",
           conversationId: context.conversationId,
@@ -511,7 +507,16 @@ export const shellTool = {
           exitCode: null,
           output: framing,
           completedAt,
+        };
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint: framing,
+          source: "background-tool",
+          persistTriggerAsEvent: true,
+          backgroundToolCompletion: completion,
         });
+
+        recordCompletedBackgroundTool(completion);
         broadcastMessage(
           {
             type: "background_tool_completed",

--- a/clients/web/src/domains/chat/api/history.test.ts
+++ b/clients/web/src/domains/chat/api/history.test.ts
@@ -356,6 +356,78 @@ describe("subagent notification extraction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Background-tool completion extraction
+// ---------------------------------------------------------------------------
+
+describe("background-tool completion extraction", () => {
+  test("projects a backgroundToolCompletion row onto backgroundToolCompletions, preserving the id exactly", async () => {
+    /**
+     * A history row that carries a `backgroundToolCompletion` record yields a
+     * `BackgroundTaskEntry` with the wire fields mapped 1:1. The `id` must be
+     * preserved verbatim: web background-card detection keys off the spawning
+     * tool result's `bg-…` id, so the seeded entry's id has to equal it.
+     */
+    nextResponse = makeJsonResponse({
+      messages: [
+        { id: "m1", role: "user", ...textBody("run it") },
+        {
+          id: "m2",
+          role: "assistant",
+          ...textBody("[Background task completed]"),
+          backgroundToolCompletion: {
+            id: "bg-abcd1234",
+            toolName: "bash",
+            conversationId: "conv-xyz",
+            command: "sleep 5 && echo done",
+            startedAt: 1000,
+            status: "completed",
+            exitCode: 0,
+            output: "done\n",
+            completedAt: 6000,
+          },
+        },
+      ],
+      hasMore: false,
+      oldestTimestamp: 0,
+      oldestMessageId: "m1",
+    });
+
+    const result = await fetchLatestHistoryPage("asst-1", "K");
+
+    expect(result.backgroundToolCompletions).toEqual([
+      {
+        id: "bg-abcd1234",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+        command: "sleep 5 && echo done",
+        startedAt: 1000,
+        status: "completed",
+        exitCode: 0,
+        output: "done\n",
+        completedAt: 6000,
+      },
+    ]);
+    expect(result.backgroundToolCompletions![0]!.id).toBe("bg-abcd1234");
+  });
+
+  test("yields an empty array when no row carries a completion", async () => {
+    nextResponse = makeJsonResponse({
+      messages: [
+        { id: "m1", role: "user", ...textBody("hello") },
+        { id: "m2", role: "assistant", ...textBody("hi") },
+      ],
+      hasMore: false,
+      oldestTimestamp: 0,
+      oldestMessageId: "m1",
+    });
+
+    const result = await fetchLatestHistoryPage("asst-1", "K");
+
+    expect(result.backgroundToolCompletions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Error handling
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -21,7 +21,11 @@ import { summarizeDisplayMessages } from "@/domains/chat/utils/diagnostics";
 
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
-import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import {
+  toBackgroundTaskEntryFromCompletion,
+  type RuntimeSubagentNotification,
+} from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 export type { PaginatedHistoryResult };
 
@@ -41,6 +45,8 @@ function parsePaginatedResponse(
   // non-notification assistant message (the message that spawned the
   // subagent). This mirrors macOS HistoryReconstructionService.
   const subagentNotifications: RuntimeSubagentNotification[] = [];
+  // Completion records re-seed completed inline cards across daemon restarts.
+  const backgroundToolCompletions: BackgroundTaskEntry[] = [];
   let lastAssistantMessageId: string | undefined;
   for (let i = 0; i < rows.length; i++) {
     const m = rows[i];
@@ -55,6 +61,11 @@ function parsePaginatedResponse(
         parentMessageId: lastAssistantMessageId,
       });
     }
+    if (m.backgroundToolCompletion) {
+      backgroundToolCompletions.push(
+        toBackgroundTaskEntryFromCompletion(m.backgroundToolCompletion),
+      );
+    }
   }
 
   const hasMore = body?.hasMore ?? false;
@@ -68,6 +79,7 @@ function parsePaginatedResponse(
     oldestTimestamp,
     oldestMessageId,
     seq,
+    backgroundToolCompletions,
     ...(subagentNotifications.length > 0 ? { subagentNotifications } : {}),
   };
 }

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -9,6 +9,7 @@
 
 import { captureError } from "@/lib/sentry/capture-error";
 import type {
+  BackgroundToolCompletion,
   ConversationContentBlock,
   ConversationMessage,
   ConversationMessageToolCall,
@@ -65,7 +66,7 @@ export interface RuntimeSubagentNotification extends ConversationSubagentNotific
  * `bg-…` id, so the seeded entry's id must equal the completion's id.
  */
 export function toBackgroundTaskEntryFromCompletion(
-  c: NonNullable<ConversationMessage["backgroundToolCompletion"]>,
+  c: BackgroundToolCompletion,
 ): BackgroundTaskEntry {
   return {
     id: c.id,

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -17,6 +17,7 @@ import type {
 import { parseAttachmentSummariesFromContent } from "@/domains/chat/utils/parse-attachment-summaries";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 import {
   attachmentsPost,
   messagesGet,
@@ -55,6 +56,28 @@ export interface RuntimeSubagentNotification extends ConversationSubagentNotific
   parentMessageStableId?: string;
   /** Daemon UUID of the parent assistant message. Stable across reloads. */
   parentMessageId?: string;
+}
+
+/**
+ * Project a history message's `backgroundToolCompletion` wire record onto the
+ * `BackgroundTaskEntry` the viewer store seeds from. The `id` is preserved
+ * exactly: web background-card detection keys off the spawning tool result's
+ * `bg-…` id, so the seeded entry's id must equal the completion's id.
+ */
+export function toBackgroundTaskEntryFromCompletion(
+  c: NonNullable<ConversationMessage["backgroundToolCompletion"]>,
+): BackgroundTaskEntry {
+  return {
+    id: c.id,
+    toolName: c.toolName,
+    conversationId: c.conversationId,
+    command: c.command,
+    startedAt: c.startedAt,
+    status: c.status,
+    exitCode: c.exitCode,
+    output: c.output,
+    completedAt: c.completedAt,
+  };
 }
 
 export async function pollForResponse(

--- a/clients/web/src/domains/chat/background-task-store.ts
+++ b/clients/web/src/domains/chat/background-task-store.ts
@@ -135,6 +135,10 @@ function mergeHistoryEntry(
   existing: BackgroundTaskEntry,
   incoming: BackgroundTaskEntry,
 ): BackgroundTaskEntry {
+  // When both are terminal, the history-seeded status overwrites the existing
+  // one (unlike completeTask, which keeps an optimistic "cancelled" over a
+  // daemon "failed"); safe because the daemon persists "cancelled" for
+  // user-aborted runs, so history agrees.
   const status =
     isActiveBackgroundTaskStatus(existing.status) ||
     !isActiveBackgroundTaskStatus(incoming.status)

--- a/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
@@ -27,6 +27,7 @@ function paginationStub(): HistoryPaginationResult {
     messages: [],
     latestPage: undefined,
     subagentNotifications: undefined,
+    backgroundToolCompletions: undefined,
     isLoading: false,
     isSuccess: false,
     isError: false,

--- a/clients/web/src/domains/chat/hooks/use-conversation-history-seed-background-tasks.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-seed-background-tasks.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+
+// ---------------------------------------------------------------------------
+// Module mocks.
+//
+// `use-history-pagination` is stubbed so the test drives the post-load
+// (data-apply) effect directly: `isSuccess: true` + a non-zero `dataUpdatedAt`
+// runs it once, and `backgroundToolCompletions` carries the persisted-history
+// payload under test. The interactions API is stubbed to `{}` so the effect's
+// async pending-interaction restore makes no network call and stays a no-op —
+// the synchronous background-task seed is all this test asserts on.
+// ---------------------------------------------------------------------------
+const realPaginationModule = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
+
+let currentCompletions: BackgroundTaskEntry[] | undefined;
+
+function paginationStub(): HistoryPaginationResult {
+  return {
+    messages: [],
+    latestPage: undefined,
+    subagentNotifications: undefined,
+    backgroundToolCompletions: currentCompletions,
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+    hasMore: false,
+    isFetchingOlderPages: false,
+    isFetching: false,
+    fetchOlderPage: () => {},
+    invalidate: async () => {},
+    removeCache: () => {},
+    latestPageOldestTimestamp: null,
+    oldestLoadedTimestamp: null,
+    dataUpdatedAt: 1,
+  };
+}
+
+mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
+  ...realPaginationModule,
+  useHistoryPagination: () => paginationStub(),
+}));
+
+mock.module("@/domains/chat/api/interactions", () => ({
+  getPendingInteractions: async () => ({}),
+}));
+
+const { useConversationHistory } = await import(
+  "@/domains/chat/hooks/use-conversation-history"
+);
+
+const queryClient = new QueryClient();
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderHistory() {
+  return renderHook(
+    () =>
+      useConversationHistory({
+        assistantId: "asst-1",
+        assistantStateKind: "active",
+        activeConversationId: "conv-A",
+      }),
+    { wrapper: Wrapper },
+  );
+}
+
+function terminalEntry(id: string): BackgroundTaskEntry {
+  return {
+    id,
+    toolName: "bash",
+    conversationId: "conv-A",
+    command: "echo hi",
+    startedAt: 1,
+    status: "completed",
+    exitCode: 0,
+    output: "hi",
+    completedAt: 2,
+  };
+}
+
+function runningEntry(id: string): BackgroundTaskEntry {
+  return {
+    id,
+    toolName: "bash",
+    conversationId: "conv-A",
+    command: "sleep 99",
+    startedAt: 1,
+    status: "running",
+  };
+}
+
+beforeEach(() => {
+  currentCompletions = undefined;
+  useBackgroundTaskStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+  useBackgroundTaskStore.getState().reset();
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+
+describe("useConversationHistory — seed background tasks from history", () => {
+  test("seeds a terminal card from persisted history", () => {
+    /**
+     * The daemon's in-memory completed ring is gone after a restart, so a
+     * completed bash card must be reconstructed from the durable history
+     * aggregate on conversation load.
+     */
+    // GIVEN history carries one terminal background-task completion
+    currentCompletions = [terminalEntry("bg-done")];
+
+    // WHEN the conversation loads
+    renderHistory();
+
+    // THEN the store holds a terminal entry keyed by that bg id
+    const entry = useBackgroundTaskStore.getState().byId["bg-done"];
+    expect(entry?.status).toBe("completed");
+    expect(useBackgroundTaskStore.getState().orderedIds).toContain("bg-done");
+  });
+
+  test("upgrades a live running entry to terminal without duplicating it", () => {
+    /**
+     * A live `running` entry and its persisted terminal share the same bg id;
+     * the idempotent terminal-wins merge must fold the history metadata in
+     * rather than appending a second row.
+     */
+    // GIVEN a live running task is already in the store for the same id
+    useBackgroundTaskStore.setState({
+      byId: { "bg-done": runningEntry("bg-done") },
+      orderedIds: ["bg-done"],
+    });
+    // AND history carries the terminal completion for that id
+    currentCompletions = [terminalEntry("bg-done")];
+
+    // WHEN the conversation loads
+    renderHistory();
+
+    // THEN the entry is upgraded in place (terminal status + filled metadata)
+    const entry = useBackgroundTaskStore.getState().byId["bg-done"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.exitCode).toBe(0);
+    expect(entry?.completedAt).toBe(2);
+    // AND it is not duplicated in the order list
+    expect(useBackgroundTaskStore.getState().orderedIds).toEqual(["bg-done"]);
+  });
+
+  test("leaves a live running entry absent from history untouched", () => {
+    /**
+     * Seeding must not retire or regress a still-running task that history
+     * doesn't mention — `retireMissing` stays owned by the live rehydration
+     * hook, which skips terminal entries.
+     */
+    // GIVEN a live running task with no matching history completion
+    useBackgroundTaskStore.setState({
+      byId: { "bg-live": runningEntry("bg-live") },
+      orderedIds: ["bg-live"],
+    });
+    // AND history carries a terminal completion for a different id
+    currentCompletions = [terminalEntry("bg-done")];
+
+    // WHEN the conversation loads
+    renderHistory();
+
+    // THEN the unrelated running task is left running
+    expect(useBackgroundTaskStore.getState().byId["bg-live"]?.status).toBe(
+      "running",
+    );
+    // AND the history completion is still seeded alongside it
+    expect(useBackgroundTaskStore.getState().byId["bg-done"]?.status).toBe(
+      "completed",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -38,6 +38,7 @@ import { anchorColdStartReplay } from "@/lib/streaming/cold-anchor";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { reconcileSubagentStoreFromNotifications } from "@/domains/chat/hooks/reconcile-subagent-hydration";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
@@ -311,6 +312,16 @@ export function useConversationHistory({
         deduped.values(),
         Date.now(),
       );
+    }
+
+    // Seed background-task cards from the durable history aggregate: the
+    // daemon's in-memory completed ring doesn't survive a restart, so live
+    // `/background-tools` rehydration alone can't rebuild a finished card.
+    // `seedFromHistory` is a terminal-wins, idempotent merge (never clobbers a
+    // live entry); retiring stays owned by `useBackgroundTaskRehydration`.
+    const completions = pagination.backgroundToolCompletions;
+    if (completions && completions.length > 0) {
+      useBackgroundTaskStore.getState().seedFromHistory(completions);
     }
 
     // Restore pending interactions (secrets, confirmations).

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -8,6 +8,7 @@ import type {
   Surface,
 } from "@/domains/chat/types/types";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 export type TranscriptItemKind =
   | "message"
@@ -102,6 +103,12 @@ export interface PaginatedHistoryResult {
   oldestMessageId: string | null;
   /** Subagent notifications extracted from history messages for state reconstruction. */
   subagentNotifications?: RuntimeSubagentNotification[];
+  /** Background-task completion records extracted from history messages, used to
+   *  re-seed completed inline cards across daemon restarts. The paginated
+   *  fetchers always populate it (an empty array when no row carried a
+   *  completion); it is optional so other constructors (snapshot spreads, tests)
+   *  need not restate it. */
+  backgroundToolCompletions?: BackgroundTaskEntry[];
   /** Global SSE `seq` this snapshot is durably persisted through for the
    *  conversation, or `null` when the daemon reports no honest position
    *  (cold conversation, post-restart, aged-out map, or an older daemon

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { aggregateSubagentNotifications } from "@/domains/chat/transcript/use-history-pagination";
+import {
+  aggregateBackgroundToolCompletions,
+  aggregateSubagentNotifications,
+} from "@/domains/chat/transcript/use-history-pagination";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 
 function notif(
@@ -11,8 +15,20 @@ function notif(
   return { subagentId, label: subagentId, status } as RuntimeSubagentNotification;
 }
 
+function completion(id: string): BackgroundTaskEntry {
+  return {
+    id,
+    toolName: "bash",
+    conversationId: "conv-1",
+    command: `echo ${id}`,
+    startedAt: 0,
+    status: "completed",
+  };
+}
+
 function page(
   subagentNotifications?: RuntimeSubagentNotification[],
+  backgroundToolCompletions?: BackgroundTaskEntry[],
 ): PaginatedHistoryResult {
   return {
     messages: [],
@@ -20,6 +36,7 @@ function page(
     oldestTimestamp: null,
     oldestMessageId: null,
     ...(subagentNotifications ? { subagentNotifications } : {}),
+    ...(backgroundToolCompletions ? { backgroundToolCompletions } : {}),
   };
 }
 
@@ -49,6 +66,41 @@ describe("aggregateSubagentNotifications", () => {
     expect(result?.map((n) => n.subagentId)).toEqual([
       "aborted-early",
       "completed-late",
+    ]);
+  });
+});
+
+describe("aggregateBackgroundToolCompletions", () => {
+  test("returns undefined for no pages", () => {
+    expect(aggregateBackgroundToolCompletions(undefined)).toBeUndefined();
+    expect(aggregateBackgroundToolCompletions([])).toBeUndefined();
+  });
+
+  test("returns undefined when no page carries completions", () => {
+    expect(
+      aggregateBackgroundToolCompletions([page(), page()]),
+    ).toBeUndefined();
+  });
+
+  test("returns a single page's completions", () => {
+    const result = aggregateBackgroundToolCompletions([
+      page(undefined, [completion("bg-a")]),
+    ]);
+    expect(result?.map((c) => c.id)).toEqual(["bg-a"]);
+  });
+
+  test("concatenates completions from multiple pages, oldest-first", () => {
+    // pages[0] = latest page, pages[1] = older. Completions from the older
+    // page must come first so first-seen order is preserved for seeding.
+    const pages = [
+      page(undefined, [completion("bg-late"), completion("bg-latest")]),
+      page(undefined, [completion("bg-early")]),
+    ];
+    const result = aggregateBackgroundToolCompletions(pages);
+    expect(result?.map((c) => c.id)).toEqual([
+      "bg-early",
+      "bg-late",
+      "bg-latest",
     ]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.ts
@@ -32,6 +32,7 @@ import { shouldRetryDaemonError } from "@/utils/daemon-errors";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import { mergeAdjacentAssistantMessages } from "@/domains/chat/utils/message-merge";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
 
 // ---------------------------------------------------------------------------
 // Query key
@@ -66,6 +67,23 @@ export function aggregateSubagentNotifications(
   return acc.length > 0 ? acc : undefined;
 }
 
+// Background-task completions across all loaded pages, oldest-first. Seeding
+// reads this rather than only the latest page so a card that completed in an
+// older page still gets re-seeded into the store after a daemon restart.
+// Dedupe is unnecessary — the store's `seedFromHistory` is idempotent — so we
+// just preserve first-seen (oldest-first) order.
+export function aggregateBackgroundToolCompletions(
+  pages: readonly PaginatedHistoryResult[] | undefined,
+): BackgroundTaskEntry[] | undefined {
+  if (!pages?.length) return undefined;
+  const acc: BackgroundTaskEntry[] = [];
+  for (let i = pages.length - 1; i >= 0; i--) {
+    const cs = pages[i]?.backgroundToolCompletions;
+    if (cs?.length) acc.push(...cs);
+  }
+  return acc.length > 0 ? acc : undefined;
+}
+
 /** The shape `useInfiniteQuery` stores under a conversation-history key. */
 export type HistoryCache = InfiniteData<PaginatedHistoryResult>;
 
@@ -88,6 +106,8 @@ export interface HistoryPaginationResult {
   subagentNotifications:
     | NonNullable<PaginatedHistoryResult["subagentNotifications"]>
     | undefined;
+  /** Background-task completions aggregated across all loaded pages, oldest-first. */
+  backgroundToolCompletions: BackgroundTaskEntry[] | undefined;
   /** First-time load with no cached data available. */
   isLoading: boolean;
   /** At least one successful fetch has completed. */
@@ -207,6 +227,11 @@ export function useHistoryPagination({
     [query.data],
   );
 
+  const backgroundToolCompletions = useMemo(
+    () => aggregateBackgroundToolCompletions(query.data?.pages),
+    [query.data],
+  );
+
   const latestPage = query.data?.pages[0];
   const oldestPage = query.data?.pages[query.data.pages.length - 1];
 
@@ -228,6 +253,7 @@ export function useHistoryPagination({
     messages,
     latestPage,
     subagentNotifications,
+    backgroundToolCompletions,
     isLoading: query.isLoading,
     isSuccess: query.isSuccess,
     isError: query.isError,


### PR DESCRIPTION
## Summary
Completed background-task cards (bash / host_bash) currently rehydrate only from the daemon's in-memory completed ring, which is wiped on every daemon restart (and bounded at 50). After a restart, reopening a finished run lost its inline card (raw chip + "Conversation Woke" wake reappeared). This stamps a structured `backgroundToolCompletion` record onto the already-persisted background-event wake message, projects it through `GET /messages`, and seeds the web background-task store from history — so terminal cards survive restarts. The in-memory ring stays the fast path; persisted history is the durable fallback. No new DB table/migration (rides on the existing wake row + `.passthrough()` metadata).

Also resolves the deferred codex P2 on the original feature (hiding the wake row lost the only durable output): the card is now a history-backed recoverable source, so the hiding is safe by the reviewer's own criterion.

## Self-review result
PASS — external-feedback, plan-faithfulness, and integration passes all PASS; one slop round fixed low/nit shape-duplication (1 fix PR). The `bg-…` correlation id is preserved verbatim end-to-end; `transcript-message-body.tsx` and `build-items.ts` are unchanged (the existing card-backed gate renders the card once a terminal entry is seeded).

## PRs merged into this feature branch
- #36631 — feat(api): add backgroundToolCompletion field to ConversationMessage
- #36633 — feat(daemon): carry background-tool completion onto the wake message metadata
- #36635 — feat(bg-task): stamp completion records from the bash/host_bash background paths
- #36636 — feat(runtime): surface backgroundToolCompletion in GET /messages projection
- #36637 — feat(web): project backgroundToolCompletions from paginated history
- #36641 — feat(web): expose backgroundToolCompletions across paginated history
- #36649 — feat(web): rehydrate terminal background-task cards from persisted history

### Self-review fix PR
- #36661 — refactor(bg-task): consolidate backgroundToolCompletion shape + validate status

## Manual QA
Run a background `sleep N && echo done`, let it finish, restart the daemon, reload → the completed inline card + detail panel are present (not the raw chip / wake message).

Part of plan: bg-card-survive-restart.md