### PR TITLE
refactor(memory): invert the consolidation-scheduler buffer gate through the persistence seam

### DIFF
--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -37,22 +37,16 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
  * TECH DEBT — residual `persistence/` → `memory/` feature back-imports.
  *
  * A genuine coupling to the memory *feature* that violates the one-way
- * memory → persistence direction, pinned here so the guard fails the moment a
- * NEW back-import is introduced.
- *
- * The lone remaining entry is the in-worker memory consolidation /
- * graph-maintenance SCHEDULER (`jobs-worker.ts` → `v2/consolidation-job` for
- * `countBufferLines`). Inverting it means memory deciding what to enqueue on
- * each worker tick — that is roadmap bullet #4 (memory-jobs → schedule-jobs),
- * deferred until the Schedules worker + `/workspace/schedules` API land.
- * Decouple it then; do not add to this list without a decoupling plan.
+ * memory → persistence direction would be pinned here so the guard fails the
+ * moment a NEW back-import is introduced. It is currently EMPTY: persistence
+ * reaches the memory feature only through the `memory-lifecycle-hooks` seam
+ * (persistence calls registered handlers; memory never gets imported), never by
+ * importing memory internals. Do not add an entry without a decoupling plan.
  *
  * Keyed by the importing persistence file (relative to repo root); the value
  * is the set of allowed `memory/<specifier>` module paths it may import.
  */
