### PR TITLE
fix(web): gate plugin rail counts on the search term, not background fetch

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -419,6 +419,54 @@ describe("PluginsTab", () => {
     expect(systemRow.textContent).toContain("1");
   });
 
+  test("hides the rail counts while a search term is active, restoring them when cleared", async () => {
+    // Search is client-side (the term never reaches the data hook), so the
+    // count gating must key off the term — not react-query's fetch state.
+    installedPlugins = [
+      installed({ id: "mailer", name: "mailer", category: "email" }),
+    ];
+    installedCategoryCounts = { email: 1 };
+    catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
+
+    const { findByRole, getByLabelText } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // With no active search the per-category badges show (email: 1, system: 1).
+    expect(
+      within(nav).getByRole("button", { name: /Email/ }).textContent,
+    ).toContain("1");
+    expect(
+      within(nav).getByRole("button", { name: /System/ }).textContent,
+    ).toContain("1");
+
+    // Typing a term hides every badge — the unfiltered counts would mislead
+    // while the visible rows are filtered client-side.
+    fireEvent.change(getByLabelText("Search plugins"), {
+      target: { value: "mailer" },
+    });
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).not.toContain("1"),
+    );
+    expect(
+      within(nav).getByRole("button", { name: /System/ }).textContent,
+    ).not.toContain("1");
+
+    // Clearing the term restores the badges.
+    fireEvent.change(getByLabelText("Search plugins"), {
+      target: { value: "" },
+    });
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).toContain("1"),
+    );
+    expect(
+      within(nav).getByRole("button", { name: /System/ }).textContent,
+    ).toContain("1");
+  });
+
   test("selecting a category filters both installed and available", async () => {
     installedPlugins = [
       installed({ id: "mailer", name: "mailer", category: "email" }),

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -253,7 +253,13 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     [items, filter, searchValue],
   );
 
+  // Background-fetch state (focus refetch, post-install invalidation); drives
+  // the search spinner only.
   const isSearching = isFetching && !isLoading;
+  // Counts gate on the live term, not isSearching: search is client-side, so
+  // it never trips the background-fetch signal — keying counts off that would
+  // never hide them while filtering.
+  const hasActiveSearch = searchValue.trim().length > 0;
 
   if (selectedPluginName) {
     // Seed the detail header icon from the already-loaded list row: catalog
@@ -334,7 +340,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         onCategoryChange={setCategory}
         counts={counts}
         totalCount={totalCount}
-        showCounts={!isSearching}
+        showCounts={!hasActiveSearch}
       />
 
       {catalogError && !isLoading && !isError ? (
@@ -350,7 +356,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
               onSelect={setCategory}
               counts={counts}
               totalCount={totalCount}
-              showCounts={!isSearching}
+              showCounts={!hasActiveSearch}
               categories={categories}
             />
           </aside>


### PR DESCRIPTION
## Summary
Self-review remediation: the Plugins category rail counts were gated on react-query background-fetch state (isSearching), which never fires for the tab's client-side search. Gate on the actual search term (hasActiveSearch) so counts correctly hide while searching and stay visible otherwise. The search spinner still uses the fetch signal.

Part of plan: plugins-tab-category-filter.md (self-review remediation, round 2)