### PR TITLE
feat(web): thread plugin `enabled` state + toggle-support latch through usePluginsList

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -140,13 +140,15 @@ const { PluginsTab } = await import("./plugins-tab");
 // ---------------------------------------------------------------------------
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default (older-daemon shape); the cast is needed
+  // because the generated element type marks it required.
   return {
     id: "simple-memory",
     name: "simple-memory",
     description: "Memory plugin",
     version: "0.1.0",
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 /** Minimal schema-valid inspect result reporting no drift (the row reads

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -25,6 +25,12 @@ export interface PluginListItem {
   version?: string;
   path?: string;
   issues?: string[];
+  /**
+   * Whether the plugin is active in this workspace. Installed rows only —
+   * catalog/available rows carry no enablement. `undefined` on daemons that
+   * predate the enable/disable surface (version-skew safeguard).
+   */
+  enabled?: boolean;
 }
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
@@ -49,6 +55,7 @@ interface InstalledPluginSource {
   version: string | null;
   path?: string;
   issues?: string[];
+  enabled?: boolean;
 }
 
 interface CatalogPluginSource {

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -70,13 +70,16 @@ const { usePluginsList } = await import(
 );
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default to model an older daemon that predates the
+  // enable/disable surface; tests opt in via `installed({ enabled })`. The cast
+  // is needed because the generated element type marks `enabled` as required.
   return {
     id: "alpha",
     name: "alpha",
     description: null,
     version: null,
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 function match(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
@@ -330,6 +333,65 @@ describe("usePluginsList", () => {
 
     await waitFor(() =>
       expect(result.current.categorySupported).toBe(false),
+    );
+  });
+
+  test("exposes enabled on installed items and latches pluginToggleSupported", async () => {
+    installedResult = installedOk([
+      installed({ id: "alpha", name: "alpha", enabled: true }),
+      installed({ id: "bravo", name: "bravo", enabled: false }),
+    ]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    // Installed rows carry the daemon's enablement (alphabetical: alpha, bravo).
+    expect(result.current.items.map((p) => p.enabled)).toEqual([true, false]);
+    expect(result.current.pluginToggleSupported).toBe(true);
+  });
+
+  test("pluginToggleSupported stays false when the daemon omits enabled", async () => {
+    // Older daemon: installed items carry no `enabled` field.
+    installedResult = installedOk([installed({ id: "alpha", name: "alpha" })]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(result.current.items[0]?.enabled).toBeUndefined();
+    expect(result.current.pluginToggleSupported).toBe(false);
+  });
+
+  test("pluginToggleSupported resets when the active assistant changes", async () => {
+    // Assistant A's daemon reports enablement, so support latches true.
+    installedResult = installedOk([
+      installed({ id: "alpha", name: "alpha", enabled: true }),
+    ]);
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client }, children);
+    }
+    const { result, rerender } = renderHook(
+      ({ assistantId }: { assistantId: string }) =>
+        usePluginsList(assistantId, null),
+      { wrapper, initialProps: { assistantId: "asst-a" } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.pluginToggleSupported).toBe(true),
+    );
+
+    // Switching to an assistant whose daemon omits `enabled` must drop the
+    // sticky latch — otherwise the toggle would render for an assistant whose
+    // daemon has no enable/disable surface.
+    installedResult = installedOk([installed({ id: "beta", name: "beta" })]);
+    rerender({ assistantId: "asst-b" });
+
+    await waitFor(() =>
+      expect(result.current.pluginToggleSupported).toBe(false),
     );
   });
 

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -53,6 +53,12 @@ export interface UsePluginsListResult {
    */
   categorySupported: boolean;
   /**
+   * True once any installed item carries `enabled` — the daemon understands
+   * the plugin enable/disable surface. Older daemons omit it; the toggle gates
+   * on this (version-skew safeguard). Sticky, reset per assistant.
+   */
+  pluginToggleSupported: boolean;
+  /**
    * Unfiltered installed category counts from the server (before the category
    * filter is applied). Undefined on daemons without taxonomy support.
    */
@@ -209,6 +215,25 @@ export function usePluginsList(
   }, [categoryCountsObserved]);
   const categorySupported = categorySupportedLatched || categoryCountsObserved;
 
+  // Latch plugin enable/disable support the same way: it's observed once any
+  // installed item carries `enabled` (a stable per-assistant daemon capability),
+  // and stays sticky across a category switch while the unfiltered source is
+  // momentarily pending. Reset on assistant change so a prior assistant's `true`
+  // can't gate the toggle for a next assistant whose daemon omits `enabled`.
+  const pluginToggleObserved = (
+    unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED
+  ).some((p) => p.enabled !== undefined);
+  const [pluginToggleSupportedLatched, setPluginToggleSupportedLatched] =
+    useState(false);
+  useEffect(() => {
+    setPluginToggleSupportedLatched(false);
+  }, [assistantId]);
+  useEffect(() => {
+    if (pluginToggleObserved) setPluginToggleSupportedLatched(true);
+  }, [pluginToggleObserved]);
+  const pluginToggleSupported =
+    pluginToggleSupportedLatched || pluginToggleObserved;
+
   // Self-heal timeout-degraded category counts. A cold catalog can make the
   // daemon's bounded category lookup time out, so the installed read buckets
   // every plugin under `system` and the client caches those counts as fresh. The
@@ -267,6 +292,7 @@ export function usePluginsList(
     isFetching: installedQuery.isFetching || catalogQuery.isFetching,
     catalogError: catalogQuery.isError,
     categorySupported,
+    pluginToggleSupported,
     installedCategoryCounts: unfilteredInstalledData?.categoryCounts,
     installedPlugins: unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED,
     installedTotal: unfilteredInstalledData?.totalCount,

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -100,6 +100,39 @@ async function fetchInstalled(
 }
 
 /**
+ * Sticky per-assistant capability latch. `observed` is the live signal that the
+ * daemon supports a feature for the current render; once true it latches so the
+ * feature's UI doesn't flicker off while the backing read is momentarily pending
+ * (e.g. mid category switch). The latch resets SYNCHRONOUSLY when `assistantId`
+ * changes — cleared during render, not in an effect — so a prior assistant's
+ * latched `true` never leaks into the first render of a next assistant whose
+ * daemon omits the capability.
+ */
+function useStickyAssistantCapability(
+  assistantId: string,
+  observed: boolean,
+): boolean {
+  const [latch, setLatch] = useState({ assistantId, latched: false });
+  const latchedForThisAssistant =
+    latch.assistantId === assistantId ? latch.latched : false;
+  if (latch.assistantId !== assistantId) {
+    // Reset during render (the discarded render's effects never commit) so the
+    // stale latch can't gate even one render for the new assistant.
+    setLatch({ assistantId, latched: false });
+  }
+  useEffect(() => {
+    if (observed) {
+      setLatch((prev) =>
+        prev.assistantId === assistantId && prev.latched
+          ? prev
+          : { assistantId, latched: true },
+      );
+    }
+  }, [assistantId, observed]);
+  return latchedForThisAssistant || observed;
+}
+
+/**
  * Single source of truth for the Plugins tab list: the installed read
  * (`pluginsGet`, with an older-daemon 404 → empty degradation) and the
  * catalog (`pluginsSearchGet`), merged via `mergePlugins` and `sortPlugins`
@@ -196,43 +229,22 @@ export function usePluginsList(
   const unfilteredInstalledData =
     category !== null ? installedCountsQuery.data : installedQuery.data;
 
-  // Latch support sticky once the unfiltered read first carries `categoryCounts`
-  // (it's a stable daemon capability): the live OR covers the current render, and
-  // the latch keeps it true across a category switch while the unfiltered source
-  // is momentarily pending, so the rail never vanishes mid-filter.
-  const categoryCountsObserved =
-    unfilteredInstalledData?.categoryCounts !== undefined;
-  const [categorySupportedLatched, setCategorySupportedLatched] =
-    useState(false);
-  // Support is a per-assistant daemon capability. Reset the latch when the
-  // active assistant changes so a `true` observed for a prior assistant can't
-  // keep the rail alive for a next assistant whose daemon omits `categoryCounts`.
-  useEffect(() => {
-    setCategorySupportedLatched(false);
-  }, [assistantId]);
-  useEffect(() => {
-    if (categoryCountsObserved) setCategorySupportedLatched(true);
-  }, [categoryCountsObserved]);
-  const categorySupported = categorySupportedLatched || categoryCountsObserved;
-
-  // Latch plugin enable/disable support the same way: it's observed once any
-  // installed item carries `enabled` (a stable per-assistant daemon capability),
-  // and stays sticky across a category switch while the unfiltered source is
-  // momentarily pending. Reset on assistant change so a prior assistant's `true`
-  // can't gate the toggle for a next assistant whose daemon omits `enabled`.
-  const pluginToggleObserved = (
-    unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED
-  ).some((p) => p.enabled !== undefined);
-  const [pluginToggleSupportedLatched, setPluginToggleSupportedLatched] =
-    useState(false);
-  useEffect(() => {
-    setPluginToggleSupportedLatched(false);
-  }, [assistantId]);
-  useEffect(() => {
-    if (pluginToggleObserved) setPluginToggleSupportedLatched(true);
-  }, [pluginToggleObserved]);
-  const pluginToggleSupported =
-    pluginToggleSupportedLatched || pluginToggleObserved;
+  // Category-rail and plugin-toggle support are both sticky per-assistant daemon
+  // capabilities: observed live from the unfiltered read, latched so the UI
+  // doesn't flicker off while that read is momentarily pending mid category
+  // switch, and reset SYNCHRONOUSLY on assistant change (see the helper) so a
+  // prior assistant's `true` can't gate one render for a next assistant whose
+  // daemon omits the capability.
+  const categorySupported = useStickyAssistantCapability(
+    assistantId,
+    unfilteredInstalledData?.categoryCounts !== undefined,
+  );
+  const pluginToggleSupported = useStickyAssistantCapability(
+    assistantId,
+    (unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED).some(
+      (p) => p.enabled !== undefined,
+    ),
+  );
 
   // Self-heal timeout-degraded category counts. A cold catalog can make the
   // daemon's bounded category lookup time out, so the installed read buckets

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -14,13 +14,15 @@ import {
 } from "./utils";
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default (older-daemon shape); the cast is needed
+  // because the generated element type marks it required.
   return {
     id: "alpha",
     name: "alpha",
     description: null,
     version: null,
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 function catalog(overrides: Partial<PluginCatalogMatch> = {}): PluginCatalogMatch {

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -27,6 +27,8 @@ export function mergePlugins(
     version: p.version ?? undefined,
     path: p.path,
     issues: p.issues,
+    // Installed rows carry enablement; older daemons omit it (undefined).
+    enabled: p.enabled,
   }));
 
   const installedNames = new Set(installedItems.map((i) => i.name));


### PR DESCRIPTION
## Summary
- Add `enabled` to `PluginListItem` (carried through `mergePlugins` for installed rows only; catalog/available rows have no enablement)
- Add a sticky `pluginToggleSupported` capability latch in `usePluginsList` (mirrors the existing `categorySupported` latch): observed when any installed item carries `enabled`, latched true once observed, reset on `assistantId` change
- UI vocabulary (Active/Off) and the actual toggle land in later PRs — this is the data layer only

## Notes
- Regenerated the gitignored daemon client (not committed); the installed-plugin `enabled` field is now required in the generated element type
- Updated the `installed()` test helpers in `utils.test.ts` and `plugins-tab.test.tsx` to cast (they omit `enabled` to model older daemons), keeping the plugins domain tsc-clean after regen
- Unrelated regen-drift tsc errors (subagent `"interrupted"` status, `LockfileAssistant`) are pre-existing and not touched here

## Verification
- `bun test` plugins domain: 93 pass
- `bunx tsc --noEmit`: no plugin-domain errors

Part of plan: plugin-enable-disable.md (PR 4 of 9)