-const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
-  "assistant/src/persistence/jobs-worker.ts": new Set(["v2/consolidation-job"]),
-};
+const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {};
 
 /**
  * PERMANENT exception — the migration registry, NOT tech debt.

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -261,6 +261,7 @@ describe("per-surface disabled-state filtering", () => {
 
   test("persistence hooks no-op while the memory plugin is disabled", async () => {
     let calls = 0;
+    const bufferLines = 25;
     const guarded = guardPersistenceHooksByDisabledState("default-memory", {
       onMessagePersisted() {
         calls++;
@@ -270,6 +271,9 @@ describe("per-surface disabled-state filtering", () => {
         return 0;
       },
       onWorkerStartup() {},
+      countMemoryBufferLines() {
+        return bufferLines;
+      },
     });
     const event: MessagePersistedEvent = {
       messageId: "msg-1",
@@ -282,16 +286,21 @@ describe("per-surface disabled-state filtering", () => {
     // Enabled: the wrapped handler runs.
     await guarded.onMessagePersisted(event);
     expect(calls).toBe(1);
+    // The gated query returns the real buffer count while enabled.
+    expect(guarded.countMemoryBufferLines()).toBe(25);
 
     // Disable via sentinel — checked at call time, no restart needed.
     await createSentinel("default-memory");
     await guarded.onMessagePersisted(event);
     expect(calls).toBe(1);
+    // Gated: reports an empty buffer while disabled, so consolidation stays inert.
+    expect(guarded.countMemoryBufferLines()).toBe(0);
 
     // Re-enable.
     await removeSentinel("default-memory");
     await guarded.onMessagePersisted(event);
     expect(calls).toBe(2);
+    expect(guarded.countMemoryBufferLines()).toBe(25);
   });
 
   test("cleanup persistence hooks run even while the memory plugin is disabled", async () => {
@@ -306,6 +315,9 @@ describe("per-surface disabled-state filtering", () => {
       },
       onWorkerStartup() {
         swept++;
+      },
+      countMemoryBufferLines() {
+        return 0;
       },
     });
 

--- a/assistant/src/persistence/jobs-worker.ts
+++ b/assistant/src/persistence/jobs-worker.ts
@@ -1,5 +1,3 @@
-import { join } from "node:path";
-
 import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -8,9 +6,7 @@ import {
   diskPressureBackgroundSkipLogFields,
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
-import { countBufferLines } from "../plugins/defaults/memory/v2/consolidation-job.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import {
   getLastScheduledCleanupEnqueueMs,
@@ -796,8 +792,10 @@ export function maybeEnqueueGraphMaintenanceJobs(
       // The checkpoint advances so the next check fires after the regular
       // interval. Manual "Run now" is unaffected (routes layer, not schedule).
       if (jobType === consolidateEntry.jobType) {
-        const bufferPath = join(getWorkspaceDir(), "memory", "buffer.md");
-        if (countBufferLines(bufferPath) < MIN_BUFFER_LINES_FOR_CONSOLIDATION) {
+        if (
+          getMemoryPersistenceHooks().countMemoryBufferLines() <
+          MIN_BUFFER_LINES_FOR_CONSOLIDATION
+        ) {
           log.debug(
             "Scheduled consolidation skipped: buffer under minimum line threshold",
           );
@@ -830,8 +828,7 @@ export function maybeEnqueueGraphMaintenanceJobs(
     maxLines !== null &&
     !hasActiveJobOfType(consolidateEntry.jobType)
   ) {
-    const bufferPath = join(getWorkspaceDir(), "memory", "buffer.md");
-    if (countBufferLines(bufferPath) >= maxLines) {
+    if (getMemoryPersistenceHooks().countMemoryBufferLines() >= maxLines) {
       enqueueMemoryJob(
         consolidateEntry.jobType,
         AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD,

--- a/assistant/src/persistence/memory-lifecycle-hooks.test.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.test.ts
@@ -24,6 +24,9 @@ const baseHooks: MemoryPersistenceHooks = {
     return 0;
   },
   onWorkerStartup() {},
+  countMemoryBufferLines() {
+    return 0;
+  },
 };
 
 describe("memory persistence-lifecycle seam", () => {
@@ -32,6 +35,18 @@ describe("memory persistence-lifecycle seam", () => {
   test("defaults to a no-op when no implementation is registered", async () => {
     // Resolves without throwing — the "memory not present" path.
     await getMemoryPersistenceHooks().onMessagePersisted(event);
+  });
+
+  test("countMemoryBufferLines defaults to 0 when memory is not present", () => {
+    expect(getMemoryPersistenceHooks().countMemoryBufferLines()).toBe(0);
+  });
+
+  test("countMemoryBufferLines returns the registered implementation's count", () => {
+    registerMemoryPersistenceHooks({
+      ...baseHooks,
+      countMemoryBufferLines: () => 42,
+    });
+    expect(getMemoryPersistenceHooks().countMemoryBufferLines()).toBe(42);
   });
 
   test("getMemoryPersistenceHooks returns the registered implementation", async () => {

--- a/assistant/src/persistence/memory-lifecycle-hooks.ts
+++ b/assistant/src/persistence/memory-lifecycle-hooks.ts
@@ -2,7 +2,8 @@ import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import type { DrizzleDb } from "./db-connection.js";
 
 /**
- * Seam for the memory feature to react to persistence-layer lifecycle events.
+ * Seam for the memory feature to react to persistence-layer lifecycle events
+ * and to answer memory-domain queries the persistence layer needs.
  *
  * Persistence is a layer below the memory plugin, so it cannot import memory
  * internals directly. Instead it calls into this registered-handler seam: the
@@ -89,6 +90,15 @@ export interface MemoryPersistenceHooks {
    * wraps it in try/catch. Cleanup — runs even while the plugin is disabled.
    */
   onWorkerStartup(): void;
+
+  /**
+   * Current line count of the memory buffer (`memory/buffer.md`). The
+   * maintenance scheduler reads it to gate scheduled consolidation — skip a
+   * scheduled run below a floor, force one above a ceiling. Returns 0 when
+   * memory is not present, which the scheduler reads as "no buffered work" and
+   * therefore no consolidation.
+   */
+  countMemoryBufferLines(): number;
 }
 
 const NOOP: MemoryPersistenceHooks = {
@@ -98,6 +108,9 @@ const NOOP: MemoryPersistenceHooks = {
     return 0;
   },
   onWorkerStartup() {},
+  countMemoryBufferLines() {
+    return 0;
+  },
 };
 
 let current: MemoryPersistenceHooks = NOOP;

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -527,6 +527,14 @@ export function guardPersistenceHooksByDisabledState(
       if (isPluginDisabled(pluginName)) return;
       return hooks.onConversationForked(event);
     },
