### PR TITLE
feat(web): Active/Off plugin status filter + capability gating

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
@@ -35,6 +35,7 @@ function baseProps() {
     counts: {} as Record<string, number>,
     totalCount: 0,
     showCounts: true,
+    pluginToggleSupported: true,
   };
 }
 
@@ -91,16 +92,29 @@ describe("Plugins FilterBar", () => {
     expect(onSearchChange).toHaveBeenCalledWith("memory");
   });
 
-  test("opening the filter and choosing Installed switches the filter", () => {
+  test("opening the filter and choosing Active switches the filter", () => {
     const onFilterChange = mock((_filter: PluginFilter) => {});
     const { getByLabelText } = render(
       <FilterBar {...baseProps()} onFilterChange={onFilterChange} />,
     );
 
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
 
-    expect(onFilterChange).toHaveBeenCalledWith("installed");
+    expect(onFilterChange).toHaveBeenCalledWith("active");
+  });
+
+  test("omits Active/Off when the daemon lacks enable/disable support", () => {
+    const { getByLabelText } = render(
+      <FilterBar {...baseProps()} pluginToggleSupported={false} />,
+    );
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(labels).toEqual(["All", "Available"]);
   });
 
   test("the mobile sheet exposes category rows that report the selected slug", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
@@ -5,6 +5,8 @@ import {
     Filter,
     LayoutGrid,
     Loader2,
+    Power,
+    PowerOff,
     Search,
 } from "lucide-react";
 import { type ChangeEvent, type ReactNode, useState } from "react";
@@ -21,11 +23,27 @@ interface FilterOption {
   icon: typeof LayoutGrid;
 }
 
-const STATUS_FILTERS: FilterOption[] = [
-  { value: "all", label: "All", icon: LayoutGrid },
-  { value: "installed", label: "Installed", icon: CheckCircle },
-  { value: "available", label: "Available", icon: ArrowDownToLine },
-];
+const ALL_FILTER: FilterOption = { value: "all", label: "All", icon: LayoutGrid };
+const AVAILABLE_FILTER: FilterOption = {
+  value: "available",
+  label: "Available",
+  icon: ArrowDownToLine,
+};
+
+/**
+ * Status options for the filter. Active/Off narrow installed rows by
+ * enablement, so they only make sense when the daemon supports toggling —
+ * without it there's no active/off distinction, so fall back to All / Available.
+ */
+function statusFilters(pluginToggleSupported: boolean): FilterOption[] {
+  if (!pluginToggleSupported) return [ALL_FILTER, AVAILABLE_FILTER];
+  return [
+    ALL_FILTER,
+    { value: "active", label: "Active", icon: Power },
+    { value: "off", label: "Off", icon: PowerOff },
+    AVAILABLE_FILTER,
+  ];
+}
 
 interface FilterBarProps {
   search: string;
@@ -42,6 +60,8 @@ interface FilterBarProps {
   counts: Record<string, number>;
   totalCount: number;
   showCounts: boolean;
+  /** Gates the Active/Off status options on daemon enable/disable support. */
+  pluginToggleSupported: boolean;
 }
 
 export function FilterBar({
@@ -56,6 +76,7 @@ export function FilterBar({
   counts,
   totalCount,
   showCounts,
+  pluginToggleSupported,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -88,6 +109,7 @@ export function FilterBar({
         counts={counts}
         totalCount={totalCount}
         showCounts={showCounts}
+        pluginToggleSupported={pluginToggleSupported}
       />
     </div>
   );
@@ -102,6 +124,7 @@ interface FilterControlProps {
   counts: Record<string, number>;
   totalCount: number;
   showCounts: boolean;
+  pluginToggleSupported: boolean;
 }
 
 /**
@@ -144,7 +167,7 @@ function FilterControl(props: FilterControlProps) {
         <ul role="listbox">
           <FilterGroup
             label="Status"
-            options={STATUS_FILTERS}
+            options={statusFilters(props.pluginToggleSupported)}
             selected={props.filter}
             onSelect={(v) => {
               props.onFilterChange(v);
@@ -179,6 +202,7 @@ function FilterSheet({
   counts,
   totalCount,
   showCounts,
+  pluginToggleSupported,
   open,
   onOpenChange,
   trigger,
@@ -200,7 +224,7 @@ function FilterSheet({
         </BottomSheet.Header>
         <BottomSheet.Body className="flex flex-col gap-3 pt-2">
           <SheetSection label="Status">
-            {STATUS_FILTERS.map((option) => (
+            {statusFilters(pluginToggleSupported).map((option) => (
               <FilterRow
                 key={option.value}
                 icon={option.icon}

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -507,6 +507,45 @@ describe("PluginsTab", () => {
     ).toContain("1");
   });
 
+  test("Active/Off category badges count only matching plugins, not the server total", async () => {
+    // Two installed email plugins — one enabled, one disabled. The server's
+    // categoryCounts is the total for ALL installed (email: 2); Active/Off must
+    // reflect only the matching subset, or a badge over-counts rows the filter
+    // hides (and a category with only hidden rows would show empty under a
+    // nonzero badge).
+    installedPlugins = [
+      installed({ id: "on", name: "on-mailer", category: "email", enabled: true }),
+      installed({ id: "off", name: "off-mailer", category: "email", enabled: false }),
+    ];
+    installedCategoryCounts = { email: 2 };
+
+    const { findByRole, getByLabelText } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // All: the server total (2) shows.
+    expect(
+      within(nav).getByRole("button", { name: /Email/ }).textContent,
+    ).toContain("2");
+
+    // Active: only the enabled email plugin — badge drops to 1, not the server's 2.
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Active");
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).toContain("1"),
+    );
+
+    // Off: only the disabled email plugin — also 1.
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Off");
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).toContain("1"),
+    );
+  });
+
   test("hides the rail counts while a search term is active, restoring them when cleared", async () => {
     // Search is client-side (the term never reaches the data hook), so the
     // count gating must key off the term — not react-query's fetch state.

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -280,18 +280,70 @@ describe("PluginsTab", () => {
     expect(queryByText("Available to install")).toBeNull();
   });
 
-  test("status filter narrows the list to installed only", async () => {
-    installedPlugins = [installed()];
+  test("the Active filter narrows to enabled installed plugins", async () => {
+    installedPlugins = [
+      installed({ id: "on", name: "on-plugin", enabled: true }),
+      installed({ id: "off", name: "off-plugin", enabled: false }),
+    ];
     catalogMatches = [catalog()];
 
     const { findByText, queryByText, getByLabelText } = renderTab();
     await findByText("apollo-bot-brain");
 
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
 
-    await waitFor(() => expect(queryByText("apollo-bot-brain")).toBeNull());
-    expect(queryByText("simple-memory")).toBeTruthy();
+    await waitFor(() => expect(queryByText("off-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeNull();
+    expect(queryByText("on-plugin")).toBeTruthy();
+  });
+
+  test("the Off filter narrows to disabled installed plugins", async () => {
+    installedPlugins = [
+      installed({ id: "on", name: "on-plugin", enabled: true }),
+      installed({ id: "off", name: "off-plugin", enabled: false }),
+    ];
+    catalogMatches = [catalog()];
+
+    const { findByText, queryByText, getByLabelText } = renderTab();
+    await findByText("apollo-bot-brain");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Off");
+
+    await waitFor(() => expect(queryByText("on-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeNull();
+    expect(queryByText("off-plugin")).toBeTruthy();
+  });
+
+  test("the Available filter narrows to catalog plugins", async () => {
+    installedPlugins = [installed({ id: "on", name: "on-plugin", enabled: true })];
+    catalogMatches = [catalog()];
+
+    const { findByText, queryByText, getByLabelText } = renderTab();
+    await findByText("on-plugin");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Available");
+
+    await waitFor(() => expect(queryByText("on-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeTruthy();
+  });
+
+  test("hides Active/Off when the daemon lacks enable/disable support", async () => {
+    // `installed()` omits `enabled` (older-daemon shape) → toggle unsupported.
+    installedPlugins = [installed()];
+    catalogMatches = [catalog()];
+
+    const { findByText, getByLabelText } = renderTab();
+    await findByText("apollo-bot-brain");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(labels).toEqual(["All", "Available"]);
   });
 
   test("search filters the list in memory", async () => {
@@ -422,9 +474,10 @@ describe("PluginsTab", () => {
   });
 
   test("respects the status filter when deriving category badges", async () => {
-    // email is installed-only; system is available-only.
+    // email is installed-only; system is available-only. `enabled` on the
+    // installed row latches toggle support so the Active option is offered.
     installedPlugins = [
-      installed({ id: "mailer", name: "mailer", category: "email" }),
+      installed({ id: "mailer", name: "mailer", category: "email", enabled: true }),
     ];
     installedCategoryCounts = { email: 1 };
     catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
@@ -440,10 +493,10 @@ describe("PluginsTab", () => {
       within(nav).getByRole("button", { name: /System/ }).textContent,
     ).toContain("1");
 
-    // "Installed": the available-only System badge drops so it no longer counts
-    // rows the status filter hides; Email (installed) stays 1.
+    // "Active" is installed-only: the available-only System badge drops so it no
+    // longer counts rows the status filter hides; Email (installed) stays 1.
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
     await waitFor(() =>
       expect(
         within(nav).getByRole("button", { name: /System/ }).textContent,

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -132,13 +132,23 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   // supports it (see `pluginToggleSupported`).
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
+  // Active/Off are only offered when the daemon supports enable/disable. If a
+  // prior Active/Off selection carries into an assistant that doesn't support
+  // it, coerce it to All so installed rows don't silently vanish (the picker
+  // only offers All/Available there). Everything that drives display reads this,
+  // not the raw `filter`; `setFilter` still records the raw user choice.
+  const effectiveFilter: PluginFilter =
+    !pluginToggleSupported && (filter === "active" || filter === "off")
+      ? "all"
+      : filter;
+
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
     installedPlugins,
     installedTotal,
     catalogMatches,
     unfilteredInstalledNames,
-    filter,
+    effectiveFilter,
   );
 
   // Two-pane rail only when the daemon understands the category taxonomy AND
@@ -268,10 +278,10 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
 
   const visibleItems = useMemo(
     () =>
-      filterByStatus(items, filter).filter((item) =>
+      filterByStatus(items, effectiveFilter).filter((item) =>
         matchesQuery(item, searchValue),
       ),
-    [items, filter, searchValue],
+    [items, effectiveFilter, searchValue],
   );
 
   // Background-fetch state (focus refetch, post-install invalidation); drives
@@ -318,7 +328,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         catalogLoading && (filter === "all" || filter === "available") ? (
           <LoadingState />
         ) : (
-          <EmptyState filter={filter} category={effectiveCategory} />
+          <EmptyState filter={effectiveFilter} category={effectiveCategory} />
         )
       ) : (
         <ul className="flex flex-col gap-2">
@@ -362,7 +372,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       <FilterBar
         search={searchValue}
         onSearchChange={setSearchValue}
-        filter={filter}
+        filter={effectiveFilter}
         onFilterChange={setFilter}
         isSearching={isSearching}
         categories={categoryRailEnabled ? categories : []}
@@ -451,14 +461,26 @@ function useMergedPluginCounts(
     const includeInstalled = filter !== "available";
     const includeCatalog = filter === "all" || filter === "available";
 
+    // Active/Off narrow the installed set by enablement — which the server's
+    // `installedCategoryCounts` (totals for ALL installed plugins) can't express.
+    // For those filters, bucket the enablement-filtered installed set on the
+    // client so badges/totals never count rows the filter hides.
+    const enablementFiltered = filter === "active" || filter === "off";
+    const matchingInstalled = enablementFiltered
+      ? installedPlugins.filter((p) =>
+          filter === "off" ? p.enabled === false : p.enabled !== false,
+        )
+      : installedPlugins;
+
     if (includeInstalled) {
       if (
+        !enablementFiltered &&
         installedCategoryCounts &&
         Object.keys(installedCategoryCounts).length > 0
       ) {
         Object.assign(counts, installedCategoryCounts);
       } else {
-        for (const plugin of installedPlugins) {
+        for (const plugin of matchingInstalled) {
           const cat = plugin.category ?? SYSTEM_CATEGORY;
           counts[cat] = (counts[cat] ?? 0) + 1;
         }
@@ -476,7 +498,9 @@ function useMergedPluginCounts(
         catalogTotal += 1;
       }
     }
-    const installedTotalResolved = installedTotal ?? installedPlugins.length;
+    const installedTotalResolved = enablementFiltered
+      ? matchingInstalled.length
+      : (installedTotal ?? installedPlugins.length);
     const totalCount =
       (includeInstalled ? installedTotalResolved : 0) + catalogTotal;
     return { counts, totalCount };

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -314,7 +314,8 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       ) : visibleItems.length === 0 ? (
         // Don't flash an "empty" state for available plugins while the
         // catalog is still loading (installed plugins already render above).
-        catalogLoading && filter !== "installed" ? (
+        // Only the filters that surface catalog rows (all/available) wait on it.
+        catalogLoading && (filter === "all" || filter === "available") ? (
           <LoadingState />
         ) : (
           <EmptyState filter={filter} category={effectiveCategory} />
@@ -370,6 +371,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         counts={counts}
         totalCount={totalCount}
         showCounts={!hasActiveSearch}
+        pluginToggleSupported={pluginToggleSupported}
       />
 
       {catalogError && !isLoading && !isError ? (
@@ -443,8 +445,11 @@ function useMergedPluginCounts(
 ): { counts: Record<string, number>; totalCount: number } {
   return useMemo(() => {
     const counts: Record<string, number> = {};
+    // all/active/off all narrow the installed set, so they include installed
+    // rows; only `available` excludes them. Catalog (available) rows count only
+    // for the filters that actually surface them — all and available.
     const includeInstalled = filter !== "available";
-    const includeCatalog = filter !== "installed";
+    const includeCatalog = filter === "all" || filter === "available";
 
     if (includeInstalled) {
       if (
@@ -671,10 +676,16 @@ function getEmptyStateCopy(
     };
   }
   switch (filter) {
-    case "installed":
+    case "active":
       return {
-        title: "No Plugins Installed",
-        subtitle: "Install a plugin from the catalog to extend your assistant.",
+        title: "No Active Plugins",
+        subtitle: "Install a plugin from the catalog, or turn on an installed one.",
+        Icon: Puzzle,
+      };
+    case "off":
+      return {
+        title: "No Plugins Turned Off",
+        subtitle: "Installed plugins you turn off will appear here.",
         Icon: Puzzle,
       };
     case "available":

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -5,7 +5,12 @@ import type {
 
 export type PluginStatus = "installed" | "available";
 
-export type PluginFilter = "all" | "installed" | "available";
+/**
+ * User-facing status filter. Orthogonal to `PluginStatus`: `active` and `off`
+ * both narrow the installed set by enablement (Active = installed & enabled,
+ * Off = installed & !enabled), while `available` is the not-installed catalog.
+ */
+export type PluginFilter = "all" | "active" | "off" | "available";
 
 /**
  * Unified row model for the Plugins tab, populated from two independent

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -139,24 +139,33 @@ describe("sortPlugins", () => {
 
 describe("filterByStatus", () => {
   const items = [
-    item({ name: "a", status: "installed" }),
-    item({ name: "b", status: "available" }),
-    item({ name: "c", status: "installed" }),
+    item({ name: "on", status: "installed", enabled: true }),
+    item({ name: "off", status: "installed", enabled: false }),
+    item({ name: "legacy", status: "installed" }), // enabled undefined
+    item({ name: "catalog", status: "available" }),
   ];
 
   test("all returns everything", () => {
-    expect(filterByStatus(items, "all")).toHaveLength(3);
+    expect(filterByStatus(items, "all")).toHaveLength(4);
   });
 
-  test("installed returns only installed", () => {
-    expect(filterByStatus(items, "installed").map((p) => p.name)).toEqual([
-      "a",
-      "c",
+  test("active returns installed rows that aren't explicitly disabled", () => {
+    // `undefined` enablement (older daemons) counts as active — the plugin is
+    // installed and not turned off, so it must not vanish.
+    expect(filterByStatus(items, "active").map((p) => p.name)).toEqual([
+      "on",
+      "legacy",
     ]);
   });
 
-  test("available returns only available", () => {
-    expect(filterByStatus(items, "available").map((p) => p.name)).toEqual(["b"]);
+  test("off returns only explicitly disabled installed rows", () => {
+    expect(filterByStatus(items, "off").map((p) => p.name)).toEqual(["off"]);
+  });
+
+  test("available returns only catalog rows", () => {
+    expect(filterByStatus(items, "available").map((p) => p.name)).toEqual([
+      "catalog",
+    ]);
   });
 });
 

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -69,8 +69,24 @@ export function filterByStatus(
   items: PluginListItem[],
   filter: PluginFilter,
 ): PluginListItem[] {
-  if (filter === "all") return items;
-  return items.filter((i) => i.status === filter);
+  switch (filter) {
+    case "all":
+      return items;
+    case "available":
+      return items.filter((i) => i.status === "available");
+    // Active = installed & enabled. Enablement `undefined` (older daemons) is
+    // treated as active, so a plugin never silently disappears when the daemon
+    // predates enable/disable.
+    case "active":
+      return items.filter(
+        (i) => i.status === "installed" && i.enabled !== false,
+      );
+    // Off = installed & explicitly disabled.
+    case "off":
+      return items.filter(
+        (i) => i.status === "installed" && i.enabled === false,
+      );
+  }
 }
 
 /** First 7 chars of a commit SHA, matching git's default short form. */


### PR DESCRIPTION
## Summary
- Replace the status filter with All / Active / Off / Available (Active/Off gated on daemon support)
- Update filterByStatus + rail count inclusion for the new values; refresh empty-state copy

Part of plan: plugin-enable-disable.md (PR 8 of 9)