### PR TITLE
feat(onboarding): personality step help text + relabel Execute→Independent

### DIFF
--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -89,8 +89,8 @@ const PERSONALITY_AXES: PersonalityAxis[] = [
   },
   {
     id: "execute-collaborate",
-    left: "Execute",
-    right: "Collaborate",
+    left: "Independent",
+    right: "Collaborative",
     leftAvatar: { bodyShape: "star", eyeStyle: "angry", color: "orange" },
     rightAvatar: { bodyShape: "flower", eyeStyle: "goofy", color: "teal" },
   },
@@ -410,10 +410,18 @@ export function CreatePersonalityStep({
           >
             Create my personality
           </h1>
-          {locked && (
+          {locked ? (
             <p className="text-center text-[15px]" style={{ color: tone.fgMuted }}>
               Personality locked — chat with your assistant to make any more
               updates
+            </p>
+          ) : (
+            <p
+              className="max-w-md text-center text-[15px]"
+              style={{ color: tone.fgMuted }}
+            >
+              How do you want me to talk to you? You can always ask me to change
+              my personality later.
             </p>
           )}
         </div>


### PR DESCRIPTION
## What

Two small copy tweaks to the **Create my personality** step (`create-personality-step.tsx`):

1. **Help text** under the title (shown when the step isn't locked):
   > How do you want me to talk to you? You can always ask me to change my personality later.
2. **Relabel** the Execute/Collaborate slider ends to **Independent / Collaborative** — matching the wording already used in the personality system-message (`Execute Independently` / `Collaborative`).

## Scope

Single file, copy/label only — no behavior change. `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)