### PR TITLE
feat(web): add PROCESS_KINDS registry (ordered)

### DIFF
--- a/clients/web/src/domains/chat/process-registry/registry.test.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+
+describe("PROCESS_KINDS registry", () => {
+  it("contains all four background-process descriptors", () => {
+    expect(PROCESS_KINDS).toHaveLength(4);
+  });
+
+  it("encodes the overlay left-to-right order", () => {
+    expect(PROCESS_KINDS.map((descriptor) => descriptor.kind)).toEqual([
+      "subagent",
+      "acp-run",
+      "workflow",
+      "background-task",
+    ]);
+  });
+
+  it("has a unique kind per descriptor", () => {
+    const kinds = PROCESS_KINDS.map((descriptor) => descriptor.kind);
+    expect(new Set(kinds).size).toBe(kinds.length);
+  });
+});

--- a/clients/web/src/domains/chat/process-registry/registry.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.ts
@@ -9,9 +9,8 @@ import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registr
  *
  * The array ORDER is load-bearing: it encodes the left-to-right order in which
  * the overlay pills are stacked above the composer — subagents, then acp-runs,
- * then workflows, then background-tasks. This replaces the former "do not
- * reorder" comment that lived next to the hard-coded slots in `chat-body.tsx`.
- * Reordering this array reorders the overlay.
+ * then workflows, then background-tasks. Reordering this array reorders the
+ * overlay.
  */
 export const PROCESS_KINDS: BackgroundProcessDescriptor[] = [
   SUBAGENT_DESCRIPTOR,

--- a/clients/web/src/domains/chat/process-registry/registry.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.ts
@@ -1,0 +1,21 @@
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
+import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
+
+/**
+ * The registry of background-process descriptors.
+ *
+ * The array ORDER is load-bearing: it encodes the left-to-right order in which
+ * the overlay pills are stacked above the composer — subagents, then acp-runs,
+ * then workflows, then background-tasks. This replaces the former "do not
+ * reorder" comment that lived next to the hard-coded slots in `chat-body.tsx`.
+ * Reordering this array reorders the overlay.
+ */
+export const PROCESS_KINDS: BackgroundProcessDescriptor[] = [
+  SUBAGENT_DESCRIPTOR,
+  ACP_RUN_DESCRIPTOR,
+  WORKFLOW_DESCRIPTOR,
+  BACKGROUND_TASK_DESCRIPTOR,
+];


### PR DESCRIPTION
## Summary
- Add PROCESS_KINDS registry array (subagent, acp-run, workflow, background-task) encoding the overlay left-to-right order.

Part of plan: background-process-registry.md (PR 9 of 17)