### PR TITLE
feat(gateway-client): shared invite hash helpers, channel gating, redemption-outcome + invite IPC contracts

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -6,6 +6,8 @@
  * to compile until a policy is added below.
  */
 
+import { isInviteCodeRedemptionEnabled as sharedIsInviteCodeRedemptionEnabled } from "@vellumai/gateway-client";
+
 import type { ChannelId } from "./types.js";
 
 export type ConversationStrategy =
@@ -24,7 +26,6 @@ export interface ChannelNotificationPolicy {
     deliveryEnabled: boolean;
     conversationStrategy: ConversationStrategy;
   };
-  invite: ChannelInvitePolicy;
 }
 
 const CHANNEL_POLICIES = {
@@ -33,17 +34,11 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: true,
       conversationStrategy: "start_new_conversation",
     },
-    invite: {
-      codeRedemptionEnabled: false,
-    },
   },
   telegram: {
     notification: {
       deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
-    },
-    invite: {
-      codeRedemptionEnabled: true,
     },
   },
   whatsapp: {
@@ -51,26 +46,17 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
     },
-    invite: {
-      codeRedemptionEnabled: true,
-    },
   },
   slack: {
     notification: {
       deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
     },
-    invite: {
-      codeRedemptionEnabled: true,
-    },
   },
   email: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
-    },
-    invite: {
-      codeRedemptionEnabled: true,
     },
   },
   platform: {
@@ -81,26 +67,17 @@ const CHANNEL_POLICIES = {
       // the channel is non-deliverable (which not_deliverable would).
       conversationStrategy: "push_only",
     },
-    invite: {
-      codeRedemptionEnabled: false,
-    },
   },
   phone: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "not_deliverable",
     },
-    invite: {
-      codeRedemptionEnabled: false,
-    },
   },
   a2a: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
-    },
-    invite: {
-      codeRedemptionEnabled: false,
     },
   },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
@@ -138,14 +115,20 @@ export function getConversationStrategy(
   return CHANNEL_POLICIES[channelId].notification.conversationStrategy;
 }
 
-/** Returns the invite policy for the given channel. */
+/**
+ * Returns the invite policy for the given channel. Delegates to the shared
+ * @vellumai/gateway-client allowlist so gateway and daemon share one source
+ * of truth.
+ */
 export function getChannelInvitePolicy(
   channelId: ChannelId,
 ): ChannelInvitePolicy {
-  return CHANNEL_POLICIES[channelId].invite;
+  return {
+    codeRedemptionEnabled: sharedIsInviteCodeRedemptionEnabled(channelId),
+  };
 }
 
 /** Whether invite code redemption is enabled for the given channel. */
 export function isInviteCodeRedemptionEnabled(channelId: ChannelId): boolean {
-  return CHANNEL_POLICIES[channelId].invite.codeRedemptionEnabled;
+  return sharedIsInviteCodeRedemptionEnabled(channelId);
 }

--- a/assistant/src/persistence/invite-store.ts
+++ b/assistant/src/persistence/invite-store.ts
@@ -6,8 +6,9 @@
  * token is returned exactly once at creation time and never stored.
  */
 
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
+import { generateInviteToken, hashInviteToken } from "@vellumai/gateway-client";
 import { and, desc, eq, gt } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
@@ -57,14 +58,10 @@ const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // Helpers
 // ---------------------------------------------------------------------------
 
