### PR TITLE
feat(onboarding): replace research suggestions with a "Let's chat" handoff

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17943,6 +17943,12 @@ paths:
                     - low
                     - medium
                     - high
+                hidden:
+                  description:
+                    When true, persist the user message but suppress it from the UI transcript (it stays in LLM-side history
+                    and still drives the turn). Used to prime a proactive assistant greeting without showing the
+                    triggering user message. Honored on the standard send path only.
+                  type: boolean
                 onboarding:
                   type: object
                   properties:

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -323,6 +323,90 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
 
+  test("hidden:true persists hidden metadata and still runs the turn", async () => {
+    listPendingByDestinationMock.mockReturnValue([]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: false,
+      decisionApplied: false,
+      type: "not_consumed",
+    });
+
+    const persistUserMessage = mock(async () => ({
+      id: "persisted-user-id",
+      deduplicated: false,
+    }));
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setTrustContext: () => {},
+      updateClient: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      ensureActorScopedHistory: async () => {},
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => false,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      trustContext: undefined,
+      hasPendingConfirmation: () => false,
+      setHostBrowserProxy: () => {},
+      setHostCuProxy: () => {},
+      setHostAppControlProxy: () => {},
+      restoreBrowserProxyAvailability: () => {},
+      addPreactivatedSkillId: () => {},
+    } as unknown as import("../daemon/conversation.js").Conversation;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-vellum-actor-principal-id": "test-user",
+        "x-vellum-principal-type": "actor",
+      },
+      body: JSON.stringify({
+        conversationKey: "guardian-conversation-key",
+        content: "Hey, how are you? Show me what you can do.",
+        sourceChannel: "vellum",
+        interface: "web",
+        hidden: true,
+      }),
+    });
+
+    const res = await callHandler(
+      (args) =>
+        handleSendMessage(args, {
+          sendMessageDeps: {
+            getOrCreateConversation: async () => session,
+            assistantEventHub: { publish: async () => {} } as any,
+            resolveAttachments: () => [],
+          },
+        }),
+      req,
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    // The hidden message is persisted with metadata.hidden so the list-messages
+    // filter suppresses it from the UI transcript while keeping it in LLM-side
+    // history (see list-messages-hidden-metadata.test.ts for the filter).
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    const persistArgs = (persistUserMessage as any).mock.calls[0][0] as {
+      metadata?: { hidden?: boolean };
+    };
+    expect(persistArgs.metadata?.hidden).toBe(true);
+    // The turn still runs — the assistant's reply streams normally, so the chat
+    // reads as a proactive greeting.
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+
   test("excludes stale tool_approval hints without a live pending confirmation", async () => {
     listPendingByDestinationMock.mockReturnValue([
       { id: "tool-approval-live", kind: "tool_approval" },

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1259,6 +1259,11 @@ export async function handleSendMessage(
     interface?: string;
     conversationType?: string;
     automated?: boolean;
+    // Persist the user message but suppress it from the UI transcript (kept in
+    // LLM history). Used by flows like research-onboarding's "Let's chat"
+    // handoff to prime a proactive assistant greeting without showing the
+    // triggering user message. Honored on the standard send path only.
+    hidden?: boolean;
     bypassSecretCheck?: boolean;
     hostHomeDir?: string;
     hostUsername?: string;
@@ -2340,7 +2345,13 @@ export async function handleSendMessage(
     content: resolvedContent,
     attachments,
     requestId,
-    metadata: body.automated === true ? { automated: true } : undefined,
+    metadata:
+      body.automated === true || body.hidden === true
+        ? {
+            ...(body.automated === true ? { automated: true } : {}),
+            ...(body.hidden === true ? { hidden: true } : {}),
+          }
+        : undefined,
     clientMessageId,
   });
 
@@ -2354,14 +2365,20 @@ export async function handleSendMessage(
     };
   }
 
-  broadcastMessage({
-    type: "user_message_echo",
-    text: resolvedContent,
-    conversationId: mapping.conversationId,
-    messageId,
-    requestId,
-    clientMessageId,
-  });
+  // A hidden message is suppressed from the UI transcript: don't echo it back
+  // to clients (the echo would render a user bubble the list-messages filter
+  // otherwise hides). The turn still runs below, and the assistant's reply
+  // streams normally — so the chat reads as a proactive greeting.
+  if (body.hidden !== true) {
+    broadcastMessage({
+      type: "user_message_echo",
+      text: resolvedContent,
+      conversationId: mapping.conversationId,
+      messageId,
+      requestId,
+      clientMessageId,
+    });
+  }
   publishConversationMessagesChanged(mapping.conversationId, originClientId);
 
   // Fire-and-forget the agent loop; events flow to the hub via broadcastMessage.
@@ -2874,6 +2891,12 @@ export const ROUTES: RouteDefinition[] = [
         .optional(),
       inferenceProfile: z.string().nullable().optional(),
       riskThreshold: z.enum(VALID_RISK_THRESHOLDS).optional(),
+      hidden: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, persist the user message but suppress it from the UI transcript (it stays in LLM-side history and still drives the turn). Used to prime a proactive assistant greeting without showing the triggering user message. Honored on the standard send path only.",
+        ),
       onboarding: z
         .object({
           tools: z.array(z.string()),

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -298,6 +298,8 @@ export function ActiveChatView() {
     reachabilityPhase: reachability.state.phase,
     reachabilityProbe: reachability.probe,
     getPendingInitialMessage: () => peekPendingPreChatContext()?.initialMessage ?? undefined,
+    getPendingInitialMessageHidden: () =>
+      peekPendingPreChatContext()?.initialMessageHidden === true,
   });
 
   // Onboarding deep-link attribution: emit the research-onboarding check-in

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -454,6 +454,7 @@ export async function postChatMessage(
   onboarding?: PreChatOnboardingContext,
   clientMessageId?: string,
   inferenceProfile?: string | null,
+  isHidden?: boolean,
 ): Promise<PostMessageResult> {
   // Wire-field selection picks exactly one of `conversationId` (0.8.6+
   // strict internal-id lookup) or `conversationKey` (legacy
@@ -511,6 +512,12 @@ export async function postChatMessage(
   // otherwise so the conversation inherits the global default profile.
   if (inferenceProfile) {
     body.inferenceProfile = inferenceProfile;
+  }
+  // Persist the message but suppress it from the transcript (it still drives the
+  // turn LLM-side). Used by the research-onboarding "Let's chat" handoff to
+  // prime a proactive assistant greeting without showing the triggering message.
+  if (isHidden) {
+    body.hidden = true;
   }
   const normalizedOnboarding = onboarding
     ? normalizePreChatOnboardingContext(onboarding)

--- a/clients/web/src/domains/chat/hooks/use-auto-send-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-auto-send-effects.ts
@@ -31,11 +31,21 @@ export interface UseAutoSendEffectsOptions {
   activeConversationId: string | null;
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
-  sendMessage: (content: string) => Promise<void>;
+  sendMessage: (
+    content: string,
+    attachments?: never[],
+    opts?: { hidden?: boolean },
+  ) => Promise<void>;
   reachabilityPhase: ReachabilityState["phase"];
   reachabilityProbe: (options?: ReachabilityProbeOptions) => void;
   /** Reads the staged pre-chat initial message from sessionStorage. */
   getPendingInitialMessage: () => string | undefined;
+  /**
+   * Whether the staged pre-chat initial message should be sent hidden — driving
+   * the assistant's reply but rendering no user bubble (used by the
+   * research-onboarding "Let's chat" handoff for a proactive greeting).
+   */
+  getPendingInitialMessageHidden?: () => boolean;
 }
 
 export function useAutoSendEffects({
@@ -47,10 +57,17 @@ export function useAutoSendEffects({
   reachabilityPhase,
   reachabilityProbe,
   getPendingInitialMessage,
+  getPendingInitialMessageHidden,
 }: UseAutoSendEffectsOptions): void {
   const getPendingInitialMessageRef = useRef(getPendingInitialMessage);
   useLayoutEffect(() => {
     getPendingInitialMessageRef.current = getPendingInitialMessage;
+  });
+  const getPendingInitialMessageHiddenRef = useRef(
+    getPendingInitialMessageHidden,
+  );
+  useLayoutEffect(() => {
+    getPendingInitialMessageHiddenRef.current = getPendingInitialMessageHidden;
   });
   // 1. URL ?prompt= auto-send.
   // Keyed by conversationId + prompt so the same text sent to different
@@ -100,6 +117,7 @@ export function useAutoSendEffects({
     const message = getPendingInitialMessageRef.current();
     if (!message) return;
     initialMessageConsumedRef.current = true;
-    void sendMessage(message);
+    const hidden = getPendingInitialMessageHiddenRef.current?.() ?? false;
+    void sendMessage(message, [], { hidden });
   }, [activeConversationId, assistantId, reachabilityPhase, sendMessage]);
 }

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -268,7 +268,7 @@ export function useSendMessage({
   // sendMessageViaStream — low-level POST + polling fallback
   // -------------------------------------------------------------------------
   const sendMessageViaStream = useCallback(
-    async (content: string, epoch: number, turnId: string, attachmentIds: string[] = [], isDraft = false, clientMessageId?: string): Promise<SendStreamResult> => {
+    async (content: string, epoch: number, turnId: string, attachmentIds: string[] = [], isDraft = false, clientMessageId?: string, isHidden = false): Promise<SendStreamResult> => {
       if (!activeConversationId || !assistantId) {
         return {
           status: "failed",
@@ -324,6 +324,7 @@ export function useSendMessage({
         onboardingContext ?? undefined,
         clientMessageId,
         inferenceProfileForSend,
+        isHidden,
       );
       if (
         useServerMint &&
@@ -637,7 +638,17 @@ export function useSendMessage({
   // sendMessage — high-level send with UI state, queuing, draft resolution
   // -------------------------------------------------------------------------
   const sendMessage = useCallback(
-    async (content: string, attachments: DisplayAttachment[] = []) => {
+    async (
+      content: string,
+      attachments: DisplayAttachment[] = [],
+      opts: { hidden?: boolean } = {},
+    ) => {
+      // A hidden send (e.g. the onboarding "Let's chat" kickoff) drives a turn
+      // and the assistant's reply, but renders NO user bubble: skip the
+      // optimistic row here and the daemon suppresses the echo. Hidden sends are
+      // always a fresh first message (conversation idle), so they never take the
+      // queue path below.
+      const isHidden = opts.hidden === true;
       if (!activeConversationId || !assistantId) {
         setError({ message: "No active conversation. Please try again." });
         return;
@@ -723,7 +734,7 @@ export function useSendMessage({
         ...(attachments.length > 0 ? { attachments } : {}),
         ...(willQueue ? { queueStatus: "queued" as const, queuePosition: 0 } : {}),
       };
-      addOptimisticSend(userMessage);
+      if (!isHidden) addOptimisticSend(userMessage);
       void getSoundManager().play("message_sent");
 
       // Queue path: POST to assistant (it queues internally) but don't
@@ -831,6 +842,7 @@ export function useSendMessage({
           attachments.map((att) => att.id),
           isDraft,
           clientMessageId,
+          isHidden,
         );
 
         if (result.status === "failed") {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -73,12 +73,22 @@ import {
   LookingYouUpStep,
   ResearchResultsStep,
   SuggestionsStep,
+  LetsChatReadyStep,
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
 import {
   OnboardingStageSizeProvider,
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+
+/**
+ * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
+ * end of the personality-onboarding flow. It drives the assistant's first reply
+ * but renders no user bubble, so the chat opens with the assistant proactively
+ * greeting the user in the persona they just configured.
+ */
+const LETS_CHAT_KICKOFF_MESSAGE =
+  "Hey, how are you? Show me what you can do, and let's get started.";
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {
@@ -346,6 +356,7 @@ export function ResearchOnboardingRoute() {
         ? { resumeConversationId: researchConversationId }
         : {}),
       onConversationCreated: setResearchConversationId,
+      includeSuggestions: !personalityEnabled,
     });
   }, [
     restored,
@@ -356,6 +367,7 @@ export function ResearchOnboardingRoute() {
     research.status,
     startResearch,
     awaitHatchReady,
+    personalityEnabled,
   ]);
 
   // If we're sitting on the results step when the research turn resolves empty
@@ -375,7 +387,7 @@ export function ResearchOnboardingRoute() {
     values: ResearchOnboardingValues,
     face: GiveMeAFaceValues | null,
     entryPrompt?: string,
-    { skip = false }: { skip?: boolean } = {},
+    { skip = false, hidden = false }: { skip?: boolean; hidden?: boolean } = {},
   ) {
     // Handing off to the chat ends the research-onboarding journey — drop the
     // resume snapshot so a later visit starts clean instead of resuming this one.
@@ -413,6 +425,10 @@ export function ResearchOnboardingRoute() {
                 occupation: role,
                 hobby: hobbies.join(", "),
               }),
+            // A hidden kickoff (the "Let's chat" handoff) drives the first reply
+            // without rendering a user bubble, so the chat opens as a proactive
+            // greeting in the configured persona.
+            ...(hidden ? { initialMessageHidden: true } : {}),
           }),
       // Friendly title for the behind-the-scenes research conversation.
       ...(isResearch
@@ -459,6 +475,9 @@ export function ResearchOnboardingRoute() {
       subject: researchSubjectFrom(values),
       conversationTitle: researchTitleFor(values),
       onConversationCreated: setResearchConversationId,
+      // The "Let's chat" final step replaces suggestions when personality
+      // onboarding is on, so don't ask the model to generate any.
+      includeSuggestions: !personalityEnabled,
     });
     goForwardTo("face");
   }
@@ -674,7 +693,35 @@ export function ResearchOnboardingRoute() {
             onForward={onForward}
           />
         )}
-        {step === "suggestions" && (
+        {step === "suggestions" && personalityEnabled && (
+          <LetsChatReadyStep
+            installedPlugins={research.installedPlugins}
+            loading={researchLoading}
+            onStart={async () => {
+              // Terminal step: the handoff leaves via enterAssistant, not
+              // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId, outcome: "completed" },
+              );
+              // Wait out any background capability installs so the primed chat
+              // can discover their skills, and any removal correction so rejected
+              // claims can't leak into it — same gating as the suggestion click.
+              await Promise.all([
+                research.awaitPluginInstalls(),
+                researchCorrectionRef.current,
+              ]);
+              // Drop into a fresh chat with the hidden kickoff so the assistant
+              // opens by greeting the user in the persona they configured.
+              enterAssistant(formValues, faceValues, LETS_CHAT_KICKOFF_MESSAGE, {
+                hidden: true,
+              });
+            }}
+            onBack={() => goBackTo(noClaims ? "looking" : "results")}
+            onForward={onForward}
+          />
+        )}
+        {step === "suggestions" && !personalityEnabled && (
           <SuggestionsStep
             suggestions={research.suggestions}
             loading={researchLoading}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -706,7 +706,6 @@ export function ResearchOnboardingRoute() {
           <LetsChatReadyStep
             installedPlugins={research.installedPlugins}
             pluginCatalog={research.pluginCatalog}
-            loading={researchLoading}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -87,8 +87,7 @@ import {
  * but renders no user bubble, so the chat opens with the assistant proactively
  * greeting the user in the persona they just configured.
  */
-const LETS_CHAT_KICKOFF_MESSAGE =
-  "Hey, how are you? Show me what you can do, and let's get started.";
+const LETS_CHAT_KICKOFF_MESSAGE = "Wake up, I'm excited to chat!";
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -287,7 +287,14 @@ export function ResearchOnboardingRoute() {
       setResearchConversationId(snapshot.researchConversationId ?? null);
       // Re-enqueue the named plugin installs against the re-hatched assistant so
       // a suggestion click awaits real (idempotent) installs, not an empty map.
-      if (snapshot.research) hydrateResearch(snapshot.research, awaitHatchReady);
+      if (snapshot.research)
+        hydrateResearch(
+          {
+            ...snapshot.research,
+            pluginCatalog: snapshot.research.pluginCatalog ?? {},
+          },
+          awaitHatchReady,
+        );
       setStep(resolveResumeStep(snapshot));
       setForwardStack([]);
     }
@@ -314,6 +321,7 @@ export function ResearchOnboardingRoute() {
               claims: research.claims,
               suggestions: research.suggestions,
               installedPlugins: research.installedPlugins,
+              pluginCatalog: research.pluginCatalog,
             }
           : null,
       ...(researchConversationId
@@ -333,6 +341,7 @@ export function ResearchOnboardingRoute() {
     research.claims,
     research.suggestions,
     research.installedPlugins,
+    research.pluginCatalog,
   ]);
 
   // Mid-flow resume: we restored a journey whose research turn hadn't settled.
@@ -696,6 +705,7 @@ export function ResearchOnboardingRoute() {
         {step === "suggestions" && personalityEnabled && (
           <LetsChatReadyStep
             installedPlugins={research.installedPlugins}
+            pluginCatalog={research.pluginCatalog}
             loading={researchLoading}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not

--- a/clients/web/src/domains/onboarding/prechat.ts
+++ b/clients/web/src/domains/onboarding/prechat.ts
@@ -49,6 +49,13 @@ export interface PreChatOnboardingContext {
   cohort?: string;
   /** Auto-send this message on first load instead of waiting for user input. */
   initialMessage?: string;
+  /**
+   * When true, the auto-sent `initialMessage` is sent hidden: it drives the
+   * assistant's first reply but renders no user bubble, so the chat opens as a
+   * proactive greeting in the persona the user just configured. Used by the
+   * research-onboarding "Let's chat" handoff.
+   */
+  initialMessageHidden?: boolean;
   /** Bootstrap template filename for the daemon to use. */
   bootstrapTemplate?: string;
   /** Skills to eagerly load. */
@@ -266,6 +273,12 @@ function isPreChatOnboardingContext(
     return false;
   }
   if (candidate.initialMessage !== undefined && typeof candidate.initialMessage !== "string") {
+    return false;
+  }
+  if (
+    candidate.initialMessageHidden !== undefined &&
+    typeof candidate.initialMessageHidden !== "boolean"
+  ) {
     return false;
   }
   if (candidate.bootstrapTemplate !== undefined && typeof candidate.bootstrapTemplate !== "string") {

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -54,6 +54,12 @@ export interface PersistedResearchResults {
   claims: ResearchFact[];
   suggestions: ResearchSuggestion[];
   installedPlugins: string[];
+  /**
+   * Name → description for the installed plugins, so a refresh-resume can still
+   * render each plugin card with its description. Optional for back-compat with
+   * snapshots written before this field existed (defaulted to {} on read).
+   */
+  pluginCatalog?: Record<string, string>;
 }
 
 export interface ResearchOnboardingSnapshot {

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -66,3 +66,39 @@ describe("buildResearchPrompt — capabilities", () => {
     expect(prompt).toContain("keep claims and suggestions aligned with my stated role");
   });
 });
+
+describe("buildResearchPrompt — suggestions toggle", () => {
+  const caps: AvailableCapability[] = [
+    { name: "marketing-expert", description: "Full-stack marketing." },
+  ];
+
+  test("includes suggestions by default (legacy flow unchanged)", () => {
+    const prompt = buildResearchPrompt(SUBJECT, caps);
+
+    expect(prompt).toContain('"suggestions"');
+    expect(prompt).toContain('Rules for "suggestions":');
+    expect(prompt).toContain("Generate EXACTLY 4 suggestions");
+    // Claims + plugins still requested.
+    expect(prompt).toContain('"claims"');
+    expect(prompt).toContain('"plugins"');
+  });
+
+  test("omits all suggestion guidance when includeSuggestions is false", () => {
+    const prompt = buildResearchPrompt(SUBJECT, caps, {
+      includeSuggestions: false,
+    });
+
+    expect(prompt).not.toContain('"suggestions"');
+    expect(prompt).not.toContain('Rules for "suggestions":');
+    expect(prompt).not.toContain("Generate EXACTLY 4 suggestions");
+    // The role-alignment line drops the "and suggestions" clause.
+    expect(prompt).toContain("keep claims aligned with my stated role");
+    expect(prompt).not.toContain("keep claims and suggestions aligned");
+    // Plugins + claims are still requested, plugins still first in the shape.
+    expect(prompt).toContain('"plugins"');
+    expect(prompt).toContain('"claims"');
+    expect(prompt.indexOf('"plugins"')).toBeLessThan(prompt.indexOf('"claims"'));
+    // The closing fallback no longer references suggestions.
+    expect(prompt).not.toContain("broadly useful suggestions");
+  });
+});

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -47,30 +47,58 @@ const MAX_INJECTED_CAPABILITIES = 12;
  * nothing was passed so the prompt is byte-for-byte unchanged for callers that
  * don't inject a catalog (e.g. the route's fallback kickoff message).
  */
-function renderCapabilitiesBlock(capabilities: AvailableCapability[]): string {
+function renderCapabilitiesBlock(
+  capabilities: AvailableCapability[],
+  includeSuggestions: boolean,
+): string {
   const lines = capabilities
     .slice(0, MAX_INJECTED_CAPABILITIES)
     .map((c) => `- ${c.name} — ${c.description}`)
     .join("\n");
   if (!lines) return "";
+  // The downstream keys this array precedes depend on whether suggestions are
+  // requested, so the "before …" hint and the "don't reference setup" reminder
+  // only name `suggestions` when that array is part of the shape.
+  const beforeKeys = includeSuggestions
+    ? 'before "claims" and "suggestions"'
+    : 'before "claims"';
+  const dontReference = includeSuggestions
+    ? "Don't reference the setup in the claims or suggestions text."
+    : "Don't reference the setup in the claims text.";
   return `
 Capabilities you can offer me — specialized skillsets you can invoke on my behalf, not generic chat:
 ${lines}
 
-Add a "plugins" array as the FIRST key in your JSON object, before "claims" and "suggestions": the 1-2 capabilities from the list above (exact names) that best fit who I am — judged by what you researched about my real role, stack, and day-to-day work. (Emit it first so setup can start while you finish the rest.) These get set up for me automatically as part of getting started, so pick by overall fit to ME, not to any single suggestion. Prefer fewer over forcing a match; use [] if nothing clearly fits. Example: "plugins": ["<exact name from the list above>"]. Don't reference the setup in the claims or suggestions text.
+Add a "plugins" array as the FIRST key in your JSON object, ${beforeKeys}: the 1-2 capabilities from the list above (exact names) that best fit who I am — judged by what you researched about my real role, stack, and day-to-day work. (Emit it first so setup can start while you finish the rest.) These get set up for me automatically as part of getting started, so pick by overall fit to ME, not to any single suggestion. Prefer fewer over forcing a match; use [] if nothing clearly fits. Example: "plugins": ["<exact name from the list above>"]. ${dontReference}
 `;
+}
+
+export interface BuildResearchPromptOptions {
+  /**
+   * Whether to ask the model for clickable follow-up `suggestions`. The
+   * suggestions-based final step is being retired in favor of the "Let's chat"
+   * handoff (gated behind the personality-onboarding flag), which installs the
+   * picked plugins and drops the user straight into a primed chat. When false,
+   * the prompt asks for ONLY `plugins` + `claims` and omits all suggestion
+   * guidance. Defaults to true so the legacy suggestions flow is unchanged.
+   */
+  includeSuggestions?: boolean;
 }
 
 export function buildResearchPrompt(
   { firstName, lastName, occupation, hobby }: ResearchSubject,
   availableCapabilities: AvailableCapability[] = [],
+  { includeSuggestions = true }: BuildResearchPromptOptions = {},
 ): string {
   const fullName = [firstName.trim(), lastName.trim()]
     .filter(Boolean)
     .join(" ");
   const role = occupation.trim();
   const hobbyText = hobby?.trim() ?? "";
-  const capabilitiesBlock = renderCapabilitiesBlock(availableCapabilities);
+  const capabilitiesBlock = renderCapabilitiesBlock(
+    availableCapabilities,
+    includeSuggestions,
+  );
   // When capabilities are advertised, the canonical shape MUST show `plugins`
   // first — otherwise "respond with exactly this shape" (which the example
   // defines) would tell the model to omit it, and nothing gets installed.
@@ -88,24 +116,24 @@ export function buildResearchPrompt(
       .join(" ") ||
     "I'd like you to get to know me before we start working together.";
 
-  return `${identity}
+  // The clickable-suggestions block is optional: the "Let's chat" final step
+  // (personality-onboarding flag) installs the picked plugins and drops the
+  // user into a primed chat instead, so it asks for only `plugins` + `claims`.
+  const suggestionsArrayExample = includeSuggestions
+    ? ` "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ]`
+    : "";
+  const claimsExample = `"claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Based in Boulder, CO", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Active climber on Mountain Project", "confidence": "maybe", "sources": [] }, { "claim": "Focused on evals or model serving infrastructure", "confidence": "guessing", "sources": ["https://github.com/example-user"] } ]`;
+  const shapeExample = `{ ${pluginsExample}${claimsExample}${
+    suggestionsArrayExample ? `,${suggestionsArrayExample}` : ""
+  } }`;
 
-Get to know me. Search the web for what's publicly known about the person matching my name and role, and infer a handful of things about who I am: what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Lean on public sources (LinkedIn, company pages, social profiles, articles, personal sites, GitHub). It's fine to make reasonable inferences and label them honestly.
+  // Keep claims and (when present) suggestions aligned with the stated role.
+  const alignedArtifacts = includeSuggestions
+    ? "claims and suggestions"
+    : "claims";
 
-Treat the name, role, and hobby I provided above as first-party context from me. Use public sources to enrich that context, not to override or correct it. If public sources use a different title or omit part of my stated role, do not frame my stated role as wrong; mention the public title only as supporting nuance when it is useful, and keep claims and suggestions aligned with my stated role.
-
-CRITICAL: your final reply must be ONLY a JSON object. No preamble, no explanation, no prose, nothing before or after it. Do your thinking and searching, then respond with exactly this shape and nothing else:
-
-{ ${pluginsExample}"claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Based in Boulder, CO", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Active climber on Mountain Project", "confidence": "maybe", "sources": [] }, { "claim": "Focused on evals or model serving infrastructure", "confidence": "guessing", "sources": ["https://github.com/example-user"] } ], "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ] }
-
-Rules for "claims":
-
-AT MOST 5 claims, typically 3 to 4. Aim for at least one "confident" and at least one "guessing"; the rest "maybe".
-Phrase each claim in third person as a short headline ("Senior engineer at an AI infra startup", "Based in Boulder, CO", "Active climber on Mountain Project"). No multi-clause sentences, no em-dash asides, no explanations. Good: "Contributed to Chirps (vector-DB security)". Bad: "You've done real work in vector database security. You contributed to Chirps, a tool for scanning vector DBs for sensitive data".
-Each claim must be independently true-or-false so I can remove the ones that are wrong.
-"confidence" is one of: "confident" (well supported by what you found), "maybe" (plausible but unverified), "guessing" (a hunch from limited signal).
-"sources": 0 to 3 URLs you actually used as evidence for that specific claim. Use [] for pure inferences.
-Rules for "suggestions":
+  const suggestionRules = includeSuggestions
+    ? `Rules for "suggestions":
 
 Each suggestion is an object with two fields:
 "suggestion": the offer in YOUR voice (the assistant), exactly as it appears on the clickable card — first-person "I" refers to you (whatever your name). Pattern: "I'll [verb] [specific artifact]" or "Connect me to [integration] and I'll [verb] [artifact]." Lead with the offer; no intake question in front of it — you gather the details in the follow-up conversation after the click.
@@ -115,7 +143,31 @@ Generate EXACTLY 4 suggestions covering four DIFFERENT capabilities, each making
 Ground every suggestion in what you actually learned about me — my real role, stack, industry, and (if given) hobby. Specific to me, not generic assistant stuff; skip bare "summarize" or "draft a post."
 CRITICAL: every suggestion must be a fast win you can deliver in the first reply, never a long-running build. NEVER suggest building an app, dashboard, tool, site, or tracker, or any multi-step "build me a ___" project — those kill the first impression. The ambitious build can come later in the conversation, never on the first card.
 Keep each SHORT and skimmable: under 10 words, ONE clause, ONE artifact, no lists of three ("X, Y, and Z"). The reader scans four cards in seconds — a long line loses them.
-${capabilitiesBlock}
-Don't include anything sensitive or private. If you found very little, lean on "guessing" claims and broadly useful suggestions for my role.
+`
+    : "";
+
+  const closingFallback = includeSuggestions
+    ? `Don't include anything sensitive or private. If you found very little, lean on "guessing" claims and broadly useful suggestions for my role.`
+    : `Don't include anything sensitive or private. If you found very little, lean on "guessing" claims.`;
+
+  return `${identity}
+
+Get to know me. Search the web for what's publicly known about the person matching my name and role, and infer a handful of things about who I am: what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Lean on public sources (LinkedIn, company pages, social profiles, articles, personal sites, GitHub). It's fine to make reasonable inferences and label them honestly.
+
+Treat the name, role, and hobby I provided above as first-party context from me. Use public sources to enrich that context, not to override or correct it. If public sources use a different title or omit part of my stated role, do not frame my stated role as wrong; mention the public title only as supporting nuance when it is useful, and keep ${alignedArtifacts} aligned with my stated role.
+
+CRITICAL: your final reply must be ONLY a JSON object. No preamble, no explanation, no prose, nothing before or after it. Do your thinking and searching, then respond with exactly this shape and nothing else:
+
+${shapeExample}
+
+Rules for "claims":
+
+AT MOST 5 claims, typically 3 to 4. Aim for at least one "confident" and at least one "guessing"; the rest "maybe".
+Phrase each claim in third person as a short headline ("Senior engineer at an AI infra startup", "Based in Boulder, CO", "Active climber on Mountain Project"). No multi-clause sentences, no em-dash asides, no explanations. Good: "Contributed to Chirps (vector-DB security)". Bad: "You've done real work in vector database security. You contributed to Chirps, a tool for scanning vector DBs for sensitive data".
+Each claim must be independently true-or-false so I can remove the ones that are wrong.
+"confidence" is one of: "confident" (well supported by what you found), "maybe" (plausible but unverified), "guessing" (a hunch from limited signal).
+"sources": 0 to 3 URLs you actually used as evidence for that specific claim. Use [] for pure inferences.
+${suggestionRules}${capabilitiesBlock}
+${closingFallback}
 Keep every string value simple so the JSON always parses: one line, no line breaks inside a value, and NO double-quote characters inside a value — use single quotes (or none) for emphasis, quoted names, or tool names. Output ONLY the JSON object. No code fence, no extra text.`;
 }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -209,6 +209,13 @@ export interface ResearchRunnerState {
    * or nothing fit.
    */
   installedPlugins: string[];
+  /**
+   * Map of plugin install name → one-line description, from the fetched
+   * first-party catalog. Lets the UI render each installed plugin with its real
+   * name + description (not just the name). Empty when the catalog was
+   * unavailable (or, after a refresh-resume, not re-fetched).
+   */
+  pluginCatalog: Record<string, string>;
 }
 
 export interface StartResearchOptions {
@@ -322,6 +329,7 @@ export function useResearchRunner(): UseResearchRunner {
     claims: [],
     suggestions: [],
     installedPlugins: [],
+    pluginCatalog: {},
   });
   // Monotonic run id: every fresh run claims the next id; in-flight loops bail
   // the moment a newer run supersedes them. Paired with the last subject key so
@@ -370,6 +378,7 @@ export function useResearchRunner(): UseResearchRunner {
         claims: [],
         suggestions: [],
         installedPlugins: [],
+        pluginCatalog: {},
       });
 
       void (async () => {
@@ -389,6 +398,13 @@ export function useResearchRunner(): UseResearchRunner {
           const { capabilities, validNames } =
             await fetchAvailableCapabilities(assistantId);
           if (isStale()) return;
+          // Name → description for the fetched catalog, so the UI can show each
+          // installed plugin with its real name + description. Carried on every
+          // state update below (the poll loop replaces state wholesale).
+          const pluginCatalog: Record<string, string> = Object.fromEntries(
+            capabilities.map((c) => [c.name, c.description]),
+          );
+          setState((s) => ({ ...s, pluginCatalog }));
           // Nothing installable (empty/unavailable catalog) — release the click
           // gate so suggestion clicks never wait on the research turn.
           if (validNames.size === 0) resolvePluginsReady();
@@ -568,6 +584,7 @@ export function useResearchRunner(): UseResearchRunner {
                   validNames,
                   modelPlugins: validPlugins,
                 }),
+                pluginCatalog,
               });
               if (complete) sawCompletePayload = true;
               stableReads = text === lastText ? stableReads + 1 : 0;

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -232,6 +232,13 @@ export interface StartResearchOptions {
    * thread if the page is refreshed mid-search.
    */
   onConversationCreated?: (conversationId: string) => void;
+  /**
+   * Whether to ask the model for clickable `suggestions`. Off for the "Let's
+   * chat" final step (personality-onboarding flag), which installs the picked
+   * plugins and primes a chat instead of surfacing suggestion cards. Defaults to
+   * true so the legacy suggestions flow is unchanged.
+   */
+  includeSuggestions?: boolean;
 }
 
 export interface UseResearchRunner extends ResearchRunnerState {
@@ -342,6 +349,7 @@ export function useResearchRunner(): UseResearchRunner {
       conversationTitle,
       resumeConversationId,
       onConversationCreated,
+      includeSuggestions = true,
     }: StartResearchOptions) => {
       const subjectKey = JSON.stringify(subject);
       if (subjectKeyRef.current === subjectKey) return;
@@ -413,7 +421,9 @@ export function useResearchRunner(): UseResearchRunner {
           const postResearchPrompt = async (cid: string): Promise<boolean> => {
             const body: MessagesPostData["body"] = {
               conversationId: cid,
-              content: buildResearchPrompt(subject, capabilities),
+              content: buildResearchPrompt(subject, capabilities, {
+                includeSuggestions,
+              }),
               sourceChannel: "vellum",
               // `interface` is the transport ("web"); the real OS travels in
               // `clientOs` so the assistant's `client_os` context is correct

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -925,7 +925,7 @@ export function LetsChatReadyStep({
             {/* The "already set up …" line. No avatar of its own — it reserves a
                 landing slot (`noteSlotRef`) for the single avatar that flies down
                 from the heading, mirroring SuggestionsStep. */}
-            <div className="mt-12 flex items-center gap-3">
+            <div className="flex items-center gap-3">
               <div
                 ref={noteSlotRef}
                 className="shrink-0"

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -811,8 +811,9 @@ export function LetsChatReadyStep({
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
-  // Constant dark surface for the UI (the plugin cards match the facts cards).
+  // Constant dark surface for the UI text; the avatar tone colors the pills.
   const tone = DARK_TONE;
+  const avatarTone = useOnboardingTone();
   const reduce = useReducedMotion();
   const [starting, setStarting] = useState(false);
 
@@ -910,10 +911,11 @@ export function LetsChatReadyStep({
           </h1>
         </div>
 
-        {/* One card per installed plugin (name + description), themed to match
-            the "facts about you" cards. Directly under the title. */}
+        {/* One entry per installed plugin: the name as an avatar-tinted pill,
+            the description directly beneath it (no card container). Directly
+            under the title. */}
         {hasPlugins && (
-          <div className="mt-4 flex flex-col gap-3">
+          <div className="mt-6 flex flex-col gap-5">
             {plugins.map((p, i) => (
               <motion.div
                 key={p.name}
@@ -922,21 +924,24 @@ export function LetsChatReadyStep({
                 transition={
                   reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
                 }
-                className="rounded-2xl px-5 py-4"
-                style={{
-                  backgroundColor: tone.isLight
-                    ? "rgba(0,0,0,0.06)"
-                    : "rgba(255,255,255,0.1)",
-                }}
+                className="flex flex-col items-start gap-1.5"
               >
-                <div className="text-[15px] font-medium">{p.displayName}</div>
+                <span
+                  className="inline-flex items-center whitespace-nowrap rounded-full px-3 py-1 text-[14px] font-medium"
+                  style={{
+                    backgroundColor: avatarTone.bg,
+                    color: avatarTone.fg,
+                  }}
+                >
+                  {p.displayName}
+                </span>
                 {p.description && (
-                  <div
-                    className="mt-1 text-[13px] leading-snug"
+                  <p
+                    className="text-[14px] leading-snug"
                     style={{ color: tone.fgMuted }}
                   >
                     {p.description}
-                  </div>
+                  </p>
                 )}
               </motion.div>
             ))}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -811,9 +811,8 @@ export function LetsChatReadyStep({
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
-  // Constant dark surface for the UI text; the avatar tone colors the pills.
+  // Constant dark surface for the UI (the plugin cards match the facts cards).
   const tone = DARK_TONE;
-  const avatarTone = useOnboardingTone();
   const reduce = useReducedMotion();
   const [starting, setStarting] = useState(false);
 
@@ -911,11 +910,10 @@ export function LetsChatReadyStep({
           </h1>
         </div>
 
-        {/* One entry per installed plugin: the name as an avatar-tinted pill,
-            the description directly beneath it (no card container). Directly
-            under the title. */}
+        {/* One card per installed plugin (name + description), themed to match
+            the "facts about you" cards. Directly under the title. */}
         {hasPlugins && (
-          <div className="mt-6 flex flex-col gap-5">
+          <div className="mt-4 flex flex-col gap-3">
             {plugins.map((p, i) => (
               <motion.div
                 key={p.name}
@@ -924,24 +922,21 @@ export function LetsChatReadyStep({
                 transition={
                   reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
                 }
-                className="flex flex-col items-start gap-1.5"
+                className="rounded-2xl px-5 py-4"
+                style={{
+                  backgroundColor: tone.isLight
+                    ? "rgba(0,0,0,0.06)"
+                    : "rgba(255,255,255,0.1)",
+                }}
               >
-                <span
-                  className="inline-flex items-center whitespace-nowrap rounded-full px-3 py-1 text-[14px] font-medium"
-                  style={{
-                    backgroundColor: avatarTone.bg,
-                    color: avatarTone.fg,
-                  }}
-                >
-                  {p.displayName}
-                </span>
+                <div className="text-[15px] font-medium">{p.displayName}</div>
                 {p.description && (
-                  <p
-                    className="text-[14px] leading-snug"
+                  <div
+                    className="mt-1 text-[13px] leading-snug"
                     style={{ color: tone.fgMuted }}
                   >
                     {p.description}
-                  </p>
+                  </div>
                 )}
               </motion.div>
             ))}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -768,3 +768,185 @@ export function SuggestionsStep({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Let's chat (plugins-ready terminal step)
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminal step for the personality-onboarding flow (replaces SuggestionsStep
+ * when that flag is on). The suggestions idea is retired: instead this confirms
+ * the capabilities already set up for the assistant — chosen from the user's
+ * role, hobby, and what the web research surfaced — and offers a single "Let's
+ * chat" button. Clicking primes a fresh chat with a hidden kickoff message so
+ * the assistant opens by proactively greeting the user in the persona they just
+ * configured.
+ *
+ * Reuses SuggestionsStep's plugin choreography: one avatar rests over the
+ * heading and flies down to land beside the "already set up …" note once the
+ * installed plugins are known.
+ */
+export function LetsChatReadyStep({
+  installedPlugins = [],
+  loading,
+  onStart,
+  onBack,
+  onForward,
+}: {
+  /**
+   * Capabilities installed for the assistant this run (deterministic floor +
+   * the model's persona-level picks, catalog-gated). Surfaced as the
+   * confirmation note; empty when none were set up.
+   */
+  installedPlugins?: string[];
+  /** True while the research turn is still streaming (plugins may still land). */
+  loading: boolean;
+  /**
+   * Enter the chat: awaits any in-flight plugin installs / corrections, then
+   * hands off to the primed conversation. May be async — the button shows a
+   * pending state until it resolves.
+   */
+  onStart: () => void | Promise<void>;
+  onBack: () => void;
+  /** Redo into this step — only set when the user has stepped back. */
+  onForward?: () => void;
+}) {
+  // Constant dark surface for the UI; the avatar tone is only for the pills.
+  const tone = DARK_TONE;
+  const avatarTone = useOnboardingTone();
+  const reduce = useReducedMotion();
+  const [starting, setStarting] = useState(false);
+
+  const pluginLabels = installedPlugins
+    .map(pluginDisplayName)
+    .filter((label) => label.length > 0);
+  const hasNote = pluginLabels.length > 0;
+
+  // A single avatar starts over the heading slot and flies down to the note's
+  // landing slot — same choreography as SuggestionsStep. We measure both slot
+  // centers (relative to the column) so the flight follows the real layout as
+  // plugins stream in.
+  const columnRef = useRef<HTMLDivElement>(null);
+  const headSlotRef = useRef<HTMLDivElement>(null);
+  const noteSlotRef = useRef<HTMLDivElement>(null);
+  const [anchors, setAnchors] = useState<{ head: Anchor; note?: Anchor } | null>(
+    null,
+  );
+  const [flown, setFlown] = useState(false);
+  const [landed, setLanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const col = columnRef.current;
+      const head = headSlotRef.current;
+      if (!col || !head) return;
+      const c = col.getBoundingClientRect();
+      const center = (r: DOMRect): Anchor => ({
+        x: r.left - c.left + r.width / 2,
+        y: r.top - c.top + r.height / 2,
+      });
+      const note = noteSlotRef.current;
+      setAnchors({
+        head: center(head.getBoundingClientRect()),
+        note: note ? center(note.getBoundingClientRect()) : undefined,
+      });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+    // Intentionally not re-measuring on `flown`: the head anchor must stay at
+    // its pre-collapse position so the flight starts from where the avatar sat.
+  }, [hasNote]);
+
+  // Fly down the moment we have the data: as soon as the note slot is measured.
+  const noteY = anchors?.note?.y;
+  useEffect(() => {
+    if (!hasNote || noteY === undefined || flown) return;
+    setFlown(true);
+  }, [hasNote, noteY, flown]);
+
+  const handleStart = () => {
+    if (starting) return;
+    setStarting(true);
+    // If the handoff rejects, re-enable the button so the user can retry.
+    void Promise.resolve()
+      .then(onStart)
+      .catch(() => setStarting(false));
+  };
+
+  return (
+    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
+      <OnboardingTopBar onBack={onBack} onNext={onForward} />
+
+      <div
+        ref={columnRef}
+        className="absolute left-1/2 top-[14%] sm:top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6"
+      >
+        <div className="flex items-center">
+          {/*
+            Empty slot the flying avatar rests over. Once the avatar departs
+            (`flown`), it collapses its width + right margin so the title slides
+            smoothly to left-aligned.
+          */}
+          <motion.div
+            ref={headSlotRef}
+            className="shrink-0"
+            style={{ height: HEADING_AVATAR }}
+            initial={false}
+            animate={
+              flown
+                ? { width: 0, marginRight: 0 }
+                : { width: HEADING_AVATAR, marginRight: 12 }
+            }
+            transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
+          />
+          <h1 className="text-[2.2rem] leading-none" style={{ fontFamily: "var(--font-serif)" }}>
+            You&rsquo;re all set
+          </h1>
+        </div>
+        <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
+          {hasNote
+            ? "I've set myself up around who you are. Let's get into it."
+            : loading
+              ? "Getting everything ready…"
+              : "I've got what I need to help. Let's get into it."}
+        </p>
+
+        {hasNote && (
+          <PluginSetupNote
+            pluginLabels={pluginLabels}
+            tone={tone}
+            pillTone={avatarTone}
+            reduce={reduce}
+            slotRef={noteSlotRef}
+            revealed={landed}
+          />
+        )}
+
+        <button
+          type="button"
+          onClick={handleStart}
+          disabled={starting}
+          className="mt-12 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+          style={{
+            backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
+            color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
+          }}
+        >
+          {starting ? "Starting…" : "Let's chat"}
+          {!starting && <ArrowRight className="h-4 w-4" />}
+        </button>
+
+        {anchors && (
+          <FlyingHeadingAvatar
+            head={anchors.head}
+            note={anchors.note}
+            flyToNote={flown && hasNote && anchors.note !== undefined}
+            reduce={reduce}
+            onLanded={() => setLanded(true)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -913,7 +913,7 @@ export function LetsChatReadyStep({
         {/* One card per installed plugin (name + description), themed to match
             the "facts about you" cards. Directly under the title. */}
         {hasPlugins && (
-          <div className="mt-7 flex flex-col gap-3">
+          <div className="mt-4 flex flex-col gap-3">
             {plugins.map((p, i) => (
               <motion.div
                 key={p.name}
@@ -959,7 +959,7 @@ export function LetsChatReadyStep({
             animate={{ opacity: landed ? 1 : 0, x: landed ? 0 : -6 }}
             transition={reduce ? { duration: 0 } : { duration: 0.35 }}
           >
-            I&rsquo;ve set myself up around who you are.
+            I&rsquo;ve set myself up with plugins around who you are.
           </motion.p>
         </div>
 

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -945,8 +945,10 @@ export function LetsChatReadyStep({
 
         {/* The avatar line below the cards. No avatar of its own — it reserves a
             landing slot (`noteSlotRef`) for the single avatar that flies down
-            from the heading, mirroring SuggestionsStep. */}
-        <div className="mt-7 flex items-center gap-3">
+            from the heading, mirroring SuggestionsStep. The margin is generous
+            because the flown 64px avatar overflows this collapsed row (~22px),
+            so the visual gap above/below it matches the title→first-card gap. */}
+        <div className="mt-16 flex items-center gap-3">
           {/* Reserves the avatar's horizontal room but not its full height, so
               the row is only as tall as the text and the flown avatar lands
               vertically centered on the line (not within a 64px box). */}
@@ -970,7 +972,7 @@ export function LetsChatReadyStep({
           type="button"
           onClick={handleStart}
           disabled={starting}
-          className="mt-10 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+          className="mt-16 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -788,6 +788,7 @@ export function SuggestionsStep({
  */
 export function LetsChatReadyStep({
   installedPlugins = [],
+  pluginCatalog = {},
   loading,
   onStart,
   onBack,
@@ -795,10 +796,12 @@ export function LetsChatReadyStep({
 }: {
   /**
    * Capabilities installed for the assistant this run (deterministic floor +
-   * the model's persona-level picks, catalog-gated). Surfaced as the
-   * confirmation note; empty when none were set up.
+   * the model's persona-level picks, catalog-gated). Surfaced as cards; empty
+   * when none were set up.
    */
   installedPlugins?: string[];
+  /** Name → description for the installed plugins, for the card subtitles. */
+  pluginCatalog?: Record<string, string>;
   /** True while the research turn is still streaming (plugins may still land). */
   loading: boolean;
   /**
@@ -811,16 +814,21 @@ export function LetsChatReadyStep({
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
-  // Constant dark surface for the UI; the avatar tone is only for the pills.
+  // Constant dark surface for the UI (the plugin cards match the facts cards).
   const tone = DARK_TONE;
-  const avatarTone = useOnboardingTone();
   const reduce = useReducedMotion();
   const [starting, setStarting] = useState(false);
 
-  const pluginLabels = installedPlugins
-    .map(pluginDisplayName)
-    .filter((label) => label.length > 0);
-  const hasNote = pluginLabels.length > 0;
+  // Each installed plugin as a card: its display name + (when known) the
+  // catalog description. Names without a display label are dropped.
+  const plugins = installedPlugins
+    .map((name) => ({
+      name,
+      displayName: pluginDisplayName(name),
+      description: pluginCatalog[name]?.trim() ?? "",
+    }))
+    .filter((p) => p.displayName.length > 0);
+  const hasNote = plugins.length > 0;
 
   // A single avatar starts over the heading slot and flies down to the note's
   // landing slot — same choreography as SuggestionsStep. We measure both slot
@@ -913,21 +921,65 @@ export function LetsChatReadyStep({
         </p>
 
         {hasNote && (
-          <PluginSetupNote
-            pluginLabels={pluginLabels}
-            tone={tone}
-            pillTone={avatarTone}
-            reduce={reduce}
-            slotRef={noteSlotRef}
-            revealed={landed}
-          />
+          <>
+            {/* The "already set up …" line. No avatar of its own — it reserves a
+                landing slot (`noteSlotRef`) for the single avatar that flies down
+                from the heading, mirroring SuggestionsStep. */}
+            <div className="mt-12 flex items-center gap-3">
+              <div
+                ref={noteSlotRef}
+                className="shrink-0"
+                style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
+              />
+              <motion.p
+                className="text-[14px]"
+                style={{ color: tone.fg }}
+                initial={false}
+                animate={{ opacity: landed ? 1 : 0, x: landed ? 0 : -6 }}
+                transition={reduce ? { duration: 0 } : { duration: 0.35 }}
+              >
+                Already set up the plugins to help with your work.
+              </motion.p>
+            </div>
+
+            {/* One card per installed plugin (name + description), themed to
+                match the "facts about you" cards. */}
+            <div className="mt-4 flex flex-col gap-3">
+              {plugins.map((p, i) => (
+                <motion.div
+                  key={p.name}
+                  initial={reduce ? false : { opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={
+                    reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
+                  }
+                  className="rounded-2xl px-5 py-4"
+                  style={{
+                    backgroundColor: tone.isLight
+                      ? "rgba(0,0,0,0.06)"
+                      : "rgba(255,255,255,0.1)",
+                  }}
+                >
+                  <div className="text-[15px] font-medium">{p.displayName}</div>
+                  {p.description && (
+                    <div
+                      className="mt-1 text-[13px] leading-snug"
+                      style={{ color: tone.fgMuted }}
+                    >
+                      {p.description}
+                    </div>
+                  )}
+                </motion.div>
+              ))}
+            </div>
+          </>
         )}
 
         <button
           type="button"
           onClick={handleStart}
           disabled={starting}
-          className="mt-12 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+          className="mt-10 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -789,7 +789,6 @@ export function SuggestionsStep({
 export function LetsChatReadyStep({
   installedPlugins = [],
   pluginCatalog = {},
-  loading,
   onStart,
   onBack,
   onForward,
@@ -802,8 +801,6 @@ export function LetsChatReadyStep({
   installedPlugins?: string[];
   /** Name → description for the installed plugins, for the card subtitles. */
   pluginCatalog?: Record<string, string>;
-  /** True while the research turn is still streaming (plugins may still land). */
-  loading: boolean;
   /**
    * Enter the chat: awaits any in-flight plugin installs / corrections, then
    * hands off to the primed conversation. May be async — the button shows a
@@ -828,12 +825,12 @@ export function LetsChatReadyStep({
       description: pluginCatalog[name]?.trim() ?? "",
     }))
     .filter((p) => p.displayName.length > 0);
-  const hasNote = plugins.length > 0;
+  const hasPlugins = plugins.length > 0;
 
   // A single avatar starts over the heading slot and flies down to the note's
-  // landing slot — same choreography as SuggestionsStep. We measure both slot
-  // centers (relative to the column) so the flight follows the real layout as
-  // plugins stream in.
+  // landing slot — same choreography as SuggestionsStep. The note sits BELOW the
+  // plugin cards, so we re-measure when the card count changes to keep the
+  // flight landing on the real note position.
   const columnRef = useRef<HTMLDivElement>(null);
   const headSlotRef = useRef<HTMLDivElement>(null);
   const noteSlotRef = useRef<HTMLDivElement>(null);
@@ -864,14 +861,14 @@ export function LetsChatReadyStep({
     return () => window.removeEventListener("resize", measure);
     // Intentionally not re-measuring on `flown`: the head anchor must stay at
     // its pre-collapse position so the flight starts from where the avatar sat.
-  }, [hasNote]);
+  }, [plugins.length]);
 
-  // Fly down the moment we have the data: as soon as the note slot is measured.
+  // Fly down the moment the note slot is measured (the note always renders).
   const noteY = anchors?.note?.y;
   useEffect(() => {
-    if (!hasNote || noteY === undefined || flown) return;
+    if (noteY === undefined || flown) return;
     setFlown(true);
-  }, [hasNote, noteY, flown]);
+  }, [noteY, flown]);
 
   const handleStart = () => {
     if (starting) return;
@@ -912,68 +909,59 @@ export function LetsChatReadyStep({
             You&rsquo;re all set
           </h1>
         </div>
-        <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
-          {hasNote
-            ? "I've set myself up around who you are. Let's get into it."
-            : loading
-              ? "Getting everything ready…"
-              : "I've got what I need to help. Let's get into it."}
-        </p>
 
-        {hasNote && (
-          <>
-            {/* The "already set up …" line. No avatar of its own — it reserves a
-                landing slot (`noteSlotRef`) for the single avatar that flies down
-                from the heading, mirroring SuggestionsStep. */}
-            <div className="flex items-center gap-3">
-              <div
-                ref={noteSlotRef}
-                className="shrink-0"
-                style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
-              />
-              <motion.p
-                className="text-[14px]"
-                style={{ color: tone.fg }}
-                initial={false}
-                animate={{ opacity: landed ? 1 : 0, x: landed ? 0 : -6 }}
-                transition={reduce ? { duration: 0 } : { duration: 0.35 }}
+        {/* One card per installed plugin (name + description), themed to match
+            the "facts about you" cards. Directly under the title. */}
+        {hasPlugins && (
+          <div className="mt-7 flex flex-col gap-3">
+            {plugins.map((p, i) => (
+              <motion.div
+                key={p.name}
+                initial={reduce ? false : { opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={
+                  reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
+                }
+                className="rounded-2xl px-5 py-4"
+                style={{
+                  backgroundColor: tone.isLight
+                    ? "rgba(0,0,0,0.06)"
+                    : "rgba(255,255,255,0.1)",
+                }}
               >
-                Already set up the plugins to help with your work.
-              </motion.p>
-            </div>
-
-            {/* One card per installed plugin (name + description), themed to
-                match the "facts about you" cards. */}
-            <div className="mt-4 flex flex-col gap-3">
-              {plugins.map((p, i) => (
-                <motion.div
-                  key={p.name}
-                  initial={reduce ? false : { opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={
-                    reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
-                  }
-                  className="rounded-2xl px-5 py-4"
-                  style={{
-                    backgroundColor: tone.isLight
-                      ? "rgba(0,0,0,0.06)"
-                      : "rgba(255,255,255,0.1)",
-                  }}
-                >
-                  <div className="text-[15px] font-medium">{p.displayName}</div>
-                  {p.description && (
-                    <div
-                      className="mt-1 text-[13px] leading-snug"
-                      style={{ color: tone.fgMuted }}
-                    >
-                      {p.description}
-                    </div>
-                  )}
-                </motion.div>
-              ))}
-            </div>
-          </>
+                <div className="text-[15px] font-medium">{p.displayName}</div>
+                {p.description && (
+                  <div
+                    className="mt-1 text-[13px] leading-snug"
+                    style={{ color: tone.fgMuted }}
+                  >
+                    {p.description}
+                  </div>
+                )}
+              </motion.div>
+            ))}
+          </div>
         )}
+
+        {/* The avatar line below the cards. No avatar of its own — it reserves a
+            landing slot (`noteSlotRef`) for the single avatar that flies down
+            from the heading, mirroring SuggestionsStep. */}
+        <div className="mt-7 flex items-center gap-3">
+          <div
+            ref={noteSlotRef}
+            className="shrink-0"
+            style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
+          />
+          <motion.p
+            className="text-[15px]"
+            style={{ color: tone.fg }}
+            initial={false}
+            animate={{ opacity: landed ? 1 : 0, x: landed ? 0 : -6 }}
+            transition={reduce ? { duration: 0 } : { duration: 0.35 }}
+          >
+            I&rsquo;ve set myself up around who you are.
+          </motion.p>
+        </div>
 
         <button
           type="button"
@@ -993,7 +981,7 @@ export function LetsChatReadyStep({
           <FlyingHeadingAvatar
             head={anchors.head}
             note={anchors.note}
-            flyToNote={flown && hasNote && anchors.note !== undefined}
+            flyToNote={flown && anchors.note !== undefined}
             reduce={reduce}
             onLanded={() => setLanded(true)}
           />

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -885,7 +885,7 @@ export function LetsChatReadyStep({
 
       <div
         ref={columnRef}
-        className="absolute left-1/2 top-[14%] sm:top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6"
+        className="absolute left-1/2 top-1/2 z-10 flex w-full max-w-xl -translate-x-1/2 -translate-y-1/2 flex-col px-6"
       >
         <div className="flex items-center">
           {/*

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -947,10 +947,13 @@ export function LetsChatReadyStep({
             landing slot (`noteSlotRef`) for the single avatar that flies down
             from the heading, mirroring SuggestionsStep. */}
         <div className="mt-7 flex items-center gap-3">
+          {/* Reserves the avatar's horizontal room but not its full height, so
+              the row is only as tall as the text and the flown avatar lands
+              vertically centered on the line (not within a 64px box). */}
           <div
             ref={noteSlotRef}
             className="shrink-0"
-            style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
+            style={{ width: NOTE_AVATAR }}
           />
           <motion.p
             className="text-[15px]"


### PR DESCRIPTION
## What

Reworks the **final step of the research-onboarding flow**: scraps the suggestions idea and replaces it with a **"Let's chat"** handoff. All of this is gated behind the **same `personality-onboarding` flag** as the personality step, so it launches together. With the flag **off**, the existing suggestions flow is byte-for-byte unchanged.

### With the flag on

1. **Prompt simplified** — the research prompt no longer asks for `suggestions`, only `plugins` + `claims`. `buildResearchPrompt` gains an `includeSuggestions` option (default `true`), threaded through the research runner and set from `!personalityOnboarding`.
2. **Claims review unchanged** — the "this is what I found" step (X-out individual claims / "this is not me") still runs. Plugins are auto-installed in the background as before (deterministic role/affinity floor + the model's research-informed picks).
3. **New terminal step `LetsChatReadyStep`** — reuses the existing plugin flying-avatar animation to confirm the capabilities set up for the assistant, with a single **"Let's chat"** button (no suggestion cards). Handles the no-plugins and still-loading cases gracefully.
4. **Primed chat** — clicking "Let's chat" awaits any in-flight plugin installs + claim corrections, then drops the user into a fresh chat with a **hidden** kickoff message:
   > Hey, how are you? Show me what you can do, and let's get started.

   so the assistant opens by **proactively greeting** the user in the persona they just configured.

### Hidden messages (new primitive)

To make the greeting feel proactive, the triggering user message must not show. The daemon already filters `metadata.hidden` messages from the UI transcript (keeping them in LLM history); this PR adds the missing ingress:

- `hidden` flag on the send endpoint (`messages_post` request body + regenerated `openapi.yaml`).
- The standard send path persists `metadata.hidden` and **suppresses the `user_message_echo`** broadcast.
- The web send path skips the optimistic user bubble; carried end-to-end via `PreChatOnboardingContext.initialMessageHidden`.

## Testing

- `research-prompt.test.ts` — `includeSuggestions` toggle (legacy includes suggestions; off omits all suggestion guidance, keeps plugins-first claims).
- `conversation-routes-guardian-reply.test.ts` — a `hidden:true` send persists `metadata.hidden` and still runs the turn.
- Existing onboarding tests (prechat / research-runner / prechat-context) green; pre-existing unrelated failures untouched.
- `bunx tsc --noEmit` clean for touched files (web + assistant); `vite build` succeeds.

## QA notes

Enable the `personality-onboarding` flag locally (feature-flags panel) and run the research-onboarding flow to the end. Verify: the claims step still works, the final screen shows installed plugins + "Let's chat", and clicking it lands you in a chat where the assistant greets you first with **no user bubble** (and the greeting is in the configured persona). Flag off → suggestions flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)