### PR TITLE
feat(plugins): add postgres plugin with install-check init hook

### DIFF
--- a/plugins/postgres/README.md
+++ b/plugins/postgres/README.md
@@ -1,0 +1,13 @@
+# postgres
+
+Experimental plugin for backing the assistant with PostgreSQL instead of
+SQLite.
+
+This is an early scaffold. Today it contributes a single `init` hook that
+verifies a PostgreSQL installation is reachable on `PATH` before the plugin
+loads. If none of `pg_ctl`, `postgres`, or `psql` respond to `--version`, the
+hook throws and the loader aborts bootstrap for this plugin so the missing
+dependency surfaces loudly.
+
+Future work (provisioning, schema, and the SQLite → PostgreSQL backend swap)
+builds on top of this check.

--- a/plugins/postgres/hooks/init.ts
+++ b/plugins/postgres/hooks/init.ts
@@ -1,0 +1,44 @@
+/**
+ * Ensures a PostgreSQL installation is present on PATH before the plugin does
+ * anything else. PostgreSQL is the database backend this plugin manages, so a
+ * missing install is a hard stop: the hook throws, the loader raises
+ * PluginExecutionError, and bootstrap for this plugin aborts loudly rather than
+ * leaving a half-wired backend.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { InitContext } from "@vellumai/plugin-api";
+
+const execFileAsync = promisify(execFile);
+
+// Entry points shipped by a PostgreSQL install. Probing several covers distro
+// layouts that package the server (`postgres`, `pg_ctl`) separately from the
+// client (`psql`).
+const POSTGRES_BINARIES = ["pg_ctl", "postgres", "psql"] as const;
+
+/** Returns the binary's `--version` output, or `null` if it isn't runnable. */
+async function probeVersion(binary: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(binary, ["--version"]);
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+export default async function init(ctx: InitContext): Promise<void> {
+  for (const binary of POSTGRES_BINARIES) {
+    const version = await probeVersion(binary);
+    if (version !== null) {
+      ctx.logger.info({ binary, version }, "postgresql detected");
+      return;
+    }
+  }
+
+  throw new Error(
+    `postgresql is not installed: none of ${POSTGRES_BINARIES.join(", ")} ` +
+      `responded to --version on PATH. Install PostgreSQL before enabling the ` +
+      `postgres plugin.`,
+  );
+}

--- a/plugins/postgres/package.json
+++ b/plugins/postgres/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "postgres",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "peerDependencies": {
+    "@vellumai/plugin-api": ">=0.8.0"
+  },
+  "vellum": {}
+}


### PR DESCRIPTION
## Prompt / plan

> we are going to start experimenting with postgres instead of sqlite as the db backing. create a top level folder called `plugins/postgres` with a simple init hook that first just ensures that postgresql is installed

This scaffolds a first-party `postgres` plugin as the starting point for experimenting with PostgreSQL as the assistant's database backend in place of SQLite. It deliberately does only one thing for now: an `init` hook that verifies a PostgreSQL installation is reachable before any further backend wiring lands.

The hook probes `pg_ctl`, `postgres`, and `psql` for a `--version` response on `PATH` (covering distro layouts that split the server and client packages). If none respond, it throws — the external-plugin loader raises `PluginExecutionError` and aborts bootstrap for this plugin, so the missing dependency surfaces loudly rather than leaving a half-wired backend. This follows the documented `init`-hook contract in `plugins/README.md` ("Throw early if your plugin can't start").

Files:
- `plugins/postgres/package.json` — manifest (`@vellumai/plugin-api` peer range `>=0.8.0`, matching the loader default).
- `plugins/postgres/hooks/init.ts` — the install-check hook.
- `plugins/postgres/README.md` — notes that this is an early scaffold and what comes next.

Not added to `plugins/marketplace.json` — that file whitelists external GitHub-sourced plugins; this is an in-repo first-party plugin (placed alongside `caveman`).

## Test plan

- `bun build plugins/postgres/hooks/init.ts --target node --external @vellumai/plugin-api` — transpiles cleanly.
- Hook conforms to the documented `InitContext` / `PluginLogger` types in `assistant/src/plugin-api/types.ts` (`ctx.logger.info(obj, msg)`, `Promise<void>` return).
- No standalone `tsc` here: `plugins/` has no local `node_modules`, and `@vellumai/plugin-api` is a loader-resolved peer dependency (same as the existing `caveman` plugin).

<!-- No new IPC routes under assistant/src/runtime/routes/; CLI verb checklist N/A. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9Pxj6M77Yh1W8rJn3cSu2)_