### PR TITLE
feat(onboarding): finish personality rewrite before entering chat

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -243,6 +243,16 @@ export function ResearchOnboardingRoute() {
   // minted — otherwise the rejected facts could still be pulled into its context.
   // Resolves immediately when nothing was corrected (never rejects).
   const researchCorrectionRef = useRef<Promise<void>>(Promise.resolve());
+  // In-flight personality rewrite (if any), fired from the personality step. The
+  // chat handoff awaits it (alongside the plugin installs + removal correction)
+  // so the assistant's persona is fully rewritten BEFORE the first real chat is
+  // minted — otherwise the greeting could land in the old, unshaped voice.
+  // Resolves immediately when personality was never applied (never rejects).
+  const personalityAppliedRef = useRef<Promise<void>>(Promise.resolve());
+  // Mirrors the ref as render state so the looking-you-up loading stage can hold
+  // its "ready" reveal until the personality rewrite settles too — the carousel
+  // keeps cycling while this is true, same as an unsettled research turn.
+  const [personalityPending, setPersonalityPending] = useState(false);
   const researchLoading =
     research.status === "idle" || research.status === "running";
   // The research turn settled with nothing to show — skip the "this is what I
@@ -604,16 +614,19 @@ export function ResearchOnboardingRoute() {
               // First continue applies the sliders to the assistant's persona on
               // a throwaway side thread (awaits hatch readiness internally, then
               // archives) and locks them — the prompt has been sent, so a later
-              // step-back can't silently diverge. Fire-and-forget: the rewrite
-              // turn finishes during the later steps, well before the chat
-              // handoff. Best-effort; never blocks the flow. A continue while
+              // step-back can't silently diverge. The rewrite turn runs during
+              // the later steps; we track its promise (and pending flag) so the
+              // looking-you-up loader holds until it settles and the chat handoff
+              // awaits it, guaranteeing the persona is reshaped before the first
+              // real chat. Best-effort; it never rejects. A continue while
               // already locked just advances.
               if (!personalityLocked) {
-                void applyPersonality({
+                setPersonalityPending(true);
+                personalityAppliedRef.current = applyPersonality({
                   awaitAssistantId: awaitHatchReady,
                   values: personalityValues,
                   userName: formValues?.firstName?.trim() || undefined,
-                });
+                }).finally(() => setPersonalityPending(false));
                 setPersonalityLocked(true);
               }
               goForwardTo("integration");
@@ -662,7 +675,10 @@ export function ResearchOnboardingRoute() {
             onBack={() => goBackTo("letschat")}
             onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
             onForward={onForward}
-            ready={!researchLoading}
+            // Hold the loader until BOTH the research turn and the personality
+            // rewrite have settled, so the results/chat never open on a persona
+            // that's still being written.
+            ready={!researchLoading && !personalityPending}
           />
         )}
         {step === "results" && (
@@ -713,11 +729,14 @@ export function ResearchOnboardingRoute() {
                 { userId, outcome: "completed" },
               );
               // Wait out any background capability installs so the primed chat
-              // can discover their skills, and any removal correction so rejected
-              // claims can't leak into it — same gating as the suggestion click.
+              // can discover their skills, any removal correction so rejected
+              // claims can't leak into it, and the personality rewrite so the
+              // greeting lands in the persona the user just configured — same
+              // gating as the suggestion click, plus the persona.
               await Promise.all([
                 research.awaitPluginInstalls(),
                 researchCorrectionRef.current,
+                personalityAppliedRef.current,
               ]);
               // Drop into a fresh chat with the hidden kickoff so the assistant
               // opens by greeting the user in the persona they configured.

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -89,8 +89,8 @@ const PERSONALITY_AXES: PersonalityAxis[] = [
   },
   {
     id: "execute-collaborate",
-    left: "Execute",
-    right: "Collaborate",
+    left: "Independent",
+    right: "Collaborative",
     leftAvatar: { bodyShape: "star", eyeStyle: "angry", color: "orange" },
     rightAvatar: { bodyShape: "flower", eyeStyle: "goofy", color: "teal" },
   },
@@ -410,10 +410,18 @@ export function CreatePersonalityStep({
           >
             Create my personality
           </h1>
-          {locked && (
+          {locked ? (
             <p className="text-center text-[15px]" style={{ color: tone.fgMuted }}>
               Personality locked — chat with your assistant to make any more
               updates
+            </p>
+          ) : (
+            <p
+              className="max-w-md text-center text-[15px]"
+              style={{ color: tone.fgMuted }}
+            >
+              How do you want me to talk to you? You can always ask me to change
+              my personality later.
             </p>
           )}
         </div>


### PR DESCRIPTION
## What

In research-onboarding, the **web search** (research turn) and the **personality** rewrite both run in the background while the user clicks through the intro/integration/calendar steps. The research turn was already gated — the "looking you up" loader waited for it and the chat handoff awaited its plugin installs/corrections. The **personality** rewrite was not: `applyPersonality()` was fired pure fire-and-forget (`void`), so:

- the loader could reveal results / the chat could open while the persona was still being written, and
- the assistant's first greeting could land in the old, unshaped voice.

## Change

Track the rewrite promise in `personalityAppliedRef` and mirror it as a `personalityPending` render flag (both default to a no-op, so the non-personality flag path is unaffected):

- **Looking-you-up loader** now holds its reveal until **both** operations settle: `ready={!researchLoading && !personalityPending}`. It keeps cycling its carousel messages until the personality rewrite finishes too.
- **Chat handoff** (`LetsChatReadyStep.onStart`) awaits `personalityAppliedRef` alongside the existing `awaitPluginInstalls()` and removal correction, so the persona is fully reshaped before the first real conversation is minted.

Still best-effort — `applyPersonality` never rejects, so a slow/failed rewrite can't wedge the flow (it settles on its 120s poll ceiling either way).

## Notes

- This branch is stacked on the (not-yet-PR'd) `feat/onboarding-personality-help-labels` work, so this PR includes that prior onboarding commit as well as the sync change.
- `bunx tsc --noEmit` and `eslint` both clean.

## Testing

- [ ] Manual QA: run onboarding with `personalityOnboarding` flag on, adjust sliders → Continue, confirm the "looking you up" loader holds until the persona rewrite lands and the greeting opens in the configured voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)