### PR TITLE
fix(test): unbreak system-prompt test after BOOTSTRAP.md rewrite

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -457,9 +457,10 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("{{userSlug}}");
     });
 
-    test("substitutes the unmodified bundled BOOTSTRAP.md template", () => {
-      // Copy the real bundled BOOTSTRAP.md into the test workspace so we
-      // verify substitution against the actual template the daemon ships.
+    test("leaves no unresolved placeholders in the bundled BOOTSTRAP.md template", () => {
+      // Render the real bundled BOOTSTRAP.md the daemon ships and verify
+      // substitution leaves no leftover {{userSlug}} placeholder, whether or
+      // not the current template happens to reference it.
       mockPersona.userSlug = "alice";
       const bundled = readFileSync(
         join(import.meta.dirname, "..", "prompts", "templates", "BOOTSTRAP.md"),
@@ -467,7 +468,6 @@ describe("buildSystemPrompt", () => {
       );
       writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), bundled);
       const result = buildSystemPrompt();
-      expect(result).toContain("users/alice.md");
       expect(result).not.toContain("{{userSlug}}");
     });
   });


### PR DESCRIPTION
## Summary
- Main CI Test job was red: `system-prompt.test.ts` > 'substitutes the unmodified bundled BOOTSTRAP.md template' asserted the rendered output contains `users/alice.md`.
- The recent BOOTSTRAP.md rewrite (`a36c8e88de`) removed the `{{userSlug}}` placeholder / `users/{{userSlug}}.md` persona instruction from the shipped template, so that string is legitimately gone.
- Reframed the test to assert the durable invariant — the bundled template renders with no leftover `{{userSlug}}` placeholder. The substitution logic remains covered by the two synthetic-template tests in the same describe block.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)