### PR TITLE
feat(memory-v3): gate selectPool on finder-lane scores

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -122,6 +122,12 @@ mock.module("../dense.js", () => ({
   ...realDense,
   denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
     carryMockActive ? [] : realDense.denseLane(...args),
+  // Defensive: this fixture never sets denseK > 0, so orchestrate does not call
+  // the scored lane today — but mirror the delegation so a future denseK > 0
+  // test can't silently reach real Qdrant after the orchestrate swap.
+  denseLaneScored: async (
+    ...args: Parameters<typeof realDense.denseLaneScored>
+  ) => (carryMockActive ? [] : realDense.denseLaneScored(...args)),
 }));
 
 let testSqlite: Database;

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -71,6 +71,12 @@ mock.module("../dense.js", () => ({
   ...realDense,
   denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
     denseMockActive ? [] : realDense.denseLane(...args),
+  // Defensive: this fixture never sets denseK > 0, so orchestrate does not call
+  // the scored lane today — but mirror the delegation so a future denseK > 0
+  // test can't silently reach real Qdrant after the orchestrate swap.
+  denseLaneScored: async (
+    ...args: Parameters<typeof realDense.denseLaneScored>
+  ) => (denseMockActive ? [] : realDense.denseLaneScored(...args)),
 }));
 
 // In-memory everInjected store backing the net-new dedup, swapped in only

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -23,6 +23,7 @@ import type { PageIndexEntry } from "../../v2/page-index.js";
 import { renderCard } from "../card.js";
 import type { EdgeGraph } from "../edge.js";
 import { buildEdgeGraph } from "../edge.js";
+import type { V3GateConfig } from "../gate.js";
 import type { OrchestrateDeps } from "../orchestrate.js";
 import { buildSectionNeedle } from "../section-needle.js";
 import { buildSectionIndex } from "../sections.js";
