### PR TITLE
refactor(web): route descriptor onOpenDetail through openProcessDetail facade

### DIFF
--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.test.tsx
@@ -10,10 +10,12 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+import { useViewerStore } from "@/stores/viewer-store";
 
 afterEach(() => {
   cleanup();
   useAcpRunStore.getState().reset();
+  useViewerStore.getState().reset();
 });
 
 /** Spawn an active ("running") run, then optionally settle it terminal. */
@@ -50,6 +52,18 @@ describe("ACP_RUN_DESCRIPTOR — static metadata", () => {
 
   test("exposes a stop action", () => {
     expect(typeof ACP_RUN_DESCRIPTOR.onStop).toBe("function");
+  });
+});
+
+describe("ACP_RUN_DESCRIPTOR — onOpenDetail", () => {
+  test("opens the acp-run detail panel through the openProcessDetail facade", () => {
+    // The descriptor routes through `openProcessDetail({ kind, id })`, which
+    // delegates to `openAcpRunDetail` — assert the resulting viewer state.
+    ACP_RUN_DESCRIPTOR.onOpenDetail("run-1");
+
+    const state = useViewerStore.getState();
+    expect(state.mainView).toBe("acp-run-detail");
+    expect(state.activeAcpRunId).toBe("run-1");
   });
 });
 

