### PR TITLE
feat(subagent): inline final synthesis into completion notification

### DIFF
--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -177,15 +177,27 @@ describe("Fork completion notifications", () => {
       deduplicated: false,
     });
     managed.conversation!.runAgentLoop = async () => {};
+    // Leave a trailing assistant message so the completion notification inlines
+    // the fork's synthesis (the new behavior) rather than the empty-text path.
+    managed.conversation!.messages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Internal analysis: revenue up 20%." }],
+      },
+    ];
 
     await asInternals(manager).runSubagent(subagentId, "Analyze data");
 
     expect(capturedNotifications).toHaveLength(1);
+    // The synthesis is inlined, and a silent fork is flagged for internal use.
     expect(capturedNotifications[0].message).toContain(
-      "do NOT share raw fork output with the user",
+      "Internal analysis: revenue up 20%.",
     );
     expect(capturedNotifications[0].message).toContain(
-      '[Fork "Analysis fork" completed]',
+      "do not relay the raw fork output to the user",
+    );
+    expect(capturedNotifications[0].message).toContain(
+      '[Fork "Analysis fork" completed — result below]',
     );
 
     asInternals(manager).stopSweep();

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -65,6 +65,23 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).toContain("Keep the result internal.");
   });
 
+  test("keeps the read pointer instead of inlining when a follow-up turn is queued", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "interactive",
+      subagentId: "sa-6",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Snapshot answer (stale).",
+      deferred: true,
+    });
+
+    // The snapshot must NOT be inlined — newer queued output is still coming.
+    expect(msg).not.toContain("Snapshot answer");
+    expect(msg).toContain("Queued follow-up guidance is still being processed");
+    expect(msg).toContain('subagent_read with subagent_id "sa-6"');
+  });
+
   test("failure message surfaces the error and discourages auto-retry", () => {
     const msg = buildSubagentTerminalMessage({
       label: "broken",

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildSubagentTerminalMessage } from "../subagent/manager.js";
+
+describe("buildSubagentTerminalMessage", () => {
+  test("inlines the final synthesis for a shared completed subagent", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "research-pricing",
+      subagentId: "sa-1",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Competitor X charges $20/mo.",
+    });
+
+    expect(msg).toContain("Competitor X charges $20/mo.");
+    expect(msg).toContain("completed — result below");
+    expect(msg).toContain("Incorporate this into your reply");
+    // The whole point: no subagent_read round-trip, nothing left to re-spawn.
+    expect(msg).not.toContain("subagent_read");
+    expect(msg).not.toContain("re-spawn");
+  });
+
+  test("marks a silent completion for internal use only", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "scan",
+      subagentId: "sa-2",
+      isFork: true,
+      outcome: "completed",
+      silent: true,
+      finalText: "Internal findings.",
+    });
+
+    expect(msg).toContain("Internal findings.");
+    expect(msg).toContain("internally");
+    expect(msg).not.toContain("subagent_read");
+  });
+
+  test("falls back to a subagent_read pointer when there is no final text", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "empty-run",
+      subagentId: "sa-3",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "   ",
+    });
+
+    expect(msg).toContain("produced no final text");
+    expect(msg).toContain('subagent_read with subagent_id "sa-3"');
+    expect(msg).not.toContain("last_n");
+  });
+
+  test("fork fallback points at last_n: 1 and keeps it internal", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "empty-fork",
+      subagentId: "sa-4",
+      isFork: true,
+      outcome: "completed",
+      silent: true,
+      finalText: undefined,
+    });
+
+    expect(msg).toContain("last_n: 1");
+    expect(msg).toContain("Keep the result internal.");
+  });
+
+  test("failure message surfaces the error and discourages auto-retry", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "broken",
+      subagentId: "sa-5",
+      isFork: false,
+      outcome: "failed",
+      silent: false,
+      error: "boom",
+    });
+
+    expect(msg).toContain('[Subagent "broken" failed]');
+    expect(msg).toContain("Error: boom");
+    expect(msg).toContain("Do NOT re-spawn or retry");
+  });
+});

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -141,8 +141,19 @@ export function buildSubagentTerminalMessage(opts: {
   silent: boolean;
   finalText?: string;
   error?: string;
+  /** A follow-up turn is still queued, so the current synthesis is a snapshot. */
+  deferred?: boolean;
 }): string {
-  const { label, subagentId, isFork, outcome, silent, finalText, error } = opts;
+  const {
+    label,
+    subagentId,
+    isFork,
+    outcome,
+    silent,
+    finalText,
+    error,
+    deferred,
+  } = opts;
   const prefix = isFork ? "Fork" : "Subagent";
 
   if (outcome === "failed") {
@@ -154,7 +165,7 @@ export function buildSubagentTerminalMessage(opts: {
   }
 
   const trimmed = finalText?.trim() ?? "";
-  if (trimmed) {
+  if (trimmed && !deferred) {
     return (
       `[${prefix} "${label}" completed — result below]\n\n` +
       `${trimmed}\n\n` +
@@ -164,13 +175,16 @@ export function buildSubagentTerminalMessage(opts: {
     );
   }
 
-  // Fallback: the run ended without trailing assistant text, so there is
-  // nothing to inline — point the parent at the persisted output instead.
+  // Read-pointer path: either the run left no trailing assistant text to inline,
+  // or a queued follow-up turn is still draining — so the current synthesis is a
+  // stale snapshot and the parent should read the latest output instead.
   const lastN = isFork ? " and last_n: 1" : "";
+  const reason = deferred
+    ? `Queued follow-up guidance is still being processed`
+    : `The ${prefix.toLowerCase()} produced no final text`;
   return (
     `[${prefix} "${label}" completed]\n\n` +
-    `The ${prefix.toLowerCase()} produced no final text. ` +
-    `Use subagent_read with subagent_id "${subagentId}"${lastN} to inspect its output.` +
+    `${reason}. Use subagent_read with subagent_id "${subagentId}"${lastN} for the latest output.` +
     (silent ? ` Keep the result internal.` : ``)
   );
 }
@@ -1401,6 +1415,9 @@ export class SubagentManager {
       silent,
       finalText,
       error: managed.state.error,
+      // A queued follow-up turn means the snapshot we hold is stale; defer to a
+      // read pointer so the parent picks up the queued turn's output instead.
+      deferred: managed.hadEnqueuedMessages === true,
     });
 
     const notification: SubagentNotificationInfo = {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -122,6 +122,59 @@ function buildSubagentSystemPrompt(
   return sections.join("\n");
 }
 
+/**
+ * Build the message injected into the parent conversation when a subagent
+ * reaches a terminal state.
+ *
+ * For a completed subagent the final synthesis is inlined directly, so the
+ * parent acts on the result without a `subagent_read` round-trip and has
+ * nothing left to re-spawn. The `subagent_read` pointer survives only as a
+ * fallback for the rare run that ends with no trailing assistant text.
+ *
+ * Exported for unit testing.
+ */
+export function buildSubagentTerminalMessage(opts: {
+  label: string;
+  subagentId: string;
+  isFork: boolean;
+  outcome: "completed" | "failed";
+  silent: boolean;
+  finalText?: string;
+  error?: string;
+}): string {
+  const { label, subagentId, isFork, outcome, silent, finalText, error } = opts;
+  const prefix = isFork ? "Fork" : "Subagent";
+
+  if (outcome === "failed") {
+    return (
+      `[${prefix} "${label}" failed]\n\n` +
+      `Error: ${error ?? "Unknown error"}\n` +
+      `Do NOT re-spawn or retry this ${prefix.toLowerCase()} unless the user explicitly asks.`
+    );
+  }
+
+  const trimmed = finalText?.trim() ?? "";
+  if (trimmed) {
+    return (
+      `[${prefix} "${label}" completed — result below]\n\n` +
+      `${trimmed}\n\n` +
+      (silent
+        ? `(Use these findings internally; do not relay the raw ${prefix.toLowerCase()} output to the user.)`
+        : `(Incorporate this into your reply to the user as appropriate.)`)
+    );
+  }
+
+  // Fallback: the run ended without trailing assistant text, so there is
+  // nothing to inline — point the parent at the persisted output instead.
+  const lastN = isFork ? " and last_n: 1" : "";
+  return (
+    `[${prefix} "${label}" completed]\n\n` +
+    `The ${prefix.toLowerCase()} produced no final text. ` +
+    `Use subagent_read with subagent_id "${subagentId}"${lastN} to inspect its output.` +
+    (silent ? ` Keep the result internal.` : ``)
+  );
+}
+
 // ── Manager ─────────────────────────────────────────────────────────────
 
 interface ManagedSubagent {
@@ -687,12 +740,12 @@ export class SubagentManager {
 
         log.info({ subagentId }, "Subagent completed");
 
-        // Notify the parent conversation so the LLM can call subagent_read.
-        // Skipped on the synchronous path — the awaiting caller receives the
-        // final text directly, so re-injecting a "read the result" prompt
-        // would be redundant noise in the parent.
+        // Notify the parent conversation, inlining the subagent's final
+        // synthesis so the LLM acts on the result without a subagent_read
+        // round-trip. Skipped on the synchronous path — the awaiting caller
+        // receives the final text directly.
         if (!managed.synchronous) {
-          this.notifyParentTerminal(managed, "completed");
+          this.notifyParentTerminal(managed, "completed", finalText);
         }
       }
     } catch (err) {
@@ -1322,43 +1375,33 @@ export class SubagentManager {
   }
 
   /**
-   * Inject a completion/failure notification into the parent conversation
-   * so the LLM automatically informs the user.
+   * Inject a completion/failure notification into the parent conversation so
+   * the LLM automatically informs the user. On completion the subagent's final
+   * synthesis is inlined (via `buildSubagentTerminalMessage`) so the parent acts
+   * on the result directly rather than issuing a `subagent_read` call.
    */
   private notifyParentTerminal(
     managed: ManagedSubagent,
     outcome: "completed" | "failed",
+    finalText?: string,
   ): void {
     const { config } = managed.state;
     const isFork = managed.state.isFork;
-    let message: string;
+    // Forks default to internal/silent unless explicitly shared; regular
+    // subagents share with the user unless explicitly silenced.
+    const silent = isFork
+      ? config.sendResultToUser !== true
+      : config.sendResultToUser === false;
 
-    if (outcome === "completed") {
-      if (isFork) {
-        const silent = config.sendResultToUser !== true;
-        message =
-          `[Fork "${config.label}" completed]\n\n` +
-          `Use subagent_read with subagent_id "${config.id}" and last_n: 1 to retrieve the final synthesis.\n` +
-          (silent
-            ? `This fork was spawned for internal processing. Process the findings internally — do NOT share raw fork output with the user.`
-            : `Do NOT re-spawn this fork — just read and share the results.`);
-      } else {
-        const silent = config.sendResultToUser === false;
-        message =
-          `[Subagent "${config.label}" completed]\n\n` +
-          `Use subagent_read with subagent_id "${config.id}" to retrieve the full output.\n` +
-          (silent
-            ? `This subagent was spawned for internal processing. Read the result for your own use but do NOT share it with the user.\nDo NOT re-spawn this subagent.`
-            : `Do NOT re-spawn this subagent — just read and share the results.`);
-      }
-    } else {
-      const error = managed.state.error ?? "Unknown error";
-      const prefix = isFork ? "Fork" : "Subagent";
-      message =
-        `[${prefix} "${config.label}" failed]\n\n` +
-        `Error: ${error}\n` +
-        `Do NOT re-spawn or retry this ${prefix.toLowerCase()} unless the user explicitly asks.`;
-    }
+    const message = buildSubagentTerminalMessage({
+      label: config.label,
+      subagentId: config.id,
+      isFork,
+      outcome,
+      silent,
+      finalText,
+      error: managed.state.error,
+    });
 
     const notification: SubagentNotificationInfo = {
       subagentId: config.id,


### PR DESCRIPTION
## Summary
- Replace the prose completion notification — which told the parent LLM to call `subagent_read` and "do NOT re-spawn" — with the subagent's **final synthesis inlined directly** into the injected turn, alongside the existing structured `subagentNotification` metadata envelope.
- This removes the two model-compliance dependencies the old path carried (the `subagent_read` round-trip and the "don't re-spawn" instruction): the result is already present in the turn, so there is nothing to fetch and nothing to re-run. A `subagent_read` pointer survives only as a fallback for the rare run that ends with no trailing assistant text.
- Silent subagents/forks still get an internal-use instruction; failures are unchanged. Extracted `buildSubagentTerminalMessage` as a pure, unit-tested helper.

## Original prompt
P0 from the subagent architecture TDD: the dominant fire-and-forget completion path delivered results as free-form prose instructing the model to call `subagent_read`, so orchestration depended on the LLM obeying English. Investigation confirmed a real `tool_result` is structurally impossible for fire-and-forget (the spawn `tool_use`/`tool_result` pair closes synchronously; a late completion can only arrive as a new user turn), so the deterministic non-blocking fix is to inline the synthesis the manager already computes via `extractFinalAssistantText`. Per the design decision, this ships the inline fix only — no blocking `await_subagent` tool.