### PR TITLE
feat(settings): add background memory worker toggle

### DIFF
--- a/clients/web/src/domains/settings/components/memory-worker-toggle.test.tsx
+++ b/clients/web/src/domains/settings/components/memory-worker-toggle.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+type WorkerStatus = {
+  status: "running" | "not_running";
+  workerEnabled: boolean;
+  syncRunner: { status: "running" | "not_running" };
+  embedding: {
+    enabled: boolean;
+    degraded: boolean;
+    provider: null;
+    model: null;
+    reason: null;
+  };
+} | null;
+
+let workerStatus: WorkerStatus;
+const startMock = mock(async () => ({ workerEnabled: true }));
+const stopMock = mock(async () => ({ workerEnabled: false }));
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => "assistant-1",
+}));
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  memoryWorkerStatusGetOptions: (options: { path: { assistant_id: string } }) => ({
+    queryKey: [{ _id: "memoryWorkerStatusGet", path: options.path }],
+    queryFn: async () => {
+      if (!workerStatus) throw new Error("not found");
+      return workerStatus;
+    },
+  }),
+  memoryWorkerStatusGetSetQueryData: (
+    _client: unknown,
+    _opts: unknown,
+    _updater: unknown,
+  ) => {},
+  useMemoryWorkerStartPostMutation: (
+    opts?: { onSuccess?: (data: unknown) => void },
+  ) => ({
+    mutateAsync: async (_args: unknown) => {
+      const result = await startMock();
+      opts?.onSuccess?.(result);
+      return result;
+    },
+    isPending: false,
+  }),
+  useMemoryWorkerStopPostMutation: (
+    opts?: { onSuccess?: (data: unknown) => void },
+  ) => ({
+    mutateAsync: async (_args: unknown) => {
+      const result = await stopMock();
+      opts?.onSuccess?.(result);
+      return result;
+    },
+    isPending: false,
+  }),
+}));
+
+const { MemoryWorkerToggle } = await import("./memory-worker-toggle");
+
+function makeStatus(workerEnabled: boolean): WorkerStatus {
+  return {
+    status: workerEnabled ? "running" : "not_running",
+    workerEnabled,
+    syncRunner: { status: workerEnabled ? "not_running" : "running" },
+    embedding: {
+      enabled: true,
+      degraded: false,
+      provider: null,
+      model: null,
+      reason: null,
+    },
+  };
+}
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  workerStatus = makeStatus(false);
+  startMock.mockClear();
+  stopMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MemoryWorkerToggle", () => {
+  test("renders off and starts the worker when toggled on", async () => {
+    renderWithQuery(<MemoryWorkerToggle memoryEnabled={true} />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Enable background memory worker",
+    });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(startMock).toHaveBeenCalled());
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  test("renders on and stops the worker when toggled off", async () => {
+    workerStatus = makeStatus(true);
+    renderWithQuery(<MemoryWorkerToggle memoryEnabled={true} />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Enable background memory worker",
+    });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(stopMock).toHaveBeenCalled());
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  test("disables the toggle when memory is off", async () => {
+    renderWithQuery(<MemoryWorkerToggle memoryEnabled={false} />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Enable background memory worker",
+    });
+    expect(toggle.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(toggle);
+    expect(startMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  test("hides the row when worker status is unavailable", async () => {
+    workerStatus = null;
+    renderWithQuery(<MemoryWorkerToggle memoryEnabled={true} />);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("switch", {
+          name: "Enable background memory worker",
+        }),
+      ).toBeNull(),
+    );
+  });
+});

