### PR TITLE
feat(onboarding): add "Who do you want me to be?" persona field (web)

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -53,4 +53,28 @@ describe("buildPersonalityMessage", () => {
     expect(msg).toContain("Coworker (0-100): 100");
     expect(msg).toContain("Companion (0-100): 0");
   });
+
+  test("weaves the persona into the message when provided", () => {
+    const msg = buildPersonalityMessage(
+      {},
+      "Akash",
+      "a noir detective on the case",
+    );
+    expect(msg).toContain(
+      'They also described the character they want you to embody: "a noir detective on the case".',
+    );
+    // Trait scores and the rewrite instruction still survive the insertion.
+    expect(msg).toContain("Companion (0-100): 50");
+    expect(msg).toContain(
+      "Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md)",
+    );
+  });
+
+  test("collapses whitespace and omits the persona block when blank", () => {
+    const multiline = buildPersonalityMessage({}, undefined, "a sassy\n  goth   girl");
+    expect(multiline).toContain('"a sassy goth girl"');
+
+    const blank = buildPersonalityMessage({}, undefined, "   ");
+    expect(blank).not.toContain("described the character");
+  });
 });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -64,6 +64,7 @@ const clamp = (n: number): number => Math.max(0, Math.min(100, Math.round(n)));
 export function buildPersonalityMessage(
   values: Record<string, number>,
   userName?: string,
+  persona?: string,
 ): string {
   const v = (id: string): number => clamp(values[id] ?? 50);
   const companionCoworker = v(AXIS.companionCoworker); // 100 = Coworker
@@ -72,6 +73,12 @@ export function buildPersonalityMessage(
   const politeUnfiltered = v(AXIS.politeUnfiltered); // 100 = Unfiltered
 
   const who = userName?.trim() || "The user";
+  // Collapse whitespace so a multi-line answer can't break the system-message
+  // framing the assistant parses.
+  const character = persona?.trim().replace(/\s+/g, " ");
+  const personaBlock = character
+    ? `\nThey also described the character they want you to embody: "${character}". Take on this persona — let it shape your voice, tone, and how you behave — while still honoring the trait scores above.\n`
+    : "";
   return `<system-message>
 ${who} wants to customize your personality.
 This is what they want you to be:
@@ -84,7 +91,7 @@ Playfulness (0 - 100): ${100 - playfulSerious}
 Seriousness (0 - 100): ${playfulSerious}
 Politeness (0 - 100): ${100 - politeUnfiltered}
 Unfiltered Rawness/Crassness (0 - 100): ${politeUnfiltered}
-
+${personaBlock}
 Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality. Write them in first person in a voice and style that matches your new personality.
 </system-message>`;
 }
@@ -115,6 +122,8 @@ export interface ApplyPersonalityOptions {
   awaitAssistantId: () => Promise<string>;
   /** The five slider values, keyed by axis id (see `AXIS`). */
   values: Record<string, number>;
+  /** Free-text character to embody, woven into the system-message. */
+  persona?: string;
   /** The user's name, woven into the system-message. */
   userName?: string;
 }
@@ -126,6 +135,7 @@ export interface ApplyPersonalityOptions {
 export async function applyPersonality({
   awaitAssistantId,
   values,
+  persona,
   userName,
 }: ApplyPersonalityOptions): Promise<void> {
   let assistantId: string | undefined;
@@ -143,7 +153,7 @@ export async function applyPersonality({
 
     const body: MessagesPostData["body"] = {
       conversationId,
-      content: buildPersonalityMessage(values, userName),
+      content: buildPersonalityMessage(values, userName, persona),
       sourceChannel: "vellum",
       interface: "vellum",
       clientMessageId: crypto.randomUUID(),

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -183,6 +183,9 @@ export function ResearchOnboardingRoute() {
   const [personalityValues, setPersonalityValues] = useState<
     Record<string, number>
   >({});
+  // Free-text persona ("who do you want me to be?"), lives alongside the slider
+  // values so it survives a step-back and is sent with them on continue.
+  const [persona, setPersona] = useState("");
   const [personalityLocked, setPersonalityLocked] = useState(false);
   // Id of the behind-the-scenes "research me" conversation. Captured the moment
   // it's minted (and restored from the snapshot on refresh) so a mid-search
@@ -572,6 +575,8 @@ export function ResearchOnboardingRoute() {
             onValueChange={(axisId, value) =>
               setPersonalityValues((prev) => ({ ...prev, [axisId]: value }))
             }
+            persona={persona}
+            onPersonaChange={setPersona}
             locked={personalityLocked}
             onContinue={() => {
               // First continue applies the sliders to the assistant's persona on
@@ -585,6 +590,7 @@ export function ResearchOnboardingRoute() {
                 void applyPersonality({
                   awaitAssistantId: awaitHatchReady,
                   values: personalityValues,
+                  persona: persona.trim() || undefined,
                   userName: formValues?.firstName?.trim() || undefined,
                 });
                 setPersonalityLocked(true);

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -4,8 +4,9 @@
  *
  * SPIKE — research-onboarding flow.
  *
- * Frontend-only for now: the slider values are held in local state and aren't
- * sent anywhere yet (a later PR will wire them to the assistant's persona). The
+ * The slider values and the free-text persona ("who do you want me to be?") are
+ * held by the route and, on continue, sent to the hatched assistant as a
+ * system-message that rewrites its identity files (see `applyPersonality`). The
  * step is part of the research-onboarding flow (no separate flag). Foreground
  * content only — the shared toned backdrop (avatar color + bottom eyes) sits
  * behind.
@@ -45,6 +46,10 @@ interface CreatePersonalityStepProps {
   values: Record<string, number>;
   /** Report a single slider's new value. */
   onValueChange: (axisId: string, value: number) => void;
+  /** Free-text character the assistant should embody, owned by the route. */
+  persona: string;
+  /** Report the persona text as the user edits it. */
+  onPersonaChange: (next: string) => void;
   /**
    * Once the user has continued, the personality prompt has already been sent
    * to the assistant — lock the sliders so a step-back can't silently diverge
@@ -56,6 +61,20 @@ interface CreatePersonalityStepProps {
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }
+
+/**
+ * Example characters cycled through the persona field's placeholder — spicy to
+ * deadpan — to convey the range of valid answers without prescribing one.
+ */
+const PERSONA_EXAMPLES = [
+  "a sassy goth girl who calls me out",
+  "a deadpan butler who's quietly judging me",
+  "a brutally honest best friend",
+  "a noir detective on the case",
+];
+
+/** Cadence for the persona placeholder rotation. */
+const PERSONA_PLACEHOLDER_INTERVAL_MS = 3000;
 
 /**
  * The five trait axes, each a 0–100 slider flanked by its end labels. Each end
@@ -349,12 +368,26 @@ function EdgeAvatarLayer({
 export function CreatePersonalityStep({
   values,
   onValueChange,
+  persona,
+  onPersonaChange,
   locked,
   onContinue,
   onBack,
   onForward,
 }: CreatePersonalityStepProps) {
   const tone = useOnboardingTone();
+  // Rotate the persona placeholder while the field is empty and editable, so a
+  // typed answer (or a locked step) isn't disrupted by a shifting example.
+  const [placeholderIndex, setPlaceholderIndex] = useState(0);
+  useEffect(() => {
+    if (locked || persona.trim()) return;
+    const interval = setInterval(() => {
+      setPlaceholderIndex((i) => (i + 1) % PERSONA_EXAMPLES.length);
+    }, PERSONA_PLACEHOLDER_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [locked, persona]);
+  const personaPlaceholder =
+    PERSONA_EXAMPLES[placeholderIndex] ?? PERSONA_EXAMPLES[0];
   const components = useBundledAvatarComponents();
   const viewportWidth = useViewportWidth();
   const isDesktop = viewportWidth >= DESKTOP_MIN_WIDTH;
@@ -432,6 +465,26 @@ export function CreatePersonalityStep({
               disabled={locked}
             />
           ))}
+
+          <div className="flex w-full flex-col items-center gap-2">
+            <label
+              htmlFor="persona-input"
+              className="text-center text-base sm:text-[17px]"
+              style={{ color: tone.fg }}
+            >
+              Who do you want me to be?
+            </label>
+            <input
+              id="persona-input"
+              type="text"
+              value={persona}
+              onChange={(e) => onPersonaChange(e.target.value)}
+              disabled={locked}
+              placeholder={personaPlaceholder}
+              className="w-full max-w-md rounded-2xl border bg-transparent px-4 py-2.5 text-center text-base outline-none transition-colors duration-150 placeholder:text-current placeholder:opacity-50 disabled:cursor-not-allowed"
+              style={{ color: tone.fg, borderColor: tone.fgMuted }}
+            />
+          </div>
         </div>
 
         <button


### PR DESCRIPTION
## What

Adds a free-text **"Who do you want me to be?"** persona input below the five trait sliders on the web **Create my personality** step (`create-personality-step.tsx`).

- Placeholder **cycles every 3s** through example characters (sassy goth girl → deadpan butler → brutally honest best friend → noir detective) to convey the range without prescribing an answer. Cycling pauses once the user types or the step is locked.
- Styled to match the toned step (mirrors the give-me-a-face input; uses `tone.fg` / `tone.fgMuted`).

## How it's wired (web-only — no daemon/contract changes)

The persona text rides the path the slider values already use:

1. `research-onboarding-route.tsx` owns a new `persona` state alongside `personalityValues` (survives a step-back), passes it into the step, and forwards it to `applyPersonality` on continue.
2. `apply-personality.ts` weaves the persona into the personality system-message posted to a throwaway side conversation, instructing the assistant to rewrite its identity files (`IDENTITY.md` / `SOUL.md` / `users/guardian.md`). So this **actually reshapes the persona** without touching the daemon onboarding contract or OpenAPI types.

Safety: the answer is `trim()`'d and whitespace-collapsed so a multi-line value can't break the `<system-message>` framing the assistant parses; a blank answer omits the persona block entirely.

## Tests

- Extended `apply-personality.test.ts`: persona woven in when provided, whitespace collapsed, block omitted when blank, existing trait/rewrite lines still survive the insertion. **5/5 pass.**
- The four touched files typecheck clean and lint clean. (The repo has unrelated pre-existing `tsc` errors from unbuilt generated workspace packages — `@vellumai/assistant-api`, `@vellumai/design-library` — none in these files.)

## Notes for review

- Targets the **research-onboarding** "Create my personality" step (the slider screen). The separate pre-chat tone flow (vibe cards) is untouched.
- Equivalent macOS Swift work was prototyped earlier; this is the web implementation. Cross-client parity can follow if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)