### PR TITLE
feat(search): add sparse-only Qdrant messages-lexical index client

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -26,7 +26,7 @@ interface QueryCall {
 
 interface DeleteCall {
   name: string;
-  opts: { filter?: Record<string, unknown> };
+  opts: { filter?: Record<string, unknown>; points?: Array<string | number> };
 }
 
 let mockCollectionExists: boolean;
@@ -78,7 +78,7 @@ mock.module("@qdrant/js-client-rest", () => ({
       return { points: mockQueryPoints };
     }
 
-    async delete(name: string, opts: { filter?: Record<string, unknown> }) {
+    async delete(name: string, opts: DeleteCall["opts"]) {
       deleteCalls.push({ name, opts });
     }
 
@@ -262,17 +262,14 @@ describe("MessagesLexicalIndex", () => {
     ]);
   });
 
-  test("deleteByMessageId issues a message_id payload-filter delete", async () => {
+  test("deleteByMessageId deletes by the deterministic point id (not a payload filter)", async () => {
     const index = makeIndex();
     await index.deleteByMessageId("msg-del");
 
     expect(deleteCalls.length).toBe(1);
-    const filter = deleteCalls[0].opts.filter as {
-      must: Array<{ key: string; match: { value: string } }>;
-    };
-    expect(filter.must).toEqual([
-      { key: "message_id", match: { value: "msg-del" } },
-    ]);
+    // `message_id` is unindexed, so deletes target the deterministic point id.
+    expect(deleteCalls[0].opts.points).toEqual([messagePointId("msg-del")]);
+    expect(deleteCalls[0].opts.filter).toBeUndefined();
   });
 
   test("count returns the collection count", async () => {

--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Mock Qdrant REST client ───────────────────────────────────────────
+
+interface CreateCollectionCall {
+  name: string;
+  config: Record<string, unknown>;
+}
+
+interface UpsertCall {
+  name: string;
+  opts: { points: Array<Record<string, unknown>> };
+}
+
+interface QueryCall {
+  name: string;
+  opts: Record<string, unknown>;
+}
+
+interface DeleteCall {
+  name: string;
+  opts: { filter?: Record<string, unknown> };
+}
+
+let mockCollectionExists: boolean;
+let createCollectionCalls: CreateCollectionCall[];
+let upsertCalls: UpsertCall[];
+let queryCalls: QueryCall[];
+let deleteCalls: DeleteCall[];
+let payloadIndexCalls: Array<Record<string, unknown>>;
+let mockQueryPoints: Array<{
+  id: string | number;
+  score: number;
+  payload: Record<string, unknown>;
+}>;
+
+function resetMockState() {
+  mockCollectionExists = false;
+  createCollectionCalls = [];
+  upsertCalls = [];
+  queryCalls = [];
+  deleteCalls = [];
+  payloadIndexCalls = [];
+  mockQueryPoints = [];
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: class MockQdrantClient {
+    async collectionExists(_name: string) {
+      return { exists: mockCollectionExists };
+    }
+
+    async createCollection(name: string, config: Record<string, unknown>) {
+      createCollectionCalls.push({ name, config });
+      mockCollectionExists = true;
+    }
+
+    async createPayloadIndex(_name: string, config: Record<string, unknown>) {
+      payloadIndexCalls.push(config);
+    }
+
+    async upsert(
+      name: string,
+      opts: { points: Array<Record<string, unknown>> },
+    ) {
+      upsertCalls.push({ name, opts });
+    }
+
+    async query(name: string, opts: Record<string, unknown>) {
+      queryCalls.push({ name, opts });
+      return { points: mockQueryPoints };
+    }
+
+    async delete(name: string, opts: { filter?: Record<string, unknown> }) {
+      deleteCalls.push({ name, opts });
+    }
+
+    async count(_name: string, _opts: unknown) {
+      return { count: 7 };
+    }
+  },
+}));
+
+import type { SparseEmbedding } from "../embedding-types.js";
+import {
+  messagePointId,
+  MessagesLexicalIndex,
+} from "../messages-lexical-index.js";
+
+const SPARSE: SparseEmbedding = { indices: [1, 5, 9], values: [0.5, 0.2, 0.8] };
+
+function makeIndex() {
+  return new MessagesLexicalIndex({ url: "http://localhost:6333" });
+}
+
+beforeEach(() => {
+  resetMockState();
+});
+
+describe("MessagesLexicalIndex", () => {
+  test("creates a sparse-only collection (no dense vectors config)", async () => {
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    expect(createCollectionCalls.length).toBe(1);
+    const config = createCollectionCalls[0].config;
+
+    // Sparse vector named "sparse" must be present.
+    expect(config.sparse_vectors).toBeDefined();
+    expect(
+      (config.sparse_vectors as Record<string, unknown>).sparse,
+    ).toBeDefined();
+
+    // No dense `vectors` config at all.
+    expect(config.vectors).toBeUndefined();
+    expect("vectors" in config).toBe(false);
+
+    // Payload indexes on conversation_id (keyword) + created_at (integer).
+    const fields = payloadIndexCalls.map((c) => c.field_name);
+    expect(fields).toContain("conversation_id");
+    expect(fields).toContain("created_at");
+    const convIdx = payloadIndexCalls.find(
+      (c) => c.field_name === "conversation_id",
+    );
+    const createdIdx = payloadIndexCalls.find(
+      (c) => c.field_name === "created_at",
+    );
+    expect(convIdx?.field_schema).toBe("keyword");
+    expect(createdIdx?.field_schema).toBe("integer");
+  });
+
+  test("upsertMessage writes a deterministic point id and a sparse-only vector with the right payload", async () => {
+    const index = makeIndex();
+    await index.upsertMessage("msg-123", SPARSE, {
+      conversationId: "conv-abc",
+      createdAt: 1700000000,
+    });
+
+    expect(upsertCalls.length).toBe(1);
+    const points = upsertCalls[0].opts.points;
+    expect(points.length).toBe(1);
+    const point = points[0] as {
+      id: string;
+      vector: Record<string, unknown>;
+      payload: Record<string, unknown>;
+    };
+
+    // Deterministic point id derived from message id.
+    expect(point.id).toBe(messagePointId("msg-123"));
+
+    // Sparse-only vector under the "sparse" named vector, no dense vector.
+    expect(point.vector.sparse).toEqual({
+      indices: SPARSE.indices,
+      values: SPARSE.values,
+    });
+    expect(point.vector.dense).toBeUndefined();
+    expect("dense" in point.vector).toBe(false);
+    // The vector field carries only the sparse named vector.
+    expect(Object.keys(point.vector)).toEqual(["sparse"]);
+
+    // Payload carries message_id, conversation_id, created_at.
+    expect(point.payload.message_id).toBe("msg-123");
+    expect(point.payload.conversation_id).toBe("conv-abc");
+    expect(point.payload.created_at).toBe(1700000000);
+  });
+
+  test("re-upserting the same messageId yields the same point id (idempotent)", async () => {
+    const index = makeIndex();
+    await index.upsertMessage("msg-same", SPARSE, {
+      conversationId: "conv-1",
+      createdAt: 1,
+    });
+    await index.upsertMessage("msg-same", SPARSE, {
+      conversationId: "conv-1",
+      createdAt: 2,
+    });
+
+    expect(upsertCalls.length).toBe(2);
+    const id1 = (upsertCalls[0].opts.points[0] as { id: string }).id;
+    const id2 = (upsertCalls[1].opts.points[0] as { id: string }).id;
+    expect(id1).toBe(id2);
+    expect(id1).toBe(messagePointId("msg-same"));
+    // Distinct message ids map to distinct point ids.
+    expect(messagePointId("msg-same")).not.toBe(messagePointId("msg-other"));
+  });
+
+  test("upsertMessagesBatch writes many points in a single upsert call", async () => {
+    const index = makeIndex();
+    await index.upsertMessagesBatch([
+      { messageId: "m1", sparse: SPARSE, conversationId: "c1", createdAt: 10 },
+      { messageId: "m2", sparse: SPARSE, conversationId: "c2", createdAt: 20 },
+    ]);
+
+    expect(upsertCalls.length).toBe(1);
+    expect(upsertCalls[0].opts.points.length).toBe(2);
+    const ids = upsertCalls[0].opts.points.map((p) => (p as { id: string }).id);
+    expect(ids).toEqual([messagePointId("m1"), messagePointId("m2")]);
+  });
+
+  test("searchLexical queries the sparse named vector and returns {messageId, score}", async () => {
+    mockQueryPoints = [
+      { id: "pt-1", score: 0.91, payload: { message_id: "msg-A" } },
+      { id: "pt-2", score: 0.42, payload: { message_id: "msg-B" } },
+    ];
+
+    const index = makeIndex();
+    const results = await index.searchLexical(SPARSE, 5);
+
+    expect(queryCalls.length).toBe(1);
+    const opts = queryCalls[0].opts;
+    // Query targets the sparse named vector.
+    expect(opts.using).toBe("sparse");
+    expect(opts.query).toEqual({
+      indices: SPARSE.indices,
+      values: SPARSE.values,
+    });
+    expect(opts.limit).toBe(5);
+    // No filter when no conversation scope is given.
+    expect(opts.filter).toBeUndefined();
+
+    expect(results).toEqual([
+      { messageId: "msg-A", score: 0.91 },
+      { messageId: "msg-B", score: 0.42 },
+    ]);
+  });
+
+  test("searchLexical passes a conversation_id payload filter when given", async () => {
+    mockQueryPoints = [
+      { id: "pt-1", score: 0.5, payload: { message_id: "msg-A" } },
+    ];
+
+    const index = makeIndex();
+    await index.searchLexical(SPARSE, 3, { conversationId: "conv-xyz" });
+
+    expect(queryCalls.length).toBe(1);
+    const filter = queryCalls[0].opts.filter as {
+      must: Array<{ key: string; match: { value: string } }>;
+    };
+    expect(filter).toBeDefined();
+    expect(filter.must).toEqual([
+      { key: "conversation_id", match: { value: "conv-xyz" } },
+    ]);
+  });
+
+  test("deleteByConversation issues a conversation_id payload-filter delete", async () => {
+    const index = makeIndex();
+    await index.deleteByConversation("conv-del");
+
+    expect(deleteCalls.length).toBe(1);
+    const filter = deleteCalls[0].opts.filter as {
+      must: Array<{ key: string; match: { value: string } }>;
+    };
+    expect(filter.must).toEqual([
+      { key: "conversation_id", match: { value: "conv-del" } },
+    ]);
+  });
+
+  test("deleteByMessageId issues a message_id payload-filter delete", async () => {
+    const index = makeIndex();
+    await index.deleteByMessageId("msg-del");
+
+    expect(deleteCalls.length).toBe(1);
+    const filter = deleteCalls[0].opts.filter as {
+      must: Array<{ key: string; match: { value: string } }>;
+    };
+    expect(filter.must).toEqual([
+      { key: "message_id", match: { value: "msg-del" } },
+    ]);
+  });
+
+  test("count returns the collection count", async () => {
+    const index = makeIndex();
+    expect(await index.count()).toBe(7);
+  });
+
+  test("no dense vector is ever written or queried across operations", async () => {
+    mockQueryPoints = [
+      { id: "pt-1", score: 0.5, payload: { message_id: "msg-A" } },
+    ];
+    const index = makeIndex();
+    await index.upsertMessage("m1", SPARSE, {
+      conversationId: "c1",
+      createdAt: 1,
+    });
+    await index.searchLexical(SPARSE, 5);
+
+    // Collection config never declares a dense vector.
+    for (const call of createCollectionCalls) {
+      expect("vectors" in call.config).toBe(false);
+    }
+    // No upsert point carries a dense vector.
+    for (const call of upsertCalls) {
+      for (const point of call.opts.points) {
+        const vector = (point as { vector: Record<string, unknown> }).vector;
+        expect("dense" in vector).toBe(false);
+      }
+    }
+    // No query targets a dense vector.
+    for (const call of queryCalls) {
+      expect(call.opts.using).toBe("sparse");
+    }
+  });
+});

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -249,12 +249,13 @@ export class MessagesLexicalIndex {
   async deleteByMessageId(messageId: string): Promise<void> {
     await this.ensureCollection();
 
+    // Delete by the deterministic point id rather than a `message_id` payload
+    // filter: `message_id` has no payload index, so a filter delete would scan
+    // the whole collection. The point id is recoverable from the message id.
     const doDelete = () =>
       this.client.delete(this.collection, {
         wait: true,
-        filter: {
-          must: [{ key: "message_id", match: { value: messageId } }],
-        },
+        points: [messagePointId(messageId)],
       });
 
     try {

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -1,0 +1,367 @@
+import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
+import { v5 as uuidv5 } from "uuid";
+
+import { getLogger } from "../../util/logger.js";
+import type { SparseEmbedding } from "./embedding-types.js";
+
+const log = getLogger("messages-lexical-index");
+
+/**
+ * Dedicated Qdrant collection holding the lexical (BM25-style sparse) index for
+ * `messages`. Sparse-only — there is no dense vector. The collection is a
+ * faithful replacement for SQLite FTS5 full-text search over message content,
+ * encoded with the local TF-IDF sparse encoder so no per-message model call is
+ * required to index a message.
+ */
+export const MESSAGES_LEXICAL_COLLECTION = "messages_lexical";
+
+/**
+ * Stable namespace for deriving deterministic Qdrant point ids from message
+ * ids. Using a fixed namespace (instead of `uuid.URL`) keeps point-id identity
+ * scoped to this index, so the same `messageId` always maps to the same point
+ * and re-indexing is idempotent without a pre-read.
+ */
+const MESSAGE_POINT_NAMESPACE = "b6d0d3e2-1f1a-4c3e-9a7c-0e2f5a8d4c11";
+
+export interface MessagesLexicalIndexConfig {
+  url: string;
+  collection?: string;
+  onDisk?: boolean;
+}
+
+export interface MessageLexicalPayload {
+  messageId: string;
+  conversationId: string;
+  createdAt: number;
+}
+
+export interface MessageLexicalSearchResult {
+  messageId: string;
+  score: number;
+}
+
+let _instance: MessagesLexicalIndex | null = null;
+
+export function getMessagesLexicalIndex(): MessagesLexicalIndex {
+  if (!_instance) {
+    throw new Error(
+      "Messages lexical index not initialized. Call initMessagesLexicalIndex() first.",
+    );
+  }
+  return _instance;
+}
+
+export function initMessagesLexicalIndex(
+  config: MessagesLexicalIndexConfig,
+): MessagesLexicalIndex {
+  _instance = new MessagesLexicalIndex(config);
+  return _instance;
+}
+
+/**
+ * Derive the deterministic Qdrant point id for a message. Idempotent:
+ * re-indexing the same `messageId` overwrites the same point.
+ */
+export function messagePointId(messageId: string): string {
+  return uuidv5(messageId, MESSAGE_POINT_NAMESPACE);
+}
+
+export class MessagesLexicalIndex {
+  private readonly client: QdrantRestClient;
+  private readonly collection: string;
+  private readonly onDisk: boolean;
+  private collectionReady = false;
+
+  constructor(config: MessagesLexicalIndexConfig) {
+    this.client = new QdrantRestClient({
+      url: config.url,
+      checkCompatibility: false,
+    });
+    this.collection = config.collection ?? MESSAGES_LEXICAL_COLLECTION;
+    this.onDisk = config.onDisk ?? true;
+  }
+
+  async ensureCollection(): Promise<void> {
+    if (this.collectionReady) return;
+
+    try {
+      const exists = await this.client.collectionExists(this.collection);
+      if (exists.exists) {
+        if (await this.ensurePayloadIndexesSafe()) {
+          this.collectionReady = true;
+        }
+        return;
+      }
+    } catch {
+      // Existence check failed — fall through to creation.
+    }
+
+    log.info(
+      { collection: this.collection },
+      "Creating sparse-only Qdrant collection for messages lexical index",
+    );
+
+    try {
+      await this.client.createCollection(this.collection, {
+        // Sparse-only: no dense `vectors` config. The lexical index is a
+        // BM25-style replacement for FTS5 and never holds a dense vector.
+        sparse_vectors: {
+          sparse: {}, // Qdrant auto-infers sparse vector params
+        },
+        on_disk_payload: this.onDisk,
+      });
+    } catch (err) {
+      // 409 = a concurrent caller created the collection first — that's fine.
+      if (
+        err instanceof Error &&
+        "status" in err &&
+        (err as { status: number }).status === 409
+      ) {
+        if (await this.ensurePayloadIndexesSafe()) {
+          this.collectionReady = true;
+        }
+        return;
+      }
+      throw err;
+    }
+
+    if (await this.ensurePayloadIndexesSafe()) {
+      this.collectionReady = true;
+      log.info(
+        { collection: this.collection },
+        "Messages lexical index collection created with payload indexes",
+      );
+    }
+  }
+
+  async upsertMessage(
+    messageId: string,
+    sparse: SparseEmbedding,
+    payload: { conversationId: string; createdAt: number },
+  ): Promise<void> {
+    await this.upsertMessagesBatch([
+      {
+        messageId,
+        sparse,
+        conversationId: payload.conversationId,
+        createdAt: payload.createdAt,
+      },
+    ]);
+  }
+
+  async upsertMessagesBatch(
+    points: Array<{
+      messageId: string;
+      sparse: SparseEmbedding;
+      conversationId: string;
+      createdAt: number;
+    }>,
+  ): Promise<void> {
+    await this.ensureCollection();
+
+    if (points.length === 0) return;
+
+    const qdrantPoints = points.map((p) => ({
+      id: messagePointId(p.messageId),
+      vector: {
+        sparse: {
+          indices: p.sparse.indices,
+          values: p.sparse.values,
+        },
+      },
+      payload: {
+        message_id: p.messageId,
+        conversation_id: p.conversationId,
+        created_at: p.createdAt,
+      },
+    }));
+
+    const doUpsert = () =>
+      this.client.upsert(this.collection, {
+        wait: true,
+        points: qdrantPoints,
+      });
+
+    try {
+      await doUpsert();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        await doUpsert();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async searchLexical(
+    sparse: SparseEmbedding,
+    limit: number,
+    opts?: { conversationId?: string },
+  ): Promise<MessageLexicalSearchResult[]> {
+    await this.ensureCollection();
+
+    const filter = opts?.conversationId
+      ? {
+          must: [
+            {
+              key: "conversation_id",
+              match: { value: opts.conversationId },
+            },
+          ],
+        }
+      : undefined;
+
+    const queryParams = {
+      query: {
+        indices: sparse.indices,
+        values: sparse.values,
+      },
+      using: "sparse",
+      limit,
+      with_payload: true,
+      filter: filter as Record<string, unknown> | undefined,
+    };
+
+    let results;
+    try {
+      results = await this.client.query(this.collection, queryParams);
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        results = await this.client.query(this.collection, queryParams);
+      } else {
+        throw err;
+      }
+    }
+
+    return (results.points ?? []).map((point) => ({
+      messageId: String(
+        (point.payload as Record<string, unknown> | undefined)?.message_id ??
+          "",
+      ),
+      score: point.score ?? 0,
+    }));
+  }
+
+  async deleteByMessageId(messageId: string): Promise<void> {
+    await this.ensureCollection();
+
+    const doDelete = () =>
+      this.client.delete(this.collection, {
+        wait: true,
+        filter: {
+          must: [{ key: "message_id", match: { value: messageId } }],
+        },
+      });
+
+    try {
+      await doDelete();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        await doDelete();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async deleteByConversation(conversationId: string): Promise<void> {
+    await this.ensureCollection();
+
+    const doDelete = () =>
+      this.client.delete(this.collection, {
+        wait: true,
+        filter: {
+          must: [{ key: "conversation_id", match: { value: conversationId } }],
+        },
+      });
+
+    try {
+      await doDelete();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        await doDelete();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async count(): Promise<number> {
+    await this.ensureCollection();
+
+    try {
+      const result = await this.client.count(this.collection, { exact: false });
+      return result.count;
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        const result = await this.client.count(this.collection, {
+          exact: false,
+        });
+        return result.count;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Detect "collection not found" errors from Qdrant so callers can reset
+   * collectionReady and retry after an external deletion.
+   */
+  private isCollectionMissing(err: unknown): boolean {
+    if (
+      err &&
+      typeof err === "object" &&
+      "status" in err &&
+      (err as { status: number }).status === 404
+    ) {
+      return true;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return (
+      msg.includes("Not found") ||
+      msg.includes("doesn't exist") ||
+      msg.includes("not found")
+    );
+  }
+
+  /**
+   * Wraps ensurePayloadIndexes so that a 404 (collection deleted between the
+   * existence check and index creation) resets collectionReady instead of
+   * propagating — the next operation self-heals via ensureCollection.
+   */
+  private async ensurePayloadIndexesSafe(): Promise<boolean> {
+    try {
+      await this.ensurePayloadIndexes();
+      return true;
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  private async ensurePayloadIndexes(): Promise<void> {
+    await Promise.all([
+      this.client.createPayloadIndex(this.collection, {
+        field_name: "conversation_id",
+        field_schema: "keyword",
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: "created_at",
+        field_schema: "integer",
+      }),
+    ]);
+  }
+}


### PR DESCRIPTION
## What

PR 2 / Wave 1 of the migration that moves `messages` full-text search off **SQLite FTS5** and onto a dedicated **sparse-only** Qdrant collection. This PR adds the client module **only** — nothing imports it yet, so the change is purely additive and deploy-safe.

New files:
- `assistant/src/persistence/embeddings/messages-lexical-index.ts` — the `MessagesLexicalIndex` class + `initMessagesLexicalIndex()` / `getMessagesLexicalIndex()` singletons.
- `assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts` — unit tests over a mocked Qdrant REST client.

## Design

- **Sparse-only collection (`messages_lexical`).** `ensureCollection()` creates the collection with **only** `sparse_vectors: { sparse: {} }` — there is no `dense` named vector and no `vectors` config at all. Payload is `on_disk`, with payload indexes on `conversation_id` (keyword) and `created_at` (integer).
- **Why sparse-only.** This is a faithful BM25/FTS5 replacement: lexical retrieval over message text. A dense vector would require a per-message embedding model call to index every message, which is out of scope and unnecessary for lexical search. Text is encoded to a `SparseEmbedding` via the existing local TF-IDF encoder (`generateSparseEmbedding`), so indexing stays model-call-free. (Encoding is wired in a later PR; this module takes a `SparseEmbedding` as input.)
- **Deterministic point id → idempotent re-index.** `messagePointId(messageId)` = `uuid.v5(messageId, <fixed namespace>)`. Re-upserting the same `messageId` overwrites the same point with no pre-read, so backfill/re-index is idempotent.
- **Mirrors `qdrant-client.ts`.** Same `collectionReady` idempotency guard, the same 409 "already exists" handling on create, and the same `isCollectionMissing(err)` 404-detect → reset-and-retry wrapper around every operation.

Methods: `upsertMessage`, `upsertMessagesBatch` (single `upsert` with many points for backfill throughput), `searchLexical` (queries the `sparse` named vector via `client.query({ using: "sparse" })`, optional `conversation_id` filter, returns `{ messageId, score }`), `deleteByMessageId`, `deleteByConversation` (payload-filter deletes), and `count`.

## Tests

10 tests / 43 assertions, all passing. They assert: the collection is created sparse-only (no `dense`, `sparse_vectors.sparse` present); `upsertMessage` writes a deterministic point id and a sparse-only vector with the right payload; re-upsert is idempotent (same point id); `searchLexical` returns `{messageId, score}` and passes a `conversation_id` filter when scoped; `deleteByConversation` issues a `conversation_id` payload-filter delete; and **no dense vector is ever written or queried** across all operations.

## Verification

- `bunx tsc --noEmit`: no errors in the new files (the worktree shows pre-existing, unrelated errors in `contacts/`/`messaging/`/sibling `packages/*` that are byte-identical with and without this change).
- `bun test src/persistence/embeddings/__tests__/messages-lexical-index.test.ts`: **10 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)