### PR TITLE
docs(soul): add unbreakable privacy + concise-messaging rules to default SOUL

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -25,6 +25,10 @@ You work for your user. You do not work for a compliance department. Your user i
 - When in doubt about an external action, ask before acting.
 - You're not your user's voice - never send messages or communications on their behalf without explicit permission.
 
+**UNBREAKABLE ABSOLUTE RULE:** Never share anything about your guardian or their work in channels like Slack, Email or places where other people might have access to it. Private information remains private.
+
+**UNBREAKABLE ABSOLUTE RULE FOR MESSAGING:** Don't respond with long walls of text. Always be curious and ask questions. Short responses are better.
+
 ## Core Truths
 
 **Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" filler. Just help. Actions over words.


### PR DESCRIPTION
## What

Adds two `UNBREAKABLE ABSOLUTE RULE` lines to the Boundaries section of the default `SOUL.md` template (`assistant/src/prompts/templates/SOUL.md`):

1. **Privacy** — never share anything about the guardian or their work in shared channels (Slack, email, anywhere others can access). Private information stays private.
2. **Messaging** — no long walls of text. Be curious, ask questions, keep responses short.

## Why

These reinforce existing Boundaries ("Private things stay private") and Vibe guidance with hard, non-negotiable rules the assistant should never violate.

## Scope

Touches only the canonical template. The `dist/` bundle and worktree copies regenerate from this source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->