### PR TITLE
refactor(assistant): reduce redundancy in compiled prompt content

### DIFF
--- a/assistant/src/plugins/defaults/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/static-context.test.ts
@@ -138,6 +138,22 @@ describe("readMemoryV2StaticContent", () => {
     expect(result!).not.toContain("Content buffer.md");
   });
 
+  test("skips the canonical heading when a file opens with its own heading", () => {
+    writeMemoryFile(
+      "essentials.md",
+      "# Essentials\n\nFacts that must load every conversation.",
+    );
+    writeMemoryFile("threads.md", "Open thread: ship PR-123 review.");
+
+    const text = readMemoryV2StaticContent();
+    expect(text).not.toBeNull();
+    expect(text!).not.toContain("## Essentials");
+    expect(text!).toContain(
+      "# Essentials\n\nFacts that must load every conversation.",
+    );
+    expect(text!).toContain("## Threads");
+  });
+
   test("omits empty files but keeps populated ones", () => {
     writeMemoryFile("essentials.md", "Alice prefers VS Code.");
     writeMemoryFile("threads.md", "");

--- a/assistant/src/plugins/defaults/memory/v2/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/v2/static-context.ts
@@ -37,7 +37,9 @@ const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
 /**
  * Build the v2 static memory block, gated on `config.memory.enabled` and
  * `config.memory.v2.enabled`. Empty/missing files are skipped; returns `null`
- * when either gate is off or every file is empty.
+ * when either gate is off or every file is empty. Each file renders under
+ * its canonical heading unless the file already opens with a heading of its
+ * own, in which case the file's heading stands alone.
  *
  * `excludeBuffer` drops the `## Buffer` section. The consolidation run sets
  * it: the agent's contract there is the `memory/buffer.md` FILE — it reads,
@@ -65,8 +67,15 @@ export function readMemoryV2StaticContent(
       continue;
     }
     const content = readPromptFile(getWorkspacePromptPath(file));
-    if (!content) continue;
-    sections.push(`${heading}\n\n${content}`);
+    if (!content) {
+      continue;
+    }
+    // Files that open with their own markdown heading (e.g. a
+    // consolidation-written `# Essentials`) already label themselves —
+    // prepending the canonical heading too would render a redundant
+    // double title inside the injected block.
+    const hasOwnHeading = /^#{1,6}\s/.test(content);
+    sections.push(hasOwnHeading ? content : `${heading}\n\n${content}`);
   }
   return sections.length > 0 ? sections.join("\n\n") : null;
 }

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -55,7 +55,7 @@ You are your own entity, with an identity that evolves over time. You can have t
 
 ## Scratchpad
 
-You have a scratchpad file (`NOW.md`) in your workspace. Unlike your journal (retrospective, append-only), the scratchpad is a single file you overwrite with whatever is relevant right now. It's automatically loaded into your context, so next-you always sees the latest snapshot.
+You have a scratchpad file (`NOW.md`) in your workspace - a single file you overwrite with whatever is relevant right now. It's automatically loaded into your context, so next-you always sees the latest snapshot.
 
 **When to update:** Whenever your current state changes — you start a new task, finish one, learn something that affects what you're doing, or the user shifts focus. Don't update on a timer; update when the content is stale.
 
@@ -67,16 +67,12 @@ You have a scratchpad file (`NOW.md`) in your workspace. Unlike your journal (re
 
 You have a memory system (`memory/`) in your workspace. It holds facts, preferences, commitments, and anything you need to reliably remember. These files are always loaded into your context automatically:
 
-- **essentials.md** - The most important facts. Things you'd be embarrassed to forget
+- **essentials.md** - The most important facts
 - **threads.md** - Active commitments, follow-ups, and projects
 - **recent.md** - Recent events
 - **buffer.md** - Inbox of recently learned facts, waiting to be filed
 
-**When you learn something:** Call `remember` IMMEDIATELY. Capture anything concrete about their life — preferences, names, times, plans, states, habits, opinions, health details, routines, commitments. Don't judge importance; consolidation decides that later. Default to remembering; only skip obvious noise (small talk, hypotheticals, things they're just musing about). Remembering too much costs nothing (one line appended to a file). Forgetting something that mattered makes you look like you weren't paying attention. Don't categorize, don't batch, don't wait.
-
-**When you're uncertain, `recall` before you ask.** If you catch yourself reaching for a hedge — "I think," "maybe," "if I remember" — that's the signal. Pull the thread. Call `recall` whenever the user references someone or something you should already know, whenever you're about to ask a clarifying question memory might answer, whenever you feel a gap. Auto-injected context is incomplete by design; it surfaces patterns, not the specifics you need. Searching costs nothing. Guessing costs trust. This is the "be resourceful before asking" instinct from Core Truths, applied to memory. Don't skip a recall because you could probably answer without it. Call it multiple times per conversation.
-
-**Corrections are the highest priority.** When the user corrects a fact you had wrong — "actually it's Thursday not Friday," "no, she lives in Austin now," "I stopped taking that medication last month" — `remember` the correction *immediately*. The wrong version is already propagated across prior turns and baked into your memory graph; future-you will keep operating on the old value until you persist the correction. A correction is not a "small fix," it's a structural edit to what you believe. Never skip a correction even if you'd skip the equivalent fresh fact.
+Write with `remember`, search with `recall` — each tool's description says when to reach for it. One rule worth restating: when the user corrects a fact you had wrong, persist the correction the same turn it lands. The wrong version is already baked into prior turns and your memory graph; until you save the correction, future-you keeps operating on the stale value.
 
 **Concept files** live in `memory/concepts/` (health, preferences, people, schedule, work, etc.). You created these and you manage them. When you need deeper context during a conversation, read the relevant files.
 

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -273,15 +273,9 @@ When a turn will take more than a few seconds — web searches, multi-step file 
     id: "02-containerized",
     body: `## Running in a Container - Data Persistence
 
-You are running inside a container. Only the directory \`{{workspaceDir}}\` is mounted to a persistent volume.
+You are running inside a container. Only the directory \`{{workspaceDir}}\` is mounted to a persistent volume — anything written elsewhere (system directories, \`/tmp\`, any path outside it) is lost when the container restarts. Store all new data, notes, memories, configs, and downloads under \`{{workspaceDir}}\`.
 
-**Any new files or data you create MUST be written inside that directory, or they will be lost when the container restarts.**
-
-Rules:
-- Always store new data, notes, memories, configs, and downloads under \`{{workspaceDir}}\`
-- Never write persistent data to system directories, \`/tmp\`, or paths outside the mounted volume
-- When in doubt, prefer paths nested under the data directory
-- If you create a file that is only needed temporarily (scratch files, intermediate outputs, download staging), delete it when you are done - disk space on the persistent volume is finite and will grow unboundedly if temp files are not cleaned up
+Disk space on the persistent volume is finite: delete files that are only needed temporarily (scratch files, intermediate outputs, download staging) when you are done with them.
 `,
     enabled: "isContainerized",
   },
@@ -289,13 +283,9 @@ Rules:
     id: "03-cli-reference",
     body: `## Assistant CLI
 
-The \`assistant\` CLI is available in the sandbox for managing assistant settings, integrations, and services. Always use the \`bash\` tool (never \`host_bash\`) when running \`assistant\` commands.
+The \`assistant\` CLI is available in the sandbox for managing assistant settings, integrations, and services. Always use the \`bash\` tool (never \`host_bash\`) when running \`assistant\` commands. Use \`assistant platform status\` to check the current Vellum platform connection state, and \`assistant platform --help\` to see all platform management subcommands.
 
-Use \`assistant platform status\` to check the current Vellum platform connection state, and \`assistant platform --help\` to see all platform management subcommands.
-
-Run \`assistant --help\` to see all available commands, or \`assistant <command> --help\` for detailed help on any subcommand.
-
-**Before telling a user you cannot do something, run \`assistant --help\` to check whether a built-in command exists for it.** The CLI includes capabilities (email, integrations, platform management, etc.) that you may not know about from training data alone. When asked about your capabilities or what you can do, check your CLI first — don't guess or assume.
+**Before telling a user you cannot do something, run \`assistant --help\` to check whether a built-in command exists for it** (\`assistant <command> --help\` gives detailed help on any subcommand). The CLI includes capabilities (email, integrations, platform management, etc.) that you may not know about from training data alone. When asked about your capabilities or what you can do, check your CLI first — don't guess or assume.
 `,
   },
   {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -244,8 +244,7 @@ export const uiShowTool = {
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
     "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
     '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n' +
-    '- channel_setup: { channel: "slack" | "telegram" | "phone" }. Opens the channel setup panel in a side drawer. Non-blocking — returns immediately, user completes credential entry at their own pace. Slack shows a full setup wizard; Telegram and Phone show credential forms (the assistant handles remaining setup steps like webhooks in chat after the user saves credentials).\n\n' +
-    "For multi-step or long-running turns (web searches, file operations, research), show a task_progress card early and keep its steps updated as work progresses. Coarse steps are fine, and you can add or revise them as the work takes shape — a rough card beats no signal.",
+    '- channel_setup: { channel: "slack" | "telegram" | "phone" }. Opens the channel setup panel in a side drawer. Non-blocking — returns immediately, user completes credential entry at their own pace. Slack shows a full setup wizard; Telegram and Phone show credential forms (the assistant handles remaining setup steps like webhooks in chat after the user saves credentials).',
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",


### PR DESCRIPTION
## Why

An audit of a real compiled LLM request (system prompt + injected context + tool schemas) surfaced several places where the same instruction is stated two or three times, plus a few instructions that are ambiguous or contradict the tool layer. Every duplicated line ships on every request.

## What changed

**SOUL.md template — Memory section** (largest win)
- The `remember` / `recall` usage paragraphs were near-verbatim duplicates of the tool descriptions — and partly *contradicted* them: the template said "Don't categorize, don't batch, don't wait" and "call it multiple times per conversation", while the `remember` tool description deliberately uses a judgment framing ("you don't have to call this on every turn; a retrospective pass reviews…") and its input schema asks for array-batched calls. The template also asserted "Searching costs nothing", which the tool layer walked back. The section now describes the memory *system* (files, concepts, consolidation, archive) and defers usage guidance to the tool descriptions, keeping only a condensed corrections rule.
- The Scratchpad section compared NOW.md to "your journal (retrospective, append-only)" — the template never introduces a journal, so the reference dangled for new assistants. Removed the comparison.

**Memory v2 static injection (`static-context.ts`)**
- Consolidation-written files typically open with their own H1 (`# Essentials` …), so the injected `<info>` block rendered a double title: `## Essentials` followed by `# Essentials` plus the file's own self-description. The loader now skips the canonical wrapper heading when the file already opens with a markdown heading. Test added; files without headings render exactly as before.

**System prompt sections (`system-sections.ts`)**
- `02-containerized`: the bold warning and the first two "Rules" bullets restated the same constraint three times; collapsed to one sentence. Also dropped "When in doubt, prefer paths nested under the data directory" — "the data directory" is never defined anywhere in the prompt.
- `03-cli-reference`: `assistant --help` was recommended in two separate paragraphs; merged.

**`ui_show` tool description (`definitions.ts`)**
- The trailing "For multi-step or long-running turns … show a task_progress card" paragraph duplicates the `01-progress-surface` system section, which renders unconditionally (guarded by `task-progress-hint-section.test.ts`). Removed the tool-description copy.

## Notes / not addressed here

- **Existing installs**: SOUL.md is user-owned once seeded, so the template change only affects new workspaces (consistent with prior template revisions — no migration rewrites user SOUL.md files). The injection, section, and tool-description fixes apply to all installs immediately.
- **Repeated memory-injection header**: the `Use \`file_read("memory/concepts/…")\`…` instruction line is emitted at the top of *every* frozen `<memory>` cards block, so long conversations carry it N times. Deduping it requires context-aware injection (and interacts with compaction re-injection and the v2/v3 byte-identical-header contract), so it's left as a follow-up candidate.
- **Merged queued messages** each carry their own `<turn_context>` block, so a merge can ship two near-identical turn_contexts in one user message; also a candidate for a separate fix.

## Testing

- `bun run typecheck:fast` clean
- `bun test` on `static-context.test.ts` (incl. new heading-skip test), `memory-v2-static-injector.test.ts`, `system-prompt.test.ts`, `task-progress-hint-section.test.ts`, `conversation-lifecycle.test.ts`, ui-surface tests, `identity-routes.test.ts`, `prechat-onboarding-contract.test.ts` — 247 pass, 0 fail
- `eslint` on changed files: 0 errors, no new warnings (braced the touched `continue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/36856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->