### PR TITLE
feat(web): useSetChatPlugins — persist a chat's plugin set (existing + draft)

### DIFF
--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.test.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.test.ts
@@ -6,6 +6,10 @@
  * design-library toast and `captureError` are mocked to observe the failure
  * path. The conversation store is the real module — reset per test.
  *
+ * A draft is modelled as the detail query settling to an `ApiError(404)` (what
+ * the daemon error interceptor produces), so the hook can distinguish a
+ * confirmed draft from a still-loading existing row.
+ *
  * Mocks are registered before the hook is dynamically imported so the
  * generated TanStack Query factories bind to the mocked SDK.
  */
@@ -20,6 +24,7 @@ import type {
   PluginsGetResponse,
 } from "@/generated/daemon/types.gen";
 import { useConversationStore } from "@/stores/conversation-store";
+import { ApiError } from "@/utils/api-errors";
 
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
@@ -29,6 +34,12 @@ type InstalledPlugin = PluginsGetResponse["plugins"][number];
 interface InstalledResult {
   data?: PluginsGetResponse;
   response: { ok: boolean; status: number };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
 }
 
 // Per-test holders the SDK mocks read.
@@ -70,7 +81,7 @@ const PLUGINS_KEY = pluginsGetQueryKey({
   query: { q: undefined },
 });
 
