### PR TITLE
feat(daemon): PUT /conversations/:id/enabledplugins to edit a chat's plugin set

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7206,6 +7206,56 @@ paths:
           description: Returned when the callId is missing or refers to a call in a different conversation.
         "404":
           description: Returned when the conversation or the referenced LLM call does not exist.
+  /v1/conversations/{id}/enabledplugins:
+    put:
+      operationId: conversations_by_id_enabledplugins_put
+      summary: Set conversation enabled plugins
+      description:
+        Scope a single conversation to a subset of installed plugins (first-party defaults are always available).
+        Pass null to clear the scope back to the default (all enabled plugins).
+      tags:
+        - conversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabledPlugins:
+                  anyOf:
+                    - type: array
+                      items:
+                        type: string
+                    - type: "null"
+              required:
+                - enabledPlugins
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  enabledPlugins:
+                    anyOf:
+                      - type: array
+                        items:
+                          type: string
+                      - type: "null"
+                required:
+                  - conversationId
+                  - enabledPlugins
+                additionalProperties: false
   /v1/conversations/{id}/inference-profile:
     put:
       operationId: conversations_by_id_inferenceprofile_put

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6459,6 +6459,12 @@ paths:
                           type: number
                         inferenceProfile:
                           type: string
+                        enabledPlugins:
+                          anyOf:
+                            - type: array
+                              items:
+                                type: string
+                            - type: "null"
                         isProcessing:
                           type: boolean
                       required:
@@ -6798,6 +6804,12 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      enabledPlugins:
+                        anyOf:
+                          - type: array
+                            items:
+                              type: string
+                          - type: "null"
                       isProcessing:
                         type: boolean
                     required:
@@ -6999,6 +7011,12 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      enabledPlugins:
+                        anyOf:
+                          - type: array
+                            items:
+                              type: string
+                          - type: "null"
                       isProcessing:
                         type: boolean
                     required:
@@ -8186,6 +8204,12 @@ paths:
                         type: number
                       inferenceProfile:
                         type: string
+                      enabledPlugins:
+                        anyOf:
+                          - type: array
+                            items:
+                              type: string
+                          - type: "null"
                       isProcessing:
                         type: boolean
                     required:

