### PR TITLE
chore(lint): warn on braceless control statements + document braces convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,10 @@ Proactively remove unused code during every change. Remove code your change make
 
 Default to no comment — bias aggressively toward terseness and rely on good naming. Follow the commenting density of the surrounding code.
 
+## Control-Flow Braces
+
+Wrap every `if` / `else` / `for` / `while` / `do…while` body in braces, even a single-statement one-liner. Braces make control flow easy to scan — the block boundary is explicit — and close a common footgun: a second line added under a braceless condition reads as if it sits inside the branch but runs unconditionally. The ESLint `curly` rule flags this in both `assistant/` and `clients/web/` (currently at `warn`); it is fully auto-fixable, so add braces to any control statement you touch.
+
 ## Generic Examples
 
 Never include personal user data — real names, emails, phone numbers, account IDs, or other identifying details of specific people — anywhere in the codebase. This covers code, tests, fixtures, documentation, comments, commit messages, and AGENTS.md files. Always use generic placeholders:

--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
       "simple-import-sort": simpleImportSort,
     },
     rules: {
+      // Require braces on every control-statement body (if/else/for/
+      // while/do). A braceless body is a maintenance hazard: a second
+      // line added under the condition reads as guarded but always runs.
+      curly: ["warn", "all"],
       "simple-import-sort/imports": [
         "error",
         {
@@ -52,7 +56,9 @@ const eslintConfig = defineConfig([
   {
     files: ["src/cli/commands/**/*.ts"],
     ignores: ["src/cli/commands/**/__tests__/**"],
-    plugins: { cli: { rules: { "no-daemon-internals": cliNoDaemonInternals } } },
+    plugins: {
+      cli: { rules: { "no-daemon-internals": cliNoDaemonInternals } },
+    },
     rules: { "cli/no-daemon-internals": "error" },
   },
 ]);

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -509,6 +509,32 @@ import { useCallback } from "react";
 const label = "Send message";
 ```
 
+### Braces on all control statements
+
+Always wrap the body of `if`, `else`, `for`, `while`, and `do…while` in
+braces, even a single statement on the same line.
+
+```ts
+// Good
+if (!user) {
+  return null;
+}
+
+// Avoid — a second line added below reads as guarded but always runs
+if (!user) return null;
+```
+
+Braces make control flow easy to scan: the block boundary is explicit,
+so it's obvious at a glance exactly what the branch runs. They also close
+a common footgun — a second line added under a braceless condition reads
+as if it sits inside the branch, but executes unconditionally.
+
+The `curly` ESLint rule flags braceless bodies (currently at `warn`). It
+is fully auto-fixable — `eslint --fix` adds the braces with no behavior
+change — so add braces to any control statement you touch.
+
+Reference: [ESLint — `curly`](https://eslint.org/docs/latest/rules/curly)
+
 ---
 
 ## Unused code

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -153,6 +153,10 @@ const eslintConfig = defineConfig([
       local: { rules: { "no-cross-domain-imports": noCrossDomainImports } },
     },
     rules: {
+      // Require braces on every control-statement body (if/else/for/
+      // while/do). A braceless body is a maintenance hazard: a second
+      // line added under the condition reads as guarded but always runs.
+      curly: ["warn", "all"],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },


### PR DESCRIPTION
## Prompt / plan

Implements the first, low-risk step of [LUM-2658](https://linear.app/vellum/issue/LUM-2658): add ESLint's [`curly`](https://eslint.org/docs/latest/rules/curly) rule in `"all"` mode as a **`warn`** to `assistant/` and `clients/web/`, and document the braces-always convention.

This isn't fixing a bug — it's a **readability** convention. Braces make control flow easy to scan (the block boundary is explicit, so a branch's extent is obvious at a glance) and close the footgun where a second line added under a braceless condition reads as guarded but runs unconditionally. This PR surfaces it as code is touched, **without** rewriting the ~11K existing occurrences.

**Scope — intentionally soft:**
- `curly: ["warn", "all"]` in both eslint configs. Surfaces in-editor and in `bun run lint` output; does **not** fail CI (warnings only).
- Convention + reasoning documented in `clients/web/docs/STYLE_GUIDE.md` (with a Good/Avoid example) and root `AGENTS.md`.
- No existing code is reformatted. Contributors add braces to control statements they touch; `eslint --fix` makes that a one-liner.

Hardening to `error` — via a one-time autofix or a decreasing violation-count gate — is left as a possible follow-up, not part of this PR.

## Test plan

- `bun run lint` passes (exit 0) in both packages — `curly` reports warnings, not errors, so CI stays green.
- Docs-only + config-only change; no source behavior touched.
