### PR TITLE
feat(schedule): return the created schedule from `schedules create`

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22860,145 +22860,143 @@ paths:
               schema:
                 type: object
                 properties:
-                  schedules:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        enabled:
-                          type: boolean
-                        syntax:
-                          type: string
-                          enum:
-                            - cron
-                            - rrule
-                        expression:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        cronExpression:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        timezone:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        message:
-                          type: string
-                        script:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        nextRunAt:
-                          type: number
-                        lastRunAt:
-                          anyOf:
-                            - type: number
-                            - type: "null"
-                        lastStatus:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        retryCount:
-                          type: number
-                        maxRetries:
-                          type: number
-                        retryBackoffMs:
-                          type: number
-                        timeoutMs:
-                          anyOf:
-                            - type: number
-                            - type: "null"
-                        inferenceProfile:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        createdFromConversationId:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        createdFromConversationExists:
-                          type: boolean
-                        createdFromConversationArchivedAt:
-                          anyOf:
-                            - type: number
-                            - type: "null"
-                        description:
-                          type: string
-                        cadenceDescription:
-                          type: string
-                        mode:
-                          type: string
-                          enum:
-                            - notify
-                            - execute
-                            - script
-                            - wake
-                            - workflow
-                        status:
-                          type: string
-                          enum:
-                            - active
-                            - firing
-                            - fired
-                            - cancelled
-                        routingIntent:
-                          type: string
-                          enum:
-                            - single_channel
-                            - multi_channel
-                            - all_channels
-                        reuseConversation:
-                          type: boolean
-                        wakeConversationId:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        workflowName:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        isOneShot:
-                          type: boolean
-                      required:
-                        - id
-                        - name
-                        - enabled
-                        - syntax
-                        - expression
-                        - cronExpression
-                        - timezone
-                        - message
-                        - script
-                        - nextRunAt
-                        - lastRunAt
-                        - lastStatus
-                        - retryCount
-                        - maxRetries
-                        - retryBackoffMs
-                        - timeoutMs
-                        - inferenceProfile
-                        - createdFromConversationId
-                        - createdFromConversationExists
-                        - createdFromConversationArchivedAt
-                        - description
-                        - cadenceDescription
-                        - mode
-                        - status
-                        - routingIntent
-                        - reuseConversation
-                        - wakeConversationId
-                        - workflowName
-                        - isOneShot
-                      additionalProperties: false
-                    description: Updated schedule list
+                  schedule:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      enabled:
+                        type: boolean
+                      syntax:
+                        type: string
+                        enum:
+                          - cron
+                          - rrule
+                      expression:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      cronExpression:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      timezone:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      message:
+                        type: string
+                      script:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      nextRunAt:
+                        type: number
+                      lastRunAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      lastStatus:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      retryCount:
+                        type: number
+                      maxRetries:
+                        type: number
+                      retryBackoffMs:
+                        type: number
+                      timeoutMs:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      inferenceProfile:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      createdFromConversationId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      createdFromConversationExists:
+                        type: boolean
+                      createdFromConversationArchivedAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      description:
+                        type: string
+                      cadenceDescription:
+                        type: string
+                      mode:
+                        type: string
+                        enum:
+                          - notify
+                          - execute
+                          - script
+                          - wake
+                          - workflow
+                      status:
+                        type: string
+                        enum:
+                          - active
+                          - firing
+                          - fired
+                          - cancelled
+                      routingIntent:
+                        type: string
+                        enum:
+                          - single_channel
+                          - multi_channel
+                          - all_channels
+                      reuseConversation:
+                        type: boolean
+                      wakeConversationId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      workflowName:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      isOneShot:
+                        type: boolean
+                    required:
+                      - id
+                      - name
+                      - enabled
+                      - syntax
+                      - expression
+                      - cronExpression
+                      - timezone
+                      - message
+                      - script
+                      - nextRunAt
+                      - lastRunAt
+                      - lastStatus
+                      - retryCount
+                      - maxRetries
+                      - retryBackoffMs
+                      - timeoutMs
+                      - inferenceProfile
+                      - createdFromConversationId
+                      - createdFromConversationExists
+                      - createdFromConversationArchivedAt
+                      - description
+                      - cadenceDescription
+                      - mode
+                      - status
+                      - routingIntent
+                      - reuseConversation
+                      - wakeConversationId
+                      - workflowName
+                      - isOneShot
+                    additionalProperties: false
+                    description: The created schedule
                 required:
