### PR TITLE
feat(onboarding): revise seeded threads.md onboarding bullets

### DIFF
--- a/assistant/src/__tests__/workspace-migration-120-revise-onboarding-threads.test.ts
+++ b/assistant/src/__tests__/workspace-migration-120-revise-onboarding-threads.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for workspace migration `120-revise-onboarding-threads`.
+ *
+ * The migration revises the onboarding bullets in `memory/threads.md` (seeded
+ * by 069, retightened by 091) only for newly-created workspaces
+ * (`ctx.isNewWorkspace === true`): it drops the personality-authoring bullet and
+ * retargets the avatar bullet at the vellum-avatar skill. It is a no-op on
+ * upgrade, when the known bullets are absent, and when the file is missing. It
+ * must be idempotent and compose with 069 and 091.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedOnboardingThreadsMigration } from "../workspace/migrations/069-seed-onboarding-threads.js";
+import { retightenMigrationOnboardingThreadMigration } from "../workspace/migrations/091-retighten-migration-onboarding-thread.js";
+import { reviseOnboardingThreadsMigration } from "../workspace/migrations/120-revise-onboarding-threads.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+// Literal copy of the 4-bullet block 069 seeds into memory/threads.md. 120
+// drops bullet 1 (personality) and rewrites bullet 2 (avatar); it leaves
+// bullets 3 and 4 untouched.
+const ONBOARDING_THREADS = `- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.
+- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.
+- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.
+- Suggest connecting to available messaging services like Slack or Telegram
+`;
+
+const PERSONALITY_SNIPPET = "Figure out what kind of personality";
+const OLD_AVATAR_BULLET =
+  "- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.";
+const NEW_AVATAR_SNIPPET =
+  "custom AI generated avatar for yourself using the `vellum-avatar` skill";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-120-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function seedThreads(content: string): void {
+  mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+  writeFileSync(join(workspaceDir, "memory", "threads.md"), content, "utf-8");
+}
+
+function readThreads(): string {
+  return readFileSync(join(workspaceDir, "memory", "threads.md"), "utf-8");
+}
+
+describe("120-revise-onboarding-threads migration", () => {
+  test("has correct id and description", () => {
+    expect(reviseOnboardingThreadsMigration.id).toBe(
+      "120-revise-onboarding-threads",
+    );
+    expect(reviseOnboardingThreadsMigration.description).toContain(
+      "threads.md",
+    );
+  });
+
+  test("is registered in WORKSPACE_MIGRATIONS", () => {
+    expect(WORKSPACE_MIGRATIONS).toContain(reviseOnboardingThreadsMigration);
+  });
+
+  test("drops the personality bullet and retargets the avatar bullet, preserving the rest", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+
+    const content = readThreads();
+    // The personality-authoring bullet is gone.
+    expect(content).not.toContain(PERSONALITY_SNIPPET);
+    // The avatar bullet is retargeted at the vellum-avatar skill.
+    expect(content).not.toContain(OLD_AVATAR_BULLET);
+    expect(content).toContain(NEW_AVATAR_SNIPPET);
+    // The other two onboarding bullets are preserved verbatim.
+    expect(content).toContain("ChatGPT, Claude");
+    expect(content).toContain("Slack or Telegram");
+    // Removing bullet 1 leaves no leading blank line — the file now begins with
+    // the (revised) avatar bullet.
+    expect(
+      content.startsWith(
+        "- Work with your user to set a custom AI generated avatar",
+      ),
+    ).toBe(true);
+  });
+
+  test("no-op on upgrade even when the bullets are present", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readThreads()).toBe(ONBOARDING_THREADS);
+  });
+
+  test("no-op when the bullets are absent (user-edited content)", () => {
+    const edited = "- A bullet the user wrote themselves.\n";
+    seedThreads(edited);
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+
+    expect(readThreads()).toBe(edited);
+  });
+
+  test("no-op when memory/threads.md does not exist", () => {
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    expect(existsSync(join(workspaceDir, "memory", "threads.md"))).toBe(false);
+  });
+
+  test("idempotent — second run produces identical content", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    const afterFirst = readThreads();
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    const afterSecond = readThreads();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("composes 069 -> 091 -> 120: fresh empty workspace ends with the revised bullets", () => {
+    // Mirror how the 069/091 tests set up: create an empty threads.md first.
+    seedThreads("");
+
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    retightenMigrationOnboardingThreadMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+
+    const content = readThreads();
+    expect(content).not.toContain(PERSONALITY_SNIPPET);
+    expect(content).toContain(NEW_AVATAR_SNIPPET);
+    // 091's retightened assistant-migration bullet survives.
+    expect(content).toContain("first real task");
+    expect(content).toContain("ChatGPT, Claude");
+    // The messaging bullet survives.
+    expect(content).toContain("Slack or Telegram");
+    // Exactly three bullets remain.
+    expect(
+      content.split("\n").filter((line) => line.startsWith("- ")).length,
+    ).toBe(3);
+  });
+
+  test("down() is a no-op — revised content remains", () => {
+    seedThreads(ONBOARDING_THREADS);
+
+    reviseOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    const revised = readThreads();
+
+    reviseOnboardingThreadsMigration.down(workspaceDir);
+
+    expect(readThreads()).toBe(revised);
+  });
+});

