### PR TITLE
fix(workspace): seed stub NOW.md scratchpad so the prompt-referenced file exists

### DIFF
--- a/assistant/src/__tests__/workspace-migration-118-seed-now-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-118-seed-now-md.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for workspace migration `118-seed-now-md`.
+ *
+ * The migration writes a stub `NOW.md` to the workspace root only when the file
+ * is absent (create-only — never clobber an existing NOW.md). Unlike the
+ * onboarding-threads seed (069) it is NOT gated on `isNewWorkspace`: existing
+ * workspaces are exactly the ones missing the file, so the stub is seeded on
+ * upgrade too. The stub is comment-only, so `stripCommentLines` reduces it to
+ * empty and nothing is injected into context — the file's existence is the
+ * point, so `file_edit`/read against NOW.md stop failing with "file not found".
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { stripCommentLines } from "../util/strip-comment-lines.js";
+import { seedNowMdMigration } from "../workspace/migrations/118-seed-now-md.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-118-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function nowPath(): string {
+  return join(workspaceDir, "NOW.md");
+}
+
+function readNow(): string {
+  return readFileSync(nowPath(), "utf-8");
+}
+
+describe("118-seed-now-md migration", () => {
+  test("has correct id and description", () => {
+    expect(seedNowMdMigration.id).toBe("118-seed-now-md");
+    expect(seedNowMdMigration.description).toContain("NOW.md");
+  });
+
+  test("creates NOW.md when absent", () => {
+    expect(existsSync(nowPath())).toBe(false);
+
+    seedNowMdMigration.run(workspaceDir);
+
+    expect(existsSync(nowPath())).toBe(true);
+    expect(readNow().length).toBeGreaterThan(0);
+  });
+
+  test("seeds on upgrade too — not gated on isNewWorkspace", () => {
+    // Existing workspaces are the ones missing the file, so an upgrade context
+    // (and a brand-new one) both seed it.
+    seedNowMdMigration.run(workspaceDir, UPGRADE_CTX);
+    expect(existsSync(nowPath())).toBe(true);
+
+    rmSync(nowPath());
+    seedNowMdMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    expect(existsSync(nowPath())).toBe(true);
+  });
+
+  test("seeded stub strips to empty — injects nothing", () => {
+    seedNowMdMigration.run(workspaceDir);
+    // Every line is a `_` comment, so the scratchpad reader (which runs the
+    // same strip) sees no content and the now-md injector emits nothing.
+    expect(stripCommentLines(readNow())).toBe("");
+  });
+
+  test("does not clobber an existing NOW.md with real content", () => {
+    const existing = "Current focus: shipping the seed migration.\n";
+    writeFileSync(nowPath(), existing, "utf-8");
+
+    seedNowMdMigration.run(workspaceDir);
+
+    expect(readNow()).toBe(existing);
+  });
+
+  test("does not clobber an existing empty NOW.md", () => {
+    writeFileSync(nowPath(), "", "utf-8");
+
+    seedNowMdMigration.run(workspaceDir);
+
+    expect(readNow()).toBe("");
+  });
+
+  test("idempotent — second run does not rewrite the stub", () => {
+    seedNowMdMigration.run(workspaceDir);
+    const afterFirst = readNow();
+
+    seedNowMdMigration.run(workspaceDir);
+    const afterSecond = readNow();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("down() is a no-op — seeded file remains", () => {
+    seedNowMdMigration.run(workspaceDir);
+    const seeded = readNow();
+
+    seedNowMdMigration.down(workspaceDir);
+
+    expect(existsSync(nowPath())).toBe(true);
+    expect(readNow()).toBe(seeded);
+  });
+});

--- a/assistant/src/workspace/migrations/118-seed-now-md.ts
+++ b/assistant/src/workspace/migrations/118-seed-now-md.ts
@@ -1,0 +1,64 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-118");
+
+/**
+ * Stub contents for a freshly-seeded NOW.md. Every line is a `_`-prefixed
+ * comment, so `stripCommentLines` reduces it to empty — the scratchpad injector
+ * sees no content and injects nothing (zero token cost) until the assistant
+ * writes real state. The file existing on disk is the point: the system prompt
+ * tells the assistant it "has a scratchpad file (NOW.md) ... a single file you
+ * overwrite", and `file_edit` requires the target to already exist, so an absent
+ * NOW.md surfaces as "file not found" the first time the assistant follows that
+ * instruction. The comment body mirrors the SOUL.md scratchpad framing so the
+ * assistant has guidance in front of it when it overwrites the file.
+ *
+ * Inlined per the migrations self-containment rule.
+ */
+const NOW_MD_STUB = `_ NOW.md — your scratchpad. Overwrite this whole file with whatever is most
+_ relevant right now. Unlike your journal (retrospective, append-only), this is
+_ a single snapshot you keep current. It's loaded into your context
+_ automatically, so next-you always sees the latest.
+_
+_ What goes here: your current focus and what you're actively working on; threads
+_ you're tracking (waiting on a reply, monitoring something, pending follow-ups);
+_ near-term priorities; temporary context that matters now but won't in a week.
+_
+_ What stays out: permanent facts (those live in memory/); personality and
+_ principles (those live in SOUL.md).
+_
+_ Lines starting with _ are comments — they aren't loaded into your context.
+_ Replace them freely.
+`;
+
+export const seedNowMdMigration: WorkspaceMigration = {
+  id: "118-seed-now-md",
+  description:
+    "Seed a stub NOW.md scratchpad file so the prompt-referenced scratchpad exists on disk for read/edit",
+
+  run(workspaceDir: string): void {
+    // Create-only: write the stub solely when NOW.md is absent. The assistant
+    // owns the file once it exists, so an existing NOW.md — seeded stub or real
+    // content — is never clobbered. Unlike the onboarding-threads seed (069),
+    // this is not gated on `isNewWorkspace`: the assistants hitting the missing
+    // file are existing workspaces, and the comment-only stub injects nothing,
+    // so re-creating it on upgrade is harmless and exactly the intended fix.
+    const filePath = join(workspaceDir, "NOW.md");
+    if (existsSync(filePath)) return;
+    try {
+      writeFileSync(filePath, NOW_MD_STUB, "utf-8");
+    } catch (err) {
+      log.warn({ err }, "Failed to seed NOW.md scratchpad stub");
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: never delete NOW.md on rollback. By the time a rollback
+    // runs the assistant may have overwritten the stub with real scratchpad
+    // state, and the file's existence is what keeps file_edit/read working.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -115,6 +115,7 @@ import { swapQualityProfileToOpusMigration } from "./114-swap-quality-profile-to
 import { dropFrontierProfileMigration } from "./115-drop-frontier-profile.js";
 import { renameMemoryPluginDisabledSentinelMigration } from "./116-rename-memory-plugin-disabled-sentinel.js";
 import { normalizeStaleLeanMemoryV3DefaultsMigration } from "./117-normalize-stale-lean-memory-v3-defaults.js";
+import { seedNowMdMigration } from "./118-seed-now-md.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -241,4 +242,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropFrontierProfileMigration,
   renameMemoryPluginDisabledSentinelMigration,
   normalizeStaleLeanMemoryV3DefaultsMigration,
+  seedNowMdMigration,
 ];


### PR DESCRIPTION
## Summary

- Add workspace migration `118-seed-now-md` that seeds a stub `NOW.md` at the workspace root when it is absent, so the scratchpad file the system prompt promises actually exists on disk.
- Fixes recurring "file not found: /workspace/now.md" errors: `SOUL.md` tells the assistant it "has a scratchpad file (NOW.md) ... a single file you overwrite" and `HEARTBEAT.md`'s first item is "Read NOW.md", but nothing ever created it — so `file_edit` (which requires an existing target) failed.
- The stub is **comment-only** (`_`-prefixed lines), so `stripCommentLines` reduces it to empty and the now-md injector emits nothing — zero token cost until the assistant overwrites it with real state.
- **Create-only**: an existing `NOW.md` (stub or real content) is never clobbered. **Not gated on `isNewWorkspace`** — the affected installs are existing workspaces, and a comment-only stub is harmless to re-create on upgrade.
- Uses `join(workspaceDir, "NOW.md")` (equivalent to `getWorkspacePromptPath("NOW.md")`) to honor the migrations self-containment rule, which forbids importing `util/platform.js`.

## Original prompt

A telemetry dashboard flagged a recurring "file not found: /workspace/now.md" error (7 users; category environment / tool file_edit). We diagnosed it: the assistant is told in its system prompt that a `NOW.md` scratchpad exists and to read/overwrite it, but the file is never scaffolded by default, so `file_edit` against it fails with "file not found". The ask was to fix it by seeding a default `NOW.md` via an idempotent, create-only workspace migration with a comment-only stub that injects nothing, plus a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)