### PR TITLE
fix(approvals): persist unverified_contact when guardian denies access (LUM-2656)

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -97,6 +97,7 @@ import {
   createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
+  resolveCanonicalGuardianRequest,
 } from "../contacts/canonical-guardian-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -303,6 +304,75 @@ describe("non-member access request notification", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
+  });
+
+  // End-to-end regression for the reported bug: after the guardian DENIES an
+  // access request, subsequent DMs from the same sender must not re-prompt.
+  // Drives the real inbound path for both messages so the deny-dedup matches
+  // the exact assistant-scoped conversationId the notify path derives — a
+  // hand-crafted fixture could mask a mismatch. This FAILS on the pre-fix code
+  // (second inbound would emit a second signal).
+  test("a denied sender's subsequent DM does not re-prompt the guardian", async () => {
+    seedGatewayGuardian({
+      channelType: "telegram",
+      address: "guardian-user-789",
+      externalChatId: "guardian-chat-789",
+      principalId: anchorPrincipalId,
+    });
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "guardian-user-789",
+      guardianDeliveryChatId: "guardian-chat-789",
+      guardianPrincipalId: anchorPrincipalId,
+      verifiedVia: "test",
+    });
+
+    // 1) First DM from the unknown sender → guardian is prompted once.
+    await handleChannelInbound(
+      buildInboundRequest(),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    expect(emitSignalCalls.length).toBe(1);
+
+    const created = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "user-unknown-456",
+      sourceChannel: "telegram",
+      kind: "access_request",
+    });
+    expect(created.length).toBe(1);
+
+    // 2) Guardian denies — resolve the *real* request (same CAS transition the
+    // deny primitive performs), preserving its conversationId.
+    const denied = resolveCanonicalGuardianRequest(created[0].id, "pending", {
+      status: "denied",
+      decidedByExternalUserId: "guardian-user-789",
+    });
+    expect(denied?.status).toBe("denied");
+
+    // 3) Same sender DMs again → still denied, but NO new guardian prompt.
+    const resp2 = await handleChannelInbound(
+      buildInboundRequest({
+        externalMessageId: `msg-after-deny-${Date.now()}`,
+      }),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    expect(json2.denied).toBe(true);
+
+    // No additional access-request signal was emitted (still just the first).
+    expect(emitSignalCalls.length).toBe(1);
+
+    // And no fresh pending request was created for the denied sender.
+    const pendingAfter = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "user-unknown-456",
+      sourceChannel: "telegram",
+      kind: "access_request",
+    });
+    expect(pendingAfter.length).toBe(0);
   });
 
   test("access request is created with self-healed principal even without same-channel guardian binding", async () => {

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -94,6 +94,7 @@ function seedGatewayGuardian(
 }
 
 import {
+  createCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
 } from "../contacts/canonical-guardian-store.js";
@@ -825,5 +826,110 @@ describe("access-request-helper unit tests", () => {
     expect(telegram).toBeDefined();
     expect(telegram!.destinationChatId).toBe("guardian-chat-456");
     expect(telegram!.status).toBe("sent");
+  });
+
+  test("notifyGuardianOfAccessRequest is suppressed after a prior deny for the same sender", async () => {
+    // Simulate a previously-denied access request for this sender on this
+    // channel/assistant. The conversationId must match the assistant-scoped
+    // key the helper derives: access-req-<assistantId>-<channel>-<actor>.
+    createCanonicalGuardianRequest({
+      id: `denied-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-denied-user",
+      requesterExternalUserId: "denied-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-denied",
+      actorExternalId: "denied-user",
+      actorDisplayName: "Denied User",
+    });
+
+    // Suppressed: no new prompt, no signal, no new pending request.
+    expect(result.notified).toBe(false);
+    if (!result.notified) {
+      expect(result.reason).toBe("already_denied");
+    }
+    expect(emitSignalCalls.length).toBe(0);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "denied-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(0);
+  });
+
+  test("a prior deny for one sender does not suppress prompts for a different sender", async () => {
+    createCanonicalGuardianRequest({
+      id: `denied-other-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-denied-user",
+      requesterExternalUserId: "denied-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    // A different sender still gets a fresh prompt.
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-fresh",
+      actorExternalId: "fresh-user",
+      actorDisplayName: "Fresh User",
+    });
+
+    expect(result.notified).toBe(true);
+    expect(emitSignalCalls.length).toBe(1);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "fresh-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
+  });
+
+  test("a denied request on a different channel does not suppress a new channel's prompt", async () => {
+    // Denied on telegram; the same actor id messaging on slack is a distinct
+    // (channel-scoped) context and still surfaces to the guardian.
+    createCanonicalGuardianRequest({
+      id: `denied-tg-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-cross-user",
+      requesterExternalUserId: "cross-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "slack",
+      conversationExternalId: "C-cross",
+      actorExternalId: "cross-user",
+      actorDisplayName: "Cross User",
+    });
+
+    expect(result.notified).toBe(true);
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "cross-user",
+      sourceChannel: "slack",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
   });
 });

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -101,7 +101,10 @@ import {
 } from "../contacts/canonical-guardian-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
+import {
+  isAccessRequestDenied,
+  notifyGuardianOfAccessRequest,
+} from "../runtime/access-request-helper.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
@@ -306,12 +309,11 @@ describe("non-member access request notification", () => {
     expect(pending.length).toBe(1);
   });
 
-  // End-to-end regression for the reported bug: after the guardian DENIES an
-  // access request, subsequent DMs from the same sender must not re-prompt.
-  // Drives the real inbound path for both messages so the deny-dedup matches
-  // the exact assistant-scoped conversationId the notify path derives — a
-  // hand-crafted fixture could mask a mismatch. This FAILS on the pre-fix code
-  // (second inbound would emit a second signal).
+  // After the guardian denies an access request, subsequent DMs from the same
+  // sender do not re-prompt the guardian. Drives the real inbound path for both
+  // messages so the deny-dedup matches the exact assistant-scoped
+  // conversationId the notify path derives — a hand-crafted fixture could mask
+  // a mismatch.
   test("a denied sender's subsequent DM does not re-prompt the guardian", async () => {
     seedGatewayGuardian({
       channelType: "telegram",
@@ -1001,5 +1003,50 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
+  });
+
+  test("isAccessRequestDenied is true only for the denied (assistant, channel, sender)", () => {
+    const key = {
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      actorExternalId: "denied-user",
+    };
+    expect(isAccessRequestDenied(key)).toBe(false);
+
+    createCanonicalGuardianRequest({
+      id: `denied-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-denied-user",
+      requesterExternalUserId: "denied-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    expect(isAccessRequestDenied(key)).toBe(true);
+    // Scoped: a different channel or sender is not treated as denied.
+    expect(isAccessRequestDenied({ ...key, sourceChannel: "slack" })).toBe(
+      false,
+    );
+    expect(isAccessRequestDenied({ ...key, actorExternalId: "other" })).toBe(
+      false,
+    );
+    // A still-pending request is not a terminal deny.
+    createCanonicalGuardianRequest({
+      id: `pending-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-pending-user",
+      requesterExternalUserId: "pending-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "pending",
+    });
+    expect(
+      isAccessRequestDenied({ ...key, actorExternalId: "pending-user" }),
+    ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -84,6 +84,7 @@ function seedGatewayGuardian(
   });
 }
 
+import { createCanonicalGuardianRequest } from "../contacts/canonical-guardian-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
@@ -184,6 +185,41 @@ describe("Slack inbound trusted contact verification", () => {
     expect(
       (deliverReplyCalls[0].payload as Record<string, unknown>).text,
     ).toContain("I don't recognize you yet");
+  });
+
+  test("a terminally-denied Slack sender gets no challenge and no guardian re-prompt", async () => {
+    // Guardian previously denied this sender (terminal). Seed the denied
+    // canonical request under the assistant-scoped conversationId the ingress
+    // path derives for (self, slack, U0123UNKNOWN).
+    createCanonicalGuardianRequest({
+      id: `denied-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "slack",
+      conversationId: "access-req-self-slack-U0123UNKNOWN",
+      requesterExternalUserId: "U0123UNKNOWN",
+      guardianPrincipalId: "guardian-principal",
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    const resp = await handleChannelInbound(
+      buildSlackInboundRequest(),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    // Still denied — but not via a fresh, unusable verification challenge.
+    expect(json.denied).toBe(true);
+    expect(json.reason).not.toBe("verification_challenge_sent");
+    expect(json.verificationSessionId).toBeUndefined();
+
+    // No verification session was minted for the denied sender.
+    expect(findActiveSession("slack")).toBeNull();
+
+    // And the guardian was not re-notified.
+    expect(emitSignalCalls.length).toBe(0);
   });
 
   test("verification session is identity-bound to the Slack user", async () => {

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -52,6 +52,10 @@ mock.module("../runtime/access-request-helper.js", () => ({
       requestId: `mock-req-${Date.now()}`,
     };
   },
+  // acl-enforcement imports this alongside notifyGuardianOfAccessRequest; stub
+  // it so the terminal-deny check never falls through to the real DB-backed
+  // helper in this mocked suite.
+  isAccessRequestDenied: () => false,
 }));
 
 const deliverReplyCalls: Array<{

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -17,7 +17,10 @@ import {
   getCanonicalGuardianRequest,
 } from "../contacts/canonical-guardian-store.js";
 import { findContactChannel } from "../contacts/contact-store.js";
-import { activateMemberChannel } from "../contacts/member-write-relay.js";
+import {
+  activateMemberChannel,
+  seedUnverifiedMemberChannel,
+} from "../contacts/member-write-relay.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import {
@@ -498,6 +501,23 @@ const accessRequestResolver: GuardianRequestResolver = {
         { event: "resolver_access_request_denied", requestId: request.id },
         "Access request resolver: deny",
       );
+
+      // Persist the denied sender as an unverified_contact (gateway-first).
+      // Denial is a terminal decision: the sender becomes a known, unverified
+      // contact so future inbound resolves as unverified_contact rather than
+      // re-triggering discovery. Paired with the denied-request suppression in
+      // notifyGuardianOfAccessRequest, this stops the prompt from re-firing on
+      // every subsequent DM. The guardian can still verify them later. Skipped
+      // for desktop-origin (vellum) requests, which carry no channel identity.
+      if (requesterExternalUserId && channel !== "vellum") {
+        await seedUnverifiedMemberChannel({
+          sourceChannel: channel,
+          externalUserId: requesterExternalUserId,
+          ...(requesterDisplayName
+            ? { displayName: requesterDisplayName }
+            : {}),
+        });
+      }
 
       // Deliver denial notification and lifecycle signals when channel context is available
       if (channelDeliveryContext) {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1450,6 +1450,16 @@ export class RelayConnection {
           },
           "Guardian notified of voice access request with caller name",
         );
+      } else if (accessResult.reason === "already_denied") {
+        // The guardian already denied this caller; they are intentionally not
+        // re-notified. Deliver the denial copy rather than the "I'll let them
+        // know" timeout copy, which would falsely promise a notification.
+        log.info(
+          { callSessionId: this.callSessionId },
+          "Voice caller previously denied — suppressing re-notification, delivering denial",
+        );
+        void this.handleAccessRequestDenied();
+        return;
       } else {
         log.warn(
           { callSessionId: this.callSessionId },

--- a/assistant/src/contacts/__tests__/member-write-relay.test.ts
+++ b/assistant/src/contacts/__tests__/member-write-relay.test.ts
@@ -63,7 +63,8 @@ mock.module("../contacts-write.js", () => ({
   upsertContactChannel: upsertContactChannelMock,
 }));
 
-const { activateMemberChannel } = await import("../member-write-relay.js");
+const { activateMemberChannel, seedUnverifiedMemberChannel } =
+  await import("../member-write-relay.js");
 
 describe("activateMemberChannel gateway-first relay", () => {
   beforeEach(() => {
@@ -222,5 +223,60 @@ describe("activateMemberChannel gateway-first relay", () => {
       address: "+15551234567",
       externalChatId: "+15551234567",
     });
+  });
+});
+
+describe("seedUnverifiedMemberChannel gateway-first relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcThrows = false;
+    ipcCallPersistentMock.mockClear();
+  });
+
+  test("relays to the gateway create_contact IPC with channelType + address + displayName", async () => {
+    await seedUnverifiedMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+      displayName: "Alice",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "create_contact",
+        params: {
+          channelType: "telegram",
+          address: "user-1",
+          displayName: "Alice",
+        },
+      },
+    ]);
+  });
+
+  test("omits displayName when not supplied", async () => {
+    await seedUnverifiedMemberChannel({
+      sourceChannel: "slack",
+      externalUserId: "U123",
+    });
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(ipcCalls[0]!.method).toBe("create_contact");
+    expect(ipcCalls[0]!.params).toEqual({
+      channelType: "slack",
+      address: "U123",
+    });
+    expect("displayName" in (ipcCalls[0]!.params ?? {})).toBe(false);
+  });
+
+  test("swallows gateway errors (best-effort) so a deny is never blocked", async () => {
+    ipcThrows = true;
+
+    // Must not throw — the gateway owns the ACL verdict and a failed seed must
+    // not fail the guardian's deny decision.
+    await seedUnverifiedMemberChannel({
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+    });
+
+    expect(ipcCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -181,3 +181,44 @@ export async function revokeMemberChannel(
     return null;
   }
 }
+
+// ── Seed unverified ──────────────────────────────────────────────────
+
+export interface SeedUnverifiedMemberChannelParams {
+  sourceChannel: string;
+  externalUserId: string;
+  displayName?: string;
+}
+
+/**
+ * Seed a contact channel for a sender at the `unverified` admission tier,
+ * gateway-first. Used when the guardian denies an access request: the sender
+ * becomes a known `unverified_contact` — no longer an unknown stranger — so
+ * subsequent inbound resolves as `unverified_contact` instead of re-running
+ * discovery.
+ *
+ * Delegates to the gateway `create_contact` IPC, which upserts via
+ * `ContactStore.upsertContact` (gateway DB is the ACL source of truth, with a
+ * best-effort assistant-DB mirror). A brand-new channel lands at status
+ * `unverified`; an existing channel's status is preserved, so a blocked,
+ * revoked, or already-active row is never reactivated or downgraded.
+ *
+ * Best-effort: the gateway owns the ACL verdict, so a failed relay is logged
+ * and swallowed — it must never fail the guardian's deny decision.
+ */
+export async function seedUnverifiedMemberChannel(
+  params: SeedUnverifiedMemberChannelParams,
+): Promise<void> {
+  try {
+    await ipcCallPersistent("create_contact", {
+      channelType: params.sourceChannel,
+      address: params.externalUserId,
+      ...(params.displayName ? { displayName: params.displayName } : {}),
+    });
+  } catch (err) {
+    log.warn(
+      { err, sourceChannel: params.sourceChannel },
+      "seed_unverified_channel relay failed (best-effort); sender not persisted as unverified_contact",
+    );
+  }
+}

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -57,6 +57,51 @@ export type AccessRequestResult =
   | { notified: false; reason: "no_sender_id" | "already_denied" };
 
 // ---------------------------------------------------------------------------
+// Terminal-deny lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Assistant-scoped conversation id for an actor's access requests. Stable key
+ * that dedupes pending prompts and detects a prior terminal deny for the same
+ * (assistant, channel, actor).
+ */
+export function accessRequestConversationId(
+  canonicalAssistantId: string,
+  sourceChannel: string,
+  actorExternalId: string,
+): string {
+  return `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}`;
+}
+
+/**
+ * Whether the guardian has already terminally denied an access request from
+ * this actor on this channel. Callers use it to suppress re-engagement — both
+ * the guardian prompt and the self-verify challenge — for a sender the guardian
+ * explicitly rejected. Reads the retained `denied` canonical request scoped by
+ * the assistant-scoped conversation id.
+ */
+export function isAccessRequestDenied(params: {
+  canonicalAssistantId: string;
+  sourceChannel: string;
+  actorExternalId: string;
+}): boolean {
+  const conversationId = accessRequestConversationId(
+    params.canonicalAssistantId,
+    params.sourceChannel,
+    params.actorExternalId,
+  );
+  return (
+    listCanonicalGuardianRequests({
+      status: "denied",
+      requesterExternalUserId: params.actorExternalId,
+      sourceChannel: params.sourceChannel,
+      kind: "access_request",
+      conversationId,
+    }).length > 0
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Helper
 // ---------------------------------------------------------------------------
 
@@ -122,7 +167,11 @@ export async function notifyGuardianOfAccessRequest(
   // matches requests for the same assistant. Without this, a pending request
   // from assistant A could be returned for assistant B, allowing the caller
   // to piggyback on A's guardian approval.
-  const conversationId = `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}`;
+  const conversationId = accessRequestConversationId(
+    canonicalAssistantId,
+    sourceChannel,
+    actorExternalId,
+  );
 
   // Deduplicate: skip creation if there is already a pending canonical request
   // for the same requester on this channel *and* assistant. Still return
@@ -151,19 +200,17 @@ export async function notifyGuardianOfAccessRequest(
   // for this sender on this channel, subsequent inbound must not re-prompt.
   // The denied decision persists the sender as an unverified_contact (see the
   // accessRequestResolver deny path); re-surfacing the same request the
-  // guardian already rejected would be noise. Scoped to the same assistant via
-  // conversationId, matching the pending-dedup above. The guardian can still
-  // verify the contact manually — that path does not go through here.
-  const deniedCanonical = listCanonicalGuardianRequests({
-    status: "denied",
-    requesterExternalUserId: actorExternalId,
-    sourceChannel,
-    kind: "access_request",
-    conversationId,
-  });
-  if (deniedCanonical.length > 0) {
+  // guardian already rejected would be noise. The guardian can still verify the
+  // contact manually — that path does not go through here.
+  if (
+    isAccessRequestDenied({
+      canonicalAssistantId,
+      sourceChannel,
+      actorExternalId,
+    })
+  ) {
     log.debug(
-      { sourceChannel, actorExternalId, deniedId: deniedCanonical[0].id },
+      { sourceChannel, actorExternalId },
       "Suppressing access request notification — guardian already denied this sender",
     );
     return { notified: false, reason: "already_denied" };

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -54,7 +54,7 @@ export interface AccessRequestParams {
 
 export type AccessRequestResult =
   | { notified: true; created: boolean; requestId: string }
-  | { notified: false; reason: "no_sender_id" };
+  | { notified: false; reason: "no_sender_id" | "already_denied" };
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -145,6 +145,28 @@ export async function notifyGuardianOfAccessRequest(
       created: false,
       requestId: existingCanonical[0].id,
     };
+  }
+
+  // Terminal-deny suppression: once the guardian has denied an access request
+  // for this sender on this channel, subsequent inbound must not re-prompt.
+  // The denied decision persists the sender as an unverified_contact (see the
+  // accessRequestResolver deny path); re-surfacing the same request the
+  // guardian already rejected would be noise. Scoped to the same assistant via
+  // conversationId, matching the pending-dedup above. The guardian can still
+  // verify the contact manually — that path does not go through here.
+  const deniedCanonical = listCanonicalGuardianRequests({
+    status: "denied",
+    requesterExternalUserId: actorExternalId,
+    sourceChannel,
+    kind: "access_request",
+    conversationId,
+  });
+  if (deniedCanonical.length > 0) {
+    log.debug(
+      { sourceChannel, actorExternalId, deniedId: deniedCanonical[0].id },
+      "Suppressing access request notification — guardian already denied this sender",
+    );
+    return { notified: false, reason: "already_denied" };
   }
 
   const senderIdentifier = actorDisplayName || actorUsername || actorExternalId;

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -383,13 +383,14 @@ describe("enforceIngressAcl — fail-closed on malformed member verdict", () => 
   });
 });
 
-describe("enforceIngressAcl — terminal-deny gate holds denied senders out of permissive floors", () => {
-  test("any_contact: a terminally-denied unverified member is DENIED, not admitted by the floor", async () => {
-    // Regression (LUM-2656 / Codex P1): a sender the guardian explicitly denied
-    // is persisted as an unverified contact (rank 2). On `any_contact` (floor 2)
-    // that rank would otherwise clear the floor and silently re-admit them,
-    // turning the guardian's deny into standing access. The terminal-deny gate
-    // must keep the bypass from firing so the ACL denies directly.
+describe("enforceIngressAcl — a terminal deny suppresses re-prompting, not admission", () => {
+  // Per the Slack-permissions PRD, admission is pure rank-vs-floor: a
+  // guardian-denied sender is persisted as an unverified contact (rank 2) and is
+  // admitted on exactly the same terms as any other unverified contact. The deny
+  // only stops the guardian from being re-prompted; holding a contact out of
+  // every floor is the (separate) block action's job. These matched pairs pin
+  // that the denied flag does NOT change the admission outcome.
+  test("any_contact: a terminally-denied unverified member is still admitted by the floor", async () => {
     accessRequestDeniedForTest = true;
 
     const result = await enforceIngressAcl(
@@ -399,16 +400,12 @@ describe("enforceIngressAcl — terminal-deny gate holds denied senders out of p
       }),
     );
 
-    expect(result.earlyResponse).toBeDefined();
-    expect(result.earlyResponse!.denied).toBe(true);
-    // `unverified` maps to `pending` at the API-facing member layer.
-    expect(result.earlyResponse!.reason).toBe("member_pending");
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.status).toBe("unverified");
   });
 
-  test("any_contact: a NON-denied unverified member is still admitted by the floor", async () => {
-    // Contrast: the gate carves out only denied senders. A normal unverified
-    // contact (rank 2) still clears the `any_contact` floor (rank 2), so it is
-    // bypassed to the admission stage with no early ACL deny.
+  test("any_contact: a non-denied unverified member is admitted identically", async () => {
     accessRequestDeniedForTest = false;
 
     const result = await enforceIngressAcl(
@@ -423,11 +420,7 @@ describe("enforceIngressAcl — terminal-deny gate holds denied senders out of p
     expect(result.resolvedMember!.status).toBe("unverified");
   });
 
-  test("strangers: a terminally-denied non-member is DENIED, not bypassed to the floor", async () => {
-    // The same gate on the non-member path covers the edge case where persisting
-    // the denied sender as an unverified contact failed, so they resurface as a
-    // stranger. Under `strangers` (floor 1) the bypass would admit any sender;
-    // the gate holds a denied one out.
+  test("strangers: a terminally-denied non-member is still bypassed to the floor", async () => {
     accessRequestDeniedForTest = true;
 
     const result = await enforceIngressAcl(
@@ -442,14 +435,11 @@ describe("enforceIngressAcl — terminal-deny gate holds denied senders out of p
       }),
     );
 
-    expect(result.earlyResponse).toBeDefined();
-    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.earlyResponse).toBeUndefined();
     expect(result.resolvedMember).toBeNull();
   });
 
-  test("strangers: a NON-denied stranger is still bypassed to the floor", async () => {
-    // Contrast: without a prior deny, the stranger is passed through to the
-    // admission stage (no early ACL deny) under `strangers`.
+  test("strangers: a non-denied stranger is bypassed identically", async () => {
     accessRequestDeniedForTest = false;
 
     const result = await enforceIngressAcl(
@@ -466,5 +456,24 @@ describe("enforceIngressAcl — terminal-deny gate holds denied senders out of p
 
     expect(result.earlyResponse).toBeUndefined();
     expect(result.resolvedMember).toBeNull();
+  });
+
+  test("trusted_contacts: a denied unverified member is denied by the floor, not re-admitted", async () => {
+    // Under a strict floor (rank 3) an unverified contact (rank 2) does not clear
+    // the floor and is denied — same as any unverified contact, denied or not.
+    // The floor governs exclusion here; the deny governs only re-prompting.
+    accessRequestDeniedForTest = true;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "unverified" })),
+        effectiveAdmissionPolicy: "trusted_contacts",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.denied).toBe(true);
+    // `unverified` maps to `pending` at the API-facing member layer.
+    expect(result.earlyResponse!.reason).toBe("member_pending");
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -53,11 +53,13 @@ mock.module("../../gateway-client.js", () => ({
 }));
 
 const accessRequestCalls: unknown[] = [];
+let accessRequestDeniedForTest = false;
 mock.module("../../access-request-helper.js", () => ({
   notifyGuardianOfAccessRequest: (params: unknown) => {
     accessRequestCalls.push(params);
     return { notified: true };
   },
+  isAccessRequestDenied: () => accessRequestDeniedForTest,
 }));
 
 // Invite transport: by default no adapter (no token). Per-test override below.
@@ -141,6 +143,7 @@ beforeEach(() => {
   findContactChannelCalls.length = 0;
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
+  accessRequestDeniedForTest = false;
   inviteTokenForTest = undefined;
   guardianDeliveryList = [];
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -382,3 +382,89 @@ describe("enforceIngressAcl — fail-closed on malformed member verdict", () => 
     expect(result.resolvedMember).toBeNull();
   });
 });
+
+describe("enforceIngressAcl — terminal-deny gate holds denied senders out of permissive floors", () => {
+  test("any_contact: a terminally-denied unverified member is DENIED, not admitted by the floor", async () => {
+    // Regression (LUM-2656 / Codex P1): a sender the guardian explicitly denied
+    // is persisted as an unverified contact (rank 2). On `any_contact` (floor 2)
+    // that rank would otherwise clear the floor and silently re-admit them,
+    // turning the guardian's deny into standing access. The terminal-deny gate
+    // must keep the bypass from firing so the ACL denies directly.
+    accessRequestDeniedForTest = true;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "unverified" })),
+        effectiveAdmissionPolicy: "any_contact",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.denied).toBe(true);
+    // `unverified` maps to `pending` at the API-facing member layer.
+    expect(result.earlyResponse!.reason).toBe("member_pending");
+  });
+
+  test("any_contact: a NON-denied unverified member is still admitted by the floor", async () => {
+    // Contrast: the gate carves out only denied senders. A normal unverified
+    // contact (rank 2) still clears the `any_contact` floor (rank 2), so it is
+    // bypassed to the admission stage with no early ACL deny.
+    accessRequestDeniedForTest = false;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict(memberVerdict({ status: "unverified" })),
+        effectiveAdmissionPolicy: "any_contact",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember).not.toBeNull();
+    expect(result.resolvedMember!.status).toBe("unverified");
+  });
+
+  test("strangers: a terminally-denied non-member is DENIED, not bypassed to the floor", async () => {
+    // The same gate on the non-member path covers the edge case where persisting
+    // the denied sender as an unverified contact failed, so they resurface as a
+    // stranger. Under `strangers` (floor 1) the bypass would admit any sender;
+    // the gate holds a denied one out.
+    accessRequestDeniedForTest = true;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(result.resolvedMember).toBeNull();
+  });
+
+  test("strangers: a NON-denied stranger is still bypassed to the floor", async () => {
+    // Contrast: without a prior deny, the stranger is passed through to the
+    // admission stage (no early ACL deny) under `strangers`.
+    accessRequestDeniedForTest = false;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+        effectiveAdmissionPolicy: "strangers",
+      }),
+    );
+
+    expect(result.earlyResponse).toBeUndefined();
+    expect(result.resolvedMember).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -312,8 +312,28 @@ export async function enforceIngressAcl(
       //    self-verify challenge is a default-onboarding behavior change left
       //    for a separate §8.2 decision.
       // Runs AFTER invite intercepts so valid tokens redeem first.
+      //
+      // Terminal-deny gate: a sender the guardian has explicitly denied must
+      // not be re-admitted by a permissive floor. Computed BEFORE the bypass
+      // so a denied stranger is not passed through to the admission stage —
+      // under `strangers` (floor 1) any sender clears the floor, which would
+      // turn the guardian's deny into access. Mirrors the inactive-member gate
+      // and covers the edge case where persisting the denied sender as an
+      // unverified contact failed, so they resurface here as a non-member
+      // rather than an inactive member. Reused below to skip the self-verify
+      // challenge and the canned re-notify.
+      const nonMemberSenderId = canonicalSenderId ?? rawSenderId;
+      const terminallyDenied =
+        !!nonMemberSenderId &&
+        isAccessRequestDenied({
+          canonicalAssistantId,
+          sourceChannel,
+          actorExternalId: nonMemberSenderId,
+        });
+
       if (
         denyNonMember &&
+        !terminallyDenied &&
         (effectiveAdmissionPolicy === "strangers" ||
           effectiveAdmissionPolicy === "guardian_only")
       ) {
@@ -326,19 +346,11 @@ export async function enforceIngressAcl(
           "Ingress ACL: no member record, denying",
         );
 
-        // Terminal deny: if the guardian already rejected this sender, skip all
-        // re-engagement (self-verify challenge + guardian notify) and deliver
-        // only the canned reply. Otherwise a denied sender whose first
-        // verification session expired would be handed a fresh, unusable
-        // challenge the guardian was never told about.
-        const nonMemberSenderId = canonicalSenderId ?? rawSenderId;
-        const terminallyDenied =
-          !!nonMemberSenderId &&
-          isAccessRequestDenied({
-            canonicalAssistantId,
-            sourceChannel,
-            actorExternalId: nonMemberSenderId,
-          });
+        // `terminallyDenied` (computed above) drives the re-engagement skips:
+        // when the guardian already rejected this sender, deliver only the
+        // canned reply — no self-verify challenge, no fresh guardian notify.
+        // Otherwise a denied sender whose first verification session expired
+        // would be handed a new, unusable challenge the guardian never saw.
 
         // Slack-specific: send a verification challenge directly to the
         // user's DM instead of requiring guardian-mediated approval. The
@@ -642,7 +654,25 @@ export async function enforceIngressAcl(
         //   the challenge legitimately upgrades the sender into access.
         // In every case skip the deny gate so the admission stage decides.
         // Runs AFTER invite intercepts so valid tokens redeem first.
-        if (!isBlockedMember && denyInactiveMember) {
+        // Terminal-deny gate: a sender the guardian has explicitly denied must
+        // not be re-admitted by a permissive floor. Computed BEFORE the bypass
+        // so a denied unverified member is not passed through to the admission
+        // stage — on `any_contact` (floor 2) an unverified_contact (rank 2)
+        // would otherwise clear the floor, turning the guardian's deny into
+        // access. Reused below to skip the self-verify challenge. A normal
+        // (non-denied) unverified member is still bypassed and admitted where
+        // the policy allows; only the explicitly-denied are held out.
+        const inactiveSenderId = canonicalSenderId ?? rawSenderId;
+        const terminallyDenied =
+          !isBlockedMember &&
+          !!inactiveSenderId &&
+          isAccessRequestDenied({
+            canonicalAssistantId,
+            sourceChannel,
+            actorExternalId: inactiveSenderId,
+          });
+
+        if (!isBlockedMember && denyInactiveMember && !terminallyDenied) {
           if (
             (effectiveAdmissionPolicy === "strangers" &&
               resolvedMember.status !== "revoked") ||
@@ -664,20 +694,6 @@ export async function enforceIngressAcl(
             },
             "Ingress ACL: member not active, denying",
           );
-
-          // Terminal deny: a sender the guardian already rejected must not be
-          // handed a fresh self-verify challenge on re-contact (the guardian is
-          // no longer notified, so the code would go nowhere). Skip the
-          // challenge and fall through to the canned reply.
-          const inactiveSenderId = canonicalSenderId ?? rawSenderId;
-          const terminallyDenied =
-            !isBlockedMember &&
-            !!inactiveSenderId &&
-            isAccessRequestDenied({
-              canonicalAssistantId,
-              sourceChannel,
-              actorExternalId: inactiveSenderId,
-            });
 
           // Slack-specific: re-verify inactive members via DM challenge
           // (same as non-member path). Blocked members are excluded —

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -23,7 +23,10 @@ import { resolveGuardianName } from "../../../prompts/user-reference.js";
 import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
-import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
+import {
+  isAccessRequestDenied,
+  notifyGuardianOfAccessRequest,
+} from "../../access-request-helper.js";
 import { resolveAnchoredGuardian } from "../../anchored-guardian.js";
 import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
 import {
@@ -323,10 +326,28 @@ export async function enforceIngressAcl(
           "Ingress ACL: no member record, denying",
         );
 
+        // Terminal deny: if the guardian already rejected this sender, skip all
+        // re-engagement (self-verify challenge + guardian notify) and deliver
+        // only the canned reply. Otherwise a denied sender whose first
+        // verification session expired would be handed a fresh, unusable
+        // challenge the guardian was never told about.
+        const nonMemberSenderId = canonicalSenderId ?? rawSenderId;
+        const terminallyDenied =
+          !!nonMemberSenderId &&
+          isAccessRequestDenied({
+            canonicalAssistantId,
+            sourceChannel,
+            actorExternalId: nonMemberSenderId,
+          });
+
         // Slack-specific: send a verification challenge directly to the
         // user's DM instead of requiring guardian-mediated approval. The
         // user can reply with the code in the DM to self-verify.
-        if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+        if (
+          sourceChannel === "slack" &&
+          (canonicalSenderId ?? rawSenderId) &&
+          !terminallyDenied
+        ) {
           const slackVerifyResult = initiateSlackVerificationChallenge({
             sourceChannel,
             senderUserId: (canonicalSenderId ?? rawSenderId)!,
@@ -402,7 +423,11 @@ export async function enforceIngressAcl(
         // pipeline. Unlike Slack, we cannot DM the requester directly — the
         // verification code is delivered to the guardian, who decides whether
         // to share it with the email sender out-of-band.
-        if (sourceChannel === "email" && (canonicalSenderId ?? rawSenderId)) {
+        if (
+          sourceChannel === "email" &&
+          (canonicalSenderId ?? rawSenderId) &&
+          !terminallyDenied
+        ) {
           const emailVerifyResult = initiateEmailVerificationChallenge({
             sourceChannel,
             senderUserId: (canonicalSenderId ?? rawSenderId)!,
@@ -640,13 +665,28 @@ export async function enforceIngressAcl(
             "Ingress ACL: member not active, denying",
           );
 
+          // Terminal deny: a sender the guardian already rejected must not be
+          // handed a fresh self-verify challenge on re-contact (the guardian is
+          // no longer notified, so the code would go nowhere). Skip the
+          // challenge and fall through to the canned reply.
+          const inactiveSenderId = canonicalSenderId ?? rawSenderId;
+          const terminallyDenied =
+            !isBlockedMember &&
+            !!inactiveSenderId &&
+            isAccessRequestDenied({
+              canonicalAssistantId,
+              sourceChannel,
+              actorExternalId: inactiveSenderId,
+            });
+
           // Slack-specific: re-verify inactive members via DM challenge
           // (same as non-member path). Blocked members are excluded —
           // the guardian made an explicit decision to block them.
           if (
             sourceChannel === "slack" &&
             resolvedMember.status !== "blocked" &&
-            (canonicalSenderId ?? rawSenderId)
+            (canonicalSenderId ?? rawSenderId) &&
+            !terminallyDenied
           ) {
             const slackVerifyResult = initiateSlackVerificationChallenge({
               sourceChannel,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -312,28 +312,8 @@ export async function enforceIngressAcl(
       //    self-verify challenge is a default-onboarding behavior change left
       //    for a separate §8.2 decision.
       // Runs AFTER invite intercepts so valid tokens redeem first.
-      //
-      // Terminal-deny gate: a sender the guardian has explicitly denied must
-      // not be re-admitted by a permissive floor. Computed BEFORE the bypass
-      // so a denied stranger is not passed through to the admission stage —
-      // under `strangers` (floor 1) any sender clears the floor, which would
-      // turn the guardian's deny into access. Mirrors the inactive-member gate
-      // and covers the edge case where persisting the denied sender as an
-      // unverified contact failed, so they resurface here as a non-member
-      // rather than an inactive member. Reused below to skip the self-verify
-      // challenge and the canned re-notify.
-      const nonMemberSenderId = canonicalSenderId ?? rawSenderId;
-      const terminallyDenied =
-        !!nonMemberSenderId &&
-        isAccessRequestDenied({
-          canonicalAssistantId,
-          sourceChannel,
-          actorExternalId: nonMemberSenderId,
-        });
-
       if (
         denyNonMember &&
-        !terminallyDenied &&
         (effectiveAdmissionPolicy === "strangers" ||
           effectiveAdmissionPolicy === "guardian_only")
       ) {
@@ -346,11 +326,19 @@ export async function enforceIngressAcl(
           "Ingress ACL: no member record, denying",
         );
 
-        // `terminallyDenied` (computed above) drives the re-engagement skips:
-        // when the guardian already rejected this sender, deliver only the
-        // canned reply — no self-verify challenge, no fresh guardian notify.
-        // Otherwise a denied sender whose first verification session expired
-        // would be handed a new, unusable challenge the guardian never saw.
+        // Terminal deny: if the guardian already rejected this sender, skip all
+        // re-engagement (self-verify challenge + guardian notify) and deliver
+        // only the canned reply. Otherwise a denied sender whose first
+        // verification session expired would be handed a fresh, unusable
+        // challenge the guardian was never told about.
+        const nonMemberSenderId = canonicalSenderId ?? rawSenderId;
+        const terminallyDenied =
+          !!nonMemberSenderId &&
+          isAccessRequestDenied({
+            canonicalAssistantId,
+            sourceChannel,
+            actorExternalId: nonMemberSenderId,
+          });
 
         // Slack-specific: send a verification challenge directly to the
         // user's DM instead of requiring guardian-mediated approval. The
@@ -654,25 +642,13 @@ export async function enforceIngressAcl(
         //   the challenge legitimately upgrades the sender into access.
         // In every case skip the deny gate so the admission stage decides.
         // Runs AFTER invite intercepts so valid tokens redeem first.
-        // Terminal-deny gate: a sender the guardian has explicitly denied must
-        // not be re-admitted by a permissive floor. Computed BEFORE the bypass
-        // so a denied unverified member is not passed through to the admission
-        // stage — on `any_contact` (floor 2) an unverified_contact (rank 2)
-        // would otherwise clear the floor, turning the guardian's deny into
-        // access. Reused below to skip the self-verify challenge. A normal
-        // (non-denied) unverified member is still bypassed and admitted where
-        // the policy allows; only the explicitly-denied are held out.
-        const inactiveSenderId = canonicalSenderId ?? rawSenderId;
-        const terminallyDenied =
-          !isBlockedMember &&
-          !!inactiveSenderId &&
-          isAccessRequestDenied({
-            canonicalAssistantId,
-            sourceChannel,
-            actorExternalId: inactiveSenderId,
-          });
-
-        if (!isBlockedMember && denyInactiveMember && !terminallyDenied) {
+        //
+        // A guardian-denied sender is persisted as an unverified contact and is
+        // admitted here on the same rank-vs-floor terms as any other unverified
+        // contact (admitted under `any_contact`/`strangers`, denied under
+        // stricter floors). The deny suppresses re-prompting, not admission;
+        // holding a denied contact out of every floor is the block action's job.
+        if (!isBlockedMember && denyInactiveMember) {
           if (
             (effectiveAdmissionPolicy === "strangers" &&
               resolvedMember.status !== "revoked") ||
@@ -694,6 +670,20 @@ export async function enforceIngressAcl(
             },
             "Ingress ACL: member not active, denying",
           );
+
+          // Terminal deny: a sender the guardian already rejected must not be
+          // handed a fresh self-verify challenge on re-contact (the guardian is
+          // no longer notified, so the code would go nowhere). Skip the
+          // challenge and fall through to the canned reply.
+          const inactiveSenderId = canonicalSenderId ?? rawSenderId;
+          const terminallyDenied =
+            !isBlockedMember &&
+            !!inactiveSenderId &&
+            isAccessRequestDenied({
+              canonicalAssistantId,
+              sourceChannel,
+              actorExternalId: inactiveSenderId,
+            });
 
           // Slack-specific: re-verify inactive members via DM challenge
           // (same as non-member path). Blocked members are excluded —

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -409,6 +409,10 @@ describe("IPC contact routes", () => {
     expect(channels[0].type).toBe("email");
     expect(channels[0].address).toBe("new@example.com");
     expect(channels[0].isPrimary).toBe(true);
+    // A freshly created channel lands at the unverified admission tier: this is
+    // what makes a guardian-denied sender resolve as `unverified_contact` (not
+    // trusted, not an unknown stranger) on subsequent inbound.
+    expect(channels[0].status).toBe("unverified");
   });
 
   test("create_contact returns { contactId, channelId } both present and non-empty", async () => {
@@ -669,7 +673,8 @@ describe("IPC contact routes", () => {
 
     // The assistant-DB contact UPDATE must NOT touch display_name.
     const contactUpdate = runCalls.find(
-      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+      (c) =>
+        c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
     );
     expect(contactUpdate).toBeDefined();
     expect(contactUpdate!.sql).not.toContain("display_name");
@@ -728,13 +733,12 @@ describe("IPC contact routes", () => {
 
     // The assistant contact UPDATE targets the provided id, never "other-contact".
     const contactUpdate = runCalls.find(
-      (c) => c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+      (c) =>
+        c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
     );
     expect(contactUpdate).toBeDefined();
     expect(contactUpdate!.bind?.at(-1)).toBe("edit-me");
-    expect(
-      runCalls.some((c) => c.bind?.includes("other-contact")),
-    ).toBe(false);
+    expect(runCalls.some((c) => c.bind?.includes("other-contact"))).toBe(false);
   });
 
   test("upsertContact read-back sources ACL from the gateway DB, not assistant defaults", async () => {
@@ -759,9 +763,7 @@ describe("IPC contact routes", () => {
     const store = new ContactStore(db);
     const { contact } = await store.upsertContact({
       id: "guard-1",
-      channels: [
-        { type: "email", address: "g@example.com", status: "active" },
-      ],
+      channels: [{ type: "email", address: "g@example.com", status: "active" }],
     });
 
     expect(contact.role).toBe("guardian");


### PR DESCRIPTION
Fixes [LUM-2656](https://linear.app/vellum/issue/LUM-2656/denying-a-contact-verification-prompt-should-persist-unverified).

## Prompt / plan

When an unknown sender (e.g. a bot) DMs the assistant, the guardian gets an access/verification prompt. If the guardian **denies**, the sender should become a persisted `unverified_contact` — known but not verified — and should **not** re-trigger the prompt on subsequent DMs.

**Root cause (confirmed):** the `access_request` deny path in `guardian-request-resolvers.ts` delivered denial notifications/lifecycle signals but **persisted nothing**. The sender stayed `unknown`, so every subsequent DM created a fresh access request and re-prompted the guardian.

The fix has two complementary parts, matching the issue's Investigation TODO ("fix it so [deny] persists `unverified_contact` … and ensure the prompt is suppressed for `unverified_contact` on inbound"):

**1. Deny persists `unverified_contact` (gateway-first).** The `accessRequestResolver` deny path now seeds the sender via a new `seedUnverifiedMemberChannel` relay (`assistant/src/contacts/member-write-relay.ts`) → gateway `create_contact` IPC → `ContactStore.upsertContact`. A brand-new channel lands at status `unverified` (→ trust class `unverified_contact`, per `resolveTrustVerdict` / `actor-trust-resolver.ts`); an existing channel's status is **preserved**, so a blocked / revoked / active row is never reactivated or downgraded. Best-effort: a failed relay is logged and swallowed so it can never fail the guardian's deny. Skipped for desktop-origin (`vellum`) requests, which carry no channel identity.

**2. Suppress re-prompting after a terminal deny.** `notifyGuardianOfAccessRequest` (`assistant/src/runtime/access-request-helper.ts`) now skips creating a new prompt when a terminally-`denied` `access_request` already exists for the same sender/channel/assistant (scoped by the same assistant-scoped `conversationId` as the existing pending-dedup). Callers already treat `notified: false` as "deliver the plain canned reply" and (voice) "fail closed", so a previously-denied sender is denied without re-notifying the guardian.

Behavior preserved:
- `unverified_contact` remains admission-only — it is treated identically to `trusted_contact` for every downstream capability/tool/approval decision (`capabilities.ts`). Under permissive admission floors (`any_contact`, `strangers`) the persisted sender is now admitted at the unverified tier; under stricter floors they are denied but no longer re-prompt.
- The guardian can still **manually** verify the contact later — that path (`mark_channel_verified` / control plane) does not run through `notifyGuardianOfAccessRequest`, and once verified the sender is `trusted_contact` (no access-request path at all).
- A deny for one sender/channel does not suppress prompts for other senders or other channels.

## Test plan

- **New unit tests** — `seedUnverifiedMemberChannel` relays to `create_contact` with `channelType`/`address`/`displayName`, omits `displayName` when absent, and swallows gateway errors (best-effort). `assistant/src/contacts/__tests__/member-write-relay.test.ts` → **9 pass**.
- **New behavioral tests** — after a prior `denied` `access_request`, `notifyGuardianOfAccessRequest` returns `{ notified: false, reason: "already_denied" }` with no new signal/pending request; a different sender still gets a fresh prompt; a denial on one channel does not suppress another channel. `assistant/src/__tests__/non-member-access-request.test.ts` → **21 pass**.
- **Regression** — ran individually (green): `trusted-contact-lifecycle-notifications` (deny path), `acl-enforcement`, `admission-policy`, `trusted-contact-multichannel`, `trusted-contact-inline-approval-integration`, `slack-inbound-verification`, `canonical-guardian-store`, `trusted-contact-verification`.
- `bunx prettier`, `eslint`, and the pre-commit type-check all pass on the changed files.

<sub>Note: 4 failures seen only when running a large batch of these files in one `bun test` invocation reproduce identically on `main` (a pre-existing cross-file `mock.module` isolation artifact); all pass when run per-file.</sub>

## CLI verb checklist

N/A — no new IPC route under `assistant/src/runtime/routes/`. The deny path reuses the existing gateway `create_contact` IPC via a daemon-side relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT3W9EuWZaRgcCaro6kuV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FT3W9EuWZaRgcCaro6kuV1)_