### PR TITLE
chore(prompts): remove the External Service Access section from the default system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1053,91 +1053,6 @@ describe("buildSystemPrompt", () => {
       });
     });
 
-    describe("access-preference section (slot 05)", () => {
-      const ACCESS_FILE = join(SYSTEM_PROMPTS_DIR, "05-access-preference.md");
-      // Mirrors the bundled `templates/system/05-access-preference.md` — both
-      // variants live in the markdown body and the renderer picks one via
-      // mustache-style `{{#hasNoClient}}` / `{{^hasNoClient}}` conditionals.
-      const TEMPLATE_BODY = [
-        "## External Service Access",
-        "",
-        "{{#hasNoClient}}",
-        "Priority: (1) sandbox `bash` — install tools yourself; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).",
-        "{{/hasNoClient}}",
-        "{{^hasNoClient}}",
-        "Priority: (1) sandbox `bash` - install tools yourself, only fall back to host when you need local files/auth; (2) `host_bash` with CLIs (gh, aws, etc.) using --json flags; (3) browser automation as last resort (no API, visual interaction, or OAuth consent).",
-        "{{/hasNoClient}}",
-        "",
-      ].join("\n");
-
-      test("with-client (default) renders the three-tier priority list", () => {
-        mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
-        writeFileSync(ACCESS_FILE, TEMPLATE_BODY);
-        const result = buildSystemPrompt();
-        expect(result).toContain("## External Service Access");
-        expect(result).toContain("`host_bash` with CLIs");
-        expect(result).toContain("browser automation as last resort");
-        // The no-client body (em-dash separator after sandbox `bash`) must
-        // not leak when the with-client variant is active.
-        expect(result).not.toContain("install tools yourself; (2) browser");
-        expect(result).toContain("## External Service Access");
-      });
-
-      test("hasNoClient=true renders the two-tier (no host_bash) priority list", () => {
-        mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
-        writeFileSync(ACCESS_FILE, TEMPLATE_BODY);
-        const result = buildSystemPrompt({ hasNoClient: true });
-        expect(result).toContain("## External Service Access");
-        expect(result).toContain("browser automation as last resort");
-        // The host_bash tier must be absent in the no-client variant.
-        expect(result).not.toContain("`host_bash` with CLIs");
-        // The no-client body uses an em-dash + semicolon separator after
-        // sandbox `bash`; the with-client body uses a comma — guard against
-        // the wrong variant leaking through.
-        expect(result).toContain("install tools yourself; (2) browser");
-        expect(result).not.toContain(
-          "only fall back to host when you need local files/auth",
-        );
-      });
-
-      test("standalone tag lines do not bleed extra blank lines into output", () => {
-        mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
-        writeFileSync(ACCESS_FILE, TEMPLATE_BODY);
-        const result = buildSystemPrompt();
-        // The heading and the active variant body should sit on adjacent
-        // lines separated by exactly one blank line — no triple-newline
-        // artifacts from the section markers.
-        expect(result).toMatch(
-          /## External Service Access\n\nPriority: \(1\) sandbox `bash` -/,
-        );
-      });
-
-      test("bundled access-preference default renders when no workspace override", () => {
-        // Bundled `05-access-preference.md` carries both with-client and
-        // no-client variants inline behind mustache section conditionals,
-        // so the default body renders without any workspace file present.
-        mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
-        const result = buildSystemPrompt();
-        expect(result).toContain("## External Service Access");
-        expect(result).toContain("`host_bash` with CLIs");
-      });
-
-      test("renders after the attachment section to preserve original order", () => {
-        mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
-        writeFileSync(
-          join(SYSTEM_PROMPTS_DIR, "04-attachment.md"),
-          "## Sending Files to the User\n\nbody.\n",
-        );
-        writeFileSync(ACCESS_FILE, TEMPLATE_BODY);
-        const result = buildSystemPrompt();
-        const attachmentIdx = result.indexOf("## Sending Files to the User");
-        const accessIdx = result.indexOf("## External Service Access");
-        expect(attachmentIdx).toBeGreaterThan(-1);
-        expect(accessIdx).toBeGreaterThan(-1);
-        expect(attachmentIdx).toBeLessThan(accessIdx);
-      });
-    });
-
     describe("mustache section interpolation", () => {
       // Reuse slot 00 (prefix) — its default-on `enabled` predicate is
       // already covered by other tests; here we only care about body
@@ -1314,17 +1229,16 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("`assistant credentials prompt`");
       });
 
