### PR TITLE
Update fitness-companion pin to v0.2.0 (USDA FoodData Central)

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -142,7 +142,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/fitness-companion",
-        "ref": "c5a310789609234f2f46ae96f7c501afedd10e9d"
+        "ref": "e1aae9dd527f30cb897dd4a04c14f35950d263d2"
       },
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",


### PR DESCRIPTION
## What

Bumps the `fitness-companion` marketplace pin from `c5a3107` to `e1aae9d` (v0.2.0).

## What changed in v0.2.0

- **USDA FoodData Central** added as primary nutrition data source (government-backed, curated, reliable)
- **OpenFoodFacts** remains as automatic fallback when no USDA key is configured
- New `data_source` param on the nutrition lookup tool: `auto` (default), `usda`, `openfoodfacts`
- `config.json` now has a `usda_api_key` field
- README updated with instructions for getting a free USDA API key
- Full 40-char SHA pinned: `e1aae9dd527f30cb897dd4a04c14f35950d263d2`

## Why

OpenFoodFacts is frequently 503 under load. USDA gives users a reliable alternative with a free key, while keeping OFF as a zero-config fallback.