### PR TITLE
feat(onboarding): add a "Who do you want me to be?" persona step

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -53,4 +53,32 @@ describe("buildPersonalityMessage", () => {
     expect(msg).toContain("Coworker (0-100): 100");
     expect(msg).toContain("Companion (0-100): 0");
   });
+
+  test("weaves the persona into the message when provided", () => {
+    const msg = buildPersonalityMessage(
+      {},
+      "Akash",
+      "a noir detective on the case",
+    );
+    expect(msg).toContain(
+      'They also described the character they want you to embody: "a noir detective on the case".',
+    );
+    // Trait scores and the rewrite instruction still survive the insertion.
+    expect(msg).toContain("Companion (0-100): 50");
+    expect(msg).toContain(
+      "Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md)",
+    );
+  });
+
+  test("collapses whitespace and omits the persona block when blank", () => {
+    const multiline = buildPersonalityMessage(
+      {},
+      undefined,
+      "a sassy\n  goth   girl",
+    );
+    expect(multiline).toContain('"a sassy goth girl"');
+
+    const blank = buildPersonalityMessage({}, undefined, "   ");
+    expect(blank).not.toContain("described the character");
+  });
 });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -64,6 +64,7 @@ const clamp = (n: number): number => Math.max(0, Math.min(100, Math.round(n)));
 export function buildPersonalityMessage(
   values: Record<string, number>,
   userName?: string,
+  persona?: string,
 ): string {
   const v = (id: string): number => clamp(values[id] ?? 50);
   const companionCoworker = v(AXIS.companionCoworker); // 100 = Coworker
@@ -72,6 +73,12 @@ export function buildPersonalityMessage(
   const politeUnfiltered = v(AXIS.politeUnfiltered); // 100 = Unfiltered
 
   const who = userName?.trim() || "The user";
+  // Collapse whitespace so a multi-line answer can't break the system-message
+  // framing the assistant parses; a blank answer omits the persona block.
+  const character = persona?.trim().replace(/\s+/g, " ");
+  const personaBlock = character
+    ? `\nThey also described the character they want you to embody: "${character}". Take on this persona — let it shape your voice, tone, and how you behave — while still honoring the trait scores above.\n`
+    : "";
   return `<system-message>
 ${who} wants to customize your personality.
 This is what they want you to be:
@@ -84,7 +91,7 @@ Playfulness (0 - 100): ${100 - playfulSerious}
 Seriousness (0 - 100): ${playfulSerious}
 Politeness (0 - 100): ${100 - politeUnfiltered}
 Unfiltered Rawness/Crassness (0 - 100): ${politeUnfiltered}
-
+${personaBlock}
 Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality. Write them in first person in a voice and style that matches your new personality.
 </system-message>`;
 }
@@ -115,6 +122,8 @@ export interface ApplyPersonalityOptions {
   awaitAssistantId: () => Promise<string>;
   /** The five slider values, keyed by axis id (see `AXIS`). */
   values: Record<string, number>;
+  /** Free-text character to embody ("who do you want me to be?"). */
+  persona?: string;
   /** The user's name, woven into the system-message. */
   userName?: string;
 }
@@ -126,6 +135,7 @@ export interface ApplyPersonalityOptions {
 export async function applyPersonality({
   awaitAssistantId,
   values,
+  persona,
   userName,
 }: ApplyPersonalityOptions): Promise<void> {
   let assistantId: string | undefined;
@@ -143,7 +153,7 @@ export async function applyPersonality({
 
     const body: MessagesPostData["body"] = {
       conversationId,
-      content: buildPersonalityMessage(values, userName),
+      content: buildPersonalityMessage(values, userName, persona),
       sourceChannel: "vellum",
       interface: "vellum",
       clientMessageId: crypto.randomUUID(),

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -54,7 +54,7 @@ export interface OnboardingFunnelStepDescriptor {
  * and ingest path. The backend stores step_name/funnel_version as open strings, so
  * these new values need no backend/terraform change.
  */
-export const RESEARCH_ONBOARDING_FUNNEL_VERSION = "research_onboarding_v1_2026_06";
+export const RESEARCH_ONBOARDING_FUNNEL_VERSION = "research_onboarding_v1_2026_07";
 
 export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
   form: { stepName: "research_form", stepIndex: 0 },
@@ -62,12 +62,13 @@ export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
   intro: { stepName: "research_intro", stepIndex: 2 },
   different: { stepName: "research_pitch", stepIndex: 3 },
   personality: { stepName: "research_personality", stepIndex: 4 },
-  integration: { stepName: "research_integration", stepIndex: 5 },
-  letschat: { stepName: "research_calendar", stepIndex: 6 },
-  meeting: { stepName: "research_meeting", stepIndex: 7 },
-  looking: { stepName: "research_looking", stepIndex: 8 },
-  results: { stepName: "research_results", stepIndex: 9 },
-  suggestions: { stepName: "research_suggestions", stepIndex: 10 },
+  persona: { stepName: "research_persona", stepIndex: 5 },
+  integration: { stepName: "research_integration", stepIndex: 6 },
+  letschat: { stepName: "research_calendar", stepIndex: 7 },
+  meeting: { stepName: "research_meeting", stepIndex: 8 },
+  looking: { stepName: "research_looking", stepIndex: 9 },
+  results: { stepName: "research_results", stepIndex: 10 },
+  suggestions: { stepName: "research_suggestions", stepIndex: 11 },
 } as const satisfies Record<ResearchStep, OnboardingFunnelStepDescriptor>;
 
 export type ResearchOnboardingFunnelStep =
@@ -97,7 +98,7 @@ export const RESEARCH_CHECKIN_CALENDAR_ATTRIBUTION = "research_checkin";
  */
 export const RESEARCH_ONBOARDING_CHECKIN_STEP = {
   stepName: "research_checkin_open",
-  stepIndex: 11,
+  stepIndex: 12,
 } as const satisfies OnboardingFunnelStepDescriptor;
 
 /**

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -67,6 +67,7 @@ import { IntroductionScreen } from "@/domains/onboarding/screens/introduction-sc
 import { PitchStep } from "@/domains/onboarding/screens/intro-pitch-steps";
 import { IntegrationStep } from "@/domains/onboarding/screens/integration-step";
 import { CreatePersonalityStep } from "@/domains/onboarding/screens/create-personality-step";
+import { PersonaStep } from "@/domains/onboarding/screens/persona-step";
 import { LetsChatTomorrowStep } from "@/domains/onboarding/screens/lets-chat-tomorrow-step";
 import {
   MeetingCreatedStep,
@@ -192,6 +193,10 @@ export function ResearchOnboardingRoute() {
   const [personalityValues, setPersonalityValues] = useState<
     Record<string, number>
   >({});
+  // Free-text persona ("who do you want me to be?"), collected on the step after
+  // the sliders. Lives here alongside the slider values so it survives a
+  // step-back and is applied together with them on the persona step's continue.
+  const [persona, setPersona] = useState("");
   const [personalityLocked, setPersonalityLocked] = useState(false);
   // Id of the behind-the-scenes "research me" conversation. Captured the moment
   // it's minted (and restored from the snapshot on refresh) so a mid-search
@@ -552,6 +557,7 @@ export function ResearchOnboardingRoute() {
   const tonedSteps = [
     "different",
     "personality",
+    "persona",
     "integration",
     "letschat",
     "meeting",
@@ -600,25 +606,39 @@ export function ResearchOnboardingRoute() {
               setPersonalityValues((prev) => ({ ...prev, [axisId]: value }))
             }
             locked={personalityLocked}
+            // The sliders + persona are applied together on the persona step's
+            // continue, so this just advances (nothing is sent yet — a step-back
+            // can still adjust the sliders until then).
+            onContinue={() => goForwardTo("persona")}
+            onBack={() => goBackTo("different")}
+            onForward={onForward}
+          />
+        )}
+        {step === "persona" && (
+          <PersonaStep
+            persona={persona}
+            onPersonaChange={setPersona}
+            locked={personalityLocked}
             onContinue={() => {
-              // First continue applies the sliders to the assistant's persona on
-              // a throwaway side thread (awaits hatch readiness internally, then
-              // archives) and locks them — the prompt has been sent, so a later
-              // step-back can't silently diverge. Fire-and-forget: the rewrite
-              // turn finishes during the later steps, well before the chat
-              // handoff. Best-effort; never blocks the flow. A continue while
-              // already locked just advances.
+              // First continue applies the sliders + persona to the assistant's
+              // identity on a throwaway side thread (awaits hatch readiness
+              // internally, then archives) and locks them — the prompt has been
+              // sent, so a later step-back can't silently diverge. Fire-and-
+              // forget: the rewrite turn finishes during the later steps, well
+              // before the chat handoff. Best-effort; never blocks the flow. A
+              // continue while already locked just advances.
               if (!personalityLocked) {
                 void applyPersonality({
                   awaitAssistantId: awaitHatchReady,
                   values: personalityValues,
+                  persona: persona.trim() || undefined,
                   userName: formValues?.firstName?.trim() || undefined,
                 });
                 setPersonalityLocked(true);
               }
               goForwardTo("integration");
             }}
-            onBack={() => goBackTo("different")}
+            onBack={() => goBackTo("personality")}
             onForward={onForward}
           />
         )}
@@ -627,7 +647,7 @@ export function ResearchOnboardingRoute() {
             onClaim={() => goForwardTo("letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
             onBack={() =>
-              goBackTo(personalityEnabled ? "personality" : "different")
+              goBackTo(personalityEnabled ? "persona" : "different")
             }
             onForward={onForward}
           />

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -41,6 +41,7 @@ export type ResearchStep =
   | "intro"
   | "different"
   | "personality"
+  | "persona"
   | "integration"
   | "letschat"
   | "meeting"

--- a/clients/web/src/domains/onboarding/screens/persona-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/persona-step.tsx
@@ -96,7 +96,7 @@ const PERSONA_EXAMPLES: PersonaExample[] = [
 ];
 
 /** Cadence for the showcase / example rotation. */
-const ROTATE_INTERVAL_MS = 3000;
+const ROTATE_INTERVAL_MS = 1600;
 
 /** Mini-avatar size in the rotating showcase. */
 const SHOWCASE_AVATAR = 52;
@@ -178,7 +178,7 @@ export function PersonaStep({
               initial={reduce ? false : { opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               exit={reduce ? { opacity: 0 } : { opacity: 0, y: -12 }}
-              transition={{ duration: 0.3, ease: "easeOut" }}
+              transition={{ duration: 0.22, ease: "easeOut" }}
             >
               <div
                 className="shrink-0"

--- a/clients/web/src/domains/onboarding/screens/persona-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/persona-step.tsx
@@ -158,7 +158,9 @@ export function PersonaStep({
     >
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
 
-      <div className="absolute left-1/2 top-1/2 flex w-full max-w-xl -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-9 px-6">
+      {/* Anchor the title at the same height as the "Create my personality"
+          step (top-[14%]) so the two read as one continuous screen. */}
+      <div className="absolute left-1/2 top-[14%] flex w-full max-w-xl -translate-x-1/2 flex-col items-center gap-9 px-6">
         <h1
           className="text-center text-[2.6rem] leading-none"
           style={{ fontFamily: "var(--font-serif)" }}

--- a/clients/web/src/domains/onboarding/screens/persona-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/persona-step.tsx
@@ -1,0 +1,235 @@
+/**
+ * "Who do you want me to be?" — the free-text persona step that follows the
+ * "Create my personality" sliders.
+ *
+ * SPIKE — research-onboarding flow (behind the personality-onboarding flag).
+ *
+ * A single broad question with a rotating showcase of example characters — each
+ * a short archetype paired with its own mini avatar that swaps in as the
+ * showcase cycles — over a free-text field. Below the field, a rotating example
+ * input the user can tap to fill it in. Foreground content only; the shared
+ * toned backdrop (avatar color + bottom eyes) sits behind, so this reads as the
+ * same "eyes" world as the surrounding steps.
+ *
+ * The typed answer rides the same path as the slider values: the route forwards
+ * it to `applyPersonality`, which weaves it into the system-message that
+ * rewrites the assistant's identity files. A blank answer is fine — the sliders
+ * still apply.
+ */
+
+import { useEffect, useState, type KeyboardEvent } from "react";
+import { ArrowRight } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import {
+  preloadBundledAvatarComponents,
+  useBundledAvatarComponents,
+} from "@/utils/use-bundled-avatar-components";
+import type { CharacterTraits } from "@/types/avatar";
+
+// Warm the bundled-avatar chunk as this lazy step's module loads.
+preloadBundledAvatarComponents();
+
+interface PersonaStepProps {
+  /** Free-text character the assistant should embody, owned by the route. */
+  persona: string;
+  /** Report the persona text as the user edits it. */
+  onPersonaChange: (next: string) => void;
+  /**
+   * Once the user has continued, the personality prompt has already been sent
+   * to the assistant — lock the field so a step-back can't silently diverge.
+   */
+  locked: boolean;
+  onContinue: () => void;
+  onBack: () => void;
+  /** Redo into the next step — only set when the user has stepped back. */
+  onForward?: () => void;
+}
+
+/**
+ * Example characters cycled through the showcase + placeholder — spicy to
+ * deadpan — to convey the range without prescribing an answer. Each pairs a
+ * short archetype (shown beside its avatar) with the full phrase used as the
+ * tappable example and the placeholder, plus a visually distinct avatar.
+ */
+interface PersonaExample {
+  archetype: string;
+  phrase: string;
+  avatar: CharacterTraits;
+}
+
+const PERSONA_EXAMPLES: PersonaExample[] = [
+  {
+    archetype: "Sassy goth",
+    phrase: "a sassy goth who calls me out",
+    avatar: { bodyShape: "urchin", eyeStyle: "grumpy", color: "purple" },
+  },
+  {
+    archetype: "Deadpan butler",
+    phrase: "a deadpan butler quietly judging me",
+    avatar: { bodyShape: "cloud", eyeStyle: "dazed", color: "green" },
+  },
+  {
+    archetype: "Honest best friend",
+    phrase: "a brutally honest best friend",
+    avatar: { bodyShape: "blob", eyeStyle: "goofy", color: "pink" },
+  },
+  {
+    archetype: "Noir detective",
+    phrase: "a noir detective on the case",
+    avatar: { bodyShape: "ninja", eyeStyle: "curious", color: "orange" },
+  },
+  {
+    archetype: "Zen mentor",
+    phrase: "a calm zen mentor who grounds me",
+    avatar: { bodyShape: "sprout", eyeStyle: "bashful", color: "teal" },
+  },
+  {
+    archetype: "Hype coach",
+    phrase: "an over-the-top hype coach",
+    avatar: { bodyShape: "star", eyeStyle: "goofy", color: "yellow" },
+  },
+];
+
+/** Cadence for the showcase / example rotation. */
+const ROTATE_INTERVAL_MS = 3000;
+
+/** Mini-avatar size in the rotating showcase. */
+const SHOWCASE_AVATAR = 52;
+
+export function PersonaStep({
+  persona,
+  onPersonaChange,
+  locked,
+  onContinue,
+  onBack,
+  onForward,
+}: PersonaStepProps) {
+  const tone = useOnboardingTone();
+  const components = useBundledAvatarComponents();
+  const reduce = useReducedMotion();
+
+  const [index, setIndex] = useState(0);
+  // Rotate while the field is empty and editable — a typed answer (or a locked
+  // step) freezes the showcase so it isn't distracting.
+  const paused = locked || persona.trim().length > 0;
+  useEffect(() => {
+    if (paused) return;
+    const t = setInterval(() => {
+      setIndex((i) => (i + 1) % PERSONA_EXAMPLES.length);
+    }, ROTATE_INTERVAL_MS);
+    return () => clearInterval(t);
+  }, [paused]);
+
+  const current = PERSONA_EXAMPLES[index] ?? PERSONA_EXAMPLES[0]!;
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" && !locked) {
+      e.preventDefault();
+      onContinue();
+    }
+  }
+
+  return (
+    <div
+      className="absolute inset-0 z-10 overflow-hidden"
+      style={{ color: tone.fg }}
+    >
+      <OnboardingTopBar onBack={onBack} onNext={onForward} />
+
+      <div className="absolute left-1/2 top-1/2 flex w-full max-w-xl -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-9 px-6">
+        <h1
+          className="text-center text-[2.6rem] leading-none"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          Who do you want me to be?
+        </h1>
+
+        {/* Rotating showcase: a mini avatar + its archetype, swapped as a unit so
+            the block re-centers cleanly as the label width changes. */}
+        <div className="flex h-[56px] items-center justify-center">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={current.archetype}
+              className="flex items-center gap-3"
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={reduce ? { opacity: 0 } : { opacity: 0, y: -12 }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
+            >
+              <div
+                className="shrink-0"
+                style={{ width: SHOWCASE_AVATAR, height: SHOWCASE_AVATAR }}
+              >
+                {components && (
+                  <AnimatedAvatar
+                    components={components}
+                    traits={current.avatar}
+                    size={SHOWCASE_AVATAR}
+                  />
+                )}
+              </div>
+              <span className="text-[20px]" style={{ color: tone.fg }}>
+                {current.archetype}
+              </span>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-3">
+          <input
+            id="persona-input"
+            type="text"
+            value={persona}
+            onChange={(e) => onPersonaChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={locked}
+            autoComplete="off"
+            placeholder={paused ? "Describe your own…" : current.phrase}
+            aria-label="Who do you want me to be?"
+            className="w-full max-w-md rounded-2xl border bg-transparent px-4 py-3 text-center text-[16px] outline-none transition-colors duration-150 placeholder:text-current placeholder:opacity-50 focus:border-current disabled:cursor-not-allowed disabled:opacity-70"
+            style={{ color: tone.fg, borderColor: tone.fgMuted }}
+          />
+
+          {/* Rotating, tappable example input — fills the field on click. Height
+              is reserved so the layout doesn't jump when it's hidden. */}
+          <div className="flex h-6 items-center justify-center">
+            <AnimatePresence mode="wait" initial={false}>
+              {!paused && (
+                <motion.button
+                  key={current.phrase}
+                  type="button"
+                  onClick={() => onPersonaChange(current.phrase)}
+                  initial={reduce ? false : { opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={reduce ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                  transition={{ duration: 0.3, ease: "easeOut" }}
+                  className="cursor-pointer text-[14px] underline-offset-2 transition-opacity hover:opacity-100 hover:underline"
+                  style={{ color: tone.fgMuted }}
+                >
+                  Try “{current.phrase}”
+                </motion.button>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onContinue}
+          className="mt-2 flex h-11 w-[234px] cursor-pointer items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition-transform duration-150 active:scale-[0.97]"
+          style={{
+            backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",
+            color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
+          }}
+        >
+          {persona.trim() ? "Continue" : "Skip for now"}
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/screens/persona-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/persona-step.tsx
@@ -17,12 +17,13 @@
  * still apply.
  */
 
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { ArrowRight } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import {
   preloadBundledAvatarComponents,
@@ -112,6 +113,23 @@ export function PersonaStep({
   const components = useBundledAvatarComponents();
   const reduce = useReducedMotion();
 
+  // The backdrop is painted in the selected avatar's color, so any showcase
+  // avatar sharing that color would melt into the background. Remap those to a
+  // distinct palette color (keeping the hand-picked color otherwise).
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
+  const selectedColor = characters[selectedIndex]?.color;
+  const examples = useMemo(() => {
+    const palette = components?.colors.map((c) => c.id) ?? [];
+    return PERSONA_EXAMPLES.map((ex) => {
+      if (ex.avatar.color !== selectedColor) return ex;
+      const alt =
+        palette.find((c) => c !== selectedColor && c !== ex.avatar.color) ??
+        palette.find((c) => c !== selectedColor);
+      return alt ? { ...ex, avatar: { ...ex.avatar, color: alt } } : ex;
+    });
+  }, [components, selectedColor]);
+
   const [index, setIndex] = useState(0);
   // Rotate while the field is empty and editable — a typed answer (or a locked
   // step) freezes the showcase so it isn't distracting.
@@ -119,12 +137,12 @@ export function PersonaStep({
   useEffect(() => {
     if (paused) return;
     const t = setInterval(() => {
-      setIndex((i) => (i + 1) % PERSONA_EXAMPLES.length);
+      setIndex((i) => (i + 1) % examples.length);
     }, ROTATE_INTERVAL_MS);
     return () => clearInterval(t);
-  }, [paused]);
+  }, [paused, examples.length]);
 
-  const current = PERSONA_EXAMPLES[index] ?? PERSONA_EXAMPLES[0]!;
+  const current = examples[index] ?? examples[0]!;
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter" && !locked) {
@@ -179,43 +197,19 @@ export function PersonaStep({
           </AnimatePresence>
         </div>
 
-        <div className="flex w-full flex-col items-center gap-3">
-          <input
-            id="persona-input"
-            type="text"
-            value={persona}
-            onChange={(e) => onPersonaChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={locked}
-            autoComplete="off"
-            placeholder={paused ? "Describe your own…" : current.phrase}
-            aria-label="Who do you want me to be?"
-            className="w-full max-w-md rounded-2xl border bg-transparent px-4 py-3 text-center text-[16px] outline-none transition-colors duration-150 placeholder:text-current placeholder:opacity-50 focus:border-current disabled:cursor-not-allowed disabled:opacity-70"
-            style={{ color: tone.fg, borderColor: tone.fgMuted }}
-          />
-
-          {/* Rotating, tappable example input — fills the field on click. Height
-              is reserved so the layout doesn't jump when it's hidden. */}
-          <div className="flex h-6 items-center justify-center">
-            <AnimatePresence mode="wait" initial={false}>
-              {!paused && (
-                <motion.button
-                  key={current.phrase}
-                  type="button"
-                  onClick={() => onPersonaChange(current.phrase)}
-                  initial={reduce ? false : { opacity: 0, y: 8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={reduce ? { opacity: 0 } : { opacity: 0, y: -8 }}
-                  transition={{ duration: 0.3, ease: "easeOut" }}
-                  className="cursor-pointer text-[14px] underline-offset-2 transition-opacity hover:opacity-100 hover:underline"
-                  style={{ color: tone.fgMuted }}
-                >
-                  Try “{current.phrase}”
-                </motion.button>
-              )}
-            </AnimatePresence>
-          </div>
-        </div>
+        <input
+          id="persona-input"
+          type="text"
+          value={persona}
+          onChange={(e) => onPersonaChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={locked}
+          autoComplete="off"
+          placeholder={paused ? "Describe your own…" : current.phrase}
+          aria-label="Who do you want me to be?"
+          className="w-full max-w-md rounded-2xl border bg-transparent px-4 py-3 text-center text-[16px] outline-none transition-colors duration-150 placeholder:text-current placeholder:opacity-50 focus:border-current disabled:cursor-not-allowed disabled:opacity-70"
+          style={{ color: tone.fg, borderColor: tone.fgMuted }}
+        />
 
         <button
           type="button"


### PR DESCRIPTION
## What

Adds a new **"Who do you want me to be?"** step right after the *Create my personality* sliders, behind the **same `personality-onboarding` flag**. It's the same toned/"eyes" world as the surrounding steps, with a single broad question and a playful rotating showcase.

Inspired by the peer prototype in #36726 (which we're **not** merging) — that added a persona field *inside* the slider step; this instead makes it its own dedicated step with a richer showcase, per your direction.

### The screen

- **Rotating showcase** — cycles example archetypes every 3s, each paired with its **own distinct mini avatar** that swaps in as it rotates (Sassy goth → Deadpan butler → Honest best friend → Noir detective → Zen mentor → Hype coach). The avatar + label animate as a unit.
- **Free-text field** — the user's own answer, centered, styled to the toned step.
- **Rotating tappable example** beneath the field — "Try '<example>'" that fills the field on click. Rotation pauses the moment the user types (or the step locks). Enter submits.
- Reduced-motion aware; button reads "Skip for now" when blank, "Continue" when filled (the answer is optional).

### How it's wired (web-only — no daemon/contract changes)

The typed persona rides the exact path the slider values already use:

1. `research-onboarding-route.tsx` owns a new `persona` state (survives step-back) and renders `PersonaStep` between `personality` and `integration`.
2. The sliders + persona are now applied **together on the persona step's continue** (deferred from the slider step) via `applyPersonality`, so there's a single identity rewrite. `buildPersonalityMessage` / `applyPersonality` gain a `persona` param that weaves the character into the system-message (whitespace-collapsed; blank omits the block).
3. New `persona` `ResearchStep` + funnel step (indices shifted, funnel version bumped); back-nav updated (`personality ↔ persona ↔ integration`).

## Tests

- Extended `apply-personality.test.ts`: persona woven in when provided, whitespace collapsed, block omitted when blank, trait/rewrite lines still survive. **5/5 pass.**
- `tsc --noEmit` clean; `vite build` succeeds.

## QA notes

Enable `personality-onboarding` locally. After the sliders you should land on "Who do you want me to be?": watch the avatar + archetype rotate, tap a "Try …" example to fill the field (or type your own), and continue. Confirm the assistant's later greeting reflects the character. Flag off → step is skipped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)