### PR TITLE
feat(memory-v3): pure injection-gate score check (checkV3Gate)

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DenseHitScored } from "../dense.js";
+import {
+  checkV3Gate,
+  DEFAULT_BM25_NORM_K,
+  type V3GateConfig,
+} from "../gate.js";
+import type { SectionNeedleScoredHit } from "../section-needle.js";
+
+/** Schema tuning defaults (memory.v3.gate) plus the effective `enabled` flag. */
+function baseConfig(overrides: Partial<V3GateConfig> = {}): V3GateConfig {
+  return {
+    enabled: true,
+    denseThreshold: 0.52,
+    sparseThreshold: 0.35,
+    sparseOnlyThreshold: 0.45,
+    denseClusterThreshold: 0.47,
+    denseClusterMaxDelta: 0.04,
+    topK: 5,
+    bm25NormK: null,
+    bypassForCore: false,
+    ...overrides,
+  };
+}
+
+let articleSeq = 0;
+function mkNeedle(score: number, article?: string): SectionNeedleScoredHit {
+  return { article: article ?? `needle-${articleSeq++}`, section: 0, score };
+}
+function mkDense(score: number, article?: string): DenseHitScored {
+  return { article: article ?? `dense-${articleSeq++}`, section: 0, score };
+}
+
+describe("checkV3Gate", () => {
+  test("dense_pass: top-1 dense clears the dense threshold", () => {
+    const result = checkV3Gate({
+      needleHits: [],
+      denseHits: [mkDense(0.6), mkDense(0.3)],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("dense_pass");
+    expect(result.topDenseScore).toBe(0.6);
+  });
+
+  test("dense_cluster: borderline top-3 dense cluster passes", () => {
+    const result = checkV3Gate({
+      needleHits: [],
+      denseHits: [mkDense(0.5), mkDense(0.48), mkDense(0.47)],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("dense_cluster");
+    // Top-1 is below denseThreshold, so this is a cluster pass, not a dense pass.
+    expect(result.topDenseScore).toBe(0.5);
+  });
+
+  test("sparse_only_strong: dense fails but normalized BM25F clears the high bar", () => {
+    const result = checkV3Gate({
+      needleHits: [mkNeedle(9)], // norm = 9 / (9 + 9) = 0.5 >= 0.45
+      denseHits: [mkDense(0.3), mkDense(0.25)],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("sparse_only_strong");
+    expect(result.topSparseScore).toBe(9);
+    expect(result.topNormSparseScore).toBeCloseTo(0.5, 10);
+  });
+
+  test("fail_dense_below_and_sparse_weak: sparse passes the floor but not the sparse-only bar", () => {
+    const result = checkV3Gate({
+      needleHits: [mkNeedle(5.52)], // norm = 5.52 / 14.52 ≈ 0.380 (≥ 0.35, < 0.45)
+      denseHits: [mkDense(0.3)],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("fail_dense_below_and_sparse_weak");
+    expect(result.topNormSparseScore!).toBeGreaterThanOrEqual(0.35);
+    expect(result.topNormSparseScore!).toBeLessThan(0.45);
+  });
+
+  test("fail_no_signal: dense below and sparse essentially nil", () => {
+    const result = checkV3Gate({
+      needleHits: [mkNeedle(0.1)], // norm ≈ 0.011
+      denseHits: [mkDense(0.3)],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("fail_no_signal");
+  });
+
+  test("hard floor: raw BM25F of 0 never opens the sparse lane even with thresholds at 0", () => {
+    const result = checkV3Gate({
+      needleHits: [mkNeedle(0)],
+      denseHits: [mkDense(0.1)],
+      config: baseConfig({ sparseThreshold: 0, sparseOnlyThreshold: 0 }),
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("fail_no_signal");
+    // Raw 0 is recorded (not null), and its normalized form is exactly 0.
+    expect(result.topSparseScore).toBe(0);
+    expect(result.topNormSparseScore).toBe(0);
+  });
+
+  test("disabled: enabled=false short-circuits to a pass with empty score fields", () => {
+    const result = checkV3Gate({
+      needleHits: [mkNeedle(9)],
+      denseHits: [mkDense(0.9)],
+      config: baseConfig({ enabled: false }),
+    });
+    expect(result).toEqual({
+      pass: true,
+      reason: "disabled",
+      topDenseScore: null,
+      topSparseScore: null,
+      topNormSparseScore: null,
+      denseScores: [],
+      sparseScores: [],
+      checkedArticles: 0,
+    });
+  });
+
+  test("empty hits: no signal at all", () => {
+    const result = checkV3Gate({
+      needleHits: [],
+      denseHits: [],
+      config: baseConfig(),
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("fail_no_signal");
+    expect(result.topDenseScore).toBeNull();
+    expect(result.topSparseScore).toBeNull();
+    expect(result.topNormSparseScore).toBeNull();
+    expect(result.denseScores).toEqual([]);
+    expect(result.sparseScores).toEqual([]);
+    expect(result.checkedArticles).toBe(0);
+  });
+
+  test("bm25NormK override changes the normalized sparse score for the same raw score", () => {
+    const params = {
+      needleHits: [mkNeedle(9)],
+      denseHits: [mkDense(0.3)],
+    };
+    const withDefault = checkV3Gate({
+      ...params,
+      config: baseConfig({ bm25NormK: null }),
+    });
+    const withOverride = checkV3Gate({
+      ...params,
+      config: baseConfig({ bm25NormK: 1 }),
+    });
+    // null -> DEFAULT_BM25_NORM_K (9): 9 / 18 = 0.5
+    expect(withDefault.topNormSparseScore).toBeCloseTo(
+      9 / (9 + DEFAULT_BM25_NORM_K),
+      10,
+    );
+    // override 1: 9 / 10 = 0.9
+    expect(withOverride.topNormSparseScore).toBeCloseTo(0.9, 10);
+    expect(withOverride.topNormSparseScore).not.toBeCloseTo(
+      withDefault.topNormSparseScore!,
+      6,
+    );
+  });
+
+  test("purity: bypassForCore is not read by checkV3Gate", () => {
+    const params = {
+      needleHits: [mkNeedle(9, "a")],
+      denseHits: [mkDense(0.6, "b")],
+    };
+    const off = checkV3Gate({
+      ...params,
+      config: baseConfig({ bypassForCore: false }),
+    });
+    const on = checkV3Gate({
+      ...params,
+      config: baseConfig({ bypassForCore: true }),
+    });
+    expect(on).toEqual(off);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/gate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/gate.ts
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------------
+// Memory v3 — per-turn injection gate (pure score check)
+// ---------------------------------------------------------------------------
+//
+// Decides whether the finder-lane retrieval scores clear the injection
+// thresholds for this turn. Three ways to pass:
+//   - dense_pass:        top-1 dense cosine clears `denseThreshold`.
+//   - dense_cluster:     dense top-1 falls short but the whole top-3 dense
+//                        cluster sits above `denseClusterThreshold` within a
+//                        tight `denseClusterMaxDelta` spread (a coherent-but-
+//                        borderline neighbourhood).
+//   - sparse_only_strong: dense fails outright but normalized top-1 BM25F clears
+//                        the higher `sparseOnlyThreshold` bar.
+//
+// A zero-overlap hard floor keeps sparse signal honest: a raw BM25F of `0` means
+// no query term matched any section, so the sparse lane can never open the gate
+// regardless of how the thresholds are tuned.
+//
+// This module is intentionally PURE — no async, no I/O, no logging, and no
+// imports beyond the two scored-hit types. `observeTurn` (a later PR) wires the
+// feature flag into `config.enabled` and feeds in the finder-lane hits.
+
+import type { DenseHitScored } from "./dense.js";
+import type { SectionNeedleScoredHit } from "./section-needle.js";
+
+/** BM25F normalization constant when config.bm25NormK is null.
+ *  TODO(memory-v3): replace with per-corpus auto-calibration. */
+export const DEFAULT_BM25_NORM_K = 9.0;
+
+export type V3GateReason =
+  | "dense_pass"
+  | "dense_cluster"
+  | "sparse_only_strong"
+  | "fail_no_signal"
+  | "fail_dense_below_and_sparse_weak"
+  | "disabled";
+
+export interface V3GateConfig {
+  enabled: boolean; // effective enable — set from the feature flag in observeTurn
+  denseThreshold: number;
+  sparseThreshold: number;
+  sparseOnlyThreshold: number;
+  denseClusterThreshold: number;
+  denseClusterMaxDelta: number;
+  topK: number;
+  bm25NormK: number | null;
+  bypassForCore: boolean; // consumed by orchestrate, not by checkV3Gate
+}
+
+export interface V3GateResult {
+  pass: boolean;
+  reason: V3GateReason;
+  topDenseScore: number | null;
+  topSparseScore: number | null; // raw BM25F
+  topNormSparseScore: number | null; // normalized BM25F
+  denseScores: number[]; // top-K cosine, desc
+  sparseScores: number[]; // top-K raw BM25F, desc
+  checkedArticles: number;
+}
+
+export interface V3CheckGateParams {
+  needleHits: SectionNeedleScoredHit[];
+  denseHits: DenseHitScored[];
+  config: V3GateConfig;
+}
+
+/**
+ * Pure injection-gate score check. Given the finder-lane hits and the gate
+ * tuning, decides whether retrieval is confident enough to run the selector.
+ *
+ * `config.bypassForCore` is intentionally NOT read here: whether a closed gate
+ * skips entirely versus selecting only the stable core prefix is an
+ * orchestrate-level decision, not part of the score check.
+ */
+export function checkV3Gate(params: V3CheckGateParams): V3GateResult {
+  const { needleHits, denseHits, config } = params;
+
+  if (!config.enabled) {
+    return {
+      pass: true,
+      reason: "disabled",
+      topDenseScore: null,
+      topSparseScore: null,
+      topNormSparseScore: null,
+      denseScores: [],
+      sparseScores: [],
+      checkedArticles: 0,
+    };
+  }
+
+  const k = Math.max(1, config.topK);
+  const denseScores = denseHits
+    .map((h) => h.score)
+    .sort((a, b) => b - a)
+    .slice(0, k);
+  const sparseScores = needleHits
+    .map((h) => h.score)
+    .sort((a, b) => b - a)
+    .slice(0, k);
+
+  const topDense = denseScores[0] ?? null;
+  const topSparseRaw = sparseScores[0] ?? null;
+
+  const normK = config.bm25NormK ?? DEFAULT_BM25_NORM_K;
+  const topNorm =
+    topSparseRaw === null ? null : topSparseRaw / (topSparseRaw + normK);
+
+  const checkedArticles = new Set(
+    [...denseHits, ...needleHits].map((h) => h.article),
+  ).size;
+
+  const densePass = topDense !== null && topDense >= config.denseThreshold;
+
+  const top3 = denseScores.slice(0, 3);
+  const denseCluster =
+    !densePass &&
+    top3.length === 3 &&
+    top3.every((s) => s >= config.denseClusterThreshold) &&
+    top3[0]! - top3[2]! <= config.denseClusterMaxDelta;
+
+  // Hard floor: a raw BM25F of 0 means no query term matched any section, so the
+  // sparse lane is treated as carrying no usable signal no matter the thresholds.
+  const sparseUsable = topSparseRaw !== null && topSparseRaw > 0;
+  const normSparse = sparseUsable ? topNorm! : 0;
+
+  const sparsePass = sparseUsable && normSparse >= config.sparseThreshold;
+  const sparseOnlyStrong =
+    !(densePass || denseCluster) &&
+    sparseUsable &&
+    normSparse >= config.sparseOnlyThreshold;
+
+  const pass = densePass || denseCluster || sparseOnlyStrong;
+
+  let reason: V3GateReason;
+  if (densePass) {
+    reason = "dense_pass";
+  } else if (denseCluster) {
+    reason = "dense_cluster";
+  } else if (sparseOnlyStrong) {
+    reason = "sparse_only_strong";
+  } else if (sparsePass) {
+    reason = "fail_dense_below_and_sparse_weak";
+  } else {
+    reason = "fail_no_signal";
+  }
+
+  return {
+    pass,
+    reason,
+    topDenseScore: topDense,
+    topSparseScore: topSparseRaw,
+    topNormSparseScore: topNorm, // null only when no sparse hits; 0 when raw is 0
+    denseScores,
+    sparseScores,
+    checkedArticles,
+  };
+}


### PR DESCRIPTION
## Summary
- Add gate.ts: pure checkV3Gate() deciding whether finder-lane scores clear the injection thresholds (dense pass / dense cluster / sparse-only-strong, with a zero-overlap hard floor)
- V3GateConfig keeps enabled (set from the feature flag in observeTurn); thresholds come from memory.v3.gate
- 10 unit tests covering every pass/fail reason, disabled, empty, normK override, and purity

Part of plan: memory-v3-injection-gate.md (PR 5 of 7)