--- a/assistant/src/workspace/migrations/120-revise-onboarding-threads.ts
+++ b/assistant/src/workspace/migrations/120-revise-onboarding-threads.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+// The onboarding bullets seeded by 069-seed-onboarding-threads. Inlined here
+// (not imported) to keep this migration self-contained and decoupled from 069.
+
+// The personality-authoring bullet, dropped entirely. Includes the trailing
+// newline so the whole line is removed without leaving a blank line behind.
+const PERSONALITY_BULLET =
+  "- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.\n";
+
+// The avatar bullet, retargeted at the vellum-avatar skill.
+const OLD_AVATAR_BULLET =
+  "- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.";
+const NEW_AVATAR_BULLET =
+  "- Work with your user to set a custom AI generated avatar for yourself using the `vellum-avatar` skill. This task is done once data/avatar/avatar-image.png exists.";
+
+export const reviseOnboardingThreadsMigration: WorkspaceMigration = {
+  id: "120-revise-onboarding-threads",
+  description:
+    "Revise memory/threads.md onboarding bullets for brand new assistants: drop the personality-authoring bullet and point the avatar bullet at the vellum-avatar skill",
+
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // Only rewrite onboarding tasks for newly-created workspaces. An existing
+    // assistant whose user has edited threads.md must not have its content
+    // rewritten on upgrade. When invoked without a context (e.g. from older
+    // callers), default to the safe path and skip — the runner always supplies
+    // one in production.
+    if (!ctx?.isNewWorkspace) return;
+    const filePath = join(workspaceDir, "memory", "threads.md");
+    if (!existsSync(filePath)) return;
+    const original = readFileSync(filePath, "utf-8");
+    const updated = original
+      .replace(PERSONALITY_BULLET, "")
+      .replace(OLD_AVATAR_BULLET, NEW_AVATAR_BULLET);
+    // Idempotent: if neither known bullet is present (already revised, or the
+    // user edited them away), there is nothing to do.
+    if (updated === original) return;
+    writeFileSync(filePath, updated, "utf-8");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: never rewrite user-visible memory content on rollback.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -117,6 +117,7 @@ import { renameMemoryPluginDisabledSentinelMigration } from "./116-rename-memory
 import { normalizeStaleLeanMemoryV3DefaultsMigration } from "./117-normalize-stale-lean-memory-v3-defaults.js";
 import { seedNowMdMigration } from "./118-seed-now-md.js";
 import { stripPersistedMemoryV3TuningDefaultsMigration } from "./119-strip-persisted-memory-v3-tuning-defaults.js";
+import { reviseOnboardingThreadsMigration } from "./120-revise-onboarding-threads.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -245,4 +246,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   normalizeStaleLeanMemoryV3DefaultsMigration,
   seedNowMdMigration,
   stripPersistedMemoryV3TuningDefaultsMigration,
+  reviseOnboardingThreadsMigration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration `120-revise-onboarding-threads` that, for brand-new assistants only, drops the personality-authoring onboarding bullet ("Figure out what kind of personality…rewrite SOUL.md and IDENTITY.md…") and retargets the avatar bullet at the `vellum-avatar` skill ("set a custom AI generated avatar for yourself using the `vellum-avatar` skill").
- Delivered as a new migration rather than an edit to the frozen `069-seed-onboarding-threads`, per the append-only workspace-migration convention (migrations are write-once). This mirrors how `091` previously retightened one of these same bullets. Gated on `isNewWorkspace`, so existing users' `threads.md` is never rewritten on upgrade.
- Adds a test file mirroring the `091` test: removal + retarget, no-op on upgrade/absent/missing, idempotency, `069 → 091 → 120` composition, and registry registration. All migration tests (069/091/120) pass; fast typecheck is clean.

## Original prompt
Remove the personality-authoring line from the default seeded `threads.md`, and change the avatar bullet to "set a custom AI generated avatar for yourself using the `vellum-avatar` skill." Because the seeded content is produced by write-once workspace migration `069`, the change ships as a new, new-workspace-gated migration (`120`) rather than editing `069` — consistent with the `091` precedent for revising these bullets. The skill name was confirmed as `vellum-avatar` (the exact first-party skill name) rather than a bare `avatar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)