### PR TITLE
fix(voice): derive processing-wait from turnCommitMaxWaitMs instead of hard-coded 3000ms (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -19,14 +19,17 @@ mock.module("../config/loader.js", () => ({
 import { resolveProcessingWaitMs } from "../calls/voice-session-bridge.js";
 
 describe("resolveProcessingWaitMs", () => {
-  test("adds a fixed margin to the default commit window", () => {
-    expect(resolveProcessingWaitMs(4000)).toBe(5000);
-    expect(resolveProcessingWaitMs(4000)).toBeGreaterThan(4000);
+  test("covers the default commit window plus abort unwind budget", () => {
+    expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
   });
 
-  test("always returns strictly greater than the commit window", () => {
-    for (const n of [1, 100, 4000, 10000]) {
-      expect(resolveProcessingWaitMs(n)).toBeGreaterThan(n);
+  test("always returns strictly greater than the max lock-hold", () => {
+    for (const commit of [1, 100, 4000, 10000]) {
+      for (const abort of [1, 5000, 8000]) {
+        expect(resolveProcessingWaitMs(commit, abort)).toBeGreaterThan(
+          commit + abort,
+        );
+      }
     }
   });
 });

--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before importing voice-session-bridge so its module-level
+// imports (logger, config loader) stay side-effect free for this pure helper.
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+import { resolveProcessingWaitMs } from "../calls/voice-session-bridge.js";
+
+describe("resolveProcessingWaitMs", () => {
+  test("adds a fixed margin to the default commit window", () => {
+    expect(resolveProcessingWaitMs(4000)).toBe(5000);
+    expect(resolveProcessingWaitMs(4000)).toBeGreaterThan(4000);
+  });
+
+  test("always returns strictly greater than the commit window", () => {
+    for (const n of [1, 100, 4000, 10000]) {
+      expect(resolveProcessingWaitMs(n)).toBeGreaterThan(n);
+    }
+  });
+});

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -35,6 +35,18 @@ import {
 
 const log = getLogger("voice-session-bridge");
 
+/**
+ * How long startVoiceTurn waits for a prior turn to release the processing
+ * lock before giving up. Must stay strictly greater than the agent loop's
+ * turn-boundary commit window (workspaceGit.turnCommitMaxWaitMs) so the
+ * bridge never gives up before the agent-loop `finally` can clear the lock.
+ * See JARVIS-1232.
+ */
+const PROCESSING_WAIT_MARGIN_MS = 1000;
+export function resolveProcessingWaitMs(turnCommitMaxWaitMs: number): number {
+  return turnCommitMaxWaitMs + PROCESSING_WAIT_MARGIN_MS;
+}
+
 // ---------------------------------------------------------------------------
 // Module-level dependency injection
 // ---------------------------------------------------------------------------
@@ -360,7 +372,10 @@ export async function startVoiceTurn(
   if (conversation.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait briefly for the
     // previous turn to finish aborting before giving up.
-    const maxWaitMs = 3000;
+    const config = getConfig();
+    const maxWaitMs = resolveProcessingWaitMs(
+      config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
+    );
     const pollIntervalMs = 50;
     let waited = 0;
     while (conversation.isProcessing() && waited < maxWaitMs) {
@@ -374,6 +389,9 @@ export async function startVoiceTurn(
       throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
+      // maxWaitMs is sized to exceed the agent loop's commit window so this
+      // bound is only a guardrail; decoupling the lock from the commit
+      // (see JARVIS-1232 PR 1) is the primary fix for the underlying race.
       throw new Error("Conversation is already processing a message");
     }
   }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -35,16 +35,23 @@ import {
 
 const log = getLogger("voice-session-bridge");
 
+const PROCESSING_WAIT_MARGIN_MS = 1000;
+// Must match ABORT_WATCHDOG_MS in conversation-agent-loop.ts. Mirrored here
+// rather than imported to keep this module (and its unit test) free of the
+// agent-loop's heavy dependency graph.
+const ABORT_UNWIND_BUDGET_MS = 5000;
 /**
  * How long startVoiceTurn waits for a prior turn to release the processing
- * lock before giving up. Must stay strictly greater than the agent loop's
- * turn-boundary commit window (workspaceGit.turnCommitMaxWaitMs) so the
- * bridge never gives up before the agent-loop `finally` can clear the lock.
- * See JARVIS-1232.
+ * lock before giving up. The prior turn can hold the lock for the abort
+ * unwind budget PLUS the awaited turn-boundary commit window, so the wait
+ * must cover both (+ margin) or a barge-in can still surface
+ * "Conversation is already processing a message". See JARVIS-1232.
  */
-const PROCESSING_WAIT_MARGIN_MS = 1000;
-export function resolveProcessingWaitMs(turnCommitMaxWaitMs: number): number {
-  return turnCommitMaxWaitMs + PROCESSING_WAIT_MARGIN_MS;
+export function resolveProcessingWaitMs(
+  turnCommitMaxWaitMs: number,
+  abortUnwindMs: number,
+): number {
+  return turnCommitMaxWaitMs + abortUnwindMs + PROCESSING_WAIT_MARGIN_MS;
 }
 
 // ---------------------------------------------------------------------------
@@ -375,6 +382,7 @@ export async function startVoiceTurn(
     const config = getConfig();
     const maxWaitMs = resolveProcessingWaitMs(
       config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
+      ABORT_UNWIND_BUDGET_MS,
     );
     const pollIntervalMs = 50;
     let waited = 0;
@@ -389,9 +397,10 @@ export async function startVoiceTurn(
       throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
-      // maxWaitMs is sized to exceed the agent loop's commit window so this
-      // bound is only a guardrail; decoupling the lock from the commit
-      // (see JARVIS-1232 PR 1) is the primary fix for the underlying race.
+      // maxWaitMs covers the abort unwind budget (ABORT_WATCHDOG_MS) plus the
+      // awaited turn-boundary commit window (turnCommitMaxWaitMs) plus a
+      // margin — the full span a prior turn can hold the lock — so reaching
+      // here means the prior turn is genuinely wedged. See JARVIS-1232.
       throw new Error("Conversation is already processing a message");
     }
   }


### PR DESCRIPTION
## Summary
- Replace the hard-coded 3000ms processing-lock wait in startVoiceTurn with a value derived from workspaceGit.turnCommitMaxWaitMs (+1000ms margin) so the bridge wait is always strictly greater than the commit window.
- Adds an exported resolveProcessingWaitMs helper with unit tests. (JARVIS-1232)

Part of plan: voice-lock-race-fix.md (PR 3 of 3)