### PR TITLE
feat(memory-v3): expose raw BM25F scores via SectionNeedle.queryScored

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -354,6 +354,7 @@ describe("orchestrate — candidate pool composition", () => {
         needleK = k;
         return [];
       },
+      queryScored: () => [],
       bestSection: () => -1,
       idf: () => 0,
     };
@@ -887,7 +888,12 @@ describe("orchestrate — degradation", () => {
     const result = await orchestrate(
       makeTurn(1, "zzzzz no-match"),
       depsOf(lanes, {
-        needle: { query: () => [], bestSection: () => -1, idf: () => 0 },
+        needle: {
+          query: () => [],
+          queryScored: () => [],
+          bestSection: () => -1,
+          idf: () => 0,
+        },
       }),
     );
     expect(result.selections).toEqual([]);
@@ -930,6 +936,7 @@ describe("orchestrate — entity lane", () => {
     // maps a message token to topic-a's HEADING section.
     const needle = {
       query: () => [{ article: "topic-a", section: leadDoc! }],
+      queryScored: () => [{ article: "topic-a", section: leadDoc!, score: 1 }],
       bestSection: () => leadDoc!,
       idf: () => 0,
     };
@@ -958,6 +965,7 @@ describe("orchestrate — entity lane", () => {
     const heading = sectionIndex.sections[headingDoc!]!;
     const needle = {
       query: () => [] as { article: Slug; section: number }[],
+      queryScored: () => [],
       bestSection: () => -1,
       idf: () => 0,
     };

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
@@ -133,3 +133,67 @@ describe("buildSectionNeedle", () => {
     expect(results.map((r) => r.article)).toEqual(["page-a", "page-b"]);
   });
 });
+
+describe("queryScored", () => {
+  /** Drop the score, leaving the shape `query` returns. */
+  const strip = ({ article, section }: { article: Slug; section: number }) => ({
+    article,
+    section,
+  });
+
+  test("scores are non-increasing in rank order", async () => {
+    const idx = await index({
+      "page-a": "## S\nshared keyword apple here",
+      "page-b": "## S\nshared keyword apple here too with extra apple apple",
+      "page-c": "## S\nshared keyword apple again",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const hits = needle.queryScored("apple", 5);
+
+    expect(hits.length).toBeGreaterThan(1);
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.score).toBeLessThanOrEqual(hits[i - 1]!.score);
+    }
+  });
+
+  test("parity with query (scores stripped)", async () => {
+    const idx = await index({
+      "page-a": "## S\nshared keyword apple here",
+      "page-b": "## S\nshared keyword apple here too",
+      "page-c": "## S\nshared keyword apple again",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    for (const k of [1, 2, 5]) {
+      expect(needle.queryScored("apple", k).map(strip)).toEqual(
+        needle.query("apple", k),
+      );
+    }
+  });
+
+  test("top score is positive and discriminates between hits", async () => {
+    const idx = await index({
+      "page-a":
+        "## Intro\ngeneral background prose\n\n## Details\nthe elephant appears only here",
+      "topic-x": "## Notes\nunrelated material about gardens",
+    });
+
+    const needle = buildSectionNeedle(idx);
+    const hits = needle.queryScored("elephant", 5);
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0]!.score).toBeGreaterThan(0);
+    if (hits.length >= 2) {
+      expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+    }
+  });
+
+  test("empty for no match and for k <= 0", async () => {
+    const idx = await index({ "page-a": "## S\nshared keyword apple here" });
+    const needle = buildSectionNeedle(idx);
+
+    expect(needle.queryScored("zzzznomatch", 5)).toEqual([]);
+    expect(needle.queryScored("apple", 0)).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-needle.ts
@@ -25,6 +25,14 @@ const HEAD_WEIGHT = 2.5;
 /** `body`-field weight in the BM25F term-frequency blend. */
 const BODY_WEIGHT = 1;
 
+/** A scored section-needle hit: the article, its best-scoring section index
+ *  (into `SectionIndex.sections`), and that section's raw BM25F score. */
+export interface SectionNeedleScoredHit {
+  article: Slug;
+  section: number;
+  score: number;
+}
+
 export interface SectionNeedle {
   /**
    * Returns up to `k` distinct articles ranked by BM25F score (descending),
@@ -32,6 +40,11 @@ export interface SectionNeedle {
    * `SectionIndex.sections`). Ties break by `(article, ordinal)`.
    */
   query(text: string, k: number): { article: Slug; section: number }[];
+  /**
+   * Like {@link query} but includes the raw BM25F score per hit, in the same
+   * rank order (score desc, then (article, ordinal) asc).
+   */
+  queryScored(text: string, k: number): SectionNeedleScoredHit[];
   /**
    * Highest-scoring section index (into `SectionIndex.sections`) for `article`
    * against `queryText`. Returns the article's first section index when no term
@@ -164,10 +177,7 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return sa.article.localeCompare(sc.article) || sa.ordinal - sc.ordinal;
   }
 
-  function query(
-    text: string,
-    k: number,
-  ): { article: Slug; section: number }[] {
+  function queryScored(text: string, k: number): SectionNeedleScoredHit[] {
     if (k <= 0 || docCount === 0) return [];
 
     const queryTerms = new Set(tokenize(text));
@@ -179,15 +189,25 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     // Dedupe to distinct articles, keeping each article's best (first-ranked)
     // section, until we have `k` articles.
     const seen = new Set<Slug>();
-    const result: { article: Slug; section: number }[] = [];
+    const result: SectionNeedleScoredHit[] = [];
     for (const doc of ranked) {
       const article = sections[doc]!.article;
       if (seen.has(article)) continue;
       seen.add(article);
-      result.push({ article, section: doc });
+      result.push({ article, section: doc, score: scores.get(doc) ?? 0 });
       if (result.length >= k) break;
     }
     return result;
+  }
+
+  function query(
+    text: string,
+    k: number,
+  ): { article: Slug; section: number }[] {
+    return queryScored(text, k).map(({ article, section }) => ({
+      article,
+      section,
+    }));
   }
 
   function bestSection(article: Slug, queryText: string): number {
@@ -211,5 +231,5 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return best;
   }
 
-  return { query, bestSection, idf };
+  return { query, queryScored, bestSection, idf };
 }


### PR DESCRIPTION
## Summary
- Add SectionNeedleScoredHit + queryScored to the section needle, exposing the raw BM25F score per hit
- query() is now a thin score-stripping wrapper over queryScored() (identical results)
- Tests cover descending scores, parity with query(), and empty/k<=0 cases

Part of plan: memory-v3-injection-gate.md (PR 1 of 7)