### PR TITLE
fix(avatar): stop writing the IDENTITY.md avatar placeholder on avatar change

### DIFF
--- a/assistant/src/avatar/identity-avatar.ts
+++ b/assistant/src/avatar/identity-avatar.ts
@@ -5,12 +5,10 @@ import { getWorkspaceDir } from "../util/platform.js";
 
 /**
  * Update the `## Avatar` section in IDENTITY.md with a plain-text description.
- *
- * If `description` is null, clears the section content (leaves the heading so
- * the assistant knows to fill it in). If the section doesn't exist, appends it.
+ * If the section doesn't exist, appends it.
  */
 export function updateIdentityAvatarSection(
-  description: string | null,
+  description: string,
   log?: { warn: (obj: Record<string, unknown>, msg: string) => void },
 ): void {
   const identityPath = join(getWorkspaceDir(), "IDENTITY.md");
@@ -31,9 +29,7 @@ export function updateIdentityAvatarSection(
     return;
   }
 
-  const sectionBody = description
-    ? `## Avatar\n${description}\n`
-    : "## Avatar\nNo description yet — describe what the current avatar looks like.\n";
+  const sectionBody = `## Avatar\n${description}\n`;
 
   // Match ## Avatar and its content up to (but not including) the next heading
   // at any level, or end of file. Uses multiline ^ to match headings at line start.

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -120,7 +120,6 @@ function handleRenderFromTraits({ body, headers }: RouteHandlerArgs) {
     }
   }
 
-  updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
   return { ok: true };
 }
@@ -153,7 +152,6 @@ async function handleGenerateAvatar({ body, headers }: RouteHandlerArgs) {
   // character sidecars (traits + ASCII), and records an AI-sourced manifest.
   setImage(result.pngBuffer, "ai");
 
-  updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
   return { ok: true, message: result.content };
 }
@@ -202,7 +200,6 @@ function handleUploadAvatarImage({ body, headers }: RouteHandlerArgs) {
   // character sidecars (traits + ASCII), and records an uploaded-image manifest.
   setImage(buffer, "upload");
 
-  updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
   return { ok: true };
 }
@@ -235,7 +232,6 @@ function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
   // recorded as an uploaded image atomically (no more stale both-files state).
   setImage(readFileSync(normalized), "upload");
 
-  updateIdentityAvatarSection(null, log);
   publishAvatarChanged(headers?.["x-vellum-client-id"]?.trim() || undefined);
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- Avatar render/generate/upload/set routes no longer rewrite the `## Avatar` section of `IDENTITY.md`. They previously cleared it to a placeholder line ("No description yet — describe what the current avatar looks like."), which polluted the persona/system prompt.
- The `vellum-avatar` skill already instructs the assistant to write a fresh `## Avatar` description after any avatar change, so that text is assistant-authored; the route-side force-clear was redundant.
- `updateIdentityAvatarSection` is narrowed to a non-null `string` with its now-dead placeholder branch removed. `avatar/remove` still writes its accurate default-state description ("Default character avatar (no custom image set)").

## Original prompt
Remove the default "No description yet — describe what the current avatar looks like." text that gets written into IDENTITY.md on every avatar change. We chose to leave the `## Avatar` section untouched rather than clear it, keeping the description authored by the avatar skill, and accepting that a UI-driven avatar swap may leave the prior description briefly stale until it is updated.