### PR TITLE
fix(cli): show what interpreter processes are running in `ps` tree

### DIFF
--- a/assistant/src/util/__tests__/process-tree.test.ts
+++ b/assistant/src/util/__tests__/process-tree.test.ts
@@ -39,8 +39,16 @@ describe("deriveName", () => {
     expect(deriveName("bun run /worker.ts")).toBe("worker");
   });
 
-  test("falls back to the interpreter when there is no script arg", () => {
-    expect(deriveName("bun repl")).toBe("bun");
+  test("surfaces the arguments when an interpreter runs no script file", () => {
+    expect(deriveName("bun repl")).toBe("bun repl");
+    expect(deriveName("bun run dev")).toBe("bun run dev");
+    expect(deriveName("bun x prettier --write .")).toBe("bun x prettier .");
+    expect(deriveName("node --inspect server")).toBe("node server");
+  });
+
+  test("falls back to the bare interpreter when only flags follow", () => {
+    expect(deriveName("bun --version")).toBe("bun");
+    expect(deriveName("bun")).toBe("bun");
   });
 
   test("handles empty input", () => {

--- a/assistant/src/util/process-tree.ts
+++ b/assistant/src/util/process-tree.ts
@@ -64,7 +64,10 @@ function scriptName(scriptPath: string): string {
  * Derive a readable name from a command line. For interpreter invocations
  * (`bun run /…/jobs/worker.ts`) the script path is far more useful than the
  * interpreter name, so prefer the first script-looking argument and summarize it
- * as `<parent-dir>-<filename>` (e.g. `jobs-worker`). Plain binaries
+ * as `<parent-dir>-<filename>` (e.g. `jobs-worker`). When an interpreter is run
+ * without a script file (`bun run dev`, `bun x prettier`, `bun repl`) the bare
+ * interpreter name says nothing about what is running, so surface the arguments
+ * — what was actually run — alongside it (e.g. `bun run dev`). Plain binaries
  * (`/…/vellum-qdrant`) keep their bare executable name.
  */
 export function deriveName(command: string): string {
@@ -73,8 +76,13 @@ export function deriveName(command: string): string {
 
   const argv0 = basename(tokens[0]);
   if (RUNTIMES.has(argv0)) {
-    const script = tokens.slice(1).find((t) => SCRIPT_EXT_RE.test(t));
+    const args = tokens.slice(1);
+    const script = args.find((t) => SCRIPT_EXT_RE.test(t));
     if (script) return scriptName(script);
+    // No script to summarize: show the non-flag arguments so the entry reads as
+    // "what was run" rather than an opaque `bun`. Flags are dropped as noise.
+    const meaningful = args.filter((t) => !t.startsWith("-"));
+    if (meaningful.length > 0) return `${argv0} ${meaningful.join(" ")}`;
   }
   return argv0;
 }


### PR DESCRIPTION
## Prompt / plan

> when it's a bun process like this `[ps tree showing a bare `bun` node]`, I'd rather know what was run instead after it

The daemon `ps` route (`assistant ps`) derives a friendly name for each process from its command line via `deriveName()` in `assistant/src/util/process-tree.ts`. For interpreter invocations that point at a script file (`bun run /app/jobs/worker.ts`) it summarizes the path as `<parent>-<file>` (→ `jobs-worker`). But when an interpreter is run **without** a script file — `bun run dev`, `bun x prettier`, `bun repl` — it fell back to the bare interpreter basename, so the tree showed an opaque `bun` that told you nothing about what was actually running.

This changes the fallback: when a runtime has no script argument to summarize, the entry now surfaces the invocation's non-flag arguments alongside the interpreter (e.g. `bun run dev`), so you can see what was run. Flags are dropped as noise. Script invocations and plain binaries are unchanged.

## Test plan

- Updated `assistant/src/util/__tests__/process-tree.test.ts`: the old "falls back to the interpreter" case now asserts the argument-surfacing behavior (`bun repl` → `bun repl`, `bun run dev` → `bun run dev`, `bun x prettier --write .` → `bun x prettier .`, `node --inspect server` → `node server`), plus a new case confirming a flags-only invocation still falls back to the bare interpreter (`bun --version` → `bun`).
- `bun test src/util/__tests__/process-tree.test.ts` → 13 pass, 0 fail.
- Existing script-path and plain-binary cases continue to pass unchanged.

## CLI verb checklist

No new routes added — this only changes name derivation inside the existing `ps` route handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wm8LUve6LxicViesN1eLY

---
_Generated by [Claude Code](https://claude.ai/code/session_014wm8LUve6LxicViesN1eLY)_