-      test("renders after the access-preference section to preserve original order", () => {
-        // Static-block order from the pre-registry inline build was
-        // access-preference → credential-security.  The numeric prefix on
-        // the registry id (`06-` > `05-`) preserves that order.
+      test("renders after the attachment section to preserve original order", () => {
+        // Registry ids sort by numeric prefix, so `06-credential-security`
+        // renders after the preceding static section `04-attachment`.
         mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
         const result = buildSystemPrompt();
-        const accessIdx = result.indexOf("## External Service Access");
+        const attachmentIdx = result.indexOf("## Sending Files to the User");
         const credentialIdx = result.indexOf("## Credential Security");
-        expect(accessIdx).toBeGreaterThan(-1);
+        expect(attachmentIdx).toBeGreaterThan(-1);
         expect(credentialIdx).toBeGreaterThan(-1);
-        expect(accessIdx).toBeLessThan(credentialIdx);
+        expect(attachmentIdx).toBeLessThan(credentialIdx);
       });
     });
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -454,9 +454,10 @@ interface SourceParityPins {
  * stored on the conversation row — the slugs are omitted so the wake keeps
  * today's persona derivation for them.
  *
- * `hasNoClient` — pinned on BOTH the persona override (the prompt's
- * `05-access-preference` section renders different text under the flag) and
- * the tool-context pin, using the live-turn derivation: interactive
+ * `hasNoClient` — pinned on BOTH the persona override (kept for prompt-build
+ * parity; no system-prompt section branches on the flag, so this pin does not
+ * affect prompt output) and the tool-context pin (the live consumer, gating
+ * tool availability), using the live-turn derivation: interactive
  * interfaces run `updateClient(_, false)` (`hasNoClient = false`), while
  * channel-routed and chrome-extension turns stay clientless (`true`) — the
  * exact `isInteractiveInterface` predicate `conversation-routes.ts` /

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -125,50 +125,23 @@ describe("buildSystemPrompt — persona override", () => {
   });
 });
 
