### PR TITLE
perf(daemon): defer non-critical end-of-turn work off the send-button critical path

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2410,15 +2410,14 @@ describe("session-agent-loop", () => {
     });
 
     test("terminal message_complete is emitted before the deferred indexer runs (LUM-2654)", async () => {
-      // Regression guard for the "long delay between last streaming token and
-      // send-button becoming available" bug. The non-critical finalize
-      // side-effects (memory segment indexing, lexical indexing, attention
-      // projection) were moved off the turn's critical path: the terminal
-      // `message_complete` SSE — which the client uses to flip stop→send — must
-      // fire FIRST, and the indexer must run afterwards (still within the turn,
-      // via the orchestrator's deferred tail). Before the fix the indexer ran
-      // inline in `handleMessageComplete`, so `message_complete` had not yet
-      // been emitted when indexing ran and this assertion would fail.
+      // Regression guard for LUM-2654 ("long delay between last streaming token
+      // and send-button becoming available"). The terminal `message_complete`
+      // SSE — which the client uses to flip stop→send — is emitted before the
+      // non-critical finalize side-effects (memory segment indexing, lexical
+      // indexing, attention projection), which the orchestrator drains from its
+      // end-of-turn tail. The tail runs within the turn, so the indexer still
+      // fires exactly once; this test pins the ordering by asserting
+      // `message_complete` is already in the client stream when it does.
       mockMessageById = {
         id: "msg-reserve",
         conversationId: "test-conv",
@@ -2442,9 +2441,9 @@ describe("session-agent-loop", () => {
       });
       await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
 
-      // The deferred indexer still ran exactly once (before the turn resolved)…
+      // The deferred indexer runs exactly once, within the turn…
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
-      // …but only AFTER the terminal SSE that re-enables the composer.
+      // …and only after the terminal SSE that re-enables the composer.
       expect(messageCompleteSeenWhenIndexed).toBe(true);
     });
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2409,6 +2409,45 @@ describe("session-agent-loop", () => {
       expect(metadataPublishes).toHaveLength(1);
     });
 
+    test("terminal message_complete is emitted before the deferred indexer runs (LUM-2654)", async () => {
+      // Regression guard for the "long delay between last streaming token and
+      // send-button becoming available" bug. The non-critical finalize
+      // side-effects (memory segment indexing, lexical indexing, attention
+      // projection) were moved off the turn's critical path: the terminal
+      // `message_complete` SSE — which the client uses to flip stop→send — must
+      // fire FIRST, and the indexer must run afterwards (still within the turn,
+      // via the orchestrator's deferred tail). Before the fix the indexer ran
+      // inline in `handleMessageComplete`, so `message_complete` had not yet
+      // been emitted when indexing ran and this assertion would fail.
+      mockMessageById = {
+        id: "msg-reserve",
+        conversationId: "test-conv",
+        createdAt: 1234567,
+        role: "assistant",
+        content: "[]",
+        metadata: null,
+      };
+
+      const events: ServerMessage[] = [];
+      let messageCompleteSeenWhenIndexed: boolean | undefined;
+      indexMessageNowMock.mockImplementationOnce(async () => {
+        messageCompleteSeenWhenIndexed = events.some(
+          (event) => event.type === "message_complete",
+        );
+        return { indexedSegments: 0, enqueuedJobs: 0 };
+      });
+
+      const ctx = makeCtx({
+        providerResponses: [textResponse("indexed reply")],
+      });
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+
+      // The deferred indexer still ran exactly once (before the turn resolved)…
+      expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
+      // …but only AFTER the terminal SSE that re-enables the composer.
+      expect(messageCompleteSeenWhenIndexed).toBe(true);
+    });
+
     test("handleMessageComplete skips sync invalidation when attention state unchanged", async () => {
       // Mirror of the previous test but with the default projector return
       // (`false`). The projection still runs every turn, but the sync

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -319,6 +319,18 @@ export interface EventHandlerState {
    * latency segment. Advances on every `handleUsage`.
    */
   latencyCursor: number;
+  /**
+   * Non-critical finalize side-effects deferred off the turn's critical path —
+   * one closure per assistant message that completes (memory segment indexing,
+   * lexical indexing, attention projection). `handleMessageComplete` persists
+   * the message content synchronously (so a snapshot/refetch on the terminal
+   * `message_complete` SSE still sees the full reply) and pushes these
+   * follow-ups here; the orchestrator drains them after the terminal SSE has
+   * re-enabled the composer but before the next turn can start. Each closure is
+   * individually best-effort. Accumulates across retries/multi-call turns so
+   * every produced assistant row is indexed.
+   */
+  readonly deferredFinalizeEffects: Array<() => Promise<void>>;
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -407,6 +419,7 @@ export function createEventHandlerState(): EventHandlerState {
     lastPersistedContentSeq: undefined,
     compactionStartMessages: new Map(),
     latencyCursor: 0,
+    deferredFinalizeEffects: [],
   };
 }
 
@@ -2016,22 +2029,27 @@ export async function handleMessageComplete(
   state.currentThinkingTimestamps = [];
   state.lastPersistedContentSeq = undefined;
 
-  // ── Indexing + attention projection ──
+  // ── Indexing + attention projection (deferred off the critical path) ──
   // `reserveMessage` + `updateMessageContent` are CRUD-only: they don't run
   // the memory indexer or the attention-cursor projector (unlike `addMessage`,
   // which runs both as side-effects of the insert). Because the assistant row
   // is reserved empty and finalized via `updateMessageContent`, both must be
-  // invoked explicitly here to keep the assistant row's external state
-  // (Qdrant segments, conversation attention cursor) in lockstep with the
-  // finalized content. Both are non-fatal — a memory hiccup must not
-  // escalate a successful generation into a turn-level throw. Indexing
-  // intentionally fires AFTER `updateContent` succeeds so we never index
-  // the empty reserved placeholder.
-  const finalizedRow = getMessageById(
-    assistantMessageId,
-    deps.ctx.conversationId,
-  );
-  if (finalizedRow) {
+  // invoked explicitly to keep the assistant row's external state (Qdrant
+  // segments, conversation attention cursor) in lockstep with the finalized
+  // content. Neither gates delivery of the reply or the composer re-enabling —
+  // memory/attention only feed the NEXT turn's retrieval and a sidebar
+  // indicator — so they are queued here and drained by the orchestrator after
+  // the terminal `message_complete` SSE fires (but before the next turn), off
+  // the send-button critical path. The content persisted synchronously above,
+  // so a snapshot/refetch on `message_complete` still sees the full reply.
+  // Both remain non-fatal — a memory hiccup must not escalate a successful
+  // generation into a turn-level throw.
+  state.deferredFinalizeEffects.push(async () => {
+    const finalizedRow = getMessageById(
+      assistantMessageId,
+      deps.ctx.conversationId,
+    );
+    if (!finalizedRow) return;
     let provenanceTrustClass:
       | "guardian"
       | "trusted_contact"
@@ -2102,7 +2120,7 @@ export async function handleMessageComplete(
         "Failed to project assistant message for attention tracking (non-fatal)",
       );
     }
-  }
+  });
 
   // Backfill message_id on all LLM request logs from this turn.
   // The agent loop is single-threaded per conversation, so all rows with

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -28,7 +28,6 @@ import {
   recordCompactionEndBestEffort,
   recordCompactionStartBestEffort,
 } from "../persistence/compaction-log-store-clickhouse.js";
-import { projectAssistantMessage } from "../persistence/conversation-attention-store.js";
 import {
   deleteMessageById,
   getConversation,
@@ -60,7 +59,6 @@ import type {
   Message,
 } from "../providers/types.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
-import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
 import {
@@ -88,6 +86,7 @@ import {
   classifyConversationError,
   maxTokensReachedClassification,
 } from "./conversation-error.js";
+import { buildDeferredFinalizeEffect } from "./conversation-turn-finalize.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
 import type {
   CardSurfaceData,
@@ -95,7 +94,6 @@ import type {
   SurfaceAction,
   UiSurfaceShow,
 } from "./message-protocol.js";
-import { conversationMetadataSyncTag } from "./message-types/sync.js";
 import type {
   ToolActivityMetadata,
   WebSearchMetadata,
@@ -2030,97 +2028,23 @@ export async function handleMessageComplete(
   state.lastPersistedContentSeq = undefined;
 
   // ── Indexing + attention projection (deferred off the critical path) ──
-  // `reserveMessage` + `updateMessageContent` are CRUD-only: they don't run
-  // the memory indexer or the attention-cursor projector (unlike `addMessage`,
-  // which runs both as side-effects of the insert). Because the assistant row
-  // is reserved empty and finalized via `updateMessageContent`, both must be
-  // invoked explicitly to keep the assistant row's external state (Qdrant
-  // segments, conversation attention cursor) in lockstep with the finalized
-  // content. Neither gates delivery of the reply or the composer re-enabling —
-  // memory/attention only feed the NEXT turn's retrieval and a sidebar
-  // indicator — so they are queued here and drained by the orchestrator after
-  // the terminal `message_complete` SSE fires (but before the next turn), off
-  // the send-button critical path. The content persisted synchronously above,
-  // so a snapshot/refetch on `message_complete` still sees the full reply.
-  // Both remain non-fatal — a memory hiccup must not escalate a successful
-  // generation into a turn-level throw.
-  state.deferredFinalizeEffects.push(async () => {
-    const finalizedRow = getMessageById(
+  // `reserveMessage` + `updateMessageContent` are CRUD-only — unlike
+  // `addMessage`, they don't run the memory indexer or the attention-cursor
+  // projector as insert side-effects — so the assistant row's external state
+  // must be brought into lockstep explicitly. Neither gates delivery of the
+  // reply or the composer re-enabling, so the work is queued here and drained
+  // by the orchestrator after the terminal `message_complete` SSE fires (but
+  // before the next turn). See `conversation-turn-finalize.ts`. The content
+  // persisted synchronously above, so a snapshot/refetch on `message_complete`
+  // still sees the full reply.
+  state.deferredFinalizeEffects.push(
+    buildDeferredFinalizeEffect({
+      conversationId: deps.ctx.conversationId,
       assistantMessageId,
-      deps.ctx.conversationId,
-    );
-    if (!finalizedRow) return;
-    let provenanceTrustClass:
-      | "guardian"
-      | "trusted_contact"
-      | "unverified_contact"
-      | "unknown"
-      | undefined;
-    let automated: boolean | undefined;
-    if (finalizedRow.metadata) {
-      try {
-        const parsedMeta = messageMetadataSchema.safeParse(
-          JSON.parse(finalizedRow.metadata),
-        );
-        if (parsedMeta.success) {
-          provenanceTrustClass = parsedMeta.data.provenanceTrustClass;
-          automated = parsedMeta.data.automated;
-        }
-      } catch {
-        // Malformed metadata JSON — fall through with undefined fields,
-        // matching the legacy behavior in `addMessage`.
-      }
-    }
-    try {
-      await indexMessageNow(
-        {
-          messageId: assistantMessageId,
-          conversationId: deps.ctx.conversationId,
-          role: "assistant",
-          content: contentJson,
-          createdAt: finalizedRow.createdAt,
-          scopeId: "default",
-          provenanceTrustClass,
-          automated,
-        },
-        getConfig().memory,
-      );
-    } catch (err) {
-      deps.rlog.warn(
-        {
-          err,
-          conversationId: deps.ctx.conversationId,
-          messageId: assistantMessageId,
-        },
-        "Failed to index assistant message for memory (non-fatal)",
-      );
-    }
-    // Dual-write the finalized assistant content into the lexical index. The
-    // reserve+finalize path bypasses `onMessagePersisted`, so enqueue here to
-    // keep the lexical index in lockstep with the segment index.
-    enqueueLexicalIndexForMessage(assistantMessageId);
-    try {
-      const attentionStateChanged = projectAssistantMessage({
-        conversationId: deps.ctx.conversationId,
-        messageId: assistantMessageId,
-        messageAt: finalizedRow.createdAt,
-      });
-      if (attentionStateChanged) {
-        void publishSyncInvalidation([
-          conversationMetadataSyncTag(deps.ctx.conversationId),
-        ]);
-      }
-    } catch (err) {
-      deps.rlog.warn(
-        {
-          err,
-          conversationId: deps.ctx.conversationId,
-          messageId: assistantMessageId,
-        },
-        "Failed to project assistant message for attention tracking (non-fatal)",
-      );
-    }
-  });
+      contentJson,
+      rlog: deps.rlog,
+    }),
+  );
 
   // Backfill message_id on all LLM request logs from this turn.
   // The agent loop is single-threaded per conversation, so all rows with

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1043,6 +1043,10 @@ export async function runAgentLoopImpl(
     };
 
     const updatedHistory = await runAgentLoop(runMessages, true);
+    // Generation is done streaming. Anything awaited between here and the
+    // terminal SSE is what the user perceives as the gap between the last
+    // token and the composer re-enabling, so keep that window minimal.
+    const generationCompletedAt = Date.now();
 
     rlog.info(
       { resultMessageCount: updatedHistory.length },
@@ -1302,39 +1306,18 @@ export async function runAgentLoopImpl(
       0,
       updatedHistory.length - lastRunNewMessages.length,
     );
-    let restoredHistory = [...loopBase, ...newMessages];
-
-    // Post-turn tool result truncation: save large results to disk and
-    // replace in-context content with a prefix/suffix stub + file pointer.
-    try {
-      const conv = getConversation(ctx.conversationId);
-      if (conv) {
-        const convDir = getResolvedConversationDirPath(
-          ctx.conversationId,
-          conv.createdAt,
-        );
-        const { messages: derefMessages, dereferencedCount } =
-          derefToolResultReReads(restoredHistory);
-        const { messages: truncatedMessages, truncatedCount } =
-          postTurnTruncateToolResults(derefMessages, {
-            conversationDir: convDir,
-          });
-        if (truncatedCount > 0 || dereferencedCount > 0) {
-          rlog.info(
-            { truncatedCount, dereferencedCount },
-            "Post-turn tool result truncation applied",
-          );
-        }
-        restoredHistory = truncatedMessages;
-      }
-    } catch (err) {
-      rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
-    }
+    const restoredHistory = [...loopBase, ...newMessages];
 
     // Persist injections in history: runtime-injected context stays on
     // historical user messages so the conversation prefix is stable for
     // Anthropic's prefix caching.  Stripping only happens during
     // compaction/overflow recovery (where a cache miss is expected).
+    //
+    // Post-turn tool-result truncation (spooling large results to disk and
+    // shrinking the next turn's context) is deferred to `runDeferredTurnTail`
+    // below. It only rewrites the in-memory history the NEXT turn is built
+    // from — never the just-delivered reply — so it must not sit on the
+    // critical path to the terminal SSE that re-enables the composer.
     ctx.messages = restoredHistory;
 
     emitUsage(
@@ -1371,11 +1354,75 @@ export async function runAgentLoopImpl(
         convForDisk.createdAt,
       );
     };
+
+    // Non-critical end-of-turn bookkeeping, drained after the terminal SSE has
+    // already re-enabled the composer but before the `finally` starts the next
+    // turn. Ordering with the next turn is preserved (it runs before
+    // `drainQueue`), while the last-token→send-button latency no longer
+    // includes it. Every step is best-effort: a hiccup here must never turn a
+    // delivered reply into a turn-level error.
+    const runDeferredTurnTail = async (): Promise<void> => {
+      const tailStartedAt = Date.now();
+      // Per-message memory/attention finalize side-effects deferred from
+      // `handleMessageComplete` (memory segment indexing, lexical indexing,
+      // attention projection) — one closure per assistant row produced this
+      // turn, in production order.
+      for (const effect of state.deferredFinalizeEffects) {
+        try {
+          await effect();
+        } catch (err) {
+          rlog.warn(
+            { err },
+            "Deferred finalize side-effect failed (non-fatal)",
+          );
+        }
+      }
+      // Post-turn tool-result truncation: spool oversized results to disk and
+      // replace their in-context content with a stub + pointer, shrinking the
+      // next turn's context. Rewrites only the in-memory history, so it has no
+      // bearing on the reply already delivered to the client.
+      try {
+        const conv = getConversation(ctx.conversationId);
+        if (conv) {
+          const convDir = getResolvedConversationDirPath(
+            ctx.conversationId,
+            conv.createdAt,
+          );
+          const { messages: derefMessages, dereferencedCount } =
+            derefToolResultReReads(ctx.messages);
+          const { messages: truncatedMessages, truncatedCount } =
+            postTurnTruncateToolResults(derefMessages, {
+              conversationDir: convDir,
+            });
+          if (truncatedCount > 0 || dereferencedCount > 0) {
+            rlog.info(
+              { truncatedCount, dereferencedCount },
+              "Post-turn tool result truncation applied",
+            );
+          }
+          ctx.messages = truncatedMessages;
+        }
+      } catch (err) {
+        rlog.warn(
+          { err },
+          "Post-turn tool result truncation failed (non-fatal)",
+        );
+      }
+      // Mirror the final assistant row into the JSONL disk view.
+      syncLastAssistantMessageToDisk();
+      rlog.info(
+        {
+          criticalSectionMs: tailStartedAt - generationCompletedAt,
+          deferredTailMs: Date.now() - tailStartedAt,
+        },
+        "End-of-turn work complete",
+      );
+    };
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
-    // so the client can re-enable the UI without delay.
+    // so the client can re-enable the UI without delay. Disk sync and the rest
+    // of the bookkeeping run in `runDeferredTurnTail` after this SSE.
     if (abortController.signal.aborted) {
-      syncLastAssistantMessageToDisk();
       ctx.emitActivityState("idle", "generation_cancelled", {
         anchor: "global",
         requestId: reqId,
@@ -1415,7 +1462,6 @@ export async function runAgentLoopImpl(
 
       ctx.lastAssistantAttachments = assistantAttachments;
       ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
-      syncLastAssistantMessageToDisk();
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {
@@ -1496,6 +1542,12 @@ export async function runAgentLoopImpl(
         publishLoopMessagesChanged();
       }
     }
+
+    // The terminal SSE for this turn has now been emitted (message_complete,
+    // generation_handoff, or generation_cancelled), so the composer is already
+    // re-enabling. Drain the deferred bookkeeping now — after the SSE, before
+    // the `finally` commits and drains the queue for the next turn.
+    await runDeferredTurnTail();
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
     const errorCtx = {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -34,10 +34,6 @@ import {
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import {
-  derefToolResultReReads,
-  postTurnTruncateToolResults,
-} from "../context/post-turn-tool-result-truncation.js";
 import { writeRelationshipState } from "../home/relationship-state-writer.js";
 import {
   clearSentryConversationContext,
@@ -56,8 +52,6 @@ import {
   updateConversationContextWindow,
   updateConversationSlackContextWatermark,
 } from "../persistence/conversation-crud.js";
-import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
-import { syncMessageToDisk } from "../persistence/conversation-disk-view.js";
 import { isReplaceableTitle } from "../persistence/conversation-title-service.js";
 import {
   backfillMessageIdOnLogs,
@@ -114,6 +108,7 @@ import {
   type SlackChronologicalContext,
 } from "./conversation-runtime-assembly.js";
 import { markSurfaceCompleted } from "./conversation-surfaces.js";
+import { runDeferredTurnTail } from "./conversation-turn-finalize.js";
 import { recordUsage } from "./conversation-usage.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
 import { getDiskPressureStatus } from "./disk-pressure-guard.js";
@@ -1344,80 +1339,6 @@ export async function runAgentLoopImpl(
       turnCronRunId,
     );
 
-    const syncLastAssistantMessageToDisk = (): void => {
-      if (!state.lastAssistantMessageId) return;
-      const convForDisk = getConversation(ctx.conversationId);
-      if (!convForDisk) return;
-      syncMessageToDisk(
-        ctx.conversationId,
-        state.lastAssistantMessageId,
-        convForDisk.createdAt,
-      );
-    };
-
-    // Non-critical end-of-turn bookkeeping, drained after the terminal SSE has
-    // already re-enabled the composer but before the `finally` starts the next
-    // turn. Ordering with the next turn is preserved (it runs before
-    // `drainQueue`), while the last-token→send-button latency no longer
-    // includes it. Every step is best-effort: a hiccup here must never turn a
-    // delivered reply into a turn-level error.
-    const runDeferredTurnTail = async (): Promise<void> => {
-      const tailStartedAt = Date.now();
-      // Per-message memory/attention finalize side-effects deferred from
-      // `handleMessageComplete` (memory segment indexing, lexical indexing,
-      // attention projection) — one closure per assistant row produced this
-      // turn, in production order.
-      for (const effect of state.deferredFinalizeEffects) {
-        try {
-          await effect();
-        } catch (err) {
-          rlog.warn(
-            { err },
-            "Deferred finalize side-effect failed (non-fatal)",
-          );
-        }
-      }
-      // Post-turn tool-result truncation: spool oversized results to disk and
-      // replace their in-context content with a stub + pointer, shrinking the
-      // next turn's context. Rewrites only the in-memory history, so it has no
-      // bearing on the reply already delivered to the client.
-      try {
-        const conv = getConversation(ctx.conversationId);
-        if (conv) {
-          const convDir = getResolvedConversationDirPath(
-            ctx.conversationId,
-            conv.createdAt,
-          );
-          const { messages: derefMessages, dereferencedCount } =
-            derefToolResultReReads(ctx.messages);
-          const { messages: truncatedMessages, truncatedCount } =
-            postTurnTruncateToolResults(derefMessages, {
-              conversationDir: convDir,
-            });
-          if (truncatedCount > 0 || dereferencedCount > 0) {
-            rlog.info(
-              { truncatedCount, dereferencedCount },
-              "Post-turn tool result truncation applied",
-            );
-          }
-          ctx.messages = truncatedMessages;
-        }
-      } catch (err) {
-        rlog.warn(
-          { err },
-          "Post-turn tool result truncation failed (non-fatal)",
-        );
-      }
-      // Mirror the final assistant row into the JSONL disk view.
-      syncLastAssistantMessageToDisk();
-      rlog.info(
-        {
-          criticalSectionMs: tailStartedAt - generationCompletedAt,
-          deferredTailMs: Date.now() - tailStartedAt,
-        },
-        "End-of-turn work complete",
-      );
-    };
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
     // so the client can re-enable the UI without delay. Disk sync and the rest
@@ -1547,7 +1468,7 @@ export async function runAgentLoopImpl(
     // generation_handoff, or generation_cancelled), so the composer is already
     // re-enabling. Drain the deferred bookkeeping now — after the SSE, before
     // the `finally` commits and drains the queue for the next turn.
-    await runDeferredTurnTail();
+    await runDeferredTurnTail({ ctx, state, rlog, generationCompletedAt });
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
     const errorCtx = {

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -1,0 +1,218 @@
+/**
+ * End-of-turn finalize work that runs OFF the send-button critical path.
+ *
+ * The web/Capacitor/CLI clients re-enable the composer the moment they observe
+ * the terminal `message_complete` / `assistant_activity_state("idle")` SSE, so
+ * any awaited work between the last streamed token and that emission is what the
+ * user perceives as the "still spinning after the reply finished" gap.
+ *
+ * None of the work here gates delivery of the reply: memory/attention indexing
+ * only feeds the NEXT turn's retrieval and a sidebar indicator, tool-result
+ * truncation only reshapes the in-memory history the next turn is built from,
+ * and the disk-view mirror is a durability convenience. The agent loop persists
+ * the reply content synchronously and emits the terminal SSE first, then drains
+ * this module's work before the turn's `finally` starts the next turn — so the
+ * bookkeeping still completes within the turn, just after the composer is free.
+ */
+
+import type pino from "pino";
+
+import { getConfig } from "../config/loader.js";
+import {
+  derefToolResultReReads,
+  postTurnTruncateToolResults,
+} from "../context/post-turn-tool-result-truncation.js";
+import { projectAssistantMessage } from "../persistence/conversation-attention-store.js";
+import {
+  getConversation,
+  getMessageById,
+  messageMetadataSchema,
+} from "../persistence/conversation-crud.js";
+import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
+import { syncMessageToDisk } from "../persistence/conversation-disk-view.js";
+import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
+import { enqueueLexicalIndexForMessage } from "../plugins/defaults/memory/job-handlers/index-message-lexical.js";
+import type { Message } from "../providers/types.js";
+import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
+import { conversationMetadataSyncTag } from "./message-types/sync.js";
+
+/** Minimal live-conversation surface the deferred tail reads and rewrites. */
+interface TurnTailContext {
+  readonly conversationId: string;
+  messages: Message[];
+}
+
+/** Minimal per-run handler state the deferred tail consumes. */
+interface TurnTailState {
+  readonly deferredFinalizeEffects: ReadonlyArray<() => Promise<void>>;
+  readonly lastAssistantMessageId: string | undefined;
+}
+
+/**
+ * Build the deferred finalize side-effect for one finalized assistant row:
+ * memory segment indexing, lexical indexing, and attention projection.
+ *
+ * `reserveMessage` + `updateMessageContent` are CRUD-only — unlike `addMessage`,
+ * they don't run the memory indexer or the attention-cursor projector as insert
+ * side-effects — so the assistant row's external state (Qdrant segments,
+ * attention cursor) is brought into lockstep with the finalized content here.
+ * The returned closure captures the row id and its already-persisted content
+ * JSON, and is drained by {@link runDeferredTurnTail} after the terminal SSE.
+ * Each step is best-effort: a memory hiccup must not escalate a delivered reply
+ * into a turn-level throw.
+ */
+export function buildDeferredFinalizeEffect(params: {
+  conversationId: string;
+  assistantMessageId: string;
+  contentJson: string;
+  rlog: pino.Logger;
+}): () => Promise<void> {
+  const { conversationId, assistantMessageId, contentJson, rlog } = params;
+  return async () => {
+    const finalizedRow = getMessageById(assistantMessageId, conversationId);
+    if (!finalizedRow) return;
+    let provenanceTrustClass:
+      | "guardian"
+      | "trusted_contact"
+      | "unverified_contact"
+      | "unknown"
+      | undefined;
+    let automated: boolean | undefined;
+    if (finalizedRow.metadata) {
+      try {
+        const parsedMeta = messageMetadataSchema.safeParse(
+          JSON.parse(finalizedRow.metadata),
+        );
+        if (parsedMeta.success) {
+          provenanceTrustClass = parsedMeta.data.provenanceTrustClass;
+          automated = parsedMeta.data.automated;
+        }
+      } catch {
+        // Malformed metadata JSON — fall through with undefined fields,
+        // matching the legacy behavior in `addMessage`.
+      }
+    }
+    try {
+      await indexMessageNow(
+        {
+          messageId: assistantMessageId,
+          conversationId,
+          role: "assistant",
+          content: contentJson,
+          createdAt: finalizedRow.createdAt,
+          scopeId: "default",
+          provenanceTrustClass,
+          automated,
+        },
+        getConfig().memory,
+      );
+    } catch (err) {
+      rlog.warn(
+        { err, conversationId, messageId: assistantMessageId },
+        "Failed to index assistant message for memory (non-fatal)",
+      );
+    }
+    // Dual-write the finalized assistant content into the lexical index. The
+    // reserve+finalize path bypasses `onMessagePersisted`, so enqueue here to
+    // keep the lexical index in lockstep with the segment index.
+    enqueueLexicalIndexForMessage(assistantMessageId);
+    try {
+      const attentionStateChanged = projectAssistantMessage({
+        conversationId,
+        messageId: assistantMessageId,
+        messageAt: finalizedRow.createdAt,
+      });
+      if (attentionStateChanged) {
+        void publishSyncInvalidation([
+          conversationMetadataSyncTag(conversationId),
+        ]);
+      }
+    } catch (err) {
+      rlog.warn(
+        { err, conversationId, messageId: assistantMessageId },
+        "Failed to project assistant message for attention tracking (non-fatal)",
+      );
+    }
+  };
+}
+
+/**
+ * Drain a turn's deferred bookkeeping after the terminal SSE has re-enabled the
+ * composer but before the agent loop's `finally` commits and drains the queue
+ * for the next turn. Ordering with the next turn is preserved (this completes
+ * before `drainQueue`), while the last-token→send-button latency no longer
+ * includes it. Every step is best-effort.
+ *
+ * `generationCompletedAt` is stamped when the agent loop returns; the emitted
+ * `criticalSectionMs` / `deferredTailMs` split makes the previously-uninstrumented
+ * end-of-turn window measurable.
+ */
+export async function runDeferredTurnTail(params: {
+  ctx: TurnTailContext;
+  state: TurnTailState;
+  rlog: pino.Logger;
+  generationCompletedAt: number;
+}): Promise<void> {
+  const { ctx, state, rlog, generationCompletedAt } = params;
+  const tailStartedAt = Date.now();
+
+  // Per-message memory/attention finalize side-effects deferred from
+  // `handleMessageComplete` — one closure per assistant row produced this turn,
+  // in production order.
+  for (const effect of state.deferredFinalizeEffects) {
+    try {
+      await effect();
+    } catch (err) {
+      rlog.warn({ err }, "Deferred finalize side-effect failed (non-fatal)");
+    }
+  }
+
+  // Post-turn tool-result truncation: spool oversized results to disk and
+  // replace their in-context content with a stub + pointer, shrinking the next
+  // turn's context. Rewrites only the in-memory history, so it has no bearing on
+  // the reply already delivered to the client.
+  try {
+    const conv = getConversation(ctx.conversationId);
+    if (conv) {
+      const convDir = getResolvedConversationDirPath(
+        ctx.conversationId,
+        conv.createdAt,
+      );
+      const { messages: derefMessages, dereferencedCount } =
+        derefToolResultReReads(ctx.messages);
+      const { messages: truncatedMessages, truncatedCount } =
+        postTurnTruncateToolResults(derefMessages, {
+          conversationDir: convDir,
+        });
+      if (truncatedCount > 0 || dereferencedCount > 0) {
+        rlog.info(
+          { truncatedCount, dereferencedCount },
+          "Post-turn tool result truncation applied",
+        );
+      }
+      ctx.messages = truncatedMessages;
+    }
+  } catch (err) {
+    rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
+  }
+
+  // Mirror the final assistant row into the JSONL disk view.
+  if (state.lastAssistantMessageId) {
+    const convForDisk = getConversation(ctx.conversationId);
+    if (convForDisk) {
+      syncMessageToDisk(
+        ctx.conversationId,
+        state.lastAssistantMessageId,
+        convForDisk.createdAt,
+      );
+    }
+  }
+
+  rlog.info(
+    {
+      criticalSectionMs: tailStartedAt - generationCompletedAt,
+      deferredTailMs: Date.now() - tailStartedAt,
+    },
+    "End-of-turn work complete",
+  );
+}

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -26,7 +26,7 @@ import { projectAssistantMessage } from "../persistence/conversation-attention-s
 import {
   getConversation,
   getMessageById,
-  messageMetadataSchema,
+  parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
 import { syncMessageToDisk } from "../persistence/conversation-disk-view.js";
@@ -46,23 +46,6 @@ interface TurnTailContext {
 interface TurnTailState {
   readonly deferredFinalizeEffects: ReadonlyArray<() => Promise<void>>;
   readonly lastAssistantMessageId: string | undefined;
-}
-
-/**
- * Parse a persisted message's metadata against `messageMetadataSchema` — the
- * single source of truth for its shape (including the actor trust class) —
- * returning the validated fields, or `undefined` when the column is absent or
- * malformed. Keeps callers off a hand-copied metadata/trust-class union.
- */
-function parseFinalizedRowMetadata(metadataJson: string | null) {
-  if (!metadataJson) return undefined;
-  try {
-    const parsed = messageMetadataSchema.safeParse(JSON.parse(metadataJson));
-    return parsed.success ? parsed.data : undefined;
-  } catch {
-    // Malformed metadata JSON — index without provenance, matching `addMessage`.
-    return undefined;
-  }
 }
 
 /**
@@ -87,11 +70,13 @@ export function buildDeferredFinalizeEffect(params: {
   const { conversationId, assistantMessageId, contentJson, rlog } = params;
   return async () => {
     const finalizedRow = getMessageById(assistantMessageId, conversationId);
-    if (!finalizedRow) return;
+    if (!finalizedRow) {
+      return;
+    }
     // Provenance/automation flags for the memory write-gate come off the
-    // persisted metadata; `messageMetadataSchema` types their shape, so read
-    // them from the parse rather than re-declaring the trust-class union.
-    const metadata = parseFinalizedRowMetadata(finalizedRow.metadata);
+    // persisted metadata via the shared `parseMessageMetadata` (the single
+    // source of truth for its shape) rather than a hand-copied union.
+    const metadata = parseMessageMetadata(finalizedRow.metadata);
     try {
       await indexMessageNow(
         {

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -49,6 +49,23 @@ interface TurnTailState {
 }
 
 /**
+ * Parse a persisted message's metadata against `messageMetadataSchema` — the
+ * single source of truth for its shape (including the actor trust class) —
+ * returning the validated fields, or `undefined` when the column is absent or
+ * malformed. Keeps callers off a hand-copied metadata/trust-class union.
+ */
+function parseFinalizedRowMetadata(metadataJson: string | null) {
+  if (!metadataJson) return undefined;
+  try {
+    const parsed = messageMetadataSchema.safeParse(JSON.parse(metadataJson));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    // Malformed metadata JSON — index without provenance, matching `addMessage`.
+    return undefined;
+  }
+}
+
+/**
  * Build the deferred finalize side-effect for one finalized assistant row:
  * memory segment indexing, lexical indexing, and attention projection.
  *
@@ -71,27 +88,10 @@ export function buildDeferredFinalizeEffect(params: {
   return async () => {
     const finalizedRow = getMessageById(assistantMessageId, conversationId);
     if (!finalizedRow) return;
-    let provenanceTrustClass:
-      | "guardian"
-      | "trusted_contact"
-      | "unverified_contact"
-      | "unknown"
-      | undefined;
-    let automated: boolean | undefined;
-    if (finalizedRow.metadata) {
-      try {
-        const parsedMeta = messageMetadataSchema.safeParse(
-          JSON.parse(finalizedRow.metadata),
-        );
-        if (parsedMeta.success) {
-          provenanceTrustClass = parsedMeta.data.provenanceTrustClass;
-          automated = parsedMeta.data.automated;
-        }
-      } catch {
-        // Malformed metadata JSON — fall through with undefined fields,
-        // matching the legacy behavior in `addMessage`.
-      }
-    }
+    // Provenance/automation flags for the memory write-gate come off the
+    // persisted metadata; `messageMetadataSchema` types their shape, so read
+    // them from the parse rather than re-declaring the trust-class union.
+    const metadata = parseFinalizedRowMetadata(finalizedRow.metadata);
     try {
       await indexMessageNow(
         {
@@ -101,8 +101,8 @@ export function buildDeferredFinalizeEffect(params: {
           content: contentJson,
           createdAt: finalizedRow.createdAt,
           scopeId: "default",
-          provenanceTrustClass,
-          automated,
+          provenanceTrustClass: metadata?.provenanceTrustClass,
+          automated: metadata?.automated,
         },
         getConfig().memory,
       );
@@ -196,16 +196,24 @@ export async function runDeferredTurnTail(params: {
     rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
   }
 
-  // Mirror the final assistant row into the JSONL disk view.
-  if (state.lastAssistantMessageId) {
-    const convForDisk = getConversation(ctx.conversationId);
-    if (convForDisk) {
-      syncMessageToDisk(
-        ctx.conversationId,
-        state.lastAssistantMessageId,
-        convForDisk.createdAt,
-      );
+  // Mirror the final assistant row into the JSONL disk view. Guarded like the
+  // steps above: this runs AFTER the terminal SSE, so a throw here (e.g. a
+  // SQLite read failure in `getConversation`) must not escape into the loop's
+  // outer catch and emit a second, contradictory terminal event for a turn the
+  // client already saw complete.
+  try {
+    if (state.lastAssistantMessageId) {
+      const convForDisk = getConversation(ctx.conversationId);
+      if (convForDisk) {
+        syncMessageToDisk(
+          ctx.conversationId,
+          state.lastAssistantMessageId,
+          convForDisk.createdAt,
+        );
+      }
     }
+  } catch (err) {
+    rlog.warn({ err }, "Failed to sync assistant message to disk (non-fatal)");
   }
 
   rlog.info(


### PR DESCRIPTION
Fixes [LUM-2654](https://linear.app/vellum/issue/LUM-2654/long-delay-between-last-streaming-token-and-send-button-becoming) — "Long delay between last streaming token and send-button becoming available" (SEV-1, every message).

## Prompt / plan

**Symptom:** After the final LLM token streams in, the composer stays in the stop/spinner state for a noticeable beat before the send button returns.

**Diagnosis:** The web client flips stop→send the moment it receives the terminal `message_complete` / `assistant_activity_state("idle")` SSE (`rolling-snapshot.ts` `nextProcessingState` → `snapshotProcessing = false`; `turn-selectors.ts` `canStopGeneration`). Those events are emitted in the agent-loop wrapper **before** the `finally` that commits + clears the persisted `processing` flag — so the turn-boundary git commit was never in the send-button path. The gap is the awaited work between the last `assistant_text_delta` and that SSE emission:

- `handleMessageComplete` ran **memory segment indexing, lexical indexing, and attention projection** inline (segment upserts + memory-job enqueues + extraction-trigger checkpoints — the heaviest item) before the loop returned.
- the wrapper then ran **post-turn tool-result truncation** (disk I/O) and the **JSONL disk-view sync** before emitting the terminal SSE.

None of that gates delivery of the reply or the composer re-enabling: memory/attention only feed the *next* turn's retrieval and a sidebar indicator, and truncation only reshapes the in-memory history the next turn is built from (it never rewrites the DB rows a refetch reads).

**Fix:** Keep only durability + attachment resolution before the terminal SSE; defer the rest.

- Persist the assistant content synchronously in `handleMessageComplete` (so a snapshot/refetch on `message_complete` still sees the full reply), then queue the per-message finalize side-effects on a new `EventHandlerState.deferredFinalizeEffects`.
- Drain them — plus post-turn truncation and the disk-view sync — in `runDeferredTurnTail()` that runs **after** the terminal SSE but **before** the `finally` commits and drains the queue for the next turn.
- Ordering constraints preserved: `backfillMessageIdOnLogs` stays inline (per-LLM-call attribution requires it before the next call), and the deferred tail completes before `drainQueue`, so the next turn sees fully-indexed/truncated state.
- Both pieces (the per-message finalize builder and the end-of-turn tail) live in a new focused module **`conversation-turn-finalize.ts`** rather than bloating `conversation-agent-loop.ts` (1.8k lines) / `conversation-agent-loop-handlers.ts` (2.7k lines); net −174 lines across those two files. No new circular deps (`lint:circular` unchanged at 402; the module is in zero cycles).
- Added a `criticalSectionMs` / `deferredTailMs` log at turn end so the previously-uninstrumented gap is measurable in prod.

### SSE contract alignment (verified in code, not just against `clients/web/docs/CONVERSATION_SSE.md`)

The change is safe *because* of the documented `seq`-idempotent transcript contract, and it touches none of the load-bearing pieces:

- **Content + `seq` watermark stay inline before the SSE.** `persistLoopMessageContent` and `recordConversationPersistedSeq` remain in `handleMessageComplete`; only the non-content side-effects moved. From the client's perspective the event stream is byte-identical — same events, same order, same `seq` — just emitted sooner.
- **The single-writer reducer is untouched.** No change to `rolling-snapshot.ts`, its fold, or `seq` stamping.
- **A reseed that races the late-clearing `processing` flag self-corrects.** `stampAndBuffer` (`assistant-stream-state.ts`) assigns a monotonic `seq` to *every* outbound event, and `persistedSeq` is the last *content* flush — so `message_complete`/`idle` always stamp **above** it. On turn-idle the client reseeds `/messages` and `resolveSnapshot` → `applyEventsToHistory` → `applyEvent` re-folds the buffered tail (`seq > fetched-snapshot.seq`) through `nextProcessingState`. So even when the fetched snapshot reads `processing = true` (it clears in the `finally` after the commit — unchanged here), re-folding the higher-`seq` terminal event converges the composer back to enabled. The ~30s replay ring always contains the just-emitted terminal event at reseed time.
- **Reseed content is correct.** `/messages` reads the DB; truncation/disk-sync write `.tool-results/` files + the JSONL mirror, never the DB rows — a reseed still gets the full finalized reply.

The one behavioral shift: the deferred window between the terminal SSE and the *authoritative* persisted `processing = false` grows by `deferredTailMs`. That flag is a reconnect/cross-client durability signal, not the same-client composer gate (which keys off the `seq`-folded SSE), and it self-heals via the metadata invalidation on clear — so it's cosmetically invisible on the reported path. Runtime rules also hold: the deferred work runs in the POST turn-processing path (not a GET handler, so the "GET handlers side-effect-free" rule is untouched) and adds nothing to the SSE backpressure path.

### Measurement

One log line per turn at the end of `runDeferredTurnTail` (`"End-of-turn work complete"`):

- **`deferredTailMs`** — how long the moved work takes (indexing + truncation + disk-view sync) = the latency reclaimed per turn.
- **`criticalSectionMs`** — remaining awaited work between generation finishing and the tail starting (i.e. still in front of the terminal SSE); should be small.

Read on any running instance after a few messages:
`grep "End-of-turn work complete" "$VELLUM_WORKSPACE_DIR/data/logs/assistant-$(date -u +%Y-%m-%d).log"`

## Test plan

- New regression test `terminal message_complete is emitted before the deferred indexer runs (LUM-2654)` — asserts the terminal SSE is in the client stream before `indexMessageNow` fires. Verified it **fails on the pre-fix source** and passes with the change.
- `bun test src/__tests__/conversation-agent-loop.test.ts` — 67 pass (was 66 + the new guard).
- Ran the affected suites individually (scoped, per AGENTS.md), all green: `tool-result-spool`, `post-turn-tool-result-truncation`, `lexical-index-dual-write`, `conversation-attention-store`, `conversation-sync-tags`, `conversation-agent-loop-overflow`, `cancel-clears-processing`, `processing-flag-persist-failure`, `conversation-loop-db-lock-resilience`, `memory-upsert-concurrency`, `abort-null-controller`, `conversation-agent-loop-disk-pressure`, `conversation-agent-loop-inference-profile`, `conversation-abort-tool-results`, `conversation-provider-retry-repair`, `build-persisted-content`, `daemon-assistant-events`, `runtime-events-sse-parity`.
- `bunx tsc --noEmit` (full project), `eslint`, `prettier --check`, and `lint:circular` (402, unchanged from baseline) all clean.

**Reviewer note (medium risk):** the deferred tail runs on all normal terminal paths (success / handoff / cancel) but is intentionally skipped if a rare wrapper-level error throws *after* a message completed — in that case that message's best-effort indexing is skipped (non-fatal, matches the pre-existing `try`/catch contract). Focus review on the wrapper reorder in `conversation-agent-loop.ts`, the deferral boundary in `handleMessageComplete`, and the extracted `conversation-turn-finalize.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx6xJ5Ep4N3m44vk49UkqL