### PR TITLE
fix(web): vertically center the ACP failed-run error icon and text

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
@@ -71,6 +71,33 @@ describe("AcpChatTerminalBlock", () => {
     expect(screen.getByText("Run failed")).toBeDefined();
   });
 
+  test("failed single-line → icon centered on the first line, no mt-0.5", () => {
+    render(<AcpChatTerminalBlock status="failed" error="Run failed" />);
+    const iconBox = screen.getByTestId("acp-chat-terminal-failed-icon");
+    // Fixed line-height flex box (12px) centers the triangle on the text line.
+    expect(iconBox.className).toContain("items-center");
+    expect(iconBox.className).toContain("h-[12px]");
+    // The legacy top-align hack must be gone from both the box and the icon.
+    expect(iconBox.className).not.toContain("mt-0.5");
+    const icon = iconBox.querySelector("svg");
+    expect(icon?.getAttribute("class") ?? "").not.toContain("mt-0.5");
+  });
+
+  test("failed multi-line → keeps the triangle on the first line", () => {
+    render(
+      <AcpChatTerminalBlock
+        status="failed"
+        error={"Run failed on a very long line that wraps across\nmultiple lines"}
+      />,
+    );
+    const root = screen.getByTestId("acp-chat-terminal-block");
+    // Row stays top-aligned so the fixed icon box pins to the first line.
+    expect(root.className).toContain("items-start");
+    expect(
+      screen.getByTestId("acp-chat-terminal-failed-icon").className,
+    ).toContain("items-center");
+  });
+
   test("cancelled status → Cancelled", () => {
     render(<AcpChatTerminalBlock status="cancelled" />);
     const root = screen.getByTestId("acp-chat-terminal-block");

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
@@ -71,7 +71,16 @@ export function AcpChatTerminalBlock({
         data-terminal-kind="failed"
         className="flex items-start gap-2 rounded-lg bg-[var(--system-negative-weak)] px-3 py-2 text-body-small-default text-[var(--system-negative-strong)]"
       >
-        <AlertTriangle aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
+        {/* Row wraps for multi-line errors; the icon box matches the 12px
+            text-body-small line-height so the triangle centers on the first
+            line rather than the wrapped block's middle. */}
+        <span
+          aria-hidden
+          data-testid="acp-chat-terminal-failed-icon"
+          className="flex h-[12px] w-4 shrink-0 items-center justify-center"
+        >
+          <AlertTriangle className="h-4 w-4" />
+        </span>
         <span>{error ?? "Run failed"}</span>
       </div>
     );


### PR DESCRIPTION
## Summary
- Center the icon+text in the ACP failed-run terminal block, matching the cancelled/completed branches; keep the triangle on the first line for multi-line errors.

Part of plan: acp-failure-surfacing.md (PR 4 of 4)