### PR TITLE
feat(cli): surface CLI-vs-runtime version drift in `assistant status` (LUM-2647)

### DIFF
--- a/assistant/eslint-rules/cli-no-daemon-internals.js
+++ b/assistant/eslint-rules/cli-no-daemon-internals.js
@@ -21,6 +21,10 @@ const ALLOWED_PREFIXES = {
     // Status command's daemon-down fallback needs socket path + platform.
     "../../ipc/socket-path",
     "../../util/platform",
+    // App version constant (leaf module; reads package.json/env, no daemon
+    // deps) — status prints it to surface CLI-vs-runtime version drift.
+    "../../version",
+    "../../../version",
     // Logger / output at depth-1 and depth-2.
     "../logger",
     "../output",

--- a/assistant/src/cli/commands/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/__tests__/status.test.ts
@@ -51,6 +51,12 @@ mock.module("../../../util/platform.js", () => ({
   getWorkspaceDirDisplay: () => "~/.vellum/workspace",
 }));
 
+// Fixed installed CLI version so drift-vs-match is deterministic.
+const INSTALLED_CLI_VERSION = "9.9.9";
+mock.module("../../../version.js", () => ({
+  APP_VERSION: INSTALLED_CLI_VERSION,
+}));
+
 mock.module("../../../util/logger.js", () => ({
   getLogger: () => ({
     info: () => {},
@@ -182,13 +188,13 @@ describe("status command — daemon unreachable (ENOENT/ECONNREFUSED)", () => {
     expect(stdout).toContain("Assistant: running");
   });
 
-  test("does not print version or memory when daemon is unreachable", async () => {
+  test("prints the installed CLI version but no runtime health when unreachable", async () => {
     mockResponse = { ok: false, error: DAEMON_UNREACHABLE_ERROR };
     socketExists = false;
 
     const { stdout, stderr } = await runStatusCommand();
 
-    expect(stdout + stderr).not.toContain("Version");
+    expect(stdout).toContain(`CLI Version: ${INSTALLED_CLI_VERSION}`);
     expect(stdout + stderr).not.toContain("Memory");
   });
 });
@@ -242,8 +248,42 @@ describe("status command — daemon up", () => {
     const { stdout, stderr } = await runStatusCommand();
     const combined = stdout + stderr;
 
+    expect(combined).toContain("Assistant Version");
     expect(combined).toContain("1.2.3");
     expect(combined).toContain("100");
     expect(combined).toContain("500");
+  });
+
+  test("flags the runtime as stale when it differs from the installed CLI", async () => {
+    mockResponse = {
+      ok: true,
+      result: {
+        version: "1.2.3",
+        memory: { currentMb: 100, maxMb: 500 },
+        disk: null,
+      },
+    };
+
+    const { stdout } = await runStatusCommand();
+
+    expect(stdout).toContain(
+      `1.2.3 (stale — restart to run ${INSTALLED_CLI_VERSION})`,
+    );
+  });
+
+  test("shows a bare version with no stale note when versions match", async () => {
+    mockResponse = {
+      ok: true,
+      result: {
+        version: INSTALLED_CLI_VERSION,
+        memory: { currentMb: 100, maxMb: 500 },
+        disk: null,
+      },
+    };
+
+    const { stdout } = await runStatusCommand();
+
+    expect(stdout).toContain(`Assistant Version  ${INSTALLED_CLI_VERSION}`);
+    expect(stdout).not.toContain("stale");
   });
 });

--- a/assistant/src/cli/commands/status.ts
+++ b/assistant/src/cli/commands/status.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import { getAssistantSocketPath } from "../../ipc/socket-path.js";
 import { getWorkspaceDirDisplay } from "../../util/platform.js";
+import { APP_VERSION } from "../../version.js";
 import { registerCommand } from "../lib/register-command.js";
 
 interface HealthResponse {
@@ -34,6 +35,9 @@ export function registerStatusCommand(program: Command): void {
             const socketPath = getAssistantSocketPath();
             const socketExists = existsSync(socketPath);
             const workspace = getWorkspaceDirDisplay();
+            // Daemon unreachable, so its runtime version is unknown; show the
+            // installed CLI version so there's always one reliable number.
+            process.stdout.write(`CLI Version: ${APP_VERSION}\n`);
             process.stdout.write(
               (socketExists ? "Assistant: running" : "Assistant: down") + "\n",
             );
@@ -52,8 +56,15 @@ export function registerStatusCommand(program: Command): void {
         const h = result.result;
         const workspace = getWorkspaceDirDisplay();
 
+        // h.version is the running runtime; APP_VERSION is the installed CLI.
+        // They drift mid-upgrade (CLI bumped, daemon not yet restarted).
+        const runtimeVersion =
+          h.version === APP_VERSION
+            ? h.version
+            : `${h.version} (stale — restart to run ${APP_VERSION})`;
+
         const rows: [string, string][] = [
-          ["Version", h.version],
+          ["Assistant Version", runtimeVersion],
           ["Workspace", workspace],
           ["", ""],
           ["Memory", `${fmtMb(h.memory.currentMb)} / ${fmtMb(h.memory.maxMb)}`],


### PR DESCRIPTION
## Summary
- `assistant status` now labels the row **Assistant Version** and, when the running runtime version differs from the installed CLI version (`APP_VERSION`), appends `(stale — restart to run <installed>)` so the drift is legible instead of looking like a bug.
- Any string mismatch counts as stale (not semver-newer-only), covering downgrades and dev builds too.
- The daemon-unreachable branch now prints `CLI Version: <installed>` so there's always one reliable number even when the runtime can't be reached.

Example when drifted:
```
Assistant Version  0.10.3 (stale — restart to run 0.10.4)
Workspace          ~/.vellum/workspace

Memory             398 MB / 2.0 GB
Disk               58.3 GB free
```

## Original prompt
Investigating LUM-2647 — a self-hosted user saw `assistant --version` and `assistant status` report different versions. The root cause is legitimate: `--version` is computed fresh in the CLI process from the installed package, while `status` asks the long-running daemon, whose version is pinned at the moment it was last started; they diverge mid-upgrade (and get stuck when an upgrade's daemon restart fails, as in ATL-923). The ask was to surface both numbers side by side in `status` so the drift is self-explanatory. Per follow-up: keep it a single row, mark 'stale' on any mismatch, and align the labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)