### PR TITLE
refactor(gateway): invite list/revoke read only the gateway DB; drop assistantDb invite SQL

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -2222,13 +2222,12 @@ describe("handleCreateInvite (gateway-native mint)", () => {
 });
 
 describe("handleListInvites (gateway-native)", () => {
-  test("returns gateway rows joined with assistant voice fields", async () => {
+  test("returns voice/display fields from the gateway row; assistant DB never queried", async () => {
     contactStoreListInvitesMock = mock(() => [
-      { ...DEFAULT_INVITE, id: "inv_1", sourceChannel: "phone" },
-    ]);
-    assistantDbQueryMock = mock(async () => [
       {
+        ...DEFAULT_INVITE,
         id: "inv_1",
+        sourceChannel: "phone",
         voiceCodeDigits: 6,
         friendName: "Alice",
         guardianName: "Bob",
@@ -2248,12 +2247,17 @@ describe("handleListInvites (gateway-native)", () => {
     expect(body.invites[0].id).toBe("inv_1");
     expect(body.invites[0].voiceCodeDigits).toBe(6);
     expect(body.invites[0].friendName).toBe("Alice");
+    expect(body.invites[0].guardianName).toBe("Bob");
+    expect(body.invites[0].expectedExternalUserId).toBe("+15551234567");
     // The brute-forceable code hash must never be exposed in list responses.
     expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
     // status filter passed through to the store query.
     expect(contactStoreListInvitesMock.mock.calls[0][0]).toEqual({
       status: "active",
     });
+    // The gateway DB is the single source: no assistant DB access, no proxy.
+    expect(assistantDbQueryMock).not.toHaveBeenCalled();
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -2267,7 +2271,6 @@ describe("handleListInvites (gateway-native)", () => {
         voiceCodeHash: "secret-voice-hash",
       },
     ]);
-    assistantDbQueryMock = mock(async () => []);
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleListInvites(
@@ -2284,11 +2287,14 @@ describe("handleListInvites (gateway-native)", () => {
     expect(body.invites[0]).not.toHaveProperty("voiceCodeHash");
   });
 
-  test("degrades gracefully when the assistant voice-field join throws", async () => {
+  test("succeeds even when the assistant DB is unavailable (list never touches it)", async () => {
     contactStoreListInvitesMock = mock(() => [
       { ...DEFAULT_INVITE, id: "inv_1" },
     ]);
     assistantDbQueryMock = mock(async () => {
+      throw new Error("assistant DB down");
+    });
+    assistantDbRunMock = mock(async () => {
       throw new Error("assistant DB down");
     });
 
@@ -2301,133 +2307,9 @@ describe("handleListInvites (gateway-native)", () => {
     const body = await res.json();
     expect(body.invites).toHaveLength(1);
     expect(body.invites[0].id).toBe("inv_1");
-    expect(body.invites[0].friendName).toBeUndefined();
     expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
-  });
-
-  test("merges assistant-only invites (no gateway row) into the list, sanitized", async () => {
-    contactStoreListInvitesMock = mock(() => [
-      { ...DEFAULT_INVITE, id: "inv_gateway", sourceChannel: "telegram" },
-    ]);
-    // The voice-join SELECT and the assistant-only merge SELECT both go through
-    // assistantDbQuery; branch on the query text to return the right shape.
-    assistantDbQueryMock = mock(async (sql: string) => {
-      if (/FROM assistant_ingress_invites/.test(sql) && /max_uses/.test(sql)) {
-        // The assistant-only merge query (selects full row + voice fields).
-        return [
-          {
-            id: "inv_assistant_only",
-            sourceChannel: "telegram",
-            note: null,
-            maxUses: 1,
-            useCount: 0,
-            expiresAt: 4_000_000_000_000,
-            status: "active",
-            redeemedByExternalUserId: null,
-            redeemedByExternalChatId: null,
-            redeemedAt: null,
-            contactId: "ct_1",
-            createdAt: 1000000,
-            updatedAt: 1000000,
-            voiceCodeDigits: 6,
-            friendName: "Carol",
-            guardianName: null,
-            expectedExternalUserId: null,
-            // Hash columns are NOT selected by the merge query; assert below.
-          },
-        ];
-      }
-      // The voice-join query for gateway rows.
-      return [];
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/contacts/invites?status=active"),
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    const ids = body.invites.map((i: { id: string }) => i.id);
-    expect(ids).toContain("inv_gateway");
-    expect(ids).toContain("inv_assistant_only");
-    const assistantOnly = body.invites.find(
-      (i: { id: string }) => i.id === "inv_assistant_only",
-    );
-    expect(assistantOnly.voiceCodeDigits).toBe(6);
-    expect(assistantOnly.friendName).toBe("Carol");
-    // Assistant-only rows must be sanitized too — never leak a code hash.
-    expect(assistantOnly).not.toHaveProperty("inviteCodeHash");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("does not duplicate an invite present in both stores (gateway wins)", async () => {
-    contactStoreListInvitesMock = mock(() => [
-      { ...DEFAULT_INVITE, id: "inv_dupe", status: "redeemed" },
-    ]);
-    // Assistant DB also has inv_dupe (e.g. as 'active'); the merge must drop it
-    // because the gateway row already covers that id.
-    assistantDbQueryMock = mock(async (sql: string) => {
-      if (/FROM assistant_ingress_invites/.test(sql) && /max_uses/.test(sql)) {
-        return [
-          {
-            id: "inv_dupe",
-            sourceChannel: "telegram",
-            note: null,
-            maxUses: 1,
-            useCount: 0,
-            expiresAt: 4_000_000_000_000,
-            status: "active",
-            redeemedByExternalUserId: null,
-            redeemedByExternalChatId: null,
-            redeemedAt: null,
-            contactId: "ct_1",
-            createdAt: 1000000,
-            updatedAt: 1000000,
-            voiceCodeDigits: null,
-            friendName: null,
-            guardianName: null,
-            expectedExternalUserId: null,
-          },
-        ];
-      }
-      return [];
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/contacts/invites"),
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    const dupes = body.invites.filter(
-      (i: { id: string }) => i.id === "inv_dupe",
-    );
-    expect(dupes).toHaveLength(1);
-    // The gateway row (lifecycle truth) wins: status is 'redeemed', not 'active'.
-    expect(dupes[0].status).toBe("redeemed");
-  });
-
-  test("degrades to gateway-only rows when the assistant-only merge query throws", async () => {
-    contactStoreListInvitesMock = mock(() => [
-      { ...DEFAULT_INVITE, id: "inv_gateway" },
-    ]);
-    assistantDbQueryMock = mock(async () => {
-      throw new Error("assistant DB down");
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/contacts/invites"),
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.invites).toHaveLength(1);
-    expect(body.invites[0].id).toBe("inv_gateway");
-    expect(body.invites[0]).not.toHaveProperty("inviteCodeHash");
+    expect(assistantDbQueryMock).not.toHaveBeenCalled();
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
   });
 
   test("returns 500 when the gateway read throws", async () => {
@@ -2446,7 +2328,7 @@ describe("handleListInvites (gateway-native)", () => {
 });
 
 describe("handleRevokeInvite (gateway-native)", () => {
-  test("revokes the invite and mirrors into the assistant DB", async () => {
+  test("revokes the invite via a single gateway UPDATE; assistant DB never touched", async () => {
     contactStoreRevokeInviteMock = mock(() => ({
       ...DEFAULT_INVITE,
       status: "revoked",
@@ -2467,19 +2349,53 @@ describe("handleRevokeInvite (gateway-native)", () => {
     // Revoke responses must not leak the brute-forceable code hash.
     expect(body.invite).not.toHaveProperty("inviteCodeHash");
     expect(contactStoreRevokeInviteMock).toHaveBeenCalledWith("inv_1");
-    // Best-effort assistant DB mirror reflects the gateway row's actual status.
-    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
-    expect(assistantDbRunMock.mock.calls[0][0]).toMatch(
-      /assistant_ingress_invites/,
-    );
-    expect(assistantDbRunMock.mock.calls[0][1]?.[0]).toBe("revoked");
+    // The gateway DB is the single source: no assistant DB access, no proxy.
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+    expect(assistantDbQueryMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("mirrors the gateway row's actual status for an already-redeemed invite", async () => {
+  test("revokes a backfilled (pre-migration) invite carrying voice/display fields", async () => {
+    contactStoreRevokeInviteMock = mock(() => ({
+      ...DEFAULT_INVITE,
+      id: "inv_backfilled",
+      sourceChannel: "phone",
+      status: "revoked",
+      tokenHash: "secret-token-hash",
+      voiceCodeHash: "secret-voice-hash",
+      voiceCodeDigits: 6,
+      friendName: "Alice",
+      guardianName: "Bob",
+      expectedExternalUserId: "+15551234567",
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleRevokeInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_backfilled", {
+        method: "DELETE",
+      }),
+      "inv_backfilled",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.invite.id).toBe("inv_backfilled");
+    expect(body.invite.status).toBe("revoked");
+    expect(body.invite.friendName).toBe("Alice");
+    expect(body.invite.voiceCodeDigits).toBe(6);
+    // No secret hash field may ever reach the wire.
+    expect(body.invite).not.toHaveProperty("inviteCodeHash");
+    expect(body.invite).not.toHaveProperty("tokenHash");
+    expect(body.invite).not.toHaveProperty("voiceCodeHash");
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
+    expect(assistantDbQueryMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("is idempotent on an already-terminal invite (returns its current state)", async () => {
     // revokeInvite() only flips an ACTIVE row to revoked; an already-redeemed
-    // invite is returned unchanged. The mirror must NOT force 'revoked' — it
-    // must reflect the gateway row's real status so the stores stay in sync.
+    // invite is returned unchanged with its terminal status.
     contactStoreRevokeInviteMock = mock(() => ({
       ...DEFAULT_INVITE,
       status: "redeemed",
@@ -2496,16 +2412,12 @@ describe("handleRevokeInvite (gateway-native)", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.invite.status).toBe("redeemed");
-    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
-    expect(assistantDbRunMock.mock.calls[0][1]?.[0]).toBe("redeemed");
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when the invite is absent from both the gateway and assistant DBs", async () => {
-    // No gateway row AND no assistant row: the SELECT re-read returns empty,
-    // so the invite is genuinely absent everywhere.
+  test("returns 404 when the invite id is unknown (no assistant DB fallback)", async () => {
     contactStoreRevokeInviteMock = mock(() => null);
-    assistantDbQueryMock = mock(async () => []);
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleRevokeInvite(
@@ -2517,194 +2429,8 @@ describe("handleRevokeInvite (gateway-native)", () => {
 
     expect(res.status).toBe(404);
     expect((await res.json()).error.code).toBe("NOT_FOUND");
-  });
-
-  test("falls back to revoking the assistant row when no gateway row exists", async () => {
-    // Assistant-only invite: gateway revoke returns null, but the row exists in
-    // the assistant DB and gets flipped active -> revoked via the fallback.
-    contactStoreRevokeInviteMock = mock(() => null);
-    assistantDbQueryMock = mock(async () => [
-      {
-        id: "inv_assistant_only",
-        sourceChannel: "telegram",
-        note: null,
-        maxUses: 1,
-        useCount: 0,
-        expiresAt: 4_000_000_000_000,
-        status: "revoked",
-        redeemedByExternalUserId: null,
-        redeemedByExternalChatId: null,
-        redeemedAt: null,
-        contactId: "ct_1",
-        createdAt: 1000000,
-        updatedAt: 2000000,
-        voiceCodeDigits: null,
-        friendName: null,
-        guardianName: null,
-        expectedExternalUserId: null,
-      },
-    ]);
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleRevokeInvite(
-      new Request(
-        "http://localhost:7830/v1/contacts/invites/inv_assistant_only",
-        { method: "DELETE" },
-      ),
-      "inv_assistant_only",
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.invite.id).toBe("inv_assistant_only");
-    expect(body.invite.status).toBe("revoked");
-    expect(body.invite).not.toHaveProperty("inviteCodeHash");
-    // The assistant fallback UPDATE ran against assistant_ingress_invites.
-    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
-    expect(assistantDbRunMock.mock.calls[0][0]).toMatch(
-      /UPDATE assistant_ingress_invites SET status='revoked'/,
-    );
-    expect(assistantDbRunMock.mock.calls[0][1]?.[1]).toBe("inv_assistant_only");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("assistant-only revoke is idempotent on an already-terminal row (UPDATE no-ops, 200 terminal)", async () => {
-    // No gateway row. The UPDATE succeeds but affects 0 rows because the invite
-    // is already redeemed; the SELECT then returns the terminal row. This is the
-    // legitimate idempotent revoke — must stay 200 with the terminal state.
-    contactStoreRevokeInviteMock = mock(() => null);
-    assistantDbRunMock = mock(async () => ({ changes: 0, lastInsertRowid: 0 }));
-    assistantDbQueryMock = mock(async () => [
-      {
-        id: "inv_terminal",
-        sourceChannel: "telegram",
-        note: null,
-        maxUses: 1,
-        useCount: 1,
-        expiresAt: 4_000_000_000_000,
-        status: "redeemed",
-        redeemedByExternalUserId: "ext_1",
-        redeemedByExternalChatId: "chat_1",
-        redeemedAt: 3000000,
-        contactId: "ct_1",
-        createdAt: 1000000,
-        updatedAt: 2000000,
-        voiceCodeDigits: null,
-        friendName: null,
-        guardianName: null,
-        expectedExternalUserId: null,
-      },
-    ]);
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleRevokeInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_terminal", {
-        method: "DELETE",
-      }),
-      "inv_terminal",
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.invite.id).toBe("inv_terminal");
-    expect(body.invite.status).toBe("redeemed");
-  });
-
-  test("assistant-only revoke surfaces 500 when the fallback UPDATE throws (no false success)", async () => {
-    // No gateway row, so assistant_ingress_invites is the only store that can
-    // revoke. If the UPDATE write throws, the handler must NOT swallow it and
-    // return 200 with the still-active row — a guardian would believe the
-    // invite was revoked while it stays redeemable via the legacy path.
-    contactStoreRevokeInviteMock = mock(() => null);
-    assistantDbRunMock = mock(async () => {
-      throw new Error("assistant DB write failed");
-    });
-    // The SELECT would still find the row active — proving the write didn't land.
-    const assistantQuerySpy = mock(async () => [
-      {
-        id: "inv_assistant_only",
-        sourceChannel: "telegram",
-        note: null,
-        maxUses: 1,
-        useCount: 0,
-        expiresAt: 4_000_000_000_000,
-        status: "active",
-        redeemedByExternalUserId: null,
-        redeemedByExternalChatId: null,
-        redeemedAt: null,
-        contactId: "ct_1",
-        createdAt: 1000000,
-        updatedAt: 2000000,
-        voiceCodeDigits: null,
-        friendName: null,
-        guardianName: null,
-        expectedExternalUserId: null,
-      },
-    ]);
-    assistantDbQueryMock = assistantQuerySpy;
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleRevokeInvite(
-      new Request(
-        "http://localhost:7830/v1/contacts/invites/inv_assistant_only",
-        { method: "DELETE" },
-      ),
-      "inv_assistant_only",
-    );
-
-    expect(res.status).toBe(500);
-    expect((await res.json()).error.code).toBe("INTERNAL_ERROR");
-    // The handler must not have read back and returned the still-active row.
-    expect(assistantQuerySpy).not.toHaveBeenCalled();
-  });
-
-  test("revoking a gateway-known invite uses the gateway path (no assistant fallback)", async () => {
-    contactStoreRevokeInviteMock = mock(() => ({
-      ...DEFAULT_INVITE,
-      status: "revoked",
-    }));
-    // assistantDbQuery would only be hit by the fallback; it must NOT run here.
-    const assistantQuerySpy = mock(async () => []);
-    assistantDbQueryMock = assistantQuerySpy;
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleRevokeInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
-        method: "DELETE",
-      }),
-      "inv_1",
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.invite.status).toBe("revoked");
-    expect(contactStoreRevokeInviteMock).toHaveBeenCalledWith("inv_1");
-    // Gateway path mirrors via assistantDbRun but never SELECTs via the fallback.
-    expect(assistantQuerySpy).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("still succeeds when the assistant DB mirror soft-fails", async () => {
-    contactStoreRevokeInviteMock = mock(() => ({
-      ...DEFAULT_INVITE,
-      status: "revoked",
-    }));
-    assistantDbRunMock = mock(async () => {
-      throw new Error("assistant DB down");
-    });
-
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleRevokeInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1", {
-        method: "DELETE",
-      }),
-      "inv_1",
-    );
-
-    expect(res.status).toBe(200);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assistantDbQueryMock).not.toHaveBeenCalled();
+    expect(assistantDbRunMock).not.toHaveBeenCalled();
   });
 
   test("returns 500 on unexpected gateway error (no proxy fallback)", async () => {
@@ -2898,9 +2624,8 @@ describe("handleCallInvite (gateway-native)", () => {
   });
 
   test("relays to the assistant when no gateway row exists (assistant-only invite)", async () => {
-    // Legacy/assistant-only invite: no gateway row, but a live row in
-    // assistant_ingress_invites. Mirror the list/revoke assistant-only fallback
-    // — don't 404; relay and let the daemon-local trigger validate its own row.
+    // Legacy assistant-only invite: no gateway row, but a live daemon-local
+    // row — don't 404; relay and let the daemon-local trigger validate it.
     contactStoreGetInviteByIdMock = mock(() => null);
     ipcCallAssistantMock = mock(async (method: string) => {
       if (method === "invites_trigger_call") {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -146,194 +146,6 @@ function sanitizeInviteRow<
   return rest;
 }
 
-/**
- * Row shape read from the assistant `assistant_ingress_invites` table for the
- * list merge. Deliberately omits every *_hash column so a code/token hash can
- * never reach the wire (the gateway list never returns hashes).
- */
-interface AssistantOnlyInviteRow {
-  id: string;
-  sourceChannel: string;
-  note: string | null;
-  maxUses: number;
-  useCount: number;
-  expiresAt: number;
-  status: string;
-  redeemedByExternalUserId: string | null;
-  redeemedByExternalChatId: string | null;
-  redeemedAt: number | null;
-  contactId: string | null;
-  createdAt: number;
-  updatedAt: number;
-  voiceCodeDigits: number | null;
-  friendName: string | null;
-  guardianName: string | null;
-  expectedExternalUserId: string | null;
-}
-
-/**
- * Query assistant-only ingress invites (those without a gateway row) for the
- * list merge. Applies the SAME sourceChannel/status filters the gateway list
- * uses and excludes any id already present in the gateway result set (gateway
- * is the lifecycle source of truth and wins on dedupe). Returns rows mapped
- * into the gateway list response shape, already sanitized (no hash columns are
- * selected). Throws on DB error so the caller can soft-fail to gateway-only.
- */
-async function listAssistantOnlyInvites(
-  query: { sourceChannel?: string; status?: string },
-  gatewayIds: Set<string>,
-): Promise<Array<Record<string, unknown>>> {
-  const conditions: string[] = [];
-  const params: Array<string | number> = [];
-  if (query.sourceChannel !== undefined) {
-    conditions.push("source_channel = ?");
-    params.push(query.sourceChannel);
-  }
-  if (query.status !== undefined) {
-    conditions.push("status = ?");
-    params.push(query.status);
-  }
-  const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
-
-  const rows = await assistantDbQuery<AssistantOnlyInviteRow>(
-    `SELECT id,
-            source_channel              AS sourceChannel,
-            note,
-            max_uses                    AS maxUses,
-            use_count                   AS useCount,
-            expires_at                  AS expiresAt,
-            status,
-            redeemed_by_external_user_id AS redeemedByExternalUserId,
-            redeemed_by_external_chat_id AS redeemedByExternalChatId,
-            redeemed_at                 AS redeemedAt,
-            contact_id                  AS contactId,
-            created_at                  AS createdAt,
-            updated_at                  AS updatedAt,
-            voice_code_digits           AS voiceCodeDigits,
-            friend_name                 AS friendName,
-            guardian_name               AS guardianName,
-            expected_external_user_id   AS expectedExternalUserId
-       FROM assistant_ingress_invites
-       ${where}`,
-    params,
-  );
-
-  return rows
-    .filter((r) => !gatewayIds.has(r.id))
-    .map((r) => {
-      const {
-        voiceCodeDigits,
-        friendName,
-        guardianName,
-        expectedExternalUserId,
-        ...invite
-      } = r;
-      // No *_hash column is selected, so there's no code hash to strip — the
-      // sanitizeInviteRow invariant is satisfied at the query boundary.
-      return {
-        ...invite,
-        ...(voiceCodeDigits != null ? { voiceCodeDigits } : {}),
-        ...(friendName ? { friendName } : {}),
-        ...(guardianName ? { guardianName } : {}),
-        ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
-      };
-    });
-}
-
-/**
- * Revoke an invite that exists only in the assistant DB (no gateway row).
- *
- * Flips an active row to revoked, then SELECTs the row to distinguish
- * "absent" (→ throw 404) from "present but already terminal" (→ success with
- * the row's resulting state). Returns the sanitized invite shape on success.
- * Idempotent: re-revoking an already-terminal invite returns success.
- */
-async function revokeAssistantOnlyInviteNative(
-  inviteId: string,
-): Promise<{ invite: Record<string, unknown> }> {
-  const now = Date.now();
-  // Flip an ACTIVE row to revoked. A terminal row is untouched (0 rows
-  // affected, no throw → idempotent). A thrown write must NOT be swallowed:
-  // returning 200 with the still-active row would tell the guardian/CLI the
-  // invite was revoked while it stays redeemable via the legacy path.
-  try {
-    await assistantDbRun(
-      "UPDATE assistant_ingress_invites SET status='revoked', updated_at=? WHERE id=? AND status='active'",
-      [now, inviteId],
-    );
-  } catch (err) {
-    log.error(
-      { err, inviteId },
-      "revoke_invite: assistant-only fallback UPDATE failed",
-    );
-    throw new InviteNativeError(
-      `Failed to revoke invite "${inviteId}"`,
-      500,
-      "INTERNAL_ERROR",
-    );
-  }
-
-  // Re-read to determine existence and the resulting status.
-  const found = await assistantDbQuery<AssistantOnlyInviteRow>(
-    `SELECT id,
-            source_channel              AS sourceChannel,
-            note,
-            max_uses                    AS maxUses,
-            use_count                   AS useCount,
-            expires_at                  AS expiresAt,
-            status,
-            redeemed_by_external_user_id AS redeemedByExternalUserId,
-            redeemed_by_external_chat_id AS redeemedByExternalChatId,
-            redeemed_at                 AS redeemedAt,
-            contact_id                  AS contactId,
-            created_at                  AS createdAt,
-            updated_at                  AS updatedAt,
-            voice_code_digits           AS voiceCodeDigits,
-            friend_name                 AS friendName,
-            guardian_name               AS guardianName,
-            expected_external_user_id   AS expectedExternalUserId
-       FROM assistant_ingress_invites
-      WHERE id = ?`,
-    [inviteId],
-  );
-
-  const row = found[0];
-  if (!row) {
-    // Absent from BOTH the gateway and the assistant DB.
-    throw new InviteNativeError(
-      `Invite "${inviteId}" not found`,
-      404,
-      "NOT_FOUND",
-    );
-  }
-
-  void ipcCallAssistant("emit_event", {
-    body: { kind: "contacts_changed" },
-  } as unknown as Record<string, unknown>).catch(() => {});
-
-  const {
-    voiceCodeDigits,
-    friendName,
-    guardianName,
-    expectedExternalUserId,
-    ...invite
-  } = row;
-  log.info(
-    { inviteId, status: row.status },
-    "revoke_invite: handled via assistant-only fallback",
-  );
-  return {
-    invite: {
-      // No *_hash column is selected, so there's no code hash to strip.
-      ...invite,
-      ...(voiceCodeDigits != null ? { voiceCodeDigits } : {}),
-      ...(friendName ? { friendName } : {}),
-      ...(guardianName ? { guardianName } : {}),
-      ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
-    },
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Transport-agnostic invite native functions
 //
@@ -346,9 +158,10 @@ async function revokeAssistantOnlyInviteNative(
 // ---------------------------------------------------------------------------
 
 /**
- * List invites (gateway rows + best-effort voice-field join + assistant-only
- * merge), sanitized (no inviteCodeHash). Throws InviteNativeError(500) when the
- * gateway read itself fails. The voice-join and assistant-only merge soft-fail.
+ * List invites from the gateway DB (single source of truth for invite rows,
+ * including the voice/display columns), sanitized (no inviteCodeHash /
+ * tokenHash / voiceCodeHash). Throws InviteNativeError(500) when the gateway
+ * read fails.
  */
 export async function listInvitesNative(
   query: ListInviteQuery,
@@ -365,66 +178,9 @@ export async function listInvitesNative(
     );
   }
 
-  // Best-effort: join voice UX fields from the assistant DB.
-  const voiceById = new Map<string, Record<string, unknown>>();
-  if (rows.length > 0) {
-    try {
-      const ids = rows.map((r) => r.id);
-      const placeholders = ids.map(() => "?").join(", ");
-      const voiceRows = await assistantDbQuery<{
-        id: string;
-        voiceCodeDigits: number | null;
-        friendName: string | null;
-        guardianName: string | null;
-        expectedExternalUserId: string | null;
-      }>(
-        `SELECT id,
-                voice_code_digits        AS voiceCodeDigits,
-                friend_name              AS friendName,
-                guardian_name            AS guardianName,
-                expected_external_user_id AS expectedExternalUserId
-           FROM assistant_ingress_invites
-          WHERE id IN (${placeholders})`,
-        ids,
-      );
-      for (const v of voiceRows) {
-        voiceById.set(v.id, {
-          ...(v.voiceCodeDigits != null
-            ? { voiceCodeDigits: v.voiceCodeDigits }
-            : {}),
-          ...(v.friendName ? { friendName: v.friendName } : {}),
-          ...(v.guardianName ? { guardianName: v.guardianName } : {}),
-          ...(v.expectedExternalUserId
-            ? { expectedExternalUserId: v.expectedExternalUserId }
-            : {}),
-        });
-      }
-    } catch (err) {
-      log.warn(
-        { err, count: rows.length },
-        "list_invites: assistant DB voice-field join failed; returning gateway rows only",
-      );
-    }
-  }
-
-  const invites: Array<Record<string, unknown>> = rows.map((r) => ({
-    ...sanitizeInviteRow(r),
-    ...(voiceById.get(r.id) ?? {}),
-  }));
-
-  // Belt-and-suspenders for the transitional window: merge in assistant-only
-  // rows (created via the IPC/CLI path with no gateway row), applying the SAME
-  // filters and sanitization. Gateway wins on id (lifecycle truth).
-  try {
-    const gatewayIds = new Set(rows.map((r) => r.id));
-    const assistantOnly = await listAssistantOnlyInvites(query, gatewayIds);
-    for (const inv of assistantOnly) invites.push(inv);
-  } catch (err) {
-    log.warn(
-      { err },
-      "list_invites: assistant-only merge query failed; returning gateway rows only",
-    );
-  }
+  const invites: Array<Record<string, unknown>> = rows.map((r) =>
+    sanitizeInviteRow(r),
+  );
 
   log.info(
     { count: invites.length, ...query },
@@ -570,11 +326,11 @@ export async function createInviteNative(
 }
 
 /**
- * Revoke an invite: flip the gateway row (source of truth), best-effort mirror
- * the actual post-revoke status into the assistant DB, and fall back to
- * revoking the assistant-only row when no gateway row exists. Returns the
- * sanitized invite. Throws InviteNativeError(404) only when the invite is
- * absent from BOTH stores, InviteNativeError(500) on unexpected gateway error.
+ * Revoke an invite: a single gateway UPDATE (source of truth). Idempotent —
+ * revoking an already-terminal (redeemed/revoked/expired) invite returns the
+ * row's current state. Returns the sanitized invite. Throws
+ * InviteNativeError(404) when the invite id is unknown, InviteNativeError(500)
+ * on unexpected gateway error.
  */
 export async function revokeInviteNative(
   inviteId: string,
@@ -592,23 +348,10 @@ export async function revokeInviteNative(
   }
 
   if (!invite) {
-    // No gateway row. Fall back to revoking the assistant-only row; 404 only
-    // when absent from BOTH stores.
-    return await revokeAssistantOnlyInviteNative(inviteId);
-  }
-
-  // Best-effort mirror into the assistant DB — reflect the gateway row's ACTUAL
-  // post-revoke status (revokeInvite only flips ACTIVE rows) so the two stores
-  // stay in sync instead of forcing 'revoked'.
-  try {
-    await assistantDbRun(
-      "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
-      [invite.status, Date.now(), inviteId],
-    );
-  } catch (err) {
-    log.warn(
-      { err, inviteId },
-      "revoke_invite: assistant DB mirror failed (best-effort)",
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
     );
   }
 
@@ -622,21 +365,20 @@ export async function revokeInviteNative(
 
 /**
  * Trigger the provider-specific outbound call for an invite. When the gateway
- * row exists (lifecycle source of truth) it gates on `active`. When it's absent
- * — a legacy/assistant-only invite that lives only in `assistant_ingress_invites`
- * (the same rows list/revoke handle via their assistant-only fallback) — it
- * falls through and lets the daemon-local trigger validate its own row. Returns
- * the provider call sid. Throws InviteNativeError(400) when a present gateway
- * row isn't active, InviteNativeError(500) on relay failure, and propagates an
- * assistant IpcHandlerError unchanged.
+ * row exists (lifecycle source of truth) it gates on `active`. When it's
+ * absent — a legacy assistant-only invite — it falls through and lets the
+ * daemon-local trigger validate its own row. Returns the provider call sid.
+ * Throws InviteNativeError(400) when a present gateway row isn't active,
+ * InviteNativeError(500) on relay failure, and propagates an assistant
+ * IpcHandlerError unchanged.
  */
 export async function triggerInviteCallNative(
   inviteId: string,
 ): Promise<{ callSid: string }> {
   const invite = new ContactStore().getInviteById(inviteId);
-  // Absent gateway row → legacy/assistant-only invite. Don't 404: fall through
-  // and relay; `handleTriggerInviteCall` validates its own assistant_ingress_invites
-  // row (active/inactive) and places the call or surfaces its own error.
+  // Absent gateway row → legacy assistant-only invite. Don't 404: fall through
+  // and relay; `handleTriggerInviteCall` validates its own local row
+  // (active/inactive) and places the call or surfaces its own error.
   if (invite && invite.status !== "active") {
     throw new InviteNativeError(
       `Invite "${inviteId}" is not active`,


### PR DESCRIPTION
## Summary
- listInvitesNative sources voice/display fields from gateway columns; assistant-DB voice join + assistant-only merge deleted
- revokeInviteNative is a single gateway UPDATE; assistantDbRun mirror + assistant-only fallback deleted
- No gateway production code references assistant_ingress_invites outside data migrations

Part of plan: invites-gateway-native.md (PR 10 of 12)