### PR TITLE
perf(conversations): batch fork message inserts into chunked multi-row inserts

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -1388,6 +1388,70 @@ describe("forkConversation", () => {
     const childState = await hydrateActivationState(db, fork.id);
     expect(childState?.currentTurn).toBe(1);
   });
+
+  test("batch-copies every message with a complete id map and last-assistant pointer", async () => {
+    // Multi-message transcript whose final row is a user message (after the
+    // last assistant). The batched insert must map every source row to a
+    // distinct forked row and track the latest *assistant* message — not the
+    // trailing user row — for the attention pointer.
+    const source = createConversation("Batch fork thread");
+    await addMessage(source.id, "user", "Question 1", { skipIndexing: true });
+    await addMessage(source.id, "assistant", "Answer 1", {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "user", "Question 2", { skipIndexing: true });
+    const lastAssistant = await addMessage(source.id, "assistant", "Answer 2", {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "user", "Trailing user message", {
+      skipIndexing: true,
+    });
+
+    const sourceMessages = getMessages(source.id);
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = getMessages(fork.id);
+
+    // Same count, roles, content, and ordering as the source.
+    expect(forkMessages).toHaveLength(sourceMessages.length);
+    expect(forkMessages.map((m) => m.role)).toEqual(
+      sourceMessages.map((m) => m.role),
+    );
+    expect(forkMessages.map((m) => m.content)).toEqual(
+      sourceMessages.map((m) => m.content),
+    );
+
+    // Every source message maps to exactly one distinct forked message via the
+    // forkSourceMessageId stamped into each copy's metadata.
+    const sourceToFork = new Map<string, string>();
+    for (const forked of forkMessages) {
+      const md = parseMetadata(forked.metadata) as {
+        forkSourceMessageId?: string;
+      } | null;
+      expect(md?.forkSourceMessageId).toBeDefined();
+      sourceToFork.set(md!.forkSourceMessageId!, forked.id);
+    }
+    expect(sourceToFork.size).toBe(sourceMessages.length);
+    for (const sourceMessage of sourceMessages) {
+      expect(sourceToFork.has(sourceMessage.id)).toBe(true);
+    }
+    // Forked ids are all fresh — no source id is reused.
+    expect(new Set(forkMessages.map((m) => m.id)).size).toBe(
+      forkMessages.length,
+    );
+    expect(
+      forkMessages.every((m, index) => m.id !== sourceMessages[index]?.id),
+    ).toBe(true);
+
+    // The attention pointer (driven by latestForkedAssistant) targets the
+    // forked copy of the last assistant row, not the trailing user message.
+    const forkState = getAttentionStateByConversationIds([fork.id]).get(
+      fork.id,
+    );
+    expect(forkState?.lastSeenAssistantMessageId).toBe(
+      sourceToFork.get(lastAssistant.id),
+    );
+    expect(forkState?.lastSeenAssistantMessageAt).toBe(lastAssistant.createdAt);
+  });
 });
 
 describe("forkConversation + memory_retrospective_state", () => {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -906,18 +906,8 @@ export function forkConversation(params: {
       messageAt: number;
     } | null = null;
 
-    for (const message of messagesToCopy) {
+    const forkedMessageValues = messagesToCopy.map((message) => {
       const forkedMessageId = uuid();
-      db.insert(messages)
-        .values({
-          id: forkedMessageId,
-          conversationId: fc.id,
-          role: message.role,
-          content: message.content,
-          createdAt: message.createdAt,
-          metadata: cloneForkMessageMetadata(message.metadata, message.id),
-        })
-        .run();
       forkedMessageIds.set(message.id, forkedMessageId);
 
       if (message.role === "assistant") {
@@ -926,6 +916,27 @@ export function forkConversation(params: {
           messageAt: message.createdAt,
         };
       }
+
+      return {
+        id: forkedMessageId,
+        conversationId: fc.id,
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt,
+        metadata: cloneForkMessageMetadata(message.metadata, message.id),
+      };
+    });
+
+    // Insert in chunks of one multi-row statement each so a large fork takes
+    // the SQLite write lock O(messages / chunk) times instead of once per row.
+    const FORK_INSERT_CHUNK_SIZE = 200;
+    for (
+      let i = 0;
+      i < forkedMessageValues.length;
+      i += FORK_INSERT_CHUNK_SIZE
+    ) {
+      const chunk = forkedMessageValues.slice(i, i + FORK_INSERT_CHUNK_SIZE);
+      db.insert(messages).values(chunk).run();
     }
 
     populateForkContentsInProcess({


### PR DESCRIPTION
## Summary

`forkConversation` copied source messages into the fork with a per-row loop — one `db.insert(messages).values({...}).run()` per copied message, each acquiring the SQLite write lock. A large fork therefore took the write lock once per message.

This builds the full array of forked message value objects up front, then inserts them in **chunks of 200 rows per multi-row statement** inside the existing fork transaction. It collapses **O(messages)** write-lock acquisitions into **O(messages / 200)**.

The exact field mapping is preserved (`id` from `uuid()`, `conversationId`, `role`, `content`, `createdAt`, `metadata: cloneForkMessageMetadata(...)`), and the `forkedMessageIds` source→fork map and `latestForkedAssistant` pointer are populated identically — iteration order is unchanged, so all derived state is byte-identical to the previous loop.

## Scope / safety

PR 1 / Wave 1 of the **"`messages_fts` → Qdrant"** migration (moving full-text search off the SQLite FTS table). This change is independently safe: it is a pure performance fix with **no behavior change** — same rows, same content, same order, same lineage and attention state.

## Tests

Extended `assistant/src/__tests__/conversation-fork-crud.test.ts` with a test that forks a multi-message transcript (ending in a trailing user row after the last assistant) and asserts:
- forked message count / roles / content / ordering match the source,
- the `forkSourceMessageId` mapping is complete and one-to-one (every source id → a distinct fresh forked id),
- the fork's attention pointer (driven by `latestForkedAssistant`) targets the forked copy of the **last assistant** row, not the trailing user message.

Existing fork tests (count/content/order/lineage, compaction inheritance, attachment relink, memory-state carry) continue to exercise behavioral equivalence.

`bunx tsc --noEmit` passes. The fork test file passes for every test touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)