### PR TITLE
feat(daemon): attribute event-loop blocks to the in-flight SQLite op

### DIFF
--- a/assistant/src/daemon/event-loop-watchdog.test.ts
+++ b/assistant/src/daemon/event-loop-watchdog.test.ts
@@ -7,15 +7,46 @@
  * - `start`/`stop` must be idempotent and safe to call in any order so daemon
  *   startup and the two shutdown paths can call them unconditionally.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+/** Captured `log.warn` calls so the report path's fields can be asserted. */
+const warnCalls: unknown[][] = [];
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
-    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+    new Proxy({} as Record<string, unknown>, {
+      get:
+        (_t, prop) =>
+        (...args: unknown[]) => {
+          if (prop === "warn") warnCalls.push(args);
+        },
+    }),
 }));
 
-const { evaluateTick, startEventLoopWatchdog, stopEventLoopWatchdog } =
-  await import("./event-loop-watchdog.js");
+// The report path fires Sentry + telemetry; stub both so tests don't touch the
+// network, DB, or consent cache.
+mock.module("@sentry/node", () => ({
+  withScope: (fn: (scope: unknown) => void) =>
+    fn({ setLevel() {}, setTag() {}, setContext() {} }),
+  captureMessage: () => {},
+}));
+mock.module("../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: () => {},
+}));
+
+const {
+  evaluateTick,
+  reportBlock,
+  startEventLoopWatchdog,
+  stopEventLoopWatchdog,
+} = await import("./event-loop-watchdog.js");
+const { __resetCurrentSqlOpForTests, markSqlOpEnd, markSqlOpStart } =
+  await import("../persistence/current-sql-op.js");
+
+afterEach(() => {
+  warnCalls.length = 0;
+  __resetCurrentSqlOpForTests();
+});
 
 describe("evaluateTick", () => {
   const INTERVAL = 1_000;
@@ -68,6 +99,41 @@ describe("evaluateTick", () => {
     // THEN the reported block excludes the one normal interval of wait
     expect(blockedMs).toBe(123_000);
     expect(exceeded).toBe(true);
+  });
+});
+
+describe("reportBlock SQLite-op attribution", () => {
+  test("names the op in flight when the block is reported", () => {
+    // GIVEN a SQLite op executing on the loop thread
+    markSqlOpStart("claimDueSchedules.recurring");
+    try {
+      // WHEN a block is reported while that op is still in flight
+      reportBlock(6_000, 5_000);
+    } finally {
+      markSqlOpEnd();
+    }
+    // THEN the warn log attributes the freeze to that op with a plausible age
+    const fields = warnCalls.at(-1)?.[0] as {
+      blockedOp: string | null;
+      blockedOpAgeMs: number | null;
+      blockedMs: number;
+    };
+    expect(fields.blockedOp).toBe("claimDueSchedules.recurring");
+    expect(fields.blockedOpAgeMs).toBeGreaterThanOrEqual(0);
+    expect(fields.blockedMs).toBe(6_000);
+  });
+
+  test("reports blockedOp null when no SQLite op is in flight", () => {
+    // GIVEN no op marked (block caused by non-SQLite work)
+    // WHEN a block is reported
+    reportBlock(7_000, 5_000);
+    // THEN no op is fabricated
+    const fields = warnCalls.at(-1)?.[0] as {
+      blockedOp: string | null;
+      blockedOpAgeMs: number | null;
+    };
+    expect(fields.blockedOp).toBeNull();
+    expect(fields.blockedOpAgeMs).toBeNull();
   });
 });
 

--- a/assistant/src/daemon/event-loop-watchdog.ts
+++ b/assistant/src/daemon/event-loop-watchdog.ts
@@ -26,6 +26,12 @@
  * handle. For deterministic attribution of a specific subsystem, time that
  * subsystem's synchronous calls at their source.
  *
