### PR TITLE
fix(trust): scope the DISABLE_HTTP_AUTH bypass to unresolved actors

### DIFF
--- a/assistant/src/__tests__/personal-memory-auth-bypass.test.ts
+++ b/assistant/src/__tests__/personal-memory-auth-bypass.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Security regression test for the personal-memory trust gate under
+ * DISABLE_HTTP_AUTH.
+ *
+ * `isPersonalMemoryAllowed` derives trust from `resolveTrustClass`, which only
+ * elevates an *unresolved* actor to guardian under DISABLE_HTTP_AUTH (the
+ * standing config in platform-managed deployments). A resolved non-guardian
+ * channel actor must therefore be denied personal memory even with auth
+ * disabled — otherwise the guardian's memory leaks to Slack/phone contacts in
+ * the cloud. See LUM-2669. These cases fail on the pre-fix behavior.
+ *
+ * Uses process.env directly (not a module mock) since isHttpAuthDisabled()
+ * reads DISABLE_HTTP_AUTH live.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  isPersonalMemoryAllowed,
+  type TrustContext,
+} from "../daemon/trust-context.js";
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+
+function slack(trustClass: TrustClass): TrustContext {
+  return { sourceChannel: "slack", trustClass };
+}
+
+let prior: string | undefined;
+
+beforeEach(() => {
+  // Platform-managed / dev-bypass posture: the flag is on process-wide.
+  prior = process.env.DISABLE_HTTP_AUTH;
+  process.env.DISABLE_HTTP_AUTH = "true";
+});
+
+afterEach(() => {
+  if (prior === undefined) delete process.env.DISABLE_HTTP_AUTH;
+  else process.env.DISABLE_HTTP_AUTH = prior;
+});
+
+describe("isPersonalMemoryAllowed — no exposure to non-guardian channel actors under DISABLE_HTTP_AUTH", () => {
+  test("blocks personal memory for a non-guardian Slack actor even with auth disabled", () => {
+    expect(isPersonalMemoryAllowed(slack("trusted_contact"))).toBe(false);
+    expect(isPersonalMemoryAllowed(slack("unknown"))).toBe(false);
+    expect(isPersonalMemoryAllowed(slack("unverified_contact"))).toBe(false);
+  });
+
+  test("allows personal memory for the guardian and for local / internal turns", () => {
+    expect(isPersonalMemoryAllowed(slack("guardian"))).toBe(true);
+    // Local/native turn — no resolved actor.
+    expect(isPersonalMemoryAllowed(undefined)).toBe(true);
+    // Internal vellum-channel flow.
+    expect(
+      isPersonalMemoryAllowed({
+        sourceChannel: "vellum",
+        trustClass: "unknown",
+      }),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/personal-memory-auth-bypass.test.ts
+++ b/assistant/src/__tests__/personal-memory-auth-bypass.test.ts
@@ -33,8 +33,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (prior === undefined) delete process.env.DISABLE_HTTP_AUTH;
-  else process.env.DISABLE_HTTP_AUTH = prior;
+  if (prior === undefined) {
+    delete process.env.DISABLE_HTTP_AUTH;
+  } else {
+    process.env.DISABLE_HTTP_AUTH = prior;
+  }
 });
 
 describe("isPersonalMemoryAllowed — no exposure to non-guardian channel actors under DISABLE_HTTP_AUTH", () => {

--- a/assistant/src/__tests__/resolve-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-trust-class.test.ts
@@ -38,19 +38,25 @@ describe("resolveTrustClass", () => {
     expect(resolveTrustClass(undefined)).toBe("unknown");
   });
 
-  test("forces guardian when HTTP auth is disabled, regardless of context trust class", () => {
+  test("does not elevate a resolved non-guardian actor when HTTP auth is disabled", () => {
+    // DISABLE_HTTP_AUTH is the standing config in platform-managed deployments,
+    // so a resolved channel actor's class must survive it — otherwise a
+    // non-guardian Slack/phone contact would be treated as the guardian
+    // (LUM-2669). Only an unresolved (local/native) turn is elevated; see below.
     fakeHttpAuthDisabled = true;
-    const ctx: Pick<TrustContext, "trustClass"> = {
-      trustClass: "trusted_contact",
-    };
-    expect(resolveTrustClass(ctx as TrustContext)).toBe("guardian");
+    expect(
+      resolveTrustClass({ trustClass: "trusted_contact" } as TrustContext),
+    ).toBe("trusted_contact");
+    expect(resolveTrustClass({ trustClass: "unknown" } as TrustContext)).toBe(
+      "unknown",
+    );
   });
 
-  test("forces guardian for unknown trust class when HTTP auth is disabled", () => {
+  test("treats an unresolved (local/native) turn as guardian when HTTP auth is disabled", () => {
+    // Local/native turns reach the daemon without a channel-resolved
+    // trustContext; in an auth-disabled (local) deployment that actor is the
+    // guardian, so control-plane gates don't block local development.
     fakeHttpAuthDisabled = true;
-    const ctx: Pick<TrustContext, "trustClass"> = {
-      trustClass: "unknown",
-    };
-    expect(resolveTrustClass(ctx as TrustContext)).toBe("guardian");
+    expect(resolveTrustClass(undefined)).toBe("guardian");
   });
 });

--- a/assistant/src/__tests__/resolve-trust-class.test.ts
+++ b/assistant/src/__tests__/resolve-trust-class.test.ts
@@ -12,6 +12,7 @@ mock.module("../config/env.js", () => ({
 // ── Real imports (after mocks) ───────────────────────────────────────
 
 import {
+  FALLBACK_TURN_TRUST,
   resolveTrustClass,
   type TrustContext,
 } from "../daemon/trust-context.js";
@@ -58,5 +59,16 @@ describe("resolveTrustClass", () => {
     // guardian, so control-plane gates don't block local development.
     fakeHttpAuthDisabled = true;
     expect(resolveTrustClass(undefined)).toBe("guardian");
+  });
+
+  test("does not elevate the FALLBACK_TURN_TRUST snapshot to guardian when HTTP auth is disabled", () => {
+    // conversation-tool-setup substitutes FALLBACK_TURN_TRUST (a *present*,
+    // unknown-class context) when no per-turn snapshot has been captured. Because
+    // it is a resolved context -- not `undefined` -- the dev-bypass must not
+    // elevate it: the fallback's documented bias-to-unknown has to survive
+    // DISABLE_HTTP_AUTH so a missing snapshot can't grant guardian trust. This is
+    // the fail-safe sibling to LUM-2665; see LUM-2669.
+    fakeHttpAuthDisabled = true;
+    expect(resolveTrustClass(FALLBACK_TURN_TRUST)).toBe("unknown");
   });
 });

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -91,7 +91,9 @@ export const FALLBACK_TURN_TRUST: TrustContext = {
 export function resolveTrustClass(
   trustContext: TrustContext | undefined,
 ): TrustClass {
-  if (trustContext === undefined && isHttpAuthDisabled()) return "guardian";
+  if (trustContext === undefined && isHttpAuthDisabled()) {
+    return "guardian";
+  }
   return trustContext?.trustClass ?? "unknown";
 }
 

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -75,17 +75,23 @@ export const FALLBACK_TURN_TRUST: TrustContext = {
 /**
  * Resolve the effective trust class for an actor.
  *
- * When HTTP auth is disabled (dev bypass), always returns `'guardian'`
- * so that control-plane gates don't block local development.
+ * Trust is a property of the actor, never of the deployment's auth posture.
+ * The dev/local bypass therefore fills in `'guardian'` only when NO actor was
+ * resolved: local/native turns reach the daemon without a channel-resolved
+ * trustContext, and in an auth-disabled (local) deployment that unresolved
+ * actor is the guardian. A *present* trustContext always reflects the real
+ * actor — even under `DISABLE_HTTP_AUTH`, which is the standing config in
+ * platform-managed deployments — so a resolved non-guardian channel actor is
+ * never elevated to guardian.
  *
- * When no trust context is available (e.g. desktop-only conversations that
- * don't go through channel trust resolution), defaults to `'unknown'`
- * to fail-closed.
+ * When no trust context is available and auth is enabled (e.g. a desktop-only
+ * conversation that hasn't gone through channel trust resolution), defaults to
+ * `'unknown'` to fail-closed.
  */
 export function resolveTrustClass(
   trustContext: TrustContext | undefined,
 ): TrustClass {
-  if (isHttpAuthDisabled()) return "guardian";
+  if (trustContext === undefined && isHttpAuthDisabled()) return "guardian";
   return trustContext?.trustClass ?? "unknown";
 }
 


### PR DESCRIPTION
**Ready for review.** This is concrete **Step-0 trust-resolution hardening** in the [LUM-2664](https://linear.app/vellum/issue/LUM-2664) tree — sibling to [LUM-2665](https://linear.app/vellum/issue/LUM-2665). LUM-2665 covers the *fail-stranger* direction (a guardian wrongly downgraded); this covers the opposite (non-guardians wrongly **upgraded** to guardian via the auth bypass). Closes [LUM-2669](https://linear.app/vellum/issue/LUM-2669).

> **Merge gate (a review question, not a blocker to reviewing):** confirm the daemon runs `DISABLE_HTTP_AUTH=true` in platform-managed cloud with channel turns hitting these gates (see below). @noanflaherty owns the trust-verdict substrate; @siddseethepalli owns the memory gate.

## Prompt / plan

`resolveTrustClass()` short-circuited to `"guardian"` whenever `isHttpAuthDisabled()` was true, **before** consulting the actor's `trustContext`:

```ts
if (isHttpAuthDisabled()) return "guardian";   // ignores the actor
return trustContext?.trustClass ?? "unknown";
```

`DISABLE_HTTP_AUTH=true` is the standing config in platform-managed deployments (per `gateway/src/http/middleware/auth.ts` + `events-dev-bypass-actor.test.ts`; the assistant's `isHttpAuthDisabled()` reads the flag alone). So in the cloud, **every actor — including non-guardian Slack/phone contacts — classified as `guardian`.** That folds a *deployment* property into a *per-actor* trust decision — exactly what the PRD's integrity boundary forbids ("trust state cannot be edited by the assistant; the daemon consumes the gateway verdict, never decides"). Every gate downstream inherited it:

- **Personal-memory exposure** — `isPersonalMemoryAllowed` sets `isTrustedActor = resolveTrustClass(...) === "guardian"`; the channel check in `shouldExposePersonalMemory` is ANDed with `!isTrustedActor`, so it doesn't save it. A Slack `trusted_contact`/`unknown` actor gets the guardian's v2 static blocks (essentials/threads/recent/buffer), PKB, and NOW.md. (Note: this is a *separate* gate from `resolveCapabilities(trustClass).canAccessMemory`, which already reads the raw class and covers a different layer — message history — so it did **not** mask this. The two gates disagreed under `DISABLE_HTTP_AUTH`; this change makes them agree.)
- **Tool-privilege escalation** — `conversation-tool-setup.ts` sets `ToolContext.trustClass = resolveTrustClass(...)`; `guardian` lets an untrusted channel actor's tools self-approve.
- **Prompt guardrail no-op** — the LUM-2655 guardrail (#36810) hit the same wall (already fixed there).

**The fix** — trust is a property of the actor, not the deployment's auth posture. The bypass now fills in `guardian` **only when no actor was resolved** (local/native turns reach the daemon with `trustContext === undefined`); a *resolved* channel actor's class always survives:

```ts
if (trustContext === undefined && isHttpAuthDisabled()) return "guardian";
return trustContext?.trustClass ?? "unknown";
```

This fixes every gate at the root, preserves local dev (its turns are `undefined`), and aligns `FALLBACK_TURN_TRUST` with its stated fail-closed-to-`unknown` intent. Note the `undefined → guardian` clause **is** the PRD's Step-0 invariant ("fail-safe, never fail-stranger on unresolved trust") applied to the platform-managed case: an unresolved actor fails to guardian (safe), never to stranger. Deliberately minimal, root-level — **not** a per-gate patch.

**Follow-up hardening (tracked in LUM-2669):** wire the already-present-but-dead `resolveLocalTrustContext()` into the local-turn ingress so local turns carry a real guardian `trustContext`, then delete the `isHttpAuthDisabled()` branch entirely — making trust purely actor-derived. Longer term, the legacy `isPersonalMemoryAllowed` should collapse onto the PRD's `CapabilitySet.canAccessMemory`.

## Confirm the premise

Does the **daemon** run with `DISABLE_HTTP_AUTH=true` in platform-managed cloud, and do gateway-forwarded channel turns invoke these gates in that process?
- **Yes** → this is a live guardian-data-exposure fix (P0-ish); land after review.
- **No** → the exposure is local-dev-only; the change is still a correctness improvement (trust shouldn't depend on auth posture), lower urgency.

## Test plan

- `bun test src/__tests__/personal-memory-auth-bypass.test.ts` — **new** security regression: a non-guardian Slack actor is denied personal memory under `DISABLE_HTTP_AUTH=true`; guardian/local/internal-vellum still allowed. Verified it **fails on the pre-fix line** and passes on the fix.
- `bun test src/__tests__/resolve-trust-class.test.ts` — updated the two "forces guardian regardless of context" cases (they asserted the vulnerable behavior) to assert: resolved non-guardian keeps its class; unresolved (undefined) turn → guardian; all under auth-disabled.
- No regressions across the trust/guardian/memory/tool suites, run individually: `trust-context-guards`, `channel-guardian` (151), `guardian-routing-invariants` (72), `guardian-routing-state`, `guardian-outbound-http`, `leaf-runner`, `conversation-tool-setup` (53) + variants, `user-prompt-submit`, `post-compaction-reinjection-idempotency`, `static-context`.
- **CI green** (Test, Type Check, Lint, OpenAPI, Socket). `tsc`/`eslint`/prettier clean.

## Review focus

One condition on a **core security helper**. Please sanity-check that `trustContext === undefined` reliably means "no resolved actor / local turn" across call sites — background jobs use `INTERNAL_GUARDIAN_TRUST_CONTEXT`/`FALLBACK_TURN_TRUST`, which are *defined*, so they take the actor-derived path (the intended behavior). And confirm the premise so we can set severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGCbyn9JntojD438mqHkhh