### PR TITLE
fix(macos): heal stale CLI install-dir name after in-place upgrade (LUM-2648)

### DIFF
--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -35,6 +35,7 @@ const existsSyncByPath: Record<string, boolean> = {};
 let readdirSyncReturn: Array<{ name: string; isDirectory: () => boolean }> = [];
 let readdirSyncError: Error | null = null;
 let writeFileSyncError: Error | null = null;
+let renameSyncError: Error | null = null;
 const chmodSyncCalls: Array<[string, number]> = [];
 const mkdirSyncCalls: Array<[string, object]> = [];
 const rmSyncCalls: Array<[string, object]> = [];
@@ -62,6 +63,7 @@ mock.module("node:fs", () => ({
     return readdirSyncReturn;
   },
   renameSync: (src: string, dst: string) => {
+    if (renameSyncError) throw renameSyncError;
     renameSyncCalls.push([src, dst]);
     fsCallOrder.push(`renameSync:${dst}`);
   },
@@ -99,6 +101,7 @@ const {
   shQuote,
   writeFileAtomicSync,
   writeCliLocator,
+  migrateStaleInstallDir,
   buildInstallEnv,
   isCliInstalled,
   ensureCliInstalled,
@@ -122,6 +125,7 @@ afterEach(() => {
   readdirSyncReturn.length = 0;
   readdirSyncError = null;
   writeFileSyncError = null;
+  renameSyncError = null;
   chmodSyncCalls.length = 0;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
@@ -265,6 +269,52 @@ describe("writeCliLocator", () => {
   });
 });
 
+// --- migrateStaleInstallDir ---
+
+describe("migrateStaleInstallDir", () => {
+  test("renames an adopted versioned dir to cli/latest", () => {
+    readdirSyncReturn = [dirEntry("0.9.0")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+
+    migrateStaleInstallDir();
+
+    // Clears any partial cli/latest, then renames the stale dir into place.
+    expect(rmSyncCalls.map(([p]) => p)).toContain(latestInstallDir);
+    expect(renameSyncCalls).toContainEqual([
+      `${userDataPath}/cli/0.9.0`,
+      latestInstallDir,
+    ]);
+  });
+
+  test("no-ops when cli/latest already holds the install", () => {
+    readdirSyncReturn = [dirEntry("0.9.0"), dirEntry("latest")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+    existsSyncByPath[cliBinPath] = true;
+
+    migrateStaleInstallDir();
+
+    expect(renameSyncCalls).toHaveLength(0);
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
+  test("no-ops when nothing is installed", () => {
+    readdirSyncReturn = [];
+
+    migrateStaleInstallDir();
+
+    expect(renameSyncCalls).toHaveLength(0);
+    expect(rmSyncCalls).toHaveLength(0);
+  });
+
+  test("swallows rename errors", () => {
+    readdirSyncReturn = [dirEntry("0.9.0")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+    renameSyncError = new Error("EXDEV: cross-device link");
+
+    expect(() => migrateStaleInstallDir()).not.toThrow();
+  });
+});
+
 // --- isCliInstalled ---
 
 describe("isCliInstalled", () => {
@@ -298,17 +348,23 @@ describe("ensureCliInstalled", () => {
     await expect(ensureCliInstalled()).resolves.toBeUndefined();
   });
 
-  test("adopts an existing install without spawning", async () => {
+  test("adopts an existing install and heals its stale versioned name", async () => {
     existsSyncDefault = false;
     readdirSyncReturn = [dirEntry("0.9.0")];
     existsSyncByPath[binPathFor("0.9.0")] = true;
 
     await ensureCliInstalled();
 
-    // The adopted dir is used as-is — no install, no cleanup.
+    // No reinstall — the contents are already bumped; only the name is stale.
     expect(spawnCalls).toHaveLength(0);
-    expect(rmSyncCalls).toHaveLength(0);
-    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+    // The stale versioned dir is renamed to the canonical cli/latest so the
+    // locator path stops misleading debugging (LUM-2648)...
+    expect(renameSyncCalls).toContainEqual([
+      `${userDataPath}/cli/0.9.0`,
+      latestInstallDir,
+    ]);
+    // ...and the locator is still refreshed.
+    expect(renameSyncCalls).toContainEqual([`${locatorPath}.tmp`, locatorPath]);
   });
 
   test("fresh unpinned install spawns bun add vellum@latest", async () => {

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -126,6 +126,42 @@ export function getCliInstallDir(): string {
 }
 
 /**
+ * Rename an adopted version-named install dir (e.g. `cli/0.9.0`) to the
+ * canonical `cli/latest` so its name reflects reality after an in-place float.
+ *
+ * Version-named dirs are only ever created by pinned builds. When a later
+ * unpinned build adopts one and bumps its contents to a newer version in
+ * place, the dir name goes stale (`cli/0.9.0` now holding 0.10.x) and the path
+ * baked into the locator/wrapper misleads debugging (LUM-2648). Pinned builds
+ * always install into a correctly-named dir, so this is a no-op for them.
+ *
+ * Non-fatal — failures are logged and leave the existing dir untouched.
+ */
+export function migrateStaleInstallDir(): void {
+  if (PINNED_CLI_VERSION) return;
+
+  const cliRoot = getCliRootDir();
+  const latestDir = path.join(cliRoot, LATEST_INSTALL_DIR);
+  if (existsSync(binPathIn(latestDir))) return; // already canonical
+
+  const existing = findExistingInstallDir();
+  if (existing === null || path.basename(existing) === LATEST_INSTALL_DIR) {
+    return;
+  }
+
+  try {
+    // Drop any partial `cli/latest` (dir without a bin) so the rename lands.
+    rmSync(latestDir, { recursive: true, force: true });
+    renameSync(existing, latestDir);
+    log.info(
+      `[cli-installer] renamed stale CLI install ${path.basename(existing)} -> ${LATEST_INSTALL_DIR}`,
+    );
+  } catch (err) {
+    log.error("[cli-installer] failed to migrate stale CLI install dir:", err);
+  }
+}
+
+/**
  * Absolute path of what the bundled bun should execute as the CLI: the repo
  * source entry in local builds, otherwise the installed `vellum` binary.
  * Everything downstream (invocation, locator, PATH wrapper) flows through
@@ -177,6 +213,9 @@ export function writeFileAtomicSync(
  * wrapper is never pointed at a missing binary.
  */
 export function writeCliLocator(): void {
+  // Heal a stale versioned install dir first so the locator points at the
+  // canonical path rather than an old version-named one (LUM-2648).
+  migrateStaleInstallDir();
   if (!isCliInstalled()) return;
 
   try {


### PR DESCRIPTION
## Summary
- Version-named CLI install dirs (`cli/0.9.0`) are only ever created by *pinned* builds. When a later *unpinned* build adopts a leftover one and floats its contents to a newer version in place, the dir keeps its stale name, so the path written into `locator.sh` (and sourced by the `~/.local/bin/vellum` wrapper) points at a version-labeled dir holding newer contents — cosmetic but misleading during debugging.
- Added `migrateStaleInstallDir()`, which renames an adopted version-named dir to the canonical `cli/latest` (the name fresh unpinned installs already use, and which never goes stale). It's invoked at the top of `writeCliLocator()`, so every launch self-heals the dir name before the locator is (re)written. Pinned builds always install into a correctly-named dir, so it's a no-op for them; failures are logged and non-fatal.
- The wrapper references only the fixed `locator.sh` path, so it self-corrects once the locator points at the accurate dir.

## Original prompt
Implement LUM-2648: after an in-place local CLI upgrade, the version-named install dir keeps its old name even though its contents are bumped (e.g. `cli/0.9.0/` now holding 0.10.x), and that stale path is written into `locator.sh` and the PATH wrapper. Nothing breaks (the path is cosmetic), but it's misleading during debugging. The ask was to have the next launch rewrite the locator (and wrapper) so the path reflects the actual installed version after each upgrade.