### PR TITLE
refactor(memory): own the frontmatter parser (narrow skills coupling)

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -142,7 +142,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../runtime/routes/types.js",
     "../../../../security/secret-scanner.js",
     "../../../../skills/catalog-cache.js",
-    "../../../../skills/frontmatter.js",
     "../../../../skills/install-meta.js",
     "../../../../skills/skill-memory.js",
     "../../../../tools/skills/delete-managed.js",

--- a/assistant/src/plugins/defaults/memory/frontmatter.ts
+++ b/assistant/src/plugins/defaults/memory/frontmatter.ts
@@ -1,0 +1,50 @@
+/**
+ * Frontmatter parsing for memory's concept-page and card `.md` files.
+ *
+ * Frontmatter is a YAML block delimited by `---` at the top of a file. Memory
+ * owns this parser rather than importing the host `skills/` copy so the plugin
+ * depends only on its own files, `@vellumai/plugin-api`, and external packages.
+ */
+
+import { parse as parseYaml } from "yaml";
+
+import { getLogger } from "../../../util/logger.js";
+
+const log = getLogger("memory-frontmatter");
+
+/** Matches a `---` delimited frontmatter block at the start of a file. */
+export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+interface FrontmatterParseResult {
+  /** Key-value pairs extracted from the frontmatter block. */
+  fields: Record<string, unknown>;
+  /** The remaining file content after the frontmatter block. */
+  body: string;
+}
+
+/**
+ * Parse frontmatter fields from file content. Extracts key-value pairs from the
+ * `---` delimited block at the top of the file via a YAML parser, handling
+ * nested objects, arrays, quoted strings, and escape sequences natively.
+ * Returns `null` if no frontmatter block is found.
+ */
+export function parseFrontmatterFields(
+  content: string,
+): FrontmatterParseResult | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+  const body = content.slice(match[0].length);
+
+  try {
+    const parsed = parseYaml(frontmatter);
+    if (parsed == null || typeof parsed !== "object") {
+      return { fields: {}, body };
+    }
+    return { fields: parsed as Record<string, unknown>, body };
+  } catch (err) {
+    log.warn({ err }, "Failed to parse YAML frontmatter");
+    return null;
+  }
+}

--- a/assistant/src/plugins/defaults/memory/v2/frontmatter-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/v2/frontmatter-sweep.ts
@@ -24,8 +24,8 @@ import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 
 import type { AssistantConfig } from "../../../../config/schema.js";
-import { FRONTMATTER_REGEX } from "../../../../skills/frontmatter.js";
 import { getLogger } from "../../../../util/logger.js";
+import { FRONTMATTER_REGEX } from "../frontmatter.js";
 import { listPages } from "./page-store.js";
 import { ConceptPageFrontmatterSchema } from "./types.js";
 

--- a/assistant/src/plugins/defaults/memory/v2/page-store.ts
+++ b/assistant/src/plugins/defaults/memory/v2/page-store.ts
@@ -31,7 +31,7 @@ import { dirname, join, relative, sep } from "node:path";
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
-import { FRONTMATTER_REGEX } from "../../../../skills/frontmatter.js";
+import { FRONTMATTER_REGEX } from "../frontmatter.js";
 import { invalidateEdgeIndex } from "./edge-index.js";
 import { invalidatePageIndex } from "./page-index.js";
 import { type ConceptPage, ConceptPageFrontmatterSchema } from "./types.js";

--- a/assistant/src/plugins/defaults/memory/v3-eval/eval-packets.ts
+++ b/assistant/src/plugins/defaults/memory/v3-eval/eval-packets.ts
@@ -35,10 +35,7 @@ import {
   conversations,
   messages,
 } from "../../../../persistence/schema/index.js";
-import {
-  FRONTMATTER_REGEX,
-  parseFrontmatterFields,
-} from "../../../../skills/frontmatter.js";
+import { FRONTMATTER_REGEX, parseFrontmatterFields } from "../frontmatter.js";
 import { injectedConceptHeader } from "../v2/injected-block-slugs.js";
 import { slugFromConceptPath } from "../v2/page-store.js";
 import { renderCard } from "../v3/card.js";

--- a/assistant/src/plugins/defaults/memory/v3/card.ts
+++ b/assistant/src/plugins/defaults/memory/v3/card.ts
@@ -1,7 +1,4 @@
-import {
-  FRONTMATTER_REGEX,
-  parseFrontmatterFields,
-} from "../../../../skills/frontmatter.js";
+import { FRONTMATTER_REGEX, parseFrontmatterFields } from "../frontmatter.js";
 import { injectedConceptHeader } from "../v2/injected-block-slugs.js";
 import type { Slug } from "./types.js";
 

--- a/assistant/src/plugins/defaults/memory/v3/edge.ts
+++ b/assistant/src/plugins/defaults/memory/v3/edge.ts
@@ -1,4 +1,4 @@
-import { parseFrontmatterFields } from "../../../../skills/frontmatter.js";
+import { parseFrontmatterFields } from "../frontmatter.js";
 import type { PageIndexEntry } from "../v2/page-index.js";
 import type { Slug } from "./types.js";
 


### PR DESCRIPTION
## Summary

First step of **narrowing memory's coupling to the host skill subsystem** before we bless anything on `@vellumai/plugin-api` (the "narrow the coupling first" direction). Inventory showed memory imports ~10 skill functions across 5 modules — more than a "skills-list" facet — so the plan is to shrink that surface internally first. This PR peels off the easy, unambiguous piece.

`skills/frontmatter` is a **generic YAML frontmatter parser**, not a capability-catalog read. Memory used it to parse its own concept-page / card `.md` files. So memory gets its **own copy** and stops importing the host module.

- New `plugins/defaults/memory/frontmatter.ts` — `FRONTMATTER_REGEX` + `parseFrontmatterFields` (verbatim; deps are `yaml` (external) + `getLogger`).
- Repoint the 5 importers (`v2/page-store`, `v2/frontmatter-sweep`, `v3/card`, `v3/edge`, `v3-eval/eval-packets`).
- Host `skills/frontmatter` **stays** — `config/skills` + `prompts/sections` still use it.
- Boundary baseline drops `skills/frontmatter` from the `memory` key.

Behavior is byte-identical (verbatim parser); **zero `@vellumai/plugin-api` change**. Gate green: typecheck, full lint, knip, prettier, boundary guard, and the affected memory tests (page-store, card, edge, eval-packets, v2-routes, edge-index) in isolation.

Part of the memory-as-a-plugin effort (F8 skills-coupling narrowing).