### PR TITLE
Unregister self-hosted platform record on local retire

### DIFF
--- a/cli/src/__tests__/retire.test.ts
+++ b/cli/src/__tests__/retire.test.ts
@@ -20,30 +20,74 @@ import { join } from "node:path";
 
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import { loadAllAssistants } from "../lib/assistant-config.js";
+import * as loopbackFetchModule from "../lib/loopback-fetch.js";
+import * as platformClientModule from "../lib/platform-client.js";
 import * as retireLocalModule from "../lib/retire-local.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-retire-test-"));
 const originalArgv = [...process.argv];
 const originalExit = process.exit;
 const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+const originalPlatformToken = process.env.VELLUM_PLATFORM_TOKEN;
 const originalStdinIsTTY = process.stdin.isTTY;
 const originalStdoutIsTTY = process.stdout.isTTY;
 const originalStdinIsRaw = process.stdin.isRaw;
 const originalSetRawMode = process.stdin.setRawMode;
 const originalStdoutWrite = process.stdout.write;
 const realRetireLocalModule = { ...retireLocalModule };
+const realPlatformClientModule = { ...platformClientModule };
+const realLoopbackFetchModule = { ...loopbackFetchModule };
 
 const retireLocalMock = mock(async () => {});
+const readPlatformTokenMock = mock((): string | null => null);
+const authHeadersMock = mock(async () => ({
+  "Content-Type": "application/json",
+  "X-Session-Token": "session-token",
+}));
+const authHeadersForKnownOrganizationMock = mock(
+  (token: string, organizationId: string) => ({
+    "Content-Type": "application/json",
+    "X-Session-Token": token,
+    "Vellum-Organization-Id": organizationId,
+  }),
+);
+const getPlatformUrlMock = mock(() => "https://platform.example.com");
+const readGatewayCredentialMock = mock(
+  async (
+    _gatewayUrl: string,
+    _name: string,
+    _bearerToken?: string,
+  ): Promise<{ value: string | null; unreachable: boolean }> => ({
+    value: null,
+    unreachable: false,
+  }),
+);
+const loopbackSafeFetchMock = mock(
+  async (): Promise<Response> => new Response(null, { status: 204 }),
+);
 
 mock.module("../lib/retire-local.js", () => ({
   ...realRetireLocalModule,
   retireLocal: retireLocalMock,
 }));
 
+mock.module("../lib/platform-client.js", () => ({
+  authHeaders: authHeadersMock,
+  authHeadersForKnownOrganization: authHeadersForKnownOrganizationMock,
+  getPlatformUrl: getPlatformUrlMock,
+  readGatewayCredential: readGatewayCredentialMock,
+  readPlatformToken: readPlatformTokenMock,
+}));
+
+mock.module("../lib/loopback-fetch.js", () => ({
+  loopbackSafeFetch: loopbackSafeFetchMock,
+}));
+
 import { retire } from "../commands/retire.js";
 
 let consoleLogSpy: ReturnType<typeof spyOn>;
 let consoleErrorSpy: ReturnType<typeof spyOn>;
