### PR TITLE
refactor(daemon): extract embedding runtime warm-up into startEmbeddingRuntimeManager()

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -31,6 +31,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-runtime-manager.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { runMemoryStartup } from "../plugins/defaults/memory/startup.js";
@@ -861,30 +862,7 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, "Assistant symlink installation failed — continuing");
   }
 
-  // Download embedding runtime in background (non-blocking).
-  // If download fails, local embeddings gracefully fall back to cloud backends.
-  void (async () => {
-    try {
-      const { EmbeddingRuntimeManager } =
-        await import("../persistence/embeddings/embedding-runtime-manager.js");
-      const runtimeManager = new EmbeddingRuntimeManager();
-      if (!runtimeManager.isReady()) {
-        log.info("Downloading embedding runtime in background...");
-        await runtimeManager.ensureInstalled();
-        // Reset the sticky local-backend failure flag so auto mode retries
-        // local embeddings without evicting a worker that may already be live.
-        const { resetLocalEmbeddingFailureState } =
-          await import("../persistence/embeddings/embedding-backend.js");
-        resetLocalEmbeddingFailureState();
-        log.info("Embedding runtime download complete");
-      }
-    } catch (err) {
-      log.warn(
-        { err },
-        "Embedding runtime download failed — local embeddings will use cloud fallback",
-      );
-    }
-  })();
+  startEmbeddingRuntimeManager();
 
   startWorkspaceHeartbeatService();
 

--- a/assistant/src/persistence/embeddings/embedding-runtime-manager.ts
+++ b/assistant/src/persistence/embeddings/embedding-runtime-manager.ts
@@ -571,3 +571,34 @@ export class EmbeddingRuntimeManager {
     }
   }
 }
+
+/**
+ * Download the local embedding runtime in the background (non-blocking).
+ *
+ * Pre-warms the runtime (bun binary + ONNX worker scripts) so the first local
+ * embed doesn't pay the download cost inline. A no-op when the runtime is
+ * already installed. Failures are swallowed with a warning: local embeddings
+ * fall back to cloud backends, so a failed download must never block or crash
+ * daemon startup. Returns immediately; the download proceeds on its own.
+ */
+export function startEmbeddingRuntimeManager(): void {
+  void (async () => {
+    try {
+      const runtimeManager = new EmbeddingRuntimeManager();
+      if (runtimeManager.isReady()) return;
+      log.info("Downloading embedding runtime in background...");
+      await runtimeManager.ensureInstalled();
+      // Reset the sticky local-backend failure flag so auto mode retries
+      // local embeddings without evicting a worker that may already be live.
+      const { resetLocalEmbeddingFailureState } =
+        await import("./embedding-backend.js");
+      resetLocalEmbeddingFailureState();
+      log.info("Embedding runtime download complete");
+    } catch (err) {
+      log.warn(
+        { err },
+        "Embedding runtime download failed — local embeddings will use cloud fallback",
+      );
+    }
+  })();
+}


### PR DESCRIPTION
## Why

`lifecycle.ts` is being pared down to a flat sequence of `startX()` calls, one per subsystem. The embedding-runtime warm-up was the odd one out — an inline ~24-line `void (async () => { ... })()` IIFE with two dynamic imports sitting between the other starters. This moves it behind a named starter so the daemon startup reads uniformly (`startEmbeddingRuntimeManager()` next to `startWorkspaceHeartbeatService()`, `startHeartbeatService()`, etc.).

## What

- Add `startEmbeddingRuntimeManager()` to `persistence/embeddings/embedding-runtime-manager.ts`, colocated with the `EmbeddingRuntimeManager` class it drives (same pattern as `startWorkspaceHeartbeatService` living in `workspace/heartbeat-service.ts`).
- Replace the inline block in `lifecycle.ts` with a single `startEmbeddingRuntimeManager();` call plus a static import.

## Behavior

Unchanged. Still:
- **Non-blocking** — fires and returns immediately; the download proceeds on its own.
- **No-op when already installed** (`isReady()` guard).
- **Swallows failures** with a warning — a failed download never blocks or crashes startup; local embeddings fall back to cloud backends. On platform-hosted (managed-proxy Gemini), the local backend is never selected, so this stays a cheap no-op.
- Still resets the sticky local-backend failure flag after a successful install.

## Notes

The `resetLocalEmbeddingFailureState` import stays dynamic (only needed after a successful download), mirroring the original. `EmbeddingRuntimeManager` is now referenced directly since the starter lives in the same module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_