### PR TITLE
feat(assistant): add non-guardian privacy guardrail to users/default.md

### DIFF
--- a/assistant/src/__tests__/workspace-migration-121-seed-default-user-guardrails.test.ts
+++ b/assistant/src/__tests__/workspace-migration-121-seed-default-user-guardrails.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for workspace migration `121-seed-default-user-guardrails`.
+ *
+ * The migration backfills `users/default.md` (the persona rendered for
+ * non-guardian actors) with the privacy guardrail. Unlike a plain create-only
+ * seed, it also writes over an *empty* file: existing installs seeded an empty
+ * `default.md` before the guardrail existed, so blank is the "unmodified"
+ * signal we must overwrite. Any real content means the guardian customized the
+ * file, so it is left untouched.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedDefaultUserGuardrailsMigration } from "../workspace/migrations/121-seed-default-user-guardrails.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-121-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function defaultPath(): string {
+  return join(workspaceDir, "users", "default.md");
+}
+
+function readDefault(): string {
+  return readFileSync(defaultPath(), "utf-8");
+}
+
+describe("121-seed-default-user-guardrails migration", () => {
+  test("has correct id and description", () => {
+    expect(seedDefaultUserGuardrailsMigration.id).toBe(
+      "121-seed-default-user-guardrails",
+    );
+    expect(seedDefaultUserGuardrailsMigration.description).toContain(
+      "default.md",
+    );
+  });
+
+  test("creates users/default.md with the guardrail when absent", () => {
+    expect(existsSync(defaultPath())).toBe(false);
+
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+
+    expect(existsSync(defaultPath())).toBe(true);
+    const content = readDefault();
+    // Guardrail body + the trust-class mustache gates the renderer resolves.
+    expect(content).toContain("Protect your guardian's privacy");
+    expect(content).toContain("{{^isGuardian}}");
+    expect(content).toContain("{{#isTrustedContact}}");
+    expect(content).toContain("{{#isStranger}}");
+  });
+
+  test("backfills an existing EMPTY default.md (the existing-install case)", () => {
+    // Older installs seeded a one-byte (newline) default.md.
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), "\n", "utf-8");
+
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+
+    expect(readDefault()).toContain("Protect your guardian's privacy");
+  });
+
+  test("backfills a whitespace-only default.md", () => {
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), "   \n\t\n", "utf-8");
+
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+
+    expect(readDefault()).toContain("Protect your guardian's privacy");
+  });
+
+  test("does not clobber a customized default.md", () => {
+    const existing = "# My contacts\n\nBe extra chatty with everyone.\n";
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), existing, "utf-8");
+
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+
+    expect(readDefault()).toBe(existing);
+  });
+
+  test("idempotent — second run does not rewrite the seeded file", () => {
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    const afterFirst = readDefault();
+
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    const afterSecond = readDefault();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("down() is a no-op — seeded file remains", () => {
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    const seeded = readDefault();
+
+    seedDefaultUserGuardrailsMigration.down(workspaceDir);
+
+    expect(existsSync(defaultPath())).toBe(true);
+    expect(readDefault()).toBe(seeded);
+  });
+});

