### PR TITLE
refactor(web): consolidate installed-plugins query + remove new-chat-plugins slop

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -934,10 +934,7 @@ export function ChatMainPanel({
 
   const newChatPluginsSlot =
     isEmptyConversation && supportsNewChatPlugins && assistantId ? (
-      <NewChatPluginsSection
-        assistantId={assistantId}
-        conversationId={activeConversation?.conversationId}
-      />
+      <NewChatPluginsSection assistantId={assistantId} />
     ) : undefined;
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.test.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.test.tsx
@@ -46,10 +46,7 @@ function renderSection(plugins: InstalledPlugin[]): string {
   return renderToStaticMarkup(
     <MemoryRouter>
       <QueryClientProvider client={client}>
-        <NewChatPluginsSection
-          assistantId={ASSISTANT_ID}
-          conversationId="draft-1"
-        />
+        <NewChatPluginsSection assistantId={ASSISTANT_ID} />
       </QueryClientProvider>
     </MemoryRouter>,
   );

--- a/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.tsx
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/new-chat-plugins-section.tsx
@@ -18,12 +18,6 @@ const TOOLTIP_COPY =
 
 interface NewChatPluginsSectionProps {
   assistantId: string;
-  /**
-   * The draft conversation the pills belong to. The selection itself is keyed
-   * off the store's active conversation inside `useNewChatPlugins`, so this is
-   * accepted for the composer's API symmetry rather than read directly here.
-   */
-  conversationId: string | undefined;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/new-chat-plugins/use-new-chat-plugins.test.ts
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/use-new-chat-plugins.test.ts
@@ -78,7 +78,6 @@ describe("useNewChatPlugins", () => {
 
     await waitFor(() => expect(result.current.plugins).toHaveLength(3));
 
-    expect(result.current.hasExplicitSelection).toBe(false);
     expect(result.current.isSelected("a")).toBe(true);
     expect(result.current.isSelected("b")).toBe(true);
     expect(result.current.isSelected("c")).toBe(true);
@@ -91,7 +90,6 @@ describe("useNewChatPlugins", () => {
 
     act(() => result.current.toggle("b"));
 
-    expect(result.current.hasExplicitSelection).toBe(true);
     expect(result.current.isSelected("a")).toBe(true);
     expect(result.current.isSelected("b")).toBe(false);
     expect(result.current.isSelected("c")).toBe(true);
@@ -113,7 +111,9 @@ describe("useNewChatPlugins", () => {
     act(() => result.current.toggle("b"));
     expect(result.current.isSelected("b")).toBe(true);
     // Re-enabling within the same draft keeps the explicit entry around.
-    expect(result.current.hasExplicitSelection).toBe(true);
+    expect(
+      useConversationStore.getState().pendingDraftPlugins.has("draft-1"),
+    ).toBe(true);
   });
 
   test("selection is independent per conversation id", async () => {
@@ -128,8 +128,7 @@ describe("useNewChatPlugins", () => {
     act(() =>
       useConversationStore.getState().setActiveConversationId("draft-2"),
     );
-    await waitFor(() => expect(result.current.hasExplicitSelection).toBe(false));
-    expect(result.current.isSelected("b")).toBe(true);
+    await waitFor(() => expect(result.current.isSelected("b")).toBe(true));
 
     // The first draft's selection is untouched.
     const stored = useConversationStore

--- a/clients/web/src/domains/chat/components/new-chat-plugins/use-new-chat-plugins.ts
+++ b/clients/web/src/domains/chat/components/new-chat-plugins/use-new-chat-plugins.ts
@@ -1,14 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 
-import { pluginsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
-import { pluginsGet } from "@/generated/daemon/sdk.gen";
 import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
 import { useConversationStore } from "@/stores/conversation-store";
-
-// The installed list (local filesystem) changes rarely, so a `staleTime`
-// keeps it warm across remounts of the new-chat composer.
-const INSTALLED_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
 type InstalledPlugin = PluginsGetResponse["plugins"][number];
@@ -16,14 +11,10 @@ type InstalledPlugin = PluginsGetResponse["plugins"][number];
 export interface UseNewChatPluginsResult {
   /** Installed plugins, the source for the composer's toggle pills. */
   plugins: InstalledPlugin[];
-  /** True until the installed list first resolves. */
-  isLoading: boolean;
   /** Whether `name` is enabled for the active draft (default: all enabled). */
   isSelected: (name: string) => boolean;
   /** Flip `name` on/off for the active draft. */
   toggle: (name: string) => void;
-  /** Whether the store holds an explicit set for the active conversation id. */
-  hasExplicitSelection: boolean;
 }
 
 /**
@@ -43,26 +34,8 @@ export function useNewChatPlugins(assistantId: string): UseNewChatPluginsResult 
   const pendingDraftPlugins = useConversationStore.use.pendingDraftPlugins();
 
   const installedQuery = useQuery({
-    queryKey: pluginsGetQueryKey({
-      path: { assistant_id: assistantId },
-      query: { q: undefined },
-    }),
-    queryFn: async ({ signal }) => {
-      const result = await pluginsGet({
-        path: { assistant_id: assistantId },
-        query: { q: undefined },
-        signal,
-        throwOnError: false,
-      });
-      const status = result.response?.status;
-      // Older daemons return 404 when the list endpoint isn't implemented
-      // yet — degrade to an empty installed list.
-      if (status === 404) return { plugins: [] } as PluginsGetResponse;
-      if (!result.response?.ok) throw new Error("Failed to load plugins");
-      return result.data ?? ({ plugins: [] } as PluginsGetResponse);
-    },
+    ...installedPluginsQueryOptions(assistantId),
     enabled: Boolean(assistantId),
-    staleTime: INSTALLED_STALE_TIME_MS,
   });
 
   const plugins = useMemo(
@@ -73,7 +46,6 @@ export function useNewChatPlugins(assistantId: string): UseNewChatPluginsResult 
   const selection = activeConversationId
     ? (pendingDraftPlugins.get(activeConversationId) ?? null)
     : null;
-  const hasExplicitSelection = selection !== null;
 
   const isSelected = useCallback(
     (name: string) => (selection ? selection.has(name) : true),
@@ -101,9 +73,7 @@ export function useNewChatPlugins(assistantId: string): UseNewChatPluginsResult 
 
   return {
     plugins,
-    isLoading: installedQuery.isLoading,
     isSelected,
     toggle,
-    hasExplicitSelection,
   };
 }

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -3,16 +3,13 @@ import { useMemo } from "react";
 
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import { mergePlugins, sortPlugins } from "@/domains/intelligence/plugins/utils";
-import {
-    pluginsGetQueryKey,
-    pluginsSearchGetOptions,
-} from "@/generated/daemon/@tanstack/react-query.gen";
-import { pluginsGet } from "@/generated/daemon/sdk.gen";
-import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { pluginsSearchGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
 
-// The installed list (local filesystem) and the catalog (the daemon's
-// cached, rate-limited GitHub listing) both change rarely, so `staleTime`
-// keeps each warm across tab switches and revisiting doesn't refetch.
+// The catalog (the daemon's cached, rate-limited GitHub listing) changes
+// rarely, so `staleTime` keeps it warm across tab switches and revisiting
+// doesn't refetch. The installed read carries its own staleTime via
+// `installedPluginsQueryOptions`.
 const CATALOG_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface UsePluginsListResult {
@@ -48,26 +45,8 @@ export interface UsePluginsListResult {
  */
 export function usePluginsList(assistantId: string): UsePluginsListResult {
   const installedQuery = useQuery({
-    queryKey: pluginsGetQueryKey({
-      path: { assistant_id: assistantId },
-      query: { q: undefined },
-    }),
-    queryFn: async ({ signal }) => {
-      const result = await pluginsGet({
-        path: { assistant_id: assistantId },
-        query: { q: undefined },
-        signal,
-        throwOnError: false,
-      });
-      const status = result.response?.status;
-      // Older daemons return 404 when the list endpoint isn't
-      // implemented yet — degrade to an empty installed list.
-      if (status === 404) return { plugins: [] } as PluginsGetResponse;
-      if (!result.response?.ok) throw new Error("Failed to load plugins");
-      return result.data ?? ({ plugins: [] } as PluginsGetResponse);
-    },
+    ...installedPluginsQueryOptions(assistantId),
     enabled: Boolean(assistantId),
-    staleTime: CATALOG_STALE_TIME_MS,
   });
 
   const catalogQuery = useQuery({

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
@@ -3,13 +3,18 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 import {
   resolveSupportsNewChatPlugins,
-  supportsNewChatPlugins,
   useSupportsNewChatPlugins,
 } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 function setVersion(version: string | null) {
   useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+/** Read the gate synchronously through the exported hook variant. */
+function readGateViaHook(version: string | null): boolean {
+  setVersion(version);
+  return renderHook(() => useSupportsNewChatPlugins()).result.current;
 }
 
 beforeEach(() => {
@@ -23,57 +28,29 @@ afterEach(() => {
 
 // Exhaustive truth-table for the underlying semver gate lives in
 // `utils.test.ts`. Here we verify the boundary on each side of 0.10.4
-// plus the conservative-on-unknown policy and the awaiting send-path
-// variant.
-describe("supportsNewChatPlugins", () => {
-  test("returns false when the version is unknown", () => {
-    setVersion(null);
-    expect(supportsNewChatPlugins()).toBe(false);
-  });
-
-  test("returns false for assistants on 0.10.3 and older", () => {
-    setVersion("0.10.3");
-    expect(supportsNewChatPlugins()).toBe(false);
-    setVersion("0.10.0");
-    expect(supportsNewChatPlugins()).toBe(false);
-    setVersion("0.9.0");
-    expect(supportsNewChatPlugins()).toBe(false);
-  });
-
-  test("returns true for assistants on 0.10.4+", () => {
-    setVersion("0.10.4");
-    expect(supportsNewChatPlugins()).toBe(true);
-    setVersion("0.11.0");
-    expect(supportsNewChatPlugins()).toBe(true);
-    setVersion("1.0.0");
-    expect(supportsNewChatPlugins()).toBe(true);
-  });
-
-  test("returns false for unparseable versions", () => {
-    setVersion("garbage");
-    expect(supportsNewChatPlugins()).toBe(false);
-    setVersion("0.10");
-    expect(supportsNewChatPlugins()).toBe(false);
-  });
-});
-
+// plus the conservative-on-unknown policy, exercised through the public
+// hook and the awaiting send-path variant. (The snapshot read is a
+// private helper; it is covered via these exported entry points.)
 describe("useSupportsNewChatPlugins", () => {
-  test("returns false while unresolved and on older daemons", () => {
-    setVersion(null);
-    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
-      false,
-    );
-    setVersion("0.10.3");
-    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
-      false,
-    );
+  test("reads false when the version is unknown", () => {
+    expect(readGateViaHook(null)).toBe(false);
   });
 
-  test("returns true on supported daemons", () => {
-    setVersion("0.10.4");
-    expect(renderHook(() => useSupportsNewChatPlugins()).result.current).toBe(
-      true,
-    );
+  test("reads false for assistants on 0.10.3 and older", () => {
+    expect(readGateViaHook("0.10.3")).toBe(false);
+    expect(readGateViaHook("0.10.0")).toBe(false);
+    expect(readGateViaHook("0.9.0")).toBe(false);
+  });
+
+  test("reads true for assistants on 0.10.4+", () => {
+    expect(readGateViaHook("0.10.4")).toBe(true);
+    expect(readGateViaHook("0.11.0")).toBe(true);
+    expect(readGateViaHook("1.0.0")).toBe(true);
+  });
+
+  test("reads false for unparseable versions", () => {
+    expect(readGateViaHook("garbage")).toBe(false);
+    expect(readGateViaHook("0.10")).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
@@ -33,14 +33,15 @@ export const MIN_VERSION = "0.10.4";
 
 /**
  * Returns `true` when the active assistant accepts the per-chat plugin
- * set. Snapshot variant for non-hook contexts (request builders, event
- * handlers).
+ * set. Snapshot read shared by the hook and async variants below.
  *
  * Returns `false` while the identity store has no version yet, when the
- * version is unparseable, or when it falls below `MIN_VERSION`. Callers
- * must omit the per-chat plugin set on the `false` branch.
+ * version is unparseable, or when it falls below `MIN_VERSION`. Not
+ * exported: snapshot reads must go through {@link resolveSupportsNewChatPlugins}
+ * (send path) so the decision awaits version hydration rather than reading
+ * the pre-hydration `false`.
  */
-export function supportsNewChatPlugins(): boolean {
+function supportsNewChatPlugins(): boolean {
   return assistantSupports(MIN_VERSION);
 }
 

--- a/clients/web/src/lib/installed-plugins-query.ts
+++ b/clients/web/src/lib/installed-plugins-query.ts
@@ -1,0 +1,45 @@
+import type { QueryFunctionContext } from "@tanstack/react-query";
+
+import { pluginsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { pluginsGet } from "@/generated/daemon/sdk.gen";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+
+// The installed list (local filesystem) changes rarely, so a `staleTime`
+// keeps it warm across remounts and tab switches.
+const INSTALLED_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Shared React Query options for the installed-plugins read (`pluginsGet`).
+ *
+ * The new-chat composer (`useNewChatPlugins`) and the Plugins tab
+ * (`usePluginsList`) both build the SAME `pluginsGetQueryKey`, so they resolve
+ * to one cache entry. Centralizing the queryKey/queryFn/staleTime here keeps
+ * that single entry consistent and stops the two read paths from drifting —
+ * notably the older-daemon 404 → empty degradation and the
+ * `!response.ok` throw.
+ *
+ * Depends only on the generated SDK, so it lives in `lib/` (no domain import).
+ */
+export function installedPluginsQueryOptions(assistantId: string) {
+  return {
+    queryKey: pluginsGetQueryKey({
+      path: { assistant_id: assistantId },
+      query: { q: undefined },
+    }),
+    queryFn: async ({ signal }: QueryFunctionContext) => {
+      const result = await pluginsGet({
+        path: { assistant_id: assistantId },
+        query: { q: undefined },
+        signal,
+        throwOnError: false,
+      });
+      const status = result.response?.status;
+      // Older daemons return 404 when the list endpoint isn't implemented
+      // yet — degrade to an empty installed list.
+      if (status === 404) return { plugins: [] } as PluginsGetResponse;
+      if (!result.response?.ok) throw new Error("Failed to load plugins");
+      return result.data ?? ({ plugins: [] } as PluginsGetResponse);
+    },
+    staleTime: INSTALLED_STALE_TIME_MS,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared installedPluginsQueryOptions to lib/ (one cache source for chat + intelligence)
- Drop unused useNewChatPlugins return fields, dead conversationId prop, and over-exported sync gate

Addresses self-review slop findings for plan: new-chat-plugin-pills.md