### PR TITLE
fix(web): hide workflow agents chip for 0/1 agents; fix stale test comments

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -294,9 +294,9 @@ describe("computeToolCallCardData — state transitions", () => {
 
 describe("computeToolCallCardData — subagent_spawn filtering", () => {
   test("a subagent_spawn-only group produces zero steps", () => {
-    // Inline `SubagentInlineProgressCard` renders the spawned subagent
-    // at the transcript level — surfacing a step inside the unified card
-    // would render the spawn twice.
+    // The subagent descriptor's `InlineProcessCard` renders the spawned
+    // subagent at the transcript level — surfacing a step inside the unified
+    // card would render the spawn twice.
     const toolCalls = [
       makeToolCall({
         id: "tc-1",

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow-agents-chip.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow-agents-chip.tsx
@@ -7,7 +7,9 @@
  * Self-contained: reads the avatar seeds (`useWorkflowAgentAvatarSeeds`) and the
  * formatted count label (`useWorkflowCardData(runId).stepCount`) off the
  * workflow store for `runId`, so the descriptor can wire it with just an id.
- * Renders nothing when the run has no card-worthy state yet.
+ * Renders nothing when the run has no card-worthy state yet, or when the count
+ * is "0 …"/"1 …" — a workflow with fewer than two agents doesn't warrant the
+ * avatar-stack chip (mirrors the legacy card's `showStepCount` gate).
  */
 
 import { Typography } from "@vellumai/design-library";
@@ -26,6 +28,11 @@ export function WorkflowAgentsChip({ runId }: { runId: string }) {
   // → render nothing, matching the inline card's short-circuit.
   if (!data) return null;
   const countLabel = data.stepCount;
+
+  // Hide the chip for 0- or 1-agent workflows: a single-agent (or empty) run
+  // doesn't warrant the avatar-stack chip, matching the legacy card's
+  // `showStepCount = !!stepCount && !"0 " && !"1 "` gate.
+  if (countLabel.startsWith("0 ") || countLabel.startsWith("1 ")) return null;
 
   return (
     <div

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.test.tsx
@@ -129,6 +129,38 @@ describe("WORKFLOW_DESCRIPTOR — static metadata", () => {
       getByTestId("workflow-inline-card-step-count").textContent,
     ).toBe("3 agents");
   });
+
+  test("hides the renderCount chip for a 0-agent workflow", () => {
+    // A run with no spawned agents projects "0 agents"; the chip self-hides so
+    // a count-of-zero workflow doesn't render the avatar-stack pill.
+    act(() => {
+      const store = useWorkflowStore.getState();
+      store.startRun({ runId: "wf-zero", label: "Zero", timestamp: 1 });
+      store.applyProgress({ runId: "wf-zero", agentsSpawned: 0 });
+    });
+
+    const { queryByTestId } = render(
+      <>{WORKFLOW_DESCRIPTOR.renderCount!("wf-zero")}</>,
+    );
+
+    expect(queryByTestId("workflow-inline-card-agents-chip")).toBeNull();
+  });
+
+  test("hides the renderCount chip for a 1-agent workflow", () => {
+    // A single-agent run projects "1 agent"; the chip self-hides so a solo
+    // workflow doesn't render the (pointless) avatar-stack pill.
+    act(() => {
+      const store = useWorkflowStore.getState();
+      store.startRun({ runId: "wf-one", label: "One", timestamp: 1 });
+      store.applyProgress({ runId: "wf-one", agentsSpawned: 1 });
+    });
+
+    const { queryByTestId } = render(
+      <>{WORKFLOW_DESCRIPTOR.renderCount!("wf-one")}</>,
+    );
+
+    expect(queryByTestId("workflow-inline-card-agents-chip")).toBeNull();
+  });
 });
 
 describe("WORKFLOW_DESCRIPTOR — onOpenDetail", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-subagent-inline.test.tsx
@@ -88,7 +88,7 @@ const noop = () => {};
 
 /**
  * Expand every collapsed `SubagentSpawnGroup` in the tree so its per-subagent
- * `SubagentInlineProgressCard` rows mount. The resting state shows the avatar
+ * `InlineProcessCardRow` rows mount. The resting state shows the avatar
  * summary; clicking each "Details" toggle reveals the rows. A group already
  * expanded (e.g. across a rerender that preserves state) has no toggle and is
  * left untouched, so the helper is safe to re-run.


### PR DESCRIPTION
## Summary
- Restore the 0/1-agent hide on the workflow agent-avatar count chip (the new countSlot path bypassed the string-count gate).
- Update two test comments that named the deleted SubagentInlineProgressCard.

Part of plan: background-process-registry.md (self-review remediation round 2)