### PR TITLE
chore(persistence): drop dead assistant_inbox_conversation_state table

### DIFF
--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -197,10 +197,9 @@ function parseDeletedCount(stdout: string | undefined): number {
  *
  * Tables with onDelete cascade on conversation FK (memory_segments,
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
- * external_conversation_bindings, assistant_inbox_conversation_state) are handled
- * automatically. Tables without cascade (messages, tool_invocations,
- * llm_request_logs, skill_loaded_events) are deleted explicitly before
- * removing the conversation row.
+ * external_conversation_bindings) are handled automatically. Tables without
+ * cascade (messages, tool_invocations, llm_request_logs, skill_loaded_events)
+ * are deleted explicitly before removing the conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,

--- a/assistant/src/persistence/migrations/312-drop-inbox-conversation-state-table.ts
+++ b/assistant/src/persistence/migrations/312-drop-inbox-conversation-state-table.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Drops the dead `assistant_inbox_conversation_state` table — no production
+ * code reads or writes it.
+ *
+ * Idempotent: DROP TABLE IF EXISTS.
+ */
+export function migrateDropInboxConversationStateTable(
+  database: DrizzleDb,
+): void {
+  database.run(
+    /*sql*/ `DROP TABLE IF EXISTS assistant_inbox_conversation_state`,
+  );
+}

--- a/assistant/src/persistence/schema/contacts.ts
+++ b/assistant/src/persistence/schema/contacts.ts
@@ -1,7 +1,5 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { conversations } from "./conversations.js";
-
 export const contacts = sqliteTable("contacts", {
   id: text("id").primaryKey(),
   displayName: text("display_name").notNull(),
@@ -78,32 +76,6 @@ export const assistantIngressInvites = sqliteTable(
     friendName: text("friend_name"),
     guardianName: text("guardian_name"),
     contactId: text("contact_id").notNull(),
-    createdAt: integer("created_at").notNull(),
-    updatedAt: integer("updated_at").notNull(),
-  },
-);
-
-export const assistantInboxConversationState = sqliteTable(
-  "assistant_inbox_conversation_state",
-  {
-    conversationId: text("conversation_id")
-      .primaryKey()
-      .references(() => conversations.id, { onDelete: "cascade" }),
-    sourceChannel: text("source_channel").notNull(),
-    externalChatId: text("external_chat_id").notNull(),
-    externalUserId: text("external_user_id"),
-    displayName: text("display_name"),
-    username: text("username"),
-    lastInboundAt: integer("last_inbound_at"),
-    lastOutboundAt: integer("last_outbound_at"),
-    lastMessageAt: integer("last_message_at"),
-    unreadCount: integer("unread_count").notNull().default(0),
-    pendingEscalationCount: integer("pending_escalation_count")
-      .notNull()
-      .default(0),
-    hasPendingEscalation: integer("has_pending_escalation")
-      .notNull()
-      .default(0),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -419,6 +419,7 @@ import { migrateAcpSessionHistoryTokenColumns } from "./migrations/308-acp-sessi
 import { migrateDropRedundantIndexes } from "./migrations/309-drop-redundant-indexes.js";
 import { migrateLlmRequestLogLatencyBreakdown } from "./migrations/310-llm-request-log-latency-breakdown.js";
 import { migrateCreateSubagentsTable } from "./migrations/311-create-subagents-table.js";
+import { migrateDropInboxConversationStateTable } from "./migrations/312-drop-inbox-conversation-state-table.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1309,4 +1310,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateDropRedundantIndexes,
   migrateLlmRequestLogLatencyBreakdown,
   migrateCreateSubagentsTable,
+  migrateDropInboxConversationStateTable,
 ];


### PR DESCRIPTION
## Summary
- Remove the unused `assistantInboxConversationState` Drizzle schema export — no production code reads or writes the table (its only references were the schema definition, historical migrations, and a comment)
- Add migration 312: idempotent `DROP TABLE IF EXISTS assistant_inbox_conversation_state`
- Update the stale cascade-table list in the conversation-prune job comment

## Original prompt
While inventorying the contact/channel/invite SQLite tables in the assistant/daemon process, we found `assistant_inbox_conversation_state` is dead: outside migrations and the schema file, the only reference in production code is a passing comment in the cleanup job. The user asked to remove this dead code, dropping the table from the assistant DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)