### PR TITLE
fix(daemon): refresh the agent-loop system prompt when trust binds late (#36694)

### DIFF
--- a/assistant/src/__tests__/agent-loop-set-system-prompt.test.ts
+++ b/assistant/src/__tests__/agent-loop-set-system-prompt.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `AgentLoop.setSystemPrompt` — the seam that lets a conversation
+ * update the loop's system prompt between turns.
+ *
+ * The loop snapshots `this.systemPrompt` once per `run()`, so a conversation
+ * that resolves its persona context after the loop is constructed (a voice
+ * call binds the caller's trust only after `getOrCreateConversation`) must be
+ * able to push the re-resolved prompt in before the next turn. These tests
+ * drive the REAL loop against a recording provider and assert the prompt the
+ * provider receives, with a pass-through `pre-model-call` hook so the loop's
+ * own prompt — not a hook mutation — is what reaches the wire.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Standard logger stub (same shape as the rest of the suite).
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Pass-through plugin pipeline: the `pre-model-call` hook returns its context
+// unchanged, so `providerOptions.systemPrompt` stays exactly the prompt the
+// loop snapshotted for the run.
+mock.module("../plugins/pipeline.js", () => ({
+  runHook: async (_hook: unknown, ctx: unknown): Promise<unknown> => ctx,
+}));
+
+let mockLlmConfig: Record<string, unknown> = {};
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { AgentLoop } from "../agent/loop.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+const trust: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+/**
+ * Provider that records the system prompt of every send and ends the turn
+ * after one call.
+ */
+function makeRecordingProvider(): {
+  provider: Provider;
+  capturedSystemPrompts: () => (string | undefined)[];
+} {
+  const captured: (string | undefined)[] = [];
+  const provider: Provider = {
+    name: "anthropic",
+    async sendMessage(
+      _messages: Message[],
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      captured.push(options?.systemPrompt);
+      return {
+        content: [{ type: "text", text: "done" }],
+        model: "mock-model",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return { provider, capturedSystemPrompts: () => captured };
+}
+
+function makeLoop(provider: Provider, systemPrompt: string): AgentLoop {
+  return new AgentLoop({
+    provider,
+    systemPrompt,
+    config: {},
+    conversationId: "test-conv",
+  });
+}
+
+async function runOnce(loop: AgentLoop): Promise<void> {
+  await loop.run({
+    requestId: "test-request",
+    messages: [userMessage],
+    onEvent: () => {},
+    trust,
+    callSite: "mainAgent",
+  });
+}
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({
+    default: { provider: "anthropic", model: "mock-model" },
+  }) as Record<string, unknown>;
+});
+
+describe("AgentLoop.setSystemPrompt", () => {
+  test("a prompt set before the run is what the provider receives", async () => {
+    const { provider, capturedSystemPrompts } = makeRecordingProvider();
+    const loop = makeLoop(provider, "CONSTRUCTION-PERSONA");
+
+    loop.setSystemPrompt("LATE-BOUND-PERSONA");
+    await runOnce(loop);
+
+    expect(capturedSystemPrompts()).toEqual(["LATE-BOUND-PERSONA"]);
+  });
+
+  test("without a push, the construction-time prompt is used", async () => {
+    const { provider, capturedSystemPrompts } = makeRecordingProvider();
+    const loop = makeLoop(provider, "CONSTRUCTION-PERSONA");
+
+    await runOnce(loop);
+
+    expect(capturedSystemPrompts()).toEqual(["CONSTRUCTION-PERSONA"]);
+  });
+
+  test("a prompt pushed between turns takes effect on the next run", async () => {
+    const { provider, capturedSystemPrompts } = makeRecordingProvider();
+    const loop = makeLoop(provider, "FIRST-PERSONA");
+
+    await runOnce(loop);
+    loop.setSystemPrompt("SECOND-PERSONA");
+    await runOnce(loop);
+
+    expect(capturedSystemPrompts()).toEqual([
+      "FIRST-PERSONA",
+      "SECOND-PERSONA",
+    ]);
+  });
+});

--- a/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
@@ -182,6 +182,7 @@ function makeCtx(overrides: Partial<Context> = {}): Conversation {
     getTurnChannelContext: () => null,
 
     buildCurrentSystemPrompt: () => "system prompt",
+    syncLoopSystemPrompt: () => {},
     modelOverride: undefined,
     graphMemory: {} as Context["graphMemory"],
     ...overrides,

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -510,6 +510,7 @@ function makeCtx(
     }),
 
     buildCurrentSystemPrompt: () => "system prompt",
+    syncLoopSystemPrompt: () => {},
     modelOverride: undefined,
 
     graphMemory: {

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -656,6 +656,7 @@ function makeCtx(
     }),
 
     buildCurrentSystemPrompt: () => "system prompt",
+    syncLoopSystemPrompt: () => {},
     modelOverride: undefined,
 
     graphMemory: {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -778,6 +778,7 @@ function makeCtx(
     }),
 
     buildCurrentSystemPrompt: () => "system prompt",
+    syncLoopSystemPrompt: () => {},
     modelOverride: undefined,
 
     graphMemory: {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -819,6 +819,19 @@ export class AgentLoop {
   }
 
   /**
+   * Replace the system prompt used by subsequent runs. The conversation pushes
+   * a freshly resolved prompt here between turns when its persona context
+   * (trust, channel, persona override) changed, so a conversation that binds
+   * that context after construction (e.g. a voice call resolving the caller's
+   * identity after the loop is built) does not stay pinned to the
+   * construction-time persona. An in-flight `run()` keeps its own snapshot
+   * (`runSystemPrompt`), so this never changes the prompt mid-run.
+   */
+  setSystemPrompt(systemPrompt: string): void {
+    this.systemPrompt = systemPrompt;
+  }
+
+  /**
    * Resolve the tool definitions sent to the provider for the given turn.
    *
    * Mirrors the logic of {@link getToolTokenBudget} but returns the tool

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -317,6 +317,13 @@ export async function runAgentLoopImpl(
   ctx.currentTurnTrustContext = ctx.trustContext;
   ctx.currentTurnChannelCapabilities = ctx.channelCapabilities;
 
+  // Re-resolve the system prompt under the snapshots just set and push it into
+  // the loop when the persona changed. The loop reuses the prompt frozen at
+  // construction otherwise, so a flow that binds trust after construction (a
+  // voice call resolves the caller only after `getOrCreateConversation`) would
+  // run the whole conversation under the construction-time persona.
+  ctx.syncLoopSystemPrompt();
+
   const abortController = ctx.abortController;
   const reqId = ctx.currentRequestId ?? uuid();
   // First-token latency instrumentation for this turn. Stamped here at the

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -837,6 +837,32 @@ export class Conversation {
         });
   }
 
+  /**
+   * Re-resolve the system prompt for the current turn's persona context and
+   * push it into the agent loop when it changed. The loop snapshots its prompt
+   * at construction and reuses it every turn; flows that bind persona context
+   * after construction — a voice call resolves the caller's trust only after
+   * the conversation is created — would otherwise stay pinned to the
+   * construction-time persona (the guardian, or `users/default.md`) for the
+   * whole conversation.
+   *
+   * Pushing only when the rebuilt prompt actually differs keeps the provider's
+   * prefix cache intact for the common case (a stable-identity conversation
+   * rebuilds to the same bytes, so no update is sent). A system-prompt override
+   * resolves verbatim via {@link buildCurrentSystemPrompt}, so override
+   * conversations (subagent forks, stored overrides) are inherently a no-op.
+   *
+   * Called by the turn runner before `agentLoop.run()`, once the turn's
+   * persona snapshots ({@link currentTurnTrustContext},
+   * {@link currentTurnChannelCapabilities}) are set.
+   */
+  syncLoopSystemPrompt(): void {
+    const next = this.buildCurrentSystemPrompt();
+    if (next === this.systemPrompt) return;
+    this.systemPrompt = next;
+    this.agentLoop.setSystemPrompt(next);
+  }
+
   // ── Prompt Cache Warming ─────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## Summary

- A conversation's system prompt is built **once at `AgentLoop` construction and frozen** for the loop's life (`run()` snapshots `this.systemPrompt`; nothing updated it between turns). Flows that bind the requester's trust **after** creating the conversation — a voice call does `getOrCreateConversation(id)` and only **then** `setTrustContext(callerTrust)` — run the whole conversation under the **construction-time persona** (the guardian, or `users/default.md`) instead of the caller's `users/<slug>.md`.
- Wire the per-turn refresh the loop already anticipates (the `run()` comment: *"the instance field is mutable — the conversation may update it between turns"* — but nothing did). The universal turn runner (`runAgentLoopImpl`) now calls `Conversation.syncLoopSystemPrompt()` right after it snapshots the turn's persona context, which re-resolves `buildCurrentSystemPrompt()` and pushes it into the loop via a new `AgentLoop.setSystemPrompt()` **only when the bytes changed**.
- **Cache-safe / no-op for the common path:** pushing only on a byte change keeps the provider prefix cache. A foreground guardian turn resolves the same `userSlug`/`channelSlug` as the construction prompt → identical bytes → no push. System-prompt overrides (subagent forks, stored overrides) resolve verbatim through `buildCurrentSystemPrompt()` → also a no-op (`subagent-fork-prompt-role.test.ts` stays green). Only a genuinely-different persona (the late-bound voice caller) triggers a one-time push.

## Original prompt

Follow-up to #36650. After that fix, foreground (guardian) and channel-routed conversations resolve the right persona at construction, but **late-bound-trust** flows — voice calls that create the conversation before resolving the caller — were still frozen onto the guardian/default persona for the entire call. Open a PR to wire the loop's prompt to refresh when trust binds after construction. **Closes #36694.**

## Review focus (high blast radius — please review, do not fast-merge)

- `assistant/src/daemon/conversation-agent-loop.ts` — the single new call site in the universal funnel (`runAgentLoopImpl`), placed right after the `currentTurnTrustContext` / `currentTurnChannelCapabilities` snapshot so `buildCurrentSystemPrompt()` reads the turn's authoritative persona context.
- `assistant/src/daemon/conversation.ts` — `syncLoopSystemPrompt()` (4 lines): rebuild → bytes-compare → push. The compare is what protects the prefix cache.
- `assistant/src/agent/loop.ts` — `setSystemPrompt()`; relies on the existing per-run snapshot (`runSystemPrompt`) so an in-flight run never changes prompt mid-run.
- **Trade-off:** `runAgentLoopImpl` now calls `buildCurrentSystemPrompt()` once per turn (the pre-freeze behavior). It's bounded (cached workspace block + one indexed contact lookup + small persona-file read) and the bytes-compare keeps the provider cache; the alternative (a persona-slug guard) was rejected as more surface for no cache benefit.

## Out of scope (noted for a follow-up)

The wake path (`agent-wake.ts:1287`) calls `agentLoop.run()` **directly**, bypassing this funnel, and does not set `currentTurnChannelCapabilities` — so its `wakePersonaOverride` is frozen by the same root cause. Fixing it needs the wake to set the channel snapshot too; left out here to keep this diff contained to the voice/#36694 path.

## Notes

- No schema/migration impact; behavior-only.
- Tests: new `agent-loop-set-system-prompt.test.ts` drives the real loop + a recording provider to prove a pushed prompt reaches the wire (before-run, control, and **turn-to-turn** — the exact late-bound scenario). The 4 funnel tests get a no-op `syncLoopSystemPrompt` stub (preserving their prior behavior); `system-prompt.test.ts` (114) and `subagent-fork-prompt-role.test.ts` (3) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)