--- a/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
+++ b/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
@@ -20,6 +20,7 @@ mock.module("../config/loader.js", () => ({
 import {
   createConversation,
   getConversation,
+  setConversationEnabledPlugins,
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -150,6 +151,25 @@ describe("PUT /v1/conversations/:id/enabledplugins", () => {
       }),
     ).rejects.toThrow(BadRequestError);
     expect(getConversation(conversation.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("rejects a missing enabledPlugins field without clearing the scope", async () => {
+    const conversation = createConversation("enabledplugins-missing");
+    // Seed an explicit scope, then send a body with no `enabledPlugins`.
+    setConversationEnabledPlugins(conversation.id, ["plugin-a"]);
+
+    await expect(
+      pluginsRoute.handler({
+        pathParams: { id: conversation.id },
+        body: {},
+        headers: {},
+      }),
+    ).rejects.toThrow(BadRequestError);
+    // The existing scope must survive a malformed request (null is the only
+    // explicit clear signal).
+    expect(getConversation(conversation.id)?.enabledPlugins).toEqual([
+      "plugin-a",
+    ]);
   });
 
   test("throws NotFoundError when the conversation does not exist", async () => {

--- a/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
+++ b/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+const config = {
+  llm: {
+    profiles: {},
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => config,
+  getConfig: () => config,
+}));
+
+import {
+  createConversation,
+  getConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
+import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+await initializeDb();
+
+const pluginsRoute = ROUTES.find(
+  (r) => r.operationId === "conversations_by_id_enabledplugins_put",
+)!;
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM conversation_assistant_attention_state");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+describe("PUT /v1/conversations/:id/enabledplugins", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  afterAll(() => {
+    resetDbForTesting();
+    mock.restore();
+  });
+
+  test("persists a string[] scope and reflects it on the conversation", async () => {
+    const conversation = createConversation("enabledplugins-route");
+
+    const result = await pluginsRoute.handler({
+      pathParams: { id: conversation.id },
+      body: { enabledPlugins: ["plugin-a", "plugin-b"] },
+      headers: {},
+    });
+
+    expect(result).toMatchObject({
+      conversationId: conversation.id,
+      enabledPlugins: ["plugin-a", "plugin-b"],
+    });
+    expect(getConversation(conversation.id)?.enabledPlugins).toEqual([
+      "plugin-a",
+      "plugin-b",
+    ]);
+  });
+
+  test("clears the scope to default when enabledPlugins is null", async () => {
+    const conversation = createConversation("enabledplugins-clear");
+
+    await pluginsRoute.handler({
+      pathParams: { id: conversation.id },
+      body: { enabledPlugins: ["plugin-x"] },
+      headers: {},
+    });
+    expect(getConversation(conversation.id)?.enabledPlugins).toEqual([
+      "plugin-x",
+    ]);
+
+    const result = await pluginsRoute.handler({
+      pathParams: { id: conversation.id },
+      body: { enabledPlugins: null },
+      headers: {},
+    });
+
+    expect(result).toMatchObject({
+      conversationId: conversation.id,
+      enabledPlugins: null,
+    });
+    expect(getConversation(conversation.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("rejects a non-array, non-null body with BadRequestError", async () => {
+    const conversation = createConversation("enabledplugins-bad");
+
+    await expect(
+      pluginsRoute.handler({
+        pathParams: { id: conversation.id },
+        body: { enabledPlugins: "not-an-array" },
+        headers: {},
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(getConversation(conversation.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("rejects an array containing a non-string with BadRequestError", async () => {
+    const conversation = createConversation("enabledplugins-bad-element");
+
+    await expect(
+      pluginsRoute.handler({
+        pathParams: { id: conversation.id },
+        body: { enabledPlugins: ["ok", 123] },
+        headers: {},
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(getConversation(conversation.id)?.enabledPlugins).toBeNull();
+  });
+
+  test("throws NotFoundError when the conversation does not exist", async () => {
+    await expect(
+      pluginsRoute.handler({
+        pathParams: { id: "missing" },
+        body: { enabledPlugins: [] },
+        headers: {},
+      }),
+    ).rejects.toThrow(NotFoundError);
+  });
+});

--- a/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
+++ b/assistant/src/__tests__/conversation-enabledplugins-route.test.ts
@@ -25,6 +25,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
 import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
+import { buildConversationDetailResponse } from "../runtime/services/conversation-serializer.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
 await initializeDb();
@@ -69,6 +70,35 @@ describe("PUT /v1/conversations/:id/enabledplugins", () => {
       "plugin-a",
       "plugin-b",
     ]);
+
+    // The HTTP conversation-detail response (what the web `conversationsByIdGet`
+    // reads) must also carry the scope, not just the internal DB getter.
+    const detail = buildConversationDetailResponse(conversation.id);
+    expect(detail?.conversation.enabledPlugins).toEqual([
+      "plugin-a",
+      "plugin-b",
+    ]);
+  });
+
+  test("detail response omits enabledPlugins by default and preserves an explicit []", async () => {
+    const conversation = createConversation("enabledplugins-detail-shape");
+
+    // Default (no per-chat restriction): the field is omitted from the wire.
+    expect(
+      "enabledPlugins" in buildConversationDetailResponse(conversation.id)!
+        .conversation,
+    ).toBe(false);
+
+    // Explicit empty scope (user cleared all optional plugins): preserved as [].
+    await pluginsRoute.handler({
+      pathParams: { id: conversation.id },
+      body: { enabledPlugins: [] },
+      headers: {},
+    });
+    expect(
+      buildConversationDetailResponse(conversation.id)?.conversation
+        .enabledPlugins,
+    ).toEqual([]);
   });
 
   test("clears the scope to default when enabledPlugins is null", async () => {

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -118,6 +118,12 @@ export const conversationSummarySchema = z.object({
   surfacedAt: z.number().optional(),
   inferenceProfile: z.string().optional(),
   /**
+   * Plugin-id list scoping this chat to a subset of installed plugins.
+   * Absent when there is no per-chat restriction (default: all enabled
+   * plugins); an explicit `[]` means the user cleared all optional plugins.
+   */
+  enabledPlugins: z.array(z.string()).nullable().optional(),
+  /**
    * True when the agent loop is currently mid-turn for this conversation.
    * Mirrors the in-memory `Conversation.isProcessing()` flag on the daemon
    * — `false` for rows that are cold (not currently resident in memory).

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -232,8 +232,15 @@ async function handleUpdateConversationEnabledPlugins({
   headers,
 }: RouteHandlerArgs) {
   const enabledPlugins = body.enabledPlugins as string[] | null | undefined;
+  // The field is required; `null` is the explicit "clear the scope" signal.
+  // A missing field (malformed/empty body) must not silently clear the scope.
+  if (enabledPlugins === undefined) {
+    throw new BadRequestError(
+      "enabledPlugins is required (use null to clear the scope)",
+    );
+  }
   if (
-    enabledPlugins != null &&
+    enabledPlugins !== null &&
     (!Array.isArray(enabledPlugins) ||
       enabledPlugins.some((p) => typeof p !== "string"))
   ) {
@@ -250,7 +257,7 @@ async function handleUpdateConversationEnabledPlugins({
 
   // `null` clears the per-chat scope back to the default (all enabled
   // plugins); a `string[]` scopes the chat to those plugin ids.
-  const nextEnabledPlugins = enabledPlugins ?? null;
+  const nextEnabledPlugins = enabledPlugins;
   setConversationEnabledPlugins(resolvedId, nextEnabledPlugins);
   findConversation(resolvedId)?.setEnabledPlugins(nextEnabledPlugins);
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -5,6 +5,7 @@
  * POST   /v1/conversations/switch         — switch to an existing conversation
  * POST   /v1/conversations/fork           — fork an existing conversation
  * PUT    /v1/conversations/:id/inference-profile — set per-conversation inference profile
+ * PUT    /v1/conversations/:id/enabledplugins — set per-conversation plugin scope
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
  * POST   /v1/conversations/:id/wipe       — wipe conversation and revert memory
@@ -20,6 +21,7 @@
 
 import { z } from "zod";
 
+import { findConversation } from "../../daemon/conversation-registry.js";
 import { destroyActiveConversation } from "../../daemon/conversation-store.js";
 import {
   cancelGeneration,
@@ -37,6 +39,7 @@ import {
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
+  setConversationEnabledPlugins,
   setConversationSurfaced,
   unarchiveConversation,
   updateConversationTitle,
@@ -54,6 +57,7 @@ import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { buildConversationDetailResponse } from "../services/conversation-serializer.js";
 import {
+  publishConversationEnabledPluginsChanged,
   publishConversationListAndMetadataChanged,
   publishConversationListChanged,
   publishConversationTitleChanged,
@@ -220,6 +224,42 @@ async function handleSetInferenceProfile({
   });
 
   return result;
+}
+
+async function handleUpdateConversationEnabledPlugins({
+  pathParams = {},
+  body = {},
+  headers,
+}: RouteHandlerArgs) {
+  const enabledPlugins = body.enabledPlugins as string[] | null | undefined;
+  if (
+    enabledPlugins != null &&
+    (!Array.isArray(enabledPlugins) ||
+      enabledPlugins.some((p) => typeof p !== "string"))
+  ) {
+    throw new BadRequestError(
+      "enabledPlugins must be an array of strings or null",
+    );
+  }
+
+  const resolvedId = resolveConversationId(pathParams.id!) ?? pathParams.id!;
+  const conversation = getConversation(resolvedId);
+  if (!conversation) {
+    throw new NotFoundError(`Conversation ${pathParams.id} not found`);
+  }
+
+  // `null` clears the per-chat scope back to the default (all enabled
+  // plugins); a `string[]` scopes the chat to those plugin ids.
+  const nextEnabledPlugins = enabledPlugins ?? null;
+  setConversationEnabledPlugins(resolvedId, nextEnabledPlugins);
+  findConversation(resolvedId)?.setEnabledPlugins(nextEnabledPlugins);
+
+  publishConversationEnabledPluginsChanged(
+    resolvedId,
+    headers?.["x-vellum-client-id"]?.trim() || undefined,
+  );
+
+  return { conversationId: resolvedId, enabledPlugins: nextEnabledPlugins };
 }
 
 function handleRenameConversation({
@@ -652,6 +692,30 @@ export const ROUTES: RouteDefinition[] = [
         .nullable(),
     }),
     handler: handleSetInferenceProfile,
+  },
+  {
+    operationId: "conversations_by_id_enabledplugins_put",
+    endpoint: "conversations/:id/enabledplugins",
+    method: "PUT",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Set conversation enabled plugins",
+    description:
+      "Scope a single conversation to a subset of installed plugins " +
+      "(first-party defaults are always available). Pass null to clear the " +
+      "scope back to the default (all enabled plugins).",
+    tags: ["conversations"],
+    pathParams: [{ name: "id", type: "uuid" }],
+    requestBody: z.object({
+      enabledPlugins: z.array(z.string()).nullable(),
+    }),
+    responseBody: z.object({
+      conversationId: z.string(),
+      enabledPlugins: z.array(z.string()).nullable(),
+    }),
+    handler: handleUpdateConversationEnabledPlugins,
   },
   {
     operationId: "renameConversation",

--- a/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
@@ -140,3 +140,22 @@ describe("serializeConversationSummary · surfaced groupId normalization", () =>
     );
   });
 });
+
+describe("serializeConversationSummary · enabledPlugins", () => {
+  test("serializes a non-empty plugin scope", () => {
+    const summary = serialize(
+      makeConversationRow({ enabledPlugins: ["plugin-a", "plugin-b"] }),
+    );
+    expect(summary.enabledPlugins).toEqual(["plugin-a", "plugin-b"]);
+  });
+
+  test("preserves an explicit empty scope (user cleared all optional plugins)", () => {
+    const summary = serialize(makeConversationRow({ enabledPlugins: [] }));
+    expect(summary.enabledPlugins).toEqual([]);
+  });
+
+  test("omits the field when there is no per-chat restriction (null)", () => {
+    const summary = serialize(makeConversationRow({ enabledPlugins: null }));
+    expect("enabledPlugins" in summary).toBe(false);
+  });
+});

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -215,6 +215,11 @@ export function serializeConversationSummary(params: {
     ...(conversation.inferenceProfile != null
       ? { inferenceProfile: conversation.inferenceProfile }
       : {}),
+    // Include when non-null so an explicit `[]` (user cleared all plugins) is
+    // preserved; `null`/default is omitted.
+    ...(conversation.enabledPlugins != null
+      ? { enabledPlugins: conversation.enabledPlugins }
+      : {}),
     isProcessing,
   };
 }

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -160,6 +160,16 @@ export function publishConversationTitleChanged(
   );
 }
 
+export function publishConversationEnabledPluginsChanged(
+  conversationId: string,
+  originClientId?: string,
+): void {
+  void publishSyncInvalidation(
+    [SYNC_TAGS.conversationsList, conversationMetadataSyncTag(conversationId)],
+    originClientId,
+  );
+}
+
 export function publishConversationInferenceProfileChanged(
   params: {
     conversationId: string;


### PR DESCRIPTION
Standalone route to edit an existing conversation's per-chat plugin scope without sending a message (mirrors the inference-profile PUT). Validates `enabledPlugins: string[] | null`, persists via `setConversationEnabledPlugins` + live-object update, and emits a sync invalidation. Regenerates openapi.yaml.

Part of plan: in-chat-plugin-pill.md (PR 1 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>