### PR TITLE
fix(daemon): complete per-chat skill scoping + CI test-mock fix

### DIFF
--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -79,6 +79,8 @@ const mockSkillRefCount = new Map<string, number>();
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
+  // Pass-through: these tests don't exercise per-chat plugin scoping.
+  filterSkillsByEnabledPlugins: (skills: unknown) => skills,
 }));
 
 mock.module("../skills/active-skill-tools.js", () => ({

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -47,6 +47,19 @@ let recordedLastUsedTouches: Array<{ skillDir: string; today: string }> = [];
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
+  // Faithful reimplementation of the real plugin-scope filter — the
+  // per-chat plugin scope suite below depends on its drop behavior.
+  filterSkillsByEnabledPlugins: (
+    skills: SkillSummary[],
+    effectiveEnabledPluginSet: Set<string> | null,
+  ) =>
+    effectiveEnabledPluginSet === null
+      ? skills
+      : skills.filter((skill) => {
+          const owner = skill.owner;
+          if (owner?.kind !== "plugin") return true;
+          return effectiveEnabledPluginSet.has(owner.id);
+        }),
 }));
 
 mock.module("../skills/active-skill-tools.js", () => {

--- a/assistant/src/__tests__/skill-load-plugin-scope.test.ts
+++ b/assistant/src/__tests__/skill-load-plugin-scope.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests that `skill_load` rejects loading a plugin-owned skill whose owning
+ * plugin is outside the conversation's effective per-chat plugin set, and lets
+ * it through when the plugin is in scope (or when there is no restriction).
+ *
+ * `loadSkillBySelector` is mocked to return a plugin-owned skill rooted at a
+ * real temp dir so the in-scope path can complete the full load.
+ */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillDefinition } from "../config/skills.js";
+
+const noopLogger = new Proxy({} as Record<string, unknown>, {
+  get: (_t, prop) => (prop === "child" ? () => noopLogger : () => {}),
+});
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (s: unknown) => String(s),
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  getConfigReadOnly: () => ({}),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  deepMergeOverwrite: (a: unknown) => a,
+  mergeDefaultWorkspaceConfig: () => {},
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+    "tavily",
+  ],
+}));
+
+// A real directory so the in-scope load's filesystem reads (reference listing,
+// version hash, tool manifest) succeed.
+const skillDir = mkdtempSync(join(tmpdir(), "skill-plugin-scope-"));
+writeFileSync(
+  join(skillDir, "SKILL.md"),
+  `---\nname: "plug-skill"\ndescription: "Owned by plugin p"\n---\n\nDo the plugin thing.\n`,
+);
+
+const pluginSkill: SkillDefinition = {
+  id: "plug-skill",
+  name: "plug-skill",
+  displayName: "Plugin Skill",
+  description: "Owned by plugin p",
+  directoryPath: skillDir,
+  skillFilePath: join(skillDir, "SKILL.md"),
+  source: "plugin",
+  owner: { kind: "plugin", id: "p" },
+  body: "Do the plugin thing.",
+  includes: [],
+};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realSkills = require("../config/skills.js");
+mock.module("../config/skills.js", () => ({
+  ...realSkills,
+  loadSkillBySelector: () => ({ skill: pluginSkill }),
+}));
+
+await import("../tools/skills/load.js");
+const { getTool } = await import("../tools/registry.js");
+
+const REJECTION = "not available in this conversation";
+
+async function loadWithScope(
+  enabledPluginSet: Set<string> | null | undefined,
+): Promise<{ content: string; isError: boolean }> {
+  const tool = getTool("skill_load");
+  if (!tool) throw new Error("skill_load tool was not registered");
+  const result = await tool.execute(
+    { skill: "plug-skill" },
+    {
+      workingDir: "/tmp",
+      conversationId: "conversation-1",
+      trustClass: "guardian",
+      enabledPluginSet,
+    },
+  );
+  return { content: result.content, isError: result.isError };
+}
+
+describe("skill_load — per-chat plugin scope", () => {
+  test("rejects a plugin skill whose owner is outside the effective set", async () => {
+    const result = await loadWithScope(new Set(["other"]));
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(REJECTION);
+    expect(result.content).toContain("plug-skill");
+  });
+
+  test("loads the plugin skill when its owner is in the effective set", async () => {
+    const result = await loadWithScope(new Set(["p"]));
+    expect(result.content).not.toContain(REJECTION);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Plugin Skill");
+  });
+
+  test("null set (no per-chat restriction) loads the plugin skill", async () => {
+    const result = await loadWithScope(null);
+    expect(result.content).not.toContain(REJECTION);
+    expect(result.isError).toBe(false);
+  });
+
+  test("absent set (no per-chat restriction) loads the plugin skill", async () => {
+    const result = await loadWithScope(undefined);
+    expect(result.content).not.toContain(REJECTION);
+    expect(result.isError).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -30,6 +30,8 @@ const DECLARED_FLAG_KEY = "contacts";
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
+  // Pass-through: these tests don't exercise per-chat plugin scoping.
+  filterSkillsByEnabledPlugins: (skills: unknown) => skills,
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -15,7 +15,7 @@
  *   gating the resolved inner tool name.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
@@ -101,6 +101,11 @@ import {
   type SkillProjectionContext,
   type ToolSetupContext,
 } from "../daemon/conversation-tool-setup.js";
+import {
+  __clearRegistryForTesting,
+  registerPluginTools,
+} from "../tools/registry.js";
+import type { Tool } from "../tools/types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -469,6 +474,78 @@ describe("createToolExecutor — execution-layer allowlist gate", () => {
     );
 
     const result = await toolFn("bash", { command: "echo hi" });
+
+    expect(result).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — per-chat plugin scope guard on the skill_execute dispatch path
+// ---------------------------------------------------------------------------
+
+describe("createToolExecutor — per-chat plugin scope (skill_execute dispatch)", () => {
+  function pluginTool(name: string): Tool {
+    return {
+      name,
+      description: name,
+      input_schema: { type: "object" },
+    } as unknown as Tool;
+  }
+
+  afterEach(() => {
+    __clearRegistryForTesting();
+  });
+
+  test("rejects a skill_execute inner tool owned by a plugin outside the effective set; executor never invoked", async () => {
+    registerPluginTools("p", [pluginTool("p_tool")]);
+    const { executor, calls } = makeCapturingExecutor();
+    // Scope excludes plugin "p" (only "other" + first-party defaults).
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({ enabledPlugins: ["other"] }),
+    );
+
+    const result = await toolFn("skill_execute", {
+      tool: "p_tool",
+      input: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Tool "p_tool" belongs to a plugin that is not enabled',
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test("allows a skill_execute inner tool whose plugin is in the effective set", async () => {
+    registerPluginTools("p", [pluginTool("p_tool")]);
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({ enabledPlugins: ["p"] }),
+    );
+
+    const result = await toolFn("skill_execute", {
+      tool: "p_tool",
+      input: {},
+    });
+
+    expect(result).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("p_tool");
+  });
+
+  test("null scope (no per-chat restriction) does not gate plugin tools", async () => {
+    registerPluginTools("p", [pluginTool("p_tool")]);
+    const { executor, calls } = makeCapturingExecutor();
+    // enabledPlugins absent → getEffectiveEnabledPluginSet returns null.
+    const toolFn = makeToolFn(executor, makeSetupCtx());
+
+    const result = await toolFn("skill_execute", {
+      tool: "p_tool",
+      input: {},
+    });
 
     expect(result).toEqual({ content: "ok", isError: false });
     expect(calls).toHaveLength(1);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -187,6 +187,27 @@ export function createToolExecutor(
     };
   };
 
+  // Per-chat plugin scope guard for the `skill_execute` dispatch path. The
+  // wire definitions + per-turn `allowedToolNames` already keep an excluded
+  // plugin's tools off the model's tool surface, but `skill_execute` names its
+  // inner tool by string, so resolve the inner tool's owner and reject when it
+  // belongs to a plugin outside the conversation's effective set. Authoritative
+  // regardless of how the name was obtained (also covers name collisions where
+  // the projected name is owned by a different, in-scope source). `null` =
+  // no per-chat restriction; non-plugin tools are never blocked.
+  const rejectOutOfScopePluginTool = (
+    toolName: string,
+    effectiveSet: Set<string> | null,
+  ): ToolExecutionResult | null => {
+    if (effectiveSet === null) return null;
+    const owner = getToolOwner(toolName);
+    if (owner?.kind !== "plugin" || effectiveSet.has(owner.id)) return null;
+    return {
+      content: `Tool "${toolName}" belongs to a plugin that is not enabled in this conversation.`,
+      isError: true,
+    };
+  };
+
   return async (
     name: string,
     input: Record<string, unknown>,
@@ -195,6 +216,11 @@ export function createToolExecutor(
   ) => {
     const { name: executionName, input: executionInput } =
       resolveToolInvocationAlias(name, input, ctx.allowedToolNames);
+
+    // Resolve the conversation's effective per-chat plugin scope once per tool
+    // call: reused for the ToolContext field (read by skill-surface tools) and
+    // the skill_execute dispatch guard below.
+    const effectiveEnabledPluginSet = getEffectiveEnabledPluginSet(ctx);
 
     // The execution-layer gate must run FIRST — before any interception or
     // pre-execution side effect (DoorDash step marking) — so a non-allowlisted
@@ -251,6 +277,7 @@ export function createToolExecutor(
       overrideProfile: ctx.currentTurnOverrideProfile,
       invokingCallSite: ctx.currentCallSite ?? "mainAgent",
       attribution: resolveConversationAttribution(ctx),
+      enabledPluginSet: effectiveEnabledPluginSet,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }
@@ -338,6 +365,14 @@ export function createToolExecutor(
       // underlying tool via the executor's allowedToolNames check.
       const innerRejection = rejectNonAllowlistedTool(toolName);
       if (innerRejection) return innerRejection;
+
+      // Per-chat plugin scope: reject the resolved inner tool when it belongs
+      // to a plugin outside the conversation's effective set.
+      const pluginRejection = rejectOutOfScopePluginTool(
+        toolName,
+        effectiveEnabledPluginSet,
+      );
+      if (pluginRejection) return pluginRejection;
 
       const rawResult = await executor.execute(
         toolName,
@@ -738,6 +773,12 @@ export function createResolveToolsCallback(
       return [];
     }
 
+    // Resolve the conversation's effective per-chat plugin scope ONCE for this
+    // turn and reuse it for the plugin-tool filter and the skill projection.
+    // `null` = no per-chat restriction; otherwise a fresh Set of the selection
+    // unioned with the always-on first-party defaults.
+    const effectiveEnabledPluginSet = getEffectiveEnabledPluginSet(ctx);
+
     // Reconcile workspace tool overrides under `<workspaceDir>/tools/` into
     // the registry, then re-read them below — the on-read replacement for a
     // filesystem watcher. Fire-and-forget: the reconcile is idempotent,
@@ -757,13 +798,14 @@ export function createResolveToolsCallback(
     // tools whose owning plugin id is in the set, mirroring the
     // `subagentAllowedTools` intersection below. Ownership lives in the registry
     // (queried via getToolOwner), not on the Tool object.
-    const enabledPlugins = getEffectiveEnabledPluginSet(ctx);
     const scopedPluginDefs =
-      enabledPlugins === null
+      effectiveEnabledPluginSet === null
         ? currentPluginDefs
         : currentPluginDefs.filter((d) => {
             const ownerId = getToolOwner(d.name)?.id;
-            return ownerId !== undefined && enabledPlugins.has(ownerId);
+            return (
+              ownerId !== undefined && effectiveEnabledPluginSet.has(ownerId)
+            );
           });
 
     // Filter core + plugin tools based on current conversation context so that
@@ -825,7 +867,7 @@ export function createResolveToolsCallback(
       cache: ctx.skillProjectionCache,
       // Scope plugin-contributed skills to the conversation's per-chat plugin
       // selection (null = no restriction).
-      effectiveEnabledPluginSet: getEffectiveEnabledPluginSet(ctx),
+      effectiveEnabledPluginSet,
       // skill_loaded telemetry context — resolved per turn so attribution
       // reflects the call site/profile the current turn actually runs on.
       telemetry:

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -105,6 +105,14 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   callSessionId?: string;
   /** The interface ID of the connected client driving the current turn (e.g. "macos", "chrome-extension"). Propagated into ToolContext for browser backend selection. */
   readonly transportInterface?: InterfaceId;
+  /**
+   * The conversation's per-chat plugin scope (mirrors
+   * {@link Conversation.enabledPlugins}). `null`/absent means no per-chat
+   * restriction. Read per tool call to derive the effective enabled-plugin set
+   * (via `getEffectiveEnabledPluginSet`) for the `ToolContext.enabledPluginSet`
+   * field and the `skill_execute` dispatch guard.
+   */
+  readonly enabledPlugins?: string[] | null;
 
   /** Turn-scoped flag: true when any tool call in the current turn received explicit user approval via interactive prompt. Cleared at turn end. */
   approvedViaPromptThisTurn?: boolean;

--- a/assistant/src/tools/skills/find-similar-skills.test.ts
+++ b/assistant/src/tools/skills/find-similar-skills.test.ts
@@ -18,6 +18,7 @@ import { basename } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
 import type { SkillSource } from "../../config/skills.js";
+import type { OwnerInfo } from "../types.js";
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -40,11 +41,12 @@ mock.module("../../skills/install-meta.js", () => ({
 import type { ToolContext } from "../types.js";
 import { executeFindSimilarSkills } from "./find-similar-skills.js";
 
-function makeContext(): ToolContext {
+function makeContext(enabledPluginSet?: Set<string> | null): ToolContext {
   return {
     workingDir: "/tmp",
     conversationId: "test-conversation",
     trustClass: "guardian",
+    enabledPluginSet,
   };
 }
 
@@ -54,6 +56,7 @@ const catalog = (
     name: string;
     description: string;
     source: SkillSource;
+    owner?: OwnerInfo;
   }[]
 ) => skills;
 
@@ -217,6 +220,79 @@ describe("find_similar_skills — enrichment", () => {
 
     expect(result.isError).toBe(false);
     expect(JSON.parse(result.content)).toEqual({ skills: [] });
+  });
+});
+
+describe("find_similar_skills — per-chat plugin scope", () => {
+  const SHORTLIST = [
+    { skillId: "core-skill", score: 0.9 },
+    { skillId: "plug-skill", score: 0.8 },
+  ];
+  const CATALOG = () =>
+    catalog(
+      {
+        id: "core-skill",
+        name: "Core Skill",
+        description: "A bundled skill",
+        source: "bundled",
+      },
+      {
+        id: "plug-skill",
+        name: "Plugin Skill",
+        description: "Owned by plugin p",
+        source: "plugin",
+        owner: { kind: "plugin", id: "p" },
+      },
+    );
+
+  test("drops a plugin skill whose owner is outside the effective set", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "do the thing" },
+      makeContext(new Set(["other"])),
+      {
+        nearestExistingSkills: async () => SHORTLIST,
+        loadCatalog: CATALOG,
+      },
+    );
+
+    const ids = (
+      JSON.parse(result.content).skills as { skill_id: string }[]
+    ).map((s) => s.skill_id);
+    expect(ids).toContain("core-skill");
+    expect(ids).not.toContain("plug-skill");
+  });
+
+  test("keeps a plugin skill whose owner is in the effective set", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "do the thing" },
+      makeContext(new Set(["p"])),
+      {
+        nearestExistingSkills: async () => SHORTLIST,
+        loadCatalog: CATALOG,
+      },
+    );
+
+    const ids = (
+      JSON.parse(result.content).skills as { skill_id: string }[]
+    ).map((s) => s.skill_id);
+    expect(ids).toContain("core-skill");
+    expect(ids).toContain("plug-skill");
+  });
+
+  test("null set (no restriction) keeps every skill", async () => {
+    const result = await executeFindSimilarSkills(
+      { goal: "do the thing" },
+      makeContext(null),
+      {
+        nearestExistingSkills: async () => SHORTLIST,
+        loadCatalog: CATALOG,
+      },
+    );
+
+    const ids = (
+      JSON.parse(result.content).skills as { skill_id: string }[]
+    ).map((s) => s.skill_id);
+    expect(ids).toEqual(["core-skill", "plug-skill"]);
   });
 });
 

--- a/assistant/src/tools/skills/find-similar-skills.ts
+++ b/assistant/src/tools/skills/find-similar-skills.ts
@@ -3,7 +3,7 @@ import { loadSkillCatalog } from "../../config/skills.js";
 import { nearestExistingSkills } from "../../plugins/defaults/memory/v3/candidate-match.js";
 import { readInstallMeta } from "../../skills/install-meta.js";
 import { getManagedSkillDir } from "../../skills/managed-store.js";
-import type { ToolContext, ToolExecutionResult } from "../types.js";
+import type { OwnerInfo, ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
  * A shortlisted skill enriched with its catalog name, description, and source.
@@ -36,7 +36,7 @@ interface EnrichedHit {
  */
 export async function executeFindSimilarSkills(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
   deps: {
     nearestExistingSkills?: typeof nearestExistingSkills;
     loadCatalog?: () => {
@@ -44,6 +44,7 @@ export async function executeFindSimilarSkills(
       name: string;
       description: string;
       source: SkillSource;
+      owner?: OwnerInfo;
     }[];
   } = {},
 ): Promise<ToolExecutionResult> {
@@ -78,10 +79,23 @@ export async function executeFindSimilarSkills(
   const catalog = loadCatalog();
   const byId = new Map(catalog.map((s) => [s.id, s]));
 
+  // Per-chat plugin scope: a plugin-owned skill whose owning plugin is outside
+  // the conversation's effective set must not be surfaced as a discovery
+  // result. `null` = no restriction; non-plugin skills are always retained
+  // (mirrors `filterSkillsByEnabledPlugins`).
+  const enabledPluginSet = context.enabledPluginSet ?? null;
+
   const enriched: EnrichedHit[] = [];
   for (const hit of hits) {
     const skill = byId.get(hit.skillId);
     if (!skill) continue;
+    if (
+      enabledPluginSet !== null &&
+      skill.owner?.kind === "plugin" &&
+      !enabledPluginSet.has(skill.owner.id)
+    ) {
+      continue;
+    }
     enriched.push({
       skill_id: hit.skillId,
       name: skill.name,

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -212,6 +212,23 @@ export const skillLoadTool = {
 
     const skill = loaded.skill;
 
+    // Per-chat plugin scope gate: a plugin-owned skill whose owning plugin is
+    // outside the conversation's effective set must not have its instructions
+    // loaded. Mirrors the projection/tools filter's owner-id lookup
+    // (`filterSkillsByEnabledPlugins`). `null` = no restriction; first-party
+    // defaults are always in the set, so bundled/workspace skills pass.
+    const enabledPluginSet = context.enabledPluginSet ?? null;
+    if (
+      enabledPluginSet !== null &&
+      skill.owner?.kind === "plugin" &&
+      !enabledPluginSet.has(skill.owner.id)
+    ) {
+      return {
+        content: `Error: skill "${skill.id}" is not available in this conversation — its plugin is not enabled here.`,
+        isError: true,
+      };
+    }
+
     // Assistant feature flag gate: reject loading if the skill's flag is OFF
     const config = getConfig();
     const flagKey = skillFlagKey(skill);

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -483,6 +483,18 @@ export interface ToolContext {
    * @legacy
    */
   sourceActorPrincipalId?: string;
+  /**
+   * The conversation's effective per-chat plugin scope, as produced by
+   * `getEffectiveEnabledPluginSet`: `null` means no per-chat restriction;
+   * otherwise a Set of allowed plugin ids (the user's selection unioned with
+   * the always-on first-party defaults). Skill-surface tools that resolve
+   * skills by id outside the per-turn projection — `skill_load` (body load)
+   * and `find_similar_skills` (discovery) — read this to drop skills owned by
+   * plugins outside the conversation's scope. Populated per tool call from the
+   * live conversation state.
+   * @legacy
+   */
+  enabledPluginSet?: Set<string> | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix CI-red: add filterSkillsByEnabledPlugins to 3 skills test mocks
- Scope skill_load + find_similar_skills (+ executor guard if execution reachable) by the conversation's effective enabled-plugin set, exempting defaults
- Hoist getEffectiveEnabledPluginSet to compute once per resolveTools callback

Addresses self-review gaps for plan: new-chat-plugin-pills.md