### PR TITLE
feat(profiles): re-enable Claude Fable 5 for the managed Quality profile

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -856,9 +856,9 @@ describe("loadConfig startup behavior", () => {
     );
     expect(raw.llm.profiles.balanced.effort).toBe("high");
     expect(raw.llm.profiles.balanced.source).toBe("managed");
-    // Quality serves Anthropic Opus, the most capable managed profile.
+    // Quality serves Anthropic Fable, the most capable managed profile.
     expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
-    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-opus-4-8");
+    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-fable-5");
     // Speed is served by DeepSeek V4 Flash on Fireworks.
     expect(raw.llm.profiles["cost-optimized"].provider).toBe("fireworks");
     expect(raw.llm.profiles["cost-optimized"].model).toBe(
@@ -899,7 +899,7 @@ describe("loadConfig startup behavior", () => {
   test("reseed updates a source-less legacy canonical managed profile", () => {
     // Migration 052 seeded canonical profiles without a `source`. Such a
     // source-less `quality-optimized` is legacy managed, not user-owned, so it
-    // must still reseed to the latest template (Opus) and be tagged managed.
+    // must still reseed to the latest template (Fable) and be tagged managed.
     writeConfig({
       llm: {
         profiles: {
@@ -915,7 +915,7 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-opus-4-8");
+    expect(raw.llm.profiles["quality-optimized"].model).toBe("claude-fable-5");
     expect(raw.llm.profiles["quality-optimized"].source).toBe("managed");
   });
 
@@ -1574,7 +1574,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.activeProfile).toBe("balanced");
-    // Balanced lives on `fireworks-managed`; `quality-optimized` (Opus on
+    // Balanced lives on `fireworks-managed`; `quality-optimized` (Fable on
     // `anthropic-managed`) is on a different connection, so selecting balanced at
     // hatch disables it. The default advisor falls to the only active managed
     // profile, `balanced`.

--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -20,7 +20,7 @@ describe("model intents", () => {
       "claude-haiku-4-5-20251001",
     );
     expect(resolveModelIntent("anthropic", "quality-optimized")).toBe(
-      "claude-opus-4-8",
+      "claude-fable-5",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
       "claude-opus-4-6",

--- a/assistant/src/__tests__/workspace-migration-123-swap-quality-profile-to-fable.test.ts
+++ b/assistant/src/__tests__/workspace-migration-123-swap-quality-profile-to-fable.test.ts
@@ -1,0 +1,191 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { swapQualityProfileToFableMigration } from "../workspace/migrations/123-swap-quality-profile-to-fable.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  const llm = readConfig().llm as Record<string, unknown>;
+  return llm.profiles as Record<string, Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-123-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("123-swap-quality-profile-to-fable migration", () => {
+  test("no-op when config.json does not exist", () => {
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("swaps quality-optimized from claude-opus-4-8", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            label: "Quality",
+          },
+        },
+      },
+    });
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    const profile = readProfiles()["quality-optimized"]!;
+    expect(profile.model).toBe("claude-fable-5");
+    expect(profile.label).toBe("Quality");
+  });
+
+  test("swaps the managed profile but not the user-owned custom copy", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+          "custom-quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    const profiles = readProfiles();
+    expect(profiles["quality-optimized"]!.model).toBe("claude-fable-5");
+    expect(profiles["custom-quality-optimized"]!.model).toBe("claude-opus-4-8");
+  });
+
+  test("swaps OpenRouter-prefixed model ids", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "openrouter",
+            model: "anthropic/claude-opus-4.8",
+          },
+        },
+      },
+    });
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readProfiles()["quality-optimized"]!.model).toBe(
+      "anthropic/claude-fable-5",
+    );
+  });
+
+  test("leaves a user-owned (source: user) profile untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            source: "user",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves user-customized models untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "quality-optimized": { provider: "openai", model: "gpt-5.4" },
+        },
+      },
+    };
+    writeConfig(original);
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves non-quality profiles untouched", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { provider: "anthropic", model: "claude-opus-4-8" },
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    const profiles = readProfiles();
+    expect(profiles["balanced"]!.model).toBe("claude-opus-4-8");
+    expect(profiles["quality-optimized"]!.model).toBe("claude-fable-5");
+  });
+
+  test("idempotency: no-op on already-swapped config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-fable-5",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    swapQualityProfileToFableMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -58,8 +58,8 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
-  // Served by Anthropic Opus via managed platform inference — the most capable
-  // managed profile. The `quality-optimized` intent resolves to Opus for the
+  // Served by Anthropic via managed platform inference — the most capable
+  // managed profile. The `quality-optimized` intent resolves to Fable for the
   // `anthropic` provider.
   "quality-optimized": {
     intent: "quality-optimized",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -13,7 +13,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     balanced: "claude-sonnet-4-6",
     "latency-optimized": "claude-haiku-4-5-20251001",
-    "quality-optimized": "claude-opus-4-8",
+    "quality-optimized": "claude-fable-5",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
@@ -43,7 +43,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   openrouter: {
     balanced: "anthropic/claude-sonnet-4.6",
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-opus-4.8",
+    "quality-optimized": "anthropic/claude-fable-5",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };

--- a/assistant/src/workspace/migrations/123-swap-quality-profile-to-fable.ts
+++ b/assistant/src/workspace/migrations/123-swap-quality-profile-to-fable.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Move the managed quality-optimized profile from Anthropic Opus 4.8 back to
+// Claude Fable 5, reversing migration 114.
+//
+// The quality-optimized intent maps to claude-fable-5, but the intent map is
+// only consulted when a profile is seeded: off-platform installs reseed managed
+// profiles on every boot, while on-platform workspaces keep the profile they
+// were hatched with — the seeder skips existing profiles there, and the hatch
+// overlay is consumed exactly once. A platform workspace holding an Opus 4.8
+// quality-optimized profile therefore keeps it until a migration rewrites it.
+//
+// Only the managed quality-optimized profile is touched — the user-owned
+// custom-quality-optimized copy is theirs to manage. Within it, only a profile
+// still on the Opus default is rewritten — matching by model value also covers
+// the OpenRouter-prefixed id. A profile whose model the user changed to
+// anything else is left untouched. The profile key stays quality-optimized, so
+// persisted inference_profile pins on conversations/schedules keep resolving.
+
+const TARGET_PROFILES = ["quality-optimized"];
+
+const MODEL_SWAPS: Record<string, string> = {
+  "claude-opus-4-8": "claude-fable-5",
+  "anthropic/claude-opus-4.8": "anthropic/claude-fable-5",
+};
+
+export const swapQualityProfileToFableMigration: WorkspaceMigration = {
+  id: "123-swap-quality-profile-to-fable",
+  description:
+    "Move the managed quality-optimized profile from Anthropic Opus 4.8 to Claude Fable 5",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    let changed = false;
+
+    for (const name of TARGET_PROFILES) {
+      const profile = readObject(profiles[name]);
+      if (profile === null) continue;
+      if (profile.source === "user") continue;
+      if (typeof profile.model !== "string") continue;
+
+      const swapped = MODEL_SWAPS[profile.model];
+      if (swapped === undefined) continue;
+
+      profile.model = swapped;
+      profiles[name] = profile;
+      changed = true;
+    }
+
+    if (changed) {
+      llm.profiles = profiles;
+      config.llm = llm;
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -120,6 +120,7 @@ import { stripPersistedMemoryV3TuningDefaultsMigration } from "./119-strip-persi
 import { reviseOnboardingThreadsMigration } from "./120-revise-onboarding-threads.js";
 import { seedDefaultUserGuardrailsMigration } from "./121-seed-default-user-guardrails.js";
 import { relocateDefaultUserBoundaryMigration } from "./122-relocate-default-user-boundary.js";
+import { swapQualityProfileToFableMigration } from "./123-swap-quality-profile-to-fable.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -251,4 +252,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   reviseOnboardingThreadsMigration,
   seedDefaultUserGuardrailsMigration,
   relocateDefaultUserBoundaryMigration,
+  swapQualityProfileToFableMigration,
 ];


### PR DESCRIPTION
## Summary
- Repoint the `quality-optimized` model intent (anthropic + openrouter) from Opus 4.8 back to Claude Fable 5, so freshly seeded and off-platform-reseeded managed profiles use Fable. Reverses #34867.
- Add workspace migration `121-swap-quality-profile-to-fable` to rewrite existing managed `quality-optimized` profiles from Opus 4.8 to Fable 5 — on-platform workspaces keep their hatched profile and aren't reseeded, so they need the migration. Mirrors migration 114 in reverse; only the managed profile and only the previous-default model value are touched.
- Update the `model-intents` and `config-loader-backfill` assertions, and add migration 121 tests.

## Notes
- The user-owned `custom-quality-optimized` profile is left untouched, matching the prior swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)