### PR TITLE
feat(memory-v3): resolve injection-gate flag and pass gate config to orchestrate

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -25,6 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { MemoryV3GateSchema } from "../../../../../config/schemas/memory-v3.js";
 import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
 import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
@@ -88,7 +89,15 @@ let extraRealConceptPages = 0;
 // Mutable mocked config knob (orchestrate-only) for asserting per-turn tuning
 // re-resolution from a live config edit.
 let selectorEnabledCfg = false;
+// Drives the `memory-v3-injection-gate` feature flag through the shared
+// assistant-feature-flags mock below (default off).
+let gateFlagEnabled = false;
 let messages: Array<{ role: string; content: string }> = [];
+
+// Schema defaults for `memory.v3.gate` (the tuning the mocked config carries and
+// the gate-config threading test asserts against). No `enabled` field — that is
+// the feature flag, threaded in by `observeTurn`.
+const GATE_DEFAULTS = MemoryV3GateSchema.parse({});
 
 // A synthetic skill capability slug the page index carries. Its rendered
 // content holds a distinctive term ("kumquat") so the real needle, built over
@@ -185,7 +194,11 @@ const FAKE_SECTION_INDEX: SectionIndex = {
 
 mock.module("../../../../../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: (key: string) =>
-    key === "memory-v3-live" ? liveEnabled : false,
+    key === "memory-v3-live"
+      ? liveEnabled
+      : key === "memory-v3-injection-gate"
+        ? gateFlagEnabled
+        : false,
 }));
 
 mock.module("../../../../../config/loader.js", () => ({
@@ -211,6 +224,9 @@ mock.module("../../../../../config/loader.js", () => ({
         },
         edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
         entity: { enabled: true, idfFloor: 4, cap: 8 },
+        // Gate TUNING only (schema defaults, no `enabled`); `observeTurn` spreads
+        // this and adds the flag-derived `enabled` before passing to orchestrate.
+        gate: GATE_DEFAULTS,
       },
       qdrant: { vectorSize: 8, onDisk: false },
     },
@@ -438,6 +454,7 @@ beforeEach(() => {
   learnedEdgesCap = 0;
   extraRealConceptPages = 0;
   selectorEnabledCfg = false;
+  gateFlagEnabled = false;
   messages = [
     {
       role: "user",
@@ -660,6 +677,31 @@ describe("memory-v3 engine", () => {
       orchestrateSpy.mock.calls as unknown as unknown[][]
     )[1]![1] as { selectorEnabled?: boolean };
     expect(secondDeps.selectorEnabled).toBe(true);
+  });
+
+  test("flag on → threads the gate tuning plus enabled:true into orchestrate", async () => {
+    gateFlagEnabled = true;
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { gateConfig?: unknown };
+    // The spread is the live gate config: the `memory.v3.gate` tuning with the
+    // flag-derived `enabled` folded in.
+    expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: true });
+  });
+
+  test("flag off (default) → gate config threads inert (enabled:false, schema-default tuning)", async () => {
+    // gateFlagEnabled defaults to false in beforeEach.
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { gateConfig?: { enabled?: boolean } };
+    // Flag off → the gate is wired in but inert, and the tuning fields are the
+    // schema defaults the config carries.
+    expect(deps.gateConfig?.enabled).toBe(false);
+    expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: false });
   });
 
   test("initLanes filters core to existing pages and excludes core from the hot set", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -44,6 +44,7 @@ import { buildEdgeGraph } from "./edge.js";
 import type { EntityIndex } from "./entity-lane.js";
 import { buildEntityIndex } from "./entity-lane.js";
 import { computeFreshSet } from "./fresh-set.js";
+import { isMemoryV3InjectionGateEnabled } from "./gate-flag.js";
 import { computeHotSet } from "./hot-set.js";
 import { computeLearnedEdgeGraph } from "./learned-edges.js";
 import type { OrchestrateResult } from "./orchestrate.js";
@@ -586,6 +587,9 @@ export async function observeTurn(
     if (cfg.memory.enabled === false) return null;
     const lanes = await getLanes(cfg);
     const v3 = cfg.memory.v3;
+    // Resolve the injection-gate flag once for the turn. The gate's tuning lives
+    // in `memory.v3.gate` (no `enabled`); the on/off comes from the feature flag.
+    const gateEnabled = isMemoryV3InjectionGateEnabled(cfg);
     // Re-resolve the corpus-adaptive tuning each turn from the CURRENT config
     // (with the lane-build corpus-size signal) so a live config.json edit to a
     // per-turn knob (selectorEnabled, denseK, replyQueryK, edge.*) takes effect
@@ -619,6 +623,10 @@ export async function observeTurn(
         v3.selectorPromptPath,
         getWorkspaceDir(),
       ),
+      // Per-turn injection gate: the `memory.v3.gate` tuning plus the
+      // flag-derived `enabled`. The spread is the compile-time drift guard —
+      // if the gate schema and `V3GateConfig` diverge, this stops typechecking.
+      gateConfig: { ...v3.gate, enabled: gateEnabled },
     });
 
     // A zero-selection turn over a non-trivial pool is unusual enough to be


### PR DESCRIPTION
## Summary
- observeTurn resolves the memory-v3-injection-gate feature flag and threads { ...memory.v3.gate, enabled } into orchestrate as gateConfig — turning the gate live (still default-off via the flag)
- The spread is the compile-time guard that the gate schema and V3GateConfig stay in sync
- shadow-plugin test asserts the gate config is threaded for flag on/off

Part of plan: memory-v3-injection-gate.md (PR 7 of 7)