### PR TITLE
fix(web): make the daemon's processing flag an authoritative close-gate for the thinking indicator

### DIFF
--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -72,6 +72,10 @@ function parsePaginatedResponse(
   const oldestTimestamp = body?.oldestTimestamp ?? null;
   const oldestMessageId = body?.oldestMessageId || null;
   const seq = body?.seq ?? null;
+  // Authoritative "is a turn in flight?" flag. Kept as-is (including
+  // `undefined`) rather than coerced to a boolean: `undefined` is the version
+  // sentinel that leaves turn-phase behavior untouched for pre-0.8.8 daemons.
+  const processing = body?.processing;
 
   return {
     messages,
@@ -80,6 +84,7 @@ function parsePaginatedResponse(
     oldestMessageId,
     seq,
     backgroundToolCompletions,
+    ...(processing !== undefined ? { processing } : {}),
     ...(subagentNotifications.length > 0 ? { subagentNotifications } : {}),
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -12,6 +12,7 @@
 
 import { useMemo } from "react";
 
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useTurnStore } from "@/domains/chat/turn-store";
 import {
@@ -79,6 +80,12 @@ export function useChatUIState(): ChatUIState {
   // while a turn is in flight.
   const transcript = useTranscriptMessages();
 
+  // The daemon's authoritative per-conversation processing flag, carried on the
+  // rolling snapshot and refreshed by every `/messages` reseed. Narrow selector
+  // so this only re-renders when the flag itself flips, not on every folded
+  // content event. `undefined` on pre-0.8.8 daemons → phase-only behavior.
+  const snapshotProcessing = useChatSessionStore((s) => s.snapshot?.processing);
+
   // TanStack Query — deduped with any other call for the same conversation.
   const activeConversation = useActiveConversation(assistantId, activeConversationId, true);
 
@@ -133,6 +140,7 @@ export function useChatUIState(): ChatUIState {
       hasUncompletedVisibleSurface,
       activeConversationIsProcessing,
       hasPendingAssistantResponse: activeConversationHasPendingAssistantResponse,
+      snapshotProcessing,
     }),
     [
       hasStreamingAssistantMessage,
@@ -144,6 +152,7 @@ export function useChatUIState(): ChatUIState {
       hasUncompletedVisibleSurface,
       activeConversationIsProcessing,
       activeConversationHasPendingAssistantResponse,
+      snapshotProcessing,
     ],
   );
 

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -282,4 +282,75 @@ describe("rolling-snapshot reducer", () => {
       ).toBe("cr-1");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Authoritative `processing` flag fold.
+  // -------------------------------------------------------------------------
+  describe("processing flag", () => {
+    const turnStart = (seq: number, id: string) =>
+      env(seq, { type: "assistant_turn_start", messageId: id } as AssistantEvent);
+    const activityIdle = (seq: number) =>
+      env(seq, { type: "assistant_activity_state", phase: "idle" } as AssistantEvent);
+    const activityThinking = (seq: number) =>
+      env(seq, {
+        type: "assistant_activity_state",
+        phase: "thinking",
+      } as AssistantEvent);
+    // A defined seed = a 0.8.8+ daemon that reported `processing` on /messages.
+    const idleSeed: PaginatedHistoryResult = { ...SEED, processing: false };
+    const busySeed: PaginatedHistoryResult = { ...SEED, processing: true };
+
+    test("turn-start folds processing → true", () => {
+      expect(applyEvent(idleSeed, turnStart(1, "a1")).processing).toBe(true);
+    });
+
+    test("assistant content folds processing → true (turn-start fallback)", () => {
+      expect(applyEvent(idleSeed, textDelta(1, "a1", "hi")).processing).toBe(true);
+      expect(applyEvent(idleSeed, thinkingDelta(1, "a1", "hmm")).processing).toBe(
+        true,
+      );
+    });
+
+    test("a non-idle activity phase keeps processing true", () => {
+      expect(applyEvent(busySeed, activityThinking(1)).processing).toBe(true);
+    });
+
+    test("activity_state(idle) folds processing → false", () => {
+      expect(applyEvent(busySeed, activityIdle(1)).processing).toBe(false);
+    });
+
+    test("message_complete folds processing → false", () => {
+      expect(applyEvent(busySeed, complete(1, "a1")).processing).toBe(false);
+    });
+
+    test("undefined seed stays undefined — the pre-0.8.8 version sentinel", () => {
+      // SEED omits `processing`; the fold must never manufacture a value, so
+      // phase-only behavior is preserved for daemons that don't report it.
+      const after = applyEvent(SEED, turnStart(1, "a1"));
+      expect(after.processing).toBeUndefined();
+      expect("processing" in after).toBe(false);
+    });
+
+    test("a replayed lower-seq turn-start cannot resurrect a closed turn", () => {
+      // idle at seq 5 closes the turn; a late/duplicated turn-start at seq 2 is
+      // below the watermark and dropped, so processing stays false.
+      const closed = applyEvent(busySeed, activityIdle(5));
+      expect(closed.processing).toBe(false);
+      expect(applyEvent(closed, turnStart(2, "a1")).processing).toBe(false);
+    });
+
+    test("converges under a noisy, out-of-order lifecycle stream", () => {
+      // The scalar-fold analogue of the message invariant: the highest-seq
+      // lifecycle event wins regardless of arrival order.
+      const clean = [turnStart(1, "a1"), textDelta(2, "a1", "hi"), activityIdle(3)];
+      const cleanProcessing = applyEventsToHistory(idleSeed, clean).processing;
+      expect(cleanProcessing).toBe(false);
+      for (let seed = 1; seed <= 50; seed++) {
+        const noisy = withReplays(clean, rng(seed));
+        expect(applyEventsToHistory(idleSeed, noisy).processing).toBe(
+          cleanProcessing,
+        );
+      }
+    });
+  });
 });

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -195,6 +195,43 @@ export function appendEventToMessages(
 }
 
 /**
+ * Advance the snapshot's authoritative `processing` flag from a folded event.
+ *
+ * `undefined` is the version sentinel — a daemon that omits `processing` on
+ * `/messages` (pre-0.8.8) never gets a synthesized value, so `undefined` stays
+ * "no authoritative signal, fall back to the turn phase." Only seq-carrying
+ * events move a defined flag, so a replayed or out-of-order tail converges the
+ * same way `seq`-idempotency converges the message fold — a bare scalar can't
+ * rely on the structural upsert that keeps message rows convergent.
+ *
+ * Mirrors the turn lifecycle the daemon's `processing_started_at` tracks:
+ * turn-start / assistant content marks a turn in flight; the terminal
+ * `assistant_activity_state(idle)` and `message_complete` mark it done. Cancel
+ * / error terminals aren't folded here — the turn phase already idles on those,
+ * and the next `/messages` reseed carries the authoritative `false`.
+ */
+function nextProcessingState(
+  current: boolean | undefined,
+  event: AssistantEvent,
+  seq: number | null | undefined,
+): boolean | undefined {
+  if (current === undefined) return undefined;
+  if (typeof seq !== "number") return current;
+  switch (event.type) {
+    case "assistant_turn_start":
+    case "assistant_text_delta":
+    case "assistant_thinking_delta":
+      return true;
+    case "assistant_activity_state":
+      return event.phase === "idle" ? false : true;
+    case "message_complete":
+      return false;
+    default:
+      return current;
+  }
+}
+
+/**
  * Fold one event envelope into the history. Drops an event whose `seq` is at or
  * below the history's `seq` — it is already folded — which is what makes replay
  * after reconnect and overlap with a resync safe. `seq` advances to the highest
@@ -217,8 +254,14 @@ export function applyEvent(
   const messages = appendEventToMessages(history.messages, envelope.message, at);
   const nextSeq =
     typeof seq === "number" ? Math.max(history.seq ?? -1, seq) : history.seq ?? null;
+  const processing = nextProcessingState(history.processing, envelope.message, seq);
 
-  return { ...history, messages, seq: nextSeq };
+  return {
+    ...history,
+    messages,
+    seq: nextSeq,
+    ...(processing !== undefined ? { processing } : {}),
+  };
 }
 
 /** Rebuild the history from a snapshot and a run of events — the full

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -115,6 +115,14 @@ export interface PaginatedHistoryResult {
    *  that omits the field). Used to align the snapshot with the `/events`
    *  stream. */
   seq?: number | null;
+  /** The daemon's authoritative "is a turn in flight?" flag for this
+   *  conversation, sourced from the persisted `processing_started_at` column
+   *  and folded forward by the turn-lifecycle events in `rolling-snapshot.ts`.
+   *  `undefined` is the version sentinel — daemons before 0.8.8 omit it on
+   *  `/messages`, and the fold never manufactures a value, so `undefined`
+   *  means "no authoritative signal; fall back to the turn phase." Consumed as
+   *  a close-gate: `false` idles a turn whose terminal SSE event was dropped. */
+  processing?: boolean;
 }
 
 /** Snapshot of the transcript pagination state held by the scroll

--- a/clients/web/src/domains/chat/turn-selectors.test.ts
+++ b/clients/web/src/domains/chat/turn-selectors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canStopGeneration,
+  shouldShowThinkingIndicator,
+  type UIContext,
+} from "@/domains/chat/turn-selectors";
+
+// A context with every gate off — the caller overrides only what a case needs.
+const ctx = (over: Partial<UIContext> = {}): UIContext => ({
+  hasStreamingAssistantMessage: false,
+  hasStreamingAssistantThinking: false,
+  hasPendingSecret: false,
+  hasPendingConfirmation: false,
+  hasPendingQuestion: false,
+  hasPendingContactRequest: false,
+  hasUncompletedVisibleSurface: false,
+  activeConversationIsProcessing: false,
+  hasPendingAssistantResponse: false,
+  ...over,
+});
+
+describe("shouldShowThinkingIndicator — authoritative processing close-gate", () => {
+  test("hides a stuck 'thinking' phase when the server reports the turn idle", () => {
+    // The incident: SSE terminal event dropped, so `phase` never left
+    // `thinking`; the reseeded snapshot reports `processing: false` and an
+    // assistant reply already rendered (no pending response).
+    expect(
+      shouldShowThinkingIndicator("thinking", 0, ctx({ snapshotProcessing: false })),
+    ).toBe(false);
+  });
+
+  test("keeps showing in the just-sent window (waiting for the first token)", () => {
+    // Right after a send the snapshot still reads the prior idle, but we are
+    // legitimately awaiting the assistant's first row — the dots must stay.
+    expect(
+      shouldShowThinkingIndicator(
+        "thinking",
+        0,
+        ctx({ snapshotProcessing: false, hasPendingAssistantResponse: true }),
+      ),
+    ).toBe(true);
+  });
+
+  test("undefined processing (pre-0.8.8) leaves phase-only behavior intact", () => {
+    expect(
+      shouldShowThinkingIndicator("thinking", 0, ctx({ snapshotProcessing: undefined })),
+    ).toBe(true);
+  });
+
+  test("processing:true does not suppress the indicator", () => {
+    expect(
+      shouldShowThinkingIndicator("thinking", 0, ctx({ snapshotProcessing: true })),
+    ).toBe(true);
+  });
+});
+
+describe("canStopGeneration — authoritative processing close-gate", () => {
+  test("cannot stop once the server reports the turn idle", () => {
+    expect(
+      canStopGeneration("thinking", ctx({ snapshotProcessing: false })),
+    ).toBe(false);
+  });
+
+  test("can still stop while awaiting the first token after a send", () => {
+    expect(
+      canStopGeneration(
+        "thinking",
+        ctx({ snapshotProcessing: false, hasPendingAssistantResponse: true }),
+      ),
+    ).toBe(true);
+  });
+
+  test("undefined processing leaves phase-driven stop behavior intact", () => {
+    expect(canStopGeneration("streaming", ctx({ snapshotProcessing: undefined }))).toBe(
+      true,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/turn-selectors.ts
+++ b/clients/web/src/domains/chat/turn-selectors.ts
@@ -31,6 +31,13 @@ export interface UIContext {
    * message yet. Used with `activeConversationIsProcessing` to restore the
    * thinking indicator after switching back to an in-flight conversation. */
   hasPendingAssistantResponse?: boolean;
+  /** The daemon's authoritative per-conversation `processing` flag, carried on
+   * the rolling snapshot (`PaginatedHistoryResult.processing`) and refreshed by
+   * every `/messages` reseed. Consumed as an authoritative CLOSE-gate: `false`
+   * means the server considers the turn over, so a `phase` left stuck by a
+   * dropped terminal SSE event stops driving the indicator. `undefined` (older
+   * daemons, or a cold snapshot) leaves phase-only behavior untouched. */
+  snapshotProcessing?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,6 +79,17 @@ export function shouldShowThinkingIndicator(
   activeToolCallCount: number,
   ctx: UIContext,
 ): boolean {
+  // Authoritative close: when the daemon reports this conversation idle
+  // (`snapshotProcessing === false`, 0.8.8+) the turn is over — even if the
+  // local `phase` never saw the terminal SSE event (dropped while the stream
+  // was disconnected). Guarded by `hasPendingAssistantResponse` so the window
+  // right after a send — before the first token, where the snapshot still
+  // legitimately reads the prior idle — keeps showing the dots. `undefined`
+  // (older daemons / cold snapshot) leaves the phase-driven behavior untouched.
+  if (ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse) {
+    return false;
+  }
+
   const restoredProcessing =
     ctx.activeConversationIsProcessing === true &&
     ctx.hasPendingAssistantResponse === true;
@@ -103,6 +121,14 @@ export function canStopGeneration(
   phase: TurnPhase,
   ctx: UIContext,
 ): boolean {
+  // Same authoritative close as the thinking indicator: nothing to stop once
+  // the server reports the turn done, even if `phase` is stuck. The
+  // `hasPendingAssistantResponse` guard keeps Stop available in the
+  // just-sent-waiting-for-first-token window.
+  if (ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse) {
+    return false;
+  }
+
   if (
     phase === "awaiting_user_input" ||
     ctx.hasPendingSecret ||


### PR DESCRIPTION
## Prompt / plan

From a support investigation: a user returned to their assistant to find the **"Thinking…"** indicator stuck on a conversation whose response had finished hours earlier. The turn ran entirely while the tab was backgrounded and the SSE stream was disconnected, so the terminal event (`message_complete` / `assistant_activity_state(idle)`) was never delivered. The turn completed server-side, but the client turn-store `phase` was left at `thinking` with no way to recover — the render gate wires the authoritative server flag only as an *additive* "show" signal (`restoredProcessing`), so `processing: false` could never *suppress* a stuck phase.

The fix keeps the indicator driven by the snapshot the client already maintains — **not** another reconciliation pass. The daemon already ships `processing` on `/messages?page=latest` (0.8.8+, sourced from the persisted `processing_started_at` column); the web client fetched it and dropped it on the floor. We carry it on the rolling snapshot and let it *close* a stuck turn.

## What changed

- **`history.ts` → `PaginatedHistoryResult.processing` (`types.ts`)** — thread the flag onto the snapshot, kept as `undefined` when the daemon omits it (the version sentinel).
- **`rolling-snapshot.ts`** — fold `processing` forward with the transcript (`nextProcessingState`): turn-start / assistant content mark a turn in flight; `assistant_activity_state(idle)` and `message_complete` mark it done. The fold is **seq-idempotent** and **never manufactures a value from `undefined`**, so replay/resync stay convergent (the property-test invariant holds) and pre-0.8.8 daemons keep phase-only behavior. Cancel/error terminals aren't folded — the phase already idles on those and the next reseed carries the authoritative `false`.
- **`turn-selectors.ts`** — `shouldShowThinkingIndicator` and `canStopGeneration` gain an authoritative **CLOSE-gate**: `snapshotProcessing === false` idles the turn even if `phase` is stuck. Guarded by `hasPendingAssistantResponse` so the just-sent, pre-first-token window (where the snapshot still legitimately reads the prior idle) keeps showing the dots. `undefined` leaves phase-only behavior untouched.
- **`use-chat-ui-state.ts`** — read the snapshot's `processing` via a narrow selector and feed it into `UIContext`.

Because every `/messages` reseed (reconnect / resume / turn-return-to-idle) refreshes the flag, a dropped terminal event now **self-heals on the next reseed** — one mechanism heals both transcript content and the indicator, with no extra reconciliation logic. This is the snapshot-backed foundation for later demoting `phase` to a live-only refinement (follow-up: retire the client processing mirror once the min daemon version reaches the gate).

Per `docs/CONVERSATION_SSE.md`, the reducer stays pure / total / seq-idempotent — `processing` is folded like the existing `seq` scalar, not written as transcript content.

## Test plan

- **`rolling-snapshot.test.ts`** (new `processing flag` block): fold directions (turn-start/content → true, idle/complete → false), the `undefined` version sentinel is never manufactured, seq-idempotency (a replayed lower-seq turn-start can't resurrect a closed turn), and noisy/out-of-order convergence. → **31 pass**.
- **`turn-selectors.test.ts`** (new): close-gate hides a stuck `thinking` phase on `processing:false`; keeps the dots in the just-sent window (`hasPendingAssistantResponse`); `undefined` and `true` leave behavior intact; same for `canStopGeneration`.
- `turn-store` (120), `turn-coordinator`, `message-handlers` (29), `use-event-stream-resume-reconcile`, `transcript-message-body` (32) all green in isolation. `bunx tsc --noEmit` clean; `eslint` clean on changed files.
- (Note: running many stateful chat suites in a single Bun process shows cross-file global-state pollution — reproduces identically without this diff; CI runs isolated via `test:ci`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfudXocrjD6NgctoBpjkom