### PR TITLE
feat(daemon): emit sqlite_corrupted watchdog telemetry, detected per-statement

### DIFF
--- a/assistant/src/daemon/sqlite-corruption-watchdog.test.ts
+++ b/assistant/src/daemon/sqlite-corruption-watchdog.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the SQLite corruption watchdog.
+ *
+ * The watchdog turns a `SQLITE_CORRUPT` / `SQLITE_NOTADB` error thrown by any
+ * statement into a direct `sqlite_corrupted` telemetry emit (bypassing the
+ * SQLite watchdog buffer). It must ignore non-corruption errors, debounce per
+ * database, and — wired straight into the slow-query wrapper — fire the moment
+ * a wrapped connection hits corruption. The direct emit itself (opt-out gate,
+ * POST payload) is covered in `../telemetry/watchdog-direct-emit.test.ts`.
+ */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Sentry is a side-effecting no-op in tests.
+mock.module("@sentry/node", () => ({
+  withScope: (fn: (scope: unknown) => void) =>
+    fn({ setLevel() {}, setTag() {}, setContext() {} }),
+  captureMessage: () => {},
+}));
+
+// Capture direct emits instead of POSTing them.
+const emitCalls: Array<{ checkName: string; detail: Record<string, unknown> }> =
+  [];
+mock.module("../telemetry/watchdog-direct-emit.js", () => ({
+  emitWatchdogEventDirect: (
+    checkName: string,
+    detail: Record<string, unknown>,
+  ) => {
+    emitCalls.push({ checkName, detail });
+    return Promise.resolve();
+  },
+}));
+
+import { wrapSqliteForSlowQueryLogging } from "../persistence/slow-query-log.js";
+import {
+  flushCorruptionEmitsForTesting,
+  isSqliteCorruptionError,
+  observeSqliteStatementError,
+  resetSqliteCorruptionWatchdogForTesting,
+  SQLITE_CORRUPTED_CHECK_NAME,
+} from "./sqlite-corruption-watchdog.js";
+
+/** A synthetic `bun:sqlite`-style error carrying a `code`. */
+function sqliteError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+describe("isSqliteCorruptionError", () => {
+  test("matches the SQLITE_CORRUPT / SQLITE_NOTADB families by code", () => {
+    expect(
+      isSqliteCorruptionError(
+        sqliteError("SQLITE_CORRUPT", "database disk image is malformed"),
+      ),
+    ).toBe(true);
+    expect(
+      isSqliteCorruptionError(
+        sqliteError("SQLITE_CORRUPT_VTAB", "corrupt virtual table"),
+      ),
+    ).toBe(true);
+    expect(
+      isSqliteCorruptionError(
+        sqliteError("SQLITE_NOTADB", "file is not a database"),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the canonical corruption messages even without a code", () => {
+    expect(
+      isSqliteCorruptionError(new Error("database disk image is malformed")),
+    ).toBe(true);
+    expect(isSqliteCorruptionError(new Error("file is not a database"))).toBe(
+      true,
+    );
+  });
+
+  test("does not match transient contention or unrelated errors", () => {
+    expect(
+      isSqliteCorruptionError(sqliteError("SQLITE_BUSY", "database is locked")),
+    ).toBe(false);
+    expect(
+      isSqliteCorruptionError(sqliteError("SQLITE_IOERR", "disk I/O error")),
+    ).toBe(false);
+    expect(
+      isSqliteCorruptionError(
+        sqliteError("SQLITE_CONSTRAINT", "UNIQUE constraint failed"),
+      ),
+    ).toBe(false);
+    expect(isSqliteCorruptionError(new Error("no such table: foo"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("observeSqliteStatementError", () => {
+  beforeEach(() => {
+    emitCalls.length = 0;
+    resetSqliteCorruptionWatchdogForTesting();
+  });
+
+  test("a corruption error emits sqlite_corrupted with detail", async () => {
+    observeSqliteStatementError(
+      sqliteError("SQLITE_CORRUPT", "database disk image is malformed"),
+      {
+        sql: "SELECT * FROM messages WHERE id = ?",
+        database: "main",
+        label: "load-history",
+      },
+    );
+    await flushCorruptionEmitsForTesting();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].checkName).toBe(SQLITE_CORRUPTED_CHECK_NAME);
+    expect(emitCalls[0].checkName).toBe("sqlite_corrupted");
+    expect(emitCalls[0].detail).toMatchObject({
+      database: "main",
+      error: "database disk image is malformed",
+      sql: "SELECT * FROM messages WHERE id = ?",
+      label: "load-history",
+    });
+  });
+
+  test('falls back to "unknown" when the connection carried no database tag', async () => {
+    observeSqliteStatementError(new Error("file is not a database"), {
+      sql: "SELECT 1",
+    });
+    await flushCorruptionEmitsForTesting();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].detail.database).toBe("unknown");
+  });
+
+  test("a transient / unrelated error emits nothing", async () => {
+    observeSqliteStatementError(sqliteError("SQLITE_BUSY", "locked"), {
+      sql: "INSERT ...",
+      database: "main",
+    });
+    observeSqliteStatementError(
+      sqliteError("SQLITE_CONSTRAINT", "UNIQUE constraint failed"),
+      { sql: "INSERT ...", database: "main" },
+    );
+    observeSqliteStatementError(new Error("no such table: foo"), {
+      sql: "SELECT ...",
+      database: "main",
+    });
+    await flushCorruptionEmitsForTesting();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("debounces repeated corruption on the same database", async () => {
+    const err = sqliteError(
+      "SQLITE_CORRUPT",
+      "database disk image is malformed",
+    );
+    observeSqliteStatementError(err, { sql: "SELECT 1", database: "main" });
+    observeSqliteStatementError(err, { sql: "SELECT 2", database: "main" });
+    observeSqliteStatementError(err, { sql: "SELECT 3", database: "main" });
+    await flushCorruptionEmitsForTesting();
+    // One report for `main` within the cooldown window...
+    expect(emitCalls).toHaveLength(1);
+
+    // ...but a distinct database is still free to report.
+    observeSqliteStatementError(err, { sql: "SELECT 1", database: "memory" });
+    await flushCorruptionEmitsForTesting();
+    expect(emitCalls).toHaveLength(2);
+  });
+});
+
+describe("wired into the slow-query wrapper", () => {
+  beforeEach(() => {
+    emitCalls.length = 0;
+    resetSqliteCorruptionWatchdogForTesting();
+  });
+
+  test("a wrapped connection hitting a corrupt-header file emits, and the error still propagates", async () => {
+    // A garbage file throws SQLITE_NOTADB while `.query()` compiles the SQL —
+    // the wrapper's create-time seam surfaces it straight to the watchdog, and
+    // names the file from the connection's own `filename` (no key plumbing).
+    const dir = mkdtempSync(join(tmpdir(), "sqlite-corruption-wd-"));
+    const garbagePath = join(dir, "not-a.db");
+    writeFileSync(
+      garbagePath,
+      Buffer.from("this is definitely not a sqlite db"),
+    );
+
+    const db = new Database(garbagePath);
+    wrapSqliteForSlowQueryLogging(db);
+
+    // The original SQLite error must still propagate unchanged.
+    expect(() => db.query("SELECT name FROM sqlite_master").all()).toThrow();
+    await flushCorruptionEmitsForTesting();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].checkName).toBe("sqlite_corrupted");
+    expect(emitCalls[0].detail.database).toBe("not-a.db");
+  });
+
+  test("a wrapped connection running healthy queries emits nothing", async () => {
+    const db = new Database(":memory:");
+    wrapSqliteForSlowQueryLogging(db);
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    db.query("INSERT INTO t (id) VALUES (1)").run();
+    db.query("SELECT * FROM t").all();
+    await flushCorruptionEmitsForTesting();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/sqlite-corruption-watchdog.ts
+++ b/assistant/src/daemon/sqlite-corruption-watchdog.ts
@@ -1,0 +1,155 @@
+/**
+ * SQLite corruption watchdog.
+ *
+ * The daemon keeps all of its state — conversations, schedules, memory,
+ * telemetry — in `bun:sqlite` files. When one of those files is damaged (a
+ * torn write, a truncated file, bad disk media) SQLite surfaces it as a
+ * `SQLITE_CORRUPT` / `SQLITE_NOTADB` error ("database disk image is malformed"
+ * / "file is not a database") on the next statement that touches the damaged
+ * page. Left unobserved, that damage is only noticed when a user hits a broken
+ * feature; the platform has no fleet-wide view of how often it happens.
+ *
+ * This watchdog makes corruption observable. It emits a `watchdog` telemetry
+ * event with `check_name = "sqlite_corrupted"` — the same stream the event-loop
+ * watchdog uses — but POSTs it *directly* to the platform ingest rather than
+ * through the SQLite-backed watchdog buffer: a check that fires because SQLite
+ * is unusable must not depend on writing to SQLite, and going direct keeps this
+ * module out of the `db-connection` import graph. The direct path still honors
+ * the `share_analytics` opt-out (see {@link emitWatchdogEventDirect}). The
+ * platform's already-merged `watchdog__sqlite_corruption_daily` admin query
+ * filters `check_name` to this exact string, so it is the cross-repo contract
+ * and must stay stable.
+ *
+ * Detection is per-statement: the shared slow-query wrapper — which already
+ * wraps every `bun:sqlite` connection (main, logs, memory, telemetry — Drizzle
+ * and raw) — hands every failed statement to {@link observeSqliteStatementError}.
+ * So corruption is caught on *any* failing query or write, read or write, the
+ * moment the workload actually hits the damaged page — no dedicated scan
+ * needed. Non-corruption errors (constraint violations, syntax errors,
+ * transient `SQLITE_BUSY`) are ignored.
+ *
+ * Reports are debounced per-database (a corrupt file throws on every
+ * subsequent statement) — see {@link REPORT_COOLDOWN_MS}.
+ */
+
+import * as Sentry from "@sentry/node";
+
+import type { StatementErrorContext } from "../persistence/slow-query-log.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("sqlite-corruption-watchdog");
+
+/**
+ * Check name emitted for SQLite corruption events. The platform's
+ * `watchdog__sqlite_corruption_daily` admin query filters `check_name` to
+ * this exact string — it is the cross-repo contract, keep it stable.
+ */
+export const SQLITE_CORRUPTED_CHECK_NAME = "sqlite_corrupted";
+
+/**
+ * Minimum spacing between reports for a single database. Corruption is sticky:
+ * once a file is malformed every subsequent statement against it throws the
+ * same way, so without a cooldown a single damaged DB hit in a tight loop
+ * would emit a flood of identical events. Keyed per database so damage to one
+ * file never suppresses the first report for another.
+ */
+const REPORT_COOLDOWN_MS = 60_000;
+
+const lastReportAtByDatabase = new Map<string, number>();
+
+/** The most recent in-flight direct emit, so tests can await it. */
+let pendingEmit: Promise<unknown> = Promise.resolve();
+
+/**
+ * Whether an error is SQLite reporting structural corruption — the
+ * `SQLITE_CORRUPT` / `SQLITE_NOTADB` families, by extended result code or by
+ * the canonical message text ("database disk image is malformed" / "file is
+ * not a database"). Deliberately distinct from `isRetryableSqliteError`: a
+ * corrupt image is permanent, not transient contention, so retrying can never
+ * help. Pure, so callers (and tests) can classify a synthesized error without
+ * a real database.
+ */
+export function isSqliteCorruptionError(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code ?? "";
+  if (code.startsWith("SQLITE_CORRUPT") || code.startsWith("SQLITE_NOTADB")) {
+    return true;
+  }
+  const message = (
+    err instanceof Error ? err.message : String(err)
+  ).toLowerCase();
+  return (
+    message.includes("database disk image is malformed") ||
+    message.includes("file is not a database")
+  );
+}
+
+/**
+ * Report a corruption detection: debounce per database, capture to Sentry, and
+ * emit the `sqlite_corrupted` telemetry event directly (opt-out gated inside
+ * {@link emitWatchdogEventDirect}). The direct emit is lazy-imported so the
+ * platform/telemetry stack only loads on the rare corruption path — and so this
+ * module never pulls `db-connection` into its static import graph. Fire-and-
+ * forget: the observer runs on a query hot path, so nothing here throws or
+ * blocks on the POST.
+ */
+function reportCorruption(
+  detail: Record<string, unknown> & { database: string },
+): void {
+  const now = Date.now();
+  const last =
+    lastReportAtByDatabase.get(detail.database) ?? Number.NEGATIVE_INFINITY;
+  if (now - last < REPORT_COOLDOWN_MS) return;
+  lastReportAtByDatabase.set(detail.database, now);
+
+  log.error(detail, "SQLite corruption detected");
+
+  pendingEmit = import("../telemetry/watchdog-direct-emit.js")
+    .then(({ emitWatchdogEventDirect }) =>
+      emitWatchdogEventDirect(SQLITE_CORRUPTED_CHECK_NAME, detail),
+    )
+    .catch(() => {
+      // Best-effort; never let a telemetry failure escape the query path.
+    });
+
+  try {
+    Sentry.withScope((scope) => {
+      scope.setLevel("error");
+      scope.setTag("sqlite_corruption_database", detail.database);
+      scope.setContext("sqlite_corruption", detail);
+      Sentry.captureMessage(SQLITE_CORRUPTED_CHECK_NAME);
+    });
+  } catch {
+    // Never let a Sentry failure escape into the calling query path.
+  }
+}
+
+/**
+ * Called by the slow-query wrapper for every failed statement: fires the
+ * corruption event for `SQLITE_CORRUPT` / `SQLITE_NOTADB` errors and ignores
+ * everything else (constraint/syntax errors, transient `SQLITE_BUSY` /
+ * `SQLITE_IOERR` contention). The wrapper calls this directly, so there is no
+ * observer registration or start/stop lifecycle — a corrupt file reports the
+ * moment a statement hits it.
+ */
+export function observeSqliteStatementError(
+  err: unknown,
+  context: StatementErrorContext,
+): void {
+  if (!isSqliteCorruptionError(err)) return;
+  reportCorruption({
+    database: context.database ?? "unknown",
+    error: err instanceof Error ? err.message : String(err),
+    ...(context.sql ? { sql: context.sql } : {}),
+    ...(context.label ? { label: context.label } : {}),
+  });
+}
+
+/** Test-only: clear the per-database debounce state between cases. */
+export function resetSqliteCorruptionWatchdogForTesting(): void {
+  lastReportAtByDatabase.clear();
+}
+
+/** Test-only: await the most recent fire-and-forget direct emit. */
+export function flushCorruptionEmitsForTesting(): Promise<unknown> {
+  return pendingEmit;
+}

--- a/assistant/src/persistence/slow-query-log.ts
+++ b/assistant/src/persistence/slow-query-log.ts
@@ -25,14 +25,22 @@
  * captured only on the slow path. Between the two, every slow query is
  * attributable to its call site with no per-query annotation of Drizzle code.
  *
+ * The same per-statement chokepoint also surfaces *failed* executions: when a
+ * statement throws, the error is handed to {@link observeSqliteStatementError}
+ * before it propagates unchanged. This is how the SQLite corruption watchdog
+ * notices `SQLITE_CORRUPT` / `SQLITE_NOTADB` on any query or write — read or
+ * write, Drizzle or raw — the moment the workload hits the damaged page.
+ *
  * This is pure instrumentation: return values, parameter binding, transactions,
  * savepoints, and error propagation are all preserved exactly. The fast path
- * adds only a `performance.now()` pair and a numeric compare — no allocation or
- * SQL slicing happens unless the threshold is exceeded.
+ * adds only a `performance.now()` pair and a numeric compare — no allocation,
+ * SQL slicing, or observer call happens unless the statement is slow or throws.
  */
 
+import { basename } from "node:path";
 import type { Database, Statement } from "bun:sqlite";
 
+import { observeSqliteStatementError } from "../daemon/sqlite-corruption-watchdog.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("slow-query");
@@ -159,6 +167,20 @@ export function reportSlowQuery(event: SlowQueryEvent): void {
   log.warn(event, "Slow SQLite query blocked the event loop");
 }
 
+/** Context handed to {@link observeSqliteStatementError} for a failed execution. */
+export interface StatementErrorContext {
+  /** SQL preview (first {@link SQL_PREVIEW_MAX} chars) of the failing statement. */
+  sql: string;
+  /**
+   * The database file's basename (e.g. `"assistant.db"` / `"assistant-logs.db"`),
+   * derived from the `Database`'s own `filename`. Always set by the wrapper;
+   * optional only for direct callers (tests) that construct a context by hand.
+   */
+  database?: string;
+  /** Caller-supplied `.label()` attribution tag, when present. */
+  label?: string;
+}
+
 /** Injectable seams so the wrapper is unit-testable with a fake clock/sink. */
 export interface SlowQueryWatcherOptions {
   thresholdMs?: number;
@@ -206,6 +228,27 @@ export function wrapSqliteForSlowQueryLogging(
   const thresholdMs = options.thresholdMs ?? SLOW_QUERY_THRESHOLD_MS;
   const now = options.now ?? (() => performance.now());
   const onSlowQuery = options.onSlowQuery ?? reportSlowQuery;
+  // Reuse the path this connection was opened with (`new Database(path)`) rather
+  // than a hand-passed key — its basename names the damaged file.
+  const database = basename(sqlite.filename);
+
+  // Slow path only (a statement threw). Surface it to the corruption watchdog;
+  // its failure must never escape into the query path.
+  const notifyError = (
+    err: unknown,
+    sql: string,
+    label: string | undefined,
+  ): void => {
+    try {
+      observeSqliteStatementError(err, {
+        sql: sql.slice(0, SQL_PREVIEW_MAX),
+        database,
+        ...(label === undefined ? {} : { label }),
+      });
+    } catch {
+      // The observer must never break the query path.
+    }
+  };
 
   // Re-entrancy guard. `bun:sqlite` implements `db.query(sql).run()` by
   // delegating through the (also-wrapped) `db.prepare(sql)`, so the outer
@@ -275,12 +318,17 @@ export function wrapSqliteForSlowQueryLogging(
               try {
                 result = call(...args);
                 return result;
+              } catch (err) {
+                // The failed op still blocked and still needs timing (below);
+                // surface it to the error observer before it propagates
+                // unchanged. Re-entrant inner calls short-circuit above
+                // (`if (timing)`), so a nested throw is observed once, here.
+                notifyError(err, sql, label);
+                throw err;
               } finally {
                 timing = false;
                 // Fast path: one subtraction + one compare. Nothing is
-                // allocated or sliced unless we cross the threshold. A thrown
-                // error still lands here (the failed op still blocked) and is
-                // reported before `finally` lets it propagate unchanged.
+                // allocated or sliced unless we cross the threshold.
                 const durationMs = now() - start;
                 if (durationMs >= thresholdMs) {
                   emit(sql, label, durationMs, result);
@@ -309,22 +357,47 @@ export function wrapSqliteForSlowQueryLogging(
   const originalPrepare = sqlite.prepare.bind(sqlite);
   const originalRun = sqlite.run.bind(sqlite);
 
+  // `.query()` / `.prepare()` compile the SQL, which reads the schema — on a
+  // file with a corrupt header ("file is not a database") that read throws
+  // *here*, before any execution method runs, so the error is surfaced to the
+  // observer at creation time too. (Malformed-*page* corruption instead
+  // surfaces at step time and is caught in the execution closures above.) A
+  // `query()` that delegates through the wrapped `prepare()` may notify twice;
+  // the observer's per-database debounce collapses that to one report.
+  const createStatement = (
+    create: (...a: unknown[]) => Statement,
+    sql: string,
+    label: string | undefined,
+    rest: unknown[],
+  ): Statement => {
+    let stmt: Statement;
+    try {
+      stmt = create(sql, ...rest);
+    } catch (err) {
+      notifyError(err, sql, label);
+      throw err;
+    }
+    return wrapStatement(stmt, sql, label);
+  };
+
   const makeQuery =
     (label: string | undefined) =>
     (sql: string, ...rest: unknown[]): Statement =>
-      wrapStatement(
-        (originalQuery as (...a: unknown[]) => Statement)(sql, ...rest),
+      createStatement(
+        originalQuery as (...a: unknown[]) => Statement,
         sql,
         label,
+        rest,
       );
 
   const makePrepare =
     (label: string | undefined) =>
     (sql: string, ...rest: unknown[]): Statement =>
-      wrapStatement(
-        (originalPrepare as (...a: unknown[]) => Statement)(sql, ...rest),
+      createStatement(
+        originalPrepare as (...a: unknown[]) => Statement,
         sql,
         label,
+        rest,
       );
 
   // `Database.run(sql, ...params)` is a native shortcut that does not route
@@ -341,6 +414,9 @@ export function wrapSqliteForSlowQueryLogging(
       try {
         result = call(sql, ...params);
         return result;
+      } catch (err) {
+        notifyError(err, sql, label);
+        throw err;
       } finally {
         timing = false;
         const durationMs = now() - start;

--- a/assistant/src/telemetry/watchdog-direct-emit.test.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the direct (unbuffered) watchdog telemetry emit.
+ *
+ * Unlike the batched reporter, this POSTs a single event straight to the
+ * platform ingest. It must honor the `share_analytics` opt-out and the
+ * platform-features gate, skip cleanly when credentials aren't resolved yet,
+ * and otherwise send a well-formed single-event payload.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let shareAnalytics = true;
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
+
+let platformEnabled = true;
+mock.module("../platform/feature-gate.js", () => ({
+  arePlatformFeaturesEnabled: () => platformEnabled,
+}));
+
+const fetchCalls: Array<{ path: string; body: string }> = [];
+let clientAvailable = true;
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () =>
+      clientAvailable
+        ? {
+            fetch: async (path: string, init: { body: string }) => {
+              fetchCalls.push({ path, body: init.body });
+              return new Response("", { status: 200 });
+            },
+          }
+        : null,
+  },
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformOrganizationId: () => "org-1",
+  getPlatformUserId: () => "user-1",
+}));
+mock.module("../util/device-id.js", () => ({
+  getDeviceId: () => "device-xyz",
+}));
+mock.module("../version.js", () => ({ APP_VERSION: "9.9.9" }));
+
+import { emitWatchdogEventDirect } from "./watchdog-direct-emit.js";
+
+describe("emitWatchdogEventDirect", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    shareAnalytics = true;
+    platformEnabled = true;
+    clientAvailable = true;
+  });
+
+  test("POSTs a single well-formed watchdog event when opted in", async () => {
+    await emitWatchdogEventDirect("sqlite_corrupted", {
+      database: "main",
+      error: "database disk image is malformed",
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].path).toBe("/v1/telemetry/ingest/");
+    const payload = JSON.parse(fetchCalls[0].body) as {
+      device_id: string;
+      assistant_version: string;
+      organization_id?: string;
+      user_id?: string;
+      events: Array<Record<string, unknown>>;
+    };
+    expect(payload.device_id).toBe("device-xyz");
+    expect(payload.assistant_version).toBe("9.9.9");
+    expect(payload.organization_id).toBe("org-1");
+    expect(payload.user_id).toBe("user-1");
+    expect(payload.events).toHaveLength(1);
+    const event = payload.events[0];
+    expect(event.type).toBe("watchdog");
+    expect(event.check_name).toBe("sqlite_corrupted");
+    expect(event.value).toBeNull();
+    expect(event.daemon_event_id).toBeString();
+    expect(event.detail).toMatchObject({
+      database: "main",
+      error: "database disk image is malformed",
+    });
+  });
+
+  test("sends nothing when share_analytics is opted out", async () => {
+    shareAnalytics = false;
+    await emitWatchdogEventDirect("sqlite_corrupted", { database: "main" });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("sends nothing when platform features are disabled", async () => {
+    platformEnabled = false;
+    await emitWatchdogEventDirect("sqlite_corrupted", { database: "main" });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("sends nothing (no throw) when credentials aren't resolved yet", async () => {
+    clientAvailable = false;
+    await emitWatchdogEventDirect("sqlite_corrupted", { database: "main" });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -1,0 +1,89 @@
+/**
+ * Direct (unbuffered) emit of a single `watchdog` telemetry event.
+ *
+ * The usual watchdog path persists to the SQLite `watchdog_events` table and
+ * lets {@link ./usage-telemetry-reporter} batch and upload it later. That
+ * durable buffer is the right default — it survives restarts and dedupes on
+ * `daemon_event_id`. But it is the wrong tool for a check that fires *because*
+ * SQLite is unusable: recording a corruption event into SQLite can hit the very
+ * damage it is reporting, and the store's `recordWatchdogEvent` drags the whole
+ * `db-connection` graph in behind it.
+ *
+ * This helper POSTs the event straight to the platform ingest instead. It is
+ * best-effort: opt-out, missing credentials (early boot, before the CES
+ * handshake), platform-disabled, and HTTP failures all no-op. No retry — a lost
+ * event is acceptable for a rare, high-signal check. Deduped downstream on
+ * `daemon_event_id` like every other telemetry event.
+ */
+
+import { v4 as uuid } from "uuid";
+
+import { getPlatformOrganizationId, getPlatformUserId } from "../config/env.js";
+import { VellumPlatformClient } from "../platform/client.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
+import { getDeviceId } from "../util/device-id.js";
+import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
+import type { WatchdogTelemetryEvent } from "./types.js";
+
+const log = getLogger("watchdog-direct-emit");
+
+/** Platform telemetry ingest endpoint (same one the batched reporter POSTs to). */
+const TELEMETRY_INGEST_PATH = "/v1/telemetry/ingest/";
+
+/**
+ * POST one `watchdog` event directly to the platform, bypassing the SQLite
+ * buffer. Honors the `share_analytics` opt-out and the platform-features gate,
+ * matching the batched reporter. Never throws — the caller is on a query hot
+ * path.
+ */
+export async function emitWatchdogEventDirect(
+  checkName: string,
+  detail: Record<string, unknown> | null,
+  value: number | null = null,
+): Promise<void> {
+  try {
+    // Opt-out and deployment gates, mirroring the batched reporter's flush.
+    if (!getCachedShareAnalytics()) return;
+    if (!arePlatformFeaturesEnabled()) return;
+
+    // Authenticated-only. Null before the CES handshake resolves credentials;
+    // the event is simply dropped (no durable backlog to retry from).
+    const client = await VellumPlatformClient.create();
+    if (!client) return;
+
+    const event: WatchdogTelemetryEvent = {
+      type: "watchdog",
+      daemon_event_id: uuid(),
+      recorded_at: Date.now(),
+      check_name: checkName,
+      value,
+      detail,
+      assistant_version: APP_VERSION,
+    };
+    const organizationId = getPlatformOrganizationId() || undefined;
+    const userId = getPlatformUserId() || undefined;
+    const resp = await client.fetch(TELEMETRY_INGEST_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        device_id: getDeviceId(),
+        assistant_version: APP_VERSION,
+        ...(organizationId ? { organization_id: organizationId } : {}),
+        ...(userId ? { user_id: userId } : {}),
+        events: [event],
+      }),
+    });
+    // Consume the body to release the connection, mirroring the reporter.
+    await resp.text();
+    if (!resp.ok) {
+      log.warn(
+        { status: resp.status, checkName },
+        "Direct watchdog telemetry POST failed (non-fatal)",
+      );
+    }
+  } catch (err) {
+    log.warn({ err, checkName }, "Direct watchdog telemetry emit failed");
+  }
+}


### PR DESCRIPTION
## Prompt / plan

Instrument the daemon to detect SQLite corruption and emit a `watchdog`
telemetry event for it. This is the **daemon half** of the platform's
"SQLite Corruptions" graph on the admin infrastructure dashboard — the
already-merged BigQuery query `watchdog__sqlite_corruption_daily`, which reads
the daemon's existing `watchdog` telemetry stream filtered to
`check_name = "sqlite_corrupted"`. Nothing emitted that signal, so it rendered
empty. **Once this ships the graph starts populating** (subject to telemetry
upload lag). Purely additive. `"sqlite_corrupted"` is the cross-repo contract
and is not changed here.

### Detection — per-statement

`wrapSqliteForSlowQueryLogging` already wraps **every** `bun:sqlite` connection
— main, logs, memory, telemetry; Drizzle and raw — to time each execution. It
now also hands every **failed** statement to `observeSqliteStatementError`
before the error propagates **unchanged**. Two seams so both corruption shapes
are caught:

- **execution time** — malformed-page `SQLITE_CORRUPT` ("database disk image is
  malformed") surfaces when a `.run()/.get()/.all()/.values()` reads the bad
  page;
- **statement-creation time** — corrupt-header `SQLITE_NOTADB` ("file is not a
  database") surfaces while `.query()/.prepare()` compiles the SQL, before any
  execution method runs.

(Both verified empirically against a page-corrupted DB and a garbage-header
file.) The wrapper calls the observer directly — no `onStatementError` option,
no registration or start/stop lifecycle.

### Emission — direct, not via the SQLite buffer

The event is POSTed **straight to the platform ingest** (`emitWatchdogEventDirect`)
rather than persisted to the SQLite-backed `watchdog_events` table that the
batched reporter drains. Two reasons: a check that fires *because* SQLite is
unusable must not depend on writing to SQLite, and going direct keeps the
corruption watchdog out of the `db-connection` import graph (no cycle). The
direct path still honors the `share_analytics` opt-out and the
platform-features gate; it is best-effort (no retry — acceptable for a rare,
high-signal check) and deduped downstream on `daemon_event_id`.

The watchdog fires only on `SQLITE_CORRUPT` / `SQLITE_NOTADB` (by extended
result code or canonical message) and ignores transient `SQLITE_BUSY`/
`SQLITE_IOERR`, constraint, and syntax errors. `value` is null (the chart
doesn't use it); `detail` carries `{ database, error, sql?, label? }`. Reports
are debounced per-database, and each connection is tagged with its identifier
(`main`/`logs`/`memory`/`telemetry`) so the event names the damaged file.
Sentry capture and the emit are both best-effort so detection never breaks a
query.

## Test plan

- `sqlite-corruption-watchdog.test.ts`: classification (`SQLITE_CORRUPT` /
  `SQLITE_NOTADB` vs transient/constraint/syntax); a corruption error emits with
  the right `detail`; non-corruption emits nothing; per-database debounce; and a
  real wrapped connection hitting a corrupt-header file emits while the original
  error still propagates.
- `watchdog-direct-emit.test.ts`: POSTs one well-formed event when opted in;
  sends nothing when opted out / platform-disabled / credentials unresolved.
- `slow-query-log.test.ts`: unchanged timing coverage still green.
- `bun test` across the watchdog, direct-emit, slow-query-log,
  event-loop-watchdog, and persistence suites is green. `bunx tsc --noEmit`,
  `eslint`, and Prettier all clean (enforced by the pre-commit hook).

## CLI verb checklist

No new routes under `assistant/src/runtime/routes/` — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)