### PR TITLE
Update fitness-companion pin: widen peer dep to >=0.8.0

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -142,7 +142,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/fitness-companion",
-        "ref": "737cf7f33b43c82f0bfeb949b3f2a507c4a8b0d1"
+        "ref": "c5a310789609234f2f46ae96f7c501afedd10e9d"
       },
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",


### PR DESCRIPTION
## What

Updates the `fitness-companion` marketplace pin to commit `c5a3107` which widens the `@vellumai/plugin-api` peer dependency from `^0.8.0` to `>=0.8.0`.

## Why

The `^0.8.0` range caps at `<0.9.0`, which fails `semver.satisfies()` against `assistant@0.10.3` in `buildPluginFromDir()`. This means the plugin would fail to load on current Vellum versions.

`>=0.8.0` keeps compatibility with 0.8.x while allowing 0.9.x, 0.10.x, and beyond.

Flagged by @chatgpt-codex-connector on PR #36675.