### PR TITLE
Rename red-pen plugin to writing-coach in marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -126,15 +126,15 @@
       "license": "MIT"
     },
     {
-      "name": "red-pen",
+      "name": "writing-coach",
       "source": {
         "source": "github",
-        "repo": "vellum-ai/red-pen",
-        "ref": "9e2c59c443f92d7800cbb33521cc166066226355"
+        "repo": "vellum-ai/writing-coach",
+        "ref": "9cb2289343fed2fd6ad8b0bb5db07616d1c8181c"
       },
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/red-pen",
+      "homepage": "https://github.com/vellum-ai/writing-coach",
       "license": "MIT"
     },
     {


### PR DESCRIPTION
Renames the red-pen plugin entry to writing-coach in marketplace.json. Repo already renamed at vellum-ai/writing-coach. Updates name, source repo, homepage URL, and ref to latest commit.