### PR TITLE
Truncate tool description to 50 chars in `tools list` table

### DIFF
--- a/assistant/src/cli/commands/tools.ts
+++ b/assistant/src/cli/commands/tools.ts
@@ -105,8 +105,12 @@ Examples:
             `${"NAME".padEnd(nameW)}  ${"SOURCE".padEnd(sourceW)}  ${"RISK".padEnd(riskW)}  DESCRIPTION`,
           );
           for (const t of tools) {
+            const description =
+              t.description.length > 50
+                ? `${t.description.slice(0, 50)}…`
+                : t.description;
             console.log(
-              `${t.name.padEnd(nameW)}  ${t.source.padEnd(sourceW)}  ${t.riskLevel.padEnd(riskW)}  ${t.description}`,
+              `${t.name.padEnd(nameW)}  ${t.source.padEnd(sourceW)}  ${t.riskLevel.padEnd(riskW)}  ${description}`,
             );
           }
           console.log(`\n${tools.length} tool(s)`);


### PR DESCRIPTION
## Why

The `assistant tools list` table printed each tool's full `description`. Long descriptions wrap across terminal lines and push the aligned `NAME`/`SOURCE`/`RISK` columns out of alignment, making the table hard to scan.

## What

Truncate the description to the first 50 characters (with a trailing `…`) in the human-readable table output only. The `--json` output is untouched and still emits the full description so scripting and programmatic consumers keep the complete text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018bSHFTnHpXb9rAf6Nz6Bu5)_