### PR TITLE
refactor(web): tidy the snapshot processing flag per review

### DIFF
--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -72,9 +72,6 @@ function parsePaginatedResponse(
   const oldestTimestamp = body?.oldestTimestamp ?? null;
   const oldestMessageId = body?.oldestMessageId || null;
   const seq = body?.seq ?? null;
-  // Authoritative "is a turn in flight?" flag. Kept as-is (including
-  // `undefined`) rather than coerced to a boolean: `undefined` is the version
-  // sentinel that leaves turn-phase behavior untouched for pre-0.8.8 daemons.
   const processing = body?.processing;
 
   return {
@@ -83,8 +80,8 @@ function parsePaginatedResponse(
     oldestTimestamp,
     oldestMessageId,
     seq,
+    processing,
     backgroundToolCompletions,
-    ...(processing !== undefined ? { processing } : {}),
     ...(subagentNotifications.length > 0 ? { subagentNotifications } : {}),
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -80,10 +80,7 @@ export function useChatUIState(): ChatUIState {
   // while a turn is in flight.
   const transcript = useTranscriptMessages();
 
-  // The daemon's authoritative per-conversation processing flag, carried on the
-  // rolling snapshot and refreshed by every `/messages` reseed. Narrow selector
-  // so this only re-renders when the flag itself flips, not on every folded
-  // content event. `undefined` on pre-0.8.8 daemons → phase-only behavior.
+  // Authoritative processing flag off the rolling snapshot; narrow selector so it re-renders only when the flag flips.
   const snapshotProcessing = useChatSessionStore((s) => s.snapshot?.processing);
 
   // TanStack Query — deduped with any other call for the same conversation.

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -328,7 +328,6 @@ describe("rolling-snapshot reducer", () => {
       // phase-only behavior is preserved for daemons that don't report it.
       const after = applyEvent(SEED, turnStart(1, "a1"));
       expect(after.processing).toBeUndefined();
-      expect("processing" in after).toBe(false);
     });
 
     test("a replayed lower-seq turn-start cannot resurrect a closed turn", () => {

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -256,12 +256,7 @@ export function applyEvent(
     typeof seq === "number" ? Math.max(history.seq ?? -1, seq) : history.seq ?? null;
   const processing = nextProcessingState(history.processing, envelope.message, seq);
 
-  return {
-    ...history,
-    messages,
-    seq: nextSeq,
-    ...(processing !== undefined ? { processing } : {}),
-  };
+  return { ...history, messages, seq: nextSeq, processing };
 }
 
 /** Rebuild the history from a snapshot and a run of events — the full

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/domains/chat/types/types";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
 import type { BackgroundTaskEntry } from "@/domains/chat/background-task-store";
+import type { MessagesGetResponse } from "@/generated/daemon/types.gen";
 
 export type TranscriptItemKind =
   | "message"
@@ -93,14 +94,24 @@ export interface LatestTurnPartition {
   responseItems: TranscriptItem[];
 }
 
-/** Result shape returned by the paginated history fetchers in
- *  `../history.ts`. Lives here so the transcript-state machine and the
- *  fetchers share a single source-of-truth definition. */
-export interface PaginatedHistoryResult {
+/** Result shape returned by the paginated history fetchers in `../history.ts`.
+ *  Lives here so the transcript-state machine and the fetchers share a single
+ *  source-of-truth definition.
+ *
+ *  The server-sourced page metadata (`hasMore`, the `oldest*` cursor, `seq`,
+ *  the authoritative `processing` flag) is inherited straight from the wire
+ *  contract so it can never drift from `/messages` — the fetcher fills the
+ *  three cursor fields defensively (so they are `Required` here), while `seq`
+ *  and `processing` keep the wire's optionality (`undefined` = an older daemon
+ *  that omits the field; consult the generated type for their full semantics).
+ *  Only `messages` genuinely differs: rendered `DisplayMessage`s, not the wire
+ *  rows — plus the two client-derived extraction fields. */
+export interface PaginatedHistoryResult
+  extends Required<
+      Pick<MessagesGetResponse, "hasMore" | "oldestTimestamp" | "oldestMessageId">
+    >,
+    Pick<MessagesGetResponse, "seq" | "processing"> {
   messages: DisplayMessage[];
-  hasMore: boolean;
-  oldestTimestamp: number | null;
-  oldestMessageId: string | null;
   /** Subagent notifications extracted from history messages for state reconstruction. */
   subagentNotifications?: RuntimeSubagentNotification[];
   /** Background-task completion records extracted from history messages, used to
@@ -109,20 +120,6 @@ export interface PaginatedHistoryResult {
    *  completion); it is optional so other constructors (snapshot spreads, tests)
    *  need not restate it. */
   backgroundToolCompletions?: BackgroundTaskEntry[];
-  /** Global SSE `seq` this snapshot is durably persisted through for the
-   *  conversation, or `null` when the daemon reports no honest position
-   *  (cold conversation, post-restart, aged-out map, or an older daemon
-   *  that omits the field). Used to align the snapshot with the `/events`
-   *  stream. */
-  seq?: number | null;
-  /** The daemon's authoritative "is a turn in flight?" flag for this
-   *  conversation, sourced from the persisted `processing_started_at` column
-   *  and folded forward by the turn-lifecycle events in `rolling-snapshot.ts`.
-   *  `undefined` is the version sentinel — daemons before 0.8.8 omit it on
-   *  `/messages`, and the fold never manufactures a value, so `undefined`
-   *  means "no authoritative signal; fall back to the turn phase." Consumed as
-   *  a close-gate: `false` idles a turn whose terminal SSE event was dropped. */
-  processing?: boolean;
 }
 
 /** Snapshot of the transcript pagination state held by the scroll


### PR DESCRIPTION
## Prompt / plan

Follow-up to the merged #36778, addressing the review comments left on it (the PR was already merged, so this lands as a separate cleanup). No behavior change — pure tidy-ups.

## What changed

- **`transcript/types.ts`** ([#36778 review](https://github.com/vellum-ai/vellum-assistant/pull/36778#discussion_r3507360837)): `PaginatedHistoryResult` now **extends the generated `/messages` response type** instead of hand-restating the server-sourced page metadata — `Required<Pick<MessagesGetResponse, "hasMore" | "oldestTimestamp" | "oldestMessageId">>` for the fields the fetcher always fills, and `Pick<…, "seq" | "processing">` for the ones that keep the wire's optionality. Only `messages` (rendered `DisplayMessage`s) and the two client-derived extraction fields are declared locally, so the shape can't drift from the wire contract.
- **`api/history.ts`** ([1](https://github.com/vellum-ai/vellum-assistant/pull/36778#discussion_r3507347727), [2](https://github.com/vellum-ai/vellum-assistant/pull/36778#discussion_r3507349590)): dropped the redundant `processing` comment and the `...(processing !== undefined ? { processing } : {})` spread — just `processing,`.
- **`transcript/rolling-snapshot.ts`** ([review](https://github.com/vellum-ai/vellum-assistant/pull/36778#discussion_r3507357412)): same simplification in `applyEvent`'s return — `processing` directly. Adjusted the one fold test that asserted key-absence.
- **`hooks/use-chat-ui-state.ts`** ([review](https://github.com/vellum-ai/vellum-assistant/pull/36778#discussion_r3507351386)): collapsed the snapshot-selector comment to one line.

The `undefined`-sentinel / fold / close-gate semantics that previously lived in the `types.ts` field docs now live with their behavior (`rolling-snapshot.ts` and `turn-selectors.ts`), where the generated type's own JSDoc covers the wire meaning.

## Test plan

- `bunx tsc --noEmit` clean (the `Required<Pick<…>>` extend resolves against the generated `MessagesGetResponse`); `eslint` clean on changed files.
- `rolling-snapshot.test.ts` (24) and `turn-selectors.test.ts` (7) green; `turn-store` (120) and `message-handlers` (21) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfudXocrjD6NgctoBpjkom

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfudXocrjD6NgctoBpjkom)_