### PR TITLE
feat(memory): flag-gate recall conversations source onto the Qdrant lexical index

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -1,6 +1,30 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import type { MessageLexicalSearchResult } from "../persistence/embeddings/messages-lexical-index.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Mutable stand-in for the Qdrant lexical candidate helper. The default
+// throws so any qdrant-path test that forgets to set an implementation fails
+// loudly rather than silently exercising an empty candidate set. FTS-path
+// tests never reach it (the flag defaults to fts5), so its value is irrelevant
+// there.
+let lexicalMockImpl: (
+  query: string,
+  limit: number,
+  opts?: { conversationId?: string },
+) => Promise<MessageLexicalSearchResult[]> = () => {
+  throw new Error("searchMessageIdsLexical mock not configured for this test");
+};
+
+mock.module("../persistence/conversation-search-lexical.js", () => ({
+  searchMessageIdsLexical: (
+    query: string,
+    limit: number,
+    opts?: { conversationId?: string },
+  ) => lexicalMockImpl(query, limit, opts),
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { rawRun } from "../persistence/raw-query.js";
@@ -342,6 +366,157 @@ describe("searchConversationSource", () => {
     });
     expect(result.evidence[0]?.excerpt).toContain("vanilla with raspberry");
     expect(result.evidence[0]?.score).toBeGreaterThan(0);
+  });
+});
+
+describe("searchConversationSource with the qdrant backend", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+    setOverridesForTesting({ "messages-search-backend": true });
+  });
+
+  afterEach(() => {
+    setOverridesForTesting({});
+    lexicalMockImpl = () => {
+      throw new Error(
+        "searchMessageIdsLexical mock not configured for this test",
+      );
+    };
+  });
+
+  test("returns app-scored evidence for Qdrant-supplied candidates", async () => {
+    const match = await seedConversation({
+      title: "Launch notes",
+      content: "The alpha launch checklist includes database backups.",
+    });
+    // A candidate the lexical index also surfaces but that the query does not
+    // actually match — proves the app-side scorer, not Qdrant order, ranks.
+    const weak = await seedConversation({
+      title: "Unrelated",
+      content: "Nothing salient in this conversation at all.",
+    });
+
+    lexicalMockImpl = async () => [
+      { messageId: weak.message.id, score: 0.9 },
+      { messageId: match.message.id, score: 0.1 },
+    ];
+
+    const result = await searchConversationSource(
+      "alpha launch",
+      makeContext(),
+      5,
+    );
+
+    expect(result.evidence[0]).toMatchObject({
+      id: `conversations:${match.conversation.id}:${match.message.id}`,
+      source: "conversations",
+      title: "Launch notes",
+      locator: `${match.conversation.id}#${match.message.id}`,
+      excerpt: "The alpha launch checklist includes database backups.",
+      metadata: {
+        role: "assistant",
+        conversationId: match.conversation.id,
+      },
+    });
+    expect(result.evidence[0]?.score).toBeGreaterThan(
+      result.evidence[1]?.score ?? -1,
+    );
+  });
+
+  test("applies source, type, and excluded-conversation filters to Qdrant candidates", async () => {
+    const visible = await seedConversation({
+      title: "User conversation",
+      content: "derivedtoken belongs to a user-authored conversation.",
+    });
+    const subagent = await seedConversation({
+      title: "Subagent conversation",
+      source: "subagent",
+      content: "derivedtoken should not include subagent output.",
+    });
+    const autoAnalysis = await seedConversation({
+      title: "Auto-analysis conversation",
+      source: "auto-analysis",
+      content: "derivedtoken should not include auto-analysis output.",
+    });
+    const notification = await seedConversation({
+      title: "Notification conversation",
+      source: "notification",
+      content: "derivedtoken should not include notification output.",
+    });
+    const current = await seedConversation({
+      title: "Current conversation",
+      content: "derivedtoken appears in the active conversation.",
+    });
+    const legacyPrivate = await seedConversation({
+      title: "Legacy private conversation",
+      content: "derivedtoken belongs to legacy private history.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
+      legacyPrivate.conversation.id,
+    );
+
+    // The lexical index does not filter — it hands back every candidate,
+    // including the ones SQL must exclude.
+    lexicalMockImpl = async () => [
+      { messageId: visible.message.id, score: 0.9 },
+      { messageId: subagent.message.id, score: 0.85 },
+      { messageId: autoAnalysis.message.id, score: 0.8 },
+      { messageId: notification.message.id, score: 0.75 },
+      { messageId: current.message.id, score: 0.7 },
+      { messageId: legacyPrivate.message.id, score: 0.65 },
+    ];
+
+    const result = await searchConversationSource(
+      "derivedtoken",
+      makeContext({ conversationId: current.conversation.id }),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
+  test("falls back to LIKE when the Qdrant lookup throws", async () => {
+    const match = await seedConversation({
+      title: "Fallback notes",
+      content: "The likefallbacktoken decision is recorded here.",
+    });
+
+    lexicalMockImpl = async () => {
+      throw new Error("qdrant unavailable");
+    };
+
+    const result = await searchConversationSource(
+      "likefallbacktoken",
+      makeContext(),
+      5,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${match.conversation.id}#${match.message.id}`,
+    ]);
+  });
+
+  test("falls back to LIKE when Qdrant returns no candidates", async () => {
+    const match = await seedConversation({
+      title: "Empty candidate notes",
+      content: "The emptycandidatetoken decision is recorded here.",
+    });
+
+    lexicalMockImpl = async () => [];
+
+    const result = await searchConversationSource(
+      "emptycandidatetoken",
+      makeContext(),
+      5,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${match.conversation.id}#${match.message.id}`,
+    ]);
   });
 });
 