--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
@@ -109,7 +109,8 @@ export const ACP_RUN_DESCRIPTOR: BackgroundProcessDescriptor = {
   overlayTitle: (n) => `${n} Active Run${n === 1 ? "" : "s"}`,
   pillAriaLabel: () => "Active runs",
   openCardAriaLabel: "Open run",
-  onOpenDetail: (id) => useViewerStore.getState().openAcpRunDetail(id),
+  onOpenDetail: (id) =>
+    useViewerStore.getState().openProcessDetail({ kind: "acp-run", id }),
   onStop: (id) => void stopAcpRun(id),
   DetailPanel: AcpRunDetailPanelById,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.test.ts
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.test.ts
@@ -22,6 +22,7 @@ mock.module("@/domains/chat/utils/background-task-actions", () => ({
 
 import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
+import { useViewerStore } from "@/stores/viewer-store";
 
 const NOW = 1700000000000;
 
@@ -42,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useViewerStore.getState().reset();
 });
 
 describe("BACKGROUND_TASK_DESCRIPTOR — useCardSummary", () => {
@@ -93,5 +95,17 @@ describe("BACKGROUND_TASK_DESCRIPTOR — metadata", () => {
 
   test("supports stopping a task", () => {
     expect(typeof BACKGROUND_TASK_DESCRIPTOR.onStop).toBe("function");
+  });
+});
+
+describe("BACKGROUND_TASK_DESCRIPTOR — onOpenDetail", () => {
+  test("opens the background-task detail panel through the openProcessDetail facade", () => {
+    // The descriptor routes through `openProcessDetail({ kind, id })`, which
+    // delegates to `openBackgroundTaskDetail` — assert the resulting state.
+    BACKGROUND_TASK_DESCRIPTOR.onOpenDetail("bg-1");
+
+    const state = useViewerStore.getState();
+    expect(state.mainView).toBe("background-task-detail");
+    expect(state.activeBackgroundTaskId).toBe("bg-1");
   });
 });

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
@@ -110,7 +110,8 @@ export const BACKGROUND_TASK_DESCRIPTOR: BackgroundProcessDescriptor = {
   overlayTitle: (count) => `${count} Active Command${count === 1 ? "" : "s"}`,
   pillAriaLabel: () => "Active commands",
   openCardAriaLabel: "Open command",
-  onOpenDetail: (id) => useViewerStore.getState().openBackgroundTaskDetail(id),
+  onOpenDetail: (id) =>
+    useViewerStore.getState().openProcessDetail({ kind: "background-task", id }),
   onStop: (id) => void stopBackgroundTask(id),
   DetailPanel: BackgroundTaskDetailPanelAdapter,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
@@ -16,6 +16,7 @@ import {
   useSubagentStore,
   type SubagentTimelineEvent,
 } from "@/domains/chat/subagent-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import type { SubagentStatus } from "@vellumai/assistant-api";
 
 const NOW = 1700000000000;
@@ -23,6 +24,7 @@ const NOW = 1700000000000;
 afterEach(() => {
   cleanup();
   useSubagentStore.getState().reset();
+  useViewerStore.getState().reset();
 });
 
 /** Spawn a subagent, seed its timeline events, and move it to `status`. */
@@ -55,6 +57,18 @@ describe("SUBAGENT_DESCRIPTOR — static config", () => {
   test("exposes the subagent aria labels", () => {
     expect(SUBAGENT_DESCRIPTOR.openCardAriaLabel).toBe("Open subagent");
     expect(SUBAGENT_DESCRIPTOR.pillAriaLabel(3)).toBe("Active subagents");
+  });
+});
+
+describe("SUBAGENT_DESCRIPTOR — onOpenDetail", () => {
+  test("opens the subagent detail panel through the openProcessDetail facade", () => {
+    // The descriptor routes through `openProcessDetail({ kind, id })`, which
+    // delegates to `openSubagentDetail` — assert the resulting viewer state.
+    SUBAGENT_DESCRIPTOR.onOpenDetail("sa-1");
+
+    const state = useViewerStore.getState();
+    expect(state.mainView).toBe("subagent-detail");
+    expect(state.activeSubagentId).toBe("sa-1");
   });
 });
 

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
@@ -90,7 +90,8 @@ export const SUBAGENT_DESCRIPTOR: BackgroundProcessDescriptor = {
   overlayTitle: (n) => `${n} Active Subagent${n === 1 ? "" : "s"}`,
   pillAriaLabel: () => "Active subagents",
   openCardAriaLabel: "Open subagent",
-  onOpenDetail: (id) => useViewerStore.getState().openSubagentDetail(id),
+  onOpenDetail: (id) =>
+    useViewerStore.getState().openProcessDetail({ kind: "subagent", id }),
   onStop: (id) => void useSubagentStore.getState().abortSubagent(id),
   DetailPanel: SubagentDetailPanelById,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
@@ -13,10 +13,12 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { useViewerStore } from "@/stores/viewer-store";
 
 afterEach(() => {
   cleanup();
   useWorkflowStore.getState().reset();
+  useViewerStore.getState().reset();
 });
 
 describe("WORKFLOW_DESCRIPTOR — useCardSummary projection", () => {
@@ -91,5 +93,17 @@ describe("WORKFLOW_DESCRIPTOR — static metadata", () => {
 
   test("exposes a stop action", () => {
     expect(WORKFLOW_DESCRIPTOR.onStop).toBeDefined();
+  });
+});
+
+describe("WORKFLOW_DESCRIPTOR — onOpenDetail", () => {
+  test("opens the workflow detail panel through the openProcessDetail facade", () => {
+    // The descriptor routes through `openProcessDetail({ kind, id })`, which
+    // delegates to `openWorkflowDetail` — assert the resulting viewer state.
+    WORKFLOW_DESCRIPTOR.onOpenDetail("wf-1");
+
+    const state = useViewerStore.getState();
+    expect(state.mainView).toBe("workflow-detail");
+    expect(state.activeWorkflowRunId).toBe("wf-1");
   });
 });

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
@@ -92,7 +92,8 @@ export const WORKFLOW_DESCRIPTOR: BackgroundProcessDescriptor = {
   overlayTitle: (n) => `${n} Active Workflow${n === 1 ? "" : "s"}`,
   pillAriaLabel: (n) => `${n} active workflow${n === 1 ? "" : "s"}`,
   openCardAriaLabel: "Open workflow",
-  onOpenDetail: (id) => useViewerStore.getState().openWorkflowDetail(id),
+  onOpenDetail: (id) =>
+    useViewerStore.getState().openProcessDetail({ kind: "workflow", id }),
   onStop: (id) => void useWorkflowStore.getState().abortRun(id),
   DetailPanel: WorkflowDetailPanelAdapter,
 };


### PR DESCRIPTION
## Summary
- All four descriptors now open detail via the additive viewer facade openProcessDetail({kind,id}); behavior unchanged.

Part of plan: background-process-registry.md (PR 17 of 17)