@@ -56,7 +57,7 @@ mock.module("../../../../../util/logger.js", () => ({
 // every other export (`OVERSAMPLE`) stays present.
 const realDense = { ...(await import("../dense.js")) };
 let denseMockActive = false;
-let denseHits: Array<{ article: Slug; section: number }> = [];
+let denseHits: Array<{ article: Slug; section: number; score?: number }> = [];
 let denseCalls: Array<{ query: string; k: number }> = [];
 mock.module("../dense.js", () => ({
   ...realDense,
@@ -64,6 +65,19 @@ mock.module("../dense.js", () => ({
     if (!denseMockActive) return realDense.denseLane(...args);
     denseCalls.push({ query: args[1], k: args[2] });
     return args[2] <= 0 ? [] : denseHits;
+  },
+  // Orchestrate now calls the SCORED variant; the mock must intercept it too
+  // (else the `...realDense` spread resolves the real lane and hits Qdrant).
+  // Same active-flag guard and `denseHits` fixture, defaulting an unset score
+  // to 1 so existing `denseK: 100` tests keep working without a score field.
+  denseLaneScored: async (
+    ...args: Parameters<typeof realDense.denseLaneScored>
+  ) => {
+    if (!denseMockActive) return realDense.denseLaneScored(...args);
+    denseCalls.push({ query: args[1], k: args[2] });
+    return args[2] <= 0
+      ? []
+      : denseHits.map((h) => ({ ...h, score: h.score ?? 1 }));
   },
 }));
 
@@ -349,12 +363,14 @@ describe("orchestrate — candidate pool composition", () => {
   test("needleK and denseK default to their constants", async () => {
     const lanes = await buildLanes();
     let needleK = -1;
+    // Orchestrate drives the finder via the SCORED query, so capture the budget
+    // there (the unscored `query` is no longer the orchestrate entry point).
     const needle = {
-      query: (_t: string, k: number) => {
+      query: () => [],
+      queryScored: (_t: string, k: number) => {
         needleK = k;
         return [];
       },
-      queryScored: () => [],
       bestSection: () => -1,
       idf: () => 0,
     };
@@ -981,5 +997,121 @@ describe("orchestrate — entity lane", () => {
     expect(hits[0]!.lane).toBe("entity");
     expect(result.matchedSections.get("topic-c")).toBe(heading);
     expect(result.selections.map((s) => s.slug)).toContain("topic-c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Injection gate: an OPT-IN, pass-open score check between the finder lanes and
+// edge expansion. A passing gate proceeds to selectPool as before; a closing
+// gate skips the selector entirely (empty selections) — or, with
+// `bypassForCore`, selects over the stable prefix only. Disabled/omitted is a
+// no-op. `selectCalls` (incremented by the provider stub) detects whether the
+// selector ran.
+// ---------------------------------------------------------------------------
+
+/** A `V3GateConfig` literal from the schema (`memory.v3.gate`) defaults plus the
+ *  effective `enabled` flag, overridable per test. */
+function gateConfigOf(overrides: Partial<V3GateConfig> = {}): V3GateConfig {
+  return {
+    enabled: true,
+    denseThreshold: 0.52,
+    sparseThreshold: 0.35,
+    sparseOnlyThreshold: 0.45,
+    denseClusterThreshold: 0.47,
+    denseClusterMaxDelta: 0.04,
+    topK: 5,
+    bm25NormK: null,
+    bypassForCore: false,
+    ...overrides,
+  };
+}
+
+describe("orchestrate — injection gate", () => {
+  test("gate pass → selects normally (provider runs once, selections produced)", async () => {
+    const lanes = await buildLanes();
+    // Dense top-1 (0.9) clears the default denseThreshold (0.52) → dense_pass.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]); // "apple" needles topic-a
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(selectCalls).toBe(1);
+    expect(result.selections.map((s) => s.slug)).toContain("topic-a");
+  });
+
+  test("gate fail → empty selections, selector never called", async () => {
+    const lanes = await buildLanes();
+    // No needle-term overlap (zero sparse signal) and a dense top-1 (0.1) well
+    // below every dense threshold → the gate closes.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider([]); // would increment selectCalls if reached
+
+    const result = await orchestrate(
+      makeTurn(1, "zzzz nomatch"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(selectCalls).toBe(0);
+    expect(result.selections).toEqual([]);
+    expect(result.lanes.finder).toEqual([]);
+  });
+
+  test("bypassForCore: true on a closed gate selects the stable prefix only (no finder lines)", async () => {
+    const lanes = await buildLanes();
+    // Low-signal query → the gate closes; bypassForCore runs selectPool over the
+    // stable prefix (core+hot) with an empty finder tail.
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "zzzz nomatch"),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        hotSlugs: ["topic-d"],
+        gateConfig: gateConfigOf({ bypassForCore: true }),
+      }),
+    );
+
+    expect(selectCalls).toBe(1);
+    // The selector input is exactly the stable prefix — two card lines, no
+    // finder candidate lines.
+    expect(lastPool).toEqual(["topic-c", "topic-d"]);
+    expect(lastPoolLines).toHaveLength(2);
+    expect(lastPoolLines.every((l) => l.includes("# memory/concepts/"))).toBe(
+      true,
+    );
+    expect(result.lanes.finder).toEqual([]);
+    expect(result.matchedSections.size).toBe(0);
+  });
+
+  test("gate disabled (omitted) → unchanged behavior (selector runs, selections produced)", async () => {
+    const lanes = await buildLanes();
+    providerStub = selectProvider(["topic-a"]);
+
+    const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
+
+    expect(selectCalls).toBe(1);
+    expect(result.selections.map((s) => s.slug)).toContain("topic-a");
+  });
+
+  test("gate enabled:false is a no-op even with gate-closing fixtures", async () => {
+    const lanes = await buildLanes();
+    // These fixtures would CLOSE the gate if it ran (weak needle, sub-threshold
+    // dense). With enabled:false the gate never runs, so selection proceeds.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        gateConfig: gateConfigOf({ enabled: false }),
+      }),
+    );
+
+    expect(selectCalls).toBe(1);
+    expect(result.selections.map((s) => s.slug)).toContain("topic-a");
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -89,6 +89,15 @@ mock.module("../dense.js", () => ({
   ...realDense,
   denseLane: async (...args: Parameters<typeof realDense.denseLane>) =>
     mockActive ? denseHits : realDense.denseLane(...args),
+  // Orchestrate calls the SCORED variant; intercept it under the same
+  // `mockActive` guard (the gate is disabled in these tests, so the score is
+  // arbitrary — a constant 1) so the swap can't leak through to real Qdrant.
+  denseLaneScored: async (
+    ...args: Parameters<typeof realDense.denseLaneScored>
+  ) =>
+    mockActive
+      ? denseHits.map((h) => ({ ...h, score: 1 }))
+      : realDense.denseLaneScored(...args),
 }));
 
 // In-memory selections DB. `summarizeSelections` reads via getDb/getSqliteFrom;

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -17,6 +17,13 @@
  *          associations the authored link graph does not record.
  *      Each lane only ever ADDS candidates, so the pool is recall-safe by
  *      construction.
+ *   1b. OPT-IN injection gate (`deps.gateConfig.enabled`, default off): once the
+ *      CURRENT-message finder lanes have run, `checkV3Gate` scores the needle +
+ *      dense hits against the tuned thresholds. A closed gate skips the
+ *      selectPool LLM call for the turn — returning empty selections (or, when
+ *      `bypassForCore` is set, running selectPool over the stable prefix only) —
+ *      so a low-signal turn pays no selector cost. The gate is pass-open: any
+ *      throw inside it logs a warning and falls through to normal selection.
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
  *      `[...core (file order), ...hot (score order), ...fresh (recency order),
  *      ...always-candidate (skills pinned every turn)]`, all computed at lane
@@ -47,11 +54,13 @@
  */
 
 import type { AssistantConfig } from "../../../../config/schema.js";
-import { denseLane } from "./dense.js";
+import { getLogger } from "../../../../util/logger.js";
+import { denseLaneScored } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
 import type { EntityIndex } from "./entity-lane.js";
 import { entityLane } from "./entity-lane.js";
+import { checkV3Gate, type V3GateConfig, type V3GateResult } from "./gate.js";
 import type { PoolCandidate, StableCandidate } from "./pool-select.js";
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
@@ -63,6 +72,10 @@ import type {
   SelectedPage,
   Slug,
 } from "./types.js";
+
+// Named to disambiguate from the unrelated `src/config/memory-v3-gate.ts`: this
+// logger names the per-turn INJECTION gate wired in below.
+const log = getLogger("memory-v3-injection-gate");
 
 /** Default number of BM25 needle articles to fold into the pool. */
 export const DEFAULT_NEEDLE_K = 12;
@@ -137,6 +150,10 @@ export interface OrchestrateDeps {
   /** Whether to run the selector LLM. False passes all pooled candidates
    *  straight through as selections, preserving pool-order slug dedup. */
   selectorEnabled?: boolean;
+  /** Per-turn injection gate config (`memory.v3.gate` tuning + the flag-derived
+   *  `enabled`, assembled in observeTurn). Omitted/disabled → the gate never
+   *  runs and every turn proceeds to selectPool as before. */
+  gateConfig?: V3GateConfig;
 }
 
 /** A finder-lane candidate: the slug, the descriptor that justified it, and
@@ -209,6 +226,26 @@ export async function orchestrate(
   );
   const stablePrefix = new Set<Slug>([...coreHotFresh, ...always]);
 
+  // The stable prefix as FULL CARDS, in cache order. Pre-rendered at lane init
+  // (`prefixCards`) so the rendered prefix is byte-identical across turns. A
+  // missing card is a lane-init bug and throws (silently degrading would violate
+  // the byte-stable-prefix contract). Built lazily so the gate's bypass path can
+  // reuse the exact same construction as the normal step-2 pool assembly.
+  const buildStable = (): StableCandidate[] =>
+    [...core, ...hot, ...fresh, ...always].map((slug) => {
+      const card = deps.prefixCards.get(slug);
+      if (card === undefined) {
+        // Lane init renders a card for every core/hot slug; a hole here means
+        // the lanes and the card map are out of sync. Throw rather than render
+        // a degraded card — the caller (observeTurn) logs and skips the turn,
+        // which is better than silently breaking the byte-stable prefix.
+        throw new Error(
+          `memory-v3: no pre-rendered card for stable-prefix slug "${slug}"`,
+        );
+      }
+      return { slug, card };
+    });
+
   // Step 1: needle (sync BM25) and the enabled dense lane (async embed +
   // Qdrant) run in parallel. Both return distinct articles each tagged with
   // their best-scoring section index/ordinal. The reply-query pass re-runs the
@@ -223,15 +260,15 @@ export async function orchestrate(
     replyK > 0 ? (turn.previousAssistantMessage ?? "").trim() : "";
   const denseEnabled = denseK > 0;
   const [needled, densed, replyNeedled, replyDensed] = await Promise.all([
-    Promise.resolve(deps.needle.query(turn.currentMessage, needleK)),
+    Promise.resolve(deps.needle.queryScored(turn.currentMessage, needleK)),
     denseEnabled
-      ? denseLane(deps.denseConfig, turn.currentMessage, denseK)
+      ? denseLaneScored(deps.denseConfig, turn.currentMessage, denseK)
       : Promise.resolve([]),
     Promise.resolve(
-      replyQuery.length > 0 ? deps.needle.query(replyQuery, replyK) : [],
+      replyQuery.length > 0 ? deps.needle.queryScored(replyQuery, replyK) : [],
     ),
     replyQuery.length > 0 && denseEnabled
-      ? denseLane(deps.denseConfig, replyQuery, replyK)
+      ? denseLaneScored(deps.denseConfig, replyQuery, replyK)
       : Promise.resolve([]),
   ]);
 
@@ -337,6 +374,63 @@ export async function orchestrate(
     }
   }
 
+  // Step 1b''': opt-in injection gate. With the CURRENT-message finder lanes in
+  // hand (needle + dense — NOT reply/entity/edge, which only add recall), decide
+  // whether retrieval is confident enough to spend the selectPool LLM call this
+  // turn. Default-off via `?.enabled`; pass-open on any throw (a gate bug must
+  // never drop a turn's memory). A closed gate either hard-skips selection
+  // (empty selections) or, when `bypassForCore` is set, runs selectPool over the
+  // stable prefix only — never the finder tail.
+  if (deps.gateConfig?.enabled) {
+    let gate: V3GateResult | null = null;
+    try {
+      gate = checkV3Gate({
+        needleHits: needled,
+        denseHits: densed,
+        config: deps.gateConfig,
+      });
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          conversationId: turn.conversationId,
+        },
+        "memory-v3 injection gate threw; passing open (proceeding with selection)",
+      );
+    }
+    if (gate) {
+      log.info(
+        {
+          conversationId: turn.conversationId,
+          turnNumber: turn.turnNumber,
+          reason: gate.reason,
+          pass: gate.pass,
+          topDenseScore: gate.topDenseScore,
+          topNormSparseScore: gate.topNormSparseScore,
+        },
+        "memory-v3 injection gate decision",
+      );
+      if (!gate.pass) {
+        // A closed gate produces no finder lane and no matched sections; only
+        // the `selections` differ between bypass (stable prefix) and hard-skip.
+        const closed = (selections: SelectedPage[]): OrchestrateResult => ({
+          selections,
+          matchedSections: new Map(),
+          lanes: { core, hot, fresh, finder: [] },
+        });
+        return deps.gateConfig.bypassForCore
+          ? closed(
+              await selectPool(
+                { stable: buildStable(), finder: [] },
+                turn,
+                deps.selectorPrompt,
+              ),
+            )
+          : closed([]);
+      }
+    }
+  }
+
   // Step 1c: edge expansion over the top needle+dense article seeds. `alive`
   // skips slugs already in the pool — finder-surfaced AND stable-prefix slugs
   // (an edge hit carries no matched section, so re-surfacing a core/hot page
@@ -408,21 +502,7 @@ export async function orchestrate(
   // its own snippet line so its CURRENT relevance stays visible; `selectPool`
   // dedupes selections by slug. Finder candidates with no match text fall
   // back to the page's lead-section snippet.
-  const stable: StableCandidate[] = [...core, ...hot, ...fresh, ...always].map(
-    (slug) => {
-      const card = deps.prefixCards.get(slug);
-      if (card === undefined) {
-        // Lane init renders a card for every core/hot slug; a hole here means
-        // the lanes and the card map are out of sync. Throw rather than render
-        // a degraded card — the caller (observeTurn) logs and skips the turn,
-        // which is better than silently breaking the byte-stable prefix.
-        throw new Error(
-          `memory-v3: no pre-rendered card for stable-prefix slug "${slug}"`,
-        );
-      }
-      return { slug, card };
-    },
-  );
+  const stable = buildStable();
   const finderTail: PoolCandidate[] = finder.map((c) => ({
     slug: c.slug,
     lane: c.lane,


### PR DESCRIPTION
## Summary
- Wire checkV3Gate into orchestrate(): after the finder lanes run, skip the selectPool LLM call (return empty selections) when scores fall below threshold; opt-in via deps.gateConfig.enabled, pass-open on throw
- Swap finder lanes to the scored variants (queryScored / denseLaneScored); bypassForCore runs selectPool over the stable prefix only
- Update dense test mocks to cover denseLaneScored; add gate pass/fail/bypass/disabled tests

Part of plan: memory-v3-injection-gate.md (PR 6 of 7)