### PR TITLE
feat(gateway): m0009 full-field ingress-invites backfill from assistant DB

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -166,6 +166,8 @@ type InviteRow = {
   id: string;
   sourceChannel: string;
   inviteCodeHash: string;
+  tokenHash?: string | null;
+  voiceCodeHash?: string | null;
   contactId: string;
   note: string | null;
   maxUses: number;
@@ -2236,6 +2238,33 @@ describe("handleListInvites (gateway-native)", () => {
       status: "active",
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("strips tokenHash and voiceCodeHash (not just inviteCodeHash) from list responses", async () => {
+    contactStoreListInvitesMock = mock(() => [
+      {
+        ...DEFAULT_INVITE,
+        id: "inv_1",
+        sourceChannel: "phone",
+        tokenHash: "secret-token-hash",
+        voiceCodeHash: "secret-voice-hash",
+      },
+    ]);
+    assistantDbQueryMock = mock(async () => []);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListInvites(
+      new Request("http://localhost:7830/v1/contacts/invites"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invites).toHaveLength(1);
+    expect(body.invites[0].id).toBe("inv_1");
+    // No secret hash field may ever reach the wire.
+    expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
+    expect(body.invites[0]).not.toHaveProperty("tokenHash");
+    expect(body.invites[0]).not.toHaveProperty("voiceCodeHash");
   });
 
   test("degrades gracefully when the assistant voice-field join throws", async () => {

--- a/gateway/src/__tests__/data-migration-m0009-invite-fields-backfill.test.ts
+++ b/gateway/src/__tests__/data-migration-m0009-invite-fields-backfill.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for m0009-invite-fields-backfill.
+ *
+ * Verifies that assistant ingress invites are backfilled into the gateway
+ * `ingress_invites` table with the full widened field set: existing gateway
+ * rows get the new columns UPDATEd (incl. correcting an m0007-era collapsed
+ * invite_code_hash to the assistant's true value or the NO_INVITE_CODE_HASH
+ * sentinel) without touching lifecycle columns, missing rows are INSERTed
+ * with all fields, a2a invites are never copied, inserts are FK-safe, and the
+ * whole migration is idempotent. Uses the same fake-assistant-DB +
+ * real in-memory gateway-DB pattern as the m0007 test.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Fake assistant DB ───────────────────────────────────────────────────────
+
+type FakeInvite = {
+  id: string;
+  source_channel: string;
+  invite_code_hash: string | null;
+  token_hash: string | null;
+  voice_code_hash: string | null;
+  voice_code_digits: number | null;
+  expected_external_user_id: string | null;
+  friend_name: string | null;
+  guardian_name: string | null;
+  source_conversation_id: string | null;
+  note: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+  status: string;
+  redeemed_by_external_user_id: string | null;
+  redeemed_by_external_chat_id: string | null;
+  redeemed_at: number | null;
+  contact_id: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+const fakeAssistantDb = {
+  invites: new Map<string, FakeInvite>(),
+  hasInvitesTable: true,
+  reset(): void {
+    this.invites.clear();
+    this.hasInvitesTable = true;
+  },
+};
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(async (sql: string) => {
+    const lower = sql.toLowerCase();
+    if (
+      lower.includes("sqlite_master") &&
+      lower.includes("'assistant_ingress_invites'")
+    ) {
+      return fakeAssistantDb.hasInvitesTable ? [{ "1": 1 }] : [];
+    }
+    if (lower.includes("from assistant_ingress_invites")) {
+      const rows = Array.from(fakeAssistantDb.invites.values());
+      // Honor the migration's a2a exclusion predicate when present.
+      return lower.includes("source_channel != 'a2a'")
+        ? rows.filter((r) => r.source_channel !== "a2a")
+        : rows;
+    }
+    return [];
+  }),
+  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
+  assistantDbExec: mock(async () => undefined),
+}));
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, ingressInvites } from "../db/schema.js";
+import { NO_INVITE_CODE_HASH } from "../db/contact-store.js";
+import {
+  up as m0009Up,
+  down as m0009Down,
+} from "../db/data-migrations/m0009-invite-fields-backfill.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contacts).run();
+  fakeAssistantDb.reset();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function seedGatewayContact(id: string): void {
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `gw-${id}`,
+      role: "contact",
+      principalId: null,
+      createdAt: 500,
+      updatedAt: 500,
+    })
+    .run();
+}
+
+function seedGatewayInvite(
+  opts: Partial<typeof ingressInvites.$inferInsert> & { id: string },
+): void {
+  getGatewayDb()
+    .insert(ingressInvites)
+    .values({
+      sourceChannel: "telegram",
+      inviteCodeHash: "gw-code-hash",
+      contactId: "c1",
+      note: null,
+      maxUses: 1,
+      useCount: 0,
+      expiresAt: 9_999_999,
+      status: "active",
+      createdAt: 100,
+      updatedAt: 200,
+      ...opts,
+    })
+    .run();
+}
+
+function seedAssistantInvite(opts: Partial<FakeInvite> & { id: string }): void {
+  // Defaults via spread so explicit `null` overrides (e.g. invite_code_hash:
+  // null for voice invites) are preserved rather than coalesced.
+  fakeAssistantDb.invites.set(opts.id, {
+    source_channel: "telegram",
+    invite_code_hash: "code-hash",
+    token_hash: "token-hash",
+    voice_code_hash: null,
+    voice_code_digits: null,
+    expected_external_user_id: null,
+    friend_name: null,
+    guardian_name: null,
+    source_conversation_id: null,
+    note: null,
+    max_uses: 1,
+    use_count: 0,
+    expires_at: 9_999_999,
+    status: "active",
+    redeemed_by_external_user_id: null,
+    redeemed_by_external_chat_id: null,
+    redeemed_at: null,
+    contact_id: null,
+    created_at: 100,
+    updated_at: 200,
+    ...opts,
+  });
+}
+
+function gatewayInviteIds(): string[] {
+  const rows = getGatewayDb().$client
+    .prepare("SELECT id FROM ingress_invites")
+    .all() as { id: string }[];
+  return rows.map((r) => r.id).sort();
+}
+
+function gatewayInvite(id: string): Record<string, unknown> | undefined {
+  return getGatewayDb().$client
+    .prepare("SELECT * FROM ingress_invites WHERE id = ?")
+    .get(id) as Record<string, unknown> | undefined;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("m0009-invite-fields-backfill", () => {
+  test("updates an existing gateway row with the widened fields", async () => {
+    seedGatewayContact("c1");
+    seedGatewayInvite({ id: "inv-1", inviteCodeHash: "the-code-hash" });
+    seedAssistantInvite({
+      id: "inv-1",
+      contact_id: "c1",
+      invite_code_hash: "the-code-hash",
+      token_hash: "tok-1",
+      voice_code_hash: null,
+      voice_code_digits: null,
+      expected_external_user_id: "+15550100",
+      friend_name: "Alice",
+      guardian_name: "Bob",
+      source_conversation_id: "conv-xyz",
+    });
+
+    const result = await m0009Up();
+
+    expect(result).toBe("done");
+    const row = gatewayInvite("inv-1")!;
+    expect(row.invite_code_hash).toBe("the-code-hash");
+    expect(row.token_hash).toBe("tok-1");
+    expect(row.voice_code_hash).toBeNull();
+    expect(row.voice_code_digits).toBeNull();
+    expect(row.expected_external_user_id).toBe("+15550100");
+    expect(row.friend_name).toBe("Alice");
+    expect(row.guardian_name).toBe("Bob");
+    expect(row.source_conversation_id).toBe("conv-xyz");
+  });
+
+  test("corrects an m0007-collapsed voice hash to the sentinel + voice_code_hash", async () => {
+    seedGatewayContact("c1");
+    // m0007 collapsed the voice hash into invite_code_hash for voice invites.
+    seedGatewayInvite({
+      id: "voice-1",
+      sourceChannel: "phone",
+      inviteCodeHash: "voice-hash",
+    });
+    seedAssistantInvite({
+      id: "voice-1",
+      contact_id: "c1",
+      source_channel: "phone",
+      invite_code_hash: null,
+      token_hash: "tok-v",
+      voice_code_hash: "voice-hash",
+      voice_code_digits: 6,
+      friend_name: "Carol",
+    });
+
+    await m0009Up();
+
+    const row = gatewayInvite("voice-1")!;
+    expect(row.invite_code_hash).toBe(NO_INVITE_CODE_HASH);
+    expect(row.voice_code_hash).toBe("voice-hash");
+    expect(row.voice_code_digits).toBe(6);
+    expect(row.token_hash).toBe("tok-v");
+    expect(row.friend_name).toBe("Carol");
+  });
+
+  test("update never touches lifecycle columns (gateway truth)", async () => {
+    seedGatewayContact("c1");
+    seedGatewayInvite({
+      id: "inv-1",
+      status: "revoked",
+      useCount: 3,
+      note: "gateway-note",
+      redeemedAt: 4242,
+    });
+    seedAssistantInvite({
+      id: "inv-1",
+      contact_id: "c1",
+      status: "active",
+      use_count: 0,
+      note: "assistant-note",
+      redeemed_at: null,
+    });
+
+    await m0009Up();
+
+    const row = gatewayInvite("inv-1")!;
+    expect(row.status).toBe("revoked");
+    expect(row.use_count).toBe(3);
+    expect(row.note).toBe("gateway-note");
+    expect(row.redeemed_at).toBe(4242);
+  });
+
+  test("inserts a missing invite with the full field set", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({
+      id: "inv-new",
+      contact_id: "c1",
+      source_channel: "phone",
+      invite_code_hash: null,
+      token_hash: "tok-n",
+      voice_code_hash: "voice-n",
+      voice_code_digits: 4,
+      expected_external_user_id: "+15550101",
+      friend_name: "Dave",
+      guardian_name: "Erin",
+      source_conversation_id: "conv-abc",
+      note: "hello",
+      max_uses: 2,
+      use_count: 1,
+      expires_at: 12345,
+      status: "redeemed",
+      redeemed_by_external_user_id: "u-9",
+      redeemed_by_external_chat_id: "chat-9",
+      redeemed_at: 7777,
+      created_at: 111,
+      updated_at: 222,
+    });
+
+    const result = await m0009Up();
+
+    expect(result).toBe("done");
+    const row = gatewayInvite("inv-new")!;
+    expect(row.source_channel).toBe("phone");
+    // NULL assistant invite_code_hash lands as the NOT NULL sentinel.
+    expect(row.invite_code_hash).toBe(NO_INVITE_CODE_HASH);
+    expect(row.token_hash).toBe("tok-n");
+    expect(row.voice_code_hash).toBe("voice-n");
+    expect(row.voice_code_digits).toBe(4);
+    expect(row.expected_external_user_id).toBe("+15550101");
+    expect(row.friend_name).toBe("Dave");
+    expect(row.guardian_name).toBe("Erin");
+    expect(row.source_conversation_id).toBe("conv-abc");
+    expect(row.note).toBe("hello");
+    expect(row.max_uses).toBe(2);
+    expect(row.use_count).toBe(1);
+    expect(row.expires_at).toBe(12345);
+    expect(row.status).toBe("redeemed");
+    expect(row.redeemed_by_external_user_id).toBe("u-9");
+    expect(row.redeemed_by_external_chat_id).toBe("chat-9");
+    expect(row.redeemed_at).toBe(7777);
+    expect(row.contact_id).toBe("c1");
+    expect(row.created_at).toBe(111);
+    expect(row.updated_at).toBe(222);
+  });
+
+  test("never copies a2a invites", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "a2a-1", contact_id: "c1", source_channel: "a2a" });
+    seedAssistantInvite({ id: "tg-1", contact_id: "c1" });
+
+    const result = await m0009Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual(["tg-1"]);
+  });
+
+  test("skips inserting an invite whose contactId is absent from gateway contacts", async () => {
+    seedAssistantInvite({ id: "orphan", contact_id: "ghost" });
+    seedAssistantInvite({ id: "nullc", contact_id: null });
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "ok", contact_id: "c1" });
+
+    const result = await m0009Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual(["ok"]);
+  });
+
+  test("idempotent: running twice yields the same rows and values", async () => {
+    seedGatewayContact("c1");
+    seedGatewayInvite({ id: "inv-1", inviteCodeHash: "voice-hash" });
+    seedAssistantInvite({
+      id: "inv-1",
+      contact_id: "c1",
+      invite_code_hash: null,
+      voice_code_hash: "voice-hash",
+    });
+    seedAssistantInvite({ id: "inv-2", contact_id: "c1" });
+
+    await m0009Up();
+    const firstRun = {
+      ids: gatewayInviteIds(),
+      inv1: gatewayInvite("inv-1"),
+      inv2: gatewayInvite("inv-2"),
+    };
+    await m0009Up();
+
+    expect(gatewayInviteIds()).toEqual(firstRun.ids);
+    expect(gatewayInvite("inv-1")).toEqual(firstRun.inv1);
+    expect(gatewayInvite("inv-2")).toEqual(firstRun.inv2);
+  });
+
+  test("returns done when assistant DB has no invites table", async () => {
+    fakeAssistantDb.hasInvitesTable = false;
+
+    const result = await m0009Up();
+
+    expect(result).toBe("done");
+    expect(gatewayInviteIds()).toEqual([]);
+  });
+
+  test("does not drop or alter the assistant table (copy, not move)", async () => {
+    seedGatewayContact("c1");
+    seedAssistantInvite({ id: "inv-1", contact_id: "c1" });
+
+    await m0009Up();
+
+    expect(fakeAssistantDb.hasInvitesTable).toBe(true);
+    expect(fakeAssistantDb.invites.has("inv-1")).toBe(true);
+  });
+
+  test("down is a no-op (returns done)", () => {
+    expect(m0009Down()).toBe("done");
+  });
+});

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -27,6 +27,7 @@ import * as m0005 from "./m0005-normalize-contact-channel-addresses.js";
 import * as m0006 from "./m0006-reconcile-contacts-from-assistant.js";
 import * as m0007 from "./m0007-backfill-ingress-invites.js";
 import * as m0008 from "./m0008-upsert-acl-columns-from-assistant.js";
