### PR TITLE
refactor(daemon): remove vestigial calls/ DI setters from lifecycle

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -191,7 +191,6 @@ mock.module("../calls/voice-session-bridge.js", () => {
   mockStartVoiceTurn = mock(createMockVoiceTurn(["Hello", " there"]));
   return {
     startVoiceTurn: (...args: unknown[]) => mockStartVoiceTurn(...args),
-    setVoiceBridgeDeps: () => {},
   };
 });
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -421,7 +421,6 @@ import {
   activeRelayConnections,
   RelayConnection,
 } from "../calls/relay-server.js";
-import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import {
   createInboundSession,
   createVerificationSession,
@@ -733,9 +732,6 @@ describe("relay-server", () => {
       };
       return session as unknown as import("../daemon/conversation.js").Conversation;
     };
-    setVoiceBridgeDeps({
-      resolveAttachments: () => [],
-    });
   });
 
   // ── Setup message handling ──────────────────────────────────────

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -95,10 +95,7 @@ import {
   type CreateScopedApprovalGrantParams,
   revokeScopedApprovalGrantsForContext,
 } from "../approvals/scoped-approval-grants.js";
-import {
-  setVoiceBridgeDeps,
-  startVoiceTurn,
-} from "../calls/voice-session-bridge.js";
+import { startVoiceTurn } from "../calls/voice-session-bridge.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -204,9 +201,6 @@ function setupBridgeDeps(
   sessionFactory: () => ReturnType<typeof createMockSession>["session"],
 ) {
   scopedGrantConversationFactory = () => sessionFactory();
-  setVoiceBridgeDeps({
-    resolveAttachments: () => [],
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -45,10 +45,7 @@ mock.module("../daemon/conversation-store.js", () => ({
   },
 }));
 
-import {
-  setVoiceBridgeDeps,
-  startVoiceTurn,
-} from "../calls/voice-session-bridge.js";
+import { startVoiceTurn } from "../calls/voice-session-bridge.js";
 import {
   createConversation,
   getMessages,
@@ -180,9 +177,6 @@ function parsePersistedMetadata(
  */
 function injectDeps(conversationFactory: () => Conversation): void {
   voiceConversationFactory = conversationFactory;
-  setVoiceBridgeDeps({
-    resolveAttachments: () => [],
-  });
 }
 
 describe("voice-session-bridge", () => {
@@ -518,9 +512,6 @@ describe("voice-session-bridge", () => {
     };
 
     voiceConversationFactory = () => session;
-    setVoiceBridgeDeps({
-      resolveAttachments: () => [],
-    });
 
     const textDeltaEvents: ServerMessage[] = [];
     const completeEvents: ServerMessage[] = [];

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -56,8 +56,9 @@ let pointerMessageProcessor: PointerMessageProcessor | undefined;
 
 /**
  * Inject the daemon-provided pointer message processor.
- * Called from daemon/lifecycle.ts at startup, following the same pattern
- * as setRelayBroadcast.
+ * Called from daemon/lifecycle.ts at startup so this low-level module can
+ * drive a full daemon conversation turn without statically importing the
+ * daemon pipeline (which would invert the layering / create an import cycle).
  */
 export function setPointerMessageProcessor(
   processor: PointerMessageProcessor,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -19,7 +19,6 @@ import {
   voiceGuardianDisplayName,
 } from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
@@ -28,6 +27,7 @@ import {
   resolveActorTrust,
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import {
   trustContextFromVerdict,
   verdictHasMemberIdentity,
@@ -178,14 +178,6 @@ export interface RelayWebSocketData {
 
 /** Active relay connections keyed by callSessionId. */
 export const activeRelayConnections = new Map<string, RelayConnection>();
-
-/** Module-level broadcast function, set by the HTTP server during startup. */
-let globalBroadcast: ((msg: ServerMessage) => void) | undefined;
-
-/** Register a broadcast function so RelayConnection can forward events to connected clients. */
-export function setRelayBroadcast(fn: (msg: ServerMessage) => void): void {
-  globalBroadcast = fn;
-}
 
 // ── RelayConnection ──────────────────────────────────────────────────
 
@@ -679,7 +671,7 @@ export class RelayConnection {
       transport,
       session?.task ?? null,
       {
-        broadcast: globalBroadcast,
+        broadcast: broadcastMessage,
         assistantId: resolved.assistantId,
         trustContext: initialTrustContext,
       },

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -4,10 +4,6 @@
  * Provides a `startVoiceTurn()` function that manages a voice turn
  * directly through the conversation, translating agent-loop events into
  * simple callbacks suitable for real-time TTS streaming.
- *
- * Dependency injection follows the same module-level setter pattern used by
- * setRelayBroadcast in relay-server.ts: the daemon lifecycle injects
- * dependencies at startup via `setVoiceBridgeDeps()`.
  */
 
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
@@ -34,30 +30,6 @@ import {
 } from "./voice-control-protocol.js";
 
 const log = getLogger("voice-session-bridge");
-
-// ---------------------------------------------------------------------------
-// Module-level dependency injection
-// ---------------------------------------------------------------------------
-
-export interface VoiceBridgeDeps {
-  resolveAttachments: (attachmentIds: string[]) => Array<{
-    id: string;
-    filename: string;
-    mimeType: string;
-    data: string;
-    filePath?: string;
-  }>;
-}
-
-let deps: VoiceBridgeDeps | undefined;
-
-/**
- * Inject dependencies from daemon lifecycle.
- * Must be called during daemon startup before any voice turns are executed.
- */
-export function setVoiceBridgeDeps(d: VoiceBridgeDeps): void {
-  deps = d;
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -271,12 +243,6 @@ function buildVoiceCallControlPrompt(opts: {
 export async function startVoiceTurn(
   opts: VoiceTurnOptions,
 ): Promise<VoiceTurnHandle> {
-  if (!deps) {
-    throw new Error(
-      "Voice bridge not initialized — setVoiceBridgeDeps() was not called",
-    );
-  }
-
   const eventSink: VoiceRunEventSink = {
     onTextDelta: (msg) => {
       opts.onTextDelta?.(msg.text);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -2,9 +2,7 @@ import { config as dotenvConfig } from "dotenv";
 
 import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
-import { setRelayBroadcast } from "../calls/relay-server.js";
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
-import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import { setIngressPublicBaseUrl, validateEnv } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
@@ -21,10 +19,6 @@ import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import {
-  getAttachmentsByIds,
-  getSourcePathsForAttachments,
-} from "../persistence/attachments-store.js";
-import {
   clearStaleProcessingFlags,
   deleteMessageById,
   getMessages,
@@ -38,7 +32,6 @@ import { runMemoryStartup } from "../plugins/defaults/memory/startup.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { initializeProviders } from "../providers/registry.js";
-import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import {
   initAuthSigningKey,
   resolveSigningKey,
@@ -674,26 +667,7 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, "Background Qdrant init failed"),
   );
 
-  // Inject voice bridge deps so the relay pipeline can resolve attachments
-  // once a call lands. Module-level state, so available even when the HTTP
-  // server failed to bind.
-  setVoiceBridgeDeps({
-    resolveAttachments: (attachmentIds) => {
-      const resolved = getAttachmentsByIds(attachmentIds, {
-        hydrateFileData: true,
-      });
-      const sourcePaths = getSourcePathsForAttachments(attachmentIds);
-      return resolved.map((a) => ({
-        id: a.id,
-        filename: a.originalFilename,
-        mimeType: a.mimeType,
-        data: a.dataBase64,
-        ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
-      }));
-    },
-  });
   try {
-    setRelayBroadcast((msg) => broadcastMessage(msg));
     setPointerMessageProcessor(
       async (conversationId, instruction, requiredFacts) => {
         const conversation = await getOrCreateConversation(conversationId);


### PR DESCRIPTION
## Why

Continuing the `lifecycle.ts` cleanup toward a flat startup sequence. Three `calls/` modules used the module-level DI-setter pattern (`setX` called from lifecycle at startup). Two of them turned out to be pointless indirection — this removes them. The third is doing real work and is intentionally left in place.

## What

**① `setRelayBroadcast` → direct import.**
It injected a plain reference to `broadcastMessage`. `relay-server.ts` now imports `broadcastMessage` from `runtime/assistant-event-hub.js` directly and uses it at the one call site. No cycle risk: `assistant-event-hub` imports nothing from `calls/`, and `relay-server` already imports from `runtime/` and `daemon/`. Zero production behavior change (lifecycle always injected this).

**② `setVoiceBridgeDeps` → deleted outright (dead code).**
The injected `resolveAttachments` closure was **never actually called** anywhere in `voice-session-bridge.ts` — the `deps` object served only as an "is the daemon initialized?" sentinel guarding `startVoiceTurn` (`if (!deps) throw`). Removed the `VoiceBridgeDeps` interface, the setter, the injected closure in `lifecycle.ts` (and its now-unused `getAttachmentsByIds`/`getSourcePathsForAttachments`/`broadcastMessage` imports), and the vestigial guard.

## Intentionally NOT changed

**③ `setPointerMessageProcessor` stays.** Unlike the other two, it doesn't inject a module reference — it injects a ~100-line daemon closure (persist → trust elevation → `runAgentLoop` → fact-check → rollback). "Inlining" it would relocate high-level conversation orchestration down into the low-level `calls/` module — a layering inversion with import-cycle risk. The DI here is genuinely load-bearing. Updated the one stale comment that referenced `setRelayBroadcast`.

## Tests

Updated the 4 test files that referenced `setVoiceBridgeDeps`. All affected suites pass in isolation (the way CI runs them):

| suite | result |
|---|---|
| voice-session-bridge | 22/0 |
| relay-server | 100/0 |
| voice-scoped-grant-consumer | 6/0 |
| call-controller | 76/0 |
| call-pointer-messages | 25/0 |

prettier / eslint / tsc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_