### PR TITLE
fix(runtime): exempt SSE stream + liveness probes from the per-minute rate limiter

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -167,10 +167,13 @@ The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (s
 
 ## Rate Limiting & Diagnostics
 
-All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):
+Most `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):
 
-- **Authenticated**: 300 requests/minute
+- **Authenticated (loopback)**: 1200 requests/minute — desktop app, CLI, anything on the daemon's own host (`127.0.0.0/8`, `::1`). A cold sidebar load at thousands of conversations legitimately bursts far beyond the remote budget.
+- **Authenticated (remote)**: 300 requests/minute — proxied non-loopback clients, keyed by the forwarded client IP.
 - **Unauthenticated**: 20 requests/minute
+
+**Exempt endpoints** (`isRateLimitExemptEndpoint`): the SSE stream (`events`) and liveness/readiness probes (`health`, `healthz`, `readyz`) bypass the per-minute limiter entirely. The stream is one long-lived connection, not a burst of requests, and 429-ing it drops the stream — which drives a client reconnect + full re-bootstrap loop that generates far more load than the limiter saves. Liveness probes must always answer or the client treats the assistant as down and reconnects harder. The events route still enforces auth downstream, and stream memory is bounded by SSE backpressure shedding + subscriber caps.
 
 When the limit is exceeded, the limiter returns 429 and logs a structured warning (module: `rate-limiter`) with the denied endpoint and a breakdown of which endpoints consumed the budget in the current window. This makes it easy to identify whether the cause is rapid conversation switching, polling, or unexpected request volume.
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -61,6 +61,7 @@ import { withErrorHandling } from "./middleware/error-handler.js";
 import {
   extractClientIp,
   ipRateLimiter,
+  isRateLimitExemptEndpoint,
   rateLimitHeaders,
   rateLimitResponse,
   selectAuthenticatedRateLimiter,
@@ -686,8 +687,13 @@ export class RuntimeHttpServer {
         ? selectAuthenticatedRateLimiter(clientIp)
         : ipRateLimiter;
       const limiterKind = token ? "authenticated" : "unauthenticated";
-      const result = limiter.check(clientIp, path);
-      if (!result.allowed) {
+      // Streaming (SSE) and liveness endpoints bypass the per-minute request
+      // limiter — see isRateLimitExemptEndpoint. `result` stays null for them,
+      // so no 429 is returned and no rate-limit headers are attached.
+      const result = isRateLimitExemptEndpoint(endpoint)
+        ? null
+        : limiter.check(clientIp, path);
+      if (result && !result.allowed) {
         return rateLimitResponse(result, {
           clientIp,
           deniedPath: path,
@@ -705,8 +711,10 @@ export class RuntimeHttpServer {
       const response =
         routerResponse ?? httpError("NOT_FOUND", "Not found", 404);
       const headers = new Headers(response.headers);
-      for (const [k, v] of Object.entries(rateLimitHeaders(result))) {
-        headers.set(k, v);
+      if (result) {
+        for (const [k, v] of Object.entries(rateLimitHeaders(result))) {
+          headers.set(k, v);
+        }
       }
       return new Response(response.body, {
         status: response.status,

--- a/assistant/src/runtime/middleware/__tests__/rate-limiter.test.ts
+++ b/assistant/src/runtime/middleware/__tests__/rate-limiter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { isLoopbackAddress } from "../auth.js";
 import {
   apiRateLimiter,
+  isRateLimitExemptEndpoint,
   loopbackApiRateLimiter,
   selectAuthenticatedRateLimiter,
 } from "../rate-limiter.js";
@@ -59,5 +60,26 @@ describe("selectAuthenticatedRateLimiter", () => {
     expect(loopback.limit).toBeGreaterThan(standard.limit);
     expect(loopback.limit).toBe(1200);
     expect(standard.limit).toBe(300);
+  });
+});
+
+describe("isRateLimitExemptEndpoint", () => {
+  test("exempts the SSE stream and liveness probes", () => {
+    // Streaming: 429-ing the events stream drops it and drives a client
+    // reconnect + re-bootstrap storm, so it bypasses the per-minute limiter.
+    expect(isRateLimitExemptEndpoint("events")).toBe(true);
+    // Liveness/readiness probes must always answer.
+    expect(isRateLimitExemptEndpoint("health")).toBe(true);
+    expect(isRateLimitExemptEndpoint("healthz")).toBe(true);
+    expect(isRateLimitExemptEndpoint("readyz")).toBe(true);
+  });
+
+  test("does not exempt ordinary data endpoints", () => {
+    expect(isRateLimitExemptEndpoint("messages")).toBe(false);
+    expect(isRateLimitExemptEndpoint("conversations")).toBe(false);
+    expect(isRateLimitExemptEndpoint("home/feed")).toBe(false);
+    // Match is exact on the normalized endpoint segment, not a prefix.
+    expect(isRateLimitExemptEndpoint("events/replay")).toBe(false);
+    expect(isRateLimitExemptEndpoint("")).toBe(false);
   });
 });

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -221,6 +221,36 @@ export function selectAuthenticatedRateLimiter(
 }
 
 /**
+ * `/v1/` endpoints that bypass the per-minute request rate limiter.
+ *
+ * - Liveness/readiness (`health`, `healthz`, `readyz`): cheap probes that
+ *   must always answer. The desktop app polls `/v1/health` every few seconds
+ *   and the reachability probe hits `/v1/healthz`; a 429 makes the client
+ *   treat the assistant as unreachable and reconnect harder.
+ * - SSE stream (`events`): a single long-lived streaming connection, not a
+ *   burst of discrete requests. Metering each (re)connect against the
+ *   per-minute budget is the wrong model — and 429-ing the stream drops it,
+ *   which drives a client reconnect + full re-bootstrap loop that generates
+ *   far more load than the limiter saves. The events route still enforces
+ *   auth downstream (an unauthenticated stream request is rejected there),
+ *   and daemon memory is bounded by SSE backpressure shedding and subscriber
+ *   caps rather than by this request-count limiter.
+ *
+ * The argument is the `/v1/`-stripped, trailing-slash-normalized endpoint
+ * segment (e.g. `events`, `health`) as computed by the HTTP server.
+ */
+const RATE_LIMIT_EXEMPT_ENDPOINTS = new Set([
+  "events",
+  "health",
+  "healthz",
+  "readyz",
+]);
+
+export function isRateLimitExemptEndpoint(endpoint: string): boolean {
+  return RATE_LIMIT_EXEMPT_ENDPOINTS.has(endpoint);
+}
+
+/**
  * Extract the client IP from a request. Only trusts proxy headers
  * (X-Forwarded-For, X-Real-IP) when the peer IP is loopback or private,
  * meaning the request arrived via the gateway. Direct connections from


### PR DESCRIPTION
## Problem

A single **loopback** desktop-app session can exceed the daemon's **1200 req/min** budget during a heavy cold boot (thousands of conversations). Diagnosed from live logs — at 22:55–22:56, `clientIp: 127.0.0.1` exceeded the 1200/min limit with:

- `/v1/conversations` ×**438**
- `/v1/events/` (SSE) ×**47**, and `identity` / `config` / `avatar/*` / `sounds/config` / `home/feed` / `apps` / `background-tools` / `acp/sessions` all ×**~47**

That flat ~47 across every *boot* endpoint = the entire app bootstrap running ~47× in 60s. It's a **self-reinforcing loop**: the SSE stream (`GET /v1/events`) gets caught in the 429 wave (**17** events-429s observed) → stream drops → `sse.closed` → reachability probe → the bus bounces the stream → `sse.opened` → full re-bootstrap → back over budget.

## Fix

Exempt the SSE stream (`events`) and liveness/readiness probes (`health`, `healthz`, `readyz`) from the per-minute request limiter (`isRateLimitExemptEndpoint`). Keeping the stream un-429'd means it never drops, so `sse.closed` never fires and the reconnect/re-bootstrap loop never starts — **this one change breaks the storm at the source.**

Data endpoints (`messages`, `conversations`, `avatar`, …) are still limited; if one 429s during a genuinely heavy boot, its own hook retries, but there's no SSE loop to amplify it.

## Safety / abuse surface (please sanity-check)

- Exempting `events` from the **limiter** does **not** bypass **auth** — an unauthenticated stream request is still rejected by the events route.
- Stream memory is bounded by SSE backpressure shedding + subscriber caps, not by this request counter.
- Liveness probes are cheap and conventionally unmetered; a 429'd health check makes the client treat the assistant as down and reconnect harder.

## Tests

- Unit test for `isRateLimitExemptEndpoint` (exempt set + exact-match, not prefix).
- `bun test src/runtime/middleware/__tests__/rate-limiter.test.ts` → 8 pass.
- `bun run typecheck:fast` → clean. Pre-commit lint/format/typecheck green.

## Follow-up (separate PR)

Client-side: the full identity/config/avatar fan-out re-fires on every `sse.opened`. Reducing that re-bootstrap amplification isn't needed to stop the storm, but it's wasteful on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)