### PR TITLE
feat(web): Active/Off toggle in the plugin detail page

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -90,6 +90,11 @@ mock.module("@/domains/intelligence/plugins/use-plugin-detail", () => ({
   // `plugins/utils`, so the real helper runs.
 }));
 
+// Stub the toggle hook so the mobile detail doesn't require a QueryClient here.
+mock.module("@/domains/intelligence/plugins/use-plugin-toggle", () => ({
+  usePluginToggle: () => ({ toggle: () => {}, togglingName: null }),
+}));
+
 const { PluginDetailMobile } = await import(
   "@/domains/intelligence/components/plugins/plugin-detail-mobile.js"
 );
@@ -181,6 +186,33 @@ describe("PluginDetailMobile", () => {
     );
 
     expect(getActionButton("Remove")).toBeTruthy();
+  });
+
+  test("installed plugin: Active/Off toggle appears when enabled is provided", () => {
+    hookState.plugin = makePlugin({ installed: true });
+
+    render(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+        enabled={true}
+      />,
+    );
+
+    // The design-library Toggle renders a role="switch"; mobile detail must wire
+    // it so phone users can enable/disable, matching the desktop detail.
+    expect(screen.getByRole("switch")).toBeTruthy();
+  });
+
+  test("installed plugin: no toggle when enabled is undefined", () => {
+    hookState.plugin = makePlugin({ installed: true });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(screen.queryByRole("switch")).toBeNull();
   });
 
   test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -14,6 +14,7 @@ import {
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailMobileProps {
@@ -26,6 +27,12 @@ interface PluginDetailMobileProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
+  /**
+   * Active/Off state from the selected list row (the per-plugin detail response
+   * doesn't carry `enabled`). `undefined` hides the toggle (older daemon /
+   * deep-link with no matching row).
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -52,6 +59,7 @@ export function PluginDetailMobile({
   name,
   onBack,
   externalHint,
+  enabled,
 }: PluginDetailMobileProps) {
   const {
     plugin,
@@ -69,6 +77,7 @@ export function PluginDetailMobile({
     isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   // Resolve the full-screen portal target after commit (SSR-safe; the element
   // is mounted by RootLayout). Falls back to inline when absent (tests, first
@@ -161,6 +170,9 @@ export function PluginDetailMobile({
           <PluginDetailActions
             plugin={plugin}
             drift={drift}
+            enabled={enabled}
+            onToggle={() => toggle(name, !enabled)}
+            isToggling={togglingName === name}
             onInstall={install}
             onRemove={remove}
             onUpgrade={upgrade}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -1,15 +1,19 @@
 /**
- * Focused tests for the presentational `PluginDetailMetadata` building block.
- * The panel/page tests cover the install/remove/upgrade flow end-to-end; this
- * pins the metadata table's net-new branch — the contributed-surface counts
+ * Focused tests for the presentational plugin-detail building blocks. The
+ * panel/page tests cover the install/remove/upgrade flow end-to-end; this pins
+ * `PluginDetailMetadata`'s net-new branch — the contributed-surface counts
  * (Skills / Hooks / Tools) that only render when an installed copy's drift
- * inspection supplies them. Presentational, so no QueryClient is needed.
+ * inspection supplies them — plus the `PluginDetailActions` Active/Off toggle.
+ * Both are presentational, so no QueryClient is needed.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { PluginDetailMetadata } from "@/domains/intelligence/components/plugins/plugin-detail-shared";
+import {
+    PluginDetailActions,
+    PluginDetailMetadata,
+} from "@/domains/intelligence/components/plugins/plugin-detail-shared";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 
@@ -72,5 +76,119 @@ describe("PluginDetailMetadata", () => {
 
     expect(html).toContain("Local");
     expect(html).not.toContain("href=\"https://github.com");
+  });
+});
+
+const updateAvailableDrift: PluginDrift = {
+  name: "level-up",
+  installed: true,
+  status: "update-available",
+  local: null,
+  remote: null,
+  remoteError: null,
+  surfaces: null,
+};
+
+const noop = () => {};
+
+const baseActionsProps = {
+  plugin: githubPlugin,
+  drift: undefined,
+  onInstall: noop,
+  onRemove: noop,
+  onUpgrade: noop,
+  isInstalling: false,
+  isRemoving: false,
+  isUpgrading: false,
+  hasLocalEdits: false,
+};
+
+describe("PluginDetailActions Active/Off toggle", () => {
+  test("renders an Active toggle + word reflecting an enabled plugin", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("Active")).toBeTruthy();
+  });
+
+  test("renders an Off toggle + word reflecting a disabled plugin", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled={false}
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    expect(screen.getByText("Off")).toBeTruthy();
+  });
+
+  test("calls onToggle when the switch is clicked (no confirm)", () => {
+    const onToggle = mock(noop);
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={onToggle}
+        isToggling={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // Optimistic: the switch flips without opening any dialog.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("keeps Upgrade available and enabled when the plugin is Off and drifted", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        drift={updateAvailableDrift}
+        enabled={false}
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    const upgrade = screen.getByRole("button", { name: /Upgrade/ });
+    expect(upgrade.hasAttribute("disabled")).toBe(false);
+  });
+
+  test("Remove still opens its confirm dialog", async () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(
+      await screen.findByText(/Remove "level-up" from this assistant\?/),
+    ).toBeTruthy();
+  });
+
+  test("hides the toggle + word when enablement is unknown", () => {
+    render(<PluginDetailActions {...baseActionsProps} />);
+
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText("Active")).toBeNull();
+    expect(screen.queryByText("Off")).toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -21,7 +21,7 @@ import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { cn } from "@/utils/misc";
-import { Button, ConfirmDialog } from "@vellumai/design-library";
+import { Button, ConfirmDialog, Toggle } from "@vellumai/design-library";
 
 /**
  * Presentational building blocks shared by the plugin detail surfaces so the
@@ -152,6 +152,19 @@ interface PluginDetailActionsProps {
   isUpgrading: boolean;
   /** Gates whether an upgrade prompts before overwriting local edits. */
   hasLocalEdits: boolean;
+  /**
+   * Whether the installed copy is active in this workspace. `undefined` when the
+   * enablement isn't known (older daemon, or a deep-link with no list row) — the
+   * Active/Off toggle is hidden in that case. Only meaningful when installed.
+   */
+  enabled?: boolean;
+  /**
+   * Flip the plugin's active state (optimistic, no confirm). Paired with
+   * `enabled`; when either is absent the toggle is hidden.
+   */
+  onToggle?: () => void;
+  /** True while this plugin's enable/disable request is in flight. */
+  isToggling?: boolean;
 }
 
 /**
@@ -171,6 +184,9 @@ export function PluginDetailActions({
   isRemoving,
   isUpgrading,
   hasLocalEdits,
+  enabled,
+  onToggle,
+  isToggling,
 }: PluginDetailActionsProps) {
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
@@ -210,6 +226,25 @@ export function PluginDetailActions({
         // Wrap on narrow (mobile overlay) widths so a Download + Upgrade +
         // Remove set can't push actions off-screen; single row on desktop.
         <div className="flex flex-wrap items-center gap-2 md:flex-nowrap md:shrink-0">
+          {/* Active/Off toggle leads the cluster (mirrors the MCP card). Hidden
+              when enablement is unknown — an older daemon or a deep-link with no
+              list row to source it from. Optimistic, so no confirm dialog. */}
+          {enabled !== undefined && onToggle ? (
+            <div className="flex items-center gap-2">
+              <Toggle
+                checked={enabled}
+                onChange={onToggle}
+                disabled={isToggling}
+                aria-label={`${enabled ? "Deactivate" : "Activate"} ${plugin.name}`}
+              />
+              <span
+                className="text-body-small-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                {enabled ? "Active" : "Off"}
+              </span>
+            </div>
+          ) : null}
           {artifact ? (
             <Button asChild leftIcon={<Download aria-hidden />}>
               <a href={artifact.url} download>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -12,6 +12,7 @@ import {
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { Button, Card } from "@vellumai/design-library";
@@ -27,6 +28,12 @@ interface PluginDetailProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
+  /**
+   * Active/Off state from the selected list row (the detail GET carries no
+   * enablement). `undefined` on older daemons or a deep-link with no matching
+   * row — the Active/Off toggle stays hidden in that case.
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -48,6 +55,7 @@ export function PluginDetail({
   name,
   onBack,
   externalHint,
+  enabled,
 }: PluginDetailProps) {
   const {
     plugin,
@@ -65,6 +73,8 @@ export function PluginDetail({
     isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
@@ -88,6 +98,9 @@ export function PluginDetail({
           isRemoving={isRemoving}
           isUpgrading={isUpgrading}
           hasLocalEdits={hasLocalEdits}
+          enabled={enabled}
+          onToggle={() => toggle(name, !enabled)}
+          isToggling={togglingName === name}
         />
       </div>
 
@@ -141,6 +154,9 @@ interface HeaderProps {
   isRemoving: boolean;
   isUpgrading: boolean;
   hasLocalEdits: boolean;
+  enabled?: boolean;
+  onToggle?: () => void;
+  isToggling: boolean;
 }
 
 function Header({
@@ -155,6 +171,9 @@ function Header({
   isRemoving,
   isUpgrading,
   hasLocalEdits,
+  enabled,
+  onToggle,
+  isToggling,
 }: HeaderProps) {
   const isExternal = plugin?.source?.kind === "github";
   // Gate the header icon on the loaded plugin, seeding the known external state
@@ -214,6 +233,9 @@ function Header({
           isRemoving={isRemoving}
           isUpgrading={isUpgrading}
           hasLocalEdits={hasLocalEdits}
+          enabled={enabled}
+          onToggle={onToggle}
+          isToggling={isToggling}
         />
       ) : null}
     </div>

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -277,17 +277,19 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   const hasActiveSearch = searchValue.trim().length > 0;
 
   if (selectedPluginName) {
-    // Seed the detail header icon from the already-loaded list row: catalog
-    // rows are known-external (📦 immediately, no load-time flash). Installed
-    // rows and unmatched deep-links are `undefined` (origin unknown), so the
-    // header shows a glyph-less placeholder until the detail query resolves.
-    const selectedExternalHint = items.find(
-      (p) => p.name === selectedPluginName,
-    )?.external;
+    // Seed the detail header icon + Active/Off toggle from the already-loaded
+    // list row: catalog rows are known-external (📦 immediately, no load-time
+    // flash). Installed rows and unmatched deep-links are `undefined` (origin
+    // unknown), so the header shows a glyph-less placeholder until the detail
+    // query resolves. `enabled` is likewise sourced from the row — the detail
+    // GET carries no enablement — and is `undefined` for available/deep-link
+    // rows, which hides the toggle.
+    const selectedRow = items.find((p) => p.name === selectedPluginName);
     const detailProps = {
       assistantId,
       name: selectedPluginName,
-      externalHint: selectedExternalHint,
+      externalHint: selectedRow?.external,
+      enabled: selectedRow?.enabled,
       onBack: handleCloseDetail,
     };
     return isMobile ? (


### PR DESCRIPTION
## Summary
- Add an Active/Off toggle (with visible label) to the plugin detail action cluster, before Upgrade/Remove
- Optimistic (no confirm); Remove keeps its confirm; Upgrade stays available even when Off

## Notes
- The detail GET response (`PluginsByNameGetResponse`) carries no `enabled` field, so enablement is threaded as a prop from the selected list row through `plugins-tab.tsx` (mirroring the existing `externalHint` seed). Undefined on older daemons / deep-links with no matching row → toggle hidden.

Part of plan: plugin-enable-disable.md (PR 7 of 9)