### PR TITLE
feat(subagent): persist + rehydrate subagent records across restart

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27020,6 +27020,7 @@ paths:
                       - completed
                       - failed
                       - aborted
+                      - interrupted
                   usage:
                     type: object
                     properties:

--- a/assistant/src/__tests__/subagent-persistence.test.ts
+++ b/assistant/src/__tests__/subagent-persistence.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { resetTestTables } from "../persistence/raw-query.js";
+import {
+  deleteSubagentRecord,
+  loadAllSubagentRecords,
+  type SubagentRecord,
+  upsertSubagentRecord,
+} from "../persistence/subagent-store.js";
+import { SubagentManager } from "../subagent/manager.js";
+
+function record(over: Partial<SubagentRecord> = {}): SubagentRecord {
+  return {
+    id: "s1",
+    parentConversationId: "parent-1",
+    conversationId: "conv-1",
+    label: "research-pricing",
+    objective: "Research competitor pricing",
+    role: "researcher",
+    isFork: false,
+    sendResultToUser: true,
+    status: "running",
+    error: null,
+    createdAt: 1000,
+    startedAt: 1001,
+    completedAt: null,
+    inputTokens: 5,
+    outputTokens: 7,
+    estimatedCost: 0.01,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Idempotent; the table may already exist from a prior run.
+  migrateCreateSubagentsTable();
+  resetTestTables("subagents");
+});
+
+describe("subagent-store", () => {
+  test("round-trips a record, mapping booleans and nullable fields", () => {
+    upsertSubagentRecord(
+      record({ isFork: true, sendResultToUser: null, error: null }),
+    );
+
+    const rows = loadAllSubagentRecords();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "s1",
+      isFork: true,
+      sendResultToUser: null,
+      role: "researcher",
+      status: "running",
+      inputTokens: 5,
+    });
+  });
+
+  test("upsert refreshes mutable lifecycle fields on conflict", () => {
+    upsertSubagentRecord(record({ status: "running" }));
+    upsertSubagentRecord(
+      record({ status: "completed", completedAt: 2000, outputTokens: 99 }),
+    );
+
+    const rows = loadAllSubagentRecords();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("completed");
+    expect(rows[0].completedAt).toBe(2000);
+    expect(rows[0].outputTokens).toBe(99);
+  });
+
+  test("delete removes the record", () => {
+    upsertSubagentRecord(record());
+    deleteSubagentRecord("s1");
+    expect(loadAllSubagentRecords()).toHaveLength(0);
+  });
+});
+
+describe("SubagentManager.rehydrateFromDb", () => {
+  test("marks in-flight subagents interrupted and loads terminal ones as-is", () => {
+    upsertSubagentRecord(
+      record({ id: "running-1", label: "still-running", status: "running" }),
+    );
+    upsertSubagentRecord(
+      record({
+        id: "done-1",
+        label: "finished",
+        status: "completed",
+        completedAt: 2000,
+      }),
+    );
+
+    const mgr = new SubagentManager();
+    const { rehydrated, interrupted } = mgr.rehydrateFromDb();
+
+    expect(rehydrated).toBe(2);
+    expect(interrupted).toBe(1);
+
+    // In-flight → interrupted (not auto-resumed); terminal loads unchanged.
+    expect(mgr.getState("running-1")?.status).toBe("interrupted");
+    expect(mgr.getState("done-1")?.status).toBe("completed");
+
+    // Reachable by label and parent, like a live subagent.
+    expect(mgr.getByLabel("still-running", "parent-1")?.config.id).toBe(
+      "running-1",
+    );
+    expect(mgr.getChildrenOf("parent-1")).toHaveLength(2);
+
+    // The interrupted transition is persisted, so a second rehydrate is a no-op.
+    expect(
+      loadAllSubagentRecords().find((r) => r.id === "running-1")?.status,
+    ).toBe("interrupted");
+
+    mgr.disposeAll();
+  });
+
+  test("returns zero counts when there are no persisted records", () => {
+    const mgr = new SubagentManager();
+    expect(mgr.rehydrateFromDb()).toEqual({ rehydrated: 0, interrupted: 0 });
+    mgr.disposeAll();
+  });
+});