-function deferred<T>() {
+function deferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (reason: unknown) => void;
   const promise = new Promise<T>((res, rej) => {
@@ -99,9 +110,26 @@ function conversationWith(
   };
 }
 
-/** Default conversation read: reject, standing in for a draft with no server row. */
+/** Default conversation read: settle to a 404, standing in for a confirmed draft. */
 function noServerRow(): Promise<{ data: ConversationsByIdGetResponse }> {
-  return Promise.reject(new Error("404 — no server row"));
+  return Promise.reject(new ApiError(404, "no server row"));
+}
+
+/** Read the enabledPlugins scope from the conversation query cache. */
+function enabledInCache(client: QueryClient): string[] | null | undefined {
+  const data =
+    client.getQueryData<ConversationsByIdGetResponse>(CONVERSATION_KEY);
+  return data?.conversation.enabledPlugins;
+}
+
+/** Body (enabledPlugins) each PUT was called with, in order. */
+function putBodies(): (string[] | null)[] {
+  return enabledPluginsPutSpy.mock.calls.map(
+    (call) =>
+      (call as unknown[])[0] as {
+        body: { enabledPlugins: string[] | null };
+      },
+  ).map((opts) => opts.body.enabledPlugins);
 }
 
 function renderSetHook(conversationId: string | undefined = CONVERSATION_ID) {
@@ -118,11 +146,6 @@ function renderSetHook(conversationId: string | undefined = CONVERSATION_ID) {
     { wrapper },
   );
   return { ...view, client };
-}
-
-function enabledInCache(client: QueryClient): string[] | null | undefined {
-  const data = client.getQueryData<ConversationsByIdGetResponse>(CONVERSATION_KEY);
-  return data?.conversation.enabledPlugins;
 }
 
 beforeEach(() => {
@@ -154,11 +177,11 @@ describe("useSetChatPlugins", () => {
 
     const { result, client } = renderSetHook();
 
-    // Both reads must resolve so the row is loaded (existing path) and the
-    // installed list is present (toggle materializes from it).
+    // Row state must be known (existing) and the installed list present before
+    // toggling — the toggle materializes from it.
     await waitFor(() => {
+      expect(result.current.canWrite).toBe(true);
       expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
-      expect(enabledInCache(client)).toBeNull();
     });
 
     act(() => {
@@ -183,11 +206,14 @@ describe("useSetChatPlugins", () => {
   });
 
   test("draft toggle → store action only, no network", async () => {
-    // Conversation read rejects → no server row → draft path.
+    // Detail read settles to a 404 → confirmed draft → draft path.
     conversationImpl = noServerRow;
     const { result, client } = renderSetHook();
 
-    await waitFor(() => expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy());
+    await waitFor(() => {
+      expect(result.current.canWrite).toBe(true);
+      expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
+    });
 
     act(() => {
       result.current.toggle("b");
@@ -216,7 +242,7 @@ describe("useSetChatPlugins", () => {
     const { result, client } = renderSetHook();
 
     await waitFor(() => {
-      expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
+      expect(result.current.canWrite).toBe(true);
       expect(enabledInCache(client)).toEqual(["a"]);
     });
 
@@ -234,5 +260,78 @@ describe("useSetChatPlugins", () => {
     await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
     await waitFor(() => expect(enabledInCache(client)).toEqual(["a"]));
     expect(captureErrorSpy).toHaveBeenCalled();
+  });
+
+  test("existing chat whose detail query is still pending → no write, canWrite false", async () => {
+    // Detail query never resolves — row state stays unknown.
+    conversationImpl = () => new Promise(() => {});
+    const { result, client } = renderSetHook();
+
+    // Installed list loads, but the row state is unknown → not writable.
+    await waitFor(() => expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy());
+    expect(result.current.canWrite).toBe(false);
+
+    act(() => {
+      result.current.toggle("b");
+    });
+    act(() => {
+      result.current.setPlugins(["a"]);
+    });
+
+    // Neither the daemon nor the draft stash was touched.
+    expect(enabledPluginsPutSpy).not.toHaveBeenCalled();
+    expect(
+      useConversationStore.getState().pendingDraftPlugins.has(CONVERSATION_ID),
+    ).toBe(false);
+    expect(result.current.canWrite).toBe(false);
+  });
+
+  test("rapid double-toggle before the first PUT resolves → last selection persists", async () => {
+    conversationImpl = () => Promise.resolve(conversationWith(null));
+    // Hand each PUT a deferred so the first stays in flight during the 2nd toggle.
+    const putDeferreds: Deferred<{ data: unknown }>[] = [];
+    putImpl = () => {
+      const d = deferred<{ data: unknown }>();
+      putDeferreds.push(d);
+      return d.promise;
+    };
+
+    const { result, client } = renderSetHook();
+
+    await waitFor(() => {
+      expect(result.current.canWrite).toBe(true);
+      expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
+    });
+
+    // Toggle 'a' off → PUT #1 (['b','c']) starts and stays pending.
+    act(() => {
+      result.current.toggle("a");
+    });
+    await waitFor(() => expect(enabledPluginsPutSpy).toHaveBeenCalledTimes(1));
+
+    // Toggle 'b' off before #1 resolves → desired becomes ['c']; the in-flight
+    // loop is coalesced, so no second PUT fires yet.
+    act(() => {
+      result.current.toggle("b");
+    });
+    expect(enabledPluginsPutSpy).toHaveBeenCalledTimes(1);
+
+    // Resolve #1 → the loop re-sends the newer desired set as PUT #2 (['c']).
+    await act(async () => {
+      putDeferreds[0]!.resolve({ data: {} });
+    });
+    await waitFor(() => expect(enabledPluginsPutSpy).toHaveBeenCalledTimes(2));
+
+    // Resolve #2 → the loop settles; desired hasn't changed, so it stops.
+    await act(async () => {
+      putDeferreds[1]!.resolve({ data: {} });
+    });
+
+    // Serialized, in order, ending on the user's last selection ['c'].
+    const bodies = putBodies();
+    expect(bodies).toHaveLength(2);
+    expect(new Set(bodies[0])).toEqual(new Set(["b", "c"]));
+    expect(new Set(bodies[1])).toEqual(new Set(["c"]));
+    await waitFor(() => expect(enabledPluginsPutSpy).toHaveBeenCalledTimes(2));
   });
 });

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.test.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for `useSetChatPlugins`, the write half of the in-chat plugin pill.
+ *
+ * The generated SDK is mocked so the two read queries (installed list +
+ * conversation row) resolve locally and the `enabledplugins` PUT is a spy; the
+ * design-library toast and `captureError` are mocked to observe the failure
+ * path. The conversation store is the real module — reset per test.
+ *
+ * Mocks are registered before the hook is dynamically imported so the
+ * generated TanStack Query factories bind to the mocked SDK.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type {
+  ConversationsByIdGetResponse,
+  PluginsGetResponse,
+} from "@/generated/daemon/types.gen";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+
+type InstalledPlugin = PluginsGetResponse["plugins"][number];
+
+interface InstalledResult {
+  data?: PluginsGetResponse;
+  response: { ok: boolean; status: number };
+}
+
+// Per-test holders the SDK mocks read.
+let installedResult: InstalledResult;
+let conversationImpl: () => Promise<{ data: ConversationsByIdGetResponse }>;
+let putImpl: () => Promise<unknown>;
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+const pluginsGetSpy = mock(async () => installedResult);
+const conversationsByIdGetSpy = mock(() => conversationImpl());
+const enabledPluginsPutSpy = mock(() => putImpl());
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsGet: pluginsGetSpy,
+  conversationsByIdGet: conversationsByIdGetSpy,
+  conversationsByIdEnabledpluginsPut: enabledPluginsPutSpy,
+}));
+
+const toastErrorSpy = mock(() => {});
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { error: toastErrorSpy },
+}));
+
+const captureErrorSpy = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorSpy,
+}));
+
+const { useSetChatPlugins } = await import("./use-set-chat-plugins");
+const { conversationsByIdGetQueryKey, pluginsGetQueryKey } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+
+const CONVERSATION_KEY = conversationsByIdGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID, id: CONVERSATION_ID },
+});
+const PLUGINS_KEY = pluginsGetQueryKey({
+  path: { assistant_id: ASSISTANT_ID },
+  query: { q: undefined },
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function installed(name: string): InstalledPlugin {
+  return { id: name, name, description: null, version: null };
+}
+
+function installedOk(plugins: InstalledPlugin[]): InstalledResult {
+  return { data: { plugins }, response: { ok: true, status: 200 } };
+}
+
+/** A loaded conversation row carrying an explicit `enabledPlugins` scope. */
+function conversationWith(
+  enabledPlugins: string[] | null,
+): { data: ConversationsByIdGetResponse } {
+  return {
+    data: {
+      conversation: { id: CONVERSATION_ID, enabledPlugins },
+    } as unknown as ConversationsByIdGetResponse,
+  };
+}
+
+/** Default conversation read: reject, standing in for a draft with no server row. */
+function noServerRow(): Promise<{ data: ConversationsByIdGetResponse }> {
+  return Promise.reject(new Error("404 — no server row"));
+}
+
+function renderSetHook(conversationId: string | undefined = CONVERSATION_ID) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+
+  const view = renderHook(
+    () => useSetChatPlugins(ASSISTANT_ID, conversationId),
+    { wrapper },
+  );
+  return { ...view, client };
+}
+
+function enabledInCache(client: QueryClient): string[] | null | undefined {
+  const data = client.getQueryData<ConversationsByIdGetResponse>(CONVERSATION_KEY);
+  return data?.conversation.enabledPlugins;
+}
+
+beforeEach(() => {
+  installedResult = installedOk([installed("a"), installed("b"), installed("c")]);
+  conversationImpl = noServerRow;
+  putImpl = () =>
+    Promise.resolve({
+      data: { conversationId: CONVERSATION_ID, enabledPlugins: [] },
+    });
+  pluginsGetSpy.mockClear();
+  conversationsByIdGetSpy.mockClear();
+  enabledPluginsPutSpy.mockClear();
+  toastErrorSpy.mockClear();
+  captureErrorSpy.mockClear();
+  useConversationStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSetChatPlugins", () => {
+  test("existing conversation toggle → PUT the materialized set + optimistic cache write", async () => {
+    // Loaded server row at its default (no explicit scope → all selected).
+    conversationImpl = () => Promise.resolve(conversationWith(null));
+    // Keep the PUT pending so the optimistic write is stable to assert.
+    const putDeferred = deferred<{ data: unknown }>();
+    putImpl = () => putDeferred.promise;
+
+    const { result, client } = renderSetHook();
+
+    // Both reads must resolve so the row is loaded (existing path) and the
+    // installed list is present (toggle materializes from it).
+    await waitFor(() => {
+      expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
+      expect(enabledInCache(client)).toBeNull();
+    });
+
+    act(() => {
+      result.current.toggle("b");
+    });
+
+    // Optimistic write is synchronous: default (all) minus the toggled-off 'b'.
+    expect(enabledInCache(client)).toEqual(["a", "c"]);
+
+    await waitFor(() => expect(enabledPluginsPutSpy).toHaveBeenCalled());
+    const call = (enabledPluginsPutSpy.mock.calls[0] as unknown[])[0] as {
+      path: { assistant_id: string; id: string };
+      body: { enabledPlugins: string[] | null };
+    };
+    expect(call.path).toEqual({ assistant_id: ASSISTANT_ID, id: CONVERSATION_ID });
+    expect(new Set(call.body.enabledPlugins)).toEqual(new Set(["a", "c"]));
+
+    // No draft stash was touched — this is the server-row path.
+    expect(
+      useConversationStore.getState().pendingDraftPlugins.has(CONVERSATION_ID),
+    ).toBe(false);
+  });
+
+  test("draft toggle → store action only, no network", async () => {
+    // Conversation read rejects → no server row → draft path.
+    conversationImpl = noServerRow;
+    const { result, client } = renderSetHook();
+
+    await waitFor(() => expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy());
+
+    act(() => {
+      result.current.toggle("b");
+    });
+
+    // Materialized the explicit set "all installed except 'b'" into the store.
+    await waitFor(() =>
+      expect(
+        useConversationStore.getState().pendingDraftPlugins.has(CONVERSATION_ID),
+      ).toBe(true),
+    );
+    const stash = useConversationStore
+      .getState()
+      .pendingDraftPlugins.get(CONVERSATION_ID)!;
+    expect(new Set(stash)).toEqual(new Set(["a", "c"]));
+
+    // No network on the draft path.
+    expect(enabledPluginsPutSpy).not.toHaveBeenCalled();
+  });
+
+  test("PUT failure → rollback optimistic write + error toast", async () => {
+    conversationImpl = () => Promise.resolve(conversationWith(["a"]));
+    const putDeferred = deferred<{ data: unknown }>();
+    putImpl = () => putDeferred.promise;
+
+    const { result, client } = renderSetHook();
+
+    await waitFor(() => {
+      expect(client.getQueryData(PLUGINS_KEY)).toBeTruthy();
+      expect(enabledInCache(client)).toEqual(["a"]);
+    });
+
+    act(() => {
+      result.current.toggle("b");
+    });
+
+    // Optimistic: prior scope ['a'] plus the toggled-on 'b'.
+    expect(new Set(enabledInCache(client) ?? [])).toEqual(new Set(["a", "b"]));
+    await waitFor(() => expect(enabledPluginsPutSpy).toHaveBeenCalled());
+
+    // Reject → catch rolls the cache back to the prior scope and toasts.
+    putDeferred.reject(new Error("500 — boom"));
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    await waitFor(() => expect(enabledInCache(client)).toEqual(["a"]));
+    expect(captureErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.ts
@@ -1,0 +1,129 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import {
+  conversationsByIdGetOptions,
+  conversationsByIdGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { conversationsByIdEnabledpluginsPut } from "@/generated/daemon/sdk.gen";
+import type { ConversationsByIdGetResponse } from "@/generated/daemon/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useConversationStore } from "@/stores/conversation-store";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { useEffectiveChatPlugins } from "./use-effective-chat-plugins";
+
+export interface UseSetChatPluginsResult {
+  /**
+   * Persist the chat's explicit plugin scope. `null` clears the scope back to
+   * the default (every installed plugin selected). Routes to the daemon for a
+   * loaded server row, or to the composer draft stash otherwise.
+   */
+  setPlugins: (next: string[] | null) => void;
+  /**
+   * Flip a single plugin on/off. Materializes the explicit set from the current
+   * effective selection (opt-out default → "all installed except the toggled-off
+   * one", mirroring `use-new-chat-plugins.ts`), then routes it through
+   * `setPlugins`.
+   */
+  toggle: (name: string) => void;
+}
+
+/**
+ * Write half of the in-chat plugin pill: persists a chat's plugin selection.
+ *
+ * Existing-vs-draft precedence mirrors `useEffectiveChatPlugins` /
+ * `use-active-profile-model.ts`:
+ *
+ * - **Existing/sent conversation** (a server row is loaded via
+ *   `conversationsByIdGetOptions`): PUT the set to
+ *   `conversationsByIdEnabledpluginsPut`, optimistically write
+ *   `conversation.enabledPlugins` into the conversation query cache, invalidate
+ *   on settle, and roll back + toast on failure — the persist pattern from
+ *   `ComposerSettingsMenu.handleProfileSelect`.
+ * - **Draft** (no server row): stash on the conversation store's
+ *   `pendingDraftPlugins`, no network.
+ */
+export function useSetChatPlugins(
+  assistantId: string | null,
+  conversationId: string | undefined,
+): UseSetChatPluginsResult {
+  const queryClient = useQueryClient();
+  const { plugins } = useEffectiveChatPlugins(assistantId, conversationId);
+
+  const { data: convData } = useQuery({
+    ...conversationsByIdGetOptions({
+      path: { assistant_id: assistantId ?? "", id: conversationId ?? "" },
+    }),
+    enabled: Boolean(assistantId) && Boolean(conversationId),
+  });
+  const hasServerRow = Boolean(convData?.conversation);
+
+  const setPlugins = useCallback(
+    (next: string[] | null) => {
+      if (!assistantId || !conversationId) return;
+
+      // Draft — no server row yet. Stash the selection locally; the send path
+      // attaches it to the minted conversation. No network, no rollback.
+      if (!hasServerRow) {
+        const store = useConversationStore.getState();
+        if (next === null) {
+          store.clearPendingDraftPlugins(conversationId);
+        } else {
+          store.setPendingDraftPlugins(conversationId, new Set(next));
+        }
+        return;
+      }
+
+      // Existing/sent conversation — persist to the daemon with an optimistic
+      // cache write so the pill/menu reflect the change before the round trip.
+      const key = conversationsByIdGetQueryKey({
+        path: { assistant_id: assistantId, id: conversationId },
+      });
+      const previous =
+        queryClient.getQueryData<ConversationsByIdGetResponse>(key);
+      queryClient.setQueryData<ConversationsByIdGetResponse>(key, (old) =>
+        old
+          ? {
+              ...old,
+              conversation: { ...old.conversation, enabledPlugins: next },
+            }
+          : old,
+      );
+
+      void (async () => {
+        try {
+          await conversationsByIdEnabledpluginsPut({
+            path: { assistant_id: assistantId, id: conversationId },
+            body: { enabledPlugins: next },
+            throwOnError: true,
+          });
+        } catch (err) {
+          // Roll back the optimistic write, then surface the failure.
+          if (previous !== undefined) {
+            queryClient.setQueryData(key, previous);
+          }
+          captureError(err, { context: "useSetChatPlugins.setPlugins" });
+          toast.error("Failed to update plugins. Please try again.");
+        } finally {
+          void queryClient.invalidateQueries({ queryKey: key });
+        }
+      })();
+    },
+    [assistantId, conversationId, hasServerRow, queryClient],
+  );
+
+  const toggle = useCallback(
+    (name: string) => {
+      const nextSet = new Set(
+        plugins.filter((plugin) => plugin.selected).map((plugin) => plugin.name),
+      );
+      if (nextSet.has(name)) nextSet.delete(name);
+      else nextSet.add(name);
+      setPlugins([...nextSet]);
+    },
+    [plugins, setPlugins],
+  );
+
+  return { setPlugins, toggle };
+}

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.ts
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/use-set-chat-plugins.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import {
   conversationsByIdGetOptions,
@@ -9,15 +9,24 @@ import { conversationsByIdEnabledpluginsPut } from "@/generated/daemon/sdk.gen";
 import type { ConversationsByIdGetResponse } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
+import { ApiError } from "@/utils/api-errors";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { useEffectiveChatPlugins } from "./use-effective-chat-plugins";
 
 export interface UseSetChatPluginsResult {
   /**
+   * True once the chat's row state is known — a loaded server row, or a settled
+   * 404 confirming a draft — so a write routes deterministically. False while the
+   * detail query is still pending/fetching or errored transiently (row state
+   * unknown); `setPlugins`/`toggle` no-op in that window. Consumers disable the
+   * control until this flips true.
+   */
+  canWrite: boolean;
+  /**
    * Persist the chat's explicit plugin scope. `null` clears the scope back to
    * the default (every installed plugin selected). Routes to the daemon for a
-   * loaded server row, or to the composer draft stash otherwise.
+   * loaded server row, or to the composer draft stash for a confirmed draft.
    */
   setPlugins: (next: string[] | null) => void;
   /**
@@ -32,17 +41,24 @@ export interface UseSetChatPluginsResult {
 /**
  * Write half of the in-chat plugin pill: persists a chat's plugin selection.
  *
- * Existing-vs-draft precedence mirrors `useEffectiveChatPlugins` /
- * `use-active-profile-model.ts`:
+ * Existing-vs-draft precedence keys off the conversation detail query's STATUS,
+ * not just data presence — a still-loading existing chat must not be mistaken
+ * for a draft (its click would land in `pendingDraftPlugins` and silently lose
+ * to the row once it loads):
  *
- * - **Existing/sent conversation** (a server row is loaded via
- *   `conversationsByIdGetOptions`): PUT the set to
- *   `conversationsByIdEnabledpluginsPut`, optimistically write
+ * - **Existing/sent conversation** (detail query resolved with a row): PUT the
+ *   set to `conversationsByIdEnabledpluginsPut`, optimistically write
  *   `conversation.enabledPlugins` into the conversation query cache, invalidate
- *   on settle, and roll back + toast on failure — the persist pattern from
- *   `ComposerSettingsMenu.handleProfileSelect`.
- * - **Draft** (no server row): stash on the conversation store's
- *   `pendingDraftPlugins`, no network.
+ *   once the send settles, and roll back + toast on failure — the persist
+ *   pattern from `ComposerSettingsMenu.handleProfileSelect`.
+ * - **Draft** (detail query settled to a 404 — no such row): stash on the
+ *   conversation store's `pendingDraftPlugins`, no network.
+ * - **Unknown** (query pending/fetching, or errored transiently): no-op, and
+ *   `canWrite` is false so the pill disables itself until the state is known.
+ *
+ * Rapid toggles coalesce: PUTs are serialized and re-sent whenever a newer
+ * selection arrived mid-flight, so concurrent toggles collapse to the final
+ * state and an older request can't overwrite a newer one.
  */
 export function useSetChatPlugins(
   assistantId: string | null,
@@ -51,20 +67,36 @@ export function useSetChatPlugins(
   const queryClient = useQueryClient();
   const { plugins } = useEffectiveChatPlugins(assistantId, conversationId);
 
-  const { data: convData } = useQuery({
+  const convEnabled = Boolean(assistantId) && Boolean(conversationId);
+  const convQuery = useQuery({
     ...conversationsByIdGetOptions({
       path: { assistant_id: assistantId ?? "", id: conversationId ?? "" },
     }),
-    enabled: Boolean(assistantId) && Boolean(conversationId),
+    enabled: convEnabled,
   });
-  const hasServerRow = Boolean(convData?.conversation);
+
+  const hasServerRow =
+    convQuery.isSuccess && Boolean(convQuery.data?.conversation);
+  const isConfirmedDraft =
+    convQuery.isError &&
+    convQuery.error instanceof ApiError &&
+    convQuery.error.status === 404;
+  const canWrite = convEnabled && (hasServerRow || isConfirmedDraft);
+
+  // Coalescing state for the serialized PUT loop. `desiredRef` holds the latest
+  // requested set; `sendingRef` guards a single in-flight loop; `rollbackRef`
+  // snapshots server truth captured before a burst's first optimistic write.
+  const desiredRef = useRef<string[] | null>(null);
+  const sendingRef = useRef(false);
+  const rollbackRef = useRef<ConversationsByIdGetResponse | undefined>(undefined);
 
   const setPlugins = useCallback(
     (next: string[] | null) => {
-      if (!assistantId || !conversationId) return;
+      // Row state unknown (or nothing to target) — never write blindly.
+      if (!canWrite || !assistantId || !conversationId) return;
 
-      // Draft — no server row yet. Stash the selection locally; the send path
-      // attaches it to the minted conversation. No network, no rollback.
+      // Confirmed draft — stash the selection locally; the send path attaches it
+      // to the minted conversation. No network, no rollback.
       if (!hasServerRow) {
         const store = useConversationStore.getState();
         if (next === null) {
@@ -80,8 +112,10 @@ export function useSetChatPlugins(
       const key = conversationsByIdGetQueryKey({
         path: { assistant_id: assistantId, id: conversationId },
       });
-      const previous =
-        queryClient.getQueryData<ConversationsByIdGetResponse>(key);
+      if (!sendingRef.current) {
+        rollbackRef.current =
+          queryClient.getQueryData<ConversationsByIdGetResponse>(key);
+      }
       queryClient.setQueryData<ConversationsByIdGetResponse>(key, (old) =>
         old
           ? {
@@ -90,31 +124,51 @@ export function useSetChatPlugins(
             }
           : old,
       );
+      desiredRef.current = next;
 
+      // A loop is already draining the latest desired set — let it pick this up.
+      if (sendingRef.current) return;
+
+      sendingRef.current = true;
       void (async () => {
         try {
-          await conversationsByIdEnabledpluginsPut({
-            path: { assistant_id: assistantId, id: conversationId },
-            body: { enabledPlugins: next },
-            throwOnError: true,
-          });
+          // Send-until-stable: serialize PUTs and re-send whenever a newer
+          // selection arrived mid-flight, so the last selection wins and older
+          // requests can't overwrite it.
+          let target = desiredRef.current;
+          let stable = false;
+          while (!stable) {
+            await conversationsByIdEnabledpluginsPut({
+              path: { assistant_id: assistantId, id: conversationId },
+              body: { enabledPlugins: target },
+              throwOnError: true,
+            });
+            if (desiredRef.current === target) {
+              stable = true;
+            } else {
+              target = desiredRef.current;
+            }
+          }
         } catch (err) {
-          // Roll back the optimistic write, then surface the failure.
-          if (previous !== undefined) {
-            queryClient.setQueryData(key, previous);
+          // Roll back to the pre-burst server truth, then surface the failure.
+          if (rollbackRef.current !== undefined) {
+            queryClient.setQueryData(key, rollbackRef.current);
           }
           captureError(err, { context: "useSetChatPlugins.setPlugins" });
           toast.error("Failed to update plugins. Please try again.");
         } finally {
+          sendingRef.current = false;
+          // Reconcile with server truth once the loop settles.
           void queryClient.invalidateQueries({ queryKey: key });
         }
       })();
     },
-    [assistantId, conversationId, hasServerRow, queryClient],
+    [assistantId, conversationId, canWrite, hasServerRow, queryClient],
   );
 
   const toggle = useCallback(
     (name: string) => {
+      if (!canWrite) return;
       const nextSet = new Set(
         plugins.filter((plugin) => plugin.selected).map((plugin) => plugin.name),
       );
@@ -122,8 +176,8 @@ export function useSetChatPlugins(
       else nextSet.add(name);
       setPlugins([...nextSet]);
     },
-    [plugins, setPlugins],
+    [plugins, setPlugins, canWrite],
   );
 
-  return { setPlugins, toggle };
+  return { canWrite, setPlugins, toggle };
 }


### PR DESCRIPTION
Write half of the in-chat plugin pill. Existing conversation → optimistic cache write + `conversationsByIdEnabledpluginsPut` + invalidate, rollback + toast on failure (mirrors ComposerSettingsMenu.handleProfileSelect). Draft → pendingDraftPlugins store stash, no network. `toggle(name)` materializes the next set from the current effective selection.

Part of plan: in-chat-plugin-pill.md (PR 4 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>