### PR TITLE
fix(persona): inject users/guardian.md for freshly hatched assistants

### DIFF
--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -132,7 +132,6 @@ afterEach(() => {
 
 describe("resolveGuardianPersonaPath", () => {
   test("returns null when no guardian exists", () => {
-
     expect(resolveGuardianPersonaPath()).toBeNull();
   });
 
@@ -206,7 +205,6 @@ describe("ensureGuardianPersonaFile", () => {
 
 describe("resolveGuardianPersonaStrict", () => {
   test("returns null when no guardian contact exists", () => {
-
     expect(resolveGuardianPersonaStrict()).toBeNull();
   });
 
@@ -350,5 +348,61 @@ describe("resolveUserSlug (guardian trust, no requester identity)", () => {
     } as TrustContext;
 
     expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+});
+
+// ── resolveUserSlug — guardian turns WITH a requester identity ─────
+//
+// A foreground guardian turn (e.g. the local desktop app after hatch) carries
+// both a `requesterExternalUserId` (the principal id) and a
+// `guardianExternalUserId`. The requester lookup can find the guardian's own
+// contact row whose `userFile` column is still null — the normal post-hatch
+// state, since onboarding writes users/guardian.md on disk but not the column.
+// That null must not strand the read on users/default.md: it has to fall
+// through to the guardian file the onboarding profile was written to.
+
+describe("resolveUserSlug (guardian trust WITH requester identity)", () => {
+  test("null-userFile guardian contact falls through to the guardian file, not default", () => {
+    // Guardian contact exists but has no explicit userFile (post-hatch state).
+    seedVellumGuardian(null);
+    // The requester principal id resolves to that same null-userFile contact.
+    mockContactsByAddress["vellum:principal-123"] = { userFile: null };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+      requesterExternalUserId: "principal-123",
+      guardianExternalUserId: "vellum:self",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("guardian");
+  });
+
+  test("an explicit requester userFile still wins over the guardian fallback", () => {
+    seedVellumGuardian(null);
+    mockContactsByAddress["vellum:principal-123"] = { userFile: "alice.md" };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+      requesterExternalUserId: "principal-123",
+      guardianExternalUserId: "vellum:self",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+
+  test("non-guardian turn with a null-userFile contact does not borrow the guardian persona", () => {
+    seedVellumGuardian(null);
+    mockContactsByAddress["vellum:principal-123"] = { userFile: null };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "trusted_contact",
+      requesterExternalUserId: "principal-123",
+      guardianExternalUserId: "vellum:self",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBeNull();
   });
 });

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -91,7 +91,9 @@ function resolveGuardianUserFile(trustContext: TrustContext): string | null {
     }
   }
   const guardian = peekGuardianForChannel(trustContext.sourceChannel);
-  return guardian ? (guardianDeliveryUserFile(guardian) ?? "guardian.md") : null;
+  return guardian
+    ? (guardianDeliveryUserFile(guardian) ?? "guardian.md")
+    : null;
 }
 
 /**
@@ -103,10 +105,7 @@ function resolveGuardianUserFile(trustContext: TrustContext): string | null {
 function guardianDeliveryUserFile(
   guardian: GuardianDelivery,
 ): string | undefined {
-  const contact = findContactByAddress(
-    guardian.channelType,
-    guardian.address,
-  );
+  const contact = findContactByAddress(guardian.channelType, guardian.address);
   return contact?.userFile ?? undefined;
 }
 
@@ -147,13 +146,18 @@ function resolveUserFilename(
         trustContext.sourceChannel,
         trustContext.requesterExternalUserId,
       );
-      if (contactWithChannels) {
-        filename = contactWithChannels.userFile ?? null;
+      if (contactWithChannels?.userFile) {
+        filename = contactWithChannels.userFile;
       } else if (trustContext.trustClass === "guardian") {
         // Managed desktop: the JWT principal ID used as requesterExternalUserId
         // may differ from the contact channel's address (they are separate
-        // identity concepts). Read the guardian's user file keyed by the
-        // verdict-bound guardian identity.
+        // identity concepts) — OR the guardian's contact row exists but carries
+        // no explicit userFile yet (the normal post-hatch state, since the
+        // guardian contact is created with a null userFile and onboarding
+        // writes the file on disk, not the column). Either way, read the
+        // guardian's user file keyed by the verdict-bound guardian identity so
+        // the onboarding profile (written to guardian.md) loads instead of
+        // falling through to users/default.md.
         filename = resolveGuardianUserFile(trustContext);
       }
     } else if (trustContext.trustClass === "guardian") {


### PR DESCRIPTION
## Summary

- A newly hatched assistant's onboarding profile (`users/guardian.md` — the "# User Profile / ## Onboarding Context" block with Preferred name and Role) never appeared in the system prompt. Root cause is a write/read slug asymmetry in `resolveUserFilename` (`assistant/src/prompts/persona-resolver.ts`): onboarding writes to `guardian.md`, but the per-turn read returned `null` (→ `users/default.md`) when the guardian's contact row had a null `userFile` — the normal post-hatch state, since the contact is created with `userFile: null` (`trust-verdict-consumer.ts`) and onboarding writes the file, not the DB column.
- Fix: gate the `requesterExternalUserId` lookup on the contact's `userFile` so a null-`userFile` guardian contact falls through to `resolveGuardianUserFile` (`guardian.md`), matching the write path and the two sibling guardian branches. Non-guardian contacts with a null `userFile` still fall back to `default.md` (fail-closed — no persona leak).
- No changes needed in the section registry or freeze/rebuild layer: `syncLoopSystemPrompt()` already re-resolves the prompt with live per-turn trust before each real inference turn (after onboarding writes the file); it was only ever resolving the wrong slug.
- Added regression tests: the fixed case (null-`userFile` guardian → `guardian`), the no-regression case (explicit `userFile` still wins), and the non-guardian fail-closed case.

## Original prompt

A user reported that when hatching a brand-new assistant, their `users/guardian.md` profile was entirely missing from the system prompt sent to the newly hatched assistant. The task was to find why the onboarding profile wasn't being injected on a fresh hatch and fix it. Investigation traced it to the per-turn persona-slug resolution returning `default` instead of `guardian` because the guardian contact's `userFile` column is null immediately after onboarding, so the profile that onboarding wrote to `guardian.md` was never read back.