+let consoleWarnSpy: ReturnType<typeof spyOn>;
 
 function makeEntry(
   assistantId: string,
@@ -123,6 +167,7 @@ function restoreTerminal(): void {
 describe("vellum retire", () => {
   beforeEach(() => {
     process.env.VELLUM_LOCKFILE_DIR = testDir;
+    delete process.env.VELLUM_PLATFORM_TOKEN;
     rmSync(join(testDir, ".vellum.lock.json"), { force: true });
     process.argv = ["bun", "vellum", "retire"];
     process.exit = ((code?: number) => {
@@ -130,9 +175,36 @@ describe("vellum retire", () => {
     }) as typeof process.exit;
     retireLocalMock.mockReset();
     retireLocalMock.mockResolvedValue(undefined);
+    readPlatformTokenMock.mockReset();
+    readPlatformTokenMock.mockReturnValue(null);
+    authHeadersMock.mockReset();
+    authHeadersMock.mockResolvedValue({
+      "Content-Type": "application/json",
+      "X-Session-Token": "session-token",
+    });
+    authHeadersForKnownOrganizationMock.mockReset();
+    authHeadersForKnownOrganizationMock.mockImplementation(
+      (token: string, organizationId: string) => ({
+        "Content-Type": "application/json",
+        "X-Session-Token": token,
+        "Vellum-Organization-Id": organizationId,
+      }),
+    );
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.example.com");
+    readGatewayCredentialMock.mockReset();
+    readGatewayCredentialMock.mockResolvedValue({
+      value: null,
+      unreachable: false,
+    });
+    loopbackSafeFetchMock.mockReset();
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
     setTerminalMode(false);
     consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -141,14 +213,22 @@ describe("vellum retire", () => {
     restoreTerminal();
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   afterAll(() => {
     mock.module("../lib/retire-local.js", () => realRetireLocalModule);
+    mock.module("../lib/platform-client.js", () => realPlatformClientModule);
+    mock.module("../lib/loopback-fetch.js", () => realLoopbackFetchModule);
     if (originalLockfileDir === undefined) {
       delete process.env.VELLUM_LOCKFILE_DIR;
     } else {
       process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+    }
+    if (originalPlatformToken === undefined) {
+      delete process.env.VELLUM_PLATFORM_TOKEN;
+    } else {
+      process.env.VELLUM_PLATFORM_TOKEN = originalPlatformToken;
     }
     rmSync(testDir, { recursive: true, force: true });
   });
@@ -167,6 +247,218 @@ describe("vellum retire", () => {
     expect(output).toContain("ID: assistant-1");
     expect(output).toContain(
       "Removed Example Assistant (assistant-1) from config.",
+    );
+  });
+
+  test("local retire unregisters the self-hosted platform record first", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test/api");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      entry.localUrl ?? entry.runtimeUrl,
+      "vellum:platform_assistant_id",
+      entry.bearerToken,
+    );
+    expect(authHeadersMock).not.toHaveBeenCalled();
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/api/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
+  test("local retire reads platform registration through the loopback gateway URL", async () => {
+    const localGatewayUrl = "http://127.0.0.1:7831";
+    const entry = makeEntry("assistant-1", {
+      name: "Example Assistant",
+      runtimeUrl: "http://assistant-1.local:7831",
+      localUrl: localGatewayUrl,
+    });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test");
+    readGatewayCredentialMock.mockImplementation(async (gatewayUrl, name) => {
+      expect(gatewayUrl).toBe(localGatewayUrl);
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      localGatewayUrl,
+      "vellum:platform_assistant_id",
+      entry.bearerToken,
+    );
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      localGatewayUrl,
+      "vellum:platform_base_url",
+      entry.bearerToken,
+    );
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      localGatewayUrl,
+      "vellum:platform_organization_id",
+      entry.bearerToken,
+    );
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      expect.any(Object),
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+  });
+
+  test("local retire skips platform unregister when stored platform URL origin mismatches", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.com");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://malicious.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(loopbackSafeFetchMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls.flat().join("\n")).toContain(
+      "Stored platform URL does not match the configured platform URL",
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+  });
+
+  test("local retire skips platform unregister when stored organization ID is missing", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(loopbackSafeFetchMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls.flat().join("\n")).toContain(
+      "Could not read platform organization ID",
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
+  test("local retire uses injected platform token from the app host", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    process.env.VELLUM_PLATFORM_TOKEN = "host-session-token";
+    readPlatformTokenMock.mockReturnValue(null);
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "host-session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+  });
+
+  test("local retire continues when self-hosted platform unregister fails", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test");
+    readGatewayCredentialMock.mockImplementation(async (_gatewayUrl, name) => {
+      if (name === "vellum:platform_assistant_id") {
+        return { value: "platform-assistant-1", unreachable: false };
+      }
+      if (name === "vellum:platform_base_url") {
+        return { value: "https://platform.example.test", unreachable: false };
+      }
+      if (name === "vellum:platform_organization_id") {
+        return { value: "org-123", unreachable: false };
+      }
+      return { value: null, unreachable: false };
+    });
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response("platform unavailable", { status: 503 }),
+    );
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+    expect(consoleWarnSpy.mock.calls.flat().join("\n")).toContain(
+      "Platform self-hosted unregister failed (503): platform unavailable",
     );
   });
 

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -20,7 +20,9 @@ import { getConfigDir } from "../lib/environments/paths.js";
 import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 import {
   authHeaders,
+  authHeadersForKnownOrganization,
   getPlatformUrl,
+  readGatewayCredential,
   readPlatformToken,
 } from "../lib/platform-client.js";
 import { retireInstance as retireAwsInstance } from "../lib/aws.js";
@@ -43,6 +45,128 @@ interface RetireArgs {
   name?: string;
   source?: string;
   yes: boolean;
+}
+
+const PLATFORM_TOKEN_ENV = "VELLUM_PLATFORM_TOKEN";
+
+function readPlatformRetireToken(): string | null {
+  const envToken = process.env[PLATFORM_TOKEN_ENV]?.trim();
+  if (envToken) return envToken;
+  return readPlatformToken();
+}
+
+function platformOrigin(platformUrl: string): string | null {
+  try {
+    return new URL(platformUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveTrustedSelfHostedPlatformUrl(
+  storedPlatformUrl: string | null,
+): string | null {
+  const configuredPlatformUrl = getPlatformUrl();
+  if (!storedPlatformUrl) return configuredPlatformUrl;
+
+  const storedOrigin = platformOrigin(storedPlatformUrl);
+  const configuredOrigin = platformOrigin(configuredPlatformUrl);
+  if (storedOrigin && configuredOrigin && storedOrigin === configuredOrigin) {
+    return configuredPlatformUrl;
+  }
+
+  console.warn(
+    "⚠️  Stored platform URL does not match the configured platform URL; skipping platform unregister.",
+  );
+  return null;
+}
+
+async function deletePlatformAssistant(
+  assistantId: string,
+  options: {
+    token: string;
+    platformUrl?: string;
+    organizationId?: string;
+    label: string;
+    successMessage: string;
+    alreadyGoneMessage: string;
+  },
+): Promise<void> {
+  const platformUrl = options.platformUrl || getPlatformUrl();
+  const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
+  const headers = options.organizationId
+    ? authHeadersForKnownOrganization(options.token, options.organizationId)
+    : await authHeaders(options.token, platformUrl);
+
+  const response = await loopbackSafeFetch(url, {
+    method: "DELETE",
+    headers,
+  });
+
+  if (!response.ok && response.status !== 404) {
+    const body = await response.text();
+    throw new Error(`${options.label} failed (${response.status}): ${body}`);
+  }
+
+  if (response.status === 404) {
+    console.log(options.alreadyGoneMessage);
+  } else {
+    console.log(options.successMessage);
+  }
+}
+
+async function unregisterSelfHostedLocalPlatformRecord(
+  entry: AssistantEntry,
+): Promise<void> {
+  const token = readPlatformRetireToken();
+  if (!token) return;
+
+  const gatewayUrl = entry.localUrl ?? entry.runtimeUrl;
+  const platformAssistant = await readGatewayCredential(
+    gatewayUrl,
+    "vellum:platform_assistant_id",
+    entry.bearerToken,
+  );
+  if (platformAssistant.unreachable) {
+    console.warn(
+      "\u26a0\ufe0f  Could not read platform registration from the local assistant; skipping platform unregister.",
+    );
+    return;
+  }
+  if (!platformAssistant.value) return;
+
+  const [platformBaseUrl, organizationId] = await Promise.all([
+    readGatewayCredential(
+      gatewayUrl,
+      "vellum:platform_base_url",
+      entry.bearerToken,
+    ),
+    readGatewayCredential(
+      gatewayUrl,
+      "vellum:platform_organization_id",
+      entry.bearerToken,
+    ),
+  ]);
+  const platformUrl = resolveTrustedSelfHostedPlatformUrl(
+    platformBaseUrl.value,
+  );
+  if (!platformUrl) return;
+  if (!organizationId.value) {
+    console.warn(
+      "⚠️  Could not read platform organization ID from the local assistant; skipping platform unregister.",
+    );
+    return;
+  }
+
+  await deletePlatformAssistant(platformAssistant.value, {
+    token,
+    platformUrl,
+    organizationId: organizationId.value,
+    label: "Platform self-hosted unregister",
+    successMessage: "\u2705 Platform self-hosted registration unregistered.",
+    alreadyGoneMessage:
+      "\u2705 Platform self-hosted registration already unregistered (404).",
+  });
 }
 
 async function retireCustom(entry: AssistantEntry): Promise<void> {
@@ -86,7 +210,7 @@ async function retireVellum(
 ): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Retiring platform-hosted instance...\n");
 
-  const token = readPlatformToken();
+  const token = readPlatformRetireToken();
   if (!token) {
     console.error(
       "Error: Not logged in. Run `vellum login --token <token>` first.",
@@ -94,32 +218,20 @@ async function retireVellum(
     process.exit(1);
   }
 
-  const platformUrl = runtimeUrl || getPlatformUrl();
-  const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
-  const response = await loopbackSafeFetch(url, {
-    method: "DELETE",
-    headers: await authHeaders(token, runtimeUrl),
-  });
-
-  // Treat 404 as success: the assistant is already gone from the platform
-  // (previously retired, deleted from the web UI, or retired from another
-  // device) so the caller's job is done. Falling through to the lockfile
-  // cleanup avoids leaving a stale entry that would otherwise wedge the
-  // macOS app in a permanent health-check loop.
-  if (!response.ok && response.status !== 404) {
-    const body = await response.text();
+  try {
+    await deletePlatformAssistant(assistantId, {
+      token,
+      platformUrl: runtimeUrl,
+      label: "Platform retire",
+      successMessage: "\u2705 Platform-hosted instance retired.",
+      alreadyGoneMessage:
+        "\u2705 Platform-hosted instance already retired (404) \u2014 cleaning up local state.",
+    });
+  } catch (error) {
     console.error(
-      `Error: Platform retire failed (${response.status}): ${body}`,
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
     );
     process.exit(1);
-  }
-
-  if (response.status === 404) {
-    console.log(
-      "\u2705 Platform-hosted instance already retired (404) — cleaning up local state.",
-    );
-  } else {
-    console.log("\u2705 Platform-hosted instance retired.");
   }
 }
 
@@ -303,6 +415,15 @@ async function retireInner(): Promise<void> {
   } else if (cloud === "docker") {
     await retireDocker(assistantId);
   } else if (cloud === "local") {
+    try {
+      await unregisterSelfHostedLocalPlatformRecord(entry);
+    } catch (error) {
+      console.warn(
+        `⚠️  Platform self-hosted unregister failed; continuing local retire: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
     await retireLocal(assistantId, entry);
   } else if (cloud === "custom") {
     await retireCustom(entry);

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -96,6 +96,20 @@ function tokenAuthHeader(token: string): Record<string, string> {
   return { "X-Session-Token": token };
 }
 
+export function authHeadersForKnownOrganization(
+  token: string,
+  organizationId: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...tokenAuthHeader(token),
+  };
+  if (!token.startsWith(VAK_PREFIX)) {
+    headers["Vellum-Organization-Id"] = organizationId;
+  }
+  return headers;
+}
+
 /** Module-level cache for org IDs to avoid redundant fetches in polling loops. */
 const orgIdCache = new Map<string, { orgId: string; expiresAt: number }>();
 const ORG_ID_CACHE_TTL_MS = 60_000; // 60 seconds


### PR DESCRIPTION
## Summary
- Adds CLI-side unregister for self-hosted local assistants before local teardown.
- Uses `VELLUM_PLATFORM_TOKEN` from the host subprocess environment first, falling back to the saved CLI platform token.
- Reads the platform assistant UUID, platform base URL, and organization ID from the running local gateway credentials, preferring the loopback local gateway URL when available.
- Validates the stored platform base URL against the configured platform origin before sending platform auth; mismatches skip platform unregister instead of deleting against the wrong origin.
- Requires the stored platform organization ID for self-hosted unregister so retire does not fall back to the token's current/default org.
- Calls `DELETE /v1/assistants/{platformAssistantId}/retire/` and treats 404 as success, matching platform-hosted retire cleanup.
- Warns and continues local teardown if the self-hosted platform unregister request fails with a non-404 response.

## Stack
- Builds on merged #36681, which passes the host session token into `runRetire()`.
- This PR intentionally does not add durable lockfile registration metadata. The offline/unhealthy-local fallback remains the next split PR.

## Verification
- `cd cli && bun test src/__tests__/retire.test.ts`
- `cd cli && bun run lint -- src/commands/retire.ts src/lib/platform-client.ts src/__tests__/retire.test.ts`
- `bunx prettier --check cli/src/commands/retire.ts cli/src/lib/platform-client.ts cli/src/__tests__/retire.test.ts`
