### PR TITLE
feat(gateway): widen ingress_invites with secrets + display fields, add resolution store methods

### DIFF
--- a/gateway/src/__tests__/contact-store-invites.test.ts
+++ b/gateway/src/__tests__/contact-store-invites.test.ts
@@ -291,4 +291,239 @@ describe("ContactStore ingress_invites", () => {
     expect(redeem.updated).toBe(false);
     expect(redeem.row).toBeNull();
   });
+
+  test("createInvite round-trips the widened secret + display columns", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+
+    const row = store.createInvite({
+      id: "inv1",
+      sourceChannel: "phone",
+      contactId: "c1",
+      expiresAt: 9999,
+      tokenHash: "tok-hash",
+      voiceCodeHash: "voice-hash",
+      voiceCodeDigits: 6,
+      expectedExternalUserId: "+15551234567",
+      friendName: "Ada",
+      guardianName: "Grace",
+      sourceConversationId: "conv-42",
+    });
+
+    // No-code invites persist the NO_INVITE_CODE_HASH sentinel (see schema.ts).
+    expect(row.inviteCodeHash).toBe("");
+    expect(row.tokenHash).toBe("tok-hash");
+    expect(row.voiceCodeHash).toBe("voice-hash");
+    expect(row.voiceCodeDigits).toBe(6);
+    expect(row.expectedExternalUserId).toBe("+15551234567");
+    expect(row.friendName).toBe("Ada");
+    expect(row.guardianName).toBe("Grace");
+    expect(row.sourceConversationId).toBe("conv-42");
+
+    // Persisted, not just echoed.
+    expect(store.getInviteById("inv1")).toEqual(row);
+  });
+
+  test("createInvite defaults the widened columns to null", () => {
+    seedContact("c1");
+    const row = new ContactStore().createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    expect(row.tokenHash).toBeNull();
+    expect(row.voiceCodeHash).toBeNull();
+    expect(row.voiceCodeDigits).toBeNull();
+    expect(row.expectedExternalUserId).toBeNull();
+    expect(row.friendName).toBeNull();
+    expect(row.guardianName).toBeNull();
+    expect(row.sourceConversationId).toBeNull();
+  });
+
+  test("findInviteByTokenHash matches regardless of status and returns null for unknown hash", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      contactId: "c1",
+      expiresAt: 9999,
+      tokenHash: "tok-1",
+    });
+
+    expect(store.findInviteByTokenHash("tok-1")?.id).toBe("inv1");
+    expect(store.findInviteByTokenHash("nope")).toBeNull();
+
+    // Non-active rows are still findable (callers inspect status themselves).
+    store.revokeInvite("inv1");
+    expect(store.findInviteByTokenHash("tok-1")?.status).toBe("revoked");
+  });
+
+  test("findInviteByCodeHash is channel-scoped and active-only", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv-sms",
+      sourceChannel: "sms",
+      inviteCodeHash: "code-1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    store.createInvite({
+      id: "inv-tg",
+      sourceChannel: "telegram",
+      inviteCodeHash: "code-1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+
+    // Same code hash on two channels → the channel scope disambiguates.
+    expect(store.findInviteByCodeHash("code-1", "sms")?.id).toBe("inv-sms");
+    expect(store.findInviteByCodeHash("code-1", "telegram")?.id).toBe("inv-tg");
+    expect(store.findInviteByCodeHash("code-1", "vellum")).toBeNull();
+
+    // Active-only: a revoked invite no longer matches.
+    store.revokeInvite("inv-sms");
+    expect(store.findInviteByCodeHash("code-1", "sms")).toBeNull();
+  });
+
+  test("code-hash lookups never match the no-code sentinel row", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    // A voice invite persists inviteCodeHash="" (NO_INVITE_CODE_HASH).
+    store.createInvite({
+      id: "inv-voice",
+      sourceChannel: "phone",
+      contactId: "c1",
+      expiresAt: Date.now() + 60_000,
+      voiceCodeHash: "v1",
+      expectedExternalUserId: "+15550001111",
+    });
+
+    expect(store.findInviteByCodeHash("", "phone")).toBeNull();
+    expect(store.findInviteByCodeHashAnyChannel("")).toBeNull();
+  });
+
+  test("findInviteByCodeHashAnyChannel ignores channel but requires active + not-expired", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "telegram",
+      inviteCodeHash: "code-1",
+      contactId: "c1",
+      expiresAt: Date.now() + 60_000,
+    });
+    store.createInvite({
+      id: "inv-expired",
+      sourceChannel: "sms",
+      inviteCodeHash: "code-old",
+      contactId: "c1",
+      expiresAt: Date.now() - 1,
+    });
+
+    // Cross-channel hit (the channel-mismatch messaging path).
+    expect(store.findInviteByCodeHashAnyChannel("code-1")?.id).toBe("inv1");
+
+    // Past-expiry rows don't match even while still status=active.
+    expect(store.findInviteByCodeHashAnyChannel("code-old")).toBeNull();
+
+    // Non-active rows don't match.
+    store.revokeInvite("inv1");
+    expect(store.findInviteByCodeHashAnyChannel("code-1")).toBeNull();
+  });
+
+  test("findActiveVoiceInvites lists active phone invites for the expected caller only", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv-voice-1",
+      sourceChannel: "phone",
+      contactId: "c1",
+      expiresAt: 9999,
+      voiceCodeHash: "v1",
+      expectedExternalUserId: "+15550001111",
+    });
+    store.createInvite({
+      id: "inv-voice-2",
+      sourceChannel: "phone",
+      contactId: "c1",
+      expiresAt: 9999,
+      voiceCodeHash: "v2",
+      expectedExternalUserId: "+15550001111",
+    });
+    // Different caller — excluded.
+    store.createInvite({
+      id: "inv-voice-other",
+      sourceChannel: "phone",
+      contactId: "c1",
+      expiresAt: 9999,
+      voiceCodeHash: "v3",
+      expectedExternalUserId: "+15559998888",
+    });
+    // Non-phone channel with the same expected user — excluded.
+    store.createInvite({
+      id: "inv-sms",
+      sourceChannel: "sms",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+      expectedExternalUserId: "+15550001111",
+    });
+
+    const found = store.findActiveVoiceInvites("+15550001111");
+    expect(found.map((r) => r.id).sort()).toEqual([
+      "inv-voice-1",
+      "inv-voice-2",
+    ]);
+
+    // Non-active rows drop out.
+    store.revokeInvite("inv-voice-1");
+    expect(store.findActiveVoiceInvites("+15550001111").map((r) => r.id)).toEqual(
+      ["inv-voice-2"],
+    );
+  });
+
+  test("markInviteExpired flips active → expired once and gates redemption", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+
+    expect(store.markInviteExpired("inv1")).toBe(true);
+    expect(store.getInviteById("inv1")?.status).toBe("expired");
+
+    // No-op on non-active rows and unknown ids.
+    expect(store.markInviteExpired("inv1")).toBe(false);
+    expect(store.markInviteExpired("nope")).toBe(false);
+
+    // recordInviteRedemption still gates on status='active'.
+    const redeem = store.recordInviteRedemption({ inviteId: "inv1" });
+    expect(redeem.updated).toBe(false);
+    expect(redeem.row!.status).toBe("expired");
+    expect(redeem.row!.useCount).toBe(0);
+  });
+
+  test("markInviteExpired does not flip a revoked invite", () => {
+    seedContact("c1");
+    const store = new ContactStore();
+    store.createInvite({
+      id: "inv1",
+      sourceChannel: "vellum",
+      inviteCodeHash: "h1",
+      contactId: "c1",
+      expiresAt: 9999,
+    });
+    store.revokeInvite("inv1");
+
+    expect(store.markInviteExpired("inv1")).toBe(false);
+    expect(store.getInviteById("inv1")?.status).toBe("revoked");
+  });
 });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1,6 +1,6 @@
 import { type Database } from "bun:sqlite";
 
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, desc, eq, gt, ne, sql } from "drizzle-orm";
 
 import {
   type AssistantContactMetadata,
@@ -34,6 +34,15 @@ export const GUARDIAN_BINDING_REVOKE_REASON = "guardian_binding_revoked";
 export type Contact = typeof contacts.$inferSelect;
 export type ContactChannel = typeof contactChannels.$inferSelect;
 export type IngressInviteRow = typeof ingressInvites.$inferSelect;
+
+/**
+ * Sentinel stored in `invite_code_hash` for invites without a 6-digit code
+ * (e.g. voice invites, which carry `voice_code_hash` instead). The column
+ * stays NOT NULL because relaxing it forces a drizzle-push table rebuild that
+ * corrupts existing DBs (see the schema.ts comment); m0009 owns normalization.
+ * Never matches a real lookup — real code hashes are SHA-256 hex.
+ */
+export const NO_INVITE_CODE_HASH = "";
 
 export class ContactStore {
   private injectedDb?: GatewayDb;
@@ -803,11 +812,18 @@ export class ContactStore {
   createInvite(params: {
     id: string;
     sourceChannel: string;
-    inviteCodeHash: string;
+    inviteCodeHash?: string | null;
     contactId: string;
     note?: string | null;
     maxUses?: number;
     expiresAt: number;
+    tokenHash?: string | null;
+    voiceCodeHash?: string | null;
+    voiceCodeDigits?: number | null;
+    expectedExternalUserId?: string | null;
+    friendName?: string | null;
+    guardianName?: string | null;
+    sourceConversationId?: string | null;
   }): IngressInviteRow {
     const now = Date.now();
     return this.db
@@ -815,7 +831,14 @@ export class ContactStore {
       .values({
         id: params.id,
         sourceChannel: params.sourceChannel,
-        inviteCodeHash: params.inviteCodeHash,
+        inviteCodeHash: params.inviteCodeHash ?? NO_INVITE_CODE_HASH,
+        tokenHash: params.tokenHash ?? null,
+        voiceCodeHash: params.voiceCodeHash ?? null,
+        voiceCodeDigits: params.voiceCodeDigits ?? null,
+        expectedExternalUserId: params.expectedExternalUserId ?? null,
+        friendName: params.friendName ?? null,
+        guardianName: params.guardianName ?? null,
+        sourceConversationId: params.sourceConversationId ?? null,
         note: params.note ?? null,
         maxUses: params.maxUses ?? 1,
         useCount: 0,
@@ -898,6 +921,111 @@ export class ContactStore {
         .where(eq(ingressInvites.id, inviteId))
         .get() ?? null
     );
+  }
+
+  /**
+   * Find an invite by its link-token hash, regardless of status. Token hashes
+   * are 256-bit and globally unique, so no channel scoping is needed; callers
+   * inspect status/expiry themselves to produce precise error messaging.
+   */
+  findInviteByTokenHash(tokenHash: string): IngressInviteRow | null {
+    return (
+      this.db
+        .select()
+        .from(ingressInvites)
+        .where(eq(ingressInvites.tokenHash, tokenHash))
+        .get() ?? null
+    );
+  }
+
+  /**
+   * Find an active invite by its 6-digit invite code hash, scoped to a
+   * specific source channel. Channel scoping is required because 6-digit
+   * codes are drawn from a small keyspace and can collide across channels —
+   * without it, `.get()` could return an arbitrary match, leading to
+   * nondeterministic redemption or false channel-mismatch failures.
+   */
+  findInviteByCodeHash(
+    codeHash: string,
+    sourceChannel: string,
+  ): IngressInviteRow | null {
+    if (codeHash === NO_INVITE_CODE_HASH) return null;
+    return (
+      this.db
+        .select()
+        .from(ingressInvites)
+        .where(
+          and(
+            eq(ingressInvites.inviteCodeHash, codeHash),
+            eq(ingressInvites.sourceChannel, sourceChannel),
+            eq(ingressInvites.status, "active"),
+          ),
+        )
+        .get() ?? null
+    );
+  }
+
+  /**
+   * Find an active, not-yet-expired invite by its 6-digit invite code hash
+   * without channel scoping. Used as a fallback after a channel-scoped lookup
+   * fails, to distinguish "code doesn't exist" from "code exists but for a
+   * different channel" — the latter should produce channel-mismatch messaging
+   * instead of silently falling through.
+   */
+  findInviteByCodeHashAnyChannel(codeHash: string): IngressInviteRow | null {
+    if (codeHash === NO_INVITE_CODE_HASH) return null;
+    return (
+      this.db
+        .select()
+        .from(ingressInvites)
+        .where(
+          and(
+            eq(ingressInvites.inviteCodeHash, codeHash),
+            eq(ingressInvites.status, "active"),
+            gt(ingressInvites.expiresAt, Date.now()),
+          ),
+        )
+        .get() ?? null
+    );
+  }
+
+  /**
+   * Find all active voice invites bound to a specific caller identity.
+   * Used by the voice invite redemption flow to locate candidate invites
+   * before code hash matching.
+   */
+  findActiveVoiceInvites(expectedExternalUserId: string): IngressInviteRow[] {
+    return this.db
+      .select()
+      .from(ingressInvites)
+      .where(
+        and(
+          eq(ingressInvites.sourceChannel, "phone"),
+          eq(ingressInvites.status, "active"),
+          eq(ingressInvites.expectedExternalUserId, expectedExternalUserId),
+        ),
+      )
+      .all();
+  }
+
+  /**
+   * Transition an invite's status to 'expired'. Safe to call on an already
+   * expired/revoked/redeemed invite — the WHERE clause scopes the update to
+   * 'active' rows so it becomes a no-op (returns false) in that case.
+   */
+  markInviteExpired(inviteId: string): boolean {
+    const updated = this.db
+      .update(ingressInvites)
+      .set({ status: "expired", updatedAt: Date.now() })
+      .where(
+        and(
+          eq(ingressInvites.id, inviteId),
+          eq(ingressInvites.status, "active"),
+        ),
+      )
+      .returning({ id: ingressInvites.id })
+      .all();
+    return updated.length > 0;
   }
 
   // ---------------------------------------------------------------------------

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -175,7 +175,25 @@ export const ingressInvites = sqliteTable(
   {
     id: text("id").primaryKey(),
     sourceChannel: text("source_channel").notNull(),
+    // Logically nullable (voice invites carry voiceCodeHash instead), but the
+    // NOT NULL constraint must stay: relaxing it (or adding a default) makes
+    // drizzle push rebuild the table, and pushSQLiteSchema's generated rebuild
+    // corrupts existing DBs (INSERT..SELECT references not-yet-existent
+    // columns, duplicated CREATE INDEX statements crash startup). The store
+    // writes the "" sentinel for invites without a code (see
+    // NO_INVITE_CODE_HASH in contact-store.ts); m0009 owns normalization.
     inviteCodeHash: text("invite_code_hash").notNull(),
+    // SHA-256 hash of the one-time invite link token (null for voice invites).
+    tokenHash: text("token_hash"),
+    // Voice invite fields (null for non-voice invites).
+    voiceCodeHash: text("voice_code_hash"),
+    voiceCodeDigits: integer("voice_code_digits"),
+    expectedExternalUserId: text("expected_external_user_id"),
+    // Display metadata for personalized invite prompts.
+    friendName: text("friend_name"),
+    guardianName: text("guardian_name"),
+    // Opaque passthrough — the gateway never interprets it.
+    sourceConversationId: text("source_conversation_id"),
     note: text("note"),
     maxUses: integer("max_uses").notNull().default(1),
     useCount: integer("use_count").notNull().default(0),
@@ -196,6 +214,11 @@ export const ingressInvites = sqliteTable(
       table.sourceChannel,
     ),
     index("idx_ingress_invites_contact").on(table.contactId),
+    index("idx_ingress_invites_token_hash").on(table.tokenHash),
+    index("idx_ingress_invites_expected_user").on(
+      table.expectedExternalUserId,
+      table.status,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Adds nullable secret/display columns (token_hash, voice_code_hash, voice_code_digits, expected_external_user_id, friend_name, guardian_name, source_conversation_id) to gateway ingress_invites, plus token-hash and expected-user indexes
- invite_code_hash stays NOT NULL with a "" sentinel (NO_INVITE_CODE_HASH) for no-code invites: relaxing NOT NULL (or adding a default) makes drizzle push rebuild the table, and pushSQLiteSchema's generated rebuild corrupts existing DBs (INSERT..SELECT references not-yet-existent columns via SQLite's double-quoted-string fallback, and duplicated CREATE INDEX statements crash startup). Verified empirically against an old-shape DB; m0009 (PR 3) owns normalization
- Adds gateway ContactStore resolution methods mirroring the assistant invite-store semantics (findInviteByTokenHash, findInviteByCodeHash, findInviteByCodeHashAnyChannel, findActiveVoiceInvites, markInviteExpired)

Part of plan: invites-gateway-native.md (PR 1 of 12)