+ * As a lightweight attribution aid it does surface the SQLite op still in
+ * flight when it fires (`blockedOp` / `blockedOpAgeMs`, from the
+ * `persistence/current-sql-op` registry). Since `bun:sqlite` is synchronous and
+ * these blocks are almost always a long or lock-contended SQLite call, that op
+ * is usually the culprit; it is `null` when the block came from non-SQLite work.
+ *
  * A cumulative event-loop-delay histogram is separately exposed pull-based over
  * SSE diagnostics (`runtime/routes/events-routes.ts`); this watchdog is the
  * push/alert counterpart and runs unconditionally for the daemon's lifetime.
@@ -33,6 +39,7 @@
 
 import * as Sentry from "@sentry/node";
 
+import { snapshotCurrentSqlOp } from "../persistence/current-sql-op.js";
 import { recordWatchdogEvent } from "../telemetry/watchdog-events-store.js";
 import { getLogger } from "../util/logger.js";
 
@@ -83,9 +90,21 @@ export function evaluateTick(
  */
 export const EVENT_LOOP_BLOCKED_CHECK_NAME = "event_loop_blocked";
 
-function reportBlock(blockedMs: number, thresholdMs: number): void {
+export function reportBlock(blockedMs: number, thresholdMs: number): void {
+  // Attribute the freeze to the SQLite op still executing on the loop thread,
+  // if any. `null` when no op is marked — the block came from non-SQLite work,
+  // and we never fabricate an op.
+  const currentOp = snapshotCurrentSqlOp();
+  const blockedOp = currentOp?.op ?? null;
+  const blockedOpAgeMs = currentOp ? Math.round(currentOp.ageMs) : null;
   log.warn(
-    { blockedMs, thresholdMs, tickIntervalMs: TICK_INTERVAL_MS },
+    {
+      blockedMs,
+      thresholdMs,
+      tickIntervalMs: TICK_INTERVAL_MS,
+      blockedOp,
+      blockedOpAgeMs,
+    },
     "event loop blocked",
   );
   // Persist a `watchdog` telemetry event so the platform can surface
@@ -101,6 +120,8 @@ function reportBlock(blockedMs: number, thresholdMs: number): void {
       detail: {
         threshold_ms: thresholdMs,
         tick_interval_ms: TICK_INTERVAL_MS,
+        blocked_op: blockedOp,
+        blocked_op_age_ms: blockedOpAgeMs,
       },
     });
   } catch {
@@ -110,10 +131,13 @@ function reportBlock(blockedMs: number, thresholdMs: number): void {
     Sentry.withScope((scope) => {
       scope.setLevel("warning");
       scope.setTag("event_loop_blocked_ms", String(blockedMs));
+      if (blockedOp !== null) scope.setTag("event_loop_blocked_op", blockedOp);
       scope.setContext("event_loop_block", {
         blocked_ms: blockedMs,
         threshold_ms: thresholdMs,
         tick_interval_ms: TICK_INTERVAL_MS,
+        blocked_op: blockedOp,
+        blocked_op_age_ms: blockedOpAgeMs,
       });
       Sentry.captureMessage(EVENT_LOOP_BLOCKED_CHECK_NAME);
     });

--- a/assistant/src/persistence/current-sql-op.test.ts
+++ b/assistant/src/persistence/current-sql-op.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the current-SQLite-op registry.
+ *
+ * - A marked op is snapshottable while in flight and gone once cleared.
+ * - Nested ops obey LIFO and never leak, including when the wrapped `fn` throws.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  __resetCurrentSqlOpForTests,
+  markSqlOpEnd,
+  markSqlOpStart,
+  snapshotCurrentSqlOp,
+  withCurrentSqlOp,
+} from "./current-sql-op.js";
+
+afterEach(() => {
+  __resetCurrentSqlOpForTests();
+});
+
+describe("snapshotCurrentSqlOp", () => {
+  test("returns null when no op is marked", () => {
+    expect(snapshotCurrentSqlOp()).toBeNull();
+  });
+
+  test("names the in-flight op with a plausible age, then null once cleared", () => {
+    // GIVEN an op marked as started at t=1000
+    markSqlOpStart("insertMessageCore");
+    // WHEN snapshotted at t=1120
+    const snap = snapshotCurrentSqlOp(performance.now() + 120);
+    // THEN the op is named with a non-negative, plausible age
+    expect(snap?.op).toBe("insertMessageCore");
+    expect(snap?.ageMs).toBeGreaterThanOrEqual(0);
+    expect(snap?.ageMs).toBeLessThan(10_000);
+    // WHEN the op clears
+    markSqlOpEnd();
+    // THEN nothing is in flight
+    expect(snapshotCurrentSqlOp()).toBeNull();
+  });
+
+  test("age never goes negative if the clock appears to move backwards", () => {
+    markSqlOpStart("claimDueSchedules.recurring");
+    const snap = snapshotCurrentSqlOp(-1);
+    expect(snap?.ageMs).toBe(0);
+  });
+});
+
+describe("nested ops", () => {
+  test("clear in strict LIFO and never leak (A -> B -> clear B -> A -> null)", () => {
+    // GIVEN outer op A
+    markSqlOpStart("A");
+    expect(snapshotCurrentSqlOp()?.op).toBe("A");
+    // WHEN a nested op B is marked, it becomes the innermost in-flight op
+    markSqlOpStart("B");
+    expect(snapshotCurrentSqlOp()?.op).toBe("B");
+    // WHEN B clears, A is once again the current op
+    markSqlOpEnd();
+    expect(snapshotCurrentSqlOp()?.op).toBe("A");
+    // WHEN A clears, nothing remains
+    markSqlOpEnd();
+    expect(snapshotCurrentSqlOp()).toBeNull();
+  });
+
+  test("withCurrentSqlOp clears even when fn throws, leaving no stale op", () => {
+    // GIVEN an outer op wrapping an inner op whose fn throws
+    expect(() =>
+      withCurrentSqlOp("outer", () => {
+        withCurrentSqlOp("inner", () => {
+          throw new Error("boom");
+        });
+      }),
+    ).toThrow("boom");
+    // THEN both marks are cleared — no leak past the throw
+    expect(snapshotCurrentSqlOp()).toBeNull();
+  });
+
+  test("withCurrentSqlOp returns the wrapped value and marks only during fn", () => {
+    const result = withCurrentSqlOp("completeScheduleRun.run", () => ({
+      value: 42,
+      opDuringFn: snapshotCurrentSqlOp()?.op ?? null,
+    }));
+    expect(result.value).toBe(42);
+    expect(result.opDuringFn).toBe("completeScheduleRun.run");
+    expect(snapshotCurrentSqlOp()).toBeNull();
+  });
+});

--- a/assistant/src/persistence/current-sql-op.ts
+++ b/assistant/src/persistence/current-sql-op.ts
@@ -1,0 +1,101 @@
+/**
+ * Current-SQLite-op registry for event-loop-block attribution.
+ *
+ * `bun:sqlite` runs synchronously on the daemon's single event-loop thread, so
+ * a statement that runs long — or spins on the WAL write-lock up to
+ * `busy_timeout` — freezes every other handler for its full duration. The
+ * event-loop watchdog (`daemon/event-loop-watchdog.ts`) detects *that* a freeze
+ * happened but cannot say *which* operation caused it.
+ *
+ * This registry lets the hot SQLite paths name the op currently executing on
+ * the loop thread. Each op brackets its synchronous work with a mark/clear pair
+ * (via {@link withCurrentSqlOp}); the watchdog reads {@link snapshotCurrentSqlOp}
+ * when it fires and attributes the block to whatever op is still in flight.
+ *
+ * Because marks only ever bracket *synchronous* sections (no `await` between a
+ * start and its `finally` clear), the marks nest in strict LIFO order. That
+ * lets the registry be a fixed-size stack of module-level fields — a couple of
+ * array writes and one `performance.now()` per op, zero heap allocation on the
+ * hot path, and no work at all unless the watchdog actually snapshots. Nested
+ * and re-entrant ops (an outer transaction whose body issues inner statements)
+ * are handled by the stack; the innermost frame is the one blocking the loop.
+ */
+
+/**
+ * Deepest nesting the stack records op labels for. Beyond this the depth
+ * counter still tracks so `finally` clears stay balanced, but frames aren't
+ * stored — 64 nested synchronous SQLite ops is far past anything realistic.
+ */
+const MAX_DEPTH = 64;
+
+const opStack: (string | undefined)[] = new Array(MAX_DEPTH).fill(undefined);
+const startedAtStack: number[] = new Array(MAX_DEPTH).fill(0);
+let depth = 0;
+
+/**
+ * Mark `op` as the SQLite operation now executing on the loop thread. Must be
+ * paired with exactly one {@link markSqlOpEnd} in a `finally` so it never leaks
+ * a stale op. Prefer {@link withCurrentSqlOp}, which pairs them for you.
+ */
+export function markSqlOpStart(op: string): void {
+  if (depth < MAX_DEPTH) {
+    opStack[depth] = op;
+    startedAtStack[depth] = performance.now();
+  }
+  depth++;
+}
+
+/** Clear the innermost op marked by {@link markSqlOpStart}. */
+export function markSqlOpEnd(): void {
+  if (depth > 0) {
+    depth--;
+    // Drop the reference so a completed op can't be read back as "in flight".
+    if (depth < MAX_DEPTH) opStack[depth] = undefined;
+  }
+}
+
+/**
+ * Run `fn` with `op` marked as the current SQLite op for the duration of its
+ * synchronous execution, clearing the mark in `finally` even if `fn` throws.
+ *
+ * `fn` is expected to be the synchronous SQLite work: if it returns a promise
+ * the mark is cleared as soon as the synchronous portion returns (before the
+ * promise settles), because only synchronous work blocks the loop thread.
+ */
+export function withCurrentSqlOp<R>(op: string, fn: () => R): R {
+  markSqlOpStart(op);
+  try {
+    return fn();
+  } finally {
+    markSqlOpEnd();
+  }
+}
+
+export interface CurrentSqlOpSnapshot {
+  /** The `op` label of the innermost in-flight SQLite operation. */
+  op: string;
+  /** How long that op has been running, in ms. */
+  ageMs: number;
+}
+
+/**
+ * Snapshot the innermost in-flight SQLite op, or `null` when none is marked
+ * (the block was caused by non-SQLite work — never fabricate an op). `nowMs`
+ * is injectable for deterministic tests.
+ */
+export function snapshotCurrentSqlOp(
+  nowMs: number = performance.now(),
+): CurrentSqlOpSnapshot | null {
+  if (depth === 0) return null;
+  const idx = Math.min(depth, MAX_DEPTH) - 1;
+  const op = opStack[idx];
+  if (op === undefined) return null;
+  return { op, ageMs: Math.max(0, nowMs - startedAtStack[idx]) };
+}
+
+/** Reset the registry. Test-only — production ops always clear via `finally`. */
+export function __resetCurrentSqlOpForTests(): void {
+  depth = 0;
+  opStack.fill(undefined);
+  startedAtStack.fill(0);
+}

--- a/assistant/src/persistence/raw-query.ts
+++ b/assistant/src/persistence/raw-query.ts
@@ -32,6 +32,7 @@
 
 import type { Database, SQLQueryBindings } from "bun:sqlite";
 
+import { withCurrentSqlOp } from "./current-sql-op.js";
 import { getLogsSqlite, getMemorySqlite, getSqlite } from "./db-connection.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
@@ -43,25 +44,29 @@ type SqlParam = SQLQueryBindings;
 
 /** Execute a raw SQL query and return a single typed row, or null if no match. */
 export function rawGet<T>(sql: string, ...params: SqlParam[]): T | null {
-  return timeSyncSection(
-    "raw-query:get",
-    () =>
-      (getSqlite()
-        .query(sql)
-        .get(...params) as T) ?? null,
-    () => ({ sql: sql.slice(0, 80) }),
+  return withCurrentSqlOp("raw:get", () =>
+    timeSyncSection(
+      "raw-query:get",
+      () =>
+        (getSqlite()
+          .query(sql)
+          .get(...params) as T) ?? null,
+      () => ({ sql: sql.slice(0, 80) }),
+    ),
   );
 }
 
 /** Execute a raw SQL query and return all matching rows with type safety. */
 export function rawAll<T>(sql: string, ...params: SqlParam[]): T[] {
-  return timeSyncSection(
-    "raw-query:all",
-    () =>
-      getSqlite()
-        .query(sql)
-        .all(...params) as T[],
-    (rows) => ({ sql: sql.slice(0, 80), rowCount: rows.length }),
+  return withCurrentSqlOp("raw:all", () =>
+    timeSyncSection(
+      "raw-query:all",
+      () =>
+        getSqlite()
+          .query(sql)
+          .all(...params) as T[],
+      (rows) => ({ sql: sql.slice(0, 80), rowCount: rows.length }),
+    ),
   );
 }
 
@@ -70,20 +75,22 @@ export function rawAll<T>(sql: string, ...params: SqlParam[]): T[] {
  * of affected rows.
  */
 export function rawRun(sql: string, ...params: SqlParam[]): number {
-  timeSyncSection(
-    "raw-query:run",
-    () =>
-      getSqlite()
-        .query(sql)
-        .run(...params),
-    () => ({ sql: sql.slice(0, 80) }),
+  withCurrentSqlOp("raw:run", () =>
+    timeSyncSection(
+      "raw-query:run",
+      () =>
+        getSqlite()
+          .query(sql)
+          .run(...params),
+      () => ({ sql: sql.slice(0, 80) }),
+    ),
   );
   return rawChanges();
 }
 
 /** Execute batch SQL (multiple statements, no bindings). */
 export function rawExec(sql: string): void {
-  getSqlite().exec(sql);
+  withCurrentSqlOp("raw:exec", () => getSqlite().exec(sql));
 }
 
 /**
@@ -116,23 +123,27 @@ function logsSqlite(): Database {
 
 /** {@link rawAll} against the memory connection. */
 export function rawMemoryAll<T>(sql: string, ...params: SqlParam[]): T[] {
-  return timeSyncSection(
-    "raw-query:memory-all",
-    () =>
-      memorySqlite()
-        .query(sql)
-        .all(...params) as T[],
-    (rows) => ({ sql: sql.slice(0, 80), rowCount: rows.length }),
+  return withCurrentSqlOp("raw:memory-all", () =>
+    timeSyncSection(
+      "raw-query:memory-all",
+      () =>
+        memorySqlite()
+          .query(sql)
+          .all(...params) as T[],
+      (rows) => ({ sql: sql.slice(0, 80), rowCount: rows.length }),
+    ),
   );
 }
 
 /** {@link rawRun} against the memory connection. */
 export function rawMemoryRun(sql: string, ...params: SqlParam[]): number {
   const sqlite = memorySqlite();
-  timeSyncSection(
-    "raw-query:memory-run",
-    () => sqlite.query(sql).run(...params),
-    () => ({ sql: sql.slice(0, 80) }),
+  withCurrentSqlOp("raw:memory-run", () =>
+    timeSyncSection(
+      "raw-query:memory-run",
+      () => sqlite.query(sql).run(...params),
+      () => ({ sql: sql.slice(0, 80) }),
+    ),
   );
   return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
 }
@@ -146,10 +157,12 @@ export function rawMemoryChanges(): number {
 /** {@link rawRun} against the logs connection. */
 export function rawLogsRun(sql: string, ...params: SqlParam[]): number {
   const sqlite = logsSqlite();
-  timeSyncSection(
-    "raw-query:logs-run",
-    () => sqlite.query(sql).run(...params),
-    () => ({ sql: sql.slice(0, 80) }),
+  withCurrentSqlOp("raw:logs-run", () =>
+    timeSyncSection(
+      "raw-query:logs-run",
+      () => sqlite.query(sql).run(...params),
+      () => ({ sql: sql.slice(0, 80) }),
+    ),
   );
   return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
 }

--- a/assistant/src/util/sqlite-retry.ts
+++ b/assistant/src/util/sqlite-retry.ts
@@ -24,6 +24,7 @@
  * committed — a retry would double-apply them.
  */
 
+import { withCurrentSqlOp } from "../persistence/current-sql-op.js";
 import { getLogger } from "./logger.js";
 import { computeRetryDelay } from "./retry.js";
 
@@ -69,7 +70,12 @@ export async function withSqliteRetry<T>(
   const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   for (let attempt = 0; ; attempt++) {
     try {
-      return await fn();
+      // Mark `op` as the current SQLite op only around the synchronous `fn()`
+      // invocation — `withCurrentSqlOp` clears the mark as soon as `fn` returns
+      // (before any promise it yields settles), so the watchdog can attribute a
+      // freeze to the op whose synchronous work was blocking the loop. Pure
+      // instrumentation: the awaited value and retry/backoff below are unchanged.
+      return await withCurrentSqlOp(options.op, fn);
     } catch (err) {
       if (attempt < maxRetries && isRetryableSqliteError(err)) {
         log.warn(


### PR DESCRIPTION
## Prompt / plan

The event-loop watchdog logs `"event loop blocked" { blockedMs, thresholdMs, tickIntervalMs }` when the loop is starved, but it doesn't say **which** operation was in flight. Since `bun:sqlite` is synchronous and `busy_timeout=5000`, these freezes are almost always a SQLite call that ran long or sat spinning on the WAL write-lock — so we want the watchdog to name the op that was executing when the loop froze.

Approach:
- **New registry** `assistant/src/persistence/current-sql-op.ts` — a tiny module-level LIFO stack of `{ op, startedAtMs }` frames. `markSqlOpStart` / `markSqlOpEnd` (paired via `withCurrentSqlOp` in a `finally`) correctly handle nested/re-entrant ops and never leak a stale op. Fixed-size backing arrays + a depth counter mean the hot path only writes a couple of fields and calls `performance.now()` once — zero heap allocation, and no work unless the watchdog snapshots.
- **`withSqliteRetry`** marks each attempt's `op` only around the **synchronous** `fn()` call (cleared before any yielded promise settles), so "current op during a block" = the op whose synchronous SQLite work was blocking the loop. Retry/backoff, transaction semantics, and return values are unchanged — pure instrumentation.
- **`event-loop-watchdog.ts`** snapshots the in-flight op when a block is reported and adds `blockedOp` / `blockedOpAgeMs` to the warn log, telemetry `detail`, and Sentry context/tag. `blockedOp` is `null` when no SQLite op is active (non-SQLite block) — never fabricated.
- **`raw-query.ts`** routes the un-retried raw paths through the same marker with consistent `raw:*` labels (`raw:get`, `raw:all`, `raw:run`, `raw:exec`, `raw:memory-all`, `raw:memory-run`, `raw:logs-run`) so blocks from un-retried queries are attributable too.

New log fields on `"event loop blocked"`: **`blockedOp`** (op label or `null`) and **`blockedOpAgeMs`** (how long it had been running, or `null`). Mirrored as `blocked_op` / `blocked_op_age_ms` in the telemetry detail and Sentry context, plus a `event_loop_blocked_op` Sentry tag.

## Test plan

- **New** `current-sql-op.test.ts`: snapshot names the in-flight op with a plausible age and returns `null` once cleared; age never goes negative; nested ops clear in strict LIFO (A → B → clear B → A → null); `withCurrentSqlOp` clears even when `fn` throws (no leak) and returns the wrapped value.
- **New** cases in `event-loop-watchdog.test.ts`: while an op is marked, `reportBlock` emits `blockedOp` + a plausible `blockedOpAgeMs`; with no op marked, both are `null`.
- Ran the new + updated unit tests (14 pass) and representative persistence suites that heavily exercise `raw-query` (`conversation-queries-search`, `attachments-store` — 68 pass) to confirm the instrumentation doesn't disturb real DB paths.
- `bunx tsc --noEmit`, `eslint`, and `prettier --check` all clean on the touched files (also enforced by the pre-commit hook).

<!-- CLI verb checklist: not applicable — this PR adds no new IPC routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VC6SREoEGjgBzy6dLxwUVc)_