### PR TITLE
feat(onboarding): make the hobbies field read as add-anything search

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -26,6 +26,7 @@ import {
   useState,
   type KeyboardEvent,
 } from "react";
+import { Plus, Search } from "lucide-react";
 
 import { Tag } from "@vellumai/design-library/components/tag";
 import { cn } from "@vellumai/design-library/utils/cn";
@@ -64,17 +65,33 @@ function filterSuggestions(
   return out;
 }
 
-/** The floating suggestion list, anchored under the field box. */
+/** One row in the dropdown: a predefined suggestion, or a free-text "add" row. */
+interface AutocompleteOption {
+  value: string;
+  /** True for the "Add '<query>'" row (free text not in the suggestion list). */
+  isAdd: boolean;
+}
+
+/**
+ * The floating suggestion list, anchored under the field box. Renders the
+ * matching suggestions plus (when the typed text isn't already a suggestion or
+ * chip) an "Add '<query>'" row so free-text entry is discoverable. A muted
+ * footer advertises that anything can be typed and added, so the list never
+ * reads as a fixed menu.
+ */
 function SuggestionList({
   id,
-  items,
+  options,
   highlighted,
+  showAddHint,
   onPick,
   onHover,
 }: {
   id: string;
-  items: string[];
+  options: AutocompleteOption[];
   highlighted: number;
+  /** Show the "type to add your own" footer (when no add-row is present). */
+  showAddHint: boolean;
   onPick: (value: string) => void;
   onHover: (index: number) => void;
 }) {
@@ -88,29 +105,50 @@ function SuggestionList({
         "animate-[fadeInUp_0.12s_ease-out]",
       )}
     >
-      {items.map((item, i) => (
+      {options.map((opt, i) => (
         <li
-          key={item}
+          key={opt.isAdd ? `__add__${opt.value}` : opt.value}
           id={`${id}-opt-${i}`}
           role="option"
           aria-selected={i === highlighted}
           // mousedown (not click) so we beat the input's blur and keep focus.
           onMouseDown={(e) => {
             e.preventDefault();
-            onPick(item);
+            onPick(opt.value);
           }}
           onMouseEnter={() => onHover(i)}
           className={cn(
-            "cursor-pointer rounded-md px-2.5 py-1.5 text-body-medium-lighter",
-            "text-[var(--content-default)]",
-            i === highlighted
-              ? "bg-[var(--surface-base)]"
-              : "bg-transparent",
+            "flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5",
+            "text-body-medium-lighter text-[var(--content-default)]",
+            i === highlighted ? "bg-[var(--surface-base)]" : "bg-transparent",
           )}
         >
-          {item}
+          {opt.isAdd ? (
+            <>
+              <Plus
+                size={15}
+                className="shrink-0 text-[var(--content-tertiary)]"
+              />
+              <span className="min-w-0 truncate">
+                Add “{opt.value}”
+              </span>
+              <span className="ml-auto shrink-0 text-body-small-default text-[var(--content-tertiary)]">
+                ↵ Enter
+              </span>
+            </>
+          ) : (
+            opt.value
+          )}
         </li>
       ))}
+      {showAddHint && (
+        <li
+          role="presentation"
+          className="mt-0.5 border-t border-[var(--border-base)] px-2.5 pb-0.5 pt-1.5 text-body-small-default text-[var(--content-tertiary)]"
+        >
+          Type anything and press ↵ to add your own
+        </li>
+      )}
     </ul>
   );
 }
@@ -187,13 +225,34 @@ export function TagAutocompleteInput({
     [suggestions, query, values],
   );
 
+  const trimmedQuery = query.trim();
+  // Offer a free-text "Add" row unless the typed value is already a visible
+  // suggestion or an existing chip — so novel hobbies are one keystroke away and
+  // the list never looks like a fixed menu.
+  const canAddCustom = useMemo(() => {
+    if (!trimmedQuery) return false;
+    const q = normalize(trimmedQuery);
+    if (values.some((v) => normalize(v) === q)) return false;
+    if (items.some((s) => normalize(s) === q)) return false;
+    return true;
+  }, [trimmedQuery, values, items]);
+
+  const options = useMemo<AutocompleteOption[]>(() => {
+    const base = items.map((value) => ({ value, isAdd: false }));
+    return canAddCustom
+      ? [...base, { value: trimmedQuery, isAdd: true }]
+      : base;
+  }, [items, canAddCustom, trimmedQuery]);
+
   useDismiss(wrapperRef, () => setOpen(false));
 
   useEffect(() => {
-    setHighlighted((h) => (h >= items.length ? items.length - 1 : h));
-  }, [items.length]);
+    setHighlighted((h) => (h >= options.length ? options.length - 1 : h));
+  }, [options.length]);
 
-  const showList = open && items.length > 0;
+  const showList = open && options.length > 0;
+  // Advertise free-text entry in the footer when no dedicated add-row shows it.
+  const showAddHint = !canAddCustom;
 
   function addChip(raw: string) {
     const next = raw.trim();
@@ -214,16 +273,17 @@ export function TagAutocompleteInput({
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setOpen(true);
-      setHighlighted((h) => Math.min(h + 1, items.length - 1));
+      setHighlighted((h) => Math.min(h + 1, options.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setHighlighted((h) => Math.max(h - 1, 0));
     } else if (e.key === "Enter") {
       // Always swallow Enter here so it commits a chip instead of submitting
-      // the form mid-list.
+      // the form mid-list. A highlighted row (suggestion or the add-row) wins;
+      // otherwise the typed text is added directly.
       if (showList && highlighted >= 0) {
         e.preventDefault();
-        addChip(items[highlighted]!);
+        addChip(options[highlighted]!.value);
       } else if (query.trim()) {
         e.preventDefault();
         addChip(query);
@@ -242,6 +302,11 @@ export function TagAutocompleteInput({
     <div ref={wrapperRef} className="relative flex flex-col gap-1.5">
       <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
       <div className={cn(FIELD_BOX, "min-h-9 flex-wrap py-1.5")}>
+        <Search
+          size={16}
+          aria-hidden
+          className="shrink-0 self-center text-[var(--content-tertiary)]"
+        />
         {values.map((v) => (
           <Tag
             key={v}
@@ -278,8 +343,9 @@ export function TagAutocompleteInput({
       {showList && (
         <SuggestionList
           id={listId}
-          items={items}
+          options={options}
           highlighted={highlighted}
+          showAddHint={showAddHint}
           onPick={addChip}
           onHover={setHighlighted}
         />


### PR DESCRIPTION
## What

Improves the **hobbies** autocomplete on the research-onboarding front door so it reads as an *add-anything* search rather than a fixed menu (follow-up to #36676).

- **Search icon** in the field, signaling it's a search input.
- **"Add '<query>'" row** — whenever the typed text isn't already a suggestion or an existing chip, the dropdown shows a dedicated add row with a `+` icon and an `↵ Enter` hint. This also means the dropdown now opens even when nothing matches the typed text, so custom hobbies are always one keystroke away.
- **Footer hint** — "Type anything and press ↵ to add your own" shows when no add-row is present, so the list never looks like a limited set of options.

Keyboard nav and Enter now operate over the combined options (suggestions + add-row); free text still commits on Enter/comma as before.

## Scope

Single file: `clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx` (the `TagAutocompleteInput` used for Hobbies).

## Testing

- `bunx tsc --noEmit` clean for the touched file; `vite build` succeeds.
- No behavior change to the free-text commit path (Enter/comma/backspace) beyond routing through the combined options list.

## QA notes

On the "Let's start with you" step, click the Hobbies field: you should see the search icon and the "type to add your own" hint. Type something not in the list (e.g. "spelunking") and confirm the "Add 'spelunking'" row appears and Enter/click adds it as a chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)