### PR TITLE
refactor(trust): canonical contact-grouping + persona trust-class helpers

### DIFF
--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -1,6 +1,7 @@
 import type { InterfaceId } from "../channels/types.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import { isContactTrustClass } from "../runtime/trust-class.js";
 import type { DiskPressureStatus } from "./disk-pressure-guard.js";
 import type { ConversationType } from "./message-types/shared.js";
 import type { TrustContext } from "./trust-context.js";
@@ -79,7 +80,7 @@ export function classifyDiskPressureTurnPolicy(
     return { action: "allow-cleanup-mode", reason: "guardian" };
   }
 
-  if (trustClass === "trusted_contact" || trustClass === "unverified_contact") {
+  if (isContactTrustClass(trustClass)) {
     return { action: "block", reason: "trusted-contact" };
   }
 

--- a/assistant/src/daemon/message-provenance.ts
+++ b/assistant/src/daemon/message-provenance.ts
@@ -8,28 +8,26 @@
  * actor filters the history down to rows whose provenance is itself
  * non-guardian.
  *
- * This lives in its own low-dependency module (types only) so both the
- * conversation lifecycle (history load) and the context compactor (image
- * manifest) can apply the identical filter without creating an import
- * cycle through `conversation-lifecycle` ↔ `window-manager` ↔ `compactor`.
+ * This lives in its own low-dependency module (types plus the zod-only
+ * trust-class leaf) so both the conversation lifecycle (history load) and the
+ * context compactor (image manifest) can apply the identical filter without
+ * creating an import cycle through `conversation-lifecycle` ↔
+ * `window-manager` ↔ `compactor`.
  */
 import type { MessageRow } from "../persistence/conversation-crud.js";
-import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import { type TrustClass, trustClassSchema } from "../runtime/trust-class.js";
 
 export function parseProvenanceTrustClass(
   metadata: string | null,
 ): TrustClass | undefined {
-  if (!metadata) return undefined;
+  if (!metadata) {
+    return undefined;
+  }
   try {
     const parsed = JSON.parse(metadata) as { provenanceTrustClass?: unknown };
-    const trustClass = parsed?.provenanceTrustClass;
-    if (
-      trustClass === "guardian" ||
-      trustClass === "trusted_contact" ||
-      trustClass === "unverified_contact" ||
-      trustClass === "unknown"
-    ) {
-      return trustClass;
+    const result = trustClassSchema.safeParse(parsed?.provenanceTrustClass);
+    if (result.success) {
+      return result.data;
     }
   } catch {
     // Ignore malformed metadata and treat as unknown provenance.

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -53,6 +53,7 @@ import {
   getTaskProgressDataFromSurfaceData,
   mergeTaskProgressData,
 } from "../../slack-task-progress.js";
+import { isContactTrustClass } from "../../trust-class.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
 import { finalizeEventDelivery } from "../channel-delivery-routes.js";
 import { deliverGeneratedApprovalPrompt } from "../guardian-approval-prompt.js";
@@ -841,9 +842,7 @@ function startTrustedContactApprovalNotifier(params: {
 
   // Only notify identity-known non-guardian contacts (trusted_contact and
   // unverified_contact) who have a resolvable guardian route.
-  const isIdentityKnownNonGuardian =
-    trustClass === "trusted_contact" || trustClass === "unverified_contact";
-  if (!isIdentityKnownNonGuardian || !guardianExternalUserId) {
+  if (!isContactTrustClass(trustClass) || !guardianExternalUserId) {
     return () => {};
   }
 

--- a/assistant/src/runtime/trust-class.test.ts
+++ b/assistant/src/runtime/trust-class.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { resolveCapabilities } from "./capabilities.js";
+import {
+  derivePersonaTrustFlags,
+  isContactTrustClass,
+  type PersonaTrustFlags,
+  trustClassSchema,
+} from "./trust-class.js";
+
+describe("isContactTrustClass", () => {
+  test("matches exactly the trusted/unverified contact pair", () => {
+    expect(isContactTrustClass("trusted_contact")).toBe(true);
+    expect(isContactTrustClass("unverified_contact")).toBe(true);
+    expect(isContactTrustClass("guardian")).toBe(false);
+    expect(isContactTrustClass("unknown")).toBe(false);
+  });
+
+  test("rejects undefined and legacy/foreign metadata strings", () => {
+    expect(isContactTrustClass(undefined)).toBe(false);
+    // Values that appear in persisted turn metadata from older builds.
+    expect(isContactTrustClass("non_guardian")).toBe(false);
+    expect(isContactTrustClass("non-guardian")).toBe(false);
+    expect(isContactTrustClass("")).toBe(false);
+  });
+
+  test("agrees with derivePersonaTrustFlags for every trust class", () => {
+    // The predicate and the persona flags encode the same grouping; pin them
+    // together so neither can drift without failing here.
+    for (const trustClass of trustClassSchema.options) {
+      expect(isContactTrustClass(trustClass)).toBe(
+        derivePersonaTrustFlags(trustClass).isTrustedContact,
+      );
+    }
+  });
+});
+
+describe("derivePersonaTrustFlags", () => {
+  test("guardian derives the guardian flag only", () => {
+    expect(derivePersonaTrustFlags("guardian")).toEqual({
+      trustClass: "guardian",
+      isGuardian: true,
+      isTrustedContact: false,
+      isStranger: false,
+    });
+  });
+
+  test("trusted_contact and unverified_contact derive identical contact flags", () => {
+    // The admission-only equivalence documented on trustClassSchema: the two
+    // classes must never drift apart at the persona layer.
+    const expected: PersonaTrustFlags = {
+      trustClass: "trusted_contact",
+      isGuardian: false,
+      isTrustedContact: true,
+      isStranger: false,
+    };
+    expect(derivePersonaTrustFlags("trusted_contact")).toEqual(expected);
+    expect(derivePersonaTrustFlags("unverified_contact")).toEqual({
+      ...expected,
+      trustClass: "unverified_contact",
+    });
+  });
+
+  test("unknown derives the stranger flag only", () => {
+    expect(derivePersonaTrustFlags("unknown")).toEqual({
+      trustClass: "unknown",
+      isGuardian: false,
+      isTrustedContact: false,
+      isStranger: true,
+    });
+  });
+
+  test("an unresolved actor (undefined) fails closed to stranger", () => {
+    // Disclosure gating must default to the guardrail, never to a guardian
+    // exemption, when no actor was resolved for the turn.
+    expect(derivePersonaTrustFlags(undefined)).toEqual({
+      trustClass: "unknown",
+      isGuardian: false,
+      isTrustedContact: false,
+      isStranger: true,
+    });
+  });
+
+  test("exactly one flag is true for every trust class", () => {
+    // Iterates the Zod enum so a newly added class is covered automatically
+    // (the helper itself won't compile until the new class gets a case).
+    for (const trustClass of trustClassSchema.options) {
+      const flags = derivePersonaTrustFlags(trustClass);
+      const trueCount = [
+        flags.isGuardian,
+        flags.isTrustedContact,
+        flags.isStranger,
+      ].filter(Boolean).length;
+      expect(trueCount).toBe(1);
+      expect(flags.trustClass).toBe(trustClass);
+    }
+  });
+
+  describe("independence from the deployment auth posture", () => {
+    const prior = process.env.DISABLE_HTTP_AUTH;
+
+    afterEach(() => {
+      if (prior === undefined) {
+        delete process.env.DISABLE_HTTP_AUTH;
+      } else {
+        process.env.DISABLE_HTTP_AUTH = prior;
+      }
+    });
+
+    test("an unresolved actor stays stranger under DISABLE_HTTP_AUTH", () => {
+      // Deliberate divergence from resolveTrustClass, which fail-safes an
+      // unresolved turn to guardian under the local auth-bypass for
+      // control-plane gates. The disclosure guardrail must instead fail closed
+      // — this test exists so the helper is never "unified" onto that bypass.
+      process.env.DISABLE_HTTP_AUTH = "true";
+      expect(derivePersonaTrustFlags(undefined).isStranger).toBe(true);
+      expect(derivePersonaTrustFlags("trusted_contact").isGuardian).toBe(false);
+    });
+  });
+
+  test("persona partition matches the capability matrix's prompt guidance", () => {
+    // The persona flags and resolveCapabilities().promptTrustGuidance encode
+    // the same three-way partition (guardian / known contact / stranger) in two
+    // homes. Pin them together so persona framing and turn-context guidance
+    // can't drift apart when either table changes.
+    const guidanceByFlag: Record<string, string> = {
+      isGuardian: "none",
+      isTrustedContact: "social-engineering-defense",
+      isStranger: "stranger-warning",
+    };
+    for (const trustClass of trustClassSchema.options) {
+      const flags = derivePersonaTrustFlags(trustClass);
+      const guidance = resolveCapabilities(trustClass).promptTrustGuidance;
+      for (const [flag, expected] of Object.entries(guidanceByFlag)) {
+        if (flags[flag as keyof PersonaTrustFlags]) {
+          expect(guidance).toBe(expected as typeof guidance);
+        }
+      }
+    }
+  });
+});

--- a/assistant/src/runtime/trust-class.ts
+++ b/assistant/src/runtime/trust-class.ts
@@ -31,3 +31,91 @@ export const trustClassSchema = z.enum([
 ]);
 
 export type TrustClass = z.infer<typeof trustClassSchema>;
+
+/**
+ * Whether a trust class names a known non-guardian contact — the
+ * `trusted_contact` / `unverified_contact` pair whose admission-only
+ * equivalence is documented on {@link trustClassSchema}.
+ *
+ * Accepts a raw string (not just `TrustClass`) because several call sites
+ * classify trust classes read back from persisted turn metadata, which may
+ * carry legacy or foreign values; anything outside the pair — including
+ * `undefined` — is not a contact.
+ */
+export function isContactTrustClass(
+  trustClass: string | undefined,
+): trustClass is "trusted_contact" | "unverified_contact" {
+  return (
+    trustClass === "trusted_contact" || trustClass === "unverified_contact"
+  );
+}
+
+/**
+ * Persona-facing view of a trust class, precomputed as booleans because the
+ * system-prompt mustache renderer only does truthy section gating, not string
+ * comparison. Exactly one flag is true per class; `trustClass` is the resolved
+ * class the flags were derived from.
+ */
+export interface PersonaTrustFlags {
+  trustClass: TrustClass;
+  isGuardian: boolean;
+  isTrustedContact: boolean;
+  isStranger: boolean;
+}
+
+/**
+ * Derive the persona/prompt-gating flags for an actor's trust class — the one
+ * home for how persona/prompt surfaces (notably `users/default.md`, the
+ * persona rendered for non-guardian actors) classify who is being spoken to.
+ *
+ * - An absent class (unresolved actor) derives as `stranger`. This is
+ *   deliberately NOT `resolveTrustClass()`: that helper fail-safes an
+ *   unresolved turn to `guardian` under the local auth-bypass so control-plane
+ *   capability gates don't block local development. A data-disclosure boundary
+ *   needs the opposite default — fail closed, so a turn that never resolved an
+ *   actor still renders the guardrail rather than a guardian exemption.
+ * - `unverified_contact` derives identically to `trusted_contact`, making the
+ *   admission-only equivalence documented on {@link trustClassSchema}
+ *   executable in one place.
+ * - The switch is exhaustive with no default: adding a `TrustClass` member is a
+ *   compile error here, forcing a deliberate persona decision for the new
+ *   class.
+ *
+ * Scope: prompt/persona rendering only — the *data-disclosure* boundary. Its
+ * complement, identity/verification hygiene, is `promptTrustGuidance` in
+ * `resolveCapabilities()` (rendered by
+ * `plugins/defaults/turn-context/unified-turn-context.ts`); capability and tool
+ * gating must keep using `resolveCapabilities()` / `resolveTrustClass()`.
+ */
+export function derivePersonaTrustFlags(
+  trustClass: TrustClass | undefined,
+): PersonaTrustFlags {
+  const resolved: TrustClass = trustClass ?? "unknown";
+  switch (resolved) {
+    case "guardian": {
+      return {
+        trustClass: resolved,
+        isGuardian: true,
+        isTrustedContact: false,
+        isStranger: false,
+      };
+    }
+    case "trusted_contact":
+    case "unverified_contact": {
+      return {
+        trustClass: resolved,
+        isGuardian: false,
+        isTrustedContact: true,
+        isStranger: false,
+      };
+    }
+    case "unknown": {
+      return {
+        trustClass: resolved,
+        isGuardian: false,
+        isTrustedContact: false,
+        isStranger: true,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Prompt / plan

Split out of #36810 (review feedback: land the pure-refactor infrastructure separately and first, since #36810 also carries a migration). Behavior-preserving; no prompt, persona, or migration changes.

**The problem:** the `trusted_contact`/`unverified_contact` grouping was hand-copied at three sites, and `message-provenance.ts` hand-listed the four-member trust-class union — exactly the drift class the `runtime/trust-class.ts` leaf module (#36833) was created to end. (One near-miss during the sweep: `disk-pressure-policy.ts`'s `"non_guardian"`/`"non-guardian"` comparisons look like drift but are **deliberate legacy tolerance** for persisted turn metadata, typed as such via `DiskPressureTurnTrustClass` — left untouched.)

**What this adds to `runtime/trust-class.ts`:**

- `isContactTrustClass()` — the admission-only trusted/unverified equivalence (already documented in prose on `trustClassSchema`) as one executable predicate. Accepts raw strings because call sites classify persisted metadata that may carry legacy values.
- `derivePersonaTrustFlags()` — persona/prompt-gating booleans (`isGuardian` / `isTrustedContact` / `isStranger`), needed because the system-prompt mustache renderer only does truthy gating. Exhaustive switch with **no default**: adding a `TrustClass` member is a compile error (TS2366) until the new class gets a deliberate persona decision. Unresolved actors fail **closed** to stranger — deliberately not `resolveTrustClass()`, whose unresolved-turn fail-safe elevates to guardian under the local auth-bypass (right for control-plane gates, inverted for disclosure gating; see #36834 / LUM-2669). The first consumer is #36810's `users/default.md` guardrail, which lands separately after this.

**Sweep of existing copies (each a behavior-identical swap):**

- `background-dispatch.ts` — contact grouping → `isContactTrustClass`
- `disk-pressure-policy.ts` — contact grouping → `isContactTrustClass`
- `message-provenance.ts` — hand-listed union → `trustClassSchema.safeParse` (same accept/reject set; the parse can no longer drift from the type — the same move #36833 made for `messageMetadataSchema.provenanceTrustClass`)

**Anti-drift locks in `trust-class.test.ts`:** predicate ↔ persona flags pinned across the enum; persona partition ↔ the capability matrix's `promptTrustGuidance` pinned; exactly-one-flag invariant iterated over `trustClassSchema.options`; fail-closed default; independence from `DISABLE_HTTP_AUTH`.

**Merge order:** this lands first; #36810 then merges `main` and shrinks to the guardrail + migration.

## Test plan

- `bun test src/runtime/trust-class.test.ts` — **10 pass** (new).
- Swept-site suites, all pass: `disk-pressure-policy` (20), `trusted-contact-approval-notifier` (14, covers the background-dispatch notifier), `conversation-load-history-repair` (12, exercises provenance parsing).
- `bunx tsc --noEmit` clean; eslint 0 errors; prettier clean; `lint:circular` unchanged at the 402 baseline (`trust-class.ts` stays a zod-only leaf).
- Exhaustiveness guard verified: removing a switch case fails compilation with TS2366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGCbyn9JntojD438mqHkhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGCbyn9JntojD438mqHkhh)_