### PR TITLE
refactor(persistence): single source of truth for trust class + message metadata

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -137,7 +137,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../persistence/schema/index.js",
     "../../../../prompts/system-prompt.js",
     "../../../../providers/platform-proxy/context.js",
-    "../../../../runtime/actor-trust-resolver.js",
     "../../../../runtime/assistant-event-hub.js",
     "../../../../runtime/auth/route-policy.js",
     "../../../../runtime/background-job-runner.js",
@@ -310,13 +309,19 @@ function collectPluginFiles(): PluginFile[] {
       cwd: process.cwd(),
     })) {
       const norm = rel.split("/").join(sep);
-      if (norm.endsWith(".test.ts") || norm.endsWith(".test.tsx")) continue;
-      if (norm.split(sep).includes("__tests__")) continue;
+      if (norm.endsWith(".test.ts") || norm.endsWith(".test.tsx")) {
+        continue;
+      }
+      if (norm.split(sep).includes("__tests__")) {
+        continue;
+      }
       const underDefaults = relative(DEFAULTS_REL, norm);
       const segments = underDefaults.split(sep);
       // A file directly under defaults/ (e.g. index.ts) is the registry, not a
       // plugin — it has no plugin directory segment.
-      if (segments.length < 2) continue;
+      if (segments.length < 2) {
+        continue;
+      }
       const absPath = join(process.cwd(), norm);
       files.push({
         plugin: segments[0]!,
@@ -344,11 +349,15 @@ function collectEscapes(files: PluginFile[]): Escape[] {
     let match: RegExpExecArray | null;
     while ((match = regex.exec(file.source)) !== null) {
       const specifier = match[1] ?? match[2] ?? match[3];
-      if (!specifier || specifier === "@vellumai/plugin-api") continue;
+      if (!specifier || specifier === "@vellumai/plugin-api") {
+        continue;
+      }
       if (specifier.startsWith(".")) {
         const resolved = resolve(dirname(file.absPath), specifier);
         // Stays inside the plugin's own directory → allowed.
-        if (!relative(pluginRoot, resolved).startsWith("..")) continue;
+        if (!relative(pluginRoot, resolved).startsWith("..")) {
+          continue;
+        }
       }
       escapes.push({ plugin: file.plugin, specifier, relPath: file.relPath });
     }
@@ -361,7 +370,9 @@ function escapesByPlugin(escapes: Escape[]): Map<string, string[]> {
   const sets = new Map<string, Set<string>>();
   for (const e of escapes) {
     let set = sets.get(e.plugin);
-    if (!set) sets.set(e.plugin, (set = new Set()));
+    if (!set) {
+      sets.set(e.plugin, (set = new Set()));
+    }
     set.add(e.specifier);
   }
   return new Map(
@@ -438,7 +449,9 @@ describe("plugin import boundary", () => {
         }
       }
       for (const spec of [...allowed].sort()) {
-        if (!found.has(spec)) stale.push(`  - ${plugin}: "${spec}"`);
+        if (!found.has(spec)) {
+          stale.push(`  - ${plugin}: "${spec}"`);
+        }
       }
     }
 
@@ -456,7 +469,9 @@ describe("plugin import boundary", () => {
       );
     }
     if (stale.length > 0) {
-      if (problems.length > 0) problems.push("");
+      if (problems.length > 0) {
+        problems.push("");
+      }
       problems.push(
         "Stale baseline entries (no longer imported — tighten the baseline):",
         ...stale,

--- a/assistant/src/export/__tests__/transcript-formatter.test.ts
+++ b/assistant/src/export/__tests__/transcript-formatter.test.ts
@@ -81,6 +81,17 @@ mock.module("../../persistence/conversation-crud.js", () => ({
   getMessages: (id: string) =>
     id === "child-conv-1" ? childMessages : parentMessages,
   messageMetadataSchema,
+  parseMessageMetadata: (json: string | null) => {
+    if (!json) {
+      return undefined;
+    }
+    try {
+      const parsed = messageMetadataSchema.safeParse(JSON.parse(json));
+      return parsed.success ? parsed.data : undefined;
+    } catch {
+      return undefined;
+    }
+  },
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 

--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -9,7 +9,7 @@ import { formatLocalTimestamp } from "../daemon/date-context.js";
 import {
   getConversation,
   getMessages,
-  messageMetadataSchema,
+  parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { truncate } from "../util/truncate.js";
 
@@ -29,7 +29,9 @@ function extractAnalysisText(blocks: ContentBlock[]): string {
   for (const block of blocks) {
     switch (block.type) {
       case "text":
-        if (block.text) parts.push(block.text);
+        if (block.text) {
+          parts.push(block.text);
+        }
         break;
       case "tool_use":
         parts.push(
@@ -155,34 +157,26 @@ function appendMessageBlock(
   lines.push(text);
   lines.push("");
 
-  if (msg.metadata) {
-    try {
-      const parsed = messageMetadataSchema.safeParse(JSON.parse(msg.metadata));
-      if (parsed.success && parsed.data.subagentNotification) {
-        const notif = parsed.data.subagentNotification;
-        if (
-          (notif.status === "completed" ||
-            notif.status === "failed" ||
-            notif.status === "aborted") &&
-          notif.conversationId
-        ) {
-          const subMessages = getMessages(notif.conversationId);
-          lines.push(`### Subagent: ${notif.label} (${notif.status})`);
-          lines.push("");
-          // Subagent conversations persist the parent assistant's objective
-          // as a `user` message (see subagent/manager.ts), so reusing the
-          // parent's display-name options would render the assistant's
-          // tasking text under the human user's name. Keep child transcripts
-          // on generic role labels — and only pass through the time zone.
-          lines.push(
-            formatSubagentMessages(subMessages, { timeZone: options.timeZone }),
-          );
-          lines.push("");
-        }
-      }
-    } catch {
-      // Skip unparseable metadata
-    }
+  const notif = parseMessageMetadata(msg.metadata)?.subagentNotification;
+  if (
+    notif &&
+    (notif.status === "completed" ||
+      notif.status === "failed" ||
+      notif.status === "aborted") &&
+    notif.conversationId
+  ) {
+    const subMessages = getMessages(notif.conversationId);
+    lines.push(`### Subagent: ${notif.label} (${notif.status})`);
+    lines.push("");
+    // Subagent conversations persist the parent assistant's objective
+    // as a `user` message (see subagent/manager.ts), so reusing the
+    // parent's display-name options would render the assistant's
+    // tasking text under the human user's name. Keep child transcripts
+    // on generic role labels — and only pass through the time zone.
+    lines.push(
+      formatSubagentMessages(subMessages, { timeZone: options.timeZone }),
+    );
+    lines.push("");
   }
 }
 
@@ -211,29 +205,19 @@ export function buildAnalysisTranscript(conversationId: string): string {
     lines.push("");
 
     // Check for subagent notifications in metadata
-    if (msg.metadata) {
-      try {
-        const parsed = messageMetadataSchema.safeParse(
-          JSON.parse(msg.metadata),
-        );
-        if (parsed.success && parsed.data.subagentNotification) {
-          const notif = parsed.data.subagentNotification;
-          if (
-            (notif.status === "completed" ||
-              notif.status === "failed" ||
-              notif.status === "aborted") &&
-            notif.conversationId
-          ) {
-            const subMessages = getMessages(notif.conversationId);
-            lines.push(`### Subagent: ${notif.label} (${notif.status})`);
-            lines.push("");
-            lines.push(formatSubagentMessages(subMessages));
-            lines.push("");
-          }
-        }
-      } catch {
-        // Skip unparseable metadata
-      }
+    const notif = parseMessageMetadata(msg.metadata)?.subagentNotification;
+    if (
+      notif &&
+      (notif.status === "completed" ||
+        notif.status === "failed" ||
+        notif.status === "aborted") &&
+      notif.conversationId
+    ) {
+      const subMessages = getMessages(notif.conversationId);
+      lines.push(`### Subagent: ${notif.label} (${notif.status})`);
+      lines.push("");
+      lines.push(formatSubagentMessages(subMessages));
+      lines.push("");
     }
   }
 

--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -143,6 +143,45 @@ export function formatMessageSliceForTranscript(
   return lines.join("\n");
 }
 
+/**
+ * Append the `### Subagent: …` section for `msg` when its metadata carries a
+ * terminal (completed/failed/aborted) subagent notification; a no-op otherwise.
+ *
+ * `subagentOptions` controls how the child transcript renders. Callers pass the
+ * parent's time zone but NOT its display names: a subagent conversation persists
+ * the parent assistant's objective as a `user` message (see subagent/manager.ts),
+ * so reusing the parent's names would render the assistant's tasking text under
+ * the human user's name. An empty options object keeps child transcripts on
+ * generic role labels.
+ */
+function appendSubagentSection(
+  lines: string[],
+  msg: TranscriptMessage,
+  subagentOptions: TranscriptFormatOptions = {},
+): void {
+  const notif = parseMessageMetadata(msg.metadata)?.subagentNotification;
+  if (
+    !notif ||
+    (notif.status !== "completed" &&
+      notif.status !== "failed" &&
+      notif.status !== "aborted") ||
+    !notif.conversationId
+  ) {
+    return;
+  }
+  const subMessages = getMessages(notif.conversationId);
+  lines.push(`### Subagent: ${notif.label} (${notif.status})`);
+  lines.push("");
+  lines.push(formatSubagentMessages(subMessages, subagentOptions));
+  lines.push("");
+}
+
+/**
+ * Render one message as a transcript block: a `## role (time)` header, the
+ * extracted body text, and any terminal subagent section. Role and time honor
+ * `options` (display names + time zone); the subagent child transcript inherits
+ * only the time zone — see {@link appendSubagentSection}.
+ */
 function appendMessageBlock(
   lines: string[],
   msg: TranscriptMessage,
@@ -157,27 +196,7 @@ function appendMessageBlock(
   lines.push(text);
   lines.push("");
 
-  const notif = parseMessageMetadata(msg.metadata)?.subagentNotification;
-  if (
-    notif &&
-    (notif.status === "completed" ||
-      notif.status === "failed" ||
-      notif.status === "aborted") &&
-    notif.conversationId
-  ) {
-    const subMessages = getMessages(notif.conversationId);
-    lines.push(`### Subagent: ${notif.label} (${notif.status})`);
-    lines.push("");
-    // Subagent conversations persist the parent assistant's objective
-    // as a `user` message (see subagent/manager.ts), so reusing the
-    // parent's display-name options would render the assistant's
-    // tasking text under the human user's name. Keep child transcripts
-    // on generic role labels — and only pass through the time zone.
-    lines.push(
-      formatSubagentMessages(subMessages, { timeZone: options.timeZone }),
-    );
-    lines.push("");
-  }
+  appendSubagentSection(lines, msg, { timeZone: options.timeZone });
 }
 
 export function buildAnalysisTranscript(conversationId: string): string {
@@ -186,7 +205,6 @@ export function buildAnalysisTranscript(conversationId: string): string {
     return `# Conversation not found: ${conversationId}\n`;
   }
 
-  const allMessages = getMessages(conversationId);
   const title = conversation.title ?? "Untitled";
   const lines: string[] = [];
 
@@ -194,31 +212,11 @@ export function buildAnalysisTranscript(conversationId: string): string {
   lines.push(`Created: ${formatLocalTimestamp(conversation.createdAt)}`);
   lines.push("");
 
-  for (const msg of allMessages) {
-    const role = formatRole(msg.role);
-    const time = formatLocalTimestamp(msg.createdAt);
-    const content = parseContent(msg.content);
-    const text = extractAnalysisText(content);
-
-    lines.push(`## ${role} (${time})`);
-    lines.push(text);
-    lines.push("");
-
-    // Check for subagent notifications in metadata
-    const notif = parseMessageMetadata(msg.metadata)?.subagentNotification;
-    if (
-      notif &&
-      (notif.status === "completed" ||
-        notif.status === "failed" ||
-        notif.status === "aborted") &&
-      notif.conversationId
-    ) {
-      const subMessages = getMessages(notif.conversationId);
-      lines.push(`### Subagent: ${notif.label} (${notif.status})`);
-      lines.push("");
-      lines.push(formatSubagentMessages(subMessages));
-      lines.push("");
-    }
+  // Analyze-conversation flow renders under generic "User"/"Assistant" labels,
+  // so no options are threaded through (see `formatMessageSliceForTranscript`
+  // for the display-name variant).
+  for (const msg of getMessages(conversationId)) {
+    appendMessageBlock(lines, msg);
   }
 
   return lines.join("\n");

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -30,6 +30,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
+import { trustClassSchema } from "../runtime/trust-class.js";
 import { UserError } from "../util/errors.js";
 import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
@@ -170,9 +171,7 @@ export const messageMetadataSchema = z
      * trust status changes later. Used by the memory write gate (indexer)
      * and read gate (conversation history loading) to enforce trust-aware access.
      */
-    provenanceTrustClass: z
-      .enum(["guardian", "trusted_contact", "unverified_contact", "unknown"])
-      .optional(),
+    provenanceTrustClass: trustClassSchema.optional(),
     provenanceSourceChannel: channelIdSchema.optional(),
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
@@ -208,6 +207,31 @@ export const messageMetadataSchema = z
     nonInteractiveContextBlock: z.string().optional(),
   })
   .passthrough();
+
+/** Validated shape of a persisted message's `metadata` column. */
+export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
+/**
+ * Parse a persisted message's metadata JSON against {@link messageMetadataSchema}
+ * — the single source of truth for its shape — returning the validated fields,
+ * or `undefined` when the column is absent, not valid JSON, or fails validation.
+ * The single place the raw JSON.parse + safeParse dance lives, so callers read
+ * typed fields (e.g. `provenanceTrustClass`, `automated`, `subagentNotification`)
+ * instead of re-implementing it.
+ */
+export function parseMessageMetadata(
+  metadataJson: string | null,
+): MessageMetadata | undefined {
+  if (!metadataJson) {
+    return undefined;
+  }
+  try {
+    const parsed = messageMetadataSchema.safeParse(JSON.parse(metadataJson));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function cloneForkMessageMetadata(
   metadata: string | null,
@@ -246,7 +270,9 @@ function cloneForkMessageMetadata(
 export function provenanceFromTrustContext(
   ctx: TrustContext | null | undefined,
 ): Record<string, unknown> {
-  if (!ctx) return { provenanceTrustClass: "unknown" };
+  if (!ctx) {
+    return { provenanceTrustClass: "unknown" };
+  }
   return {
     provenanceTrustClass: ctx.trustClass,
     provenanceSourceChannel: ctx.sourceChannel,
@@ -1039,7 +1065,9 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
   const attachmentIdMap = new Map<string, string>();
   for (const message of messagesToCopy) {
     const forkedMessageId = forkedMessageIds.get(message.id);
-    if (!forkedMessageId) continue;
+    if (!forkedMessageId) {
+      continue;
+    }
 
     const attachmentLinks = db
       .select({
@@ -1153,7 +1181,9 @@ function latestForkedAssistantFrom(
 ): { messageId: string; messageAt: number } | null {
   for (let i = messagesToCopy.length - 1; i >= 0; i--) {
     const message = messagesToCopy[i]!;
-    if (message.role !== "assistant") continue;
+    if (message.role !== "assistant") {
+      continue;
+    }
     const forkedMessageId = forkedMessageIds.get(message.id);
     if (forkedMessageId) {
       return { messageId: forkedMessageId, messageAt: message.createdAt };
@@ -1797,7 +1827,9 @@ export function countMessagesAfter(
     .from(messages)
     .where(eq(messages.id, afterMessageId))
     .get();
-  if (!ref) return 0;
+  if (!ref) {
+    return 0;
+  }
   // Tie-breaker on `messages.id` so rows that share a millisecond timestamp
   // with the reference are not permanently skipped. Mirrors the
   // `(createdAt, id)` cursor pattern used by the backfill job-handler and
@@ -1850,7 +1882,9 @@ export function getMessagesAfter(
     .from(messages)
     .where(eq(messages.id, afterMessageId))
     .get();
-  if (!ref) return [];
+  if (!ref) {
+    return [];
+  }
   // Same `(createdAt, id)` cursor as `countMessagesAfter` — rows sharing
   // the reference's millisecond timestamp would otherwise be skipped.
   return db
@@ -1991,15 +2025,23 @@ export function getMessagesPaginated(
       .all()
       .map(parseMessage);
 
-    if (chunk.length === 0) break;
+    if (chunk.length === 0) {
+      break;
+    }
     rowsScanned += chunk.length;
 
     for (const row of chunk) {
-      if (!filter || filter(row)) visible.push(row);
-      if (visible.length >= limit + 1) break;
+      if (!filter || filter(row)) {
+        visible.push(row);
+      }
+      if (visible.length >= limit + 1) {
+        break;
+      }
     }
 
-    if (chunk.length < chunkSize) break;
+    if (chunk.length < chunkSize) {
+      break;
+    }
     const lastRow = chunk[chunk.length - 1];
     lastScanned = { createdAt: lastRow.createdAt, id: lastRow.id };
     cursorCreatedAt = lastRow.createdAt;
@@ -2011,7 +2053,9 @@ export function getMessagesPaginated(
   // the scanned window, so report `hasMore: true` to keep the client draining
   // — returning `false` here is the stall this loop exists to prevent.
   const hasMore = filledPage || scanCapTruncated;
-  if (filledPage) visible.splice(limit);
+  if (filledPage) {
+    visible.splice(limit);
+  }
   visible.reverse();
 
   // Only hand back a resume cursor when the cap (not DB exhaustion) cut the
@@ -2093,7 +2137,9 @@ export function updateConversationTitle(
 ): void {
   const db = getDb();
   const set: Record<string, unknown> = { title, updatedAt: Date.now() };
-  if (isAutoTitle !== undefined) set.isAutoTitle = isAutoTitle;
+  if (isAutoTitle !== undefined) {
+    set.isAutoTitle = isAutoTitle;
+  }
   db.update(conversations).set(set).where(eq(conversations.id, id)).run();
 
   // Update disk view meta.json with the new title
@@ -2182,7 +2228,9 @@ export function updateConversationSlackContextWatermark(
 
 export function archiveConversation(id: string): boolean {
   const conv = getConversation(id);
-  if (!conv) return false;
+  if (!conv) {
+    return false;
+  }
   const now = Date.now();
   rawRun(
     "UPDATE conversations SET archived_at = ?, updated_at = ? WHERE id = ?",
@@ -2195,7 +2243,9 @@ export function archiveConversation(id: string): boolean {
 
 export function unarchiveConversation(id: string): boolean {
   const conv = getConversation(id);
-  if (!conv) return false;
+  if (!conv) {
+    return false;
+  }
   const now = Date.now();
   rawRun(
     "UPDATE conversations SET archived_at = NULL, updated_at = ? WHERE id = ?",
@@ -2245,7 +2295,9 @@ export function clearStaleProcessingFlags(): number {
  */
 export function isConversationProcessing(id: string): boolean {
   const inMemory = findConversation(id)?.isProcessing();
-  if (inMemory != null) return inMemory;
+  if (inMemory != null) {
+    return inMemory;
+  }
   const row = rawGet<{ processing_started_at: number | null }>(
     "SELECT processing_started_at FROM conversations WHERE id = ?",
     id,
@@ -2283,7 +2335,9 @@ export function getConversationPersistedSeq(id: string): number | null {
  * Non-positive or non-finite `seq` values are ignored.
  */
 export function recordConversationPersistedSeq(id: string, seq: number): void {
-  if (!Number.isFinite(seq) || seq <= 0) return;
+  if (!Number.isFinite(seq) || seq <= 0) {
+    return;
+  }
   rawRun(
     "UPDATE conversations SET seq = ? WHERE id = ? AND (seq IS NULL OR seq < ?)",
     seq,
@@ -2310,7 +2364,9 @@ export function setConversationSurfaced(
   surfaced: boolean,
 ): { surfacedAt: number | null } | null {
   const conv = getConversation(id);
-  if (!conv) return null;
+  if (!conv) {
+    return null;
+  }
   const now = Date.now();
   const surfacedAt = surfaced ? now : null;
   rawRun(
@@ -2392,7 +2448,9 @@ export function clearExpiredInferenceProfiles(
     )
     .all(now) as Array<{ conversationId: string; sessionId: string | null }>;
 
-  if (expired.length === 0) return [];
+  if (expired.length === 0) {
+    return [];
+  }
 
   const ids = expired.map((r) => r.conversationId);
   const placeholders = ids.map(() => "?").join(", ");
@@ -2673,7 +2731,9 @@ export function deleteLastExchange(conversationId: string): number {
     .limit(1)
     .get();
 
-  if (!lastUserMsg) return 0;
+  if (!lastUserMsg) {
+    return 0;
+  }
 
   // Use rowid to identify the last user message and everything after it.
   // rowid is monotonically increasing for inserts, so this is safe even if
@@ -2689,7 +2749,9 @@ export function deleteLastExchange(conversationId: string): number {
     .from(messages)
     .where(condition)
     .all();
-  if (deleted === 0) return 0;
+  if (deleted === 0) {
+    return 0;
+  }
 
   // Collect attachment IDs linked to the messages being deleted so we can
   // scope orphan cleanup to only those candidates (not freshly uploaded ones).
@@ -2859,7 +2921,9 @@ export function relinkAttachments(
   fromMessageIds: string[],
   toMessageId: string,
 ): number {
-  if (fromMessageIds.length === 0) return 0;
+  if (fromMessageIds.length === 0) {
+    return 0;
+  }
   const db = getDb();
 
   // Count how many links will be moved before updating.
@@ -2869,7 +2933,9 @@ export function relinkAttachments(
     .where(inArray(messageAttachments.messageId, fromMessageIds))
     .all();
 
-  if (total === 0) return 0;
+  if (total === 0) {
+    return 0;
+  }
 
   db.update(messageAttachments)
     .set({ messageId: toMessageId })
@@ -3051,13 +3117,7 @@ export function getConversationRecentProvenanceTrustClass(
      ORDER BY created_at DESC LIMIT 1`,
     conversationId,
   );
-  if (!row?.metadata) return undefined;
-  try {
-    const parsed = messageMetadataSchema.safeParse(JSON.parse(row.metadata));
-    return parsed.success ? parsed.data.provenanceTrustClass : undefined;
-  } catch {
-    return undefined;
-  }
+  return parseMessageMetadata(row?.metadata ?? null)?.provenanceTrustClass;
 }
 
 // ---------------------------------------------------------------------------
@@ -3162,7 +3222,9 @@ export function getDisplayMetaForConversations(
     string,
     { displayOrder: number | null; isPinned: boolean; groupId: string | null }
   >();
-  if (conversationIds.length === 0) return result;
+  if (conversationIds.length === 0) {
+    return result;
+  }
   for (const id of conversationIds) {
     const row = rawGet<{
       display_order: number | null;
@@ -3191,10 +3253,14 @@ export function getDisplayMetaForConversations(
  * be treated as turn boundaries.
  */
 function isToolResultMessage(role: string, content: string): boolean {
-  if (role !== "user") return false;
+  if (role !== "user") {
+    return false;
+  }
   try {
     const parsed = JSON.parse(content);
-    if (!Array.isArray(parsed) || parsed.length === 0) return false;
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return false;
+    }
     return parsed.every(
       (block: unknown) =>
         block != null &&
@@ -3350,7 +3416,9 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   // Look up the target message to get its conversationId and createdAt.
   const target = getMessageById(messageId);
-  if (!target) return [messageId];
+  if (!target) {
+    return [messageId];
+  }
 
   // Walk backward from the target message to find the turn boundary.
   // Limit to 50 rows — sufficient for even aggressive tool-use loops.
@@ -3455,7 +3523,9 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   // Sort by createdAt to ensure stable ordering.
   // Re-fetch createdAt for all collected IDs so the sort is accurate.
-  if (assistantIds.length <= 1) return assistantIds;
+  if (assistantIds.length <= 1) {
+    return assistantIds;
+  }
 
   const idSet = new Set(assistantIds);
   const sorted = db

--- a/assistant/src/plugins/defaults/memory/job-handlers/backfill.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/backfill.ts
@@ -6,37 +6,17 @@ import {
   resetMessageCursorCheckpoint,
   writeMessageCursorCheckpoint,
 } from "../../../../persistence/checkpoints.js";
-import { messageMetadataSchema } from "../../../../persistence/conversation-crud.js";
+import { parseMessageMetadata } from "../../../../persistence/conversation-crud.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
   type MemoryJob,
 } from "../../../../persistence/jobs-store.js";
 import { messages } from "../../../../persistence/schema/index.js";
-import type { TrustClass } from "../../../../runtime/actor-trust-resolver.js";
 import { indexMessageNow } from "../indexer.js";
 
 const BACKFILL_CHECKPOINT_KEY = "memory:backfill:last_created_at";
 const BACKFILL_CHECKPOINT_ID_KEY = "memory:backfill:last_message_id";
-
-function parseMessageMetadata(rawMetadata: string | null): {
-  provenanceTrustClass: TrustClass | undefined;
-  automated: boolean | undefined;
-} {
-  if (!rawMetadata)
-    return { provenanceTrustClass: undefined, automated: undefined };
-  try {
-    const parsed = messageMetadataSchema.safeParse(JSON.parse(rawMetadata));
-    if (!parsed.success)
-      return { provenanceTrustClass: undefined, automated: undefined };
-    return {
-      provenanceTrustClass: parsed.data.provenanceTrustClass,
-      automated: parsed.data.automated,
-    };
-  } catch {
-    return { provenanceTrustClass: undefined, automated: undefined };
-  }
-}
 
 export async function backfillJob(
   job: MemoryJob,
@@ -73,9 +53,7 @@ export async function backfillJob(
 
   if (batch.length > 0) {
     for (const message of batch) {
-      const { provenanceTrustClass, automated } = parseMessageMetadata(
-        message.metadata ?? null,
-      );
+      const meta = parseMessageMetadata(message.metadata ?? null);
       await indexMessageNow(
         {
           messageId: message.id,
@@ -84,8 +62,8 @@ export async function backfillJob(
           content: message.content,
           createdAt: message.createdAt,
           scopeId: "default",
-          provenanceTrustClass,
-          automated,
+          provenanceTrustClass: meta?.provenanceTrustClass,
+          automated: meta?.automated,
         },
         config.memory,
       );

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -34,6 +34,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { getCachedMemberAcl } from "./member-verdict-cache.js";
+import type { TrustClass } from "./trust-class.js";
 
 const log = getLogger("actor-trust-resolver");
 
@@ -44,27 +45,11 @@ export type { TrustContext } from "../daemon/trust-context.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Trust classification for an inbound actor.
- *
- * - `'guardian'`: The sender matches the active guardian binding for this
- *   (assistant, channel). Guardians have full control-plane access and
- *   self-approve tool invocations.
- * - `'trusted_contact'`: The sender is an active contact with a channel
- *   (not the guardian). Trusted contacts can invoke tools but require
- *   guardian approval for sensitive operations.
- * - `'unverified_contact'`: The sender matches a contact channel whose
- *   status is `pending` or `unverified` — known to the guardian but not yet
- *   verified. Treated identically to `trusted_contact` for every downstream
- *   capability/tool/approval decision; the distinction is admission-only.
- * - `'unknown'`: The sender has no contact record, no identity could be
- *   established, or the sender is a blocked/revoked contact. Unknown
- *   actors are fail-closed with no escalation path.
+ * Trust classification for an inbound actor. Defined once in `./trust-class.ts`
+ * (shared with the persistence metadata schema) and re-exported here, the
+ * canonical import site for the resolver's consumers.
  */
-export type TrustClass =
-  | "guardian"
-  | "trusted_contact"
-  | "unverified_contact"
-  | "unknown";
+export type { TrustClass };
 
 /**
  * Fully resolved trust context from the actor trust resolver.
@@ -211,7 +196,8 @@ export function resolveActorTrust(
     };
     guardianPrincipalId = guardianDelivery.principalId ?? undefined;
     isGuardian =
-      guardianDelivery.address.toLowerCase() === canonicalSenderId.toLowerCase();
+      guardianDelivery.address.toLowerCase() ===
+      canonicalSenderId.toLowerCase();
   }
 
   log.debug(

--- a/assistant/src/runtime/trust-class.ts
+++ b/assistant/src/runtime/trust-class.ts
@@ -1,0 +1,33 @@
+/**
+ * Trust classification for an inbound actor — the single source of truth for
+ * both the {@link TrustClass} type and the Zod enum ({@link trustClassSchema})
+ * that validates it in persisted message metadata.
+ *
+ * Kept as a leaf module (imports only `zod`) so the runtime trust layer and the
+ * persistence schema can share one definition without a circular import.
+ *
+ * - `'guardian'`: The sender matches the active guardian binding for this
+ *   (assistant, channel). Guardians have full control-plane access and
+ *   self-approve tool invocations.
+ * - `'trusted_contact'`: The sender is an active contact with a channel
+ *   (not the guardian). Trusted contacts can invoke tools but require
+ *   guardian approval for sensitive operations.
+ * - `'unverified_contact'`: The sender matches a contact channel whose
+ *   status is `pending` or `unverified` — known to the guardian but not yet
+ *   verified. Treated identically to `trusted_contact` for every downstream
+ *   capability/tool/approval decision; the distinction is admission-only.
+ * - `'unknown'`: The sender has no contact record, no identity could be
+ *   established, or the sender is a blocked/revoked contact. Unknown
+ *   actors are fail-closed with no escalation path.
+ */
+
+import { z } from "zod";
+
+export const trustClassSchema = z.enum([
+  "guardian",
+  "trusted_contact",
+  "unverified_contact",
+  "unknown",
+]);
+
+export type TrustClass = z.infer<typeof trustClassSchema>;


### PR DESCRIPTION
Foundational cleanup split out of #36811 (LUM-2654). That PR needed the memory write-gate's `provenanceTrustClass` / `automated` fields, and to type them it had hand-copied the trust-class union + the metadata-parse dance — a third+ copy of things that already exist. This removes the duplication at the source so #36811 (and the existing call sites) consume one canonical definition. Intended to land first; #36811 then rebases onto it.

## Prompt / plan

Two overlapping duplications, both hand-authored and drift-prone:

1. **Trust-class union declared twice** — the `TrustClass` type (`runtime/actor-trust-resolver.ts`) and the `messageMetadataSchema.provenanceTrustClass` Zod enum (`persistence/conversation-crud.ts`) independently list the same four strings.
2. **The `JSON.parse` + `messageMetadataSchema.safeParse` dance repeated ~4×** (conversation-crud, transcript-formatter twice, memory backfill — which had grown its own local `parseMessageMetadata`), with no exported `MessageMetadata` type.

**Changes:**

- New leaf module **`runtime/trust-class.ts`** owns the union once: `trustClassSchema` (Zod enum) + `export type TrustClass = z.infer<typeof trustClassSchema>`, with the per-value docs. It imports only `zod`, so it's a dependency sink — nothing can cycle through it.
- `actor-trust-resolver.ts` imports `TrustClass` for its own use and **re-exports** it, so every existing `import { type TrustClass } from ".../actor-trust-resolver.js"` is unchanged.
- `messageMetadataSchema.provenanceTrustClass` now uses `trustClassSchema.optional()` instead of re-listing the strings.
- `conversation-crud.ts` exports **`MessageMetadata`** (`z.infer<typeof messageMetadataSchema>`) and **`parseMessageMetadata(json: string | null): MessageMetadata | undefined`** — the single home for the parse dance (returns `undefined` on absent/invalid/malformed JSON).
- The four hand-rolled parse copies now call `parseMessageMetadata`; `backfill.ts`'s local helper is deleted. The two `transcript-formatter` sites also flatten from `if (metadata) { try { safeParse … if (success && notif) …` to `const notif = parseMessageMetadata(msg.metadata)?.subagentNotification`.

**Why a leaf module (not co-locating the schema in `actor-trust-resolver.ts`):** persistence would then import the runtime trust resolver, risking a cycle through its transitive deps. A zod-only leaf both layers import is guaranteed cycle-free — confirmed below.

## Test plan

- `bunx tsc --noEmit` (full project) clean — the schema-inferred type is assignable everywhere `TrustClass` was used, so the two former definitions provably agreed.
- `eslint` + `prettier --check` clean on all five files.
- `lint:circular` — **402, unchanged** from baseline; `trust-class.ts` appears in zero cycles.
- Ran the affected suites individually (scoped, per AGENTS.md), all green: `export/__tests__/transcript-formatter`, `resolve-trust-class`, `actor-trust-resolver-address-fallback`, `runtime/__tests__/trust-verdict-consumer`, `list-messages-hidden-metadata`, `annotate-activity-metadata`, `tool-result-metadata-plumbing`, `runtime-attachment-metadata`, `conversation-lifecycle-auto-analyze`. (A metadata-suite batch shows 9 failures only when several DB-touching files share a process — identical on baseline `main`, i.e. pre-existing test isolation, not this change.)

**Reviewer note:** behavior-preserving — same enum values, same parse semantics. Blast radius is the trust-class definition move (re-exported, so call sites are untouched) and swapping four parse copies for one helper. `actor-trust-resolver.ts` is trust-sensitive, but the type it exports is byte-identical; no resolution logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx6xJ5Ep4N3m44vk49UkqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx6xJ5Ep4N3m44vk49UkqL)_