### PR TITLE
fix: restore Installed status filter for daemons without enable/disable

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
@@ -33,10 +33,17 @@ const AVAILABLE_FILTER: FilterOption = {
 /**
  * Status options for the filter. Active/Off narrow installed rows by
  * enablement, so they only make sense when the daemon supports toggling —
- * without it there's no active/off distinction, so fall back to All / Available.
+ * without it there's no active/off distinction, so offer a plain Installed
+ * option instead (All / Installed / Available).
  */
 function statusFilters(pluginToggleSupported: boolean): FilterOption[] {
-  if (!pluginToggleSupported) return [ALL_FILTER, AVAILABLE_FILTER];
+  if (!pluginToggleSupported) {
+    return [
+      ALL_FILTER,
+      { value: "installed", label: "Installed", icon: CheckCircle },
+      AVAILABLE_FILTER,
+    ];
+  }
   return [
     ALL_FILTER,
     { value: "active", label: "Active", icon: Power },

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -330,20 +330,26 @@ describe("PluginsTab", () => {
     expect(queryByText("apollo-bot-brain")).toBeTruthy();
   });
 
-  test("hides Active/Off when the daemon lacks enable/disable support", async () => {
+  test("offers Installed (not Active/Off) and filters to installed rows when the daemon lacks enable/disable support", async () => {
     // `installed()` omits `enabled` (older-daemon shape) → toggle unsupported.
     installedPlugins = [installed()];
     catalogMatches = [catalog()];
 
-    const { findByText, getByLabelText } = renderTab();
+    const { findByText, queryByText, getByLabelText } = renderTab();
     await findByText("apollo-bot-brain");
 
     fireEvent.click(getByLabelText("Filter plugins"));
 
+    // Active/Off are replaced by a plain Installed option.
     const labels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(labels).toEqual(["All", "Available"]);
+    expect(labels).toEqual(["All", "Installed", "Available"]);
+
+    // Installed narrows to installed rows; the catalog (available) row drops.
+    clickStatusOption("Installed");
+    await waitFor(() => expect(queryByText("apollo-bot-brain")).toBeNull());
+    expect(queryByText("simple-memory")).toBeTruthy();
   });
 
   test("search filters the list in memory", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -132,15 +132,18 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   // supports it (see `pluginToggleSupported`).
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
-  // Active/Off are only offered when the daemon supports enable/disable. If a
-  // prior Active/Off selection carries into an assistant that doesn't support
-  // it, coerce it to All so installed rows don't silently vanish (the picker
-  // only offers All/Available there). Everything that drives display reads this,
-  // not the raw `filter`; `setFilter` still records the raw user choice.
-  const effectiveFilter: PluginFilter =
-    !pluginToggleSupported && (filter === "active" || filter === "off")
-      ? "all"
-      : filter;
+  // The picker offers different status options per daemon capability
+  // (All/Active/Off/Available when it can toggle, All/Installed/Available when
+  // it can't). If a prior selection carries into an assistant whose picker no
+  // longer offers it, coerce to All so rows don't silently vanish under an
+  // unreachable filter. Everything that drives display reads this, not the raw
+  // `filter`; `setFilter` still records the raw user choice.
+  const offeredFilters: PluginFilter[] = pluginToggleSupported
+    ? ["all", "active", "off", "available"]
+    : ["all", "installed", "available"];
+  const effectiveFilter: PluginFilter = offeredFilters.includes(filter)
+    ? filter
+    : "all";
 
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
@@ -325,7 +328,8 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         // Don't flash an "empty" state for available plugins while the
         // catalog is still loading (installed plugins already render above).
         // Only the filters that surface catalog rows (all/available) wait on it.
-        catalogLoading && (filter === "all" || filter === "available") ? (
+        catalogLoading &&
+          (effectiveFilter === "all" || effectiveFilter === "available") ? (
           <LoadingState />
         ) : (
           <EmptyState filter={effectiveFilter} category={effectiveCategory} />
@@ -700,6 +704,13 @@ function getEmptyStateCopy(
     };
   }
   switch (filter) {
+    case "installed":
+      return {
+        title: "No Plugins Installed",
+        subtitle:
+          "Browse the catalog to install plugins that extend your assistant.",
+        Icon: Puzzle,
+      };
     case "active":
       return {
         title: "No Active Plugins",

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -8,9 +8,16 @@ export type PluginStatus = "installed" | "available";
 /**
  * User-facing status filter. Orthogonal to `PluginStatus`: `active` and `off`
  * both narrow the installed set by enablement (Active = installed & enabled,
- * Off = installed & !enabled), while `available` is the not-installed catalog.
+ * Off = installed & !enabled), `installed` is the whole installed set
+ * regardless of enablement (offered when the daemon can't toggle), and
+ * `available` is the not-installed catalog.
  */
-export type PluginFilter = "all" | "active" | "off" | "available";
+export type PluginFilter =
+  | "all"
+  | "installed"
+  | "active"
+  | "off"
+  | "available";
 
 /**
  * Unified row model for the Plugins tab, populated from two independent

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -149,6 +149,14 @@ describe("filterByStatus", () => {
     expect(filterByStatus(items, "all")).toHaveLength(4);
   });
 
+  test("installed returns every installed row regardless of enablement", () => {
+    expect(filterByStatus(items, "installed").map((p) => p.name)).toEqual([
+      "on",
+      "off",
+      "legacy",
+    ]);
+  });
+
   test("active returns installed rows that aren't explicitly disabled", () => {
     // `undefined` enablement (older daemons) counts as active — the plugin is
     // installed and not turned off, so it must not vanish.

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -74,6 +74,10 @@ export function filterByStatus(
       return items;
     case "available":
       return items.filter((i) => i.status === "available");
+    // Every installed plugin, regardless of enablement — offered instead of
+    // Active/Off on daemons that predate enable/disable.
+    case "installed":
+      return items.filter((i) => i.status === "installed");
     // Active = installed & enabled. Enablement `undefined` (older daemons) is
     // treated as active, so a plugin never silently disappears when the daemon
     // predates enable/disable.


### PR DESCRIPTION
## Summary
Self-review gap: newer web + older daemon (no enable/disable) lost the Installed filter. Restore All/Installed/Available when unsupported; generalize effectiveFilter to coerce any not-offered filter to All.

Part of plan: plugin-enable-disable.md (self-review remediation)