### PR TITLE
[codex] fix effort none profile save

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -26,6 +26,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const EFFORT_OPTIONS = [
+  "inherit",
   "none",
   "low",
   "medium",
@@ -38,8 +39,8 @@ const VERBOSITY_OPTIONS = ["low", "medium", "high"] as const;
 
 /**
  * Sentinel for the Gemini thinking-level selector: "inherit" → omit
- * thinking.level so the daemon applies the model default (mirrors effort's
- * "none"). Concrete levels come from `geminiThinkingLevels(model)`.
+ * thinking.level so the daemon applies the model default. Concrete levels come
+ * from `geminiThinkingLevels(model)`.
  */
 export const THINKING_LEVEL_INHERIT = "default";
 
@@ -339,10 +340,7 @@ export function ProfileAdvancedParams({
       {visibility.effort && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Effort{" "}
-            <span className="text-[var(--content-disabled)]">
-              (none = inherit)
-            </span>
+            Effort
           </label>
           <SegmentControl
             items={EFFORT_OPTIONS.map((v) => ({ value: v, label: v }))}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -100,7 +100,7 @@ function makeConnection(name: string, provider = "anthropic"): ProviderConnectio
 
 function Wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: { queries: { retry: false, enabled: false } },
   });
   return createElement(QueryClientProvider, { client }, children);
 }
@@ -564,6 +564,31 @@ describe("ProfileEditorModal create mode — provider-first", () => {
       expect(resolved).toBe(true);
     });
     expect(toastSuccessCalls).toEqual([]);
+  });
+
+  test('saving Fireworks DeepSeek V4 Flash with effort "none" persists the explicit opt-out', async () => {
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+
+    renderCreate([makeConnection("fireworks-managed", "fireworks")], onSave);
+
+    selectProvider("Fireworks");
+    selectModel("DeepSeek V4 Flash");
+    fireEvent.click(getButton("Advanced"));
+    fireEvent.click(getButton("none"));
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.effort).toBe("none");
   });
 });
 

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -48,6 +48,7 @@ import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
 // of selecting a provider.
 const CREATE_NEW_PROVIDER_SENTINEL = "__create_new_provider__";
+type EffortSelection = "inherit" | NonNullable<ProfileEntry["effort"]>;
 
 export interface ProfileEditorModalProps {
   isOpen: boolean;
@@ -218,9 +219,8 @@ function ProfileEditorModalInner({
     );
 
   // Advanced params — segment controls
-  // effort: "none" is the sentinel for "not overridden"
-  const [effort, setEffort] = useState<NonNullable<ProfileEntry["effort"]>>(
-    initialValues?.effort ?? "none",
+  const [effort, setEffort] = useState<EffortSelection>(
+    initialValues?.effort ?? "inherit",
   );
   // speed: "standard" is the sentinel for "not overridden"
   const [speed, setSpeed] = useState<NonNullable<ProfileEntry["speed"]>>(
@@ -373,7 +373,7 @@ function ProfileEditorModalInner({
     // Reset all advanced params when provider changes
     setMaxTokens(null);
     setContextWindowMaxInputTokens(null);
-    setEffort("none");
+    setEffort("inherit");
     setSpeed("standard");
     setVerbosity("medium");
     setTemperatureEnabled(false);
@@ -571,7 +571,7 @@ function ProfileEditorModalInner({
       if (visibility.contextWindow && contextWindowMaxInputTokens !== null) {
         entry.contextWindow = { maxInputTokens: contextWindowMaxInputTokens };
       }
-      if (visibility.effort && effort !== "none") {
+      if (visibility.effort && effort !== "inherit") {
         entry.effort = effort;
       }
       if (visibility.speed && speed !== "standard") {


### PR DESCRIPTION
## Summary
- Split the profile editor effort control's inherit state from the literal `none` effort value.
- Save `effort: "none"` when users explicitly choose none, so Fireworks DeepSeek V4 requests can disable reasoning instead of inheriting a higher effort.
- Add a regression test for saving Fireworks DeepSeek V4 Flash with effort `none`.

## Root cause
The profile editor used `none` as its local “inherit / omit override” sentinel. That meant selecting `none` dropped `entry.effort`, letting config resolution fall back to the inherited profile/default effort before the provider payload was built.

## Validation
- `cd clients/web && bun test src/domains/settings/ai/profile-editor-modal.test.tsx`
- `cd clients/web && bun test src/domains/settings/ai/profile-advanced-params.test.tsx`
- `cd assistant && bun test src/__tests__/openai-provider.test.ts --grep "FireworksProvider reasoning_effort ceiling"`
- `cd clients/web && bunx tsc --noEmit`