### PR TITLE
feat(web): invalidate the Plugins tab on plugins:list sync_changed

### DIFF
--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -9,6 +9,8 @@ import {
   configGetQueryKey,
   homeFeedGetQueryKey,
   homeStateGetQueryKey,
+  pluginsGetQueryKey,
+  pluginsSearchGetQueryKey,
   schedulesGetQueryKey,
   soundsConfigGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -176,6 +178,67 @@ describe("useAssistantResourceSync", () => {
       })
     ).toBe(true);
     expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
+  });
+
+  test("invalidates plugin list / catalog queries on plugins:list sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const calls: unknown[] = [];
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      calls.push(arg);
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit((syncEvent([SYNC_TAGS.pluginsList]) as unknown) as AssistantEvent);
+    await waitFor(() => {
+      const queryKeys = calls.map(
+        (arg) => (arg as { queryKey: readonly unknown[] }).queryKey
+      );
+      const pathOpts = { path: { assistant_id: "asst-1" } };
+      expect(queryKeys).toEqual(
+        expect.arrayContaining([
+          pluginsGetQueryKey(pathOpts),
+          pluginsSearchGetQueryKey(pathOpts),
+        ]) as never
+      );
+    });
+  });
+
+  test("reconciles plugin queries on non-fresh sse.opened reconnect", async () => {
+    const queryClient = freshQueryClient();
+    const calls: unknown[] = [];
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      calls.push(arg);
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+    await waitFor(() => {
+      const queryKeys = calls.map(
+        (arg) => (arg as { queryKey: readonly unknown[] }).queryKey
+      );
+      const pathOpts = { path: { assistant_id: "asst-1" } };
+      expect(queryKeys).toEqual(
+        expect.arrayContaining([
+          pluginsGetQueryKey(pathOpts),
+          pluginsSearchGetQueryKey(pathOpts),
+        ]) as never
+      );
+    });
+  });
+
+  test("does not reconcile on fresh sse.opened", () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    publish("sse.opened", { assistantId: "asst-1", cause: "fresh" });
+    expect(spy).not.toHaveBeenCalled();
   });
 
   test("invalidates home-feed query on home_feed_updated", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -2,7 +2,7 @@
  * Bus consumer for assistant-level resource cache invalidation.
  *
  * Routes `sync_changed` tags (avatar, identity, config, sounds, schedules,
- * apps) and discrete SSE events (`home_feed_updated`,
+ * apps, plugins) and discrete SSE events (`home_feed_updated`,
  * `relationship_state_updated`, `identity_changed`, `avatar_updated`) into
  * TanStack Query cache invalidations.
  *
@@ -29,6 +29,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import {
   configGetQueryKey,
   identityGetQueryKey,
@@ -105,6 +106,9 @@ export function useAssistantResourceSync(
                 predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
               });
               break;
+            case SYNC_TAGS.pluginsList:
+              invalidatePluginQueries(queryClient, assistantId);
+              break;
           }
         }
         return;
@@ -170,6 +174,7 @@ export function useAssistantResourceSync(
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
     });
+    invalidatePluginQueries(queryClient, assistantId);
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "homeFeedGet"),
     });

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -5,6 +5,7 @@ export const SYNC_TAGS = {
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
   appsList: "apps:list",
+  pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",


### PR DESCRIPTION
## Summary
- Add the plugins:list web sync tag + a case in useAssistantResourceSync that invalidates plugin queries
- Reuses the generic sync_changed contract (repo AGENTS.md §164) — no bespoke event; reconnect reconciles

Part of plan: plugin-enable-disable.md (PR 9 of 9)