### PR TITLE
feat(persistence): instrument per-LLM-call DB writes for stall attribution

### DIFF
--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -450,105 +450,117 @@ async function insertMessageCore(
   // The timestamp is recomputed each attempt so a late retry doesn't persist a
   // stale `updatedAt`.
   return withSqliteRetry(
-    (): InsertedMessage => {
-      const now = monotonicNow();
-      const values = {
-        id: messageId,
-        conversationId,
-        role,
-        content,
-        createdAt: now,
-        ...(metadataStr ? { metadata: metadataStr } : {}),
-        ...(clientMessageId ? { clientMessageId } : {}),
-      };
+    (): InsertedMessage =>
+      timeSyncSection(
+        "messages:insert",
+        (): InsertedMessage => {
+          const now = monotonicNow();
+          const values = {
+            id: messageId,
+            conversationId,
+            role,
+            content,
+            createdAt: now,
+            ...(metadataStr ? { metadata: metadataStr } : {}),
+            ...(clientMessageId ? { clientMessageId } : {}),
+          };
 
-      if (clientMessageId) {
-        // Idempotent insert: skip silently if this clientMessageId was
-        // already persisted for the conversation.
-        const raw = getSqliteFrom(db);
-        raw.exec("SAVEPOINT insert_msg");
-        try {
-          db.insert(messages).values(values).run();
-          if (originChannelCandidate) {
-            db.update(conversations)
-              .set({ originChannel: originChannelCandidate })
-              .where(
-                and(
-                  eq(conversations.id, conversationId),
-                  isNull(conversations.originChannel),
-                ),
-              )
-              .run();
-          }
-          db.update(conversations)
-            .set({ updatedAt: now, lastMessageAt: now })
-            .where(eq(conversations.id, conversationId))
-            .run();
-          raw.exec("RELEASE insert_msg");
-        } catch (insertErr) {
-          raw.exec("ROLLBACK TO insert_msg");
-          raw.exec("RELEASE insert_msg");
-          const code = (insertErr as { code?: string }).code ?? "";
-          if (code === "SQLITE_CONSTRAINT_UNIQUE") {
-            // Duplicate clientMessageId — return the existing row.
-            const existing = db
-              .select()
-              .from(messages)
-              .where(
-                and(
-                  eq(messages.conversationId, conversationId),
-                  eq(messages.clientMessageId, clientMessageId),
-                ),
-              )
-              .get();
-            if (existing) {
-              return {
-                id: existing.id,
-                conversationId: existing.conversationId,
-                role: existing.role as MessageRole,
-                content: existing.content,
-                createdAt: existing.createdAt,
-                ...(existing.metadata ? { metadata: existing.metadata } : {}),
-                clientMessageId: existing.clientMessageId ?? undefined,
-                deduplicated: true,
-              };
+          if (clientMessageId) {
+            // Idempotent insert: skip silently if this clientMessageId was
+            // already persisted for the conversation.
+            const raw = getSqliteFrom(db);
+            raw.exec("SAVEPOINT insert_msg");
+            try {
+              db.insert(messages).values(values).run();
+              if (originChannelCandidate) {
+                db.update(conversations)
+                  .set({ originChannel: originChannelCandidate })
+                  .where(
+                    and(
+                      eq(conversations.id, conversationId),
+                      isNull(conversations.originChannel),
+                    ),
+                  )
+                  .run();
+              }
+              db.update(conversations)
+                .set({ updatedAt: now, lastMessageAt: now })
+                .where(eq(conversations.id, conversationId))
+                .run();
+              raw.exec("RELEASE insert_msg");
+            } catch (insertErr) {
+              raw.exec("ROLLBACK TO insert_msg");
+              raw.exec("RELEASE insert_msg");
+              const code = (insertErr as { code?: string }).code ?? "";
+              if (code === "SQLITE_CONSTRAINT_UNIQUE") {
+                // Duplicate clientMessageId — return the existing row.
+                const existing = db
+                  .select()
+                  .from(messages)
+                  .where(
+                    and(
+                      eq(messages.conversationId, conversationId),
+                      eq(messages.clientMessageId, clientMessageId),
+                    ),
+                  )
+                  .get();
+                if (existing) {
+                  return {
+                    id: existing.id,
+                    conversationId: existing.conversationId,
+                    role: existing.role as MessageRole,
+                    content: existing.content,
+                    createdAt: existing.createdAt,
+                    ...(existing.metadata
+                      ? { metadata: existing.metadata }
+                      : {}),
+                    clientMessageId: existing.clientMessageId ?? undefined,
+                    deduplicated: true,
+                  };
+                }
+              }
+              throw insertErr;
             }
+          } else {
+            // No clientMessageId — standard insert inside a transaction.
+            db.transaction((tx) => {
+              tx.insert(messages).values(values).run();
+              if (originChannelCandidate) {
+                tx.update(conversations)
+                  .set({ originChannel: originChannelCandidate })
+                  .where(
+                    and(
+                      eq(conversations.id, conversationId),
+                      isNull(conversations.originChannel),
+                    ),
+                  )
+                  .run();
+              }
+              tx.update(conversations)
+                .set({ updatedAt: now, lastMessageAt: now })
+                .where(eq(conversations.id, conversationId))
+                .run();
+            });
           }
-          throw insertErr;
-        }
-      } else {
-        // No clientMessageId — standard insert inside a transaction.
-        db.transaction((tx) => {
-          tx.insert(messages).values(values).run();
-          if (originChannelCandidate) {
-            tx.update(conversations)
-              .set({ originChannel: originChannelCandidate })
-              .where(
-                and(
-                  eq(conversations.id, conversationId),
-                  isNull(conversations.originChannel),
-                ),
-              )
-              .run();
-          }
-          tx.update(conversations)
-            .set({ updatedAt: now, lastMessageAt: now })
-            .where(eq(conversations.id, conversationId))
-            .run();
-        });
-      }
 
-      return {
-        id: messageId,
-        conversationId,
-        role,
-        content,
-        createdAt: now,
-        ...(metadataStr ? { metadata: metadataStr } : {}),
-        ...(clientMessageId ? { clientMessageId } : {}),
-        deduplicated: false,
-      };
-    },
+          return {
+            id: messageId,
+            conversationId,
+            role,
+            content,
+            createdAt: now,
+            ...(metadataStr ? { metadata: metadataStr } : {}),
+            ...(clientMessageId ? { clientMessageId } : {}),
+            deduplicated: false,
+          };
+        },
+        () => ({
+          conversationId,
+          role,
+          contentBytes:
+            typeof content === "string" ? content.length : undefined,
+        }),
+      ),
     { op: "insertMessageCore", context: { conversationId } },
   );
 }

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -26,6 +26,7 @@ import {
 } from "./conversation-crud.js";
 import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
 import { llmRequestLogs, messages } from "./schema/index.js";
+import { timeSyncSection } from "./slow-sync-log.js";
 
 /**
  * The logs connection (`assistant-logs.db`), where `llm_request_logs` lives.
@@ -167,27 +168,42 @@ export function recordRequestLog(
 ): string {
   const db = logsDb();
   const id = uuid();
-  db.insert(llmRequestLogs)
-    .values({
-      id,
+  // Synchronous insert of the full request/response payloads (an entire
+  // context window for main-agent calls) into the append-only logs DB, on the
+  // per-LLM-call critical path. Timed so an event-loop freeze the watchdog
+  // detects can be attributed to this write (see slow-sync-log).
+  timeSyncSection(
+    "llm-request-log:write",
+    () =>
+      db
+        .insert(llmRequestLogs)
+        .values({
+          id,
+          conversationId,
+          messageId: messageId ?? null,
+          provider: provider ?? null,
+          requestPayload,
+          responsePayload,
+          createdAt: Date.now(),
+          // Stamped later via setAgentLoopExitReasonOnLatestLog, once the
+          // agent loop body actually exits. Intermediate rows stay NULL.
+          agentLoopExitReason: null,
+          // Logical call site (`mainAgent`, `compactionAgent`, …). NULL when
+          // a caller hasn't been updated yet — preserves backward compat
+          // while we plumb call sites through one site at a time.
+          callSite: callSite ?? null,
+          // JSON first-token latency waterfall, supplied by `handleUsage` for
+          // main-agent calls. NULL for failed/non-instrumented call paths.
+          latencyBreakdown: latencyBreakdown ?? null,
+        })
+        .run(),
+    () => ({
       conversationId,
-      messageId: messageId ?? null,
-      provider: provider ?? null,
-      requestPayload,
-      responsePayload,
-      createdAt: Date.now(),
-      // Stamped later via setAgentLoopExitReasonOnLatestLog, once the
-      // agent loop body actually exits. Intermediate rows stay NULL.
-      agentLoopExitReason: null,
-      // Logical call site (`mainAgent`, `compactionAgent`, …). NULL when
-      // a caller hasn't been updated yet — preserves backward compat
-      // while we plumb call sites through one site at a time.
       callSite: callSite ?? null,
-      // JSON first-token latency waterfall, supplied by `handleUsage` for
-      // main-agent calls. NULL for failed/non-instrumented call paths.
-      latencyBreakdown: latencyBreakdown ?? null,
-    })
-    .run();
+      requestBytes: requestPayload.length,
+      responseBytes: responsePayload.length,
+    }),
+  );
   return id;
 }
 


### PR DESCRIPTION
## Why

Follow-up to #36758. After that probe deployed to a large instance, the data **contradicted my prediction** — which is the point of measuring first:

| signal (since the instrumented restart) | count | magnitude |
|---|---|---|
| `event-loop-watchdog` freezes | **17** | up to **36s** (36, 23, 15.6, 13.9…) |
| `slow-sync` captures | 2 | ~1.2s (both FTS search) |

So the big 5–36s freezes are **not** in the paths #36758 instrumented, **not** WAL checkpoints (the WAL is <5MB), and they start **right after `[agent-loop] LLM call start`** — i.e. synchronous work on the per-LLM-call critical path that #36758 didn't cover (drizzle writes, not raw-query).

## What

Wrap the two prime suspects — the synchronous drizzle writes that run every turn and scale with the (large) context:

- **`recordRequestLog`** → `llm-request-log:write` — inserts the full request/response payloads (an entire context window for main-agent calls) into the **25 GB** append-only logs DB. Detail: request/response byte sizes + call site.
- **`insertMessageCore`** → `messages:insert` — the choke point for every message write into the **35 GB** main DB. Detail: content bytes + role.

## Not a fix — still a probe

Pure observability, no write behavior change. **The large `conversation-crud` diff is just the re-indent** from wrapping the retry callback in `timeSyncSection` — review with whitespace off and it's a one-line wrapper. One restart-day of logs will show which (if either) owns the 5–36s tail.

Then the fix targets the confirmed blocker **without touching the retained corpus** — the leading candidate is moving the append-only `llm_request_logs` write off the turn's critical path (it never needs to block a turn).

## Tests
Instrumented write paths exercised by `list-messages-tool-merge.test.ts` (9 pass); `typecheck:fast` + pre-commit lint/format/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)