### PR TITLE
feat(assistant): carve A2A invites into a dedicated a2a_invites table

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
@@ -38,7 +38,7 @@ await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();
-  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM a2a_invites");
   sqlite.run("DELETE FROM assistant_contact_metadata");
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -26,17 +26,29 @@ import {
 } from "../../../contacts/contact-store.js";
 import { getSqlite } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
-import { findById } from "../../../persistence/invite-store.js";
 import { completeA2AInvite, createA2AInvite } from "../config-a2a.js";
 
 await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();
-  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM a2a_invites");
   sqlite.run("DELETE FROM assistant_contact_metadata");
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
+}
+
+interface A2aInviteRow {
+  id: string;
+  contact_id: string;
+  status: string;
+  use_count: number;
+}
+
+function getInviteRow(id: string): A2aInviteRow | null {
+  return getSqlite()
+    .prepare("SELECT * FROM a2a_invites WHERE id = ?")
+    .get(id) as A2aInviteRow | null;
 }
 
 function setConfig(opts: {
@@ -92,10 +104,10 @@ describe("completeA2AInvite", () => {
     expect(result.error).toBeUndefined();
 
     // Verify the placeholder contact was promoted
-    const invite = findById(created.inviteId!);
+    const invite = getInviteRow(created.inviteId!);
     expect(invite).not.toBeNull();
 
-    const contact = getContact(invite!.contactId);
+    const contact = getContact(invite!.contact_id);
     expect(contact).not.toBeNull();
     expect(contact!.displayName).toBe("Acceptor Bot");
     expect(contact!.channels).toHaveLength(1);
@@ -116,8 +128,8 @@ describe("completeA2AInvite", () => {
     });
     expect(result.success).toBe(true);
 
-    const invite = findById(created.inviteId!);
-    const contact = getContact(invite!.contactId);
+    const invite = getInviteRow(created.inviteId!);
+    const contact = getContact(invite!.contact_id);
     expect(contact!.channels[0]!.address).toBe("upper-case-id-123");
   });
 
@@ -130,8 +142,8 @@ describe("completeA2AInvite", () => {
     });
     expect(result.success).toBe(true);
 
-    const invite = findById(created.inviteId!);
-    const metadata = getAssistantContactMetadata(invite!.contactId);
+    const invite = getInviteRow(created.inviteId!);
+    const metadata = getAssistantContactMetadata(invite!.contact_id);
     expect(metadata).not.toBeNull();
     expect(metadata!.species).toBe("vellum");
     expect(metadata!.metadata).toEqual({
@@ -159,10 +171,10 @@ describe("completeA2AInvite", () => {
     // The invite was just created with 0 hours expiry, so expiresAt ~= now
     // Manually expire it by updating the DB
     const sqlite = getSqlite();
-    sqlite.run(
-      "UPDATE assistant_ingress_invites SET expires_at = ? WHERE id = ?",
-      [Date.now() - 1000, created.inviteId!],
-    );
+    sqlite.run("UPDATE a2a_invites SET expires_at = ? WHERE id = ?", [
+      Date.now() - 1000,
+      created.inviteId!,
+    ]);
 
     const result = completeA2AInvite({
       token: created.token!,
@@ -238,8 +250,8 @@ describe("completeA2AInvite", () => {
     expect(result.error).toContain("public base URL");
 
     // Verify the invite was NOT consumed
-    const invite = findById(created.inviteId!);
+    const invite = getInviteRow(created.inviteId!);
     expect(invite!.status).toBe("active");
-    expect(invite!.useCount).toBe(0);
+    expect(invite!.use_count).toBe(0);
   });
 });

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
@@ -23,17 +23,31 @@ import {
 import { getContact } from "../../../contacts/contact-store.js";
 import { getSqlite } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
-import { findById } from "../../../persistence/invite-store.js";
 import { createA2AInvite, getA2AConfig } from "../config-a2a.js";
 
 await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();
-  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM a2a_invites");
   sqlite.run("DELETE FROM assistant_contact_metadata");
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
+}
+
+interface A2aInviteRow {
+  id: string;
+  contact_id: string;
+  status: string;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+}
+
+function getInviteRow(id: string): A2aInviteRow | null {
+  return getSqlite()
+    .prepare("SELECT * FROM a2a_invites WHERE id = ?")
+    .get(id) as A2aInviteRow | null;
 }
 
 function setConfig(opts: {
@@ -75,15 +89,14 @@ describe("createA2AInvite", () => {
     expect(result.error).toBeUndefined();
   });
 
-  test("creates invite in DB with source_channel=a2a, status=active, max_uses=1", () => {
+  test("creates invite in a2a_invites with status=active, max_uses=1", () => {
     const result = createA2AInvite({});
     expect(result.inviteId).toBeDefined();
 
-    const invite = findById(result.inviteId!);
+    const invite = getInviteRow(result.inviteId!);
     expect(invite).not.toBeNull();
-    expect(invite!.sourceChannel).toBe("a2a");
     expect(invite!.status).toBe("active");
-    expect(invite!.maxUses).toBe(1);
+    expect(invite!.max_uses).toBe(1);
   });
 
   test("auto-enables A2A if not already on", () => {
@@ -101,10 +114,10 @@ describe("createA2AInvite", () => {
     const result = createA2AInvite({});
     expect(result.inviteId).toBeDefined();
 
-    const invite = findById(result.inviteId!);
+    const invite = getInviteRow(result.inviteId!);
     expect(invite).not.toBeNull();
 
-    const contact = getContact(invite!.contactId);
+    const contact = getContact(invite!.contact_id);
     expect(contact).not.toBeNull();
     expect(contact!.displayName).toBe("Pending A2A invite");
     expect(contact!.channels).toHaveLength(0);
@@ -128,13 +141,13 @@ describe("createA2AInvite", () => {
     const after = Date.now();
     expect(result.success).toBe(true);
 
-    const invite = findById(result.inviteId!);
+    const invite = getInviteRow(result.inviteId!);
     expect(invite).not.toBeNull();
 
     const expectedMinMs = before + 24 * 60 * 60 * 1000;
     const expectedMaxMs = after + 24 * 60 * 60 * 1000;
-    expect(invite!.expiresAt).toBeGreaterThanOrEqual(expectedMinMs);
-    expect(invite!.expiresAt).toBeLessThanOrEqual(expectedMaxMs);
+    expect(invite!.expires_at).toBeGreaterThanOrEqual(expectedMinMs);
+    expect(invite!.expires_at).toBeLessThanOrEqual(expectedMaxMs);
   });
 
   test("default expiry is 72 hours", () => {
@@ -143,12 +156,12 @@ describe("createA2AInvite", () => {
     const after = Date.now();
     expect(result.success).toBe(true);
 
-    const invite = findById(result.inviteId!);
+    const invite = getInviteRow(result.inviteId!);
     expect(invite).not.toBeNull();
 
     const expectedMinMs = before + 72 * 60 * 60 * 1000;
     const expectedMaxMs = after + 72 * 60 * 60 * 1000;
-    expect(invite!.expiresAt).toBeGreaterThanOrEqual(expectedMinMs);
-    expect(invite!.expiresAt).toBeLessThanOrEqual(expectedMaxMs);
+    expect(invite!.expires_at).toBeGreaterThanOrEqual(expectedMinMs);
+    expect(invite!.expires_at).toBeLessThanOrEqual(expectedMaxMs);
   });
 });

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -26,12 +26,11 @@ import {
 } from "../../contacts/contact-store.js";
 import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
-import { getDb } from "../../persistence/db-connection.js";
 import {
-  claimA2AInvite,
-  createInvite,
-  hashToken,
-} from "../../persistence/invite-store.js";
+  claimA2aInvite,
+  createA2aInvite,
+} from "../../persistence/a2a-invite-store.js";
+import { getDb } from "../../persistence/db-connection.js";
 import { assistantContactMetadata } from "../../persistence/schema/index.js";
 import type { HttpErrorResponse } from "../../runtime/http-errors.js";
 import { getLogger } from "../../util/logger.js";
@@ -157,8 +156,7 @@ export function createA2AInvite(params: {
 
   // 4. Create the invite
   const expiresInMs = (params.expiresInHours ?? 72) * 60 * 60 * 1000;
-  const { invite, rawToken } = createInvite({
-    sourceChannel: "a2a",
+  const { invite, rawToken } = createA2aInvite({
     contactId: contact.id,
     maxUses: 1,
     expiresInMs,
@@ -197,9 +195,8 @@ export function completeA2AInvite(params: {
     };
   }
 
-  const tokenHash = hashToken(params.token);
-  const claimResult = claimA2AInvite({
-    tokenHash,
+  const claimResult = claimA2aInvite({
+    token: params.token,
     redeemedByExternalUserId: params.acceptor.assistantId,
   });
 

--- a/assistant/src/persistence/a2a-invite-store.ts
+++ b/assistant/src/persistence/a2a-invite-store.ts
@@ -1,0 +1,210 @@
+/**
+ * Store for daemon-local A2A invites.
+ *
+ * A2A invites bind a placeholder assistant contact to a shareable token used
+ * for link-based peer-assistant connection. Each invite carries a SHA-256
+ * hashed token — the raw token is returned exactly once at creation time and
+ * never stored.
+ */
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+
+import { getDb } from "./db-connection.js";
+import { a2aInvites } from "./schema/a2a.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type A2aInviteStatus = "active" | "redeemed" | "revoked" | "expired";
+
+export interface A2aInvite {
+  id: string;
+  tokenHash: string;
+  contactId: string;
+  maxUses: number;
+  useCount: number;
+  expiresAt: number;
+  status: A2aInviteStatus;
+  redeemedByExternalUserId: string | null;
+  redeemedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hashToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+function generateToken(): string {
+  // 32 bytes = 256 bits of entropy, base64url-encoded to a 43-character URL-safe string.
+  return randomBytes(32).toString("base64url");
+}
+
+function rowToInvite(row: typeof a2aInvites.$inferSelect): A2aInvite {
+  return { ...row, status: row.status as A2aInviteStatus };
+}
+
+function findByTokenHash(tokenHash: string): A2aInvite | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(a2aInvites)
+    .where(eq(a2aInvites.tokenHash, tokenHash))
+    .get();
+  return row ? rowToInvite(row) : null;
+}
+
+/**
+ * Transition an invite's status to 'expired' in storage. Safe to call even if
+ * the invite is already expired — the WHERE clause scopes the update to
+ * 'active' rows so it becomes a no-op in that case.
+ */
+function markExpired(inviteId: string): void {
+  const db = getDb();
+  db.update(a2aInvites)
+    .set({ status: "expired", updatedAt: Date.now() })
+    .where(and(eq(a2aInvites.id, inviteId), eq(a2aInvites.status, "active")))
+    .run();
+}
+
+/**
+ * Increment an invite's use count and record redemption metadata. Returns
+ * `true` if the use was recorded, or `false` if the invite was concurrently
+ * revoked/expired (the WHERE clause constrains to `status = 'active'` so a
+ * stale write is impossible).
+ */
+function recordUse(params: {
+  inviteId: string;
+  redeemedByExternalUserId: string;
+}): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  const invite = db
+    .select()
+    .from(a2aInvites)
+    .where(eq(a2aInvites.id, params.inviteId))
+    .get();
+
+  if (!invite) {
+    return false;
+  }
+
+  const newUseCount = invite.useCount + 1;
+  const newStatus = newUseCount >= invite.maxUses ? "redeemed" : "active";
+
+  db.update(a2aInvites)
+    .set({
+      useCount: newUseCount,
+      status: newStatus,
+      redeemedByExternalUserId: params.redeemedByExternalUserId,
+      redeemedAt: now,
+      updatedAt: now,
+    })
+    .where(and(eq(a2aInvites.id, invite.id), eq(a2aInvites.status, "active")))
+    .run();
+
+  // Re-read to confirm the update took effect (the WHERE clause constrains
+  // to status = 'active', so a concurrent revoke/expire would prevent it).
+  const updated = db
+    .select({ useCount: a2aInvites.useCount })
+    .from(a2aInvites)
+    .where(eq(a2aInvites.id, invite.id))
+    .get();
+
+  return !!updated && updated.useCount === newUseCount;
+}
+
+// ---------------------------------------------------------------------------
+// createA2aInvite
+// ---------------------------------------------------------------------------
+
+export function createA2aInvite(params: {
+  contactId: string;
+  maxUses?: number;
+  expiresInMs?: number;
+}): { invite: A2aInvite; rawToken: string } {
+  const db = getDb();
+  const now = Date.now();
+  const rawToken = generateToken();
+
+  const row = {
+    id: randomUUID(),
+    tokenHash: hashToken(rawToken),
+    contactId: params.contactId,
+    maxUses: params.maxUses ?? 1,
+    useCount: 0,
+    expiresAt: now + (params.expiresInMs ?? DEFAULT_EXPIRY_MS),
+    status: "active" as const,
+    redeemedByExternalUserId: null,
+    redeemedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(a2aInvites).values(row).run();
+
+  return { invite: rowToInvite(row), rawToken };
+}
+
+// ---------------------------------------------------------------------------
+// claimA2aInvite — validate + consume an A2A invite token
+// ---------------------------------------------------------------------------
+
+export function claimA2aInvite(params: {
+  token: string;
+  redeemedByExternalUserId: string;
+}): { claimed: boolean; invite: A2aInvite | null; error?: string } {
+  const tokenHash = hashToken(params.token);
+  const invite = findByTokenHash(tokenHash);
+
+  if (!invite) {
+    return { claimed: false, invite: null, error: "not_found" };
+  }
+
+  // Idempotency: if already redeemed by the same acceptor, return success
+  if (invite.status === "redeemed") {
+    if (invite.redeemedByExternalUserId === params.redeemedByExternalUserId) {
+      return { claimed: true, invite };
+    }
+    return { claimed: false, invite, error: "already_redeemed_by_other" };
+  }
+
+  if (invite.status !== "active") {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  if (Date.now() >= invite.expiresAt) {
+    markExpired(invite.id);
+    return { claimed: false, invite, error: "expired" };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { claimed: false, invite, error: "already_redeemed" };
+  }
+
+  const recorded = recordUse({
+    inviteId: invite.id,
+    redeemedByExternalUserId: params.redeemedByExternalUserId,
+  });
+
+  if (!recorded) {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  // Re-read to get updated state
+  return { claimed: true, invite: findByTokenHash(tokenHash) };
+}

--- a/assistant/src/persistence/invite-store.ts
+++ b/assistant/src/persistence/invite-store.ts
@@ -364,59 +364,6 @@ export function findActiveVoiceInvites(params: {
 }
 
 // ---------------------------------------------------------------------------
-// claimA2AInvite — validate + consume an A2A invite token
-// ---------------------------------------------------------------------------
-
-export function claimA2AInvite(params: {
-  tokenHash: string;
-  redeemedByExternalUserId: string;
-}): { claimed: boolean; invite: IngressInvite | null; error?: string } {
-  const invite = findByTokenHash(params.tokenHash);
-
-  if (!invite) {
-    return { claimed: false, invite: null, error: "not_found" };
-  }
-
-  if (invite.sourceChannel !== "a2a") {
-    return { claimed: false, invite, error: "wrong_channel" };
-  }
-
-  // Idempotency: if already redeemed by the same acceptor, return success
-  if (invite.status === "redeemed") {
-    if (invite.redeemedByExternalUserId === params.redeemedByExternalUserId) {
-      return { claimed: true, invite };
-    }
-    return { claimed: false, invite, error: "already_redeemed_by_other" };
-  }
-
-  if (invite.status !== "active") {
-    return { claimed: false, invite, error: "not_found" };
-  }
-
-  if (Date.now() >= invite.expiresAt) {
-    markInviteExpired(invite.id);
-    return { claimed: false, invite, error: "expired" };
-  }
-
-  if (invite.useCount >= invite.maxUses) {
-    return { claimed: false, invite, error: "already_redeemed" };
-  }
-
-  const recorded = recordInviteUse({
-    inviteId: invite.id,
-    externalUserId: params.redeemedByExternalUserId,
-  });
-
-  if (!recorded) {
-    return { claimed: false, invite, error: "not_found" };
-  }
-
-  // Re-read to get updated state
-  const updated = findByTokenHash(params.tokenHash);
-  return { claimed: true, invite: updated };
-}
-
-// ---------------------------------------------------------------------------
 // findByInviteCodeHash
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/persistence/migrations/313-create-a2a-invites.ts
+++ b/assistant/src/persistence/migrations/313-create-a2a-invites.ts
@@ -1,0 +1,58 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Creates the `a2a_invites` table: daemon-local store for A2A invite tokens.
+ *
+ * A2A invites are peer-assistant bindings outside the human-trust ACL model,
+ * so they live in the assistant DB rather than the gateway's `ingress_invites`
+ * table. The table carries exactly the columns the A2A flow uses.
+ *
+ * Existing A2A rows are copied from `assistant_ingress_invites` (guarded on
+ * the source table's existence) so in-flight invites survive. Source rows are
+ * left in place — that table is dropped wholesale by a later migration.
+ *
+ * Idempotent: `IF NOT EXISTS` table creation and `INSERT OR IGNORE` copy.
+ */
+export function migrateCreateA2aInvitesTable(db: DrizzleDb): void {
+  const raw = getSqliteFrom(db);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS a2a_invites (
+      id                           TEXT PRIMARY KEY,
+      token_hash                   TEXT NOT NULL,
+      contact_id                   TEXT NOT NULL,
+      max_uses                     INTEGER NOT NULL DEFAULT 1,
+      use_count                    INTEGER NOT NULL DEFAULT 0,
+      expires_at                   INTEGER NOT NULL,
+      status                       TEXT NOT NULL DEFAULT 'active',
+      redeemed_by_external_user_id TEXT,
+      redeemed_at                  INTEGER,
+      created_at                   INTEGER NOT NULL,
+      updated_at                   INTEGER NOT NULL
+    )
+  `);
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_a2a_invites_token_hash ON a2a_invites(token_hash)`,
+  );
+
+  const sourceExists = raw
+    .prepare(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_ingress_invites'`,
+    )
+    .get();
+  if (!sourceExists) {
+    return;
+  }
+
+  raw.exec(/*sql*/ `
+    INSERT OR IGNORE INTO a2a_invites (
+      id, token_hash, contact_id, max_uses, use_count, expires_at, status,
+      redeemed_by_external_user_id, redeemed_at, created_at, updated_at
+    )
+    SELECT
+      id, token_hash, contact_id, max_uses, use_count, expires_at, status,
+      redeemed_by_external_user_id, redeemed_at, created_at, updated_at
+    FROM assistant_ingress_invites
+    WHERE source_channel = 'a2a'
+  `);
+}

--- a/assistant/src/persistence/migrations/__tests__/313-create-a2a-invites.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/313-create-a2a-invites.test.ts
@@ -1,0 +1,161 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import { migrateCreateA2aInvitesTable } from "../313-create-a2a-invites.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  return drizzle(sqlite, { schema });
+}
+
+function createSourceTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE assistant_ingress_invites (
+      id TEXT PRIMARY KEY,
+      source_channel TEXT NOT NULL,
+      token_hash TEXT NOT NULL,
+      source_conversation_id TEXT,
+      note TEXT,
+      max_uses INTEGER NOT NULL DEFAULT 1,
+      use_count INTEGER NOT NULL DEFAULT 0,
+      expires_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      redeemed_by_external_user_id TEXT,
+      redeemed_by_external_chat_id TEXT,
+      redeemed_at INTEGER,
+      expected_external_user_id TEXT,
+      voice_code_hash TEXT,
+      voice_code_digits INTEGER,
+      invite_code_hash TEXT,
+      friend_name TEXT,
+      guardian_name TEXT,
+      contact_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function seedInvite(
+  raw: Database,
+  opts: {
+    id: string;
+    sourceChannel: string;
+    status?: string;
+    useCount?: number;
+    redeemedBy?: string | null;
+    redeemedAt?: number | null;
+  },
+): void {
+  raw.run(
+    `INSERT INTO assistant_ingress_invites
+       (id, source_channel, token_hash, max_uses, use_count, expires_at,
+        status, redeemed_by_external_user_id, redeemed_at, contact_id,
+        created_at, updated_at)
+     VALUES (?, ?, ?, 1, ?, 9999999999999, ?, ?, ?, ?, 1000, 1000)`,
+    [
+      opts.id,
+      opts.sourceChannel,
+      `hash-${opts.id}`,
+      opts.useCount ?? 0,
+      opts.status ?? "active",
+      opts.redeemedBy ?? null,
+      opts.redeemedAt ?? null,
+      `contact-${opts.id}`,
+    ],
+  );
+}
+
+interface A2aInviteRow {
+  id: string;
+  token_hash: string;
+  contact_id: string;
+  max_uses: number;
+  use_count: number;
+  status: string;
+  redeemed_by_external_user_id: string | null;
+  redeemed_at: number | null;
+}
+
+function listA2aInvites(raw: Database): A2aInviteRow[] {
+  return raw
+    .prepare(`SELECT * FROM a2a_invites ORDER BY id`)
+    .all() as A2aInviteRow[];
+}
+
+describe("migration 313 — create a2a_invites", () => {
+  test("creates the table and copies only a2a rows from assistant_ingress_invites", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    createSourceTable(raw);
+    seedInvite(raw, { id: "inv-a2a-1", sourceChannel: "a2a" });
+    seedInvite(raw, {
+      id: "inv-a2a-2",
+      sourceChannel: "a2a",
+      status: "redeemed",
+      useCount: 1,
+      redeemedBy: "acceptor-1",
+      redeemedAt: 2000,
+    });
+    seedInvite(raw, { id: "inv-telegram", sourceChannel: "telegram" });
+    seedInvite(raw, { id: "inv-phone", sourceChannel: "phone" });
+
+    migrateCreateA2aInvitesTable(db);
+
+    const copied = listA2aInvites(raw);
+    expect(copied.map((r) => r.id)).toEqual(["inv-a2a-1", "inv-a2a-2"]);
+    expect(copied[0]).toMatchObject({
+      token_hash: "hash-inv-a2a-1",
+      contact_id: "contact-inv-a2a-1",
+      max_uses: 1,
+      use_count: 0,
+      status: "active",
+      redeemed_by_external_user_id: null,
+      redeemed_at: null,
+    });
+    expect(copied[1]).toMatchObject({
+      status: "redeemed",
+      use_count: 1,
+      redeemed_by_external_user_id: "acceptor-1",
+      redeemed_at: 2000,
+    });
+
+    // Source rows are left untouched — the table drops wholesale later.
+    const sourceCount = raw
+      .prepare(`SELECT COUNT(*) AS n FROM assistant_ingress_invites`)
+      .get() as { n: number };
+    expect(sourceCount.n).toBe(4);
+  });
+
+  test("is idempotent — re-running does not duplicate or clobber rows", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    createSourceTable(raw);
+    seedInvite(raw, { id: "inv-a2a-1", sourceChannel: "a2a" });
+
+    migrateCreateA2aInvitesTable(db);
+
+    // Mutate the copied row so a re-run's INSERT OR IGNORE must not clobber it.
+    raw.run(`UPDATE a2a_invites SET status = 'redeemed', use_count = 1`);
+
+    migrateCreateA2aInvitesTable(db);
+
+    const rows = listA2aInvites(raw);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("redeemed");
+    expect(rows[0]!.use_count).toBe(1);
+  });
+
+  test("creates an empty table when assistant_ingress_invites does not exist", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    expect(() => migrateCreateA2aInvitesTable(db)).not.toThrow();
+    expect(listA2aInvites(raw)).toHaveLength(0);
+  });
+});

--- a/assistant/src/persistence/schema/a2a.ts
+++ b/assistant/src/persistence/schema/a2a.ts
@@ -1,5 +1,19 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
+export const a2aInvites = sqliteTable("a2a_invites", {
+  id: text("id").primaryKey(),
+  tokenHash: text("token_hash").notNull(),
+  contactId: text("contact_id").notNull(),
+  maxUses: integer("max_uses").notNull().default(1),
+  useCount: integer("use_count").notNull().default(0),
+  expiresAt: integer("expires_at").notNull(),
+  status: text("status").notNull().default("active"),
+  redeemedByExternalUserId: text("redeemed_by_external_user_id"),
+  redeemedAt: integer("redeemed_at"),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 export const a2aTasks = sqliteTable("a2a_tasks", {
   id: text("id").primaryKey(),
   contextId: text("context_id"),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -420,6 +420,7 @@ import { migrateDropRedundantIndexes } from "./migrations/309-drop-redundant-ind
 import { migrateLlmRequestLogLatencyBreakdown } from "./migrations/310-llm-request-log-latency-breakdown.js";
 import { migrateCreateSubagentsTable } from "./migrations/311-create-subagents-table.js";
 import { migrateDropInboxConversationStateTable } from "./migrations/312-drop-inbox-conversation-state-table.js";
+import { migrateCreateA2aInvitesTable } from "./migrations/313-create-a2a-invites.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1311,4 +1312,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateLlmRequestLogLatencyBreakdown,
   migrateCreateSubagentsTable,
   migrateDropInboxConversationStateTable,
+  migrateCreateA2aInvitesTable,
 ];


### PR DESCRIPTION
## Summary
- New daemon-local a2a_invites table + migration copying existing a2a rows from assistant_ingress_invites
- New a2a-invite-store with exactly the A2A dependency surface (create + claim)
- config-a2a.ts switched off invite-store; claimA2AInvite removed from invite-store

Part of plan: invites-gateway-native.md (PR 11 of 12)