### PR TITLE
refactor(memory): read config via a getMemoryConfig() slice accessor (1/n)

### DIFF
--- a/assistant/src/plugins/defaults/memory/config.ts
+++ b/assistant/src/plugins/defaults/memory/config.ts
@@ -1,0 +1,15 @@
+import { getConfig } from "../../../config/loader.js";
+import type { MemoryConfig } from "../../../config/types.js";
+
+/**
+ * The memory slice of the assistant config. Memory reads its own configuration
+ * through this accessor rather than the full `getConfig()`, so the plugin's
+ * config dependency is a narrow slice — the shape a future `@vellumai/plugin-api`
+ * accessor would expose — instead of the whole `AssistantConfig`. Reads that
+ * genuinely need cross-cutting config (e.g. embeddings backend, MCP) still call
+ * `getConfig()` directly; those are the residual to resolve before the slice can
+ * be blessed.
+ */
+export function getMemoryConfig(): MemoryConfig {
+  return getConfig().memory;
+}

--- a/assistant/src/plugins/defaults/memory/config.ts
+++ b/assistant/src/plugins/defaults/memory/config.ts
@@ -2,13 +2,9 @@ import { getConfig } from "../../../config/loader.js";
 import type { MemoryConfig } from "../../../config/types.js";
 
 /**
- * The memory slice of the assistant config. Memory reads its own configuration
- * through this accessor rather than the full `getConfig()`, so the plugin's
- * config dependency is a narrow slice — the shape a future `@vellumai/plugin-api`
- * accessor would expose — instead of the whole `AssistantConfig`. Reads that
- * genuinely need cross-cutting config (e.g. embeddings backend, MCP) still call
- * `getConfig()` directly; those are the residual to resolve before the slice can
- * be blessed.
+ * The `memory` slice of the live assistant config. Memory code reads its own
+ * configuration through this accessor rather than the full `getConfig()`, so its
+ * config dependency is a narrow slice of `AssistantConfig`.
  */
 export function getMemoryConfig(): MemoryConfig {
   return getConfig().memory;

--- a/assistant/src/plugins/defaults/memory/hooks/init.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/init.ts
@@ -7,14 +7,14 @@
 
 import type { HookFunction, InitContext } from "@vellumai/plugin-api";
 
-import { getConfig } from "../../../../config/loader.js";
 import { getLogger } from "../../../../util/logger.js";
+import { getMemoryConfig } from "../config.js";
 import { FilingService } from "../filing-service.js";
 
 const log = getLogger("filing-service");
 
 const init: HookFunction<InitContext> = async () => {
-  if (getConfig().memory.v2.enabled) {
+  if (getMemoryConfig().v2.enabled) {
     log.info(
       "Filing service skipped — memory v2 consolidation is the active background memory job",
     );

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -20,7 +20,6 @@ import { resolve } from "node:path";
 
 import type { Message } from "@vellumai/plugin-api";
 
-import { getConfig } from "../../../config/loader.js";
 import type { InjectionMatcher } from "../../../context/strip-injections.js";
 import { getInContextPkbPaths } from "../../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../../daemon/pkb-reminder-builder.js";
@@ -37,6 +36,7 @@ import {
 } from "../../types.js";
 import { hasInjectedUserTextBlock } from "../injection-presence.js";
 import { DEFAULT_INJECTOR_ORDER } from "../injector-order.js";
+import { getMemoryConfig } from "./config.js";
 import { getLiveGraphMemory } from "./graph/conversation-graph-memory.js";
 import { getPkbAutoInjectList } from "./pkb/autoinject.js";
 import { readPkbContext } from "./pkb/context.js";
@@ -64,7 +64,7 @@ const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
  * unchanged.
  */
 function isPkbInjectionSilencedByV2(): boolean {
-  return getConfig().memory.v2.enabled;
+  return getMemoryConfig().v2.enabled;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
@@ -51,7 +51,6 @@ import {
   sql,
 } from "drizzle-orm";
 
-import { getConfig } from "../../../config/loader.js";
 import { deleteConversation } from "../../../persistence/conversation-crud.js";
 import { getDb, getMemoryDb } from "../../../persistence/db-connection.js";
 import {
@@ -59,6 +58,7 @@ import {
   memoryJobs,
 } from "../../../persistence/schema/index.js";
 import { getLogger } from "../../../util/logger.js";
+import { getMemoryConfig } from "./config.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 
@@ -94,7 +94,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   // retained superseded run from a crash orphan. Tradeoff: under this opt-in,
   // genuine crash orphans persist too. That's acceptable — the operator asked
   // for full run history, and an orphan is just one more retained conversation.
-  if (getConfig().memory?.retrospective?.keepSupersededRuns === true) {
+  if (getMemoryConfig()?.retrospective?.keepSupersededRuns === true) {
     return { swept: 0 };
   }
 

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,12 +1,12 @@
 import { join } from "node:path";
 
-import { getConfig } from "../../../config/loader.js";
 import type {
   ConversationForkedEvent,
   MemoryPersistenceHooks,
   MessagePersistedEvent,
 } from "../../../persistence/memory-lifecycle-hooks.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
+import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
@@ -35,7 +35,7 @@ import {
  */
 export const memoryPersistenceHooks: MemoryPersistenceHooks = {
   async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
-    await indexMessageNow({ ...event, scopeId: "default" }, getConfig().memory);
+    await indexMessageNow({ ...event, scopeId: "default" }, getMemoryConfig());
   },
 
   onConversationForked(event: ConversationForkedEvent): void {

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-search.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-search.ts
@@ -2,7 +2,6 @@
 // PKB — Qdrant hybrid search for indexed PKB markdown files
 // ---------------------------------------------------------------------------
 
-import { getConfig } from "../../../../config/loader.js";
 import {
   isQdrantBreakerOpen,
   withQdrantBreaker,
@@ -13,6 +12,7 @@ import type {
 } from "../../../../persistence/embeddings/qdrant-client.js";
 import { getQdrantClient } from "../../../../persistence/embeddings/qdrant-client.js";
 import { getLogger } from "../../../../util/logger.js";
+import { getMemoryConfig } from "../config.js";
 import type { PkbSearchResult } from "./types.js";
 import { PKB_TARGET_TYPE } from "./types.js";
 
@@ -44,7 +44,7 @@ export async function searchPkbFiles(
   // v2 owns the read path when enabled; v2 absorbs PKB as a read source,
   // so PKB hint search short-circuits to keep traffic off the v1 collection
   // (avoiding OOM-crash risk from a corrupted sparse segment).
-  if (getConfig().memory.v2.enabled) return [];
+  if (getMemoryConfig().v2.enabled) return [];
 
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping PKB search");

--- a/assistant/src/plugins/defaults/memory/search/semantic.ts
+++ b/assistant/src/plugins/defaults/memory/search/semantic.ts
@@ -1,6 +1,5 @@
 import { inArray } from "drizzle-orm";
 
-import { getConfig } from "../../../../config/loader.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import type {
@@ -12,6 +11,7 @@ import {
   memorySegments,
   memorySummaries,
 } from "../../../../persistence/schema/index.js";
+import { getMemoryConfig } from "../config.js";
 import { mapCosineToUnit } from "../validation.js";
 // ── Types (inlined from deleted types.ts) ──────────────────────────
 
@@ -62,7 +62,7 @@ export async function semanticSearch(
   // v2 owns the read path when enabled; the v1 `memory` collection is in
   // active retirement, and routing semantic recall there would re-enter the
   // same corrupted sparse segments that can OOM-crash Qdrant.
-  if (getConfig().memory.v2.enabled) return [];
+  if (getMemoryConfig().v2.enabled) return [];
 
   const qdrant = getQdrantClient();
 

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -60,9 +60,9 @@
 
 import type { ContentBlock, Message } from "@vellumai/plugin-api";
 
-import { getConfig } from "../../../../config/loader.js";
 import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
 import { getLogger } from "../../../../util/logger.js";
+import { getMemoryConfig } from "../config.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory-marker.js";
 import {
   INJECTED_CONCEPT_HEADER_REGEX,
@@ -393,7 +393,7 @@ export async function runPruneValve(
   options: PruneValveOptions,
 ): Promise<PrunePlan | null> {
   // Defensive read: test configs may omit the prune block entirely.
-  const pruneConfig = getConfig().memory?.v3?.prune;
+  const pruneConfig = getMemoryConfig()?.v3?.prune;
   if (!pruneConfig) return null;
 
   // Planning needs only the store (cheap); the persisted-metadata scan for


### PR DESCRIPTION
## Summary

Narrows memory's **config coupling toward a slice**, so the eventual `@vellumai/plugin-api` config surface is a `MemoryConfig` accessor rather than the whole `AssistantConfig`.

- New memory-internal `plugins/defaults/memory/config.ts` → `getMemoryConfig(): MemoryConfig` (returns `getConfig().memory`).
- Migrate the **7 unambiguous chain-form readers** (`getConfig().memory.*`): `hooks/init`, `injectors`, `memory-retrospective-startup-cleanup`, `persistence-hooks`, `pkb/pkb-search`, `search/semantic`, `v3/prune`. They no longer touch the full config.

**Why a memory-internal wrapper (not a host `getMemoryConfig` yet):** it calls the still-mockable host `getConfig()`, so the **33 tests that mock `config/loader` keep working unchanged** — no test fallout. Validated: `startup-cleanup`, `pkb-search`, `prune` (all mock `config/loader`) pass, plus the v2/v3 injection + orchestrate suites.

**Scope / what's left:** files that genuinely need the full `AssistantConfig` (embeddings-backend checks like `selectedBackendSupportsMultimodal(getConfig())`, route handlers) keep `getConfig()` — they're the residual to resolve, mostly via **F2 embeddings**, before the slice can be blessed on the contract. Binding-form readers (`const config = getConfig()`) migrate in follow-ups. This is prep: it establishes the accessor and makes the "needs full config" set an explicit worklist; the boundary baseline is unchanged for now.

Zero `@vellumai/plugin-api` change; behavior byte-identical. Gate green: typecheck, full lint, knip, prettier, boundary guard, affected tests in isolation.

Part of the memory-as-a-plugin effort (config narrowing, step 1).