### PR TITLE
feat: per-assistant plugin enable/disable (Active/Off toggle)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20879,6 +20879,11 @@ paths:
                         name:
                           type: string
                           description: Display name. Equal to `id` today.
+                        enabled:
+                          type: boolean
+                          description:
+                            Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its
+                            directory; `true` otherwise.
                         description:
                           anyOf:
                             - type: string
@@ -20907,6 +20912,7 @@ paths:
                       required:
                         - id
                         - name
+                        - enabled
                         - description
                         - version
                       additionalProperties: false

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21196,6 +21196,80 @@ paths:
           description: The install recorded no commit or no fingerprint to re-materialize and verify a baseline from.
         "503":
           description: The plugin source (GitHub) was temporarily unavailable; the diff is retryable.
+  /v1/plugins/{name}/disable:
+    post:
+      operationId: plugins_by_name_disable_post
+      summary: Disable a plugin
+      description:
+        Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant
+        plugins disable <name>`. The change is honored live at read time by every tool / injector / hook gate — no
+        restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients
+        refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404
+        (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+        "400":
+          description: The plugin name failed validation (not kebab-case alphanumerics).
+        "404":
+          description: No plugin directory exists with the given name (user plugins must already be installed).
+        "409":
+          description: The plugin is already disabled.
+  /v1/plugins/{name}/enable:
+    post:
+      operationId: plugins_by_name_enable_post
+      summary: Enable a plugin
+      description:
+        Enable a plugin in this workspace by removing its `.disabled` sentinel, mirroring the CLI's `assistant
+        plugins enable <name>`. The change is honored live at read time by every tool / injector / hook gate — no
+        restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients
+        refetch `GET /v1/plugins`. An already-enabled plugin returns 409; a name with no plugin directory returns 404
+        (prefix a default plugin with `default-`); a malformed name returns 400.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+        "400":
+          description: The plugin name failed validation (not kebab-case alphanumerics).
+        "404":
+          description: No plugin directory exists with the given name.
+        "409":
+          description: The plugin is already enabled.
   /v1/plugins/{name}/inspect:
     get:
       operationId: plugins_by_name_inspect_get

--- a/assistant/src/cli/lib/__tests__/toggle-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/toggle-plugin.test.ts
@@ -132,6 +132,13 @@ describe("enablePlugin", () => {
     );
   });
 
+  it("throws PluginDirectoryNotFoundError for non-default plugin with no directory", () => {
+    // A missing user plugin must 404, not surface as an already-enabled no-op.
+    expect(() => enablePlugin("nonexistent-plugin")).toThrow(
+      PluginDirectoryNotFoundError,
+    );
+  });
+
   it("throws InvalidPluginNameError for path traversal attempts", () => {
     expect(() => enablePlugin("../state")).toThrow(InvalidPluginNameError);
     expect(() => enablePlugin("foo/bar")).toThrow(InvalidPluginNameError);

--- a/assistant/src/cli/lib/toggle-plugin.ts
+++ b/assistant/src/cli/lib/toggle-plugin.ts
@@ -16,7 +16,13 @@
  * it was the sentinel).
  */
 
-import { existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -125,6 +131,14 @@ export function enablePlugin(name: string): TogglePluginResult {
   const pluginsDir = getWorkspacePluginsDir();
   const pluginDir = join(pluginsDir, validated);
   const sentinelPath = join(pluginDir, DISABLED_FILE);
+
+  // A missing user plugin is a 404, not a no-op: without this, a typo/deleted
+  // name has no sentinel and would fall through to "already enabled" (409),
+  // indistinguishable from a genuinely-enabled plugin. Default plugins have no
+  // directory when enabled, so they skip this check (their no-op stays 409).
+  if (!validated.startsWith("default-") && !existsSync(pluginDir)) {
+    throw new PluginDirectoryNotFoundError(validated);
+  }
 
   if (!existsSync(sentinelPath)) {
     throw new PluginAlreadyInStateException(validated, "enable");

--- a/assistant/src/cli/lib/toggle-plugin.ts
+++ b/assistant/src/cli/lib/toggle-plugin.ts
@@ -22,6 +22,7 @@ import {
   readdirSync,
   rmSync,
   unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 
@@ -117,7 +118,11 @@ export function disablePlugin(name: string): TogglePluginResult {
   }
 
   // Write empty sentinel file — content is irrelevant, existence is the signal.
-  Bun.write(sentinelPath, "");
+  // Synchronous (like `enablePlugin`'s `unlinkSync`) so the sentinel is durable
+  // before the caller publishes `sync_changed`/returns 200, and a write failure
+  // throws synchronously into the route's try/catch instead of an unawaited
+  // `Bun.write` promise that could resolve/reject after the response.
+  writeFileSync(sentinelPath, "");
   return { name: validated, action: "disable", sentinelPath };
 }
 

--- a/assistant/src/cli/lib/toggle-plugin.ts
+++ b/assistant/src/cli/lib/toggle-plugin.ts
@@ -119,9 +119,9 @@ export function disablePlugin(name: string): TogglePluginResult {
 
   // Write empty sentinel file — content is irrelevant, existence is the signal.
   // Synchronous (like `enablePlugin`'s `unlinkSync`) so the sentinel is durable
-  // before the caller publishes `sync_changed`/returns 200, and a write failure
-  // throws synchronously into the route's try/catch instead of an unawaited
-  // `Bun.write` promise that could resolve/reject after the response.
+  // before the caller returns, and a write failure throws synchronously into the
+  // caller's try/catch instead of an unawaited `Bun.write` promise that could
+  // resolve/reject after the response.
   writeFileSync(sentinelPath, "");
   return { name: validated, action: "disable", sentinelPath };
 }

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -14,6 +14,7 @@ export const SYNC_TAGS = {
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
   appsList: "apps:list",
+  pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -96,6 +96,16 @@ mock.module("../../../cli/lib/list-installed-plugins.js", () => ({
   listInstalledPlugins: () => installedFixture,
 }));
 
+// Set of plugin dir names carrying a `.disabled` sentinel. Tests populate it to
+// mark a plugin disabled; the real check reads the workspace filesystem, so we
+// substitute an in-memory set to keep the route's `enabled` projection
+// deterministic and decoupled from disk.
+const disabledFixture = new Set<string>();
+
+mock.module("../../../plugins/disabled-state.js", () => ({
+  isPluginDisabled: (name: string) => disabledFixture.has(name),
+}));
+
 // Mock the catalog cache: `getCatalogSpy` records every invocation and
 // returns the (unfiltered) catalog the route then filters in memory via the
 // real `filterPluginCatalog`. The real `search-plugins.js` module is left
@@ -323,6 +333,7 @@ function pluginEntry(
 
 beforeEach(() => {
   installedFixture = [];
+  disabledFixture.clear();
 });
 
 describe("GET /v1/plugins", () => {
@@ -363,6 +374,8 @@ describe("GET /v1/plugins", () => {
     expect(result.plugins[0]).toEqual({
       id: "alpha",
       name: "alpha",
+      // No `.disabled` sentinel → the plugin is enabled.
+      enabled: true,
       description: "Alpha plugin",
       version: "1.2.3",
       path: "/workspace/plugins/alpha",
@@ -444,6 +457,21 @@ describe("GET /v1/plugins", () => {
 
     const [entry] = (await invoke()).plugins;
     expect(entry?.issues).toEqual(["missing package.json"]);
+  });
+
+  test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {
+    installedFixture = [
+      pluginEntry({ name: "off" }),
+      pluginEntry({ name: "on" }),
+    ];
+    // Only `off` carries the sentinel; `on` has none.
+    disabledFixture.add("off");
+
+    const byId = new Map(
+      (await invoke()).plugins.map((p) => [p.id, p.enabled]),
+    );
+    expect(byId.get("off")).toBe(false);
+    expect(byId.get("on")).toBe(true);
   });
 
   test("?q= filters case-insensitively on id, name, and description", async () => {

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -26,6 +26,8 @@
  * DELETE /v1/plugins/:name (uninstall):
  *   - Forwards `pathParams.name` to the `uninstallPlugin` lib
  *   - Returns `{ name, target }` mirroring the lib's `UninstallPluginResult`
+ *   - Publishes `sync_changed(plugins:list)` on success (threading the
+ *     `x-vellum-client-id` origin); no broadcast on an error path
  *   - Maps `InvalidPluginNameError` → BadRequestError (400)
  *   - Maps `PluginNotInstalledError` → NotFoundError (404)
  *   - Maps unknown errors → InternalError (500) with message preserved
@@ -1089,6 +1091,7 @@ function invokeUninstall(args: RouteHandlerArgs = {}): {
 describe("DELETE /v1/plugins/:name", () => {
   beforeEach(() => {
     uninstallSpy.mockReset();
+    broadcastMessageSpy.mockReset();
   });
 
   test("forwards pathParams.name to uninstallPlugin and returns its result", () => {
@@ -1104,6 +1107,35 @@ describe("DELETE /v1/plugins/:name", () => {
     expect(result).toEqual({
       name: "simple-memory",
       target: "/workspace/.vellum/plugins/simple-memory",
+    });
+  });
+
+  test("publishes sync_changed(plugins:list) on a successful uninstall", () => {
+    uninstallSpy.mockImplementation((opts) => ({
+      name: opts.name,
+      target: `/workspace/.vellum/plugins/${opts.name}`,
+    }));
+
+    invokeUninstall({ pathParams: { name: "simple-memory" } });
+
+    expectPluginsListBroadcast();
+  });
+
+  test("threads x-vellum-client-id into the published event's originClientId", () => {
+    uninstallSpy.mockImplementation((opts) => ({
+      name: opts.name,
+      target: `/workspace/.vellum/plugins/${opts.name}`,
+    }));
+
+    invokeUninstall({
+      pathParams: { name: "simple-memory" },
+      headers: { "x-vellum-client-id": "client-abc" },
+    });
+
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-abc",
     });
   });
 
@@ -1131,7 +1163,7 @@ describe("DELETE /v1/plugins/:name", () => {
     ).toThrow(BadRequestError);
   });
 
-  test("PluginNotInstalledError → NotFoundError (404)", () => {
+  test("PluginNotInstalledError → NotFoundError (404), no broadcast", () => {
     uninstallSpy.mockImplementation((opts) => {
       throw new PluginNotInstalledError(
         opts.name,
@@ -1142,6 +1174,8 @@ describe("DELETE /v1/plugins/:name", () => {
     expect(() => invokeUninstall({ pathParams: { name: "ghost" } })).toThrow(
       NotFoundError,
     );
+    // A failed uninstall must not fan out a spurious invalidation.
+    expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
   test("unknown errors → InternalError with original message preserved", () => {
@@ -1304,6 +1338,7 @@ describe("POST /v1/plugins/install", () => {
   beforeEach(() => {
     installSpy.mockReset();
     resolvePinSpy.mockReset();
+    broadcastMessageSpy.mockReset();
   });
 
   test("forwards name/force and shapes the result, pinning ref to the default", async () => {
@@ -1331,6 +1366,43 @@ describe("POST /v1/plugins/install", () => {
       name: "caveman",
       ref: "main",
       force: true,
+    });
+  });
+
+  test("publishes sync_changed(plugins:list) on a successful install", async () => {
+    installSpy.mockImplementation(async (opts) => ({
+      name: opts.name,
+      target: `/workspace/.vellum/plugins/${opts.name}`,
+      fileCount: 7,
+      ref: opts.ref ?? "main",
+      commit: null,
+      committedAt: null,
+    }));
+
+    await invokeInstall({ body: { name: "caveman" } });
+
+    expectPluginsListBroadcast();
+  });
+
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
+    installSpy.mockImplementation(async (opts) => ({
+      name: opts.name,
+      target: `/workspace/.vellum/plugins/${opts.name}`,
+      fileCount: 7,
+      ref: opts.ref ?? "main",
+      commit: null,
+      committedAt: null,
+    }));
+
+    await invokeInstall({
+      body: { name: "caveman" },
+      headers: { "x-vellum-client-id": "client-abc" },
+    });
+
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-abc",
     });
   });
 
@@ -1390,7 +1462,7 @@ describe("POST /v1/plugins/install", () => {
     ).rejects.toBeInstanceOf(ConflictError);
   });
 
-  test("PluginNotFoundError → NotFoundError (404)", async () => {
+  test("PluginNotFoundError → NotFoundError (404), no broadcast", async () => {
     installSpy.mockImplementation(async (opts) => {
       throw new PluginNotFoundError(opts.name, "main", "example-org/ghost");
     });
@@ -1398,6 +1470,8 @@ describe("POST /v1/plugins/install", () => {
     await expect(
       invokeInstall({ body: { name: "ghost" } }),
     ).rejects.toBeInstanceOf(NotFoundError);
+    // A failed install must not fan out a spurious invalidation.
+    expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
   test("PluginSourceUnavailableError → ServiceUnavailableError (503)", async () => {
@@ -1743,6 +1817,30 @@ async function invokeUpgrade(args: RouteHandlerArgs = {}): Promise<{
 describe("POST /v1/plugins/:name/upgrade", () => {
   beforeEach(() => {
     upgradeSpy.mockReset();
+    broadcastMessageSpy.mockReset();
+  });
+
+  test("publishes sync_changed(plugins:list) on a successful upgrade", async () => {
+    upgradeSpy.mockImplementation(async () => upgradeResult());
+
+    await invokeUpgrade({ pathParams: { name: "level-up" } });
+
+    expectPluginsListBroadcast();
+  });
+
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
+    upgradeSpy.mockImplementation(async () => upgradeResult());
+
+    await invokeUpgrade({
+      pathParams: { name: "level-up" },
+      headers: { "x-vellum-client-id": "client-abc" },
+    });
+
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-abc",
+    });
   });
 
   test("forwards name + dryRun and projects the upgrade result", async () => {
@@ -1878,7 +1976,7 @@ describe("POST /v1/plugins/:name/upgrade", () => {
     ).rejects.toBeInstanceOf(BadRequestError);
   });
 
-  test("PluginNotInstalledError → NotFoundError (404)", async () => {
+  test("PluginNotInstalledError → NotFoundError (404), no broadcast", async () => {
     upgradeSpy.mockImplementation(async () => {
       throw new PluginNotInstalledError(
         "ghost",
@@ -1889,6 +1987,8 @@ describe("POST /v1/plugins/:name/upgrade", () => {
     await expect(
       invokeUpgrade({ pathParams: { name: "ghost" } }),
     ).rejects.toBeInstanceOf(NotFoundError);
+    // A failed upgrade must not fan out a spurious invalidation.
+    expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
   test("PluginNotUpgradableError → ConflictError (409)", async () => {

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -30,6 +30,14 @@
  *   - Maps `PluginNotInstalledError` → NotFoundError (404)
  *   - Maps unknown errors → InternalError (500) with message preserved
  *
+ * POST /v1/plugins/:name/enable | disable (toggle):
+ *   - Forwards `pathParams.name` to the `enablePlugin` / `disablePlugin` lib
+ *   - Returns `{ ok: true }` and broadcasts a `sync_changed` carrying the
+ *     `plugins:list` tag (enable and disable emit the SAME invalidation)
+ *   - Maps `InvalidPluginNameError` → BadRequestError (400)
+ *   - Maps `PluginDirectoryNotFoundError` → NotFoundError (404)
+ *   - Maps `PluginAlreadyInStateException` → ConflictError (409); no broadcast
+ *
  * The library functions themselves are covered by
  * `assistant/src/cli/lib/__tests__/list-installed-plugins.test.ts`,
  * `.../search-plugins.test.ts`, and `.../uninstall-plugin.test.ts`;
@@ -75,6 +83,12 @@ import type {
   SearchPluginsDeps,
 } from "../../../cli/lib/search-plugins.js";
 import { PluginCatalogUnavailableError } from "../../../cli/lib/search-plugins.js";
+import {
+  InvalidPluginNameError as ToggleInvalidPluginNameError,
+  PluginAlreadyInStateException,
+  PluginDirectoryNotFoundError,
+  type TogglePluginResult,
+} from "../../../cli/lib/toggle-plugin.js";
 import {
   PluginNotInstalledError,
   type UninstallPluginOptions,
@@ -242,6 +256,35 @@ mock.module("../../../cli/lib/plugin-pin-history.js", () => ({
   resolvePinToMarketplaceCommit: resolvePinSpy,
 }));
 
+// Mock the toggle-plugin lib. `enablePlugin` / `disablePlugin` flip a
+// `.disabled` sentinel on disk in production; here we spy on them so the
+// route's broadcast + error mapping is the wiring under test. The error
+// classes pass through real so the handler's `instanceof` checks resolve to
+// the same classes the spies throw.
+const enablePluginSpy = mock((_name: string): TogglePluginResult => {
+  throw new Error("enablePluginSpy default impl not configured");
+});
+const disablePluginSpy = mock((_name: string): TogglePluginResult => {
+  throw new Error("disablePluginSpy default impl not configured");
+});
+
+mock.module("../../../cli/lib/toggle-plugin.js", () => ({
+  InvalidPluginNameError: ToggleInvalidPluginNameError,
+  PluginAlreadyInStateException,
+  PluginDirectoryNotFoundError,
+  disablePlugin: disablePluginSpy,
+  enablePlugin: enablePluginSpy,
+}));
+
+// Spy on broadcastMessage so we can assert the sync_changed invalidation the
+// enable/disable handlers emit. `buildSyncChangedMessage` is left real, so the
+// spy receives the actual `{ type: "sync_changed", tags: [...] }` payload.
+const broadcastMessageSpy = mock((_msg: unknown): void => {});
+
+mock.module("../../assistant-event-hub.js", () => ({
+  broadcastMessage: broadcastMessageSpy,
+}));
+
 // Make the valid-slug source deterministic: the real `getLocalCategorySlugs`
 // reads the bundled YAML (absent in the test sandbox), so we pin it to the
 // authoritative Skills taxonomy. This decouples the route's category
@@ -294,6 +337,8 @@ const inspectHandler = findHandler("plugins_inspect");
 const versionsHandler = findHandler("plugins_versions");
 const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
+const enableHandler = findHandler("plugins_enable");
+const disableHandler = findHandler("plugins_disable");
 
 async function invoke(args: RouteHandlerArgs = {}): Promise<{
   plugins: Array<Record<string, unknown>>;
@@ -2023,5 +2068,135 @@ describe("POST /v1/plugins/:name/diff", () => {
     }
     expect(caught).toBeInstanceOf(InternalError);
     expect((caught as Error).message).toContain("ECONNRESET");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/plugins/:name/enable | disable (toggle)
+// ---------------------------------------------------------------------------
+
+function toggleResult(
+  name: string,
+  action: "enable" | "disable",
+): TogglePluginResult {
+  return {
+    name,
+    action,
+    sentinelPath: `/workspace/.vellum/plugins/${name}/.disabled`,
+  };
+}
+
+function invokeEnable(args: RouteHandlerArgs = {}): { ok: boolean } {
+  return enableHandler(args) as { ok: boolean };
+}
+
+function invokeDisable(args: RouteHandlerArgs = {}): { ok: boolean } {
+  return disableHandler(args) as { ok: boolean };
+}
+
+/** Assert the spy received exactly one sync_changed carrying `plugins:list`. */
+function expectPluginsListBroadcast(): void {
+  expect(broadcastMessageSpy.mock.calls).toHaveLength(1);
+  const [msg] = broadcastMessageSpy.mock.calls[0]!;
+  expect(msg).toMatchObject({ type: "sync_changed" });
+  expect((msg as { tags: string[] }).tags).toContain("plugins:list");
+}
+
+describe("POST /v1/plugins/:name/enable", () => {
+  beforeEach(() => {
+    enablePluginSpy.mockReset();
+    broadcastMessageSpy.mockReset();
+  });
+
+  test("enables the plugin and broadcasts sync_changed(plugins:list)", () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+
+    const result = invokeEnable({ pathParams: { name: "simple-memory" } });
+
+    expect(result).toEqual({ ok: true });
+    expect(enablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");
+    expectPluginsListBroadcast();
+  });
+
+  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
+    enablePluginSpy.mockImplementation((name) => {
+      throw new PluginAlreadyInStateException(name, "enable");
+    });
+
+    expect(() =>
+      invokeEnable({ pathParams: { name: "simple-memory" } }),
+    ).toThrow(ConflictError);
+    // A no-op toggle must not fan out a spurious invalidation.
+    expect(broadcastMessageSpy).not.toHaveBeenCalled();
+  });
+
+  test("PluginDirectoryNotFoundError → NotFoundError (404)", () => {
+    enablePluginSpy.mockImplementation((name) => {
+      throw new PluginDirectoryNotFoundError(name);
+    });
+
+    expect(() => invokeEnable({ pathParams: { name: "ghost" } })).toThrow(
+      NotFoundError,
+    );
+  });
+
+  test("InvalidPluginNameError → BadRequestError (400)", () => {
+    enablePluginSpy.mockImplementation(() => {
+      throw new ToggleInvalidPluginNameError("../escape");
+    });
+
+    expect(() => invokeEnable({ pathParams: { name: "../escape" } })).toThrow(
+      BadRequestError,
+    );
+  });
+});
+
+describe("POST /v1/plugins/:name/disable", () => {
+  beforeEach(() => {
+    disablePluginSpy.mockReset();
+    broadcastMessageSpy.mockReset();
+  });
+
+  test("disables the plugin and broadcasts sync_changed(plugins:list)", () => {
+    disablePluginSpy.mockImplementation((name) => toggleResult(name, "disable"));
+
+    const result = invokeDisable({ pathParams: { name: "simple-memory" } });
+
+    expect(result).toEqual({ ok: true });
+    expect(disablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");
+    // Enable and disable emit the SAME invalidation — the tag names the
+    // resource, not the new value.
+    expectPluginsListBroadcast();
+  });
+
+  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
+    disablePluginSpy.mockImplementation((name) => {
+      throw new PluginAlreadyInStateException(name, "disable");
+    });
+
+    expect(() =>
+      invokeDisable({ pathParams: { name: "simple-memory" } }),
+    ).toThrow(ConflictError);
+    expect(broadcastMessageSpy).not.toHaveBeenCalled();
+  });
+
+  test("PluginDirectoryNotFoundError → NotFoundError (404)", () => {
+    disablePluginSpy.mockImplementation((name) => {
+      throw new PluginDirectoryNotFoundError(name);
+    });
+
+    expect(() => invokeDisable({ pathParams: { name: "ghost" } })).toThrow(
+      NotFoundError,
+    );
+  });
+
+  test("InvalidPluginNameError → BadRequestError (400)", () => {
+    disablePluginSpy.mockImplementation(() => {
+      throw new ToggleInvalidPluginNameError("../escape");
+    });
+
+    expect(() => invokeDisable({ pathParams: { name: "../escape" } })).toThrow(
+      BadRequestError,
+    );
   });
 });

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -32,8 +32,12 @@
  *
  * POST /v1/plugins/:name/enable | disable (toggle):
  *   - Forwards `pathParams.name` to the `enablePlugin` / `disablePlugin` lib
- *   - Returns `{ ok: true }` and broadcasts a `sync_changed` carrying the
- *     `plugins:list` tag (enable and disable emit the SAME invalidation)
+ *   - Returns `{ ok: true }` and publishes a `sync_changed` carrying the
+ *     `plugins:list` tag via the canonical resource-sync publisher (enable and
+ *     disable emit the SAME invalidation)
+ *   - Threads `x-vellum-client-id` into the published event's `originClientId`
+ *   - A broadcast failure does not fail a successful toggle (the publisher
+ *     swallows hub errors)
  *   - Maps `InvalidPluginNameError` → BadRequestError (400)
  *   - Maps `PluginDirectoryNotFoundError` → NotFoundError (404)
  *   - Maps `PluginAlreadyInStateException` → ConflictError (409); no broadcast
@@ -277,8 +281,10 @@ mock.module("../../../cli/lib/toggle-plugin.js", () => ({
 }));
 
 // Spy on broadcastMessage so we can assert the sync_changed invalidation the
-// enable/disable handlers emit. `buildSyncChangedMessage` is left real, so the
-// spy receives the actual `{ type: "sync_changed", tags: [...] }` payload.
+// enable/disable handlers emit. The handlers publish through the canonical
+// `publishPluginsChanged` → `publishSyncInvalidation` path (both left real), so
+// the spy receives the actual `{ type: "sync_changed", tags: [...],
+// originClientId? }` payload the publisher builds.
 const broadcastMessageSpy = mock((_msg: unknown): void => {});
 
 mock.module("../../assistant-event-hub.js", () => ({
@@ -2118,6 +2124,35 @@ describe("POST /v1/plugins/:name/enable", () => {
     expectPluginsListBroadcast();
   });
 
+  test("threads x-vellum-client-id into the published event's originClientId", () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+
+    invokeEnable({
+      pathParams: { name: "simple-memory" },
+      headers: { "x-vellum-client-id": "client-abc" },
+    });
+
+    // The initiating client's id flows through the canonical publisher so it
+    // can self-echo-suppress its own invalidation.
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-abc",
+    });
+  });
+
+  test("a broadcast failure does not fail a successful toggle", () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+    // The sentinel was already flipped; a hub throw AFTER that must not surface
+    // as a 500 — the canonical publisher swallows broadcast errors.
+    broadcastMessageSpy.mockImplementation(() => {
+      throw new Error("hub unavailable");
+    });
+
+    const result = invokeEnable({ pathParams: { name: "simple-memory" } });
+    expect(result).toEqual({ ok: true });
+  });
+
   test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
     enablePluginSpy.mockImplementation((name) => {
       throw new PluginAlreadyInStateException(name, "enable");
@@ -2158,7 +2193,9 @@ describe("POST /v1/plugins/:name/disable", () => {
   });
 
   test("disables the plugin and broadcasts sync_changed(plugins:list)", () => {
-    disablePluginSpy.mockImplementation((name) => toggleResult(name, "disable"));
+    disablePluginSpy.mockImplementation((name) =>
+      toggleResult(name, "disable"),
+    );
 
     const result = invokeDisable({ pathParams: { name: "simple-memory" } });
 
@@ -2167,6 +2204,23 @@ describe("POST /v1/plugins/:name/disable", () => {
     // Enable and disable emit the SAME invalidation — the tag names the
     // resource, not the new value.
     expectPluginsListBroadcast();
+  });
+
+  test("threads x-vellum-client-id into the published event's originClientId", () => {
+    disablePluginSpy.mockImplementation((name) =>
+      toggleResult(name, "disable"),
+    );
+
+    invokeDisable({
+      pathParams: { name: "simple-memory" },
+      headers: { "x-vellum-client-id": "client-xyz" },
+    });
+
+    const [msg] = broadcastMessageSpy.mock.calls[0]!;
+    expect(msg).toMatchObject({
+      type: "sync_changed",
+      originClientId: "client-xyz",
+    });
   });
 
   test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -49,7 +49,10 @@ import { compareSemver } from "../../daemon/handlers/shared.js";
 import { computeContentId } from "../../util/content-id.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { publishAppsChanged } from "../sync/resource-sync-events.js";
+import {
+  getOriginClientId,
+  publishAppsChanged,
+} from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -62,12 +65,6 @@ const log = getLogger("app-management-routes");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getOriginClientId(
-  headers: RouteHandlerArgs["headers"],
-): string | undefined {
-  return headers?.["x-vellum-client-id"]?.trim() || undefined;
-}
 
 function getSharedAppsDir(): string {
   return join(

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -73,6 +73,7 @@ import {
   type PluginUpgradeStrategy,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
+import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -96,6 +97,11 @@ const pluginInfoSchema = z.object({
       "Plugin's directory name (kebab-case). Matches `assistant plugins install <id>`.",
     ),
   name: z.string().describe("Display name. Equal to `id` today."),
+  enabled: z
+    .boolean()
+    .describe(
+      "Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its directory; `true` otherwise.",
+    ),
   description: z
     .string()
     .nullable()
@@ -635,6 +641,7 @@ const pluginDiffResponseSchema = z.object({
 interface PluginView {
   id: string;
   name: string;
+  enabled: boolean;
   description: string | null;
   version: string | null;
   path: string;
@@ -649,6 +656,8 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   const view: PluginView = {
     id: entry.name,
     name: entry.name,
+    // `entry.name` is the plugin directory name, which is the sentinel key.
+    enabled: !isPluginDisabled(entry.name),
     description: entry.packageJson?.description ?? null,
     version: entry.packageJson?.version ?? null,
     path: entry.target,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -941,6 +941,7 @@ interface PluginUninstallResponse {
 
 function handleUninstallPlugin({
   pathParams = {},
+  headers,
 }: RouteHandlerArgs): PluginUninstallResponse {
   // The HTTP router has already URL-decoded `:name` for us; pass it
   // through verbatim — `uninstallPlugin` runs the same
@@ -950,6 +951,7 @@ function handleUninstallPlugin({
 
   try {
     const result = uninstallPlugin({ name: rawName });
+    publishPluginsChanged(getOriginClientId(headers));
     return { name: result.name, target: result.target };
   } catch (err) {
     if (err instanceof InvalidPluginNameError) {
@@ -1021,7 +1023,7 @@ async function resolveInstallMarketplaceRef(
   return entry.marketplaceCommit;
 }
 
-async function handleInstallPlugin({ body = {} }: RouteHandlerArgs) {
+async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
   const name = typeof body.name === "string" ? body.name : "";
   if (!name) {
     throw new BadRequestError("`name` is required");
@@ -1045,6 +1047,7 @@ async function handleInstallPlugin({ body = {} }: RouteHandlerArgs) {
       { name, ref: marketplaceRef, force },
       { fetch: globalThis.fetch.bind(globalThis) },
     );
+    publishPluginsChanged(getOriginClientId(headers));
     return {
       ok: true as const,
       name: result.name,
@@ -1195,6 +1198,7 @@ async function handleDiffPlugin({ pathParams = {} }: RouteHandlerArgs) {
 async function handleUpgradePlugin({
   pathParams = {},
   body = {},
+  headers,
 }: RouteHandlerArgs) {
   const rawName = pathParams.name ?? "";
   const dryRun = typeof body.dryRun === "boolean" ? body.dryRun : undefined;
@@ -1212,6 +1216,7 @@ async function handleUpgradePlugin({
       { name: rawName, dryRun, strategy },
       { fetch: globalThis.fetch.bind(globalThis) },
     );
+    publishPluginsChanged(getOriginClientId(headers));
     return {
       name: result.name,
       outcome: result.outcome,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -64,6 +64,13 @@ import {
   type PluginSearchMatch,
 } from "../../cli/lib/search-plugins.js";
 import {
+  disablePlugin,
+  enablePlugin,
+  InvalidPluginNameError as InvalidTogglePluginNameError,
+  PluginAlreadyInStateException,
+  PluginDirectoryNotFoundError,
+} from "../../cli/lib/toggle-plugin.js";
+import {
   PluginNotInstalledError,
   uninstallPlugin,
 } from "../../cli/lib/uninstall-plugin.js";
@@ -73,8 +80,13 @@ import {
   type PluginUpgradeStrategy,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
+import {
+  buildSyncChangedMessage,
+  SYNC_TAGS,
+} from "../../daemon/message-types/sync.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -1250,6 +1262,58 @@ async function handleUpgradePlugin({
 }
 
 // ---------------------------------------------------------------------------
+// Handler — enable / disable
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a `toggle-plugin` lib error onto the transport-agnostic route error.
+ * `enablePlugin` / `disablePlugin` throw their own taxonomy (distinct from the
+ * install/uninstall libs): a malformed name → 400, no plugin directory → 404,
+ * and a no-op toggle (already in the requested state) → 409. Anything else
+ * (e.g. a filesystem failure) surfaces as an unexpected 500.
+ */
+function mapTogglePluginError(err: unknown): RouteError {
+  if (err instanceof InvalidTogglePluginNameError) {
+    return new BadRequestError(err.message);
+  }
+  if (err instanceof PluginDirectoryNotFoundError) {
+    return new NotFoundError(err.message);
+  }
+  if (err instanceof PluginAlreadyInStateException) {
+    return new ConflictError(err.message);
+  }
+  return new InternalError(
+    err instanceof Error ? err.message : "plugin toggle failed",
+  );
+}
+
+/**
+ * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
+ * then broadcast a generic `sync_changed(plugins:list)` so every client
+ * refetches `GET /v1/plugins`. Enable and disable emit the SAME invalidation —
+ * the tag names WHICH resource is stale, not the new value.
+ */
+function handleEnablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+  try {
+    enablePlugin(pathParams.name ?? "");
+    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    return { ok: true };
+  } catch (err) {
+    throw mapTogglePluginError(err);
+  }
+}
+
+function handleDisablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+  try {
+    disablePlugin(pathParams.name ?? "");
+    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    return { ok: true };
+  } catch (err) {
+    throw mapTogglePluginError(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -1570,5 +1634,76 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleUpgradePlugin,
+  },
+  {
+    operationId: "plugins_enable",
+    endpoint: "plugins/:name/enable",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Enable a plugin",
+    description:
+      "Enable a plugin in this workspace by removing its `.disabled` sentinel, mirroring the CLI's `assistant plugins enable <name>`. The change is honored live at read time by every tool / injector / hook gate — no restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-enabled plugin returns 409; a name with no plugin directory returns 404 (prefix a default plugin with `default-`); a malformed name returns 400.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description:
+          "Directory name under `<workspaceDir>/plugins/`. Prefix a default plugin with `default-`. Must be kebab-case alphanumerics.",
+      },
+    ],
+    responseBody: z.object({ ok: z.boolean() }),
+    additionalResponses: {
+      "400": {
+        description:
+          "The plugin name failed validation (not kebab-case alphanumerics).",
+      },
+      "404": {
+        description: "No plugin directory exists with the given name.",
+      },
+      "409": {
+        description: "The plugin is already enabled.",
+      },
+    },
+    handler: handleEnablePlugin,
+  },
+  {
+    operationId: "plugins_disable",
+    endpoint: "plugins/:name/disable",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Disable a plugin",
+    description:
+      "Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant plugins disable <name>`. The change is honored live at read time by every tool / injector / hook gate — no restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description:
+          "Directory name under `<workspaceDir>/plugins/`. Prefix a default plugin with `default-`. Must be kebab-case alphanumerics.",
+      },
+    ],
+    responseBody: z.object({ ok: z.boolean() }),
+    additionalResponses: {
+      "400": {
+        description:
+          "The plugin name failed validation (not kebab-case alphanumerics).",
+      },
+      "404": {
+        description:
+          "No plugin directory exists with the given name (user plugins must already be installed).",
+      },
+      "409": {
+        description: "The plugin is already disabled.",
+      },
+    },
+    handler: handleDisablePlugin,
   },
 ];

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -80,14 +80,13 @@ import {
   type PluginUpgradeStrategy,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
-import {
-  buildSyncChangedMessage,
-  SYNC_TAGS,
-} from "../../daemon/message-types/sync.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
-import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  getOriginClientId,
+  publishPluginsChanged,
+} from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   ConflictError,
@@ -1289,24 +1288,28 @@ function mapTogglePluginError(err: unknown): RouteError {
 
 /**
  * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
- * then broadcast a generic `sync_changed(plugins:list)` so every client
- * refetches `GET /v1/plugins`. Enable and disable emit the SAME invalidation —
- * the tag names WHICH resource is stale, not the new value.
+ * then publish a generic `sync_changed(plugins:list)` via the canonical
+ * resource-sync publisher so every client refetches `GET /v1/plugins`. Enable
+ * and disable emit the SAME invalidation — the tag names WHICH resource is
+ * stale, not the new value. The origin client id is threaded through so the
+ * initiating client can self-echo-suppress; `publishPluginsChanged` swallows
+ * broadcast failures, so a hub error never fails a toggle that already
+ * succeeded.
  */
-function handleEnablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+function handleEnablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {
     enablePlugin(pathParams.name ?? "");
-    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    publishPluginsChanged(getOriginClientId(headers));
     return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);
   }
 }
 
-function handleDisablePlugin({ pathParams = {} }: RouteHandlerArgs) {
+function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {
     disablePlugin(pathParams.name ?? "");
-    broadcastMessage(buildSyncChangedMessage([SYNC_TAGS.pluginsList]));
+    publishPluginsChanged(getOriginClientId(headers));
     return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1272,9 +1272,8 @@ async function handleUpgradePlugin({
 /**
  * Map a `toggle-plugin` lib error onto the transport-agnostic route error.
  * `enablePlugin` / `disablePlugin` throw their own taxonomy (distinct from the
- * install/uninstall libs): a malformed name → 400, no plugin directory → 404,
- * and a no-op toggle (already in the requested state) → 409. Anything else
- * (e.g. a filesystem failure) surfaces as an unexpected 500.
+ * install/uninstall libs), which the branches below narrow to 400 / 404 / 409;
+ * anything unrecognized surfaces as an unexpected 500.
  */
 function mapTogglePluginError(err: unknown): RouteError {
   if (err instanceof InvalidTogglePluginNameError) {
@@ -1293,13 +1292,10 @@ function mapTogglePluginError(err: unknown): RouteError {
 
 /**
  * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
- * then publish a generic `sync_changed(plugins:list)` via the canonical
- * resource-sync publisher so every client refetches `GET /v1/plugins`. Enable
- * and disable emit the SAME invalidation — the tag names WHICH resource is
- * stale, not the new value. The origin client id is threaded through so the
- * initiating client can self-echo-suppress; `publishPluginsChanged` swallows
- * broadcast failures, so a hub error never fails a toggle that already
- * succeeded.
+ * then publish a generic `sync_changed(plugins:list)` so every client refetches
+ * `GET /v1/plugins`. Enable and disable emit the SAME invalidation — the tag
+ * names WHICH resource is stale, not the new value. The origin client id is
+ * threaded through for self-echo suppression.
  */
 function handleEnablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -9,6 +9,17 @@ import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
 
+/**
+ * Derive the initiating client's id from request headers so a sync publish can
+ * carry it as `originClientId`, letting that client self-echo-suppress its own
+ * invalidation. Trimmed; blank/absent headers yield `undefined`.
+ */
+export function getOriginClientId(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  return headers?.["x-vellum-client-id"]?.trim() || undefined;
+}
+
 export function publishAvatarChanged(originClientId?: string): void {
   broadcastMessage({
     type: "avatar_updated",
@@ -48,6 +59,10 @@ export function publishSchedulesChanged(originClientId?: string): void {
 
 export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
+}
+
+export function publishPluginsChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.pluginsList], originClientId);
 }
 
 /**

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -90,6 +90,11 @@ mock.module("@/domains/intelligence/plugins/use-plugin-detail", () => ({
   // `plugins/utils`, so the real helper runs.
 }));
 
+// Stub the toggle hook so the mobile detail doesn't require a QueryClient here.
+mock.module("@/domains/intelligence/plugins/use-plugin-toggle", () => ({
+  usePluginToggle: () => ({ toggle: () => {}, togglingName: null }),
+}));
+
 const { PluginDetailMobile } = await import(
   "@/domains/intelligence/components/plugins/plugin-detail-mobile.js"
 );
@@ -181,6 +186,33 @@ describe("PluginDetailMobile", () => {
     );
 
     expect(getActionButton("Remove")).toBeTruthy();
+  });
+
+  test("installed plugin: Active/Off toggle appears when enabled is provided", () => {
+    hookState.plugin = makePlugin({ installed: true });
+
+    render(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+        enabled={true}
+      />,
+    );
+
+    // The design-library Toggle renders a role="switch"; mobile detail must wire
+    // it so phone users can enable/disable, matching the desktop detail.
+    expect(screen.getByRole("switch")).toBeTruthy();
+  });
+
+  test("installed plugin: no toggle when enabled is undefined", () => {
+    hookState.plugin = makePlugin({ installed: true });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(screen.queryByRole("switch")).toBeNull();
   });
 
   test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -188,7 +188,7 @@ describe("PluginDetailMobile", () => {
     expect(getActionButton("Remove")).toBeTruthy();
   });
 
-  test("installed plugin: Active/Off toggle appears when enabled is provided", () => {
+  test("installed plugin: Active/Off control appears when enabled is provided", () => {
     hookState.plugin = makePlugin({ installed: true });
 
     render(
@@ -200,19 +200,19 @@ describe("PluginDetailMobile", () => {
       />,
     );
 
-    // The design-library Toggle renders a role="switch"; mobile detail must wire
-    // it so phone users can enable/disable, matching the desktop detail.
-    expect(screen.getByRole("switch")).toBeTruthy();
+    // The Active/Off SegmentControl renders a role="radiogroup"; mobile detail
+    // must wire it so phone users can enable/disable, matching desktop detail.
+    expect(screen.getByRole("radiogroup")).toBeTruthy();
   });
 
-  test("installed plugin: no toggle when enabled is undefined", () => {
+  test("installed plugin: no control when enabled is undefined", () => {
     hookState.plugin = makePlugin({ installed: true });
 
     render(
       <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
     );
 
-    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
   });
 
   test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -188,7 +188,7 @@ describe("PluginDetailMobile", () => {
     expect(getActionButton("Remove")).toBeTruthy();
   });
 
-  test("installed plugin: Active/Off control appears when enabled is provided", () => {
+  test("installed plugin: auto-include toggle appears when enabled is provided", () => {
     hookState.plugin = makePlugin({ installed: true });
 
     render(
@@ -200,19 +200,19 @@ describe("PluginDetailMobile", () => {
       />,
     );
 
-    // The Active/Off SegmentControl renders a role="radiogroup"; mobile detail
-    // must wire it so phone users can enable/disable, matching desktop detail.
-    expect(screen.getByRole("radiogroup")).toBeTruthy();
+    // The Auto-include Toggle renders a role="switch"; mobile detail must wire
+    // it so phone users can enable/disable, matching desktop detail.
+    expect(screen.getByRole("switch")).toBeTruthy();
   });
 
-  test("installed plugin: no control when enabled is undefined", () => {
+  test("installed plugin: no toggle when enabled is undefined", () => {
     hookState.plugin = makePlugin({ installed: true });
 
     render(
       <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
     );
 
-    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.queryByRole("switch")).toBeNull();
   });
 
   test("while loading with no externalHint, the header shows a glyph-less placeholder (no 🧩, no 📦)", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -14,6 +14,7 @@ import {
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailMobileProps {
@@ -26,6 +27,12 @@ interface PluginDetailMobileProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
+  /**
+   * Active/Off state from the selected list row (the per-plugin detail response
+   * doesn't carry `enabled`). `undefined` hides the toggle (older daemon /
+   * deep-link with no matching row).
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -52,6 +59,7 @@ export function PluginDetailMobile({
   name,
   onBack,
   externalHint,
+  enabled,
 }: PluginDetailMobileProps) {
   const {
     plugin,
@@ -69,6 +77,7 @@ export function PluginDetailMobile({
     isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   // Resolve the full-screen portal target after commit (SSR-safe; the element
   // is mounted by RootLayout). Falls back to inline when absent (tests, first
@@ -161,6 +170,9 @@ export function PluginDetailMobile({
           <PluginDetailActions
             plugin={plugin}
             drift={drift}
+            enabled={enabled}
+            onToggle={() => toggle(name, !enabled)}
+            isToggling={togglingName === name}
             onInstall={install}
             onRemove={remove}
             onUpgrade={upgrade}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -27,11 +27,7 @@ interface PluginDetailMobileProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
-  /**
-   * Active/Off state from the selected list row (the per-plugin detail response
-   * doesn't carry `enabled`). `undefined` hides the toggle (older daemon /
-   * deep-link with no matching row).
-   */
+  /** Active/Off state seeded from the selected list row (see `PluginListItem.enabled`); `undefined` hides the toggle. */
   enabled?: boolean;
 }
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -103,8 +103,8 @@ const baseActionsProps = {
   hasLocalEdits: false,
 };
 
-describe("PluginDetailActions Active/Off toggle", () => {
-  test("renders an Active toggle + word reflecting an enabled plugin", () => {
+describe("PluginDetailActions Active/Off control", () => {
+  test("renders the Active segment checked for an enabled plugin", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}
@@ -114,11 +114,15 @@ describe("PluginDetailActions Active/Off toggle", () => {
       />,
     );
 
-    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
-    expect(screen.getByText("Active")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "Active" }).getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("radio", { name: "Off" }).getAttribute("aria-checked"),
+    ).toBe("false");
   });
 
-  test("renders an Off toggle + word reflecting a disabled plugin", () => {
+  test("renders the Off segment checked for a disabled plugin", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}
@@ -128,13 +132,15 @@ describe("PluginDetailActions Active/Off toggle", () => {
       />,
     );
 
-    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
-      "false",
-    );
-    expect(screen.getByText("Off")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "Off" }).getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("radio", { name: "Active" }).getAttribute("aria-checked"),
+    ).toBe("false");
   });
 
-  test("calls onToggle when the switch is clicked (no confirm)", () => {
+  test("calls onToggle when the other segment is clicked (no confirm)", () => {
     const onToggle = mock(noop);
     render(
       <PluginDetailActions
@@ -145,10 +151,10 @@ describe("PluginDetailActions Active/Off toggle", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("radio", { name: "Off" }));
 
     expect(onToggle).toHaveBeenCalledTimes(1);
-    // Optimistic: the switch flips without opening any dialog.
+    // Optimistic: the state flips without opening any dialog.
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
@@ -184,10 +190,10 @@ describe("PluginDetailActions Active/Off toggle", () => {
     ).toBeTruthy();
   });
 
-  test("hides the toggle + word when enablement is unknown", () => {
+  test("hides the control when enablement is unknown", () => {
     render(<PluginDetailActions {...baseActionsProps} />);
 
-    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
     expect(screen.queryByText("Active")).toBeNull();
     expect(screen.queryByText("Off")).toBeNull();
   });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -151,7 +151,7 @@ describe("PluginDetailActions auto-include toggle", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  test("keeps Upgrade available and enabled when the plugin is Auto-off and drifted", () => {
+  test("keeps Upgrade available and enabled when the plugin is disabled and drifted", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -103,8 +103,8 @@ const baseActionsProps = {
   hasLocalEdits: false,
 };
 
-describe("PluginDetailActions Active/Off control", () => {
-  test("renders the Active segment checked for an enabled plugin", () => {
+describe("PluginDetailActions auto-include toggle", () => {
+  test("renders a checked toggle labelled Auto-include for an enabled plugin", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}
@@ -114,15 +114,11 @@ describe("PluginDetailActions Active/Off control", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("radio", { name: "Active" }).getAttribute("aria-checked"),
-    ).toBe("true");
-    expect(
-      screen.getByRole("radio", { name: "Off" }).getAttribute("aria-checked"),
-    ).toBe("false");
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("Auto-include in chat")).toBeTruthy();
   });
 
-  test("renders the Off segment checked for a disabled plugin", () => {
+  test("renders an unchecked toggle for a disabled plugin", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}
@@ -132,15 +128,12 @@ describe("PluginDetailActions Active/Off control", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("radio", { name: "Off" }).getAttribute("aria-checked"),
-    ).toBe("true");
-    expect(
-      screen.getByRole("radio", { name: "Active" }).getAttribute("aria-checked"),
-    ).toBe("false");
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false",
+    );
   });
 
-  test("calls onToggle when the other segment is clicked (no confirm)", () => {
+  test("calls onToggle when the switch is clicked (no confirm)", () => {
     const onToggle = mock(noop);
     render(
       <PluginDetailActions
@@ -151,14 +144,14 @@ describe("PluginDetailActions Active/Off control", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: "Off" }));
+    fireEvent.click(screen.getByRole("switch"));
 
     expect(onToggle).toHaveBeenCalledTimes(1);
     // Optimistic: the state flips without opening any dialog.
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  test("keeps Upgrade available and enabled when the plugin is Off and drifted", () => {
+  test("keeps Upgrade available and enabled when the plugin is Auto-off and drifted", () => {
     render(
       <PluginDetailActions
         {...baseActionsProps}
@@ -190,11 +183,10 @@ describe("PluginDetailActions Active/Off control", () => {
     ).toBeTruthy();
   });
 
-  test("hides the control when enablement is unknown", () => {
+  test("hides the toggle when enablement is unknown", () => {
     render(<PluginDetailActions {...baseActionsProps} />);
 
-    expect(screen.queryByRole("radiogroup")).toBeNull();
-    expect(screen.queryByText("Active")).toBeNull();
-    expect(screen.queryByText("Off")).toBeNull();
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText("Auto-include in chat")).toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -1,15 +1,19 @@
 /**
- * Focused tests for the presentational `PluginDetailMetadata` building block.
- * The panel/page tests cover the install/remove/upgrade flow end-to-end; this
- * pins the metadata table's net-new branch — the contributed-surface counts
+ * Focused tests for the presentational plugin-detail building blocks. The
+ * panel/page tests cover the install/remove/upgrade flow end-to-end; this pins
+ * `PluginDetailMetadata`'s net-new branch — the contributed-surface counts
  * (Skills / Hooks / Tools) that only render when an installed copy's drift
- * inspection supplies them. Presentational, so no QueryClient is needed.
+ * inspection supplies them — plus the `PluginDetailActions` Active/Off toggle.
+ * Both are presentational, so no QueryClient is needed.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { PluginDetailMetadata } from "@/domains/intelligence/components/plugins/plugin-detail-shared";
+import {
+    PluginDetailActions,
+    PluginDetailMetadata,
+} from "@/domains/intelligence/components/plugins/plugin-detail-shared";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 
@@ -72,5 +76,119 @@ describe("PluginDetailMetadata", () => {
 
     expect(html).toContain("Local");
     expect(html).not.toContain("href=\"https://github.com");
+  });
+});
+
+const updateAvailableDrift: PluginDrift = {
+  name: "level-up",
+  installed: true,
+  status: "update-available",
+  local: null,
+  remote: null,
+  remoteError: null,
+  surfaces: null,
+};
+
+const noop = () => {};
+
+const baseActionsProps = {
+  plugin: githubPlugin,
+  drift: undefined,
+  onInstall: noop,
+  onRemove: noop,
+  onUpgrade: noop,
+  isInstalling: false,
+  isRemoving: false,
+  isUpgrading: false,
+  hasLocalEdits: false,
+};
+
+describe("PluginDetailActions Active/Off toggle", () => {
+  test("renders an Active toggle + word reflecting an enabled plugin", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("Active")).toBeTruthy();
+  });
+
+  test("renders an Off toggle + word reflecting a disabled plugin", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled={false}
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    expect(screen.getByText("Off")).toBeTruthy();
+  });
+
+  test("calls onToggle when the switch is clicked (no confirm)", () => {
+    const onToggle = mock(noop);
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={onToggle}
+        isToggling={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // Optimistic: the switch flips without opening any dialog.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("keeps Upgrade available and enabled when the plugin is Off and drifted", () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        drift={updateAvailableDrift}
+        enabled={false}
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    const upgrade = screen.getByRole("button", { name: /Upgrade/ });
+    expect(upgrade.hasAttribute("disabled")).toBe(false);
+  });
+
+  test("Remove still opens its confirm dialog", async () => {
+    render(
+      <PluginDetailActions
+        {...baseActionsProps}
+        enabled
+        onToggle={noop}
+        isToggling={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(
+      await screen.findByText(/Remove "level-up" from this assistant\?/),
+    ).toBeTruthy();
+  });
+
+  test("hides the toggle + word when enablement is unknown", () => {
+    render(<PluginDetailActions {...baseActionsProps} />);
+
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText("Active")).toBeNull();
+    expect(screen.queryByText("Off")).toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -224,6 +224,9 @@ export function PluginDetailActions({
           {enabled !== undefined && onToggle ? (
             <div className="flex items-center gap-2">
               <Toggle
+                // inline-flex so the switch centers on the box (not the text
+                // baseline) and lines up with the label + Remove button.
+                className="inline-flex"
                 checked={enabled}
                 onChange={onToggle}
                 disabled={isToggling}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import {
     PLUGIN_INSTALL_ERROR,
     PLUGIN_REMOVE_ERROR,
+    PLUGIN_TOGGLE_SEGMENTS,
     PLUGIN_UPGRADE_ERROR,
     pluginRemoveConfirmMessage,
     pluginRiskyUpgradeConfirmLabel,
@@ -21,7 +22,7 @@ import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { cn } from "@/utils/misc";
-import { Button, ConfirmDialog, Toggle } from "@vellumai/design-library";
+import { Button, ConfirmDialog, SegmentControl } from "@vellumai/design-library";
 
 /**
  * Presentational building blocks shared by the plugin detail surfaces so the
@@ -218,27 +219,22 @@ export function PluginDetailActions({
         // Wrap on narrow (mobile overlay) widths so a Download + Upgrade +
         // Remove set can't push actions off-screen; single row on desktop.
         <div className="flex flex-wrap items-center gap-2 md:flex-nowrap md:shrink-0">
-          {/* Active/Off toggle leads the cluster (mirrors the MCP card). Hidden
+          {/* Active/Off control leads the cluster (mirrors the MCP card). Hidden
               when enablement is unknown — an older daemon or a deep-link with no
               list row to source it from. Optimistic, so no confirm dialog. */}
           {enabled !== undefined && onToggle ? (
-            <div className="flex items-center gap-2">
-              <Toggle
-                // inline-flex so the switch centers on the box (not the text
-                // baseline) and lines up with the label + Remove button.
-                className="inline-flex"
-                checked={enabled}
-                onChange={onToggle}
-                disabled={isToggling}
-                aria-label={`${enabled ? "Deactivate" : "Activate"} ${plugin.name}`}
-              />
-              <span
-                className="text-body-small-default"
-                style={{ color: "var(--content-tertiary)" }}
-              >
-                {enabled ? "Active" : "Off"}
-              </span>
-            </div>
+            <SegmentControl
+              className="w-auto [&_[role=radio]]:flex-none [&_[role=radio]]:text-body-large-default"
+              items={PLUGIN_TOGGLE_SEGMENTS.map((s) => ({
+                ...s,
+                disabled: isToggling,
+              }))}
+              value={enabled ? "active" : "off"}
+              // Two states, so any change is a flip; SegmentControl already
+              // suppresses same-segment (no-op) clicks.
+              onChange={() => onToggle()}
+              ariaLabel={`Turn ${plugin.name} on or off`}
+            />
           ) : null}
           {artifact ? (
             <Button asChild leftIcon={<Download aria-hidden />}>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -152,18 +152,10 @@ interface PluginDetailActionsProps {
   isUpgrading: boolean;
   /** Gates whether an upgrade prompts before overwriting local edits. */
   hasLocalEdits: boolean;
-  /**
-   * Whether the installed copy is active in this workspace. `undefined` when the
-   * enablement isn't known (older daemon, or a deep-link with no list row) — the
-   * Active/Off toggle is hidden in that case. Only meaningful when installed.
-   */
+  /** Active state of the installed copy; `undefined` hides the Active/Off toggle (see `PluginListItem.enabled`). */
   enabled?: boolean;
-  /**
-   * Flip the plugin's active state (optimistic, no confirm). Paired with
-   * `enabled`; when either is absent the toggle is hidden.
-   */
+  /** Flip the plugin's active state (optimistic, no confirm dialog). */
   onToggle?: () => void;
-  /** True while this plugin's enable/disable request is in flight. */
   isToggling?: boolean;
 }
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -21,7 +21,7 @@ import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { cn } from "@/utils/misc";
-import { Button, ConfirmDialog } from "@vellumai/design-library";
+import { Button, ConfirmDialog, Toggle } from "@vellumai/design-library";
 
 /**
  * Presentational building blocks shared by the plugin detail surfaces so the
@@ -152,6 +152,19 @@ interface PluginDetailActionsProps {
   isUpgrading: boolean;
   /** Gates whether an upgrade prompts before overwriting local edits. */
   hasLocalEdits: boolean;
+  /**
+   * Whether the installed copy is active in this workspace. `undefined` when the
+   * enablement isn't known (older daemon, or a deep-link with no list row) — the
+   * Active/Off toggle is hidden in that case. Only meaningful when installed.
+   */
+  enabled?: boolean;
+  /**
+   * Flip the plugin's active state (optimistic, no confirm). Paired with
+   * `enabled`; when either is absent the toggle is hidden.
+   */
+  onToggle?: () => void;
+  /** True while this plugin's enable/disable request is in flight. */
+  isToggling?: boolean;
 }
 
 /**
@@ -171,6 +184,9 @@ export function PluginDetailActions({
   isRemoving,
   isUpgrading,
   hasLocalEdits,
+  enabled,
+  onToggle,
+  isToggling,
 }: PluginDetailActionsProps) {
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
@@ -210,6 +226,25 @@ export function PluginDetailActions({
         // Wrap on narrow (mobile overlay) widths so a Download + Upgrade +
         // Remove set can't push actions off-screen; single row on desktop.
         <div className="flex flex-wrap items-center gap-2 md:flex-nowrap md:shrink-0">
+          {/* Active/Off toggle leads the cluster (mirrors the MCP card). Hidden
+              when enablement is unknown — an older daemon or a deep-link with no
+              list row to source it from. Optimistic, so no confirm dialog. */}
+          {enabled !== undefined && onToggle ? (
+            <div className="flex items-center gap-2">
+              <Toggle
+                checked={enabled}
+                onChange={onToggle}
+                disabled={isToggling}
+                aria-label={`${enabled ? "Deactivate" : "Activate"} ${plugin.name}`}
+              />
+              <span
+                className="text-body-small-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                {enabled ? "Active" : "Off"}
+              </span>
+            </div>
+          ) : null}
           {artifact ? (
             <Button asChild leftIcon={<Download aria-hidden />}>
               <a href={artifact.url} download>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -12,7 +12,6 @@ import { useState } from "react";
 import {
     PLUGIN_INSTALL_ERROR,
     PLUGIN_REMOVE_ERROR,
-    PLUGIN_TOGGLE_SEGMENTS,
     PLUGIN_UPGRADE_ERROR,
     pluginRemoveConfirmMessage,
     pluginRiskyUpgradeConfirmLabel,
@@ -22,7 +21,7 @@ import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { cn } from "@/utils/misc";
-import { Button, ConfirmDialog, SegmentControl } from "@vellumai/design-library";
+import { Button, ConfirmDialog, Toggle } from "@vellumai/design-library";
 
 /**
  * Presentational building blocks shared by the plugin detail surfaces so the
@@ -153,9 +152,9 @@ interface PluginDetailActionsProps {
   isUpgrading: boolean;
   /** Gates whether an upgrade prompts before overwriting local edits. */
   hasLocalEdits: boolean;
-  /** Active state of the installed copy; `undefined` hides the Active/Off toggle (see `PluginListItem.enabled`). */
+  /** Auto-include state of the installed copy; `undefined` hides the toggle (see `PluginListItem.enabled`). */
   enabled?: boolean;
-  /** Flip the plugin's active state (optimistic, no confirm dialog). */
+  /** Flip the auto-include state (optimistic, no confirm dialog). */
   onToggle?: () => void;
   isToggling?: boolean;
 }
@@ -219,21 +218,15 @@ export function PluginDetailActions({
         // Wrap on narrow (mobile overlay) widths so a Download + Upgrade +
         // Remove set can't push actions off-screen; single row on desktop.
         <div className="flex flex-wrap items-center gap-2 md:flex-nowrap md:shrink-0">
-          {/* Active/Off control leads the cluster (mirrors the MCP card). Hidden
-              when enablement is unknown — an older daemon or a deep-link with no
-              list row to source it from. Optimistic, so no confirm dialog. */}
+          {/* Auto-include toggle leads the cluster (mirrors the MCP card).
+              Hidden when enablement is unknown — an older daemon or a deep-link
+              with no list row to source it from. Optimistic, no confirm. */}
           {enabled !== undefined && onToggle ? (
-            <SegmentControl
-              className="w-auto [&_[role=radio]]:flex-none [&_[role=radio]]:text-body-large-default"
-              items={PLUGIN_TOGGLE_SEGMENTS.map((s) => ({
-                ...s,
-                disabled: isToggling,
-              }))}
-              value={enabled ? "active" : "off"}
-              // Two states, so any change is a flip; SegmentControl already
-              // suppresses same-segment (no-op) clicks.
+            <Toggle
+              label="Auto-include in chat"
+              checked={enabled}
               onChange={() => onToggle()}
-              ariaLabel={`Turn ${plugin.name} on or off`}
+              disabled={isToggling}
             />
           ) : null}
           {artifact ? (

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -12,6 +12,7 @@ import {
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
 import { Button, Card } from "@vellumai/design-library";
@@ -27,6 +28,12 @@ interface PluginDetailProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
+  /**
+   * Active/Off state from the selected list row (the detail GET carries no
+   * enablement). `undefined` on older daemons or a deep-link with no matching
+   * row — the Active/Off toggle stays hidden in that case.
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -48,6 +55,7 @@ export function PluginDetail({
   name,
   onBack,
   externalHint,
+  enabled,
 }: PluginDetailProps) {
   const {
     plugin,
@@ -65,6 +73,8 @@ export function PluginDetail({
     isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
@@ -88,6 +98,9 @@ export function PluginDetail({
           isRemoving={isRemoving}
           isUpgrading={isUpgrading}
           hasLocalEdits={hasLocalEdits}
+          enabled={enabled}
+          onToggle={() => toggle(name, !enabled)}
+          isToggling={togglingName === name}
         />
       </div>
 
@@ -141,6 +154,9 @@ interface HeaderProps {
   isRemoving: boolean;
   isUpgrading: boolean;
   hasLocalEdits: boolean;
+  enabled?: boolean;
+  onToggle?: () => void;
+  isToggling: boolean;
 }
 
 function Header({
@@ -155,6 +171,9 @@ function Header({
   isRemoving,
   isUpgrading,
   hasLocalEdits,
+  enabled,
+  onToggle,
+  isToggling,
 }: HeaderProps) {
   const isExternal = plugin?.source?.kind === "github";
   // Gate the header icon on the loaded plugin, seeding the known external state
@@ -214,6 +233,9 @@ function Header({
           isRemoving={isRemoving}
           isUpgrading={isUpgrading}
           hasLocalEdits={hasLocalEdits}
+          enabled={enabled}
+          onToggle={onToggle}
+          isToggling={isToggling}
         />
       ) : null}
     </div>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -28,11 +28,7 @@ interface PluginDetailProps {
    * glyph immediately. `undefined` for deep-links with no matching row.
    */
   externalHint?: boolean;
-  /**
-   * Active/Off state from the selected list row (the detail GET carries no
-   * enablement). `undefined` on older daemons or a deep-link with no matching
-   * row — the Active/Off toggle stays hidden in that case.
-   */
+  /** Active/Off state seeded from the selected list row (see `PluginListItem.enabled`); `undefined` hides the toggle. */
   enabled?: boolean;
 }
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
@@ -114,7 +114,9 @@ describe("Plugins FilterBar", () => {
     const labels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(labels).toEqual(["All", "Available"]);
+    // No enable/disable support → Active/Off are omitted, but Installed is
+    // restored (older daemons keep the installed/available distinction).
+    expect(labels).toEqual(["All", "Installed", "Available"]);
   });
 
   test("the mobile sheet exposes category rows that report the selected slug", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.test.tsx
@@ -35,6 +35,7 @@ function baseProps() {
     counts: {} as Record<string, number>,
     totalCount: 0,
     showCounts: true,
+    pluginToggleSupported: true,
   };
 }
 
@@ -91,16 +92,29 @@ describe("Plugins FilterBar", () => {
     expect(onSearchChange).toHaveBeenCalledWith("memory");
   });
 
-  test("opening the filter and choosing Installed switches the filter", () => {
+  test("opening the filter and choosing Active switches the filter", () => {
     const onFilterChange = mock((_filter: PluginFilter) => {});
     const { getByLabelText } = render(
       <FilterBar {...baseProps()} onFilterChange={onFilterChange} />,
     );
 
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
 
-    expect(onFilterChange).toHaveBeenCalledWith("installed");
+    expect(onFilterChange).toHaveBeenCalledWith("active");
+  });
+
+  test("omits Active/Off when the daemon lacks enable/disable support", () => {
+    const { getByLabelText } = render(
+      <FilterBar {...baseProps()} pluginToggleSupported={false} />,
+    );
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(labels).toEqual(["All", "Available"]);
   });
 
   test("the mobile sheet exposes category rows that report the selected slug", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
@@ -33,10 +33,17 @@ const AVAILABLE_FILTER: FilterOption = {
 /**
  * Status options for the filter. Active/Off narrow installed rows by
  * enablement, so they only make sense when the daemon supports toggling —
- * without it there's no active/off distinction, so fall back to All / Available.
+ * without it there's no active/off distinction, so offer a plain Installed
+ * option instead (All / Installed / Available).
  */
 function statusFilters(pluginToggleSupported: boolean): FilterOption[] {
-  if (!pluginToggleSupported) return [ALL_FILTER, AVAILABLE_FILTER];
+  if (!pluginToggleSupported) {
+    return [
+      ALL_FILTER,
+      { value: "installed", label: "Installed", icon: CheckCircle },
+      AVAILABLE_FILTER,
+    ];
+  }
   return [
     ALL_FILTER,
     { value: "active", label: "Active", icon: Power },

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-filters.tsx
@@ -5,6 +5,8 @@ import {
     Filter,
     LayoutGrid,
     Loader2,
+    Power,
+    PowerOff,
     Search,
 } from "lucide-react";
 import { type ChangeEvent, type ReactNode, useState } from "react";
@@ -21,11 +23,27 @@ interface FilterOption {
   icon: typeof LayoutGrid;
 }
 
-const STATUS_FILTERS: FilterOption[] = [
-  { value: "all", label: "All", icon: LayoutGrid },
-  { value: "installed", label: "Installed", icon: CheckCircle },
-  { value: "available", label: "Available", icon: ArrowDownToLine },
-];
+const ALL_FILTER: FilterOption = { value: "all", label: "All", icon: LayoutGrid };
+const AVAILABLE_FILTER: FilterOption = {
+  value: "available",
+  label: "Available",
+  icon: ArrowDownToLine,
+};
+
+/**
+ * Status options for the filter. Active/Off narrow installed rows by
+ * enablement, so they only make sense when the daemon supports toggling —
+ * without it there's no active/off distinction, so fall back to All / Available.
+ */
+function statusFilters(pluginToggleSupported: boolean): FilterOption[] {
+  if (!pluginToggleSupported) return [ALL_FILTER, AVAILABLE_FILTER];
+  return [
+    ALL_FILTER,
+    { value: "active", label: "Active", icon: Power },
+    { value: "off", label: "Off", icon: PowerOff },
+    AVAILABLE_FILTER,
+  ];
+}
 
 interface FilterBarProps {
   search: string;
@@ -42,6 +60,8 @@ interface FilterBarProps {
   counts: Record<string, number>;
   totalCount: number;
   showCounts: boolean;
+  /** Gates the Active/Off status options on daemon enable/disable support. */
+  pluginToggleSupported: boolean;
 }
 
 export function FilterBar({
@@ -56,6 +76,7 @@ export function FilterBar({
   counts,
   totalCount,
   showCounts,
+  pluginToggleSupported,
 }: FilterBarProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
@@ -88,6 +109,7 @@ export function FilterBar({
         counts={counts}
         totalCount={totalCount}
         showCounts={showCounts}
+        pluginToggleSupported={pluginToggleSupported}
       />
     </div>
   );
@@ -102,6 +124,7 @@ interface FilterControlProps {
   counts: Record<string, number>;
   totalCount: number;
   showCounts: boolean;
+  pluginToggleSupported: boolean;
 }
 
 /**
@@ -144,7 +167,7 @@ function FilterControl(props: FilterControlProps) {
         <ul role="listbox">
           <FilterGroup
             label="Status"
-            options={STATUS_FILTERS}
+            options={statusFilters(props.pluginToggleSupported)}
             selected={props.filter}
             onSelect={(v) => {
               props.onFilterChange(v);
@@ -179,6 +202,7 @@ function FilterSheet({
   counts,
   totalCount,
   showCounts,
+  pluginToggleSupported,
   open,
   onOpenChange,
   trigger,
@@ -200,7 +224,7 @@ function FilterSheet({
         </BottomSheet.Header>
         <BottomSheet.Body className="flex flex-col gap-3 pt-2">
           <SheetSection label="Status">
-            {STATUS_FILTERS.map((option) => (
+            {statusFilters(pluginToggleSupported).map((option) => (
               <FilterRow
                 key={option.value}
                 icon={option.icon}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -213,7 +213,7 @@ describe("PluginListRow", () => {
     ).not.toBeNull();
   });
 
-  test("Auto-on installed row shows an Auto-on tag beside Remove (no toggle)", () => {
+  test("Enabled installed row shows an Enabled tag beside Remove (no toggle)", () => {
     const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: true })}
@@ -222,7 +222,7 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(getByText("Auto-on")).toBeTruthy();
+    expect(getByText("Enabled")).toBeTruthy();
     // The row carries no interactive toggle — changing it happens on detail.
     expect(document.querySelector('button[role="switch"]')).toBeNull();
     expect(
@@ -230,7 +230,7 @@ describe("PluginListRow", () => {
     ).not.toBeNull();
   });
 
-  test("Auto-off row is dimmed and shows an Auto-off tag", () => {
+  test("Disabled row is dimmed and shows a Disabled tag", () => {
     const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: false })}
@@ -238,12 +238,12 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(getByText("Auto-off")).toBeTruthy();
-    // Off rows dim the name to the tertiary content token.
+    expect(getByText("Disabled")).toBeTruthy();
+    // Disabled rows dim the name to the tertiary content token.
     expect(getByText("Test Plugin").style.color).toContain("content-tertiary");
   });
 
-  test("drift renders the Update chip (Remove stays), even when Auto-off", () => {
+  test("drift renders the Update chip (Remove stays), even when Disabled", () => {
     const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: false })}
@@ -261,8 +261,8 @@ describe("PluginListRow", () => {
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
-    // The chip shows regardless of the auto-include state — here it's Auto-off.
-    expect(getByText("Auto-off")).toBeTruthy();
+    // The chip shows regardless of the enablement state — here it's Disabled.
+    expect(getByText("Disabled")).toBeTruthy();
   });
 
   test("available row shows only Install (no tag, no Remove)", () => {
@@ -277,8 +277,8 @@ describe("PluginListRow", () => {
     expect(
       document.querySelector('button[aria-label="Install plugin"]'),
     ).not.toBeNull();
-    expect(queryByText("Auto-on")).toBeNull();
-    expect(queryByText("Auto-off")).toBeNull();
+    expect(queryByText("Enabled")).toBeNull();
+    expect(queryByText("Disabled")).toBeNull();
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).toBeNull();
@@ -293,8 +293,8 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(queryByText("Auto-on")).toBeNull();
-    expect(queryByText("Auto-off")).toBeNull();
+    expect(queryByText("Enabled")).toBeNull();
+    expect(queryByText("Disabled")).toBeNull();
     // Remove is still present for installed rows.
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -57,6 +57,18 @@ function getButton(label: string): HTMLButtonElement {
   return match;
 }
 
+/** Find an Active/Off segment by its visible label (the SegmentControl's
+ *  segments are `role="radio"` buttons whose accessible name is their text). */
+function getSegment(label: "Active" | "Off"): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('button[role="radio"]'),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(`expected an Active/Off segment labelled "${label}"`);
+  }
+  return match;
+}
+
 describe("PluginListRow", () => {
   test("clicking the row fires onSelect", () => {
     const onSelect = mock(() => {});
@@ -213,7 +225,7 @@ describe("PluginListRow", () => {
     ).not.toBeNull();
   });
 
-  test("Active installed row shows an on switch beside Remove", () => {
+  test("Active installed row shows the Active segment checked beside Remove", () => {
     render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: true })}
@@ -223,15 +235,13 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(getButton("Turn Test Plugin off").getAttribute("aria-checked")).toBe(
-      "true",
-    );
+    expect(getSegment("Active").getAttribute("aria-checked")).toBe("true");
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
   });
 
-  test("toggling an Active row fires onToggle(false) without selecting", () => {
+  test("clicking Off on an Active row fires onToggle(false) without selecting", () => {
     const onSelect = mock(() => {});
     const onToggle = mock((_next: boolean) => {});
 
@@ -243,14 +253,14 @@ describe("PluginListRow", () => {
       />,
     );
 
-    fireEvent.click(getButton("Turn Test Plugin off"));
+    fireEvent.click(getSegment("Off"));
 
     expect(onToggle).toHaveBeenCalledTimes(1);
     expect(onToggle).toHaveBeenCalledWith(false);
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  test("Off row is dimmed and its switch reads off", () => {
+  test("Off row is dimmed and its Off segment reads checked", () => {
     const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: false })}
@@ -259,9 +269,8 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
-      "false",
-    );
+    expect(getSegment("Off").getAttribute("aria-checked")).toBe("true");
+    expect(getSegment("Active").getAttribute("aria-checked")).toBe("false");
     // Off rows dim the name to the tertiary content token.
     expect(getByText("Test Plugin").style.color).toContain("content-tertiary");
   });
@@ -286,12 +295,10 @@ describe("PluginListRow", () => {
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
     // The chip shows regardless of Active/Off — the row here is Off.
-    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
-      "false",
-    );
+    expect(getSegment("Active").getAttribute("aria-checked")).toBe("false");
   });
 
-  test("available row shows only Install (no switch, no Remove)", () => {
+  test("available row shows only Install (no toggle, no Remove)", () => {
     render(
       <PluginListRow
         item={makeItem({ status: "available" })}
@@ -303,13 +310,13 @@ describe("PluginListRow", () => {
     expect(
       document.querySelector('button[aria-label="Install plugin"]'),
     ).not.toBeNull();
-    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    expect(document.querySelector('[role="radiogroup"]')).toBeNull();
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).toBeNull();
   });
 
-  test("installed row without `enabled` (older daemon) renders no switch", () => {
+  test("installed row without `enabled` (older daemon) renders no toggle", () => {
     render(
       <PluginListRow
         item={makeItem({ status: "installed" })}
@@ -319,7 +326,7 @@ describe("PluginListRow", () => {
       />,
     );
 
-    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    expect(document.querySelector('[role="radiogroup"]')).toBeNull();
     // Remove is still present for installed rows.
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -57,18 +57,6 @@ function getButton(label: string): HTMLButtonElement {
   return match;
 }
 
-/** Find an Active/Off segment by its visible label (the SegmentControl's
- *  segments are `role="radio"` buttons whose accessible name is their text). */
-function getSegment(label: "Active" | "Off"): HTMLButtonElement {
-  const match = Array.from(
-    document.querySelectorAll<HTMLButtonElement>('button[role="radio"]'),
-  ).find((b) => b.textContent?.trim() === label);
-  if (!match) {
-    throw new Error(`expected an Active/Off segment labelled "${label}"`);
-  }
-  return match;
-}
-
 describe("PluginListRow", () => {
   test("clicking the row fires onSelect", () => {
     const onSelect = mock(() => {});
@@ -225,63 +213,42 @@ describe("PluginListRow", () => {
     ).not.toBeNull();
   });
 
-  test("Active installed row shows the Active segment checked beside Remove", () => {
-    render(
+  test("Auto-on installed row shows an Auto-on tag beside Remove (no toggle)", () => {
+    const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: true })}
         onSelect={mock(() => {})}
-        onToggle={mock(() => {})}
         onRemove={mock(() => {})}
       />,
     );
 
-    expect(getSegment("Active").getAttribute("aria-checked")).toBe("true");
+    expect(getByText("Auto-on")).toBeTruthy();
+    // The row carries no interactive toggle — changing it happens on detail.
+    expect(document.querySelector('button[role="switch"]')).toBeNull();
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
   });
 
-  test("clicking Off on an Active row fires onToggle(false) without selecting", () => {
-    const onSelect = mock(() => {});
-    const onToggle = mock((_next: boolean) => {});
-
-    render(
-      <PluginListRow
-        item={makeItem({ status: "installed", enabled: true })}
-        onSelect={onSelect}
-        onToggle={onToggle}
-      />,
-    );
-
-    fireEvent.click(getSegment("Off"));
-
-    expect(onToggle).toHaveBeenCalledTimes(1);
-    expect(onToggle).toHaveBeenCalledWith(false);
-    expect(onSelect).not.toHaveBeenCalled();
-  });
-
-  test("Off row is dimmed and its Off segment reads checked", () => {
+  test("Auto-off row is dimmed and shows an Auto-off tag", () => {
     const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: false })}
         onSelect={mock(() => {})}
-        onToggle={mock(() => {})}
       />,
     );
 
-    expect(getSegment("Off").getAttribute("aria-checked")).toBe("true");
-    expect(getSegment("Active").getAttribute("aria-checked")).toBe("false");
+    expect(getByText("Auto-off")).toBeTruthy();
     // Off rows dim the name to the tertiary content token.
     expect(getByText("Test Plugin").style.color).toContain("content-tertiary");
   });
 
-  test("drift renders the Update chip (Remove stays), even when Off", () => {
-    render(
+  test("drift renders the Update chip (Remove stays), even when Auto-off", () => {
+    const { getByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed", enabled: false })}
         drift={makeDrift("update-available")}
         onSelect={mock(() => {})}
-        onToggle={mock(() => {})}
         onRemove={mock(() => {})}
         onUpgrade={mock(() => {})}
       />,
@@ -294,12 +261,12 @@ describe("PluginListRow", () => {
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
-    // The chip shows regardless of Active/Off — the row here is Off.
-    expect(getSegment("Active").getAttribute("aria-checked")).toBe("false");
+    // The chip shows regardless of the auto-include state — here it's Auto-off.
+    expect(getByText("Auto-off")).toBeTruthy();
   });
 
-  test("available row shows only Install (no toggle, no Remove)", () => {
-    render(
+  test("available row shows only Install (no tag, no Remove)", () => {
+    const { queryByText } = render(
       <PluginListRow
         item={makeItem({ status: "available" })}
         onSelect={mock(() => {})}
@@ -310,23 +277,24 @@ describe("PluginListRow", () => {
     expect(
       document.querySelector('button[aria-label="Install plugin"]'),
     ).not.toBeNull();
-    expect(document.querySelector('[role="radiogroup"]')).toBeNull();
+    expect(queryByText("Auto-on")).toBeNull();
+    expect(queryByText("Auto-off")).toBeNull();
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).toBeNull();
   });
 
-  test("installed row without `enabled` (older daemon) renders no toggle", () => {
-    render(
+  test("installed row without `enabled` (older daemon) renders no tag", () => {
+    const { queryByText } = render(
       <PluginListRow
         item={makeItem({ status: "installed" })}
         onSelect={mock(() => {})}
-        onToggle={mock(() => {})}
         onRemove={mock(() => {})}
       />,
     );
 
-    expect(document.querySelector('[role="radiogroup"]')).toBeNull();
+    expect(queryByText("Auto-on")).toBeNull();
+    expect(queryByText("Auto-off")).toBeNull();
     // Remove is still present for installed rows.
     expect(
       document.querySelector('button[aria-label="Remove plugin"]'),

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -144,6 +144,21 @@ describe("PluginListRow", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  test("Remove is disabled while an upgrade is in flight (no concurrent delete)", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        drift={makeDrift("update-available")}
+        onSelect={() => {}}
+        onRemove={() => {}}
+        onUpgrade={() => {}}
+        isUpgrading
+      />,
+    );
+
+    expect(getButton("Remove plugin").disabled).toBe(true);
+  });
+
   test("does not render an origin badge (origin is unknowable from the list)", () => {
     const onSelect = mock(() => {});
 
@@ -164,6 +179,7 @@ describe("PluginListRow", () => {
 
   test("upgrade affordance only appears with update-available drift", () => {
     const onSelect = mock(() => {});
+    const onUpgrade = mock(() => {});
 
     // Up-to-date installed plugin shows Remove, not Upgrade.
     const { rerender } = render(
@@ -171,6 +187,7 @@ describe("PluginListRow", () => {
         item={makeItem({ status: "installed" })}
         drift={makeDrift("up-to-date")}
         onSelect={onSelect}
+        onUpgrade={onUpgrade}
       />,
     );
 
@@ -181,17 +198,131 @@ describe("PluginListRow", () => {
       document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
 
-    // Same plugin with drift now exposes Upgrade.
+    // Same plugin with drift now exposes Upgrade (Remove stays put).
     rerender(
       <PluginListRow
         item={makeItem({ status: "installed" })}
         drift={makeDrift("update-available")}
         onSelect={onSelect}
+        onUpgrade={onUpgrade}
       />,
     );
 
     expect(
       document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).not.toBeNull();
+  });
+
+  test("Active installed row shows an on switch beside Remove", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: true })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(getButton("Turn Test Plugin off").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).not.toBeNull();
+  });
+
+  test("toggling an Active row fires onToggle(false) without selecting", () => {
+    const onSelect = mock(() => {});
+    const onToggle = mock((_next: boolean) => {});
+
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: true })}
+        onSelect={onSelect}
+        onToggle={onToggle}
+      />,
+    );
+
+    fireEvent.click(getButton("Turn Test Plugin off"));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith(false);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("Off row is dimmed and its switch reads off", () => {
+    const { getByText } = render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: false })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+      />,
+    );
+
+    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    // Off rows dim the name to the tertiary content token.
+    expect(getByText("Test Plugin").style.color).toContain("content-tertiary");
+  });
+
+  test("drift renders the Update chip (Remove stays), even when Off", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed", enabled: false })}
+        drift={makeDrift("update-available")}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+        onUpgrade={mock(() => {})}
+      />,
+    );
+
+    // Drift is an Update chip, not a Remove-replacing button: both are present.
+    expect(
+      document.querySelector('button[aria-label="Upgrade plugin"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).not.toBeNull();
+    // The chip shows regardless of Active/Off — the row here is Off.
+    expect(getButton("Turn Test Plugin on").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  test("available row shows only Install (no switch, no Remove)", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "available" })}
+        onSelect={mock(() => {})}
+        onInstall={mock(() => {})}
+      />,
+    );
+
+    expect(
+      document.querySelector('button[aria-label="Install plugin"]'),
+    ).not.toBeNull();
+    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
+    ).toBeNull();
+  });
+
+  test("installed row without `enabled` (older daemon) renders no switch", () => {
+    render(
+      <PluginListRow
+        item={makeItem({ status: "installed" })}
+        onSelect={mock(() => {})}
+        onToggle={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(document.querySelector('button[role="switch"]')).toBeNull();
+    // Remove is still present for installed rows.
+    expect(
+      document.querySelector('button[aria-label="Remove plugin"]'),
     ).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -3,10 +3,9 @@ import type { KeyboardEvent } from "react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
-import { PLUGIN_TOGGLE_SEGMENTS } from "@/domains/intelligence/plugins/constants";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
-import { Button, Card, SegmentControl } from "@vellumai/design-library";
+import { Button, Card, Tag } from "@vellumai/design-library";
 
 interface PluginListRowProps {
   item: PluginListItem;
@@ -17,13 +16,9 @@ interface PluginListRowProps {
   onInstall?: () => void;
   onRemove?: () => void;
   onUpgrade?: () => void;
-  /** Enable/disable the installed plugin. Wired only when the daemon supports
-   *  toggling (older daemons omit `enabled`, so no switch renders). */
-  onToggle?: (nextEnabled: boolean) => void;
   isInstalling?: boolean;
   isRemoving?: boolean;
   isUpgrading?: boolean;
-  isToggling?: boolean;
 }
 
 /**
@@ -38,15 +33,15 @@ export function PluginListRow({
   onInstall,
   onRemove,
   onUpgrade,
-  onToggle,
   isInstalling = false,
   isRemoving = false,
   isUpgrading = false,
-  isToggling = false,
 }: PluginListRowProps) {
   const available = item.status === "available";
   const updateAvailable = drift?.status === "update-available";
-  const showToggle = onToggle !== undefined && item.enabled !== undefined;
+  // Read-only auto-include state. Rendered when the daemon reports it; changing
+  // it happens on the detail page (the row is not interactive).
+  const showEnablement = item.enabled !== undefined;
   const dimmed = item.enabled === false;
 
   const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -97,7 +92,7 @@ export function PluginListRow({
                 source, so a list row can't tell Local from External. The detail
                 view derives origin from the plugin's own `source` instead. */}
             {/* The chip is the Upgrade control; it shows on any drift,
-                regardless of Active/Off. */}
+                regardless of the auto-include state. */}
             {updateAvailable ? (
               <UpdateAvailableBadge
                 onClick={onUpgrade}
@@ -148,27 +143,15 @@ export function PluginListRow({
             />
           )
         ) : (
-          // Installed: Active/Off control beside an always-present Remove (Upgrade
-          // lives in the version-line chip), so the pair never shifts.
+          // Installed: a read-only auto-include tag beside an always-present
+          // Remove (Upgrade lives in the version-line chip), so the pair never
+          // shifts. The tag is informational — clicking the row opens the detail
+          // page, where the setting is changed.
           <div className="flex shrink-0 items-center gap-2">
-            {showToggle ? (
-              // Wrap to stopPropagation: the row is a role="button" and would
-              // otherwise select when a segment is clicked.
-              <span
-                className="inline-flex items-center"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <SegmentControl
-                  className="w-auto [&_[role=radio]]:flex-none [&_[role=radio]]:text-body-large-default"
-                  items={PLUGIN_TOGGLE_SEGMENTS.map((s) => ({
-                    ...s,
-                    disabled: isToggling,
-                  }))}
-                  value={item.enabled ? "active" : "off"}
-                  onChange={(next) => onToggle?.(next === "active")}
-                  ariaLabel={`Turn ${item.name} on or off`}
-                />
-              </span>
+            {showEnablement ? (
+              <Tag tone={item.enabled ? "positive" : "neutral"}>
+                {item.enabled ? "Auto-on" : "Auto-off"}
+              </Tag>
             ) : null}
             <Button
               type="button"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -153,8 +153,14 @@ export function PluginListRow({
             {showToggle ? (
               // Toggle has no onClick to stopPropagation, so wrap it: the row is
               // a role="button" and would otherwise select on switch clicks.
-              <span onClick={(e) => e.stopPropagation()}>
+              // inline-flex on both wrappers drops the switch's baseline gap so
+              // it centers with the Remove button.
+              <span
+                className="inline-flex items-center"
+                onClick={(e) => e.stopPropagation()}
+              >
                 <Toggle
+                  className="inline-flex"
                   checked={item.enabled ?? false}
                   onChange={() => onToggle?.(!item.enabled)}
                   disabled={isToggling}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -143,14 +143,14 @@ export function PluginListRow({
             />
           )
         ) : (
-          // Installed: a read-only auto-include tag beside an always-present
+          // Installed: a read-only Enabled/Disabled tag beside an always-present
           // Remove (Upgrade lives in the version-line chip), so the pair never
           // shifts. The tag is informational — clicking the row opens the detail
           // page, where the setting is changed.
           <div className="flex shrink-0 items-center gap-2">
             {showEnablement ? (
               <Tag tone={item.enabled ? "positive" : "neutral"}>
-                {item.enabled ? "Auto-on" : "Auto-off"}
+                {item.enabled ? "Enabled" : "Disabled"}
               </Tag>
             ) : null}
             <Button

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -3,9 +3,10 @@ import type { KeyboardEvent } from "react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
+import { PLUGIN_TOGGLE_SEGMENTS } from "@/domains/intelligence/plugins/constants";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
-import { Button, Card, Toggle } from "@vellumai/design-library";
+import { Button, Card, SegmentControl } from "@vellumai/design-library";
 
 interface PluginListRowProps {
   item: PluginListItem;
@@ -147,24 +148,25 @@ export function PluginListRow({
             />
           )
         ) : (
-          // Installed: Active/Off switch beside an always-present Remove (Upgrade
+          // Installed: Active/Off control beside an always-present Remove (Upgrade
           // lives in the version-line chip), so the pair never shifts.
           <div className="flex shrink-0 items-center gap-2">
             {showToggle ? (
-              // Toggle has no onClick to stopPropagation, so wrap it: the row is
-              // a role="button" and would otherwise select on switch clicks.
-              // inline-flex on both wrappers drops the switch's baseline gap so
-              // it centers with the Remove button.
+              // Wrap to stopPropagation: the row is a role="button" and would
+              // otherwise select when a segment is clicked.
               <span
                 className="inline-flex items-center"
                 onClick={(e) => e.stopPropagation()}
               >
-                <Toggle
-                  className="inline-flex"
-                  checked={item.enabled ?? false}
-                  onChange={() => onToggle?.(!item.enabled)}
-                  disabled={isToggling}
-                  aria-label={`Turn ${item.name} ${item.enabled ? "off" : "on"}`}
+                <SegmentControl
+                  className="w-auto [&_[role=radio]]:flex-none [&_[role=radio]]:text-body-large-default"
+                  items={PLUGIN_TOGGLE_SEGMENTS.map((s) => ({
+                    ...s,
+                    disabled: isToggling,
+                  }))}
+                  value={item.enabled ? "active" : "off"}
+                  onChange={(next) => onToggle?.(next === "active")}
+                  ariaLabel={`Turn ${item.name} on or off`}
                 />
               </span>
             ) : null}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -1,11 +1,11 @@
-import { ArrowDownToLine, ArrowUpCircle, Loader2, Trash2 } from "lucide-react";
+import { ArrowDownToLine, Loader2, Trash2 } from "lucide-react";
 import type { KeyboardEvent } from "react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
-import { Button, Card } from "@vellumai/design-library";
+import { Button, Card, Toggle } from "@vellumai/design-library";
 
 interface PluginListRowProps {
   item: PluginListItem;
@@ -16,18 +16,23 @@ interface PluginListRowProps {
   onInstall?: () => void;
   onRemove?: () => void;
   onUpgrade?: () => void;
+  /** Enable/disable the installed plugin. Wired only when the daemon supports
+   *  toggling (older daemons omit `enabled`, so no switch renders). */
+  onToggle?: (nextEnabled: boolean) => void;
   isInstalling?: boolean;
   isRemoving?: boolean;
   isUpgrading?: boolean;
+  isToggling?: boolean;
 }
 
 /**
  * Unified row for the Plugins tab, mirroring `SkillRow`: an emoji icon, the
- * name with version + update badge, a description, and a single trailing
- * inline action chosen by status (Install for catalog entries, Upgrade when an
- * installed copy is behind the marketplace pin, otherwise Remove). The whole
- * row is a `role="button"` that fires `onSelect`; the trailing action
- * `stopPropagation`s so it never also selects the row.
+ * name with version + update badge, a description, and trailing inline
+ * actions. Catalog entries show only Install; installed rows show an
+ * Active/Off `Toggle` beside an always-present Remove, plus an "Update" chip
+ * on the version line when the installed copy is behind the marketplace pin.
+ * The whole row is a `role="button"` that fires `onSelect`; every trailing
+ * control `stopPropagation`s so it never also selects the row.
  */
 export function PluginListRow({
   item,
@@ -36,12 +41,16 @@ export function PluginListRow({
   onInstall,
   onRemove,
   onUpgrade,
+  onToggle,
   isInstalling = false,
   isRemoving = false,
   isUpgrading = false,
+  isToggling = false,
 }: PluginListRowProps) {
   const available = item.status === "available";
   const updateAvailable = drift?.status === "update-available";
+  const showToggle = onToggle !== undefined && item.enabled !== undefined;
+  const dimmed = item.enabled === false;
 
   const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     // Ignore key events bubbling up from a focused inline action button —
@@ -62,12 +71,20 @@ export function PluginListRow({
         onKeyDown={handleRowKeyDown}
         className="flex cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-        <PluginIcon size="sm" external={item.external} />
+        <PluginIcon
+          size="sm"
+          external={item.external}
+          className={dimmed ? "opacity-50" : undefined}
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span
               className="truncate text-body-medium-default"
-              style={{ color: "var(--content-emphasised)" }}
+              style={{
+                color: dimmed
+                  ? "var(--content-tertiary)"
+                  : "var(--content-emphasised)",
+              }}
             >
               {item.name}
             </span>
@@ -82,7 +99,14 @@ export function PluginListRow({
             {/* No origin badge here: the installed-list endpoint carries no
                 source, so a list row can't tell Local from External. The detail
                 view derives origin from the plugin's own `source` instead. */}
-            {updateAvailable ? <UpdateAvailableBadge /> : null}
+            {/* The chip is the Upgrade control; it shows on any drift,
+                regardless of Active/Off. */}
+            {updateAvailable ? (
+              <UpdateAvailableBadge
+                onClick={onUpgrade}
+                isUpgrading={isUpgrading}
+              />
+            ) : null}
           </div>
           <p
             className="mt-1 truncate text-body-medium-lighter"
@@ -126,43 +150,41 @@ export function PluginListRow({
               expandOnMobile={false}
             />
           )
-        ) : updateAvailable ? (
-          <Button
-            type="button"
-            iconOnly={
-              isUpgrading ? (
-                <Loader2 className="animate-spin" aria-hidden />
-              ) : (
-                <ArrowUpCircle aria-hidden />
-              )
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              onUpgrade?.();
-            }}
-            disabled={isUpgrading || !onUpgrade}
-            aria-label="Upgrade plugin"
-            expandOnMobile={false}
-          />
         ) : (
-          <Button
-            type="button"
-            variant="dangerOutline"
-            iconOnly={
-              isRemoving ? (
-                <Loader2 className="animate-spin" aria-hidden />
-              ) : (
-                <Trash2 aria-hidden />
-              )
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove?.();
-            }}
-            disabled={isRemoving || !onRemove}
-            aria-label="Remove plugin"
-            expandOnMobile={false}
-          />
+          // Installed: Active/Off switch beside an always-present Remove (Upgrade
+          // lives in the version-line chip), so the pair never shifts.
+          <div className="flex shrink-0 items-center gap-2">
+            {showToggle ? (
+              // Toggle has no onClick to stopPropagation, so wrap it: the row is
+              // a role="button" and would otherwise select on switch clicks.
+              <span onClick={(e) => e.stopPropagation()}>
+                <Toggle
+                  checked={item.enabled ?? false}
+                  onChange={() => onToggle?.(!item.enabled)}
+                  disabled={isToggling}
+                  aria-label={`Turn ${item.name} ${item.enabled ? "off" : "on"}`}
+                />
+              </span>
+            ) : null}
+            <Button
+              type="button"
+              variant="dangerOutline"
+              iconOnly={
+                isRemoving ? (
+                  <Loader2 className="animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 aria-hidden />
+                )
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove?.();
+              }}
+              disabled={isRemoving || isUpgrading || !onRemove}
+              aria-label="Remove plugin"
+              expandOnMobile={false}
+            />
+          </div>
         )}
       </div>
     </Card.Root>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -26,13 +26,9 @@ interface PluginListRowProps {
 }
 
 /**
- * Unified row for the Plugins tab, mirroring `SkillRow`: an emoji icon, the
- * name with version + update badge, a description, and trailing inline
- * actions. Catalog entries show only Install; installed rows show an
- * Active/Off `Toggle` beside an always-present Remove, plus an "Update" chip
- * on the version line when the installed copy is behind the marketplace pin.
- * The whole row is a `role="button"` that fires `onSelect`; every trailing
- * control `stopPropagation`s so it never also selects the row.
+ * Unified row for the Plugins tab, mirroring `SkillRow`. The whole row is a
+ * `role="button"` that fires `onSelect`; every trailing control
+ * `stopPropagation`s so it never also selects the row.
  */
 export function PluginListRow({
   item,

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -140,13 +140,15 @@ const { PluginsTab } = await import("./plugins-tab");
 // ---------------------------------------------------------------------------
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default (older-daemon shape); the cast is needed
+  // because the generated element type marks it required.
   return {
     id: "simple-memory",
     name: "simple-memory",
     description: "Memory plugin",
     version: "0.1.0",
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 /** Minimal schema-valid inspect result reporting no drift (the row reads

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -330,20 +330,26 @@ describe("PluginsTab", () => {
     expect(queryByText("apollo-bot-brain")).toBeTruthy();
   });
 
-  test("hides Active/Off when the daemon lacks enable/disable support", async () => {
+  test("offers Installed (not Active/Off) and filters to installed rows when the daemon lacks enable/disable support", async () => {
     // `installed()` omits `enabled` (older-daemon shape) → toggle unsupported.
     installedPlugins = [installed()];
     catalogMatches = [catalog()];
 
-    const { findByText, getByLabelText } = renderTab();
+    const { findByText, queryByText, getByLabelText } = renderTab();
     await findByText("apollo-bot-brain");
 
     fireEvent.click(getByLabelText("Filter plugins"));
 
+    // Active/Off are replaced by a plain Installed option.
     const labels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(labels).toEqual(["All", "Available"]);
+    expect(labels).toEqual(["All", "Installed", "Available"]);
+
+    // Installed narrows to installed rows; the catalog (available) row drops.
+    clickStatusOption("Installed");
+    await waitFor(() => expect(queryByText("apollo-bot-brain")).toBeNull());
+    expect(queryByText("simple-memory")).toBeTruthy();
   });
 
   test("search filters the list in memory", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -280,18 +280,70 @@ describe("PluginsTab", () => {
     expect(queryByText("Available to install")).toBeNull();
   });
 
-  test("status filter narrows the list to installed only", async () => {
-    installedPlugins = [installed()];
+  test("the Active filter narrows to enabled installed plugins", async () => {
+    installedPlugins = [
+      installed({ id: "on", name: "on-plugin", enabled: true }),
+      installed({ id: "off", name: "off-plugin", enabled: false }),
+    ];
     catalogMatches = [catalog()];
 
     const { findByText, queryByText, getByLabelText } = renderTab();
     await findByText("apollo-bot-brain");
 
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
 
-    await waitFor(() => expect(queryByText("apollo-bot-brain")).toBeNull());
-    expect(queryByText("simple-memory")).toBeTruthy();
+    await waitFor(() => expect(queryByText("off-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeNull();
+    expect(queryByText("on-plugin")).toBeTruthy();
+  });
+
+  test("the Off filter narrows to disabled installed plugins", async () => {
+    installedPlugins = [
+      installed({ id: "on", name: "on-plugin", enabled: true }),
+      installed({ id: "off", name: "off-plugin", enabled: false }),
+    ];
+    catalogMatches = [catalog()];
+
+    const { findByText, queryByText, getByLabelText } = renderTab();
+    await findByText("apollo-bot-brain");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Off");
+
+    await waitFor(() => expect(queryByText("on-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeNull();
+    expect(queryByText("off-plugin")).toBeTruthy();
+  });
+
+  test("the Available filter narrows to catalog plugins", async () => {
+    installedPlugins = [installed({ id: "on", name: "on-plugin", enabled: true })];
+    catalogMatches = [catalog()];
+
+    const { findByText, queryByText, getByLabelText } = renderTab();
+    await findByText("on-plugin");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Available");
+
+    await waitFor(() => expect(queryByText("on-plugin")).toBeNull());
+    expect(queryByText("apollo-bot-brain")).toBeTruthy();
+  });
+
+  test("hides Active/Off when the daemon lacks enable/disable support", async () => {
+    // `installed()` omits `enabled` (older-daemon shape) → toggle unsupported.
+    installedPlugins = [installed()];
+    catalogMatches = [catalog()];
+
+    const { findByText, getByLabelText } = renderTab();
+    await findByText("apollo-bot-brain");
+
+    fireEvent.click(getByLabelText("Filter plugins"));
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(labels).toEqual(["All", "Available"]);
   });
 
   test("search filters the list in memory", async () => {
@@ -422,9 +474,10 @@ describe("PluginsTab", () => {
   });
 
   test("respects the status filter when deriving category badges", async () => {
-    // email is installed-only; system is available-only.
+    // email is installed-only; system is available-only. `enabled` on the
+    // installed row latches toggle support so the Active option is offered.
     installedPlugins = [
-      installed({ id: "mailer", name: "mailer", category: "email" }),
+      installed({ id: "mailer", name: "mailer", category: "email", enabled: true }),
     ];
     installedCategoryCounts = { email: 1 };
     catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
@@ -440,10 +493,10 @@ describe("PluginsTab", () => {
       within(nav).getByRole("button", { name: /System/ }).textContent,
     ).toContain("1");
 
-    // "Installed": the available-only System badge drops so it no longer counts
-    // rows the status filter hides; Email (installed) stays 1.
+    // "Active" is installed-only: the available-only System badge drops so it no
+    // longer counts rows the status filter hides; Email (installed) stays 1.
     fireEvent.click(getByLabelText("Filter plugins"));
-    clickStatusOption("Installed");
+    clickStatusOption("Active");
     await waitFor(() =>
       expect(
         within(nav).getByRole("button", { name: /System/ }).textContent,
@@ -452,6 +505,45 @@ describe("PluginsTab", () => {
     expect(
       within(nav).getByRole("button", { name: /Email/ }).textContent,
     ).toContain("1");
+  });
+
+  test("Active/Off category badges count only matching plugins, not the server total", async () => {
+    // Two installed email plugins — one enabled, one disabled. The server's
+    // categoryCounts is the total for ALL installed (email: 2); Active/Off must
+    // reflect only the matching subset, or a badge over-counts rows the filter
+    // hides (and a category with only hidden rows would show empty under a
+    // nonzero badge).
+    installedPlugins = [
+      installed({ id: "on", name: "on-mailer", category: "email", enabled: true }),
+      installed({ id: "off", name: "off-mailer", category: "email", enabled: false }),
+    ];
+    installedCategoryCounts = { email: 2 };
+
+    const { findByRole, getByLabelText } = renderTab();
+    const nav = await findByRole("navigation", { name: "Plugin categories" });
+
+    // All: the server total (2) shows.
+    expect(
+      within(nav).getByRole("button", { name: /Email/ }).textContent,
+    ).toContain("2");
+
+    // Active: only the enabled email plugin — badge drops to 1, not the server's 2.
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Active");
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).toContain("1"),
+    );
+
+    // Off: only the disabled email plugin — also 1.
+    fireEvent.click(getByLabelText("Filter plugins"));
+    clickStatusOption("Off");
+    await waitFor(() =>
+      expect(
+        within(nav).getByRole("button", { name: /Email/ }).textContent,
+      ).toContain("1"),
+    );
   });
 
   test("hides the rail counts while a search term is active, restoring them when cleared", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -27,7 +27,6 @@ import {
     pluginRiskyUpgradeConfirmMessage,
 } from "@/domains/intelligence/plugins/constants";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
-import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type {
     InstalledPlugin,
     PluginCatalogMatch,
@@ -127,10 +126,6 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     catalogMatches,
     unfilteredInstalledNames,
   } = usePluginsList(assistantId, effectiveCategory);
-
-  // Optimistic enable/disable. Wired into installed rows only when the daemon
-  // supports it (see `pluginToggleSupported`).
-  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   // The picker offers different status options per daemon capability
   // (All/Active/Off/Available when it can toggle, All/Installed/Available when
@@ -296,7 +291,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   const hasActiveSearch = searchValue.trim().length > 0;
 
   if (selectedPluginName) {
-    // Seed the detail header icon + Active/Off toggle from the already-loaded
+    // Seed the detail header icon + auto-include toggle from the already-loaded
     // list row: catalog rows are known-external (📦 immediately, no load-time
     // flash). Installed rows and unmatched deep-links are `undefined` (origin
     // unknown), so the header shows a glyph-less placeholder until the detail
@@ -345,14 +340,8 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
                   onSelect={() => handleSelect(item)}
                   onRemove={() => setPendingRemoval(item)}
                   onUpgrade={(drift) => handleUpgrade(item, drift)}
-                  onToggle={
-                    pluginToggleSupported
-                      ? (next) => toggle(item.name, next)
-                      : undefined
-                  }
                   isRemoving={removingName === item.name}
                   isUpgrading={upgradingName === item.name}
-                  isToggling={togglingName === item.name}
                 />
               ) : (
                 <PluginListRow
@@ -524,11 +513,8 @@ interface InstalledPluginRowProps {
   onSelect: () => void;
   onRemove: () => void;
   onUpgrade: (drift: PluginDrift | undefined) => void;
-  /** `undefined` when the daemon doesn't support toggling (no switch). */
-  onToggle: ((nextEnabled: boolean) => void) | undefined;
   isRemoving: boolean;
   isUpgrading: boolean;
-  isToggling: boolean;
 }
 
 /**
@@ -543,10 +529,8 @@ function InstalledPluginRow({
   onSelect,
   onRemove,
   onUpgrade,
-  onToggle,
   isRemoving,
   isUpgrading,
-  isToggling,
 }: InstalledPluginRowProps) {
   const driftQuery = usePluginDrift({ assistantId, name: item.name });
   const drift = driftQuery.data;
@@ -558,10 +542,8 @@ function InstalledPluginRow({
       onSelect={onSelect}
       onRemove={onRemove}
       onUpgrade={() => onUpgrade(drift)}
-      onToggle={onToggle}
       isRemoving={isRemoving}
       isUpgrading={isUpgrading}
-      isToggling={isToggling}
     />
   );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -132,15 +132,18 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   // supports it (see `pluginToggleSupported`).
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
-  // Active/Off are only offered when the daemon supports enable/disable. If a
-  // prior Active/Off selection carries into an assistant that doesn't support
-  // it, coerce it to All so installed rows don't silently vanish (the picker
-  // only offers All/Available there). Everything that drives display reads this,
-  // not the raw `filter`; `setFilter` still records the raw user choice.
-  const effectiveFilter: PluginFilter =
-    !pluginToggleSupported && (filter === "active" || filter === "off")
-      ? "all"
-      : filter;
+  // The picker offers different status options per daemon capability
+  // (All/Active/Off/Available when it can toggle, All/Installed/Available when
+  // it can't). If a prior selection carries into an assistant whose picker no
+  // longer offers it, coerce to All so rows don't silently vanish under an
+  // unreachable filter. Everything that drives display reads this, not the raw
+  // `filter`; `setFilter` still records the raw user choice.
+  const offeredFilters: PluginFilter[] = pluginToggleSupported
+    ? ["all", "active", "off", "available"]
+    : ["all", "installed", "available"];
+  const effectiveFilter: PluginFilter = offeredFilters.includes(filter)
+    ? filter
+    : "all";
 
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
@@ -325,7 +328,8 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         // Don't flash an "empty" state for available plugins while the
         // catalog is still loading (installed plugins already render above).
         // Only the filters that surface catalog rows (all/available) wait on it.
-        catalogLoading && (filter === "all" || filter === "available") ? (
+        catalogLoading &&
+          (effectiveFilter === "all" || effectiveFilter === "available") ? (
           <LoadingState />
         ) : (
           <EmptyState filter={effectiveFilter} category={effectiveCategory} />
@@ -700,6 +704,13 @@ function getEmptyStateCopy(
     };
   }
   switch (filter) {
+    case "installed":
+      return {
+        title: "No Plugins Installed",
+        subtitle:
+          "Browse the catalog to install plugins that extend your assistant.",
+        Icon: Puzzle,
+      };
     case "active":
       return {
         title: "No Active Plugins",

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -132,13 +132,23 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   // supports it (see `pluginToggleSupported`).
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
+  // Active/Off are only offered when the daemon supports enable/disable. If a
+  // prior Active/Off selection carries into an assistant that doesn't support
+  // it, coerce it to All so installed rows don't silently vanish (the picker
+  // only offers All/Available there). Everything that drives display reads this,
+  // not the raw `filter`; `setFilter` still records the raw user choice.
+  const effectiveFilter: PluginFilter =
+    !pluginToggleSupported && (filter === "active" || filter === "off")
+      ? "all"
+      : filter;
+
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
     installedPlugins,
     installedTotal,
     catalogMatches,
     unfilteredInstalledNames,
-    filter,
+    effectiveFilter,
   );
 
   // Two-pane rail only when the daemon understands the category taxonomy AND
@@ -268,10 +278,10 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
 
   const visibleItems = useMemo(
     () =>
-      filterByStatus(items, filter).filter((item) =>
+      filterByStatus(items, effectiveFilter).filter((item) =>
         matchesQuery(item, searchValue),
       ),
-    [items, filter, searchValue],
+    [items, effectiveFilter, searchValue],
   );
 
   // Background-fetch state (focus refetch, post-install invalidation); drives
@@ -314,10 +324,11 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       ) : visibleItems.length === 0 ? (
         // Don't flash an "empty" state for available plugins while the
         // catalog is still loading (installed plugins already render above).
-        catalogLoading && filter !== "installed" ? (
+        // Only the filters that surface catalog rows (all/available) wait on it.
+        catalogLoading && (filter === "all" || filter === "available") ? (
           <LoadingState />
         ) : (
-          <EmptyState filter={filter} category={effectiveCategory} />
+          <EmptyState filter={effectiveFilter} category={effectiveCategory} />
         )
       ) : (
         <ul className="flex flex-col gap-2">
@@ -361,7 +372,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
       <FilterBar
         search={searchValue}
         onSearchChange={setSearchValue}
-        filter={filter}
+        filter={effectiveFilter}
         onFilterChange={setFilter}
         isSearching={isSearching}
         categories={categoryRailEnabled ? categories : []}
@@ -370,6 +381,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
         counts={counts}
         totalCount={totalCount}
         showCounts={!hasActiveSearch}
+        pluginToggleSupported={pluginToggleSupported}
       />
 
       {catalogError && !isLoading && !isError ? (
@@ -443,17 +455,32 @@ function useMergedPluginCounts(
 ): { counts: Record<string, number>; totalCount: number } {
   return useMemo(() => {
     const counts: Record<string, number> = {};
+    // all/active/off all narrow the installed set, so they include installed
+    // rows; only `available` excludes them. Catalog (available) rows count only
+    // for the filters that actually surface them — all and available.
     const includeInstalled = filter !== "available";
-    const includeCatalog = filter !== "installed";
+    const includeCatalog = filter === "all" || filter === "available";
+
+    // Active/Off narrow the installed set by enablement — which the server's
+    // `installedCategoryCounts` (totals for ALL installed plugins) can't express.
+    // For those filters, bucket the enablement-filtered installed set on the
+    // client so badges/totals never count rows the filter hides.
+    const enablementFiltered = filter === "active" || filter === "off";
+    const matchingInstalled = enablementFiltered
+      ? installedPlugins.filter((p) =>
+          filter === "off" ? p.enabled === false : p.enabled !== false,
+        )
+      : installedPlugins;
 
     if (includeInstalled) {
       if (
+        !enablementFiltered &&
         installedCategoryCounts &&
         Object.keys(installedCategoryCounts).length > 0
       ) {
         Object.assign(counts, installedCategoryCounts);
       } else {
-        for (const plugin of installedPlugins) {
+        for (const plugin of matchingInstalled) {
           const cat = plugin.category ?? SYSTEM_CATEGORY;
           counts[cat] = (counts[cat] ?? 0) + 1;
         }
@@ -471,7 +498,9 @@ function useMergedPluginCounts(
         catalogTotal += 1;
       }
     }
-    const installedTotalResolved = installedTotal ?? installedPlugins.length;
+    const installedTotalResolved = enablementFiltered
+      ? matchingInstalled.length
+      : (installedTotal ?? installedPlugins.length);
     const totalCount =
       (includeInstalled ? installedTotalResolved : 0) + catalogTotal;
     return { counts, totalCount };
@@ -671,10 +700,16 @@ function getEmptyStateCopy(
     };
   }
   switch (filter) {
-    case "installed":
+    case "active":
       return {
-        title: "No Plugins Installed",
-        subtitle: "Install a plugin from the catalog to extend your assistant.",
+        title: "No Active Plugins",
+        subtitle: "Install a plugin from the catalog, or turn on an installed one.",
+        Icon: Puzzle,
+      };
+    case "off":
+      return {
+        title: "No Plugins Turned Off",
+        subtitle: "Installed plugins you turn off will appear here.",
         Icon: Puzzle,
       };
     case "available":

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -283,17 +283,19 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   const hasActiveSearch = searchValue.trim().length > 0;
 
   if (selectedPluginName) {
-    // Seed the detail header icon from the already-loaded list row: catalog
-    // rows are known-external (📦 immediately, no load-time flash). Installed
-    // rows and unmatched deep-links are `undefined` (origin unknown), so the
-    // header shows a glyph-less placeholder until the detail query resolves.
-    const selectedExternalHint = items.find(
-      (p) => p.name === selectedPluginName,
-    )?.external;
+    // Seed the detail header icon + Active/Off toggle from the already-loaded
+    // list row: catalog rows are known-external (📦 immediately, no load-time
+    // flash). Installed rows and unmatched deep-links are `undefined` (origin
+    // unknown), so the header shows a glyph-less placeholder until the detail
+    // query resolves. `enabled` is likewise sourced from the row — the detail
+    // GET carries no enablement — and is `undefined` for available/deep-link
+    // rows, which hides the toggle.
+    const selectedRow = items.find((p) => p.name === selectedPluginName);
     const detailProps = {
       assistantId,
       name: selectedPluginName,
-      externalHint: selectedExternalHint,
+      externalHint: selectedRow?.external,
+      enabled: selectedRow?.enabled,
       onBack: handleCloseDetail,
     };
     return isMobile ? (

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -27,6 +27,7 @@ import {
     pluginRiskyUpgradeConfirmMessage,
 } from "@/domains/intelligence/plugins/constants";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
+import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type {
     InstalledPlugin,
     PluginCatalogMatch,
@@ -119,12 +120,17 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
     isFetching,
     catalogError,
     categorySupported,
+    pluginToggleSupported,
     installedCategoryCounts,
     installedPlugins,
     installedTotal,
     catalogMatches,
     unfilteredInstalledNames,
   } = usePluginsList(assistantId, effectiveCategory);
+
+  // Optimistic enable/disable. Wired into installed rows only when the daemon
+  // supports it (see `pluginToggleSupported`).
+  const { toggle, togglingName } = usePluginToggle(assistantId);
 
   const { counts, totalCount } = useMergedPluginCounts(
     installedCategoryCounts,
@@ -322,8 +328,14 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
                   onSelect={() => handleSelect(item)}
                   onRemove={() => setPendingRemoval(item)}
                   onUpgrade={(drift) => handleUpgrade(item, drift)}
+                  onToggle={
+                    pluginToggleSupported
+                      ? (next) => toggle(item.name, next)
+                      : undefined
+                  }
                   isRemoving={removingName === item.name}
                   isUpgrading={upgradingName === item.name}
+                  isToggling={togglingName === item.name}
                 />
               ) : (
                 <PluginListRow
@@ -477,8 +489,11 @@ interface InstalledPluginRowProps {
   onSelect: () => void;
   onRemove: () => void;
   onUpgrade: (drift: PluginDrift | undefined) => void;
+  /** `undefined` when the daemon doesn't support toggling (no switch). */
+  onToggle: ((nextEnabled: boolean) => void) | undefined;
   isRemoving: boolean;
   isUpgrading: boolean;
+  isToggling: boolean;
 }
 
 /**
@@ -493,8 +508,10 @@ function InstalledPluginRow({
   onSelect,
   onRemove,
   onUpgrade,
+  onToggle,
   isRemoving,
   isUpgrading,
+  isToggling,
 }: InstalledPluginRowProps) {
   const driftQuery = usePluginDrift({ assistantId, name: item.name });
   const drift = driftQuery.data;
@@ -506,8 +523,10 @@ function InstalledPluginRow({
       onSelect={onSelect}
       onRemove={onRemove}
       onUpgrade={() => onUpgrade(drift)}
+      onToggle={onToggle}
       isRemoving={isRemoving}
       isUpgrading={isUpgrading}
+      isToggling={isToggling}
     />
   );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
@@ -2,16 +2,55 @@
  * Small pill flagging that an installed plugin is behind the marketplace
  * pin. Shared by the plugins list row and the plugin detail header so the
  * "update available" affordance reads identically on both surfaces.
+ *
+ * Pass `onClick` to turn the pill into the Upgrade control (list row); omit
+ * it for the static detail-header badge.
  */
-import { ArrowUpCircle } from "lucide-react";
+import { ArrowUpCircle, Loader2 } from "lucide-react";
 import { createElement } from "react";
 
 import { Tag } from "@vellumai/design-library";
 
-export function UpdateAvailableBadge() {
-  return (
-    <Tag tone="warning" leftIcon={createElement(ArrowUpCircle)} className="shrink-0">
+interface UpdateAvailableBadgeProps {
+  /**
+   * When provided the pill becomes an interactive Upgrade control: clicking it
+   * triggers the upgrade and stops the click from selecting the row it sits in.
+   */
+  onClick?: () => void;
+  /** Swap the icon for a spinner and disable the control while upgrading. */
+  isUpgrading?: boolean;
+}
+
+export function UpdateAvailableBadge({
+  onClick,
+  isUpgrading = false,
+}: UpdateAvailableBadgeProps = {}) {
+  const badge = (
+    <Tag
+      tone="warning"
+      leftIcon={createElement(isUpgrading ? Loader2 : ArrowUpCircle, {
+        className: isUpgrading ? "animate-spin" : undefined,
+      })}
+      className="shrink-0"
+    >
       Update available
     </Tag>
+  );
+
+  if (!onClick) return badge;
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      disabled={isUpgrading}
+      aria-label="Upgrade plugin"
+      className="shrink-0 rounded-[6px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed"
+    >
+      {badge}
+    </button>
   );
 }

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -3,7 +3,6 @@
  * detail, and the Plugins tab), kept in one place so the confirm dialogs and
  * failure messages stay in lockstep across them.
  */
-import type { SegmentControlItem } from "@vellumai/design-library";
 
 /** Confirm-dialog body for removing an installed plugin. */
 export const pluginRemoveConfirmMessage = (name: string): string =>
@@ -24,9 +23,3 @@ export const PLUGIN_UPGRADE_ERROR =
   "Failed to upgrade plugin. Please try again.";
 export const PLUGIN_TOGGLE_ERROR =
   "Failed to update plugin. Please try again.";
-
-/** Active/Off segments for the plugin enablement control (list row + detail). */
-export const PLUGIN_TOGGLE_SEGMENTS: SegmentControlItem<"active" | "off">[] = [
-  { value: "active", label: "Active" },
-  { value: "off", label: "Off" },
-];

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -21,3 +21,5 @@ export const PLUGIN_INSTALL_ERROR =
 export const PLUGIN_REMOVE_ERROR = "Failed to remove plugin. Please try again.";
 export const PLUGIN_UPGRADE_ERROR =
   "Failed to upgrade plugin. Please try again.";
+export const PLUGIN_TOGGLE_ERROR =
+  "Failed to update plugin. Please try again.";

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -3,6 +3,7 @@
  * detail, and the Plugins tab), kept in one place so the confirm dialogs and
  * failure messages stay in lockstep across them.
  */
+import type { SegmentControlItem } from "@vellumai/design-library";
 
 /** Confirm-dialog body for removing an installed plugin. */
 export const pluginRemoveConfirmMessage = (name: string): string =>
@@ -23,3 +24,9 @@ export const PLUGIN_UPGRADE_ERROR =
   "Failed to upgrade plugin. Please try again.";
 export const PLUGIN_TOGGLE_ERROR =
   "Failed to update plugin. Please try again.";
+
+/** Active/Off segments for the plugin enablement control (list row + detail). */
+export const PLUGIN_TOGGLE_SEGMENTS: SegmentControlItem<"active" | "off">[] = [
+  { value: "active", label: "Active" },
+  { value: "off", label: "Off" },
+];

--- a/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
+++ b/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
@@ -8,9 +8,12 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 
 /**
- * Invalidate the plugin queries an install / remove / upgrade can stale. The
- * installed list and catalog search always go stale; the per-plugin detail
- * read and its drift inspect only when a specific plugin `name` is supplied.
+ * Invalidate the plugin queries an install / remove / upgrade / toggle can
+ * stale. The installed list and catalog search always go stale. For the
+ * per-plugin detail read and its drift inspect: a specific `name` invalidates
+ * just that plugin's; omitting `name` (a broad, name-agnostic `plugins:list`
+ * sync or a reconnect reconcile) invalidates every open plugin detail for the
+ * assistant, since any of them may have changed on another client.
  */
 export function invalidatePluginQueries(
   queryClient: QueryClient,
@@ -36,5 +39,17 @@ export function invalidatePluginQueries(
         path: { assistant_id: assistantId, name },
       }),
     });
+    return;
   }
+  // No name: invalidate every by-name detail + drift inspect for this assistant
+  // via partial-key match (the generated keys are `[{ _id, baseUrl, path }]`;
+  // omitting `name`/`baseUrl` matches all names — mirrors the schedules sync).
+  void queryClient.invalidateQueries({
+    queryKey: [{ _id: "pluginsByNameGet", path: { assistant_id: assistantId } }],
+  });
+  void queryClient.invalidateQueries({
+    queryKey: [
+      { _id: "pluginsByNameInspectGet", path: { assistant_id: assistantId } },
+    ],
+  });
 }

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -5,7 +5,12 @@ import type {
 
 export type PluginStatus = "installed" | "available";
 
-export type PluginFilter = "all" | "installed" | "available";
+/**
+ * User-facing status filter. Orthogonal to `PluginStatus`: `active` and `off`
+ * both narrow the installed set by enablement (Active = installed & enabled,
+ * Off = installed & !enabled), while `available` is the not-installed catalog.
+ */
+export type PluginFilter = "all" | "active" | "off" | "available";
 
 /**
  * Unified row model for the Plugins tab, populated from two independent

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -8,9 +8,16 @@ export type PluginStatus = "installed" | "available";
 /**
  * User-facing status filter. Orthogonal to `PluginStatus`: `active` and `off`
  * both narrow the installed set by enablement (Active = installed & enabled,
- * Off = installed & !enabled), while `available` is the not-installed catalog.
+ * Off = installed & !enabled), `installed` is the whole installed set
+ * regardless of enablement (offered when the daemon can't toggle), and
+ * `available` is the not-installed catalog.
  */
-export type PluginFilter = "all" | "active" | "off" | "available";
+export type PluginFilter =
+  | "all"
+  | "installed"
+  | "active"
+  | "off"
+  | "available";
 
 /**
  * Unified row model for the Plugins tab, populated from two independent

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -25,6 +25,12 @@ export interface PluginListItem {
   version?: string;
   path?: string;
   issues?: string[];
+  /**
+   * Whether the plugin is active in this workspace. Installed rows only —
+   * catalog/available rows carry no enablement. `undefined` on daemons that
+   * predate the enable/disable surface (version-skew safeguard).
+   */
+  enabled?: boolean;
 }
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
@@ -49,6 +55,7 @@ interface InstalledPluginSource {
   version: string | null;
   path?: string;
   issues?: string[];
+  enabled?: boolean;
 }
 
 interface CatalogPluginSource {

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `usePluginToggle`, the optimistic enable/disable mutation backing
+ * the Plugins tab toggle. It flips the installed row's `enabled` across every
+ * cached `pluginsGet` variant (unfiltered + each `?category=` read)
+ * immediately, treats a 409 (already-in-state) as success, rolls back only the
+ * toggled row's field and toasts on real failure, invalidates the plugin
+ * queries on settle, and exposes the in-flight `togglingName`.
+ *
+ * The generated SDK layer is mocked so the enable/disable endpoints resolve
+ * locally with a controllable HTTP status (or reject, to drive the rollback
+ * branch); the design-library barrel is mocked so `toast.error` is spy-able.
+ * Module-level holders let a case gate the request pending, set the response
+ * status, or force the endpoint to reject.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { PLUGIN_TOGGLE_ERROR } from "@/domains/intelligence/plugins/constants";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+const NAME = "alpha";
+const CATEGORY = "system";
+
+// Per-test holders the SDK mocks read. `*Status` sets the HTTP status the
+// matching endpoint responds with (200 ok, 409 already-in-state). `*Fails`
+// forces the matching endpoint to reject (a network-level failure).
+// `toggleGate`, when set, holds the request pending so a case can assert the
+// optimistic state before it settles.
+let enableStatus = 200;
+let disableStatus = 200;
+let enableFails = false;
+let disableFails = false;
+let toggleGate: Promise<unknown> | null = null;
+
+function respond(status: number) {
+  return {
+    data: { ok: true },
+    error: undefined,
+    response: new Response(null, { status }),
+  };
+}
+
+const enableSpy = mock(async (_options: unknown) => {
+  if (toggleGate) await toggleGate;
+  if (enableFails) throw new Error("enable failed");
+  return respond(enableStatus);
+});
+const disableSpy = mock(async (_options: unknown) => {
+  if (toggleGate) await toggleGate;
+  if (disableFails) throw new Error("disable failed");
+  return respond(disableStatus);
+});
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsByNameEnablePost: enableSpy,
+  pluginsByNameDisablePost: disableSpy,
+}));
+
+const toastErrorSpy = mock((_message: string) => {});
+const dlActual = await import("@vellumai/design-library");
+mock.module("@vellumai/design-library", () => ({
+  ...dlActual,
+  toast: Object.assign((_message: string) => {}, {
+    success: () => {},
+    error: toastErrorSpy,
+    dismiss: () => {},
+  }),
+}));
+
+const { pluginsGetQueryKey } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+const { usePluginToggle } = await import(
+  "@/domains/intelligence/plugins/use-plugin-toggle"
+);
+
+const LIST_KEY = pluginsGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID },
+  query: { q: undefined },
+});
+// The distinct key `usePluginsList` reads when a category rail item is picked.
+const CATEGORY_KEY = pluginsGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID },
+  query: { q: undefined, category: CATEGORY },
+});
+
+function listOf(
+  plugins: Array<{ name: string; enabled: boolean }>,
+): PluginsGetResponse {
+  return {
+    plugins: plugins.map(({ name, enabled }) => ({
+      id: name,
+      name,
+      description: null,
+      version: null,
+      enabled,
+    })),
+  } as PluginsGetResponse;
+}
+
+function cachedEnabled(
+  client: QueryClient,
+  name = NAME,
+  key: readonly unknown[] = LIST_KEY,
+): boolean | undefined {
+  return client
+    .getQueryData<PluginsGetResponse>(key)
+    ?.plugins.find((p) => p.name === name)?.enabled;
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function mountToggle(client: QueryClient) {
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+  return renderHook(() => usePluginToggle(ASSISTANT_ID), { wrapper });
+}
+
+function renderToggle({ enabled = true }: { enabled?: boolean } = {}) {
+  const client = newClient();
+  client.setQueryData<PluginsGetResponse>(LIST_KEY, listOf([{ name: NAME, enabled }]));
+  const invalidateSpy = mock(client.invalidateQueries.bind(client));
+  client.invalidateQueries = invalidateSpy;
+
+  const view = mountToggle(client);
+  return { ...view, client, invalidateSpy };
+}
+
+beforeEach(() => {
+  enableStatus = 200;
+  disableStatus = 200;
+  enableFails = false;
+  disableFails = false;
+  toggleGate = null;
+  enableSpy.mockClear();
+  disableSpy.mockClear();
+  toastErrorSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePluginToggle", () => {
+  test("flips enabled optimistically and exposes togglingName while pending", async () => {
+    // Hold the request pending so the optimistic flip is observable before it
+    // settles.
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result, client } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    // The cached row flips to disabled and the in-flight name is exposed, all
+    // before the endpoint resolves.
+    await waitFor(() => expect(cachedEnabled(client)).toBe(false));
+    expect(result.current.togglingName).toBe(NAME);
+
+    // Once it settles, togglingName clears.
+    release();
+    await waitFor(() => expect(result.current.togglingName).toBe(null));
+  });
+
+  test("flips the row across category-filtered cache variants too", async () => {
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result, client } = renderToggle({ enabled: true });
+    // Seed a second, category-filtered cache holding the same row — the view a
+    // selected category rail item mounts.
+    client.setQueryData<PluginsGetResponse>(
+      CATEGORY_KEY,
+      listOf([{ name: NAME, enabled: true }]),
+    );
+
+    result.current.toggle(NAME, false);
+
+    // Both the unfiltered and the category-filtered caches flip optimistically.
+    await waitFor(() => expect(cachedEnabled(client)).toBe(false));
+    expect(cachedEnabled(client, NAME, CATEGORY_KEY)).toBe(false);
+
+    release();
+    await waitFor(() => expect(result.current.togglingName).toBe(null));
+  });
+
+  test("calls the enable endpoint with the assistant + name path", async () => {
+    const { result } = renderToggle({ enabled: false });
+
+    result.current.toggle(NAME, true);
+
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(1));
+    expect(enableSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    });
+    expect(disableSpy).not.toHaveBeenCalled();
+  });
+
+  test("calls the disable endpoint when disabling", async () => {
+    const { result } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    await waitFor(() => expect(disableSpy).toHaveBeenCalledTimes(1));
+    expect(disableSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+    });
+    expect(enableSpy).not.toHaveBeenCalled();
+  });
+
+  test("treats a 409 (already in state) as success — no rollback, no toast", async () => {
+    // Enabling an already-enabled plugin: the daemon 409s but the desired end
+    // state already holds.
+    enableStatus = 409;
+    const { result, client, invalidateSpy } = renderToggle({ enabled: false });
+
+    result.current.toggle(NAME, true);
+
+    // Settles as success: the optimistic value stays, no rollback, no error
+    // toast, and the invalidation still runs to reconcile with the server.
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+    expect(cachedEnabled(client)).toBe(true);
+    expect(toastErrorSpy).not.toHaveBeenCalled();
+    expect(result.current.togglingName).toBe(null);
+  });
+
+  test("rolls back the optimistic flip and toasts on error", async () => {
+    disableFails = true;
+    const { result, client } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    // Rolls back to the pre-toggle value and surfaces the failure copy.
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(PLUGIN_TOGGLE_ERROR),
+    );
+    expect(cachedEnabled(client)).toBe(true);
+    expect(result.current.togglingName).toBe(null);
+  });
+
+  test("rollback restores only the toggled row, preserving a concurrent update", async () => {
+    // Two rows both enabled. `alpha` is toggled off and will fail; `beta` is
+    // concurrently flipped off (as another client / mutation would) while
+    // alpha's request is in flight.
+    let release: () => void = () => {};
+    toggleGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    disableFails = true;
+
+    const client = newClient();
+    client.setQueryData<PluginsGetResponse>(
+      LIST_KEY,
+      listOf([
+        { name: "alpha", enabled: true },
+        { name: "beta", enabled: true },
+      ]),
+    );
+    const { result } = mountToggle(client);
+
+    result.current.toggle("alpha", false);
+    await waitFor(() => expect(cachedEnabled(client, "alpha")).toBe(false));
+
+    // A concurrent update flips beta off while alpha's request is pending.
+    client.setQueryData<PluginsGetResponse>(LIST_KEY, (prev) =>
+      prev
+        ? {
+            ...prev,
+            plugins: prev.plugins.map((p) =>
+              p.name === "beta" ? { ...p, enabled: false } : p,
+            ),
+          }
+        : prev,
+    );
+
+    // Alpha fails: only alpha is rolled back; beta's newer value survives.
+    release();
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(PLUGIN_TOGGLE_ERROR),
+    );
+    expect(cachedEnabled(client, "alpha")).toBe(true);
+    expect(cachedEnabled(client, "beta")).toBe(false);
+  });
+
+  test("invalidates the plugin queries on settle", async () => {
+    const { result, invalidateSpy } = renderToggle({ enabled: true });
+
+    result.current.toggle(NAME, false);
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-toggle.ts
@@ -1,0 +1,105 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { PLUGIN_TOGGLE_ERROR } from "@/domains/intelligence/plugins/constants";
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
+import { pluginsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+    pluginsByNameDisablePost,
+    pluginsByNameEnablePost,
+} from "@/generated/daemon/sdk.gen";
+import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { toast } from "@vellumai/design-library";
+
+interface TogglePluginVariables {
+  name: string;
+  nextEnabled: boolean;
+}
+
+export interface UsePluginToggleResult {
+  /** Enable (`nextEnabled=true`) or disable a plugin, optimistically. */
+  toggle: (name: string, nextEnabled: boolean) => void;
+  /** Name of the plugin whose toggle is in flight, or `null` when idle. */
+  togglingName: string | null;
+}
+
+/**
+ * Optimistic enable/disable mutation for the Plugins tab. Flips the installed
+ * row's `enabled` in every cached `pluginsGet` variant immediately (the
+ * unfiltered list plus every `?category=` filtered read `usePluginsList`
+ * mounts), rolls back only that row's field and toasts on failure, and
+ * invalidates the plugin queries on settle so the cache re-syncs with the
+ * daemon (which also broadcasts `sync_changed`). Mirrors the optimistic
+ * pattern in `settings/pages/sounds-page.tsx`.
+ *
+ * No confirm dialog — the action is reversible.
+ */
+export function usePluginToggle(assistantId: string): UsePluginToggleResult {
+  const queryClient = useQueryClient();
+
+  // Partial key matching every `pluginsGet` cache for this assistant — the
+  // unfiltered list AND each server-side `?category=` filtered read. Omitting
+  // `query` makes TanStack partial-match all variants (same idiom as
+  // `invalidatePluginQueries`); patching only the unfiltered key would leave a
+  // category-filtered view stale until the settle refetch.
+  const listQueryFilter = {
+    queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
+  };
+
+  // Set `name`'s `enabled` across every matching cache variant, leaving other
+  // rows (and other caches) untouched.
+  const setRowEnabled = (name: string, enabled: boolean) => {
+    queryClient.setQueriesData<PluginsGetResponse>(listQueryFilter, (prev) =>
+      prev
+        ? {
+            ...prev,
+            plugins: prev.plugins.map((plugin) =>
+              plugin.name === name ? { ...plugin, enabled } : plugin,
+            ),
+          }
+        : prev,
+    );
+  };
+
+  const mutation = useMutation({
+    mutationFn: async ({ name, nextEnabled }: TogglePluginVariables) => {
+      const result = await (nextEnabled
+        ? pluginsByNameEnablePost({
+            path: { assistant_id: assistantId, name },
+            throwOnError: false,
+          })
+        : pluginsByNameDisablePost({
+            path: { assistant_id: assistantId, name },
+            throwOnError: false,
+          }));
+      // 409 means the plugin is already in the desired state — a no-op from a
+      // stale cache or a second client. The end state holds, so treat it as
+      // success and let `onSettled` refetch the truth; only other non-ok
+      // statuses are real failures.
+      const status = result.response?.status;
+      if (result.response?.ok || status === 409) return result;
+      throw new Error(`Plugin toggle failed (${status ?? "network error"})`);
+    },
+    onMutate: async ({ name, nextEnabled }) => {
+      await queryClient.cancelQueries(listQueryFilter);
+      setRowEnabled(name, nextEnabled);
+    },
+    onError: (_error, { name, nextEnabled }) => {
+      // Roll back only this row's `enabled` — a full-snapshot restore would
+      // clobber a concurrent toggle's newer value on a different row.
+      setRowEnabled(name, !nextEnabled);
+      toast.error(PLUGIN_TOGGLE_ERROR);
+    },
+    onSettled: (_data, _error, variables) => {
+      invalidatePluginQueries(queryClient, assistantId, variables.name);
+    },
+  });
+
+  const toggle = (name: string, nextEnabled: boolean) => {
+    mutation.mutate({ name, nextEnabled });
+  };
+
+  return {
+    toggle,
+    togglingName: mutation.isPending ? (mutation.variables?.name ?? null) : null,
+  };
+}

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.test.ts
@@ -70,13 +70,16 @@ const { usePluginsList } = await import(
 );
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default to model an older daemon that predates the
+  // enable/disable surface; tests opt in via `installed({ enabled })`. The cast
+  // is needed because the generated element type marks `enabled` as required.
   return {
     id: "alpha",
     name: "alpha",
     description: null,
     version: null,
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 function match(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
@@ -330,6 +333,65 @@ describe("usePluginsList", () => {
 
     await waitFor(() =>
       expect(result.current.categorySupported).toBe(false),
+    );
+  });
+
+  test("exposes enabled on installed items and latches pluginToggleSupported", async () => {
+    installedResult = installedOk([
+      installed({ id: "alpha", name: "alpha", enabled: true }),
+      installed({ id: "bravo", name: "bravo", enabled: false }),
+    ]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    // Installed rows carry the daemon's enablement (alphabetical: alpha, bravo).
+    expect(result.current.items.map((p) => p.enabled)).toEqual([true, false]);
+    expect(result.current.pluginToggleSupported).toBe(true);
+  });
+
+  test("pluginToggleSupported stays false when the daemon omits enabled", async () => {
+    // Older daemon: installed items carry no `enabled` field.
+    installedResult = installedOk([installed({ id: "alpha", name: "alpha" })]);
+
+    const { result } = renderPluginsList();
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(result.current.items[0]?.enabled).toBeUndefined();
+    expect(result.current.pluginToggleSupported).toBe(false);
+  });
+
+  test("pluginToggleSupported resets when the active assistant changes", async () => {
+    // Assistant A's daemon reports enablement, so support latches true.
+    installedResult = installedOk([
+      installed({ id: "alpha", name: "alpha", enabled: true }),
+    ]);
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client }, children);
+    }
+    const { result, rerender } = renderHook(
+      ({ assistantId }: { assistantId: string }) =>
+        usePluginsList(assistantId, null),
+      { wrapper, initialProps: { assistantId: "asst-a" } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.pluginToggleSupported).toBe(true),
+    );
+
+    // Switching to an assistant whose daemon omits `enabled` must drop the
+    // sticky latch — otherwise the toggle would render for an assistant whose
+    // daemon has no enable/disable surface.
+    installedResult = installedOk([installed({ id: "beta", name: "beta" })]);
+    rerender({ assistantId: "asst-b" });
+
+    await waitFor(() =>
+      expect(result.current.pluginToggleSupported).toBe(false),
     );
   });
 

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -229,12 +229,9 @@ export function usePluginsList(
   const unfilteredInstalledData =
     category !== null ? installedCountsQuery.data : installedQuery.data;
 
-  // Category-rail and plugin-toggle support are both sticky per-assistant daemon
-  // capabilities: observed live from the unfiltered read, latched so the UI
-  // doesn't flicker off while that read is momentarily pending mid category
-  // switch, and reset SYNCHRONOUSLY on assistant change (see the helper) so a
-  // prior assistant's `true` can't gate one render for a next assistant whose
-  // daemon omits the capability.
+  // Both are sticky per-assistant capabilities (see useStickyAssistantCapability),
+  // observed live from the unfiltered read: category support = counts present,
+  // toggle support = any installed plugin carries `enabled`.
   const categorySupported = useStickyAssistantCapability(
     assistantId,
     unfilteredInstalledData?.categoryCounts !== undefined,

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -53,6 +53,12 @@ export interface UsePluginsListResult {
    */
   categorySupported: boolean;
   /**
+   * True once any installed item carries `enabled` — the daemon understands
+   * the plugin enable/disable surface. Older daemons omit it; the toggle gates
+   * on this (version-skew safeguard). Sticky, reset per assistant.
+   */
+  pluginToggleSupported: boolean;
+  /**
    * Unfiltered installed category counts from the server (before the category
    * filter is applied). Undefined on daemons without taxonomy support.
    */
@@ -91,6 +97,39 @@ async function fetchInstalled(
   if (status === 404) return { plugins: [] } as PluginsGetResponse;
   if (!result.response?.ok) throw new Error("Failed to load plugins");
   return result.data ?? ({ plugins: [] } as PluginsGetResponse);
+}
+
+/**
+ * Sticky per-assistant capability latch. `observed` is the live signal that the
+ * daemon supports a feature for the current render; once true it latches so the
+ * feature's UI doesn't flicker off while the backing read is momentarily pending
+ * (e.g. mid category switch). The latch resets SYNCHRONOUSLY when `assistantId`
+ * changes — cleared during render, not in an effect — so a prior assistant's
+ * latched `true` never leaks into the first render of a next assistant whose
+ * daemon omits the capability.
+ */
+function useStickyAssistantCapability(
+  assistantId: string,
+  observed: boolean,
+): boolean {
+  const [latch, setLatch] = useState({ assistantId, latched: false });
+  const latchedForThisAssistant =
+    latch.assistantId === assistantId ? latch.latched : false;
+  if (latch.assistantId !== assistantId) {
+    // Reset during render (the discarded render's effects never commit) so the
+    // stale latch can't gate even one render for the new assistant.
+    setLatch({ assistantId, latched: false });
+  }
+  useEffect(() => {
+    if (observed) {
+      setLatch((prev) =>
+        prev.assistantId === assistantId && prev.latched
+          ? prev
+          : { assistantId, latched: true },
+      );
+    }
+  }, [assistantId, observed]);
+  return latchedForThisAssistant || observed;
 }
 
 /**
@@ -190,24 +229,22 @@ export function usePluginsList(
   const unfilteredInstalledData =
     category !== null ? installedCountsQuery.data : installedQuery.data;
 
-  // Latch support sticky once the unfiltered read first carries `categoryCounts`
-  // (it's a stable daemon capability): the live OR covers the current render, and
-  // the latch keeps it true across a category switch while the unfiltered source
-  // is momentarily pending, so the rail never vanishes mid-filter.
-  const categoryCountsObserved =
-    unfilteredInstalledData?.categoryCounts !== undefined;
-  const [categorySupportedLatched, setCategorySupportedLatched] =
-    useState(false);
-  // Support is a per-assistant daemon capability. Reset the latch when the
-  // active assistant changes so a `true` observed for a prior assistant can't
-  // keep the rail alive for a next assistant whose daemon omits `categoryCounts`.
-  useEffect(() => {
-    setCategorySupportedLatched(false);
-  }, [assistantId]);
-  useEffect(() => {
-    if (categoryCountsObserved) setCategorySupportedLatched(true);
-  }, [categoryCountsObserved]);
-  const categorySupported = categorySupportedLatched || categoryCountsObserved;
+  // Category-rail and plugin-toggle support are both sticky per-assistant daemon
+  // capabilities: observed live from the unfiltered read, latched so the UI
+  // doesn't flicker off while that read is momentarily pending mid category
+  // switch, and reset SYNCHRONOUSLY on assistant change (see the helper) so a
+  // prior assistant's `true` can't gate one render for a next assistant whose
+  // daemon omits the capability.
+  const categorySupported = useStickyAssistantCapability(
+    assistantId,
+    unfilteredInstalledData?.categoryCounts !== undefined,
+  );
+  const pluginToggleSupported = useStickyAssistantCapability(
+    assistantId,
+    (unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED).some(
+      (p) => p.enabled !== undefined,
+    ),
+  );
 
   // Self-heal timeout-degraded category counts. A cold catalog can make the
   // daemon's bounded category lookup time out, so the installed read buckets
@@ -267,6 +304,7 @@ export function usePluginsList(
     isFetching: installedQuery.isFetching || catalogQuery.isFetching,
     catalogError: catalogQuery.isError,
     categorySupported,
+    pluginToggleSupported,
     installedCategoryCounts: unfilteredInstalledData?.categoryCounts,
     installedPlugins: unfilteredInstalledData?.plugins ?? EMPTY_INSTALLED,
     installedTotal: unfilteredInstalledData?.totalCount,

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -139,24 +139,33 @@ describe("sortPlugins", () => {
 
 describe("filterByStatus", () => {
   const items = [
-    item({ name: "a", status: "installed" }),
-    item({ name: "b", status: "available" }),
-    item({ name: "c", status: "installed" }),
+    item({ name: "on", status: "installed", enabled: true }),
+    item({ name: "off", status: "installed", enabled: false }),
+    item({ name: "legacy", status: "installed" }), // enabled undefined
+    item({ name: "catalog", status: "available" }),
   ];
 
   test("all returns everything", () => {
-    expect(filterByStatus(items, "all")).toHaveLength(3);
+    expect(filterByStatus(items, "all")).toHaveLength(4);
   });
 
-  test("installed returns only installed", () => {
-    expect(filterByStatus(items, "installed").map((p) => p.name)).toEqual([
-      "a",
-      "c",
+  test("active returns installed rows that aren't explicitly disabled", () => {
+    // `undefined` enablement (older daemons) counts as active — the plugin is
+    // installed and not turned off, so it must not vanish.
+    expect(filterByStatus(items, "active").map((p) => p.name)).toEqual([
+      "on",
+      "legacy",
     ]);
   });
 
-  test("available returns only available", () => {
-    expect(filterByStatus(items, "available").map((p) => p.name)).toEqual(["b"]);
+  test("off returns only explicitly disabled installed rows", () => {
+    expect(filterByStatus(items, "off").map((p) => p.name)).toEqual(["off"]);
+  });
+
+  test("available returns only catalog rows", () => {
+    expect(filterByStatus(items, "available").map((p) => p.name)).toEqual([
+      "catalog",
+    ]);
   });
 });
 

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -149,6 +149,14 @@ describe("filterByStatus", () => {
     expect(filterByStatus(items, "all")).toHaveLength(4);
   });
 
+  test("installed returns every installed row regardless of enablement", () => {
+    expect(filterByStatus(items, "installed").map((p) => p.name)).toEqual([
+      "on",
+      "off",
+      "legacy",
+    ]);
+  });
+
   test("active returns installed rows that aren't explicitly disabled", () => {
     // `undefined` enablement (older daemons) counts as active — the plugin is
     // installed and not turned off, so it must not vanish.

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -14,13 +14,15 @@ import {
 } from "./utils";
 
 function installed(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  // `enabled` is omitted by default (older-daemon shape); the cast is needed
+  // because the generated element type marks it required.
   return {
     id: "alpha",
     name: "alpha",
     description: null,
     version: null,
     ...overrides,
-  };
+  } as InstalledPlugin;
 }
 
 function catalog(overrides: Partial<PluginCatalogMatch> = {}): PluginCatalogMatch {

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -74,6 +74,10 @@ export function filterByStatus(
       return items;
     case "available":
       return items.filter((i) => i.status === "available");
+    // Every installed plugin, regardless of enablement — offered instead of
+    // Active/Off on daemons that predate enable/disable.
+    case "installed":
+      return items.filter((i) => i.status === "installed");
     // Active = installed & enabled. Enablement `undefined` (older daemons) is
     // treated as active, so a plugin never silently disappears when the daemon
     // predates enable/disable.

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -27,6 +27,8 @@ export function mergePlugins(
     version: p.version ?? undefined,
     path: p.path,
     issues: p.issues,
+    // Installed rows carry enablement; older daemons omit it (undefined).
+    enabled: p.enabled,
   }));
 
   const installedNames = new Set(installedItems.map((i) => i.name));

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -69,8 +69,24 @@ export function filterByStatus(
   items: PluginListItem[],
   filter: PluginFilter,
 ): PluginListItem[] {
-  if (filter === "all") return items;
-  return items.filter((i) => i.status === filter);
+  switch (filter) {
+    case "all":
+      return items;
+    case "available":
+      return items.filter((i) => i.status === "available");
+    // Active = installed & enabled. Enablement `undefined` (older daemons) is
+    // treated as active, so a plugin never silently disappears when the daemon
+    // predates enable/disable.
+    case "active":
+      return items.filter(
+        (i) => i.status === "installed" && i.enabled !== false,
+      );
+    // Off = installed & explicitly disabled.
+    case "off":
+      return items.filter(
+        (i) => i.status === "installed" && i.enabled === false,
+      );
+  }
 }
 
 /** First 7 chars of a commit SHA, matching git's default short form. */

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -9,6 +9,8 @@ import {
   configGetQueryKey,
   homeFeedGetQueryKey,
   homeStateGetQueryKey,
+  pluginsGetQueryKey,
+  pluginsSearchGetQueryKey,
   schedulesGetQueryKey,
   soundsConfigGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -176,6 +178,67 @@ describe("useAssistantResourceSync", () => {
       })
     ).toBe(true);
     expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
+  });
+
+  test("invalidates plugin list / catalog queries on plugins:list sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const calls: unknown[] = [];
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      calls.push(arg);
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit((syncEvent([SYNC_TAGS.pluginsList]) as unknown) as AssistantEvent);
+    await waitFor(() => {
+      const queryKeys = calls.map(
+        (arg) => (arg as { queryKey: readonly unknown[] }).queryKey
+      );
+      const pathOpts = { path: { assistant_id: "asst-1" } };
+      expect(queryKeys).toEqual(
+        expect.arrayContaining([
+          pluginsGetQueryKey(pathOpts),
+          pluginsSearchGetQueryKey(pathOpts),
+        ]) as never
+      );
+    });
+  });
+
+  test("reconciles plugin queries on non-fresh sse.opened reconnect", async () => {
+    const queryClient = freshQueryClient();
+    const calls: unknown[] = [];
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      calls.push(arg);
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+    await waitFor(() => {
+      const queryKeys = calls.map(
+        (arg) => (arg as { queryKey: readonly unknown[] }).queryKey
+      );
+      const pathOpts = { path: { assistant_id: "asst-1" } };
+      expect(queryKeys).toEqual(
+        expect.arrayContaining([
+          pluginsGetQueryKey(pathOpts),
+          pluginsSearchGetQueryKey(pathOpts),
+        ]) as never
+      );
+    });
+  });
+
+  test("does not reconcile on fresh sse.opened", () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    publish("sse.opened", { assistantId: "asst-1", cause: "fresh" });
+    expect(spy).not.toHaveBeenCalled();
   });
 
   test("invalidates home-feed query on home_feed_updated", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -180,7 +180,7 @@ describe("useAssistantResourceSync", () => {
     expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
   });
 
-  test("invalidates plugin list / catalog queries on plugins:list sync tag", async () => {
+  test("invalidates plugin list / catalog / open-detail queries on plugins:list sync tag", async () => {
     const queryClient = freshQueryClient();
     const calls: unknown[] = [];
     queryClient.invalidateQueries = ((arg: unknown) => {
@@ -200,6 +200,10 @@ describe("useAssistantResourceSync", () => {
         expect.arrayContaining([
           pluginsGetQueryKey(pathOpts),
           pluginsSearchGetQueryKey(pathOpts),
+          // The broad sync carries no name, so every open plugin detail + drift
+          // inspect is invalidated via partial key (see invalidatePluginQueries).
+          [{ _id: "pluginsByNameGet", path: { assistant_id: "asst-1" } }],
+          [{ _id: "pluginsByNameInspectGet", path: { assistant_id: "asst-1" } }],
         ]) as never
       );
     });
@@ -225,6 +229,9 @@ describe("useAssistantResourceSync", () => {
         expect.arrayContaining([
           pluginsGetQueryKey(pathOpts),
           pluginsSearchGetQueryKey(pathOpts),
+          // Reconnect reconcile is name-agnostic too — open details invalidate.
+          [{ _id: "pluginsByNameGet", path: { assistant_id: "asst-1" } }],
+          [{ _id: "pluginsByNameInspectGet", path: { assistant_id: "asst-1" } }],
         ]) as never
       );
     });

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -2,7 +2,7 @@
  * Bus consumer for assistant-level resource cache invalidation.
  *
  * Routes `sync_changed` tags (avatar, identity, config, sounds, schedules,
- * apps) and discrete SSE events (`home_feed_updated`,
+ * apps, plugins) and discrete SSE events (`home_feed_updated`,
  * `relationship_state_updated`, `identity_changed`, `avatar_updated`) into
  * TanStack Query cache invalidations.
  *
@@ -29,6 +29,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 
+import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import {
   configGetQueryKey,
   identityGetQueryKey,
@@ -105,6 +106,9 @@ export function useAssistantResourceSync(
                 predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
               });
               break;
+            case SYNC_TAGS.pluginsList:
+              invalidatePluginQueries(queryClient, assistantId);
+              break;
           }
         }
         return;
@@ -170,6 +174,7 @@ export function useAssistantResourceSync(
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
     });
+    invalidatePluginQueries(queryClient, assistantId);
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "homeFeedGet"),
     });

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -5,6 +5,7 @@ export const SYNC_TAGS = {
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
   appsList: "apps:list",
+  pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",


### PR DESCRIPTION
## Summary
Add per-workspace enable/disable for installed plugins, at parity with how Skills work. A disabled plugin stays installed (keeps its dir/version/config) but its tools/surfaces aren't loaded; it's reversible and applies live with no restart. Surfaced as an **Active/Off** toggle on each installed row (left of Remove, MCP-card style; drift → Update chip) and in the plugin detail page, plus an Active/Off status filter.

- **Daemon:** `enabled` on the plugin list (sourced from the existing `.disabled` sentinel); `POST /v1/plugins/:name/enable|disable` routes (existing toggle-plugin lib, 400/404/409 mapping) that emit the generic `sync_changed(plugins:list)` via the canonical resource-sync publisher (per AGENTS.md §164 — no bespoke event).
- **Web:** optimistic `usePluginToggle` (all cache variants, 409-as-success, targeted rollback), card + detail Active/Off toggles (desktop + mobile), `pluginToggleSupported` capability gating, Active/Off status filter (Installed fallback on older daemons), and live `sync_changed` reconcile via `useAssistantResourceSync`.

## Self-review result
PASS — 4 fresh-eyes passes (plan faithfulness, slop, external feedback, integration) + integration re-review. 2 gaps found and fixed (older-daemon Installed filter; canonical sync publisher / originClientId).

## PRs merged into feature branch
- #36760 daemon: `enabled` on GET /v1/plugins
- #36761 daemon: `plugins:list` sync tag
- #36763 daemon: enable/disable routes + broadcast
- #36762 web: `enabled` field + toggle-support latch
- #36766 web: `usePluginToggle` optimistic mutation
- #36765 web: reconcile on `plugins:list` sync_changed
- #36768 web: card Active/Off toggle + Update chip
- #36769 web: detail Active/Off toggle
- #36770 web: Active/Off status filter + gating

### Self-review remediation
- #36772 fix: restore Installed filter for daemons without enable/disable
- #36773 fix(daemon): emit plugin sync via canonical publisher with originClientId

Part of plan: plugin-enable-disable.md