### PR TITLE
fix(calls): do not speak "technical issue" on transient processing-lock contention (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1025,6 +1025,45 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("lock-contention rejection: swallowed, no technical-issue speech, returns to idle", async () => {
+    mockStartVoiceTurn.mockImplementation(async () => {
+      throw new Error("Conversation is already processing a message");
+    });
+
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hello");
+
+    // The transient lock-contention race must never be spoken to the caller.
+    const errorTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("technical issue"),
+    );
+    expect(errorTokens.length).toBe(0);
+
+    // Controller goes idle and re-arms the silence watchdog.
+    expect(controller.getState()).toBe("idle");
+
+    controller.destroy();
+  });
+
+  test("genuine non-lock-contention error still speaks the technical-issue fallback", async () => {
+    mockStartVoiceTurn.mockImplementation(async () => {
+      throw new Error("boom");
+    });
+
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hello");
+
+    const errorTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("technical issue"),
+    );
+    expect(errorTokens.length).toBeGreaterThan(0);
+    expect(controller.getState()).toBe("idle");
+
+    controller.destroy();
+  });
+
   test("handleUserAnswer: returns false when no pending consultation exists", async () => {
     const { controller } = setupController();
 

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1040,6 +1040,13 @@ describe("call-controller", () => {
     );
     expect(errorTokens.length).toBe(0);
 
+    // An empty end-of-turn marker (last=true) must still be sent so the relay
+    // transitions back to listening despite swallowing the error.
+    const endOfTurnMarkers = relay.sentTokens.filter(
+      (t) => t.token === "" && t.last === true,
+    );
+    expect(endOfTurnMarkers.length).toBeGreaterThan(0);
+
     // Controller goes idle and re-arms the silence watchdog.
     expect(controller.getState()).toBe("idle");
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -566,6 +566,9 @@ export class CallController {
           { callSessionId: this.callSessionId },
           "Swallowing transient processing-lock contention race",
         );
+        // Send an empty end-of-turn marker so the relay transitions back to
+        // listening, without speaking any technical-issue text.
+        this.transport.sendTextToken("", true);
         this.state = "idle";
         this.resetSilenceTimer();
         this.flushPendingInstructions();

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -561,6 +561,16 @@ export class CallController {
         );
         return;
       }
+      if (this.isLockContentionError(err) && this.isCurrentRun(runVersion)) {
+        log.debug(
+          { callSessionId: this.callSessionId },
+          "Swallowing transient processing-lock contention race",
+        );
+        this.state = "idle";
+        this.resetSilenceTimer();
+        this.flushPendingInstructions();
+        return;
+      }
       log.error({ err, callSessionId: this.callSessionId }, "Voice turn error");
       this.transport.sendTextToken(
         "I'm sorry, I encountered a technical issue. Could you repeat that?",
@@ -1219,6 +1229,19 @@ export class CallController {
   private isExpectedAbortError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
     return err.name === "AbortError" || err.name === "APIUserAbortError";
+  }
+
+  /**
+   * Transient teardown race: a new voice turn reached the session bridge
+   * before the previous turn released the conversation processing lock.
+   * This is not a real error and must never be spoken to the caller. See
+   * JARVIS-1232.
+   */
+  private isLockContentionError(err: unknown): boolean {
+    return (
+      err instanceof Error &&
+      err.message.includes("already processing a message")
+    );
   }
 
   private isCurrentRun(runVersion: number): boolean {


### PR DESCRIPTION
## Summary
- Detect the transient 'Conversation is already processing a message' race in runTurnInner and swallow it (go idle, re-arm silence watchdog) instead of speaking a canned technical-error line to the caller.
- Genuine errors still surface the spoken fallback. (JARVIS-1232)

Part of plan: voice-lock-race-fix.md (PR 2 of 3)