### PR TITLE
fix(memory-v3): harden injection gate (bypass/selectorEnabled, dense-unavailable, telemetry)

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1059,10 +1059,37 @@ describe("orchestrate — injection gate", () => {
     expect(result.lanes.finder).toEqual([]);
   });
 
+  test("gate stays inert when the dense lane produced no hits (denseK = 0 new-user/outage case)", async () => {
+    const lanes = await buildLanes();
+    // denseK: 0 leaves `densed` empty — the new-user profile, or any embedding
+    // outage. A low-score needle hit (norm ≈ 0.011) would CLOSE the gate if it
+    // ran on sparse signal alone, but zero dense hits means dense is
+    // unavailable, not low-relevance: the gate is dense-gated and never runs, so
+    // selection proceeds and memory is not suppressed.
+    const needle = {
+      query: () => [],
+      queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    providerStub = selectProvider(["topic-a"]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { needle, denseK: 0, gateConfig: gateConfigOf() }),
+    );
+
+    expect(selectCalls).toBe(1);
+    expect(result.selections.map((s) => s.slug)).toContain("topic-a");
+  });
+
   test("bypassForCore: true on a closed gate selects the stable prefix only (no finder lines)", async () => {
     const lanes = await buildLanes();
-    // Low-signal query → the gate closes; bypassForCore runs selectPool over the
-    // stable prefix (core+hot) with an empty finder tail.
+    // Non-empty low-score dense (0.1, below every dense threshold) makes the
+    // dense-gated gate run and close for the low-signal query; bypassForCore
+    // then runs selectPool over the stable prefix (core+hot) with an empty
+    // finder tail.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
     providerStub = selectProvider([]);
 
     const result = await orchestrate(
@@ -1070,6 +1097,7 @@ describe("orchestrate — injection gate", () => {
       depsOf(lanes, {
         coreSlugs: ["topic-c"],
         hotSlugs: ["topic-d"],
+        denseK: 100,
         gateConfig: gateConfigOf({ bypassForCore: true }),
       }),
     );
@@ -1082,6 +1110,37 @@ describe("orchestrate — injection gate", () => {
     expect(lastPoolLines.every((l) => l.includes("# memory/concepts/"))).toBe(
       true,
     );
+    expect(result.lanes.finder).toEqual([]);
+    expect(result.matchedSections.size).toBe(0);
+  });
+
+  test("bypassForCore honors selectorEnabled: false — stable prefix passes through without the selector", async () => {
+    const lanes = await buildLanes();
+    // Non-empty low-score dense closes the gate; with the selector off (the
+    // new-user profile), the bypass mirrors the normal path and passes the
+    // stable prefix straight through via selectAllPoolCandidates rather than
+    // forcing the selectPool LLM call.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider([]); // must NOT be called
+
+    const result = await orchestrate(
+      makeTurn(1, "zzzz nomatch"),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        hotSlugs: ["topic-d"],
+        denseK: 100,
+        selectorEnabled: false,
+        gateConfig: gateConfigOf({ bypassForCore: true }),
+      }),
+    );
+
+    // The selector never ran; selections are exactly the stable-prefix slugs in
+    // cache order (selectAllPoolCandidates over the stable-only pool).
+    expect(selectCalls).toBe(0);
+    expect(result.selections.map((s) => s.slug)).toEqual([
+      "topic-c",
+      "topic-d",
+    ]);
     expect(result.lanes.finder).toEqual([]);
     expect(result.matchedSections.size).toBe(0);
   });

--- a/assistant/src/plugins/defaults/memory/v3/gate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/gate.ts
@@ -17,8 +17,9 @@
 // regardless of how the thresholds are tuned.
 //
 // This module is intentionally PURE — no async, no I/O, no logging, and no
-// imports beyond the two scored-hit types. `observeTurn` (a later PR) wires the
-// feature flag into `config.enabled` and feeds in the finder-lane hits.
+// imports beyond the two scored-hit types. `config.enabled` is the resolved
+// injection-gate flag value supplied by the caller, which also feeds in the
+// finder-lane hits.
 
 import type { DenseHitScored } from "./dense.js";
 import type { SectionNeedleScoredHit } from "./section-needle.js";

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -61,7 +61,11 @@ import { edgeExpand } from "./edge.js";
 import type { EntityIndex } from "./entity-lane.js";
 import { entityLane } from "./entity-lane.js";
 import { checkV3Gate, type V3GateConfig, type V3GateResult } from "./gate.js";
-import type { PoolCandidate, StableCandidate } from "./pool-select.js";
+import type {
+  PoolCandidate,
+  SelectorPool,
+  StableCandidate,
+} from "./pool-select.js";
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
 import type {
@@ -246,6 +250,15 @@ export async function orchestrate(
       return { slug, card };
     });
 
+  // Run the selector over a pool, or pass its candidates straight through when
+  // the selector LLM is disabled (`selectorEnabled: false`, the new-user
+  // profile). Shared by the normal step-3 selection and the gate's
+  // bypass-to-stable path so the two cannot diverge.
+  const runSelection = async (pool: SelectorPool): Promise<SelectedPage[]> =>
+    deps.selectorEnabled === false
+      ? selectAllPoolCandidates(pool)
+      : selectPool(pool, turn, deps.selectorPrompt);
+
   // Step 1: needle (sync BM25) and the enabled dense lane (async embed +
   // Qdrant) run in parallel. Both return distinct articles each tagged with
   // their best-scoring section index/ordinal. The reply-query pass re-runs the
@@ -381,7 +394,16 @@ export async function orchestrate(
   // never drop a turn's memory). A closed gate either hard-skips selection
   // (empty selections) or, when `bypassForCore` is set, runs selectPool over the
   // stable prefix only — never the finder tail.
-  if (deps.gateConfig?.enabled) {
+  //
+  // The gate is dense-gated: it only runs when the dense lane produced hits
+  // (`densed.length > 0`). In healthy operation dense returns top-k hits for any
+  // query, so zero dense hits means dense is unavailable — denseK=0 (the
+  // new-user/small-corpus profile), a degraded embedding backend, or a Qdrant
+  // error (`denseLaneScored` swallows these to `[]`) — NOT low relevance.
+  // checkV3Gate reads only finder scores and cannot tell those apart, so without
+  // dense signal we pass open rather than suppress all memory (not even the
+  // core/hot/fresh prefix) on every lexically-weak turn.
+  if (deps.gateConfig?.enabled && densed.length > 0) {
     let gate: V3GateResult | null = null;
     try {
       gate = checkV3Gate({
@@ -403,10 +425,7 @@ export async function orchestrate(
         {
           conversationId: turn.conversationId,
           turnNumber: turn.turnNumber,
-          reason: gate.reason,
-          pass: gate.pass,
-          topDenseScore: gate.topDenseScore,
-          topNormSparseScore: gate.topNormSparseScore,
+          gate,
         },
         "memory-v3 injection gate decision",
       );
@@ -418,15 +437,18 @@ export async function orchestrate(
           matchedSections: new Map(),
           lanes: { core, hot, fresh, finder: [] },
         });
-        return deps.gateConfig.bypassForCore
-          ? closed(
-              await selectPool(
-                { stable: buildStable(), finder: [] },
-                turn,
-                deps.selectorPrompt,
-              ),
-            )
-          : closed([]);
+        if (deps.gateConfig.bypassForCore) {
+          // Select over the stable prefix only. `runSelection` mirrors the
+          // normal path: with the selector off (the new-user profile) it passes
+          // the stable candidates straight through rather than forcing the
+          // selectPool LLM call — which that profile disables and which throws
+          // MemoryV3RetrievalUnavailableError with no provider, escaping the
+          // gate on a benign low-signal turn.
+          return closed(
+            await runSelection({ stable: buildStable(), finder: [] }),
+          );
+        }
+        return closed([]);
       }
     }
   }
@@ -517,10 +539,7 @@ export async function orchestrate(
   // contract. `selectorPrompt` is the (optionally overridden) instruction
   // scaffold; `undefined` falls through to the bundled default.
   const pool = { stable, finder: finderTail };
-  const selections =
-    deps.selectorEnabled === false
-      ? selectAllPoolCandidates(pool)
-      : await selectPool(pool, turn, deps.selectorPrompt);
+  const selections = await runSelection(pool);
 
   return {
     selections,


### PR DESCRIPTION
## Summary
Self-review remediation for the memory-v3 injection gate:
- bypassForCore path now mirrors the normal selectorEnabled branch (selectAllPoolCandidates when the selector is off), so a closed-gate turn no longer forces an LLM call or throws MemoryV3RetrievalUnavailableError to the user
- Gate only runs when the dense lane produced hits (densed.length > 0); zero dense hits means dense is disabled (denseK=0 new-user profile) or degraded, so pass-open instead of suppressing all memory
- Log the full gate result (consumes the diagnostic score fields)
- Present-tense gate.ts comment

Self-review fix for plan: memory-v3-injection-gate.md