+import * as m0009 from "./m0009-invite-fields-backfill.js";
 
 const log = getLogger("data-migrations");
 
@@ -46,6 +47,7 @@ const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0006-reconcile-contacts-from-assistant", mod: m0006 },
   { key: "m0007-backfill-ingress-invites", mod: m0007 },
   { key: "m0008-upsert-acl-columns-from-assistant", mod: m0008 },
+  { key: "m0009-invite-fields-backfill", mod: m0009 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0009-invite-fields-backfill.ts
+++ b/gateway/src/db/data-migrations/m0009-invite-fields-backfill.ts
@@ -1,0 +1,208 @@
+/**
+ * One-time migration: full-field backfill of assistant ingress invites into
+ * the gateway `ingress_invites` table, covering the columns added after the
+ * m0007 backfill (token_hash, voice_code_hash, voice_code_digits,
+ * expected_external_user_id, friend_name, guardian_name,
+ * source_conversation_id).
+ *
+ * Also corrects `invite_code_hash`: m0007 collapsed
+ * `invite_code_hash ?? voice_code_hash ?? token_hash` into the gateway's
+ * single hash column. This migration restores the assistant row's true
+ * `invite_code_hash`, writing the NO_INVITE_CODE_HASH ("") sentinel when the
+ * assistant value is NULL — the gateway column stays NOT NULL (relaxing it
+ * requires a drizzle-push table rebuild that corrupts existing DBs; see the
+ * schema.ts comment).
+ *
+ * Rows already in the gateway are UPDATEd (new columns + hash correction
+ * only — lifecycle columns are gateway truth). Rows absent gateway-side are
+ * INSERTed with the full field set. A2A invites live in the assistant's
+ * dedicated `a2a_invites` flow and are excluded.
+ *
+ * Idempotent: UPDATE writes the same values on re-run; INSERT OR IGNORE never
+ * duplicates. FK safety: inserts skip rows whose contact_id is missing from
+ * gateway `contacts` (same as m0007).
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getGatewayDb } from "../connection.js";
+import { getLogger } from "../../logger.js";
+import { assistantDbQuery } from "../assistant-db-proxy.js";
+import { NO_INVITE_CODE_HASH } from "../contact-store.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0009-invite-fields-backfill");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+interface AssistantInviteRow {
+  id: string;
+  source_channel: string;
+  invite_code_hash: string | null;
+  token_hash: string | null;
+  voice_code_hash: string | null;
+  voice_code_digits: number | null;
+  expected_external_user_id: string | null;
+  friend_name: string | null;
+  guardian_name: string | null;
+  source_conversation_id: string | null;
+  note: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+  status: string;
+  redeemed_by_external_user_id: string | null;
+  redeemed_by_external_chat_id: string | null;
+  redeemed_at: number | null;
+  contact_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export async function up(): Promise<MigrationResult> {
+  const gwDb = getRawGatewayDb();
+
+  try {
+    // ── 1. Bail if the assistant table doesn't exist (fresh install) ───────
+    const hasTable = await assistantDbQuery<{ "1": number }>(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_ingress_invites'`,
+    );
+    if (hasTable.length === 0) {
+      log.info(
+        "Assistant DB has no assistant_ingress_invites table — nothing to backfill",
+      );
+      return "done";
+    }
+
+    // ── 2. Read every non-a2a assistant invite ──────────────────────────────
+    const rows = await assistantDbQuery<AssistantInviteRow>(
+      `SELECT id, source_channel, invite_code_hash, token_hash, voice_code_hash,
+              voice_code_digits, expected_external_user_id, friend_name,
+              guardian_name, source_conversation_id, note, max_uses, use_count,
+              expires_at, status, redeemed_by_external_user_id,
+              redeemed_by_external_chat_id, redeemed_at, contact_id,
+              created_at, updated_at
+         FROM assistant_ingress_invites
+        WHERE source_channel != 'a2a'`,
+    );
+
+    if (rows.length === 0) {
+      log.info("No assistant ingress invites to backfill");
+      return "done";
+    }
+
+    // ── 3. Resolve existing gateway invites + contacts (FK safety) ─────────
+    const gatewayInviteIds = new Set(
+      gwDb
+        .prepare("SELECT id FROM ingress_invites")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    );
+    const gatewayContactIds = new Set(
+      gwDb
+        .prepare("SELECT id FROM contacts")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    );
+
+    // Only the widened columns + the hash correction — lifecycle columns
+    // (status, use_count, redeemed_*) are gateway truth and never touched.
+    const update = gwDb.prepare(
+      `UPDATE ingress_invites
+          SET invite_code_hash = ?, token_hash = ?, voice_code_hash = ?,
+              voice_code_digits = ?, expected_external_user_id = ?,
+              friend_name = ?, guardian_name = ?, source_conversation_id = ?
+        WHERE id = ?`,
+    );
+
+    const insert = gwDb.prepare(
+      `INSERT OR IGNORE INTO ingress_invites
+         (id, source_channel, invite_code_hash, token_hash, voice_code_hash,
+          voice_code_digits, expected_external_user_id, friend_name,
+          guardian_name, source_conversation_id, note, max_uses, use_count,
+          expires_at, status, redeemed_by_external_user_id,
+          redeemed_by_external_chat_id, redeemed_at, contact_id,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    let updated = 0;
+    let inserted = 0;
+    let skippedMissingContact = 0;
+
+    const txn = gwDb.transaction(() => {
+      for (const row of rows) {
+        const inviteCodeHash = row.invite_code_hash ?? NO_INVITE_CODE_HASH;
+
+        if (gatewayInviteIds.has(row.id)) {
+          update.run(
+            inviteCodeHash,
+            row.token_hash,
+            row.voice_code_hash,
+            row.voice_code_digits,
+            row.expected_external_user_id,
+            row.friend_name,
+            row.guardian_name,
+            row.source_conversation_id,
+            row.id,
+          );
+          updated += 1;
+          continue;
+        }
+
+        // FK safety: skip inserts whose contact is null or absent in gateway.
+        if (!row.contact_id || !gatewayContactIds.has(row.contact_id)) {
+          skippedMissingContact += 1;
+          continue;
+        }
+
+        insert.run(
+          row.id,
+          row.source_channel,
+          inviteCodeHash,
+          row.token_hash,
+          row.voice_code_hash,
+          row.voice_code_digits,
+          row.expected_external_user_id,
+          row.friend_name,
+          row.guardian_name,
+          row.source_conversation_id,
+          row.note,
+          row.max_uses,
+          row.use_count,
+          row.expires_at,
+          row.status,
+          row.redeemed_by_external_user_id,
+          row.redeemed_by_external_chat_id,
+          row.redeemed_at,
+          row.contact_id,
+          row.created_at,
+          row.updated_at,
+        );
+        inserted += 1;
+      }
+    });
+    txn();
+
+    log.info(
+      { total: rows.length, updated, inserted, skippedMissingContact },
+      "m0009: backfilled full invite fields into gateway",
+    );
+
+    return "done";
+  } catch (err) {
+    log.error(
+      { err },
+      "m0009: invite fields backfill failed — will retry on next startup",
+    );
+    return "skip";
+  }
+}
+
+export function down(): MigrationResult {
+  // No-op: backfilled fields are legitimate gateway data; never delete on rollback.
+  return "done";
+}

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -113,14 +113,25 @@ const VALID_CONTACT_TYPES = ["human", "assistant"] as const;
 
 /**
  * Strip code/token hashes from a gateway invite row before returning it over
- * HTTP. `inviteCodeHash` is the unsalted SHA-256 of a 6-digit code; returning
- * it lets any list-capable caller brute-force the ~10^6 keyspace offline and
- * redeem an active invite. All invite responses MUST go through this.
+ * HTTP. `inviteCodeHash` and `voiceCodeHash` are unsalted SHA-256 of a
+ * 6-digit code; returning either lets any list-capable caller brute-force the
+ * ~10^6 keyspace offline and redeem an active invite. `tokenHash` is the
+ * redemption secret for link invites. All invite responses MUST go through
+ * this.
  */
-function sanitizeInviteRow<T extends { inviteCodeHash?: unknown }>(
-  row: T,
-): Omit<T, "inviteCodeHash"> {
-  const { inviteCodeHash: _omit, ...rest } = row;
+function sanitizeInviteRow<
+  T extends {
+    inviteCodeHash?: unknown;
+    tokenHash?: unknown;
+    voiceCodeHash?: unknown;
+  },
+>(row: T): Omit<T, "inviteCodeHash" | "tokenHash" | "voiceCodeHash"> {
+  const {
+    inviteCodeHash: _code,
+    tokenHash: _token,
+    voiceCodeHash: _voice,
+    ...rest
+  } = row;
   return rest;
 }
 


### PR DESCRIPTION
## Summary
- m0009 data migration: backfills secrets + display fields from assistant_ingress_invites into gateway ingress_invites (update-existing + insert-missing, non-a2a only, idempotent)
- Corrects m0007-era collapsed invite_code_hash values using the NO_INVITE_CODE_HASH sentinel
- Widens sanitizeInviteRow to strip token_hash/voice_code_hash from list responses

Part of plan: invites-gateway-native.md (PR 3 of 12)