### PR TITLE
feat(gateway): mint invites natively in the gateway; delete invites_mint daemon relay

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5613,6 +5613,9 @@ paths:
                 expectedExternalUserId:
                   type: string
                   description: Expected user ID (E.164 for phone)
+                sourceConversationId:
+                  type: string
+                  description: Conversation the invite was created from (opaque)
               required:
                 - contactId
       responses:

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -47,9 +47,13 @@ mock.module("../ipc/gateway-client.js", () => ({
     method: string,
     params?: Record<string, unknown>,
   ) => {
-    if (method === "record_invite_redemption") return gatewayIpc.claim;
+    if (method === "record_invite_redemption") {
+      return gatewayIpc.claim;
+    }
     if (method === "upsert_verified_channel") {
-      if (!gatewayIpc.activationVerified) return { ok: true, verified: false };
+      if (!gatewayIpc.activationVerified) {
+        return { ok: true, verified: false };
+      }
       return {
         ok: true,
         verified: true,
@@ -71,37 +75,25 @@ mock.module("../ipc/gateway-client.js", () => ({
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { revokeInvite } from "../persistence/invite-store.js";
+import { createInvite, revokeInvite } from "../persistence/invite-store.js";
 import {
-  createIngressInvite,
+  composeInvitePresentation,
   triggerInviteCall,
 } from "../runtime/invite-service.js";
 import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
+import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 
 /**
- * The CLI/HTTP create/list/revoke/trigger route handlers relay to the gateway
- * (see invite-relay-routes.test.ts). The assistant-native invite logic the
- * gateway invokes via `invites_mint` + its native handlers is exercised here
- * against the assistant DB through the `invite-service` functions. Redemption
- * stays daemon-local and is driven through the route handler.
+ * Invite create/list/revoke are gateway-native (the daemon route handlers
+ * relay — see invite-relay-routes.test.ts; the gateway mint is exercised in
+ * gateway/src/__tests__/contacts-control-plane-proxy.test.ts). What stays
+ * daemon-local — token/voice redemption against the local invite table, the
+ * outbound call trigger, and the presentation composition layered onto the
+ * gateway's create payload — is exercised here.
  */
 function fakeResponse(body: unknown, status = 200) {
   return { status, json: async () => body };
-}
-
-async function handleCreateInvite(req: Request) {
-  const body = (await req.json()) as Record<string, string | number>;
-  const result = await createIngressInvite({
-    sourceChannel: body.sourceChannel as string | undefined,
-    note: body.note as string | undefined,
-    maxUses: body.maxUses as number | undefined,
-    expiresInMs: body.expiresInMs as number | undefined,
-    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    contactId: body.contactId as string,
-  });
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
-  return fakeResponse({ ok: true, invite: result.data }, 201);
 }
 
 async function handleRedeemInvite(req: Request) {
@@ -110,15 +102,18 @@ async function handleRedeemInvite(req: Request) {
     const result = await _handleRedeemInvite({ body });
     return fakeResponse(result);
   } catch (err) {
-    if (err instanceof RouteError)
+    if (err instanceof RouteError) {
       return fakeResponse({ ok: false, error: err.message }, err.statusCode);
+    }
     throw err;
   }
 }
 
 async function handleTriggerInviteCall(inviteId: string) {
   const result = await triggerInviteCall(inviteId);
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  if (!result.ok) {
+    return fakeResponse({ ok: false, error: result.error }, 400);
+  }
   return fakeResponse({ ok: true, callSid: result.data.callSid });
 }
 
@@ -129,6 +124,23 @@ function createTargetContact(displayName = "Test Contact"): string {
   return upsertContact({ displayName, role: "contact" }).id;
 }
 
+/** Seed a local voice invite row (redemption still reads the local table). */
+function seedVoiceInvite(
+  callerPhone = "+15551234567",
+  opts: { contactId?: string; maxUses?: number } = {},
+) {
+  const code = generateVoiceCode(6);
+  const { invite } = createInvite({
+    sourceChannel: "phone",
+    contactId: opts.contactId ?? createTargetContact(),
+    maxUses: opts.maxUses ?? 1,
+    expectedExternalUserId: callerPhone,
+    voiceCodeHash: hashVoiceCode(code),
+    voiceCodeDigits: 6,
+  });
+  return { invite, code };
+}
+
 function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
@@ -136,106 +148,24 @@ function resetTables() {
 }
 
 // ---------------------------------------------------------------------------
-// Invite routes
+// Token redemption (daemon-local)
 // ---------------------------------------------------------------------------
 
-describe("ingress invite HTTP routes", () => {
+describe("ingress invite redemption routes", () => {
   beforeEach(resetTables);
 
-  test("POST /v1/contacts/invites — creates an invite", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "telegram",
-        contactId: createTargetContact(),
-        note: "Test invite",
-        maxUses: 5,
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    expect(invite.sourceChannel).toBe("telegram");
-    expect(invite.note).toBe("Test invite");
-    expect(invite.maxUses).toBe(5);
-    expect(invite.status).toBe("active");
-    // Raw token should be returned on create
-    expect(typeof invite.token).toBe("string");
-    expect((invite.token as string).length).toBeGreaterThan(0);
-  });
-
-  test("POST /v1/contacts/invites — includes canonical share URL when bot username is configured", async () => {
-    mockTelegramBotUsername = "test_invite_bot";
-
-    try {
-      const req = new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-          note: "Share link test",
-        }),
-      });
-
-      const res = await handleCreateInvite(req);
-      const body = (await res.json()) as Record<string, unknown>;
-      const invite = body.invite as Record<string, unknown>;
-      const token = invite.token as string;
-      const share = invite.share as Record<string, unknown>;
-
-      expect(res.status).toBe(201);
-      expect(body.ok).toBe(true);
-      expect(typeof token).toBe("string");
-      expect(token.length).toBeGreaterThan(0);
-      expect(share).toBeDefined();
-      expect(share.url).toBe(`https://t.me/test_invite_bot?start=iv_${token}`);
-      expect(typeof share.displayText).toBe("string");
-    } finally {
-      mockTelegramBotUsername = undefined;
-    }
-  });
-
-  test("POST /v1/contacts/invites — missing sourceChannel returns 400", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ note: "No channel" }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as { ok: boolean; error: string };
-
-    expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
-    expect(body.error).toContain("sourceChannel");
-  });
-
   test("POST /v1/contacts/invites/redeem — redeems an invite", async () => {
-    // Create an invite first
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-          maxUses: 1,
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { token: string } };
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: createTargetContact(),
+      maxUses: 1,
+    });
 
     const req = new Request("http://localhost/v1/contacts/invites/redeem", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        token: created.invite.token,
+        token: rawToken,
         externalUserId: "redeemer-1",
         sourceChannel: "telegram",
       }),
@@ -280,175 +210,29 @@ describe("ingress invite HTTP routes", () => {
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Shared logic round-trip
-// ---------------------------------------------------------------------------
+  test("create + revoke round-trip against the local store", async () => {
+    const { invite } = createInvite({
+      sourceChannel: "telegram",
+      contactId: createTargetContact(),
+    });
+    expect(invite.status).toBe("active");
 
-describe("ingress service shared logic", () => {
-  beforeEach(resetTables);
-
-  test("invite create + revoke round-trip through shared service", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as {
-      invite: { id: string; status: string };
-    };
-    expect(created.invite.status).toBe("active");
-
-    const revoked = revokeInvite(created.invite.id);
+    const revoked = revokeInvite(invite.id);
     expect(revoked?.status).toBe("revoked");
-    expect(revoked?.id).toBe(created.invite.id);
+    expect(revoked?.id).toBe(invite.id);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Voice invite routes
+// Voice invite redemption (daemon-local)
 // ---------------------------------------------------------------------------
 
-describe("voice invite HTTP routes", () => {
+describe("voice invite redemption routes", () => {
   beforeEach(resetTables);
-
-  test("POST /v1/contacts/invites with sourceChannel voice — creates invite with voiceCode, stores hash only", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "phone",
-        contactId: createTargetContact("Alice"),
-        expectedExternalUserId: "+15551234567",
-        maxUses: 3,
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    expect(invite.sourceChannel).toBe("phone");
-    // Voice code should be returned (6 digits by default)
-    expect(typeof invite.voiceCode).toBe("string");
-    expect((invite.voiceCode as string).length).toBe(6);
-    expect(/^\d{6}$/.test(invite.voiceCode as string)).toBe(true);
-    // Hash should be stored
-    expect(typeof invite.tokenHash).toBe("string");
-    expect((invite.tokenHash as string).length).toBeGreaterThan(0);
-    // voiceCodeDigits should be recorded
-    expect(invite.voiceCodeDigits).toBe(6);
-    // expectedExternalUserId should be recorded
-    expect(invite.expectedExternalUserId).toBe("+15551234567");
-    // friendName is mirrored from the bound contact's displayName, not a flag
-    expect(invite.friendName).toBe("Alice");
-  });
-
-  test("voice invite creation requires expectedExternalUserId", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "phone",
-        contactId: createTargetContact(),
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
-    expect(body.error).toContain("expectedExternalUserId");
-  });
-
-  test("voice invite creation validates E.164 format", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "phone",
-        contactId: createTargetContact(),
-        expectedExternalUserId: "not-a-phone-number",
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
-    expect(body.error).toContain("E.164");
-  });
-
-  test("voiceCodeDigits is always 6 — custom values are ignored", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "phone",
-        contactId: createTargetContact(),
-        expectedExternalUserId: "+15551234567",
-        voiceCodeDigits: 8,
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    expect((invite.voiceCode as string).length).toBe(6);
-    expect(invite.voiceCodeDigits).toBe(6);
-  });
-
-  test("voice invites do NOT return token in response", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sourceChannel: "phone",
-        contactId: createTargetContact(),
-        expectedExternalUserId: "+15551234567",
-      }),
-    });
-
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(201);
-    const invite = body.invite as Record<string, unknown>;
-    // Voice invites must not expose the raw token — callers redeem via
-    // the identity-bound voice code flow
-    expect(invite.token).toBeUndefined();
-  });
 
   test("POST /v1/contacts/invites/redeem — redeems a voice invite code via unified endpoint", async () => {
-    // Create a voice invite
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "phone",
-          contactId: createTargetContact(),
-          expectedExternalUserId: "+15551234567",
-          maxUses: 1,
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as {
-      invite: { voiceCode: string };
-    };
+    const { code } = seedVoiceInvite("+15551234567");
 
     // Redeem the voice code via the unified /redeem endpoint
     const redeemReq = new Request(
@@ -458,7 +242,7 @@ describe("voice invite HTTP routes", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           callerExternalUserId: "+15551234567",
-          code: created.invite.voiceCode,
+          code,
         }),
       },
     );
@@ -489,19 +273,7 @@ describe("voice invite HTTP routes", () => {
   });
 
   test("POST /v1/contacts/invites/redeem — wrong voice code returns 400", async () => {
-    // Create a voice invite
-    await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "phone",
-          contactId: createTargetContact(),
-          expectedExternalUserId: "+15551234567",
-          maxUses: 1,
-        }),
-      }),
-    );
+    seedVoiceInvite("+15551234567");
 
     const req = new Request("http://localhost/v1/contacts/invites/redeem", {
       method: "POST",
@@ -518,28 +290,83 @@ describe("voice invite HTTP routes", () => {
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
   });
+});
 
-  test("voice invite creation returns guardianInstruction with the contact's first name", async () => {
-    const req = new Request("http://localhost/v1/contacts/invites", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+// ---------------------------------------------------------------------------
+// Presentation composition (daemon-owned layer over the gateway mint payload)
+// ---------------------------------------------------------------------------
+
+describe("composeInvitePresentation", () => {
+  beforeEach(resetTables);
+
+  test("voice invites get a guardianInstruction with the contact's first name", async () => {
+    const contactId = createTargetContact("Carolina Example");
+
+    const invite = await composeInvitePresentation({
+      contactId,
+      invite: {
+        id: "inv-voice-1",
         sourceChannel: "phone",
-        contactId: createTargetContact("Carolina Flaherty"),
-        expectedExternalUserId: "+15551234567",
-      }),
+        voiceCode: "123456",
+        voiceCodeDigits: 6,
+      },
     });
 
-    const res = await handleCreateInvite(req);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    // First-token of the contact's displayName is used in the instruction
     expect(invite.guardianInstruction).toBe(
       "Carolina will need this code when they answer. Share it with them first.",
     );
+    // Voice invites never gain a share payload (no raw token exists).
+    expect(invite.share).toBeUndefined();
+  });
+
+  test("voice invites fall back to the generic instruction when no contact name resolves", async () => {
+    const invite = await composeInvitePresentation({
+      contactId: "missing-contact",
+      invite: { id: "inv-voice-2", sourceChannel: "phone" },
+    });
+
+    expect(invite.guardianInstruction).toBe(
+      "Share this code with them — they'll need it when they answer the call.",
+    );
+  });
+
+  test("telegram invites gain share URL + guardianInstruction when bot username is configured", async () => {
+    mockTelegramBotUsername = "test_invite_bot";
+
+    try {
+      const rawToken = "raw-token-abc";
+      const invite = await composeInvitePresentation({
+        contactId: createTargetContact("Alice"),
+        invite: {
+          id: "inv-tg-1",
+          sourceChannel: "telegram",
+          token: rawToken,
+          inviteCode: "654321",
+        },
+        rawToken,
+      });
+
+      const share = invite.share as Record<string, unknown>;
+      expect(share).toBeDefined();
+      expect(share.url).toBe(`https://t.me/test_invite_bot?start=iv_${rawToken}`);
+      expect(typeof share.displayText).toBe("string");
+      expect(typeof invite.guardianInstruction).toBe("string");
+      expect((invite.guardianInstruction as string).length).toBeGreaterThan(0);
+      // One-time secrets from the gateway payload pass through untouched.
+      expect(invite.token).toBe(rawToken);
+      expect(invite.inviteCode).toBe("654321");
+    } finally {
+      mockTelegramBotUsername = undefined;
+    }
+  });
+
+  test("non-voice payloads without an inviteCode pass through unchanged", async () => {
+    const payload = { id: "inv-x", sourceChannel: "telegram", status: "active" };
+    const invite = await composeInvitePresentation({
+      contactId: createTargetContact(),
+      invite: payload,
+    });
+    expect(invite).toEqual(payload);
   });
 });
 
@@ -554,20 +381,9 @@ describe("POST /v1/contacts/invites/:id/call", () => {
   });
 
   test("triggers a call for an active phone invite", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "phone",
-          contactId: createTargetContact(),
-          expectedExternalUserId: "+15551234567",
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { id: string } };
+    const { invite } = seedVoiceInvite("+15551234567");
 
-    const res = await handleTriggerInviteCall(created.invite.id);
+    const res = await handleTriggerInviteCall(invite.id);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -585,23 +401,12 @@ describe("POST /v1/contacts/invites/:id/call", () => {
   });
 
   test("returns 400 for a revoked (non-active) invite", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "phone",
-          contactId: createTargetContact(),
-          expectedExternalUserId: "+15551234567",
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { id: string } };
+    const { invite } = seedVoiceInvite("+15551234567");
 
     // Revoke the invite
-    revokeInvite(created.invite.id);
+    revokeInvite(invite.id);
 
-    const res = await handleTriggerInviteCall(created.invite.id);
+    const res = await handleTriggerInviteCall(invite.id);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(400);
@@ -610,19 +415,12 @@ describe("POST /v1/contacts/invites/:id/call", () => {
   });
 
   test("returns 400 for a non-phone invite", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { id: string } };
+    const { invite } = createInvite({
+      sourceChannel: "telegram",
+      contactId: createTargetContact(),
+    });
 
-    const res = await handleTriggerInviteCall(created.invite.id);
+    const res = await handleTriggerInviteCall(invite.id);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(400);

--- a/assistant/src/__tests__/invite-service-ipc.test.ts
+++ b/assistant/src/__tests__/invite-service-ipc.test.ts
@@ -91,14 +91,9 @@ function richContactForId(contactId: string | undefined) {
 }
 
 import { getContact, upsertContact } from "../contacts/contact-store.js";
-import { handleMintInvite } from "../ipc/routes/invite-ipc-routes.js";
 import { getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import {
-  createInvite,
-  findById,
-  hashToken,
-} from "../persistence/invite-store.js";
+import { createInvite } from "../persistence/invite-store.js";
 import {
   handleRedeemTokenInvite,
   handleRedeemVoiceInvite,
@@ -117,90 +112,6 @@ function resetTables() {
 function createTargetContact(displayName = "Target Contact"): string {
   return upsertContact({ displayName, role: "contact" }).id;
 }
-
-describe("handleMintInvite (invites_mint)", () => {
-  beforeEach(resetTables);
-
-  test("returns rawToken + gateway projection and persists the assistant row", async () => {
-    const contactId = createTargetContact();
-
-    const result = (await handleMintInvite({
-      body: { sourceChannel: "telegram", contactId, maxUses: 3 },
-    })) as {
-      ok: boolean;
-      invite: { id: string; token?: string };
-      rawToken?: string;
-      gateway: {
-        id: string;
-        inviteCodeHash: string;
-        sourceChannel: string;
-        contactId: string;
-        note: string | null;
-        maxUses: number;
-        expiresAt: number;
-      };
-    };
-
-    expect(result.ok).toBe(true);
-    expect(result.rawToken).toBeDefined();
-    expect(typeof result.rawToken).toBe("string");
-
-    // Gateway projection carries exactly the mirrored fields.
-    expect(result.gateway).toEqual({
-      id: result.invite.id,
-      inviteCodeHash: expect.any(String),
-      sourceChannel: "telegram",
-      contactId,
-      note: null,
-      maxUses: 3,
-      expiresAt: expect.any(Number),
-    });
-
-    // The assistant row is persisted and only the token hash is stored.
-    const row = findById(result.invite.id);
-    expect(row).not.toBeNull();
-    expect(row!.contactId).toBe(contactId);
-    expect(row!.tokenHash).toBe(hashToken(result.rawToken!));
-    expect(row!.inviteCodeHash).toBe(result.gateway.inviteCodeHash);
-  });
-
-  test("voice mint does not expose a raw token but persists voice fields", async () => {
-    const contactId = createTargetContact();
-
-    const result = (await handleMintInvite({
-      body: {
-        sourceChannel: "phone",
-        contactId,
-        expectedExternalUserId: "+12025550100",
-      },
-    })) as {
-      ok: boolean;
-      invite: { id: string; voiceCode?: string };
-      rawToken?: string;
-      gateway: { sourceChannel: string; inviteCodeHash: string };
-    };
-
-    expect(result.ok).toBe(true);
-    // Voice invites never expose the generic redemption token.
-    expect(result.rawToken).toBeUndefined();
-    expect(result.gateway.sourceChannel).toBe("phone");
-
-    const row = findById(result.invite.id);
-    expect(row).not.toBeNull();
-    expect(row!.expectedExternalUserId).toBe("+12025550100");
-    expect(row!.voiceCodeHash).toBeTruthy();
-    // Voice invites have no non-voice inviteCodeHash; the gateway projection
-    // mirrors the voice code hash instead so the NOT NULL mirror constraint holds.
-    expect(row!.inviteCodeHash).toBeNull();
-    expect(row!.voiceCodeHash).toBe(result.gateway.inviteCodeHash);
-  });
-
-  test("returns a 400 when required params are missing", async () => {
-    await expect(
-      handleMintInvite({ body: { contactId: createTargetContact() } }),
-    ).rejects.toThrow();
-  });
-});
 
 describe("handleRedeemTokenInvite (invites_redeem_token)", () => {
   beforeEach(resetTables);

--- a/assistant/src/ipc/routes/__tests__/invite-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/invite-ipc-routes.test.ts
@@ -1,7 +1,7 @@
 /**
- * The three gateway-facing invite methods are IPC-only: registered on the
- * assistant IPC server by operationId, and absent from the shared HTTP route
- * set / `get_route_schema`. Relocating them out of `ROUTES` (per the
+ * The gateway-facing invite redemption methods are IPC-only: registered on
+ * the assistant IPC server by operationId, and absent from the shared HTTP
+ * route set / `get_route_schema`. Relocating them out of `ROUTES` (per the
  * documented IPC-only pattern) is what structurally guarantees they can never
  * reach the gateway's HTTP IPC proxy route schema.
  */
@@ -26,7 +26,6 @@ import { INVITE_IPC_METHODS } from "../invite-ipc-routes.js";
 import { routeDefinitionsToIpcMethods } from "../route-adapter.js";
 
 const INVITE_IPC_OPERATION_IDS = [
-  "invites_mint",
   "invites_redeem_voice",
   "invites_redeem_token",
 ] as const;

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -2,51 +2,20 @@
  * IPC-only invite methods called by the gateway's native invite HTTP
  * handlers over the assistant IPC socket (`ipcCallAssistant`).
  *
- * Token secrecy + voice fields are assistant-owned, so the gateway mints
- * tokens / redeems codes here and mirrors the canonical lifecycle into its
- * own DB. These have no HTTP surface: they are registered directly on the
- * IPC server and never enter the shared `ROUTES` array, so they can never
+ * The gateway redeems codes here while redemption remains daemon-local.
+ * These have no HTTP surface: they are registered directly on the IPC
+ * server and never enter the shared `ROUTES` array, so they can never
  * reach the gateway's HTTP IPC proxy route schema (`get_route_schema`).
  *
  * Per `assistant/AGENTS.md`, IPC-only methods are registered here rather
  * than flagged inside `ROUTES`.
  */
 
-import { mintIngressInvite } from "../../runtime/invite-service.js";
 import {
   handleRedeemTokenInvite,
   handleRedeemVoiceInvite,
 } from "../../runtime/routes/contact-routes.js";
-import { BadRequestError } from "../../runtime/routes/errors.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
-
-/**
- * Mint an invite for the gateway (`invites_mint`).
- *
- * Returns the raw token plus the minimal projection the gateway mirrors into
- * its own store. Token generation/hashing and voice fields stay
- * assistant-owned.
- */
-export async function handleMintInvite({ body = {} }: RouteHandlerArgs) {
-  const result = await mintIngressInvite({
-    sourceChannel: body.sourceChannel as string | undefined,
-    note: body.note as string | undefined,
-    maxUses: body.maxUses as number | undefined,
-    expiresInMs: body.expiresInMs as number | undefined,
-    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    contactId: body.contactId as string,
-  });
-
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
-  }
-  return {
-    ok: true,
-    invite: result.data.invite,
-    rawToken: result.data.rawToken,
-    gateway: result.data.gateway,
-  };
-}
 
 /**
  * IPC-only invite methods, keyed by IPC operationId. Registered directly on
@@ -60,7 +29,6 @@ export const INVITE_IPC_METHODS: Record<
   string,
   (args: RouteHandlerArgs) => unknown
 > = {
-  invites_mint: handleMintInvite,
   invites_redeem_voice: handleRedeemVoiceInvite,
   invites_redeem_token: handleRedeemTokenInvite,
 };

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -12,7 +12,6 @@ import { startInviteCall } from "../calls/call-domain.js";
 import { isChannelId } from "../channels/types.js";
 import { getContact } from "../contacts/contact-store.js";
 import {
-  createInvite,
   findById,
   findByTokenHash,
   hashToken,
@@ -24,8 +23,6 @@ import {
   DEFAULT_USER_REFERENCE,
   resolveGuardianName,
 } from "../prompts/user-reference.js";
-import { isValidE164 } from "../util/phone.js";
-import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import {
   getInviteAdapterRegistry,
   resolveAdapterHandle,
@@ -150,205 +147,92 @@ export type IngressResult<T> =
 // Invite operations
 // ---------------------------------------------------------------------------
 
-export async function createIngressInvite(params: {
-  sourceChannel?: string;
-  note?: string;
-  maxUses?: number;
-  expiresInMs?: number;
-  // Voice invite parameters. Display metadata is no longer accepted from
-  // callers: the invitee's name is resolved from the bound contact's
-  // displayName at every read site (voice greeting, instructions), and the
-  // guardian label is resolved at runtime via resolveGuardianName().
-  expectedExternalUserId?: string;
-  contactId: string;
-}): Promise<IngressResult<InviteResponseData>> {
-  if (!params.sourceChannel) {
-    return { ok: false, error: "sourceChannel is required for create" };
+/**
+ * Guardian display label attached to voice invites, resolved from the
+ * guardian persona with the placeholder/declined sentinels filtered out.
+ * The daemon passes it through to the gateway mint, which stores it on the
+ * invite row and never interprets it.
+ */
+export function resolveInviteGuardianName(): string | undefined {
+  const name = resolveGuardianName();
+  if (
+    !name ||
+    name === DEFAULT_USER_REFERENCE ||
+    name === DECLINED_BY_USER_SENTINEL
+  ) {
+    return undefined;
+  }
+  return name;
+}
+
+/**
+ * Layer the daemon-owned presentation fields onto a gateway-minted invite
+ * payload: the share link, the guardian instruction (LLM-generated for
+ * non-voice channels), and the resolved channel handle. The gateway owns the
+ * invite row and its secrets; everything added here is display-only, derived
+ * from the one-time create response, and never persisted.
+ */
+export async function composeInvitePresentation(params: {
+  contactId?: string;
+  invite: Record<string, unknown>;
+  rawToken?: string;
+}): Promise<Record<string, unknown>> {
+  const invite = params.invite;
+  const sourceChannel =
+    typeof invite.sourceChannel === "string" ? invite.sourceChannel : "";
+  const isVoice = sourceChannel === "phone";
+  const inviteCode =
+    typeof invite.inviteCode === "string" ? invite.inviteCode : undefined;
+  if (!isVoice && !inviteCode) {
+    return invite;
   }
 
-  if (!params.contactId) {
-    return { ok: false, error: "contactId is required for create" };
-  }
-
-  // Resolve the bound contact's displayName as the canonical invitee name.
-  // The greeting and instruction copy use this rather than a free-text flag.
-  const boundContact = getContact(params.contactId);
-  const resolvedContactName = boundContact?.displayName?.trim() || undefined;
-  const resolvedFirstName = resolvedContactName?.split(/\s+/)[0];
-
-  // For voice invites: generate a one-time numeric code, hash it, and pass
-  // the hash to the store. The plaintext code is included in the response
-  // exactly once and never stored.
-  let voiceCode: string | undefined;
-  let voiceCodeHash: string | undefined;
-  let effectiveGuardianName: string | undefined;
-  const isVoice = params.sourceChannel === "phone";
-
-  // For non-voice invites: generate a 6-digit invite code for guardian-mediated
-  // redemption. The plaintext code is returned once in the response; only the
-  // hash is persisted for later redemption lookup.
-  let inviteCode: string | undefined;
-  let inviteCodeHash: string | undefined;
+  // The invitee's name comes from the bound contact's displayName; fall back
+  // to the gateway-stamped friendName when the local mirror lacks the contact.
+  const boundContact = params.contactId
+    ? getContact(params.contactId)
+    : undefined;
+  const resolvedContactName =
+    boundContact?.displayName?.trim() ||
+    (typeof invite.friendName === "string"
+      ? invite.friendName.trim()
+      : undefined) ||
+    undefined;
 
   if (isVoice) {
-    if (!params.expectedExternalUserId) {
-      return {
-        ok: false,
-        error: "expectedExternalUserId is required for voice invites",
-      };
-    }
-    if (!isValidE164(params.expectedExternalUserId)) {
-      return {
-        ok: false,
-        error:
-          "expectedExternalUserId must be in E.164 format (e.g., +15551234567)",
-      };
-    }
-    effectiveGuardianName = resolveGuardianName();
-    if (
-      !effectiveGuardianName ||
-      effectiveGuardianName === DEFAULT_USER_REFERENCE ||
-      effectiveGuardianName === DECLINED_BY_USER_SENTINEL
-    ) {
-      effectiveGuardianName = undefined;
-    }
-    voiceCode = generateVoiceCode(6);
-    voiceCodeHash = hashVoiceCode(voiceCode);
-  } else {
-    inviteCode = generateVoiceCode(6);
-    inviteCodeHash = hashVoiceCode(inviteCode);
-  }
-
-  const { invite, rawToken } = createInvite({
-    sourceChannel: params.sourceChannel,
-    contactId: params.contactId,
-    note: params.note,
-    maxUses: params.maxUses,
-    expiresInMs: params.expiresInMs,
-    ...(isVoice
-      ? {
-          expectedExternalUserId: params.expectedExternalUserId,
-          voiceCodeHash,
-          voiceCodeDigits: 6,
-          // Mirror the contact-resolved names into the legacy columns so
-          // outbound invite calls (which still read invite.friendName /
-          // invite.guardianName) keep working without a separate lookup.
-          friendName: resolvedContactName,
-          guardianName: effectiveGuardianName,
-        }
-      : { inviteCodeHash }),
-  });
-
-  // Build invite instruction for non-voice invites via LLM generation
-  let guardianInstruction: string | undefined;
-  let channelHandle: string | undefined;
-  if (!isVoice && inviteCode) {
-    const channelId = isChannelId(params.sourceChannel)
-      ? params.sourceChannel
-      : undefined;
-    const adapter = channelId
-      ? getInviteAdapterRegistry().get(channelId)
-      : undefined;
-    if (params.sourceChannel === "telegram") {
-      const { ensureTelegramBotUsernameResolved } =
-        await import("./channel-invite-transports/telegram.js");
-      await ensureTelegramBotUsernameResolved();
-    }
-    channelHandle = adapter ? await resolveAdapterHandle(adapter) : undefined;
-    const share = buildSharePayload(params.sourceChannel, rawToken);
-    guardianInstruction = await generateInviteInstruction({
-      contactName: resolvedContactName,
-      channelType: params.sourceChannel,
-      channelHandle,
-      hasShareUrl: !!share?.url,
-      shareUrl: share?.url,
-    });
-  }
-
-  if (isVoice) {
-    guardianInstruction = resolvedFirstName
+    const resolvedFirstName = resolvedContactName?.split(/\s+/)[0];
+    const guardianInstruction = resolvedFirstName
       ? `${resolvedFirstName} will need this code when they answer. Share it with them first.`
       : "Share this code with them — they'll need it when they answer the call.";
+    return { ...invite, guardianInstruction };
   }
 
-  // Voice invites must not expose the token — callers must redeem via the
-  // identity-bound voice code flow, not the generic token redemption path.
-  return {
-    ok: true,
-    data: inviteToResponse(invite, {
-      rawToken: isVoice ? undefined : rawToken,
-      voiceCode,
-      inviteCode,
-      guardianInstruction,
-      channelHandle,
-    }),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Mint — gateway-facing projection
-//
-// The gateway owns the canonical invite lifecycle in its own DB, but token
-// generation/hashing and voice fields are assistant-owned. `mintIngressInvite`
-// runs the same `createIngressInvite` path and surfaces the raw token plus the
-// minimal projection the gateway mirrors. The raw token is returned exactly
-// once and never persisted in plaintext.
-// ---------------------------------------------------------------------------
-
-/** Minimal invite projection the gateway mirrors into its own store. */
-export interface GatewayInviteProjection {
-  id: string;
-  /** Hash of whatever code redeems this invite: token hash for token invites,
-   * voice code hash for voice/phone invites. Always non-null and mirrorable. */
-  inviteCodeHash: string;
-  sourceChannel: string;
-  contactId: string;
-  note: string | null;
-  maxUses: number;
-  expiresAt: number;
-}
-
-export interface MintInviteResult {
-  invite: InviteResponseData;
-  rawToken?: string;
-  gateway: GatewayInviteProjection;
-}
-
-export async function mintIngressInvite(
-  params: Parameters<typeof createIngressInvite>[0],
-): Promise<IngressResult<MintInviteResult>> {
-  const result = await createIngressInvite(params);
-  if (!result.ok) return result;
-
-  // The persisted row carries fields the response projection omits
-  // (inviteCodeHash); read it back to build the gateway projection.
-  const row = findById(result.data.id);
-  if (!row) {
-    return { ok: false, error: "Invite not found after mint" };
+  const channelId = isChannelId(sourceChannel) ? sourceChannel : undefined;
+  const adapter = channelId
+    ? getInviteAdapterRegistry().get(channelId)
+    : undefined;
+  if (sourceChannel === "telegram") {
+    const { ensureTelegramBotUsernameResolved } =
+      await import("./channel-invite-transports/telegram.js");
+    await ensureTelegramBotUsernameResolved();
   }
-
-  // The gateway mirrors the hash of whatever code redeems this invite. Token
-  // invites carry inviteCodeHash; voice/phone invites gate on voiceCodeHash.
-  const inviteCodeHash = row.inviteCodeHash ?? row.voiceCodeHash;
-  if (!inviteCodeHash) {
-    return { ok: false, error: "Invite is missing a redemption code hash" };
-  }
+  const channelHandle = adapter
+    ? await resolveAdapterHandle(adapter)
+    : undefined;
+  const share = buildSharePayload(sourceChannel, params.rawToken);
+  const guardianInstruction = await generateInviteInstruction({
+    contactName: resolvedContactName,
+    channelType: sourceChannel,
+    channelHandle,
+    hasShareUrl: !!share?.url,
+    shareUrl: share?.url,
+  });
 
   return {
-    ok: true,
-    data: {
-      invite: result.data,
-      rawToken: result.data.token,
-      gateway: {
-        id: row.id,
-        inviteCodeHash,
-        sourceChannel: row.sourceChannel,
-        contactId: row.contactId,
-        note: row.note,
-        maxUses: row.maxUses,
-        expiresAt: row.expiresAt,
-      },
-    },
+    ...invite,
+    ...(share ? { share } : {}),
+    ...(guardianInstruction ? { guardianInstruction } : {}),
+    ...(channelHandle ? { channelHandle } : {}),
   };
 }
 

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -71,6 +71,9 @@ const actualInviteService = await import("../../invite-service.js");
 mock.module("../../invite-service.js", () => ({
   ...actualInviteService,
   triggerInviteCall: triggerInviteCallMock,
+  // Deterministic guardian label so the voice-create passthrough is assertable
+  // (the real resolver reads the guardian persona file).
+  resolveInviteGuardianName: () => "Guardian Name",
 }));
 
 const {
@@ -144,9 +147,9 @@ describe("invite relay routes", () => {
             expiresInMs: undefined,
             expectedExternalUserId: undefined,
           },
-          // The create relay uses a generous timeout (gateway invites_mint can
-          // spend ~5s in generateInviteInstruction); list/revoke use the default.
-          timeoutMs: 30_000,
+          // The gateway mint is a fast native DB write; the LLM presentation
+          // step runs daemon-side after the relay, so the default timeout fits.
+          timeoutMs: undefined,
         },
       ]);
       expect(result).toEqual({
@@ -164,6 +167,35 @@ describe("invite relay routes", () => {
       });
 
       expect(result).toEqual({ ok: true, invite: { id: "i9" } });
+    });
+
+    test("supplies guardianName (voice) and sourceConversationId passthrough", async () => {
+      ipcResult = { invite: { id: "iv" } };
+      await handleCreateInvite({
+        body: {
+          contactId: "c1",
+          sourceChannel: "phone",
+          expectedExternalUserId: "+15551234567",
+          sourceConversationId: "conv-1",
+        },
+      });
+
+      expect(ipcCalls[0].params).toMatchObject({
+        contactId: "c1",
+        sourceChannel: "phone",
+        expectedExternalUserId: "+15551234567",
+        guardianName: "Guardian Name",
+        sourceConversationId: "conv-1",
+      });
+    });
+
+    test("omits guardianName for non-voice creates", async () => {
+      ipcResult = { invite: { id: "i9" } };
+      await handleCreateInvite({
+        body: { contactId: "c1", sourceChannel: "telegram" },
+      });
+
+      expect("guardianName" in (ipcCalls[0].params ?? {})).toBe(false);
     });
   });
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -28,8 +28,10 @@ import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
+  composeInvitePresentation,
   redeemIngressInvite,
   redeemVoiceInviteCode,
+  resolveInviteGuardianName,
   triggerInviteCall,
 } from "../invite-service.js";
 import { BadRequestError, NotFoundError, RouteError } from "./errors.js";
@@ -296,17 +298,12 @@ export async function handleGetContact(contactId: string) {
 // Invite handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
-// The gateway owns the canonical invite write path. These CLI handlers relay
-// to the gateway IPC methods via `ipcCallPersistent`; the assistant DB is
-// written only by the gateway. (Redemption stays daemon-local — see the redeem route.)
-
-// The invite-CREATE relay needs a generous timeout: the gateway's `invites_mint`
-// handler calls `createIngressInvite` → `generateInviteInstruction`, which can spend
-// up to GENERATION_TIMEOUT_MS (~5s) waiting on an LLM before falling back. The default
-// 5s persistent-IPC timeout can fire mid-mint, so the caller sees a spurious failure
-// even though the gateway is still writing the invite. 30s safely exceeds the inner
-// ~5s fallback plus IPC overhead on both nested hops. (List/revoke keep the default.)
-const INVITE_CREATE_RELAY_TIMEOUT_MS = 30_000;
+// The gateway owns the canonical invite write path, including the mint: it
+// generates the secrets and writes the single gateway invite row. These CLI
+// handlers relay via `ipcCallPersistent`; the daemon then layers the
+// presentation fields (share link, LLM guardian instruction, channel handle)
+// onto the gateway's one-time create payload. (Redemption stays daemon-local
+// — see the redeem route.)
 
 export async function handleListInvites({
   queryParams = {},
@@ -325,29 +322,41 @@ export async function handleListInvites({
 }
 
 export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
+  const contactId = body.contactId as string;
+  const sourceChannel = body.sourceChannel as string | undefined;
+  // The guardian display label on voice invites is daemon-resolved and passed
+  // through to the gateway, which stores it and never interprets it.
+  const guardianName =
+    sourceChannel === "phone" ? resolveInviteGuardianName() : undefined;
+  let result: { invite: Record<string, unknown>; rawToken?: string };
   try {
-    const result = (await ipcCallPersistent(
-      "invites_create",
-      {
-        contactId: body.contactId as string,
-        sourceChannel: body.sourceChannel as string | undefined,
-        note: body.note as string | undefined,
-        maxUses: body.maxUses as number | undefined,
-        expiresInMs: body.expiresInMs as number | undefined,
-        expectedExternalUserId: body.expectedExternalUserId as
-          | string
-          | undefined,
-      },
-      INVITE_CREATE_RELAY_TIMEOUT_MS,
-    )) as { invite: Record<string, unknown>; rawToken?: string };
-    return {
-      ok: true,
-      invite: result.invite,
-      ...(result.rawToken ? { rawToken: result.rawToken } : {}),
-    };
+    result = (await ipcCallPersistent("invites_create", {
+      contactId,
+      sourceChannel,
+      note: body.note as string | undefined,
+      maxUses: body.maxUses as number | undefined,
+      expiresInMs: body.expiresInMs as number | undefined,
+      expectedExternalUserId: body.expectedExternalUserId as
+        | string
+        | undefined,
+      ...(guardianName ? { guardianName } : {}),
+      ...(typeof body.sourceConversationId === "string"
+        ? { sourceConversationId: body.sourceConversationId }
+        : {}),
+    })) as { invite: Record<string, unknown>; rawToken?: string };
   } catch (err) {
     rethrowGatewayError(err);
   }
+  const invite = await composeInvitePresentation({
+    contactId,
+    invite: result.invite,
+    rawToken: result.rawToken,
+  });
+  return {
+    ok: true,
+    invite,
+    ...(result.rawToken ? { rawToken: result.rawToken } : {}),
+  };
 }
 
 export async function handleRevokeInvite({
@@ -560,6 +569,10 @@ export const ROUTES: RouteDefinition[] = [
       expectedExternalUserId: z
         .string()
         .describe("Expected user ID (E.164 for phone)")
+        .optional(),
+      sourceConversationId: z
+        .string()
+        .describe("Conversation the invite was created from (opaque)")
         .optional(),
     }),
     responseBody: z.object({

--- a/assistant/src/util/phone.ts
+++ b/assistant/src/util/phone.ts
@@ -5,12 +5,9 @@
  * them to E.164 before validation, rate-limit lookups, or storage.
  */
 
-/**
- * Basic E.164 phone number validation: starts with +, followed by 10-15 digits.
- */
-export function isValidE164(phone: string): boolean {
-  return /^\+\d{10,15}$/.test(phone);
-}
+// Thin alias over the shared @vellumai/gateway-client invite contract so the
+// daemon and the gateway validate voice-invite phone bindings identically.
+export { isValidE164 } from "@vellumai/gateway-client";
 
 /**
  * Normalize a phone number string to E.164 format.

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -7,6 +7,7 @@ import {
   beforeAll,
   afterAll,
 } from "bun:test";
+import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey } from "../auth/token-service.js";
 
@@ -166,6 +167,15 @@ type InviteRow = {
   id: string;
   sourceChannel: string;
   inviteCodeHash: string;
+  // Secret/display columns are optional here so the legacy list/revoke
+  // fixtures stay minimal; the mint echo mock fills them all in.
+  tokenHash?: string | null;
+  voiceCodeHash?: string | null;
+  voiceCodeDigits?: number | null;
+  expectedExternalUserId?: string | null;
+  friendName?: string | null;
+  guardianName?: string | null;
+  sourceConversationId?: string | null;
   contactId: string;
   note: string | null;
   maxUses: number;
@@ -190,7 +200,9 @@ const DEFAULT_INVITE: InviteRow = {
   updatedAt: 1000000,
 };
 
-type GetContactFn = (contactId: string) => { id: string } | undefined;
+type GetContactFn = (
+  contactId: string,
+) => { id: string; displayName?: string } | undefined;
 let contactStoreGetContactMock: ReturnType<typeof mock<GetContactFn>> = mock(
   () => ({ id: "ct_1" }),
 );
@@ -203,6 +215,38 @@ let contactStoreListInvitesMock: ReturnType<typeof mock<ListInvitesFn>> = mock(
 type CreateInviteFn = (params: unknown) => InviteRow;
 let contactStoreCreateInviteMock: ReturnType<typeof mock<CreateInviteFn>> =
   mock(() => DEFAULT_INVITE);
+
+/**
+ * Echo store mock for the native mint: returns a row built from the exact
+ * params `createInviteNative` writes, so response/persistence assertions see
+ * what the store was actually asked to persist.
+ */
+function makeEchoCreateInviteMock() {
+  return mock((params: unknown): InviteRow => {
+    const p = params as Record<string, unknown>;
+    return {
+      id: p.id as string,
+      sourceChannel: p.sourceChannel as string,
+      inviteCodeHash: (p.inviteCodeHash as string) ?? "",
+      tokenHash: (p.tokenHash as string | null) ?? null,
+      voiceCodeHash: (p.voiceCodeHash as string | null) ?? null,
+      voiceCodeDigits: (p.voiceCodeDigits as number | null) ?? null,
+      expectedExternalUserId:
+        (p.expectedExternalUserId as string | null) ?? null,
+      friendName: (p.friendName as string | null) ?? null,
+      guardianName: (p.guardianName as string | null) ?? null,
+      sourceConversationId: (p.sourceConversationId as string | null) ?? null,
+      contactId: p.contactId as string,
+      note: (p.note as string | null) ?? null,
+      maxUses: (p.maxUses as number) ?? 1,
+      useCount: 0,
+      expiresAt: p.expiresAt as number,
+      status: "active",
+      createdAt: 1000000,
+      updatedAt: 1000000,
+    };
+  });
+}
 
 type RevokeInviteFn = (inviteId: string) => InviteRow | null;
 let contactStoreRevokeInviteMock: ReturnType<typeof mock<RevokeInviteFn>> =
@@ -221,6 +265,7 @@ let contactStoreGetInviteByIdMock: ReturnType<typeof mock<GetInviteByIdFn>> =
   mock(() => DEFAULT_INVITE);
 
 mock.module("../db/contact-store.js", () => ({
+  NO_INVITE_CODE_HASH: "",
   ContactStore: class MockContactStore {
     upsertContact(...args: Parameters<UpsertFn>) {
       return contactStoreUpsertMock(...args);
@@ -1964,108 +2009,68 @@ describe("handleDeleteContact (gateway-native)", () => {
   });
 });
 
-describe("handleCreateInvite (gateway-native)", () => {
-  test("returns the assistant's minted invite payload (one-time codes), not the gateway row", async () => {
-    // The minted payload carries creation-only fields (inviteCode/token/share)
-    // that the gateway row does NOT — these must reach the client.
-    const mintInvite = {
-      id: "inv_1",
-      sourceChannel: "telegram",
-      inviteCode: "123456",
-      guardianInstruction: "Share this code with them first.",
-      token: "raw-token-abc",
-      share: { url: "https://t.me/bot?start=abc", displayText: "Open invite" },
-      status: "active",
-    };
-    ipcCallAssistantMock = mock(async (method: string) => {
-      if (method === "invites_mint") {
-        return {
-          ok: true,
-          invite: mintInvite,
-          rawToken: "raw-token-abc",
-          gateway: {
-            id: "inv_1",
-            inviteCodeHash: "hash_1",
-            sourceChannel: "telegram",
-            contactId: "ct_1",
-            note: null,
-            maxUses: 1,
-            expiresAt: 2000000,
-          },
-        };
-      }
-      return {};
-    });
-    contactStoreCreateInviteMock = mock(() => DEFAULT_INVITE);
+describe("handleCreateInvite (gateway-native mint)", () => {
+  test("mints token + 6-digit code natively for non-voice invites; only hashes reach the store", async () => {
+    contactStoreCreateInviteMock = makeEchoCreateInviteMock();
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
       new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "telegram" }),
+        body: JSON.stringify({
+          contactId: "ct_1",
+          sourceChannel: "telegram",
+          note: "For Alice",
+          maxUses: 3,
+        }),
       }),
     );
 
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(body.rawToken).toBe("raw-token-abc");
-    expect(body.invite.id).toBe("inv_1");
-    // One-time creation fields must come from the mint payload — the gateway
-    // row (DEFAULT_INVITE) carries none of these.
-    expect(body.invite.inviteCode).toBe("123456");
-    expect(body.invite.token).toBe("raw-token-abc");
-    expect(body.invite.guardianInstruction).toBe(
-      "Share this code with them first.",
-    );
-    expect(body.invite.share).toEqual({
-      url: "https://t.me/bot?start=abc",
-      displayText: "Open invite",
-    });
-    // Gateway row is still written as the lifecycle source of truth.
+
+    // One-time plaintext secrets are returned exactly once.
+    expect(typeof body.rawToken).toBe("string");
+    expect(body.invite.token).toBe(body.rawToken);
+    expect(/^\d{6}$/.test(body.invite.inviteCode)).toBe(true);
+    expect(body.invite.voiceCode).toBeUndefined();
+    expect(body.invite.note).toBe("For Alice");
+    expect(body.invite.maxUses).toBe(3);
+    expect(body.invite.status).toBe("active");
+
+    // Exactly one gateway row write; only hashes persist — never plaintext.
     expect(contactStoreCreateInviteMock).toHaveBeenCalledTimes(1);
     const [createParams] = contactStoreCreateInviteMock.mock.calls[0] as [
       Record<string, unknown>,
     ];
-    expect(createParams.id).toBe("inv_1");
-    expect(createParams.inviteCodeHash).toBe("hash_1");
+    expect(createParams.tokenHash).toBe(hashInviteToken(body.rawToken));
+    expect(createParams.inviteCodeHash).toBe(
+      hashInviteCode(body.invite.inviteCode),
+    );
+    expect(createParams.voiceCodeHash).toBeNull();
+    expect(Object.values(createParams)).not.toContain(body.rawToken);
+    expect(Object.values(createParams)).not.toContain(body.invite.inviteCode);
+
+    // Brute-forceable hashes never reach the response.
+    expect(body.invite.inviteCodeHash).toBeUndefined();
+    expect(body.invite.voiceCodeHash).toBeUndefined();
+    // tokenHash is response-shape compatible (256-bit preimage, not guessable).
+    expect(body.invite.tokenHash).toBe(createParams.tokenHash);
+
+    // No assistant mint relay — only the contacts_changed notification.
+    const ipcMethods = ipcCallAssistantMock.mock.calls.map((c) => c[0]);
+    expect(ipcMethods).not.toContain("invites_mint");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("returns the minted voiceCode for phone invites", async () => {
-    const mintInvite = {
-      id: "inv_phone",
-      sourceChannel: "phone",
-      voiceCode: "987654",
-      voiceCodeDigits: 6,
-      status: "active",
-    };
-    ipcCallAssistantMock = mock(async (method: string) => {
-      if (method === "invites_mint") {
-        return {
-          ok: true,
-          invite: mintInvite,
-          // Voice invites never expose a token.
-          rawToken: undefined,
-          gateway: {
-            id: "inv_phone",
-            inviteCodeHash: "voicehash_1",
-            sourceChannel: "phone",
-            contactId: "ct_1",
-            note: null,
-            maxUses: 1,
-            expiresAt: 2000000,
-          },
-        };
-      }
-      return {};
-    });
-    contactStoreCreateInviteMock = mock(() => ({
-      ...DEFAULT_INVITE,
-      id: "inv_phone",
-      sourceChannel: "phone",
+  test("mints an identity-bound voiceCode for phone invites — no token, passthrough fields stored", async () => {
+    contactStoreGetContactMock = mock(() => ({
+      id: "ct_1",
+      displayName: "Sam Example",
     }));
+    contactStoreCreateInviteMock = makeEchoCreateInviteMock();
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
@@ -2076,15 +2081,73 @@ describe("handleCreateInvite (gateway-native)", () => {
           contactId: "ct_1",
           sourceChannel: "phone",
           expectedExternalUserId: "+15551234567",
-          friendName: "Sam",
+          guardianName: "Guardian Example",
+          sourceConversationId: "conv-9",
         }),
       }),
     );
 
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.invite.voiceCode).toBe("987654");
-    expect(body.invite.id).toBe("inv_phone");
+
+    // Voice invites never expose a token; the spoken code is the credential.
+    expect(body.rawToken).toBeUndefined();
+    expect(body.invite.token).toBeUndefined();
+    expect(body.invite.tokenHash).toBeUndefined();
+    expect(/^\d{6}$/.test(body.invite.voiceCode)).toBe(true);
+    expect(body.invite.voiceCodeDigits).toBe(6);
+    expect(body.invite.expectedExternalUserId).toBe("+15551234567");
+    // friendName resolves from the gateway contact's displayName.
+    expect(body.invite.friendName).toBe("Sam Example");
+    // guardianName is a stored passthrough (daemon-supplied, never interpreted).
+    expect(body.invite.guardianName).toBe("Guardian Example");
+
+    const [createParams] = contactStoreCreateInviteMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(createParams.voiceCodeHash).toBe(
+      hashInviteCode(body.invite.voiceCode),
+    );
+    expect(createParams.tokenHash).toBeNull();
+    // No 6-digit channel code for voice — the sentinel keeps NOT NULL happy.
+    expect(createParams.inviteCodeHash).toBe("");
+    expect(createParams.guardianName).toBe("Guardian Example");
+    expect(createParams.sourceConversationId).toBe("conv-9");
+    expect(Object.values(createParams)).not.toContain(body.invite.voiceCode);
+  });
+
+  test("returns 400 when expectedExternalUserId is missing for phone invites", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "phone" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/expectedExternalUserId/);
+    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 for a non-E.164 expectedExternalUserId", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleCreateInvite(
+      new Request("http://localhost:7830/v1/contacts/invites", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contactId: "ct_1",
+          sourceChannel: "phone",
+          expectedExternalUserId: "not-a-phone-number",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/E\.164/);
+    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
   });
 
   test("returns 400 for invalid JSON body", async () => {
@@ -2135,28 +2198,10 @@ describe("handleCreateInvite (gateway-native)", () => {
     expect(res.status).toBe(404);
     expect((await res.json()).error.code).toBe("NOT_FOUND");
     expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
   });
 
   test("returns 500 when gateway DB write fails (no proxy fallback)", async () => {
-    ipcCallAssistantMock = mock(async (method: string) => {
-      if (method === "invites_mint") {
-        return {
-          ok: true,
-          invite: { id: "inv_1" },
-          rawToken: "raw",
-          gateway: {
-            id: "inv_1",
-            inviteCodeHash: "hash_1",
-            sourceChannel: "telegram",
-            contactId: "ct_1",
-            note: null,
-            maxUses: 1,
-            expiresAt: 2000000,
-          },
-        };
-      }
-      return {};
-    });
     contactStoreCreateInviteMock = mock(() => {
       throw new Error("gateway DB unavailable");
     });
@@ -2173,32 +2218,6 @@ describe("handleCreateInvite (gateway-native)", () => {
     expect(res.status).toBe(500);
     expect((await res.json()).error.code).toBe("INTERNAL_ERROR");
     expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("maps assistant mint 400 (IpcHandlerError) to a 400 response", async () => {
-    ipcCallAssistantMock = mock(async (method: string) => {
-      if (method === "invites_mint") {
-        throw new IpcHandlerError(
-          "expectedExternalUserId is required for voice invites",
-          400,
-          "BAD_REQUEST",
-        );
-      }
-      return {};
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/contacts/invites", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ contactId: "ct_1", sourceChannel: "phone" }),
-      }),
-    );
-
-    expect(res.status).toBe(400);
-    expect((await res.json()).error.message).toMatch(/expectedExternalUserId/);
-    expect(contactStoreCreateInviteMock).not.toHaveBeenCalled();
   });
 });
 

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -5,7 +5,16 @@
  * auth handling rather than falling through to the catch-all proxy.
  */
 
+import { randomUUID } from "node:crypto";
+
 import { proxyForward } from "@vellumai/assistant-client";
+import {
+  generateInviteCode,
+  generateInviteToken,
+  hashInviteCode,
+  hashInviteToken,
+  isValidE164,
+} from "@vellumai/gateway-client";
 import { eq } from "drizzle-orm";
 
 import { mintServiceToken } from "../../auth/token-exchange.js";
@@ -19,9 +28,11 @@ import {
   ContactStore,
   CannotRevokeBlockedError,
   MergeContactsError,
+  NO_INVITE_CODE_HASH,
   type ChannelAcl,
   type ContactAcl,
   type ContactWithInfo,
+  type IngressInviteRow,
 } from "../../db/contact-store.js";
 import { contacts } from "../../db/schema.js";
 import { fetchImpl } from "../../fetch.js";
@@ -113,14 +124,25 @@ const VALID_CONTACT_TYPES = ["human", "assistant"] as const;
 
 /**
  * Strip code/token hashes from a gateway invite row before returning it over
- * HTTP. `inviteCodeHash` is the unsalted SHA-256 of a 6-digit code; returning
- * it lets any list-capable caller brute-force the ~10^6 keyspace offline and
- * redeem an active invite. All invite responses MUST go through this.
+ * HTTP. `inviteCodeHash` / `voiceCodeHash` are unsalted SHA-256 of 6-digit
+ * codes; returning either lets any list-capable caller brute-force the ~10^6
+ * keyspace offline and redeem an active invite. `tokenHash` is stripped for
+ * consistency (list/revoke responses never carry hashes). All invite
+ * responses MUST go through this.
  */
-function sanitizeInviteRow<T extends { inviteCodeHash?: unknown }>(
-  row: T,
-): Omit<T, "inviteCodeHash"> {
-  const { inviteCodeHash: _omit, ...rest } = row;
+function sanitizeInviteRow<
+  T extends {
+    inviteCodeHash?: unknown;
+    voiceCodeHash?: unknown;
+    tokenHash?: unknown;
+  },
+>(row: T): Omit<T, "inviteCodeHash" | "voiceCodeHash" | "tokenHash"> {
+  const {
+    inviteCodeHash: _omitCode,
+    voiceCodeHash: _omitVoice,
+    tokenHash: _omitToken,
+    ...rest
+  } = row;
   return rest;
 }
 
@@ -411,21 +433,30 @@ export async function listInvitesNative(
   return { invites };
 }
 
+/** Default invite lifetime when the caller supplies no `expiresInMs`. */
+const DEFAULT_INVITE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 /**
- * Create an invite: verify the contact exists, relay to the assistant mint
- * (token/hash + voice fields), then write the canonical gateway lifecycle row.
- * Returns the assistant's minted one-time payload + rawToken. Throws
- * InviteNativeError(404) when the contact is unknown, InviteNativeError(500)
- * when the mint or gateway write fails, and propagates an assistant mint
- * IpcHandlerError unchanged so its status/code reach the caller.
+ * Create an invite natively: verify the contact exists, mint the secrets via
+ * the shared invite-contract helpers, and write the single canonical gateway
+ * row. Voice invites (`sourceChannel === "phone"`) get an identity-bound
+ * spoken code and NO link token; every other channel gets a link token plus a
+ * 6-digit code for guardian-mediated redemption. Plaintext secrets
+ * (`token` / `inviteCode` / `voiceCode`) are returned exactly once on the
+ * invite payload and never persisted — only their hashes reach the row.
+ * Presentation fields (share link, guardian instruction, channel handle) are
+ * daemon-owned and layered on by the daemon's create relay.
+ *
+ * Throws InviteNativeError(404) when the contact is unknown, (400) on invalid
+ * voice parameters, and (500) when the gateway write fails.
  */
 export async function createInviteNative(
   input: CreateInviteInput,
 ): Promise<{ invite: Record<string, unknown>; rawToken?: string }> {
   const store = new ContactStore();
 
-  // Verify the contact exists in the gateway DB before minting.
-  if (!store.getContact(input.contactId)) {
+  const contact = store.getContact(input.contactId);
+  if (!contact) {
     throw new InviteNativeError(
       `Contact "${input.contactId}" not found`,
       404,
@@ -433,53 +464,65 @@ export async function createInviteNative(
     );
   }
 
-  // ── Assistant mints (token/hash + voice fields) ──────────────────
-  let mint: {
-    invite: Record<string, unknown>;
-    rawToken?: string;
-    gateway: {
-      id: string;
-      inviteCodeHash: string;
-      sourceChannel: string;
-      contactId: string;
-      note: string | null;
-      maxUses: number;
-      expiresAt: number;
-    };
-  };
-  try {
-    mint = (await ipcCallAssistant("invites_mint", {
-      body: input,
-    } as unknown as Record<string, unknown>)) as typeof mint;
-  } catch (err) {
-    if (err instanceof IpcHandlerError) {
-      // Propagate the assistant's status/code unchanged.
-      throw err;
+  const isVoice = input.sourceChannel === "phone";
+
+  let rawToken: string | undefined;
+  let tokenHash: string | undefined;
+  let inviteCode: string | undefined;
+  let inviteCodeHash: string | undefined;
+  let voiceCode: string | undefined;
+  let voiceCodeHash: string | undefined;
+  let friendName: string | undefined;
+
+  if (isVoice) {
+    if (!input.expectedExternalUserId) {
+      throw new InviteNativeError(
+        "expectedExternalUserId is required for voice invites",
+        400,
+        "BAD_REQUEST",
+      );
     }
-    log.error(
-      { err, contactId: input.contactId },
-      "create_invite: mint failed",
-    );
-    throw new InviteNativeError("Failed to mint invite", 500, "INTERNAL_ERROR");
+    if (!isValidE164(input.expectedExternalUserId)) {
+      throw new InviteNativeError(
+        "expectedExternalUserId must be in E.164 format (e.g., +15551234567)",
+        400,
+        "BAD_REQUEST",
+      );
+    }
+    voiceCode = generateInviteCode(6);
+    voiceCodeHash = hashInviteCode(voiceCode);
+    // The invitee's canonical name is the bound contact's displayName —
+    // mirrored onto the row so voice greeting/call reads need no extra lookup.
+    friendName = contact.displayName?.trim() || undefined;
+  } else {
+    rawToken = generateInviteToken();
+    tokenHash = hashInviteToken(rawToken);
+    inviteCode = generateInviteCode(6);
+    inviteCodeHash = hashInviteCode(inviteCode);
   }
 
-  // ── Gateway DB write (source of truth) ───────────────────────────
-  const gw = mint.gateway;
-  let invite;
+  let row: IngressInviteRow;
   try {
-    invite = store.createInvite({
-      id: gw.id,
-      inviteCodeHash: gw.inviteCodeHash,
-      sourceChannel: gw.sourceChannel,
-      contactId: gw.contactId,
-      note: gw.note,
-      maxUses: gw.maxUses,
-      expiresAt: gw.expiresAt,
+    row = store.createInvite({
+      id: randomUUID(),
+      sourceChannel: input.sourceChannel,
+      contactId: input.contactId,
+      note: input.note ?? null,
+      maxUses: input.maxUses,
+      expiresAt: Date.now() + (input.expiresInMs ?? DEFAULT_INVITE_EXPIRY_MS),
+      inviteCodeHash: inviteCodeHash ?? NO_INVITE_CODE_HASH,
+      tokenHash: tokenHash ?? null,
+      voiceCodeHash: voiceCodeHash ?? null,
+      voiceCodeDigits: isVoice ? 6 : null,
+      expectedExternalUserId: isVoice ? input.expectedExternalUserId : null,
+      friendName: friendName ?? null,
+      guardianName: input.guardianName ?? null,
+      sourceConversationId: input.sourceConversationId ?? null,
     });
   } catch (err) {
     log.error(
-      { err, inviteId: gw?.id, contactId: input.contactId },
-      "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
+      { err, contactId: input.contactId },
+      "create_invite: gateway DB write failed",
     );
     throw new InviteNativeError(
       "Failed to record invite",
@@ -494,14 +537,36 @@ export async function createInviteNative(
   } as unknown as Record<string, unknown>).catch(() => {});
 
   log.info(
-    { inviteId: invite.id, contactId: input.contactId },
+    { inviteId: row.id, contactId: input.contactId },
     "create_invite: handled natively",
   );
-  // The gateway row is the lifecycle source of truth, but the response must
-  // carry the assistant's minted one-time fields (voiceCode for phone;
-  // inviteCode/guardianInstruction/share/token for non-phone) — returned only
-  // at creation time and never fetchable later.
-  return { invite: mint.invite, rawToken: mint.rawToken };
+
+  // One-time create payload: row fields plus the plaintext secrets. tokenHash
+  // is included for response compatibility with the historical create shape;
+  // the brute-forceable code hashes never leave the DB.
+  const invite: Record<string, unknown> = {
+    id: row.id,
+    sourceChannel: row.sourceChannel,
+    ...(rawToken ? { token: rawToken } : {}),
+    ...(row.tokenHash ? { tokenHash: row.tokenHash } : {}),
+    maxUses: row.maxUses,
+    useCount: row.useCount,
+    expiresAt: row.expiresAt,
+    status: row.status,
+    ...(row.note ? { note: row.note } : {}),
+    ...(row.expectedExternalUserId
+      ? { expectedExternalUserId: row.expectedExternalUserId }
+      : {}),
+    ...(voiceCode ? { voiceCode } : {}),
+    ...(row.voiceCodeDigits != null
+      ? { voiceCodeDigits: row.voiceCodeDigits }
+      : {}),
+    ...(row.friendName ? { friendName: row.friendName } : {}),
+    ...(row.guardianName ? { guardianName: row.guardianName } : {}),
+    ...(inviteCode ? { inviteCode } : {}),
+    createdAt: row.createdAt,
+  };
+  return { invite, rawToken };
 }
 
 /**
@@ -1628,10 +1693,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     // ── Invite routes (gateway-native) ──
     //
     // The gateway DB's ingress_invites is the source of truth for invite
-    // lifecycle. Token mint, voice/token redemption, and outbound call relay
-    // to the assistant over IPC (token secrecy + voice UX are assistant-owned);
-    // the gateway records the canonical ACL-relevant lifecycle. None of these
-    // handlers fall back to `forward` on error — mutations 500 instead.
+    // lifecycle and secrets: mint is fully gateway-native. Voice/token
+    // redemption and outbound calls still relay to the assistant over IPC.
+    // None of these handlers fall back to `forward` on error — mutations 500
+    // instead.
 
     /**
      * GET /v1/contacts/invites — gateway-native invite list.
@@ -1655,11 +1720,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     /**
      * POST /v1/contacts/invites — gateway-native invite create.
      *
-     * Inverted dual-write vs contacts: the assistant mints first (it owns
-     * token secrecy + voice UX, writes voice fields, returns the raw token +
-     * projection), then the gateway records the canonical lifecycle row in its
-     * own DB (source of truth for ACL). If the gateway write throws → 500, no
-     * fallback: the assistant row already existing is stale-over-lost.
+     * The gateway mints the secrets and writes the single canonical invite
+     * row in its own DB (no assistant round-trip). The response carries the
+     * one-time plaintext secrets; daemon-owned presentation (share link,
+     * guardian instruction) is layered on by the daemon's create relay.
      */
     async handleCreateInvite(req: Request): Promise<Response> {
       let body: unknown;

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -23,6 +23,10 @@ export interface CreateInviteInput {
   maxUses?: number;
   expiresInMs?: number;
   expectedExternalUserId?: string;
+  // Daemon-supplied passthrough fields — the gateway stores them on the
+  // invite row and never interprets them.
+  guardianName?: string;
+  sourceConversationId?: string;
 }
 
 export type ParseResult<T> =
@@ -40,6 +44,8 @@ export const createInviteSchema = z.object({
   maxUses: positiveNumber.optional(),
   expiresInMs: positiveNumber.optional(),
   expectedExternalUserId: z.string().optional(),
+  guardianName: z.string().optional(),
+  sourceConversationId: z.string().optional(),
 });
 
 function firstIssueMessage(error: z.ZodError): string {

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -21,9 +21,11 @@
  *   invites_create
  *     params : { contactId: string; sourceChannel: string; note?: string;
  *                maxUses?: number; expiresInMs?: number;
- *                expectedExternalUserId?: string }
+ *                expectedExternalUserId?: string; guardianName?: string;
+ *                sourceConversationId?: string }
  *     returns: { invite: Record<string, unknown>; rawToken?: string }
- *              (the assistant's one-time minted payload)
+ *              (the gateway's one-time minted payload — row fields plus the
+ *              plaintext token/inviteCode/voiceCode, never fetchable later)
  *
  *   invites_revoke
  *     params : { id: string }
@@ -125,8 +127,8 @@ export const inviteRoutes: IpcRoute[] = [
     },
   },
   {
-    // Verify contact → relay assistant mint → write canonical gateway row.
-    // Returns the assistant's one-time minted payload + rawToken.
+    // Verify contact → mint secrets natively → write the canonical gateway
+    // row. Returns the gateway's one-time minted payload + rawToken.
     method: "invites_create",
     schema: CreateInviteParamsSchema,
     handler: async (params?: Record<string, unknown>) => {

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -105,6 +105,7 @@ export {
   InviteRedeemedNotificationSchema,
   InviteRedemptionOutcomeSchema,
   isInviteCodeRedemptionEnabled,
+  isValidE164,
   RedeemInviteByCodeRequestSchema,
   RedeemInviteByTokenRequestSchema,
   RedeemVoiceInviteRequestSchema,

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -46,6 +46,15 @@ export function generateInviteToken(): string {
 }
 
 /**
+ * Basic E.164 phone number validation: starts with +, followed by 10-15
+ * digits. Gates `expectedExternalUserId` on voice invites so the identity
+ * binding is a real dialable number.
+ */
+export function isValidE164(phone: string): boolean {
+  return /^\+\d{10,15}$/.test(phone);
+}
+
+/**
  * Generate a cryptographically random numeric code of the given length.
  * Uses node:crypto randomInt for uniform distribution.
  */


### PR DESCRIPTION
## Summary
- createInviteNative mints secrets and writes the single gateway invite row (no daemon round-trip); accepts guardianName/sourceConversationId passthrough
- Daemon composes invite presentation (LLM instruction, share payload, channel handle) from the gateway response; InviteResponseData shape unchanged
- invites_mint IPC method and mintIngressInvite deleted

Part of plan: invites-gateway-native.md (PR 4 of 12)