### PR TITLE
feat(config): reintroduce the managed Frontier profile on Claude Fable 5

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -191,6 +191,16 @@ export const MANAGED_PROFILE_NAMES = new Set([
   OS_BETA_PROFILE_KEY,
 ]);
 
+// Canonicals that migration 052 seeded without `source` metadata: a
+// source-less profile under one of these names is legacy managed. Any other
+// managed-name profile without `source` predates its template and is the
+// user's (e.g. a `frontier` created before this template existed).
+const LEGACY_SOURCELESS_MANAGED_NAMES = new Set([
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+]);
+
 const MIX_MIN_ARMS = 2;
 
 export type SeedInferenceProfilesOptions = {
@@ -306,15 +316,15 @@ export function seedInferenceProfiles(
     const previous = readObject(profiles[name]);
     // Never clobber a user-owned profile that shares a managed name (e.g. a
     // user-owned `frontier` that migration 115 deliberately preserved). A
-    // source-less profile is legacy managed (migration 052 seeded canonicals
-    // without `source`), so only an explicit non-managed source is skipped.
-    if (
-      previous !== null &&
-      previous.source !== undefined &&
-      previous.source !== "managed"
-    ) {
-      continue;
-    }
+    // source-less profile counts as user-owned — matching migration 115 and
+    // the flag-gated reconcile — except for the canonicals migration 052
+    // seeded without `source`, which are legacy managed.
+    const isOursToManage =
+      previous === null ||
+      previous.source === "managed" ||
+      (previous.source === undefined &&
+        LEGACY_SOURCELESS_MANAGED_NAMES.has(name));
+    if (!isOursToManage) continue;
     const effectiveTemplate: ManagedProfileTemplate = isByokMode
       ? { ...template, label: `${template.label} (Managed)` }
       : template;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -58,16 +58,31 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
-  // Served by Anthropic Opus via managed platform inference — the most capable
-  // managed profile. The `quality-optimized` intent resolves to Opus for the
-  // `anthropic` provider.
+  // Served by Anthropic Opus via managed platform inference. The
+  // `quality-optimized` intent resolves to Opus for the `anthropic` provider.
   "quality-optimized": {
     intent: "quality-optimized",
     provider: "anthropic",
     connectionName: "anthropic-managed",
     source: "managed",
     label: "Quality",
-    description: "High-quality results with the most capable model",
+    description: "High-quality results for demanding tasks",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  // Served by Anthropic Fable via managed platform inference — the frontier
+  // tier above Quality (Opus). `model` is pinned explicitly since no catalog
+  // intent maps to Fable; the wire layer (providers/retry.ts) handles its
+  // adaptive-thinking-only constraint.
+  frontier: {
+    model: "claude-fable-5",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
+    source: "managed",
+    label: "Frontier",
+    description: "The most advanced frontier model (Claude Fable 5)",
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -304,6 +304,17 @@ export function seedInferenceProfiles(
     if (preservedProfileNames.has(name)) continue;
 
     const previous = readObject(profiles[name]);
+    // Never clobber a user-owned profile that shares a managed name (e.g. a
+    // user-owned `frontier` that migration 115 deliberately preserved). A
+    // source-less profile is legacy managed (migration 052 seeded canonicals
+    // without `source`), so only an explicit non-managed source is skipped.
+    if (
+      previous !== null &&
+      previous.source !== undefined &&
+      previous.source !== "managed"
+    ) {
+      continue;
+    }
     const effectiveTemplate: ManagedProfileTemplate = isByokMode
       ? { ...template, label: `${template.label} (Managed)` }
       : template;


### PR DESCRIPTION
## Summary
- Re-add the managed `frontier` inference profile to `MANAGED_PROFILE_TEMPLATES`, pinned explicitly to `claude-fable-5` on the `anthropic-managed` connection (no catalog intent maps to Fable). Seeded/reconciled on every daemon boot like the other managed profiles.
- Fable's adaptive-thinking-only constraint is already handled by the wire layer (`providers/retry.ts`), and boot ordering is safe: workspace migrations (including 115, which dropped the old Opus-backed Frontier) run before profile seeding, so the reseeded profile is never clobbered.
- Update the Quality profile's description ("High-quality results for demanding tasks") since it can no longer claim "the most capable model" with Frontier above it.

## Original prompt
Update the default model profile config for "Frontier" to use Anthropic Fable. The managed Frontier profile had been removed (folded into Quality when both resolved to Opus), so this re-introduces it pointing at `claude-fable-5`, restoring a distinct top tier above the Opus-backed Quality profile.