### PR TITLE
Bump marketing-expert pin to drop the system-prompt activation injection

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -70,7 +70,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/marketing-expert",
-        "ref": "15d1f38c2e3c82b8f206ea8009fb158c5ba4746f"
+        "ref": "e0457d8c8b5874255a04ef6361c076d5abfec303"
       },
       "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
       "category": "marketing",


### PR DESCRIPTION
## Summary
- Bump the pinned `marketing-expert` marketplace SHA to `e0457d8` (vellum-ai/marketing-expert#5), which deletes the `pre-model-call` hook that appended a `<!-- marketing-expert:activation -->` block to the user-facing system prompt every turn.
- New installs get the plugin's skills and tools with no per-turn system-prompt footprint; the `marketing-expert` skill stays discoverable via its `activation-hints`, so no capability is lost.

## Original prompt
Onboarding auto-installs `marketing-expert` (for founder/marketer roles), whose `pre-model-call` hook injects a persistent `<!-- marketing-expert:activation -->` block at the end of the system prompt. We removed that injection at the source in vellum-ai/marketing-expert#5; this bumps the marketplace pin so new installs pick it up. Existing installs keep the old hook until reinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)