### PR TITLE
fix(onboarding): use a casual kickoff primer for the "Let's chat" handoff

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -87,7 +87,7 @@ import {
  * but renders no user bubble, so the chat opens with the assistant proactively
  * greeting the user in the persona they just configured.
  */
-const LETS_CHAT_KICKOFF_MESSAGE = "Wake up, I'm excited to chat!";
+const LETS_CHAT_KICKOFF_MESSAGE = "hey, what's up";
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {


### PR DESCRIPTION
## Summary
- The research/personality onboarding "Let's chat" handoff sends a hidden primer on the user's behalf to drive the assistant's first proactive greeting. It was `"Wake up, I'm excited to chat!"`, whose "wake up" framing reads to the model like an orient/boot command — producing a meta, "getting oriented" first reply.
- Replaced it with the casual `"hey, what's up"` so the assistant opens with a natural greeting in the configured persona.
- Scope is deliberately limited to `LETS_CHAT_KICKOFF_MESSAGE` (a real LLM turn). The separate `"Wake up, my friend!"` pre-chat default is intercepted by `isWakeUpGreeting()` and served as a canned greeting with **no LLM call**, so it can't cause this behavior and is left unchanged. No test asserts the changed string.

## Original prompt
Change the "Wake up, I'm excited to chat" onboarding framing — it throws the model off by making it "get oriented" before responding — to something casual like "hey, what's up" for a more natural first reply. Exploration confirmed the target is the research-onboarding hidden kickoff primer (not the canned "Wake up, my friend!" pre-chat default, which never reaches the model), that changing it has no collision with the canned-greeting detection or the client-side forwarding branch, and that no test asserts the string.