### PR TITLE
refactor(daemon): extract pointer turn runner, drop setPointerMessageProcessor DI

### DIFF
--- a/assistant/src/__tests__/call-pointer-messages.test.ts
+++ b/assistant/src/__tests__/call-pointer-messages.test.ts
@@ -7,11 +7,40 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Stand in for the daemon conversation-turn path so these tests can drive its
+// behavior (success / throw) without pulling in the real conversation pipeline.
+// `runPointerTurnImpl` is swapped per-test via setProcessor/resetProcessor.
+let runPointerTurnImpl: (
+  conversationId: string,
+  instruction: string,
+  requiredFacts?: string[],
+) => Promise<void> = async () => {};
+
+mock.module("../daemon/pointer-turn-runner.js", () => ({
+  runPointerMessageTurn: (
+    conversationId: string,
+    instruction: string,
+    requiredFacts?: string[],
+  ) => runPointerTurnImpl(conversationId, instruction, requiredFacts),
+}));
+
+function setProcessor(
+  fn: (
+    conversationId: string,
+    instruction: string,
+    requiredFacts?: string[],
+  ) => Promise<void>,
+): void {
+  runPointerTurnImpl = fn;
+}
+
+function resetProcessor(): void {
+  runPointerTurnImpl = async () => {};
+}
+
 import {
   addPointerMessage,
   formatDuration,
-  resetPointerMessageProcessor,
-  setPointerMessageProcessor,
 } from "../calls/call-pointer-messages.js";
 import { addMessage, getMessages } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