--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -36,6 +36,22 @@ mock.module("../persistence/conversation-search-lexical.js", () => ({
   },
 }));
 
+// Drives the real recall backend gate: when true the source must fall back to
+// FTS regardless of the flag, because the lexical index write path is
+// suppressed and Qdrant is never populated. Defaults false so every other test
+// exercises its intended backend. Spread the real module so the other 9 exports
+// (job handlers, enqueue helpers) stay intact for transitive importers.
+let suppressIndexing = false;
+const realLexicalModule =
+  await import("../plugins/defaults/memory/job-handlers/index-message-lexical.js");
+mock.module(
+  "../plugins/defaults/memory/job-handlers/index-message-lexical.js",
+  () => ({
+    ...realLexicalModule,
+    isMemoryIndexingSuppressed: () => suppressIndexing,
+  }),
+);
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { rawRun } from "../persistence/raw-query.js";
@@ -385,16 +401,45 @@ describe("searchConversationSource with the qdrant backend", () => {
     getDb().run("DELETE FROM messages");
     getDb().run("DELETE FROM conversations");
     lexicalCalls = [];
+    suppressIndexing = false;
     setOverridesForTesting({ "messages-search-backend": true });
   });
 
   afterEach(() => {
     setOverridesForTesting({});
+    suppressIndexing = false;
     lexicalMockImpl = () => {
       throw new Error(
         "searchMessageIdsLexical mock not configured for this test",
       );
     };
+  });
+
+  test("falls back to FTS when memory indexing is suppressed, even with the qdrant flag on", async () => {
+    const match = await seedConversation({
+      title: "Suppressed indexing notes",
+      content: "The suppressedtoken decision is recorded here.",
+    });
+
+    // The lexical index is not populated while indexing is suppressed, so the
+    // source must NOT query Qdrant — it must use the FTS path.
+    suppressIndexing = true;
+    lexicalMockImpl = async () => {
+      throw new Error("searchMessageIdsLexical must not run while suppressed");
+    };
+
+    const result = await searchConversationSource(
+      "suppressedtoken",
+      makeContext(),
+      5,
+    );
+
+    // FTS path found the row (proves the backend fell back), and the Qdrant
+    // candidate helper was never called.
+    expect(lexicalCalls).toHaveLength(0);
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${match.conversation.id}#${match.message.id}`,
+    ]);
   });
 
   test("over-fetches a wide candidate pool from Qdrant, not the FTS prefetch window", async () => {

--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -442,6 +442,28 @@ describe("searchConversationSource with the qdrant backend", () => {
     ]);
   });
 
