### PR TITLE
refactor(daemon): drop redundant try/catch around installAssistantSymlink()

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -873,12 +873,9 @@ export async function runDaemon(): Promise<void> {
   writePid(process.pid);
 
   // Install the `assistant` CLI symlink idempotently on every daemon start.
-  // Non-blocking — failures are logged but don't affect startup.
-  try {
-    installAssistantSymlink();
-  } catch (err) {
-    log.warn({ err }, "Assistant symlink installation failed — continuing");
-  }
+  // Best-effort and self-contained: every step swallows its own errors, so a
+  // failure never affects startup.
+  installAssistantSymlink();
 
   startEmbeddingRuntimeManager();
 


### PR DESCRIPTION
## Why

Part of paring `lifecycle.ts` down to a flat sequence of single-purpose calls. `installAssistantSymlink()` was wrapped in a `try/catch` in the startup sequence, but the wrapper is redundant: the function is already fully self-contained best-effort — every internal step (`trySymlink`, `ensureLocalBinInShellProfile`, `commandResolvesElsewhere`) swallows its own errors, and the top-level path (`resolveAssistantBinary` + path joins) cannot throw. So the outer handler never fires.

## What

- Remove the `try/catch` and call `installAssistantSymlink()` bare, matching the other startup steps.
- Update the comment to state the best-effort guarantee lives inside the function.

## Behavior

Unchanged — a symlink-install failure still cannot affect startup; the swallowing just happens one level down where it already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_