### PR TITLE
perf(search): make message-content matching index-only — drop the LIKE scan fallbacks

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -98,7 +98,10 @@ describe("searchConversationSource", () => {
     });
   });
 
-  test("uses LIKE fallback for short and non-ASCII queries", async () => {
+  test("returns no evidence for short and non-ASCII queries (content matching is index-only)", async () => {
+    // Short/punctuation-only and CJK queries produce no usable ≥2-char match
+    // shape. There is no content-scan fallback, so such queries yield no
+    // conversation evidence even when an exact substring exists.
     await seedConversation({
       title: "C++ notes",
       role: "user",
@@ -116,12 +119,8 @@ describe("searchConversationSource", () => {
       5,
     );
 
-    expect(shortResult.evidence.map((item) => item.title)).toEqual([
-      "C++ notes",
-    ]);
-    expect(unicodeResult.evidence.map((item) => item.title)).toEqual([
-      "Unicode notes",
-    ]);
+    expect(shortResult.evidence).toEqual([]);
+    expect(unicodeResult.evidence).toEqual([]);
   });
 
   test("does not return derived subagent, auto-analysis, or notification conversations", async () => {
@@ -196,27 +195,6 @@ describe("searchConversationSource", () => {
       makeContext(),
       10,
     );
-
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${visible.conversation.id}#${visible.message.id}`,
-    ]);
-  });
-
-  test("excludes legacy private conversations through the LIKE fallback", async () => {
-    const visible = await seedConversation({
-      title: "Visible non-ASCII conversation",
-      content: "東京 appears in a normal conversation.",
-    });
-    const legacyPrivate = await seedConversation({
-      title: "Legacy private non-ASCII conversation",
-      content: "東京 appears in a private conversation.",
-    });
-    rawRun(
-      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
-      legacyPrivate.conversation.id,
-    );
-
-    const result = await searchConversationSource("東京", makeContext(), 10);
 
     expect(result.evidence.map((item) => item.locator)).toEqual([
       `${visible.conversation.id}#${visible.message.id}`,
@@ -478,16 +456,17 @@ describe("searchConversationSource with the qdrant backend", () => {
     ]);
   });
 
-  test("routes short/punctuation-only queries to the exact LIKE path, not Qdrant", async () => {
-    const match = await seedConversation({
+  test("short/punctuation-only queries return no evidence and never hit Qdrant", async () => {
+    await seedConversation({
       title: "C++ notes",
       role: "user",
       content: "Use C++ when the example needs deterministic lifetime notes.",
     });
 
-    // `C++` produces no usable ≥2-char FTS match shape, so the source must use
-    // the exact LIKE path rather than the sparse encoder (which would still
-    // emit a noisy 1-char `c` token). The mock throws to prove it never runs.
+    // `C++` produces no usable ≥2-char FTS match shape. The sparse encoder
+    // would still emit a noisy 1-char `c` token, so the source must return no
+    // evidence WITHOUT querying the index. The mock throws to prove it never
+    // runs.
     lexicalMockImpl = async () => {
       throw new Error("searchMessageIdsLexical must not run for a short query");
     };
@@ -495,9 +474,7 @@ describe("searchConversationSource with the qdrant backend", () => {
     const result = await searchConversationSource("C++", makeContext(), 5);
 
     expect(lexicalCalls).toHaveLength(0);
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${match.conversation.id}#${match.message.id}`,
-    ]);
+    expect(result.evidence).toEqual([]);
   });
 
   test("over-fetches a wide candidate pool from Qdrant, not the FTS prefetch window", async () => {
@@ -620,10 +597,10 @@ describe("searchConversationSource with the qdrant backend", () => {
     ]);
   });
 
-  test("falls back to LIKE when the Qdrant lookup throws", async () => {
-    const match = await seedConversation({
-      title: "Fallback notes",
-      content: "The likefallbacktoken decision is recorded here.",
+  test("returns no evidence when the Qdrant lookup throws", async () => {
+    await seedConversation({
+      title: "Failure notes",
+      content: "The qdranterrortoken decision is recorded here.",
     });
 
     lexicalMockImpl = async () => {
@@ -631,18 +608,18 @@ describe("searchConversationSource with the qdrant backend", () => {
     };
 
     const result = await searchConversationSource(
-      "likefallbacktoken",
+      "qdranterrortoken",
       makeContext(),
       5,
     );
 
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${match.conversation.id}#${match.message.id}`,
-    ]);
+    // Content matching is index-only: the failure is logged and the source
+    // yields no conversation evidence — no content-scan recovery.
+    expect(result.evidence).toEqual([]);
   });
 
-  test("falls back to LIKE when Qdrant returns no candidates", async () => {
-    const match = await seedConversation({
+  test("returns no evidence when Qdrant returns no candidates", async () => {
+    await seedConversation({
       title: "Empty candidate notes",
       content: "The emptycandidatetoken decision is recorded here.",
     });
@@ -655,9 +632,9 @@ describe("searchConversationSource with the qdrant backend", () => {
       5,
     );
 
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${match.conversation.id}#${match.message.id}`,
-    ]);
+    // The index is authoritative for content matching — an empty candidate
+    // set is an empty result, not a trigger for a table-scan fallback.
+    expect(result.evidence).toEqual([]);
   });
 });
 

--- a/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
+++ b/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
@@ -5,9 +5,10 @@
  * message-content candidates are sourced from the Qdrant lexical index (mocked
  * here) instead of `messages_fts`, while the visibility/archived SQL filtering,
  * the title `LIKE` merge, and the result shape stay identical to the FTS path.
- * A Qdrant lookup failure degrades to the `messages.content LIKE` scan, and the
- * `fts5` fallback (memory disabled / backfill not yet drained) is verified to
- * still ignore the lexical index entirely.
+ * Content matching is index-only (no `messages.content` scan fallback): a
+ * Qdrant lookup failure and a non-tokenizable query both leave title matches
+ * as the only arm. The `fts5` fallback (memory disabled / backfill not yet
+ * drained) is verified to still ignore the lexical index entirely.
  *
  * The lexical index is mocked at the `conversation-search-lexical` seam so no
  * real Qdrant is required; a real SQLite DB backs the visibility/archived SQL.
@@ -286,9 +287,12 @@ describe("searchConversations · qdrant backend", () => {
     expect(results[0]!.matchingMessages).toEqual([]);
   });
 
-  test("degrades to a LIKE content scan when the lexical lookup throws", async () => {
-    const conv = createConversation("Degrade notes");
-    insertMessage("d-1", conv.id, "flux capacitor via like fallback");
+  test("returns title matches only when the lexical lookup throws", async () => {
+    // Content matching is index-only: a lexical failure is logged and the
+    // content arm contributes nothing — no messages.content scan recovers it.
+    const contentOnly = createConversation("Degrade notes");
+    insertMessage("c-1", contentOnly.id, "flux capacitor mentioned in content");
+    const titleMatch = createConversation("Flux capacitor planning");
 
     searchMessageIdsLexicalMock.mockImplementation(async () => {
       throw new Error("qdrant unreachable");
@@ -297,12 +301,10 @@ describe("searchConversations · qdrant backend", () => {
     const results = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
-    // Even though Qdrant failed, the LIKE scan over messages.content recovers
-    // the match — the conversation and its message are still returned.
-    expect(results.map((r) => r.conversationId)).toEqual([conv.id]);
-    expect(results[0]!.matchingMessages.map((m) => m.messageId)).toEqual([
-      "d-1",
-    ]);
+    // The content-only conversation is dropped; the title-matched conversation
+    // still surfaces, without content excerpts.
+    expect(results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
+    expect(results[0]!.matchingMessages).toEqual([]);
   });
 
   test("uses the fts5 path (not qdrant) when memory is disabled", async () => {
@@ -347,16 +349,19 @@ describe("searchConversations · qdrant backend", () => {
     ]);
   });
 
-  test("non-tokenizable queries use the LIKE fallback without hitting the index", async () => {
+  test("non-tokenizable queries return title matches only, without hitting the index", async () => {
     // Single-char / non-ASCII queries produce no tokens, so neither FTS nor the
-    // sparse encoder yields terms — both backends use the LIKE content scan.
-    const conv = createConversation("Symbols");
-    insertMessage("s-1", conv.id, "review the C§ draft");
+    // sparse encoder yields terms. Content matching is index-only, so only the
+    // title LIKE arm can match such queries.
+    const contentOnly = createConversation("Symbols");
+    insertMessage("s-1", contentOnly.id, "review the C§ draft");
+    const titleMatch = createConversation("C§ symbol reference");
 
     const results = await searchConversations("C§");
 
     expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
-    expect(results.map((r) => r.conversationId)).toEqual([conv.id]);
+    expect(results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
+    expect(results[0]!.matchingMessages).toEqual([]);
   });
 
   test("returns [] when the index yields no candidates and nothing matches by title", async () => {

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -507,58 +507,11 @@ function likeContainsPattern(query: string): string {
 }
 
 /**
- * Collect visible, non-archived conversation ids whose message content matches
- * `query` via a `messages.content LIKE` substring scan. Shared by the
- * non-tokenizable-query path (both backends) and the Qdrant error-degrade path.
- */
-function likeContentMatchConvIds(query: string): string[] {
-  interface ConvIdRow {
-    conversation_id: string;
-  }
-  const rows = rawAll<ConvIdRow>(
-    `
-    SELECT DISTINCT m.conversation_id
-    FROM messages m
-    JOIN conversations c ON c.id = m.conversation_id
-    WHERE m.content LIKE ? ESCAPE '\\' AND ${standardListingVisibilitySql("c")} AND c.archived_at IS NULL
-    LIMIT 1000
-  `,
-    likeContainsPattern(query),
-  );
-  return rows.map((r) => r.conversation_id);
-}
-
-/**
- * Per-conversation top messages matching `query` by `content LIKE` substring,
- * ordered oldest-first and capped at `limit`. The `messages.content LIKE`
- * fallback used when there are no lexical tokens or Qdrant is unavailable.
- */
-function likeContentMatchMessages(
-  conversationId: string,
-  query: string,
-  limit: number,
-): ConversationSearchMsgRow[] {
-  return rawAll<ConversationSearchMsgRow>(
-    `
-    SELECT id, role, content, created_at
-    FROM messages
-    WHERE conversation_id = ? AND content LIKE ? ESCAPE '\\'
-    ORDER BY created_at ASC
-    LIMIT ?
-  `,
-    conversationId,
-    likeContainsPattern(query),
-    limit,
-  );
-}
-
-/**
  * Resolve the effective message-search backend for the persistence read site.
  *
  * The sparse Qdrant `messages_lexical` index is the backend, downgraded to
  * `fts5` in two cases where the Qdrant collection is not a safe source (each
- * would return an empty result — not a throw — so the Qdrant-error degrade
- * never fires):
+ * would return an empty result — not a throw):
  *   1. Memory is disabled — the per-message write path is suppressed, so the
  *      collection is never forward-filled. `!isMemoryEnabled()` is the
  *      layer-clean check available from `persistence/`.
@@ -586,10 +539,12 @@ function resolveMessageSearchBackend(): "fts5" | "qdrant" {
  * match on conversation titles, and return matching conversations with their
  * relevant messages ordered by most recently updated.
  *
- * A query that tokenizes to nothing under the shared tokenizer (non-ASCII or
- * single-char input like "你", "é", "C++") falls back to a `messages.content
- * LIKE` scan for both backends. If the Qdrant lexical lookup throws, the search
- * degrades to that same `LIKE` scan.
+ * Content matching is index-only — there is no `messages.content` scan
+ * fallback. A query that tokenizes to nothing under the shared tokenizer
+ * (non-ASCII or single-char input like "你", "é", "C++") can only match by
+ * conversation title, and a Qdrant lexical failure is logged and likewise
+ * leaves only the title arm. An unindexed or unreachable index yields fewer
+ * results, by design.
  *
  * Both backends cap on distinct conversations, not matching messages. Qdrant
  * ranks at message grain, so its path over-fetches a candidate pool
@@ -614,10 +569,9 @@ export async function searchConversations(
   // The Qdrant lexical index is populated by the memory plugin's per-message
   // write path, which is suppressed while memory is disabled — so with memory
   // off the index stays empty and a `qdrant` lookup silently returns no content
-  // matches (an empty result, not a throw, so the Qdrant-error degrade never
-  // fires). Fall back to `fts5` — which is always populated — when the index
-  // isn't being written. `!isMemoryEnabled()` is the
-  // layer-clean check available from `persistence/`; the rarer
+  // matches (an empty result, not a throw). Fall back to `fts5` — which is
+  // always populated — when the index isn't being written. `!isMemoryEnabled()`
+  // is the layer-clean check available from `persistence/`; the rarer
   // memory-enabled-but-plugin-disabled case (part of the plugin's full
   // `isMemoryIndexingSuppressed` predicate) can't be reached from here without a
   // persistence -> plugin import, and is covered by the backfill/population
@@ -643,10 +597,9 @@ export async function searchConversations(
   // When the Qdrant backend answers, `qdrantCandidatesByConv` maps each
   // conversation to its candidate message ids so the per-conversation message
   // fetch reuses the single lexical round-trip instead of issuing a second one.
-  // `qdrantDegraded` records a lexical-lookup failure so the per-conversation
-  // fetch mirrors the conv-id collection and falls back to the LIKE scan.
+  // On a lexical-lookup failure it stays null, so the content arm contributes
+  // nothing and only title matches surface.
   let qdrantCandidatesByConv: Map<string, string[]> | null = null;
-  let qdrantDegraded = false;
 
   if (ftsMatch && backend === "qdrant") {
     // The lexical index is written asynchronously by the memory job queue, so
@@ -662,16 +615,13 @@ export async function searchConversations(
         QDRANT_SEARCH_CANDIDATE_LIMIT,
       );
     } catch (err) {
-      qdrantDegraded = true;
       log.warn(
         { err, query: query.slice(0, 80) },
-        "searchConversations: Qdrant lexical query failed — falling back to LIKE content match",
+        "searchConversations: Qdrant lexical query failed — returning title matches only",
       );
     }
 
-    if (qdrantDegraded) {
-      for (const id of likeContentMatchConvIds(query)) contentConvIds.add(id);
-    } else if (candidates.length > 0) {
+    if (candidates.length > 0) {
       const candidateIds = candidates.map((c) => c.messageId);
       // Filter the lexical candidates down to visible, non-archived
       // conversations in SQL (Qdrant has no visibility filtering). No SQL
@@ -742,10 +692,14 @@ export async function searchConversations(
       );
     }
   } else {
-    // The query tokenized to nothing (non-ASCII, single-char, etc.) — fall back
-    // to a LIKE-based message content search so queries like "你", "é", or
-    // "C++" still match message text.
-    for (const id of likeContentMatchConvIds(query)) contentConvIds.add(id);
+    // The query tokenized to nothing (non-ASCII, single-char, etc. — "你",
+    // "é", "C++"). Content matching is index-only, so such queries can only
+    // match by conversation title below. The breadcrumb explains an otherwise
+    // surprising empty result.
+    log.info(
+      { query: query.slice(0, 80) },
+      "searchConversations: query produced no lexical tokens — title matches only",
+    );
   }
 
   // Title-only matches (message-content indexes don't cover conversation titles).
@@ -786,8 +740,11 @@ export async function searchConversations(
   const results: ConversationSearchResult[] = [];
 
   for (const conv of matchingConversations) {
+    // Conversations without content candidates — title-only matches, every
+    // match on a no-token query, and all matches when the Qdrant lookup
+    // failed — carry no content excerpts: `matchingMsgs` stays empty.
     let matchingMsgs: ConversationSearchMsgRow[] = [];
-    if (ftsMatch && backend === "qdrant" && !qdrantDegraded) {
+    if (ftsMatch && backend === "qdrant") {
       // Reuse the lexical candidates already fetched above — no second Qdrant
       // round-trip. Select this conversation's candidate message rows by id,
       // ordered oldest-first to match the FTS path.
@@ -807,7 +764,7 @@ export async function searchConversations(
           maxMsgsPerConv,
         );
       }
-    } else if (ftsMatch && backend !== "qdrant") {
+    } else if (ftsMatch) {
       try {
         matchingMsgs = rawAll<ConversationSearchMsgRow>(
           `
@@ -828,10 +785,6 @@ export async function searchConversations(
           "searchConversations: FTS per-conversation query failed",
         );
       }
-    } else {
-      // No lexical tokens, or the Qdrant lookup degraded — LIKE fallback for
-      // non-ASCII / short-token queries and the Qdrant-error path.
-      matchingMsgs = likeContentMatchMessages(conv.id, query, maxMsgsPerConv);
     }
 
     results.push({

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
@@ -649,26 +649,6 @@ describe("searchConversations · surfaced conversations", () => {
     expect(await searchConversations("Quarterly metrics")).toEqual([]);
     expect(await searchConversations("flux capacitor")).toEqual([]);
   });
-
-  test("LIKE content fallback (non-FTS-tokenizable query) honors surfacing", async () => {
-    // Single-char queries produce no FTS tokens, exercising the LIKE fallback.
-    const surfaced = createConversation({
-      title: "bg-run",
-      conversationType: "background",
-    });
-    setSurfaced(surfaced.id);
-    insertMessage(surfaced.id, "review the C§ draft");
-
-    const hidden = createConversation({
-      title: "bg-hidden",
-      conversationType: "background",
-    });
-    insertMessage(hidden.id, "another C§ mention", 2000);
-
-    const results = await searchConversations("C§");
-
-    expect(results.map((r) => r.conversationId)).toEqual([surfaced.id]);
-  });
 });
 
 describe("listPinnedConversations · surfaced conversations", () => {

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -11,8 +11,11 @@ import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,
 } from "../../../../../security/untrusted-content.js";
+import { getLogger } from "../../../../../util/logger.js";
 import { isMemoryIndexingSuppressed } from "../../job-handlers/index-message-lexical.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
+
+const log = getLogger("recall-conversations-source");
 
 const SUBAGENT_SOURCE = "subagent";
 const NOTIFICATION_SOURCE = "notification";
@@ -141,18 +144,18 @@ export async function searchConversationSource(
       : "qdrant";
 
   // Tokenize once. Short/punctuation-only queries (`C++`, CJK) produce no
-  // usable ≥2-char match shape, and both backends must route those straight to
-  // the exact `searchWithLike` path — the FTS path already does (an empty match
-  // list yields no rows and falls through to LIKE below). The Qdrant path needs
-  // this guard explicitly: the sparse encoder still emits a 1-char token for
-  // such queries, so it would return noisy hits and wrongly skip the exact-LIKE
-  // fallback. Only query a lexical index when the query genuinely tokenizes.
+  // usable ≥2-char match shape. Content matching is index-only, so such
+  // queries yield no conversation evidence. The early return matters for the
+  // Qdrant path in particular: the sparse encoder still emits a 1-char token
+  // for these queries, so querying the index anyway would return noisy hits.
+  // Only query a lexical index when the query genuinely tokenizes.
   const ftsMatches = buildRecallFtsMatchQueries(trimmedQuery);
+  if (ftsMatches.length === 0) {
+    return { evidence: [] };
+  }
 
   let rows: ConversationEvidenceRow[];
-  if (ftsMatches.length === 0) {
-    rows = searchWithLike(trimmedQuery, queryLimit, context.conversationId);
-  } else if (backend === "qdrant") {
+  if (backend === "qdrant") {
     // A brief post-edit staleness window (an edited message whose re-index job
     // has not yet run, or a just-deleted message still present as a point) is
     // an ACCEPTED consequence of async indexing. Recall is fuzzy evidence
@@ -175,10 +178,6 @@ export async function searchConversationSource(
       normalizedLimit,
       context.conversationId,
     );
-  }
-
-  if (rows.length === 0) {
-    rows = searchWithLike(trimmedQuery, queryLimit, context.conversationId);
   }
 
   const sortedRows = rows
@@ -210,8 +209,7 @@ export async function searchConversationSource(
  * Generate candidate rows via SQLite FTS5 from precomputed match shapes. Walks
  * the shapes (progressively broader), merging matches until enough rows are
  * collected, and swallows a malformed-query error on any single shape so a
- * broader shape can still run. Returns an empty array when no shape matches —
- * the caller then degrades to the LIKE fallback.
+ * broader shape can still run. Returns an empty array when no shape matches.
  */
 function gatherCandidateRowsFromFts(
   ftsMatches: readonly string[],
@@ -251,9 +249,8 @@ function gatherCandidateRowsFromFts(
  * `LIMIT` is a no-op ceiling here; it exists only to bound the returned rows.
  *
  * Returns an empty array when the query tokenizes to no sparse terms (the
- * lexical helper's empty guard) or when the Qdrant call throws — in both cases
- * the caller degrades to the LIKE fallback, mirroring how the FTS path falls
- * back when it matches nothing.
+ * lexical helper's empty guard) or when the Qdrant call throws (logged) — the
+ * source then yields no conversation evidence for the query.
  */
 async function gatherCandidateRowsFromQdrant(
   query: string,
@@ -263,7 +260,11 @@ async function gatherCandidateRowsFromQdrant(
   let candidates: Array<{ messageId: string }>;
   try {
     candidates = await searchMessageIdsLexical(query, candidateLimit);
-  } catch {
+  } catch (err) {
+    log.warn(
+      { err, query: query.slice(0, 80) },
+      "recall conversations source: Qdrant lexical query failed — no conversation evidence for this query",
+    );
     return [];
   }
 
@@ -340,39 +341,6 @@ function searchByIds(
     LIMIT ?
     `,
     ...messageIds,
-    SUBAGENT_SOURCE,
-    AUTO_ANALYSIS_SOURCE,
-    NOTIFICATION_SOURCE,
-    excludedConversationId,
-    limit,
-  );
-}
-
-function searchWithLike(
-  query: string,
-  limit: number,
-  excludedConversationId: string,
-): ConversationEvidenceRow[] {
-  return rawAll<ConversationEvidenceRow>(
-    `
-    SELECT
-      m.id AS message_id,
-      m.conversation_id,
-      m.role,
-      m.content,
-      m.created_at,
-      m.metadata,
-      c.title
-    FROM messages m
-    JOIN conversations c ON c.id = m.conversation_id
-    WHERE m.content LIKE ? ESCAPE '\\'
-      AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
-      AND c.id != ?
-      AND c.conversation_type != 'private'
-    ORDER BY m.created_at DESC
-    LIMIT ?
-    `,
-    buildLikePattern(query),
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
     NOTIFICATION_SOURCE,
@@ -510,11 +478,4 @@ function compareScoredConversationRows(
   const scoreCompare = b.score - a.score;
   if (scoreCompare !== 0) return scoreCompare;
   return b.row.created_at - a.row.created_at;
-}
-
-function buildLikePattern(query: string): string {
-  return `%${query
-    .replace(/\\/g, "\\\\")
-    .replace(/%/g, "\\%")
-    .replace(/_/g, "\\_")}%`;
 }


### PR DESCRIPTION
## What

Makes message-content matching **index-only**: removes every `messages.content LIKE '%…%'` scan from both message-search read sites (user-facing `searchConversations` and the memory recall `conversations` source).

- **Non-tokenizable queries** ("你", "é", "C++") no longer trigger a content table scan. `searchConversations` returns title matches only (with an info-log breadcrumb explaining the empty content arm); the recall source returns no conversation evidence.
- **Qdrant lexical failure** no longer degrades to a LIKE scan. `searchConversations` logs and returns title matches only; the recall source logs and yields no evidence. The dead `qdrantDegraded` flag goes with it.
- **Recall zero-result recovery** is gone: previously *every* recall query that matched nothing in the index ran a full-table `LIKE` scan over `messages.content` as a catch-all. On a multi-GB messages table that scan is the single most expensive query in the search path, fired on the least useful inputs.

Title `LIKE` matching is untouched — it is the only title-match mechanism, not a fallback.

**−124 lines across 5 files.**

## Why

Follow-up to #36792 (Qdrant as the default message-search backend). The LIKE scans were the safety net under FTS/Qdrant misses, but:

- The full-table `%substring%` scan is unindexable and scales with total message history — exactly the pathological load the messages_fts→Qdrant migration is removing.
- The queries it serves are rare and low-value: CJK/single-char content search, and exact-phrase recovery for queries the index already failed to match (for multi-term queries, the `%full phrase%` scan is *stricter* than the index's OR-broadened shapes, so it almost never recovers anything the index missed).
- With the fallback gone, a Qdrant outage degrades search visibly-but-safely (title matches only, warn-logged) instead of silently converting every search into a table scan.

Behavior change accepted per review of the fallback's value: fewer results from an unreachable or unmatched index, by design.

## Tests

- `searchConversations`: qdrant-error and non-tokenizable queries now assert title-only results (content-bearing conversations absent, `matchingMessages` empty); the LIKE-recovery assertions are replaced.
- Recall source: short/CJK queries, qdrant-error, and empty-candidate cases now assert empty evidence; the LIKE-path private-exclusion test is deleted with the path.
- The plugin-import-boundary guard stays green (the recall source's new logger import uses a specifier already in the memory baseline).

Part of the messages_fts → Qdrant migration (next: release cut, then removing the FTS triggers/table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
