### PR TITLE
chore(voice): fold orphaned watchdog comment into withAbortWatchdog; collapse wait test (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -19,11 +19,8 @@ mock.module("../config/loader.js", () => ({
 import { resolveProcessingWaitMs } from "../calls/voice-session-bridge.js";
 
 describe("resolveProcessingWaitMs", () => {
-  test("covers the default commit window plus abort unwind budget", () => {
+  test("sums commit window, abort unwind budget, and fixed margin", () => {
     expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
-  });
-
-  test("adds the fixed margin to commit window plus abort budget", () => {
     expect(resolveProcessingWaitMs(1000, 5000)).toBe(7000);
     expect(resolveProcessingWaitMs(4000, 0)).toBe(5000);
   });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -197,27 +197,26 @@ export interface AssistantSurface {
 
 // ── abort watchdog ───────────────────────────────────────────────────
 
-/*
- * The watchdog is a backstop that drives an aborted turn to its `finally` even
- * if some awaited operation fails to observe the abort signal. Abort is
- * otherwise cooperative and already wired into the slow paths: the provider call
- * forwards the signal to its HTTP/streaming fetch, and tool execution races the
- * signal so a stuck tool can't block cancellation. The watchdog only fires when
- * a future code path silently ignores abort — without it, such a path would hang
- * the loop forever and latch the conversation's `processing` flag true (the
- * wedged "Thinking…" indicator). It is defense-in-depth, not the primary
- * mechanism: in the common case abort settles in-flight work in well under a
- * second, so ABORT_WATCHDOG_MS is ample headroom for a cooperative unwind while
- * still releasing a genuinely wedged turn promptly.
- */
-
 /**
- * Race `work` against an abort watchdog. The watchdog stays disarmed until the
- * signal fires; once it does, the turn has `timeoutMs` to settle before the
- * watchdog rejects with the signal's own abort reason so the caller unwinds to
- * its `finally` and the reason classifies as a user cancellation downstream.
- * The abandoned `work` promise keeps running detached — its eventual rejection
- * is swallowed so it can't surface as an unhandled rejection.
+ * Race `work` against an abort watchdog. The watchdog is a backstop that drives
+ * an aborted turn to its `finally` even if some awaited operation fails to
+ * observe the abort signal. Abort is otherwise cooperative and already wired
+ * into the slow paths: the provider call forwards the signal to its
+ * HTTP/streaming fetch, and tool execution races the signal so a stuck tool
+ * can't block cancellation. The watchdog only fires when a future code path
+ * silently ignores abort — without it, such a path would hang the loop forever
+ * and latch the conversation's `processing` flag true (the wedged "Thinking…"
+ * indicator). It is defense-in-depth, not the primary mechanism: in the common
+ * case abort settles in-flight work in well under a second, so ABORT_WATCHDOG_MS
+ * is ample headroom for a cooperative unwind while still releasing a genuinely
+ * wedged turn promptly.
+ *
+ * The watchdog stays disarmed until the signal fires; once it does, the turn has
+ * `timeoutMs` to settle before the watchdog rejects with the signal's own abort
+ * reason so the caller unwinds to its `finally` and the reason classifies as a
+ * user cancellation downstream. The abandoned `work` promise keeps running
+ * detached — its eventual rejection is swallowed so it can't surface as an
+ * unhandled rejection.
  */
 async function withAbortWatchdog<T>(
   work: Promise<T>,


### PR DESCRIPTION
## Summary
- Fold the abort-watchdog rationale comment (left floating after ABORT_WATCHDOG_MS was extracted to a leaf module) into withAbortWatchdog's JSDoc so it documents a real symbol.
- Collapse two redundant processing-wait test blocks into one.

Cosmetic self-review remediation (round 2) for plan: voice-lock-race-fix.md