### PR TITLE
fix(web): drop DetailPanel from descriptor; fix div-in-span

### DIFF
--- a/clients/web/src/domains/chat/process-registry/active-process-overlay.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/active-process-overlay.test.tsx
@@ -115,7 +115,6 @@ function fakeDescriptor(
     pillAriaLabel: (count) => `${count} active processes`,
     openCardAriaLabel: "Open process",
     onOpenDetail: () => {},
-    DetailPanel: () => null,
     ...overrides,
   };
 }

--- a/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/acp-run.tsx
@@ -8,7 +8,6 @@
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { AcpAgentIcon } from "@/domains/chat/components/acp-run-inline-card/acp-agent-icon";
 import { useAcpRunCardData } from "@/domains/chat/components/acp-run-inline-card/use-acp-run-card-data";
-import { AcpRunDetailPanel } from "@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel";
 import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
 import { MAX_VISIBLE_STACKED_CHIPS } from "@/domains/chat/process-registry/constants";
 import type {
@@ -72,24 +71,6 @@ function AcpAgentChip({ id }: { id: string }) {
   );
 }
 
-/**
- * Adapter to the descriptor's `{ id; onClose }` detail-panel contract.
- * `AcpRunDetailPanel` takes the full store entry, so resolve it by id here and
- * short-circuit to `null` for an unknown run (the entry is gone / not yet
- * spawned).
- */
-function AcpRunDetailPanelById({
-  id,
-  onClose,
-}: {
-  id: string;
-  onClose: () => void;
-}) {
-  const entry = useAcpRunStore((s) => s.byId[id]);
-  if (!entry) return null;
-  return <AcpRunDetailPanel entry={entry} onClose={onClose} />;
-}
-
 export const ACP_RUN_DESCRIPTOR: BackgroundProcessDescriptor = {
   kind: "acp-run",
   useActiveIds,
@@ -111,5 +92,4 @@ export const ACP_RUN_DESCRIPTOR: BackgroundProcessDescriptor = {
     void stopAcpRun(id).catch((err) => {
       captureError(err, { context: "AcpRunDescriptor.stop" });
     }),
-  DetailPanel: AcpRunDetailPanelById,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
@@ -10,7 +10,6 @@
 
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { BackgroundTaskGlyph } from "@/domains/chat/components/background-task-glyph";
-import { BackgroundTaskDetailPanel } from "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel";
 import { useBackgroundTaskCardData } from "@/domains/chat/components/background-task-inline-card/use-background-task-card-data";
 import { useActiveBackgroundTaskIds } from "@/domains/chat/hooks/use-active-background-task-ids";
 import { MAX_VISIBLE_STACKED_CHIPS } from "@/domains/chat/process-registry/constants";
@@ -63,25 +62,6 @@ function BackgroundTaskChip({ id }: { id: string }) {
   );
 }
 
-/**
- * Adapter from the registry's `{ id; onClose }` detail-panel contract to
- * `BackgroundTaskDetailPanel`'s `{ entry; onClose }` shape. Resolves the live
- * store entry by id; renders `null` when no entry exists (e.g. the panel was
- * opened for a task that has since been cleared), matching how the existing
- * call sites guard on the resolved entry being present.
- */
-function BackgroundTaskDetailPanelAdapter({
-  id,
-  onClose,
-}: {
-  id: string;
-  onClose: () => void;
-}) {
-  const entry = useBackgroundTaskStore((s) => s.byId[id]);
-  if (!entry) return null;
-  return <BackgroundTaskDetailPanel entry={entry} onClose={onClose} />;
-}
-
 export const BACKGROUND_TASK_DESCRIPTOR: BackgroundProcessDescriptor = {
   kind: "background-task",
   useActiveIds,
@@ -110,5 +90,4 @@ export const BACKGROUND_TASK_DESCRIPTOR: BackgroundProcessDescriptor = {
     void stopBackgroundTask(id).catch((err) => {
       captureError(err, { context: "BackgroundTaskDescriptor.stop" });
     }),
-  DetailPanel: BackgroundTaskDetailPanelAdapter,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx
@@ -5,7 +5,6 @@
  */
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
-import { SubagentDetailPanel } from "@/domains/chat/components/subagent-detail-panel";
 import { MAX_VISIBLE_SUBAGENT_AVATARS } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
 import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
 import { useSubagentCardData } from "@/domains/chat/hooks/use-subagent-card-data";
@@ -59,24 +58,6 @@ function useCardSummary(id: string): CardSummary | null {
   };
 }
 
-/**
- * Detail-panel adapter: the shared descriptor renders `DetailPanel` with an
- * `{ id, onClose }` contract, but `SubagentDetailPanel` reads its `entry` from
- * the store. Resolve the entry by id here and short-circuit to `null` when it's
- * absent (spawn race / cleared), matching the inline surface.
- */
-function SubagentDetailPanelById({
-  id,
-  onClose,
-}: {
-  id: string;
-  onClose: () => void;
-}) {
-  const entry = useSubagentStore((s) => s.byId[id]);
-  if (!entry) return null;
-  return <SubagentDetailPanel entry={entry} onClose={onClose} />;
-}
-
 export const SUBAGENT_DESCRIPTOR: BackgroundProcessDescriptor = {
   kind: "subagent",
   useActiveIds,
@@ -100,5 +81,4 @@ export const SUBAGENT_DESCRIPTOR: BackgroundProcessDescriptor = {
   onOpenDetail: (id) =>
     useViewerStore.getState().openProcessDetail({ kind: "subagent", id }),
   onStop: (id) => void useSubagentStore.getState().abortSubagent(id),
-  DetailPanel: SubagentDetailPanelById,
 };

--- a/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/workflow.tsx
@@ -17,43 +17,7 @@ import type {
 } from "@/domains/chat/process-registry/types";
 import { WorkflowAgentsChip } from "@/domains/chat/process-registry/descriptors/workflow-agents-chip";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
-import { WorkflowDetailPanel } from "@/domains/chat/components/workflow-detail-panel";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
-
-/**
- * Adapts the `{ id; onClose }` descriptor contract onto
- * {@link WorkflowDetailPanel}, which keys on a resolved `WorkflowEntry` rather
- * than a run id. Subscribes to the workflow store entry for `id` and wires the
- * panel's stop + journal callbacks to the store the same way the existing
- * chat-content-layout host does (`abortRun` / `fetchJournalIfNeeded`). Renders
- * `null` until an entry exists, matching the host's `workflowById[id]` guard.
- */
-function WorkflowDetailPanelAdapter({
-  id,
-  onClose,
-}: {
-  id: string;
-  onClose: () => void;
-}) {
-  const entry = useWorkflowStore((s) => s.byId[id]);
-  if (!entry) return null;
-  return (
-    <WorkflowDetailPanel
-      entry={entry}
-      onClose={onClose}
-      onStop={(runId) => void useWorkflowStore.getState().abortRun(runId)}
-      onRequestJournal={(runId) => {
-        const assistantId =
-          useResolvedAssistantsStore.getState().activeAssistantId;
-        if (!assistantId) return;
-        void useWorkflowStore
-          .getState()
-          .fetchJournalIfNeeded(assistantId, runId);
-      }}
-    />
-  );
-}
 
 /**
  * Projects a single run's {@link useWorkflowCardData} into the shared
@@ -95,5 +59,4 @@ export const WORKFLOW_DESCRIPTOR: BackgroundProcessDescriptor = {
     useViewerStore.getState().openProcessDetail({ kind: "workflow", id }),
   onStop: (id) => void useWorkflowStore.getState().abortRun(id),
   renderCount: (id) => <WorkflowAgentsChip runId={id} />,
-  DetailPanel: WorkflowDetailPanelAdapter,
 };

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -106,7 +106,7 @@ export function InlineProcessCard({
           bypassDwell={summary.state !== "loading"}
         />
       </span>
-      <span className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         {countSlot != null ? (
           countSlot
         ) : showCount ? (
@@ -128,7 +128,7 @@ export function InlineProcessCard({
             onClick={handleStop}
           />
         ) : null}
-      </span>
+      </div>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/process-registry/types.test.ts
+++ b/clients/web/src/domains/chat/process-registry/types.test.ts
@@ -31,7 +31,6 @@ describe("BackgroundProcessDescriptor contract", () => {
       openCardAriaLabel: "Open agents",
       onOpenDetail: () => {},
       onStop: () => {},
-      DetailPanel: () => null,
     };
 
     expect(descriptor.pill.variant).toBe("stacked");
@@ -50,7 +49,6 @@ describe("BackgroundProcessDescriptor contract", () => {
       openCardAriaLabel: "Open tasks",
       onOpenDetail: () => {},
       // No `onStop` — valid for kinds without a stop action.
-      DetailPanel: () => null,
     };
 
     expect(descriptor.pill.variant).toBe("count");

--- a/clients/web/src/domains/chat/process-registry/types.ts
+++ b/clients/web/src/domains/chat/process-registry/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import type { ToolProgressCardState } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
 
@@ -76,7 +76,6 @@ export type ProcessPillConfig =
  *   when the kind has no stop action.
  * - `renderCount` — optional custom count slot; overrides the default string
  *   `count` rendering when present (e.g. the workflow agent-avatar chip).
- * - `DetailPanel` — each kind renders a different detail UI.
  */
 export interface BackgroundProcessDescriptor {
   /** Discriminant used to look the descriptor up in the registry. */
@@ -107,6 +106,4 @@ export interface BackgroundProcessDescriptor {
    * present. Omit to fall back to the {@link CardSummary.count} string.
    */
   renderCount?: (id: string) => ReactNode;
-  /** Detail-panel component rendered for a single process. */
-  DetailPanel: ComponentType<{ id: string; onClose: () => void }>;
 }


### PR DESCRIPTION
## Summary
Addresses codex review on #36685:
- Remove the unused DetailPanel field + adapters from BackgroundProcessDescriptor — it eagerly imported each detail panel onto the chat critical path, defeating ChatContentLayout's lazy loading. Live routing already goes through openProcessDetail → the lazy panels.
- Change the inline card's right-cluster span to a div so the workflow count chip (div root) doesn't produce div-in-span nesting warnings.

Part of plan: background-process-registry.md (self-review remediation round 3)