### PR TITLE
feat(web): version gate for the standalone edit-chat-plugins route

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useSupportsInchatPluginEdit } from "@/lib/backwards-compat/use-supports-inchat-plugin-edit";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+/** Read the gate synchronously through the exported hook. */
+function readGate(version: string | null): boolean {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+  return renderHook(() => useSupportsInchatPluginEdit()).result.current;
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
+// boundary on each side of 0.10.5 plus the conservative-on-unknown policy,
+// exercised through the public hook. The edit route ships strictly after the
+// 0.10.4 send-path release, so 0.10.4 must read false.
+describe("useSupportsInchatPluginEdit", () => {
+  test("reads false when the version is unknown", () => {
+    expect(readGate(null)).toBe(false);
+  });
+
+  test("reads false below 0.10.5 (incl. the 0.10.4 send-path release)", () => {
+    expect(readGate("0.10.4")).toBe(false);
+    expect(readGate("0.10.3")).toBe(false);
+    expect(readGate("0.9.0")).toBe(false);
+  });
+
+  test("reads true for assistants on 0.10.5+", () => {
+    expect(readGate("0.10.5")).toBe(true);
+    expect(readGate("0.11.0")).toBe(true);
+    expect(readGate("1.0.0")).toBe(true);
+  });
+
+  test("reads false for unparseable versions", () => {
+    expect(readGate("garbage")).toBe(false);
+    expect(readGate("0.10")).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
@@ -1,0 +1,31 @@
+/**
+ * Backwards-compat gate: in-chat plugin editing.
+ *
+ * The in-chat plugin pill lets a user change an EXISTING conversation's plugin
+ * set mid-chat via the standalone `PUT /conversations/:id/enabledplugins` route.
+ * That route is a newer daemon capability than send-path per-chat plugin
+ * selection (see `use-supports-new-chat-plugins.ts`, which gates on 0.10.4).
+ *
+ * The web app always serves the latest bundle, but the assistant can be any
+ * locally-installed version. Without the edit route the pill cannot persist a
+ * change, so it must stay hidden until the active assistant is known to support
+ * it — gated on the identity store's resolved version, conservative on unknown.
+ *
+ * TODO(version): MIN_VERSION is a near-future placeholder above the 0.10.4
+ * send-path release. Bump it to the exact assistant release that ships
+ * `PUT /conversations/:id/enabledplugins` once cut.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.5";
+
+/**
+ * Returns `true` when the active assistant exposes the standalone
+ * edit-chat-plugins route, so the in-chat plugin pill can be shown. Subscribes
+ * to the identity store, so the pill appears/disappears as the active
+ * assistant's version crosses `MIN_VERSION`. Conservative on an unknown or
+ * unparseable version (returns `false`).
+ */
+export function useSupportsInchatPluginEdit(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
`useSupportsInchatPluginEdit()` gates the in-chat plugin pill on the assistant supporting the standalone PUT /conversations/:id/enabledplugins route (a newer capability than send-path per-chat plugins). Mirrors `use-supports-new-chat-plugins`. MIN_VERSION 0.10.5 (TODO(version) placeholder above the 0.10.4 send-path release).

Part of plan: in-chat-plugin-pill.md (PR 3 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>