-                  - schedules
+                  - schedule
                 additionalProperties: false
   /v1/schedules/{id}:
     delete:

--- a/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
+++ b/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
@@ -229,10 +229,10 @@ describe("POST /schedules — workflow mode does not require a message", () => {
         workflowName: "triage-inbox",
         // no `message`
       },
-    })) as { schedules: Array<{ mode: string; workflowName: string | null }> };
+    })) as { schedule: { mode: string; workflowName: string | null } };
 
-    const created = result.schedules.find((s) => s.mode === "workflow");
-    expect(created?.workflowName).toBe("triage-inbox");
+    expect(result.schedule.mode).toBe("workflow");
+    expect(result.schedule.workflowName).toBe("triage-inbox");
   });
 
   test("still rejects a workflow schedule with no workflowName", async () => {

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1160,7 +1160,7 @@ describe("POST /schedules — create", () => {
   async function postCreate(body: Record<string, unknown>) {
     const route = findRoute("schedules", "POST");
     return (await route.handler({ body })) as {
-      schedules: Array<{ id: string; inferenceProfile: string | null }>;
+      schedule: { id: string; inferenceProfile: string | null };
     };
   }
 
@@ -1171,7 +1171,7 @@ describe("POST /schedules — create", () => {
       expression: "0 9 * * *",
       message: "good morning",
     });
-    expect(result.schedules).toHaveLength(1);
+    expect(result.schedule.id).toBeDefined();
     const job = listSchedules()[0];
     expect(job.name).toBe("Morning ping");
     expect(job.mode).toBe("execute");
@@ -1329,7 +1329,7 @@ describe("POST /schedules — create", () => {
       message: "write the digest",
       inferenceProfile: "cost-optimized",
     });
-    expect(result.schedules[0].inferenceProfile).toBe("cost-optimized");
+    expect(result.schedule.inferenceProfile).toBe("cost-optimized");
     expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 
@@ -1340,7 +1340,7 @@ describe("POST /schedules — create", () => {
       expression: "0 9 * * *",
       message: "hi",
     });
-    expect(result.schedules[0].inferenceProfile).toBeNull();
+    expect(result.schedule.inferenceProfile).toBeNull();
   });
 
   test("rejects an unknown inferenceProfile", async () => {

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -670,33 +670,31 @@ describe("schedules create", () => {
     mockIpcResult = {
       ok: true,
       result: {
-        schedules: [
-          {
-            id: "new-schedule-id",
-            name: "Heartbeat",
-            enabled: true,
-            syntax: "cron",
-            expression: "*/30 * * * *",
-            cronExpression: "*/30 * * * *",
-            timezone: null,
-            message: "run heartbeat",
-            script: null,
-            nextRunAt: 1_778_800_000_000,
-            lastRunAt: null,
-            lastStatus: null,
-            retryCount: 0,
-            maxRetries: 3,
-            retryBackoffMs: 60_000,
-            description: "Checks service heartbeat",
-            cadenceDescription: "Every 30 minutes",
-            mode: "execute",
-            status: "active",
-            routingIntent: "all_channels",
-            reuseConversation: false,
-            wakeConversationId: null,
-            isOneShot: false,
-          },
-        ],
+        schedule: {
+          id: "new-schedule-id",
+          name: "Heartbeat",
+          enabled: true,
+          syntax: "cron",
+          expression: "*/30 * * * *",
+          cronExpression: "*/30 * * * *",
+          timezone: null,
+          message: "run heartbeat",
+          script: null,
+          nextRunAt: 1_778_800_000_000,
+          lastRunAt: null,
+          lastStatus: null,
+          retryCount: 0,
+          maxRetries: 3,
+          retryBackoffMs: 60_000,
+          description: "Checks service heartbeat",
+          cadenceDescription: "Every 30 minutes",
+          mode: "execute",
+          status: "active",
+          routingIntent: "all_channels",
+          reuseConversation: false,
+          wakeConversationId: null,
+          isOneShot: false,
+        },
       },
     };
 
@@ -715,13 +713,11 @@ describe("schedules create", () => {
 
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      schedules: [
-        expect.objectContaining({
-          id: "new-schedule-id",
-          description: "Checks service heartbeat",
-          cadenceDescription: "Every 30 minutes",
-        }),
-      ],
+      schedule: expect.objectContaining({
+        id: "new-schedule-id",
+        description: "Checks service heartbeat",
+        cadenceDescription: "Every 30 minutes",
+      }),
     });
     expect(logLines).toEqual([]);
   });

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -560,16 +560,15 @@ Examples:
             if (opts.timezone != null) body.timezone = opts.timezone;
             if (opts.profile != null) body.inferenceProfile = opts.profile;
 
-            const result = await cliIpcCall<ListSchedulesResponse>(
+            const result = await cliIpcCall<GetScheduleResponse>(
               "createSchedule",
               { body },
             );
 
             if (!result.ok) return exitFromIpcResult(result, cmd);
 
-            const response = result.result ?? { schedules: [] };
             if (opts.json) {
-              writeOutput(cmd, response);
+              writeOutput(cmd, result.result ?? {});
               return;
             }
 

--- a/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
@@ -17,22 +17,22 @@ const createHandler = (() => {
   return route.handler;
 })();
 
-interface ListResult {
-  schedules: Array<{
+interface CreateResult {
+  schedule: {
     name: string;
     mode: string;
     script: string | null;
     timeoutMs: number | null;
-  }>;
+  };
 }
 
-async function create(body: Record<string, unknown>): Promise<ListResult> {
-  return (await createHandler({ body })) as ListResult;
+async function create(body: Record<string, unknown>): Promise<CreateResult> {
+  return (await createHandler({ body })) as CreateResult;
 }
 
 describe("createSchedule route — script mode", () => {
-  test("creates a script-mode schedule with its command + timeout", async () => {
-    const res = await create({
+  test("returns the created script schedule with its command + timeout", async () => {
+    const { schedule } = await create({
       name: "wt-script-create",
       mode: "script",
       script: 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
@@ -40,23 +40,21 @@ describe("createSchedule route — script mode", () => {
       description: "polls github",
       timeoutMs: 120000,
     });
-    const job = res.schedules.find((s) => s.name === "wt-script-create");
-    expect(job?.mode).toBe("script");
-    expect(job?.script).toContain("bun poll.ts");
-    expect(job?.timeoutMs).toBe(120000);
+    expect(schedule.name).toBe("wt-script-create");
+    expect(schedule.mode).toBe("script");
+    expect(schedule.script).toContain("bun poll.ts");
+    expect(schedule.timeoutMs).toBe(120000);
   });
 
   test("script mode does not require a message", async () => {
-    const res = await create({
+    const { schedule } = await create({
       name: "wt-script-nomsg",
       mode: "script",
       script: "echo hi",
       expression: "0 * * * *",
       description: "d",
     });
-    expect(
-      res.schedules.find((s) => s.name === "wt-script-nomsg")?.mode,
-    ).toBe("script");
+    expect(schedule.mode).toBe("script");
   });
 
   test("rejects script mode without a script", async () => {

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -321,11 +321,11 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
         { id: job.id, name: job.name, workflowName },
         "Workflow schedule created",
       );
+      return { schedule: serializeSchedule(job, new Map()) };
     } catch (err) {
       if (err instanceof Error) throw new BadRequestError(err.message);
       throw err;
     }
-    return handleListSchedules({});
   }
 
   if (mode === "script") {
@@ -352,11 +352,11 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
         timeoutMs,
       });
       log.info({ id: job.id, name: job.name }, "Script schedule created");
+      return { schedule: serializeSchedule(job, new Map()) };
     } catch (err) {
       if (err instanceof Error) throw new BadRequestError(err.message);
       throw err;
     }
-    return handleListSchedules({});
   }
 
   try {
@@ -372,11 +372,11 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
       inferenceProfile,
     });
     log.info({ id: job.id, name: job.name }, "Schedule created");
+    return { schedule: serializeSchedule(job, new Map()) };
   } catch (err) {
     if (err instanceof Error) throw new BadRequestError(err.message);
     throw err;
   }
-  return handleListSchedules({});
 }
 
 async function handleToggleSchedule(id: string, body: Record<string, unknown>) {
@@ -762,7 +762,7 @@ export const ROUTES: RouteDefinition[] = [
         .optional(),
     }),
     responseBody: z.object({
-      schedules: z.array(scheduleSchema).describe("Updated schedule list"),
+      schedule: scheduleSchema.describe("The created schedule"),
     }),
     handler: ({ body }: RouteHandlerArgs) => handleCreateSchedule(body ?? {}),
   },


### PR DESCRIPTION
ref ATL-911

`schedules create` (route + CLI) returned the full unbounded schedule list — which no consumer reads and which can't identify the newly-created row. Now returns the created `{ schedule }`, matching the get-one shape, so callers get the new id directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)