### PR TITLE
docs(web): refresh channel-conversation comments after read-only removal

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -384,8 +384,7 @@ describe("ChatBody — active-process overlays slot", () => {
 
 describe("ChatBody — composer always renders", () => {
   // Channel-origin (Slack/Email/etc.) conversations render the standard
-  // composer regardless of conversation origin, with no read-only banner
-  // replacing it.
+  // composer, with no read-only banner replacing it.
   test("renders the composer and no read-only banner", () => {
     const html = renderToStaticMarkup(<ChatBody {...baseProps()} />);
 

--- a/clients/web/src/domains/chat/utils/channel-conversation-display.ts
+++ b/clients/web/src/domains/chat/utils/channel-conversation-display.ts
@@ -19,7 +19,7 @@ function cleanLabel(value: string | null | undefined): string | undefined {
  * The raw `externalChatId` (e.g. a Telegram numeric chat id) is treated as
  * a non-label fallback and intentionally omitted: it is not meaningful to
  * a human reader. Returns `undefined` when no friendly name is available,
- * in which case the footer shows only the channel-level read-only copy.
+ * in which case the header label falls back to the channel name alone.
  */
 export function getChannelBindingDisplayText(
   binding: ConversationChannelBinding | null | undefined,

--- a/clients/web/src/domains/chat/utils/conversation-channel.ts
+++ b/clients/web/src/domains/chat/utils/conversation-channel.ts
@@ -4,8 +4,9 @@ import type { Conversation } from "@/types/conversation-types";
  * Predicate matching macOS `ConversationModel.isChannelConversation`.
  *
  * Returns true when a conversation originated from an external channel
- * (Slack, Telegram, voice/phone, etc.) — these conversations are
- * read-only from the desktop/web/iOS surface because the daemon does not
+ * (Slack, Telegram, voice/phone, etc.). On web this gates the
+ * native-only edit/undo/recall path (the composer stays writable);
+ * macOS/iOS keep these conversations read-only since the daemon does not
  * mirror outbound writes back to the source channel.
  *
  * Excluded prefixes (treated as native):

--- a/clients/web/src/types/conversation-types.ts
+++ b/clients/web/src/types/conversation-types.ts
@@ -47,7 +47,8 @@ export interface Conversation {
    * `"phone"`, `"vellum"`, or `"notification:*"`. Sourced from the daemon's
    * `channelBinding.sourceChannel` (when present) and falling back to
    * `conversationOriginChannel`. Used by `isChannelConversation` to gate
-   * read-only behavior for externally-bound conversations.
+   * the native-only edit/undo/recall path on web (and read-only rendering
+   * on macOS/iOS) for externally-bound conversations.
    */
   originChannel?: string;
   /** True for optimistic stubs not yet confirmed by the server. */


### PR DESCRIPTION
## Summary
Update doc comments that still described the removed read-only web behavior; describe the present native-only edit/undo/recall gating instead.

Gap from plan review for continue-channel-convos-in-vellum.md (comment-only, no logic change).