-export function hashToken(rawToken: string): string {
-  return createHash("sha256").update(rawToken).digest("hex");
-}
-
-function generateToken(): string {
-  // 32 bytes = 256 bits of entropy, base64url-encoded to a 43-character URL-safe string.
-  return randomBytes(32).toString("base64url");
-}
+// Thin alias over the shared @vellumai/gateway-client invite contract so
+// gateway-computed hashes stay byte-for-byte compatible with daemon-minted
+// ones.
+export const hashToken = hashInviteToken;
 
 function rowToInvite(
   row: typeof assistantIngressInvites.$inferSelect,
@@ -117,7 +114,7 @@ export function createInvite(params: {
   const db = getDb();
   const now = Date.now();
   const id = randomUUID();
-  const rawToken = generateToken();
+  const rawToken = generateInviteToken();
   const tokenH = hashToken(rawToken);
 
   const row = {

--- a/assistant/src/util/voice-code.ts
+++ b/assistant/src/util/voice-code.ts
@@ -4,28 +4,13 @@
  * Generates short numeric codes (default 6 digits) for voice-channel invite
  * redemption. The plaintext code is returned once at creation time and never
  * stored — only its SHA-256 hash is persisted.
+ *
+ * Thin aliases over the shared @vellumai/gateway-client invite contract so
+ * gateway-computed hashes stay byte-for-byte compatible with daemon-minted
+ * ones.
  */
 
-import { createHash, randomInt } from "node:crypto";
-
-/**
- * Generate a cryptographically random numeric code of the given length.
- * Uses node:crypto randomInt for uniform distribution.
- */
-export function generateVoiceCode(digits: number = 6): string {
-  if (digits < 4 || digits > 10) {
-    throw new Error(
-      `Voice code digit count must be between 4 and 10, got ${digits}`,
-    );
-  }
-  const min = Math.pow(10, digits - 1); // e.g. 100000 for 6 digits
-  const max = Math.pow(10, digits); // e.g. 1000000 for 6 digits
-  return String(randomInt(min, max));
-}
-
-/**
- * SHA-256 hash a voice code for storage comparison.
- */
-export function hashVoiceCode(code: string): string {
-  return createHash("sha256").update(code).digest("hex");
-}
+export {
+  generateInviteCode as generateVoiceCode,
+  hashInviteCode as hashVoiceCode,
+} from "@vellumai/gateway-client";

--- a/packages/gateway-client/src/__tests__/invite-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/invite-contract.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the shared invite contract.
+ *
+ * The pinned hash vectors below were computed with the ORIGINAL daemon
+ * implementations (`assistant/src/persistence/invite-store.ts` `hashToken`
+ * and `assistant/src/util/voice-code.ts` `hashVoiceCode`) before they were
+ * repointed here. They prove the shared helpers stay byte-for-byte
+ * compatible with hashes already stored in assistant/gateway DBs — do not
+ * update them to "fix" a failure; a mismatch means the hash scheme broke.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ActiveVoiceInviteSchema,
+  generateInviteCode,
+  generateInviteToken,
+  GetActiveVoiceInviteRequestSchema,
+  hashInviteCode,
+  hashInviteToken,
+  INVITE_CODE_REDEMPTION_CHANNELS,
+  InviteRedeemedNotificationSchema,
+  InviteRedemptionOutcomeSchema,
+  isInviteCodeRedemptionEnabled,
+  RedeemInviteByCodeRequestSchema,
+  RedeemInviteByTokenRequestSchema,
+  RedeemVoiceInviteRequestSchema,
+  type InviteRedemptionOutcome,
+} from "../invite-contract.js";
+
+describe("hash helpers — pinned vectors from the original daemon implementations", () => {
+  test("hashInviteToken matches invite-store.ts hashToken output", () => {
+    expect(hashInviteToken("test-raw-token")).toBe(
+      "7ef58e99b3406554f5ce0c0055b8ed3ea4db2c8a36613092d644c57c6a033330",
+    );
+    expect(hashInviteToken("AbC123_-xyz")).toBe(
+      "860c47c13bb8d13decd6815b20be7de8cf11597e4b704af58b00048e90a5a337",
+    );
+  });
+
+  test("hashInviteCode matches voice-code.ts hashVoiceCode output", () => {
+    expect(hashInviteCode("123456")).toBe(
+      "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92",
+    );
+    expect(hashInviteCode("0000")).toBe(
+      "9af15b336e6a9619928537df30b2e6a2376569fcf9d7e773eccede65606529a0",
+    );
+    expect(hashInviteCode("987654321")).toBe(
+      "8a9bcf1e51e812d0af8465a8dbcc9f741064bf0af3b3d08e6b0246437c19f7fb",
+    );
+  });
+});
+
+describe("generateInviteToken", () => {
+  test("produces a 43-character base64url token", () => {
+    const token = generateInviteToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  test("produces unique tokens", () => {
+    expect(generateInviteToken()).not.toBe(generateInviteToken());
+  });
+});
+
+describe("generateInviteCode", () => {
+  test("defaults to 6 digits with no leading zero", () => {
+    const code = generateInviteCode();
+    expect(code).toMatch(/^[1-9]\d{5}$/);
+  });
+
+  test("honors the digit count at both bounds", () => {
+    expect(generateInviteCode(4)).toMatch(/^[1-9]\d{3}$/);
+    expect(generateInviteCode(10)).toMatch(/^[1-9]\d{9}$/);
+  });
+
+  test("rejects out-of-range digit counts", () => {
+    expect(() => generateInviteCode(3)).toThrow();
+    expect(() => generateInviteCode(11)).toThrow();
+  });
+});
+
+describe("invite-code channel gating", () => {
+  test("allows exactly the redemption-enabled channels", () => {
+    expect([...INVITE_CODE_REDEMPTION_CHANNELS].sort()).toEqual([
+      "email",
+      "slack",
+      "telegram",
+      "whatsapp",
+    ]);
+  });
+
+  test("isInviteCodeRedemptionEnabled matches the allowlist", () => {
+    for (const channel of ["telegram", "whatsapp", "slack", "email"]) {
+      expect(isInviteCodeRedemptionEnabled(channel)).toBe(true);
+    }
+    for (const channel of ["vellum", "platform", "phone", "a2a", "nope"]) {
+      expect(isInviteCodeRedemptionEnabled(channel)).toBe(false);
+    }
+  });
+});
+
+const fullOutcome: InviteRedemptionOutcome = {
+  inviteId: "inv-1",
+  contactId: "c-1",
+  sourceChannel: "telegram",
+  memberExternalUserId: "tg-user-1",
+  memberExternalChatId: "tg-chat-1",
+  displayName: "Member Name",
+  username: "member",
+  sourceConversationId: "conv-1",
+  result: "redeemed",
+};
+
+describe("InviteRedemptionOutcomeSchema", () => {
+  test("round-trips a fully-populated outcome", () => {
+    expect(InviteRedemptionOutcomeSchema.parse(fullOutcome)).toEqual(
+      fullOutcome,
+    );
+  });
+
+  test("parses a minimal outcome", () => {
+    const minimal = {
+      inviteId: "inv-1",
+      contactId: "c-1",
+      sourceChannel: "slack",
+      memberExternalUserId: "U123",
+      result: "already_member",
+    } satisfies InviteRedemptionOutcome;
+    expect(InviteRedemptionOutcomeSchema.parse(minimal)).toEqual(minimal);
+  });
+
+  test("rejects an invalid result", () => {
+    expect(() =>
+      InviteRedemptionOutcomeSchema.parse({
+        ...fullOutcome,
+        result: "definitely_not_a_result",
+      }),
+    ).toThrow();
+  });
+
+  test("InviteRedeemedNotificationSchema carries the outcome verbatim", () => {
+    expect(InviteRedeemedNotificationSchema.parse(fullOutcome)).toEqual(
+      fullOutcome,
+    );
+  });
+});
+
+describe("invite IPC request schemas", () => {
+  test("RedeemInviteByCodeRequestSchema round-trips full and minimal requests", () => {
+    const full = {
+      code: "123456",
+      sourceChannel: "telegram",
+      externalUserId: "tg-user-1",
+      externalChatId: "tg-chat-1",
+      displayName: "Member Name",
+      username: "member",
+    };
+    expect(RedeemInviteByCodeRequestSchema.parse(full)).toEqual(full);
+    const minimal = { code: "123456", sourceChannel: "email" };
+    expect(RedeemInviteByCodeRequestSchema.parse(minimal)).toEqual(minimal);
+    expect(() =>
+      RedeemInviteByCodeRequestSchema.parse({ code: "", sourceChannel: "" }),
+    ).toThrow();
+  });
+
+  test("RedeemInviteByTokenRequestSchema round-trips full and minimal requests", () => {
+    const full = {
+      rawToken: "raw-token",
+      sourceChannel: "slack",
+      externalUserId: "U123",
+      externalChatId: "D456",
+      displayName: "Member Name",
+      username: "member",
+    };
+    expect(RedeemInviteByTokenRequestSchema.parse(full)).toEqual(full);
+    const minimal = { rawToken: "raw-token", sourceChannel: "slack" };
+    expect(RedeemInviteByTokenRequestSchema.parse(minimal)).toEqual(minimal);
+    expect(() =>
+      RedeemInviteByTokenRequestSchema.parse({ sourceChannel: "slack" }),
+    ).toThrow();
+  });
+
+  test("RedeemVoiceInviteRequestSchema requires caller and code", () => {
+    const request = { callerExternalUserId: "+15555550100", code: "123456" };
+    expect(RedeemVoiceInviteRequestSchema.parse(request)).toEqual(request);
+    expect(() =>
+      RedeemVoiceInviteRequestSchema.parse({ callerExternalUserId: "+1555" }),
+    ).toThrow();
+  });
+
+  test("GetActiveVoiceInviteRequestSchema requires the caller", () => {
+    const request = { callerExternalUserId: "+15555550100" };
+    expect(GetActiveVoiceInviteRequestSchema.parse(request)).toEqual(request);
+    expect(() => GetActiveVoiceInviteRequestSchema.parse({})).toThrow();
+  });
+});
+
+describe("ActiveVoiceInviteSchema", () => {
+  test("round-trips populated and null display fields", () => {
+    const populated = {
+      inviteId: "inv-1",
+      inviteeName: "Friend",
+      guardianName: "Guardian",
+      codeDigits: 6,
+    };
+    expect(ActiveVoiceInviteSchema.parse(populated)).toEqual(populated);
+    const anonymous = {
+      inviteId: "inv-2",
+      inviteeName: null,
+      guardianName: null,
+      codeDigits: 6,
+    };
+    expect(ActiveVoiceInviteSchema.parse(anonymous)).toEqual(anonymous);
+  });
+
+  test("rejects a non-integer codeDigits", () => {
+    expect(() =>
+      ActiveVoiceInviteSchema.parse({
+        inviteId: "inv-1",
+        inviteeName: null,
+        guardianName: null,
+        codeDigits: 6.5,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/gateway-client/src/__tests__/invite-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/invite-contract.test.ts
@@ -1,12 +1,11 @@
 /**
  * Tests for the shared invite contract.
  *
- * The pinned hash vectors below were computed with the ORIGINAL daemon
- * implementations (`assistant/src/persistence/invite-store.ts` `hashToken`
- * and `assistant/src/util/voice-code.ts` `hashVoiceCode`) before they were
- * repointed here. They prove the shared helpers stay byte-for-byte
- * compatible with hashes already stored in assistant/gateway DBs — do not
- * update them to "fix" a failure; a mismatch means the hash scheme broke.
+ * The pinned hash vectors below define the hash compatibility contract:
+ * `hashInviteToken` and `hashInviteCode` must produce exactly these outputs
+ * because invite hashes already stored in the assistant and gateway DBs were
+ * produced with them. Do not update the vectors to "fix" a failure — a
+ * mismatch means the hash scheme broke.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -28,7 +27,7 @@ import {
   type InviteRedemptionOutcome,
 } from "../invite-contract.js";
 
-describe("hash helpers — pinned vectors from the original daemon implementations", () => {
+describe("hash helpers — pinned compatibility vectors", () => {
   test("hashInviteToken matches invite-store.ts hashToken output", () => {
     expect(hashInviteToken("test-raw-token")).toBe(
       "7ef58e99b3406554f5ce0c0055b8ed3ea4db2c8a36613092d644c57c6a033330",

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -91,6 +91,36 @@ export type {
   TrustVerdict,
 } from "./trust-verdict-contract.js";
 
+// Invite contract (shared gateway ↔ daemon) — hash/generate helpers,
+// channel gating, redemption outcome + invite IPC schemas
+export {
+  ActiveVoiceInviteSchema,
+  generateInviteCode,
+  generateInviteToken,
+  GetActiveVoiceInviteRequestSchema,
+  hashInviteCode,
+  hashInviteToken,
+  INVITE_CODE_REDEMPTION_CHANNELS,
+  INVITE_REDEMPTION_RESULT_VALUES,
+  InviteRedeemedNotificationSchema,
+  InviteRedemptionOutcomeSchema,
+  isInviteCodeRedemptionEnabled,
+  RedeemInviteByCodeRequestSchema,
+  RedeemInviteByTokenRequestSchema,
+  RedeemVoiceInviteRequestSchema,
+} from "./invite-contract.js";
+
+export type {
+  ActiveVoiceInvite,
+  GetActiveVoiceInviteRequest,
+  InviteRedeemedNotification,
+  InviteRedemptionOutcome,
+  InviteRedemptionResult,
+  RedeemInviteByCodeRequest,
+  RedeemInviteByTokenRequest,
+  RedeemVoiceInviteRequest,
+} from "./invite-contract.js";
+
 // Guardian delivery contract (daemon → gateway pull) — Zod schemas + derived types
 export {
   GuardianDeliverySchema,

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared invite contracts for the gateway-native invite lifecycle.
+ *
+ * Hash + generation helpers live here so gateway-computed hashes match
+ * assistant-minted (and backfilled) hashes byte-for-byte — hash compatibility
+ * with rows already stored in both DBs is load-bearing, so do not change the
+ * scheme. The channel-gating allowlist and the redemption-outcome / invite
+ * IPC schemas are shared so gateway and daemon converge on one source of
+ * truth instead of drifting copies.
+ */
+
+import { createHash, randomBytes, randomInt } from "node:crypto";
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Hash + generation helpers
+// ---------------------------------------------------------------------------
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * SHA-256 hash an invite token for storage comparison. Ported verbatim from
+ * the assistant's `invite-store.ts` `hashToken`.
+ */
+export function hashInviteToken(rawToken: string): string {
+  return sha256Hex(rawToken);
+}
+
+/**
+ * SHA-256 hash a numeric invite/voice code for storage comparison. Ported
+ * verbatim from the assistant's `voice-code.ts` `hashVoiceCode`.
+ */
+export function hashInviteCode(code: string): string {
+  return sha256Hex(code);
+}
+
+/**
+ * Generate a raw invite token: 32 bytes = 256 bits of entropy,
+ * base64url-encoded to a 43-character URL-safe string.
+ */
+export function generateInviteToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Generate a cryptographically random numeric code of the given length.
+ * Uses node:crypto randomInt for uniform distribution. Ported verbatim from
+ * the assistant's `voice-code.ts` `generateVoiceCode`.
+ */
+export function generateInviteCode(digits: number = 6): string {
+  if (digits < 4 || digits > 10) {
+    throw new Error(
+      `Voice code digit count must be between 4 and 10, got ${digits}`,
+    );
+  }
+  const min = Math.pow(10, digits - 1); // e.g. 100000 for 6 digits
+  const max = Math.pow(10, digits); // e.g. 1000000 for 6 digits
+  return String(randomInt(min, max));
+}
+
+// ---------------------------------------------------------------------------
+// Channel gating
+// ---------------------------------------------------------------------------
+
+/**
+ * Channels where inbound invite-code redemption is supported. Mirrors the
+ * `invite.codeRedemptionEnabled` flags in the assistant's channel policy
+ * registry (`assistant/src/channels/config.ts`), which delegates here so
+ * gateway and daemon share one allowlist.
+ */
+export const INVITE_CODE_REDEMPTION_CHANNELS: ReadonlySet<string> = new Set([
+  "telegram",
+  "whatsapp",
+  "slack",
+  "email",
+]);
+
+/** Whether invite code redemption is enabled for the given channel. */
+export function isInviteCodeRedemptionEnabled(channelType: string): boolean {
+  return INVITE_CODE_REDEMPTION_CHANNELS.has(channelType);
+}
+
+// ---------------------------------------------------------------------------
+// Redemption outcome
+// ---------------------------------------------------------------------------
+
+export const INVITE_REDEMPTION_RESULT_VALUES = [
+  "redeemed",
+  "already_member",
+] as const;
+
+export type InviteRedemptionResult =
+  (typeof INVITE_REDEMPTION_RESULT_VALUES)[number];
+
+/**
+ * Result of a successful invite redemption resolved by the gateway. Carries
+ * the identity fields the daemon needs to mirror the activation locally
+ * (`already_member` = the sender was already an active member, so no invite
+ * use was consumed).
+ */
+export const InviteRedemptionOutcomeSchema = z.object({
+  inviteId: z.string(),
+  contactId: z.string(),
+  sourceChannel: z.string(),
+  memberExternalUserId: z.string(),
+  memberExternalChatId: z.string().optional(),
+  displayName: z.string().optional(),
+  username: z.string().optional(),
+  // Opaque passthrough — the gateway stores but never interprets it.
+  sourceConversationId: z.string().optional(),
+  result: z.enum(INVITE_REDEMPTION_RESULT_VALUES),
+});
+
+export type InviteRedemptionOutcome = z.infer<
+  typeof InviteRedemptionOutcomeSchema
+>;
+
+// ---------------------------------------------------------------------------
+// IPC schemas
+// ---------------------------------------------------------------------------
+
+/** IPC request for `redeem_invite_by_code` (6-digit invite code). */
+export const RedeemInviteByCodeRequestSchema = z.object({
+  code: z.string().min(1),
+  sourceChannel: z.string().min(1),
+  externalUserId: z.string().optional(),
+  externalChatId: z.string().optional(),
+  displayName: z.string().optional(),
+  username: z.string().optional(),
+});
+
+export type RedeemInviteByCodeRequest = z.infer<
+  typeof RedeemInviteByCodeRequestSchema
+>;
+
+/** IPC request for `redeem_invite_by_token` (raw link token). */
+export const RedeemInviteByTokenRequestSchema = z.object({
+  rawToken: z.string().min(1),
+  sourceChannel: z.string().min(1),
+  externalUserId: z.string().optional(),
+  externalChatId: z.string().optional(),
+  displayName: z.string().optional(),
+  username: z.string().optional(),
+});
+
+export type RedeemInviteByTokenRequest = z.infer<
+  typeof RedeemInviteByTokenRequestSchema
+>;
+
+/** IPC request for `redeem_voice_invite` (voice-channel spoken code). */
+export const RedeemVoiceInviteRequestSchema = z.object({
+  callerExternalUserId: z.string().min(1),
+  code: z.string().min(1),
+});
+
+export type RedeemVoiceInviteRequest = z.infer<
+  typeof RedeemVoiceInviteRequestSchema
+>;
+
+/** IPC request for `get_active_voice_invite`. */
+export const GetActiveVoiceInviteRequestSchema = z.object({
+  callerExternalUserId: z.string().min(1),
+});
+
+export type GetActiveVoiceInviteRequest = z.infer<
+  typeof GetActiveVoiceInviteRequestSchema
+>;
+
+/**
+ * Active voice invite awaiting the expected caller — display metadata for
+ * the personalized voice prompt; never carries the code or its hash.
+ */
+export const ActiveVoiceInviteSchema = z.object({
+  inviteId: z.string(),
+  inviteeName: z.string().nullable(),
+  guardianName: z.string().nullable(),
+  codeDigits: z.number().int(),
+});
+
+export type ActiveVoiceInvite = z.infer<typeof ActiveVoiceInviteSchema>;
+
+/**
+ * Daemon-bound `invite_redeemed` info-mirror event, fired best-effort by the
+ * gateway after a successful redemption so the daemon can mirror the member
+ * activation locally. Payload is the redemption outcome verbatim.
+ */
+export const InviteRedeemedNotificationSchema = InviteRedemptionOutcomeSchema;
+
+export type InviteRedeemedNotification = z.infer<
+  typeof InviteRedeemedNotificationSchema
+>;

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -121,8 +121,20 @@ export type InviteRedemptionOutcome = z.infer<
 // ---------------------------------------------------------------------------
 // IPC schemas
 // ---------------------------------------------------------------------------
+//
+// The schemas below define the gateway-native invite redemption IPC surface.
+// Schema-to-method mapping:
+//
+// - `RedeemInviteByCodeRequestSchema` / `RedeemInviteByTokenRequestSchema` —
+//   request shapes for the gateway redemption engine (code and link-token
+//   redemption).
+// - `RedeemVoiceInviteRequestSchema` — gateway IPC `redeem_voice_invite`.
+// - `GetActiveVoiceInviteRequestSchema` — gateway IPC
+//   `get_active_voice_invite`.
+// - `InviteRedeemedNotificationSchema` — daemon IPC `invite_redeemed`
+//   notification.
 
-/** IPC request for `redeem_invite_by_code` (6-digit invite code). */
+/** Gateway redemption-engine request for code redemption (6-digit code). */
 export const RedeemInviteByCodeRequestSchema = z.object({
   code: z.string().min(1),
   sourceChannel: z.string().min(1),
@@ -136,7 +148,7 @@ export type RedeemInviteByCodeRequest = z.infer<
   typeof RedeemInviteByCodeRequestSchema
 >;
 
-/** IPC request for `redeem_invite_by_token` (raw link token). */
+/** Gateway redemption-engine request for token redemption (raw link token). */
 export const RedeemInviteByTokenRequestSchema = z.object({
   rawToken: z.string().min(1),
   sourceChannel: z.string().min(1),
@@ -150,7 +162,7 @@ export type RedeemInviteByTokenRequest = z.infer<
   typeof RedeemInviteByTokenRequestSchema
 >;
 
-/** IPC request for `redeem_voice_invite` (voice-channel spoken code). */
+/** Request for gateway IPC `redeem_voice_invite` (voice-channel spoken code). */
 export const RedeemVoiceInviteRequestSchema = z.object({
   callerExternalUserId: z.string().min(1),
   code: z.string().min(1),
@@ -160,7 +172,7 @@ export type RedeemVoiceInviteRequest = z.infer<
   typeof RedeemVoiceInviteRequestSchema
 >;
 
-/** IPC request for `get_active_voice_invite`. */
+/** Request for gateway IPC `get_active_voice_invite`. */
 export const GetActiveVoiceInviteRequestSchema = z.object({
   callerExternalUserId: z.string().min(1),
 });

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -22,16 +22,16 @@ function sha256Hex(input: string): string {
 }
 
 /**
- * SHA-256 hash an invite token for storage comparison. Ported verbatim from
- * the assistant's `invite-store.ts` `hashToken`.
+ * SHA-256 hash an invite token for storage comparison. Must remain stable:
+ * stored invite rows hold hashes produced by this function.
  */
 export function hashInviteToken(rawToken: string): string {
   return sha256Hex(rawToken);
 }
 
 /**
- * SHA-256 hash a numeric invite/voice code for storage comparison. Ported
- * verbatim from the assistant's `voice-code.ts` `hashVoiceCode`.
+ * SHA-256 hash a numeric invite/voice code for storage comparison. Must
+ * remain stable: stored invite rows hold hashes produced by this function.
  */
 export function hashInviteCode(code: string): string {
   return sha256Hex(code);
@@ -47,8 +47,7 @@ export function generateInviteToken(): string {
 
 /**
  * Generate a cryptographically random numeric code of the given length.
- * Uses node:crypto randomInt for uniform distribution. Ported verbatim from
- * the assistant's `voice-code.ts` `generateVoiceCode`.
+ * Uses node:crypto randomInt for uniform distribution.
  */
 export function generateInviteCode(digits: number = 6): string {
   if (digits < 4 || digits > 10) {


### PR DESCRIPTION
## Summary
- Adds packages/gateway-client invite-contract.ts: shared token/code hash+generate helpers (pinned-vector compatible), shared invite-code channel gating, redemption-outcome + invite IPC zod schemas
- Repoints assistant hashToken/hashVoiceCode/generateVoiceCode to the shared implementations as thin aliases (no behavior change)

Part of plan: invites-gateway-native.md (PR 2 of 12)