### PR TITLE
[codex] Request Google scopes explicitly for managed OAuth

### DIFF
--- a/clients/web/src/domains/onboarding/screens/google-connect-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/google-connect-screen.tsx
@@ -16,6 +16,7 @@ import {
     oauthCompletionStorageKey,
     type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
+import { resolveManagedOAuthRequestedScopes } from "@/lib/auth/google-oauth-scopes";
 import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
@@ -248,7 +249,8 @@ export function GoogleConnectScreen({
               provider: GOOGLE_PROVIDER_KEY,
             },
             body: {
-              requested_scopes: [],
+              requested_scopes:
+                resolveManagedOAuthRequestedScopes(GOOGLE_PROVIDER_KEY),
               redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}&native=1`,
             },
           },
@@ -369,7 +371,8 @@ export function GoogleConnectScreen({
         {
           path: { assistant_id: platformAssistantId, provider: GOOGLE_PROVIDER_KEY },
           body: {
-            requested_scopes: [],
+            requested_scopes:
+              resolveManagedOAuthRequestedScopes(GOOGLE_PROVIDER_KEY),
             redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}`,
           },
         },

--- a/clients/web/src/hooks/use-oauth-connect.ts
+++ b/clients/web/src/hooks/use-oauth-connect.ts
@@ -14,6 +14,7 @@ import {
   parseOAuthCompletePayload,
   type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
+import { resolveManagedOAuthRequestedScopes } from "@/lib/auth/google-oauth-scopes";
 import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -40,8 +41,9 @@ interface UseOAuthConnectOptions {
 interface UseOAuthConnectResult {
   /**
    * Start the managed OAuth flow. Pass `requestedScopes` to ask the provider
-   * for a specific subset of scopes (e.g. Calendar-only for Google); omit it
-   * to request the provider's full default scope set.
+   * for a specific subset of scopes (e.g. Calendar-only for Google). Omitted
+   * scopes use the provider default, except Google full-connects explicitly
+   * request the managed granular scope set.
    */
   handleConnect: (requestedScopes?: string[]) => void;
   oauthInProgress: boolean;
@@ -320,7 +322,10 @@ export function useOAuthConnect({
         {
           path: { assistant_id: platformAssistantId, provider: providerKey },
           body: {
-            requested_scopes: requestedScopes,
+            requested_scopes: resolveManagedOAuthRequestedScopes(
+              providerKey,
+              requestedScopes,
+            ),
             redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}${isNative ? "&native=1" : ""}`,
           },
         },

--- a/clients/web/src/lib/auth/google-managed-oauth-request-scopes.test.tsx
+++ b/clients/web/src/lib/auth/google-managed-oauth-request-scopes.test.tsx
@@ -1,0 +1,203 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import type { ReactNode } from "react";
+
+import { GOOGLE_MANAGED_FULL_CONNECT_SCOPES } from "@/lib/auth/google-oauth-scopes";
+
+const startOAuthMutateMock = mock(
+  (_variables: unknown, _callbacks?: unknown) => undefined,
+);
+const resolveLocalAssistantPlatformIdentityMock = mock(
+  async (assistantId: string) => `platform-${assistantId}`,
+);
+const useIsNativePlatformMock = mock(() => false);
+const openUrlMock = mock(async (_url: string) => undefined);
+const openUrlFinishedListenerMock = mock((_callback: () => void) => () => {});
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  assistantsOauthConnectionsListOptions: (options: unknown) => ({
+    queryKey: ["assistantsOauthConnectionsList", options],
+    queryFn: async () => [],
+  }),
+  useAssistantsOauthStartCreateMutation: () => ({
+    isPending: false,
+    mutate: startOAuthMutateMock,
+  }),
+}));
+
+mock.module("@/lib/local-platform-identity", () => ({
+  resolveLocalAssistantPlatformIdentity:
+    resolveLocalAssistantPlatformIdentityMock,
+}));
+
+mock.module("@/runtime/browser", () => ({
+  openUrl: openUrlMock,
+  openUrlFinishedListener: openUrlFinishedListenerMock,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: useIsNativePlatformMock,
+}));
+
+const { GoogleConnectScreen } = await import(
+  "@/domains/onboarding/screens/google-connect-screen"
+);
+const { useOAuthConnect } = await import("@/hooks/use-oauth-connect");
+
+let originalWindowOpen: typeof window.open;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function installPopupWindowMock() {
+  const popup = {
+    closed: false,
+    close: mock(() => {
+      popup.closed = true;
+    }),
+    location: { href: "" },
+  };
+
+  Object.defineProperty(window, "open", {
+    configurable: true,
+    value: mock(() => popup as unknown as Window),
+  });
+}
+
+function firstStartOAuthVariables() {
+  return startOAuthMutateMock.mock.calls[0]?.[0] as {
+    body: { requested_scopes: string[]; redirect_after_connect: string };
+    path: { assistant_id: string; provider: string };
+  };
+}
+
+beforeEach(() => {
+  originalWindowOpen = window.open;
+  installPopupWindowMock();
+  startOAuthMutateMock.mockClear();
+  resolveLocalAssistantPlatformIdentityMock.mockClear();
+  resolveLocalAssistantPlatformIdentityMock.mockImplementation(
+    async (assistantId: string) => `platform-${assistantId}`,
+  );
+  useIsNativePlatformMock.mockClear();
+  useIsNativePlatformMock.mockImplementation(() => false);
+  openUrlMock.mockClear();
+  openUrlFinishedListenerMock.mockClear();
+  openUrlFinishedListenerMock.mockImplementation(() => () => {});
+});
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "open", {
+    configurable: true,
+    value: originalWindowOpen,
+  });
+});
+
+describe("managed Google OAuth request scopes", () => {
+  test("settings full Google connect starts OAuth with explicit managed scopes", async () => {
+    const { result } = renderHook(
+      () =>
+        useOAuthConnect({
+          allConnections: [],
+          assistantId: "asst-1",
+          connectionsQueryKey: ["connections"],
+          displayName: "Google",
+          managedAvailable: true,
+          providerKey: "google",
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => result.current.handleConnect());
+
+    await waitFor(() => {
+      expect(startOAuthMutateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(firstStartOAuthVariables()).toMatchObject({
+      body: {
+        requested_scopes: [...GOOGLE_MANAGED_FULL_CONNECT_SCOPES],
+      },
+      path: { assistant_id: "platform-asst-1", provider: "google" },
+    });
+  });
+
+  test("settings scoped Google connect preserves the requested subset", async () => {
+    const requestedScopes = [
+      "openid",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/calendar.events",
+    ];
+    const { result } = renderHook(
+      () =>
+        useOAuthConnect({
+          allConnections: [],
+          assistantId: "asst-1",
+          connectionsQueryKey: ["connections"],
+          displayName: "Google",
+          managedAvailable: true,
+          providerKey: "google",
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => result.current.handleConnect(requestedScopes));
+
+    await waitFor(() => {
+      expect(startOAuthMutateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(firstStartOAuthVariables().body.requested_scopes).toEqual(
+      requestedScopes,
+    );
+  });
+
+  test("onboarding Google connect starts OAuth with explicit managed scopes", async () => {
+    render(
+      <GoogleConnectScreen
+        assistantId="asst-1"
+        assistantName="Example Assistant"
+        onBack={() => undefined}
+        onConnect={() => undefined}
+        onSkip={() => undefined}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect Google" }));
+
+    await waitFor(() => {
+      expect(startOAuthMutateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(firstStartOAuthVariables()).toMatchObject({
+      body: {
+        requested_scopes: [...GOOGLE_MANAGED_FULL_CONNECT_SCOPES],
+      },
+      path: { assistant_id: "platform-asst-1", provider: "google" },
+    });
+  });
+});

--- a/clients/web/src/lib/auth/google-oauth-scopes.test.ts
+++ b/clients/web/src/lib/auth/google-oauth-scopes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  GOOGLE_MANAGED_FULL_CONNECT_SCOPES,
+  resolveManagedOAuthRequestedScopes,
+} from "./google-oauth-scopes";
+
+describe("resolveManagedOAuthRequestedScopes", () => {
+  test("requests the explicit full Google managed scope set by default", () => {
+    expect(resolveManagedOAuthRequestedScopes("google")).toEqual([
+      ...GOOGLE_MANAGED_FULL_CONNECT_SCOPES,
+    ]);
+  });
+
+  test("preserves scoped overrides", () => {
+    expect(
+      resolveManagedOAuthRequestedScopes("google", [
+        "https://www.googleapis.com/auth/calendar.events",
+      ]),
+    ).toEqual(["https://www.googleapis.com/auth/calendar.events"]);
+  });
+
+  test("leaves non-Google providers on their platform defaults", () => {
+    expect(resolveManagedOAuthRequestedScopes("slack")).toEqual([]);
+  });
+});

--- a/clients/web/src/lib/auth/google-oauth-scopes.ts
+++ b/clients/web/src/lib/auth/google-oauth-scopes.ts
@@ -1,0 +1,28 @@
+export const GOOGLE_MANAGED_FULL_CONNECT_SCOPES: readonly string[] = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/gmail.settings.basic",
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/drive",
+  "https://www.googleapis.com/auth/contacts.readonly",
+];
+
+export function resolveManagedOAuthRequestedScopes(
+  providerKey: string,
+  requestedScopes: readonly string[] = [],
+): string[] {
+  if (requestedScopes.length > 0) {
+    return [...requestedScopes];
+  }
+
+  if (providerKey === "google") {
+    return [...GOOGLE_MANAGED_FULL_CONNECT_SCOPES];
+  }
+
+  return [];
+}


### PR DESCRIPTION
## Summary
- Add a shared managed Google OAuth full-connect scope set.
- Use it for Google full-connects from onboarding and the settings integrations page.
- Preserve scoped overrides, such as Calendar-only connects, and leave non-Google providers on platform defaults.
- Add caller-level tests for the OAuth start payloads so local QA does not require a configured Google OAuth app.

## Why
Google granular consent can show empty permission checkboxes when the OAuth start request does not explicitly include the granular scopes the user is expected to grant. The affected client entry points were sending an empty scope array or an omitted default for full Google connects, relying on platform defaults instead of making the requested Google permissions explicit in the start payload.

## Impact
Full Google connects in onboarding and settings now send the Gmail, Calendar, Drive, Contacts, and identity scopes in `requested_scopes`, which lets the generated Google OAuth URL carry the intended permissions. Google still controls the initial checkbox state in the consent UI, so the deterministic contract this PR owns is the OAuth start payload.

## QA
Local browser QA cannot reliably reach Google's consent screen unless the local redirect URI is registered on the Google OAuth app. The primary local QA path is automated:

- `google-oauth-scopes.test.ts` verifies the Google full-connect scope set and scoped override behavior.
- `google-managed-oauth-request-scopes.test.tsx` verifies that settings full-connect and onboarding full-connect both POST the explicit Google scope list, while scoped settings connects preserve their narrower requested scope set.

Manual consent-screen QA should happen in a deployed dev/staging environment whose OAuth redirect URI is registered with Google. In that environment, verify the `POST /v1/assistants/<assistant_id>/oauth/google/start/` request body has non-empty `requested_scopes` and that the returned `connect_url` includes those scopes in its `scope=` query param before checking Google's UI.

## Validation
- `cd clients/web && bun test src/lib/auth/google-oauth-scopes.test.ts src/lib/auth/google-managed-oauth-request-scopes.test.tsx`
- `cd clients/web && bunx tsc --noEmit`
- `cd clients/web && bun run lint` (passes with existing warnings outside the touched files)