--- a/assistant/src/api/events/subagent-status-changed.ts
+++ b/assistant/src/api/events/subagent-status-changed.ts
@@ -22,7 +22,9 @@ import { z } from "zod";
 /**
  * Subagent lifecycle status. Mirrors `SubagentStatus` in
  * `assistant/src/subagent/types.ts`. `aborted` is a terminal state
- * reached via explicit `subagent_abort` request.
+ * reached via explicit `subagent_abort` request; `interrupted` is a
+ * terminal state assigned on daemon restart to a subagent that was
+ * still in flight (it is not auto-resumed).
  */
 export const SubagentStatusSchema = z.enum([
   "pending",
@@ -31,6 +33,7 @@ export const SubagentStatusSchema = z.enum([
   "completed",
   "failed",
   "aborted",
+  "interrupted",
 ]);
 
 export type SubagentStatus = z.infer<typeof SubagentStatusSchema>;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -48,6 +48,7 @@ import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streamin
 import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { getSubagentManager } from "../subagent/index.js";
 import { startUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
@@ -641,6 +642,23 @@ export async function runDaemon(): Promise<void> {
       { err },
       "Workflow run reconciliation failed — continuing startup",
     );
+  }
+
+  // Rehydrate subagent records persisted by a prior run: load terminal
+  // subagents so `subagent_read`/`getState` keep working post-restart, and mark
+  // any that were still in flight when the process died as `interrupted` (we do
+  // not auto-resume). Mirrors the workflow-run reconciliation above; never
+  // blocks startup, and runs before the scheduler so no new spawn races it.
+  try {
+    const { rehydrated, interrupted } = getSubagentManager().rehydrateFromDb();
+    if (rehydrated > 0) {
+      log.info(
+        { rehydrated, interrupted },
+        "Rehydrated subagent records from a prior run",
+      );
+    }
+  } catch (err) {
+    log.error({ err }, "Subagent rehydration failed — continuing startup");
   }
 
   startScheduler();

--- a/assistant/src/persistence/migrations/311-create-subagents-table.ts
+++ b/assistant/src/persistence/migrations/311-create-subagents-table.ts
@@ -1,0 +1,50 @@
+import { getSqlite } from "../db-connection.js";
+
+/**
+ * Creates the `subagents` table: durable lifecycle records for subagents
+ * spawned by `SubagentManager`.
+ *
+ * Subagents run as background child conversations whose rows already persist
+ * via `bootstrapConversation`, but the manager-only fields (parent link,
+ * label, objective, role, fork flag, status, timestamps, usage) live only in
+ * the manager's in-memory maps and are lost on restart. This table persists
+ * them so a restart can rehydrate completed subagents (their output is read
+ * from the child conversation's messages) and mark any that were still in
+ * flight as `interrupted` rather than silently orphaning them.
+ *
+ * Rows are written on spawn and on every status transition, and deleted when
+ * the manager disposes the subagent during normal operation (TTL sweep or
+ * parent eviction) — never on shutdown, so in-flight rows survive the restart.
+ *
+ * Idempotent (`IF NOT EXISTS`). No backfill — pre-existing subagents predate
+ * the table and were already only in-memory.
+ */
+export function migrateCreateSubagentsTable(): void {
+  const raw = getSqlite();
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS subagents (
+      id                     TEXT PRIMARY KEY,
+      parent_conversation_id TEXT NOT NULL,
+      conversation_id        TEXT NOT NULL,
+      label                  TEXT NOT NULL,
+      objective              TEXT NOT NULL,
+      role                   TEXT NOT NULL DEFAULT 'general',
+      is_fork                INTEGER NOT NULL DEFAULT 0,
+      send_result_to_user    INTEGER,
+      status                 TEXT NOT NULL DEFAULT 'pending',
+      error                  TEXT,
+      created_at             INTEGER NOT NULL,
+      started_at             INTEGER,
+      completed_at           INTEGER,
+      input_tokens           INTEGER NOT NULL DEFAULT 0,
+      output_tokens          INTEGER NOT NULL DEFAULT 0,
+      estimated_cost         REAL NOT NULL DEFAULT 0
+    )
+  `);
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_subagents_parent_conversation_id ON subagents(parent_conversation_id)`,
+  );
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_subagents_status ON subagents(status)`,
+  );
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -418,6 +418,7 @@ import { migrateAcpSessionHistoryUsageColumns } from "./migrations/307-acp-sessi
 import { migrateAcpSessionHistoryTokenColumns } from "./migrations/308-acp-session-history-token-columns.js";
 import { migrateDropRedundantIndexes } from "./migrations/309-drop-redundant-indexes.js";
 import { migrateLlmRequestLogLatencyBreakdown } from "./migrations/310-llm-request-log-latency-breakdown.js";
+import { migrateCreateSubagentsTable } from "./migrations/311-create-subagents-table.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1307,4 +1308,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryTokenColumns,
   migrateDropRedundantIndexes,
   migrateLlmRequestLogLatencyBreakdown,
+  migrateCreateSubagentsTable,
 ];

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -1,0 +1,122 @@
+/**
+ * Persistence for subagent lifecycle records (the `subagents` table, created by
+ * migration 311).
+ *
+ * This module owns only the durable row shape and raw SQL. The mapping to and
+ * from the manager's `SubagentState` lives in `SubagentManager`, keeping this
+ * layer decoupled from the subagent domain types.
+ */
+
+import { rawAll, rawRun } from "./raw-query.js";
+
+/** A durable subagent lifecycle record (camelCase mirror of the row). */
+export interface SubagentRecord {
+  id: string;
+  parentConversationId: string;
+  conversationId: string;
+  label: string;
+  objective: string;
+  role: string;
+  isFork: boolean;
+  /** Tri-state: null when the spawner left it unset. */
+  sendResultToUser: boolean | null;
+  status: string;
+  error: string | null;
+  createdAt: number;
+  startedAt: number | null;
+  completedAt: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+}
+
+/** Raw row shape (snake_case, SQLite stores booleans as 0/1). */
+interface SubagentRow {
+  id: string;
+  parent_conversation_id: string;
+  conversation_id: string;
+  label: string;
+  objective: string;
+  role: string;
+  is_fork: number;
+  send_result_to_user: number | null;
+  status: string;
+  error: string | null;
+  created_at: number;
+  started_at: number | null;
+  completed_at: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  estimated_cost: number;
+}
+
+function rowToRecord(r: SubagentRow): SubagentRecord {
+  return {
+    id: r.id,
+    parentConversationId: r.parent_conversation_id,
+    conversationId: r.conversation_id,
+    label: r.label,
+    objective: r.objective,
+    role: r.role,
+    isFork: r.is_fork === 1,
+    sendResultToUser:
+      r.send_result_to_user == null ? null : r.send_result_to_user === 1,
+    status: r.status,
+    error: r.error,
+    createdAt: r.created_at,
+    startedAt: r.started_at,
+    completedAt: r.completed_at,
+    inputTokens: r.input_tokens,
+    outputTokens: r.output_tokens,
+    estimatedCost: r.estimated_cost,
+  };
+}
+
+/**
+ * Insert or update a subagent record. Called on spawn and on every status
+ * transition; the conflict clause refreshes the mutable lifecycle fields while
+ * the immutable identity/config columns stay as first written.
+ */
+export function upsertSubagentRecord(rec: SubagentRecord): void {
+  rawRun(
+    `INSERT INTO subagents (
+       id, parent_conversation_id, conversation_id, label, objective, role,
+       is_fork, send_result_to_user, status, error, created_at, started_at,
+       completed_at, input_tokens, output_tokens, estimated_cost
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       status = excluded.status,
+       error = excluded.error,
+       started_at = excluded.started_at,
+       completed_at = excluded.completed_at,
+       input_tokens = excluded.input_tokens,
+       output_tokens = excluded.output_tokens,
+       estimated_cost = excluded.estimated_cost`,
+    rec.id,
+    rec.parentConversationId,
+    rec.conversationId,
+    rec.label,
+    rec.objective,
+    rec.role,
+    rec.isFork ? 1 : 0,
+    rec.sendResultToUser == null ? null : rec.sendResultToUser ? 1 : 0,
+    rec.status,
+    rec.error,
+    rec.createdAt,
+    rec.startedAt,
+    rec.completedAt,
+    rec.inputTokens,
+    rec.outputTokens,
+    rec.estimatedCost,
+  );
+}
+
+/** Load every persisted subagent record. Used once at startup to rehydrate. */
+export function loadAllSubagentRecords(): SubagentRecord[] {
+  return rawAll<SubagentRow>(`SELECT * FROM subagents`).map(rowToRecord);
+}
+
+/** Delete a subagent record once the manager is fully done with it. */
+export function deleteSubagentRecord(id: string): void {
+  rawRun(`DELETE FROM subagents WHERE id = ?`, id);
+}

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -931,8 +931,12 @@ export class SubagentManager {
   }
 
   /**
-   * Update the parent sender for all active children of a conversation.
-   * Called when the parent client reconnects to a new socket.
+   * Update the parent sender for all active children of a conversation and
+   * re-emit each child's current status to it. Called when the parent client
+   * reconnects to a new socket, so a reconnecting client resyncs any status it
+   * missed while disconnected (e.g. a subagent marked `interrupted` during
+   * rehydration after a daemon restart, whose card would otherwise stay stuck
+   * on a stale `running`).
    */
   updateParentSender(
     parentConversationId: string,
@@ -943,9 +947,19 @@ export class SubagentManager {
 
     for (const childId of children) {
       const managed = this.subagents.get(childId);
-      if (managed && !TERMINAL_STATUSES.has(managed.state.status)) {
+      if (!managed) continue;
+      if (!TERMINAL_STATUSES.has(managed.state.status)) {
         managed.parentSendToClient = newSendToClient;
       }
+      // Re-emit the current status so the reconnecting client corrects any card
+      // it left in a stale state while disconnected.
+      newSendToClient({
+        type: "subagent_status_changed",
+        subagentId: childId,
+        status: managed.state.status,
+        error: managed.state.error,
+        usage: managed.state.usage,
+      } as ServerMessage);
     }
   }
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -614,8 +614,11 @@ export class SubagentManager {
     // Read the current parent sender so reconnects are picked up.
     const getSender = () => managed.parentSendToClient;
 
-    this.setStatus(subagentId, "running", getSender());
+    // Stamp startedAt before the status transition so the persistence hook
+    // inside setStatus captures it on the running row (otherwise a crash mid-run
+    // rehydrates as interrupted with no start time).
     managed.state.startedAt = Date.now();
+    this.setStatus(subagentId, "running", getSender());
 
     try {
       // For forks, inject the parent's message history before the first message.

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -20,6 +20,11 @@ import {
 } from "../daemon/conversation-registry.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
+import {
+  deleteSubagentRecord,
+  loadAllSubagentRecords,
+  upsertSubagentRecord,
+} from "../persistence/subagent-store.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import { resolveDefaultProvider } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
@@ -189,6 +194,13 @@ export class SubagentManager {
   private parentToChildren = new Map<string, Set<string>>();
   /** `${parentConversationId}:${normalizedLabel}` → subagentId */
   private labelIndex = new Map<string, string>();
+
+  /**
+   * Set during `disposeAll()` (shutdown) so `dispose()` keeps the durable rows
+   * instead of deleting them — an in-flight subagent must survive as a row to
+   * be rehydrated as `interrupted` on the next boot.
+   */
+  private shuttingDown = false;
 
   /**
    * Cross-conversation rate-limit window. The conversation store reads this
@@ -484,6 +496,9 @@ export class SubagentManager {
       this.parentToChildren.set(config.parentConversationId, new Set());
     }
     this.parentToChildren.get(config.parentConversationId)!.add(subagentId);
+
+    // Persist the initial record so the subagent survives a daemon restart.
+    this.persistState(managed.state);
 
     // Notify client that a subagent was spawned.
     parentSendToClient({
@@ -805,6 +820,7 @@ export class SubagentManager {
       }
     } else {
       managed.state.status = "aborted";
+      this.persistState(managed.state);
     }
 
     log.info({ subagentId }, "Subagent aborted");
@@ -981,6 +997,17 @@ export class SubagentManager {
     }
     this.subagents.delete(subagentId);
 
+    // Drop the durable record too — but only during normal operation. On
+    // shutdown we keep rows so a subagent that was in flight can rehydrate as
+    // `interrupted` on the next boot.
+    if (!this.shuttingDown) {
+      try {
+        deleteSubagentRecord(subagentId);
+      } catch (err) {
+        log.warn({ subagentId, err }, "Failed to delete subagent record");
+      }
+    }
+
     // Remove from label index only if it still maps to this subagent
     // (guards against stale delete when a newer subagent reused the label).
     const label = managed.state.config.label;
@@ -1003,10 +1030,120 @@ export class SubagentManager {
 
   /** Dispose all subagents. Called on daemon shutdown. */
   disposeAll(): void {
+    // Mark shutdown so dispose() keeps the durable rows: an in-flight subagent
+    // must survive as a row to be rehydrated as `interrupted` on the next boot.
+    this.shuttingDown = true;
     this.stopSweep();
     for (const id of [...this.subagents.keys()]) {
       this.dispose(id);
     }
+  }
+
+  // ── Persistence / rehydration ─────────────────────────────────────────
+
+  /**
+   * Write the subagent's current state to the durable `subagents` table.
+   * Best-effort: persistence failures are logged, never thrown — a background
+   * subagent must not fail because its bookkeeping row could not be written.
+   */
+  private persistState(state: SubagentState): void {
+    try {
+      upsertSubagentRecord({
+        id: state.config.id,
+        parentConversationId: state.config.parentConversationId,
+        conversationId: state.conversationId,
+        label: state.config.label,
+        objective: state.config.objective,
+        role: state.config.role ?? "general",
+        isFork: state.isFork,
+        sendResultToUser: state.config.sendResultToUser ?? null,
+        status: state.status,
+        error: state.error ?? null,
+        createdAt: state.createdAt,
+        startedAt: state.startedAt ?? null,
+        completedAt: state.completedAt ?? null,
+        inputTokens: state.usage.inputTokens,
+        outputTokens: state.usage.outputTokens,
+        estimatedCost: state.usage.estimatedCost,
+      });
+    } catch (err) {
+      log.warn(
+        { subagentId: state.config.id, err },
+        "Failed to persist subagent record",
+      );
+    }
+  }
+
+  /**
+   * Rebuild in-memory subagent metadata from the durable table after a restart.
+   * Terminal records load as-is so `subagent_read`/`getState` keep working
+   * (output is read from the child conversation's persisted messages). Records
+   * still in flight when the process died are marked `interrupted` — the run is
+   * not resumed; the parent decides whether to re-spawn. Rehydrated entries
+   * carry a no-op sender and no live conversation, and are swept on the normal
+   * TTL like any other terminal subagent.
+   *
+   * Best-effort and idempotent: a second restart re-reads `interrupted` rows
+   * and leaves them unchanged.
+   */
+  rehydrateFromDb(): { rehydrated: number; interrupted: number } {
+    const records = loadAllSubagentRecords();
+    let interrupted = 0;
+    const now = Date.now();
+    for (const rec of records) {
+      const wasInFlight = !TERMINAL_STATUSES.has(rec.status as SubagentStatus);
+      const status: SubagentStatus = wasInFlight
+        ? "interrupted"
+        : (rec.status as SubagentStatus);
+      if (wasInFlight) interrupted++;
+
+      const state: SubagentState = {
+        config: {
+          id: rec.id,
+          parentConversationId: rec.parentConversationId,
+          label: rec.label,
+          objective: rec.objective,
+          role: rec.role as SubagentRole,
+          fork: rec.isFork,
+          ...(rec.sendResultToUser != null
+            ? { sendResultToUser: rec.sendResultToUser }
+            : {}),
+        },
+        status,
+        conversationId: rec.conversationId,
+        isFork: rec.isFork,
+        ...(rec.error != null ? { error: rec.error } : {}),
+        createdAt: rec.createdAt,
+        ...(rec.startedAt != null ? { startedAt: rec.startedAt } : {}),
+        ...(rec.completedAt != null ? { completedAt: rec.completedAt } : {}),
+        usage: {
+          inputTokens: rec.inputTokens,
+          outputTokens: rec.outputTokens,
+          estimatedCost: rec.estimatedCost,
+        },
+      };
+
+      const managed: ManagedSubagent = {
+        conversation: null,
+        state,
+        parentSendToClient: () => {},
+        retainedUntil: now + TERMINAL_RETENTION_MS,
+      };
+      this.subagents.set(rec.id, managed);
+
+      const labelKey = `${rec.parentConversationId}:${rec.label.toLowerCase().trim()}`;
+      this.labelIndex.set(labelKey, rec.id);
+
+      if (!this.parentToChildren.has(rec.parentConversationId)) {
+        this.parentToChildren.set(rec.parentConversationId, new Set());
+      }
+      this.parentToChildren.get(rec.parentConversationId)!.add(rec.id);
+
+      // Persist the interrupted transition so a second restart is a no-op.
+      if (wasInFlight) this.persistState(state);
+    }
+    if (records.length > 0) this.ensureSweepRunning();
+    return { rehydrated: records.length, interrupted };
   }
 
   // ── TTL sweep for terminal metadata ──────────────────────────────────
@@ -1097,6 +1234,9 @@ export class SubagentManager {
       error,
       usage: managed.state.usage,
     } as ServerMessage);
+
+    // Mirror the transition to the durable record.
+    this.persistState(managed.state);
   }
 
   // ── Child → Parent notification ────────────────────────────────────

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -17,11 +17,15 @@ export type SubagentStatus =
   | "awaiting_input"
   | "completed"
   | "failed"
-  | "aborted";
+  | "aborted"
+  // Assigned on daemon restart to a subagent that was still in flight when the
+  // process died. Terminal — the run is not auto-resumed; the parent is left to
+  // decide whether to re-spawn.
+  | "interrupted";
 
 /** Terminal states — once entered, a subagent cannot transition out. */
 export const TERMINAL_STATUSES: ReadonlySet<SubagentStatus> =
-  new Set<SubagentStatus>(["completed", "failed", "aborted"]);
+  new Set<SubagentStatus>(["completed", "failed", "aborted", "interrupted"]);
 
 // ── Config (spawn-time) ─────────────────────────────────────────────────
 

--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -22,6 +22,7 @@ function deriveBadgeState(status: SubagentStatus): BadgeState {
       return "completed";
     case "failed":
     case "aborted":
+    case "interrupted":
       return "errored";
     default:
       return "in-flight";
@@ -36,6 +37,7 @@ const STATUS_ARIA_LABEL: Record<SubagentStatus, string> = {
   completed: "completed",
   failed: "failed",
   aborted: "canceled",
+  interrupted: "interrupted",
 };
 
 export function SubagentAvatarBadge({

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -318,6 +318,7 @@ function deriveCardState(status: SubagentStatus): ToolCallCardData["state"] {
       return "complete";
     case "failed":
     case "aborted":
+    case "interrupted":
       return "error";
     default:
       return "loading";
@@ -574,14 +575,16 @@ function deriveCurrentStep(
   const isTerminal =
     entry.status === "completed" ||
     entry.status === "failed" ||
-    entry.status === "aborted";
+    entry.status === "aborted" ||
+    entry.status === "interrupted";
 
   if (steps.length === 0) {
-    // Branch on the actual terminal status so a subagent that failed or
-    // aborted before emitting any events doesn't read as "Finished".
+    // Branch on the actual terminal status so a subagent that failed, aborted,
+    // or was interrupted before emitting any events doesn't read as "Finished".
     let title: string;
     if (entry.status === "failed") title = "Failed";
     else if (entry.status === "aborted") title = "Aborted";
+    else if (entry.status === "interrupted") title = "Interrupted";
     else if (entry.status === "completed") title = "Finished";
     else title = "Working";
     return {

--- a/clients/web/src/utils/subagent-status.ts
+++ b/clients/web/src/utils/subagent-status.ts
@@ -18,6 +18,7 @@ export function statusColor(status: SubagentStatus): string {
       return "var(--system-positive-strong)";
     case "failed":
     case "aborted":
+    case "interrupted":
       return "var(--system-negative-strong)";
     default:
       return "var(--primary-base)";
@@ -39,6 +40,8 @@ export function statusLabel(status: SubagentStatus): string {
       return "Failed";
     case "aborted":
       return "Aborted";
+    case "interrupted":
+      return "Interrupted";
     default:
       return "Unknown";
   }


### PR DESCRIPTION
## Summary
- Persist subagent lifecycle records to a new `subagents` table (migration 311) on spawn and on every status transition. Rows are deleted when the manager disposes a subagent during normal operation (TTL sweep / parent eviction) but kept on shutdown, so an in-flight subagent survives the restart as a row.
- On daemon startup (before the scheduler), `SubagentManager.rehydrateFromDb()` loads terminal subagents back into memory so `subagent_read`/`getState` keep working post-restart — output is read from the child conversation's persisted messages — and marks any subagent that was still in flight when the process died as `interrupted` (it is **not** auto-resumed; the parent decides whether to re-spawn). Mirrors the existing workflow-run orphan reconciliation.
- Adds an `interrupted` terminal status across the stack: daemon `SubagentStatus` union + `TERMINAL_STATUSES`, the `@vellumai/assistant-api` zod enum + regenerated `openapi.yaml`, and the web status display (color/label/aria/badge).
- Persistence is best-effort (logged, never thrown) so a background subagent never fails on a bookkeeping write.

## Original prompt
P0 durability item from the subagent architecture TDD review. Today all subagent runtime state lives in the manager's in-memory maps, so a daemon restart silently loses in-flight subagents and orphans their conversation rows. This persists a lightweight record per subagent and rehydrates on boot. Per the design decision, in-flight subagents are marked `interrupted` rather than auto-resumed. Validated: assistant tsc clean, subagent test suites green per-file, new `subagent-persistence.test.ts` covers store round-trip + rehydration, web type-checks against the updated API type, OpenAPI spec regenerated.