### PR TITLE
chore(prompts): remove the Communication section from the default system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -312,6 +312,7 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("## External Communications Identity");
     expect(result).not.toContain("## In-Chat Configuration");
     expect(result).not.toContain("## Historical Mentions Are Read-Only");
+    expect(result).not.toContain("## Communication");
   });
 
   test("does not include removed domain routing sections", () => {
@@ -664,26 +665,6 @@ describe("buildSystemPrompt", () => {
       expect(result).toContain("Batch independent tool calls");
     });
 
-    test("bundled communication section renders and sorts before the parallel-tool-calls block", () => {
-      // `01-communication` sorts ahead of `01-parallel-tool-calls`, so the
-      // communication guidance leads the operational sections.
-      const result = buildSystemPrompt();
-      expect(result).toContain("## Communication");
-      // The core rule: deliberation belongs in private thinking, not text.
-      expect(result).toContain(
-        "in your private thinking — never in user-facing text",
-      );
-      // Closes by deferring to the user's established communication preferences.
-      expect(result).toContain(
-        "Always prioritize communication preferences that you've established",
-      );
-      const communicationIdx = result.indexOf("## Communication");
-      const parallelIdx = result.indexOf("<use_parallel_tool_calls>");
-      expect(communicationIdx).toBeGreaterThan(-1);
-      expect(parallelIdx).toBeGreaterThan(-1);
-      expect(communicationIdx).toBeLessThan(parallelIdx);
-    });
-
     test("workspace prefix with frontmatter renders body at the very top", () => {
       mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
       writeFileSync(
@@ -887,7 +868,9 @@ describe("buildSystemPrompt", () => {
         // after the stable instruction sections
         const boundaryIdx = result.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
         expect(boundaryIdx).toBeGreaterThan(-1);
-        expect(result.indexOf("## Communication")).toBeLessThan(boundaryIdx);
+        expect(result.indexOf("<use_parallel_tool_calls>")).toBeLessThan(
+          boundaryIdx,
+        );
         expect(result.indexOf("# Voice Profile")).toBeGreaterThan(boundaryIdx);
       });
 
@@ -967,7 +950,9 @@ describe("buildSystemPrompt", () => {
         expect(result.indexOf("Custom head section.")).toBeLessThan(
           boundaryIdx,
         );
-        expect(result.indexOf("## Communication")).toBeGreaterThan(boundaryIdx);
+        expect(result.indexOf("<use_parallel_tool_calls>")).toBeGreaterThan(
+          boundaryIdx,
+        );
 
         // AND the bundled default declaration on 11-channel-persona is
         // ignored — no second marker

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -247,21 +247,6 @@ export const BUNDLED_SYSTEM_SECTIONS: readonly BundledSection[] = [
     enabled: "!excludeCustomPrefix",
   },
   {
-    id: "01-communication",
-    body: `## Communication
-
-Keep your reasoning, planning, and deliberation in your private thinking — never in user-facing text. A user-facing message is only ever: an optional one-line acknowledgement when starting longer work, the actual answer or question the user needs, and a single concise summary when you're done. 
-
-Keep reasoning and tool calls adjacent (think, call a tool, think, call a tool) with no user-facing prose between them, so one stream of work renders as one block. 
-
-Meet your user where they are. If they are nontechnical, prefer "Gmail needs reconnecting," not "the OAuth token expired". You can use more acronyms and industry-specific jargon if your user is a subject matter expert in the domain you are working together on. This applies for marketers, engineers, consultants, entrepreneurs, etc. 
-
-Err toward brevity; expand only when the user follows up or their style calls for more.
-
-These are default guidelines. Always prioritize communication preferences that you've established through your relationship with your human.
-`,
-  },
-  {
     id: "01-delegate-subagents",
     body: `## Delegate independent work
 


### PR DESCRIPTION
## Summary
- Remove the `01-communication` section (`## Communication`) from `BUNDLED_SYSTEM_SECTIONS` in `assistant/src/prompts/templates/system-sections.ts`, so the shipped default system prompt no longer carries the communication guidance (private-thinking-only reasoning, adjacency of reasoning/tool calls, meet-the-user-at-their-level, brevity, defer-to-relationship-preferences).
- Update `system-prompt.test.ts`: drop the dedicated communication-section test, retarget two cache-breakpoint ordering anchors to the always-on `<use_parallel_tool_calls>` section, and add a `## Communication` regression guard to the removed-sections test.
- No migration needed: `collectSectionIds()` unions the bundled registry with workspace `.md` filenames, so any user who authored `prompts/system/01-communication.md` keeps rendering their override — only the shipped default is dropped.

## Original prompt
Remove the injected "Communication" section at the top of the default system prompt. It was the first substantive bundled section (`01-communication`), rendered right after the empty `00-prefix` slot. The change should drop it from the shipped defaults while preserving any user workspace overrides and keeping the section-ordering and cache-breakpoint tests green.