### PR TITLE
Pass host platform token through local retire

### DIFF
--- a/clients/macos/src/main/bundle-flow.test.ts
+++ b/clients/macos/src/main/bundle-flow.test.ts
@@ -26,7 +26,9 @@ mock.module("electron", () => ({
 }));
 
 const getLockfileDataMock = mock(
-  (_paths: string[]): { ok: true; data: unknown } | { ok: false; status: number } => ({
+  (
+    _paths: string[],
+  ): { ok: true; data: unknown } | { ok: false; status: number } => ({
     ok: false as const,
     status: 500,
   }),
@@ -35,9 +37,10 @@ const resolveLockfilePathsMock = mock((_env: NodeJS.ProcessEnv) => [
   "/fake/lockfile",
 ]);
 const resolveConfigDirMock = mock((_env: NodeJS.ProcessEnv) => "/fake/config");
-const getGuardianAccessTokenMock = mock(
-  async () => ({ ok: true as const, accessToken: "fake-token" }),
-);
+const getGuardianAccessTokenMock = mock(async () => ({
+  ok: true as const,
+  accessToken: "fake-token",
+}));
 
 // Full `@vellumai/local-mode` surface so the real `./local-mode` (imported by
 // bundle-flow for resolveCliInvocation) links cleanly.
@@ -67,9 +70,11 @@ mock.module("./cli-installer", () => ({
   ensureCliInstalled: ensureCliInstalledMock,
 }));
 
-const openBundleConfirmationMock = mock(
-  async (_data: BundleScanData) => true,
-);
+mock.module("./session-token-store", () => ({
+  getSessionToken: () => null,
+}));
+
+const openBundleConfirmationMock = mock(async (_data: BundleScanData) => true);
 const installBundleConfirmationMock = mock(() => undefined);
 
 mock.module("./bundle-confirmation", () => ({
@@ -283,7 +288,9 @@ describe("handleBundleFile", () => {
 
     expect(showErrorBoxMock).toHaveBeenCalledTimes(1);
     expect(showErrorBoxMock.mock.calls[0]?.[0]).toBe("Bundle blocked");
-    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain("Detected malicious script");
+    expect(showErrorBoxMock.mock.calls[0]?.[1]).toContain(
+      "Detected malicious script",
+    );
     expect(openBundleConfirmationMock).not.toHaveBeenCalled();
   });
 

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -32,7 +32,10 @@ mock.module("electron", () => ({
     getAppPath: () => appState.appPath,
   },
   ipcMain: {
-    handle: (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+    handle: (
+      channel: string,
+      handler: (event: unknown, ...args: unknown[]) => unknown,
+    ) => {
       handlers[channel] = handler;
     },
   },
@@ -42,8 +45,10 @@ import { FakeChild } from "./test-helpers";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[]]> = [];
-const spawnMock = mock((command: string, args: string[]) => {
+const spawnOptions: unknown[] = [];
+const spawnMock = mock((command: string, args: string[], options?: unknown) => {
   spawnArgs.push([command, args]);
+  spawnOptions.push(options);
   lastChild = new FakeChild();
   return lastChild;
 });
@@ -95,6 +100,11 @@ process.env.VELLUM_ENVIRONMENT = "production";
 process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
 process.env.XDG_CONFIG_HOME = configHomeDir;
 const lockfilePath = path.join(lockfileDir, ".vellum.lock.json");
+
+let mockSessionToken: string | null = null;
+mock.module("./session-token-store", () => ({
+  getSessionToken: () => mockSessionToken,
+}));
 
 const { installLocalMode } = await import("./local-mode");
 const { resolveAllowedOrigin } = await import("./app-origin");
@@ -151,10 +161,12 @@ afterEach(() => {
   appState.isPackaged = false;
   appState.appPath = "/repo/clients/macos";
   spawnArgs.length = 0;
+  spawnOptions.length = 0;
   spawnMock.mockClear();
   ensureCliInstalledMock.mockClear();
   cliInstallerState.isInstalled = false;
   cliInstallerState.installError = null;
+  mockSessionToken = null;
   delete process.env.VELLUM_CLI_PATH;
   for (const key of Object.keys(existsSyncOverrides)) {
     delete existsSyncOverrides[key];
@@ -277,7 +289,10 @@ describe("vellum:localMode:hatch handler", () => {
     lastChild.stderr.emit("data", Buffer.from("daemon already running"));
     lastChild.emit("close", 1);
 
-    expect(await pending).toEqual({ ok: false, error: "daemon already running" });
+    expect(await pending).toEqual({
+      ok: false,
+      error: "daemon already running",
+    });
   });
 
   test("a non-zero exit with no output carries a descriptive fallback error", async () => {
@@ -353,7 +368,10 @@ const replacePlatformAssistants = (platformAssistants: unknown): WriteResult =>
     platformAssistants,
   ) as WriteResult;
 const retire = (assistantId?: unknown): Promise<unknown> =>
-  handlers["vellum:localMode:retire"](allowedEvent, assistantId) as Promise<unknown>;
+  handlers["vellum:localMode:retire"](
+    allowedEvent,
+    assistantId,
+  ) as Promise<unknown>;
 const wake = (assistantId?: unknown, options?: unknown): Promise<unknown> =>
   handlers["vellum:localMode:wake"](
     allowedEvent,
@@ -415,7 +433,11 @@ describe("lockfile IPC handlers", () => {
     if (!result.ok) return;
     expect(result.lockfile.activeAssistant).toBe("asst-1");
     expect(result.lockfile.assistants).toEqual([
-      { assistantId: "asst-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "asst-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
     ]);
 
     const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
@@ -440,7 +462,11 @@ describe("lockfile IPC handlers", () => {
 
   test("replacePlatformAssistants swaps platform entries while preserving local ones", () => {
     saveLockfileAssistant(
-      { assistantId: "local-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "local-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
       "local-1",
     );
     saveLockfileAssistant(
@@ -454,15 +480,19 @@ describe("lockfile IPC handlers", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const ids = (result.lockfile.assistants as Array<{ assistantId: string }>).map(
-      (a) => a.assistantId,
-    );
+    const ids = (
+      result.lockfile.assistants as Array<{ assistantId: string }>
+    ).map((a) => a.assistantId);
     expect(ids).toEqual(["local-1", "new-platform"]);
   });
 
   test("replacePlatformAssistants rejects a non-array argument without touching disk", () => {
     saveLockfileAssistant(
-      { assistantId: "local-1", cloud: "local", runtimeUrl: "http://127.0.0.1:1" },
+      {
+        assistantId: "local-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+      },
       "local-1",
     );
 
@@ -505,8 +535,35 @@ describe("vellum:localMode:retire handler", () => {
     expect(await pending).toEqual({ ok: false, error: "no such assistant" });
   });
 
+  test("passes the current session token through the shared retire invocation", async () => {
+    mockSessionToken = "tok-electron";
+    const previousPlatformToken = process.env.VELLUM_PLATFORM_TOKEN;
+    process.env.VELLUM_PLATFORM_TOKEN = "parent-token";
+    try {
+      const pending = retire("asst-1");
+      await tick();
+      lastChild.emit("close", 0);
+
+      expect(await pending).toEqual({ ok: true });
+      expect(
+        (spawnOptions[0] as { env?: NodeJS.ProcessEnv }).env
+          ?.VELLUM_PLATFORM_TOKEN,
+      ).toBe("tok-electron");
+      expect(process.env.VELLUM_PLATFORM_TOKEN).toBe("parent-token");
+    } finally {
+      if (previousPlatformToken === undefined) {
+        delete process.env.VELLUM_PLATFORM_TOKEN;
+      } else {
+        process.env.VELLUM_PLATFORM_TOKEN = previousPlatformToken;
+      }
+    }
+  });
+
   test("rejects a missing assistant id without spawning", async () => {
-    expect(await retire("")).toEqual({ ok: false, error: "Missing assistantId" });
+    expect(await retire("")).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
     expect(await retire(undefined)).toEqual({
       ok: false,
       error: "Missing assistantId",

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -31,6 +31,7 @@ import {
   getBundledBunPath,
   getCliBinPath,
 } from "./cli-installer";
+import { getSessionToken } from "./session-token-store";
 
 /**
  * Local-mode host bridge: provisions and retires local assistants and reads
@@ -130,7 +131,9 @@ async function retire(assistantId: string): Promise<RetireResult> {
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runRetire(invocation, assistantId);
+  const result = await runRetire(invocation, assistantId, {
+    platformToken: getSessionToken() ?? undefined,
+  });
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
@@ -294,7 +297,11 @@ export const installLocalMode = (): void => {
     "vellum:localMode:replacePlatformAssistants",
     z.tuple([z.array(assistantRecord), z.string().optional()]),
     ([list, organizationId]): LockfileWriteResult => {
-      const result = replacePlatformAssistants(lockfilePaths, list, organizationId);
+      const result = replacePlatformAssistants(
+        lockfilePaths,
+        list,
+        organizationId,
+      );
       return result.ok
         ? { ok: true, lockfile: result.lockfile }
         : { ok: false, error: result.error };

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -422,7 +422,9 @@ function retireMiddleware(
         return;
       }
 
-      runRetire(invocation, assistantId).then((result) => {
+      runRetire(invocation, assistantId, {
+        platformToken: getDevPlatformToken() ?? undefined,
+      }).then((result) => {
         res.statusCode = result.ok ? 200 : result.status;
         res.setHeader("Content-Type", "application/json");
         res.end(

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import type { CliInvocation } from "../util";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+let lastChild: FakeChild;
+const spawnArgs: Array<
+  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }]
+> = [];
+const spawnMock = mock(
+  (
+    command: string,
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+  ) => {
+    spawnArgs.push([command, args, options]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+);
+
+mock.module("node:child_process", () => ({ spawn: spawnMock }));
+
+let runRetire: typeof import("../retire").runRetire;
+
+beforeAll(async () => {
+  ({ runRetire } = await import("../retire"));
+});
+
+afterEach(() => {
+  spawnArgs.length = 0;
+  spawnMock.mockClear();
+  delete process.env.VELLUM_PLATFORM_TOKEN;
+});
+
+const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
+
+describe("runRetire", () => {
+  test("spawns the CLI retire command", async () => {
+    const pending = runRetire(invocation, "asst-42");
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "retire", "asst-42", "--yes"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ]);
+  });
+
+  test("passes a host platform token to the CLI subprocess", async () => {
+    const pending = runRetire(invocation, "asst-42", {
+      platformToken: "session-token",
+    });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]?.[2].env?.VELLUM_PLATFORM_TOKEN).toBe("session-token");
+    expect(process.env.VELLUM_PLATFORM_TOKEN).toBeUndefined();
+  });
+
+  test("a non-zero exit resolves to a failure carrying the CLI output", async () => {
+    const pending = runRetire(invocation, "asst-42");
+    lastChild.stderr.emit("data", Buffer.from("retire failed"));
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "retire failed",
+    });
+  });
+});

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -14,9 +14,18 @@ export {
   resolveDevCliInvocation,
 } from "./util";
 export type { CliInvocation } from "./util";
-export { resolveLocalConfigFromEnv, resolveLockfilePaths, resolveConfigDir, guardianTokenPath } from "./config";
+export {
+  resolveLocalConfigFromEnv,
+  resolveLockfilePaths,
+  resolveConfigDir,
+  guardianTokenPath,
+} from "./config";
 export type { LocalEndpointConfig } from "./config";
-export { defaultEnvironmentFilePath, readDefaultEnvironment, resolveEnvironmentName } from "./environment";
+export {
+  defaultEnvironmentFilePath,
+  readDefaultEnvironment,
+  resolveEnvironmentName,
+} from "./environment";
 export {
   getLockfileData,
   upsertLockfileAssistant,
@@ -34,7 +43,7 @@ export type {
 export { runHatch } from "./hatch";
 export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
-export type { RetireResult } from "./retire";
+export type { RetireOptions, RetireResult } from "./retire";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";

--- a/packages/local-mode/src/retire.ts
+++ b/packages/local-mode/src/retire.ts
@@ -5,18 +5,32 @@ import type { CliInvocation } from "./util";
 const RETIRE_TIMEOUT_MS = 60_000;
 
 export type RetireResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
+  { ok: true } | { ok: false; status: number; error: string };
+
+export interface RetireOptions {
+  platformToken?: string;
+}
 
 export function runRetire(
   invocation: CliInvocation,
   assistantId: string,
+  options: RetireOptions = {},
 ): Promise<RetireResult> {
   return new Promise((resolve) => {
     const child = spawn(
       invocation.command,
       [...invocation.baseArgs, "retire", assistantId, "--yes"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      {
+        ...(options.platformToken
+          ? {
+              env: {
+                ...process.env,
+                VELLUM_PLATFORM_TOKEN: options.platformToken,
+              },
+            }
+          : {}),
+        stdio: ["ignore", "pipe", "pipe"],
+      },
     );
 
     let stdout = "";
@@ -32,7 +46,11 @@ export function runRetire(
 
     const timeout = setTimeout(() => {
       child.kill("SIGTERM");
-      finish({ ok: false, status: 500, error: "Retire timed out after 60 seconds" });
+      finish({
+        ok: false,
+        status: 500,
+        error: "Retire timed out after 60 seconds",
+      });
     }, RETIRE_TIMEOUT_MS);
 
     child.stdout.on("data", (data: Buffer) => {
@@ -52,7 +70,11 @@ export function runRetire(
     });
 
     child.on("error", (err) => {
-      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+      finish({
+        ok: false,
+        status: 500,
+        error: `Failed to spawn CLI: ${err.message}`,
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds an optional `platformToken` to the shared local-mode `runRetire()` subprocess helper.
- Passes the Electron session token and local web dev server token into the CLI retire subprocess as `VELLUM_PLATFORM_TOKEN`.
- Adds focused package and macOS tests to prove the token is scoped to the child process environment.

## Context
`origin/main` already contains the shared local retire runner and host wiring. This is the remaining PR 1 plumbing needed before the platform-unregister PR can consume the token in the CLI retire command.

## Verification
- `cd packages/local-mode && bun test src/__tests__/retire.test.ts`
- `cd packages/local-mode && bun run typecheck`
- `cd clients/macos && bun test src/main/local-mode.test.ts`
- `cd clients/macos && bun test src/main/bundle-flow.test.ts`
- `cd clients/macos && bunx tsc --noEmit`
- `cd clients/web && bun run lint -- vite-plugin-local-mode.ts`
- `cd clients/web && bunx tsc --noEmit`