--- a/assistant/src/plugins/defaults/turn-context/unified-turn-context.ts
+++ b/assistant/src/plugins/defaults/turn-context/unified-turn-context.ts
@@ -191,8 +191,9 @@ export function buildUnifiedTurnContextBlock(
     // from tone, don't self-approve, don't explain the verification system).
     // Its complement — the data-disclosure boundary (never reveal the guardian's
     // private data: schedule, contacts, files, memories) — lives in the
-    // `users/default.md` persona guardrail, gated by the trust booleans in
-    // `prompts/system-prompt.ts`. Keep the two distinct.
+    // `users/default.md` persona guardrail, gated by
+    // `derivePersonaTrustFlags()` in `runtime/trust-class.ts`. Keep the two
+    // distinct.
     switch (resolveCapabilities(ctx.trustClass).promptTrustGuidance) {
       case "social-engineering-defense": {
         lines.push("");

--- a/assistant/src/plugins/defaults/turn-context/unified-turn-context.ts
+++ b/assistant/src/plugins/defaults/turn-context/unified-turn-context.ts
@@ -186,6 +186,13 @@ export function buildUnifiedTurnContextBlock(
 
     // Behavioral guidance - only for non-guardian actors where social
     // engineering defense matters. Guardian case needs no instruction.
+    //
+    // Scope: this is identity/verification hygiene (don't infer guardian status
+    // from tone, don't self-approve, don't explain the verification system).
+    // Its complement — the data-disclosure boundary (never reveal the guardian's
+    // private data: schedule, contacts, files, memories) — lives in the
+    // `users/default.md` persona guardrail, gated by the trust booleans in
+    // `prompts/system-prompt.ts`. Keep the two distinct.
     switch (resolveCapabilities(ctx.trustClass).promptTrustGuidance) {
       case "social-engineering-defense": {
         lines.push("");

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -197,14 +197,39 @@ describe("buildSystemPrompt — default persona trust-class guardrail", () => {
   });
 
   test("renders for a non-guardian even when HTTP auth is disabled", () => {
-    // Platform-managed deployments run with DISABLE_HTTP_AUTH=true, under which
-    // resolveTrustClass() collapses every actor to "guardian". The guardrail
-    // must gate on the actor's real trust class instead, or it would silently
-    // switch off for the non-guardian channel actors it exists to protect.
+    // Platform-managed deployments run with DISABLE_HTTP_AUTH=true. A *present*
+    // trustContext must keep the actor's real class under that posture
+    // (resolveTrustClass only fail-safes *unresolved* actors), or the guardrail
+    // would silently switch off for the non-guardian channel actors it exists
+    // to protect.
     process.env.DISABLE_HTTP_AUTH = "true";
     const result = buildSystemPrompt({
       trustContext: { sourceChannel: "slack", trustClass: "unknown" },
     });
+
+    expect(result).toContain(GUARDRAIL);
+    expect(result).toContain(STRANGER_GREETING);
+  });
+
+  test("gates off for an unresolved local build when HTTP auth is disabled", () => {
+    // Initial-prompt warming, home generation, and btw sidechains build
+    // prompts with NO trustContext on behalf of the owner. In an auth-disabled
+    // (local / platform-managed) deployment that unresolved actor is the
+    // guardian, so the guardrail must not render into those guardian-facing
+    // prompts (fail-stranger would stonewall the owner about their own data).
+    process.env.DISABLE_HTTP_AUTH = "true";
+    const result = buildSystemPrompt({});
+
+    expect(result).not.toContain(GUARDRAIL);
+    expect(result).not.toContain(TRUSTED_GREETING);
+    expect(result).not.toContain(STRANGER_GREETING);
+  });
+
+  test("fails closed to the guardrail for an unresolved build when auth is enabled", () => {
+    // With auth enabled there is no basis to assume the unresolved actor is
+    // the guardian, so an unclassifiable build keeps the boundary.
+    delete process.env.DISABLE_HTTP_AUTH;
+    const result = buildSystemPrompt({});
 
     expect(result).toContain(GUARDRAIL);
     expect(result).toContain(STRANGER_GREETING);

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -8,7 +8,7 @@
 
 import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
@@ -122,6 +122,96 @@ describe("buildSystemPrompt — persona override", () => {
     });
 
     expect(result).toContain(DEFAULT_SENTINEL);
+  });
+});
+
+describe("buildSystemPrompt — default persona trust-class guardrail", () => {
+  // Marker strings from the bundled users/default.md template.
+  const GUARDRAIL = "Protect your guardian's privacy";
+  const TRUSTED_GREETING = "You're talking with a trusted contact";
+  const STRANGER_GREETING = "You're talking with someone you don't recognize";
+
+  const templatesDir = join(import.meta.dirname!, "..", "templates");
+  let priorAuthEnv: string | undefined;
+
+  beforeEach(() => {
+    // resolveTrustClass short-circuits to "guardian" when HTTP auth is
+    // disabled; pin it off so the passed trust context drives the render.
+    priorAuthEnv = process.env.DISABLE_HTTP_AUTH;
+    process.env.DISABLE_HTTP_AUTH = "false";
+
+    mkdirSync(join(TEST_DIR, "users"), { recursive: true });
+    // Render the real shipped template, not a sentinel.
+    copyFileSync(
+      join(templatesDir, "users", "default.md"),
+      join(TEST_DIR, "users", "default.md"),
+    );
+  });
+
+  afterEach(() => {
+    if (priorAuthEnv === undefined) delete process.env.DISABLE_HTTP_AUTH;
+    else process.env.DISABLE_HTTP_AUTH = priorAuthEnv;
+  });
+
+  test("stranger (unknown) sees the guardrail and the stranger greeting", () => {
+    const result = buildSystemPrompt({
+      trustContext: { sourceChannel: "slack", trustClass: "unknown" },
+    });
+
+    expect(result).toContain(GUARDRAIL);
+    expect(result).toContain(STRANGER_GREETING);
+    expect(result).not.toContain(TRUSTED_GREETING);
+  });
+
+  test("trusted contact sees the guardrail and the trusted greeting", () => {
+    const result = buildSystemPrompt({
+      trustContext: { sourceChannel: "slack", trustClass: "trusted_contact" },
+    });
+
+    expect(result).toContain(GUARDRAIL);
+    expect(result).toContain(TRUSTED_GREETING);
+    expect(result).not.toContain(STRANGER_GREETING);
+  });
+
+  test("unverified contact is framed like a trusted contact", () => {
+    const result = buildSystemPrompt({
+      trustContext: {
+        sourceChannel: "slack",
+        trustClass: "unverified_contact",
+      },
+    });
+
+    expect(result).toContain(GUARDRAIL);
+    expect(result).toContain(TRUSTED_GREETING);
+    expect(result).not.toContain(STRANGER_GREETING);
+  });
+
+  test("guardian trust class gates the whole default persona off", () => {
+    // A guardian normally renders their own users/<slug>.md; if they ever fall
+    // back to default.md, every section is gated off and nothing leaks.
+    const result = buildSystemPrompt({
+      trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+    });
+
+    expect(result).not.toContain(GUARDRAIL);
+    expect(result).not.toContain(TRUSTED_GREETING);
+    expect(result).not.toContain(STRANGER_GREETING);
+  });
+
+  test("never leaks literal mustache tags or comment lines", () => {
+    for (const trustClass of [
+      "unknown",
+      "trusted_contact",
+      "unverified_contact",
+      "guardian",
+    ] as const) {
+      const result = buildSystemPrompt({
+        trustContext: { sourceChannel: "slack", trustClass },
+      });
+      expect(result).not.toContain("{{");
+      expect(result).not.toContain("}}");
+      expect(result).not.toContain("Lines starting with");
+    }
   });
 });
 

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -135,10 +135,8 @@ describe("buildSystemPrompt — default persona trust-class guardrail", () => {
   let priorAuthEnv: string | undefined;
 
   beforeEach(() => {
-    // resolveTrustClass short-circuits to "guardian" when HTTP auth is
-    // disabled; pin it off so the passed trust context drives the render.
+    // Captured so the DISABLE_HTTP_AUTH regression test below can restore it.
     priorAuthEnv = process.env.DISABLE_HTTP_AUTH;
-    process.env.DISABLE_HTTP_AUTH = "false";
 
     mkdirSync(join(TEST_DIR, "users"), { recursive: true });
     // Render the real shipped template, not a sentinel.
@@ -196,6 +194,20 @@ describe("buildSystemPrompt — default persona trust-class guardrail", () => {
     expect(result).not.toContain(GUARDRAIL);
     expect(result).not.toContain(TRUSTED_GREETING);
     expect(result).not.toContain(STRANGER_GREETING);
+  });
+
+  test("renders for a non-guardian even when HTTP auth is disabled", () => {
+    // Platform-managed deployments run with DISABLE_HTTP_AUTH=true, under which
+    // resolveTrustClass() collapses every actor to "guardian". The guardrail
+    // must gate on the actor's real trust class instead, or it would silently
+    // switch off for the non-guardian channel actors it exists to protect.
+    process.env.DISABLE_HTTP_AUTH = "true";
+    const result = buildSystemPrompt({
+      trustContext: { sourceChannel: "slack", trustClass: "unknown" },
+    });
+
+    expect(result).toContain(GUARDRAIL);
+    expect(result).toContain(STRANGER_GREETING);
   });
 
   test("never leaks literal mustache tags or comment lines", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
-import type { TrustContext } from "../daemon/trust-context.js";
+import {
+  resolveTrustClass,
+  type TrustContext,
+} from "../daemon/trust-context.js";
 import { markActivationSession } from "../plugins/defaults/memory/activation-session-store.js";
 import { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } from "../telemetry/activation-funnel.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
@@ -393,6 +396,23 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const hasNoClient =
     options?.personaOverride?.hasNoClient ?? options?.hasNoClient;
 
+  // Trust class of the current actor, lifted onto the render context so
+  // persona sections — notably `users/default.md`, the persona rendered for
+  // non-guardian actors — can gate privacy guardrails on who is being spoken
+  // to. `resolveTrustClass` applies the dev-bypass (HTTP auth disabled →
+  // guardian) and the fail-closed default (no trust context → unknown)
+  // uniformly, matching the semantics every other trust gate uses. The
+  // booleans are precomputed because the mustache renderer only does truthy
+  // gating, not string comparison.
+  const trustClass = resolveTrustClass(options?.trustContext);
+  const isGuardian = trustClass === "guardian";
+  // `unverified_contact` is treated identically to `trusted_contact` for every
+  // downstream capability decision (see TrustClass docs), so persona-level
+  // framing groups them too.
+  const isTrustedContact =
+    trustClass === "trusted_contact" || trustClass === "unverified_contact";
+  const isStranger = trustClass === "unknown";
+
   // Section render context.  Workspace section frontmatter `enabled:`
   // predicates, `{{key}}` / `{{#flag}}...{{/flag}}` body interpolation,
   // and `{{key}}` paths inside `workspacePath` all resolve against this
@@ -409,6 +429,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     workspaceDir: getWorkspaceDir(),
     userSlug,
     channelSlug,
+    trustClass,
+    isGuardian,
+    isTrustedContact,
+    isStranger,
   };
 
   // Every system-prompt block flows through the bundled section

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -397,14 +397,23 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // persona sections — notably `users/default.md`, the persona rendered for
   // non-guardian actors — can gate privacy guardrails on who is being spoken
   // to. This reads the actor's resolved class straight off the turn's
-  // `trustContext` (fail-closed to `unknown` when absent) rather than
-  // `resolveTrustClass`: that helper collapses to `guardian` whenever
-  // `DISABLE_HTTP_AUTH` is set, which is the standing config for
-  // platform-managed deployments. Using it here would flip `isGuardian` true
-  // for genuine non-guardian channel actors and silently disable the privacy
-  // guardrail in exactly the cloud/Slack scenario it exists to cover. The
-  // booleans are precomputed because the mustache renderer only does truthy
-  // gating, not string comparison.
+  // `trustContext`, defaulting to `unknown` (stranger) when absent, rather than
+  // routing through `resolveTrustClass`. For a *resolved* actor the two agree;
+  // they diverge only on an unresolved turn under the platform auth-bypass,
+  // where `resolveTrustClass` fail-safes to `guardian` so control-plane
+  // capability gates don't block a local/dev turn. A data-disclosure guardrail
+  // needs the opposite default — fail *closed* to `stranger`, so a turn that
+  // never resolved an actor still gets the boundary instead of a guardian
+  // exemption — which is exactly what reading the raw class gives.
+  //
+  // Scope: these booleans gate the *data-disclosure* boundary (never reveal the
+  // guardian's private data) in `users/default.md`. Its complement — the
+  // *identity/verification hygiene* guidance (don't infer guardian status from
+  // tone, don't self-approve, don't explain the verification system) — is the
+  // `promptTrustGuidance` switch in
+  // `plugins/defaults/turn-context/unified-turn-context.ts`; keep the two
+  // distinct. The booleans are precomputed because the mustache renderer only
+  // does truthy gating, not string comparison.
   const trustClass = options?.trustContext?.trustClass ?? "unknown";
   const isGuardian = trustClass === "guardian";
   // `unverified_contact` is treated identically to `trusted_contact` for every

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -10,10 +10,7 @@ import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
-import {
-  resolveTrustClass,
-  type TrustContext,
-} from "../daemon/trust-context.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { markActivationSession } from "../plugins/defaults/memory/activation-session-store.js";
 import { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } from "../telemetry/activation-funnel.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
@@ -399,12 +396,16 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // Trust class of the current actor, lifted onto the render context so
   // persona sections — notably `users/default.md`, the persona rendered for
   // non-guardian actors — can gate privacy guardrails on who is being spoken
-  // to. `resolveTrustClass` applies the dev-bypass (HTTP auth disabled →
-  // guardian) and the fail-closed default (no trust context → unknown)
-  // uniformly, matching the semantics every other trust gate uses. The
+  // to. This reads the actor's resolved class straight off the turn's
+  // `trustContext` (fail-closed to `unknown` when absent) rather than
+  // `resolveTrustClass`: that helper collapses to `guardian` whenever
+  // `DISABLE_HTTP_AUTH` is set, which is the standing config for
+  // platform-managed deployments. Using it here would flip `isGuardian` true
+  // for genuine non-guardian channel actors and silently disable the privacy
+  // guardrail in exactly the cloud/Slack scenario it exists to cover. The
   // booleans are precomputed because the mustache renderer only does truthy
   // gating, not string comparison.
-  const trustClass = resolveTrustClass(options?.trustContext);
+  const trustClass = options?.trustContext?.trustClass ?? "unknown";
   const isGuardian = trustClass === "guardian";
   // `unverified_contact` is treated identically to `trusted_contact` for every
   // downstream capability decision (see TrustClass docs), so persona-level

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -12,6 +12,7 @@ import { getIsContainerized } from "../config/env-registry.js";
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { markActivationSession } from "../plugins/defaults/memory/activation-session-store.js";
+import { derivePersonaTrustFlags } from "../runtime/trust-class.js";
 import { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } from "../telemetry/activation-funnel.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
@@ -393,35 +394,14 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const hasNoClient =
     options?.personaOverride?.hasNoClient ?? options?.hasNoClient;
 
-  // Trust class of the current actor, lifted onto the render context so
+  // Trust flags for the current actor, lifted onto the render context so
   // persona sections — notably `users/default.md`, the persona rendered for
   // non-guardian actors — can gate privacy guardrails on who is being spoken
-  // to. This reads the actor's resolved class straight off the turn's
-  // `trustContext`, defaulting to `unknown` (stranger) when absent, rather than
-  // routing through `resolveTrustClass`. For a *resolved* actor the two agree;
-  // they diverge only on an unresolved turn under the platform auth-bypass,
-  // where `resolveTrustClass` fail-safes to `guardian` so control-plane
-  // capability gates don't block a local/dev turn. A data-disclosure guardrail
-  // needs the opposite default — fail *closed* to `stranger`, so a turn that
-  // never resolved an actor still gets the boundary instead of a guardian
-  // exemption — which is exactly what reading the raw class gives.
-  //
-  // Scope: these booleans gate the *data-disclosure* boundary (never reveal the
-  // guardian's private data) in `users/default.md`. Its complement — the
-  // *identity/verification hygiene* guidance (don't infer guardian status from
-  // tone, don't self-approve, don't explain the verification system) — is the
-  // `promptTrustGuidance` switch in
-  // `plugins/defaults/turn-context/unified-turn-context.ts`; keep the two
-  // distinct. The booleans are precomputed because the mustache renderer only
-  // does truthy gating, not string comparison.
-  const trustClass = options?.trustContext?.trustClass ?? "unknown";
-  const isGuardian = trustClass === "guardian";
-  // `unverified_contact` is treated identically to `trusted_contact` for every
-  // downstream capability decision (see TrustClass docs), so persona-level
-  // framing groups them too.
-  const isTrustedContact =
-    trustClass === "trusted_contact" || trustClass === "unverified_contact";
-  const isStranger = trustClass === "unknown";
+  // to. All classification policy (the fail-closed-to-stranger default for
+  // unresolved actors, the trusted/unverified grouping, why this is not
+  // `resolveTrustClass`) lives on {@link derivePersonaTrustFlags}.
+  const { trustClass, isGuardian, isTrustedContact, isStranger } =
+    derivePersonaTrustFlags(options?.trustContext?.trustClass);
 
   // Section render context.  Workspace section frontmatter `enabled:`
   // predicates, `{{key}}` / `{{#flag}}...{{/flag}}` body interpolation,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
-import type { TrustContext } from "../daemon/trust-context.js";
+import {
+  resolveTrustClass,
+  type TrustContext,
+} from "../daemon/trust-context.js";
 import { markActivationSession } from "../plugins/defaults/memory/activation-session-store.js";
 import { derivePersonaTrustFlags } from "../runtime/trust-class.js";
 import { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } from "../telemetry/activation-funnel.js";
@@ -397,11 +400,17 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // Trust flags for the current actor, lifted onto the render context so
   // persona sections — notably `users/default.md`, the persona rendered for
   // non-guardian actors — can gate privacy guardrails on who is being spoken
-  // to. All classification policy (the fail-closed-to-stranger default for
-  // unresolved actors, the trusted/unverified grouping, why this is not
-  // `resolveTrustClass`) lives on {@link derivePersonaTrustFlags}.
+  // to. The class is resolved through `resolveTrustClass` first: a *present*
+  // trustContext always keeps the actor's real class (a resolved non-guardian
+  // channel actor is never elevated, even under DISABLE_HTTP_AUTH), while an
+  // *absent* one follows the actor-resolution contract — guardian for
+  // local/native builds in an auth-disabled deployment (initial-prompt
+  // warming, home generation, and btw sidechains build prompts with no
+  // trustContext for the owner), unknown otherwise so an unclassifiable turn
+  // still fails closed to the guardrail. The flag grouping itself lives on
+  // {@link derivePersonaTrustFlags}.
   const { trustClass, isGuardian, isTrustedContact, isStranger } =
-    derivePersonaTrustFlags(options?.trustContext?.trustClass);
+    derivePersonaTrustFlags(resolveTrustClass(options?.trustContext));
 
   // Section render context.  Workspace section frontmatter `enabled:`
   // predicates, `{{key}}` / `{{#flag}}...{{/flag}}` body interpolation,

--- a/assistant/src/runtime/trust-class.test.ts
+++ b/assistant/src/runtime/trust-class.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { resolveCapabilities } from "./capabilities.js";
+import {
+  derivePersonaTrustFlags,
+  type PersonaTrustFlags,
+  trustClassSchema,
+} from "./trust-class.js";
+
+describe("derivePersonaTrustFlags", () => {
+  test("guardian derives the guardian flag only", () => {
+    expect(derivePersonaTrustFlags("guardian")).toEqual({
+      trustClass: "guardian",
+      isGuardian: true,
+      isTrustedContact: false,
+      isStranger: false,
+    });
+  });
+
+  test("trusted_contact and unverified_contact derive identical contact flags", () => {
+    // The admission-only equivalence documented on trustClassSchema: the two
+    // classes must never drift apart at the persona layer.
+    const expected: PersonaTrustFlags = {
+      trustClass: "trusted_contact",
+      isGuardian: false,
+      isTrustedContact: true,
+      isStranger: false,
+    };
+    expect(derivePersonaTrustFlags("trusted_contact")).toEqual(expected);
+    expect(derivePersonaTrustFlags("unverified_contact")).toEqual({
+      ...expected,
+      trustClass: "unverified_contact",
+    });
+  });
+
+  test("unknown derives the stranger flag only", () => {
+    expect(derivePersonaTrustFlags("unknown")).toEqual({
+      trustClass: "unknown",
+      isGuardian: false,
+      isTrustedContact: false,
+      isStranger: true,
+    });
+  });
+
+  test("an unresolved actor (undefined) fails closed to stranger", () => {
+    // Disclosure gating must default to the guardrail, never to a guardian
+    // exemption, when no actor was resolved for the turn.
+    expect(derivePersonaTrustFlags(undefined)).toEqual({
+      trustClass: "unknown",
+      isGuardian: false,
+      isTrustedContact: false,
+      isStranger: true,
+    });
+  });
+
+  test("exactly one flag is true for every trust class", () => {
+    // Iterates the Zod enum so a newly added class is covered automatically
+    // (the helper itself won't compile until the new class gets a case).
+    for (const trustClass of trustClassSchema.options) {
+      const flags = derivePersonaTrustFlags(trustClass);
+      const trueCount = [
+        flags.isGuardian,
+        flags.isTrustedContact,
+        flags.isStranger,
+      ].filter(Boolean).length;
+      expect(trueCount).toBe(1);
+      expect(flags.trustClass).toBe(trustClass);
+    }
+  });
+
+  describe("independence from the deployment auth posture", () => {
+    const prior = process.env.DISABLE_HTTP_AUTH;
+
+    afterEach(() => {
+      if (prior === undefined) {
+        delete process.env.DISABLE_HTTP_AUTH;
+      } else {
+        process.env.DISABLE_HTTP_AUTH = prior;
+      }
+    });
+
+    test("an unresolved actor stays stranger under DISABLE_HTTP_AUTH", () => {
+      // Deliberate divergence from resolveTrustClass, which fail-safes an
+      // unresolved turn to guardian under the local auth-bypass for
+      // control-plane gates. The disclosure guardrail must instead fail closed
+      // — this test exists so the helper is never "unified" onto that bypass.
+      process.env.DISABLE_HTTP_AUTH = "true";
+      expect(derivePersonaTrustFlags(undefined).isStranger).toBe(true);
+      expect(derivePersonaTrustFlags("trusted_contact").isGuardian).toBe(false);
+    });
+  });
+
+  test("persona partition matches the capability matrix's prompt guidance", () => {
+    // The persona flags and resolveCapabilities().promptTrustGuidance encode
+    // the same three-way partition (guardian / known contact / stranger) in two
+    // homes. Pin them together so persona framing and turn-context guidance
+    // can't drift apart when either table changes.
+    const guidanceByFlag: Record<string, string> = {
+      isGuardian: "none",
+      isTrustedContact: "social-engineering-defense",
+      isStranger: "stranger-warning",
+    };
+    for (const trustClass of trustClassSchema.options) {
+      const flags = derivePersonaTrustFlags(trustClass);
+      const guidance = resolveCapabilities(trustClass).promptTrustGuidance;
+      for (const [flag, expected] of Object.entries(guidanceByFlag)) {
+        if (flags[flag as keyof PersonaTrustFlags]) {
+          expect(guidance).toBe(expected as typeof guidance);
+        }
+      }
+    }
+  });
+});

--- a/assistant/src/runtime/trust-class.ts
+++ b/assistant/src/runtime/trust-class.ts
@@ -31,3 +31,73 @@ export const trustClassSchema = z.enum([
 ]);
 
 export type TrustClass = z.infer<typeof trustClassSchema>;
+
+/**
+ * Persona-facing view of a trust class, precomputed as booleans because the
+ * system-prompt mustache renderer only does truthy section gating, not string
+ * comparison. Exactly one flag is true per class; `trustClass` is the resolved
+ * class the flags were derived from.
+ */
+export interface PersonaTrustFlags {
+  trustClass: TrustClass;
+  isGuardian: boolean;
+  isTrustedContact: boolean;
+  isStranger: boolean;
+}
+
+/**
+ * Derive the persona/prompt-gating flags for an actor's trust class — the one
+ * home for how persona sections (notably `users/default.md`, which carries the
+ * non-guardian privacy guardrail) classify who is being spoken to.
+ *
+ * - An absent class (unresolved actor) derives as `stranger`. This is
+ *   deliberately NOT `resolveTrustClass()`: that helper fail-safes an
+ *   unresolved turn to `guardian` under the local auth-bypass so control-plane
+ *   capability gates don't block local development. A data-disclosure boundary
+ *   needs the opposite default — fail closed, so a turn that never resolved an
+ *   actor still renders the guardrail rather than a guardian exemption.
+ * - `unverified_contact` derives identically to `trusted_contact`, making the
+ *   admission-only equivalence documented on {@link trustClassSchema}
+ *   executable in one place.
+ * - The switch is exhaustive with no default: adding a `TrustClass` member is a
+ *   compile error here, forcing a deliberate persona decision for the new
+ *   class.
+ *
+ * Scope: prompt/persona rendering only — the *data-disclosure* boundary. Its
+ * complement, identity/verification hygiene, is `promptTrustGuidance` in
+ * `resolveCapabilities()` (rendered by
+ * `plugins/defaults/turn-context/unified-turn-context.ts`); capability and tool
+ * gating must keep using `resolveCapabilities()` / `resolveTrustClass()`.
+ */
+export function derivePersonaTrustFlags(
+  trustClass: TrustClass | undefined,
+): PersonaTrustFlags {
+  const resolved: TrustClass = trustClass ?? "unknown";
+  switch (resolved) {
+    case "guardian": {
+      return {
+        trustClass: resolved,
+        isGuardian: true,
+        isTrustedContact: false,
+        isStranger: false,
+      };
+    }
+    case "trusted_contact":
+    case "unverified_contact": {
+      return {
+        trustClass: resolved,
+        isGuardian: false,
+        isTrustedContact: true,
+        isStranger: false,
+      };
+    }
+    case "unknown": {
+      return {
+        trustClass: resolved,
+        isGuardian: false,
+        isTrustedContact: false,
+        isStranger: true,
+      };
+    }
+  }
+}

--- a/assistant/src/workspace/migrations/121-seed-default-user-guardrails.ts
+++ b/assistant/src/workspace/migrations/121-seed-default-user-guardrails.ts
@@ -1,4 +1,16 @@
-_ Lines starting with _ are comments — they won't appear in the system prompt.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Inlined snapshot of the bundled `users/default.md` persona template so this
+// migration is self-contained even if the template later changes or moves.
+// This is the persona rendered for non-guardian actors (Slack and other
+// channel contacts); the mustache gates resolve against the trust class lifted
+// onto the system-prompt render context. The privacy guardrail keeps the
+// assistant from disclosing the guardian's personal information to anyone who
+// is not the guardian.
+const DEFAULT_USER_PERSONA_TEMPLATE = `_ Lines starting with _ are comments — they won't appear in the system prompt.
 _ This file shapes how you behave when the person you're talking to is NOT your guardian:
 _ a trusted contact your guardian has added, or someone you don't recognize. Your guardian
 _ has their own users/<name>.md profile, so editing this file never changes how you treat
@@ -34,3 +46,37 @@ If you're asked for any of this, don't share it. Offer to pass along a message, 
 
 You can still be genuinely helpful — answer general questions, do research, and help with the person's own request — as long as doing so doesn't reveal your guardian's private information. When something is borderline, don't disclose; check with your guardian first.
 {{/isGuardian}}
+`;
+
+export const seedDefaultUserGuardrailsMigration: WorkspaceMigration = {
+  id: "121-seed-default-user-guardrails",
+  description:
+    "Seed users/default.md with the non-guardian privacy guardrail for existing installs",
+
+  down(_workspaceDir: string): void {
+    // No-op: we don't delete or revert user-editable persona files on rollback.
+  },
+
+  run(workspaceDir: string): void {
+    const usersDir = join(workspaceDir, "users");
+    const defaultPath = join(usersDir, "default.md");
+
+    // Existing installs seeded an empty users/default.md before the guardrail
+    // existed. Populate it only when it is absent or blank so we backfill the
+    // guardrail without clobbering any customization the guardian has written.
+    // Fresh installs already receive the guardrail from the bundled template
+    // via ensurePromptFiles() (which runs before workspace migrations), so this
+    // is a no-op there.
+    if (existsSync(defaultPath)) {
+      try {
+        if (readFileSync(defaultPath, "utf-8").trim().length > 0) return;
+      } catch {
+        // Unreadable file: leave it untouched rather than risk overwriting.
+        return;
+      }
+    }
+
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(defaultPath, DEFAULT_USER_PERSONA_TEMPLATE, "utf-8");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -118,6 +118,7 @@ import { normalizeStaleLeanMemoryV3DefaultsMigration } from "./117-normalize-sta
 import { seedNowMdMigration } from "./118-seed-now-md.js";
 import { stripPersistedMemoryV3TuningDefaultsMigration } from "./119-strip-persisted-memory-v3-tuning-defaults.js";
 import { reviseOnboardingThreadsMigration } from "./120-revise-onboarding-threads.js";
+import { seedDefaultUserGuardrailsMigration } from "./121-seed-default-user-guardrails.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -247,4 +248,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedNowMdMigration,
   stripPersistedMemoryV3TuningDefaultsMigration,
   reviseOnboardingThreadsMigration,
+  seedDefaultUserGuardrailsMigration,
 ];


### PR DESCRIPTION
## Why we're doing this

When a non-guardian talks to an assistant through Slack (or any other channel), the assistant can be prompted to hand over personal details about the guardian — their schedule, contacts, location, files, memories. The gateway ACL controls *who* is allowed to talk to the assistant, but once a trusted contact or an unknown sender is in the conversation, there is **no prompt-level boundary** stopping the model from disclosing the guardian's private information. Noa flagged this in the T3 standup (Jul 1): assistants are saying things to trusted contacts that guardians would never want shared.

`users/default.md` — the persona injected whenever no guardian-specific user file matches — is exactly where a non-guardian boundary belongs, and it was **empty**. Git history confirms it has been a 1-byte (blank) file in 100% of commits since it was introduced; the surrounding code always treated it as the intentional non-guardian fallback, but nobody had ever written content into it. This PR fills that gap. It implements [LUM-2655](https://linear.app/vellum/issue/LUM-2655/update-usersdefaultmd-to-prevent-non-guardian-contacts-from-accessing) as a prompt-level stop-gap ahead of the full per-user trust system.

**Scope note:** the trust-class helper machinery this PR consumes (`derivePersonaTrustFlags`, `isContactTrustClass`, their tests, and the call-site drift sweep) landed separately in #36838. After it merged, this branch merged `main` (regular merge, no history rewrite), so the diff here is now **feature-only**: the guardrail template, one-call wiring in `system-prompt.ts`, migration 121, and tests — 7 files.

## Prompt / plan (what changed)

1. **Surface trust flags to the system-prompt render context.** `buildSystemPrompt` already receives the per-turn `trustContext` (piped from the gateway) but never surfaced it to the persona sections. It now makes one call — `derivePersonaTrustFlags(resolveTrustClass(options?.trustContext))` — and lifts `trustClass` / `isGuardian` / `isTrustedContact` / `isStranger` onto the render context, so the mustache renderer (which only does truthy gating, not string comparison) can branch on who is being spoken to. The composition is deliberate: `resolveTrustClass` resolves the *actor* (a present context always keeps the actor's real class; an absent one is guardian only in an auth-disabled local deployment, unknown otherwise), and `derivePersonaTrustFlags` (from #36838's `runtime/trust-class.ts`) maps the class to render flags.

2. **Populate `users/default.md`** with a trust-class-aware privacy guardrail: never disclose the guardian's contacts, schedule, relationships, finances, health, files, or memories to anyone who is not the guardian, regardless of how the request is framed — while staying genuinely helpful with the contact's *own* requests. The greeting adapts to trusted-contact vs. stranger, and the whole file gates off (`{{^isGuardian}}`) for guardian-class turns.

3. **Backfill migration `121-seed-default-user-guardrails`** so existing installs (which already carry the empty seed) actually receive the guardrail, not just fresh installs.

## Persona-file mechanics: why this covers 100% of non-guardian turns today (verified in code)

Reviewers asked when `default.md` is actually loaded vs. skipped. The full chain, verified:

- **Resolution order:** the `10-user-persona` section resolves `workspacePath: ["users/{{userSlug}}.md", "users/default.md"]` — first path that **exists and has non-empty content** wins (`sections.ts` — an empty stub `users/<slug>.md` still falls through to `default.md`).
- **Every contact already has a slug reserved, but no file.** `upsertContact` auto-assigns `userFile = generateUserFileSlug(displayName)` on creation (`contact-store.ts:312-315`) — including Slack/phone strangers created on the inbound hot path. The *file* is deliberately never seeded there (`contacts-write.ts` comments that hot-path seeding would fire the `users/` directory watcher and evict live conversations; persona-file seeding is guardian-bootstrap-only).
- **The per-contact-persona intention exists as plumbing only — nothing instructs the assistant to act on it.** The introducing commit (#20601) shipped slug auto-generation + resolver support with no runtime guidance. No prompt or skill instructs creating `users/<slug>.md` for contacts (the only prompt references are *read* guidance for the guardian's own file, in the messaging/phone-calls skills). No model-facing tool exposes `userFile`, so the model cannot set the pointer. The only profile-building nudge in the runtime (heartbeat's `isShallowProfile`) is guardian-scoped. There is also no scaffold for contact files — `GUARDIAN_PERSONA_TEMPLATE` is guardian-only and carries no privacy language.
- **Net:** non-guardians fall through to `default.md` on every turn today, so this guardrail covers 100% of non-guardian turns. The residual risk is that the guardrail is disarmed for a contact the moment something writes *real content* to their reserved path — the guardian by hand, future contact-flow code, or the model unprompted (nothing forbids it). That residual is tracked as [LUM-2659](https://linear.app/vellum/issue/LUM-2659/non-guardian-privacy-guardrail-must-move-to-an-always-on-boundary) (see Follow-ups) and is not a blocker: nothing creates these files today.
- **Owner-facing builds without a trust context resolve the guardian.** Initial-prompt warming (`resolveInitialSystemPrompt`, which warms guardian bindings for exactly this reason), home greeting / suggested-prompts generation, and btw sidechains build prompts with no `trustContext` on behalf of the owner. Via `resolveTrustClass`, those unresolved builds classify as guardian in auth-disabled (local / platform-managed) deployments, so the guardrail never renders into the owner's own prompts; with auth enabled an unresolved build stays `unknown` and keeps the boundary (fail-closed). Caught by Codex review at HEAD; regression-tested in both directions.
- **Layers that survive even a bypass:** `SOUL.md`'s "never share anything about your guardian in channels" rule and the `promptTrustGuidance` turn-context block (identity/verification hygiene) are always-on and independent of persona-file selection. They complement — but do not replace — this data-disclosure boundary.

## Interaction with the in-flight trust PRs

- **#36834 (merged):** scoped the `DISABLE_HTTP_AUTH → guardian` bypass to unresolved actors, so a resolved non-guardian channel actor can no longer classify as guardian in platform-managed deployments — without it, this guardrail would have been a no-op in the cloud (upgrade-direction fix). This PR's composition relies on exactly that contract.
- **#36835 (open, LUM-2665 guardian-by-principal):** zero file overlap; order-independent. It fixes this guardrail's main false-positive: today a guardian speaking on a channel where they lack a same-channel binding resolves `unknown`, which would render the **stranger guardrail against the guardian**. Guardian-by-principal makes them resolve as guardian → `{{^isGuardian}}` gates the file off. Its upgrade path cannot misfire in the other direction (requires guardian identity + bound principal; NULL principal → `resolutionFailed` soft-deny; plain members never upgraded), so it cannot disarm this boundary for a real contact.
- **#36838 (merged):** the helper + anti-drift home this PR consumes.

Together: #36834 stopped non-guardians being *upgraded* by deployment posture, #36835 stops guardians being *downgraded* by binding gaps, and this PR consumes the now-correct-in-both-directions class for the disclosure boundary.

## Why this is the right approach

- **Minimal, targeted intervention.** `users/default.md` already renders into the system prompt for non-guardians; it was just empty. We're filling existing real estate rather than adding a new system-prompt section, which keeps us aligned with AGENTS.md "System Prompt Minimalism." Only one classification call lives in code; all guardrail *text* lives in the persona file — exactly where the repo's own pre-commit advisory on `system-prompt.ts` points.
- **Reuses the trust class the gateway already pipes.** The per-turn `trustContext` already carries the actor's resolved class; we just expose it to the renderer through the canonical helpers. No new plumbing, no new trust source, no new source of truth.
- **Consistent with an existing rule.** `SOUL.md` already carries an "UNBREAKABLE ABSOLUTE RULE: Never share anything about your guardian… in channels like Slack, Email…". This guardrail is a per-turn, actor-aware restatement of that principle, scoped to the non-guardian path and matched to the house style (comment-line convention, `{{#flag}}` mustache, heading/bullet structure, non-moralizing voice).
- **Correct in both directions, by construction.** A *present* trust context always keeps the actor's real class — a resolved non-guardian channel actor renders the guardrail even under `DISABLE_HTTP_AUTH` (the standing cloud config; regression-tested). An *absent* context follows the actor-resolution contract (`resolveTrustClass`): guardian for owner-facing local/internal builds in auth-disabled deployments, `unknown` → guardrail otherwise, so an unclassifiable turn still fails closed. Both directions are pinned by tests (see Test plan); the flag grouping itself is test-pinned on the helper in #36838.

## Why this is safe

- **Guardian conversations are unchanged.** A guardian renders their own `users/.md`, not `default.md`. And even in the rare pre-onboarding fallback where a guardian would hit `default.md`, the `{{^isGuardian}}` gate collapses the entire file to empty, so the section is omitted (a guardian only falls back to `default.md` before their persona file is seeded, during which `BOOTSTRAP.md` carries onboarding context — so the empty user-persona section is harmless). Guardian-path prompts are byte-identical to before this PR.
- **Blast radius is one persona file.** The new render-context keys only affect sections that reference them — i.e. only `default.md`. Every other section renders byte-for-byte identically.
- **Fork-retrospective byte-parity is preserved.** Memory retrospectives thread the source conversation's `trustContext`, and the guardrail derives entirely from that trust context, so a fork reproduces the source's persona exactly (no prompt-cache regression).
- **No literal-tag leakage.** The renderer resolves sections in a single pass, so the file uses **flat sibling** sections (`{{#isTrustedContact}}`, `{{#isStranger}}`, `{{^isGuardian}}`) rather than nested ones. Tests assert no `{{`/`}}` or comment lines ever reach the output for any trust class.

## Why the migration is safe

- **It never clobbers a customized file.** The guard writes only when `default.md` is **absent or blank** (`readFileSync(...).trim().length > 0` → skip). Any real content the guardian has written is left untouched. There's a dedicated test for this.
- **Correct by ordering.** `ensurePromptFiles()` runs before workspace migrations, so: fresh installs are already seeded from the updated template (non-blank → migration is a no-op); existing installs carry the old blank seed (blank → migration backfills); customized installs are skipped by both. All three outcomes are correct without special-casing.
- **Idempotent and run-once.** After it writes, the file is non-blank, so a re-run skips. Migrations are also checkpointed by id and run at most once per install, so this can't fight a user who edits the file later. `down()` is a no-op — we don't delete user-editable persona files on rollback.
- **Follows existing precedent.** It mirrors the repo's other persona-seed migrations (`035-seed-slack-channel-persona`, `118-seed-now-md`), extended to also treat *blank* as "unmodified" — the one nuance, and a deliberate one: blank is the only signal an existing install gives, and it's the only way to reach the very users this guardrail is meant to protect. The one edge: a guardian who *deliberately emptied* the file would get it backfilled once — indistinguishable from never-touched (the file shipped blank in 100% of its history), and for a security boundary, filling wins; they can re-edit afterward and the migration never runs again.

## Test plan

All re-verified on the post-merge branch (after #36838 landed and this branch merged `main`):

- `bun test src/prompts/__tests__/system-prompt.test.ts` — trust-class gating cases (stranger, trusted, unverified, guardian) asserting the guardrail renders for non-guardians, gates off for guardians, never leaks literal mustache tags or comment lines, **still renders for a non-guardian under `DISABLE_HTTP_AUTH=true`** (the platform-managed bypass), **gates off for an unresolved owner-facing build under `DISABLE_HTTP_AUTH=true`** (initial-prompt/home/btw — fails pre-fix), and **fails closed to the guardrail for an unresolved build with auth enabled**. **19 pass.**
- `bun test src/__tests__/workspace-migration-121-seed-default-user-guardrails.test.ts` — absent / empty / whitespace backfill, no-clobber of customized files, idempotency, no-op `down()`. **7 pass.**
- `bun test src/__tests__/workspace-migrations-runner.test.ts` — registry still valid (unique ids / order) after appending migration 121. **24 pass.**
- `bun test src/runtime/trust-class.test.ts` — #36838's helper suite, re-run on the merged branch. **10 pass.**
- `bun test src/__tests__/conversation-initial-prompt.test.ts` (**5 pass**) and `src/__tests__/btw-routes.test.ts` (**14 pass**) — the undefined-trust-context callers exercised directly.
- Persona/prompt suites (`persona-resolver`, `conversation-initial-prompt`, `user-reference`, `onboarding-persona-write`, `migration-parity-persistence`, `prechat-onboarding-contract`) pass **individually**. Running these mock-heavy files together trips a pre-existing cross-file `mock.module` pollution that reproduces identically on `main` — it is independent of this change.
- `bunx tsc --noEmit` clean; eslint 0 errors; prettier clean.

## Follow-ups

- [LUM-2659](https://linear.app/vellum/issue/LUM-2659/non-guardian-privacy-guardrail-must-move-to-an-always-on-boundary) — **the guardrail must move to an always-on boundary**, and the trigger is weaker than "when per-contact personas ship": every contact already has their `userFile` slug pre-reserved, so the *first meaningful write* to that path (guardian by hand, future contact-flow code, or the model unprompted) silently swaps the guardrail out for whatever the file says. The fix is a bundled `{{^isGuardian}}` section in `system-sections.ts` — a small change now that the flags are on `main` via #36838. The issue carries today's verified findings (slug pre-assignment, no guidance/scaffold/tool for contact files, surviving layers) plus the optional interim hardening of instructing the model *not* to create contact persona files until the boundary is always-on. **Not a blocker for this PR** — nothing creates these files today.

## Why this is good, safe, and valuable to merge

- **It closes a real, reported security gap** (guardian PII disclosure to non-guardians over channels) with a defense-in-depth prompt boundary sitting behind the gateway ACL.
- **It is universally correct today:** it covers every non-guardian turn — including in platform-managed (`DISABLE_HTTP_AUTH`) deployments — and it cannot degrade the guardian experience (guardian prompts are byte-identical; owner-facing internal builds resolve the guardian).
- **It is low-risk and reversible:** one persona file plus a non-clobbering, idempotent, ordering-correct migration; guardian and fork paths provably unchanged.
- **It is small by construction:** the reusable trust-class machinery landed first in #36838, so this PR is just the guardrail, its wiring, and its migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGCbyn9JntojD438mqHkhh