### PR TITLE
feat(search): add resumable backfill of existing messages into the Qdrant lexical index

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18815,6 +18815,29 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/messages/lexical/backfill:
+    post:
+      operationId: messages_lexical_backfill_post
+      summary: Enqueue a resumable backfill of messages into the lexical index
+      description:
+        "Enqueues the cursor-checkpointed backfill job that indexes existing messages into the Qdrant lexical
+        (BM25-style) collection in batches. Resumable and idempotent — re-running continues from the last checkpoint.
+        Pass `force: true` to reset the cursor and re-index from the beginning. Not run at daemon startup."
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+              additionalProperties: false
+      responses:
+        "200":
+          description: Successful response
   /v1/messages/queued/{id}:
     delete:
       operationId: messages_queued_by_id_delete

--- a/assistant/src/__tests__/job-handler-registry-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registry-guard.test.ts
@@ -45,6 +45,7 @@ const MEMORY_JOB_TYPES = [
   "memory_retrospective",
   "index_message_lexical",
   "purge_conversation_lexical",
+  "backfill_lexical_index",
 ].sort();
 
 /**

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -64,6 +64,7 @@ export type MemoryJobType =
   | "memory_v3_maintain"
   | "index_message_lexical"
   | "purge_conversation_lexical"
+  | "backfill_lexical_index"
   // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -28,6 +28,7 @@ import {
 import { runNarrativeRefinement } from "./graph/narrative.js";
 import { runPatternScan } from "./graph/pattern-scan.js";
 import { backfillJob } from "./job-handlers/backfill.js";
+import { backfillLexicalIndexJob } from "./job-handlers/backfill-lexical-index.js";
 import {
   embedAttachmentJob,
   embedMediaJob,
@@ -211,5 +212,9 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   {
     type: "purge_conversation_lexical",
     handler: (job, config) => purgeConversationLexicalJob(job, config),
+  },
+  {
+    type: "backfill_lexical_index",
+    handler: (job, config) => backfillLexicalIndexJob(job, config),
   },
 ];

--- a/assistant/src/plugins/defaults/memory/job-handlers/__tests__/backfill-lexical-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/__tests__/backfill-lexical-index.test.ts
@@ -1,0 +1,310 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SparseEmbedding } from "../../../../../persistence/embeddings/embedding-types.js";
+
+mock.module("../../../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Capture the batched upserts into the lexical index singleton.
+const upsertBatchCalls: Array<
+  Array<{
+    messageId: string;
+    sparse: SparseEmbedding;
+    conversationId: string;
+    createdAt: number;
+  }>
+> = [];
+
+const fakeIndex = {
+  upsertMessagesBatch: async (
+    points: Array<{
+      messageId: string;
+      sparse: SparseEmbedding;
+      conversationId: string;
+      createdAt: number;
+    }>,
+  ) => {
+    upsertBatchCalls.push(points);
+  },
+};
+
+// Model the process-local singleton so `resolveLexicalIndex` resolves the fake
+// index without a real Qdrant client.
+let singletonReady = true;
+
+function resetLexicalSingleton(ready: boolean): void {
+  singletonReady = ready;
+}
+
+mock.module(
+  "../../../../../persistence/embeddings/messages-lexical-index.js",
+  () => ({
+    MESSAGES_LEXICAL_COLLECTION: "messages_lexical",
+    getMessagesLexicalIndex: () => {
+      if (!singletonReady) {
+        throw new Error("Messages lexical index not initialized.");
+      }
+      return fakeIndex;
+    },
+    initMessagesLexicalIndex: () => {
+      singletonReady = true;
+      return fakeIndex;
+    },
+  }),
+);
+
+// `withQdrantBreaker` just invokes the operation in tests — replace it with a
+// pass-through so the breaker's timing/state machinery stays out of the way.
+mock.module(
+  "../../../../../persistence/embeddings/qdrant-circuit-breaker.js",
+  () => ({
+    withQdrantBreaker: <T>(op: () => Promise<T>) => op(),
+  }),
+);
+
+// `generateSparseEmbedding` is a pure local TF-IDF encoder (no provider call),
+// so it runs unmocked — mocking `embedding-backend.js` wholesale would starve
+// its other named exports that the db-init import graph pulls in.
+import { resetDbForTesting } from "../../../../../__tests__/db-test-helpers.js";
+import { DEFAULT_CONFIG } from "../../../../../config/defaults.js";
+import type { AssistantConfig } from "../../../../../config/types.js";
+import {
+  readMessageCursorCheckpoint,
+  resetMessageCursorCheckpoint,
+  writeMessageCursorCheckpoint,
+} from "../../../../../persistence/checkpoints.js";
+import {
+  getDb,
+  getMemoryDb,
+} from "../../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../../persistence/db-init.js";
+import { generateSparseEmbedding } from "../../../../../persistence/embeddings/embedding-backend.js";
+import type { MemoryJob } from "../../../../../persistence/jobs-store.js";
+import {
+  conversations,
+  memoryJobs,
+  messages,
+} from "../../../../../persistence/schema/index.js";
+import { backfillLexicalIndexJob } from "../backfill-lexical-index.js";
+
+const TEST_CONFIG: AssistantConfig = DEFAULT_CONFIG;
+
+const CHECKPOINT_KEY = "lexical:messages:last_created_at";
+const CHECKPOINT_ID_KEY = "lexical:messages:last_id";
+
+function makeJob(payload: Record<string, unknown>): MemoryJob {
+  return {
+    id: "job-1",
+    type: "backfill_lexical_index",
+    payload,
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function insertConversation(id: string): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({ id, createdAt: now, updatedAt: now })
+    .run();
+}
+
+function insertMessage(opts: {
+  id: string;
+  conversationId: string;
+  content: string;
+  createdAt: number;
+}): void {
+  getDb()
+    .insert(messages)
+    .values({
+      id: opts.id,
+      conversationId: opts.conversationId,
+      role: "user",
+      content: opts.content,
+      createdAt: opts.createdAt,
+    })
+    .run();
+}
+
+/** Count pending `backfill_lexical_index` jobs enqueued in the memory DB. */
+function pendingBackfillJobCount(): number {
+  const rows = getMemoryDb()!
+    .select({ id: memoryJobs.id })
+    .from(memoryJobs)
+    .all();
+  return rows.length;
+}
+
+describe("backfillLexicalIndexJob", () => {
+  // initializeDb runs the full migration chain; under parallel CI load it can
+  // exceed bun's default 5s hook timeout, so allow more.
+  beforeAll(async () => {
+    await initializeDb();
+  }, 30_000);
+
+  beforeEach(async () => {
+    upsertBatchCalls.length = 0;
+    resetLexicalSingleton(true);
+    resetDbForTesting();
+    await initializeDb();
+    // The template-restore path leaves stale WAL sidecars, so rows can bleed
+    // across tests. This backfill scans the whole `messages` table, so clear
+    // the tables and cursor it reads/writes to guarantee per-test isolation.
+    getDb().delete(messages).run();
+    getDb().delete(conversations).run();
+    getMemoryDb()!.delete(memoryJobs).run();
+    resetMessageCursorCheckpoint(CHECKPOINT_KEY, CHECKPOINT_ID_KEY);
+  }, 30_000);
+
+  test("indexes a batch of messages and advances the checkpoint", async () => {
+    insertConversation("conv-1");
+    insertMessage({
+      id: "msg-a",
+      conversationId: "conv-1",
+      content: "first lexical message",
+      createdAt: 1_000,
+    });
+    insertMessage({
+      id: "msg-b",
+      conversationId: "conv-1",
+      content: "second lexical message",
+      createdAt: 2_000,
+    });
+
+    await backfillLexicalIndexJob(makeJob({}), TEST_CONFIG);
+
+    // One batched upsert carrying both messages in (createdAt asc, id asc) order.
+    expect(upsertBatchCalls).toHaveLength(1);
+    const batch = upsertBatchCalls[0];
+    expect(batch.map((p) => p.messageId)).toEqual(["msg-a", "msg-b"]);
+    expect(batch[0].sparse).toEqual(
+      generateSparseEmbedding("first lexical message"),
+    );
+    expect(batch[0].conversationId).toBe("conv-1");
+    expect(batch[0].createdAt).toBe(1_000);
+
+    // Cursor advanced to the last message in the batch.
+    const cursor = readMessageCursorCheckpoint(
+      CHECKPOINT_KEY,
+      CHECKPOINT_ID_KEY,
+    );
+    expect(cursor).toEqual({ createdAt: 2_000, messageId: "msg-b" });
+
+    // A short batch does not re-enqueue.
+    expect(pendingBackfillJobCount()).toBe(0);
+  });
+
+  test("resumes from the persisted cursor, skipping already-indexed rows", async () => {
+    insertConversation("conv-2");
+    insertMessage({
+      id: "msg-old",
+      conversationId: "conv-2",
+      content: "already indexed",
+      createdAt: 1_000,
+    });
+    insertMessage({
+      id: "msg-new",
+      conversationId: "conv-2",
+      content: "not yet indexed",
+      createdAt: 2_000,
+    });
+
+    // Pretend the first message was already indexed by a prior invocation.
+    writeMessageCursorCheckpoint(CHECKPOINT_KEY, CHECKPOINT_ID_KEY, {
+      createdAt: 1_000,
+      messageId: "msg-old",
+    });
+
+    await backfillLexicalIndexJob(makeJob({}), TEST_CONFIG);
+
+    expect(upsertBatchCalls).toHaveLength(1);
+    expect(upsertBatchCalls[0].map((p) => p.messageId)).toEqual(["msg-new"]);
+  });
+
+  test("re-enqueues itself when the batch is full", async () => {
+    insertConversation("conv-3");
+    // 200 messages == BATCH_SIZE, so the job re-enqueues to continue draining.
+    for (let i = 0; i < 200; i++) {
+      insertMessage({
+        id: `msg-${String(i).padStart(4, "0")}`,
+        conversationId: "conv-3",
+        content: `message number ${i}`,
+        createdAt: 1_000 + i,
+      });
+    }
+
+    await backfillLexicalIndexJob(makeJob({}), TEST_CONFIG);
+
+    expect(upsertBatchCalls).toHaveLength(1);
+    expect(upsertBatchCalls[0]).toHaveLength(200);
+    // Exactly one follow-up job enqueued to process the remaining rows.
+    expect(pendingBackfillJobCount()).toBe(1);
+  });
+
+  test("does nothing (no upsert, no re-enqueue) when there are no messages", async () => {
+    await backfillLexicalIndexJob(makeJob({}), TEST_CONFIG);
+    expect(upsertBatchCalls).toHaveLength(0);
+    expect(pendingBackfillJobCount()).toBe(0);
+  });
+
+  test("force resets the cursor and re-indexes from the beginning", async () => {
+    insertConversation("conv-4");
+    insertMessage({
+      id: "msg-x",
+      conversationId: "conv-4",
+      content: "reindex me",
+      createdAt: 5_000,
+    });
+
+    // A stale cursor past every row would normally skip everything.
+    writeMessageCursorCheckpoint(CHECKPOINT_KEY, CHECKPOINT_ID_KEY, {
+      createdAt: 9_999,
+      messageId: "msg-zzz",
+    });
+
+    await backfillLexicalIndexJob(makeJob({ force: true }), TEST_CONFIG);
+
+    // force reset the cursor to the origin, so the message is re-indexed.
+    expect(upsertBatchCalls).toHaveLength(1);
+    expect(upsertBatchCalls[0].map((p) => p.messageId)).toEqual(["msg-x"]);
+
+    // Cursor now points at the last re-indexed message, not the stale value.
+    const cursor = readMessageCursorCheckpoint(
+      CHECKPOINT_KEY,
+      CHECKPOINT_ID_KEY,
+    );
+    expect(cursor).toEqual({ createdAt: 5_000, messageId: "msg-x" });
+  });
+
+  test("lazily initializes the index when not yet initialized (worker process)", async () => {
+    // Simulate the out-of-process worker, which never runs runMemoryStartup —
+    // the singleton is not initialized in this process.
+    resetLexicalSingleton(false);
+
+    insertConversation("conv-w");
+    insertMessage({
+      id: "msg-w",
+      conversationId: "conv-w",
+      content: "indexed by the worker",
+      createdAt: 1_000,
+    });
+
+    await backfillLexicalIndexJob(makeJob({}), TEST_CONFIG);
+
+    // The handler initialized the index from config instead of throwing.
+    expect(upsertBatchCalls).toHaveLength(1);
+    expect(upsertBatchCalls[0].map((p) => p.messageId)).toEqual(["msg-w"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/job-handlers/backfill-lexical-index.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/backfill-lexical-index.ts
@@ -1,0 +1,108 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../../../config/types.js";
+import {
+  readMessageCursorCheckpoint,
+  resetMessageCursorCheckpoint,
+  writeMessageCursorCheckpoint,
+} from "../../../../persistence/checkpoints.js";
+import { getDb } from "../../../../persistence/db-connection.js";
+import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
+import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
+import {
+  enqueueMemoryJob,
+  type MemoryJob,
+} from "../../../../persistence/jobs-store.js";
+import { messages } from "../../../../persistence/schema/index.js";
+import { resolveLexicalIndex } from "./index-message-lexical.js";
+
+/**
+ * Cursor checkpoint keys for the lexical-index backfill. Kept distinct from the
+ * dense embedding backfill's keys (`memory:backfill:*`) so the two backfills
+ * advance independently — enabling lexical without re-running the dense one, and
+ * vice versa.
+ */
+const LEXICAL_BACKFILL_CHECKPOINT_KEY = "lexical:messages:last_created_at";
+const LEXICAL_BACKFILL_CHECKPOINT_ID_KEY = "lexical:messages:last_id";
+
+/** Messages indexed per job invocation before the job re-enqueues itself. */
+const BATCH_SIZE = 200;
+
+/**
+ * Resumable, cursor-checkpointed backfill of existing messages into the Qdrant
+ * lexical index. Selects the next {@link BATCH_SIZE} messages ordered by
+ * `(createdAt asc, id asc)` after the persisted cursor, encodes each with the
+ * local sparse encoder, batch-upserts them, advances the cursor, and
+ * re-enqueues itself when the batch is full — draining the whole `messages`
+ * table across many short invocations without blocking the event loop.
+ *
+ * Idempotent: the upsert keys on a deterministic point id derived from the
+ * message id, so re-indexing the same message overwrites the same point. Pass
+ * `payload.force` to reset the cursor and re-index from the beginning.
+ */
+export async function backfillLexicalIndexJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const db = getDb();
+  const force = job.payload.force === true;
+  if (force) {
+    resetMessageCursorCheckpoint(
+      LEXICAL_BACKFILL_CHECKPOINT_KEY,
+      LEXICAL_BACKFILL_CHECKPOINT_ID_KEY,
+    );
+  }
+
+  const cursor = readMessageCursorCheckpoint(
+    LEXICAL_BACKFILL_CHECKPOINT_KEY,
+    LEXICAL_BACKFILL_CHECKPOINT_ID_KEY,
+  );
+  const batch = db
+    .select({
+      id: messages.id,
+      conversationId: messages.conversationId,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      or(
+        gt(messages.createdAt, cursor.createdAt),
+        and(
+          eq(messages.createdAt, cursor.createdAt),
+          gt(messages.id, cursor.messageId),
+        ),
+      ),
+    )
+    .orderBy(asc(messages.createdAt), asc(messages.id))
+    .limit(BATCH_SIZE)
+    .all();
+
+  if (batch.length > 0) {
+    const index = resolveLexicalIndex(config);
+    const points = batch.map((message) => ({
+      messageId: message.id,
+      sparse: generateSparseEmbedding(message.content),
+      conversationId: message.conversationId,
+      createdAt: message.createdAt,
+    }));
+    await withQdrantBreaker(() => index.upsertMessagesBatch(points));
+
+    const lastMessage = batch[batch.length - 1];
+    writeMessageCursorCheckpoint(
+      LEXICAL_BACKFILL_CHECKPOINT_KEY,
+      LEXICAL_BACKFILL_CHECKPOINT_ID_KEY,
+      {
+        createdAt: lastMessage.createdAt,
+        messageId: lastMessage.id,
+      },
+    );
+  }
+
+  // A full batch means there may be more rows past the new cursor — re-enqueue
+  // to continue draining. Never carry `force` forward: the reset already
+  // happened this invocation, and re-resetting would loop over the same head.
+  if (batch.length === BATCH_SIZE) {
+    enqueueMemoryJob("backfill_lexical_index", {});
+  }
+}

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-message-lexical.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-message-lexical.ts
@@ -25,7 +25,9 @@ import { messages } from "../../../../persistence/schema/index.js";
  * (re)points the singleton at an equivalent client — so re-initializing from
  * the same config is safe.
  */
-function resolveLexicalIndex(config: AssistantConfig): MessagesLexicalIndex {
+export function resolveLexicalIndex(
+  config: AssistantConfig,
+): MessagesLexicalIndex {
   try {
     return getMessagesLexicalIndex();
   } catch {

--- a/assistant/src/plugins/defaults/memory/routes/messages-lexical-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/messages-lexical-routes.ts
@@ -1,0 +1,67 @@
+/**
+ * Messages lexical-index route — enqueues the resumable backfill that indexes
+ * existing messages into the Qdrant lexical collection.
+ *
+ * Deliberately NOT gated on `memory.v2.enabled`: the lexical index is a
+ * BM25-style full-text replacement for message search that is independent of
+ * the v2 concept-page machinery. The backfill runs off the event loop as a
+ * cursor-checkpointed memory job and is never triggered at daemon startup — an
+ * operator (or the client) enqueues it on demand.
+ */
+
+import { z } from "zod";
+
+import {
+  enqueueMemoryJob,
+  type MemoryJobType,
+} from "../../../../persistence/jobs-store.js";
+import { ACTOR_PRINCIPALS } from "../../../../runtime/auth/route-policy.js";
+import type {
+  RouteDefinition,
+  RouteHandlerArgs,
+} from "../../../../runtime/routes/types.js";
+
+const BACKFILL_LEXICAL_INDEX_JOB: MemoryJobType = "backfill_lexical_index";
+
+const MessagesLexicalBackfillParams = z
+  .object({
+    /**
+     * Reset the cursor and re-index every message from the beginning. Omit (or
+     * pass false) to resume from the last checkpoint — the common case for
+     * continuing an interrupted backfill.
+     */
+    force: z.boolean().optional(),
+  })
+  .strict();
+
+export type MessagesLexicalBackfillResult = {
+  jobId: string;
+};
+
+async function handleBackfillLexicalIndex({
+  body = {},
+}: RouteHandlerArgs): Promise<MessagesLexicalBackfillResult> {
+  const { force } = MessagesLexicalBackfillParams.parse(body);
+  const payload: Record<string, unknown> =
+    force === true ? { force: true } : {};
+  const jobId = enqueueMemoryJob(BACKFILL_LEXICAL_INDEX_JOB, payload);
+  return { jobId };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "messages_lexical_backfill",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    endpoint: "messages/lexical/backfill",
+    handler: handleBackfillLexicalIndex,
+    summary: "Enqueue a resumable backfill of messages into the lexical index",
+    description:
+      "Enqueues the cursor-checkpointed backfill job that indexes existing messages into the Qdrant lexical (BM25-style) collection in batches. Resumable and idempotent — re-running continues from the last checkpoint. Pass `force: true` to reset the cursor and re-index from the beginning. Not run at daemon startup.",
+    tags: ["memory"],
+    requestBody: MessagesLexicalBackfillParams,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -12,6 +12,7 @@ import { ROUTES as MEMORY_EVAL_ROUTES } from "../../plugins/defaults/memory/rout
 import { ROUTES as MEMORY_ITEM_ROUTES } from "../../plugins/defaults/memory/routes/memory-item-routes.js";
 import { ROUTES as MEMORY_V2_ROUTES } from "../../plugins/defaults/memory/routes/memory-v2-routes.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "../../plugins/defaults/memory/routes/memory-v3-routes.js";
+import { ROUTES as MESSAGES_LEXICAL_ROUTES } from "../../plugins/defaults/memory/routes/messages-lexical-routes.js";
 import { ROUTES as ACP_ROUTES } from "./acp-routes.js";
 import { ROUTES as APP_MANAGEMENT_ROUTES } from "./app-management-routes.js";
 import { ROUTES as APP_ROUTES } from "./app-routes.js";
@@ -230,6 +231,7 @@ export const ROUTES: RouteDefinition[] = [
   ...MEMORY_V2_ROUTES,
   ...MEMORY_V3_ROUTES,
   ...MEMORY_WORKER_ROUTES,
+  ...MESSAGES_LEXICAL_ROUTES,
   ...MIGRATION_ROLLBACK_ROUTES,
   ...MIGRATION_ROUTES,
   ...NOTIFICATION_ROUTES,


### PR DESCRIPTION
## What

Adds an **on-demand, cursor-checkpointed, batched, resumable** job that indexes all existing messages into the Qdrant lexical (BM25-style) collection. This backfills the lexical index for messages that predate the `index_message_lexical` per-message path (PR 3). PR 5 of the messages-FTS-on-Qdrant effort (Wave 3).

## How

- **Job type** — adds `backfill_lexical_index` to the `MemoryJobType` union in `jobs-store.ts`, and to the canonical `MEMORY_JOB_TYPES` array in the `job-handler-registry-guard` test (the guard asserts the exact plugin-contributed set).
- **Handler** (`job-handlers/backfill-lexical-index.ts`, modeled on the dense `backfill.ts`):
  - Reads a `(createdAt, messageId)` cursor from checkpoint keys `lexical:messages:last_created_at` / `lexical:messages:last_id` — deliberately **distinct** from the dense backfill's `memory:backfill:*` keys, so the two backfills advance independently.
  - Selects the next **200** messages ordered by `(createdAt asc, id asc)` strictly after the cursor.
  - Encodes each with the shared local sparse encoder (`generateSparseEmbedding`) and **batch-upserts** via `MessagesLexicalIndex.upsertMessagesBatch`, wrapped in `withQdrantBreaker` so a transient Qdrant outage defers rather than throws.
  - Advances the checkpoint to the last row, and **re-enqueues itself** when the batch is full (200) to keep draining off the event loop.
  - `payload.force` resets the cursor to re-index from the beginning (never carried into the re-enqueue).
- **Register** the handler in `job-handlers.ts`.
- **Route** — new module `routes/messages-lexical-routes.ts` exposing `POST /v1/messages/lexical/backfill` (optional `force`), wired into the shared `ROUTES` array. **Not** gated on `memory.v2.enabled` (the lexical index is independent of the v2 concept-page machinery) and **not** run at daemon startup — enqueued on demand only.
- Exports `resolveLexicalIndex` from `index-message-lexical.ts` so the backfill reuses the same lazy-singleton resolution (single source of truth) instead of duplicating it.
- Regenerated `openapi.yaml` (`bun run generate:openapi`) for the new operation.

## Idempotency & resumability

The upsert keys on a deterministic point id derived from the message id, so re-indexing overwrites the same point — safe to re-run after an interrupted backfill. The cursor is persisted after each batch, so a crash mid-drain resumes from the last committed batch.

## Guard lists updated (PR 3 tripped these)

- `job-handler-registry-guard.test.ts` — added `backfill_lexical_index` to `MEMORY_JOB_TYPES`.
- `plugin-import-boundary-guard.test.ts` — **no baseline change needed**: the handler and route reuse only specifiers already baselined for the `memory` plugin (checkpoints, jobs-store, db-connection, messages-lexical-index, embedding-backend, qdrant-circuit-breaker, schema, drizzle-orm, route-policy, routes/types, zod).

## Tests

New `job-handlers/__tests__/backfill-lexical-index.test.ts`: seeds messages, runs the handler → asserts a batch is indexed via `upsertMessagesBatch` with the correct sparse encoding/payload and the checkpoint advances; resumes from a persisted cursor; re-enqueues when the batch is full (200); no-ops on empty; `force` resets the cursor; and lazy-init from config in the worker-process scenario.

## Verification

```
bun test src/plugins/defaults/memory/job-handlers/__tests__/backfill-lexical-index.test.ts \
         src/__tests__/job-handler-registry-guard.test.ts \
         src/__tests__/plugin-import-boundary-guard.test.ts
# 12 pass, 0 fail
bunx tsc --noEmit   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)