### PR TITLE
feat(web): plugin card Active/Off toggle beside Remove

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -144,6 +144,21 @@ describe("PluginListRow", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  test("Remove is disabled while an upgrade is in flight (no concurrent delete)", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        drift={makeDrift("update-available")}
+        onSelect={() => {}}
+        onRemove={() => {}}
+        onUpgrade={() => {}}
+        isUpgrading
+      />,
+    );
+
+    expect(getButton("Remove plugin").disabled).toBe(true);
+  });
+
   test("does not render an origin badge (origin is unknowable from the list)", () => {
     const onSelect = mock(() => {});
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -164,6 +164,7 @@ describe("PluginListRow", () => {
 
   test("upgrade affordance only appears with update-available drift", () => {
     const onSelect = mock(() => {});
+    const onUpgrade = mock(() => {});
 
     // Up-to-date installed plugin shows Remove, not Upgrade.
     const { rerender } = render(
@@ -171,6 +172,7 @@ describe("PluginListRow", () => {
         item={makeItem({ status: "installed" })}
         drift={makeDrift("up-to-date")}
         onSelect={onSelect}
+        onUpgrade={onUpgrade}
       />,
     );
 
@@ -181,17 +183,131 @@ describe("PluginListRow", () => {
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
 
-    // Same plugin with drift now exposes Upgrade.
+    // Same plugin with drift now exposes Upgrade (Remove stays put).
     rerender(
       <PluginListRow
         item={makeItem({ status: "installed" })}
         drift={makeDrift("update-available")}
         onSelect={onSelect}
+        onUpgrade={onUpgrade}
       />,
     );
 
     expect(
       document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).not.toBeNull();
+  });
+
+  test("Active installed row shows an on switch beside Remove", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: true })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(getButton("Turn Test Plugin off").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).not.toBeNull();
+  });
+
+  test("toggling an Active row fires onToggle(false) without selecting", () => {
+    const onSelect = mock(() => {});
+    const onToggle = mock((_next: boolean) => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: true })}
+        onSelect={onSelect}
+        onToggle={onToggle}
+      />,
+    );
+
+    fireEvent.click(getButton("Turn Test Plugin off"));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith(false);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("Off row is dimmed and its switch reads off", () => {
+    const { getByText } = render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: false })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+      />,
+    );
+
+    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    // Off rows dim the name to the tertiary content token.
+    expect(getByText("Test Plugin").style.color).toContain("content-tertiary");
+  });
+
+  test("drift renders the Update chip (Remove stays), even when Off", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: false })}
+        drift={makeDrift("update-available")}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+        onUpgrade={mock(() => {})}
+      />,
+    );
+
+    // Drift is an Update chip, not a Remove-replacing button: both are present.
+    expect(
+      document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).not.toBeNull();
+    // The chip shows regardless of Active/Off — the row here is Off.
+    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  test("available row shows only Install (no switch, no Remove)", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "available" })}
+        onSelect={mock(() => {})}
+        onInstall={mock(() => {})}
+      />,
+    );
+
+    expect(
+      document.querySelector('button[aria-label="Install plugin"]'),
+    ).not.toBeNull();
+    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).toBeNull();
+  });
+
+  test("installed row without `enabled` (older daemon) renders no switch", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    // Remove is still present for installed rows.
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -180,7 +180,7 @@ export function PluginListRow({
                 e.stopPropagation();
                 onRemove?.();
               }}
-              disabled={isRemoving || !onRemove}
+              disabled={isRemoving || isUpgrading || !onRemove}
               aria-label="Remove plugin"
               expandOnMobile={false}
             />

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -1,11 +1,11 @@
-import { ArrowDownToLine, ArrowUpCircle, Loader2, Trash2 } from "lucide-react";
+import { ArrowDownToLine, Loader2, Trash2 } from "lucide-react";
 import type { KeyboardEvent } from "react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
-import { Button, Card } from "@vellumai/design-library";
+import { Button, Card, Toggle } from "@vellumai/design-library";
 
 interface PluginListRowProps {
   item: PluginListItem;
@@ -16,18 +16,23 @@ interface PluginListRowProps {
   onInstall?: () => void;
   onRemove?: () => void;
   onUpgrade?: () => void;
+  /** Enable/disable the installed plugin. Wired only when the daemon supports
+   *  toggling (older daemons omit `enabled`, so no switch renders). */
+  onToggle?: (nextEnabled: boolean) => void;
   isInstalling?: boolean;
   isRemoving?: boolean;
   isUpgrading?: boolean;
+  isToggling?: boolean;
 }
 
 /**
  * Unified row for the Plugins tab, mirroring `SkillRow`: an emoji icon, the
- * name with version + update badge, a description, and a single trailing
- * inline action chosen by status (Install for catalog entries, Upgrade when an
- * installed copy is behind the marketplace pin, otherwise Remove). The whole
- * row is a `role="button"` that fires `onSelect`; the trailing action
- * `stopPropagation`s so it never also selects the row.
+ * name with version + update badge, a description, and trailing inline
+ * actions. Catalog entries show only Install; installed rows show an
+ * Active/Off `Toggle` beside an always-present Remove, plus an "Update" chip
+ * on the version line when the installed copy is behind the marketplace pin.
+ * The whole row is a `role="button"` that fires `onSelect`; every trailing
+ * control `stopPropagation`s so it never also selects the row.
  */
 export function PluginListRow({
   item,
@@ -36,12 +41,16 @@ export function PluginListRow({
   onInstall,
   onRemove,
   onUpgrade,
+  onToggle,
   isInstalling = false,
   isRemoving = false,
   isUpgrading = false,
+  isToggling = false,
 }: PluginListRowProps) {
   const available = item.status === "available";
   const updateAvailable = drift?.status === "update-available";
+  const showToggle = onToggle !== undefined && item.enabled !== undefined;
+  const dimmed = item.enabled === false;
 
   const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     // Ignore key events bubbling up from a focused inline action button —
@@ -62,12 +71,20 @@ export function PluginListRow({
         onKeyDown={handleRowKeyDown}
         className="flex cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-        <PluginIcon size="sm" external={item.external} />
+        <PluginIcon
+          size="sm"
+          external={item.external}
+          className={dimmed ? "opacity-50" : undefined}
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span
               className="truncate text-body-medium-default"
-              style={{ color: "var(--content-emphasised)" }}
+              style={{
+                color: dimmed
+                  ? "var(--content-tertiary)"
+                  : "var(--content-emphasised)",
+              }}
             >
               {item.name}
             </span>
@@ -82,7 +99,14 @@ export function PluginListRow({
             {/* No origin badge here: the installed-list endpoint carries no
                 source, so a list row can't tell Local from External. The detail
                 view derives origin from the plugin's own `source` instead. */}
-            {updateAvailable ? <UpdateAvailableBadge /> : null}
+            {/* The chip is the Upgrade control; it shows on any drift,
+                regardless of Active/Off. */}
+            {updateAvailable ? (
+              <UpdateAvailableBadge
+                onClick={onUpgrade}
+                isUpgrading={isUpgrading}
+              />
+            ) : null}
           </div>
           <p
             className="mt-1 truncate text-body-medium-lighter"
@@ -126,43 +150,41 @@ export function PluginListRow({
               expandOnMobile={false}
             />
           )
-        ) : updateAvailable ? (
-          <Button
-            type="button"
-            iconOnly={
-              isUpgrading ? (
-                <Loader2 className="animate-spin" aria-hidden />
-              ) : (
-                <ArrowUpCircle aria-hidden />
-              )
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              onUpgrade?.();
-            }}
-            disabled={isUpgrading || !onUpgrade}
-            aria-label="Upgrade plugin"
-            expandOnMobile={false}
-          />
         ) : (
-          <Button
-            type="button"
-            variant="dangerOutline"
-            iconOnly={
-              isRemoving ? (
-                <Loader2 className="animate-spin" aria-hidden />
-              ) : (
-                <Trash2 aria-hidden />
-              )
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove?.();
-            }}
-            disabled={isRemoving || !onRemove}
-            aria-label="Remove plugin"
-            expandOnMobile={false}
-          />
+          // Installed: Active/Off switch beside an always-present Remove (Upgrade
+          // lives in the version-line chip), so the pair never shifts.
+          <div className="flex shrink-0 items-center gap-2">
+            {showToggle ? (
+              // Toggle has no onClick to stopPropagation, so wrap it: the row is
+              // a role="button" and would otherwise select on switch clicks.
+              <span onClick={(e) => e.stopPropagation()}>
+                <Toggle
+                  checked={item.enabled ?? false}
+                  onChange={() => onToggle?.(!item.enabled)}
+                  disabled={isToggling}
+                  aria-label={`Turn ${item.name} ${item.enabled ? "off" : "on"}`}
+                />
+              </span>
+            ) : null}
+            <Button
+              type="button"
+              variant="dangerOutline"
+              iconOnly={
+                isRemoving ? (
+                  <Loader2 className="animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 aria-hidden />
+                )
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove?.();
+              }}
+              disabled={isRemoving || !onRemove}
+              aria-label="Remove plugin"
+              expandOnMobile={false}
+            />
+          </div>
         )}
       </div>
     </Card.Root>

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -27,6 +27,7 @@ import {
     pluginRiskyUpgradeConfirmMessage,
 } from "@/domains/intelligence/plugins/constants";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type {
     InstalledPlugin,
     PluginCatalogMatch,
@@ -119,12 +120,17 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     isFetching,
     catalogError,
     categorySupported,
+    pluginToggleSupported,
     installedCategoryCounts,
     installedPlugins,
     installedTotal,
     catalogMatches,
     unfilteredInstalledNames,
   } = usePluginsList(assistantId, effectiveCategory);
+
+  // Optimistic enable/disable. Wired into installed rows only when the daemon
+  // supports it (see `pluginToggleSupported`).
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
@@ -322,8 +328,14 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
                   onSelect={() => handleSelect(item)}
                   onRemove={() => setPendingRemoval(item)}
                   onUpgrade={(drift) => handleUpgrade(item, drift)}
+                  onToggle={
+                    pluginToggleSupported
+                      ? (next) => toggle(item.name, next)
+                      : undefined
+                  }
                   isRemoving={removingName === item.name}
                   isUpgrading={upgradingName === item.name}
+                  isToggling={togglingName === item.name}
                 />
               ) : (
                 <PluginListRow
@@ -477,8 +489,11 @@ interface InstalledPluginRowProps {
   onSelect: () => void;
   onRemove: () => void;
   onUpgrade: (drift: PluginDrift | undefined) => void;
+  /** `undefined` when the daemon doesn't support toggling (no switch). */
+  onToggle: ((nextEnabled: boolean) => void) | undefined;
   isRemoving: boolean;
   isUpgrading: boolean;
+  isToggling: boolean;
 }
 
 /**
@@ -493,8 +508,10 @@ function InstalledPluginRow({
   onSelect,
   onRemove,
   onUpgrade,
+  onToggle,
   isRemoving,
   isUpgrading,
+  isToggling,
 }: InstalledPluginRowProps) {
   const driftQuery = usePluginDrift({ assistantId, name: item.name });
   const drift = driftQuery.data;
@@ -506,8 +523,10 @@ function InstalledPluginRow({
       onSelect={onSelect}
       onRemove={onRemove}
       onUpgrade={() => onUpgrade(drift)}
+      onToggle={onToggle}
       isRemoving={isRemoving}
       isUpgrading={isUpgrading}
+      isToggling={isToggling}
     />
   );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
@@ -2,16 +2,55 @@
  * Small pill flagging that an installed plugin is behind the marketplace
  * pin. Shared by the plugins list row and the plugin detail header so the
  * "update available" affordance reads identically on both surfaces.
+ *
+ * Pass `onClick` to turn the pill into the Upgrade control (list row); omit
+ * it for the static detail-header badge.
  */
-import { ArrowUpCircle } from "lucide-react";
+import { ArrowUpCircle, Loader2 } from "lucide-react";
 import { createElement } from "react";
 
 import { Tag } from "@vellumai/design-library";
 
-export function UpdateAvailableBadge() {
-  return (
-    <Tag tone="warning" leftIcon={createElement(ArrowUpCircle)} className="shrink-0">
+interface UpdateAvailableBadgeProps {
+  /**
+   * When provided the pill becomes an interactive Upgrade control: clicking it
+   * triggers the upgrade and stops the click from selecting the row it sits in.
+   */
+  onClick?: () => void;
+  /** Swap the icon for a spinner and disable the control while upgrading. */
+  isUpgrading?: boolean;
+}
+
+export function UpdateAvailableBadge({
+  onClick,
+  isUpgrading = false,
+}: UpdateAvailableBadgeProps = {}) {
+  const badge = (
+    <Tag
+      tone="warning"
+      leftIcon={createElement(isUpgrading ? Loader2 : ArrowUpCircle, {
+        className: isUpgrading ? "animate-spin" : undefined,
+      })}
+      className="shrink-0"
+    >
       Update available
     </Tag>
+  );
+
+  if (!onClick) return badge;
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      disabled={isUpgrading}
+      aria-label="Upgrade plugin"
+      className="shrink-0 rounded-[6px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed"
+    >
+      {badge}
+    </button>
   );
 }


### PR DESCRIPTION
## Summary
- Add an Active/Off Toggle to installed plugin rows (left of Remove, MCP-card style); dim Off rows
- Move drift to an Update chip so Remove is always present; wire usePluginToggle in the tab (gated on support)

Part of plan: plugin-enable-disable.md (PR 6 of 9)