@@ -97,7 +126,7 @@ describe("addPointerMessage", () => {
   });
 
   afterEach(() => {
-    resetPointerMessageProcessor();
+    resetProcessor();
   });
 
   test("adds a started pointer message", () => {
@@ -204,7 +233,7 @@ describe("addPointerMessage", () => {
     ensureConversation(convId);
 
     const processorCalled = { value: false };
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled.value = true;
     });
 
@@ -220,7 +249,7 @@ describe("addPointerMessage", () => {
     ensureConversation(convId, { originChannel: "vellum" });
 
     const processorCalled = { value: false };
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled.value = true;
     });
 
@@ -242,7 +271,7 @@ describe("addPointerMessage", () => {
 
     let capturedInstruction = "";
     let capturedFacts: string[] = [];
-    setPointerMessageProcessor(async (_convId, instruction, requiredFacts) => {
+    setProcessor(async (_convId, instruction, requiredFacts) => {
       capturedInstruction = instruction;
       capturedFacts = requiredFacts ?? [];
     });
@@ -265,7 +294,7 @@ describe("addPointerMessage", () => {
     const convId = "conv-ptr-processor-fail";
     ensureConversation(convId, { originChannel: "vellum" });
 
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       throw new Error("Daemon unavailable");
     });
 
@@ -282,7 +311,7 @@ describe("addPointerMessage", () => {
     ensureConversation(convId, { originChannel: "vellum" });
 
     let processorCalled = false;
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled = true;
     });
 
@@ -297,7 +326,7 @@ describe("addPointerMessage", () => {
     ensureConversation(convId);
 
     const processorCalled = { value: false };
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled.value = true;
     });
 
@@ -318,7 +347,7 @@ describe("addPointerMessage", () => {
     });
 
     let processorCalled = false;
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled = true;
     });
 
@@ -335,7 +364,7 @@ describe("addPointerMessage", () => {
     });
 
     let processorCalled = false;
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled = true;
     });
 
@@ -362,7 +391,7 @@ describe("addPointerMessage", () => {
 
     // And that pointer-audience trust treats it identically to trusted_contact.
     let processorCalled = false;
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled = true;
     });
 
@@ -378,7 +407,7 @@ describe("addPointerMessage", () => {
     });
 
     const processorCalled = { value: false };
-    setPointerMessageProcessor(async () => {
+    setProcessor(async () => {
       processorCalled.value = true;
     });
 

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -9,6 +9,7 @@
  * written directly to the conversation store.
  */
 
+import { runPointerMessageTurn } from "../daemon/pointer-turn-runner.js";
 import {
   addMessage,
   getConversationOriginChannel,
@@ -31,45 +32,6 @@ type PointerEvent =
   | "verification_failed";
 
 type PointerAudienceMode = "auto" | "trusted" | "untrusted";
-
-/**
- * Daemon-injected function that sends a message through the daemon conversation
- * pipeline (persistAndProcessMessage), letting the assistant generate the
- * pointer text as a natural conversation turn.
- *
- * @param requiredFacts - facts that must appear verbatim in the generated
- *   text (phone number, duration, outcome keyword, etc.). The processor
- *   should validate the output and throw if any are missing so the
- *   deterministic fallback fires.
- */
-type PointerMessageProcessor = (
-  conversationId: string,
-  instruction: string,
-  requiredFacts?: string[],
-) => Promise<void>;
-
-// ---------------------------------------------------------------------------
-// Module-level processor injection (set by daemon lifecycle at startup)
-// ---------------------------------------------------------------------------
-
-let pointerMessageProcessor: PointerMessageProcessor | undefined;
-
-/**
- * Inject the daemon-provided pointer message processor.
- * Called from daemon/lifecycle.ts at startup so this low-level module can
- * drive a full daemon conversation turn without statically importing the
- * daemon pipeline (which would invert the layering / create an import cycle).
- */
-export function setPointerMessageProcessor(
-  processor: PointerMessageProcessor,
-): void {
-  pointerMessageProcessor = processor;
-}
-
-/** @internal Reset for tests. */
-export function resetPointerMessageProcessor(): void {
-  pointerMessageProcessor = undefined;
-}
 
 // ---------------------------------------------------------------------------
 // Trust resolution
@@ -158,13 +120,13 @@ export async function addPointerMessage(
     audienceMode === "trusted" ||
     (audienceMode === "auto" && resolvePointerAudienceTrust(conversationId));
 
-  if (trustedAudience && pointerMessageProcessor) {
+  if (trustedAudience) {
     // Route through the daemon conversation — the assistant generates the
     // pointer text as a natural conversation turn, shaped by context,
     // identity, and preferences.
     const instruction = buildPointerInstruction(context);
     try {
-      await pointerMessageProcessor(conversationId, instruction, requiredFacts);
+      await runPointerMessageTurn(conversationId, instruction, requiredFacts);
       return;
     } catch (err) {
       log.warn(
@@ -172,7 +134,7 @@ export async function addPointerMessage(
         "Daemon pointer processing failed, falling back to deterministic",
       );
     }
-  } else if (!trustedAudience && pointerMessageProcessor) {
+  } else {
     log.debug(
       { event, conversationId },
       "Untrusted audience — using deterministic pointer copy",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,6 +1,5 @@
 import { config as dotenvConfig } from "dotenv";
 
-import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
@@ -18,11 +17,7 @@ import { startCliIpcServer } from "../ipc/assistant-server.js";
 import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
-import {
-  clearStaleProcessingFlags,
-  deleteMessageById,
-  getMessages,
-} from "../persistence/conversation-crud.js";
+import { clearStaleProcessingFlags } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-runtime-manager.js";
@@ -66,7 +61,6 @@ import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import { startAppSourceWatcher } from "./app-source-watcher.js";
 import { startConfigWatcher } from "./config-watcher.js";
 import { startConversationEvictor } from "./conversation-evictor.js";
-import { getOrCreateConversation } from "./conversation-store.js";
 import { writePid } from "./daemon-control.js";
 import { setDbReady, setStartupComplete } from "./daemon-readiness.js";
 import {
@@ -79,7 +73,6 @@ import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
 import { installAssistantSymlink } from "./install-symlink.js";
 import { startOrphanReaper } from "./orphan-reaper.js";
-import { elevatePointerConversationToGuardian } from "./pointer-conversation-trust.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
 import {
   initializeProvidersAndTools,
@@ -667,156 +660,9 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, "Background Qdrant init failed"),
   );
 
-  try {
-    setPointerMessageProcessor(
-      async (conversationId, instruction, requiredFacts) => {
-        const conversation = await getOrCreateConversation(conversationId);
-
-        // Pointer turns are guardian-gated owner self-maintenance: elevate to
-        // the internal guardian context and rehydrate history so a cold
-        // (evicted) load doesn't filter guardian history to empty and ship a
-        // cache-missing turn. `restoreTrustContext` undoes the elevation after
-        // the turn. See pointer-conversation-trust.ts for the full rationale.
-        const restoreTrustContext =
-          await elevatePointerConversationToGuardian(conversation);
-
-        // Constrain pointer generation to a tool-disabled path so call-
-        // status events cannot trigger unintended side-effect tools.
-        // Incrementing toolsDisabledDepth causes the resolveTools callback
-        // to return an empty tool list, preventing the LLM from seeing or
-        // invoking any tools during the pointer agent loop.
-        //
-        // A depth counter (rather than a boolean) ensures that overlapping
-        // pointer requests on the same conversation don't clear each other's
-        // constraint — each caller increments on entry and decrements in
-        // its own finally block.
-        conversation.toolsDisabledDepth++;
-        try {
-          const { id: messageId } = await conversation.persistUserMessage({
-            content: instruction,
-            metadata: { pointerInstruction: true },
-            displayContent: "[Call status event]",
-          });
-
-          // Helper: roll back persisted messages on failure, then reload
-          // in-memory history from the (now cleaned) DB. Reloading avoids
-          // stale-index issues when context compaction reassigns the
-          // messages array during runAgentLoop.
-          const rollback = async (extraMessageIds?: string[]) => {
-            try {
-              deleteMessageById(messageId);
-            } catch {
-              /* best effort */
-            }
-            for (const id of extraMessageIds ?? []) {
-              try {
-                deleteMessageById(id);
-              } catch {
-                /* best effort */
-              }
-            }
-            try {
-              await conversation.loadFromDb();
-            } catch {
-              /* best effort */
-            }
-          };
-
-          // Snapshot message IDs before the agent loop so we can diff
-          // afterwards to find exactly which messages this run created,
-          // avoiding positional heuristics that break under concurrency.
-          //
-          // Caveat: the diff captures *all* new messages in the
-          // conversation during the loop window, not just those from
-          // this specific agent loop.  If a concurrent pointer event
-          // falls back to a deterministic addMessage() while our loop
-          // is in flight, that message lands in our diff.  The race
-          // requires two pointer events for the same conversation
-          // within the agent loop window *and* this run must fail or
-          // fail fact-check — narrow enough to accept.  A future
-          // improvement could tag messages with a per-run correlation
-          // ID so rollback only targets its own output.
-          const preRunMessageIds = new Set(
-            getMessages(conversationId).map((m) => m.id),
-          );
-
-          let agentLoopError: string | undefined;
-          let generatedText = "";
-          await conversation.runAgentLoop(instruction, messageId, {
-            onEvent: (msg) => {
-              if (
-                "type" in msg &&
-                msg.type === "assistant_text_delta" &&
-                "text" in msg
-              ) {
-                generatedText += (msg as { text: string }).text;
-              }
-              if (
-                "type" in msg &&
-                (msg.type === "error" || msg.type === "conversation_error")
-              ) {
-                agentLoopError =
-                  "message" in msg
-                    ? (msg as { message: string }).message
-                    : "userMessage" in msg
-                      ? (msg as { userMessage: string }).userMessage
-                      : "Agent loop failed";
-              }
-            },
-          });
-
-          // Identify messages created during this run by diffing against
-          // the pre-run snapshot. This captures all messages added to the
-          // conversation during the loop window, which may include messages
-          // from concurrent pointer events (see over-capture caveat above).
-          const postRunMessages = getMessages(conversationId);
-          const createdMessageIds = postRunMessages
-            .filter((m) => !preRunMessageIds.has(m.id) && m.id !== messageId)
-            .map((m) => m.id);
-
-          if (agentLoopError) {
-            await rollback(createdMessageIds);
-            throw new Error(agentLoopError);
-          }
-
-          // Post-generation fact check: verify the assistant's response
-          // includes all required factual details (phone number, duration,
-          // outcome keyword, etc.). If the model omitted or rewrote them,
-          // remove both the instruction and generated messages and throw so
-          // the deterministic fallback fires.
-          //
-          // Validation uses text accumulated from assistant_text_delta
-          // events during the agent loop rather than a DB lookup, avoiding
-          // any positional ambiguity when concurrent pointer events
-          // interleave messages in the conversation.
-          if (requiredFacts && requiredFacts.length > 0) {
-            const missingFacts = requiredFacts.filter(
-              (fact) => !generatedText.includes(fact),
-            );
-            if (missingFacts.length > 0) {
-              log.warn(
-                { conversationId, missingFacts },
-                "Generated pointer text failed fact validation — falling back to deterministic",
-              );
-              await rollback(createdMessageIds);
-              throw new Error("Generated pointer text failed fact validation");
-            }
-          }
-        } finally {
-          // Restore tool availability so subsequent turns aren't affected.
-          conversation.toolsDisabledDepth--;
-          // Undo the temporary guardian elevation installed above.
-          restoreTrustContext();
-        }
-      },
-    );
-    broadcastDaemonStatus();
-  } catch (err) {
-    log.warn(
-      { err },
-      "Failed to wire runtime HTTP server deps, continuing without them",
-    );
-  }
+  // The runtime HTTP server is up; broadcast the fresh daemon status so
+  // connected clients pick up the transition.
+  broadcastDaemonStatus();
 
   // Register built-in TTS providers so the provider abstraction can resolve
   // them by ID. Must happen before call controllers or routes are created.

--- a/assistant/src/daemon/pointer-turn-runner.ts
+++ b/assistant/src/daemon/pointer-turn-runner.ts
@@ -1,0 +1,174 @@
+/**
+ * Runs a call pointer/status event as a real daemon conversation turn: the
+ * assistant generates the pointer text in-context (identity, preferences,
+ * history) rather than emitting deterministic boilerplate.
+ *
+ * Pointer turns are guardian-gated owner self-maintenance. The turn is
+ * tool-disabled and fact-checked: if the model drops a required fact or the
+ * agent loop errors, the persisted messages are rolled back and the function
+ * throws so the caller can fall back to deterministic copy.
+ */
+
+import {
+  deleteMessageById,
+  getMessages,
+} from "../persistence/conversation-crud.js";
+import { getLogger } from "../util/logger.js";
+import { getOrCreateConversation } from "./conversation-store.js";
+import { elevatePointerConversationToGuardian } from "./pointer-conversation-trust.js";
+
+const log = getLogger("pointer-turn-runner");
+
+/**
+ * Generate and persist a pointer message as a conversation turn.
+ *
+ * @param requiredFacts - facts that must appear verbatim in the generated
+ *   text (phone number, duration, outcome keyword, etc.). The generated text
+ *   is validated against these; if any are missing the turn is rolled back
+ *   and this function throws so the caller's deterministic fallback fires.
+ * @throws if the agent loop errors or the generated text fails fact validation.
+ */
+export async function runPointerMessageTurn(
+  conversationId: string,
+  instruction: string,
+  requiredFacts?: string[],
+): Promise<void> {
+  const conversation = await getOrCreateConversation(conversationId);
+
+  // Pointer turns are guardian-gated owner self-maintenance: elevate to
+  // the internal guardian context and rehydrate history so a cold
+  // (evicted) load doesn't filter guardian history to empty and ship a
+  // cache-missing turn. `restoreTrustContext` undoes the elevation after
+  // the turn. See pointer-conversation-trust.ts for the full rationale.
+  const restoreTrustContext =
+    await elevatePointerConversationToGuardian(conversation);
+
+  // Constrain pointer generation to a tool-disabled path so call-
+  // status events cannot trigger unintended side-effect tools.
+  // Incrementing toolsDisabledDepth causes the resolveTools callback
+  // to return an empty tool list, preventing the LLM from seeing or
+  // invoking any tools during the pointer agent loop.
+  //
+  // A depth counter (rather than a boolean) ensures that overlapping
+  // pointer requests on the same conversation don't clear each other's
+  // constraint — each caller increments on entry and decrements in
+  // its own finally block.
+  conversation.toolsDisabledDepth++;
+  try {
+    const { id: messageId } = await conversation.persistUserMessage({
+      content: instruction,
+      metadata: { pointerInstruction: true },
+      displayContent: "[Call status event]",
+    });
+
+    // Helper: roll back persisted messages on failure, then reload
+    // in-memory history from the (now cleaned) DB. Reloading avoids
+    // stale-index issues when context compaction reassigns the
+    // messages array during runAgentLoop.
+    const rollback = async (extraMessageIds?: string[]) => {
+      try {
+        deleteMessageById(messageId);
+      } catch {
+        /* best effort */
+      }
+      for (const id of extraMessageIds ?? []) {
+        try {
+          deleteMessageById(id);
+        } catch {
+          /* best effort */
+        }
+      }
+      try {
+        await conversation.loadFromDb();
+      } catch {
+        /* best effort */
+      }
+    };
+
+    // Snapshot message IDs before the agent loop so we can diff
+    // afterwards to find exactly which messages this run created,
+    // avoiding positional heuristics that break under concurrency.
+    //
+    // Caveat: the diff captures *all* new messages in the
+    // conversation during the loop window, not just those from
+    // this specific agent loop.  If a concurrent pointer event
+    // falls back to a deterministic addMessage() while our loop
+    // is in flight, that message lands in our diff.  The race
+    // requires two pointer events for the same conversation
+    // within the agent loop window *and* this run must fail or
+    // fail fact-check — narrow enough to accept.  A future
+    // improvement could tag messages with a per-run correlation
+    // ID so rollback only targets its own output.
+    const preRunMessageIds = new Set(
+      getMessages(conversationId).map((m) => m.id),
+    );
+
+    let agentLoopError: string | undefined;
+    let generatedText = "";
+    await conversation.runAgentLoop(instruction, messageId, {
+      onEvent: (msg) => {
+        if (
+          "type" in msg &&
+          msg.type === "assistant_text_delta" &&
+          "text" in msg
+        ) {
+          generatedText += (msg as { text: string }).text;
+        }
+        if (
+          "type" in msg &&
+          (msg.type === "error" || msg.type === "conversation_error")
+        ) {
+          agentLoopError =
+            "message" in msg
+              ? (msg as { message: string }).message
+              : "userMessage" in msg
+                ? (msg as { userMessage: string }).userMessage
+                : "Agent loop failed";
+        }
+      },
+    });
+
+    // Identify messages created during this run by diffing against
+    // the pre-run snapshot. This captures all messages added to the
+    // conversation during the loop window, which may include messages
+    // from concurrent pointer events (see over-capture caveat above).
+    const postRunMessages = getMessages(conversationId);
+    const createdMessageIds = postRunMessages
+      .filter((m) => !preRunMessageIds.has(m.id) && m.id !== messageId)
+      .map((m) => m.id);
+
+    if (agentLoopError) {
+      await rollback(createdMessageIds);
+      throw new Error(agentLoopError);
+    }
+
+    // Post-generation fact check: verify the assistant's response
+    // includes all required factual details (phone number, duration,
+    // outcome keyword, etc.). If the model omitted or rewrote them,
+    // remove both the instruction and generated messages and throw so
+    // the deterministic fallback fires.
+    //
+    // Validation uses text accumulated from assistant_text_delta
+    // events during the agent loop rather than a DB lookup, avoiding
+    // any positional ambiguity when concurrent pointer events
+    // interleave messages in the conversation.
+    if (requiredFacts && requiredFacts.length > 0) {
+      const missingFacts = requiredFacts.filter(
+        (fact) => !generatedText.includes(fact),
+      );
+      if (missingFacts.length > 0) {
+        log.warn(
+          { conversationId, missingFacts },
+          "Generated pointer text failed fact validation — falling back to deterministic",
+        );
+        await rollback(createdMessageIds);
+        throw new Error("Generated pointer text failed fact validation");
+      }
+    }
+  } finally {
+    // Restore tool availability so subsequent turns aren't affected.
+    conversation.toolsDisabledDepth--;
+    // Undo the temporary guardian elevation installed above.
+    restoreTrustContext();
+  }
+}


### PR DESCRIPTION
## Why

The last of the three `calls/` DI setters. `setPointerMessageProcessor` was wired from `lifecycle.ts` with a ~100-line inline closure. Unlike a plain module reference, this one carried real orchestration — but it captured **nothing** from the lifecycle scope (only module-level imports), so it's freely extractable into a normal function and imported directly where it's used.

## What

- **New `daemon/pointer-turn-runner.ts`** exporting `runPointerMessageTurn()` — owns the conversation-turn orchestration verbatim (guardian trust elevation, tool-disabled agent loop, required-fact check, message rollback).
- **`call-pointer-messages.ts`** imports `runPointerMessageTurn` directly and calls it on the trusted-audience path. The existing `try/catch` still falls back to deterministic copy on failure. Removes the `PointerMessageProcessor` type, the module-level slot, and the `set`/`reset` setters.
- **`lifecycle.ts`** drops the injection block and its now-unused imports (`getOrCreateConversation`, `elevatePointerConversationToGuardian`, `deleteMessageById`, `getMessages`, `setPointerMessageProcessor`); keeps the post-HTTP `broadcastDaemonStatus()`.

## Circular-dependency handling

Per the request, this is a **module extraction**, not an inline/dynamic `import()`. I verified the dependency graph with `madge`:

- `call-pointer-messages` was **already inside the conversation SCC** before this change — it imports `conversation-crud`, which is deep in that component (baseline: it was already in a cycle). The DI setter was **not** actually keeping it cycle-free.
- The new `runPointerMessageTurn` needs the conversation machinery (`getOrCreateConversation` → `conversation`), which is intrinsic to running an agent turn. `pointer-turn-runner` therefore joins the **same** existing SCC — **no module that was previously cycle-free gains a new SCC.**
- Every cross-module reference is used **at call time** (inside functions), never at module-eval, so module init order is unaffected — the same property that makes the pre-existing ~159 cycles safe.

A fully cycle-free version isn't reachable by extraction alone: it would require untangling the unrelated `conversation → cli/memory → calls` chain that makes the `calls/` layer reachable from `conversation`. Happy to scope that separately if desired.

## Behavior

Unchanged for production. In-daemon call flows always have the conversation pipeline available, so the trusted-audience path routes through `runPointerMessageTurn` exactly as it did when the processor was injected; untrusted audiences and runner failures still use the deterministic fallback.

## Tests

`call-pointer-messages.test.ts` now mocks `pointer-turn-runner.js` with a swappable impl (replacing the removed setter). All affected suites pass in isolation:

| suite | result |
|---|---|
| call-pointer-messages | 25/0 |
| call-controller | 82/0 |
| relay-server | 100/0 |
| voice-session-bridge | 22/0 |
| voice-scoped-grant-consumer | 6/0 |

prettier / eslint / tsc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_