+  test("routes short/punctuation-only queries to the exact LIKE path, not Qdrant", async () => {
+    const match = await seedConversation({
+      title: "C++ notes",
+      role: "user",
+      content: "Use C++ when the example needs deterministic lifetime notes.",
+    });
+
+    // `C++` produces no usable ≥2-char FTS match shape, so the source must use
+    // the exact LIKE path rather than the sparse encoder (which would still
+    // emit a noisy 1-char `c` token). The mock throws to prove it never runs.
+    lexicalMockImpl = async () => {
+      throw new Error("searchMessageIdsLexical must not run for a short query");
+    };
+
+    const result = await searchConversationSource("C++", makeContext(), 5);
+
+    expect(lexicalCalls).toHaveLength(0);
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${match.conversation.id}#${match.message.id}`,
+    ]);
+  });
+
   test("over-fetches a wide candidate pool from Qdrant, not the FTS prefetch window", async () => {
     const match = await seedConversation({
       title: "Launch notes",

--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -17,12 +17,23 @@ let lexicalMockImpl: (
   throw new Error("searchMessageIdsLexical mock not configured for this test");
 };
 
+// Records the arguments of every mock invocation so tests can assert the
+// candidate over-fetch count the qdrant branch requests.
+let lexicalCalls: Array<{
+  query: string;
+  limit: number;
+  opts?: { conversationId?: string };
+}> = [];
+
 mock.module("../persistence/conversation-search-lexical.js", () => ({
   searchMessageIdsLexical: (
     query: string,
     limit: number,
     opts?: { conversationId?: string },
-  ) => lexicalMockImpl(query, limit, opts),
+  ) => {
+    lexicalCalls.push({ query, limit, opts });
+    return lexicalMockImpl(query, limit, opts);
+  },
 }));
 
 import { getDb } from "../persistence/db-connection.js";
@@ -373,6 +384,7 @@ describe("searchConversationSource with the qdrant backend", () => {
   beforeEach(() => {
     getDb().run("DELETE FROM messages");
     getDb().run("DELETE FROM conversations");
+    lexicalCalls = [];
     setOverridesForTesting({ "messages-search-backend": true });
   });
 
@@ -383,6 +395,32 @@ describe("searchConversationSource with the qdrant backend", () => {
         "searchMessageIdsLexical mock not configured for this test",
       );
     };
+  });
+
+  test("over-fetches a wide candidate pool from Qdrant, not the FTS prefetch window", async () => {
+    const match = await seedConversation({
+      title: "Launch notes",
+      content: "The widecandidatetoken launch checklist is recorded here.",
+    });
+
+    lexicalMockImpl = async () => [{ messageId: match.message.id, score: 0.9 }];
+
+    // limit = 5 → FTS would prefetch 5 × 5 = 25. The qdrant branch instead
+    // over-fetches max(5 × 20, 200) = 200 candidates so post-filter yield stays
+    // healthy when top lexical hits are excluded by the SQL predicates.
+    const result = await searchConversationSource(
+      "widecandidatetoken",
+      makeContext(),
+      5,
+    );
+
+    expect(lexicalCalls).toHaveLength(1);
+    expect(lexicalCalls[0]?.limit).toBe(200);
+    // Filtering still yields the correctly-scored surviving row.
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${match.conversation.id}#${match.message.id}`,
+    ]);
+    expect(result.evidence[0]?.score).toBeGreaterThan(0);
   });
 
   test("returns app-scored evidence for Qdrant-supplied candidates", async () => {

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -78,10 +78,12 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../util/logger.js",
   ],
   memory: [
+    "../../../../../config/assistant-feature-flags.js",
     "../../../../../config/types.js",
     "../../../../../messaging/providers/slack/message-metadata.js",
     "../../../../../persistence/auto-analysis-constants.js",
     "../../../../../persistence/conversation-queries.js",
+    "../../../../../persistence/conversation-search-lexical.js",
     "../../../../../persistence/db-connection.js",
     "../../../../../persistence/embeddings/embed.js",
     "../../../../../persistence/embeddings/embedding-backend.js",

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -1,9 +1,11 @@
+import { getMessagesSearchBackend } from "../../../../../config/assistant-feature-flags.js";
 import { readSlackMetadata } from "../../../../../messaging/providers/slack/message-metadata.js";
 import { AUTO_ANALYSIS_SOURCE } from "../../../../../persistence/auto-analysis-constants.js";
 import {
   buildFtsMatchQuery,
   buildRecallEvidenceExcerpt,
 } from "../../../../../persistence/conversation-queries.js";
+import { searchMessageIdsLexical } from "../../../../../persistence/conversation-search-lexical.js";
 import { rawAll } from "../../../../../persistence/raw-query.js";
 import {
   parseExternalContentEnvelope,
@@ -90,20 +92,21 @@ export async function searchConversationSource(
     normalizedLimit,
     normalizedLimit * CONVERSATION_SEARCH_PREFETCH_MULTIPLIER,
   );
-  const ftsMatches = buildRecallFtsMatchQueries(trimmedQuery);
-  let rows: ConversationEvidenceRow[] = [];
 
-  for (const ftsMatch of ftsMatches) {
-    try {
-      rows = mergeConversationRows(
-        rows,
-        searchWithFts(ftsMatch, queryLimit, context.conversationId),
-      );
-    } catch {
-      // Try the next, broader query shape.
-    }
-
-    if (rows.length >= normalizedLimit) break;
+  let rows: ConversationEvidenceRow[];
+  if (getMessagesSearchBackend(context.config) === "qdrant") {
+    rows = await gatherCandidateRowsFromQdrant(
+      trimmedQuery,
+      queryLimit,
+      context.conversationId,
+    );
+  } else {
+    rows = gatherCandidateRowsFromFts(
+      trimmedQuery,
+      queryLimit,
+      normalizedLimit,
+      context.conversationId,
+    );
   }
 
   if (rows.length === 0) {
@@ -135,6 +138,68 @@ export async function searchConversationSource(
   };
 }
 
+/**
+ * Generate candidate rows via SQLite FTS5. Walks progressively broader match
+ * shapes, merging matches until enough rows are collected, and swallows a
+ * malformed-query error on any single shape so a broader shape can still run.
+ * Returns an empty array when no shape matches — the caller then degrades to
+ * the LIKE fallback.
+ */
+function gatherCandidateRowsFromFts(
+  query: string,
+  queryLimit: number,
+  normalizedLimit: number,
+  excludedConversationId: string,
+): ConversationEvidenceRow[] {
+  const ftsMatches = buildRecallFtsMatchQueries(query);
+  let rows: ConversationEvidenceRow[] = [];
+
+  for (const ftsMatch of ftsMatches) {
+    try {
+      rows = mergeConversationRows(
+        rows,
+        searchWithFts(ftsMatch, queryLimit, excludedConversationId),
+      );
+    } catch {
+      // Try the next, broader query shape.
+    }
+
+    if (rows.length >= normalizedLimit) break;
+  }
+
+  return rows;
+}
+
+/**
+ * Generate candidate rows via the Qdrant lexical index. Qdrant is
+ * candidate-generation only: it supplies over-fetched message-id candidates
+ * (ranked by sparse score) whose rows are then re-fetched with the exact same
+ * source/type/excluded-conversation predicates FTS applies, so only the
+ * candidate *source* differs. Final ordering stays with the app-side scorer.
+ *
+ * Returns an empty array when the query tokenizes to no sparse terms (the
+ * lexical helper's empty guard) or when the Qdrant call throws — in both cases
+ * the caller degrades to the LIKE fallback, mirroring how the FTS path falls
+ * back when it matches nothing.
+ */
+async function gatherCandidateRowsFromQdrant(
+  query: string,
+  queryLimit: number,
+  excludedConversationId: string,
+): Promise<ConversationEvidenceRow[]> {
+  let candidates: Array<{ messageId: string }>;
+  try {
+    candidates = await searchMessageIdsLexical(query, queryLimit);
+  } catch {
+    return [];
+  }
+
+  const candidateIds = candidates.map((candidate) => candidate.messageId);
+  if (candidateIds.length === 0) return [];
+
+  return searchByIds(candidateIds, queryLimit, excludedConversationId);
+}
+
 function searchWithFts(
   ftsMatch: string,
   limit: number,
@@ -161,6 +226,47 @@ function searchWithFts(
     LIMIT ?
     `,
     ftsMatch,
+    SUBAGENT_SOURCE,
+    AUTO_ANALYSIS_SOURCE,
+    NOTIFICATION_SOURCE,
+    excludedConversationId,
+    limit,
+  );
+}
+
+/**
+ * Fetch evidence rows for an explicit set of candidate message ids, applying
+ * the identical source/type/excluded-conversation predicates `searchWithFts`
+ * enforces. Only the candidate source differs (`m.id IN (...)` vs
+ * `messages_fts MATCH`); the app-side scorer determines final ordering, so the
+ * SQL tie-break falls back to recency.
+ */
+function searchByIds(
+  messageIds: readonly string[],
+  limit: number,
+  excludedConversationId: string,
+): ConversationEvidenceRow[] {
+  const placeholders = messageIds.map(() => "?").join(", ");
+  return rawAll<ConversationEvidenceRow>(
+    `
+    SELECT
+      m.id AS message_id,
+      m.conversation_id,
+      m.role,
+      m.content,
+      m.created_at,
+      m.metadata,
+      c.title
+    FROM messages m
+    JOIN conversations c ON c.id = m.conversation_id
+    WHERE m.id IN (${placeholders})
+      AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
+      AND c.id != ?
+      AND c.conversation_type != 'private'
+    ORDER BY m.created_at DESC
+    LIMIT ?
+    `,
+    ...messageIds,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     NOTIFICATION_SOURCE,

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -132,8 +132,19 @@ export async function searchConversationSource(
     ? "fts5"
     : getMessagesSearchBackend(context.config);
 
+  // Tokenize once. Short/punctuation-only queries (`C++`, CJK) produce no
+  // usable ≥2-char match shape, and both backends must route those straight to
+  // the exact `searchWithLike` path — the FTS path already does (an empty match
+  // list yields no rows and falls through to LIKE below). The Qdrant path needs
+  // this guard explicitly: the sparse encoder still emits a 1-char token for
+  // such queries, so it would return noisy hits and wrongly skip the exact-LIKE
+  // fallback. Only query a lexical index when the query genuinely tokenizes.
+  const ftsMatches = buildRecallFtsMatchQueries(trimmedQuery);
+
   let rows: ConversationEvidenceRow[];
-  if (backend === "qdrant") {
+  if (ftsMatches.length === 0) {
+    rows = searchWithLike(trimmedQuery, queryLimit, context.conversationId);
+  } else if (backend === "qdrant") {
     // A brief post-edit staleness window (an edited message whose re-index job
     // has not yet run, or a just-deleted message still present as a point) is
     // an ACCEPTED consequence of async indexing. Recall is fuzzy evidence
@@ -151,7 +162,7 @@ export async function searchConversationSource(
     );
   } else {
     rows = gatherCandidateRowsFromFts(
-      trimmedQuery,
+      ftsMatches,
       queryLimit,
       normalizedLimit,
       context.conversationId,
@@ -188,19 +199,18 @@ export async function searchConversationSource(
 }
 
 /**
- * Generate candidate rows via SQLite FTS5. Walks progressively broader match
- * shapes, merging matches until enough rows are collected, and swallows a
- * malformed-query error on any single shape so a broader shape can still run.
- * Returns an empty array when no shape matches — the caller then degrades to
- * the LIKE fallback.
+ * Generate candidate rows via SQLite FTS5 from precomputed match shapes. Walks
+ * the shapes (progressively broader), merging matches until enough rows are
+ * collected, and swallows a malformed-query error on any single shape so a
+ * broader shape can still run. Returns an empty array when no shape matches —
+ * the caller then degrades to the LIKE fallback.
  */
 function gatherCandidateRowsFromFts(
-  query: string,
+  ftsMatches: readonly string[],
   queryLimit: number,
   normalizedLimit: number,
   excludedConversationId: string,
 ): ConversationEvidenceRow[] {
-  const ftsMatches = buildRecallFtsMatchQueries(query);
   let rows: ConversationEvidenceRow[] = [];
 
   for (const ftsMatch of ftsMatches) {

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -11,6 +11,7 @@ import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,
 } from "../../../../../security/untrusted-content.js";
+import { isMemoryIndexingSuppressed } from "../../job-handlers/index-message-lexical.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
 const SUBAGENT_SOURCE = "subagent";
@@ -122,8 +123,23 @@ export async function searchConversationSource(
     normalizedLimit * CONVERSATION_SEARCH_PREFETCH_MULTIPLIER,
   );
 
+  // The Qdrant lexical index is forward-filled by the memory write path, which
+  // is gated on `isMemoryIndexingSuppressed()`. When indexing is suppressed
+  // (memory disabled or the memory plugin disabled) the collection is never
+  // populated, so a qdrant-backed read would silently return nothing while FTS
+  // still works — force the FTS path regardless of the flag in that case.
+  const backend = isMemoryIndexingSuppressed()
+    ? "fts5"
+    : getMessagesSearchBackend(context.config);
+
   let rows: ConversationEvidenceRow[];
-  if (getMessagesSearchBackend(context.config) === "qdrant") {
+  if (backend === "qdrant") {
+    // A brief post-edit staleness window (an edited message whose re-index job
+    // has not yet run, or a just-deleted message still present as a point) is
+    // an ACCEPTED consequence of async indexing. Recall is fuzzy evidence
+    // re-ranked by the app-side scorer, and the wide candidate pool dilutes a
+    // single stale hit; we do not re-verify candidate content against the query
+    // (a substring re-check would wrongly drop valid stemmed matches).
     const qdrantCandidateLimit = Math.max(
       normalizedLimit * QDRANT_RECALL_CANDIDATE_MULTIPLIER,
       QDRANT_RECALL_MIN_CANDIDATES,

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -28,6 +28,35 @@ interface ConversationEvidenceRow {
 
 const CONVERSATION_SEARCH_PREFETCH_MULTIPLIER = 5;
 
+/**
+ * Qdrant candidate over-fetch multiplier for the lexical read path.
+ *
+ * FTS applies the source/type/excluded-conversation predicates *inside* SQL
+ * before its LIMIT, so its post-filter window is already correct. The Qdrant
+ * path instead fetches ranked message-id candidates first and filters them in
+ * SQL afterwards, so it must over-fetch enough candidates that excluded rows
+ * (the active conversation, subagent/auto-analysis/notification sources,
+ * private history) don't starve the post-filter pool. This is deliberately
+ * larger than the FTS prefetch multiplier — a generous candidate pool is cheap
+ * (the final consumer takes top-N after the app-side scorer anyway).
+ *
+ * This is a proportionate over-fetch, NOT a hard parity guarantee: a query
+ * whose visible matches all rank beyond the widened window can still be
+ * under-filled. True parity would need pagination or Qdrant group-search;
+ * that stronger fix is deferred to pre-flip hardening if Gate A shows recall
+ * regressions.
+ */
+const QDRANT_RECALL_CANDIDATE_MULTIPLIER = 20;
+
+/**
+ * Floor for the Qdrant candidate pool, so small `max_results` requests still
+ * over-fetch a healthy number of candidates before SQL filtering. Recall's
+ * `max_results` is capped at `MAX_RECALL_MAX_RESULTS` (20), so the pool is
+ * bounded at 20 × 20 = 400 candidate ids — far under the SQLite bound-variable
+ * limit (32766), so the `WHERE m.id IN (...)` query needs no chunking.
+ */
+const QDRANT_RECALL_MIN_CANDIDATES = 200;
+
 const NON_SALIENT_RECALL_TERMS = new Set([
   "a",
   "about",
@@ -95,9 +124,13 @@ export async function searchConversationSource(
 
   let rows: ConversationEvidenceRow[];
   if (getMessagesSearchBackend(context.config) === "qdrant") {
+    const qdrantCandidateLimit = Math.max(
+      normalizedLimit * QDRANT_RECALL_CANDIDATE_MULTIPLIER,
+      QDRANT_RECALL_MIN_CANDIDATES,
+    );
     rows = await gatherCandidateRowsFromQdrant(
       trimmedQuery,
-      queryLimit,
+      qdrantCandidateLimit,
       context.conversationId,
     );
   } else {
@@ -177,6 +210,12 @@ function gatherCandidateRowsFromFts(
  * source/type/excluded-conversation predicates FTS applies, so only the
  * candidate *source* differs. Final ordering stays with the app-side scorer.
  *
+ * `candidateLimit` is the widened over-fetch count (see
+ * {@link QDRANT_RECALL_CANDIDATE_MULTIPLIER}) — it bounds both the Qdrant fetch
+ * and the post-filter SQL `LIMIT`, so surviving candidates aren't dropped
+ * before scoring. Filtering shrinks the pool but never grows it, so the final
+ * `LIMIT` is a no-op ceiling here; it exists only to bound the returned rows.
+ *
  * Returns an empty array when the query tokenizes to no sparse terms (the
  * lexical helper's empty guard) or when the Qdrant call throws — in both cases
  * the caller degrades to the LIKE fallback, mirroring how the FTS path falls
@@ -184,12 +223,12 @@ function gatherCandidateRowsFromFts(
  */
 async function gatherCandidateRowsFromQdrant(
   query: string,
-  queryLimit: number,
+  candidateLimit: number,
   excludedConversationId: string,
 ): Promise<ConversationEvidenceRow[]> {
   let candidates: Array<{ messageId: string }>;
   try {
-    candidates = await searchMessageIdsLexical(query, queryLimit);
+    candidates = await searchMessageIdsLexical(query, candidateLimit);
   } catch {
     return [];
   }
@@ -197,7 +236,7 @@ async function gatherCandidateRowsFromQdrant(
   const candidateIds = candidates.map((candidate) => candidate.messageId);
   if (candidateIds.length === 0) return [];
 
-  return searchByIds(candidateIds, queryLimit, excludedConversationId);
+  return searchByIds(candidateIds, candidateLimit, excludedConversationId);
 }
 
 function searchWithFts(

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-message-lexical.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-message-lexical.ts
@@ -32,11 +32,16 @@ const log = getLogger("messages-lexical-enqueue");
  * the FULL disabled-state check the host applies in
  * `guardPersistenceHooksByDisabledState`, because the index-write call sites
  * (streaming finalize, import, edit, consolidation) call
- * {@link enqueueLexicalIndexForMessage} directly, outside that guard. Applies
- * ONLY to the index/write path — the cleanup paths (purge/delete/clear) must
- * still run while disabled so points written when enabled are not orphaned.
+ * {@link enqueueLexicalIndexForMessage} directly, outside that guard.
+ *
+ * On the write side this suppresses ONLY the index/write path — the cleanup
+ * paths (purge/delete/clear) must still run while disabled so points written
+ * when enabled are not orphaned. It doubles as the read-side population signal:
+ * when suppression is active the lexical index is not being forward-filled, so
+ * lexical-backed reads must fall back to FTS rather than query a stale/empty
+ * `messages_lexical` collection.
  */
-function isMemoryIndexingSuppressed(): boolean {
+export function isMemoryIndexingSuppressed(): boolean {
   return !isMemoryEnabled() || isPluginDisabled(memoryPkg.name);
 }
 


### PR DESCRIPTION
## What

PR 7 of the `messages_fts` → Qdrant migration. Cuts the **recall tool's conversations source** read path over to the sparse Qdrant lexical index (`messages_lexical`), behind the `messages-search-backend` flag.

When `getMessagesSearchBackend(config)` resolves to `"qdrant"`:
- Candidate message ids come from `searchMessageIdsLexical(query, queryLimit)` (over-fetched via the existing `CONVERSATION_SEARCH_PREFETCH_MULTIPLIER`) instead of `messages_fts MATCH`.
- Those candidate rows are re-fetched via a new `searchByIds()` helper that applies the **exact same** SQL predicates `searchWithFts` uses — same `SELECT` columns, same source-exclusion (`c.source IS NULL OR c.source NOT IN (subagent, auto-analysis, notification)`), same excluded-current-conversation (`c.id != ?`), same `conversation_type != 'private'` filter. Only the candidate **source** differs.
- The existing app-side `scoreConversationRow` / `compareScoredConversationRows` re-ranking is preserved unchanged — Qdrant order only affects which candidates are considered, never final order. Qdrant is candidate-generation only; all filtering + ranking stays in SQL / app code.

## Flag-gated (default `fts5` = no-op)

- Backend `"fts5"` (default): the FTS path is **byte-identical** to today — the existing multi-shape FTS loop is extracted verbatim into `gatherCandidateRowsFromFts` with no logic change.
- **Qdrant failure** (the `searchMessageIdsLexical` call throwing) **degrades to the existing LIKE fallback**, mirroring how the FTS path falls back to LIKE when it matches nothing (the branch returns `[]`, so the shared `if (rows.length === 0) rows = searchWithLike(...)` handles it).
- **Empty candidate set** (from the encoder's empty-sparse-query guard) also returns `[]` ⇒ same LIKE fallback.

## Predicate parity

`searchByIds` differs from `searchWithFts` only where it must: `FROM messages m` + `WHERE m.id IN (<candidates>)` replaces the `messages_fts` join + `MATCH`, and the `ORDER BY` drops `bm25(messages_fts)` (unavailable without the FTS table), keeping `m.created_at DESC` as the tie-break. The app-side scorer determines final ordering regardless.

## Import boundary

Adds the two new host-internal couplings to the `memory` plugin's import-boundary baseline in `plugin-import-boundary-guard.test.ts` (both are host-internal with no `@vellumai/plugin-api` equivalent; the memory plugin already reaches into `config/` and `persistence/` extensively):
- `../../../../../config/assistant-feature-flags.js`
- `../../../../../persistence/conversation-search-lexical.js`

## Tests

Extends `context-search-conversations-source.test.ts` with a `qdrant` describe block (flag forced via `setOverridesForTesting`, `searchMessageIdsLexical` mocked via `mock.module`, real DB seeding so the SQL predicates run for real):
- Qdrant-supplied candidates return app-scored evidence (proves the app scorer, not Qdrant order, ranks).
- Source / type / excluded-conversation filters are applied to Qdrant candidates.
- Qdrant throw → LIKE fallback.
- Qdrant empty candidates → LIKE fallback.

The existing FTS/LIKE tests are unchanged and still pass (17 pass / 0 fail total). `bunx tsc --noEmit` is clean.

Part of the messages_fts → Qdrant migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — addressing Codex P2 (`0583deba46`)

**Finding:** the qdrant branch fetched only `limit × CONVERSATION_SEARCH_PREFETCH_MULTIPLIER` (= `limit × 5`) candidate ids *before* `searchByIds` applies the current-conversation / source / private predicates. If the top lexical hits are dominated by excluded rows but ≥1 survives, the empty→LIKE fallback is skipped and the result is under-filled — visible matches ranked just past the small pre-filter window are never considered. FTS avoids this because it filters inside SQL before its `LIMIT`.

**Fix (qdrant branch only):** over-fetch a dedicated, wider candidate pool: `max(limit × QDRANT_RECALL_CANDIDATE_MULTIPLIER, QDRANT_RECALL_MIN_CANDIDATES)` = `max(limit × 20, 200)`. This pool bounds **both** the Qdrant fetch and the post-filter SQL `LIMIT`, so surviving candidates aren't dropped before the app-side scorer. The FTS multiplier (5) is deliberately **not** reused.

**Bound-param safety:** recall's `max_results` is hard-capped at `MAX_RECALL_MAX_RESULTS` (20), so the candidate pool is bounded at `20 × 20 = 400` ids. The `WHERE m.id IN (...)` param count (≈405 incl. fixed params) is far under the SQLite bound-variable limit (empirically verified at 32766 in bun:sqlite), so **no chunking is needed**.

**This is a proportionate over-fetch, NOT a hard parity guarantee** — a query whose visible matches all rank beyond the widened window can still be under-filled. This is a conscious, documented bound (see the comment on `QDRANT_RECALL_CANDIDATE_MULTIPLIER`), not a silent cap. True parity would need **pagination or Qdrant group-search**; that stronger fix is **deferred to pre-flip hardening** if Gate A shows recall regressions.

FTS path remains byte-identical; empty/throw → LIKE fallback unchanged. Added a test asserting the qdrant branch requests the wider candidate count (200, not the FTS 25) and that filtering still yields correctly-scored rows (18 pass / 0 fail). `bunx tsc --noEmit` clean.
