### PR TITLE
feat(daemon): surface plugin `enabled` state on GET /v1/plugins

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20879,6 +20879,11 @@ paths:
                         name:
                           type: string
                           description: Display name. Equal to `id` today.
+                        enabled:
+                          type: boolean
+                          description:
+                            Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its
+                            directory; `true` otherwise.
                         description:
                           anyOf:
                             - type: string
@@ -20907,6 +20912,7 @@ paths:
                       required:
                         - id
                         - name
+                        - enabled
                         - description
                         - version
                       additionalProperties: false

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -96,6 +96,16 @@ mock.module("../../../cli/lib/list-installed-plugins.js", () => ({
   listInstalledPlugins: () => installedFixture,
 }));
 
+// Set of plugin dir names carrying a `.disabled` sentinel. Tests populate it to
+// mark a plugin disabled; the real check reads the workspace filesystem, so we
+// substitute an in-memory set to keep the route's `enabled` projection
+// deterministic and decoupled from disk.
+const disabledFixture = new Set<string>();
+
+mock.module("../../../plugins/disabled-state.js", () => ({
+  isPluginDisabled: (name: string) => disabledFixture.has(name),
+}));
+
 // Mock the catalog cache: `getCatalogSpy` records every invocation and
 // returns the (unfiltered) catalog the route then filters in memory via the
 // real `filterPluginCatalog`. The real `search-plugins.js` module is left
@@ -323,6 +333,7 @@ function pluginEntry(
 
 beforeEach(() => {
   installedFixture = [];
+  disabledFixture.clear();
 });
 
 describe("GET /v1/plugins", () => {
@@ -363,6 +374,8 @@ describe("GET /v1/plugins", () => {
     expect(result.plugins[0]).toEqual({
       id: "alpha",
       name: "alpha",
+      // No `.disabled` sentinel → the plugin is enabled.
+      enabled: true,
       description: "Alpha plugin",
       version: "1.2.3",
       path: "/workspace/plugins/alpha",
@@ -444,6 +457,21 @@ describe("GET /v1/plugins", () => {
 
     const [entry] = (await invoke()).plugins;
     expect(entry?.issues).toEqual(["missing package.json"]);
+  });
+
+  test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {
+    installedFixture = [
+      pluginEntry({ name: "off" }),
+      pluginEntry({ name: "on" }),
+    ];
+    // Only `off` carries the sentinel; `on` has none.
+    disabledFixture.add("off");
+
+    const byId = new Map(
+      (await invoke()).plugins.map((p) => [p.id, p.enabled]),
+    );
+    expect(byId.get("off")).toBe(false);
+    expect(byId.get("on")).toBe(true);
   });
 
   test("?q= filters case-insensitively on id, name, and description", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -73,6 +73,7 @@ import {
   type PluginUpgradeStrategy,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
+import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -96,6 +97,11 @@ const pluginInfoSchema = z.object({
       "Plugin's directory name (kebab-case). Matches `assistant plugins install <id>`.",
     ),
   name: z.string().describe("Display name. Equal to `id` today."),
+  enabled: z
+    .boolean()
+    .describe(
+      "Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its directory; `true` otherwise.",
+    ),
   description: z
     .string()
     .nullable()
@@ -635,6 +641,7 @@ const pluginDiffResponseSchema = z.object({
 interface PluginView {
   id: string;
   name: string;
+  enabled: boolean;
   description: string | null;
   version: string | null;
   path: string;
@@ -649,6 +656,8 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   const view: PluginView = {
     id: entry.name,
     name: entry.name,
+    // `entry.name` is the plugin directory name, which is the sentinel key.
+    enabled: !isPluginDisabled(entry.name),
     description: entry.packageJson?.description ?? null,
     version: entry.packageJson?.version ?? null,
     path: entry.target,


### PR DESCRIPTION
## Summary
- Add `enabled: boolean` to the plugin list schema, sourced from the `.disabled` sentinel via `isPluginDisabled`
- Regenerate `openapi.yaml`; extend plugins-routes tests to cover enabled true/false

Part of plan: plugin-enable-disable.md (PR 1 of 9)