### PR TITLE
fix(calls): graceful re-prompt (not silence) when prior voice turn is genuinely wedged (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1025,7 +1025,7 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("lock-contention rejection: swallowed, no technical-issue speech, returns to idle", async () => {
+  test("lock-contention rejection: speaks a brief re-prompt, no technical-issue speech, returns to idle", async () => {
     mockStartVoiceTurn.mockImplementation(async () => {
       throw new Error("Conversation is already processing a message");
     });
@@ -1034,18 +1034,18 @@ describe("call-controller", () => {
 
     await controller.handleCallerUtterance("Hello");
 
-    // The transient lock-contention race must never be spoken to the caller.
+    // A wedged prior turn must never surface a technical-error message.
     const errorTokens = relay.sentTokens.filter((t) =>
       t.token.includes("technical issue"),
     );
     expect(errorTokens.length).toBe(0);
 
-    // An empty end-of-turn marker (last=true) must still be sent so the relay
-    // transitions back to listening despite swallowing the error.
-    const endOfTurnMarkers = relay.sentTokens.filter(
-      (t) => t.token === "" && t.last === true,
+    // A brief natural re-prompt (last=true) is spoken so the caller knows to
+    // repeat themselves and the relay transitions back to listening.
+    const reprompts = relay.sentTokens.filter(
+      (t) => t.token === "Sorry, could you say that again?" && t.last === true,
     );
-    expect(endOfTurnMarkers.length).toBeGreaterThan(0);
+    expect(reprompts.length).toBeGreaterThan(0);
 
     // Controller goes idle and re-arms the silence watchdog.
     expect(controller.getState()).toBe("idle");

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -564,11 +564,13 @@ export class CallController {
       if (this.isLockContentionError(err) && this.isCurrentRun(runVersion)) {
         log.debug(
           { callSessionId: this.callSessionId },
-          "Swallowing transient processing-lock contention race",
+          "Prior voice turn wedged past lock-hold budget; re-prompting caller",
         );
-        // Send an empty end-of-turn marker so the relay transitions back to
-        // listening, without speaking any technical-issue text.
-        this.transport.sendTextToken("", true);
+        // Reaching here means the prior turn is genuinely wedged past the full
+        // lock-hold wait budget, so surface a brief natural re-prompt (never a
+        // technical-error message) and re-arm listening. last=true doubles as
+        // the end-of-turn marker.
+        this.transport.sendTextToken("Sorry, could you say that again?", true);
         this.state = "idle";
         this.resetSilenceTimer();
         this.flushPendingInstructions();


### PR DESCRIPTION
## Summary
- After widening the bridge wait to cover the full lock-hold, reaching the lock-contention throw means the prior turn is genuinely wedged. Replace the silent swallow with a brief, natural, non-technical spoken re-prompt so the caller isn't left with dead air (still never surfaces a 'technical issue' message).

Self-review remediation for plan: voice-lock-race-fix.md