### PR TITLE
fix(daemon): emit plugin sync via canonical publisher with originClientId

### DIFF
--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -32,8 +32,12 @@
  *
  * POST /v1/plugins/:name/enable | disable (toggle):
  *   - Forwards `pathParams.name` to the `enablePlugin` / `disablePlugin` lib
- *   - Returns `{ ok: true }` and broadcasts a `sync_changed` carrying the
- *     `plugins:list` tag (enable and disable emit the SAME invalidation)
+ *   - Returns `{ ok: true }` and publishes a `sync_changed` carrying the
+ *     `plugins:list` tag via the canonical resource-sync publisher (enable and
+ *     disable emit the SAME invalidation)
+ *   - Threads `x-vellum-client-id` into the published event's `originClientId`
+ *   - A broadcast failure does not fail a successful toggle (the publisher
+ *     swallows hub errors)
  *   - Maps `InvalidPluginNameError` → BadRequestError (400)
  *   - Maps `PluginDirectoryNotFoundError` → NotFoundError (404)
  *   - Maps `PluginAlreadyInStateException` → ConflictError (409); no broadcast
@@ -277,8 +281,10 @@ mock.module("../../../cli/lib/toggle-plugin.js", () => ({
 }));
 
 // Spy on broadcastMessage so we can assert the sync_changed invalidation the
-// enable/disable handlers emit. `buildSyncChangedMessage` is left real, so the
-// spy receives the actual `{ type: "sync_changed", tags: [...] }` payload.
+// enable/disable handlers emit. The handlers publish through the canonical
+// `publishPluginsChanged` → `publishSyncInvalidation` path (both left real), so
+// the spy receives the actual `{ type: "sync_changed", tags: [...],
+// originClientId? }` payload the publisher builds.
 const broadcastMessageSpy = mock((_msg: unknown): void => {});
 
 mock.module("../../assistant-event-hub.js", () => ({
@@ -2118,6 +2124,35 @@ describe("POST /v1/plugins/:name/enable", () => {
     expectPluginsListBroadcast();
   });
 
+  test("threads x-vellum-client-id into the published event's originClientId", () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+
+    invokeEnable({
+      pathParams: { name: "simple-memory" },
+      headers: { "x-vellum-client-id": "client-abc" },
+    });
+
+    // The initiating client's id flows through the canonical publisher so it
+    // can self-echo-suppress its own invalidation.
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-abc",
+    });
+  });
+
+  test("a broadcast failure does not fail a successful toggle", () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+    // The sentinel was already flipped; a hub throw AFTER that must not surface
+    // as a 500 — the canonical publisher swallows broadcast errors.
+    broadcastMessageSpy.mockImplementation(() => {
+      throw new Error("hub unavailable");
+    });
+
+    const result = invokeEnable({ pathParams: { name: "simple-memory" } });
+    expect(result).toEqual({ ok: true });
+  });
+
   test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
     enablePluginSpy.mockImplementation((name) => {
       throw new PluginAlreadyInStateException(name, "enable");
@@ -2158,7 +2193,9 @@ describe("POST /v1/plugins/:name/disable", () => {
   });
 
   test("disables the plugin and broadcasts sync_changed(plugins:list)", () => {
-    disablePluginSpy.mockImplementation((name) => toggleResult(name, "disable"));
+    disablePluginSpy.mockImplementation((name) =>
+      toggleResult(name, "disable"),
+    );
 
     const result = invokeDisable({ pathParams: { name: "simple-memory" } });
 
@@ -2167,6 +2204,23 @@ describe("POST /v1/plugins/:name/disable", () => {
     // Enable and disable emit the SAME invalidation — the tag names the
     // resource, not the new value.
     expectPluginsListBroadcast();
+  });
+
+  test("threads x-vellum-client-id into the published event's originClientId", () => {
+    disablePluginSpy.mockImplementation((name) =>
+      toggleResult(name, "disable"),
+    );
+
+    invokeDisable({
+      pathParams: { name: "simple-memory" },
+      headers: { "x-vellum-client-id": "client-xyz" },
+    });
+
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-xyz",
+    });
   });
 
   test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -49,7 +49,10 @@ import { compareSemver } from "../../daemon/handlers/shared.js";
 import { computeContentId } from "../../util/content-id.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { publishAppsChanged } from "../sync/resource-sync-events.js";
+import {
+  getOriginClientId,
+  publishAppsChanged,
+} from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -62,12 +65,6 @@ const log = getLogger("app-management-routes");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getOriginClientId(
-  headers: RouteHandlerArgs["headers"],
-): string | undefined {
-  return headers?.["x-vellum-client-id"]?.trim() || undefined;
-}
 
 function getSharedAppsDir(): string {
   return join(

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -80,14 +80,13 @@ import {
   type PluginUpgradeStrategy,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
-import {
-  buildSyncChangedMessage,
-  SYNC_TAGS,
-} from "../../daemon/message-types/sync.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
-import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  getOriginClientId,
+  publishPluginsChanged,
+} from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   ConflictError,
@@ -1289,24 +1288,28 @@ function mapTogglePluginError(err: unknown): RouteError {
 
 /**
  * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
- * then broadcast a generic `sync_changed(plugins:list)` so every client
- * refetches `GET /v1/plugins`. Enable and disable emit the SAME invalidation —
- * the tag names WHICH resource is stale, not the new value.
+ * then publish a generic `sync_changed(plugins:list)` via the canonical
+ * resource-sync publisher so every client refetches `GET /v1/plugins`. Enable
+ * and disable emit the SAME invalidation — the tag names WHICH resource is
+ * stale, not the new value. The origin client id is threaded through so the
+ * initiating client can self-echo-suppress; `publishPluginsChanged` swallows
+ * broadcast failures, so a hub error never fails a toggle that already
+ * succeeded.
  */
-function handleEnablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+function handleEnablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {
     enablePlugin(pathParams.name ?? "");
-    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    publishPluginsChanged(getOriginClientId(headers));
     return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);
   }
 }
 
-function handleDisablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {
     disablePlugin(pathParams.name ?? "");
-    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    publishPluginsChanged(getOriginClientId(headers));
     return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -9,6 +9,17 @@ import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
 
+/**
+ * Derive the initiating client's id from request headers so a sync publish can
+ * carry it as `originClientId`, letting that client self-echo-suppress its own
+ * invalidation. Trimmed; blank/absent headers yield `undefined`.
+ */
+export function getOriginClientId(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  return headers?.["x-vellum-client-id"]?.trim() || undefined;
+}
+
 export function publishAvatarChanged(originClientId?: string): void {
   broadcastMessage({
     type: "avatar_updated",
@@ -48,6 +59,10 @@ export function publishSchedulesChanged(originClientId?: string): void {
 
 export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
+}
+
+export function publishPluginsChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.pluginsList], originClientId);
 }
 
 /**


### PR DESCRIPTION
## Summary
Self-review gap: plugin enable/disable routes bypassed the canonical resource-sync publisher. Use publishPluginsChanged(getOriginClientId(headers)) so self-echo suppression works and a broadcast failure can't 500 a successful toggle.

Part of plan: plugin-enable-disable.md (self-review remediation)