### PR TITLE
feat(subagent): validate role tool-allowlists at boot

### DIFF
--- a/assistant/src/__tests__/subagent-allowlist-validation.test.ts
+++ b/assistant/src/__tests__/subagent-allowlist-validation.test.ts
@@ -14,8 +14,8 @@ function allReferencedToolNames(): Set<string> {
 
 describe("findUnknownAllowlistTools", () => {
   test("returns [] when every referenced tool name is registered", () => {
-    // Mirrors today's production state: every allowlist entry resolves to a
-    // real registered tool, so the boot-time check is a silent no-op.
+    // A registered-name set that covers every allowlist entry yields no
+    // unknowns — a fully-resolvable registry is a silent no-op.
     expect(findUnknownAllowlistTools(allReferencedToolNames())).toEqual([]);
   });
 

--- a/assistant/src/__tests__/subagent-allowlist-validation.test.ts
+++ b/assistant/src/__tests__/subagent-allowlist-validation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { SUBAGENT_ROLE_REGISTRY } from "../subagent/index.js";
+import { findUnknownAllowlistTools } from "../subagent/validate-allowlists.js";
+
+/** Union of every tool name referenced by any role allowlist. */
+function allReferencedToolNames(): Set<string> {
+  const names = new Set<string>();
+  for (const config of Object.values(SUBAGENT_ROLE_REGISTRY)) {
+    for (const tool of config.allowedTools ?? []) names.add(tool);
+  }
+  return names;
+}
+
+describe("findUnknownAllowlistTools", () => {
+  test("returns [] when every referenced tool name is registered", () => {
+    // Mirrors today's production state: every allowlist entry resolves to a
+    // real registered tool, so the boot-time check is a silent no-op.
+    expect(findUnknownAllowlistTools(allReferencedToolNames())).toEqual([]);
+  });
+
+  test("flags an allowlist entry whose tool name is not registered", () => {
+    // Simulate a tool rename that left the allowlists stale: drop one real
+    // name from the registered set and confirm exactly the roles that list it
+    // are flagged — and nothing else.
+    const registered = allReferencedToolNames();
+    registered.delete("web_search");
+
+    const unknown = findUnknownAllowlistTools(registered);
+    expect(unknown.length).toBeGreaterThan(0);
+    expect(unknown.every((u) => u.tool === "web_search")).toBe(true);
+
+    const flaggedRoles = unknown.map((u) => u.role).sort();
+    const expectedRoles = Object.entries(SUBAGENT_ROLE_REGISTRY)
+      .filter(([, config]) => config.allowedTools?.includes("web_search"))
+      .map(([role]) => role)
+      .sort();
+    expect(flaggedRoles).toEqual(expectedRoles);
+  });
+
+  test("skips roles with no allowlist (general imposes no filter)", () => {
+    // `general` has allowedTools: undefined, so even against an empty registry
+    // it contributes no entries.
+    const unknown = findUnknownAllowlistTools(new Set());
+    expect(unknown.some((u) => u.role === "general")).toBe(false);
+  });
+});

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -16,6 +16,7 @@ import { registerMessagingProvider } from "../messaging/registry.js";
 import { initializeProviders } from "../providers/registry.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { validateSubagentRoleAllowlists } from "../subagent/validate-allowlists.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
 import { initializeTools, registerMcpTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -109,6 +110,21 @@ export async function initializeProvidersAndTools(
   // `<workspaceDir>/tools/` once core tools have settled, so they own
   // their names before the MCP / plugin registrations below run.
   await initializeTools();
+
+  // Validate subagent role tool-allowlists against the now-registered core
+  // tool set (every allowlisted name is an eager core tool, so they are all
+  // present at this point). A renamed tool would otherwise silently strip a
+  // role's access — the stale name just never matches. Warn-and-continue per
+  // the daemon startup philosophy: a stale allowlist is a logic bug, not a
+  // reason to refuse boot.
+  try {
+    validateSubagentRoleAllowlists();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Subagent role allowlist validation failed — continuing startup",
+    );
+  }
 
   // Start MCP servers and register their tools
   if (config.mcp?.servers && Object.keys(config.mcp.servers).length > 0) {

--- a/assistant/src/subagent/validate-allowlists.ts
+++ b/assistant/src/subagent/validate-allowlists.ts
@@ -1,0 +1,65 @@
+/**
+ * Boot-time validation that every tool named in a subagent role's allowlist
+ * resolves to a real registered tool.
+ *
+ * A role allowlist (`SUBAGENT_ROLE_REGISTRY[role].allowedTools` in ./types.ts)
+ * is a list of plain tool-name strings. The names are matched against the live
+ * tool set purely by string equality (`subagentAllowedTools.has(name)`), so if
+ * a tool is renamed in the registry without updating the allowlist, the role
+ * silently loses access to it — the stale name simply never matches anything.
+ * This check surfaces that drift as a startup warning instead of a silent
+ * capability gap.
+ */
+
+import { getAllTools } from "../tools/registry.js";
+import { getLogger } from "../util/logger.js";
+import { SUBAGENT_ROLE_REGISTRY } from "./types.js";
+
+const log = getLogger("subagent-allowlist");
+
+/** A role allowlist entry that has no matching registered tool. */
+export interface UnknownAllowlistTool {
+  role: string;
+  tool: string;
+}
+
+/**
+ * Pure core: given the set of registered tool names, return every allowlist
+ * entry that has no matching registered tool. Roles with no allowlist
+ * (`allowedTools: undefined`, e.g. `general`) impose no filter and contribute
+ * nothing. Exported for direct unit testing without standing up the real tool
+ * registry.
+ */
+export function findUnknownAllowlistTools(
+  registeredToolNames: ReadonlySet<string>,
+): UnknownAllowlistTool[] {
+  const unknown: UnknownAllowlistTool[] = [];
+  for (const [role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+    if (!config.allowedTools) continue;
+    for (const tool of config.allowedTools) {
+      if (!registeredToolNames.has(tool)) unknown.push({ role, tool });
+    }
+  }
+  return unknown;
+}
+
+/**
+ * Validate every subagent role allowlist against the live tool registry,
+ * logging a warning for each unknown tool name. Uses `getAllTools()` — the raw
+ * registry, including tools owned by disabled plugins — rather than
+ * `getEnabledTools()`, so a legitimately-disabled plugin does not produce a
+ * false-positive warning: we are checking that the *name* exists, not that the
+ * tool is currently enabled. Never throws; returns the list of unknown
+ * `${role}:${tool}` entries (empty when every allowlist entry resolves).
+ */
+export function validateSubagentRoleAllowlists(): string[] {
+  const registered = new Set(getAllTools().map((tool) => tool.name));
+  const unknown = findUnknownAllowlistTools(registered);
+  for (const { role, tool } of unknown) {
+    log.warn(
+      { role, tool },
+      "Subagent role allowlist references unknown tool — role will silently lack access to it",
+    );
+  }
+  return unknown.map(({ role, tool }) => `${role}:${tool}`);
+}


### PR DESCRIPTION
## Summary
- Add `validateSubagentRoleAllowlists()`, run at daemon startup right after `initializeTools()`, which warns when any `SUBAGENT_ROLE_REGISTRY` allowlist names a tool that is absent from the live registry. This catches the silent access loss that happens when a tool is renamed but a role's allowlist isn't updated — today the stale name just never matches and the role quietly loses the tool.
- Warn-and-continue: never throws and never blocks boot, per the daemon startup philosophy (a stale allowlist is a logic bug, not a reason to refuse to start). Uses `getAllTools()` (raw registry, includes disabled-plugin tools) so a legitimately-disabled plugin can't produce a false positive.
- Factored as a pure `findUnknownAllowlistTools(registeredNames)` core + a thin logging wrapper, with unit tests. No-op against today's registry — all current allowlist names resolve.

## Original prompt
P1 hardening item from the subagent architecture TDD review. The role registry hardcodes per-role tool allowlists as plain strings with no compile-time link to real tool names, so a rename silently strips a subagent's access. Asked to add a cheap boot-time validator that surfaces this drift as a warning. All names match today, so this ships as a guard against future regressions.