### PR TITLE
fix(assistant): drop deleted skill-host-contracts COPY from Dockerfile

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -24,7 +24,6 @@ COPY packages/egress-proxy ./packages/egress-proxy
 COPY packages/environments ./packages/environments
 COPY packages/gateway-client ./packages/gateway-client
 COPY packages/ipc-server-utils ./packages/ipc-server-utils
-COPY packages/skill-host-contracts ./packages/skill-host-contracts
 COPY packages/slack-text ./packages/slack-text
 COPY packages/twilio-client ./packages/twilio-client
 


### PR DESCRIPTION
## Summary
- Remove `COPY packages/skill-host-contracts` from `assistant/Dockerfile`. The package was deleted in #36707, so fresh CI checkouts no longer have the directory and the Docker build fails with `"/packages/skill-host-contracts": not found`.
- Nothing else references the package (it is not among the `bun install` shared packages), so the COPY was pure dead reference.

## Original prompt
Fix the build error in the Dev Release run's `push-assistant-image` jobs, which failed with `failed to compute cache key: ... "/packages/skill-host-contracts": not found`. The refactor in #36707 deleted the `skill-host-contracts` package but left a stale `COPY` line in the assistant Dockerfile, breaking the image build on clean checkouts.