### PR TITLE
fix(setup): drop stale evals/ from setup.sh dependency loop

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ git config core.hooksPath .githooks
 # ---------------------------------------------------------------------------
 # Install dependencies and register local packages as linkable
 # ---------------------------------------------------------------------------
-for dir in cli gateway assistant credential-executor evals; do
+for dir in cli gateway assistant credential-executor; do
   info "Installing dependencies in ${dir}/"
   (cd "${REPO_ROOT}/${dir}" && bun install)
   info "Registering ${dir}/ as a linkable package"


### PR DESCRIPTION
## Problem

`./setup.sh` fails on a fresh checkout:

```
setup.sh: line 52: cd: /path/to/vellum-assistant/evals: No such file or directory
```

PR #36323 (*Remove evals/ from monorepo*) deleted the `evals/` directory — evals were migrated to [`vellum-ai/evals`](https://github.com/vellum-ai/evals) — but it did not update `setup.sh`, which still loops over `evals` when installing and linking local packages. `(cd "${REPO_ROOT}/evals" && bun install)` then aborts the whole script under `set -e`.

This also breaks the `vellum-assistant-platform` `vel setup` flow, which invokes this `setup.sh` as one of its steps.

## Fix

Remove the stale `evals` entry from the linkable-package loop. Verified `bash -n setup.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)