### PR TITLE
refactor(web): render transcript inline cards via generic InlineProcessCard

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
@@ -4,8 +4,8 @@
  * Drives the Zustand subagent store with spawned ids so badges/rows render,
  * then asserts the collapse/expand contract: the resting state is the compact
  * `SubagentAvatarRow` summary (badges present, list rows absent); "Details"
- * expands into the `SubagentInlineProgressCard` list plus a "Collapse" toggle;
- * and "Collapse" returns to the summary.
+ * expands into the generic `InlineProcessCard` list (testid `inline-process-card`)
+ * plus a "Collapse" toggle; and "Collapse" returns to the summary.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -52,7 +52,7 @@ describe("SubagentSpawnGroup", () => {
 
     // Badges present, but the expanded list rows are not yet rendered.
     expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(3);
-    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
+    expect(queryAllByTestId("inline-process-card")).toHaveLength(0);
   });
 
   test("Details expands to the row list plus a Collapse toggle", async () => {
@@ -65,7 +65,7 @@ describe("SubagentSpawnGroup", () => {
 
     // The crossfade defers the incoming view (AnimatePresence mode="wait"),
     // so wait for the inline cards to mount.
-    expect(await findAllByTestId("subagent-inline-progress-card")).toHaveLength(
+    expect(await findAllByTestId("inline-process-card")).toHaveLength(
       3,
     );
     expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(0);
@@ -81,7 +81,7 @@ describe("SubagentSpawnGroup", () => {
     fireEvent.click(await findByTestId("subagent-spawn-group-collapse"));
 
     expect(await findAllByTestId("subagent-avatar-badge")).toHaveLength(3);
-    expect(queryAllByTestId("subagent-inline-progress-card")).toHaveLength(0);
+    expect(queryAllByTestId("inline-process-card")).toHaveLength(0);
     expect(queryByTestId("subagent-spawn-group-collapse")).toBeNull();
   });
 
@@ -104,14 +104,14 @@ describe("SubagentSpawnGroup", () => {
 
     fireEvent.click(getByTestId("subagent-avatar-row-details"));
 
-    const rows = await findAllByTestId("subagent-inline-progress-card");
+    const rows = await findAllByTestId("inline-process-card");
     // The open affordance lives on the leading cluster (a `role="button"`
     // element inside the row), not on the row container itself, so the stop
     // button is not nested inside it. Click the affordance, not the row.
     fireEvent.click(within(rows[0]).getByRole("button", { name: /open subagent/i }));
     expect(clicked).toEqual([ids[0]]);
 
-    const stopButtons = getAllByTestId("subagent-inline-card-stop");
+    const stopButtons = getAllByTestId("inline-process-card-stop");
     fireEvent.click(stopButtons[1]);
     expect(stopped).toEqual([ids[1]]);
   });

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
@@ -1,5 +1,5 @@
 // Collapsible wrapper for a set of spawned subagents: the SubagentAvatarRow
-// summary when collapsed, the SubagentInlineProgressCard list when expanded.
+// summary when collapsed, the generic inline-process card list when expanded.
 
 import { ChevronUp } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -8,7 +8,8 @@ import { useState } from "react";
 import { Typography } from "@vellumai/design-library";
 
 import { SubagentAvatarRow } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
-import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
 
 export interface SubagentSpawnGroupProps {
   subagentIds: string[];
@@ -57,11 +58,14 @@ export function SubagentSpawnGroup({
         >
           <div className="flex w-full flex-col gap-1">
             {subagentIds.map((id) => (
-              <SubagentInlineProgressCard
+              <InlineProcessCardRow
                 key={id}
-                subagentId={id}
-                onSubagentClick={onSubagentClick}
-                onStopSubagent={onStopSubagent}
+                descriptor={SUBAGENT_DESCRIPTOR}
+                id={id}
+                onOpen={onSubagentClick ? () => onSubagentClick(id) : undefined}
+                onStop={onStopSubagent ? () => onStopSubagent(id) : undefined}
+                stopAriaLabel="Stop subagent"
+                testId="inline-process-card"
               />
             ))}
           </div>

--- a/clients/web/src/domains/chat/process-registry/inline-process-card-row.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card-row.tsx
@@ -1,0 +1,53 @@
+// Connects a {@link BackgroundProcessDescriptor} to the generic
+// {@link InlineProcessCard}: subscribes to the descriptor's per-id
+// `useCardSummary` hook and projects the result into the shared card, supplying
+// the descriptor's leading icon + open-affordance label. Returns `null` in the
+// spawn race (no card-worthy state yet), matching the bespoke cards it replaces.
+//
+// The descriptor hook MUST run inside a component (not a bare `.map` callback),
+// so each row is its own component subscribing to its own id.
+//
+// `onOpen` / `onStop` are threaded from the caller — the transcript keeps its
+// existing per-kind handler wiring rather than the descriptor's `onOpenDetail` /
+// `onStop`, so behavior stays byte-identical.
+
+import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
+import { InlineProcessCard } from "@/domains/chat/process-registry/inline-process-card";
+
+export interface InlineProcessCardRowProps {
+  /** Descriptor whose store/projection drives this row. */
+  descriptor: BackgroundProcessDescriptor;
+  /** Process id within the descriptor's kind. */
+  id: string;
+  /** Opens the process's detail panel; omit to make the leading cluster inert. */
+  onOpen?: () => void;
+  /** Stops the in-flight process; omit to hide the stop button. */
+  onStop?: () => void;
+  /** Accessible label for the stop button; defaults to the card's `"Stop"`. */
+  stopAriaLabel?: string;
+  /** `data-testid` for the root row. */
+  testId?: string;
+}
+
+export function InlineProcessCardRow({
+  descriptor,
+  id,
+  onOpen,
+  onStop,
+  stopAriaLabel,
+  testId,
+}: InlineProcessCardRowProps) {
+  const summary = descriptor.useCardSummary(id);
+  if (!summary) return null;
+  return (
+    <InlineProcessCard
+      summary={summary}
+      leadingIcon={descriptor.renderCardLeading(id)}
+      openAriaLabel={descriptor.openCardAriaLabel}
+      onOpen={onOpen}
+      onStop={onStop}
+      stopAriaLabel={stopAriaLabel}
+      testId={testId}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -125,6 +125,47 @@ mock.module(
   }),
 );
 
+// The four transcript inline-card render paths (workflow / ACP run /
+// background task — and subagent, via `SubagentSpawnGroup`) all route through
+// the generic `InlineProcessCardRow`. Stub it so these tests can assert which
+// descriptor + id each render helper maps to, and that the transcript's
+// `onOpen`/`onStop` wiring reaches the row — without hydrating each kind's
+// store (the row's own markup is covered by `inline-process-card.test`).
+mock.module(
+  "@/domains/chat/process-registry/inline-process-card-row",
+  () => ({
+    InlineProcessCardRow: ({
+      descriptor,
+      id,
+      onOpen,
+      onStop,
+    }: {
+      descriptor: { kind: string };
+      id: string;
+      onOpen?: () => void;
+      onStop?: () => void;
+    }) => (
+      <div
+        data-testid="inline-process-card"
+        data-process-kind={descriptor.kind}
+        data-process-id={id}
+        data-has-stop={onStop ? "true" : "false"}
+      >
+        <button
+          type="button"
+          data-testid="inline-process-card-open"
+          onClick={() => onOpen?.()}
+        />
+        <button
+          type="button"
+          data-testid="inline-process-card-stop"
+          onClick={() => onStop?.()}
+        />
+      </div>
+    ),
+  }),
+);
+
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage, Surface } from "@/domains/chat/types/types";
@@ -1014,3 +1055,108 @@ function taskProgressSurface(surfaceId: string): Surface {
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Generic inline card (PR 10): each render helper maps resolved ids → the
+// generic `InlineProcessCardRow` (stubbed above) with the right descriptor,
+// and preserves the transcript's existing `onOpen`/`onStop` handler wiring.
+// ---------------------------------------------------------------------------
+
+describe("TranscriptMessageBody — generic inline process cards", () => {
+  function renderBody(
+    message: DisplayMessage,
+    props: {
+      onWorkflowClick?: (id: string) => void;
+      onStopWorkflow?: (id: string) => void;
+    } = {},
+  ) {
+    return render(
+      <TranscriptMessageBody
+        message={message}
+        onSurfaceAction={noop}
+        onWorkflowClick={props.onWorkflowClick}
+        onStopWorkflow={props.onStopWorkflow}
+      />,
+    );
+  }
+
+  test("renders the workflow descriptor row and wires open + stop", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-wf",
+      name: "run_workflow",
+      input: {},
+      result: JSON.stringify({ runId: "wf-1" }),
+      completedAt: 1,
+    };
+    const opened: string[] = [];
+    const stopped: string[] = [];
+    const { getByTestId } = renderBody(
+      {
+        id: "m-wf",
+        role: "assistant",
+        contentBlocks: [toolUseBlock(toolCall)],
+        toolCalls: [toolCall],
+        timestamp: 1_000,
+      },
+      {
+        onWorkflowClick: (id) => opened.push(id),
+        onStopWorkflow: (id) => stopped.push(id),
+      },
+    );
+
+    const row = getByTestId("inline-process-card");
+    expect(row.getAttribute("data-process-kind")).toBe("workflow");
+    expect(row.getAttribute("data-process-id")).toBe("wf-1");
+    expect(row.getAttribute("data-has-stop")).toBe("true");
+
+    fireEvent.click(getByTestId("inline-process-card-open"));
+    fireEvent.click(getByTestId("inline-process-card-stop"));
+    expect(opened).toEqual(["wf-1"]);
+    expect(stopped).toEqual(["wf-1"]);
+  });
+
+  test("renders the ACP-run descriptor row, open only (no stop in transcript)", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-acp",
+      name: "acp_spawn",
+      input: {},
+      result: JSON.stringify({ acpSessionId: "acp-1" }),
+      completedAt: 1,
+    };
+    const { getByTestId } = renderBody({
+      id: "m-acp",
+      role: "assistant",
+      contentBlocks: [toolUseBlock(toolCall)],
+      toolCalls: [toolCall],
+      timestamp: 1_000,
+    });
+
+    const row = getByTestId("inline-process-card");
+    expect(row.getAttribute("data-process-kind")).toBe("acp-run");
+    expect(row.getAttribute("data-process-id")).toBe("acp-1");
+    // ACP passes no stop handler in the transcript today.
+    expect(row.getAttribute("data-has-stop")).toBe("false");
+  });
+
+  test("renders the background-task descriptor row, open only (no stop in transcript)", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-bg",
+      name: "bash",
+      input: { background: true },
+      result: JSON.stringify({ backgrounded: true, id: "bg-1" }),
+      completedAt: 1,
+    };
+    const { getByTestId } = renderBody({
+      id: "m-bg",
+      role: "assistant",
+      contentBlocks: [toolUseBlock(toolCall)],
+      toolCalls: [toolCall],
+      timestamp: 1_000,
+    });
+
+    const row = getByTestId("inline-process-card");
+    expect(row.getAttribute("data-process-kind")).toBe("background-task");
+    expect(row.getAttribute("data-process-id")).toBe("bg-1");
+    expect(row.getAttribute("data-has-stop")).toBe("false");
+  });
+});

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -16,9 +16,10 @@ import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-mes
 import { toast } from "@vellumai/design-library";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { SubagentSpawnGroup } from "@/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group";
-import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
-import { AcpRunInlineProgressCard } from "@/domains/chat/components/acp-run-inline-card/acp-run-inline-progress-card";
-import { BackgroundTaskInlineProgressCard } from "@/domains/chat/components/background-task-inline-card/background-task-inline-progress-card";
+import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
+import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import { SingleActivity } from "@/domains/chat/components/single-activity/single-activity";
 import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
@@ -352,11 +353,14 @@ export function TranscriptMessageBody({
     return (
       <div className="flex w-full flex-col gap-1.5">
         {runIds.map((runId) => (
-          <WorkflowInlineProgressCard
+          <InlineProcessCardRow
             key={runId}
-            runId={runId}
-            onWorkflowClick={onWorkflowClick}
-            onStopWorkflow={onStopWorkflow}
+            descriptor={WORKFLOW_DESCRIPTOR}
+            id={runId}
+            onOpen={onWorkflowClick ? () => onWorkflowClick(runId) : undefined}
+            onStop={onStopWorkflow ? () => onStopWorkflow(runId) : undefined}
+            stopAriaLabel="Stop workflow"
+            testId="inline-process-card"
           />
         ))}
       </div>
@@ -373,10 +377,12 @@ export function TranscriptMessageBody({
     return (
       <div className="flex w-full flex-col gap-1.5">
         {acpSessionIds.map((acpSessionId) => (
-          <AcpRunInlineProgressCard
+          <InlineProcessCardRow
             key={acpSessionId}
-            acpSessionId={acpSessionId}
-            onAcpRunClick={handleAcpRunClick}
+            descriptor={ACP_RUN_DESCRIPTOR}
+            id={acpSessionId}
+            onOpen={() => handleAcpRunClick(acpSessionId)}
+            testId="inline-process-card"
           />
         ))}
       </div>
@@ -391,10 +397,12 @@ export function TranscriptMessageBody({
     return (
       <div className="flex w-full flex-col gap-1.5">
         {taskIds.map((id) => (
-          <BackgroundTaskInlineProgressCard
+          <InlineProcessCardRow
             key={id}
+            descriptor={BACKGROUND_TASK_DESCRIPTOR}
             id={id}
-            onClick={handleBackgroundTaskClick}
+            onOpen={() => handleBackgroundTaskClick(id)}
+            testId="inline-process-card"
           />
         ))}
       </div>

--- a/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
@@ -6,9 +6,9 @@
  *
  * `SubagentSpawnGroup` and its collapsed `SubagentAvatarRow` summary render
  * real, so the resting state shows `subagent-avatar-badge`s; the per-subagent
- * `SubagentInlineProgressCard` rows render only after expansion and are stubbed
- * here so we can assert id resolution + callback wiring without depending on the
- * inline card's internal markup (covered by its own test file).
+ * `InlineProcessCardRow` rows render only after expansion and are stubbed here
+ * so we can assert id resolution + callback wiring without depending on the
+ * generic inline card's internal markup (covered by `inline-process-card.test`).
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -40,28 +40,32 @@ mock.module(
   }),
 );
 
+// `SubagentSpawnGroup` now renders the generic `InlineProcessCardRow` (wired to
+// `SUBAGENT_DESCRIPTOR`). Stub the row so id resolution + the transcript's
+// `onSubagentClick`/`onStopSubagent` wiring can be asserted without depending on
+// the generic card's internal markup (covered by `inline-process-card.test`).
 mock.module(
-  "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card",
+  "@/domains/chat/process-registry/inline-process-card-row",
   () => ({
-    SubagentInlineProgressCard: ({
-      subagentId,
-      onSubagentClick,
-      onStopSubagent,
+    InlineProcessCardRow: ({
+      id,
+      onOpen,
+      onStop,
     }: {
-      subagentId: string;
-      onSubagentClick?: (id: string) => void;
-      onStopSubagent?: (id: string) => void;
+      id: string;
+      onOpen?: () => void;
+      onStop?: () => void;
     }) => (
-      <div data-testid="subagent-inline-card" data-subagent-id={subagentId}>
+      <div data-testid="subagent-inline-card" data-subagent-id={id}>
         <button
           type="button"
           data-testid="subagent-inline-card-open"
-          onClick={() => onSubagentClick?.(subagentId)}
+          onClick={() => onOpen?.()}
         />
         <button
           type="button"
           data-testid="subagent-inline-card-stop"
-          onClick={() => onStopSubagent?.(subagentId)}
+          onClick={() => onStop?.()}
         />
       </div>
     ),


### PR DESCRIPTION
## Summary
- Repoint the four transcript inline-card render paths to the generic InlineProcessCard via descriptors; SubagentSpawnGroup retained; existing handler wiring preserved; testids reconciled.

Part of plan: background-process-registry.md (PR 10 of 17)