### PR TITLE
test(assistant): clear leaked abort-watchdog timers in conversation-queue tests

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -827,6 +827,13 @@ describe("Conversation message queue", () => {
       (e) => e.type === "conversation_error",
     );
     expect(conversationErr3).toBeUndefined();
+
+    // Settle the aborted in-flight run so its abort watchdog clears the
+    // real-time timer it armed. A leaked ~5s timer otherwise fires during a
+    // later test and drives this stale turn into commitTurnChanges, inflating
+    // the shared turnCommitCalls counter that other tests assert against.
+    await resolveRun(0);
+    await new Promise((r) => setTimeout(r, 10));
   });
 
   test("conversation-scoped errors emit both conversation_error and generic error", async () => {
@@ -2801,6 +2808,13 @@ describe("Regression: cancel semantics and error channel split", () => {
       );
       expect(conversationErr).toBeUndefined();
     }
+
+    // Settle the aborted in-flight run so its abort watchdog clears the
+    // real-time timer it armed. A leaked ~5s timer otherwise fires during a
+    // later test and drives this stale turn into commitTurnChanges, inflating
+    // the shared turnCommitCalls counter that other tests assert against.
+    await resolveRun(0);
+    await new Promise((r) => setTimeout(r, 10));
   });
 
   test("commitTurnChanges never resolving within budget -> turn still completes and drains queue", async () => {


### PR DESCRIPTION
## Summary
- Two `conversation-queue.test.ts` tests (`abort() clears the queue and sends generation_cancelled for each queued message` and `cancel after queued messages produces no conversation_error for any queued entry`) call `conversation.abort()` on an in-flight run but never settle it. The mocked `AgentLoop.run()` ignores the abort signal, so `withAbortWatchdog` arms its real-time ~5s timer and never clears it — the timer outlives the test.
- When that leaked timer fires during a later test, it drives the stale turn into its `finally`, calling `commitTurnChanges` and pushing a spurious entry into the module-global `turnCommitCalls` array. This flaked `commitTurnChanges never resolving within budget -> turn still completes and drains queue` at `expect(turnCommitCalls).toHaveLength(1)` (received 2) in [job 84434928523](https://github.com/vellum-ai/vellum-assistant/actions/runs/28486804886/job/84434928523).
- Fix: settle the aborted in-flight run at the end of each of those two tests (mirroring the sibling `user cancellation emits generation_cancelled` test, which already does this), so `withAbortWatchdog` clears its timer before the test returns. No production code changes. Verified the file green across repeated local runs (53 pass / 0 fail).

## Original prompt
Fix only the specific CI failure in the `Test` job of run 28486804886 (CI Main Assistant Checks): `conversation-queue.test.ts` failing at `expect(turnCommitCalls).toHaveLength(1)` with received length 2. The failure is a pre-existing flake unrelated to the head commit (a search feature, #36724) — a leaked abort-watchdog timer bleeding across test boundaries. Scope the fix to that issue only.