### PR TITLE
feat(memory-v3): expose raw cosine scores via denseLaneScored

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -81,7 +81,7 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
-const { denseLane, OVERSAMPLE } = await import("../dense.js");
+const { denseLane, denseLaneScored, OVERSAMPLE } = await import("../dense.js");
 const { SECTION_COLLECTION, _resetSectionDenseStoreForTests } =
   await import("../section-dense-store.js");
 
@@ -207,5 +207,80 @@ describe("memory v3 dense lane", () => {
     expect(hits).toEqual([]);
     expect(embedState.calls).toEqual([]);
     expect(state.queryCalls).toHaveLength(0);
+  });
+});
+
+describe("denseLaneScored", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("flows raw cosine scores through in descending order, deduped to best section per article", async () => {
+    // page-a's best section is ordinal 2 (highest score); the later page-a
+    // section is ignored once the article is already represented.
+    state.points = [
+      point("page-a", 2, 0.95),
+      point("topic-x", 0, 0.9),
+      point("page-a", 1, 0.5),
+    ];
+
+    const hits = await denseLaneScored(CONFIG, "query", 5);
+
+    expect(hits).toEqual([
+      { article: "page-a", section: 2, score: 0.95 },
+      { article: "topic-x", section: 0, score: 0.9 },
+    ]);
+  });
+
+  test("a missing point.score defaults to 0", async () => {
+    state.points = [
+      {
+        payload: { article: "page-a", ordinal: 0 },
+      } as unknown as MockPoint,
+    ];
+
+    const hits = await denseLaneScored(CONFIG, "query", 5);
+
+    expect(hits).toEqual([{ article: "page-a", section: 0, score: 0 }]);
+  });
+
+  test("non-positive k short-circuits to []", async () => {
+    const hits = await denseLaneScored(CONFIG, "query", 0);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("a committed-dimension/reachable-backend mismatch degrades to []", async () => {
+    embedState.dimensionAvailable = false;
+
+    const hits = await denseLaneScored(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("a thrown Qdrant search degrades to []", async () => {
+    state.queryThrows = new Error("qdrant unreachable");
+
+    const hits = await denseLaneScored(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+  });
+
+  test("denseLane returns denseLaneScored hits with the score stripped", async () => {
+    state.points = [
+      point("page-a", 2, 0.95),
+      point("topic-x", 0, 0.9),
+      point("page-a", 1, 0.5),
+    ];
+
+    const scored = await denseLaneScored(CONFIG, "query", 5);
+    const plain = await denseLane(CONFIG, "query", 5);
+
+    expect(plain).toEqual(
+      scored.map(({ article, section }) => ({ article, section })),
+    );
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -42,12 +42,21 @@ export interface DenseHit {
   section: number;
 }
 
+/** A dense-lane hit plus the raw cosine similarity Qdrant returned. */
+export interface DenseHitScored {
+  article: Slug;
+  section: number;
+  score: number;
+}
+
 /**
- * Run the dense lane: embed `query`, search the section collection for the top
- * `k * OVERSAMPLE` section points, then dedupe to the top-`k` distinct articles
- * — each with its best-scoring section ordinal. Section points are returned by
- * Qdrant in descending score order, so the first time an article is seen is its
- * best section; subsequent sections of the same article are ignored.
+ * Run the dense lane and keep each hit's raw cosine score: embed `query`, search
+ * the section collection for the top `k * OVERSAMPLE` section points, then dedupe
+ * to the top-`k` distinct articles — each with its best-scoring section ordinal
+ * and that section's cosine score. Section points are returned by Qdrant in
+ * descending score order, so the first time an article is seen is its best
+ * section; subsequent sections of the same article are ignored. A point that
+ * arrives without a `score` is recorded as `0`.
  *
  * Returns `[]` on any embedding or Qdrant failure (logged at warn level), and
  * short-circuits to `[]` when the reachable backend cannot produce vectors of
@@ -55,11 +64,11 @@ export interface DenseHit {
  * so a 3072-dim collection committed while only a 384-dim backend is reachable
  * narrows recall cleanly rather than failing the dimension assertion every turn.
  */
-export async function denseLane(
+export async function denseLaneScored(
   config: AssistantConfig,
   query: string,
   k: number,
-): Promise<DenseHit[]> {
+): Promise<DenseHitScored[]> {
   if (k <= 0) return [];
 
   if (!(await isEmbeddingDimensionAvailable(config))) {
@@ -89,7 +98,7 @@ export async function denseLane(
   // Walk hits in score order, keeping the first (best) section per article and
   // stopping once we have `k` distinct articles.
   const seen = new Set<Slug>();
-  const hits: DenseHit[] = [];
+  const hits: DenseHitScored[] = [];
   for (const point of points) {
     const payload = point.payload as
       | { article?: unknown; ordinal?: unknown }
@@ -100,9 +109,35 @@ export async function denseLane(
     if (typeof article !== "string" || typeof ordinal !== "number") continue;
     if (seen.has(article)) continue;
     seen.add(article);
-    hits.push({ article, section: ordinal });
+    hits.push({ article, section: ordinal, score: point.score ?? 0 });
     if (hits.length >= k) break;
   }
 
   return hits;
+}
+
+/**
+ * Run the dense lane: embed `query`, search the section collection for the top
+ * `k * OVERSAMPLE` section points, then dedupe to the top-`k` distinct articles
+ * — each with its best-scoring section ordinal. Section points are returned by
+ * Qdrant in descending score order, so the first time an article is seen is its
+ * best section; subsequent sections of the same article are ignored.
+ *
+ * Returns `[]` on any embedding or Qdrant failure (logged at warn level), and
+ * short-circuits to `[]` when the reachable backend cannot produce vectors of
+ * the committed collection dimension (degraded backend or dimension mismatch) —
+ * so a 3072-dim collection committed while only a 384-dim backend is reachable
+ * narrows recall cleanly rather than failing the dimension assertion every turn.
+ *
+ * Thin wrapper over {@link denseLaneScored} that drops the raw cosine score for
+ * callers that only need the matched article and section.
+ */
+export async function denseLane(
+  config: AssistantConfig,
+  query: string,
+  k: number,
+): Promise<DenseHit[]> {
+  return (await denseLaneScored(config, query, k)).map(
+    ({ article, section }) => ({ article, section }),
+  );
 }


### PR DESCRIPTION
## Summary
- Add DenseHitScored + denseLaneScored, exposing the raw Qdrant cosine score per hit (missing score -> 0)
- denseLane() is now a thin score-stripping wrapper over denseLaneScored() (identical results)
- Tests cover score pass-through, dedupe, missing-score default, and degradation paths

Part of plan: memory-v3-injection-gate.md (PR 2 of 7)