### PR TITLE
chore(memory): raise default consolidation interval to 8 hours

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -22,7 +22,7 @@ describe("MemoryV2ConfigSchema", () => {
       sparse_weight: 0.15,
       bm25_k1: 1.2,
       bm25_b: 0.4,
-      consolidation_interval_hours: 4,
+      consolidation_interval_hours: 8,
       consolidation_max_buffer_lines: 100,
       consolidation_max_entries_per_run: 150,
       max_page_chars: 5000,
@@ -222,7 +222,7 @@ describe("MemoryConfigSchema integration with v2 block", () => {
     expect(parsed.v2.d).toBe(0.3);
     expect(parsed.v2.dense_weight).toBe(0.85);
     expect(parsed.v2.sparse_weight).toBe(0.15);
-    expect(parsed.v2.consolidation_interval_hours).toBe(4);
+    expect(parsed.v2.consolidation_interval_hours).toBe(8);
     expect(parsed.v2.max_page_chars).toBe(5000);
   });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -190,7 +190,7 @@ export const MemoryV2ConfigSchema = z
       .positive(
         "memory.v2.consolidation_interval_hours must be a positive integer",
       )
-      .default(4)
+      .default(8)
       .describe(
         "Hours between scheduled consolidation runs that synthesize buffered memories into concept pages",
       ),


### PR DESCRIPTION
## Summary
- Raise the default `memory.v2.consolidation_interval_hours` from 4 to 8, so the time-based memory consolidation run fires half as often for new and unconfigured assistants.
- Update the two schema tests that assert the parsed default (empty-object parse) to expect 8h.
- Config-schema default only — no DB or workspace migration; assistants with an explicit `consolidation_interval_hours` keep their value, and the size-based trigger (`consolidation_max_buffer_lines`, default 100) is unchanged.

## Original prompt
Increase the default memory consolidation period to 8 hours. The time-based consolidation cadence is controlled by the `memory.v2.consolidation_interval_hours` config field, which defaulted to 4 hours; the ask was to bump that shipped default to 8 while leaving the size-based trigger and any explicit per-assistant overrides intact.