### PR TITLE
refactor(voice): share ABORT_WATCHDOG_MS across agent-loop and voice bridge (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -23,13 +23,8 @@ describe("resolveProcessingWaitMs", () => {
     expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
   });
 
-  test("always returns strictly greater than the max lock-hold", () => {
-    for (const commit of [1, 100, 4000, 10000]) {
-      for (const abort of [1, 5000, 8000]) {
-        expect(resolveProcessingWaitMs(commit, abort)).toBeGreaterThan(
-          commit + abort,
-        );
-      }
-    }
+  test("adds the fixed margin to commit window plus abort budget", () => {
+    expect(resolveProcessingWaitMs(1000, 5000)).toBe(7000);
+    expect(resolveProcessingWaitMs(4000, 0)).toBe(5000);
   });
 });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -18,6 +18,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
@@ -36,10 +37,6 @@ import {
 const log = getLogger("voice-session-bridge");
 
 const PROCESSING_WAIT_MARGIN_MS = 1000;
-// Must match ABORT_WATCHDOG_MS in conversation-agent-loop.ts. Mirrored here
-// rather than imported to keep this module (and its unit test) free of the
-// agent-loop's heavy dependency graph.
-const ABORT_UNWIND_BUDGET_MS = 5000;
 /**
  * How long startVoiceTurn waits for a prior turn to release the processing
  * lock before giving up. The prior turn can hold the lock for the abort
@@ -382,7 +379,7 @@ export async function startVoiceTurn(
     const config = getConfig();
     const maxWaitMs = resolveProcessingWaitMs(
       config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
-      ABORT_UNWIND_BUDGET_MS,
+      ABORT_WATCHDOG_MS,
     );
     const pollIntervalMs = 50;
     let waited = 0;
@@ -397,10 +394,10 @@ export async function startVoiceTurn(
       throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
-      // maxWaitMs covers the abort unwind budget (ABORT_WATCHDOG_MS) plus the
-      // awaited turn-boundary commit window (turnCommitMaxWaitMs) plus a
-      // margin — the full span a prior turn can hold the lock — so reaching
-      // here means the prior turn is genuinely wedged. See JARVIS-1232.
+      // Waited the full budget (see resolveProcessingWaitMs) without the lock
+      // releasing, so the prior turn is genuinely wedged. The controller
+      // catches this terminal error and speaks a brief non-technical
+      // re-prompt rather than staying silent. See JARVIS-1232.
       throw new Error("Conversation is already processing a message");
     }
   }

--- a/assistant/src/daemon/abort-watchdog.ts
+++ b/assistant/src/daemon/abort-watchdog.ts
@@ -1,0 +1,7 @@
+/**
+ * Grace period after an abort signal fires for a turn to settle before the
+ * abort watchdog force-unwinds the agent loop. Shared source of truth: the
+ * voice session bridge sizes its processing-lock wait to cover this budget,
+ * so the two must not drift. See JARVIS-1232.
+ */
+export const ABORT_WATCHDOG_MS = 5_000;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -81,6 +81,7 @@ import { timeAgo } from "../util/time.js";
 import { truncate } from "../util/truncate.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
 import { commitTurnChanges } from "../workspace/turn-commit.js";
+import { ABORT_WATCHDOG_MS } from "./abort-watchdog.js";
 import { cleanAssistantContent } from "./assistant-attachments.js";
 import { conversationSupportsDynamicUi } from "./channel-ui-capability.js";
 import type { Conversation } from "./conversation.js";
@@ -196,21 +197,19 @@ export interface AssistantSurface {
 
 // ── abort watchdog ───────────────────────────────────────────────────
 
-/**
- * Backstop that drives an aborted turn to its `finally` even if some awaited
- * operation fails to observe the abort signal.
- *
- * Abort is otherwise cooperative and already wired into the slow paths: the
- * provider call forwards the signal to its HTTP/streaming fetch, and tool
- * execution races the signal so a stuck tool can't block cancellation. This
- * watchdog only fires when a future code path silently ignores abort — without
- * it, such a path would hang the loop forever and latch the conversation's
- * `processing` flag true (the wedged "Thinking…" indicator). It is
- * defense-in-depth, not the primary mechanism: in the common case abort settles
- * in-flight work in well under a second, so a few seconds is ample headroom for
- * a cooperative unwind while still releasing a genuinely wedged turn promptly.
+/*
+ * The watchdog is a backstop that drives an aborted turn to its `finally` even
+ * if some awaited operation fails to observe the abort signal. Abort is
+ * otherwise cooperative and already wired into the slow paths: the provider call
+ * forwards the signal to its HTTP/streaming fetch, and tool execution races the
+ * signal so a stuck tool can't block cancellation. The watchdog only fires when
+ * a future code path silently ignores abort — without it, such a path would hang
+ * the loop forever and latch the conversation's `processing` flag true (the
+ * wedged "Thinking…" indicator). It is defense-in-depth, not the primary
+ * mechanism: in the common case abort settles in-flight work in well under a
+ * second, so ABORT_WATCHDOG_MS is ample headroom for a cooperative unwind while
+ * still releasing a genuinely wedged turn promptly.
  */
-const ABORT_WATCHDOG_MS = 5_000;
 
 /**
  * Race `work` against an abort watchdog. The watchdog stays disarmed until the


### PR DESCRIPTION
## Summary
- Extract ABORT_WATCHDOG_MS into a dependency-free leaf module so the voice bridge's processing-lock wait can't silently drift from the agent loop's abort watchdog.
- Tighten the processing-wait test to concrete values; trim a duplicated rationale comment.

Self-review remediation for plan: voice-lock-race-fix.md