-describe("buildSystemPrompt — hasNoClient pin", () => {
-  // Marker unique to the `{{^hasNoClient}}` branch of 05-access-preference:
-  // host fallbacks only render when a client is connected.
-  const WITH_CLIENT_MARKER = "`host_bash` with CLIs";
-
+describe("buildSystemPrompt — hasNoClient no longer affects the prompt", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
 
-  test("hasNoClient renders divergent access-preference text", () => {
-    expect(buildSystemPrompt({ hasNoClient: false })).toContain(
-      WITH_CLIENT_MARKER,
-    );
-    expect(buildSystemPrompt({ hasNoClient: true })).not.toContain(
-      WITH_CLIENT_MARKER,
-    );
-  });
-
-  test("personaOverride.hasNoClient pins the flag over the conversation-derived option", () => {
-    // Fork-retrospective case: the fork is hydrated clientless
-    // (hasNoClient: true) but pins the source's live-turn value (false) so
-    // the prompt byte-matches the source's cached prefix.
+  // No system-prompt section branches on hasNoClient, so neither the flag nor
+  // the SystemPromptPersonaOverride.hasNoClient pin changes prompt output.
+  // Guards against a future section re-coupling to the flag.
+  test("output is identical regardless of the flag or its pin", () => {
+    const base = buildSystemPrompt({ hasNoClient: false });
+    expect(buildSystemPrompt({ hasNoClient: true })).toBe(base);
     expect(
       buildSystemPrompt({
         hasNoClient: true,
         personaOverride: { hasNoClient: false },
       }),
-    ).toContain(WITH_CLIENT_MARKER);
-    // And the pin wins in the other direction too.
-    expect(
-      buildSystemPrompt({
-        hasNoClient: false,
-        personaOverride: { hasNoClient: true },
-      }),
-    ).not.toContain(WITH_CLIENT_MARKER);
-  });
-
-  test("a personaOverride without the pin leaves the conversation-derived flag untouched", () => {
-    expect(
-      buildSystemPrompt({ hasNoClient: true, personaOverride: {} }),
-    ).not.toContain(WITH_CLIENT_MARKER);
-    expect(
-      buildSystemPrompt({ hasNoClient: false, personaOverride: {} }),
-    ).toContain(WITH_CLIENT_MARKER);
+    ).toBe(base);
   });
 });
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -319,14 +319,12 @@ export interface SystemPromptPersonaOverride {
   /**
    * Pins the `hasNoClient` flag for the prompt build, taking precedence over
    * the top-level `BuildSystemPromptOptions.hasNoClient` (which mirrors the
-   * conversation's live client state). The `05-access-preference` section
-   * renders different text under the flag — early in the prompt, so a
-   * mismatch breaks byte-parity with a cached prefix even when persona and
-   * profile match. Used by fork-based memory retrospectives: the fork is
-   * hydrated clientless (`hasNoClient = true`) while the source's live turns
-   * ran under the source's own client state (`false` for interactive
-   * interfaces, `true` for channel-routed sources) — the pin carries that
-   * live-turn value.
+   * conversation's live client state). No system-prompt section branches on
+   * `hasNoClient`, so this pin does not affect prompt output; it is retained
+   * so fork-based memory retrospectives can thread the source conversation's
+   * live-turn value (`false` for interactive interfaces, `true` for
+   * channel-routed sources) through the build without depending on the fork's
+   * clientless hydration default.
    */
   hasNoClient?: boolean;
 }

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -312,18 +312,6 @@ Embed images/GIFs inline using standard markdown: \`![description](URL)\`.
 `,
   },
   {
-    id: "05-access-preference",
-    body: `## External Service Access
-
-{{#hasNoClient}}
-Priority: (1) sandbox \`bash\` — install tools yourself; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).
-{{/hasNoClient}}
-{{^hasNoClient}}
-Priority: (1) sandbox \`bash\` - install tools yourself, only fall back to host when you need local files/auth; (2) \`host_bash\` with CLIs (gh, aws, etc.) using --json flags; (3) browser automation as last resort (no API, visual interaction, or OAuth consent).
-{{/hasNoClient}}
-`,
-  },
-  {
     id: "06-credential-security",
     body: `## Credential Security
 


### PR DESCRIPTION
## Summary
- Remove the `05-access-preference` ("External Service Access") section from `BUNDLED_SYSTEM_SECTIONS` — the escalation ladder telling the assistant to prefer `bash`, then `host_bash`, then browser/computer use.
- This section was the **only** system-prompt content that branched on the `hasNoClient` flag, so the flag no longer changes prompt output. The `hasNoClient` build option and its persona-override pin (used by fork-based memory retrospectives) are retained but now inert for the prompt; their comments are updated to say so (minimal change — full removal would ripple through every `buildSystemPrompt` caller and the fork-retrospective parity path).
- Trim the tests that asserted on the removed section, re-anchor the credential-security ordering test to `04-attachment`, and add a guard test that prompt output is invariant to `hasNoClient`.

## Original prompt
Remove the default system prompt section that instructs the assistant to escalate along `bash → host_bash → browser/computer use` (the `05-access-preference` section). We chose the minimal path: delete the section and fix the fallout (broken tests, now-stale comments) while keeping the `hasNoClient` plumbing intact rather than rippling a full removal through the conversation stack and the fork-retrospective byte-parity logic.