### PR TITLE
Voice barge-in "already processing" race fix (JARVIS-1232)

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2771,6 +2771,62 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: stays 'processing' during synthesis latency, so barge-in cannot abort an inaudible turn", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderRegistry();
+    let releaseChunk: (() => void) | undefined;
+    const chunkGate = new Promise<void>((resolve) => {
+      releaseChunk = resolve;
+    });
+    const fishAudioStreaming: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        return { audio: Buffer.from("x"), contentType: "audio/mpeg" };
+      },
+      async synthesizeStream(_request, onChunk) {
+        // Simulate provider latency: emit no audio until the gate releases.
+        await chunkGate;
+        onChunk(Buffer.from("fish-audio-stream"));
+        return {
+          audio: Buffer.from("fish-audio-stream"),
+          contentType: "audio/mpeg",
+        };
+      },
+    };
+    registerTtsProvider(fishAudioStreaming);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from synthesized path."]),
+    );
+    const { relay, controller } = setupController();
+
+    const turn = controller.handleCallerUtterance("Hi");
+    // Let the turn generate its text and reach synthesis, blocked on the gate.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // No audio has reached the caller yet (play URL not sent), so the controller
+    // must stay in `processing` — a barge-in here would abort a turn the caller
+    // cannot hear. See JARVIS-1232.
+    expect(relay.sentPlayUrls.length).toBe(0);
+    expect(controller.getState()).toBe("processing");
+    expect(controller.handleBargeIn()).toBe(false);
+
+    // Release audio → play URL sent → turn finishes and returns to idle.
+    releaseChunk?.();
+    await turn;
+    expect(relay.sentPlayUrls.length).toBeGreaterThan(0);
+    expect(controller.getState()).toBe("idle");
+
+    controller.destroy();
+  });
+
   test("Deepgram selected path resolves useSynthesizedPath to true", () => {
     const cfg = loadConfig();
     cfg.services.tts.provider = "deepgram";

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1025,7 +1025,7 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("lock-contention rejection: swallowed, no technical-issue speech, returns to idle", async () => {
+  test("lock-contention rejection: speaks a brief re-prompt, no technical-issue speech, returns to idle", async () => {
     mockStartVoiceTurn.mockImplementation(async () => {
       throw new Error("Conversation is already processing a message");
     });
@@ -1034,18 +1034,18 @@ describe("call-controller", () => {
 
     await controller.handleCallerUtterance("Hello");
 
-    // The transient lock-contention race must never be spoken to the caller.
+    // A wedged prior turn must never surface a technical-error message.
     const errorTokens = relay.sentTokens.filter((t) =>
       t.token.includes("technical issue"),
     );
     expect(errorTokens.length).toBe(0);
 
-    // An empty end-of-turn marker (last=true) must still be sent so the relay
-    // transitions back to listening despite swallowing the error.
-    const endOfTurnMarkers = relay.sentTokens.filter(
-      (t) => t.token === "" && t.last === true,
+    // A brief natural re-prompt (last=true) is spoken so the caller knows to
+    // repeat themselves and the relay transitions back to listening.
+    const reprompts = relay.sentTokens.filter(
+      (t) => t.token === "Sorry, could you say that again?" && t.last === true,
     );
-    expect(endOfTurnMarkers.length).toBeGreaterThan(0);
+    expect(reprompts.length).toBeGreaterThan(0);
 
     // Controller goes idle and re-arms the silence watchdog.
     expect(controller.getState()).toBe("idle");

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2868,10 +2868,12 @@ describe("call-controller", () => {
     // Supersede the in-flight synthesized turn (bumps run version + aborts synthesis).
     controller.handleInterrupt();
 
-    // Releasing the stale synthesis must NOT send a play URL for the old run.
+    // Releasing the stale synthesis must NOT send a play URL for the old run,
+    // nor inject a stale end-of-turn marker into the relay stream.
     releaseChunk?.();
     await turn;
     expect(relay.sentPlayUrls.length).toBe(0);
+    expect(relay.sentTokens.filter((t) => t.last).length).toBe(0);
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1100,17 +1100,13 @@ describe("call-controller", () => {
         onComplete: () => void;
       }) => {
         return new Promise((resolve) => {
-          // Simulate a long-running turn that can be aborted
-          const timeout = setTimeout(() => {
-            opts.onTextDelta("This should be interrupted");
-            opts.onComplete();
-            resolve({ turnId: "run-1", abort: () => {} });
-          }, 1000);
+          // Emit a token right away so the assistant is actively speaking
+          // (state flips to `speaking`) before the interrupt arrives.
+          opts.onTextDelta("This should be interrupted");
 
           opts.signal?.addEventListener(
             "abort",
             () => {
-              clearTimeout(timeout);
               // In the real system, generation_cancelled triggers
               // onComplete via the event sink. The AbortSignal listener
               // in call-controller also resolves turnComplete defensively.
@@ -2169,7 +2165,10 @@ describe("call-controller", () => {
       "Are you still there?",
     );
     await new Promise((r) => setTimeout(r, 10));
-    expect(controller.getState()).toBe("speaking");
+    // The turn is paused before emitting any token, so the controller is still
+    // in the pre-speech `processing` phase (it only flips to `speaking` once
+    // real outbound audio/tokens begin).
+    expect(controller.getState()).toBe("processing");
 
     // Answer arrives while the controller is processing/speaking
     const accepted = await controller.handleUserAnswer("3pm works");
@@ -2887,16 +2886,13 @@ describe("call-controller", () => {
         onComplete: () => void;
       }) => {
         return new Promise((resolve) => {
-          const timeout = setTimeout(() => {
-            opts.onTextDelta("This should be interrupted");
-            opts.onComplete();
-            resolve({ turnId: "run-1", abort: () => {} });
-          }, 1000);
+          // Emit a token right away so the assistant is actively speaking
+          // before the interrupt arrives.
+          opts.onTextDelta("This should be interrupted");
 
           opts.signal?.addEventListener(
             "abort",
             () => {
-              clearTimeout(timeout);
               opts.onComplete();
               resolve({ turnId: "run-1", abort: () => {} });
             },
@@ -3018,45 +3014,95 @@ describe("call-controller", () => {
       controller.destroy();
     });
 
-    test("handleBargeIn returns false when controller is processing", async () => {
-      // Use a slow turn that never completes so we can observe
-      // the processing state.
+    test("handleBargeIn returns false and does not abort while still processing (no output yet)", async () => {
+      // Simulate a turn stuck waiting for the processing lock: no tokens
+      // emitted, no completion. The controller must stay in `processing` and
+      // NOT flip to `speaking`, so barge-in can't abort a silent turn.
       mockStartVoiceTurn.mockImplementation(
         async (opts: {
           onTextDelta: (t: string) => void;
           onComplete: () => void;
           signal?: AbortSignal;
         }) => {
-          // Don't call onComplete — keep in processing/speaking
+          // Never emit tokens or complete — remain in the pre-speech phase.
           return { turnId: "run-slow", abort: () => opts.onComplete() };
         },
       );
 
       const { relay, controller } = setupController();
-      // Kick off a turn (moves to speaking state)
       const turnPromise = controller.handleCallerUtterance("Hello");
 
       // Wait for microtasks to settle
       for (let i = 0; i < 5; i++) await Promise.resolve();
 
-      // The controller transitions to "speaking" once runTurnInner starts.
-      // Before any onTextDelta, a barge-in should be accepted if speaking.
-      // But if no text has been emitted yet, the state is "speaking" per
-      // the implementation (state is set to speaking at the start of
-      // runTurnInner). So handleBargeIn should accept. Let's verify the
-      // state and behavior.
-      const bargeResult = controller.handleBargeIn();
+      // No outbound audio/tokens yet → still processing.
+      expect(controller.getState()).toBe("processing");
 
-      // Regardless of the specific state, if accepted the transport
-      // should see an interrupt token.
-      if (bargeResult) {
-        const endTokens = relay.sentTokens.filter(
-          (t) => t.last === true && t.token === "",
-        );
-        expect(endTokens.length).toBeGreaterThan(0);
-      }
+      const bargeResult = controller.handleBargeIn();
+      expect(bargeResult).toBe(false);
+      // Still processing (not aborted), and no interrupt/end-of-turn token sent.
+      expect(controller.getState()).toBe("processing");
+      const endTokens = relay.sentTokens.filter(
+        (t) => t.last === true && t.token === "",
+      );
+      expect(endTokens.length).toBe(0);
 
       // Cleanup: abort the pending turn
+      controller.destroy();
+      await turnPromise.catch(() => {});
+    });
+
+    test("stays in processing until first token, then flips to speaking and barge-in is accepted", async () => {
+      // Gate the first token so we can observe the pre-speech processing phase
+      // (e.g. the lock-wait / generation window) before any audio is emitted.
+      let emitFirstToken!: () => void;
+      const firstTokenGate = new Promise<void>((r) => {
+        emitFirstToken = r;
+      });
+      let releaseTurn!: () => void;
+      const completeGate = new Promise<void>((r) => {
+        releaseTurn = r;
+      });
+
+      mockStartVoiceTurn.mockImplementation(
+        async (opts: {
+          onTextDelta: (t: string) => void;
+          onComplete: () => void;
+          signal?: AbortSignal;
+        }) => {
+          await firstTokenGate;
+          if (opts.signal?.aborted) {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            throw err;
+          }
+          opts.onTextDelta("Hello");
+          // Hold the turn open so state remains `speaking` until we barge in.
+          opts.signal?.addEventListener("abort", () => releaseTurn());
+          await completeGate;
+          opts.onComplete();
+          return { turnId: "run-gate", abort: () => releaseTurn() };
+        },
+      );
+
+      const { controller } = setupController();
+      const turnPromise = controller.handleCallerUtterance("Hi");
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      // Before any token: processing, barge-in ignored (turn not aborted).
+      expect(controller.getState()).toBe("processing");
+      expect(controller.handleBargeIn()).toBe(false);
+      expect(controller.getState()).toBe("processing");
+
+      // Release the first token → controller flips to speaking.
+      emitFirstToken();
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(controller.getState()).toBe("speaking");
+
+      // Now barge-in is accepted and interrupts the turn.
+      expect(controller.handleBargeIn()).toBe(true);
+      expect(controller.getState()).toBe("idle");
+
       controller.destroy();
       await turnPromise.catch(() => {});
     });

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2827,6 +2827,55 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: a superseded turn does not send a stale play URL", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderRegistry();
+    let releaseChunk: (() => void) | undefined;
+    const chunkGate = new Promise<void>((resolve) => {
+      releaseChunk = resolve;
+    });
+    const fishAudioStreaming: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        return { audio: Buffer.from("x"), contentType: "audio/mpeg" };
+      },
+      async synthesizeStream(_request, onChunk) {
+        // Block until released so we can supersede the turn mid-synthesis.
+        await chunkGate;
+        onChunk(Buffer.from("stale-audio"));
+        return { audio: Buffer.from("stale-audio"), contentType: "audio/mpeg" };
+      },
+    };
+    registerTtsProvider(fishAudioStreaming);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from synthesized path."]),
+    );
+    const { relay, controller } = setupController();
+
+    const turn = controller.handleCallerUtterance("first");
+    // Let the turn generate text and block inside provider synthesis.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    // Supersede the in-flight synthesized turn (bumps run version + aborts synthesis).
+    controller.handleInterrupt();
+
+    // Releasing the stale synthesis must NOT send a play URL for the old run.
+    releaseChunk?.();
+    await turn;
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    controller.destroy();
+  });
+
   test("Deepgram selected path resolves useSynthesizedPath to true", () => {
     const cfg = loadConfig();
     cfg.services.tts.provider = "deepgram";

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1025,6 +1025,52 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("lock-contention rejection: swallowed, no technical-issue speech, returns to idle", async () => {
+    mockStartVoiceTurn.mockImplementation(async () => {
+      throw new Error("Conversation is already processing a message");
+    });
+
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hello");
+
+    // The transient lock-contention race must never be spoken to the caller.
+    const errorTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("technical issue"),
+    );
+    expect(errorTokens.length).toBe(0);
+
+    // An empty end-of-turn marker (last=true) must still be sent so the relay
+    // transitions back to listening despite swallowing the error.
+    const endOfTurnMarkers = relay.sentTokens.filter(
+      (t) => t.token === "" && t.last === true,
+    );
+    expect(endOfTurnMarkers.length).toBeGreaterThan(0);
+
+    // Controller goes idle and re-arms the silence watchdog.
+    expect(controller.getState()).toBe("idle");
+
+    controller.destroy();
+  });
+
+  test("genuine non-lock-contention error still speaks the technical-issue fallback", async () => {
+    mockStartVoiceTurn.mockImplementation(async () => {
+      throw new Error("boom");
+    });
+
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hello");
+
+    const errorTokens = relay.sentTokens.filter((t) =>
+      t.token.includes("technical issue"),
+    );
+    expect(errorTokens.length).toBeGreaterThan(0);
+    expect(controller.getState()).toBe("idle");
+
+    controller.destroy();
+  });
+
   test("handleUserAnswer: returns false when no pending consultation exists", async () => {
     const { controller } = setupController();
 

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2727,6 +2727,65 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: a superseded run does not emit native fallback text", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderRegistry();
+    // elevenlabs present so native fallback is available for fish-audio.
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize() {
+        return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+      },
+    };
+    registerTtsProvider(elevenlabs);
+
+    let releaseSynth: (() => void) | undefined;
+    const synthGate = new Promise<void>((resolve) => {
+      releaseSynth = resolve;
+    });
+    const fishAudioGatedFailing: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        throw new Error("fish-audio synth failure");
+      },
+      async synthesizeStream() {
+        // Ignore the abort signal, block, then fail with no audio — this would
+        // normally trigger the native fallback text emission.
+        await synthGate;
+        throw new Error("fish-audio stream failure");
+      },
+    };
+    registerTtsProvider(fishAudioGatedFailing);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Stale synthesized response"]),
+    );
+    const { relay, controller } = setupController();
+
+    const turn = controller.handleCallerUtterance("Hi");
+    await new Promise((r) => setTimeout(r, 20)); // reach synthesis, blocked
+
+    // Supersede the turn mid-synthesis, then let synthesis fail.
+    controller.handleInterrupt();
+    releaseSynth?.();
+    await turn;
+
+    // The stale run must NOT leak its native fallback text into the relay.
+    const emitted = relay.sentTokens.map((t) => t.token).join("");
+    expect(emitted).not.toContain("Stale synthesized response");
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    controller.destroy();
+  });
+
   test("synthesized provider: play URL uses public base URL", async () => {
     const cfg = loadConfig();
     cfg.ingress.publicBaseUrl = "https://twilio.example.com/";

--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -19,11 +19,8 @@ mock.module("../config/loader.js", () => ({
 import { resolveProcessingWaitMs } from "../calls/voice-session-bridge.js";
 
 describe("resolveProcessingWaitMs", () => {
-  test("covers the default commit window plus abort unwind budget", () => {
+  test("sums commit window, abort unwind budget, and fixed margin", () => {
     expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
-  });
-
-  test("adds the fixed margin to commit window plus abort budget", () => {
     expect(resolveProcessingWaitMs(1000, 5000)).toBe(7000);
     expect(resolveProcessingWaitMs(4000, 0)).toBe(5000);
   });

--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before importing voice-session-bridge so its module-level
+// imports (logger, config loader) stay side-effect free for this pure helper.
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+import { resolveProcessingWaitMs } from "../calls/voice-session-bridge.js";
+
+describe("resolveProcessingWaitMs", () => {
+  test("covers the default commit window plus abort unwind budget", () => {
+    expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
+  });
+
+  test("always returns strictly greater than the max lock-hold", () => {
+    for (const commit of [1, 100, 4000, 10000]) {
+      for (const abort of [1, 5000, 8000]) {
+        expect(resolveProcessingWaitMs(commit, abort)).toBeGreaterThan(
+          commit + abort,
+        );
+      }
+    }
+  });
+});

--- a/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge-processing-wait.test.ts
@@ -23,13 +23,8 @@ describe("resolveProcessingWaitMs", () => {
     expect(resolveProcessingWaitMs(4000, 5000)).toBe(10000);
   });
 
-  test("always returns strictly greater than the max lock-hold", () => {
-    for (const commit of [1, 100, 4000, 10000]) {
-      for (const abort of [1, 5000, 8000]) {
-        expect(resolveProcessingWaitMs(commit, abort)).toBeGreaterThan(
-          commit + abort,
-        );
-      }
-    }
+  test("adds the fixed margin to commit window plus abort budget", () => {
+    expect(resolveProcessingWaitMs(1000, 5000)).toBe(7000);
+    expect(resolveProcessingWaitMs(4000, 0)).toBe(5000);
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -395,11 +395,6 @@ export class CallController {
     const wasSpeaking = this.state === "speaking";
     this.abortCurrentTurn();
     this.llmRunVersion++;
-    // Cancel in-flight synthesized TTS on barge-in
-    if (this.activeSynthesisAbort) {
-      this.activeSynthesisAbort.abort();
-      this.activeSynthesisAbort = null;
-    }
     // Explicitly terminate the in-progress TTS turn so the relay can
     // immediately hand control back to the caller after barge-in.
     if (wasSpeaking) {
@@ -483,6 +478,12 @@ export class CallController {
     }
     this.abortController.abort();
     this.abortController = new AbortController();
+    // Abort any in-flight synthesized-TTS playback too, so a superseded or
+    // torn-down turn's audio isn't streamed to the caller after they move on.
+    if (this.activeSynthesisAbort) {
+      this.activeSynthesisAbort.abort();
+      this.activeSynthesisAbort = null;
+    }
   }
 
   private formatCallerUtterance(
@@ -811,6 +812,9 @@ export class CallController {
       const url = `${baseUrl}/v1/audio/${handle.audioId}`;
       const sendPlayUrlOnce = (): void => {
         if (playUrlSent) return;
+        // Superseded/aborted while synthesis was pending — don't start playing
+        // a stale response after the caller has already moved on.
+        if (!this.isCurrentRun(runVersion)) return;
         // Audio is now actually reaching the caller — flip to `speaking` so
         // barge-in can interrupt (it stays `processing` until this point).
         this.beginSpeaking(runVersion);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -764,6 +764,12 @@ export class CallController {
       );
     }
 
+    // Synthesized playback (and its native fallback) can await provider
+    // latency; re-check the run wasn't superseded meanwhile so a stale turn
+    // doesn't inject its end-of-turn marker (or fallback text) into the next
+    // turn's relay stream.
+    if (!this.isCurrentRun(runVersion)) return fullResponseText;
+
     // Signal end of this turn's speech.  An empty token with `last: true`
     // tells ConversationRelay to start listening — it does NOT trigger TTS
     // synthesis.  This is required even when a synthesized provider handled

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -754,7 +754,7 @@ export class CallController {
       // Do NOT flip to `speaking` here — provider synthesis latency (or the
       // no-audio fallback window) would still be silent. The transition happens
       // inside synthesizeAndStreamAudio when the play URL / first audio chunk
-      // (or native fallback token) is actually emitted. See JARVIS-1232.
+      // (or native fallback token) is actually emitted.
       await this.synthesizeAndStreamAudio(
         provider,
         sanitizedSynthText,
@@ -1251,8 +1251,7 @@ export class CallController {
   /**
    * Transient teardown race: a new voice turn reached the session bridge
    * before the previous turn released the conversation processing lock.
-   * This is not a real error and must never be spoken to the caller. See
-   * JARVIS-1232.
+   * This is not a real error and must never be spoken to the caller.
    */
   private isLockContentionError(err: unknown): boolean {
     return (
@@ -1266,7 +1265,7 @@ export class CallController {
    * first real outbound audio/token is emitted. Guarded so a superseded or
    * aborted (idle) turn never (re)enters `speaking`, and so barge-in
    * (handleBargeIn, gated on `speaking`) can't abort a turn that is still
-   * waiting for the processing lock or generating with no audio yet. See JARVIS-1232.
+   * waiting for the processing lock or generating with no audio yet.
    */
   private beginSpeaking(runVersion: number): void {
     if (!this.isCurrentRun(runVersion)) return;

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -751,7 +751,10 @@ export class CallController {
     const sanitizedSynthText = sanitizeForTts(synthesizedTextBuffer.trim());
     if (useSynthesizedPath && provider && sanitizedSynthText.length > 0) {
       if (!this.isCurrentRun(runVersion)) return fullResponseText;
-      this.beginSpeaking(runVersion);
+      // Do NOT flip to `speaking` here — provider synthesis latency (or the
+      // no-audio fallback window) would still be silent. The transition happens
+      // inside synthesizeAndStreamAudio when the play URL / first audio chunk
+      // (or native fallback token) is actually emitted. See JARVIS-1232.
       await this.synthesizeAndStreamAudio(
         provider,
         sanitizedSynthText,
@@ -784,7 +787,7 @@ export class CallController {
   private async synthesizeAndStreamAudio(
     provider: TtsProvider,
     text: string,
-    _runVersion: number,
+    runVersion: number,
     format: "mp3" | "wav" | "opus" = "mp3",
   ): Promise<void> {
     let handle: ReturnType<typeof createStreamingEntry> | null = null;
@@ -808,6 +811,9 @@ export class CallController {
       const url = `${baseUrl}/v1/audio/${handle.audioId}`;
       const sendPlayUrlOnce = (): void => {
         if (playUrlSent) return;
+        // Audio is now actually reaching the caller — flip to `speaking` so
+        // barge-in can interrupt (it stays `processing` until this point).
+        this.beginSpeaking(runVersion);
         this.transport.sendPlayUrl(url);
         playUrlSent = true;
       };
@@ -895,6 +901,7 @@ export class CallController {
         // hears a response instead of silence. This fallback is only
         // used for providers whose catalog entry allows native fallback.
         if (!playUrlSent && !this.transport.requiresWavAudio) {
+          this.beginSpeaking(runVersion);
           this.transport.sendTextToken(text, false);
         }
       }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -910,7 +910,13 @@ export class CallController {
         // token-based speech on ConversationRelay so the caller still
         // hears a response instead of silence. This fallback is only
         // used for providers whose catalog entry allows native fallback.
-        if (!playUrlSent && !this.transport.requiresWavAudio) {
+        // Skip it entirely for a superseded run so a stale response can't
+        // leak into the next caller turn.
+        if (
+          !playUrlSent &&
+          !this.transport.requiresWavAudio &&
+          this.isCurrentRun(runVersion)
+        ) {
           this.beginSpeaking(runVersion);
           this.transport.sendTextToken(text, false);
         }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -523,7 +523,10 @@ export class CallController {
     }
 
     try {
-      this.state = "speaking";
+      // Stay in `processing` through the lock-wait and LLM generation; flip to
+      // `speaking` only when real outbound audio/tokens start (see
+      // beginSpeaking). This keeps barge-in from aborting a silent turn.
+      this.state = "processing";
 
       const fullResponseText = await this.streamTtsTokens(
         content,
@@ -628,6 +631,7 @@ export class CallController {
       if (useSynthesizedPath) {
         synthesizedTextBuffer += cleaned;
       } else {
+        this.beginSpeaking(runVersion);
         this.transport.sendTextToken(cleaned, false);
       }
     };
@@ -747,6 +751,7 @@ export class CallController {
     const sanitizedSynthText = sanitizeForTts(synthesizedTextBuffer.trim());
     if (useSynthesizedPath && provider && sanitizedSynthText.length > 0) {
       if (!this.isCurrentRun(runVersion)) return fullResponseText;
+      this.beginSpeaking(runVersion);
       await this.synthesizeAndStreamAudio(
         provider,
         sanitizedSynthText,
@@ -1247,6 +1252,18 @@ export class CallController {
       err instanceof Error &&
       err.message.includes("already processing a message")
     );
+  }
+
+  /**
+   * Flip from the pre-speech `processing` phase to `speaking` at the moment the
+   * first real outbound audio/token is emitted. Guarded so a superseded or
+   * aborted (idle) turn never (re)enters `speaking`, and so barge-in
+   * (handleBargeIn, gated on `speaking`) can't abort a turn that is still
+   * waiting for the processing lock or generating with no audio yet. See JARVIS-1232.
+   */
+  private beginSpeaking(runVersion: number): void {
+    if (!this.isCurrentRun(runVersion)) return;
+    if (this.state === "processing") this.state = "speaking";
   }
 
   private isCurrentRun(runVersion: number): boolean {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -561,6 +561,19 @@ export class CallController {
         );
         return;
       }
+      if (this.isLockContentionError(err) && this.isCurrentRun(runVersion)) {
+        log.debug(
+          { callSessionId: this.callSessionId },
+          "Swallowing transient processing-lock contention race",
+        );
+        // Send an empty end-of-turn marker so the relay transitions back to
+        // listening, without speaking any technical-issue text.
+        this.transport.sendTextToken("", true);
+        this.state = "idle";
+        this.resetSilenceTimer();
+        this.flushPendingInstructions();
+        return;
+      }
       log.error({ err, callSessionId: this.callSessionId }, "Voice turn error");
       this.transport.sendTextToken(
         "I'm sorry, I encountered a technical issue. Could you repeat that?",
@@ -1219,6 +1232,19 @@ export class CallController {
   private isExpectedAbortError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
     return err.name === "AbortError" || err.name === "APIUserAbortError";
+  }
+
+  /**
+   * Transient teardown race: a new voice turn reached the session bridge
+   * before the previous turn released the conversation processing lock.
+   * This is not a real error and must never be spoken to the caller. See
+   * JARVIS-1232.
+   */
+  private isLockContentionError(err: unknown): boolean {
+    return (
+      err instanceof Error &&
+      err.message.includes("already processing a message")
+    );
   }
 
   private isCurrentRun(runVersion: number): boolean {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -564,11 +564,13 @@ export class CallController {
       if (this.isLockContentionError(err) && this.isCurrentRun(runVersion)) {
         log.debug(
           { callSessionId: this.callSessionId },
-          "Swallowing transient processing-lock contention race",
+          "Prior voice turn wedged past lock-hold budget; re-prompting caller",
         );
-        // Send an empty end-of-turn marker so the relay transitions back to
-        // listening, without speaking any technical-issue text.
-        this.transport.sendTextToken("", true);
+        // Reaching here means the prior turn is genuinely wedged past the full
+        // lock-hold wait budget, so surface a brief natural re-prompt (never a
+        // technical-error message) and re-arm listening. last=true doubles as
+        // the end-of-turn marker.
+        this.transport.sendTextToken("Sorry, could you say that again?", true);
         this.state = "idle";
         this.resetSilenceTimer();
         this.flushPendingInstructions();

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -18,6 +18,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
@@ -36,10 +37,6 @@ import {
 const log = getLogger("voice-session-bridge");
 
 const PROCESSING_WAIT_MARGIN_MS = 1000;
-// Must match ABORT_WATCHDOG_MS in conversation-agent-loop.ts. Mirrored here
-// rather than imported to keep this module (and its unit test) free of the
-// agent-loop's heavy dependency graph.
-const ABORT_UNWIND_BUDGET_MS = 5000;
 /**
  * How long startVoiceTurn waits for a prior turn to release the processing
  * lock before giving up. The prior turn can hold the lock for the abort
@@ -382,7 +379,7 @@ export async function startVoiceTurn(
     const config = getConfig();
     const maxWaitMs = resolveProcessingWaitMs(
       config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
-      ABORT_UNWIND_BUDGET_MS,
+      ABORT_WATCHDOG_MS,
     );
     const pollIntervalMs = 50;
     let waited = 0;
@@ -397,10 +394,10 @@ export async function startVoiceTurn(
       throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
-      // maxWaitMs covers the abort unwind budget (ABORT_WATCHDOG_MS) plus the
-      // awaited turn-boundary commit window (turnCommitMaxWaitMs) plus a
-      // margin — the full span a prior turn can hold the lock — so reaching
-      // here means the prior turn is genuinely wedged. See JARVIS-1232.
+      // Waited the full budget (see resolveProcessingWaitMs) without the lock
+      // releasing, so the prior turn is genuinely wedged. The controller
+      // catches this terminal error and speaks a brief non-technical
+      // re-prompt rather than staying silent. See JARVIS-1232.
       throw new Error("Conversation is already processing a message");
     }
   }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -35,6 +35,25 @@ import {
 
 const log = getLogger("voice-session-bridge");
 
+const PROCESSING_WAIT_MARGIN_MS = 1000;
+// Must match ABORT_WATCHDOG_MS in conversation-agent-loop.ts. Mirrored here
+// rather than imported to keep this module (and its unit test) free of the
+// agent-loop's heavy dependency graph.
+const ABORT_UNWIND_BUDGET_MS = 5000;
+/**
+ * How long startVoiceTurn waits for a prior turn to release the processing
+ * lock before giving up. The prior turn can hold the lock for the abort
+ * unwind budget PLUS the awaited turn-boundary commit window, so the wait
+ * must cover both (+ margin) or a barge-in can still surface
+ * "Conversation is already processing a message". See JARVIS-1232.
+ */
+export function resolveProcessingWaitMs(
+  turnCommitMaxWaitMs: number,
+  abortUnwindMs: number,
+): number {
+  return turnCommitMaxWaitMs + abortUnwindMs + PROCESSING_WAIT_MARGIN_MS;
+}
+
 // ---------------------------------------------------------------------------
 // Module-level dependency injection
 // ---------------------------------------------------------------------------
@@ -360,7 +379,11 @@ export async function startVoiceTurn(
   if (conversation.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait briefly for the
     // previous turn to finish aborting before giving up.
-    const maxWaitMs = 3000;
+    const config = getConfig();
+    const maxWaitMs = resolveProcessingWaitMs(
+      config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
+      ABORT_UNWIND_BUDGET_MS,
+    );
     const pollIntervalMs = 50;
     let waited = 0;
     while (conversation.isProcessing() && waited < maxWaitMs) {
@@ -374,6 +397,10 @@ export async function startVoiceTurn(
       throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
+      // maxWaitMs covers the abort unwind budget (ABORT_WATCHDOG_MS) plus the
+      // awaited turn-boundary commit window (turnCommitMaxWaitMs) plus a
+      // margin — the full span a prior turn can hold the lock — so reaching
+      // here means the prior turn is genuinely wedged. See JARVIS-1232.
       throw new Error("Conversation is already processing a message");
     }
   }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -42,7 +42,7 @@ const PROCESSING_WAIT_MARGIN_MS = 1000;
  * lock before giving up. The prior turn can hold the lock for the abort
  * unwind budget PLUS the awaited turn-boundary commit window, so the wait
  * must cover both (+ margin) or a barge-in can still surface
- * "Conversation is already processing a message". See JARVIS-1232.
+ * "Conversation is already processing a message".
  */
 export function resolveProcessingWaitMs(
   turnCommitMaxWaitMs: number,
@@ -397,7 +397,7 @@ export async function startVoiceTurn(
       // Waited the full budget (see resolveProcessingWaitMs) without the lock
       // releasing, so the prior turn is genuinely wedged. The controller
       // catches this terminal error and speaks a brief non-technical
-      // re-prompt rather than staying silent. See JARVIS-1232.
+      // re-prompt rather than staying silent.
       throw new Error("Conversation is already processing a message");
     }
   }

--- a/assistant/src/daemon/abort-watchdog.ts
+++ b/assistant/src/daemon/abort-watchdog.ts
@@ -1,0 +1,7 @@
+/**
+ * Grace period after an abort signal fires for a turn to settle before the
+ * abort watchdog force-unwinds the agent loop. Shared source of truth: the
+ * voice session bridge sizes its processing-lock wait to cover this budget,
+ * so the two must not drift. See JARVIS-1232.
+ */
+export const ABORT_WATCHDOG_MS = 5_000;

--- a/assistant/src/daemon/abort-watchdog.ts
+++ b/assistant/src/daemon/abort-watchdog.ts
@@ -2,6 +2,6 @@
  * Grace period after an abort signal fires for a turn to settle before the
  * abort watchdog force-unwinds the agent loop. Shared source of truth: the
  * voice session bridge sizes its processing-lock wait to cover this budget,
- * so the two must not drift. See JARVIS-1232.
+ * so the two must not drift.
  */
 export const ABORT_WATCHDOG_MS = 5_000;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -81,6 +81,7 @@ import { timeAgo } from "../util/time.js";
 import { truncate } from "../util/truncate.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
 import { commitTurnChanges } from "../workspace/turn-commit.js";
+import { ABORT_WATCHDOG_MS } from "./abort-watchdog.js";
 import { cleanAssistantContent } from "./assistant-attachments.js";
 import { conversationSupportsDynamicUi } from "./channel-ui-capability.js";
 import type { Conversation } from "./conversation.js";
@@ -196,21 +197,19 @@ export interface AssistantSurface {
 
 // ── abort watchdog ───────────────────────────────────────────────────
 
-/**
- * Backstop that drives an aborted turn to its `finally` even if some awaited
- * operation fails to observe the abort signal.
- *
- * Abort is otherwise cooperative and already wired into the slow paths: the
- * provider call forwards the signal to its HTTP/streaming fetch, and tool
- * execution races the signal so a stuck tool can't block cancellation. This
- * watchdog only fires when a future code path silently ignores abort — without
- * it, such a path would hang the loop forever and latch the conversation's
- * `processing` flag true (the wedged "Thinking…" indicator). It is
- * defense-in-depth, not the primary mechanism: in the common case abort settles
- * in-flight work in well under a second, so a few seconds is ample headroom for
- * a cooperative unwind while still releasing a genuinely wedged turn promptly.
+/*
+ * The watchdog is a backstop that drives an aborted turn to its `finally` even
+ * if some awaited operation fails to observe the abort signal. Abort is
+ * otherwise cooperative and already wired into the slow paths: the provider call
+ * forwards the signal to its HTTP/streaming fetch, and tool execution races the
+ * signal so a stuck tool can't block cancellation. The watchdog only fires when
+ * a future code path silently ignores abort — without it, such a path would hang
+ * the loop forever and latch the conversation's `processing` flag true (the
+ * wedged "Thinking…" indicator). It is defense-in-depth, not the primary
+ * mechanism: in the common case abort settles in-flight work in well under a
+ * second, so ABORT_WATCHDOG_MS is ample headroom for a cooperative unwind while
+ * still releasing a genuinely wedged turn promptly.
  */
-const ABORT_WATCHDOG_MS = 5_000;
 
 /**
  * Race `work` against an abort watchdog. The watchdog stays disarmed until the

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -197,27 +197,26 @@ export interface AssistantSurface {
 
 // ── abort watchdog ───────────────────────────────────────────────────
 
-/*
- * The watchdog is a backstop that drives an aborted turn to its `finally` even
- * if some awaited operation fails to observe the abort signal. Abort is
- * otherwise cooperative and already wired into the slow paths: the provider call
- * forwards the signal to its HTTP/streaming fetch, and tool execution races the
- * signal so a stuck tool can't block cancellation. The watchdog only fires when
- * a future code path silently ignores abort — without it, such a path would hang
- * the loop forever and latch the conversation's `processing` flag true (the
- * wedged "Thinking…" indicator). It is defense-in-depth, not the primary
- * mechanism: in the common case abort settles in-flight work in well under a
- * second, so ABORT_WATCHDOG_MS is ample headroom for a cooperative unwind while
- * still releasing a genuinely wedged turn promptly.
- */
-
 /**
- * Race `work` against an abort watchdog. The watchdog stays disarmed until the
- * signal fires; once it does, the turn has `timeoutMs` to settle before the
- * watchdog rejects with the signal's own abort reason so the caller unwinds to
- * its `finally` and the reason classifies as a user cancellation downstream.
- * The abandoned `work` promise keeps running detached — its eventual rejection
- * is swallowed so it can't surface as an unhandled rejection.
+ * Race `work` against an abort watchdog. The watchdog is a backstop that drives
+ * an aborted turn to its `finally` even if some awaited operation fails to
+ * observe the abort signal. Abort is otherwise cooperative and already wired
+ * into the slow paths: the provider call forwards the signal to its
+ * HTTP/streaming fetch, and tool execution races the signal so a stuck tool
+ * can't block cancellation. The watchdog only fires when a future code path
+ * silently ignores abort — without it, such a path would hang the loop forever
+ * and latch the conversation's `processing` flag true (the wedged "Thinking…"
+ * indicator). It is defense-in-depth, not the primary mechanism: in the common
+ * case abort settles in-flight work in well under a second, so ABORT_WATCHDOG_MS
+ * is ample headroom for a cooperative unwind while still releasing a genuinely
+ * wedged turn promptly.
+ *
+ * The watchdog stays disarmed until the signal fires; once it does, the turn has
+ * `timeoutMs` to settle before the watchdog rejects with the signal's own abort
+ * reason so the caller unwinds to its `finally` and the reason classifies as a
+ * user cancellation downstream. The abandoned `work` promise keeps running
+ * detached — its eventual rejection is swallowed so it can't surface as an
+ * unhandled rejection.
  */
 async function withAbortWatchdog<T>(
   work: Promise<T>,


### PR DESCRIPTION
## Summary
Fixes JARVIS-1232: on an inbound voice call, a barge-in during an in-flight/slow assistant turn could throw `Conversation is already processing a message` and speak a canned "technical issue" line to the caller. Root cause was a two-timeout ordering bug — the agent loop holds the conversation `processing` lock across the abort-unwind + turn-boundary commit (up to ~9s), while the voice bridge only waited 3s before throwing, and that error was surfaced as spoken caller audio.

## Approach
The plan's original PR 1 (decouple the lock by making the turn-boundary commit fire-and-forget) was **dropped after adversarial review**: it breaks the cross-turn git-attribution invariant precisely under slow git — the exact JARVIS-1232 trigger condition. Instead the fix sizes the bridge wait to cover the full lock-hold and never surfaces the contention as a scary error.

## Merged into this feature branch
- **#36741** — `call-controller`: swallow the transient lock-contention error instead of speaking "I encountered a technical issue".
- **#36742** — `voice-session-bridge`: derive the processing-lock wait from `workspaceGit.turnCommitMaxWaitMs` instead of a hard-coded 3000ms.
- **#36746** — `call-controller`: when the prior turn is genuinely wedged past the full wait budget, speak a brief non-technical re-prompt ("Sorry, could you say that again?") instead of dead air.
- **#36745** — extract `ABORT_WATCHDOG_MS` into a dependency-free leaf module (`abort-watchdog.ts`) so the bridge wait can't silently drift from the agent loop's abort watchdog; tighten the wait test.
- **#36750** — cosmetic tidy: fold an orphaned watchdog comment into `withAbortWatchdog`; collapse a redundant test block.

Final budget: bridge wait = `turnCommitMaxWaitMs (4000) + ABORT_WATCHDOG_MS (5000) + margin (1000)` = 10000ms > worst-case lock-hold of ~9000ms.

## Dropped
- **#36740** (closed) — the fire-and-forget commit decoupling; unsafe (git attribution corruption under slow git).

## Self-review result
Four-pass fresh-eyes review + 2 remediation rounds. Final: integration PASS, plan-faithfulness PASS, slop PASS (after fixes). Attribution invariant preserved (the agent-loop `finally` still awaits the commit before `setProcessing(false)`).

## Follow-ups (out of scope for JARVIS-1232)
- `live-voice/live-voice-session.ts` (local macOS live-voice) also calls `startVoiceTurn` and surfaces the raw error as a text protocol frame (not spoken audio); protected by the widened wait but could get the same swallow for parity.
- The tmux-appimage terminfo case-collision that makes `git add -A` fail every turn (the latency amplifier) is tracked separately.

Part of plan: voice-lock-race-fix.md