### PR TITLE
fix(onboarding): force a full identity rewrite in the personality step

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -35,6 +35,12 @@ describe("buildPersonalityMessage", () => {
     expect(msg).toContain("Politeness (0 - 100): 40");
     expect(msg).toContain("Unfiltered Rawness/Crassness (0 - 100): 60");
     expect(msg).toContain("Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md)");
+    // The instruction forces a full overwrite rather than an append, so the
+    // rewrite lands the persona in the assistant's voice instead of stacking a
+    // patch on top of the default text.
+    expect(msg).toContain("Overwrite each file completely with file_write");
+    expect(msg).toContain("not an edit");
+    expect(msg).toContain("do not append");
     expect(msg).toContain("<system-message>");
     expect(msg).toContain("</system-message>");
   });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -85,7 +85,11 @@ Seriousness (0 - 100): ${playfulSerious}
 Politeness (0 - 100): ${100 - politeUnfiltered}
 Unfiltered Rawness/Crassness (0 - 100): ${politeUnfiltered}
 
-Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality. Write them in first person in a voice and style that matches your new personality.
+Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality — first person, in a voice and style that matches it.
+
+Overwrite each file completely with file_write: write the whole file fresh in one pass. This is a from-scratch rewrite, not an edit — do not append to what's already there, do not patch individual lines, and leave none of the current default wording behind. Fill in every IDENTITY.md placeholder (the _(not yet chosen)_ / _(not yet established)_ fields).
+
+Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, every file should read top-to-bottom as this new personality, with nothing left in the generic default voice.
 </system-message>`;
 }
 


### PR DESCRIPTION
## Summary

- Strengthen the onboarding personality-step system-message so the assistant **fully overwrites** its identity files (`IDENTITY.md`, `SOUL.md`, `users/guardian.md`) with `file_write` instead of appending a persona patch on top of the default template text — the failure the old soft "rewrite … to reflect" wording invited.
- Spell out the constraints: a from-scratch rewrite (not an edit), fill every `IDENTITY.md` placeholder, and keep `SOUL.md` **complete** (memory / boundaries / compliance re-expressed in the new voice, not dropped) — `SOUL.md` is the sole home of that operating guidance (system-prompt section `09-soul`), so a naive "personality-only" overwrite would strip the assistant's memory/compliance behavior.
- Lock the new wording with assertions in `apply-personality.test.ts`.

Prompt-only change scoped to `clients/web`; the autonomous `threads.md` rewrite bullet is intentionally left alone (already dropped for new workspaces by migration `120-revise-onboarding-threads`).

## Original prompt

The onboarding personality step was appending to the identity/voice file instead of rewriting it in the assistant's new voice, leaving a mix of default template text plus an appended patch. The ask was to strengthen the onboarding rewrite prompt so it performs a full rewrite. Investigation confirmed the only live path is `buildPersonalityMessage()` in `apply-personality.ts` (the older `threads.md` path was dropped by migration 120, and the platform repo has no such logic), and the chosen approach is a total `file_write` overwrite of all three files — kept complete so `SOUL.md`'s memory/compliance/boundary guidance survives.