### PR TITLE
feat(acp): retain recent adapter stderr for failure diagnostics

### DIFF
--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { AcpAgentProcess } from "./agent-process.js";
+import type { AcpAgentConfig } from "./types.js";
+
+const config: AcpAgentConfig = { command: "noop", args: [] };
+
+// The client factory is never invoked in these tests (no spawn), so a stub is
+// sufficient.
+const clientFactory = (() => ({})) as never;
+
+function newProcess(): AcpAgentProcess {
+  return new AcpAgentProcess("test-agent", config, clientFactory);
+}
+
+// retainStderr is the private handler path the stderr "data" listener calls
+// after logging; feed it directly to keep the test deterministic (no real
+// child process or stream timing).
+function feed(proc: AcpAgentProcess, line: string): void {
+  (proc as unknown as { retainStderr(text: string): void }).retainStderr(line);
+}
+
+describe("AcpAgentProcess.recentStderr", () => {
+  test("returns empty string before any stderr is captured", () => {
+    expect(newProcess().recentStderr()).toBe("");
+  });
+
+  test("retains captured lines joined by newlines, in order", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+    feed(proc, "line 3");
+
+    expect(proc.recentStderr()).toBe("line 1\nline 2\nline 3");
+  });
+
+  test("evicts oldest lines once the byte cap is exceeded", () => {
+    const proc = newProcess();
+    // Each line is ~1 KB; a handful exceeds the ~4 KB cap and forces eviction
+    // of the earliest lines while preserving newest-line ordering.
+    const kb = "x".repeat(1024);
+    for (let i = 0; i < 8; i++) {
+      feed(proc, `${i}:${kb}`);
+    }
+
+    const retained = proc.recentStderr().split("\n");
+    // Oldest ("0:") evicted, newest ("7:") retained, still in insertion order.
+    expect(retained.at(0)).not.toContain("0:");
+    expect(retained.at(-1)).toContain("7:");
+    expect(Buffer.byteLength(proc.recentStderr())).toBeLessThanOrEqual(
+      4096 + kb.length,
+    );
+
+    const indices = retained.map((l) => Number(l.split(":")[0]));
+    const sorted = [...indices].sort((a, b) => a - b);
+    expect(indices).toEqual(sorted);
+  });
+
+  test("keeps at least the newest line even when it alone exceeds the cap", () => {
+    const proc = newProcess();
+    const huge = "y".repeat(8192);
+    feed(proc, huge);
+
+    expect(proc.recentStderr()).toBe(huge);
+  });
+
+  test("recentStderr is pure: repeated reads do not clear the buffer", () => {
+    const proc = newProcess();
+    feed(proc, "only line");
+
+    expect(proc.recentStderr()).toBe("only line");
+    expect(proc.recentStderr()).toBe("only line");
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -31,6 +31,12 @@ const log = getLogger("acp");
 const AUTH_REQUIRED_CODE = -32000;
 
 /**
+ * Rough byte cap for retained stderr. Oldest lines are evicted once the sum of
+ * retained line lengths exceeds this, so recentStderr() stays bounded.
+ */
+const STDERR_RETENTION_BYTES = 4096;
+
+/**
  * Detects the ACP auth-required error. Checks the `code` property rather than
  * `instanceof acp.RequestError` so plain JSON-RPC error objects are also
  * recognized.
@@ -68,6 +74,13 @@ export class AcpAgentProcess {
    * afterwards.
    */
   private spawnedEnv: NodeJS.ProcessEnv | null = null;
+
+  /**
+   * Ring of the most recent stderr lines, bounded to ~STDERR_RETENTION_BYTES.
+   * Read once on the failure path to surface the real adapter error.
+   */
+  private stderrRing: string[] = [];
+  private stderrRingBytes = 0;
 
   constructor(
     public readonly agentId: string,
@@ -108,6 +121,7 @@ export class AcpAgentProcess {
       const text = chunk.toString().trim();
       if (text) {
         log.error({ agentId: this.agentId, stderr: text }, "ACP agent stderr");
+        this.retainStderr(text);
       }
     });
 
@@ -122,6 +136,31 @@ export class AcpAgentProcess {
         "ACP agent process error",
       );
     });
+  }
+
+  /**
+   * Appends a stderr line to the ring, evicting oldest lines once the retained
+   * total exceeds STDERR_RETENTION_BYTES. Always keeps at least the newest line
+   * so a single oversized line is not fully dropped.
+   */
+  private retainStderr(text: string): void {
+    this.stderrRing.push(text);
+    this.stderrRingBytes += Buffer.byteLength(text);
+    while (
+      this.stderrRingBytes > STDERR_RETENTION_BYTES &&
+      this.stderrRing.length > 1
+    ) {
+      const evicted = this.stderrRing.shift()!;
+      this.stderrRingBytes -= Buffer.byteLength(evicted);
+    }
+  }
+
+  /**
+   * Returns the retained recent stderr lines joined by newlines. Pure: reading
+   * it does not mutate or clear the buffer.
+   */
+  recentStderr(): string {
+    return this.stderrRing.join("\n");
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add a bounded stderr ring + recentStderr() accessor to AcpAgentProcess so the real adapter error can be surfaced on the failure path.

Part of plan: acp-failure-surfacing.md (PR 1 of 4)