### PR TITLE
Persist local platform registration for retire fallback

### DIFF
--- a/cli/src/__tests__/retire.test.ts
+++ b/cli/src/__tests__/retire.test.ts
@@ -341,6 +341,67 @@ describe("vellum retire", () => {
     expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
   });
 
+  test("local retire uses saved platform registration when local credentials are unreachable", async () => {
+    const entry = makeEntry("assistant-1", {
+      name: "Example Assistant",
+      platformAssistantId: "platform-assistant-1",
+      platformBaseUrl: "https://platform.example.test",
+      platformOrganizationId: "org-123",
+    });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    getPlatformUrlMock.mockReturnValue("https://platform.example.test");
+    readGatewayCredentialMock.mockResolvedValue({
+      value: null,
+      unreachable: true,
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(readGatewayCredentialMock).toHaveBeenCalledWith(
+      entry.localUrl ?? entry.runtimeUrl,
+      "vellum:platform_assistant_id",
+      entry.bearerToken,
+    );
+    expect(loopbackSafeFetchMock).toHaveBeenCalledWith(
+      "https://platform.example.test/v1/assistants/platform-assistant-1/retire/",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Session-Token": "session-token",
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    );
+    expect(consoleWarnSpy.mock.calls.flat().join("\n")).toContain(
+      "using saved platform registration",
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
+  test("local retire continues when local credentials are unreachable and no saved platform registration exists", async () => {
+    const entry = makeEntry("assistant-1", { name: "Example Assistant" });
+    writeLockfile([entry]);
+    readPlatformTokenMock.mockReturnValue("session-token");
+    readGatewayCredentialMock.mockResolvedValue({
+      value: null,
+      unreachable: true,
+    });
+    process.argv = ["bun", "vellum", "retire", "assistant-1", "--yes"];
+
+    await retire();
+
+    expect(loopbackSafeFetchMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls.flat().join("\n")).toContain(
+      "no saved platform registration is available",
+    );
+    expect(retireLocalMock).toHaveBeenCalledWith("assistant-1", entry);
+    expect(loadAllAssistants()).toEqual([]);
+  });
+
   test("local retire skips platform unregister when stored platform URL origin mismatches", async () => {
     const entry = makeEntry("assistant-1", { name: "Example Assistant" });
     writeLockfile([entry]);

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -2266,6 +2266,14 @@ describe("platform credential injection", () => {
         userId: "user-1",
         webhookSecret: "webhook-secret-123",
       });
+      expect(saveAssistantEntryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assistantId: "my-local",
+          platformAssistantId: "platform-assistant-1",
+          platformBaseUrl: "https://platform.vellum.ai",
+          platformOrganizationId: "org-1",
+        }),
+      );
     } finally {
       restoreFetch();
     }

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -7,6 +7,7 @@ import {
   loadAllAssistants,
   removeAssistantEntry,
   resolveAssistant,
+  saveAssistantEntry,
   setActiveAssistant,
 } from "../lib/assistant-config";
 import { computeDeviceId } from "../lib/guardian-token";
@@ -383,6 +384,7 @@ export async function login(): Promise<void> {
           fetchCurrentVersion(entry.runtimeUrl),
           fetchAssistantIngressUrl(entry.runtimeUrl, entry.bearerToken),
         ]);
+        const platformUrl = getPlatformUrl();
         const registration = await ensureSelfHostedLocalRegistration(
           token,
           orgId,
@@ -390,9 +392,15 @@ export async function login(): Promise<void> {
           entry.assistantId,
           "cli",
           assistantVersion,
-          getPlatformUrl(),
+          platformUrl,
           ingressUrl,
         );
+        saveAssistantEntry({
+          ...entry,
+          platformAssistantId: registration.assistant.id,
+          platformBaseUrl: platformUrl,
+          platformOrganizationId: orgId,
+        });
         console.log(
           `Registered assistant: ${registration.assistant.name} (${registration.assistant.id})`,
         );
@@ -433,7 +441,7 @@ export async function login(): Promise<void> {
           bearerToken: entry.bearerToken,
           assistantApiKey,
           platformAssistantId: registration.assistant.id,
-          platformBaseUrl: getPlatformUrl(),
+          platformBaseUrl: platformUrl,
           organizationId: orgId,
           userId: user.id,
           webhookSecret: registration.webhook_secret,

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -47,6 +47,12 @@ interface RetireArgs {
   yes: boolean;
 }
 
+interface SelfHostedPlatformRegistration {
+  platformAssistantId: string;
+  platformBaseUrl: string | null;
+  organizationId: string | null;
+}
+
 const PLATFORM_TOKEN_ENV = "VELLUM_PLATFORM_TOKEN";
 
 function readPlatformRetireToken(): string | null {
@@ -79,6 +85,24 @@ function resolveTrustedSelfHostedPlatformUrl(
     "⚠️  Stored platform URL does not match the configured platform URL; skipping platform unregister.",
   );
   return null;
+}
+
+function nonEmptyString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function lockfileSelfHostedPlatformRegistration(
+  entry: AssistantEntry,
+): SelfHostedPlatformRegistration | null {
+  const platformAssistantId = nonEmptyString(entry.platformAssistantId);
+  if (!platformAssistantId) return null;
+
+  return {
+    platformAssistantId,
+    platformBaseUrl: nonEmptyString(entry.platformBaseUrl),
+    organizationId: nonEmptyString(entry.platformOrganizationId),
+  };
 }
 
 async function deletePlatformAssistant(
@@ -115,12 +139,10 @@ async function deletePlatformAssistant(
   }
 }
 
-async function unregisterSelfHostedLocalPlatformRecord(
+async function readSelfHostedPlatformRegistration(
   entry: AssistantEntry,
-): Promise<void> {
-  const token = readPlatformRetireToken();
-  if (!token) return;
-
+): Promise<SelfHostedPlatformRegistration | null> {
+  const fallback = lockfileSelfHostedPlatformRegistration(entry);
   const gatewayUrl = entry.localUrl ?? entry.runtimeUrl;
   const platformAssistant = await readGatewayCredential(
     gatewayUrl,
@@ -128,12 +150,21 @@ async function unregisterSelfHostedLocalPlatformRecord(
     entry.bearerToken,
   );
   if (platformAssistant.unreachable) {
+    if (fallback) {
+      console.warn(
+        "\u26a0\ufe0f  Could not read platform registration from the local assistant; using saved platform registration.",
+      );
+      return fallback;
+    }
     console.warn(
-      "\u26a0\ufe0f  Could not read platform registration from the local assistant; skipping platform unregister.",
+      "\u26a0\ufe0f  Could not read platform registration from the local assistant and no saved platform registration is available; skipping platform unregister.",
     );
-    return;
+    return null;
   }
-  if (!platformAssistant.value) return;
+
+  const platformAssistantId =
+    nonEmptyString(platformAssistant.value) ?? fallback?.platformAssistantId;
+  if (!platformAssistantId) return null;
 
   const [platformBaseUrl, organizationId] = await Promise.all([
     readGatewayCredential(
@@ -147,21 +178,42 @@ async function unregisterSelfHostedLocalPlatformRecord(
       entry.bearerToken,
     ),
   ]);
+
+  return {
+    platformAssistantId,
+    platformBaseUrl:
+      nonEmptyString(platformBaseUrl.value) ??
+      fallback?.platformBaseUrl ??
+      null,
+    organizationId:
+      nonEmptyString(organizationId.value) ?? fallback?.organizationId ?? null,
+  };
+}
+
+async function unregisterSelfHostedLocalPlatformRecord(
+  entry: AssistantEntry,
+): Promise<void> {
+  const token = readPlatformRetireToken();
+  if (!token) return;
+
+  const registration = await readSelfHostedPlatformRegistration(entry);
+  if (!registration) return;
+
   const platformUrl = resolveTrustedSelfHostedPlatformUrl(
-    platformBaseUrl.value,
+    registration.platformBaseUrl,
   );
   if (!platformUrl) return;
-  if (!organizationId.value) {
+  if (!registration.organizationId) {
     console.warn(
       "⚠️  Could not read platform organization ID from the local assistant; skipping platform unregister.",
     );
     return;
   }
 
-  await deletePlatformAssistant(platformAssistant.value, {
+  await deletePlatformAssistant(registration.platformAssistantId, {
     token,
     platformUrl,
-    organizationId: organizationId.value,
+    organizationId: registration.organizationId,
     label: "Platform self-hosted unregister",
     successMessage: "\u2705 Platform self-hosted registration unregistered.",
     alreadyGoneMessage:

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1123,6 +1123,7 @@ async function tryInjectPlatformCredentials(
       fetchCurrentVersion(entry.runtimeUrl),
       fetchAssistantIngressUrl(entry.runtimeUrl, entry.bearerToken),
     ]);
+    const platformUrl = getPlatformUrl();
     const registration = await ensureSelfHostedLocalRegistration(
       token,
       orgId,
@@ -1130,9 +1131,15 @@ async function tryInjectPlatformCredentials(
       entry.assistantId,
       "cli",
       assistantVersion,
-      getPlatformUrl(),
+      platformUrl,
       ingressUrl,
     );
+    saveAssistantEntry({
+      ...entry,
+      platformAssistantId: registration.assistant.id,
+      platformBaseUrl: platformUrl,
+      platformOrganizationId: orgId,
+    });
 
     // Resolve the API key: 1) fresh from registration, 2) existing from
     // daemon credential store, 3) reprovision as last resort (revokes old key).
@@ -1164,7 +1171,7 @@ async function tryInjectPlatformCredentials(
       bearerToken: entry.bearerToken,
       assistantApiKey,
       platformAssistantId: registration.assistant.id,
-      platformBaseUrl: getPlatformUrl(),
+      platformBaseUrl: platformUrl,
       organizationId: orgId,
       userId: user.id,
       webhookSecret: registration.webhook_secret,

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -219,6 +219,7 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
+  updateLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},
   getLocalGatewayUrl: () => localGatewayUrlValue,
@@ -491,8 +492,7 @@ describe("onboarding lifecycle sync", () => {
       render(<HatchingScreen />);
 
       await waitFor(
-        () =>
-          expect(connectLocalAssistantMock).toHaveBeenCalledWith("local-1"),
+        () => expect(connectLocalAssistantMock).toHaveBeenCalledWith("local-1"),
         { timeout: 5_000 },
       );
     } finally {

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -205,11 +205,27 @@ export async function saveLockfileAssistant(assistant: {
   runtimeUrl: string;
   hatchedAt: string;
   organizationId?: string;
+  platformAssistantId?: string;
+  platformBaseUrl?: string;
+  platformOrganizationId?: string;
 }): Promise<void> {
   const result = await saveLockfileAssistantHost(
     assistant,
     assistant.assistantId,
   );
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
+}
+
+/**
+ * Update an existing assistant entry without changing the lockfile's active
+ * assistant pointer.
+ */
+export async function updateLockfileAssistant(
+  assistant: LockfileAssistant,
+): Promise<void> {
+  const result = await saveLockfileAssistantHost({ ...assistant }, undefined);
   if (result.ok) {
     commitLockfile(result.lockfile);
   }

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -6,6 +6,8 @@ const OTHER_PLATFORM_ASSISTANT_ID = "019ed7d1-e995-71cc-9859-c54f422ace3d";
 const ORGANIZATION_ID = "019ed7d1-e995-71cc-9859-c54f422ace3e";
 const GATEWAY_URL = "http://localhost:5173/assistant/__gateway/20101";
 const HOST_INSTALLATION_ID = "host-installation-1";
+const STATUS_PLATFORM_BASE_URL = "https://registered-platform.example.com";
+const CONFIG_PLATFORM_BASE_URL = "http://localhost:8000";
 
 type RecordedRequest = {
   pathname: string;
@@ -49,7 +51,7 @@ mock.module("@/lib/auth/request-headers", () => ({
 mock.module("@/lib/local-mode", () => ({
   getActiveAssistant: () => activeAssistant,
   getLocalGatewayUrl: () => "/assistant/__gateway/20101",
-  getPlatformRuntimeUrl: () => "http://localhost:8000",
+  getPlatformRuntimeUrl: () => CONFIG_PLATFORM_BASE_URL,
   getSelectedAssistant: () => activeAssistant,
   isLocalAssistant: (assistant: { cloud?: string }) =>
     assistant?.cloud === "local",
@@ -132,6 +134,7 @@ beforeEach(() => {
   browserDeviceId = null;
   statusBody = {
     assistant_id: PLATFORM_ASSISTANT_ID,
+    baseUrl: STATUS_PLATFORM_BASE_URL,
     organization_id: ORGANIZATION_ID,
     has_assistant_api_key: true,
     client_installation_id: HOST_INSTALLATION_ID,
@@ -202,7 +205,27 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
     expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
       ...activeAssistant,
       platformAssistantId: PLATFORM_ASSISTANT_ID,
-      platformBaseUrl: "http://localhost:8000",
+      platformBaseUrl: STATUS_PLATFORM_BASE_URL,
+      platformOrganizationId: ORGANIZATION_ID,
+    });
+  });
+
+  test("falls back to the configured platform URL when status omits its base URL", async () => {
+    statusBody = {
+      assistant_id: PLATFORM_ASSISTANT_ID,
+      organization_id: ORGANIZATION_ID,
+      has_assistant_api_key: true,
+      client_installation_id: HOST_INSTALLATION_ID,
+    };
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
+      ...activeAssistant,
+      platformAssistantId: PLATFORM_ASSISTANT_ID,
+      platformBaseUrl: CONFIG_PLATFORM_BASE_URL,
       platformOrganizationId: ORGANIZATION_ID,
     });
   });
@@ -210,6 +233,7 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
   test("repairs a stored platform id when the local assistant is missing its API key", async () => {
     statusBody = {
       assistant_id: PLATFORM_ASSISTANT_ID,
+      baseUrl: STATUS_PLATFORM_BASE_URL,
       organization_id: ORGANIZATION_ID,
       has_assistant_api_key: false,
       client_installation_id: HOST_INSTALLATION_ID,
@@ -264,10 +288,15 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       name: "vellum:platform_assistant_id",
       value: PLATFORM_ASSISTANT_ID,
     });
+    expect(injectedSecrets).toContainEqual({
+      type: "credential",
+      name: "vellum:platform_base_url",
+      value: STATUS_PLATFORM_BASE_URL,
+    });
     expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
       ...activeAssistant,
       platformAssistantId: PLATFORM_ASSISTANT_ID,
-      platformBaseUrl: "http://localhost:8000",
+      platformBaseUrl: STATUS_PLATFORM_BASE_URL,
       platformOrganizationId: ORGANIZATION_ID,
     });
   });

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -40,6 +40,7 @@ const buildVellumMutatingHeadersMock = mock(
 );
 const primeLocalGatewayConnectionWithRepairMock = mock(async () => {});
 const fetchOrganizationsMock = mock(async () => {});
+const updateLockfileAssistantMock = mock(async (_assistant: unknown) => {});
 
 mock.module("@/lib/auth/request-headers", () => ({
   buildVellumMutatingHeaders: buildVellumMutatingHeadersMock,
@@ -50,12 +51,14 @@ mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => "/assistant/__gateway/20101",
   getPlatformRuntimeUrl: () => "http://localhost:8000",
   getSelectedAssistant: () => activeAssistant,
-  isLocalAssistant: (assistant: { cloud?: string }) => assistant?.cloud === "local",
+  isLocalAssistant: (assistant: { cloud?: string }) =>
+    assistant?.cloud === "local",
   isLocalMode: () => isLocalModeValue,
   isPlatformDisabled: () => isPlatformDisabledValue,
   isRemoteGatewayMode: () => isRemoteGatewayModeValue,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
+  updateLockfileAssistant: updateLockfileAssistantMock,
 }));
 
 mock.module("@/lib/self-hosted/connection", () => ({
@@ -144,6 +147,7 @@ beforeEach(() => {
   buildVellumMutatingHeadersMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   fetchOrganizationsMock.mockClear();
+  updateLockfileAssistantMock.mockClear();
   resetLocalPlatformIdentityCacheForTesting();
 
   globalThis.fetch = mock(
@@ -166,14 +170,12 @@ beforeEach(() => {
         return jsonResponse(statusBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/ensure-registration/"
+        url.pathname === "/v1/assistants/self-hosted-local/ensure-registration/"
       ) {
         return jsonResponse(ensureRegistrationBody);
       }
       if (
-        url.pathname ===
-        "/v1/assistants/self-hosted-local/reprovision-api-key/"
+        url.pathname === "/v1/assistants/self-hosted-local/reprovision-api-key/"
       ) {
         return jsonResponse(reprovisionApiKeyBody);
       }
@@ -197,6 +199,12 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(requestNames()).toEqual(["status"]);
+    expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
+      ...activeAssistant,
+      platformAssistantId: PLATFORM_ASSISTANT_ID,
+      platformBaseUrl: "http://localhost:8000",
+      platformOrganizationId: ORGANIZATION_ID,
+    });
   });
 
   test("repairs a stored platform id when the local assistant is missing its API key", async () => {
@@ -256,15 +264,23 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       name: "vellum:platform_assistant_id",
       value: PLATFORM_ASSISTANT_ID,
     });
+    expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
+      ...activeAssistant,
+      platformAssistantId: PLATFORM_ASSISTANT_ID,
+      platformBaseUrl: "http://localhost:8000",
+      platformOrganizationId: ORGANIZATION_ID,
+    });
   });
 
   test("repairs gateway access by default for blocking platform identity resolution", async () => {
     selfHostedIngressUrl = null;
     selfHostedActorToken = null;
-    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(async () => {
-      selfHostedIngressUrl = GATEWAY_URL;
-      selfHostedActorToken = "actor-token";
-    });
+    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(
+      async () => {
+        selfHostedIngressUrl = GATEWAY_URL;
+        selfHostedActorToken = "actor-token";
+      },
+    );
 
     const platformAssistantId =
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -9,6 +9,7 @@ import {
   isPlatformDisabled,
   isRemoteGatewayMode,
   primeLocalGatewayConnectionWithRepair,
+  updateLockfileAssistant,
   type LockfileAssistant,
 } from "@/lib/local-mode";
 import {
@@ -156,6 +157,15 @@ async function ensureLocalAssistantPlatformIdentity(
       ? status.assistantId
       : null;
   if (statusPlatformAssistantId && status?.hasAssistantApiKey !== false) {
+    const statusOrganizationId =
+      status?.organizationId ?? assistant.platformOrganizationId ?? null;
+    if (statusOrganizationId) {
+      await persistPlatformRegistrationMetadata(assistant, {
+        platformAssistantId: statusPlatformAssistantId,
+        platformBaseUrl: getPlatformRuntimeUrl(),
+        organizationId: statusOrganizationId,
+      });
+    }
     return statusPlatformAssistantId;
   }
 
@@ -164,7 +174,9 @@ async function ensureLocalAssistantPlatformIdentity(
     assistant,
   );
   if (!organizationId) {
-    throw new Error("Sign in to Vellum and select an organization to register this local assistant.");
+    throw new Error(
+      "Sign in to Vellum and select an organization to register this local assistant.",
+    );
   }
 
   const clientInstallationId =
@@ -209,8 +221,31 @@ async function ensureLocalAssistantPlatformIdentity(
     organizationId,
     webhookSecret: stringValue(registration.webhook_secret),
   });
+  await persistPlatformRegistrationMetadata(assistant, {
+    platformAssistantId,
+    platformBaseUrl: getPlatformRuntimeUrl(),
+    organizationId,
+  });
 
   return platformAssistantId;
+}
+
+async function persistPlatformRegistrationMetadata(
+  assistant: LockfileAssistant,
+  params: {
+    platformAssistantId: string;
+    platformBaseUrl: string;
+    organizationId: string;
+  },
+): Promise<void> {
+  await updateLockfileAssistant({
+    ...assistant,
+    platformAssistantId: params.platformAssistantId,
+    platformBaseUrl: params.platformBaseUrl,
+    platformOrganizationId: params.organizationId,
+  }).catch((error: unknown) => {
+    console.warn("local assistant platform lockfile update failed", error);
+  });
 }
 
 async function ensureGatewayAccess(
@@ -234,7 +269,9 @@ async function ensureGatewayAccess(
   }
 
   if (!gatewayUrl || !actorToken) {
-    throw new Error("Unable to reach the local assistant for platform identity setup.");
+    throw new Error(
+      "Unable to reach the local assistant for platform identity setup.",
+    );
   }
 
   return { gatewayUrl, actorToken };
@@ -244,7 +281,10 @@ async function fetchPlatformStatus(
   gateway: { gatewayUrl: string; actorToken: string },
   runtimeAssistantId: string,
 ): Promise<LocalPlatformStatus | null> {
-  const url = gatewayUrl(gateway.gatewayUrl, `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`);
+  const url = gatewayUrl(
+    gateway.gatewayUrl,
+    `/v1/assistants/${encodeURIComponent(runtimeAssistantId)}/platform/status`,
+  );
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
@@ -254,9 +294,9 @@ async function fetchPlatformStatus(
   }).catch(() => null);
   if (!response?.ok) return null;
 
-  const body = (await response.json().catch(() => null)) as
-    | PlatformStatusBody
-    | null;
+  const body = (await response
+    .json()
+    .catch(() => null)) as PlatformStatusBody | null;
   return {
     assistantId: firstString(body?.assistantId, body?.assistant_id),
     organizationId: firstString(body?.organizationId, body?.organization_id),
@@ -277,14 +317,21 @@ async function resolveOrganizationId(
 ): Promise<string | null> {
   const existing =
     statusOrganizationId ??
+    assistant.platformOrganizationId ??
     getActiveOrganizationIdForRequests() ??
     assistant.organizationId ??
     null;
   if (existing) return existing;
 
-  await useOrganizationStore.getState().fetchOrganizations().catch(() => {});
+  await useOrganizationStore
+    .getState()
+    .fetchOrganizations()
+    .catch(() => {});
   return (
-    getActiveOrganizationIdForRequests() ?? assistant.organizationId ?? null
+    getActiveOrganizationIdForRequests() ??
+    assistant.platformOrganizationId ??
+    assistant.organizationId ??
+    null
   );
 }
 
@@ -346,16 +393,19 @@ async function platformPost<T>(
     );
   }
 
-  const response = await fetch(new URL(path, window.location.origin).toString(), {
-    method: "POST",
-    headers,
-    credentials: isElectron() ? "omit" : "same-origin",
-    body: JSON.stringify({
-      client_installation_id: clientInstallationId,
-      runtime_assistant_id: assistant.assistantId,
-      client_platform: isElectron() ? "macos" : "web",
-    }),
-  }).catch((error: unknown) => {
+  const response = await fetch(
+    new URL(path, window.location.origin).toString(),
+    {
+      method: "POST",
+      headers,
+      credentials: isElectron() ? "omit" : "same-origin",
+      body: JSON.stringify({
+        client_installation_id: clientInstallationId,
+        runtime_assistant_id: assistant.assistantId,
+        client_platform: isElectron() ? "macos" : "web",
+      }),
+    },
+  ).catch((error: unknown) => {
     throw new Error(
       `Unable to reach the platform registration endpoint: ${errorMessage(error)}`,
     );

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -31,6 +31,8 @@ const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
 type PlatformStatusBody = {
   assistantId?: unknown;
   assistant_id?: unknown;
+  baseUrl?: unknown;
+  base_url?: unknown;
   organizationId?: unknown;
   organization_id?: unknown;
   hasAssistantApiKey?: unknown;
@@ -41,6 +43,7 @@ type PlatformStatusBody = {
 
 type LocalPlatformStatus = {
   assistantId: string | null;
+  baseUrl: string | null;
   organizationId: string | null;
   hasAssistantApiKey: boolean | null;
   clientInstallationId: string | null;
@@ -162,7 +165,7 @@ async function ensureLocalAssistantPlatformIdentity(
     if (statusOrganizationId) {
       await persistPlatformRegistrationMetadata(assistant, {
         platformAssistantId: statusPlatformAssistantId,
-        platformBaseUrl: getPlatformRuntimeUrl(),
+        platformBaseUrl: status?.baseUrl ?? getPlatformRuntimeUrl(),
         organizationId: statusOrganizationId,
       });
     }
@@ -214,16 +217,17 @@ async function ensureLocalAssistantPlatformIdentity(
     );
   }
 
+  const platformBaseUrl = status?.baseUrl ?? getPlatformRuntimeUrl();
   await injectPlatformCredentials(gateway, {
     assistantApiKey,
     platformAssistantId,
-    platformBaseUrl: getPlatformRuntimeUrl(),
+    platformBaseUrl,
     organizationId,
     webhookSecret: stringValue(registration.webhook_secret),
   });
   await persistPlatformRegistrationMetadata(assistant, {
     platformAssistantId,
-    platformBaseUrl: getPlatformRuntimeUrl(),
+    platformBaseUrl,
     organizationId,
   });
 
@@ -299,6 +303,7 @@ async function fetchPlatformStatus(
     .catch(() => null)) as PlatformStatusBody | null;
   return {
     assistantId: firstString(body?.assistantId, body?.assistant_id),
+    baseUrl: firstString(body?.baseUrl, body?.base_url),
     organizationId: firstString(body?.organizationId, body?.organization_id),
     hasAssistantApiKey: firstBoolean(
       body?.hasAssistantApiKey,

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -115,8 +115,7 @@ export const SYSTEM_PERMISSION_KINDS = [
   "notifications",
 ] as const;
 
-export type SystemPermissionKind =
-  (typeof SYSTEM_PERMISSION_KINDS)[number];
+export type SystemPermissionKind = (typeof SYSTEM_PERMISSION_KINDS)[number];
 
 export const SYSTEM_PERMISSION_STATUSES = [
   "unknown",
@@ -381,6 +380,9 @@ export interface LockfileAssistant {
   species?: string;
   hatchedAt?: string;
   organizationId?: string;
+  platformAssistantId?: string;
+  platformBaseUrl?: string;
+  platformOrganizationId?: string;
   resources?: LocalAssistantResources;
 }
 

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -21,6 +21,9 @@ describe("parseLockfile", () => {
           species: "vellum",
           hatchedAt: "2026-01-01T00:00:00.000Z",
           organizationId: "org_1",
+          platformAssistantId: "platform-assistant-1",
+          platformBaseUrl: "https://platform.example.com",
+          platformOrganizationId: "org_1",
           resources: { gatewayPort: 7777, daemonPort: 7778 },
         },
       ],
@@ -274,13 +277,19 @@ describe("parseLockfile", () => {
     expect(parseLockfile(raw).assistants).toEqual([
       { assistantId: "gcp_1", cloud: "gcp", runtimeUrl: "https://a" },
       { assistantId: "ssh_1", cloud: "custom", runtimeUrl: "https://b" },
-      { assistantId: "local_1", cloud: "local", runtimeUrl: "http://localhost:7830" },
+      {
+        assistantId: "local_1",
+        cloud: "local",
+        runtimeUrl: "http://localhost:7830",
+      },
     ]);
   });
 
   test("prefers an explicit cloud over legacy remote markers", () => {
     const raw = {
-      assistants: [{ assistantId: "a", cloud: "vellum", project: "stale-proj" }],
+      assistants: [
+        { assistantId: "a", cloud: "vellum", project: "stale-proj" },
+      ],
       activeAssistant: null,
     };
     expect(parseLockfile(raw).assistants).toEqual([

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -109,6 +109,12 @@ export const LockfileAssistantSchema = z.object({
   hatchedAt: z.string().optional(),
   /** Owning org for platform assistants; absent for local ones. */
   organizationId: z.string().optional(),
+  /** Platform assistant UUID for a self-hosted local assistant registration. */
+  platformAssistantId: z.string().optional(),
+  /** Platform base URL used for a self-hosted local assistant registration. */
+  platformBaseUrl: z.string().optional(),
+  /** Platform organization UUID used for a self-hosted local assistant registration. */
+  platformOrganizationId: z.string().optional(),
   resources: LocalAssistantResourcesSchema.optional(),
 });
 

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -171,6 +171,32 @@ describe("upsertLockfileAssistant", () => {
       name: "Renamed",
     });
   });
+
+  test("preserves activeAssistant when no active id is provided", () => {
+    writeOnDisk({
+      activeAssistant: "asst_active",
+      assistants: [
+        {
+          assistantId: "asst_active",
+          cloud: "local",
+          runtimeUrl: "http://active",
+        },
+        { assistantId: "asst_1", cloud: "local", runtimeUrl: "http://a" },
+      ],
+    });
+
+    const result = upsertLockfileAssistant(
+      [lockfilePath],
+      { assistantId: "asst_1", name: "Renamed" },
+      undefined,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readOnDisk().activeAssistant).toBe("asst_active");
+    if (result.ok) {
+      expect(result.lockfile.activeAssistant).toBe("asst_active");
+    }
+  });
 });
 
 describe("replacePlatformAssistants", () => {
@@ -270,7 +296,9 @@ describe("replacePlatformAssistants", () => {
       "org_a",
     );
 
-    const assistants = readOnDisk().assistants as Array<Record<string, unknown>>;
+    const assistants = readOnDisk().assistants as Array<
+      Record<string, unknown>
+    >;
     expect(assistants).toHaveLength(1);
     expect(assistants[0]).toMatchObject({
       assistantId: "asst_dup",


### PR DESCRIPTION
## Summary
- Persist non-secret self-hosted platform registration metadata on local lockfile assistant entries from web/Electron and CLI registration flows.
- Let `vellum retire` use saved platform metadata when the local assistant cannot serve registration credentials.
- Extend the shared lockfile/IPC contract and add regression coverage for fallback unregister behavior.

## Why
The previous retire path unregisters the platform record when it can read the local platform credentials from the running gateway. If that credential read is unavailable during retire, the platform delete is skipped. This PR makes the unregister inputs durable by saving the platform assistant id, platform base URL, and organization id in the local lockfile. These fields are registration metadata, not bearer tokens.

## Verification
- `cd cli && bun test src/__tests__/retire.test.ts`
- `cd cli && bun test src/__tests__/teleport.test.ts --grep "platform credential injection"`
- `cd cli && bun run lint -- src/commands/retire.ts src/commands/login.ts src/commands/teleport.ts src/__tests__/retire.test.ts src/__tests__/teleport.test.ts src/lib/platform-client.ts`
- `cd clients/web && bun test src/lib/local-platform-identity.test.ts`
- `cd clients/web && bun run lint -- src/lib/local-mode.ts src/lib/local-platform-identity.ts src/lib/local-platform-identity.test.ts`
- `cd packages/local-mode && bun test src/lockfile-contract.test.ts`
- `cd packages/local-mode && bunx tsc --noEmit`
- `cli/node_modules/.bin/prettier --check cli/src/commands/retire.ts cli/src/commands/login.ts cli/src/commands/teleport.ts cli/src/__tests__/retire.test.ts cli/src/__tests__/teleport.test.ts clients/web/src/lib/local-mode.ts clients/web/src/lib/local-platform-identity.ts clients/web/src/lib/local-platform-identity.test.ts packages/local-mode/src/lockfile-contract.ts packages/local-mode/src/lockfile-contract.test.ts packages/ipc-contract/src/types.ts`
- `git diff --check`

## Known local check result
- `cd clients/web && bunx tsc --noEmit` is currently blocked by existing unrelated generated/type drift in subagent and background tool types (`interrupted`, `BackgroundToolCompletion`). The focused web test and lint for the touched files pass.
