### PR TITLE
fix(web): address self-review gaps in background-process registry

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -611,7 +611,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
     for (const entry of entries) {
       // byId / orderedIds / merge are handled above by seedEntriesFromHistory;
       // this loop only maintains the spawn-anchor index and the seq high-water
-      // mark. Use the shared setToolUseAnchor helper (PR 13) for the index.
+      // mark. Use the shared setToolUseAnchor helper for the index.
       nextByToolUseId = setToolUseAnchor(
         nextByToolUseId,
         entry.parentToolUseId,

--- a/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
+++ b/clients/web/src/domains/chat/components/acp-run-inline-card/use-acp-run-card-data.ts
@@ -1,9 +1,10 @@
 /**
- * Builds the props for `AcpRunInlineProgressCard` from a single ACP run's
- * store entry. Projects the run's raw event buffer into the carousel via
- * `useAcpRunSteps` + `acpStepsToCarousel`, then maps the run status to the
- * shared card props consumed by the tool-progress card chrome — the same shape
- * the workflow and subagent inline cards feed their shells.
+ * Builds the `ToolCallCardData` consumed by `InlineProcessCard` via the acp-run
+ * descriptor, from a single ACP run's store entry. Projects the run's raw event
+ * buffer into the carousel via `useAcpRunSteps` + `acpStepsToCarousel`, then
+ * maps the run status to the shared card props consumed by the tool-progress
+ * card chrome — the same shape the workflow and subagent inline cards feed their
+ * shells.
  *
  * Returns `null` when no entry exists for the given session yet — the
  * spawn-race window where the assistant message containing the inline card

--- a/clients/web/src/domains/chat/components/background-task-inline-card/use-background-task-card-data.ts
+++ b/clients/web/src/domains/chat/components/background-task-inline-card/use-background-task-card-data.ts
@@ -1,8 +1,8 @@
 /**
- * Builds the props for `BackgroundTaskInlineProgressCard` from a single
- * background task's store entry. Maps the task status to the shared
- * tool-progress card props — the same shape the workflow, subagent, and ACP
- * inline cards feed their shells.
+ * Builds the `ToolCallCardData` consumed by `InlineProcessCard` via the
+ * background-task descriptor, from a single background task's store entry. Maps
+ * the task status to the shared tool-progress card props — the same shape the
+ * workflow, subagent, and ACP inline cards feed their shells.
  *
  * Returns `null` when no entry exists for the given id yet — the window where
  * the assistant message containing the inline card mounts a hair before the

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -39,6 +39,7 @@ import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachmen
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
 import { PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
 import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
 import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
@@ -157,7 +158,8 @@ export type ChatRouteContentProps = ChatMainPanelProps;
  * active conversation internally, so the hooks are called here at the
  * orchestrator level (where the conversation lives in context). They must be
  * called explicitly per-kind — the Rules of Hooks forbid iterating
- * `PROCESS_KINDS` with hooks — and kept aligned with `PROCESS_KINDS` order.
+ * `PROCESS_KINDS` with hooks — and the results are keyed by `descriptor.kind`,
+ * so the overlay row order follows `PROCESS_KINDS` without positional coupling.
  *
  * `hasAny` lets the caller omit the row entirely when nothing is active, so the
  * absolutely-positioned container never mounts empty; the overlays themselves
@@ -168,13 +170,20 @@ function useActiveProcessSlots() {
   const acpRunIds = ACP_RUN_DESCRIPTOR.useActiveIds();
   const workflowIds = WORKFLOW_DESCRIPTOR.useActiveIds();
   const backgroundTaskIds = BACKGROUND_TASK_DESCRIPTOR.useActiveIds();
-  const idsByKind = [subagentIds, acpRunIds, workflowIds, backgroundTaskIds];
-  const hasAny = idsByKind.some((ids) => ids.length > 0);
-  const overlays = PROCESS_KINDS.map((descriptor, i) => (
+  // Keyed by `descriptor.kind` (not array position) so reordering
+  // `PROCESS_KINDS` can't silently feed an overlay the wrong kind's ids.
+  const idsByKind: Record<ProcessKind, string[]> = {
+    subagent: subagentIds,
+    "acp-run": acpRunIds,
+    workflow: workflowIds,
+    "background-task": backgroundTaskIds,
+  };
+  const hasAny = Object.values(idsByKind).some((ids) => ids.length > 0);
+  const overlays = PROCESS_KINDS.map((descriptor) => (
     <ActiveProcessOverlay
       key={descriptor.kind}
       descriptor={descriptor}
-      ids={idsByKind[i]}
+      ids={idsByKind[descriptor.kind]}
     />
   ));
   return { overlays, hasAny };

--- a/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -219,8 +219,8 @@ function expandedHeaderLabel(
  *   is preserved bit-for-bit from the legacy card.
  * - Zero renderable steps (today: a group made up entirely of
  *   `subagent_spawn` calls, which `useToolCallCardData` filters out) → render
- *   `null`; the spawned subagents render as inline
- *   `SubagentInlineProgressCard`s elsewhere in the transcript.
+ *   `null`; the spawned subagents render as inline `InlineProcessCard`s (via the
+ *   subagent descriptor) elsewhere in the transcript.
  */
 export function MultiActivityGroup(props: MultiActivityGroupProps) {
   const {
@@ -238,9 +238,9 @@ export function MultiActivityGroup(props: MultiActivityGroupProps) {
   // once via a single hook call so there are no conditional hooks.
   //
   // `subagent_spawn` calls are filtered out inside the projection — they're
-  // rendered inline by `SubagentInlineProgressCard` at the transcript level.
-  // If a group reduces to zero renderable steps the dispatcher falls through
-  // to a no-op below.
+  // rendered inline by `InlineProcessCard` (via the subagent descriptor) at the
+  // transcript level. If a group reduces to zero renderable steps the
+  // dispatcher falls through to a no-op below.
   const effectiveItems = useMemo(
     () => props.items ?? buildDefaultItems(toolCalls),
     [props.items, toolCalls],

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -6,9 +6,12 @@ import { ChevronDown } from "lucide-react";
 import { SubagentAvatarBadge } from "@/components/avatar/subagent-avatar-badge";
 import { Typography } from "@vellumai/design-library";
 
-// Visible-avatar cap before the "+N" overflow chip; 6 matches the Figma mock
-// (6063:148462: 6 avatars + "+6").
-export const MAX_VISIBLE_SUBAGENT_AVATARS = 6;
+import { MAX_VISIBLE_STACKED_CHIPS } from "@/domains/chat/process-registry/constants";
+
+// Visible-avatar cap before the "+N" overflow chip. Aliases the shared
+// stacked-chips cap so the avatar row and the overlay pills share one source of
+// truth.
+export const MAX_VISIBLE_SUBAGENT_AVATARS = MAX_VISIBLE_STACKED_CHIPS;
 
 export interface SubagentAvatarRowProps {
   subagentIds: string[];

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -1,6 +1,7 @@
 /**
- * Builds the props for `SubagentInlineProgressCard` from a single
- * subagent's store entry. Translates the subagent's timeline events
+ * Builds the `ToolCallCardData` consumed by `InlineProcessCard` via the
+ * subagent descriptor, from a single subagent's store entry. Translates the
+ * subagent's timeline events
  * (`SubagentTimelineEvent[]`) into the unified `ToolCallCardStep[]`
  * shape consumed by the shared tool-progress card chrome.
  *

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -1,6 +1,7 @@
 /**
- * Builds the props for `WorkflowInlineProgressCard` from a single
- * workflow run's store entry. Projects the run's leaves
+ * Builds the `ToolCallCardData` consumed by `InlineProcessCard` via the
+ * workflow descriptor, from a single workflow run's store entry. Projects the
+ * run's leaves
  * (`WorkflowLeaf[]`) into the unified `ToolCallCardStep[]` shape consumed
  * by the shared tool-progress card chrome — the same shape the subagent
  * inline card uses, so both share one renderer contract.

--- a/clients/web/src/domains/chat/process-registry/active-process-overlay.tsx
+++ b/clients/web/src/domains/chat/process-registry/active-process-overlay.tsx
@@ -15,7 +15,7 @@ import { Typography } from "@vellumai/design-library";
 
 import { ActiveOverlayShell } from "@/domains/chat/components/active-overlay-shell";
 import { ChatPill } from "@/domains/chat/components/chat-pill";
-import { InlineProcessCard } from "@/domains/chat/process-registry/inline-process-card";
+import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
 import { StackedChipsPill } from "@/domains/chat/process-registry/stacked-chips-pill";
 import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
 
@@ -27,12 +27,14 @@ export interface ActiveProcessOverlayProps {
 }
 
 /**
- * One inline-card row inside the expanded dropdown.
+ * One inline-card row inside the expanded dropdown. Renders through the shared
+ * {@link InlineProcessCardRow} (so the summary fetch, null short-circuit, and
+ * custom count slot all live in one place), wiring the descriptor's own
+ * `onOpenDetail` / `onStop` handlers.
  *
- * Its own component (not a bare `.map` callback) because it calls the
- * `descriptor.useCardSummary` hook — hooks can't run inside a loop callback.
- * Returns `null` while the summary is unavailable so a not-yet-projected
- * process simply doesn't render a row.
+ * Opening drills into the detail panel and dismisses the dropdown so the two
+ * layers stop competing for column width; stopping keeps it open
+ * (`InlineProcessCard` gates the stop button on `state === "loading"`).
  */
 function OverlayRow({
   descriptor,
@@ -43,17 +45,10 @@ function OverlayRow({
   id: string;
   onClose: () => void;
 }) {
-  const summary = descriptor.useCardSummary(id);
-  if (!summary) return null;
-
   return (
-    <InlineProcessCard
-      summary={summary}
-      leadingIcon={descriptor.renderCardLeading(id)}
-      openAriaLabel={descriptor.openCardAriaLabel}
-      // Opening drills into the detail panel and dismisses the dropdown so the
-      // two layers stop competing for column width; stopping keeps it open
-      // (`InlineProcessCard` gates the stop button on `state === "loading"`).
+    <InlineProcessCardRow
+      descriptor={descriptor}
+      id={id}
       onOpen={() => {
         descriptor.onOpenDetail(id);
         onClose();
@@ -97,7 +92,7 @@ export function ActiveProcessOverlay({
             size="compact"
           >
             {/* pointer-events-none so the ChatPill button owns clicks + cursor —
-                clicking anywhere toggles. Mirrors `active-workflows-pill`. */}
+                clicking anywhere toggles. */}
             <span className="pointer-events-none inline-flex items-center gap-1.5">
               {pill.glyph}
               <Typography

--- a/clients/web/src/domains/chat/process-registry/constants.ts
+++ b/clients/web/src/domains/chat/process-registry/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared cap on the number of stacked chips an overlay pill renders before
+ * collapsing the remainder into a "+N" overflow. One source of truth for the
+ * subagent / acp-run / background-task stacked pills (and the subagent
+ * collapsed avatar row), so the surfaces cap at the same count. 6 matches the
+ * Figma mock (6063:148462: 6 avatars + "+6").
+ */
+export const MAX_VISIBLE_STACKED_CHIPS = 6;

--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
@@ -1,11 +1,8 @@
 /**
- * `BackgroundProcessDescriptor` for ACP runs — the registry projection of the
- * existing acp-run inline-card / detail-panel / overlay-pill surface.
- *
- * Behavior-preserving: every axis maps onto a symbol the current ACP UI
- * already uses, so the generic registry renders the same agent-glyph leading
- * mark, the same stacked `AcpAgentChip` pill, and the same `warning` state for
- * a cancelled-completed run.
+ * `BackgroundProcessDescriptor` for ACP runs — projects the acp-run store into
+ * the shared inline-card / detail-panel / overlay-pill surface, rendering an
+ * agent-glyph leading mark, a stacked `AcpAgentChip` pill, and the `warning`
+ * state for a cancelled-completed run.
  */
 
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
@@ -13,18 +10,15 @@ import { AcpAgentIcon } from "@/domains/chat/components/acp-run-inline-card/acp-
 import { useAcpRunCardData } from "@/domains/chat/components/acp-run-inline-card/use-acp-run-card-data";
 import { AcpRunDetailPanel } from "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel";
 import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
+import { MAX_VISIBLE_STACKED_CHIPS } from "@/domains/chat/process-registry/constants";
 import type {
   BackgroundProcessDescriptor,
   CardSummary,
 } from "@/domains/chat/process-registry/types";
 import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
-
-// Visible agent-mark cap before the "+N" overflow. Mirrors the literal in
-// `active-acp-runs-pill.tsx` (and the subagents pill) so the registry pill caps
-// at the same count as the surface it generalizes.
-const MAX_VISIBLE_ACP_AGENTS = 6;
 
 /**
  * No-arg active-id hook for the descriptor. `useActiveAcpRunIds` is scoped to a
@@ -104,13 +98,18 @@ export const ACP_RUN_DESCRIPTOR: BackgroundProcessDescriptor = {
   pill: {
     variant: "stacked",
     renderChip: (id) => <AcpAgentChip key={id} id={id} />,
-    max: MAX_VISIBLE_ACP_AGENTS,
+    max: MAX_VISIBLE_STACKED_CHIPS,
   },
   overlayTitle: (n) => `${n} Active Run${n === 1 ? "" : "s"}`,
   pillAriaLabel: () => "Active runs",
   openCardAriaLabel: "Open run",
   onOpenDetail: (id) =>
     useViewerStore.getState().openProcessDetail({ kind: "acp-run", id }),
-  onStop: (id) => void stopAcpRun(id),
+  // `stopAcpRun` can reject (offline / non-OK / no active assistant); report
+  // instead of leaving an unhandled rejection. Mirrors the bespoke callers.
+  onStop: (id) =>
+    void stopAcpRun(id).catch((err) => {
+      captureError(err, { context: "AcpRunDescriptor.stop" });
+    }),
   DetailPanel: AcpRunDetailPanelById,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
@@ -6,10 +6,6 @@
  * {@link CardSummary} omits `count` and the inline card leads with a
  * tool-keyed terminal glyph (`bash` → square-terminal, `host_bash` →
  * file-terminal) instead of an avatar.
- *
- * Behavior-preserving: every projection here mirrors the existing
- * `useBackgroundTaskCardData`, `ActiveBackgroundTasksPill`, and
- * `BackgroundTaskDetailPanel` surfaces — see the per-field notes below.
  */
 
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
@@ -17,17 +13,12 @@ import { BackgroundTaskGlyph } from "@/domains/chat/components/background-task-g
 import { BackgroundTaskDetailPanel } from "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel";
 import { useBackgroundTaskCardData } from "@/domains/chat/components/background-task-inline-card/use-background-task-card-data";
 import { useActiveBackgroundTaskIds } from "@/domains/chat/hooks/use-active-background-task-ids";
+import { MAX_VISIBLE_STACKED_CHIPS } from "@/domains/chat/process-registry/constants";
 import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
 import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
-
-/**
- * Cap on stacked terminal glyphs before the overlay pill collapses the
- * remainder to "+N". Mirrors the local cap in `ActiveBackgroundTasksPill`,
- * which is file-private there.
- */
-const MAX_VISIBLE_BACKGROUND_TASK_GLYPHS = 6;
 
 /**
  * Active background-task ids for the currently-selected conversation.
@@ -105,13 +96,19 @@ export const BACKGROUND_TASK_DESCRIPTOR: BackgroundProcessDescriptor = {
   pill: {
     variant: "stacked",
     renderChip: (id) => <BackgroundTaskChip key={id} id={id} />,
-    max: MAX_VISIBLE_BACKGROUND_TASK_GLYPHS,
+    max: MAX_VISIBLE_STACKED_CHIPS,
   },
   overlayTitle: (count) => `${count} Active Command${count === 1 ? "" : "s"}`,
   pillAriaLabel: () => "Active commands",
   openCardAriaLabel: "Open command",
   onOpenDetail: (id) =>
     useViewerStore.getState().openProcessDetail({ kind: "background-task", id }),
-  onStop: (id) => void stopBackgroundTask(id),
+  // `stopBackgroundTask` can reject (offline / non-OK / no active assistant);
+  // report instead of leaving an unhandled rejection. Mirrors the bespoke
+  // callers.
+  onStop: (id) =>
+    void stopBackgroundTask(id).catch((err) => {
+      captureError(err, { context: "BackgroundTaskDescriptor.stop" });
+    }),
   DetailPanel: BackgroundTaskDetailPanelAdapter,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.test.ts
@@ -80,7 +80,7 @@ describe("SUBAGENT_DESCRIPTOR — useCardSummary projection", () => {
     expect(result.current).toBeNull();
   });
 
-  test("projects a running, no-step subagent's card data", () => {
+  test("promotes the subagent label to the title; info falls back to the activity verb", () => {
     act(() => {
       seed("sa-1", "running", [], "Find tigers");
     });
@@ -89,17 +89,19 @@ describe("SUBAGENT_DESCRIPTOR — useCardSummary projection", () => {
       SUBAGENT_DESCRIPTOR.useCardSummary("sa-1"),
     );
 
-    // Mirrors `deriveSubagentCardData` for a running entry with no steps:
-    // state "loading", title "Working", info = label, count "0 steps".
+    // Title = the subagent's label (its task name), so labeled subagents read
+    // distinctly. `currentStepInfo` for a no-step running entry is the label
+    // itself, so the info line falls back to the activity verb ("Working")
+    // rather than echoing the title — mirroring the bespoke card.
     expect(result.current).toEqual({
       state: "loading",
-      title: "Working",
-      info: "Find tigers",
+      title: "Find tigers",
+      info: "Working",
       count: "0 steps",
     });
   });
 
-  test("projects step title/info/count for a subagent mid-tool-call", () => {
+  test("keeps the live activity on the info line when it differs from the label", () => {
     act(() => {
       seed("sa-2", "running", [
         {
@@ -117,9 +119,11 @@ describe("SUBAGENT_DESCRIPTOR — useCardSummary projection", () => {
       SUBAGENT_DESCRIPTOR.useCardSummary("sa-2"),
     );
 
+    // Label ("Research Agent") is the title; the live tool activity ("ls -la")
+    // differs from the label so it stays on the info line.
     expect(result.current).toEqual({
       state: "loading",
-      title: "Working",
+      title: "Research Agent",
       info: "ls -la",
       count: "1 step",
     });
@@ -141,7 +145,7 @@ describe("SUBAGENT_DESCRIPTOR — useCardSummary projection", () => {
 
     expect(result.current).toEqual({
       state: "complete",
-      title: "Thought",
+      title: "Wrap up",
       info: "Done.",
       count: "1 step",
     });

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
@@ -2,11 +2,6 @@
  * The `subagent` {@link BackgroundProcessDescriptor} — the registry entry that
  * projects the subagent store into the shared inline-card + overlay-pill +
  * detail-panel surface.
- *
- * Behaviour-preserving: every field mirrors what the bespoke subagent surface
- * already renders (the inline progress card, the active-subagents overlay/pill,
- * and the subagent detail panel). Nothing consumes this descriptor yet — the
- * registry + generic surface wiring lands in a later PR.
  */
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
@@ -40,14 +35,26 @@ function useActiveIds(): string[] {
  * inline card's short-circuit. The 4-value `ToolCallCardData["state"]` is a
  * subset of `ToolProgressCardState` (it never emits `warning`/`denied`), so it
  * passes through unchanged.
+ *
+ * Title = the subagent's `label` (its task name), so labeled/multiple subagents
+ * read distinctly instead of all showing the generic activity verb; falls back
+ * to the live `currentStepTitle` when there's no label. The info line keeps the
+ * live activity (`currentStepInfo`), but falls back to `currentStepTitle` when
+ * it would just echo the label-as-title — mirroring the bespoke card.
  */
 function useCardSummary(id: string): CardSummary | null {
+  const label = useSubagentStore((s) => s.byId[id]?.label);
   const data = useSubagentCardData(id);
   if (data === null) return null;
+  const title = label ?? data.currentStepTitle;
+  const info =
+    data.currentStepInfo && data.currentStepInfo !== label
+      ? data.currentStepInfo
+      : data.currentStepTitle;
   return {
     state: data.state,
-    title: data.currentStepTitle,
-    info: data.currentStepInfo,
+    title,
+    info,
     count: data.stepCount,
   };
 }

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow-agents-chip.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow-agents-chip.tsx
@@ -1,0 +1,65 @@
+/**
+ * Agent-count chip for the workflow inline card — the workflow kind's custom
+ * `renderCount` slot. Renders a rounded `--surface-overlay` pill with an
+ * overlapping stack of decorative subagent avatars followed by the formatted
+ * count ("N agents").
+ *
+ * Self-contained: reads the avatar seeds (`useWorkflowAgentAvatarSeeds`) and the
+ * formatted count label (`useWorkflowCardData(runId).stepCount`) off the
+ * workflow store for `runId`, so the descriptor can wire it with just an id.
+ * Renders nothing when the run has no card-worthy state yet.
+ */
+
+import { Typography } from "@vellumai/design-library";
+
+import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
+import {
+  useWorkflowAgentAvatarSeeds,
+  useWorkflowCardData,
+} from "@/domains/chat/hooks/use-workflow-card-data";
+
+export function WorkflowAgentsChip({ runId }: { runId: string }) {
+  const seeds = useWorkflowAgentAvatarSeeds(runId);
+  const data = useWorkflowCardData(runId);
+
+  // `stepCount` is the pre-formatted noun string (e.g. "3 agents"). No entry yet
+  // → render nothing, matching the inline card's short-circuit.
+  if (!data) return null;
+  const countLabel = data.stepCount;
+
+  return (
+    <div
+      data-testid="workflow-inline-card-agents-chip"
+      className="inline-flex items-center gap-1 rounded-full bg-[var(--surface-overlay)] px-1.5 py-1"
+    >
+      {seeds.length > 0 && (
+        // Decorative identicons seeded by `runId:seq` (not real subagent
+        // identities), so the stack is aria-hidden and the count text carries
+        // the accessible meaning. The wrappers are divs because
+        // `SubagentAvatarChip` renders a div, which is invalid inside a span.
+        <div aria-hidden className="flex items-center">
+          {seeds.map((seed, index) => (
+            <SubagentAvatarChip
+              key={seed}
+              subagentId={seed}
+              size={14}
+              className={
+                index === 0
+                  ? undefined
+                  : "-ml-1 rounded-full ring-2 ring-[var(--surface-overlay)]"
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+        data-testid="workflow-inline-card-step-count"
+      >
+        {countLabel}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
@@ -8,8 +8,18 @@
  * would. The remaining assertions pin the static descriptor metadata that the
  * shared overlay/pill chrome depends on.
  */
-import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+
+// `WorkflowAgentsChip` (the descriptor's `renderCount` slot) renders
+// `SubagentAvatarChip`, which lazily loads a ~48 kB bundled-avatar payload.
+// Stub it to a testid so the `renderCount` test stays focused on the chip's
+// count text + avatar-per-seed structure.
+mock.module("@/components/avatar/subagent-avatar-chip", () => ({
+  SubagentAvatarChip: ({ subagentId }: { subagentId: string }) => (
+    <span data-testid="avatar-stub" data-subagent-id={subagentId} />
+  ),
+}));
 
 import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -19,6 +29,10 @@ afterEach(() => {
   cleanup();
   useWorkflowStore.getState().reset();
   useViewerStore.getState().reset();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("WORKFLOW_DESCRIPTOR — useCardSummary projection", () => {
@@ -93,6 +107,27 @@ describe("WORKFLOW_DESCRIPTOR — static metadata", () => {
 
   test("exposes a stop action", () => {
     expect(WORKFLOW_DESCRIPTOR.onStop).toBeDefined();
+  });
+
+  test("provides a renderCount slot (the agent-avatar chip)", () => {
+    expect(WORKFLOW_DESCRIPTOR.renderCount).toBeDefined();
+
+    act(() => {
+      const store = useWorkflowStore.getState();
+      store.startRun({ runId: "wf-chip", label: "Chip", timestamp: 1 });
+      store.applyProgress({ runId: "wf-chip", agentsSpawned: 3 });
+    });
+
+    const { getByTestId } = render(
+      <>{WORKFLOW_DESCRIPTOR.renderCount!("wf-chip")}</>,
+    );
+
+    // The custom count slot renders the agent-avatar chip with the formatted
+    // "N agents" label rather than the default string-count Typography.
+    expect(getByTestId("workflow-inline-card-agents-chip")).toBeTruthy();
+    expect(
+      getByTestId("workflow-inline-card-step-count").textContent,
+    ).toBe("3 agents");
   });
 });
 

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
@@ -2,11 +2,9 @@
  * Background-process descriptor for the **workflow** kind.
  *
  * Workflow is the lone count-variant surface: its overlay pill renders a single
- * static {@link Workflow} glyph next to the active count (see
- * `active-workflows-pill.tsx`), not a stack of per-process chips. The card,
- * detail panel, and copy mirror the existing workflow UI exactly — this
- * descriptor is a behavior-preserving adapter onto the shared
- * {@link BackgroundProcessDescriptor} contract.
+ * static {@link Workflow} glyph next to the active count, not a stack of
+ * per-process chips. The inline card's count slot is a custom
+ * {@link WorkflowAgentsChip} (avatar stack + "N agents") via `renderCount`.
  */
 
 import { Workflow } from "lucide-react";
@@ -17,6 +15,7 @@ import type {
   BackgroundProcessDescriptor,
   CardSummary,
 } from "@/domains/chat/process-registry/types";
+import { WorkflowAgentsChip } from "@/domains/chat/process-registry/descriptors/workflow-agents-chip";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { WorkflowDetailPanel } from "@/domains/chat/components/workflow-detail-panel";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -95,5 +94,6 @@ export const WORKFLOW_DESCRIPTOR: BackgroundProcessDescriptor = {
   onOpenDetail: (id) =>
     useViewerStore.getState().openProcessDetail({ kind: "workflow", id }),
   onStop: (id) => void useWorkflowStore.getState().abortRun(id),
+  renderCount: (id) => <WorkflowAgentsChip runId={id} />,
   DetailPanel: WorkflowDetailPanelAdapter,
 };

--- a/clients/web/src/domains/chat/process-registry/inline-process-card-row.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card-row.tsx
@@ -1,15 +1,17 @@
 // Connects a {@link BackgroundProcessDescriptor} to the generic
 // {@link InlineProcessCard}: subscribes to the descriptor's per-id
 // `useCardSummary` hook and projects the result into the shared card, supplying
-// the descriptor's leading icon + open-affordance label. Returns `null` in the
-// spawn race (no card-worthy state yet), matching the bespoke cards it replaces.
+// the descriptor's leading icon, open-affordance label, and custom count slot
+// (`descriptor.renderCount`). Returns `null` in the spawn race (no card-worthy
+// state yet), matching the bespoke cards it replaces.
 //
 // The descriptor hook MUST run inside a component (not a bare `.map` callback),
 // so each row is its own component subscribing to its own id.
 //
-// `onOpen` / `onStop` are threaded from the caller — the transcript keeps its
-// existing per-kind handler wiring rather than the descriptor's `onOpenDetail` /
-// `onStop`, so behavior stays byte-identical.
+// `onOpen` / `onStop` are threaded from the caller: the transcript wires its own
+// per-kind open/stop handlers, while the active-process overlay wires the
+// descriptor's `onOpenDetail` / `onStop`. Both call sites render through this
+// one row component.
 
 import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
 import { InlineProcessCard } from "@/domains/chat/process-registry/inline-process-card";
@@ -47,6 +49,7 @@ export function InlineProcessCardRow({
       onOpen={onOpen}
       onStop={onStop}
       stopAriaLabel={stopAriaLabel}
+      countSlot={descriptor.renderCount?.(id)}
       testId={testId}
     />
   );

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -36,6 +36,11 @@ export interface InlineProcessCardProps {
   onStop?: () => void;
   /** Accessible label for the stop button; defaults to `"Stop"`. */
   stopAriaLabel?: string;
+  /**
+   * Custom count slot. When provided, replaces the default string-count
+   * `Typography` (e.g. the workflow agent-avatar chip).
+   */
+  countSlot?: ReactNode;
   /** `data-testid` for the root row. */
   testId?: string;
 }
@@ -47,6 +52,7 @@ export function InlineProcessCard({
   onOpen,
   onStop,
   stopAriaLabel,
+  countSlot,
   testId,
 }: InlineProcessCardProps) {
   const handleOpenKeyDown = useCallback(
@@ -101,7 +107,9 @@ export function InlineProcessCard({
         />
       </span>
       <span className="flex shrink-0 items-center gap-2">
-        {showCount ? (
+        {countSlot != null ? (
+          countSlot
+        ) : showCount ? (
           <Typography
             variant="body-small-default"
             className="text-[var(--content-tertiary)]"

--- a/clients/web/src/domains/chat/process-registry/types.ts
+++ b/clients/web/src/domains/chat/process-registry/types.ts
@@ -47,8 +47,8 @@ export interface CardSummary {
  * - `count` — renders a single static `glyph` next to the count. Used by kinds
  *   whose processes are visually interchangeable.
  */
-export type ProcessPillConfig<Id extends string = string> =
-  | { variant: "stacked"; renderChip: (id: Id) => ReactNode; max: number }
+export type ProcessPillConfig =
+  | { variant: "stacked"; renderChip: (id: string) => ReactNode; max: number }
   | { variant: "count"; glyph: ReactNode };
 
 /**
@@ -74,22 +74,24 @@ export type ProcessPillConfig<Id extends string = string> =
  *   navigation/selection logic.
  * - `onStop` — only some kinds support stopping an in-flight process; omitted
  *   when the kind has no stop action.
+ * - `renderCount` — optional custom count slot; overrides the default string
+ *   `count` rendering when present (e.g. the workflow agent-avatar chip).
  * - `DetailPanel` — each kind renders a different detail UI.
  */
-export interface BackgroundProcessDescriptor<Id extends string = string> {
+export interface BackgroundProcessDescriptor {
   /** Discriminant used to look the descriptor up in the registry. */
   kind: ProcessKind;
   /** Hook returning the ids of the currently-active processes for this kind. */
-  useActiveIds: () => Id[];
+  useActiveIds: () => string[];
   /**
    * Hook projecting a single process's store state into a {@link CardSummary},
    * or `null` when the process has no card-worthy state.
    */
-  useCardSummary: (id: Id) => CardSummary | null;
+  useCardSummary: (id: string) => CardSummary | null;
   /** Renders the leading slot of the inline card for a single process. */
-  renderCardLeading: (id: Id) => ReactNode;
+  renderCardLeading: (id: string) => ReactNode;
   /** Overlay-pill presentation config. */
-  pill: ProcessPillConfig<Id>;
+  pill: ProcessPillConfig;
   /** Count-dependent overlay title copy, e.g. `(3) => "3 agents"`. */
   overlayTitle: (count: number) => string;
   /** Count-dependent aria label for the overlay pill. */
@@ -97,9 +99,14 @@ export interface BackgroundProcessDescriptor<Id extends string = string> {
   /** Static aria label for the inline card's open affordance. */
   openCardAriaLabel: string;
   /** Opens the detail panel for a single process. */
-  onOpenDetail: (id: Id) => void;
+  onOpenDetail: (id: string) => void;
   /** Stops an in-flight process; omitted for kinds without a stop action. */
-  onStop?: (id: Id) => void;
+  onStop?: (id: string) => void;
+  /**
+   * Custom count slot; overrides the default string `count` rendering when
+   * present. Omit to fall back to the {@link CardSummary.count} string.
+   */
+  renderCount?: (id: string) => ReactNode;
   /** Detail-panel component rendered for a single process. */
-  DetailPanel: ComponentType<{ id: Id; onClose: () => void }>;
+  DetailPanel: ComponentType<{ id: string; onClose: () => void }>;
 }

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -22,6 +22,18 @@ mock.module("@/domains/chat/components/chat-attachments/message-attachments", ()
   MessageAttachments: () => <div data-testid="attachments" />,
 }));
 
+// The ACP-run and background-task rows wire their transcript stop button to
+// these standalone actions; stub them so clicking Stop records the call without
+// pulling in the daemon SDK / store wiring.
+const stopAcpRunMock = mock(async () => {});
+const stopBackgroundTaskMock = mock(async () => {});
+mock.module("@/domains/chat/utils/acp-run-actions", () => ({
+  stopAcpRun: stopAcpRunMock,
+}));
+mock.module("@/domains/chat/utils/background-task-actions", () => ({
+  stopBackgroundTask: stopBackgroundTaskMock,
+}));
+
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
   ChatMarkdownMessage: ({
     content,
@@ -1115,7 +1127,8 @@ describe("TranscriptMessageBody — generic inline process cards", () => {
     expect(stopped).toEqual(["wf-1"]);
   });
 
-  test("renders the ACP-run descriptor row, open only (no stop in transcript)", () => {
+  test("renders the ACP-run descriptor row and wires open + stop", () => {
+    stopAcpRunMock.mockClear();
     const toolCall: ChatMessageToolCall = {
       id: "tc-acp",
       name: "acp_spawn",
@@ -1134,11 +1147,14 @@ describe("TranscriptMessageBody — generic inline process cards", () => {
     const row = getByTestId("inline-process-card");
     expect(row.getAttribute("data-process-kind")).toBe("acp-run");
     expect(row.getAttribute("data-process-id")).toBe("acp-1");
-    // ACP passes no stop handler in the transcript today.
-    expect(row.getAttribute("data-has-stop")).toBe("false");
+    expect(row.getAttribute("data-has-stop")).toBe("true");
+
+    fireEvent.click(getByTestId("inline-process-card-stop"));
+    expect(stopAcpRunMock).toHaveBeenCalledWith("acp-1");
   });
 
-  test("renders the background-task descriptor row, open only (no stop in transcript)", () => {
+  test("renders the background-task descriptor row and wires open + stop", () => {
+    stopBackgroundTaskMock.mockClear();
     const toolCall: ChatMessageToolCall = {
       id: "tc-bg",
       name: "bash",
@@ -1157,6 +1173,9 @@ describe("TranscriptMessageBody — generic inline process cards", () => {
     const row = getByTestId("inline-process-card");
     expect(row.getAttribute("data-process-kind")).toBe("background-task");
     expect(row.getAttribute("data-process-id")).toBe("bg-1");
-    expect(row.getAttribute("data-has-stop")).toBe("false");
+    expect(row.getAttribute("data-has-stop")).toBe("true");
+
+    fireEvent.click(getByTestId("inline-process-card-stop"));
+    expect(stopBackgroundTaskMock).toHaveBeenCalledWith("bg-1");
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -34,6 +34,9 @@ import {
   isSuppressedUiTool,
 } from "@/domains/chat/transcript/message-content";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
+import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
+import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
+import { captureError } from "@/lib/sentry/capture-error";
 import { getSlackLinkUrl } from "@/domains/chat/types/types";
 import { wireSurfaceToDisplay } from "@/domains/chat/utils/map-runtime-message";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -382,6 +385,12 @@ export function TranscriptMessageBody({
             descriptor={ACP_RUN_DESCRIPTOR}
             id={acpSessionId}
             onOpen={() => handleAcpRunClick(acpSessionId)}
+            onStop={() =>
+              void stopAcpRun(acpSessionId).catch((err) => {
+                captureError(err, { context: "TranscriptMessageBody.stopAcpRun" });
+              })
+            }
+            stopAriaLabel="Stop run"
             testId="inline-process-card"
           />
         ))}
@@ -402,6 +411,14 @@ export function TranscriptMessageBody({
             descriptor={BACKGROUND_TASK_DESCRIPTOR}
             id={id}
             onOpen={() => handleBackgroundTaskClick(id)}
+            onStop={() =>
+              void stopBackgroundTask(id).catch((err) => {
+                captureError(err, {
+                  context: "TranscriptMessageBody.stopBackgroundTask",
+                });
+              })
+            }
+            stopAriaLabel="Stop command"
             testId="inline-process-card"
           />
         ))}

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -154,8 +154,8 @@ export type ToolCallCardStep =
  * successful and failed tool calls can render a distinct chrome state.
  *
  * The subagent leading-icon slot (`<SubagentAvatarChip>`) is plumbed directly
- * through the shell's `leadingIcon` ReactNode prop by
- * `SubagentInlineProgressCard`, so this data shape doesn't need to carry it.
+ * through the inline card's `leadingIcon` ReactNode prop by the subagent
+ * descriptor's `renderCardLeading`, so this data shape doesn't need to carry it.
  */
 export interface ToolCallCardData {
   /**
@@ -795,9 +795,9 @@ export function computeToolCallCardDataFromItems(
         i.kind === "toolCall",
     )
     .map((i) => i.toolCall);
-  // `subagent_spawn` calls are rendered inline by `SubagentInlineProgressCard`
-  // at the transcript level — surfacing them as steps inside the unified card
-  // would render the spawn twice.
+  // `subagent_spawn` calls are rendered inline by `InlineProcessCard` (via the
+  // subagent descriptor) at the transcript level — surfacing them as steps
+  // inside the unified card would render the spawn twice.
   const renderableToolCalls = toolCalls.filter(
     (tc) => !isSubagentSpawnCall(tc),
   );


### PR DESCRIPTION
## Summary
Remediates self-review findings on the background-process registry refactor:
- Restore subagent label as inline-card/overlay title (was showing generic activity verb).
- Restore ACP + background-task transcript stop buttons.
- Add .catch to ACP/background-task descriptor onStop (unhandled rejection).
- Restore workflow agent-avatar count chip via a renderCount descriptor axis.
- Key useActiveProcessSlots ids by descriptor.kind (was positionally coupled to PROCESS_KINDS).
- Centralize MAX_VISIBLE_STACKED_CHIPS; drop unused <Id> generic; fold OverlayRow into InlineProcessCardRow; fix stale comments.

Part of plan: background-process-registry.md (self-review remediation)