### PR TITLE
move assistant source code copy to runner stage

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -52,7 +52,6 @@ RUN set -eu; for pkg in /app/skills/*/package.json; do \
       (cd "$dir" && (bun install --frozen-lockfile 2>/dev/null || bun install)); \
     done
 
-COPY assistant ./assistant
 
 # Final stage
 FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS runner
@@ -122,6 +121,11 @@ RUN apt-get update && apt-get install -y \
 # Copy bun binary from builder instead of re-installing
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
+
+# Copy installed deps, shared packages, and bundled skills from the builder stage.
+COPY --from=builder /app /app
+
+COPY assistant /app/assistant
 
 # Install assistant CLI launcher backed by the bundled assistant package
 RUN printf '#!/usr/bin/env sh\nexec bun run /app/assistant/src/index.ts "$@"\n' > /usr/local/bin/assistant && \
@@ -227,10 +231,6 @@ EXPOSE 3001
 
 ENV RUNTIME_HTTP_PORT=3001
 ENV IS_CONTAINERIZED=true
-
-# Copy installed deps, shared packages, bundled skills, assistant source,
-# and the generated meet-join manifest from the builder stage.
-COPY --from=builder /app /app
 
 COPY packages/block-volume-bootstrap/scripts/*.sh /usr/local/bin/
 


### PR DESCRIPTION
Follow up to https://github.com/vellum-ai/vellum-assistant/pull/36721

Previously the
```
COPY --from=builder /app /app
```
step would get invalidated by any change to `assistant/` source code.

This reordering lets us reuse the builder stage cache for simple changes to `assistant/` source. In local testing, docker (re)build time drops from ~30s -> 4s after modifying some `assistant/` source files.

---

Note that `assistant` depends on local sibling `packages/`, copied and installed during the `builder` stage. Modifying source in `packages/` leads to the same layer invalidation issue as before.

_Maybe_ bun workspaces has some functionality to help with this? Wanted to look into workspaces anyway to untangle our usage of our component library