+    // Gated like the active side effects above: a disabled plugin reports an
+    // empty buffer, so the maintenance scheduler treats it as "no buffered
+    // work" and skips consolidation — matching how disabled injectors/hooks go
+    // inert.
+    countMemoryBufferLines() {
+      if (isPluginDisabled(pluginName)) return 0;
+      return hooks.countMemoryBufferLines();
+    },
     // Cleanup hooks are NOT gated on disabled-state: they must run even while
     // the plugin is disabled, or jobs/conversations created while it was
     // enabled would be orphaned.

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -57,6 +57,7 @@ afterAll(() => {
     process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
   }
   rmSync(tmpWorkspace, { recursive: true, force: true });
+  resetMemoryPersistenceHooksForTests();
 });
 
 const { getMemoryDb } =
@@ -70,6 +71,14 @@ const { getMemoryCheckpoint, setMemoryCheckpoint, deleteMemoryCheckpoint } =
   await import("../../../../persistence/checkpoints.js");
 const { maybeEnqueueGraphMaintenanceJobs } =
   await import("../../../../persistence/jobs-worker.js");
+const { registerMemoryPersistenceHooks, resetMemoryPersistenceHooksForTests } =
+  await import("../../../../persistence/memory-lifecycle-hooks.js");
+const { memoryPersistenceHooks } = await import("../persistence-hooks.js");
+
+// The scheduler reads the memory buffer's line count through the persistence
+// seam; register the real memory implementation so `countMemoryBufferLines`
+// reflects the buffer files these tests write.
+registerMemoryPersistenceHooks(memoryPersistenceHooks);
 
 const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
 

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,9 +1,12 @@
+import { join } from "node:path";
+
 import { getConfig } from "../../../config/loader.js";
 import type {
   ConversationForkedEvent,
   MemoryPersistenceHooks,
   MessagePersistedEvent,
 } from "../../../persistence/memory-lifecycle-hooks.js";
+import { getWorkspaceDir } from "../../../util/platform.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
@@ -13,6 +16,7 @@ import {
   forkActivationState,
   seedForkActivationState,
 } from "./v2/activation-store.js";
+import { countBufferLines } from "./v2/consolidation-job.js";
 import {
   extractInjectedConceptSlugs,
   readInjectedBlock,
@@ -115,5 +119,9 @@ export const memoryPersistenceHooks: MemoryPersistenceHooks = {
 
   onWorkerStartup(): void {
     sweepOrphanMemoryRetrospectiveConversations();
+  },
+
+  countMemoryBufferLines(): number {
+    return countBufferLines(join(getWorkspaceDir(), "memory", "buffer.md"));
   },
 };


### PR DESCRIPTION
## Summary
- Inverts the **lone remaining `persistence → memory` back-import** through the Step-C `MemoryPersistenceHooks` seam. The in-worker maintenance scheduler (`maybeEnqueueGraphMaintenanceJobs` in `persistence/jobs-worker.ts`) imported `countBufferLines` from the memory plugin to gate scheduled consolidation on buffer size; it now reads a new `countMemoryBufferLines()` seam method.
- **`PERSISTENCE_TO_MEMORY_ALLOWLIST` is now EMPTY** — persistence reaches the memory feature only through the seam (registered handlers), never by importing memory internals. The layering guard ratchets to zero.
- **Behavior-identical:** the same buffer count drives the same skip-gate + size-trigger decisions; only the source changed (direct import → seam). Gated like the active side effects (disabled plugin → empty buffer → consolidation inert); the NOOP returns 0.
- Both worker processes register the seam before their tick loop (daemon bootstrap + the standalone worker's `registerMemoryJobHandlers` self-register — the C3 cross-process fix), so the scheduler reads the real count in either.

## Why now, not deferred to bullet #4
This is the **seam-level inversion** — doable now, exactly like C2–C4. It's distinct from the larger "memory-jobs → schedules" migration (roadmap bullet #4), which rewrites the scheduling model and is gated on the Schedules worker + `/workspace/schedules` API.

## Validation
`typecheck:fast` + `lint` + `lint:unused` + `prettier`; the persistence-layering guard (empty allowlist, no stale entries), the seam unit test, the disabled-state gating test, and the full `jobs-worker-v2-schedule` scheduler suite (21 tests, buffer-gate driven through the seam) all pass in isolation. Zero `@vellumai/plugin-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)