### PR TITLE
fix(contacts): GC orphaned seed contact on guardian claim + stop access-request re-fire after approval (LUM-2672, LUM-2673)

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -105,6 +105,7 @@ import {
   isAccessRequestDenied,
   notifyGuardianOfAccessRequest,
 } from "../runtime/access-request-helper.js";
+import { createOutboundSession } from "../runtime/channel-verification-service.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
@@ -124,6 +125,7 @@ const TEST_BEARER_TOKEN = "test-token";
 function resetState(): string {
   const db = getDb();
   db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM conversations");
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM canonical_guardian_requests");
@@ -937,6 +939,86 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(0);
+  });
+
+  // LUM-2673: an approved request whose verification code is still live must
+  // not be re-created by the sender's follow-up inbound — that re-delivered a
+  // fresh Approve/Reject card on top of the one the guardian just decided.
+  test("suppressed while an approved request's verification session is live", async () => {
+    createCanonicalGuardianRequest({
+      id: `approved-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-approved-user",
+      requesterExternalUserId: "approved-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "approved",
+    });
+    createOutboundSession({
+      channel: "telegram",
+      expectedExternalUserId: "approved-user",
+      expectedChatId: "chat-approved",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-approved",
+      verificationPurpose: "trusted_contact",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-approved",
+      actorExternalId: "approved-user",
+      actorDisplayName: "Approved User",
+    });
+
+    expect(result.notified).toBe(false);
+    if (!result.notified) {
+      expect(result.reason).toBe("approval_pending_verification");
+    }
+    expect(emitSignalCalls.length).toBe(0);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "approved-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(0);
+  });
+
+  test("re-prompts once the approved request's verification session has lapsed", async () => {
+    createCanonicalGuardianRequest({
+      id: `approved-stale-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-stale-user",
+      requesterExternalUserId: "stale-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "approved",
+    });
+    // No live verification session: the code lapsed unconsumed, so the
+    // sender's next message legitimately re-prompts the guardian.
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-stale",
+      actorExternalId: "stale-user",
+      actorDisplayName: "Stale User",
+    });
+
+    expect(result.notified).toBe(true);
+    expect(emitSignalCalls.length).toBe(1);
+
+    const pending = listCanonicalGuardianRequests({
+      status: "pending",
+      requesterExternalUserId: "stale-user",
+      kind: "access_request",
+    });
+    expect(pending.length).toBe(1);
   });
 
   test("a prior deny for one sender does not suppress prompts for a different sender", async () => {

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -9,6 +9,8 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { sql } from "drizzle-orm";
+
 // ---------------------------------------------------------------------------
 // Test isolation: in-memory SQLite via temp directory
 // ---------------------------------------------------------------------------
@@ -105,7 +107,6 @@ import {
   isAccessRequestDenied,
   notifyGuardianOfAccessRequest,
 } from "../runtime/access-request-helper.js";
-import { createOutboundSession } from "../runtime/channel-verification-service.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
@@ -125,7 +126,6 @@ const TEST_BEARER_TOKEN = "test-token";
 function resetState(): string {
   const db = getDb();
   db.run("DELETE FROM channel_inbound_events");
-  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM conversations");
   db.run("DELETE FROM notification_events");
   db.run("DELETE FROM canonical_guardian_requests");
@@ -824,7 +824,9 @@ describe("access-request-helper unit tests", () => {
     });
 
     expect(result.notified).toBe(true);
-    if (!result.notified) return;
+    if (!result.notified) {
+      return;
+    }
 
     await flushAsyncAccessRequestBookkeeping();
 
@@ -885,7 +887,9 @@ describe("access-request-helper unit tests", () => {
     });
 
     expect(result.notified).toBe(true);
-    if (!result.notified) return;
+    if (!result.notified) {
+      return;
+    }
 
     await flushAsyncAccessRequestBookkeeping();
 
@@ -941,10 +945,10 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(0);
   });
 
-  // LUM-2673: an approved request whose verification code is still live must
-  // not be re-created by the sender's follow-up inbound — that re-delivered a
-  // fresh Approve/Reject card on top of the one the guardian just decided.
-  test("suppressed while an approved request's verification session is live", async () => {
+  // LUM-2673: inside the post-approval verification window, inbound from the
+  // sender must not create a new request or re-notify the guardian — the
+  // handshake is waiting on the sender to enter their code.
+  test("suppressed while the approval's verification window is open", async () => {
     createCanonicalGuardianRequest({
       id: `approved-${Date.now()}`,
       kind: "access_request",
@@ -955,14 +959,6 @@ describe("access-request-helper unit tests", () => {
       guardianPrincipalId: anchorPrincipalId,
       toolName: "ingress_access_request",
       status: "approved",
-    });
-    createOutboundSession({
-      channel: "telegram",
-      expectedExternalUserId: "approved-user",
-      expectedChatId: "chat-approved",
-      identityBindingStatus: "bound",
-      destinationAddress: "chat-approved",
-      verificationPurpose: "trusted_contact",
     });
 
     const result = await notifyGuardianOfAccessRequest({
@@ -987,9 +983,10 @@ describe("access-request-helper unit tests", () => {
     expect(pending.length).toBe(0);
   });
 
-  test("re-prompts once the approved request's verification session has lapsed", async () => {
+  test("re-prompts once the approval's verification window has lapsed", async () => {
+    const requestId = `approved-stale-${Date.now()}`;
     createCanonicalGuardianRequest({
-      id: `approved-stale-${Date.now()}`,
+      id: requestId,
       kind: "access_request",
       sourceType: "channel",
       sourceChannel: "telegram",
@@ -999,8 +996,13 @@ describe("access-request-helper unit tests", () => {
       toolName: "ingress_access_request",
       status: "approved",
     });
-    // No live verification session: the code lapsed unconsumed, so the
-    // sender's next message legitimately re-prompts the guardian.
+    // Age the approval decision past the verification-code TTL: the code can
+    // no longer be redeemed, so the sender's next message legitimately
+    // re-prompts the guardian.
+    const staleUpdatedAt = Date.now() - 11 * 60 * 1000;
+    getDb().run(
+      sql`UPDATE canonical_guardian_requests SET updated_at = ${staleUpdatedAt} WHERE id = ${requestId}`,
+    );
 
     const result = await notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
@@ -1019,6 +1021,45 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
+  });
+
+  test("a terminal deny wins over an in-window approval for the same sender", async () => {
+    createCanonicalGuardianRequest({
+      id: `approved-then-denied-a-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-flip-user",
+      requesterExternalUserId: "flip-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "approved",
+    });
+    createCanonicalGuardianRequest({
+      id: `approved-then-denied-d-${Date.now()}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "access-req-self-telegram-flip-user",
+      requesterExternalUserId: "flip-user",
+      guardianPrincipalId: anchorPrincipalId,
+      toolName: "ingress_access_request",
+      status: "denied",
+    });
+
+    const result = await notifyGuardianOfAccessRequest({
+      canonicalAssistantId: "self",
+      sourceChannel: "telegram",
+      conversationExternalId: "chat-flip",
+      actorExternalId: "flip-user",
+      actorDisplayName: "Flip User",
+    });
+
+    expect(result.notified).toBe(false);
+    if (!result.notified) {
+      expect(result.reason).toBe("already_denied");
+    }
+    expect(emitSignalCalls.length).toBe(0);
   });
 
   test("a prior deny for one sender does not suppress prompts for a different sender", async () => {

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -26,6 +26,7 @@ import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
 import { resolveAnchoredGuardian } from "./anchored-guardian.js";
+import { findSessionByIdentity } from "./channel-verification-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
 
 const log = getLogger("access-request-helper");
@@ -54,7 +55,13 @@ export interface AccessRequestParams {
 
 export type AccessRequestResult =
   | { notified: true; created: boolean; requestId: string }
-  | { notified: false; reason: "no_sender_id" | "already_denied" };
+  | {
+      notified: false;
+      reason:
+        | "no_sender_id"
+        | "already_denied"
+        | "approval_pending_verification";
+    };
 
 // ---------------------------------------------------------------------------
 // Terminal-deny lookup
@@ -194,6 +201,34 @@ export async function notifyGuardianOfAccessRequest(
       created: false,
       requestId: existingCanonical[0].id,
     };
+  }
+
+  // Handshake-in-progress suppression: once the guardian APPROVES an access
+  // request, the requester holds a live verification code and the flow is
+  // waiting on them to enter it. Until that session lapses, further inbound
+  // from the same sender (messages, code attempts, button callbacks) must not
+  // re-create a request the guardian already decided — the resolved request no
+  // longer matches the pending-dedupe above, so without this check every
+  // post-approval inbound minted a fresh canonical request and re-delivered a
+  // new Approve/Reject card on top of the just-approved one (LUM-2673). Once
+  // the session expires unconsumed, re-prompting is allowed again.
+  const hasApprovedRequest =
+    listCanonicalGuardianRequests({
+      status: "approved",
+      requesterExternalUserId: actorExternalId,
+      sourceChannel,
+      kind: "access_request",
+      conversationId,
+    }).length > 0;
+  if (
+    hasApprovedRequest &&
+    findSessionByIdentity(sourceChannel, actorExternalId)
+  ) {
+    log.debug(
+      { sourceChannel, actorExternalId },
+      "Suppressing access request notification — approval granted, verification session still live",
+    );
+    return { notified: false, reason: "approval_pending_verification" };
   }
 
   // Terminal-deny suppression: once the guardian has denied an access request

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -26,7 +26,7 @@ import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
 import { resolveAnchoredGuardian } from "./anchored-guardian.js";
-import { findSessionByIdentity } from "./channel-verification-service.js";
+import { CHALLENGE_TTL_MS } from "./channel-verification-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
 
 const log = getLogger("access-request-helper");
@@ -106,6 +106,46 @@ export function isAccessRequestDenied(params: {
       conversationId,
     }).length > 0
   );
+}
+
+/**
+ * Whether this sender is inside the post-approval verification window: the
+ * guardian approved their access request recently enough that the minted
+ * 6-digit code could still be redeemable. In that state the handshake is in
+ * progress — the sender needs to enter the code, not trigger a fresh access
+ * request.
+ *
+ * Keyed on the approval decision time (the request row's `updatedAt`) bounded
+ * by the verification-code TTL, deliberately NOT on live verification-session
+ * rows: session lookups cannot distinguish the approval-minted session from a
+ * self-verify challenge session the ACL mints on the same inbound, or from an
+ * unrelated session bound to the same identity (guardian-initiated
+ * verification, invites).
+ *
+ * Voice is excluded: phone approvals activate the caller directly and never
+ * mint a code.
+ */
+export function isApprovalHandshakeInProgress(params: {
+  canonicalAssistantId: string;
+  sourceChannel: string;
+  actorExternalId: string;
+}): boolean {
+  if (params.sourceChannel === "phone") {
+    return false;
+  }
+  const conversationId = accessRequestConversationId(
+    params.canonicalAssistantId,
+    params.sourceChannel,
+    params.actorExternalId,
+  );
+  const windowStart = Date.now() - CHALLENGE_TTL_MS;
+  return listCanonicalGuardianRequests({
+    status: "approved",
+    requesterExternalUserId: params.actorExternalId,
+    sourceChannel: params.sourceChannel,
+    kind: "access_request",
+    conversationId,
+  }).some((request) => request.updatedAt >= windowStart);
 }
 
 // ---------------------------------------------------------------------------
@@ -203,40 +243,14 @@ export async function notifyGuardianOfAccessRequest(
     };
   }
 
-  // Handshake-in-progress suppression: once the guardian APPROVES an access
-  // request, the requester holds a live verification code and the flow is
-  // waiting on them to enter it. Until that session lapses, further inbound
-  // from the same sender (messages, code attempts, button callbacks) must not
-  // re-create a request the guardian already decided — the resolved request no
-  // longer matches the pending-dedupe above, so without this check every
-  // post-approval inbound minted a fresh canonical request and re-delivered a
-  // new Approve/Reject card on top of the just-approved one (LUM-2673). Once
-  // the session expires unconsumed, re-prompting is allowed again.
-  const hasApprovedRequest =
-    listCanonicalGuardianRequests({
-      status: "approved",
-      requesterExternalUserId: actorExternalId,
-      sourceChannel,
-      kind: "access_request",
-      conversationId,
-    }).length > 0;
-  if (
-    hasApprovedRequest &&
-    findSessionByIdentity(sourceChannel, actorExternalId)
-  ) {
-    log.debug(
-      { sourceChannel, actorExternalId },
-      "Suppressing access request notification — approval granted, verification session still live",
-    );
-    return { notified: false, reason: "approval_pending_verification" };
-  }
-
   // Terminal-deny suppression: once the guardian has denied an access request
   // for this sender on this channel, subsequent inbound must not re-prompt.
   // The denied decision persists the sender as an unverified_contact (see the
   // accessRequestResolver deny path); re-surfacing the same request the
   // guardian already rejected would be noise. The guardian can still verify the
-  // contact manually — that path does not go through here.
+  // contact manually — that path does not go through here. Checked before the
+  // handshake window below so a standing deny always wins over an earlier
+  // approval.
   if (
     isAccessRequestDenied({
       canonicalAssistantId,
@@ -249,6 +263,25 @@ export async function notifyGuardianOfAccessRequest(
       "Suppressing access request notification — guardian already denied this sender",
     );
     return { notified: false, reason: "already_denied" };
+  }
+
+  // Handshake-in-progress suppression: within the verification-code window
+  // after the guardian approves, the flow is waiting on the requester to enter
+  // their code. Inbound from the sender in that window must not create a new
+  // request or re-notify the guardian; once the window lapses unconsumed,
+  // re-prompting is allowed again.
+  if (
+    isApprovalHandshakeInProgress({
+      canonicalAssistantId,
+      sourceChannel,
+      actorExternalId,
+    })
+  ) {
+    log.debug(
+      { sourceChannel, actorExternalId },
+      "Suppressing access request notification — approval granted, verification window still open",
+    );
+    return { notified: false, reason: "approval_pending_verification" };
   }
 
   const senderIdentifier = actorDisplayName || actorUsername || actorExternalId;

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -48,8 +48,12 @@ import { composeApprovalMessage } from "./approval-message-composer.js";
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Challenge TTL in milliseconds (10 minutes). */
-const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+/**
+ * Challenge TTL in milliseconds (10 minutes). Exported so consumers that
+ * reason about "is a just-issued code still redeemable" (e.g. the
+ * access-request handshake window) share this exact bound.
+ */
+export const CHALLENGE_TTL_MS = 10 * 60 * 1000;
 
 /** Maximum invalid verification attempts within the throttling window before lockout. */
 const RATE_LIMIT_MAX_ATTEMPTS = 5;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -454,6 +454,13 @@ export async function handleChannelInbound({
     ? admissionPolicyFromGateway
     : undefined;
 
+  // Callback payloads (button presses, delete sentinels) are decision
+  // attempts / lifecycle events, not access attempts: the ACL stage must not
+  // respond to one by minting a verification challenge or creating an access
+  // request (LUM-2673). Reactions are intercepted before this point; the
+  // guard is defensive.
+  const isCallbackInteraction = hasCallbackData && !isSlackReactionEvent(body);
+
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({
     canonicalSenderId,
@@ -470,6 +477,7 @@ export async function handleChannelInbound({
     assistantId,
     externalMessageId,
     effectiveAdmissionPolicy: effectiveAdmissionPolicyForAcl,
+    isCallbackInteraction,
   });
   if (aclResult.earlyResponse) return aclResult.earlyResponse;
   const { resolvedMember } = aclResult;
@@ -798,48 +806,57 @@ export async function handleChannelInbound({
     // `acl-enforcement.ts:267-449` for `not_a_member`, so denials are
     // visible in the same UI. previousMemberStatus is only meaningful when
     // a member record exists; we pass it through when available so the
-    // guardian sees "previously pending" etc.
+    // guardian sees "previously pending" etc. Callback interactions never
+    // create an access request (LUM-2673).
     let guardianNotified = false;
-    try {
-      const accessResult = await notifyGuardianOfAccessRequest({
-        canonicalAssistantId,
-        sourceChannel,
-        conversationExternalId,
-        actorExternalId: canonicalSenderId ?? rawSenderId,
-        actorDisplayName: body.actorDisplayName,
-        actorUsername: body.actorUsername,
-        ...(resolvedMember
-          ? {
-              previousMemberStatus: channelStatusToMemberStatus(
-                resolvedMember.status,
-              ),
-            }
-          : {}),
-        messagePreview: truncate(trimmedContent, MESSAGE_PREVIEW_MAX_LENGTH),
-        ...(typeof sourceMetadata?.isStranger === "boolean"
-          ? { isStranger: sourceMetadata.isStranger }
-          : {}),
-        ...(typeof sourceMetadata?.isRestricted === "boolean"
-          ? { isRestricted: sourceMetadata.isRestricted }
-          : {}),
-        ...(typeof sourceMetadata?.messageId === "string"
-          ? { messageTs: sourceMetadata.messageId }
-          : {}),
-      });
-      guardianNotified = accessResult.notified;
-    } catch (err) {
-      log.error(
-        { err, sourceChannel, conversationExternalId },
-        "Failed to notify guardian of access request (admission policy)",
-      );
+    let handshakeInProgress = false;
+    if (!isCallbackInteraction) {
+      try {
+        const accessResult = await notifyGuardianOfAccessRequest({
+          canonicalAssistantId,
+          sourceChannel,
+          conversationExternalId,
+          actorExternalId: canonicalSenderId ?? rawSenderId,
+          actorDisplayName: body.actorDisplayName,
+          actorUsername: body.actorUsername,
+          ...(resolvedMember
+            ? {
+                previousMemberStatus: channelStatusToMemberStatus(
+                  resolvedMember.status,
+                ),
+              }
+            : {}),
+          messagePreview: truncate(trimmedContent, MESSAGE_PREVIEW_MAX_LENGTH),
+          ...(typeof sourceMetadata?.isStranger === "boolean"
+            ? { isStranger: sourceMetadata.isStranger }
+            : {}),
+          ...(typeof sourceMetadata?.isRestricted === "boolean"
+            ? { isRestricted: sourceMetadata.isRestricted }
+            : {}),
+          ...(typeof sourceMetadata?.messageId === "string"
+            ? { messageTs: sourceMetadata.messageId }
+            : {}),
+        });
+        guardianNotified = accessResult.notified;
+        handshakeInProgress =
+          !accessResult.notified &&
+          accessResult.reason === "approval_pending_verification";
+      } catch (err) {
+        log.error(
+          { err, sourceChannel, conversationExternalId },
+          "Failed to notify guardian of access request (admission policy)",
+        );
+      }
     }
 
     // Canned reply mirrors the not_a_member surface. §8.2: no upgrade
     // challenge text for `trusted_contacts` / `guardian_only` denials —
     // sender gets the standard "ask the guardian" copy.
-    const replyText = guardianNotified
-      ? "Hmm looks like you don't have access to talk to me. I'll let your guardian know you tried."
-      : "Sorry, you haven't been approved to message this assistant.";
+    const replyText = handshakeInProgress
+      ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
+      : guardianNotified
+        ? "Hmm looks like you don't have access to talk to me. I'll let your guardian know you tried."
+        : "Sorry, you haven't been approved to message this assistant.";
     let replyDelivered = false;
     if (replyCallbackUrl) {
       const replyPayload: Parameters<typeof deliverChannelReply>[1] = {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -90,14 +90,20 @@ import { wrapUntrustedContent } from "../../security/untrusted-content.js";
 import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
-import { notifyGuardianOfAccessRequest } from "../access-request-helper.js";
+import {
+  isApprovalHandshakeInProgress,
+  notifyGuardianOfAccessRequest,
+} from "../access-request-helper.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { deliverChannelReply } from "../gateway-client.js";
 import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
-import { enforceIngressAcl } from "./inbound-stages/acl-enforcement.js";
+import {
+  composeAccessDenialReply,
+  enforceIngressAcl,
+} from "./inbound-stages/acl-enforcement.js";
 import { enforceAdmissionPolicy } from "./inbound-stages/admission-policy.js";
 import { processChannelMessageInBackground } from "./inbound-stages/background-dispatch.js";
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";
@@ -457,9 +463,9 @@ export async function handleChannelInbound({
   // Callback payloads (button presses, delete sentinels) are decision
   // attempts / lifecycle events, not access attempts: the ACL stage must not
   // respond to one by minting a verification challenge or creating an access
-  // request (LUM-2673). Reactions are intercepted before this point; the
-  // guard is defensive.
-  const isCallbackInteraction = hasCallbackData && !isSlackReactionEvent(body);
+  // request (LUM-2673). Reaction callbacks never reach this point — the
+  // intercept above returns for them.
+  const isCallbackInteraction = hasCallbackData;
 
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({
@@ -807,16 +813,26 @@ export async function handleChannelInbound({
     // visible in the same UI. previousMemberStatus is only meaningful when
     // a member record exists; we pass it through when available so the
     // guardian sees "previously pending" etc. Callback interactions never
-    // create an access request (LUM-2673).
+    // create an access request (LUM-2673); the handshake window is still
+    // probed for reply copy.
     let guardianNotified = false;
     let handshakeInProgress = false;
-    if (!isCallbackInteraction) {
+    const floorSenderId = canonicalSenderId ?? rawSenderId;
+    if (isCallbackInteraction) {
+      if (floorSenderId) {
+        handshakeInProgress = isApprovalHandshakeInProgress({
+          canonicalAssistantId,
+          sourceChannel,
+          actorExternalId: floorSenderId,
+        });
+      }
+    } else {
       try {
         const accessResult = await notifyGuardianOfAccessRequest({
           canonicalAssistantId,
           sourceChannel,
           conversationExternalId,
-          actorExternalId: canonicalSenderId ?? rawSenderId,
+          actorExternalId: floorSenderId,
           actorDisplayName: body.actorDisplayName,
           actorUsername: body.actorUsername,
           ...(resolvedMember
@@ -852,11 +868,11 @@ export async function handleChannelInbound({
     // Canned reply mirrors the not_a_member surface. §8.2: no upgrade
     // challenge text for `trusted_contacts` / `guardian_only` denials —
     // sender gets the standard "ask the guardian" copy.
-    const replyText = handshakeInProgress
-      ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
-      : guardianNotified
-        ? "Hmm looks like you don't have access to talk to me. I'll let your guardian know you tried."
-        : "Sorry, you haven't been approved to message this assistant.";
+    const replyText = await composeAccessDenialReply({
+      sourceChannel,
+      guardianNotified,
+      handshakeInProgress,
+    });
     let replyDelivered = false;
     if (replyCallbackUrl) {
       const replyPayload: Parameters<typeof deliverChannelReply>[1] = {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -96,6 +96,25 @@ mock.module("../../../persistence/delivery-status.js", () => ({
   markProcessed: () => {},
 }));
 
+// Verification session service: track challenge minting so the callback
+// exemption (LUM-2673) can assert no session is created for button presses.
+const createOutboundSessionCalls: unknown[] = [];
+mock.module("../../channel-verification-service.js", () => ({
+  createOutboundSession: (params: unknown) => {
+    createOutboundSessionCalls.push(params);
+    return {
+      sessionId: "session-1",
+      secret: "123456",
+      challengeHash: "hash",
+      expiresAt: Date.now() + 600_000,
+      ttlSeconds: 600,
+    };
+  },
+  findActiveSession: () => null,
+  getPendingSession: () => null,
+  resolveBootstrapToken: () => null,
+}));
+
 import type { AclEnforcementParams } from "./acl-enforcement.js";
 import { enforceIngressAcl } from "./acl-enforcement.js";
 
@@ -143,6 +162,7 @@ beforeEach(() => {
   findContactChannelCalls.length = 0;
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
+  createOutboundSessionCalls.length = 0;
   accessRequestDeniedForTest = false;
   inviteTokenForTest = undefined;
   guardianDeliveryList = [];
@@ -592,5 +612,94 @@ describe("enforceIngressAcl — a terminal deny suppresses re-prompting, not adm
     expect(result.earlyResponse!.denied).toBe(true);
     // `unverified` maps to `pending` at the API-facing member layer.
     expect(result.earlyResponse!.reason).toBe("member_pending");
+  });
+});
+
+describe("enforceIngressAcl — callback interactions never spawn stranger-lane side effects (LUM-2673)", () => {
+  test("a stranger callback is denied without creating an access request", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        trimmedContent: "apr:req-1:approve_once",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+        isCallbackInteraction: true,
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(accessRequestCalls.length).toBe(0);
+    expect(createOutboundSessionCalls.length).toBe(0);
+    // The deny reply still goes out so the click isn't a silent no-op.
+    expect(deliverReplyCalls.length).toBe(1);
+  });
+
+  test("a Slack stranger callback initiates no verification challenge", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        trimmedContent: "apr:req-1:approve_once",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "U123STRANGER",
+        }),
+        isCallbackInteraction: true,
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("a Slack unverified-member callback initiates no challenge and no access request", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123MEMBER",
+        rawSenderId: "U123MEMBER",
+        trimmedContent: "apr:req-1:approve_once",
+        sourceMetadata: withVerdict(
+          memberVerdict({
+            status: "unverified",
+            canonicalSenderId: "U123MEMBER",
+            address: "U123MEMBER",
+            type: "slack",
+          }),
+        ),
+        isCallbackInteraction: true,
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("member_pending");
+    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("a Slack stranger MESSAGE still gets the challenge + access request (control)", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "U123STRANGER",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(accessRequestCalls.length).toBe(1);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -54,12 +54,14 @@ mock.module("../../gateway-client.js", () => ({
 
 const accessRequestCalls: unknown[] = [];
 let accessRequestDeniedForTest = false;
+let approvalHandshakeForTest = false;
 mock.module("../../access-request-helper.js", () => ({
   notifyGuardianOfAccessRequest: (params: unknown) => {
     accessRequestCalls.push(params);
     return { notified: true };
   },
   isAccessRequestDenied: () => accessRequestDeniedForTest,
+  isApprovalHandshakeInProgress: () => approvalHandshakeForTest,
 }));
 
 // Invite transport: by default no adapter (no token). Per-test override below.
@@ -135,6 +137,7 @@ function makeParams(
     replyCallbackUrl: "http://localhost/deliver",
     assistantId: "assistant-1",
     externalMessageId: "msg-1",
+    isCallbackInteraction: false,
     ...overrides,
   };
 }
@@ -164,6 +167,7 @@ beforeEach(() => {
   accessRequestCalls.length = 0;
   createOutboundSessionCalls.length = 0;
   accessRequestDeniedForTest = false;
+  approvalHandshakeForTest = false;
   inviteTokenForTest = undefined;
   guardianDeliveryList = [];
 });
@@ -682,6 +686,31 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
     expect(result.earlyResponse!.reason).toBe("member_pending");
     expect(createOutboundSessionCalls.length).toBe(0);
     expect(accessRequestCalls.length).toBe(0);
+  });
+
+  test("a callback inside the approval handshake window gets next-step copy, not a denial", async () => {
+    approvalHandshakeForTest = true;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        trimmedContent: "apr:req-1:approve_once",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+        isCallbackInteraction: true,
+      }),
+    );
+
+    expect(result.earlyResponse).toBeDefined();
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(accessRequestCalls.length).toBe(0);
+    expect(deliverReplyCalls.length).toBe(1);
+    const payload = deliverReplyCalls[0].payload as { text: string };
+    expect(payload.text).toContain("approved");
+    expect(payload.text).toContain("verification code");
   });
 
   test("a Slack stranger MESSAGE still gets the challenge + access request (control)", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -26,6 +26,7 @@ import { truncate } from "../../../util/truncate.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import {
   isAccessRequestDenied,
+  isApprovalHandshakeInProgress,
   notifyGuardianOfAccessRequest,
 } from "../../access-request-helper.js";
 import { resolveAnchoredGuardian } from "../../anchored-guardian.js";
@@ -67,6 +68,32 @@ async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
   return resolveGuardianName(anchored?.displayName);
 }
 
+/**
+ * Compose the requester-facing reply for a denied inbound, keyed on the
+ * access-request outcome. Single source for this copy — the not_a_member,
+ * inactive-member, and admission-floor deny lanes all route through it.
+ *
+ * - Handshake in progress: the guardian already approved and a verification
+ *   code is live; tell the sender their next step. The code is DM'd directly
+ *   to the requester on Slack but relayed via the guardian elsewhere, so the
+ *   copy covers both.
+ * - Guardian notified: the standard "I'll let <guardian> know" copy.
+ * - Otherwise: the plain not-approved copy.
+ */
+export async function composeAccessDenialReply(params: {
+  sourceChannel: ChannelId;
+  guardianNotified: boolean;
+  handshakeInProgress: boolean;
+}): Promise<string> {
+  if (params.handshakeInProgress) {
+    return `Your access request was approved! Reply here with the 6-digit verification code to finish connecting — if you don't have it, ask ${await resolveGuardianLabel(params.sourceChannel)} for it.`;
+  }
+  if (params.guardianNotified) {
+    return `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(params.sourceChannel)} know you tried talking to me and get back to you.`;
+  }
+  return "Sorry, you haven't been approved to message this assistant.";
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -105,9 +132,10 @@ export interface AclEnforcementParams {
    * verification challenge or create an access request — a stale button
    * press from an unrecognized sender would otherwise spawn a fresh
    * Approve/Reject card the guardian already dealt with (LUM-2673). The
-   * deny itself (and its canned reply) still applies.
+   * deny itself (and its canned reply) still applies. Required so every
+   * caller makes the classification explicitly.
    */
-  isCallbackInteraction?: boolean;
+  isCallbackInteraction: boolean;
 }
 
 /**
@@ -421,9 +449,7 @@ export async function enforceIngressAcl(
 
         // Slack-specific: send a verification challenge directly to the
         // user's DM instead of requiring guardian-mediated approval. The
-        // user can reply with the code in the DM to self-verify. Callback
-        // interactions never initiate a challenge — a button press is not a
-        // conversation attempt.
+        // user can reply with the code in the DM to self-verify.
         if (
           sourceChannel === "slack" &&
           (canonicalSenderId ?? rawSenderId) &&
@@ -556,10 +582,17 @@ export async function enforceIngressAcl(
         // Uses the shared helper which handles guardian binding lookup,
         // deduplication, canonical request creation, and notification emission.
         // Skipped for callback interactions — a button press must not create
-        // an access request.
+        // an access request — but the handshake window is still probed so the
+        // reply doesn't tell a just-approved sender they lack access.
         let guardianNotified = false;
         let handshakeInProgress = false;
-        if (!isCallbackInteraction) {
+        if (isCallbackInteraction) {
+          handshakeInProgress = isApprovalHandshakeInProgress({
+            canonicalAssistantId,
+            sourceChannel,
+            actorExternalId: (canonicalSenderId ?? rawSenderId)!,
+          });
+        } else {
           try {
             const accessResult = await notifyGuardianOfAccessRequest({
               canonicalAssistantId,
@@ -588,11 +621,11 @@ export async function enforceIngressAcl(
           }
         }
 
-        const replyText = handshakeInProgress
-          ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
-          : guardianNotified
-            ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
-            : "Sorry, you haven't been approved to message this assistant.";
+        const replyText = await composeAccessDenialReply({
+          sourceChannel,
+          guardianNotified,
+          handshakeInProgress,
+        });
         let replyDelivered = false;
         if (replyCallbackUrl) {
           const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
@@ -780,8 +813,7 @@ export async function enforceIngressAcl(
 
           // Slack-specific: re-verify inactive members via DM challenge
           // (same as non-member path). Blocked members are excluded —
-          // the guardian made an explicit decision to block them. Callback
-          // interactions never initiate a challenge.
+          // the guardian made an explicit decision to block them.
           if (
             sourceChannel === "slack" &&
             resolvedMember.status !== "blocked" &&
@@ -861,46 +893,55 @@ export async function enforceIngressAcl(
           // For revoked/pending members, notify the guardian so they can
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
-          // Callback interactions never create an access request.
+          // Callback interactions never create an access request; the
+          // handshake window is still probed for reply copy.
           let guardianNotified = false;
           let handshakeInProgress = false;
-          if (resolvedMember.status !== "blocked" && !isCallbackInteraction) {
-            try {
-              const accessResult = await notifyGuardianOfAccessRequest({
+          if (resolvedMember.status !== "blocked") {
+            if (isCallbackInteraction) {
+              handshakeInProgress = isApprovalHandshakeInProgress({
                 canonicalAssistantId,
                 sourceChannel,
-                conversationExternalId,
-                actorExternalId: canonicalSenderId ?? rawSenderId,
-                actorDisplayName,
-                actorUsername,
-                previousMemberStatus: channelStatusToMemberStatus(
-                  resolvedMember.status,
-                ),
-                messagePreview: truncate(
-                  trimmedContent,
-                  MESSAGE_PREVIEW_MAX_LENGTH,
-                ),
-                isStranger,
-                isRestricted,
-                messageTs,
+                actorExternalId: (canonicalSenderId ?? rawSenderId)!,
               });
-              guardianNotified = accessResult.notified;
-              handshakeInProgress =
-                !accessResult.notified &&
-                accessResult.reason === "approval_pending_verification";
-            } catch (err) {
-              log.error(
-                { err, sourceChannel, conversationExternalId },
-                "Failed to notify guardian of access request",
-              );
+            } else {
+              try {
+                const accessResult = await notifyGuardianOfAccessRequest({
+                  canonicalAssistantId,
+                  sourceChannel,
+                  conversationExternalId,
+                  actorExternalId: canonicalSenderId ?? rawSenderId,
+                  actorDisplayName,
+                  actorUsername,
+                  previousMemberStatus: channelStatusToMemberStatus(
+                    resolvedMember.status,
+                  ),
+                  messagePreview: truncate(
+                    trimmedContent,
+                    MESSAGE_PREVIEW_MAX_LENGTH,
+                  ),
+                  isStranger,
+                  isRestricted,
+                  messageTs,
+                });
+                guardianNotified = accessResult.notified;
+                handshakeInProgress =
+                  !accessResult.notified &&
+                  accessResult.reason === "approval_pending_verification";
+              } catch (err) {
+                log.error(
+                  { err, sourceChannel, conversationExternalId },
+                  "Failed to notify guardian of access request",
+                );
+              }
             }
           }
 
-          const inactiveReplyText = handshakeInProgress
-            ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
-            : guardianNotified
-              ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
-              : "Sorry, you haven't been approved to message this assistant.";
+          const inactiveReplyText = await composeAccessDenialReply({
+            sourceChannel,
+            guardianNotified,
+            handshakeInProgress,
+          });
           let inactiveReplyDelivered = false;
           if (replyCallbackUrl) {
             const inactiveReplyPayload: Parameters<

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -97,6 +97,17 @@ export interface AclEnforcementParams {
    * replies for senders who will be admitted by the floor stage anyway.
    */
   effectiveAdmissionPolicy?: AdmissionPolicy;
+  /**
+   * True when the inbound event is an interaction callback (e.g. a Slack
+   * Block Kit button press or a message_deleted sentinel) rather than a
+   * message the sender composed. Callbacks are decision attempts / lifecycle
+   * events, not access attempts: a denied callback must never mint a
+   * verification challenge or create an access request — a stale button
+   * press from an unrecognized sender would otherwise spawn a fresh
+   * Approve/Reject card the guardian already dealt with (LUM-2673). The
+   * deny itself (and its canned reply) still applies.
+   */
+  isCallbackInteraction?: boolean;
 }
 
 /**
@@ -151,6 +162,7 @@ export async function enforceIngressAcl(
     assistantId,
     externalMessageId,
     effectiveAdmissionPolicy,
+    isCallbackInteraction,
   } = params;
 
   let isValidatedBootstrap = false;
@@ -409,11 +421,14 @@ export async function enforceIngressAcl(
 
         // Slack-specific: send a verification challenge directly to the
         // user's DM instead of requiring guardian-mediated approval. The
-        // user can reply with the code in the DM to self-verify.
+        // user can reply with the code in the DM to self-verify. Callback
+        // interactions never initiate a challenge — a button press is not a
+        // conversation attempt.
         if (
           sourceChannel === "slack" &&
           (canonicalSenderId ?? rawSenderId) &&
-          !terminallyDenied
+          !terminallyDenied &&
+          !isCallbackInteraction
         ) {
           const slackVerifyResult = initiateSlackVerificationChallenge({
             sourceChannel,
@@ -493,7 +508,8 @@ export async function enforceIngressAcl(
         if (
           sourceChannel === "email" &&
           (canonicalSenderId ?? rawSenderId) &&
-          !terminallyDenied
+          !terminallyDenied &&
+          !isCallbackInteraction
         ) {
           const emailVerifyResult = initiateEmailVerificationChallenge({
             sourceChannel,
@@ -539,34 +555,44 @@ export async function enforceIngressAcl(
         // Notify the guardian about the access request so they can approve/deny.
         // Uses the shared helper which handles guardian binding lookup,
         // deduplication, canonical request creation, and notification emission.
+        // Skipped for callback interactions — a button press must not create
+        // an access request.
         let guardianNotified = false;
-        try {
-          const accessResult = await notifyGuardianOfAccessRequest({
-            canonicalAssistantId,
-            sourceChannel,
-            conversationExternalId,
-            actorExternalId: canonicalSenderId ?? rawSenderId,
-            actorDisplayName,
-            actorUsername,
-            messagePreview: truncate(
-              trimmedContent,
-              MESSAGE_PREVIEW_MAX_LENGTH,
-            ),
-            isStranger,
-            isRestricted,
-            messageTs,
-          });
-          guardianNotified = accessResult.notified;
-        } catch (err) {
-          log.error(
-            { err, sourceChannel, conversationExternalId },
-            "Failed to notify guardian of access request",
-          );
+        let handshakeInProgress = false;
+        if (!isCallbackInteraction) {
+          try {
+            const accessResult = await notifyGuardianOfAccessRequest({
+              canonicalAssistantId,
+              sourceChannel,
+              conversationExternalId,
+              actorExternalId: canonicalSenderId ?? rawSenderId,
+              actorDisplayName,
+              actorUsername,
+              messagePreview: truncate(
+                trimmedContent,
+                MESSAGE_PREVIEW_MAX_LENGTH,
+              ),
+              isStranger,
+              isRestricted,
+              messageTs,
+            });
+            guardianNotified = accessResult.notified;
+            handshakeInProgress =
+              !accessResult.notified &&
+              accessResult.reason === "approval_pending_verification";
+          } catch (err) {
+            log.error(
+              { err, sourceChannel, conversationExternalId },
+              "Failed to notify guardian of access request",
+            );
+          }
         }
 
-        const replyText = guardianNotified
-          ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
-          : "Sorry, you haven't been approved to message this assistant.";
+        const replyText = handshakeInProgress
+          ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
+          : guardianNotified
+            ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+            : "Sorry, you haven't been approved to message this assistant.";
         let replyDelivered = false;
         if (replyCallbackUrl) {
           const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
@@ -754,12 +780,14 @@ export async function enforceIngressAcl(
 
           // Slack-specific: re-verify inactive members via DM challenge
           // (same as non-member path). Blocked members are excluded —
-          // the guardian made an explicit decision to block them.
+          // the guardian made an explicit decision to block them. Callback
+          // interactions never initiate a challenge.
           if (
             sourceChannel === "slack" &&
             resolvedMember.status !== "blocked" &&
             (canonicalSenderId ?? rawSenderId) &&
-            !terminallyDenied
+            !terminallyDenied &&
+            !isCallbackInteraction
           ) {
             const slackVerifyResult = initiateSlackVerificationChallenge({
               sourceChannel,
@@ -833,8 +861,10 @@ export async function enforceIngressAcl(
           // For revoked/pending members, notify the guardian so they can
           // re-approve. Blocked members are intentionally excluded — the
           // guardian already made an explicit decision to block them.
+          // Callback interactions never create an access request.
           let guardianNotified = false;
-          if (resolvedMember.status !== "blocked") {
+          let handshakeInProgress = false;
+          if (resolvedMember.status !== "blocked" && !isCallbackInteraction) {
             try {
               const accessResult = await notifyGuardianOfAccessRequest({
                 canonicalAssistantId,
@@ -855,6 +885,9 @@ export async function enforceIngressAcl(
                 messageTs,
               });
               guardianNotified = accessResult.notified;
+              handshakeInProgress =
+                !accessResult.notified &&
+                accessResult.reason === "approval_pending_verification";
             } catch (err) {
               log.error(
                 { err, sourceChannel, conversationExternalId },
@@ -863,9 +896,11 @@ export async function enforceIngressAcl(
             }
           }
 
-          const inactiveReplyText = guardianNotified
-            ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
-            : "Sorry, you haven't been approved to message this assistant.";
+          const inactiveReplyText = handshakeInProgress
+            ? "Your access has been approved! Reply with the 6-digit verification code you received to finish connecting."
+            : guardianNotified
+              ? `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+              : "Sorry, you haven't been approved to message this assistant.";
           let inactiveReplyDelivered = false;
           if (replyCallbackUrl) {
             const inactiveReplyPayload: Parameters<

--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -50,6 +50,8 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   },
 }));
 
+import { eq } from "drizzle-orm";
+
 import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
 import {
   initGatewayDb,
@@ -204,5 +206,111 @@ describe("createGuardianBinding id resolution", () => {
 
     expect(result.contactId).toBe("guardian-contact");
     expect(result.channelId).toBe("guardian-channel");
+  });
+
+  // LUM-2672: claiming an inbound-seeded channel must not strand the seed
+  // contact as a channel-less duplicate of the guardian.
+  test("claiming a seeded channel garbage-collects the orphaned seed contact", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const orphan = getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(eq(contacts.id, "seed-contact"))
+      .get();
+    expect(orphan).toBeUndefined();
+  });
+
+  test("keeps the previous parent contact when it still has other channels", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "seed-telegram-channel",
+        contactId: "seed-contact",
+        type: "telegram",
+        address: "tg-1001",
+        isPrimary: false,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      .run();
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const kept = getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(eq(contacts.id, "seed-contact"))
+      .get();
+    expect(kept?.id).toBe("seed-contact");
+  });
+
+  test("never garbage-collects a principal-bearing previous parent", async () => {
+    seedGwGuardianContact();
+    getGatewayDb()
+      .insert(contacts)
+      .values({
+        id: "principal-contact",
+        displayName: "Example User",
+        role: "contact",
+        principalId: "some-other-principal",
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      .run();
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "principal-channel",
+        contactId: "principal-contact",
+        type: "slack",
+        address: "U123EXAMPLE",
+        externalChatId: "D123EXAMPLE",
+        isPrimary: false,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      .run();
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const kept = getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(eq(contacts.id, "principal-contact"))
+      .get();
+    expect(kept?.id).toBe("principal-contact");
   });
 });

--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -18,6 +18,9 @@ import {
   test,
 } from "bun:test";
 import { Database } from "bun:sqlite";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { SqliteValue } from "../db/assistant-db-proxy.js";
 
@@ -29,6 +32,16 @@ function db(): Database {
   if (!assistantDb) throw new Error("test DB not initialized");
   return assistantDb;
 }
+
+// Fake socket file so the orphan GC's assistant-mirror inspection runs
+// against the in-memory mirror instead of being skipped as unreachable.
+const TEST_SOCKET_PATH = join(
+  tmpdir(),
+  `vellum-guardian-binding-reuse-test-${process.pid}.sock`,
+);
+mock.module("../ipc/socket-path.js", () => ({
+  resolveIpcSocketPath: () => ({ path: TEST_SOCKET_PATH }),
+}));
 
 mock.module("../db/assistant-db-proxy.js", () => ({
   async assistantDbQuery(sql: string, bind: SqliteValue[] = []) {
@@ -132,6 +145,8 @@ beforeEach(() => {
   gw.delete(contactChannels).run();
   gw.delete(contacts).run();
 
+  writeFileSync(TEST_SOCKET_PATH, "");
+
   assistantDb = new Database(":memory:");
   assistantDb.exec(`
     CREATE TABLE contacts (
@@ -140,8 +155,16 @@ beforeEach(() => {
       role TEXT NOT NULL DEFAULT 'contact',
       principal_id TEXT,
       notes TEXT,
+      user_file TEXT,
+      contact_type TEXT NOT NULL DEFAULT 'human',
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE assistant_contact_metadata (
+      contact_id TEXT PRIMARY KEY REFERENCES contacts(id) ON DELETE CASCADE,
+      species TEXT NOT NULL,
+      metadata TEXT
     );
 
     CREATE TABLE contact_channels (
@@ -171,7 +194,43 @@ afterAll(() => {
   resetGatewayDb();
   assistantDb?.close();
   assistantDb = null;
+  rmSync(TEST_SOCKET_PATH, { force: true });
 });
+
+/** Seed an assistant-mirror contact row for the inbound-seeded stub. */
+function seedMirrorSeedContact(
+  fields: { notes?: string; user_file?: string; contact_type?: string } = {},
+): void {
+  db()
+    .prepare(
+      `INSERT INTO contacts (id, display_name, notes, user_file, contact_type, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, 1)`,
+    )
+    .run(
+      "seed-contact",
+      "Example User",
+      fields.notes ?? null,
+      fields.user_file ?? null,
+      fields.contact_type ?? "human",
+    );
+}
+
+function gwSeedContactExists(): boolean {
+  return (
+    getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(eq(contacts.id, "seed-contact"))
+      .get() !== undefined
+  );
+}
+
+function mirrorSeedContactExists(): boolean {
+  return (
+    db().prepare(`SELECT id FROM contacts WHERE id = ?`).get("seed-contact") !=
+    null
+  );
+}
 
 describe("createGuardianBinding id resolution", () => {
   test("claims a preseeded Slack channel for the guardian instead of minting", async () => {
@@ -265,6 +324,84 @@ describe("createGuardianBinding id resolution", () => {
       .where(eq(contacts.id, "seed-contact"))
       .get();
     expect(kept?.id).toBe("seed-contact");
+  });
+
+  test("claiming a seeded channel also deletes a pristine assistant-mirror stub", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+    seedMirrorSeedContact();
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(gwSeedContactExists()).toBe(false);
+    expect(mirrorSeedContactExists()).toBe(false);
+  });
+
+  test("guardian-authored notes on the mirror veto the delete in BOTH stores", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+    seedMirrorSeedContact({ notes: "my colleague from work" });
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(gwSeedContactExists()).toBe(true);
+    expect(mirrorSeedContactExists()).toBe(true);
+  });
+
+  test("a persona-file pointer on the mirror vetoes the delete", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+    seedMirrorSeedContact({ user_file: "users/example-user.md" });
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(gwSeedContactExists()).toBe(true);
+    expect(mirrorSeedContactExists()).toBe(true);
+  });
+
+  test("assistant-species metadata on the mirror vetoes the delete", async () => {
+    seedGwGuardianContact();
+    seedGwSlackChannel("U123EXAMPLE");
+    seedMirrorSeedContact();
+    db()
+      .prepare(
+        `INSERT INTO assistant_contact_metadata (contact_id, species, metadata)
+         VALUES (?, ?, ?)`,
+      )
+      .run("seed-contact", "vellum", "{}");
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(gwSeedContactExists()).toBe(true);
+    expect(mirrorSeedContactExists()).toBe(true);
   });
 
   test("never garbage-collects a principal-bearing previous parent", async () => {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -23,6 +23,7 @@ import { credentialKey } from "../credential-key.js";
 import { arePlatformFeaturesEnabled } from "../feature-flag-resolver.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { getLogger } from "../logger.js";
+import { deleteContactIfOrphaned } from "../verification/contact-helpers.js";
 
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { mintToken } from "./token-service.js";
@@ -404,6 +405,15 @@ export async function createGuardianBinding(
       { err: mirrorErr },
       "Failed to mirror guardian binding identity to assistant DB",
     );
+  }
+
+  // The claim above can re-parent a channel that inbound seeding attached to
+  // a stub contact (first message from a then-unbound guardian identity).
+  // Garbage-collect that stub when the claim stripped its last channel, so
+  // the guardian doesn't end up with a duplicate of themselves in the
+  // Contacts pane (LUM-2672). Best-effort — never fails the binding.
+  if (claimableChannel && claimableChannel.contactId !== contactId) {
+    await deleteContactIfOrphaned(claimableChannel.contactId);
   }
 
   log.info(

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -180,11 +180,6 @@ function writeVerifiedGatewayChannel(params: {
  * Re-parent a gateway channel to the invite's target contact, ensuring the
  * target contact row exists first. Best-effort: a gateway DB error is logged,
  * not thrown, so a legitimate activation still proceeds.
- *
- * When the re-parent strips the previous parent of its last channel, the
- * previous parent is garbage-collected if it is an inbound-seeded stub (see
- * `deleteContactIfOrphaned`) so channel claims don't strand duplicate
- * contacts (LUM-2672).
  */
 function reassignChannelContact(params: {
   type: string;
@@ -207,18 +202,6 @@ function reassignChannelContact(params: {
       })
       .onConflictDoNothing()
       .run();
-    // Capture the previous parent before the update so an orphaned seed
-    // contact can be garbage-collected after the re-parent.
-    const previousParent = gwDb
-      .select({ contactId: gwContactChannels.contactId })
-      .from(gwContactChannels)
-      .where(
-        and(
-          eq(gwContactChannels.type, type),
-          sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
-        ),
-      )
-      .get();
     // Match by the (type,address) logical key, not the assistant channel id:
     // the gateway row can live under a different UUID (m0006 reconcile), and an
     // id-only update would re-parent nothing.
@@ -232,37 +215,40 @@ function reassignChannelContact(params: {
         ),
       )
       .run();
-    if (previousParent && previousParent.contactId !== toContactId) {
-      void deleteContactIfOrphaned(previousParent.contactId);
-    }
   } catch (gwErr) {
     log.warn({ err: gwErr }, "Gateway channel reassignment dual-write failed");
   }
 }
 
 /**
- * Garbage-collect a contact stranded by a channel re-parent (LUM-2672).
+ * Garbage-collect a contact stranded by the guardian-binding channel claim
+ * (LUM-2672).
  *
  * Inbound seeding (`upsertContactChannel` below) creates a stub contact for a
- * first-seen sender keyed only by (type, address). When that sender later
- * turns out to be the guardian (channel verification) or an invite target,
- * the claim re-parents the channel to the real contact and the stub is left
- * behind with zero channels — a duplicate the guardian sees in the Contacts
- * pane.
+ * first-seen sender keyed only by (type, address). When that sender turns out
+ * to be the guardian, channel verification re-parents the seeded channel to
+ * the guardian contact and the stub is left behind with zero channels — a
+ * duplicate of the guardian in the Contacts pane.
  *
  * Deletion is deliberately narrow so a claim can never destroy real data:
- * the contact must have role `contact`, no principal, and no remaining
- * channels in the gateway DB (source of truth). The assistant mirror row is
- * deleted best-effort and only when it, too, is channel-less and carries no
- * guardian-authored notes.
+ * the gateway contact must have role `contact`, no principal, and no
+ * remaining channels; the assistant mirror must agree (no channels) and
+ * carry no guardian-authored notes. When any check fails, BOTH rows are
+ * kept, so the two stores never disagree about the contact's existence.
+ * A mirror that is unreachable (IPC socket absent) does not block the
+ * gateway-side delete; a leftover mirror row is recoverable via the
+ * tolerant contact delete (LUM-2662).
  *
- * Never throws. Returns true when the gateway row was deleted.
+ * Callers must invoke this only after all re-parent writes (gateway AND
+ * assistant mirror) have completed, or the mirror inspection can observe the
+ * pre-claim channel and veto the delete. Never throws.
  */
 export async function deleteContactIfOrphaned(
   contactId: string,
-): Promise<boolean> {
+): Promise<void> {
+  const gwDb = getGatewayDb();
+
   try {
-    const gwDb = getGatewayDb();
     const contact = gwDb
       .select({
         role: gwContacts.role,
@@ -272,7 +258,7 @@ export async function deleteContactIfOrphaned(
       .where(eq(gwContacts.id, contactId))
       .get();
     if (!contact || contact.role !== "contact" || contact.principalId) {
-      return false;
+      return;
     }
     const remainingChannel = gwDb
       .select({ id: gwContactChannels.id })
@@ -280,54 +266,81 @@ export async function deleteContactIfOrphaned(
       .where(eq(gwContactChannels.contactId, contactId))
       .limit(1)
       .get();
-    if (remainingChannel) return false;
+    if (remainingChannel) {
+      return;
+    }
+  } catch (gwErr) {
+    log.warn(
+      { err: gwErr, contactId },
+      "Orphaned contact garbage-collection failed (gateway inspection)",
+    );
+    return;
+  }
 
+  // Inspect the assistant mirror BEFORE deleting anything: a mirror row with
+  // channels or guardian-authored notes vetoes the whole delete so both
+  // stores keep the contact.
+  let mirrorRowPresent = false;
+  const { path: socketPath } = resolveIpcSocketPath("assistant");
+  const mirrorReachable = existsSync(socketPath);
+  if (mirrorReachable) {
+    try {
+      const mirrorChannels = await assistantDbQuery<{ id: string }>(
+        `SELECT id FROM contact_channels WHERE contact_id = ? LIMIT 1`,
+        [contactId],
+      );
+      if (mirrorChannels.length > 0) {
+        return;
+      }
+      const mirrorNotes = await assistantDbQuery<{ notes: string | null }>(
+        `SELECT notes FROM contacts WHERE id = ?`,
+        [contactId],
+      );
+      mirrorRowPresent = mirrorNotes.length > 0;
+      if (
+        mirrorRowPresent &&
+        mirrorNotes[0].notes &&
+        mirrorNotes[0].notes.trim().length > 0
+      ) {
+        log.info(
+          { contactId },
+          "Keeping orphaned seed contact: assistant mirror carries notes",
+        );
+        return;
+      }
+    } catch (mirrorErr) {
+      log.warn(
+        { err: mirrorErr, contactId },
+        "Orphaned contact garbage-collection failed (mirror inspection)",
+      );
+      return;
+    }
+  }
+
+  try {
     gwDb.delete(gwContacts).where(eq(gwContacts.id, contactId)).run();
     log.info(
       { contactId },
-      "Deleted orphaned seed contact after channel re-parent",
+      "Deleted orphaned seed contact after guardian channel claim",
     );
   } catch (gwErr) {
     log.warn(
       { err: gwErr, contactId },
-      "Orphaned contact garbage-collection failed (gateway)",
+      "Orphaned contact garbage-collection failed (gateway delete)",
     );
-    return false;
+    return;
   }
 
-  // Assistant mirror cleanup: best-effort, and skipped entirely when the IPC
-  // socket is unavailable (test environments) or the mirror still has
-  // channels or notes — a leftover mirror row is recoverable via the tolerant
-  // contact delete (LUM-2662), lost notes are not.
-  try {
-    const { path: socketPath } = resolveIpcSocketPath("assistant");
-    if (!existsSync(socketPath)) return true;
-
-    const mirrorChannels = await assistantDbQuery<{ id: string }>(
-      `SELECT id FROM contact_channels WHERE contact_id = ? LIMIT 1`,
-      [contactId],
-    );
-    if (mirrorChannels.length > 0) return true;
-    const mirrorNotes = await assistantDbQuery<{ notes: string | null }>(
-      `SELECT notes FROM contacts WHERE id = ?`,
-      [contactId],
-    );
-    if (mirrorNotes.length === 0) return true;
-    if (mirrorNotes[0].notes && mirrorNotes[0].notes.trim().length > 0) {
-      log.info(
-        { contactId },
-        "Keeping assistant-mirror contact with notes after gateway orphan delete",
+  if (mirrorRowPresent) {
+    try {
+      await assistantDbRun(`DELETE FROM contacts WHERE id = ?`, [contactId]);
+    } catch (mirrorErr) {
+      log.warn(
+        { err: mirrorErr, contactId },
+        "Orphaned contact garbage-collection failed (assistant mirror delete)",
       );
-      return true;
     }
-    await assistantDbRun(`DELETE FROM contacts WHERE id = ?`, [contactId]);
-  } catch (mirrorErr) {
-    log.warn(
-      { err: mirrorErr, contactId },
-      "Orphaned contact garbage-collection failed (assistant mirror)",
-    );
   }
-  return true;
 }
 
 /**

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -233,10 +233,11 @@ function reassignChannelContact(params: {
  * Deletion is deliberately narrow so a claim can never destroy real data:
  * the gateway contact must have role `contact`, no principal, and no
  * remaining channels; the assistant mirror must agree (no channels) and
- * carry no guardian-authored notes. When any check fails, BOTH rows are
- * kept, so the two stores never disagree about the contact's existence.
- * A mirror that is unreachable (IPC socket absent) does not block the
- * gateway-side delete; a leftover mirror row is recoverable via the
+ * carry no guardian-authored data (notes, persona-file pointer, non-default
+ * contact type, or assistant-species metadata). When any check fails, BOTH
+ * rows are kept, so the two stores never disagree about the contact's
+ * existence. A mirror that is unreachable (IPC socket absent) does not block
+ * the gateway-side delete; a leftover mirror row is recoverable via the
  * tolerant contact delete (LUM-2662).
  *
  * Callers must invoke this only after all re-parent writes (gateway AND
@@ -277,9 +278,11 @@ export async function deleteContactIfOrphaned(
     return;
   }
 
-  // Inspect the assistant mirror BEFORE deleting anything: a mirror row with
-  // channels or guardian-authored notes vetoes the whole delete so both
-  // stores keep the contact.
+  // Inspect the assistant mirror BEFORE deleting anything: a mirror row that
+  // carries channels or any guardian-authored data — notes, a persona file
+  // pointer, a non-default contact type, or assistant-species metadata
+  // (cascade-deleted with the contact) — vetoes the whole delete so both
+  // stores keep the contact and nothing user-authored is discarded.
   let mirrorRowPresent = false;
   const { path: socketPath } = resolveIpcSocketPath("assistant");
   const mirrorReachable = existsSync(socketPath);
@@ -292,21 +295,41 @@ export async function deleteContactIfOrphaned(
       if (mirrorChannels.length > 0) {
         return;
       }
-      const mirrorNotes = await assistantDbQuery<{ notes: string | null }>(
-        `SELECT notes FROM contacts WHERE id = ?`,
+      const mirrorRows = await assistantDbQuery<{
+        notes: string | null;
+        userFile: string | null;
+        contactType: string;
+      }>(
+        `SELECT notes, user_file AS userFile, contact_type AS contactType
+         FROM contacts WHERE id = ?`,
         [contactId],
       );
-      mirrorRowPresent = mirrorNotes.length > 0;
-      if (
-        mirrorRowPresent &&
-        mirrorNotes[0].notes &&
-        mirrorNotes[0].notes.trim().length > 0
-      ) {
-        log.info(
-          { contactId },
-          "Keeping orphaned seed contact: assistant mirror carries notes",
+      mirrorRowPresent = mirrorRows.length > 0;
+      if (mirrorRowPresent) {
+        const mirror = mirrorRows[0];
+        const hasGuardianAuthoredData =
+          (mirror.notes && mirror.notes.trim().length > 0) ||
+          (mirror.userFile && mirror.userFile.trim().length > 0) ||
+          mirror.contactType !== "human";
+        if (hasGuardianAuthoredData) {
+          log.info(
+            { contactId },
+            "Keeping orphaned seed contact: assistant mirror carries guardian-authored data",
+          );
+          return;
+        }
+        const mirrorMetadata = await assistantDbQuery<{ contactId: string }>(
+          `SELECT contact_id AS contactId FROM assistant_contact_metadata
+           WHERE contact_id = ? LIMIT 1`,
+          [contactId],
         );
-        return;
+        if (mirrorMetadata.length > 0) {
+          log.info(
+            { contactId },
+            "Keeping orphaned seed contact: assistant mirror carries contact metadata",
+          );
+          return;
+        }
       }
     } catch (mirrorErr) {
       log.warn(

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -180,6 +180,11 @@ function writeVerifiedGatewayChannel(params: {
  * Re-parent a gateway channel to the invite's target contact, ensuring the
  * target contact row exists first. Best-effort: a gateway DB error is logged,
  * not thrown, so a legitimate activation still proceeds.
+ *
+ * When the re-parent strips the previous parent of its last channel, the
+ * previous parent is garbage-collected if it is an inbound-seeded stub (see
+ * `deleteContactIfOrphaned`) so channel claims don't strand duplicate
+ * contacts (LUM-2672).
  */
 function reassignChannelContact(params: {
   type: string;
@@ -202,6 +207,18 @@ function reassignChannelContact(params: {
       })
       .onConflictDoNothing()
       .run();
+    // Capture the previous parent before the update so an orphaned seed
+    // contact can be garbage-collected after the re-parent.
+    const previousParent = gwDb
+      .select({ contactId: gwContactChannels.contactId })
+      .from(gwContactChannels)
+      .where(
+        and(
+          eq(gwContactChannels.type, type),
+          sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+        ),
+      )
+      .get();
     // Match by the (type,address) logical key, not the assistant channel id:
     // the gateway row can live under a different UUID (m0006 reconcile), and an
     // id-only update would re-parent nothing.
@@ -215,9 +232,102 @@ function reassignChannelContact(params: {
         ),
       )
       .run();
+    if (previousParent && previousParent.contactId !== toContactId) {
+      void deleteContactIfOrphaned(previousParent.contactId);
+    }
   } catch (gwErr) {
     log.warn({ err: gwErr }, "Gateway channel reassignment dual-write failed");
   }
+}
+
+/**
+ * Garbage-collect a contact stranded by a channel re-parent (LUM-2672).
+ *
+ * Inbound seeding (`upsertContactChannel` below) creates a stub contact for a
+ * first-seen sender keyed only by (type, address). When that sender later
+ * turns out to be the guardian (channel verification) or an invite target,
+ * the claim re-parents the channel to the real contact and the stub is left
+ * behind with zero channels — a duplicate the guardian sees in the Contacts
+ * pane.
+ *
+ * Deletion is deliberately narrow so a claim can never destroy real data:
+ * the contact must have role `contact`, no principal, and no remaining
+ * channels in the gateway DB (source of truth). The assistant mirror row is
+ * deleted best-effort and only when it, too, is channel-less and carries no
+ * guardian-authored notes.
+ *
+ * Never throws. Returns true when the gateway row was deleted.
+ */
+export async function deleteContactIfOrphaned(
+  contactId: string,
+): Promise<boolean> {
+  try {
+    const gwDb = getGatewayDb();
+    const contact = gwDb
+      .select({
+        role: gwContacts.role,
+        principalId: gwContacts.principalId,
+      })
+      .from(gwContacts)
+      .where(eq(gwContacts.id, contactId))
+      .get();
+    if (!contact || contact.role !== "contact" || contact.principalId) {
+      return false;
+    }
+    const remainingChannel = gwDb
+      .select({ id: gwContactChannels.id })
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.contactId, contactId))
+      .limit(1)
+      .get();
+    if (remainingChannel) return false;
+
+    gwDb.delete(gwContacts).where(eq(gwContacts.id, contactId)).run();
+    log.info(
+      { contactId },
+      "Deleted orphaned seed contact after channel re-parent",
+    );
+  } catch (gwErr) {
+    log.warn(
+      { err: gwErr, contactId },
+      "Orphaned contact garbage-collection failed (gateway)",
+    );
+    return false;
+  }
+
+  // Assistant mirror cleanup: best-effort, and skipped entirely when the IPC
+  // socket is unavailable (test environments) or the mirror still has
+  // channels or notes — a leftover mirror row is recoverable via the tolerant
+  // contact delete (LUM-2662), lost notes are not.
+  try {
+    const { path: socketPath } = resolveIpcSocketPath("assistant");
+    if (!existsSync(socketPath)) return true;
+
+    const mirrorChannels = await assistantDbQuery<{ id: string }>(
+      `SELECT id FROM contact_channels WHERE contact_id = ? LIMIT 1`,
+      [contactId],
+    );
+    if (mirrorChannels.length > 0) return true;
+    const mirrorNotes = await assistantDbQuery<{ notes: string | null }>(
+      `SELECT notes FROM contacts WHERE id = ?`,
+      [contactId],
+    );
+    if (mirrorNotes.length === 0) return true;
+    if (mirrorNotes[0].notes && mirrorNotes[0].notes.trim().length > 0) {
+      log.info(
+        { contactId },
+        "Keeping assistant-mirror contact with notes after gateway orphan delete",
+      );
+      return true;
+    }
+    await assistantDbRun(`DELETE FROM contacts WHERE id = ?`, [contactId]);
+  } catch (mirrorErr) {
+    log.warn(
+      { err: mirrorErr, contactId },
+      "Orphaned contact garbage-collection failed (assistant mirror)",
+    );
+  }
+  return true;
 }
 
 /**
@@ -225,7 +335,10 @@ function reassignChannelContact(params: {
  * (type, address) COLLATE NOCASE. The gateway is the source of truth; the
  * assistant mirror can lag behind a block/revoke landed gateway-side.
  */
-export function gatewayChannelStatus(type: string, address: string): string | null {
+export function gatewayChannelStatus(
+  type: string,
+  address: string,
+): string | null {
   const row = getGatewayDb()
     .select({ status: gwContactChannels.status })
     .from(gwContactChannels)


### PR DESCRIPTION
# Prompt / plan

Fixes the two guardian access-request bugs from the Jul 1 incident (v0.10.4): the duplicate "Ashlee Radka" contact and the Slack Approve/Reject card coming back after approval. Filed as [LUM-2672](https://linear.app/vellum/issue/LUM-2672) and [LUM-2673](https://linear.app/vellum/issue/LUM-2673) under LUM-2664; both root-caused in code before fixing. Neither was covered by #36835 (LUM-2665, merged — this branch is rebased on top of it and composes with its guardian-by-principal short-circuit) or #36810.

**LUM-2672 — orphaned duplicate contact.** Inbound Slack seeding (`gateway/src/index.ts` → `upsertContactChannel`) creates a stub contact keyed only by `(type, address)` for a first-seen sender. When that sender turns out to be the guardian, channel verification (`createGuardianBinding`) claims the seeded channel by `(type, address)` and re-parents it to the guardian contact — leaving the stub behind with zero channels, visible as a duplicate of the guardian in the Contacts pane. Fix: after the guardian-binding claim strips a previous parent of its last channel, `deleteContactIfOrphaned` garbage-collects it — but only when it is `role='contact'`, has no principal, and has no remaining channels in the gateway DB, and the assistant mirror agrees (no channels) and carries no guardian-authored data (notes, persona-file pointer, non-default contact type, or assistant-species metadata). Any failed check keeps BOTH rows so the two stores never disagree. The GC is deliberately scoped to `createGuardianBinding` only — the invite-path `reassignChannelContact` is left untouched, since an invite can legitimately claim a channel away from a guardian-curated contact and the caller's mirror re-parent completes after that function returns. Note: #36835 does not prevent this bug — at first contact there is no member row and no guardian channel carrying the Slack UID, and the seeded stub actively defeats its member-row arm (member row → `role='contact'` → guardian identity filter nulled).

**LUM-2673 — access-request re-fire ("card reverts" symptom).** `notifyGuardianOfAccessRequest` deduped only `pending` and `denied` requests. Once a request was **approved**, every subsequent inbound from the still-unverified sender (message, code attempt, button click) minted a fresh canonical request and re-delivered a brand-new Approve/Reject card right after the withdrawal edit showed "Approved". Three coordinated changes:
1. **Approval handshake window** (`isApprovalHandshakeInProgress`): re-creation is suppressed while the approval decision (`updatedAt` on the approved request) is within the verification-code TTL (`CHALLENGE_TTL_MS`, 10 min). Deliberately keyed on decision recency and NOT on live verification-session rows — a session lookup cannot distinguish the approval-minted session from the self-verify challenge session the ACL mints on the same inbound, or from unrelated sessions bound to the same identity. Voice is excluded (phone approvals activate directly, no code). The window check runs **after** the terminal-deny check so a standing deny always wins over an earlier approval. Once the window lapses unconsumed, re-prompting works again.
2. **Callback exemption**: interaction callbacks (`apr:` button presses, delete sentinels) are decision attempts, not access attempts. The ACL stage never responds to one by minting a verification challenge or creating an access request (`isCallbackInteraction` is a required param so future deny lanes must classify explicitly). Callback denies still probe the handshake window so a just-approved sender is never told they lack access.
3. **One reply composer** (`composeAccessDenialReply`): the handshake / guardian-notified / not-approved denial copy previously lived in three drifting copies across two files; all three deny lanes now share one composer, and the handshake copy tells the sender to ask the guardian for the code (the code is DM'd directly only on Slack).

# Test plan

- Gateway (`guardian-binding-channel-reuse.test.ts`, 9 tests): claiming a seeded channel GCs the orphan in both stores; previous parent with other channels kept; principal-bearing parent never deleted; mirror notes / persona-file pointer / assistant-species metadata each veto the delete in BOTH stores.
- Assistant (`non-member-access-request.test.ts`, 26 tests): suppression inside the approval handshake window (no signal, no new request, `approval_pending_verification` reason); re-prompt after the window lapses; terminal deny wins over an in-window approval.
- Assistant (`acl-enforcement.test.ts`, 23 tests): stranger/unverified-member callbacks denied with no access request and no challenge (telegram + slack); callback inside the handshake window gets next-step copy instead of a denial; control test pins that a stranger *message* still gets the challenge + access request.
- Adjacent suites green on the rebased branch (post-#36835): `guardian-routing-invariants` (72), `admission-policy` (12), `slack-inbound-verification` (7), `relay-server` (100), gateway `trust-verdict-resolver` (18), `upsert-verified-contact-channel` (33), `guardian-channel-create` (3), `guardian-bootstrap-lookups` (14).
- `bunx tsc --noEmit` clean in both `assistant/` and `gateway/`; repo pre-commit lint/typecheck gates pass.
- Adversarial self-review (8 independent finder angles + verification) ran before ready-for-review; its findings are fixed in the second commit (see commit message for the list). Codex's review finding (mirror veto covered only notes) is fixed in the third commit.
- Not exercised end-to-end against a live Slack workspace; the incident flow (guardian first-contact → approve → verify) is covered by the unit/integration layers above.

# Interaction with in-flight work

- **#36835 / LUM-2665 (merged):** disjoint layers — that PR fixes guardian *recognition*; this one fixes what the stranger lane leaves behind. LUM-2672's stub actively defeats #36835's member-row arm, so this improves it.
- **LUM-2670 (introduction card, not started):** will eventually supersede the handshake *copy* for the no-code "Trust" outcome; the orphan GC, deny-wins precedence, and callback exemption are flow-agnostic invariants that persist under it. "Verify with code" keeps this exact window.
- **Combo 12 (invites gateway-native):** no overlap — the GC is scoped away from the invite re-parent path.

# CLI verb checklist

No new routes added — changes are confined to the gateway contact claim path and existing inbound pipeline stages.

---

Closes LUM-2672, LUM-2673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrH5cwuyVdNvoy1cuVHMvi