### PR TITLE
feat(web): useEffectiveChatPlugins — resolve a chat's effective plugin set

### DIFF
--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.test.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for `useEffectiveChatPlugins`, the read-only hook that resolves a
+ * chat's effective plugin selection by joining the installed list
+ * (`pluginsGet`) against the conversation's explicit scope.
+ *
+ * The generated SDK is mocked so both reads resolve locally: module-level
+ * holders let each test drive the installed payload and the conversation
+ * response (or make the conversation read reject, standing in for a draft with
+ * no server row). The conversation store is the real module — reset per test.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type {
+  ConversationsByIdGetResponse,
+  PluginsGetResponse,
+} from "@/generated/daemon/types.gen";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+
+type InstalledPlugin = PluginsGetResponse["plugins"][number];
+
+interface InstalledResult {
+  data?: PluginsGetResponse;
+  response: { ok: boolean; status: number };
+}
+
+// Per-test holders the SDK mocks read.
+let installedResult: InstalledResult;
+let conversationImpl: () => Promise<{ data: ConversationsByIdGetResponse }>;
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+const pluginsGetSpy = mock(async () => installedResult);
+const conversationsByIdGetSpy = mock(() => conversationImpl());
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsGet: pluginsGetSpy,
+  conversationsByIdGet: conversationsByIdGetSpy,
+}));
+
+const { useEffectiveChatPlugins } = await import("./use-effective-chat-plugins");
+
+function installed(name: string): InstalledPlugin {
+  return { id: name, name, description: null, version: null };
+}
+
+function installedOk(plugins: InstalledPlugin[]): InstalledResult {
+  return { data: { plugins }, response: { ok: true, status: 200 } };
+}
+
+/**
+ * A loaded conversation row carrying an explicit `enabledPlugins` scope.
+ * `enabledPlugins` isn't on the generated conversation type yet (the sibling
+ * daemon PR adds it), so cast through the response shape.
+ */
+function conversationWith(
+  enabledPlugins: string[] | null,
+): { data: ConversationsByIdGetResponse } {
+  return {
+    data: {
+      conversation: { id: CONVERSATION_ID, enabledPlugins },
+    } as unknown as ConversationsByIdGetResponse,
+  };
+}
+
+/** Default conversation read: reject, standing in for a draft with no server row. */
+function noServerRow(): Promise<{ data: ConversationsByIdGetResponse }> {
+  return Promise.reject(new Error("404 — no server row"));
+}
+
+function renderEffective(conversationId: string | undefined = CONVERSATION_ID) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+
+  return renderHook(() => useEffectiveChatPlugins(ASSISTANT_ID, conversationId), {
+    wrapper,
+  });
+}
+
+beforeEach(() => {
+  // Installed list is deliberately unsorted so the hook's stable sort is exercised.
+  installedResult = installedOk([
+    installed("c"),
+    installed("a"),
+    installed("b"),
+  ]);
+  conversationImpl = noServerRow;
+  pluginsGetSpy.mockClear();
+  conversationsByIdGetSpy.mockClear();
+  useConversationStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useEffectiveChatPlugins", () => {
+  test("draft with no stored entry → every plugin selected, isDefault true", async () => {
+    const { result } = renderEffective();
+
+    await waitFor(() => expect(result.current.total).toBe(3));
+
+    expect(result.current.isDefault).toBe(true);
+    expect(result.current.selectedCount).toBe(3);
+    expect(result.current.plugins.every((p) => p.selected)).toBe(true);
+    // Sorted alphabetically regardless of installed-list order.
+    expect(result.current.plugins.map((p) => p.name)).toEqual(["a", "b", "c"]);
+  });
+
+  test("sent conversation with enabledPlugins ['a'] → only 'a' selected", async () => {
+    conversationImpl = () => Promise.resolve(conversationWith(["a"]));
+    // A conflicting draft stash must lose to the loaded server row.
+    useConversationStore
+      .getState()
+      .setPendingDraftPlugins(CONVERSATION_ID, new Set(["a", "b"]));
+
+    const { result } = renderEffective();
+
+    await waitFor(() => expect(result.current.selectedCount).toBe(1));
+
+    expect(result.current.isDefault).toBe(false);
+    expect(result.current.total).toBe(3);
+    const byName = Object.fromEntries(
+      result.current.plugins.map((p) => [p.name, p.selected]),
+    );
+    expect(byName).toEqual({ a: true, b: false, c: false });
+  });
+
+  test("sent conversation with enabledPlugins null → default, all selected", async () => {
+    conversationImpl = () => Promise.resolve(conversationWith(null));
+    // Draft stash would select only 'a'; the loaded null scope must override it
+    // back to the all-selected default.
+    useConversationStore
+      .getState()
+      .setPendingDraftPlugins(CONVERSATION_ID, new Set(["a"]));
+
+    const { result } = renderEffective();
+
+    await waitFor(() => expect(result.current.isDefault).toBe(true));
+
+    expect(result.current.selectedCount).toBe(3);
+    expect(result.current.plugins.every((p) => p.selected)).toBe(true);
+  });
+
+  test("selected joins installed metadata (name + label per plugin)", async () => {
+    conversationImpl = () => Promise.resolve(conversationWith(["b"]));
+
+    const { result } = renderEffective();
+
+    await waitFor(() => expect(result.current.selectedCount).toBe(1));
+
+    expect(result.current.plugins).toEqual([
+      { name: "a", label: "a", selected: false },
+      { name: "b", label: "b", selected: true },
+      { name: "c", label: "c", selected: false },
+    ]);
+  });
+
+  test("draft stash (no server row) drives selection when the row is absent", async () => {
+    // Row read rejects (draft); the composer stash is the source of truth.
+    useConversationStore
+      .getState()
+      .setPendingDraftPlugins(CONVERSATION_ID, new Set(["b", "c"]));
+
+    const { result } = renderEffective();
+
+    await waitFor(() => expect(result.current.selectedCount).toBe(2));
+
+    expect(result.current.isDefault).toBe(false);
+    const byName = Object.fromEntries(
+      result.current.plugins.map((p) => [p.name, p.selected]),
+    );
+    expect(byName).toEqual({ a: false, b: true, c: true });
+  });
+});

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.ts
@@ -15,13 +15,9 @@ type InstalledPlugin = PluginsGetResponse["plugins"][number];
 type ConversationDetail = ConversationsByIdGetResponse["conversation"];
 
 /**
- * The persisted per-conversation plugin scope (`enabled_plugins` column,
- * migration 312) is exposed on the conversation GET response by the sibling
- * daemon PR that adds the standalone edit route. Widen the generated
- * conversation shape locally so this read-only hook compiles and behaves
- * standalone (`null`/absent = default, all installed selected); once the
- * generated type declares the field this intersection is a no-op and surfaces
- * any wire-shape drift.
+ * Conversation detail shape widened with the per-chat plugin scope:
+ * `enabledPlugins` is `null`/absent when the chat has no restriction (every
+ * installed plugin selected), or a `string[]` scoping it to a subset.
  */
 type ConversationWithEnabledPlugins = ConversationDetail & {
   enabledPlugins?: string[] | null;

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins.ts
@@ -1,0 +1,136 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { conversationsByIdGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type {
+  ConversationsByIdGetResponse,
+  PluginsGetResponse,
+} from "@/generated/daemon/types.gen";
+import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
+import { useConversationStore } from "@/stores/conversation-store";
+
+/** Generated element type for an installed plugin (`pluginsGet`). */
+type InstalledPlugin = PluginsGetResponse["plugins"][number];
+
+type ConversationDetail = ConversationsByIdGetResponse["conversation"];
+
+/**
+ * The persisted per-conversation plugin scope (`enabled_plugins` column,
+ * migration 312) is exposed on the conversation GET response by the sibling
+ * daemon PR that adds the standalone edit route. Widen the generated
+ * conversation shape locally so this read-only hook compiles and behaves
+ * standalone (`null`/absent = default, all installed selected); once the
+ * generated type declares the field this intersection is a no-op and surfaces
+ * any wire-shape drift.
+ */
+type ConversationWithEnabledPlugins = ConversationDetail & {
+  enabledPlugins?: string[] | null;
+};
+
+/** A single installed plugin joined with its selection state for the chat. */
+export interface EffectiveChatPlugin {
+  name: string;
+  label: string;
+  icon?: string;
+  selected: boolean;
+}
+
+export interface UseEffectiveChatPluginsResult {
+  /** Installed plugins joined with per-chat selection, stably sorted. */
+  plugins: EffectiveChatPlugin[];
+  /** How many installed plugins are selected for this chat. */
+  selectedCount: number;
+  /** Installed plugin count (the denominator). */
+  total: number;
+  /** True when the chat has no explicit set — every installed plugin selected. */
+  isDefault: boolean;
+}
+
+const EMPTY_RESULT: UseEffectiveChatPluginsResult = {
+  plugins: [],
+  selectedCount: 0,
+  total: 0,
+  isDefault: true,
+};
+
+/** Installed-tier ordering: alphabetical by name (mirrors the Plugins tab's `sortPlugins`). */
+function sortByName(a: InstalledPlugin, b: InstalledPlugin): number {
+  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
+/**
+ * Resolves the effective plugin selection for a chat conversation by joining
+ * the installed plugins against the conversation's explicit scope.
+ *
+ * Precedence mirrors `use-active-profile-model.ts` (existing row vs. draft):
+ *
+ * - **Existing/sent conversation** (a server row is loaded): the source is
+ *   `conversation.enabledPlugins`. `null`/absent = default (all installed
+ *   selected).
+ * - **Draft** (no server row yet): the source is the composer's
+ *   `pendingDraftPlugins.get(conversationId)`, with the same opt-out default as
+ *   `use-new-chat-plugins.ts` (no entry = all selected).
+ *
+ * Read-only: this hook never mutates the store or issues a write. The returned
+ * shape is memoized so pill/menu consumers don't re-render on unrelated store
+ * churn.
+ */
+export function useEffectiveChatPlugins(
+  assistantId: string | null,
+  conversationId: string | undefined,
+): UseEffectiveChatPluginsResult {
+  const pendingDraftPlugins = useConversationStore.use.pendingDraftPlugins();
+
+  const { data: installedData } = useQuery({
+    ...installedPluginsQueryOptions(assistantId ?? ""),
+    enabled: Boolean(assistantId),
+  });
+
+  const { data: convData } = useQuery({
+    ...conversationsByIdGetOptions({
+      path: { assistant_id: assistantId ?? "", id: conversationId ?? "" },
+    }),
+    enabled: Boolean(assistantId) && Boolean(conversationId),
+  });
+
+  return useMemo(() => {
+    const installed = installedData?.plugins ?? [];
+    if (installed.length === 0) return EMPTY_RESULT;
+
+    // The explicit scope for this chat, or `null` when the chat is at its
+    // default (every installed plugin selected). A loaded server row is the
+    // source of truth; without one, fall back to the composer draft stash.
+    let explicit: Set<string> | null;
+    if (convData?.conversation) {
+      const conversation = convData.conversation as ConversationWithEnabledPlugins;
+      explicit = conversation.enabledPlugins
+        ? new Set(conversation.enabledPlugins)
+        : null;
+    } else {
+      const pending = conversationId
+        ? pendingDraftPlugins.get(conversationId)
+        : undefined;
+      explicit = pending ?? null;
+    }
+
+    const isDefault = explicit === null;
+    const plugins: EffectiveChatPlugin[] = [...installed]
+      .sort(sortByName)
+      .map((plugin) => ({
+        name: plugin.name,
+        label: plugin.name,
+        selected: explicit === null ? true : explicit.has(plugin.name),
+      }));
+
+    const selectedCount = isDefault
+      ? plugins.length
+      : plugins.reduce((count, plugin) => count + (plugin.selected ? 1 : 0), 0);
+
+    return {
+      plugins,
+      selectedCount,
+      total: plugins.length,
+      isDefault,
+    };
+  }, [installedData?.plugins, convData, conversationId, pendingDraftPlugins]);
+}


### PR DESCRIPTION
Read-only hook joining installed plugins against a chat's explicit scope, mirroring use-active-profile-model.ts precedence (loaded server row → conversation.enabledPlugins; draft → pendingDraftPlugins; null/absent = default all-selected). Returns memoized { plugins, selectedCount, total, isDefault }.

Note: the conversation GET serialization of enabledPlugins is added by PR 1 (sibling daemon PR); until it lands + the client regenerates, the hook widens the conversation type locally via a documented intersection.

Part of plan: in-chat-plugin-pill.md (PR 2 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>