### PR TITLE
feat(web): usePluginToggle optimistic enable/disable mutation

### DIFF
--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -21,3 +21,5 @@ export const PLUGIN_INSTALL_ERROR =
 export const PLUGIN_REMOVE_ERROR = "Failed to remove plugin. Please try again.";
 export const PLUGIN_UPGRADE_ERROR =
   "Failed to upgrade plugin. Please try again.";
+export const PLUGIN_TOGGLE_ERROR =
+  "Failed to update plugin. Please try again.";

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for `usePluginToggle`, the optimistic enable/disable mutation backing
+ * the Plugins tab toggle. It flips the installed row's `enabled` in the cached
+ * list immediately, rolls the snapshot back and toasts on failure, invalidates
+ * the plugin queries on settle, and exposes the in-flight `togglingName`.
+ *
+ * The generated SDK layer is mocked so the enable/disable endpoints resolve
+ * locally (or reject, to drive the rollback branch); the design-library barrel
+ * is mocked so `toast.error` is spy-able. Module-level holders let a case gate
+ * the request pending or force the endpoint to fail.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { PLUGIN_TOGGLE_ERROR } from "@/domains/intelligence/plugins/constants";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+const NAME = "alpha";
+const okResponse = { response: new Response(), error: undefined };
+
+// Per-test holders the SDK mocks read. `*Fails` forces the matching endpoint to
+// reject (the rollback branch); `toggleGate`, when set, holds the request
+// pending so a case can assert the optimistic state before it settles.
+let enableFails = false;
+let disableFails = false;
+let toggleGate: Promise<unknown> | null = null;
+
+const enableSpy = mock(async (_options: unknown) => {
+  if (toggleGate) await toggleGate;
+  if (enableFails) throw new Error("enable failed");
+  return { data: { ok: true }, ...okResponse };
+});
+const disableSpy = mock(async (_options: unknown) => {
+  if (toggleGate) await toggleGate;
+  if (disableFails) throw new Error("disable failed");
+  return { data: { ok: true }, ...okResponse };
+});
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsByNameEnablePost: enableSpy,
+  pluginsByNameDisablePost: disableSpy,
+}));
+
+const toastErrorSpy = mock((_message: string) => {});
+const dlActual = await import("@vellumai/design-library");
+mock.module("@vellumai/design-library", () => ({
+  ...dlActual,
+  toast: Object.assign((_message: string) => {}, {
+    success: () => {},
+    error: toastErrorSpy,
+    dismiss: () => {},
+  }),
+}));
+
+const { pluginsGetQueryKey } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+const { usePluginToggle } = await import(
+  "@/domains/intelligence/plugins/use-plugin-toggle"
+);
+
+const LIST_KEY = pluginsGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID },
+  query: { q: undefined },
+});
+
+function seededList(enabled: boolean): PluginsGetResponse {
+  return {
+    plugins: [
+      { id: NAME, name: NAME, description: null, version: null, enabled },
+    ],
+  } as PluginsGetResponse;
+}
+
+function cachedEnabled(client: QueryClient): boolean | undefined {
+  return client
+    .getQueryData<PluginsGetResponse>(LIST_KEY)
+    ?.plugins.find((p) => p.name === NAME)?.enabled;
+}
+
+function renderToggle({ enabled = true }: { enabled?: boolean } = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  client.setQueryData<PluginsGetResponse>(LIST_KEY, seededList(enabled));
+  const invalidateSpy = mock(client.invalidateQueries.bind(client));
+  client.invalidateQueries = invalidateSpy;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+
+  const view = renderHook(() => usePluginToggle(ASSISTANT_ID), { wrapper });
+  return { ...view, client, invalidateSpy };
+}
+
+beforeEach(() => {
+  enableFails = false;
+  disableFails = false;
+  toggleGate = null;
+  enableSpy.mockClear();
+  disableSpy.mockClear();
+  toastErrorSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePluginToggle", () => {
+  test("flips enabled optimistically and exposes togglingName while pending", async () => {
+    // Hold the request pending so the optimistic flip is observable before it
+    // settles.
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result, client } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    // The cached row flips to disabled and the in-flight name is exposed, all
+    // before the endpoint resolves.
+    await waitFor(() => expect(cachedEnabled(client)).toBe(false));
+    expect(result.current.togglingName).toBe(NAME);
+
+    // Once it settles, togglingName clears.
+    release();
+    await waitFor(() => expect(result.current.togglingName).toBe(null));
+  });
+
+  test("calls the enable endpoint with the assistant + name path", async () => {
+    const { result } = renderToggle({ enabled: false });
+
+    result.current.toggle(NAME, true);
+
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(1));
+    expect(enableSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    });
+    expect(disableSpy).not.toHaveBeenCalled();
+  });
+
+  test("calls the disable endpoint when disabling", async () => {
+    const { result } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    await waitFor(() => expect(disableSpy).toHaveBeenCalledTimes(1));
+    expect(disableSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    });
+    expect(enableSpy).not.toHaveBeenCalled();
+  });
+
+  test("rolls back the optimistic flip and toasts on error", async () => {
+    disableFails = true;
+    const { result, client } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    // Rolls back to the pre-toggle value and surfaces the failure copy.
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(PLUGIN_TOGGLE_ERROR),
+    );
+    expect(cachedEnabled(client)).toBe(true);
+    expect(result.current.togglingName).toBe(null);
+  });
+
+  test("invalidates the plugin queries on settle", async () => {
+    const { result, invalidateSpy } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
@@ -1,13 +1,16 @@
 /**
  * Tests for `usePluginToggle`, the optimistic enable/disable mutation backing
- * the Plugins tab toggle. It flips the installed row's `enabled` in the cached
- * list immediately, rolls the snapshot back and toasts on failure, invalidates
- * the plugin queries on settle, and exposes the in-flight `togglingName`.
+ * the Plugins tab toggle. It flips the installed row's `enabled` across every
+ * cached `pluginsGet` variant (unfiltered + each `?category=` read)
+ * immediately, treats a 409 (already-in-state) as success, rolls back only the
+ * toggled row's field and toasts on real failure, invalidates the plugin
+ * queries on settle, and exposes the in-flight `togglingName`.
  *
  * The generated SDK layer is mocked so the enable/disable endpoints resolve
- * locally (or reject, to drive the rollback branch); the design-library barrel
- * is mocked so `toast.error` is spy-able. Module-level holders let a case gate
- * the request pending or force the endpoint to fail.
+ * locally with a controllable HTTP status (or reject, to drive the rollback
+ * branch); the design-library barrel is mocked so `toast.error` is spy-able.
+ * Module-level holders let a case gate the request pending, set the response
+ * status, or force the endpoint to reject.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -20,24 +23,36 @@ import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
 
 const ASSISTANT_ID = "asst-1";
 const NAME = "alpha";
-const okResponse = { response: new Response(), error: undefined };
+const CATEGORY = "system";
 
-// Per-test holders the SDK mocks read. `*Fails` forces the matching endpoint to
-// reject (the rollback branch); `toggleGate`, when set, holds the request
-// pending so a case can assert the optimistic state before it settles.
+// Per-test holders the SDK mocks read. `*Status` sets the HTTP status the
+// matching endpoint responds with (200 ok, 409 already-in-state). `*Fails`
+// forces the matching endpoint to reject (a network-level failure).
+// `toggleGate`, when set, holds the request pending so a case can assert the
+// optimistic state before it settles.
+let enableStatus = 200;
+let disableStatus = 200;
 let enableFails = false;
 let disableFails = false;
 let toggleGate: Promise<unknown> | null = null;
 
+function respond(status: number) {
+  return {
+    data: { ok: true },
+    error: undefined,
+    response: new Response(null, { status }),
+  };
+}
+
 const enableSpy = mock(async (_options: unknown) => {
   if (toggleGate) await toggleGate;
   if (enableFails) throw new Error("enable failed");
-  return { data: { ok: true }, ...okResponse };
+  return respond(enableStatus);
 });
 const disableSpy = mock(async (_options: unknown) => {
   if (toggleGate) await toggleGate;
   if (disableFails) throw new Error("disable failed");
-  return { data: { ok: true }, ...okResponse };
+  return respond(disableStatus);
 });
 
 const sdkActual = await import("@/generated/daemon/sdk.gen");
@@ -69,41 +84,65 @@ const LIST_KEY = pluginsGetQueryKey({
   path: { assistant_id: ASSISTANT_ID },
   query: { q: undefined },
 });
+// The distinct key `usePluginsList` reads when a category rail item is picked.
+const CATEGORY_KEY = pluginsGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID },
+  query: { q: undefined, category: CATEGORY },
+});
 
-function seededList(enabled: boolean): PluginsGetResponse {
+function listOf(
+  plugins: Array<{ name: string; enabled: boolean }>,
+): PluginsGetResponse {
   return {
-    plugins: [
-      { id: NAME, name: NAME, description: null, version: null, enabled },
-    ],
+    plugins: plugins.map(({ name, enabled }) => ({
+      id: name,
+      name,
+      description: null,
+      version: null,
+      enabled,
+    })),
   } as PluginsGetResponse;
 }
 
-function cachedEnabled(client: QueryClient): boolean | undefined {
+function cachedEnabled(
+  client: QueryClient,
+  name = NAME,
+  key: readonly unknown[] = LIST_KEY,
+): boolean | undefined {
   return client
-    .getQueryData<PluginsGetResponse>(LIST_KEY)
-    ?.plugins.find((p) => p.name === NAME)?.enabled;
+    .getQueryData<PluginsGetResponse>(key)
+    ?.plugins.find((p) => p.name === name)?.enabled;
 }
 
-function renderToggle({ enabled = true }: { enabled?: boolean } = {}) {
-  const client = new QueryClient({
+function newClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
-  client.setQueryData<PluginsGetResponse>(LIST_KEY, seededList(enabled));
-  const invalidateSpy = mock(client.invalidateQueries.bind(client));
-  client.invalidateQueries = invalidateSpy;
+}
 
+function mountToggle(client: QueryClient) {
   function wrapper({ children }: { children: ReactNode }) {
     return createElement(QueryClientProvider, { client }, children);
   }
+  return renderHook(() => usePluginToggle(ASSISTANT_ID), { wrapper });
+}
 
-  const view = renderHook(() => usePluginToggle(ASSISTANT_ID), { wrapper });
+function renderToggle({ enabled = true }: { enabled?: boolean } = {}) {
+  const client = newClient();
+  client.setQueryData<PluginsGetResponse>(LIST_KEY, listOf([{ name: NAME, enabled }]));
+  const invalidateSpy = mock(client.invalidateQueries.bind(client));
+  client.invalidateQueries = invalidateSpy;
+
+  const view = mountToggle(client);
   return { ...view, client, invalidateSpy };
 }
 
 beforeEach(() => {
+  enableStatus = 200;
+  disableStatus = 200;
   enableFails = false;
   disableFails = false;
   toggleGate = null;
@@ -138,6 +177,29 @@ describe("usePluginToggle", () => {
     await waitFor(() => expect(result.current.togglingName).toBe(null));
   });
 
+  test("flips the row across category-filtered cache variants too", async () => {
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result, client } = renderToggle({ enabled: true });
+    // Seed a second, category-filtered cache holding the same row — the view a
+    // selected category rail item mounts.
+    client.setQueryData<PluginsGetResponse>(
+      CATEGORY_KEY,
+      listOf([{ name: NAME, enabled: true }]),
+    );
+
+    result.current.toggle(NAME, false);
+
+    // Both the unfiltered and the category-filtered caches flip optimistically.
+    await waitFor(() => expect(cachedEnabled(client)).toBe(false));
+    expect(cachedEnabled(client, NAME, CATEGORY_KEY)).toBe(false);
+
+    release();
+    await waitFor(() => expect(result.current.togglingName).toBe(null));
+  });
+
   test("calls the enable endpoint with the assistant + name path", async () => {
     const { result } = renderToggle({ enabled: false });
 
@@ -162,6 +224,22 @@ describe("usePluginToggle", () => {
     expect(enableSpy).not.toHaveBeenCalled();
   });
 
+  test("treats a 409 (already in state) as success — no rollback, no toast", async () => {
+    // Enabling an already-enabled plugin: the daemon 409s but the desired end
+    // state already holds.
+    enableStatus = 409;
+    const { result, client, invalidateSpy } = renderToggle({ enabled: false });
+
+    result.current.toggle(NAME, true);
+
+    // Settles as success: the optimistic value stays, no rollback, no error
+    // toast, and the invalidation still runs to reconcile with the server.
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+    expect(cachedEnabled(client)).toBe(true);
+    expect(toastErrorSpy).not.toHaveBeenCalled();
+    expect(result.current.togglingName).toBe(null);
+  });
+
   test("rolls back the optimistic flip and toasts on error", async () => {
     disableFails = true;
     const { result, client } = renderToggle({ enabled: true });
@@ -174,6 +252,50 @@ describe("usePluginToggle", () => {
     );
     expect(cachedEnabled(client)).toBe(true);
     expect(result.current.togglingName).toBe(null);
+  });
+
+  test("rollback restores only the toggled row, preserving a concurrent update", async () => {
+    // Two rows both enabled. `alpha` is toggled off and will fail; `beta` is
+    // concurrently flipped off (as another client / mutation would) while
+    // alpha's request is in flight.
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    disableFails = true;
+
+    const client = newClient();
+    client.setQueryData<PluginsGetResponse>(
+      LIST_KEY,
+      listOf([
+        { name: "alpha", enabled: true },
+        { name: "beta", enabled: true },
+      ]),
+    );
+    const { result } = mountToggle(client);
+
+    result.current.toggle("alpha", false);
+    await waitFor(() => expect(cachedEnabled(client, "alpha")).toBe(false));
+
+    // A concurrent update flips beta off while alpha's request is pending.
+    client.setQueryData<PluginsGetResponse>(LIST_KEY, (prev) =>
+      prev
+        ? {
+            ...prev,
+            plugins: prev.plugins.map((p) =>
+              p.name === "beta" ? { ...p, enabled: false } : p,
+            ),
+          }
+        : prev,
+    );
+
+    // Alpha fails: only alpha is rolled back; beta's newer value survives.
+    release();
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(PLUGIN_TOGGLE_ERROR),
+    );
+    expect(cachedEnabled(client, "alpha")).toBe(true);
+    expect(cachedEnabled(client, "beta")).toBe(false);
   });
 
   test("invalidates the plugin queries on settle", async () => {

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
@@ -24,56 +24,69 @@ export interface UsePluginToggleResult {
 
 /**
  * Optimistic enable/disable mutation for the Plugins tab. Flips the installed
- * row's `enabled` in the cached list immediately, rolls the snapshot back and
- * toasts on failure, and invalidates the plugin queries on settle so the cache
- * re-syncs with the daemon (which also broadcasts `sync_changed`). Mirrors the
- * optimistic pattern in `settings/pages/sounds-page.tsx`.
+ * row's `enabled` in every cached `pluginsGet` variant immediately (the
+ * unfiltered list plus every `?category=` filtered read `usePluginsList`
+ * mounts), rolls back only that row's field and toasts on failure, and
+ * invalidates the plugin queries on settle so the cache re-syncs with the
+ * daemon (which also broadcasts `sync_changed`). Mirrors the optimistic
+ * pattern in `settings/pages/sounds-page.tsx`.
  *
  * No confirm dialog — the action is reversible.
  */
 export function usePluginToggle(assistantId: string): UsePluginToggleResult {
   const queryClient = useQueryClient();
 
-  // The unfiltered installed-list key `usePluginsList` reads for the default
-  // (no category) view; also the key `invalidatePluginQueries` staleness-marks.
-  const listQueryKey = pluginsGetQueryKey({
-    path: { assistant_id: assistantId },
-    query: { q: undefined },
-  });
+  // Partial key matching every `pluginsGet` cache for this assistant — the
+  // unfiltered list AND each server-side `?category=` filtered read. Omitting
+  // `query` makes TanStack partial-match all variants (same idiom as
+  // `invalidatePluginQueries`); patching only the unfiltered key would leave a
+  // category-filtered view stale until the settle refetch.
+  const listQueryFilter = {
+    queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
+  };
+
+  // Set `name`'s `enabled` across every matching cache variant, leaving other
+  // rows (and other caches) untouched.
+  const setRowEnabled = (name: string, enabled: boolean) => {
+    queryClient.setQueriesData<PluginsGetResponse>(listQueryFilter, (prev) =>
+      prev
+        ? {
+            ...prev,
+            plugins: prev.plugins.map((plugin) =>
+              plugin.name === name ? { ...plugin, enabled } : plugin,
+            ),
+          }
+        : prev,
+    );
+  };
 
   const mutation = useMutation({
-    mutationFn: ({ name, nextEnabled }: TogglePluginVariables) =>
-      nextEnabled
+    mutationFn: async ({ name, nextEnabled }: TogglePluginVariables) => {
+      const result = await (nextEnabled
         ? pluginsByNameEnablePost({
             path: { assistant_id: assistantId, name },
-            throwOnError: true,
+            throwOnError: false,
           })
         : pluginsByNameDisablePost({
             path: { assistant_id: assistantId, name },
-            throwOnError: true,
-          }),
-    onMutate: async ({ name, nextEnabled }) => {
-      await queryClient.cancelQueries({ queryKey: listQueryKey });
-      const previous =
-        queryClient.getQueryData<PluginsGetResponse>(listQueryKey);
-      queryClient.setQueryData<PluginsGetResponse>(listQueryKey, (prev) =>
-        prev
-          ? {
-              ...prev,
-              plugins: prev.plugins.map((plugin) =>
-                plugin.name === name
-                  ? { ...plugin, enabled: nextEnabled }
-                  : plugin,
-              ),
-            }
-          : prev,
-      );
-      return { previous };
+            throwOnError: false,
+          }));
+      // 409 means the plugin is already in the desired state — a no-op from a
+      // stale cache or a second client. The end state holds, so treat it as
+      // success and let `onSettled` refetch the truth; only other non-ok
+      // statuses are real failures.
+      const status = result.response?.status;
+      if (result.response?.ok || status === 409) return result;
+      throw new Error(`Plugin toggle failed (${status ?? "network error"})`);
     },
-    onError: (_error, _variables, context) => {
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(listQueryKey, context.previous);
-      }
+    onMutate: async ({ name, nextEnabled }) => {
+      await queryClient.cancelQueries(listQueryFilter);
+      setRowEnabled(name, nextEnabled);
+    },
+    onError: (_error, { name, nextEnabled }) => {
+      // Roll back only this row's `enabled` — a full-snapshot restore would
+      // clobber a concurrent toggle's newer value on a different row.
+      setRowEnabled(name, !nextEnabled);
       toast.error(PLUGIN_TOGGLE_ERROR);
     },
     onSettled: (_data, _error, variables) => {

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { PLUGIN_TOGGLE_ERROR } from "@/domains/intelligence/plugins/constants";
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
+import { pluginsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+    pluginsByNameDisablePost,
+    pluginsByNameEnablePost,
+} from "@/generated/daemon/sdk.gen";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { toast } from "@vellumai/design-library";
+
+interface TogglePluginVariables {
+  name: string;
+  nextEnabled: boolean;
+}
+
+export interface UsePluginToggleResult {
+  /** Enable (`nextEnabled=true`) or disable a plugin, optimistically. */
+  toggle: (name: string, nextEnabled: boolean) => void;
+  /** Name of the plugin whose toggle is in flight, or `null` when idle. */
+  togglingName: string | null;
+}
+
+/**
+ * Optimistic enable/disable mutation for the Plugins tab. Flips the installed
+ * row's `enabled` in the cached list immediately, rolls the snapshot back and
+ * toasts on failure, and invalidates the plugin queries on settle so the cache
+ * re-syncs with the daemon (which also broadcasts `sync_changed`). Mirrors the
+ * optimistic pattern in `settings/pages/sounds-page.tsx`.
+ *
+ * No confirm dialog — the action is reversible.
+ */
+export function usePluginToggle(assistantId: string): UsePluginToggleResult {
+  const queryClient = useQueryClient();
+
+  // The unfiltered installed-list key `usePluginsList` reads for the default
+  // (no category) view; also the key `invalidatePluginQueries` staleness-marks.
+  const listQueryKey = pluginsGetQueryKey({
+    path: { assistant_id: assistantId },
+    query: { q: undefined },
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({ name, nextEnabled }: TogglePluginVariables) =>
+      nextEnabled
+        ? pluginsByNameEnablePost({
+            path: { assistant_id: assistantId, name },
+            throwOnError: true,
+          })
+        : pluginsByNameDisablePost({
+            path: { assistant_id: assistantId, name },
+            throwOnError: true,
+          }),
+    onMutate: async ({ name, nextEnabled }) => {
+      await queryClient.cancelQueries({ queryKey: listQueryKey });
+      const previous =
+        queryClient.getQueryData<PluginsGetResponse>(listQueryKey);
+      queryClient.setQueryData<PluginsGetResponse>(listQueryKey, (prev) =>
+        prev
+          ? {
+              ...prev,
+              plugins: prev.plugins.map((plugin) =>
+                plugin.name === name
+                  ? { ...plugin, enabled: nextEnabled }
+                  : plugin,
+              ),
+            }
+          : prev,
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(listQueryKey, context.previous);
+      }
+      toast.error(PLUGIN_TOGGLE_ERROR);
+    },
+    onSettled: (_data, _error, variables) => {
+      invalidatePluginQueries(queryClient, assistantId, variables.name);
+    },
+  });
+
+  const toggle = (name: string, nextEnabled: boolean) => {
+    mutation.mutate({ name, nextEnabled });
+  };
+
+  return {
+    toggle,
+    togglingName: mutation.isPending ? (mutation.variables?.name ?? null) : null,
+  };
+}


### PR DESCRIPTION
## Summary
- Optimistic enable/disable mutation hook (flip + rollback + toast + invalidate), mirroring the sounds-page pattern
- Adds PLUGIN_TOGGLE_ERROR copy

`usePluginToggle(assistantId)` returns `{ toggle(name, nextEnabled), togglingName }`. One `useMutation` branches on `nextEnabled` to call the regenerated `pluginsByNameEnablePost` / `pluginsByNameDisablePost` with `{ path: { assistant_id, name } }`. `onMutate` cancels + snapshots the unfiltered installed-list query and optimistically flips that row's `enabled`; `onError` restores the snapshot and toasts `PLUGIN_TOGGLE_ERROR`; `onSettled` invalidates the plugin queries. `togglingName` is derived from the mutation's pending state. No confirm dialog (reversible). No UI wiring yet.

Part of plan: plugin-enable-disable.md (PR 5 of 9)