### PR TITLE
fix(plugins): block workspace plugins from publishing host_* control events

### DIFF
--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -126,6 +126,33 @@ describe("plugin-facing assistantEventHub facade", () => {
     }
   });
 
+  test("freezes the published snapshot so a subscriber cannot mutate it mid-fanout (Codex P1)", async () => {
+    const hostReceived: AssistantEvent[] = [];
+    // A malicious subscriber registered first tries to turn the in-flight event
+    // into a host request before the host-capable client (registered after)
+    // receives the same fanned-out object.
+    const attacker = rawHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        try {
+          (event as { message: { type: string } }).message.type =
+            "host_bash_request";
+        } catch {
+          // Frozen snapshot — the mutation is rejected.
+        }
+      },
+    });
+    const hostSub = subscribeHostClient("facade-fanout-client", hostReceived);
+    try {
+      await pluginHub.publish(envelope("sync_changed"));
+      expect(hostReceived).toHaveLength(1);
+      expect(eventType(hostReceived[0])).toBe("sync_changed");
+    } finally {
+      attacker.dispose();
+      hostSub.dispose();
+    }
+  });
+
   test("delegates non-host publish to the shared singleton", async () => {
     const received: AssistantEvent[] = [];
     // Subscribe on the RAW hub, publish through the FACADE: delivery proves the

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Guard test: the event hub exposed to workspace plugins through
+ * `@vellumai/plugin-api` must refuse to publish daemon-to-client host-proxy
+ * control events (`host_*`). Publishing one drives privileged shell / file /
+ * input execution on the desktop client, which the host proxies gate upstream;
+ * an in-process plugin must not be able to bypass that gate by publishing the
+ * event directly. Non-host publishing and subscription must still work and
+ * share state with the real hub.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { assistantEventHub as pluginHub } from "../plugin-api/index.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  type AssistantEventCallback,
+  assistantEventHub as rawHub,
+} from "../runtime/assistant-event-hub.js";
+
+/** Minimal event envelope; the facade guard keys only off `message.type`. */
+function envelope(type: string): AssistantEvent {
+  return { message: { type } } as unknown as AssistantEvent;
+}
+
+describe("plugin-facing assistantEventHub facade", () => {
+  test("rejects publishing host-proxy control events", async () => {
+    for (const type of [
+      "host_bash_request",
+      "host_bash_cancel",
+      "host_file_request",
+      "host_transfer_request",
+      "host_browser_request",
+      "host_cu_request",
+      "host_app_control_request",
+    ]) {
+      let rejected: unknown;
+      try {
+        await pluginHub.publish(envelope(type));
+      } catch (err) {
+        rejected = err;
+      }
+      expect(rejected).toBeInstanceOf(Error);
+      expect((rejected as Error).message).toMatch(/host-proxy control events/);
+    }
+  });
+
+  test("delegates non-host publish to the shared singleton", async () => {
+    const received: AssistantEvent[] = [];
+    const callback: AssistantEventCallback = (event) => {
+      received.push(event);
+    };
+    // Subscribe on the RAW hub, publish through the FACADE: delivery proves the
+    // facade delegates to the same instance (shared subscriber state).
+    const sub = rawHub.subscribe({ type: "process", callback });
+    try {
+      const event = envelope("sync_changed");
+      await pluginHub.publish(event);
+      expect(received).toContain(event);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("delegates subscribe and read queries without throwing", () => {
+    const sub = pluginHub.subscribe({ type: "process", callback: () => {} });
+    try {
+      expect(typeof sub.dispose).toBe("function");
+      expect(
+        Array.isArray(pluginHub.listClientsByCapability("host_bash")),
+      ).toBe(true);
+    } finally {
+      sub.dispose();
+    }
+  });
+});

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -153,6 +153,35 @@ describe("plugin-facing assistantEventHub facade", () => {
     }
   });
 
+  test("rejects host events disguised as boxed strings (Codex P1)", async () => {
+    const received: AssistantEvent[] = [];
+    const sub = subscribeHostClient("facade-boxed-client", received);
+    try {
+      // `new String(...)` is typeof "object" (slipping a naive string guard) but
+      // JSON-serializes to the primitive the client acts on. The canonical wire
+      // snapshot coerces it so the guard still blocks it.
+
+      const boxedType = new String("host_bash_request");
+      const boxed = {
+        message: { type: boxedType },
+      } as unknown as AssistantEvent;
+      let rejected: unknown;
+      try {
+        await pluginHub.publish(boxed, {
+          targetClientId: "facade-boxed-client",
+          targetCapability: "host_bash",
+        });
+      } catch (err) {
+        rejected = err;
+      }
+      expect(rejected).toBeInstanceOf(Error);
+      expect((rejected as Error).message).toMatch(/host-proxy control events/);
+      expect(received).toHaveLength(0);
+    } finally {
+      sub.dispose();
+    }
+  });
+
   test("delegates non-host publish to the shared singleton", async () => {
     const received: AssistantEvent[] = [];
     // Subscribe on the RAW hub, publish through the FACADE: delivery proves the

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -267,4 +267,38 @@ describe("plugin-facing assistantEventHub facade", () => {
       hostSub.dispose();
     }
   });
+
+  test("snapshots plugin subscription filters so a filter getter never runs during fanout (Codex P1)", async () => {
+    let getterCalls = 0;
+    const filter = {};
+    Object.defineProperty(filter, "conversationId", {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return undefined;
+      },
+    });
+    const pluginSub = pluginHub.subscribe({
+      type: "process",
+      filter: filter as { conversationId?: string },
+      callback: () => {},
+    });
+    const hostSub = subscribeHostClient("facade-filter-client", []);
+    try {
+      const callsAfterSubscribe = getterCalls;
+      // A conversation-scoped event makes the hub read `entry.filter.conversationId`
+      // during fanout; with an inert snapshot the plugin's getter never fires.
+      await rawHub.publish(
+        {
+          message: { type: "host_bash_request" },
+          conversationId: "conv-1",
+        } as unknown as AssistantEvent,
+        { targetCapability: "host_bash" },
+      );
+      expect(getterCalls).toBe(callsAfterSubscribe);
+    } finally {
+      pluginSub.dispose();
+      hostSub.dispose();
+    }
+  });
 });

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -1,25 +1,39 @@
 /**
  * Guard test: the event hub exposed to workspace plugins through
- * `@vellumai/plugin-api` must refuse to publish daemon-to-client host-proxy
- * control events (`host_*`). Publishing one drives privileged shell / file /
- * input execution on the desktop client, which the host proxies gate upstream;
- * an in-process plugin must not be able to bypass that gate by publishing the
- * event directly. Non-host publishing and subscription must still work and
- * share state with the real hub.
+ * `@vellumai/plugin-api` must not let an in-process plugin drive privileged
+ * host execution. It refuses to publish daemon-to-client host-proxy control
+ * events (`host_*`), withholds methods that hand out live subscriber callbacks
+ * (a direct delivery primitive), and snapshots published events so a mutating
+ * getter cannot slip a host event past the guard. Subscription and non-host
+ * publishing must still work and share state with the real hub.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import { assistantEventHub as pluginHub } from "../plugin-api/index.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
-import {
-  type AssistantEventCallback,
-  assistantEventHub as rawHub,
-} from "../runtime/assistant-event-hub.js";
+import { assistantEventHub as rawHub } from "../runtime/assistant-event-hub.js";
 
 /** Minimal event envelope; the facade guard keys only off `message.type`. */
 function envelope(type: string): AssistantEvent {
   return { message: { type } } as unknown as AssistantEvent;
+}
+
+function eventType(event: unknown): unknown {
+  return (event as { message?: { type?: unknown } }).message?.type;
+}
+
+/** Register a host-capable desktop client subscriber on the raw hub. */
+function subscribeHostClient(clientId: string, sink: AssistantEvent[]) {
+  return rawHub.subscribe({
+    type: "client",
+    clientId,
+    interfaceId: "macos",
+    capabilities: ["host_bash"],
+    callback: (event) => {
+      sink.push(event);
+    },
+  } as Parameters<typeof rawHub.subscribe>[0]);
 }
 
 describe("plugin-facing assistantEventHub facade", () => {
@@ -44,32 +58,21 @@ describe("plugin-facing assistantEventHub facade", () => {
     }
   });
 
-  test("does not expose raw publish through the prototype chain (Codex P1 bypass)", async () => {
-    // The facade has no prototype, so `Object.getPrototypeOf` / `.constructor`
-    // cannot reach the unguarded `AssistantEventHub.prototype.publish`.
-    expect(Object.getPrototypeOf(pluginHub)).toBeNull();
-    expect(
-      (pluginHub as { constructor?: unknown }).constructor,
-    ).toBeUndefined();
+  test("does not expose the raw hub publish via the prototype chain (Codex P1)", async () => {
+    // A plain frozen object: its prototype is Object.prototype, which has no
+    // `publish`, so `Object.getPrototypeOf(...).publish` / `.constructor` cannot
+    // reach the unguarded `AssistantEventHub.prototype.publish`.
+    const proto = Object.getPrototypeOf(pluginHub) as { publish?: unknown };
+    expect(typeof proto?.publish).not.toBe("function");
 
-    // End-to-end: replicate the reported exploit and assert nothing reaches a
-    // host-capable subscriber.
     const received: AssistantEvent[] = [];
-    const sub = rawHub.subscribe({
-      type: "client",
-      clientId: "facade-bypass-test-client",
-      interfaceId: "macos",
-      capabilities: ["host_bash"],
-      callback: (event) => {
-        received.push(event);
-      },
-    } as Parameters<typeof rawHub.subscribe>[0]);
+    const sub = subscribeHostClient("facade-proto-client", received);
     try {
-      const proto = Object.getPrototypeOf(pluginHub) as {
+      const p = Object.getPrototypeOf(pluginHub) as {
         publish?: (event: AssistantEvent, options?: unknown) => Promise<void>;
       } | null;
-      await proto?.publish?.call(pluginHub, envelope("host_bash_request"), {
-        targetClientId: "facade-bypass-test-client",
+      await p?.publish?.call(pluginHub, envelope("host_bash_request"), {
+        targetClientId: "facade-proto-client",
         targetCapability: "host_bash",
       });
       expect(received).toHaveLength(0);
@@ -78,30 +81,77 @@ describe("plugin-facing assistantEventHub facade", () => {
     }
   });
 
-  test("delegates non-host publish to the shared singleton", async () => {
+  test("withholds methods that leak subscriber callbacks (Codex P1)", () => {
+    const facade = pluginHub as unknown as Record<string, unknown>;
+    for (const method of [
+      "listClients",
+      "listClientsByCapability",
+      "listClientsByInterface",
+      "getClientById",
+      "getMostRecentClientByCapability",
+      "disposeClient",
+      "touchClient",
+    ]) {
+      expect(facade[method]).toBeUndefined();
+    }
+  });
+
+  test("snapshots the event so a mutating type getter cannot bypass the guard (Codex P1)", async () => {
     const received: AssistantEvent[] = [];
-    const callback: AssistantEventCallback = (event) => {
-      received.push(event);
-    };
-    // Subscribe on the RAW hub, publish through the FACADE: delivery proves the
-    // facade delegates to the same instance (shared subscriber state).
-    const sub = rawHub.subscribe({ type: "process", callback });
+    const sub = subscribeHostClient("facade-toctou-client", received);
     try {
-      const event = envelope("sync_changed");
-      await pluginHub.publish(event);
-      expect(received).toContain(event);
+      // `message.type` reads benign first (what the guard would see) then turns
+      // into a host event — the classic time-of-check/time-of-use trick.
+      let reads = 0;
+      const message: Record<string, unknown> = {};
+      Object.defineProperty(message, "type", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return reads === 1 ? "sync_changed" : "host_bash_request";
+        },
+      });
+      const sneaky = { message } as unknown as AssistantEvent;
+
+      await pluginHub.publish(sneaky, {
+        targetClientId: "facade-toctou-client",
+        targetCapability: "host_bash",
+      });
+
+      // The client only ever sees the inert snapshot, never the host type.
+      expect(received).toHaveLength(1);
+      expect(eventType(received[0])).toBe("sync_changed");
     } finally {
       sub.dispose();
     }
   });
 
-  test("delegates subscribe and read queries without throwing", () => {
+  test("delegates non-host publish to the shared singleton", async () => {
+    const received: AssistantEvent[] = [];
+    // Subscribe on the RAW hub, publish through the FACADE: delivery proves the
+    // facade delegates to the same instance (shared subscriber state). The
+    // delivered event is a snapshot, so it is compared by value, not identity.
+    const sub = rawHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+    try {
+      await pluginHub.publish(envelope("sync_changed"));
+      expect(received.some((e) => eventType(e) === "sync_changed")).toBe(true);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("delegates subscribe and hasSubscribersForEvent", () => {
     const sub = pluginHub.subscribe({ type: "process", callback: () => {} });
     try {
       expect(typeof sub.dispose).toBe("function");
       expect(
-        Array.isArray(pluginHub.listClientsByCapability("host_bash")),
-      ).toBe(true);
+        typeof pluginHub.hasSubscribersForEvent({ conversationId: undefined }),
+      ).toBe("boolean");
     } finally {
       sub.dispose();
     }

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -301,4 +301,23 @@ describe("plugin-facing assistantEventHub facade", () => {
       hostSub.dispose();
     }
   });
+
+  test("guard survives String.prototype.startsWith being monkey-patched (Codex P1)", async () => {
+    const originalStartsWith = String.prototype.startsWith;
+    // Simulate a malicious plugin neutering the prototype method the guard reads.
+
+    String.prototype.startsWith = () => false;
+    try {
+      let rejected: unknown;
+      try {
+        await pluginHub.publish(envelope("host_bash_request"));
+      } catch (err) {
+        rejected = err;
+      }
+      expect(rejected).toBeInstanceOf(Error);
+      expect((rejected as Error).message).toMatch(/host-proxy control events/);
+    } finally {
+      String.prototype.startsWith = originalStartsWith;
+    }
+  });
 });

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -44,6 +44,40 @@ describe("plugin-facing assistantEventHub facade", () => {
     }
   });
 
+  test("does not expose raw publish through the prototype chain (Codex P1 bypass)", async () => {
+    // The facade has no prototype, so `Object.getPrototypeOf` / `.constructor`
+    // cannot reach the unguarded `AssistantEventHub.prototype.publish`.
+    expect(Object.getPrototypeOf(pluginHub)).toBeNull();
+    expect(
+      (pluginHub as { constructor?: unknown }).constructor,
+    ).toBeUndefined();
+
+    // End-to-end: replicate the reported exploit and assert nothing reaches a
+    // host-capable subscriber.
+    const received: AssistantEvent[] = [];
+    const sub = rawHub.subscribe({
+      type: "client",
+      clientId: "facade-bypass-test-client",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      callback: (event) => {
+        received.push(event);
+      },
+    } as Parameters<typeof rawHub.subscribe>[0]);
+    try {
+      const proto = Object.getPrototypeOf(pluginHub) as {
+        publish?: (event: AssistantEvent, options?: unknown) => Promise<void>;
+      } | null;
+      await proto?.publish?.call(pluginHub, envelope("host_bash_request"), {
+        targetClientId: "facade-bypass-test-client",
+        targetCapability: "host_bash",
+      });
+      expect(received).toHaveLength(0);
+    } finally {
+      sub.dispose();
+    }
+  });
+
   test("delegates non-host publish to the shared singleton", async () => {
     const received: AssistantEvent[] = [];
     const callback: AssistantEventCallback = (event) => {

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -212,4 +212,59 @@ describe("plugin-facing assistantEventHub facade", () => {
       sub.dispose();
     }
   });
+
+  test("downgrades plugin client subscriptions to in-process (no host-event interception) (Codex P1)", async () => {
+    const received: AssistantEvent[] = [];
+    // Ask for a host-capable client subscription; the facade must register a
+    // process subscriber, which never receives capability-targeted host events.
+    const sub = pluginHub.subscribe({
+      type: "client",
+      clientId: "plugin-fake-client",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      callback: (event) => {
+        received.push(event);
+      },
+    } as Parameters<typeof pluginHub.subscribe>[0]);
+    try {
+      await rawHub.publish(envelope("host_bash_request"), {
+        targetCapability: "host_bash",
+      });
+      expect(received).toHaveLength(0);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("isolates plugin callbacks so they cannot mutate the in-flight fanout event (Codex P1)", async () => {
+    const hostReceived: AssistantEvent[] = [];
+    // The plugin subscribes first and, from its callback, tries to rewrite the
+    // shared in-flight event into a host request. It must only see an isolated
+    // copy, leaving the real client's event untouched.
+    const pluginSub = pluginHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        try {
+          (event as { message: { type: string } }).message.type =
+            "host_bash_request";
+        } catch {
+          // Isolated frozen copy — the mutation is rejected.
+        }
+      },
+    });
+    const hostSub = subscribeHostClient(
+      "facade-isolation-client",
+      hostReceived,
+    );
+    try {
+      // Daemon-published untargeted event (not via the facade): the plugin runs
+      // first in the fanout but only receives an isolated copy.
+      await rawHub.publish(envelope("sync_changed"));
+      expect(hostReceived).toHaveLength(1);
+      expect(eventType(hostReceived[0])).toBe("sync_changed");
+    } finally {
+      pluginSub.dispose();
+      hostSub.dispose();
+    }
+  });
 });

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -24,6 +24,12 @@
  *   handing one to a plugin would let it deliver a forged host event without
  *   going through the guarded `publish` at all.
  *
+ * `subscribe` registers the plugin as an in-process consumer only (never a
+ * device "client"), so it cannot impersonate a real client by id or receive
+ * host-capability-targeted events; its callback is handed an isolated, frozen
+ * snapshot so it cannot mutate an in-flight event a real client receives later
+ * in the same fanout.
+ *
  * `publish` canonicalizes the caller's event (and options) to their JSON wire
  * form — the exact representation the client receives — then deep-freezes that
  * snapshot before checking the type and forwards it. JSON canonicalization
@@ -99,7 +105,26 @@ function hostControlEventType(event: AssistantEvent): string | undefined {
 
 /** The plugin-facing event hub. See module docs. */
 export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
-  subscribe: (subscriber) => assistantEventHub.subscribe(subscriber),
+  subscribe: (subscriber) =>
+    // Plugins subscribe as in-process consumers only — never as device
+    // "clients" — so a plugin cannot impersonate/evict a real client by id or
+    // receive host-capability-targeted events meant for the desktop app. Its
+    // callback is handed an isolated, frozen snapshot so it cannot mutate an
+    // in-flight event that a real client receives later in the same fanout (the
+    // hub delivers one shared object to every subscriber in turn).
+    assistantEventHub.subscribe({
+      type: "process",
+      filter: subscriber.filter,
+      callback: (event) => {
+        let isolated: AssistantEvent;
+        try {
+          isolated = deepFreeze(wireSnapshot(event));
+        } catch {
+          return;
+        }
+        return subscriber.callback(isolated);
+      },
+    }),
 
   publish: async (event, options) => {
     let snapshot: AssistantEvent;

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -42,6 +42,7 @@
 
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import {
+  type AssistantEventFilter,
   type AssistantEventHub,
   assistantEventHub,
 } from "../runtime/assistant-event-hub.js";
@@ -105,16 +106,24 @@ function hostControlEventType(event: AssistantEvent): string | undefined {
 
 /** The plugin-facing event hub. See module docs. */
 export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
-  subscribe: (subscriber) =>
+  subscribe: (subscriber) => {
     // Plugins subscribe as in-process consumers only — never as device
     // "clients" — so a plugin cannot impersonate/evict a real client by id or
-    // receive host-capability-targeted events meant for the desktop app. Its
+    // receive host-capability-targeted events meant for the desktop app. The
+    // filter is canonicalized to inert data so the hub never invokes a
+    // plugin-defined getter while reading `entry.filter` during fanout, and the
     // callback is handed an isolated, frozen snapshot so it cannot mutate an
-    // in-flight event that a real client receives later in the same fanout (the
-    // hub delivers one shared object to every subscriber in turn).
-    assistantEventHub.subscribe({
+    // in-flight event a real client receives later in the same fanout (the hub
+    // delivers one shared object to every subscriber in turn).
+    let filter: AssistantEventFilter | undefined;
+    try {
+      filter = subscriber.filter ? wireSnapshot(subscriber.filter) : undefined;
+    } catch {
+      filter = undefined;
+    }
+    return assistantEventHub.subscribe({
       type: "process",
-      filter: subscriber.filter,
+      filter,
       callback: (event) => {
         let isolated: AssistantEvent;
         try {
@@ -124,7 +133,8 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
         }
         return subscriber.callback(isolated);
       },
-    }),
+    });
+  },
 
   publish: async (event, options) => {
     let snapshot: AssistantEvent;
@@ -145,5 +155,9 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
   },
 
   hasSubscribersForEvent: (event) =>
-    assistantEventHub.hasSubscribersForEvent(event),
+    // Read the caller's `conversationId` once and pass an inert object, so the
+    // hub never reads a plugin-defined getter.
+    assistantEventHub.hasSubscribersForEvent({
+      conversationId: event?.conversationId,
+    }),
 });

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -1,0 +1,72 @@
+/**
+ * Capability-restricted view of the assistant event hub handed to workspace
+ * plugins through `@vellumai/plugin-api`.
+ *
+ * Plugins receive this facade instead of the raw {@link AssistantEventHub}
+ * singleton. It delegates every operation to the one daemon hub instance — so
+ * subscriptions and reads observe the same shared state — except
+ * {@link AssistantEventHub.publish}, which refuses daemon-to-client host-proxy
+ * control events (`host_bash_*`, `host_file_*`, `host_transfer_*`,
+ * `host_browser_*`, `host_cu_*`, `host_app_control_*`).
+ *
+ * Those events drive privileged shell / file / input / browser execution on
+ * the desktop client. The host proxies gate that execution (risk
+ * classification, user approval, same-actor binding, pending-interaction
+ * registration) before publishing. Letting an in-process plugin publish the
+ * event directly would bypass the gate and reach the host machine outside any
+ * sandbox, so the plugin-facing hub rejects it.
+ */
+
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  type AssistantEventHub,
+  assistantEventHub,
+} from "../runtime/assistant-event-hub.js";
+
+/**
+ * Type prefix shared by every daemon-to-client host-proxy control event. Each
+ * host-proxy message type (`host_bash_request`, `host_file_cancel`, …) begins
+ * with it, so a prefix test covers all current and future host-proxy kinds.
+ */
+const HOST_CONTROL_EVENT_TYPE_PREFIX = "host_";
+
+/** The blocked event type if `event` is a host-proxy control event, else `undefined`. */
+function hostControlEventType(event: AssistantEvent): string | undefined {
+  const type: unknown = event.message?.type;
+  return typeof type === "string" &&
+    type.startsWith(HOST_CONTROL_EVENT_TYPE_PREFIX)
+    ? type
+    : undefined;
+}
+
+/**
+ * The plugin-facing event hub. A {@link Proxy} over the daemon singleton:
+ * `publish` is wrapped with the host-control guard; every other member is
+ * delegated to — and bound to — the real instance so subscriber state is
+ * shared.
+ */
+export const pluginAssistantEventHub: AssistantEventHub = new Proxy(
+  assistantEventHub,
+  {
+    get(target, prop) {
+      if (prop === "publish") {
+        return (
+          event: AssistantEvent,
+          options?: Parameters<AssistantEventHub["publish"]>[1],
+        ): Promise<void> => {
+          const blockedType = hostControlEventType(event);
+          if (blockedType !== undefined) {
+            return Promise.reject(
+              new Error(
+                `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
+              ),
+            );
+          }
+          return target.publish(event, options);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  },
+);

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -3,18 +3,24 @@
  * plugins through `@vellumai/plugin-api`.
  *
  * Plugins receive this facade instead of the raw {@link AssistantEventHub}
- * singleton. It delegates every operation to the one daemon hub instance — so
- * subscriptions and reads observe the same shared state — except
- * {@link AssistantEventHub.publish}, which refuses daemon-to-client host-proxy
- * control events (`host_bash_*`, `host_file_*`, `host_transfer_*`,
- * `host_browser_*`, `host_cu_*`, `host_app_control_*`).
+ * singleton. Every hub method is delegated to the one daemon instance — so
+ * subscriptions and reads observe the same shared state — except `publish`,
+ * which refuses daemon-to-client host-proxy control events (`host_bash_*`,
+ * `host_file_*`, `host_transfer_*`, `host_browser_*`, `host_cu_*`,
+ * `host_app_control_*`).
  *
  * Those events drive privileged shell / file / input / browser execution on
  * the desktop client. The host proxies gate that execution (risk
  * classification, user approval, same-actor binding, pending-interaction
- * registration) before publishing. Letting an in-process plugin publish the
+ * registration) before publishing; letting an in-process plugin publish the
  * event directly would bypass the gate and reach the host machine outside any
- * sandbox, so the plugin-facing hub rejects it.
+ * sandbox.
+ *
+ * The facade is a frozen, null-prototype object of bound methods. It does NOT
+ * inherit from `AssistantEventHub.prototype`, so a plugin cannot reach the
+ * unguarded `publish` through the prototype chain (`Object.getPrototypeOf`,
+ * `.constructor`, …). The real hub is captured only inside the bound closures,
+ * which never hand it back out.
  */
 
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -40,33 +46,38 @@ function hostControlEventType(event: AssistantEvent): string | undefined {
 }
 
 /**
- * The plugin-facing event hub. A {@link Proxy} over the daemon singleton:
- * `publish` is wrapped with the host-control guard; every other member is
- * delegated to — and bound to — the real instance so subscriber state is
- * shared.
+ * Build the plugin-facing facade over `hub`: every method bound to the real
+ * instance (shared state), `publish` replaced with the host-control guard, on
+ * a null prototype so the raw `publish` is unreachable by reflection.
  */
-export const pluginAssistantEventHub: AssistantEventHub = new Proxy(
-  assistantEventHub,
-  {
-    get(target, prop) {
-      if (prop === "publish") {
-        return (
-          event: AssistantEvent,
-          options?: Parameters<AssistantEventHub["publish"]>[1],
-        ): Promise<void> => {
-          const blockedType = hostControlEventType(event);
-          if (blockedType !== undefined) {
-            return Promise.reject(
-              new Error(
-                `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
-              ),
-            );
-          }
-          return target.publish(event, options);
-        };
-      }
-      const value = Reflect.get(target, prop, target);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  },
-);
+function buildPluginEventHub(hub: AssistantEventHub): AssistantEventHub {
+  const guardedPublish: AssistantEventHub["publish"] = (event, options) => {
+    const blockedType = hostControlEventType(event);
+    if (blockedType !== undefined) {
+      return Promise.reject(
+        new Error(
+          `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
+        ),
+      );
+    }
+    return hub.publish(event, options);
+  };
+
+  const facade: Record<string, unknown> = Object.create(null);
+  const prototype = Object.getPrototypeOf(hub) as object;
+  const members = hub as unknown as Record<string, unknown>;
+  for (const name of Object.getOwnPropertyNames(prototype)) {
+    if (name === "constructor") continue;
+    const member = members[name];
+    if (typeof member !== "function") continue;
+    facade[name] =
+      name === "publish"
+        ? guardedPublish
+        : (member as (...args: unknown[]) => unknown).bind(hub);
+  }
+  return Object.freeze(facade) as unknown as AssistantEventHub;
+}
+
+/** The plugin-facing event hub. See module docs. */
+export const pluginAssistantEventHub: AssistantEventHub =
+  buildPluginEventHub(assistantEventHub);

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -3,24 +3,31 @@
  * plugins through `@vellumai/plugin-api`.
  *
  * Plugins receive this facade instead of the raw {@link AssistantEventHub}
- * singleton. Every hub method is delegated to the one daemon instance — so
- * subscriptions and reads observe the same shared state — except `publish`,
- * which refuses daemon-to-client host-proxy control events (`host_bash_*`,
- * `host_file_*`, `host_transfer_*`, `host_browser_*`, `host_cu_*`,
- * `host_app_control_*`).
+ * singleton. It exposes only the operations a plugin legitimately needs —
+ * subscribing to runtime events, publishing non-host events, and checking for
+ * subscribers — each delegated to the one daemon hub instance so subscriptions
+ * and reads observe the same shared state.
  *
- * Those events drive privileged shell / file / input / browser execution on
- * the desktop client. The host proxies gate that execution (risk
- * classification, user approval, same-actor binding, pending-interaction
- * registration) before publishing; letting an in-process plugin publish the
- * event directly would bypass the gate and reach the host machine outside any
- * sandbox.
+ * Two classes of hub method are withheld:
  *
- * The facade is a frozen, null-prototype object of bound methods. It does NOT
- * inherit from `AssistantEventHub.prototype`, so a plugin cannot reach the
- * unguarded `publish` through the prototype chain (`Object.getPrototypeOf`,
- * `.constructor`, …). The real hub is captured only inside the bound closures,
- * which never hand it back out.
+ * - **`publish` of host-proxy control events** (`host_bash_*`, `host_file_*`,
+ *   `host_transfer_*`, `host_browser_*`, `host_cu_*`, `host_app_control_*`).
+ *   These drive privileged shell / file / input / browser execution on the
+ *   desktop client; the host proxies gate that execution (risk classification,
+ *   user approval, same-actor binding, pending-interaction registration) before
+ *   publishing. The facade's `publish` rejects them so an in-process plugin
+ *   cannot reach the host machine outside the sandbox.
+ *
+ * - **Methods returning live subscriber entries or mutating hub state**
+ *   (`listClients*`, `getClientById`, `disposeClient`, …). A `ClientEntry`
+ *   carries the subscriber's `callback` — a direct event-delivery primitive — so
+ *   handing one to a plugin would let it deliver a forged host event without
+ *   going through the guarded `publish` at all.
+ *
+ * `publish` deep-clones the caller's event (and options) into an inert snapshot
+ * before checking the type and forwards that same snapshot, so a host event
+ * cannot slip past the guard via a mutating getter / Proxy (time-of-check vs.
+ * time-of-use) or be re-read with a different type by the client.
  */
 
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -30,11 +37,28 @@ import {
 } from "../runtime/assistant-event-hub.js";
 
 /**
+ * The subset of {@link AssistantEventHub} workspace plugins may use. Picking
+ * method signatures off the class keeps the facade in sync with the hub while
+ * statically withholding everything else.
+ */
+export type PluginEventHub = Pick<
+  AssistantEventHub,
+  "subscribe" | "publish" | "hasSubscribersForEvent"
+>;
+
+/**
  * Type prefix shared by every daemon-to-client host-proxy control event. Each
  * host-proxy message type (`host_bash_request`, `host_file_cancel`, …) begins
  * with it, so a prefix test covers all current and future host-proxy kinds.
  */
 const HOST_CONTROL_EVENT_TYPE_PREFIX = "host_";
+
+/**
+ * The structured-clone primitive, pinned at module-load time — before any user
+ * plugin loads and could swap the global — so the publish snapshot always
+ * produces inert data.
+ */
+const cloneValue: typeof structuredClone = structuredClone;
 
 /** The blocked event type if `event` is a host-proxy control event, else `undefined`. */
 function hostControlEventType(event: AssistantEvent): string | undefined {
@@ -45,39 +69,28 @@ function hostControlEventType(event: AssistantEvent): string | undefined {
     : undefined;
 }
 
-/**
- * Build the plugin-facing facade over `hub`: every method bound to the real
- * instance (shared state), `publish` replaced with the host-control guard, on
- * a null prototype so the raw `publish` is unreachable by reflection.
- */
-function buildPluginEventHub(hub: AssistantEventHub): AssistantEventHub {
-  const guardedPublish: AssistantEventHub["publish"] = (event, options) => {
-    const blockedType = hostControlEventType(event);
+/** The plugin-facing event hub. See module docs. */
+export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
+  subscribe: (subscriber) => assistantEventHub.subscribe(subscriber),
+
+  publish: async (event, options) => {
+    let snapshot: AssistantEvent;
+    let snapshotOptions: Parameters<AssistantEventHub["publish"]>[1];
+    try {
+      snapshot = cloneValue(event);
+      snapshotOptions = options ? cloneValue(options) : undefined;
+    } catch {
+      throw new Error("Plugins may not publish a non-serializable event.");
+    }
+    const blockedType = hostControlEventType(snapshot);
     if (blockedType !== undefined) {
-      return Promise.reject(
-        new Error(
-          `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
-        ),
+      throw new Error(
+        `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
       );
     }
-    return hub.publish(event, options);
-  };
+    return assistantEventHub.publish(snapshot, snapshotOptions);
+  },
 
-  const facade: Record<string, unknown> = Object.create(null);
-  const prototype = Object.getPrototypeOf(hub) as object;
-  const members = hub as unknown as Record<string, unknown>;
-  for (const name of Object.getOwnPropertyNames(prototype)) {
-    if (name === "constructor") continue;
-    const member = members[name];
-    if (typeof member !== "function") continue;
-    facade[name] =
-      name === "publish"
-        ? guardedPublish
-        : (member as (...args: unknown[]) => unknown).bind(hub);
-  }
-  return Object.freeze(facade) as unknown as AssistantEventHub;
-}
-
-/** The plugin-facing event hub. See module docs. */
-export const pluginAssistantEventHub: AssistantEventHub =
-  buildPluginEventHub(assistantEventHub);
+  hasSubscribersForEvent: (event) =>
+    assistantEventHub.hasSubscribersForEvent(event),
+});

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -95,11 +95,20 @@ function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
   return Object.freeze(value);
 }
 
+/**
+ * `String.prototype.startsWith` bound at module-load time — before any user
+ * plugin loads and could monkey-patch the prototype — so the host-prefix check
+ * cannot be neutralized by a patched method.
+ */
+const startsWith = Function.prototype.call.bind(
+  String.prototype.startsWith,
+) as (str: string, search: string) => boolean;
+
 /** The blocked event type if `event` is a host-proxy control event, else `undefined`. */
 function hostControlEventType(event: AssistantEvent): string | undefined {
   const type: unknown = event.message?.type;
   return typeof type === "string" &&
-    type.startsWith(HOST_CONTROL_EVENT_TYPE_PREFIX)
+    startsWith(type, HOST_CONTROL_EVENT_TYPE_PREFIX)
     ? type
     : undefined;
 }

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -24,10 +24,12 @@
  *   handing one to a plugin would let it deliver a forged host event without
  *   going through the guarded `publish` at all.
  *
- * `publish` deep-clones the caller's event (and options) into an inert snapshot
- * before checking the type and forwards that same snapshot, so a host event
- * cannot slip past the guard via a mutating getter / Proxy (time-of-check vs.
- * time-of-use) or be re-read with a different type by the client.
+ * `publish` deep-clones the caller's event (and options) into an inert,
+ * deep-frozen snapshot before checking the type and forwards that same
+ * snapshot. Cloning defeats a mutating getter / Proxy that would show the guard
+ * a benign type and the client a host type (time-of-check vs. time-of-use);
+ * freezing defeats a subscriber that mutates the in-flight event mid-fanout
+ * (the hub delivers one object to every subscriber in turn).
  */
 
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -60,6 +62,23 @@ const HOST_CONTROL_EVENT_TYPE_PREFIX = "host_";
  */
 const cloneValue: typeof structuredClone = structuredClone;
 
+/**
+ * Recursively freeze a value (cycle-safe). The hub fans the same event object
+ * out to every subscriber in turn; freezing the snapshot stops a malicious
+ * subscriber — e.g. a plugin that subscribed and then calls `publish` — from
+ * mutating the in-flight event into a host request before a later host-capable
+ * client receives it.
+ */
+function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+  for (const key of Object.keys(value)) {
+    deepFreeze((value as Record<string, unknown>)[key], seen);
+  }
+  return Object.freeze(value);
+}
+
 /** The blocked event type if `event` is a host-proxy control event, else `undefined`. */
 function hostControlEventType(event: AssistantEvent): string | undefined {
   const type: unknown = event.message?.type;
@@ -77,7 +96,7 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
     let snapshot: AssistantEvent;
     let snapshotOptions: Parameters<AssistantEventHub["publish"]>[1];
     try {
-      snapshot = cloneValue(event);
+      snapshot = deepFreeze(cloneValue(event));
       snapshotOptions = options ? cloneValue(options) : undefined;
     } catch {
       throw new Error("Plugins may not publish a non-serializable event.");

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -24,12 +24,14 @@
  *   handing one to a plugin would let it deliver a forged host event without
  *   going through the guarded `publish` at all.
  *
- * `publish` deep-clones the caller's event (and options) into an inert,
- * deep-frozen snapshot before checking the type and forwards that same
- * snapshot. Cloning defeats a mutating getter / Proxy that would show the guard
- * a benign type and the client a host type (time-of-check vs. time-of-use);
- * freezing defeats a subscriber that mutates the in-flight event mid-fanout
- * (the hub delivers one object to every subscriber in turn).
+ * `publish` canonicalizes the caller's event (and options) to their JSON wire
+ * form — the exact representation the client receives — then deep-freezes that
+ * snapshot before checking the type and forwards it. JSON canonicalization
+ * collapses getters / Proxies to inert values and coerces boxed values (e.g.
+ * `new String("host_bash_request")`) to primitives, so the guard cannot be
+ * shown a benign type while the client acts on a host one (time-of-check vs.
+ * time-of-use). Freezing stops a subscriber from mutating the in-flight event
+ * mid-fanout (the hub delivers one object to every subscriber in turn).
  */
 
 import type { AssistantEvent } from "../runtime/assistant-event.js";
@@ -56,11 +58,18 @@ export type PluginEventHub = Pick<
 const HOST_CONTROL_EVENT_TYPE_PREFIX = "host_";
 
 /**
- * The structured-clone primitive, pinned at module-load time — before any user
- * plugin loads and could swap the global — so the publish snapshot always
- * produces inert data.
+ * JSON primitives pinned at module-load time — before any user plugin loads and
+ * could swap the globals. A JSON round-trip canonicalizes a published event to
+ * exactly the wire form the client receives, so the guard checks the same
+ * representation the client will act on.
  */
-const cloneValue: typeof structuredClone = structuredClone;
+const jsonStringify: typeof JSON.stringify = JSON.stringify;
+const jsonParse: typeof JSON.parse = JSON.parse;
+
+/** Canonicalize a value to its JSON wire form. Throws if it is not serializable. */
+function wireSnapshot<T>(value: T): T {
+  return jsonParse(jsonStringify(value)) as T;
+}
 
 /**
  * Recursively freeze a value (cycle-safe). The hub fans the same event object
@@ -96,8 +105,8 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
     let snapshot: AssistantEvent;
     let snapshotOptions: Parameters<AssistantEventHub["publish"]>[1];
     try {
-      snapshot = deepFreeze(cloneValue(event));
-      snapshotOptions = options ? cloneValue(options) : undefined;
+      snapshot = deepFreeze(wireSnapshot(event));
+      snapshotOptions = options ? wireSnapshot(options) : undefined;
     } catch {
       throw new Error("Plugins may not publish a non-serializable event.");
     }

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -128,7 +128,12 @@ export type {
   AssistantEventHub,
   AssistantEventSubscription,
 } from "../runtime/assistant-event-hub.js";
-export { assistantEventHub } from "../runtime/assistant-event-hub.js";
+// The hub plugins receive is a capability-restricted facade over the daemon
+// singleton: `subscribe` and reads share the real hub's state, but `publish`
+// refuses daemon-to-client host-proxy control events (`host_*`) so a workspace
+// plugin cannot drive privileged host execution without the host proxies'
+// approval gate. See `event-hub-facade.ts`.
+export { pluginAssistantEventHub as assistantEventHub } from "./event-hub-facade.js";
 export { getModelProfiles } from "./model-profiles.js";
 // Check whether a model or profile can process image input. Accepts a concrete
 // model id, a profile key, or a `ModelProfileInfo`; a bare string is resolved

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -129,10 +129,13 @@ export type {
   AssistantEventSubscription,
 } from "../runtime/assistant-event-hub.js";
 // The hub plugins receive is a capability-restricted facade over the daemon
-// singleton: `subscribe` and reads share the real hub's state, but `publish`
-// refuses daemon-to-client host-proxy control events (`host_*`) so a workspace
-// plugin cannot drive privileged host execution without the host proxies'
-// approval gate. See `event-hub-facade.ts`.
+// singleton (see `event-hub-facade.ts`): plugins may `subscribe` to runtime
+// events (shared subscriber state), `publish` non-host events, and check
+// `hasSubscribersForEvent`. `publish` refuses daemon-to-client host-proxy
+// control events (`host_*`), and methods that return live subscriber callbacks
+// or mutate hub state are withheld — both would let a plugin drive privileged
+// host execution without the host proxies' approval gate.
+export type { PluginEventHub } from "./event-hub-facade.js";
 export { pluginAssistantEventHub as assistantEventHub } from "./event-hub-facade.js";
 export { getModelProfiles } from "./model-profiles.js";
 // Check whether a model or profile can process image input. Accepts a concrete


### PR DESCRIPTION
## Summary

- Workspace plugins reach the **canonical** `assistantEventHub` through `@vellumai/plugin-api` (the boot-time shim re-binds `globalThis[Symbol.for("vellum.plugin-api")]`). `publish()` has no `host_*` guard and `listClientsByCapability("host_bash")` is public, so a malicious or compromised plugin could publish a forged `host_bash_request` straight to the desktop client — which runs `spawn("/bin/bash", ["-c", "--", command])` with **no approval, risk classification, same-actor binding, or pending-interaction registration** (all of which live in the daemon `HostBashProxy`, upstream of `publish()`). Highest impact in Docker/managed mode, where it becomes a container→host escape.
- Exposes a **capability-restricted facade** (`assistant/src/plugin-api/event-hub-facade.ts`) to plugins instead of the raw singleton. It delegates `subscribe`, reads, and **non-host** `publish` to the same hub instance (shared subscriber state), but rejects publishing daemon→client host-proxy control events (`host_*`). Restores the parity the deleted skill-IPC `host_*` blocklist (ATL-321 / #29266) once provided for the skill surface.
- The raw `assistantEventHub` singleton stays daemon-internal — all 101 in-daemon callers import it from `runtime/assistant-event-hub.js` and are unaffected; only the plugin-facing export is wrapped. Plugin event subscription and non-host UI events keep working. Adds a guard test.

## Original prompt

Triage of `Codex finding: d41403a219488191a826ae80f83c3801`, which flagged the `globalThis.__vellumPluginRuntime` bridge exposing the raw `assistantEventHub` to workspace plugins. **The finding's named mechanism and every cited path were stale** — generated against the Jun-8 commit `a3d455fa32`, since refactored: `__vellumPluginRuntime`/`external-api.ts` were removed (#34198), the `ipc/skill-routes/events.ts` blocklist was deleted with the whole skill-IPC transport (#36596), and the native-Swift macOS client was replaced by Electron. But the underlying vulnerability **survived** through the `@vellumai/plugin-api` shim, which still re-exports the canonical hub. This PR fixes it at its current location, applying the finding's "capability-restricted facade" remedy.

## Review focus

- The facade is a `Proxy` that delegates to the **same** singleton instance (not a second hub) — verify shared subscriber state is preserved (guard test covers raw-subscribe → facade-publish delivery).
- Only `host_*` publish is blocked; `subscribe`, reads, and non-host publish must keep working (workspace plugins subscribe to runtime events through this hub).
- Public `@vellumai/plugin-api` contract surface — the exported `assistantEventHub` is now a facade.