--- a/clients/web/src/domains/settings/components/memory-worker-toggle.tsx
+++ b/clients/web/src/domains/settings/components/memory-worker-toggle.tsx
@@ -1,0 +1,101 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import {
+  memoryWorkerStatusGetOptions,
+  memoryWorkerStatusGetSetQueryData,
+  useMemoryWorkerStartPostMutation,
+  useMemoryWorkerStopPostMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { toast } from "@vellumai/design-library/components/toast";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export interface MemoryWorkerToggleProps {
+  /**
+   * Whether long-term memory is enabled. The background worker only drains the
+   * memory job queue while memory is on, so its toggle is disabled when memory
+   * is off (turning memory off already pauses consolidation).
+   */
+  memoryEnabled: boolean;
+}
+
+/**
+ * Sub-row of the Memory settings card that controls the out-of-process memory
+ * worker. Enabling it spawns a dedicated worker process to drain the memory job
+ * queue; disabling it hands the queue back to the daemon's synchronous
+ * in-process runner.
+ *
+ * The status query gates the row's visibility: assistants whose daemon predates
+ * the worker control routes return no status, so the row stays hidden rather
+ * than offering a toggle the daemon can't honor.
+ */
+export function MemoryWorkerToggle({ memoryEnabled }: MemoryWorkerToggleProps) {
+  const assistantId = useActiveAssistantId();
+  const queryClient = useQueryClient();
+
+  const { data: status } = useQuery({
+    ...memoryWorkerStatusGetOptions({ path: { assistant_id: assistantId } }),
+    staleTime: 30_000,
+  });
+
+  // Optimistically reflect the new state in the status cache so the toggle
+  // settles immediately; the next status fetch reconciles against the daemon.
+  const setWorkerEnabled = (enabled: boolean) => {
+    memoryWorkerStatusGetSetQueryData(
+      queryClient,
+      { path: { assistant_id: assistantId } },
+      (old) => (old ? { ...old, workerEnabled: enabled } : old),
+    );
+  };
+
+  const startMutation = useMemoryWorkerStartPostMutation({
+    onSuccess: () => setWorkerEnabled(true),
+  });
+  const stopMutation = useMemoryWorkerStopPostMutation({
+    onSuccess: () => setWorkerEnabled(false),
+  });
+
+  const handleWorkerToggle = async (enabled: boolean) => {
+    try {
+      if (enabled) {
+        await startMutation.mutateAsync({
+          path: { assistant_id: assistantId },
+        });
+        toast.success("Background worker enabled.");
+      } else {
+        await stopMutation.mutateAsync({
+          path: { assistant_id: assistantId },
+        });
+        toast.success("Background worker disabled.");
+      }
+    } catch (error) {
+      captureError(error, { context: "settings-memory-worker-toggle" });
+      toast.error("Failed to update background worker setting.");
+    }
+  };
+
+  if (!status) return null;
+
+  const isPending = startMutation.isPending || stopMutation.isPending;
+
+  return (
+    <div className="flex flex-row items-start justify-between gap-4 border-t border-[var(--border-subtle)] pt-4">
+      <div className="flex min-w-0 flex-col gap-2">
+        <h3 className="text-body-medium-default text-[var(--content-emphasised)]">
+          Background worker
+        </h3>
+        <p className="text-body-medium-default text-[var(--content-tertiary)]">
+          Run memory consolidation in a dedicated background process instead of
+          inline. Recommended for heavier memory workloads.
+        </p>
+      </div>
+      <Toggle
+        checked={status.workerEnabled === true}
+        onChange={(enabled) => void handleWorkerToggle(enabled)}
+        aria-label="Enable background memory worker"
+        disabled={!memoryEnabled || isPending}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/pages/advanced-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/advanced-page.test.tsx
@@ -35,6 +35,15 @@ mock.module("@/assistant/use-active-assistant-id", () => ({
   useActiveAssistantId: () => "assistant-1",
 }));
 
+// The worker toggle has its own unit test (memory-worker-toggle.test.tsx); stub
+// it here so these tests stay focused on the memory.enabled control and don't
+// need the worker status/start/stop query mocks.
+mock.module("@/domains/settings/components/memory-worker-toggle", () => ({
+  MemoryWorkerToggle: ({ memoryEnabled }: { memoryEnabled: boolean }) => (
+    <div data-testid="memory-worker-toggle" data-memory-enabled={memoryEnabled} />
+  ),
+}));
+
 mock.module("@/generated/daemon/sdk.gen", () => ({
   configGet: mock(async () => ({ data: daemonConfig })),
   configPatch: async () => {
@@ -92,6 +101,11 @@ describe("AdvancedPage memory settings", () => {
     expect(screen.getByText("Memory")).toBeTruthy();
     const toggle = screen.getByRole("switch", { name: "Enable memory" });
     expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+    // The background-worker sub-control renders inside the memory card and is
+    // told memory is currently enabled.
+    const workerToggle = screen.getByTestId("memory-worker-toggle");
+    expect(workerToggle.getAttribute("data-memory-enabled")).toBe("true");
 
     fireEvent.click(toggle);
 

--- a/clients/web/src/domains/settings/pages/advanced-page.tsx
+++ b/clients/web/src/domains/settings/pages/advanced-page.tsx
@@ -4,6 +4,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { useAssistantWithHealthz } from "@/domains/settings/components/assistant-status-panel";
+import { MemoryWorkerToggle } from "@/domains/settings/components/memory-worker-toggle";
 import { UpdateWindowPolicy } from "@/domains/settings/components/update-window-policy";
 import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
@@ -78,7 +79,9 @@ export function AdvancedPage() {
             />
           }
           compactAccessory
-        />
+        >
+          <MemoryWorkerToggle memoryEnabled={memoryEnabled} />
+        </DetailCard>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Prompt / plan

> Extend this memory section to include a toggle for the background worker. We should already have routes for enabling, disabling, and statusing the memory worker, so hopefully this is a UI-only PR.

This is a UI-only change. The Memory section in **Settings → Advanced** now has a second sub-control for the out-of-process memory worker, wired to the existing daemon routes:

- `POST /v1/memory/worker/start` (`useMemoryWorkerStartPostMutation`)
- `POST /v1/memory/worker/stop` (`useMemoryWorkerStopPostMutation`)
- `GET  /v1/memory/worker/status` (`memoryWorkerStatusGetOptions`)

### Behavior

- Enabling the toggle spawns a dedicated worker process to drain the memory job queue; disabling it hands the queue back to the daemon's synchronous in-process runner.
- The toggle is **disabled while memory itself is off** — turning memory off already pauses consolidation, so there's nothing for the worker to do.
- The whole sub-row stays **hidden when the daemon doesn't report worker status** (older daemons that predate the control routes), so we never surface a toggle the daemon can't honor.
- On success the worker `status` query cache is updated optimistically so the toggle settles immediately; the next status fetch reconciles against the daemon.

The worker control lives inside the existing `Memory` `DetailCard` as a divided sub-row (`children`), keeping it visually nested under the memory setting it depends on. Built from existing design-library primitives (`Toggle`, `DetailCard`).

## Test plan

- New unit test `memory-worker-toggle.test.tsx`: renders off→start, on→stop, disabled-when-memory-off, and hidden-when-status-unavailable.
- Updated `advanced-page.test.tsx`: stubs the new sub-control and asserts it renders with the current memory-enabled state inside the Memory card.
- `bunx tsc --noEmit` — clean.
- `eslint` on all changed files — clean.

<!-- CLI verb checklist omitted: no new routes added (UI-only). -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoxiggZctTQK2DZHFfNe5u)_