### PR TITLE
chore(assistant): remove unused postgres dependency

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -37,7 +37,6 @@
         "pino": "9.14.0",
         "pino-pretty": "13.1.3",
         "playwright": "1.58.2",
-        "postgres": "3.4.8",
         "quickjs-emscripten": "0.32.0",
         "re2js": "2.8.3",
         "remark-gfm": "4.0.1",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -66,7 +66,6 @@
     "pino": "9.14.0",
     "pino-pretty": "13.1.3",
     "playwright": "1.58.2",
-    "postgres": "3.4.8",
     "quickjs-emscripten": "0.32.0",
     "re2js": "2.8.3",
     "remark-gfm": "4.0.1",


### PR DESCRIPTION
## Summary
- `postgres` was an unused direct dependency in `assistant/package.json` left over from earlier days. The assistant DB layer is SQLite via `drizzle-orm/bun-sqlite` and nothing imports the `postgres` package. Removed the declaration and updated `bun.lock`.
- postgres still appears in `bun.lock` as a satisfied optional peer of `drizzle-orm`; it is no longer a direct dependency of the assistant.