### PR TITLE
Add fitness-companion plugin to marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -136,6 +136,18 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/red-pen",
       "license": "MIT"
+    },
+    {
+      "name": "fitness-companion",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/fitness-companion",
+        "ref": "6d71272d8e2c9e67732cb309499316baa13aca50"
+      },
+      "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
+      "category": "health",
+      "homepage": "https://github.com/vellum-ai/fitness-companion",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -142,7 +142,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/fitness-companion",
-        "ref": "2d889b556372a5b0fde8cfd4d904c269f5a4adf8"
+        "ref": "737cf7f33b43c82f0bfeb949b3f2a507c4a8b0d1"
       },
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -142,7 +142,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/fitness-companion",
-        "ref": "6d71272d8e2c9e67732cb309499316baa13aca50"
+        "ref": "2d889b556372a5b0fde8cfd4d904c269f5a4adf8"
       },
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",


### PR DESCRIPTION
## What

Adds [`fitness-companion`](https://github.com/vellum-ai/fitness-companion) to the curated plugin catalog.

## What the plugin does

A fitness and nutrition companion that turns the assistant into a health coach. No credentials required, any user can install and it just works.

**6 tools:**
- `fitness_log_meal` — log meals with calories and macros
- `fitness_log_workout` — log workouts with sets/reps/weight
- `fitness_log_weight` — log body weight with delta from last entry
- `fitness_nutrition_lookup` — search OpenFoodFacts (free, no API key)
- `fitness_calc_macros` — Mifflin-St Jeor BMR + activity multipliers
- `fitness_get_progress` — calorie averages, workout streaks, weight trends

**3 skills:**
- `nutrition-coaching` — meal structuring, protein targets, hydration
- `workout-planning` — beginner to advanced routines, progressive overload
- `habit-building` — sleep, steps, consistency, behavior change

**2 hooks:**
- `init` — bootstraps CSV storage in plugin `data/` dir
- `pre-model-call` — injects daily fitness context (calories, protein, workouts, weight) into every turn

**Data:** CSV files in `plugins/fitness-companion/data/`, preserved across upgrades.

## Verification

- `assistant plugins list` shows status `ok`
- `assistant plugins inspect fitness-companion` lists all 6 tools, 3 skills, 2 hooks
- 0 load issues
- Pinned to commit `6d71272d8e2c9e67732cb309499316baa13aca50`

## Category

`health`

## License

MIT