### PR TITLE
refactor(web): drive active-process overlays from PROCESS_KINDS

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -318,9 +318,13 @@ describe("ChatBody — startersSlot rendering", () => {
 
 });
 
-describe("ChatBody — active subagents overlay slot", () => {
-  const activeSubagentsSlot = (
-    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
+describe("ChatBody — active-process overlays slot", () => {
+  // The orchestrator builds the registry-driven row (subagents → acp runs →
+  // workflows → background tasks) and passes it as a single node; ChatBody
+  // only positions it in the top-center overlay (and gates it on the empty
+  // state). Ordering across kinds is owned by the registry, not ChatBody.
+  const activeProcessOverlaysSlot = (
+    <div data-testid="active-process-overlays">ACTIVE_PROCESSES</div>
   );
 
   test("renders the slot top-center when scrolled up and slot is provided", () => {
@@ -328,11 +332,11 @@ describe("ChatBody — active subagents overlay slot", () => {
       <ChatBody
         {...baseProps({
           showScrollToLatest: true,
-          activeSubagentsSlot,
+          activeProcessOverlaysSlot,
         })}
       />,
     );
-    expect(html).toContain("ACTIVE_SUBAGENTS");
+    expect(html).toContain("ACTIVE_PROCESSES");
   });
 
   test("renders the slot even when pinned (showScrollToLatest false) — always-on while running", () => {
@@ -340,11 +344,11 @@ describe("ChatBody — active subagents overlay slot", () => {
       <ChatBody
         {...baseProps({
           showScrollToLatest: false,
-          activeSubagentsSlot,
+          activeProcessOverlaysSlot,
         })}
       />,
     );
-    expect(html).toContain("ACTIVE_SUBAGENTS");
+    expect(html).toContain("ACTIVE_PROCESSES");
   });
 
   test("does NOT render the slot on the empty state", () => {
@@ -352,11 +356,18 @@ describe("ChatBody — active subagents overlay slot", () => {
       <ChatBody
         {...withEmptyState({
           showScrollToLatest: true,
-          activeSubagentsSlot,
+          activeProcessOverlaysSlot,
         })}
       />,
     );
-    expect(html).not.toContain("ACTIVE_SUBAGENTS");
+    expect(html).not.toContain("ACTIVE_PROCESSES");
+  });
+
+  test("does NOT render the overlay row when the slot is undefined", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody {...baseProps({ showScrollToLatest: true })} />,
+    );
+    expect(html).not.toContain("ACTIVE_PROCESSES");
   });
 
   test("Go-to-Newest bottom overlay still renders alongside the slot (no regression)", () => {
@@ -364,87 +375,12 @@ describe("ChatBody — active subagents overlay slot", () => {
       <ChatBody
         {...baseProps({
           showScrollToLatest: true,
-          activeSubagentsSlot,
+          activeProcessOverlaysSlot,
         })}
       />,
     );
     expect(html).toContain("SCROLL_TO_LATEST");
-    expect(html).toContain("ACTIVE_SUBAGENTS");
-  });
-});
-
-describe("ChatBody — active workflows overlay slot", () => {
-  const activeSubagentsSlot = (
-    <div data-testid="active-subagents-slot">ACTIVE_SUBAGENTS</div>
-  );
-  const activeWorkflowsSlot = (
-    <div data-testid="active-workflows-slot">ACTIVE_WORKFLOWS</div>
-  );
-
-  test("renders the slot top-center when scrolled up and slot is provided", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...baseProps({
-          showScrollToLatest: true,
-          activeWorkflowsSlot,
-        })}
-      />,
-    );
-    expect(html).toContain("ACTIVE_WORKFLOWS");
-  });
-
-  test("renders the slot even when pinned (showScrollToLatest false) — always-on while running", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...baseProps({
-          showScrollToLatest: false,
-          activeWorkflowsSlot,
-        })}
-      />,
-    );
-    expect(html).toContain("ACTIVE_WORKFLOWS");
-  });
-
-  test("does NOT render the slot on the empty state", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...withEmptyState({
-          showScrollToLatest: true,
-          activeWorkflowsSlot,
-        })}
-      />,
-    );
-    expect(html).not.toContain("ACTIVE_WORKFLOWS");
-  });
-
-  test("renders BOTH slots simultaneously when both are provided", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...baseProps({
-          showScrollToLatest: true,
-          activeSubagentsSlot,
-          activeWorkflowsSlot,
-        })}
-      />,
-    );
-    expect(html).toContain("ACTIVE_SUBAGENTS");
-    expect(html).toContain("ACTIVE_WORKFLOWS");
-  });
-
-  test("renders the subagent pill to the LEFT of the workflow pill", () => {
-    const html = renderToStaticMarkup(
-      <ChatBody
-        {...baseProps({
-          showScrollToLatest: true,
-          activeSubagentsSlot,
-          activeWorkflowsSlot,
-        })}
-      />,
-    );
-    // DOM order: subagents must precede workflows in the centered row.
-    expect(html.indexOf("ACTIVE_SUBAGENTS")).toBeLessThan(
-      html.indexOf("ACTIVE_WORKFLOWS"),
-    );
+    expect(html).toContain("ACTIVE_PROCESSES");
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -175,23 +175,14 @@ export interface ChatBodyProps {
   dockStartersToBottom?: boolean;
 
   /**
-   * Top-center floating overlay. Shown whenever there is ≥1 active subagent,
-   * independent of scroll position; the caller passes the slot only when its
-   * active list is non-empty.
+   * Top-center floating row of active background-process overlays (subagents,
+   * ACP runs, workflows, background tasks), shown independent of scroll
+   * position. The caller builds this from the process registry and passes it
+   * only when at least one process is active; each overlay self-gates on its
+   * own active ids. Omitting it (or passing `undefined`) keeps the row from
+   * mounting.
    */
-  activeSubagentsSlot?: ReactNode;
-
-  /**
-   * Top-center floating overlay for active ACP runs; gated identically to
-   * {@link activeSubagentsSlot} and placed alongside it.
-   */
-  activeAcpRunsSlot?: ReactNode;
-
-  /** Floating overlay for active workflow runs; gated like activeSubagentsSlot. */
-  activeWorkflowsSlot?: ReactNode;
-
-  /** Floating overlay for active background tasks; gated like activeSubagentsSlot. */
-  activeBackgroundTasksSlot?: ReactNode;
+  activeProcessOverlaysSlot?: ReactNode;
 }
 
 /**
@@ -249,10 +240,7 @@ export function ChatBody({
   startersSlot,
   belowFoldSlot,
   dockStartersToBottom = false,
-  activeSubagentsSlot,
-  activeAcpRunsSlot,
-  activeWorkflowsSlot,
-  activeBackgroundTasksSlot,
+  activeProcessOverlaysSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
   const bottomBannerOverlayRef = useRef<HTMLDivElement | null>(null);
@@ -476,21 +464,14 @@ export function ChatBody({
         bottomOverlayReservePx={bottomOverlayReservePx}
       />
 
-      {!isEmptyState &&
-        (activeSubagentsSlot ||
-          activeAcpRunsSlot ||
-          activeWorkflowsSlot ||
-          activeBackgroundTasksSlot) && (
-          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-            {/* Always shown while a background process of that type is running,
-                independent of scroll position. subagents, then active acp runs,
-                then workflows, then background tasks (do not reorder). */}
-            {activeSubagentsSlot}
-            {activeAcpRunsSlot}
-            {activeWorkflowsSlot}
-            {activeBackgroundTasksSlot}
-          </div>
-        )}
+      {!isEmptyState && activeProcessOverlaysSlot && (
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+          {/* Registry-driven row of active background-process overlays. Order is
+              owned by PROCESS_KINDS (subagents, acp runs, workflows, background
+              tasks); each overlay self-gates on its own active ids. */}
+          {activeProcessOverlaysSlot}
+        </div>
+      )}
 
       {renderComposerStack(startersSlot)}
       {dragOverlay}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -19,12 +19,8 @@
 
 import { type Dispatch, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
-import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
-import { useActiveBackgroundTaskIds } from "@/domains/chat/hooks/use-active-background-task-ids";
 import { useAcpRunRehydration } from "@/domains/chat/hooks/use-acp-run-rehydration";
 import { useBackgroundTaskRehydration } from "@/domains/chat/hooks/use-background-task-rehydration";
-import { useActiveWorkflowRunIds } from "@/domains/chat/hooks/use-active-workflow-run-ids";
 import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
@@ -41,10 +37,12 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
-import { ActiveSubagentsOverlay } from "@/domains/chat/components/active-subagents-overlay/active-subagents-overlay";
-import { ActiveAcpRunsOverlay } from "@/domains/chat/components/active-acp-runs-overlay/active-acp-runs-overlay";
-import { ActiveBackgroundTasksOverlay } from "@/domains/chat/components/active-background-tasks-overlay/active-background-tasks-overlay";
-import { ActiveWorkflowsOverlay } from "@/domains/chat/components/active-workflows-overlay/active-workflows-overlay";
+import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
+import { PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
+import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
@@ -151,6 +149,36 @@ export interface ChatMainPanelProps {
 
 /** @deprecated Use {@link ChatMainPanelProps} — kept as a re-export for migration. */
 export type ChatRouteContentProps = ChatMainPanelProps;
+
+/**
+ * Builds the registry-driven row of active background-process overlays.
+ *
+ * Each descriptor's `useActiveIds()` is a zero-arg hook that resolves the
+ * active conversation internally, so the hooks are called here at the
+ * orchestrator level (where the conversation lives in context). They must be
+ * called explicitly per-kind — the Rules of Hooks forbid iterating
+ * `PROCESS_KINDS` with hooks — and kept aligned with `PROCESS_KINDS` order.
+ *
+ * `hasAny` lets the caller omit the row entirely when nothing is active, so the
+ * absolutely-positioned container never mounts empty; the overlays themselves
+ * also self-gate on their own ids.
+ */
+function useActiveProcessSlots() {
+  const subagentIds = SUBAGENT_DESCRIPTOR.useActiveIds();
+  const acpRunIds = ACP_RUN_DESCRIPTOR.useActiveIds();
+  const workflowIds = WORKFLOW_DESCRIPTOR.useActiveIds();
+  const backgroundTaskIds = BACKGROUND_TASK_DESCRIPTOR.useActiveIds();
+  const idsByKind = [subagentIds, acpRunIds, workflowIds, backgroundTaskIds];
+  const hasAny = idsByKind.some((ids) => ids.length > 0);
+  const overlays = PROCESS_KINDS.map((descriptor, i) => (
+    <ActiveProcessOverlay
+      key={descriptor.kind}
+      descriptor={descriptor}
+      ids={idsByKind[i]}
+    />
+  ));
+  return { overlays, hasAny };
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -279,10 +307,8 @@ export function ChatMainPanel({
     if (assistantId) void useViewerStore.getState().loadDocument(assistantId, surfaceId);
   }, [assistantId]);
 
-  const activeSubagentIds = useActiveSubagentIds(activeConversationId);
-  const activeAcpRunIds = useActiveAcpRunIds(activeConversationId);
-  const activeBackgroundTaskIds = useActiveBackgroundTaskIds(activeConversationId);
-  const activeWorkflowRunIds = useActiveWorkflowRunIds();
+  const { overlays: activeProcessOverlays, hasAny: hasActiveProcess } =
+    useActiveProcessSlots();
 
   // Rehydrate ACP runs from the daemon on conversation load so completed and
   // in-progress runs reappear after a refresh / reconnect.
@@ -294,14 +320,6 @@ export function ChatMainPanel({
 
   const onSubagentClick = useCallback((id: string) => {
     useViewerStore.getState().openSubagentDetail(id);
-  }, []);
-
-  const onAcpRunClick = useCallback((acpSessionId: string) => {
-    useViewerStore.getState().openAcpRunDetail(acpSessionId);
-  }, []);
-
-  const onBackgroundTaskClick = useCallback((id: string) => {
-    useViewerStore.getState().openBackgroundTaskDetail(id);
   }, []);
 
   const onStopSubagent = useCallback(
@@ -913,40 +931,6 @@ export function ChatMainPanel({
     transcriptProps: chatTranscriptProps,
   };
 
-  const activeSubagentsSlot =
-    activeSubagentIds.length > 0 ? (
-      <ActiveSubagentsOverlay
-        subagentIds={activeSubagentIds}
-        onSubagentClick={onSubagentClick}
-        onStopSubagent={onStopSubagent}
-      />
-    ) : undefined;
-
-  const activeAcpRunsSlot =
-    activeAcpRunIds.length > 0 ? (
-      <ActiveAcpRunsOverlay
-        acpRunIds={activeAcpRunIds}
-        onAcpRunClick={onAcpRunClick}
-      />
-    ) : undefined;
-
-  const activeWorkflowsSlot =
-    activeWorkflowRunIds.length > 0 ? (
-      <ActiveWorkflowsOverlay
-        workflowRunIds={activeWorkflowRunIds}
-        onWorkflowClick={onWorkflowClick}
-        onStopWorkflow={onStopWorkflow}
-      />
-    ) : undefined;
-
-  const activeBackgroundTasksSlot =
-    activeBackgroundTaskIds.length > 0 ? (
-      <ActiveBackgroundTasksOverlay
-        taskIds={activeBackgroundTaskIds}
-        onTaskClick={onBackgroundTaskClick}
-      />
-    ) : undefined;
-
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -983,10 +967,9 @@ export function ChatMainPanel({
       startersSlot={startersSlot}
       belowFoldSlot={belowFoldSlot}
       dockStartersToBottom={dockStartersToBottom}
-      activeSubagentsSlot={activeSubagentsSlot}
-      activeAcpRunsSlot={activeAcpRunsSlot}
-      activeWorkflowsSlot={activeWorkflowsSlot}
-      activeBackgroundTasksSlot={activeBackgroundTasksSlot}
+      activeProcessOverlaysSlot={
+        hasActiveProcess ? activeProcessOverlays : undefined
+      }
     />
   );
 


### PR DESCRIPTION
## Summary
- Collapse chat-body's four hardcoded overlay slots into one registry-driven row (PROCESS_KINDS.map → ActiveProcessOverlay); chat-route-content uses useActiveProcessSlots. Same order/gating/behavior.

Part of plan: background-process-registry.md (PR 11 of 17)