### PR TITLE
tune(memory-v3): raise gate sparseOnlyThreshold default to 0.75

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -29,7 +29,7 @@ describe("MemoryV3ConfigSchema", () => {
       gate: {
         denseThreshold: 0.66,
         sparseThreshold: 0.35,
-        sparseOnlyThreshold: 0.62,
+        sparseOnlyThreshold: 0.75,
         denseClusterThreshold: 0.6,
         denseClusterMaxDelta: 0.02,
         topK: 5,
@@ -139,7 +139,7 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed.gate).toEqual({
       denseThreshold: 0.6,
       sparseThreshold: 0.35,
-      sparseOnlyThreshold: 0.62,
+      sparseOnlyThreshold: 0.75,
       denseClusterThreshold: 0.6,
       denseClusterMaxDelta: 0.02,
       topK: 5,

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -277,7 +277,7 @@ export const MemoryV3GateSchema = z
       .number({ error: "memory.v3.gate.sparseOnlyThreshold must be a number" })
       .min(0)
       .max(1)
-      .default(0.62)
+      .default(0.75)
       .describe(
         "Higher normalized-BM25F bar to pass on sparse signal alone when dense fails.",
       ),


### PR DESCRIPTION
## Summary
Raise the memory-v3 injection-gate default `sparseOnlyThreshold` from 0.62 to 0.75.

## Why
Live calibration on a real corpus (Gemini 3072-dim embeddings) showed the sparse-only backstop leaking: off-topic prompts (e.g. "tell me a random fun fact") were opening the gate via `sparse_only_strong` at normalized BM25F ~0.636, clearing the old 0.62 bar on a spurious lexical match — even though the dense path correctly closed them (topDense 0.57 < denseThreshold 0.66). Real hits open via dense (topDense ~0.68 ≥ 0.66) regardless of the sparse bar, so lifting sparse-only to 0.75 (above the observed lexical-noise floor) closes off-topic turns without losing genuine matches.

Gate config is re-read per turn, so this also takes effect on any assistant already running the gate without a redeploy. denseThreshold (0.66) unchanged — it's well-placed.

Schema default-shape + partial-override tests updated to match. `bun test memory-v3.test.ts`: 12 pass.