### PR TITLE
[codex] Add self-hosted Ollama model profile support

### DIFF
--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -83,14 +83,11 @@ function comparableModel(model: MetaCatalogModel) {
 }
 
 describe("parity with meta/llm-provider-catalog.json", () => {
-  // Intentional asymmetries between the web mirror and the meta catalog:
-  // - the web mirror omits daemon-only providers (ollama);
-  // - openai-compatible has a per-connection model list, so its (empty)
-  //   catalog entry is excluded from model/default comparisons.
+  // Intentional asymmetry between the web mirror and the meta catalog:
+  // openai-compatible has a per-connection model list, so its (empty)
+  // catalog entry is excluded from model/default comparisons.
   // Field parity therefore iterates web keys, not meta providers; the
   // coverage test below guards the reverse direction.
-  const DAEMON_ONLY_PROVIDERS = new Set(["ollama"]);
-
   const metaCatalog: MetaCatalog = JSON.parse(
     readFileSync(META_CATALOG_PATH, "utf-8"),
   );
@@ -101,12 +98,11 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[]
   ).filter((id) => id !== "openai-compatible");
 
-  test("every meta provider except daemon-only ones exists in the web mirror", () => {
+  test("every meta provider exists in the web mirror", () => {
     // This is the original MiniMax bug: a provider added to the daemon
     // catalog but never mirrored here, leaving an empty Model dropdown.
     const webKeys = new Set<string>(Object.keys(MODELS_BY_PROVIDER));
     for (const provider of metaCatalog.providers) {
-      if (DAEMON_ONLY_PROVIDERS.has(provider.id)) continue;
       expect(
         webKeys.has(provider.id),
         `meta provider "${provider.id}" is missing from MODELS_BY_PROVIDER`,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -638,7 +638,8 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
-  "openai-compatible": [],
+  "openai-compatible": [
+  ],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
 
 export type LlmProviderId = keyof typeof MODELS_BY_PROVIDER;

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -3,8 +3,8 @@
 // Source of truth: assistant/src/providers/model-catalog.ts, which
 // generates meta/llm-provider-catalog.json via
 //   cd assistant && bun run sync:llm-catalog
-// This file mirrors the subset the web UI needs (no ollama, no
-// pricing/vision/caching fields).
+// This file mirrors the subset the web UI needs (no pricing/vision/caching
+// fields).
 //
 // Parity is enforced by llm-model-catalog.test.ts: update the daemon
 // catalog first, run the sync, then mirror the change here.
@@ -220,6 +220,22 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 65_536,
       supportsThinking: true,
       longContextPricingThresholdTokens: 200_000,
+    },
+  ],
+  ollama: [
+    {
+      id: "llama3.2",
+      displayName: "Llama 3.2",
+      contextWindowTokens: 128_000,
+      defaultContextWindowTokens: 128_000,
+      maxOutputTokens: 4_096,
+    },
+    {
+      id: "mistral",
+      displayName: "Mistral",
+      contextWindowTokens: 32_768,
+      defaultContextWindowTokens: 32_768,
+      maxOutputTokens: 4_096,
     },
   ],
   fireworks: [
@@ -622,8 +638,7 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
-  "openai-compatible": [
-  ],
+  "openai-compatible": [],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
 
 export type LlmProviderId = keyof typeof MODELS_BY_PROVIDER;
@@ -632,6 +647,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-5.5",
   gemini: "gemini-2.5-flash",
+  ollama: "llama3.2",
   fireworks: "accounts/fireworks/models/kimi-k2p5",
   together: "MiniMaxAI/MiniMax-M3",
   openrouter: "x-ai/grok-4.20-beta",
@@ -642,8 +658,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
 
 /**
  * Provider id → human-readable label. Covers every provider in the
- * daemon catalog (including ones not in MODELS_BY_PROVIDER such as
- * ollama). Consumers should fall back to the raw id on miss:
+ * daemon catalog. Consumers should fall back to the raw id on miss:
  *   PROVIDER_DISPLAY_NAMES[id] ?? id
  */
 export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {

--- a/clients/web/src/domains/settings/ai/call-site-overrides-modal.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-modal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/domains/settings/ai/call-site-helpers";
 import { CallSiteOverrideRow } from "@/domains/settings/ai/call-site-overrides-row";
 import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
+import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
 import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
 import {
   configGetOptions,
@@ -117,6 +118,7 @@ function CallSiteOverridesModalInner({
     () => buildOrderedProfiles(profiles, profileOrder),
     [profiles, profileOrder],
   );
+  const selectableInferenceProviders = useSelectableInferenceProviders();
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
@@ -296,7 +298,8 @@ function CallSiteOverridesModalInner({
       if (seedProfile) {
         setDraftEdits((prev) => ({ ...prev, [id]: { profile: seedProfile } }));
       } else {
-        const defaultProvider = INFERENCE_PROVIDERS[0];
+        const defaultProvider =
+          selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
         const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
         setDraftEdits((prev) => ({
           ...prev,
@@ -304,7 +307,7 @@ function CallSiteOverridesModalInner({
         }));
       }
     },
-    [gatedCallSites, orderedProfiles],
+    [gatedCallSites, orderedProfiles, selectableInferenceProviders],
   );
 
   // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -2,16 +2,18 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import {
-    getDefaultModelForProvider,
-    getModelsForProvider,
-    PROVIDER_DISPLAY_NAMES,
+  getDefaultModelForProvider,
+  getModelsForProvider,
+  PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 import type { CallSiteOverrideDraft } from "@/generated/daemon/types.gen";
 
+import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
 import {
-    INFERENCE_PROVIDERS,
-} from "@/domains/settings/ai/constants";
-import { CUSTOM_SENTINEL, isDraftActive } from "@/domains/settings/ai/call-site-helpers";
+  CUSTOM_SENTINEL,
+  isDraftActive,
+} from "@/domains/settings/ai/call-site-helpers";
+import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,7 +58,12 @@ export function CallSiteOverrideRow({
   })();
 
   const isCustom = profileVal === CUSTOM_SENTINEL;
-  const currentProvider = INFERENCE_PROVIDERS.find((p) => p === draft?.provider) ?? INFERENCE_PROVIDERS[0];
+  const selectableInferenceProviders = useSelectableInferenceProviders();
+  const defaultProvider =
+    selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
+  const currentProvider =
+    selectableInferenceProviders.find((p) => p === draft?.provider) ??
+    defaultProvider;
   const availableModels = getModelsForProvider(currentProvider);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
@@ -66,9 +73,12 @@ export function CallSiteOverrideRow({
 
   function handleProfilePickerChange(val: string) {
     if (val === CUSTOM_SENTINEL) {
-      const defaultProvider = INFERENCE_PROVIDERS[0];
       const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
-      onDraftChange(id, { profile: null, provider: defaultProvider, model: defaultModel });
+      onDraftChange(id, {
+        profile: null,
+        provider: defaultProvider,
+        model: defaultModel,
+      });
     } else if (val === "") {
       onDraftChange(id, null);
     } else {
@@ -76,9 +86,16 @@ export function CallSiteOverrideRow({
     }
   }
 
-  function handleProviderChange(provider: (typeof INFERENCE_PROVIDERS)[number]) {
+  function handleProviderChange(
+    provider: (typeof INFERENCE_PROVIDERS)[number],
+  ) {
     const defaultModel = getDefaultModelForProvider(provider) ?? "";
-    onDraftChange(id, { ...(draft ?? {}), profile: null, provider, model: defaultModel });
+    onDraftChange(id, {
+      ...(draft ?? {}),
+      profile: null,
+      provider,
+      model: defaultModel,
+    });
   }
 
   function handleModelChange(model: string) {
@@ -134,7 +151,7 @@ export function CallSiteOverrideRow({
               <Dropdown
                 value={currentProvider ?? ""}
                 onChange={handleProviderChange}
-                options={INFERENCE_PROVIDERS.map((p) => ({
+                options={selectableInferenceProviders.map((p) => ({
                   value: p,
                   label: PROVIDER_DISPLAY_NAMES[p] ?? p,
                 }))}

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -2,17 +2,16 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import {
-  getDefaultModelForProvider,
-  getModelsForProvider,
-  PROVIDER_DISPLAY_NAMES,
+    getDefaultModelForProvider,
+    getModelsForProvider,
+    PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 import type { CallSiteOverrideDraft } from "@/generated/daemon/types.gen";
 
-import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
 import {
-  CUSTOM_SENTINEL,
-  isDraftActive,
-} from "@/domains/settings/ai/call-site-helpers";
+    INFERENCE_PROVIDERS,
+} from "@/domains/settings/ai/constants";
+import { CUSTOM_SENTINEL, isDraftActive } from "@/domains/settings/ai/call-site-helpers";
 import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
 
 // ---------------------------------------------------------------------------
@@ -59,11 +58,8 @@ export function CallSiteOverrideRow({
 
   const isCustom = profileVal === CUSTOM_SENTINEL;
   const selectableInferenceProviders = useSelectableInferenceProviders();
-  const defaultProvider =
-    selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
-  const currentProvider =
-    selectableInferenceProviders.find((p) => p === draft?.provider) ??
-    defaultProvider;
+  const defaultProvider = selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
+  const currentProvider = selectableInferenceProviders.find((p) => p === draft?.provider) ?? defaultProvider;
   const availableModels = getModelsForProvider(currentProvider);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
@@ -74,11 +70,7 @@ export function CallSiteOverrideRow({
   function handleProfilePickerChange(val: string) {
     if (val === CUSTOM_SENTINEL) {
       const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
-      onDraftChange(id, {
-        profile: null,
-        provider: defaultProvider,
-        model: defaultModel,
-      });
+      onDraftChange(id, { profile: null, provider: defaultProvider, model: defaultModel });
     } else if (val === "") {
       onDraftChange(id, null);
     } else {
@@ -86,16 +78,9 @@ export function CallSiteOverrideRow({
     }
   }
 
-  function handleProviderChange(
-    provider: (typeof INFERENCE_PROVIDERS)[number],
-  ) {
+  function handleProviderChange(provider: (typeof INFERENCE_PROVIDERS)[number]) {
     const defaultModel = getDefaultModelForProvider(provider) ?? "";
-    onDraftChange(id, {
-      ...(draft ?? {}),
-      profile: null,
-      provider,
-      model: defaultModel,
-    });
+    onDraftChange(id, { ...(draft ?? {}), profile: null, provider, model: defaultModel });
   }
 
   function handleModelChange(model: string) {

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -14,6 +14,7 @@ export const INFERENCE_PROVIDERS = [
   "together",
   "openrouter",
   "gemini",
+  "ollama",
   "minimax",
   "atlascloud",
 ] as const;

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -23,6 +23,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 
@@ -32,6 +33,7 @@ import * as sdkGen from "@/generated/daemon/sdk.gen";
 
 let createdConnection: ProviderConnection;
 let toastSuccessCalls: string[] = [];
+const initialLifecycleState = useAssistantLifecycleStore.getState();
 
 // Spy on the design-library toast so we can assert the shared ProfileEditorModal
 // does NOT fire a profile-create success toast itself — that toast belongs to
@@ -311,6 +313,7 @@ function fillCreateForm(): void {
 beforeEach(() => {
   createdConnection = makeConnection("anthropic-personal");
   toastSuccessCalls = [];
+  useAssistantLifecycleStore.setState(initialLifecycleState, true);
 });
 
 afterEach(() => {
@@ -419,6 +422,9 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("Ollama connections offer the bundled local models", () => {
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "self_hosted" },
+    });
     renderCreate([makeConnection("ollama", "ollama")]);
 
     selectProvider("Ollama");
@@ -434,6 +440,20 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     selectModel("Mistral");
     expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe("Mistral");
     expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe("mistral");
+  });
+
+  test("platform-hosted assistants do not offer Ollama as a new profile provider", () => {
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "active", isLocal: false },
+    });
+    renderCreate([makeConnection("ollama", "ollama")]);
+
+    fireEvent.click(providerTrigger());
+
+    const optionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(optionLabels).toEqual(["+ Create new provider"]);
   });
 
   test("+ Create new provider mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -61,14 +61,12 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     }),
 }));
 
+
 // Stub the credential hooks so the inline ProviderCreateForm renders without
 // issuing real daemon queries.
 mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
-  credentialPresenceQueryKey: (
-    assistantId: string,
-    kind: string,
-    name: string,
-  ) => ["credentialPresence", assistantId, kind, name] as const,
+  credentialPresenceQueryKey: (assistantId: string, kind: string, name: string) =>
+    ["credentialPresence", assistantId, kind, name] as const,
   useStoredCredentialPresence: () => ({
     hasStoredCredential: false,
     isLoading: false,
@@ -82,8 +80,9 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProfileEditorModal } =
-  await import("@/domains/settings/ai/profile-editor-modal");
+const { ProfileEditorModal } = await import(
+  "@/domains/settings/ai/profile-editor-modal"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,10 +90,7 @@ const { ProfileEditorModal } =
 
 const ASSISTANT_ID = "asst-1";
 
-function makeConnection(
-  name: string,
-  provider = "anthropic",
-): ProviderConnection {
+function makeConnection(name: string, provider = "anthropic"): ProviderConnection {
   return {
     name,
     label: null,
@@ -289,9 +285,9 @@ function topPSwitch(): HTMLElement {
  */
 function findTopPSlider(): HTMLElement | null {
   return (
-    Array.from(document.querySelectorAll<HTMLElement>('[role="slider"]')).find(
-      (el) => el.getAttribute("aria-valuemax") === "1",
-    ) ?? null
+    Array.from(
+      document.querySelectorAll<HTMLElement>('[role="slider"]'),
+    ).find((el) => el.getAttribute("aria-valuemax") === "1") ?? null
   );
 }
 
@@ -472,7 +468,9 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     // After create, the sub-form collapses and the provider is selected.
     await waitFor(() => {
-      expect(document.body.textContent).toContain(
+      expect(
+        document.body.textContent,
+      ).toContain(
         "New provider connection will show up in the Providers section.",
       );
     });
@@ -612,10 +610,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 // ---------------------------------------------------------------------------
 
 describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
-  function renderEdit(
-    initialValues: Record<string, unknown>,
-    connection: ProviderConnection,
-  ) {
+  function renderEdit(initialValues: Record<string, unknown>, connection: ProviderConnection) {
     return render(
       <Wrapper>
         <ProfileEditorModal

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -59,12 +59,14 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     }),
 }));
 
-
 // Stub the credential hooks so the inline ProviderCreateForm renders without
 // issuing real daemon queries.
 mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
-  credentialPresenceQueryKey: (assistantId: string, kind: string, name: string) =>
-    ["credentialPresence", assistantId, kind, name] as const,
+  credentialPresenceQueryKey: (
+    assistantId: string,
+    kind: string,
+    name: string,
+  ) => ["credentialPresence", assistantId, kind, name] as const,
   useStoredCredentialPresence: () => ({
     hasStoredCredential: false,
     isLoading: false,
@@ -78,9 +80,8 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProfileEditorModal } = await import(
-  "@/domains/settings/ai/profile-editor-modal"
-);
+const { ProfileEditorModal } =
+  await import("@/domains/settings/ai/profile-editor-modal");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,7 +89,10 @@ const { ProfileEditorModal } = await import(
 
 const ASSISTANT_ID = "asst-1";
 
-function makeConnection(name: string, provider = "anthropic"): ProviderConnection {
+function makeConnection(
+  name: string,
+  provider = "anthropic",
+): ProviderConnection {
   return {
     name,
     label: null,
@@ -283,9 +287,9 @@ function topPSwitch(): HTMLElement {
  */
 function findTopPSlider(): HTMLElement | null {
   return (
-    Array.from(
-      document.querySelectorAll<HTMLElement>('[role="slider"]'),
-    ).find((el) => el.getAttribute("aria-valuemax") === "1") ?? null
+    Array.from(document.querySelectorAll<HTMLElement>('[role="slider"]')).find(
+      (el) => el.getAttribute("aria-valuemax") === "1",
+    ) ?? null
   );
 }
 
@@ -414,6 +418,24 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     );
   });
 
+  test("Ollama connections offer the bundled local models", () => {
+    renderCreate([makeConnection("ollama", "ollama")]);
+
+    selectProvider("Ollama");
+
+    const triggerLabels = dropdownTriggers().map((t) => t.textContent?.trim());
+    expect(triggerLabels).toContain("Select a model");
+    expect(triggerLabels).not.toContain("No models available");
+
+    selectModel("Llama 3.2");
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe("Llama 3.2");
+    expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe("llama-3-2");
+
+    selectModel("Mistral");
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe("Mistral");
+    expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe("mistral");
+  });
+
   test("+ Create new provider mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {
     renderCreate([]);
 
@@ -430,9 +452,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     // After create, the sub-form collapses and the provider is selected.
     await waitFor(() => {
-      expect(
-        document.body.textContent,
-      ).toContain(
+      expect(document.body.textContent).toContain(
         "New provider connection will show up in the Providers section.",
       );
     });
@@ -572,7 +592,10 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 // ---------------------------------------------------------------------------
 
 describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
-  function renderEdit(initialValues: Record<string, unknown>, connection: ProviderConnection) {
+  function renderEdit(
+    initialValues: Record<string, unknown>,
+    connection: ProviderConnection,
+  ) {
     return render(
       <Wrapper>
         <ProfileEditorModal

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -37,12 +37,14 @@ import {
   resolveProfileParamVisibility,
 } from "@/domains/settings/ai/profile-param-visibility";
 import { deriveProfileDefaults } from "@/domains/settings/ai/profile-prefill";
+import { isProviderSelectableForAssistant } from "@/domains/settings/ai/provider-availability";
 import type {
   ConnectionProvider,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
+import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
 
 // Sentinel value for the "+ Create new provider" option in the create-mode
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
@@ -167,6 +169,7 @@ function ProfileEditorModalInner({
     "create" | "edit" | "view"
   >(mode);
   const isReadOnly = effectiveMode === "view";
+  const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
 
   // Managed profiles open the editor in view mode (mode === "view") so they
   // can't be reshaped (provider, model, advanced params) — those are
@@ -766,6 +769,14 @@ function ProfileEditorModalInner({
       label: string;
     }[] = [];
     for (const c of effectiveConnections) {
+      if (
+        !isProviderSelectableForAssistant(
+          c.provider,
+          activeAssistantIsSelfHosted,
+        )
+      ) {
+        continue;
+      }
       if (!seen.has(c.provider)) {
         seen.add(c.provider);
         opts.push({
@@ -779,7 +790,7 @@ function ProfileEditorModalInner({
       label: "+ Create new provider",
     });
     return opts;
-  }, [effectiveConnections]);
+  }, [activeAssistantIsSelfHosted, effectiveConnections]);
 
   const createProviderSection = (
     <div className="space-y-4">

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -4,17 +4,13 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
-  getModelsForProvider,
-  PROVIDER_DISPLAY_NAMES,
+    getModelsForProvider,
+    PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import { useSelectableCatalogProviders } from "@/domains/settings/ai/provider-availability";
-import type {
-  ConnectionModel,
-  ConnectionProvider,
-  ProviderConnection,
-} from "@/generated/daemon/types.gen";
+import type { ConnectionModel, ConnectionProvider, ProviderConnection } from "@/generated/daemon/types.gen";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.5",
@@ -23,9 +19,7 @@ const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.3-codex",
 ]);
 
-function connectionModelsToCatalog(
-  models: ConnectionModel[] | null | undefined,
-) {
+function connectionModelsToCatalog(models: ConnectionModel[] | null | undefined) {
   return (models ?? []).map((m) => ({
     id: m.id,
     displayName: m.displayName ?? m.id,
@@ -122,7 +116,11 @@ export function ProfileEditorProviderSection({
       providerSet.add(provider);
     }
     return allProvidersForPicker.filter((p) => providerSet.has(p));
-  }, [allProvidersForPicker, connections, provider]);
+  }, [
+    allProvidersForPicker,
+    connections,
+    provider,
+  ]);
 
   // Pre-load fallback: when `connections` is `undefined` the parent hasn't
   // resolved its `listConnections` fetch yet. Fall back to the full catalog
@@ -138,81 +136,72 @@ export function ProfileEditorProviderSection({
   // Provider must be selected; without it we can't filter or label.
   const showConnectionField =
     provider !== "" &&
-    (availableConnectionsForProvider.length > 0 || providerConnection !== "");
+    (availableConnectionsForProvider.length > 0 ||
+      providerConnection !== "");
 
   // For openai-compatible providers the static catalog is empty — use models
   // from the selected connection instead. When no specific connection is
   // selected, merge models from all available openai-compatible connections.
-  const availableModels: readonly { id: string; displayName: string }[] =
-    useMemo(() => {
-      if (!provider) return [];
-      const catalogModels = getModelsForProvider(provider);
-      if (catalogModels.length > 0) {
-        const selectedConn = providerConnection
-          ? availableConnectionsForProvider.find(
-              (c) => c.name === providerConnection,
-            )
-          : undefined;
-        if (selectedConn?.auth.type === "oauth_subscription") {
-          return catalogModels.filter((m) =>
-            CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
-          );
-        }
-        if (
-          !providerConnection &&
-          availableConnectionsForProvider.length > 0 &&
-          availableConnectionsForProvider.every(
-            (c) => c.auth.type === "oauth_subscription",
-          )
-        ) {
-          return catalogModels.filter((m) =>
-            CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
-          );
-        }
-        return catalogModels;
+  const availableModels: readonly { id: string; displayName: string }[] = useMemo(() => {
+    if (!provider) return [];
+    const catalogModels = getModelsForProvider(provider);
+    if (catalogModels.length > 0) {
+      const selectedConn = providerConnection
+        ? availableConnectionsForProvider.find((c) => c.name === providerConnection)
+        : undefined;
+      if (selectedConn?.auth.type === "oauth_subscription") {
+        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
       }
-      // Static catalog is empty (openai-compatible) — derive from connections.
-      if (providerConnection) {
-        const conn = availableConnectionsForProvider.find(
-          (c) => c.name === providerConnection,
-        );
-        return conn ? connectionModelsToCatalog(conn.models) : [];
+      if (
+        !providerConnection &&
+        availableConnectionsForProvider.length > 0 &&
+        availableConnectionsForProvider.every((c) => c.auth.type === "oauth_subscription")
+      ) {
+        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
       }
-      // No specific connection: merge models from all available connections,
-      // deduplicating by id.
-      const seen = new Set<string>();
-      const merged: { id: string; displayName: string }[] = [];
-      for (const conn of availableConnectionsForProvider) {
-        for (const m of conn.models ?? []) {
-          if (!seen.has(m.id)) {
-            seen.add(m.id);
-            merged.push({ id: m.id, displayName: m.displayName ?? m.id });
-          }
+      return catalogModels;
+    }
+    // Static catalog is empty (openai-compatible) — derive from connections.
+    if (providerConnection) {
+      const conn = availableConnectionsForProvider.find((c) => c.name === providerConnection);
+      return conn ? connectionModelsToCatalog(conn.models) : [];
+    }
+    // No specific connection: merge models from all available connections,
+    // deduplicating by id.
+    const seen = new Set<string>();
+    const merged: { id: string; displayName: string }[] = [];
+    for (const conn of availableConnectionsForProvider) {
+      for (const m of conn.models ?? []) {
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          merged.push({ id: m.id, displayName: m.displayName ?? m.id });
         }
       }
-      return merged;
-    }, [provider, providerConnection, availableConnectionsForProvider]);
+    }
+    return merged;
+  }, [
+    provider,
+    providerConnection,
+    availableConnectionsForProvider,
+  ]);
 
   // The Model dropdown always offers the profile's currently-bound model, even
   // when it's absent from the static catalog — a profile can be bound (via Chat)
   // to a model this build doesn't list: a new or cloaked provider model, or one
   // carried only on the connection. Label it from the catalog, then connection
   // models, then the raw id.
-  const modelOptions: readonly { id: string; displayName: string }[] =
-    useMemo(() => {
-      if (!model || availableModels.some((m) => m.id === model)) {
-        return availableModels;
-      }
-      const fromCatalog = getModelsForProvider(provider).find(
-        (m) => m.id === model,
-      );
-      const fromConnection = availableConnectionsForProvider
-        .flatMap((c) => c.models ?? [])
-        .find((m) => m.id === model);
-      const displayName =
-        fromCatalog?.displayName ?? fromConnection?.displayName ?? model;
-      return [...availableModels, { id: model, displayName }];
-    }, [model, availableModels, provider, availableConnectionsForProvider]);
+  const modelOptions: readonly { id: string; displayName: string }[] = useMemo(() => {
+    if (!model || availableModels.some((m) => m.id === model)) {
+      return availableModels;
+    }
+    const fromCatalog = getModelsForProvider(provider).find((m) => m.id === model);
+    const fromConnection = availableConnectionsForProvider
+      .flatMap((c) => c.models ?? [])
+      .find((m) => m.id === model);
+    const displayName =
+      fromCatalog?.displayName ?? fromConnection?.displayName ?? model;
+    return [...availableModels, { id: model, displayName }];
+  }, [model, availableModels, provider, availableConnectionsForProvider]);
 
   // Single discriminator for the Model field's empty states — the dropdown
   // placeholder and the hint below both derive from it so the two can't
@@ -241,10 +230,7 @@ export function ProfileEditorProviderSection({
   useEffect(() => {
     if (!provider) return;
     const catalogModels = getModelsForProvider(provider);
-    if (
-      catalogModels.length > 0 &&
-      !catalogModels.some((m) => m.id === model)
-    ) {
+    if (catalogModels.length > 0 && !catalogModels.some((m) => m.id === model)) {
       return;
     }
     if (
@@ -324,7 +310,8 @@ export function ProfileEditorProviderSection({
                 : []),
               ...availableConnectionsForProvider.map((c) => ({
                 value: c.name,
-                label: c.label && c.label.trim() !== "" ? c.label : c.name,
+                label:
+                  c.label && c.label.trim() !== "" ? c.label : c.name,
               })),
               // Include the stale binding as an explicit option so the trigger
               // renders its name. The warning below explains the state; on save,
@@ -345,8 +332,8 @@ export function ProfileEditorProviderSection({
               as="p"
               className="text-(--system-negative-strong)"
             >
-              Connection &ldquo;{providerConnection}&rdquo; not found. Will be
-              cleared on save unless you pick another.
+              Connection &ldquo;{providerConnection}&rdquo; not found.
+              Will be cleared on save unless you pick another.
             </Typography>
           ) : null}
         </div>

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -4,15 +4,17 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
-    getModelsForProvider,
-    PROVIDER_DISPLAY_NAMES,
-    MODELS_BY_PROVIDER,
+  getModelsForProvider,
+  PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
-import type { ConnectionModel, ConnectionProvider, ProviderConnection } from "@/generated/daemon/types.gen";
-
-const ALL_PROVIDERS = Object.keys(MODELS_BY_PROVIDER) as (keyof typeof MODELS_BY_PROVIDER)[];
+import { useSelectableCatalogProviders } from "@/domains/settings/ai/provider-availability";
+import type {
+  ConnectionModel,
+  ConnectionProvider,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.5",
@@ -21,7 +23,9 @@ const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.3-codex",
 ]);
 
-function connectionModelsToCatalog(models: ConnectionModel[] | null | undefined) {
+function connectionModelsToCatalog(
+  models: ConnectionModel[] | null | undefined,
+) {
   return (models ?? []).map((m) => ({
     id: m.id,
     displayName: m.displayName ?? m.id,
@@ -103,7 +107,7 @@ export function ProfileEditorProviderSection({
   const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
-  const allProvidersForPicker = ALL_PROVIDERS;
+  const allProvidersForPicker = useSelectableCatalogProviders();
 
   // Filter to providers with at least one connection — picking a provider
   // with zero connections binds a profile to a route the daemon can't
@@ -118,11 +122,7 @@ export function ProfileEditorProviderSection({
       providerSet.add(provider);
     }
     return allProvidersForPicker.filter((p) => providerSet.has(p));
-  }, [
-    allProvidersForPicker,
-    connections,
-    provider,
-  ]);
+  }, [allProvidersForPicker, connections, provider]);
 
   // Pre-load fallback: when `connections` is `undefined` the parent hasn't
   // resolved its `listConnections` fetch yet. Fall back to the full catalog
@@ -138,72 +138,81 @@ export function ProfileEditorProviderSection({
   // Provider must be selected; without it we can't filter or label.
   const showConnectionField =
     provider !== "" &&
-    (availableConnectionsForProvider.length > 0 ||
-      providerConnection !== "");
+    (availableConnectionsForProvider.length > 0 || providerConnection !== "");
 
   // For openai-compatible providers the static catalog is empty — use models
   // from the selected connection instead. When no specific connection is
   // selected, merge models from all available openai-compatible connections.
-  const availableModels: readonly { id: string; displayName: string }[] = useMemo(() => {
-    if (!provider) return [];
-    const catalogModels = getModelsForProvider(provider);
-    if (catalogModels.length > 0) {
-      const selectedConn = providerConnection
-        ? availableConnectionsForProvider.find((c) => c.name === providerConnection)
-        : undefined;
-      if (selectedConn?.auth.type === "oauth_subscription") {
-        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
+  const availableModels: readonly { id: string; displayName: string }[] =
+    useMemo(() => {
+      if (!provider) return [];
+      const catalogModels = getModelsForProvider(provider);
+      if (catalogModels.length > 0) {
+        const selectedConn = providerConnection
+          ? availableConnectionsForProvider.find(
+              (c) => c.name === providerConnection,
+            )
+          : undefined;
+        if (selectedConn?.auth.type === "oauth_subscription") {
+          return catalogModels.filter((m) =>
+            CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+          );
+        }
+        if (
+          !providerConnection &&
+          availableConnectionsForProvider.length > 0 &&
+          availableConnectionsForProvider.every(
+            (c) => c.auth.type === "oauth_subscription",
+          )
+        ) {
+          return catalogModels.filter((m) =>
+            CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+          );
+        }
+        return catalogModels;
       }
-      if (
-        !providerConnection &&
-        availableConnectionsForProvider.length > 0 &&
-        availableConnectionsForProvider.every((c) => c.auth.type === "oauth_subscription")
-      ) {
-        return catalogModels.filter((m) => CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id));
+      // Static catalog is empty (openai-compatible) — derive from connections.
+      if (providerConnection) {
+        const conn = availableConnectionsForProvider.find(
+          (c) => c.name === providerConnection,
+        );
+        return conn ? connectionModelsToCatalog(conn.models) : [];
       }
-      return catalogModels;
-    }
-    // Static catalog is empty (openai-compatible) — derive from connections.
-    if (providerConnection) {
-      const conn = availableConnectionsForProvider.find((c) => c.name === providerConnection);
-      return conn ? connectionModelsToCatalog(conn.models) : [];
-    }
-    // No specific connection: merge models from all available connections,
-    // deduplicating by id.
-    const seen = new Set<string>();
-    const merged: { id: string; displayName: string }[] = [];
-    for (const conn of availableConnectionsForProvider) {
-      for (const m of conn.models ?? []) {
-        if (!seen.has(m.id)) {
-          seen.add(m.id);
-          merged.push({ id: m.id, displayName: m.displayName ?? m.id });
+      // No specific connection: merge models from all available connections,
+      // deduplicating by id.
+      const seen = new Set<string>();
+      const merged: { id: string; displayName: string }[] = [];
+      for (const conn of availableConnectionsForProvider) {
+        for (const m of conn.models ?? []) {
+          if (!seen.has(m.id)) {
+            seen.add(m.id);
+            merged.push({ id: m.id, displayName: m.displayName ?? m.id });
+          }
         }
       }
-    }
-    return merged;
-  }, [
-    provider,
-    providerConnection,
-    availableConnectionsForProvider,
-  ]);
+      return merged;
+    }, [provider, providerConnection, availableConnectionsForProvider]);
 
   // The Model dropdown always offers the profile's currently-bound model, even
   // when it's absent from the static catalog — a profile can be bound (via Chat)
   // to a model this build doesn't list: a new or cloaked provider model, or one
   // carried only on the connection. Label it from the catalog, then connection
   // models, then the raw id.
-  const modelOptions: readonly { id: string; displayName: string }[] = useMemo(() => {
-    if (!model || availableModels.some((m) => m.id === model)) {
-      return availableModels;
-    }
-    const fromCatalog = getModelsForProvider(provider).find((m) => m.id === model);
-    const fromConnection = availableConnectionsForProvider
-      .flatMap((c) => c.models ?? [])
-      .find((m) => m.id === model);
-    const displayName =
-      fromCatalog?.displayName ?? fromConnection?.displayName ?? model;
-    return [...availableModels, { id: model, displayName }];
-  }, [model, availableModels, provider, availableConnectionsForProvider]);
+  const modelOptions: readonly { id: string; displayName: string }[] =
+    useMemo(() => {
+      if (!model || availableModels.some((m) => m.id === model)) {
+        return availableModels;
+      }
+      const fromCatalog = getModelsForProvider(provider).find(
+        (m) => m.id === model,
+      );
+      const fromConnection = availableConnectionsForProvider
+        .flatMap((c) => c.models ?? [])
+        .find((m) => m.id === model);
+      const displayName =
+        fromCatalog?.displayName ?? fromConnection?.displayName ?? model;
+      return [...availableModels, { id: model, displayName }];
+    }, [model, availableModels, provider, availableConnectionsForProvider]);
 
   // Single discriminator for the Model field's empty states — the dropdown
   // placeholder and the hint below both derive from it so the two can't
@@ -232,7 +241,10 @@ export function ProfileEditorProviderSection({
   useEffect(() => {
     if (!provider) return;
     const catalogModels = getModelsForProvider(provider);
-    if (catalogModels.length > 0 && !catalogModels.some((m) => m.id === model)) {
+    if (
+      catalogModels.length > 0 &&
+      !catalogModels.some((m) => m.id === model)
+    ) {
       return;
     }
     if (
@@ -312,8 +324,7 @@ export function ProfileEditorProviderSection({
                 : []),
               ...availableConnectionsForProvider.map((c) => ({
                 value: c.name,
-                label:
-                  c.label && c.label.trim() !== "" ? c.label : c.name,
+                label: c.label && c.label.trim() !== "" ? c.label : c.name,
               })),
               // Include the stale binding as an explicit option so the trigger
               // renders its name. The warning below explains the state; on save,
@@ -334,8 +345,8 @@ export function ProfileEditorProviderSection({
               as="p"
               className="text-(--system-negative-strong)"
             >
-              Connection &ldquo;{providerConnection}&rdquo; not found.
-              Will be cleared on save unless you pick another.
+              Connection &ldquo;{providerConnection}&rdquo; not found. Will be
+              cleared on save unless you pick another.
             </Typography>
           ) : null}
         </div>

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -1,0 +1,61 @@
+import { MODELS_BY_PROVIDER } from "@/assistant/llm-model-catalog";
+import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
+
+import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
+import { CONNECTION_PROVIDERS } from "@/domains/settings/ai/provider-editor-constants";
+
+import type { ConnectionProvider } from "@/generated/daemon/types.gen";
+
+const LOCAL_ONLY_PROVIDERS = new Set<string>(["ollama"]);
+
+export function isProviderSelectableForAssistant(
+  provider: string,
+  activeAssistantIsSelfHosted: boolean,
+): boolean {
+  return !LOCAL_ONLY_PROVIDERS.has(provider) || activeAssistantIsSelfHosted;
+}
+
+export function selectableInferenceProvidersForAssistant(
+  activeAssistantIsSelfHosted: boolean,
+): Array<(typeof INFERENCE_PROVIDERS)[number]> {
+  return INFERENCE_PROVIDERS.filter((provider) =>
+    isProviderSelectableForAssistant(provider, activeAssistantIsSelfHosted),
+  );
+}
+
+export function selectableConnectionProvidersForAssistant(
+  activeAssistantIsSelfHosted: boolean,
+): ConnectionProvider[] {
+  return CONNECTION_PROVIDERS.filter((provider) =>
+    isProviderSelectableForAssistant(provider, activeAssistantIsSelfHosted),
+  );
+}
+
+export function selectableCatalogProvidersForAssistant(
+  activeAssistantIsSelfHosted: boolean,
+): Array<keyof typeof MODELS_BY_PROVIDER> {
+  return (
+    Object.keys(MODELS_BY_PROVIDER) as Array<keyof typeof MODELS_BY_PROVIDER>
+  ).filter((provider) =>
+    isProviderSelectableForAssistant(provider, activeAssistantIsSelfHosted),
+  );
+}
+
+export function useSelectableInferenceProviders(): Array<
+  (typeof INFERENCE_PROVIDERS)[number]
+> {
+  const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
+  return selectableInferenceProvidersForAssistant(activeAssistantIsSelfHosted);
+}
+
+export function useSelectableConnectionProviders(): ConnectionProvider[] {
+  const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
+  return selectableConnectionProvidersForAssistant(activeAssistantIsSelfHosted);
+}
+
+export function useSelectableCatalogProviders(): Array<
+  keyof typeof MODELS_BY_PROVIDER
+> {
+  const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
+  return selectableCatalogProvidersForAssistant(activeAssistantIsSelfHosted);
+}

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -78,11 +78,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 // Stub the credential hooks so render doesn't issue real daemon queries.
 // `hasStoredCredential: false` matches the empty create-mode state.
 mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
-  credentialPresenceQueryKey: (
-    assistantId: string,
-    kind: string,
-    name: string,
-  ) => ["credentialPresence", assistantId, kind, name] as const,
+  credentialPresenceQueryKey: (assistantId: string, kind: string, name: string) =>
+    ["credentialPresence", assistantId, kind, name] as const,
   useStoredCredentialPresence: () => ({
     hasStoredCredential: false,
     isLoading: false,
@@ -96,8 +93,9 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProviderCreateForm } =
-  await import("@/domains/settings/ai/provider-create-form");
+const { ProviderCreateForm } = await import(
+  "@/domains/settings/ai/provider-create-form"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -24,6 +24,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { createElement, type ReactNode } from "react";
 
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 
@@ -46,6 +47,7 @@ let createdConnection: ProviderConnection;
 let createResponseOk = true;
 let createResponseStatus = 200;
 let toastSuccessCalls: string[] = [];
+const initialLifecycleState = useAssistantLifecycleStore.getState();
 
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: {
@@ -195,6 +197,7 @@ beforeEach(() => {
   createResponseOk = true;
   createResponseStatus = 200;
   toastSuccessCalls = [];
+  useAssistantLifecycleStore.setState(initialLifecycleState, true);
 });
 
 afterEach(() => {
@@ -365,6 +368,9 @@ describe("ProviderCreateForm submit sequence", () => {
   });
 
   test("Ollama creates a keyless connection without saving a secret", async () => {
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "self_hosted" },
+    });
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -393,6 +399,34 @@ describe("ProviderCreateForm submit sequence", () => {
       name: "ollama",
       provider: "ollama",
       auth: { type: "none" },
+    });
+  });
+
+  test("platform-hosted assistants ignore an Ollama default provider seed", async () => {
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "active", isLocal: false },
+    });
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="ollama"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "anthropic",
+      provider: "anthropic",
+      auth: { type: "platform" },
     });
   });
 

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -76,8 +76,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 // Stub the credential hooks so render doesn't issue real daemon queries.
 // `hasStoredCredential: false` matches the empty create-mode state.
 mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
-  credentialPresenceQueryKey: (assistantId: string, kind: string, name: string) =>
-    ["credentialPresence", assistantId, kind, name] as const,
+  credentialPresenceQueryKey: (
+    assistantId: string,
+    kind: string,
+    name: string,
+  ) => ["credentialPresence", assistantId, kind, name] as const,
   useStoredCredentialPresence: () => ({
     hasStoredCredential: false,
     isLoading: false,
@@ -91,9 +94,8 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProviderCreateForm } = await import(
-  "@/domains/settings/ai/provider-create-form"
-);
+const { ProviderCreateForm } =
+  await import("@/domains/settings/ai/provider-create-form");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -360,6 +362,38 @@ describe("ProviderCreateForm submit sequence", () => {
     );
 
     expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
+  });
+
+  test("Ollama creates a keyless connection without saving a secret", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="ollama"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    expect(
+      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+        (input) => input.placeholder === "Enter your API key",
+      ),
+    ).toBe(false);
+
+    fireEvent.click(getButton("Create"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(secretsPostCalls).toEqual([]);
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "ollama",
+      provider: "ollama",
+      auth: { type: "none" },
+    });
   });
 
   test("fires a 'Provider connected' success toast on a successful create", async () => {

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -8,25 +8,36 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-    inferenceProviderconnectionsPost,
-    secretsPost,
+  inferenceProviderconnectionsPost,
+  secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import {
+  providerSupportsPlatformAuth,
+  PROVIDER_DISPLAY_NAMES,
+} from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import { deriveProviderDefaults } from "@/domains/settings/ai/profile-prefill";
-import type { Auth, ConnectionProvider, InferenceProviderconnectionsPostData, ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  Auth,
+  ConnectionProvider,
+  InferenceProviderconnectionsPostData,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-    AUTH_TYPE_DISPLAY_NAMES,
-    CONNECTION_PROVIDERS,
-    connectionSaveErrorMessage,
-    parseCredentialRef,
-    type AuthType,
+  AUTH_TYPE_DISPLAY_NAMES,
+  connectionSaveErrorMessage,
+  parseCredentialRef,
+  type AuthType,
 } from "@/domains/settings/ai/provider-editor-constants";
+import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
@@ -72,14 +83,22 @@ export function ProviderCreateForm({
   onCancel,
   variant = "modal",
 }: ProviderCreateFormProps) {
-  const initialProvider: ConnectionProvider = defaultProviderType ?? "anthropic";
+  const selectableConnectionProviders = useSelectableConnectionProviders();
+  const initialProvider: ConnectionProvider =
+    defaultProviderType &&
+    selectableConnectionProviders.includes(defaultProviderType)
+      ? defaultProviderType
+      : (selectableConnectionProviders[0] ?? "anthropic");
 
   // Seed Display Name (label) + Key (name) from the initial provider type so
   // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
   // deduped against existing connection names. The user can override both, and
   // a provider-type change re-seeds only while they haven't edited the fields
   // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
+  const initialDefaults = deriveProviderDefaults(
+    initialProvider,
+    existingNames,
+  );
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
@@ -103,37 +122,41 @@ export function ProviderCreateForm({
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
-    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
-      return [...CONNECTION_PROVIDERS, provider];
+    if (provider && !selectableConnectionProviders.includes(provider)) {
+      return [...selectableConnectionProviders, provider];
     }
-    return CONNECTION_PROVIDERS;
-  }, [provider]);
+    return selectableConnectionProviders;
+  }, [provider, selectableConnectionProviders]);
 
-  const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
-    useLabelKeySync("create", setLabel, setName);
+  const {
+    handleLabelChange,
+    handleKeyChange: handleNameChange,
+    getDirty,
+  } = useLabelKeySync("create", setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
+  const parsedCredRef = useMemo(
+    () => parseCredentialRef(credential),
+    [credential],
+  );
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const {
-    hasStoredCredential,
-    isLoading: isLoadingCredential,
-  } = useStoredCredentialPresence({
-    assistantId,
-    credentialKind: "credential",
-    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
-    enabled: needsCredentialCheck,
-  });
+  const { hasStoredCredential, isLoading: isLoadingCredential } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "credential",
+      credentialName: parsedCredRef
+        ? `${parsedCredRef.service}:${parsedCredRef.field}`
+        : "",
+      enabled: needsCredentialCheck,
+    });
 
   // --- Available credentials list ---
-  const {
-    credentials: availableCredentials,
-  } = useProviderCredentialsList({
+  const { credentials: availableCredentials } = useProviderCredentialsList({
     assistantId,
     enabled: true,
   });
@@ -188,7 +211,9 @@ export function ProviderCreateForm({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
+              queryKey: secretsGetQueryKey({
+                path: { assistant_id: assistantId },
+              }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -205,12 +230,16 @@ export function ProviderCreateForm({
       } else if (authType === "oauth_subscription") {
         // OAuth subscription connections are created by the OAuth flow
         // (ChatgptOAuthSection), not through Save.
-        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
+        setError(
+          'Use the "Sign in with ChatGPT" button to connect your subscription.',
+        );
         return;
       } else if (authType === "none") {
         auth = { type: "none" };
       } else if (authType === "service_account") {
-        setError("Service account connections cannot be created through this form.");
+        setError(
+          "Service account connections cannot be created through this form.",
+        );
         return;
       } else {
         auth = { type: "platform" };
@@ -233,10 +262,11 @@ export function ProviderCreateForm({
             : null,
         }),
       };
-      const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
-        path: { assistant_id: assistantId },
-        body: input,
-      });
+      const { data: created, response: createRes } =
+        await inferenceProviderconnectionsPost({
+          path: { assistant_id: assistantId },
+          body: input,
+        });
       if (!createRes?.ok) {
         setError(connectionSaveErrorMessage(createRes?.status, name.trim()));
         return;
@@ -343,10 +373,7 @@ export function ProviderCreateForm({
                 if (prev === "none") {
                   return "api_key";
                 }
-                if (
-                  prev === "oauth_subscription" &&
-                  newProvider !== "openai"
-                ) {
+                if (prev === "oauth_subscription" && newProvider !== "openai") {
                   return "api_key";
                 }
                 if (

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -8,34 +8,23 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import {
-  credentialPresenceQueryKey,
-  useStoredCredentialPresence,
-} from "@/domains/settings/ai/use-stored-credential-presence";
+import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  inferenceProviderconnectionsPost,
-  secretsPost,
+    inferenceProviderconnectionsPost,
+    secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import {
-  providerSupportsPlatformAuth,
-  PROVIDER_DISPLAY_NAMES,
-} from "@/assistant/llm-model-catalog";
+import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import { deriveProviderDefaults } from "@/domains/settings/ai/profile-prefill";
-import type {
-  Auth,
-  ConnectionProvider,
-  InferenceProviderconnectionsPostData,
-  ProviderConnection,
-} from "@/generated/daemon/types.gen";
+import type { Auth, ConnectionProvider, InferenceProviderconnectionsPostData, ProviderConnection } from "@/generated/daemon/types.gen";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-  AUTH_TYPE_DISPLAY_NAMES,
-  connectionSaveErrorMessage,
-  parseCredentialRef,
-  type AuthType,
+    AUTH_TYPE_DISPLAY_NAMES,
+    connectionSaveErrorMessage,
+    parseCredentialRef,
+    type AuthType,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
@@ -95,10 +84,7 @@ export function ProviderCreateForm({
   // deduped against existing connection names. The user can override both, and
   // a provider-type change re-seeds only while they haven't edited the fields
   // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = deriveProviderDefaults(
-    initialProvider,
-    existingNames,
-  );
+  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
@@ -128,35 +114,31 @@ export function ProviderCreateForm({
     return selectableConnectionProviders;
   }, [provider, selectableConnectionProviders]);
 
-  const {
-    handleLabelChange,
-    handleKeyChange: handleNameChange,
-    getDirty,
-  } = useLabelKeySync("create", setLabel, setName);
+  const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
+    useLabelKeySync("create", setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(
-    () => parseCredentialRef(credential),
-    [credential],
-  );
+  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const { hasStoredCredential, isLoading: isLoadingCredential } =
-    useStoredCredentialPresence({
-      assistantId,
-      credentialKind: "credential",
-      credentialName: parsedCredRef
-        ? `${parsedCredRef.service}:${parsedCredRef.field}`
-        : "",
-      enabled: needsCredentialCheck,
-    });
+  const {
+    hasStoredCredential,
+    isLoading: isLoadingCredential,
+  } = useStoredCredentialPresence({
+    assistantId,
+    credentialKind: "credential",
+    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
+    enabled: needsCredentialCheck,
+  });
 
   // --- Available credentials list ---
-  const { credentials: availableCredentials } = useProviderCredentialsList({
+  const {
+    credentials: availableCredentials,
+  } = useProviderCredentialsList({
     assistantId,
     enabled: true,
   });
@@ -211,9 +193,7 @@ export function ProviderCreateForm({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({
-                path: { assistant_id: assistantId },
-              }),
+              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -230,16 +210,12 @@ export function ProviderCreateForm({
       } else if (authType === "oauth_subscription") {
         // OAuth subscription connections are created by the OAuth flow
         // (ChatgptOAuthSection), not through Save.
-        setError(
-          'Use the "Sign in with ChatGPT" button to connect your subscription.',
-        );
+        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
         return;
       } else if (authType === "none") {
         auth = { type: "none" };
       } else if (authType === "service_account") {
-        setError(
-          "Service account connections cannot be created through this form.",
-        );
+        setError("Service account connections cannot be created through this form.");
         return;
       } else {
         auth = { type: "platform" };
@@ -262,11 +238,10 @@ export function ProviderCreateForm({
             : null,
         }),
       };
-      const { data: created, response: createRes } =
-        await inferenceProviderconnectionsPost({
-          path: { assistant_id: assistantId },
-          body: input,
-        });
+      const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
+        path: { assistant_id: assistantId },
+        body: input,
+      });
       if (!createRes?.ok) {
         setError(connectionSaveErrorMessage(createRes?.status, name.trim()));
         return;
@@ -373,7 +348,10 @@ export function ProviderCreateForm({
                 if (prev === "none") {
                   return "api_key";
                 }
-                if (prev === "oauth_subscription" && newProvider !== "openai") {
+                if (
+                  prev === "oauth_subscription" &&
+                  newProvider !== "openai"
+                ) {
                   return "api_key";
                 }
                 if (

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -7,25 +7,36 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-    inferenceProviderconnectionsByNamePatch,
-    secretsPost,
+  inferenceProviderconnectionsByNamePatch,
+  secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import {
+  providerSupportsPlatformAuth,
+  PROVIDER_DISPLAY_NAMES,
+} from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
-import type { Auth, ConnectionProvider, InferenceProviderconnectionsByNamePatchData, ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  Auth,
+  ConnectionProvider,
+  InferenceProviderconnectionsByNamePatchData,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-    AUTH_TYPE_DISPLAY_NAMES,
-    type AuthType,
-    CONNECTION_PROVIDERS,
-    connectionSaveErrorMessage,
-    parseCredentialRef,
+  AUTH_TYPE_DISPLAY_NAMES,
+  type AuthType,
+  connectionSaveErrorMessage,
+  parseCredentialRef,
 } from "@/domains/settings/ai/provider-editor-constants";
+import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
@@ -116,42 +127,47 @@ export function ProviderEditorContent({
   const [error, setError] = useState<string | null>(null);
 
   const isOpenAICompatible = provider === "openai-compatible";
+  const selectableConnectionProviders = useSelectableConnectionProviders();
   const connectionProviderOptions = useMemo(() => {
-    if (provider && !CONNECTION_PROVIDERS.includes(provider)) {
-      return [...CONNECTION_PROVIDERS, provider];
+    if (provider && !selectableConnectionProviders.includes(provider)) {
+      return [...selectableConnectionProviders, provider];
     }
-    return CONNECTION_PROVIDERS;
-  }, [provider]);
+    return selectableConnectionProviders;
+  }, [provider, selectableConnectionProviders]);
 
-  const { handleLabelChange, resetDirty } =
-    useLabelKeySync(effectiveMode, setLabel, setName);
+  const { handleLabelChange, resetDirty } = useLabelKeySync(
+    effectiveMode,
+    setLabel,
+    setName,
+  );
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
+  const parsedCredRef = useMemo(
+    () => parseCredentialRef(credential),
+    [credential],
+  );
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const {
-    hasStoredCredential,
-    isLoading: isLoadingCredential,
-  } = useStoredCredentialPresence({
-    assistantId,
-    credentialKind: "credential",
-    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
-    enabled: needsCredentialCheck,
-  });
+  const { hasStoredCredential, isLoading: isLoadingCredential } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "credential",
+      credentialName: parsedCredRef
+        ? `${parsedCredRef.service}:${parsedCredRef.field}`
+        : "",
+      enabled: needsCredentialCheck,
+    });
 
   // --- Available credentials list ---
   // Create mode is fully owned by ProviderCreateForm (early return below), so
   // the only reachable path here is edit / managed-edit — gate purely on auth.
   const needsCredentialsList = authType === "api_key";
 
-  const {
-    credentials: availableCredentials,
-  } = useProviderCredentialsList({
+  const { credentials: availableCredentials } = useProviderCredentialsList({
     assistantId,
     enabled: needsCredentialsList,
   });
@@ -252,7 +268,9 @@ export function ProviderEditorContent({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
+              queryKey: secretsGetQueryKey({
+                path: { assistant_id: assistantId },
+              }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -271,14 +289,18 @@ export function ProviderEditorContent({
         } else {
           // OAuth subscription connections are created by the OAuth flow
           // (handleChatgptUrlSubmit), not through Save.
-          setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
+          setError(
+            'Use the "Sign in with ChatGPT" button to connect your subscription.',
+          );
           return;
         }
       } else if (authType === "service_account") {
         if (connection?.auth.type === "service_account") {
           auth = connection.auth;
         } else {
-          setError("Service account connections cannot be created through this form.");
+          setError(
+            "Service account connections cannot be created through this form.",
+          );
           return;
         }
       } else if (authType === "none") {
@@ -305,10 +327,14 @@ export function ProviderEditorContent({
             : null,
         }),
       };
-      const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
-        path: { assistant_id: assistantId, name: connection?.name ?? name.trim() },
-        body: input,
-      });
+      const { data: updated, response: updateRes } =
+        await inferenceProviderconnectionsByNamePatch({
+          path: {
+            assistant_id: assistantId,
+            name: connection?.name ?? name.trim(),
+          },
+          body: input,
+        });
       if (!updateRes?.ok) {
         setError(connectionSaveErrorMessage(updateRes?.status, name.trim()));
         return;
@@ -341,8 +367,7 @@ export function ProviderEditorContent({
   const isEditingApiKeyConnection =
     effectiveMode !== "create" && connection?.auth.type === "api_key";
   const shouldShowAdvancedSection =
-    providerCredentials.length > 0 ||
-    isEditingApiKeyConnection;
+    providerCredentials.length > 0 || isEditingApiKeyConnection;
   const apiKeyPlaceholder = secretPlaceholder(
     "Enter your API key",
     hasStoredCredential,
@@ -519,10 +544,7 @@ export function ProviderEditorContent({
 
         {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
         {authType === "oauth_subscription" && (
-          <ChatgptOAuthSection
-            assistantId={assistantId}
-            onConnected={onSave}
-          />
+          <ChatgptOAuthSection assistantId={assistantId} onConnected={onSave} />
         )}
 
         {error && (

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -7,34 +7,23 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import {
-  credentialPresenceQueryKey,
-  useStoredCredentialPresence,
-} from "@/domains/settings/ai/use-stored-credential-presence";
+import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  inferenceProviderconnectionsByNamePatch,
-  secretsPost,
+    inferenceProviderconnectionsByNamePatch,
+    secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import {
-  providerSupportsPlatformAuth,
-  PROVIDER_DISPLAY_NAMES,
-} from "@/assistant/llm-model-catalog";
+import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
-import type {
-  Auth,
-  ConnectionProvider,
-  InferenceProviderconnectionsByNamePatchData,
-  ProviderConnection,
-} from "@/generated/daemon/types.gen";
+import type { Auth, ConnectionProvider, InferenceProviderconnectionsByNamePatchData, ProviderConnection } from "@/generated/daemon/types.gen";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-  AUTH_TYPE_DISPLAY_NAMES,
-  type AuthType,
-  connectionSaveErrorMessage,
-  parseCredentialRef,
+    AUTH_TYPE_DISPLAY_NAMES,
+    type AuthType,
+    connectionSaveErrorMessage,
+    parseCredentialRef,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
@@ -135,39 +124,35 @@ export function ProviderEditorContent({
     return selectableConnectionProviders;
   }, [provider, selectableConnectionProviders]);
 
-  const { handleLabelChange, resetDirty } = useLabelKeySync(
-    effectiveMode,
-    setLabel,
-    setName,
-  );
+  const { handleLabelChange, resetDirty } =
+    useLabelKeySync(effectiveMode, setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(
-    () => parseCredentialRef(credential),
-    [credential],
-  );
+  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const { hasStoredCredential, isLoading: isLoadingCredential } =
-    useStoredCredentialPresence({
-      assistantId,
-      credentialKind: "credential",
-      credentialName: parsedCredRef
-        ? `${parsedCredRef.service}:${parsedCredRef.field}`
-        : "",
-      enabled: needsCredentialCheck,
-    });
+  const {
+    hasStoredCredential,
+    isLoading: isLoadingCredential,
+  } = useStoredCredentialPresence({
+    assistantId,
+    credentialKind: "credential",
+    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
+    enabled: needsCredentialCheck,
+  });
 
   // --- Available credentials list ---
   // Create mode is fully owned by ProviderCreateForm (early return below), so
   // the only reachable path here is edit / managed-edit — gate purely on auth.
   const needsCredentialsList = authType === "api_key";
 
-  const { credentials: availableCredentials } = useProviderCredentialsList({
+  const {
+    credentials: availableCredentials,
+  } = useProviderCredentialsList({
     assistantId,
     enabled: needsCredentialsList,
   });
@@ -268,9 +253,7 @@ export function ProviderEditorContent({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({
-                path: { assistant_id: assistantId },
-              }),
+              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -289,18 +272,14 @@ export function ProviderEditorContent({
         } else {
           // OAuth subscription connections are created by the OAuth flow
           // (handleChatgptUrlSubmit), not through Save.
-          setError(
-            'Use the "Sign in with ChatGPT" button to connect your subscription.',
-          );
+          setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
           return;
         }
       } else if (authType === "service_account") {
         if (connection?.auth.type === "service_account") {
           auth = connection.auth;
         } else {
-          setError(
-            "Service account connections cannot be created through this form.",
-          );
+          setError("Service account connections cannot be created through this form.");
           return;
         }
       } else if (authType === "none") {
@@ -327,14 +306,10 @@ export function ProviderEditorContent({
             : null,
         }),
       };
-      const { data: updated, response: updateRes } =
-        await inferenceProviderconnectionsByNamePatch({
-          path: {
-            assistant_id: assistantId,
-            name: connection?.name ?? name.trim(),
-          },
-          body: input,
-        });
+      const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
+        path: { assistant_id: assistantId, name: connection?.name ?? name.trim() },
+        body: input,
+      });
       if (!updateRes?.ok) {
         setError(connectionSaveErrorMessage(updateRes?.status, name.trim()));
         return;
@@ -367,7 +342,8 @@ export function ProviderEditorContent({
   const isEditingApiKeyConnection =
     effectiveMode !== "create" && connection?.auth.type === "api_key";
   const shouldShowAdvancedSection =
-    providerCredentials.length > 0 || isEditingApiKeyConnection;
+    providerCredentials.length > 0 ||
+    isEditingApiKeyConnection;
   const apiKeyPlaceholder = secretPlaceholder(
     "Enter your API key",
     hasStoredCredential,
@@ -544,7 +520,10 @@ export function ProviderEditorContent({
 
         {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
         {authType === "oauth_subscription" && (
-          <ChatgptOAuthSection assistantId={assistantId} onConnected={onSave} />
+          <ChatgptOAuthSection
+            assistantId={assistantId}
+            onConnected={onSave}
+          />
         )}
 
         {error && (

--- a/clients/web/src/hooks/use-platform-gate.ts
+++ b/clients/web/src/hooks/use-platform-gate.ts
@@ -80,7 +80,7 @@ export interface PlatformGateOptions {
  * `initializing`, `cleaning_up`, `error`, and `active` with
  * `isLocal: false`).
  */
-function useActiveAssistantIsSelfHosted(): boolean {
+export function useActiveAssistantIsSelfHosted(): boolean {
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   if (assistantState.kind === "self_hosted") return true;
   if (assistantState.kind === "active" && assistantState.isLocal) return true;


### PR DESCRIPTION
## Summary
- Add Ollama to the web LLM model catalog with Llama 3.2 and Mistral.
- Keep catalog parity intact, but filter selectable Ollama provider options to active self-hosted assistants only.
- Apply the self-hosted provider filter across profile creation, provider connection creation/edit display, and call-site override custom providers.
- Add regression coverage for self-hosted Ollama model selection, platform-hosted Ollama exclusion, and keyless Ollama connection creation.

## Root Cause
The web catalog intentionally excluded Ollama as daemon-only, so the profile editor treated an Ollama provider connection as catalog-empty and rendered "No models available" even though onboarding and the daemon catalog know about the local models.

Ollama also needs active-assistant hosting semantics, not build-mode semantics: a platform-mode web app can point at a self-hosted assistant, and that assistant should still be able to use Ollama.

## Validation
- `cd clients/web && bun test src/assistant/llm-model-catalog.test.ts src/domains/settings/ai/profile-editor-modal.test.tsx src/domains/settings/ai/provider-create-form.test.tsx src/domains/settings/ai/call-site-overrides-modal.test.tsx`
- `cd clients/web && bun run openapi-ts`
- `cd clients/web && bunx tsc --noEmit`
- Commit hook: changed-file ESLint and web type-check

Note: `profile-editor-modal.test.tsx` still emits its pre-existing DialogContent warning and background config-fetch `ECONNREFUSED` noise, but the run passes.