### PR TITLE
feat(gateway): redeem invites at ingress — 6-digit/token intercept, atomic redemption, daemon info-mirror event

### DIFF
--- a/assistant/src/__tests__/invite-redeemed-ipc.test.ts
+++ b/assistant/src/__tests__/invite-redeemed-ipc.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the IPC-only `invite_redeemed` info-mirror handler: the gateway
+ * fires it best-effort after a gateway-native redemption, and the daemon
+ * upserts the local contact/channel identity row (including inviteId).
+ * Repeated delivery of the same outcome must be idempotent.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Prevent channel adapters (imported transitively via contact-routes) from
+// reading real credentials.
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => {},
+}));
+
+import { findContactChannel, getContact } from "../contacts/contact-store.js";
+import { handleInviteRedeemed } from "../ipc/routes/invite-ipc-routes.js";
+import { getSqlite } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+function resetTables() {
+  getSqlite().run("DELETE FROM contact_channels");
+  getSqlite().run("DELETE FROM contacts");
+}
+
+const OUTCOME = {
+  inviteId: "inv-1",
+  contactId: "contact-target-1",
+  sourceChannel: "telegram",
+  memberExternalUserId: "U_SENDER",
+  memberExternalChatId: "chat-sender",
+  displayName: "Curated Name",
+  username: "sender",
+  result: "redeemed",
+};
+
+describe("handleInviteRedeemed (invite_redeemed)", () => {
+  beforeEach(resetTables);
+
+  test("mirrors the local contact/channel info row from the outcome", () => {
+    const result = handleInviteRedeemed({ body: { ...OUTCOME } }) as {
+      ok: boolean;
+    };
+
+    expect(result.ok).toBe(true);
+
+    const contact = getContact("contact-target-1");
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Curated Name");
+
+    const found = findContactChannel({
+      channelType: "telegram",
+      address: "U_SENDER",
+    });
+    expect(found).not.toBeNull();
+    expect(found!.contact.id).toBe("contact-target-1");
+    expect(found!.channel.externalChatId).toBe("chat-sender");
+    // The local contact_channels.invite_id column persists until the ACL
+    // column drop; the mirror carries it through.
+    expect(found!.channel.inviteId).toBe("inv-1");
+  });
+
+  test("is idempotent for repeated delivery of the same outcome", () => {
+    handleInviteRedeemed({ body: { ...OUTCOME } });
+    handleInviteRedeemed({ body: { ...OUTCOME } });
+
+    const contactRows = getSqlite()
+      .query("SELECT COUNT(*) AS n FROM contacts")
+      .get() as { n: number };
+    const channelRows = getSqlite()
+      .query("SELECT COUNT(*) AS n FROM contact_channels")
+      .get() as { n: number };
+
+    expect(contactRows.n).toBe(1);
+    expect(channelRows.n).toBe(1);
+
+    const found = findContactChannel({
+      channelType: "telegram",
+      address: "U_SENDER",
+    });
+    expect(found!.contact.id).toBe("contact-target-1");
+  });
+
+  test("rejects a malformed outcome payload", () => {
+    expect(() =>
+      handleInviteRedeemed({ body: { inviteId: "inv-1" } }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -11,6 +11,9 @@
  * than flagged inside `ROUTES`.
  */
 
+import { InviteRedeemedNotificationSchema } from "@vellumai/gateway-client";
+
+import { upsertContactChannel } from "../../contacts/contacts-write.js";
 import {
   handleRedeemTokenInvite,
   handleRedeemVoiceInvite,
@@ -18,12 +21,37 @@ import {
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
 
 /**
+ * Best-effort local info mirror for a gateway-native invite redemption.
+ *
+ * The gateway owns the ACL outcome; this handler only upserts the local
+ * contact/channel identity row from the outcome's identity fields (including
+ * `inviteId`, which the local `contact_channels` schema still carries).
+ * `upsertContactChannel` is an idempotent upsert and fires
+ * `notifyContactsChanged()` internally, so repeated delivery of the same
+ * outcome is safe.
+ */
+export function handleInviteRedeemed({ body = {} }: RouteHandlerArgs) {
+  const outcome = InviteRedeemedNotificationSchema.parse(body);
+  upsertContactChannel({
+    sourceChannel: outcome.sourceChannel,
+    externalUserId: outcome.memberExternalUserId,
+    externalChatId: outcome.memberExternalChatId,
+    displayName: outcome.displayName,
+    username: outcome.username,
+    inviteId: outcome.inviteId,
+    contactId: outcome.contactId,
+  });
+  return { ok: true };
+}
+
+/**
  * IPC-only invite methods, keyed by IPC operationId. Registered directly on
  * the assistant IPC server (see `assistant-server.ts`).
  *
  * `invites_redeem_voice` / `invites_redeem_token` reuse the same split
  * handlers that back the shared HTTP `invites_redeem` route, so token/voice
- * redemption behaves identically across both transports.
+ * redemption behaves identically across both transports. `invite_redeemed`
+ * is the gateway's post-redemption info-mirror notification.
  */
 export const INVITE_IPC_METHODS: Record<
   string,
@@ -31,4 +59,5 @@ export const INVITE_IPC_METHODS: Record<
 > = {
   invites_redeem_voice: handleRedeemVoiceInvite,
   invites_redeem_token: handleRedeemTokenInvite,
+  invite_redeemed: handleInviteRedeemed,
 };

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Invite redemption intercept tests for `handle-inbound.ts`:
+ *
+ *  - A valid 6-digit code (or /start iv_<token> deep link) from a non-member
+ *    is redeemed at the gateway: no forward, reply delivered via the
+ *    callback URL, gateway channel activated, daemon `invite_redeemed`
+ *    info-mirror fired.
+ *  - A bare 6-digit matching no invite falls through to normal forwarding.
+ *  - Member senders and disabled channels are never intercepted.
+ *  - A cross-channel code hit intercepts with the mismatch reply and
+ *    consumes nothing.
+ *  - The verification intercept wins when both could match.
+ *
+ * The gateway DB is real; the runtime client, verification intercept,
+ * assistant IPC, and assistant DB proxy are mocked.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
+
+import type { GatewayConfig } from "../config.js";
+import type {
+  RuntimeInboundPayload,
+  RuntimeInboundResponse,
+} from "../runtime/client.js";
+import type { GatewayInboundEvent } from "../types.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+const fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async (input, init) => {
+  fetchCalls.push({
+    url: String(input),
+    body: init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {},
+  });
+  return new Response();
+});
+
+let runtimePayloads: RuntimeInboundPayload[] = [];
+const forwardToRuntimeMock = mock(
+  async (
+    _config: GatewayConfig,
+    payload: RuntimeInboundPayload,
+  ): Promise<RuntimeInboundResponse> => {
+    runtimePayloads.push(payload);
+    return { accepted: true, duplicate: false, eventId: "runtime-event-1" };
+  },
+);
+
+let interceptResult: { intercepted: boolean; [k: string]: unknown } = {
+  intercepted: false,
+};
+const tryTextVerificationInterceptMock = mock(async () => interceptResult);
+
+let ipcCalls: { method: string; params?: Record<string, unknown> }[] = [];
+const ipcCallAssistantMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return { ok: true };
+  },
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+mock.module("../runtime/client.js", () => ({
+  CircuitBreakerOpenError: class CircuitBreakerOpenError extends Error {
+    readonly retryAfterSecs: number;
+    constructor(retryAfterSecs: number) {
+      super("Circuit breaker is open");
+      this.retryAfterSecs = retryAfterSecs;
+    }
+  },
+  forwardToRuntime: (...args: Parameters<typeof forwardToRuntimeMock>) =>
+    forwardToRuntimeMock(...args),
+  // Not exercised here, but mock.module bleeds across files in a combined
+  // `bun test` run — keep the surface a superset of what other files import.
+  resetConversation: async () => {},
+}));
+
+mock.module("../verification/text-verification.js", () => ({
+  tryTextVerificationIntercept: (...args: unknown[]) =>
+    tryTextVerificationInterceptMock(...(args as [])),
+}));
+
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: (...args: Parameters<typeof ipcCallAssistantMock>) =>
+    ipcCallAssistantMock(...args),
+}));
+
+// The redemption engine's ACL side effect dual-writes an assistant-DB info
+// mirror; stub it so tests never touch a socket.
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: async () => [],
+  assistantDbRun: async () => {},
+}));
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const {
+  initAdmissionPolicyCache,
+  resetAdmissionPolicyCache,
+} = await import("../risk/admission-policy-cache.js");
+const { contacts, contactChannels, ingressInvites } = await import(
+  "../db/schema.js"
+);
+const { ContactStore } = await import("../db/contact-store.js");
+const { handleInbound } = await import("../handlers/handle-inbound.js");
+
+const CHANNEL = "telegram";
+const CODE = "123456";
+const TOKEN = "tok_raw_abc123";
+const REPLY_URL = "http://127.0.0.1:7830/deliver/telegram";
+
+function seedContact(id: string): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `name-${id}`,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedChannel(args: {
+  contactId: string;
+  address: string;
+  status?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: crypto.randomUUID(),
+      contactId: args.contactId,
+      type: CHANNEL,
+      address: args.address,
+      externalChatId: "chat-1",
+      status: args.status ?? "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+function seedInvite(overrides: { sourceChannel?: string } = {}): string {
+  const id = crypto.randomUUID();
+  new ContactStore().createInvite({
+    id,
+    sourceChannel: overrides.sourceChannel ?? CHANNEL,
+    inviteCodeHash: hashInviteCode(CODE),
+    tokenHash: hashInviteToken(TOKEN),
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+  });
+  return id;
+}
+
+function inviteRow(id: string) {
+  return new ContactStore().getInviteById(id)!;
+}
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: "default-assistant",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: { default: 50 * 1024 * 1024 },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    unmappedPolicy: "default",
+    trustProxy: false,
+  } as unknown as GatewayConfig;
+}
+
+function makeEvent(
+  overrides: Record<string, unknown> = {},
+): GatewayInboundEvent {
+  return {
+    sourceChannel: CHANNEL,
+    source: { updateId: "u1", messageId: "m1", chatType: "private" },
+    actor: {
+      actorExternalId: "U_SENDER",
+      displayName: "Sender Name",
+      username: "sender",
+    },
+    message: {
+      conversationExternalId: "chat-sender",
+      externalMessageId: "extmsg-1",
+      content: CODE,
+    },
+    ...overrides,
+  } as GatewayInboundEvent;
+}
+
+const ROUTING = {
+  routingOverride: { assistantId: "asst-1", routeSource: "default" as const },
+};
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetAdmissionPolicyCache();
+  await initGatewayDb();
+  getGatewayDb().delete(ingressInvites).run();
+  getGatewayDb().delete(contactChannels).run();
+  getGatewayDb().delete(contacts).run();
+  initAdmissionPolicyCache();
+  runtimePayloads = [];
+  fetchCalls = [];
+  ipcCalls = [];
+  forwardToRuntimeMock.mockClear();
+  interceptResult = { intercepted: false };
+});
+
+afterEach(() => {
+  resetAdmissionPolicyCache();
+  resetGatewayDb();
+});
+
+describe("handle-inbound invite redemption intercept", () => {
+  test("valid 6-digit code from a non-member: redeems, replies, does not forward, fires invite_redeemed", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+
+    const result = await handleInbound(makeConfig(), makeEvent(), {
+      ...ROUTING,
+      replyCallbackUrl: REPLY_URL,
+    });
+
+    expect(result.inviteIntercepted).toBe(true);
+    expect(result.forwarded).toBe(false);
+    expect(result.rejected).toBe(false);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+
+    // Reply delivered via the callback URL (no pending reply text).
+    expect(result.inviteReplyText).toBeUndefined();
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe(REPLY_URL);
+    expect(fetchCalls[0]!.body.text).toBe(
+      "Welcome! You've been granted access.",
+    );
+
+    // Redemption landed: use consumed, gateway channel active.
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    const channel = getGatewayDb().select().from(contactChannels).all()[0];
+    expect(channel?.status).toBe("active");
+    expect(channel?.verifiedVia).toBe("invite");
+
+    // Daemon info-mirror fired best-effort with the outcome.
+    const mirror = ipcCalls.find((c) => c.method === "invite_redeemed");
+    expect(mirror).toBeDefined();
+    expect(mirror!.params!.body).toMatchObject({
+      inviteId,
+      contactId: "c1",
+      sourceChannel: CHANNEL,
+      memberExternalUserId: "U_SENDER",
+      result: "redeemed",
+    });
+  });
+
+  test("without a replyCallbackUrl the reply text is surfaced on the result", async () => {
+    seedContact("c1");
+    seedInvite();
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.inviteIntercepted).toBe(true);
+    expect(result.inviteReplyText).toBe("Welcome! You've been granted access.");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("/start iv_<token> deep link (commandIntent) redeems at the gateway", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+
+    const result = await handleInbound(
+      makeConfig(),
+      makeEvent({
+        message: {
+          conversationExternalId: "chat-sender",
+          externalMessageId: "extmsg-1",
+          content: `/start iv_${TOKEN}`,
+        },
+      }),
+      {
+        ...ROUTING,
+        replyCallbackUrl: REPLY_URL,
+        sourceMetadata: {
+          commandIntent: { type: "start", payload: `iv_${TOKEN}` },
+        },
+      },
+    );
+
+    expect(result.inviteIntercepted).toBe(true);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+    expect(inviteRow(inviteId).useCount).toBe(1);
+  });
+
+  test("bare 6-digit matching no invite falls through to normal forwarding", async () => {
+    seedContact("c1");
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.inviteIntercepted).toBeUndefined();
+    expect(result.forwarded).toBe(true);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("member sender is NOT intercepted — the bare 6-digit forwards normally", async () => {
+    seedContact("c1");
+    seedChannel({ contactId: "c1", address: "U_SENDER", status: "active" });
+    const inviteId = seedInvite();
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.inviteIntercepted).toBeUndefined();
+    expect(result.forwarded).toBe(true);
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+
+  test("disabled channel is NOT intercepted", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ sourceChannel: "phone" });
+
+    const result = await handleInbound(
+      makeConfig(),
+      makeEvent({ sourceChannel: "phone" }),
+      ROUTING,
+    );
+
+    expect(result.inviteIntercepted).toBeUndefined();
+    expect(result.forwarded).toBe(true);
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+
+  test("cross-channel code hit: intercepts with the mismatch reply, consumes nothing", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ sourceChannel: "whatsapp" });
+
+    const result = await handleInbound(makeConfig(), makeEvent(), {
+      ...ROUTING,
+      replyCallbackUrl: REPLY_URL,
+    });
+
+    expect(result.inviteIntercepted).toBe(true);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+    expect(fetchCalls[0]!.body.text).toBe(
+      "This invite is not valid for this channel.",
+    );
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(ipcCalls.find((c) => c.method === "invite_redeemed")).toBeUndefined();
+  });
+
+  test("blocked sender with a valid code: intercepted failure, channel stays blocked", async () => {
+    seedContact("c1");
+    seedChannel({ contactId: "c1", address: "U_SENDER", status: "blocked" });
+    const inviteId = seedInvite();
+
+    const result = await handleInbound(makeConfig(), makeEvent(), {
+      ...ROUTING,
+      replyCallbackUrl: REPLY_URL,
+    });
+
+    expect(result.inviteIntercepted).toBe(true);
+    expect(fetchCalls[0]!.body.text).toBe("This invite is no longer valid.");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    const channel = getGatewayDb().select().from(contactChannels).all()[0];
+    expect(channel?.status).toBe("blocked");
+    expect(ipcCalls.find((c) => c.method === "invite_redeemed")).toBeUndefined();
+  });
+
+  test("verification intercept wins when both could match", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    interceptResult = {
+      intercepted: true,
+      outcome: "verified",
+      trustClass: "trusted_contact",
+      pendingReplyText: "Verified!",
+    };
+
+    const result = await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    expect(result.verificationIntercepted).toBe(true);
+    expect(result.inviteIntercepted).toBeUndefined();
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -92,10 +92,13 @@ mock.module("../ipc/assistant-client.js", () => ({
 }));
 
 // The redemption engine's ACL side effect dual-writes an assistant-DB info
-// mirror; stub it so tests never touch a socket.
+// mirror; stub it so tests never touch a socket. Mutable impls let tests
+// simulate a down assistant DB proxy.
+let assistantDbQueryImpl: () => Promise<unknown[]> = async () => [];
+let assistantDbRunImpl: () => Promise<void> = async () => {};
 mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: async () => [],
-  assistantDbRun: async () => {},
+  assistantDbQuery: () => assistantDbQueryImpl(),
+  assistantDbRun: () => assistantDbRunImpl(),
 }));
 
 await import("./test-preload.js");
@@ -229,6 +232,8 @@ beforeEach(async () => {
   ipcCalls = [];
   forwardToRuntimeMock.mockClear();
   interceptResult = { intercepted: false };
+  assistantDbQueryImpl = async () => [];
+  assistantDbRunImpl = async () => {};
 });
 
 afterEach(() => {
@@ -386,6 +391,37 @@ describe("handle-inbound invite redemption intercept", () => {
     const channel = getGatewayDb().select().from(contactChannels).all()[0];
     expect(channel?.status).toBe("blocked");
     expect(ipcCalls.find((c) => c.method === "invite_redeemed")).toBeUndefined();
+  });
+
+  test("assistant DB proxy down: valid code still redeems with the success reply, never forwards", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    assistantDbQueryImpl = async () => {
+      throw new Error("assistant IPC unavailable");
+    };
+    assistantDbRunImpl = async () => {
+      throw new Error("assistant IPC unavailable");
+    };
+
+    const result = await handleInbound(makeConfig(), makeEvent(), {
+      ...ROUTING,
+      replyCallbackUrl: REPLY_URL,
+    });
+
+    // The mirror is best-effort: the raw code must never reach the runtime
+    // once the gateway claimed the use.
+    expect(result.inviteIntercepted).toBe(true);
+    expect(result.forwarded).toBe(false);
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.body.text).toBe(
+      "Welcome! You've been granted access.",
+    );
+
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    const channel = getGatewayDb().select().from(contactChannels).all()[0];
+    expect(channel?.status).toBe("active");
+    expect(channel?.verifiedVia).toBe("invite");
   });
 
   test("verification intercept wins when both could match", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -15,9 +15,12 @@ import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
 
 // The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
 // assistant-DB info mirror over IPC; stub it so tests never touch a socket.
+// The impls are mutable so tests can simulate a down/failing mirror.
+let assistantDbQueryImpl: () => Promise<unknown[]> = async () => [];
+let assistantDbRunImpl: () => Promise<void> = async () => {};
 mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: async () => [],
-  assistantDbRun: async () => {},
+  assistantDbQuery: () => assistantDbQueryImpl(),
+  assistantDbRun: () => assistantDbRunImpl(),
 }));
 
 await import("./test-preload.js");
@@ -46,6 +49,8 @@ beforeEach(() => {
   db.delete(ingressInvites).run();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  assistantDbQueryImpl = async () => [];
+  assistantDbRunImpl = async () => {};
 });
 
 afterAll(() => {
@@ -346,6 +351,62 @@ describe("redeemInviteByCode", () => {
     expect(result.status).toBe("failed");
     if (result.status !== "failed") throw new Error("unreachable");
     expect(result.reason).toBe("missing_identity");
+  });
+});
+
+describe("post-claim failure isolation", () => {
+  test("assistant mirror IPC down (lookup + writes throw): still redeemed, gateway ACL active", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    assistantDbQueryImpl = async () => {
+      throw new Error("assistant IPC unavailable");
+    };
+    assistantDbRunImpl = async () => {
+      throw new Error("assistant IPC unavailable");
+    };
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.replyText).toBe("Welcome! You've been granted access.");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    const channel = gwChannel("U_SENDER");
+    expect(channel?.status).toBe("active");
+    expect(channel?.verifiedVia).toBe("invite");
+    expect(channel?.contactId).toBe("c1");
+  });
+
+  test("assistant mirror write fails on an existing mirror row: still redeemed, gateway ACL active", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    assistantDbQueryImpl = async () => [
+      { channelId: "mirror-ch-1", contactId: "c1" },
+    ];
+    assistantDbRunImpl = async () => {
+      throw new Error("mirror UPDATE failed");
+    };
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(gwChannel("U_SENDER")?.status).toBe("active");
+  });
+
+  test("post-claim engine throw outside the ACL helper (getContact) still yields redeemed", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    const store = new ContactStore();
+    store.getContact = () => {
+      throw new Error("gateway read failed");
+    };
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY, store });
+
+    expect(result.status).toBe("redeemed");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(gwChannel("U_SENDER")?.status).toBe("active");
   });
 });
 

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for the gateway-native invite redemption engine
+ * (verification/invite-redemption.ts): code + token resolution, lifecycle
+ * validation (expiry lazy-marking, use counts, channel match), the
+ * already-member no-consume gate, blocked-row refusal, revoked reactivation,
+ * atomic double-redeem, and the ACL side effect on the gateway DB.
+ *
+ * The gateway DB is real (shared test preload); the assistant DB mirror is
+ * mocked out — it is a best-effort info mirror and not under test here.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
+
+// The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
+// assistant-DB info mirror over IPC; stub it so tests never touch a socket.
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: async () => [],
+  assistantDbRun: async () => {},
+}));
+
+await import("./test-preload.js");
+
+const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts, contactChannels, ingressInvites } = await import(
+  "../db/schema.js"
+);
+const { ContactStore } = await import("../db/contact-store.js");
+const { redeemInviteByCode, redeemInviteByToken } = await import(
+  "../verification/invite-redemption.js"
+);
+
+const CHANNEL = "telegram";
+const CODE = "123456";
+const TOKEN = "tok_raw_abc123";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(id: string, displayName = `name-${id}`): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({ id, displayName, role: "contact", createdAt: now, updatedAt: now })
+    .run();
+}
+
+function seedChannel(args: {
+  id: string;
+  contactId: string;
+  address: string;
+  status: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: CHANNEL,
+      address: args.address,
+      externalChatId: "chat-1",
+      status: args.status,
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+function seedInvite(
+  overrides: Partial<
+    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
+  > = {},
+): string {
+  const store = new ContactStore();
+  const id = overrides.id ?? crypto.randomUUID();
+  store.createInvite({
+    id,
+    sourceChannel: CHANNEL,
+    inviteCodeHash: hashInviteCode(CODE),
+    tokenHash: hashInviteToken(TOKEN),
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  });
+  return id;
+}
+
+function inviteRow(id: string) {
+  return new ContactStore().getInviteById(id)!;
+}
+
+function gwChannel(address: string) {
+  return getGatewayDb()
+    .select()
+    .from(contactChannels)
+    .all()
+    .find(
+      (ch) =>
+        ch.type === CHANNEL &&
+        ch.address.toLowerCase() === address.toLowerCase(),
+    );
+}
+
+const IDENTITY = {
+  sourceChannel: CHANNEL,
+  externalUserId: "U_SENDER",
+  externalChatId: "chat-sender",
+  displayName: "Sender Name",
+  username: "sender",
+};
+
+describe("redeemInviteByCode", () => {
+  test("valid code: claims atomically, activates the gateway channel, returns the outcome", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.replyText).toBe("Welcome! You've been granted access.");
+    expect(result.outcome).toMatchObject({
+      inviteId,
+      contactId: "c1",
+      sourceChannel: CHANNEL,
+      memberExternalUserId: "U_SENDER",
+      memberExternalChatId: "chat-sender",
+      result: "redeemed",
+    });
+
+    const invite = inviteRow(inviteId);
+    expect(invite.useCount).toBe(1);
+    expect(invite.status).toBe("redeemed");
+    expect(invite.redeemedByExternalUserId).toBe("U_SENDER");
+
+    const channel = gwChannel("U_SENDER");
+    expect(channel?.status).toBe("active");
+    expect(channel?.verifiedVia).toBe("invite");
+    expect(channel?.contactId).toBe("c1");
+  });
+
+  test("preserves the target contact's curated displayName in the outcome", async () => {
+    seedContact("c1", "Curated Name");
+    seedInvite();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.outcome.displayName).toBe("Curated Name");
+  });
+
+  test("passes sourceConversationId through opaquely", async () => {
+    seedContact("c1");
+    seedInvite({ sourceConversationId: "conv-xyz" });
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.outcome.sourceConversationId).toBe("conv-xyz");
+  });
+
+  test("code matching no invite anywhere → no_match (fall through)", async () => {
+    seedContact("c1");
+    seedInvite();
+
+    const result = await redeemInviteByCode({ code: "999999", ...IDENTITY });
+
+    expect(result.status).toBe("no_match");
+  });
+
+  test("code active on another channel → channel_mismatch, no use consumed", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ sourceChannel: "whatsapp" });
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("channel_mismatch");
+    expect(result.replyText).toBe("This invite is not valid for this channel.");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+
+  test("expired invite is lazily marked expired, no use consumed", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ expiresAt: Date.now() - 1 });
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("expired");
+    expect(result.replyText).toBe("This invite is no longer valid.");
+    const invite = inviteRow(inviteId);
+    expect(invite.status).toBe("expired");
+    expect(invite.useCount).toBe(0);
+  });
+
+  test("exhausted invite → max_uses_reached", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    // Exhaust the single use with a first redemption, then reset the sender's
+    // gateway channel so the second attempt isn't gated as already_member.
+    await redeemInviteByCode({ code: CODE, ...IDENTITY });
+    getGatewayDb().delete(contactChannels).run();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    // The channel-scoped lookup only returns active invites, and the
+    // exhausted row is status "redeemed" — the code no longer resolves.
+    expect(result.status).toBe("no_match");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+  });
+
+  test("already-active member: already_member, NO use consumed", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: "U_SENDER",
+      status: "active",
+    });
+    const inviteId = seedInvite();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("already_member");
+    if (result.status !== "already_member") throw new Error("unreachable");
+    expect(result.replyText).toBe("You already have access.");
+    expect(result.outcome.result).toBe("already_member");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(inviteRow(inviteId).status).toBe("active");
+  });
+
+  test("blocked gateway channel is NEVER reactivated: generic failure, no use consumed", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: "U_SENDER",
+      status: "blocked",
+    });
+    const inviteId = seedInvite();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("invalid_token");
+    expect(result.replyText).toBe("This invite is no longer valid.");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(gwChannel("U_SENDER")?.status).toBe("blocked");
+  });
+
+  test("revoked gateway channel IS reactivated by an invite (allowRevokedReactivation)", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: "U_SENDER",
+      status: "revoked",
+    });
+    const inviteId = seedInvite();
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(gwChannel("U_SENDER")?.status).toBe("active");
+    expect(gwChannel("U_SENDER")?.verifiedVia).toBe("invite");
+  });
+
+  test("atomic double-redeem: two concurrent redemptions → exactly one success", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ maxUses: 1 });
+
+    const results = await Promise.all([
+      redeemInviteByCode({ code: CODE, ...IDENTITY }),
+      redeemInviteByCode({
+        code: CODE,
+        sourceChannel: CHANNEL,
+        externalUserId: "U_OTHER",
+        externalChatId: "chat-other",
+      }),
+    ]);
+
+    // Whichever interleaving occurs, exactly one caller redeems; the loser
+    // either loses the atomic claim (failed) or no longer resolves the
+    // consumed code (no_match). Never two redemptions.
+    const redeemed = results.filter((r) => r.status === "redeemed");
+    expect(redeemed).toHaveLength(1);
+    expect(inviteRow(inviteId).useCount).toBe(1);
+  });
+
+  test("atomic claim: the second of two claims on the same resolved invite is gated out", () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ maxUses: 1 });
+    const store = new ContactStore();
+
+    // Both callers resolved the same active row (pre-claim state), then race
+    // the status="active"-gated claim: only the first consumes it.
+    const first = store.recordInviteRedemption({
+      inviteId,
+      redeemedByExternalUserId: "U_SENDER",
+    });
+    const second = store.recordInviteRedemption({
+      inviteId,
+      redeemedByExternalUserId: "U_OTHER",
+    });
+
+    expect(first.updated).toBe(true);
+    expect(second.updated).toBe(false);
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(inviteRow(inviteId).redeemedByExternalUserId).toBe("U_SENDER");
+  });
+
+  test("no identity at all → missing_identity", async () => {
+    seedContact("c1");
+    seedInvite();
+
+    const result = await redeemInviteByCode({
+      code: CODE,
+      sourceChannel: CHANNEL,
+    });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("missing_identity");
+  });
+});
+
+describe("redeemInviteByToken", () => {
+  test("valid token redeems and activates the gateway channel", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+
+    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+
+    expect(result.status).toBe("redeemed");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(gwChannel("U_SENDER")?.status).toBe("active");
+  });
+
+  test("unknown token is a definitive invalid invite (no fall-through)", async () => {
+    seedContact("c1");
+    seedInvite();
+
+    const result = await redeemInviteByToken({
+      rawToken: "not-a-token",
+      ...IDENTITY,
+    });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("invalid_token");
+    expect(result.replyText).toBe("This invite is no longer valid.");
+  });
+
+  test("revoked invite → revoked reason with the generic invalid reply", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite();
+    new ContactStore().revokeInvite(inviteId);
+
+    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("revoked");
+    expect(result.replyText).toBe("This invite is no longer valid.");
+  });
+
+  test("token minted for another channel → channel_mismatch, no use consumed", async () => {
+    seedContact("c1");
+    const inviteId = seedInvite({ sourceChannel: "whatsapp" });
+
+    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") throw new Error("unreachable");
+    expect(result.reason).toBe("channel_mismatch");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+});

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -23,6 +23,7 @@ import {
 } from "../runtime/client.js";
 import type { RuntimeInboundResponse } from "../runtime/client.js";
 import type { GatewayInboundEvent } from "../types.js";
+import { tryInviteRedemptionIntercept } from "../verification/invite-redemption.js";
 import { tryTextVerificationIntercept } from "../verification/text-verification.js";
 
 const log = getLogger("handle-inbound");
@@ -33,6 +34,9 @@ export type InboundResult = {
   verificationIntercepted?: boolean;
   /** Reply text when the verification intercept couldn't deliver (no replyCallbackUrl). */
   verificationReplyText?: string;
+  inviteIntercepted?: boolean;
+  /** Reply text when the invite intercept couldn't deliver (no replyCallbackUrl). */
+  inviteReplyText?: string;
   runtimeResponse?: RuntimeInboundResponse;
   rejectionReason?: string;
 };
@@ -157,15 +161,11 @@ export async function handleInbound(
     };
   }
 
-  const transportHints = normalizeTransportHints(
-    options?.transportMetadata?.hints,
-  );
-  const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
-  const sourceChannelName = event.source.channelName?.trim();
-
   // ── Per-actor trust verdict ──
   // Resolved from the gateway ACL DB and stamped on sourceMetadata for the
-  // runtime to consume.
+  // runtime to consume. Runs after the verification intercept (messages it
+  // consumes never pay resolution cost) and before the invite intercept,
+  // which gates on the resolved class.
   let trustVerdict: TrustVerdict | undefined;
   try {
     trustVerdict = await resolveTrustVerdict({
@@ -180,6 +180,45 @@ export async function handleInbound(
       canonicalSenderIdFor(event.sourceChannel, event.actor.actorExternalId),
     );
   }
+
+  // ── Invite redemption intercept ──
+  // Bare 6-digit invite codes and `/start iv_<token>` deep links from
+  // non-member senders are redeemed at the gateway; the runtime never sees
+  // them. A code that matches no invite falls through as a normal message.
+  const inviteResult = await tryInviteRedemptionIntercept({
+    sourceChannel: event.sourceChannel,
+    messageContent: event.message.content,
+    commandIntent: options?.sourceMetadata?.commandIntent,
+    actorExternalUserId: event.actor.actorExternalId,
+    actorChatId: event.message.conversationExternalId,
+    actorDisplayName: event.actor.displayName,
+    actorUsername: event.actor.username,
+    replyCallbackUrl: options?.replyCallbackUrl,
+    assistantId: routing.assistantId,
+    trustVerdict,
+  });
+
+  if (inviteResult.intercepted) {
+    log.info(
+      {
+        sourceChannel: event.sourceChannel,
+        outcome: inviteResult.outcome,
+      },
+      "Invite redemption intercepted — not forwarding to runtime",
+    );
+    return {
+      forwarded: false,
+      rejected: false,
+      inviteIntercepted: true,
+      inviteReplyText: inviteResult.pendingReplyText,
+    };
+  }
+
+  const transportHints = normalizeTransportHints(
+    options?.transportMetadata?.hints,
+  );
+  const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
+  const sourceChannelName = event.source.channelName?.trim();
 
   try {
     const response = await forwardToRuntime(

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -14,6 +14,7 @@ import {
 } from "../../routing/resolve-assistant.js";
 import {
   handleCircuitBreakerError,
+  interceptedReply,
   processInboundResult,
 } from "../../webhook-pipeline.js";
 
@@ -208,17 +209,18 @@ export function createEmailWebhookHandler(
         },
       });
 
-      // Verification reply — short-circuit before processInboundResult
-      if (result.verificationIntercepted && result.verificationReplyText) {
+      // Verification / invite reply — short-circuit before processInboundResult
+      const intercept = interceptedReply(result);
+      if (intercept) {
         dedupCache.mark(eventId);
         tlog.info(
           { from: event.actor.actorExternalId, to: recipientAddress },
-          "Verification intercepted — returning reply text to platform",
+          "Gateway intercept — returning reply text to platform",
         );
         return Response.json({
           ok: true,
-          verificationIntercepted: true,
-          replyText: result.verificationReplyText,
+          [intercept.flag]: true,
+          replyText: intercept.text,
         });
       }
 

--- a/gateway/src/http/routes/mailgun-webhook.ts
+++ b/gateway/src/http/routes/mailgun-webhook.ts
@@ -16,6 +16,7 @@ import {
 } from "../../routing/resolve-assistant.js";
 import {
   handleCircuitBreakerError,
+  interceptedReply,
   processInboundResult,
 } from "../../webhook-pipeline.js";
 
@@ -374,11 +375,12 @@ export function createMailgunWebhookHandler(
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
 
-      // ── Verification reply ──────────────────────────────────────
-      // Not gated by recordDenialReplyIfAllowed — verification success
-      // confirmations must always be delivered regardless of prior denial
-      // replies to this sender.
-      if (result.verificationIntercepted && result.verificationReplyText) {
+      // ── Verification / invite reply ─────────────────────────────
+      // Not gated by recordDenialReplyIfAllowed — verification and invite
+      // redemption confirmations must always be delivered regardless of
+      // prior denial replies to this sender.
+      const intercept = interceptedReply(result);
+      if (intercept) {
         const mailgunApiKeyForVerify = await resolveCredential(
           credentialKey("mailgun", "api_key"),
         );
@@ -394,7 +396,7 @@ export function createMailgunWebhookHandler(
                 "subject",
                 `Re: ${vellumPayload.subject ?? "(no subject)"}`,
               );
-              form.set("text", result.verificationReplyText);
+              form.set("text", intercept.text);
               if (vellumPayload.messageId) {
                 form.set("h:In-Reply-To", vellumPayload.messageId);
               }
@@ -412,7 +414,7 @@ export function createMailgunWebhookHandler(
               if (sendResponse.ok) {
                 tlog.info(
                   { from: recipientAddress, to: senderAddress },
-                  "Sent verification reply via Mailgun",
+                  "Sent intercept reply via Mailgun",
                 );
               } else {
                 tlog.warn(
@@ -421,19 +423,19 @@ export function createMailgunWebhookHandler(
                     from: recipientAddress,
                     to: senderAddress,
                   },
-                  "Failed to send verification reply via Mailgun",
+                  "Failed to send intercept reply via Mailgun",
                 );
               }
             } catch (err) {
               tlog.error(
                 { err, from: recipientAddress, to: senderAddress },
-                "Error sending verification reply via Mailgun",
+                "Error sending intercept reply via Mailgun",
               );
             }
           }
         }
         dedupCache.mark(token);
-        return Response.json({ ok: true, verificationIntercepted: true });
+        return Response.json({ ok: true, [intercept.flag]: true });
       }
 
       dedupCache.mark(token);

--- a/gateway/src/http/routes/resend-webhook.ts
+++ b/gateway/src/http/routes/resend-webhook.ts
@@ -16,6 +16,7 @@ import {
 } from "../../routing/resolve-assistant.js";
 import {
   handleCircuitBreakerError,
+  interceptedReply,
   processInboundResult,
 } from "../../webhook-pipeline.js";
 
@@ -446,15 +447,12 @@ export function createResendWebhookHandler(
         },
       });
 
-      // ── Verification reply ──────────────────────────────────────
-      // Not gated by recordDenialReplyIfAllowed — verification success
-      // confirmations must always be delivered regardless of prior denial
-      // replies to this sender.
-      if (
-        result.verificationIntercepted &&
-        result.verificationReplyText &&
-        apiKey
-      ) {
+      // ── Verification / invite reply ─────────────────────────────
+      // Not gated by recordDenialReplyIfAllowed — verification and invite
+      // redemption confirmations must always be delivered regardless of
+      // prior denial replies to this sender.
+      const intercept = interceptedReply(result);
+      if (intercept && apiKey) {
         const senderAddress = gatewayEvent.actor.actorExternalId;
         try {
           const sendResponse = await fetch("https://api.resend.com/emails", {
@@ -467,7 +465,7 @@ export function createResendWebhookHandler(
               from: recipientAddress,
               to: [senderAddress],
               subject: `Re: ${vellumPayload.subject ?? "(no subject)"}`,
-              text: result.verificationReplyText,
+              text: intercept.text,
               ...(vellumPayload.messageId
                 ? {
                     headers: {
@@ -480,7 +478,7 @@ export function createResendWebhookHandler(
           if (sendResponse.ok) {
             tlog.info(
               { from: recipientAddress, to: senderAddress },
-              "Sent verification reply via Resend",
+              "Sent intercept reply via Resend",
             );
           } else {
             tlog.warn(
@@ -489,17 +487,17 @@ export function createResendWebhookHandler(
                 from: recipientAddress,
                 to: senderAddress,
               },
-              "Failed to send verification reply via Resend",
+              "Failed to send intercept reply via Resend",
             );
           }
         } catch (err) {
           tlog.error(
             { err, from: recipientAddress, to: senderAddress },
-            "Error sending verification reply via Resend",
+            "Error sending intercept reply via Resend",
           );
         }
         dedupCache.mark(messageId);
-        return Response.json({ ok: true, verificationIntercepted: true });
+        return Response.json({ ok: true, [intercept.flag]: true });
       }
 
       const processed = processInboundResult(

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -419,8 +419,8 @@ export function createTelegramWebhookHandler(
               );
             });
           }
-        } else if (result.verificationIntercepted) {
-          // Verification handled — no error, no forward needed
+        } else if (result.verificationIntercepted || result.inviteIntercepted) {
+          // Verification/invite handled at the gateway — no forward needed
         } else if (!result.forwarded) {
           tlog.error(
             { updateId: payload.update_id },
@@ -741,7 +741,7 @@ export function createTelegramWebhookHandler(
         return respond({ ok: true });
       }
 
-      if (result.verificationIntercepted) {
+      if (result.verificationIntercepted || result.inviteIntercepted) {
         return respond({ ok: true });
       }
 

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -308,6 +308,13 @@ export async function upsertVerifiedContactChannel(params: {
   verifiedVia?: string;
   contactId?: string;
   allowRevokedReactivation?: boolean;
+  /**
+   * "soft": assistant-mirror (IPC) failures are logged, never thrown — the
+   * result reflects the gateway ACL write alone. Used post-claim by invite
+   * redemption, where the mirror is best-effort and a throw would regress an
+   * already-consumed invite to a non-intercepted path.
+   */
+  mirrorFailureMode?: "soft";
 }): Promise<{ verified: boolean }> {
   const now = Date.now();
   const {
@@ -319,6 +326,21 @@ export async function upsertVerifiedContactChannel(params: {
     allowRevokedReactivation,
   } = params;
   const verifiedVia = params.verifiedVia ?? "challenge";
+  const mirrorSoft = params.mirrorFailureMode === "soft";
+  const runMirror = async (
+    op: () => Promise<unknown>,
+    what: string,
+  ): Promise<void> => {
+    try {
+      await op();
+    } catch (mirrorErr) {
+      if (!mirrorSoft) throw mirrorErr;
+      log.warn(
+        { err: mirrorErr, sourceChannel },
+        `Assistant mirror ${what} failed (soft); gateway ACL result stands`,
+      );
+    }
+  };
 
   const address =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
@@ -327,18 +349,30 @@ export async function upsertVerifiedContactChannel(params: {
 
   // Resolve the existing channel's identity (id, parent contact) only. The
   // ACL/status decision is owned by the gateway pre-check below; the most
-  // recently updated mirror row is preferred.
-  const existing = await assistantDbQuery<{
-    channelId: string;
-    contactId: string;
-  }>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId
-     FROM contact_channels cc
-     WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     ORDER BY cc.updated_at DESC
-     LIMIT 1`,
-    [sourceChannel, address],
-  );
+  // recently updated mirror row is preferred. In soft mode a failed lookup
+  // falls through to the create path: the gateway write resolves by logical
+  // key either way, and the mirror writes below are soft too.
+  let existing: { channelId: string; contactId: string }[];
+  try {
+    existing = await assistantDbQuery<{
+      channelId: string;
+      contactId: string;
+    }>(
+      `SELECT cc.id AS channelId, cc.contact_id AS contactId
+       FROM contact_channels cc
+       WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
+       ORDER BY cc.updated_at DESC
+       LIMIT 1`,
+      [sourceChannel, address],
+    );
+  } catch (mirrorErr) {
+    if (!mirrorSoft) throw mirrorErr;
+    log.warn(
+      { err: mirrorErr, sourceChannel },
+      "Assistant mirror lookup failed (soft); proceeding gateway-only",
+    );
+    existing = [];
+  }
 
   // The gateway is the source of truth: a blocked/revoked gateway row rejects
   // the verification, gating BOTH the existing-channel update and the
@@ -439,13 +473,17 @@ export async function upsertVerifiedContactChannel(params: {
 
     // Activate the assistant mirror. ACL columns are gateway-owned; only
     // identity/info columns are written here.
-    await assistantDbRun(
-      `UPDATE contact_channels
-       SET address = ?,
-           external_chat_id = ?,
-           updated_at = ?
-       WHERE id = ?`,
-      [address, externalChatId, now, row.channelId],
+    await runMirror(
+      () =>
+        assistantDbRun(
+          `UPDATE contact_channels
+           SET address = ?,
+               external_chat_id = ?,
+               updated_at = ?
+           WHERE id = ?`,
+          [address, externalChatId, now, row.channelId],
+        ),
+      "update",
     );
 
     return { verified: true };
@@ -529,21 +567,23 @@ export async function upsertVerifiedContactChannel(params: {
 
   // Create the assistant mirror. OR IGNORE for idempotency under retries; if the
   // channel insert fails mid-flight, the orphan contact row is harmless.
-  await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
-     VALUES (?, ?, ?, ?)`,
-    [contactId, contactDisplayName, now, now],
-  );
+  await runMirror(async () => {
+    await assistantDbRun(
+      `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
+       VALUES (?, ?, ?, ?)`,
+      [contactId, contactDisplayName, now, now],
+    );
 
-  // ACL columns are gateway-owned; the mirror carries identity/info only and
-  // relies on the schema defaults (status='unverified', policy='allow').
-  await assistantDbRun(
-    `INSERT OR IGNORE INTO contact_channels
-       (id, contact_id, type, address, is_primary, external_chat_id,
-        interaction_count, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
-    [channelId, contactId, sourceChannel, address, externalChatId, now, now],
-  );
+    // ACL columns are gateway-owned; the mirror carries identity/info only and
+    // relies on the schema defaults (status='unverified', policy='allow').
+    await assistantDbRun(
+      `INSERT OR IGNORE INTO contact_channels
+         (id, contact_id, type, address, is_primary, external_chat_id,
+          interaction_count, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)`,
+      [channelId, contactId, sourceChannel, address, externalChatId, now, now],
+    );
+  }, "create");
 
   return { verified: true };
 }

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -1,0 +1,473 @@
+/**
+ * Gateway-native invite redemption engine + inbound text intercept.
+ *
+ * Resolves a 6-digit invite code or invite link token against the
+ * gateway-canonical `ingress_invites` table, validates lifecycle
+ * (status / expiry / use count / channel), gates on existing gateway
+ * membership, claims the row atomically, and applies the verified-channel
+ * ACL side effect — entirely inside the gateway. After a successful
+ * redemption the daemon is notified best-effort (`invite_redeemed`) so it
+ * can mirror the contact info row locally; the mirror never blocks the
+ * ACL path.
+ *
+ * Reply copy mirrors the daemon's invite redemption templates verbatim.
+ */
+
+import {
+  hashInviteCode,
+  hashInviteToken,
+  isInviteCodeRedemptionEnabled,
+  type CommandIntent,
+  type InviteRedemptionOutcome,
+  type TrustVerdict,
+} from "@vellumai/gateway-client";
+
+import { ContactStore, type IngressInviteRow } from "../db/contact-store.js";
+import { ipcCallAssistant } from "../ipc/assistant-client.js";
+import { getLogger } from "../logger.js";
+import { extractEmailReplyBody } from "./code-parsing.js";
+import {
+  upsertVerifiedContactChannel,
+  getGatewayChannelByKey,
+} from "./contact-helpers.js";
+import { canonicalizeInboundIdentity } from "./identity.js";
+import { deliverVerificationReply } from "./reply-delivery.js";
+
+const log = getLogger("invite-redemption");
+
+// ---------------------------------------------------------------------------
+// Reply copy — ported verbatim from the daemon's invite-redemption-templates
+// so user-visible text is identical across redemption paths.
+// ---------------------------------------------------------------------------
+
+const INVITE_REPLY_TEMPLATES = {
+  redeemed: "Welcome! You've been granted access.",
+  already_member: "You already have access.",
+  invalid_token: "This invite is no longer valid.",
+  expired: "This invite is no longer valid.",
+  revoked: "This invite is no longer valid.",
+  max_uses_reached: "This invite is no longer valid.",
+  channel_mismatch: "This invite is not valid for this channel.",
+  missing_identity:
+    "Unable to process this invite. Please contact the person who shared it.",
+} as const;
+
+export type InviteRedemptionFailureReason = Exclude<
+  keyof typeof INVITE_REPLY_TEMPLATES,
+  "redeemed" | "already_member"
+>;
+
+// ---------------------------------------------------------------------------
+// Engine result
+// ---------------------------------------------------------------------------
+
+export type InviteRedemptionEngineResult =
+  | {
+      status: "redeemed" | "already_member";
+      outcome: InviteRedemptionOutcome;
+      replyText: string;
+    }
+  | {
+      status: "failed";
+      reason: InviteRedemptionFailureReason;
+      replyText: string;
+    }
+  /** Code matched no invite anywhere — the message may be a normal one. */
+  | { status: "no_match" };
+
+function failed(
+  reason: InviteRedemptionFailureReason,
+): InviteRedemptionEngineResult {
+  return { status: "failed", reason, replyText: INVITE_REPLY_TEMPLATES[reason] };
+}
+
+export interface RedeemIdentityParams {
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+}
+
+// ---------------------------------------------------------------------------
+// redeemInviteByCode / redeemInviteByToken
+// ---------------------------------------------------------------------------
+
+/**
+ * Redeem a 6-digit invite code. The lookup is channel-scoped (small keyspace
+ * collides across channels); an active-elsewhere hit yields the
+ * channel-mismatch reply WITHOUT consuming a use, and a full miss yields
+ * `no_match` so a bare 6-digit message can fall through as normal content.
+ */
+export async function redeemInviteByCode(
+  params: RedeemIdentityParams & { code: string; store?: ContactStore },
+): Promise<InviteRedemptionEngineResult> {
+  const store = params.store ?? new ContactStore();
+  if (!params.externalUserId && !params.externalChatId) {
+    return failed("missing_identity");
+  }
+
+  const codeHash = hashInviteCode(params.code);
+  const invite = store.findInviteByCodeHash(codeHash, params.sourceChannel);
+  if (!invite) {
+    if (store.findInviteByCodeHashAnyChannel(codeHash)) {
+      return failed("channel_mismatch");
+    }
+    return { status: "no_match" };
+  }
+
+  return finishRedemption(store, invite, params);
+}
+
+/**
+ * Redeem an invite link token (`iv_<token>` deep-link payload). Token hashes
+ * are 256-bit and globally unique, so an unmatched token is a definitive
+ * invalid invite — never a fall-through.
+ */
+export async function redeemInviteByToken(
+  params: RedeemIdentityParams & { rawToken: string; store?: ContactStore },
+): Promise<InviteRedemptionEngineResult> {
+  const store = params.store ?? new ContactStore();
+  if (!params.externalUserId && !params.externalChatId) {
+    return failed("missing_identity");
+  }
+
+  const invite = store.findInviteByTokenHash(hashInviteToken(params.rawToken));
+  if (!invite) {
+    return failed("invalid_token");
+  }
+
+  return finishRedemption(store, invite, params);
+}
+
+// ---------------------------------------------------------------------------
+// Shared validation + claim + ACL side effect
+// ---------------------------------------------------------------------------
+
+function reasonForStatus(status: string): InviteRedemptionFailureReason {
+  if (status === "expired") return "expired";
+  if (status === "revoked") return "revoked";
+  if (status === "redeemed") return "max_uses_reached";
+  return "invalid_token";
+}
+
+async function finishRedemption(
+  store: ContactStore,
+  invite: IngressInviteRow,
+  params: RedeemIdentityParams,
+): Promise<InviteRedemptionEngineResult> {
+  const { sourceChannel, externalUserId, externalChatId, username } = params;
+
+  if (invite.status !== "active") {
+    return failed(reasonForStatus(invite.status));
+  }
+  if (invite.expiresAt <= Date.now()) {
+    store.markInviteExpired(invite.id);
+    return failed("expired");
+  }
+  if (invite.useCount >= invite.maxUses) {
+    return failed("max_uses_reached");
+  }
+  if (invite.sourceChannel !== sourceChannel) {
+    return failed("channel_mismatch");
+  }
+
+  // ── Membership gate — gateway ACL rows only ──
+  // Same (type, address) COLLATE NOCASE resolution the trust-verdict resolver
+  // uses. `already_member` never consumes a use, and a blocked gateway channel
+  // is NEVER reactivated by a code match (generic failure so membership
+  // status doesn't leak to callers holding a valid code).
+  const canonicalUserId = externalUserId
+    ? (canonicalizeInboundIdentity(sourceChannel, externalUserId) ??
+      externalUserId)
+    : undefined;
+  const existing = canonicalUserId
+    ? getGatewayChannelByKey(sourceChannel, canonicalUserId)
+    : null;
+  // An existing channel under a different contact is not "already a member"
+  // for this invite: the invite binds the sender to its target contact.
+  const targetMismatch = !!existing && existing.contactId !== invite.contactId;
+
+  if (existing && existing.status === "active" && !targetMismatch) {
+    return {
+      status: "already_member",
+      outcome: {
+        inviteId: invite.id,
+        contactId: existing.contactId,
+        sourceChannel,
+        memberExternalUserId: canonicalUserId!,
+        ...(externalChatId ? { memberExternalChatId: externalChatId } : {}),
+        result: "already_member",
+      },
+      replyText: INVITE_REPLY_TEMPLATES.already_member,
+    };
+  }
+
+  if (existing && existing.status === "blocked") {
+    log.warn(
+      { sourceChannel, inviteId: invite.id },
+      "Invite redemption refused: gateway channel is blocked",
+    );
+    return failed("invalid_token");
+  }
+
+  // ── Atomic claim ──
+  // recordInviteRedemption gates on status="active", so only the first of two
+  // concurrent redeemers (or a redeemer racing a revoke) consumes the row.
+  const claim = store.recordInviteRedemption({
+    inviteId: invite.id,
+    redeemedByExternalUserId: externalUserId ?? null,
+    redeemedByExternalChatId: externalChatId ?? null,
+  });
+  if (!claim.updated) {
+    return failed("invalid_token");
+  }
+
+  // Preserve the target contact's curated displayName over the raw
+  // transport-provided name (mirrors the daemon redemption service).
+  const targetContact = store.getContact(invite.contactId);
+  const displayName = targetContact?.displayName?.trim().length
+    ? targetContact.displayName
+    : params.displayName;
+
+  // ── ACL side effect ──
+  // The same gateway store path the `upsert_verified_channel` IPC handler
+  // uses, with the same `allowRevokedReactivation` semantics the daemon's
+  // member-write-relay passes: an invite may reactivate a revoked member;
+  // blocked actors are still refused inside the helper.
+  const address = externalUserId ?? externalChatId!;
+  const { verified } = await upsertVerifiedContactChannel({
+    sourceChannel,
+    externalUserId: address,
+    externalChatId: externalChatId ?? address,
+    displayName,
+    username,
+    verifiedVia: "invite",
+    contactId: invite.contactId,
+    allowRevokedReactivation: true,
+  });
+  if (!verified) {
+    // The authoritative write was refused (a block landed under the race).
+    // The claimed use is wasted — same semantics as the daemon engine.
+    log.warn(
+      { sourceChannel, inviteId: invite.id },
+      "Invite redemption: gateway channel upsert refused after claim",
+    );
+    return failed("invalid_token");
+  }
+
+  return {
+    status: "redeemed",
+    outcome: {
+      inviteId: invite.id,
+      contactId: invite.contactId,
+      sourceChannel,
+      memberExternalUserId: canonicalUserId ?? address,
+      ...(externalChatId ? { memberExternalChatId: externalChatId } : {}),
+      ...(displayName ? { displayName } : {}),
+      ...(username ? { username } : {}),
+      ...(invite.sourceConversationId
+        ? { sourceConversationId: invite.sourceConversationId }
+        : {}),
+      result: "redeemed",
+    },
+    replyText: INVITE_REPLY_TEMPLATES.redeemed,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Daemon info-mirror event (best-effort)
+// ---------------------------------------------------------------------------
+
+/**
+ * Notify the daemon of a successful redemption so it mirrors the contact
+ * info row locally. Fire-and-forget: the info mirror must never block or
+ * fail the ACL path.
+ */
+export function notifyDaemonInviteRedeemed(
+  outcome: InviteRedemptionOutcome,
+): void {
+  void ipcCallAssistant("invite_redeemed", { body: outcome }).catch((err) => {
+    log.warn(
+      { err, inviteId: outcome.inviteId },
+      "invite_redeemed daemon info-mirror failed (best-effort)",
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Inbound text intercept
+// ---------------------------------------------------------------------------
+
+const INVITE_TOKEN_PREFIX = "iv_";
+
+/**
+ * Extract an invite token from a `/start iv_<token>` deep link. The
+ * structured command intent from the gateway's own normalization wins; raw
+ * content parsing is the fallback (mirrors the daemon's Telegram adapter).
+ */
+export function extractInviteToken(
+  commandIntent: CommandIntent | undefined,
+  content: string,
+): string | undefined {
+  if (commandIntent?.type === "start") {
+    const payload = commandIntent.payload;
+    if (payload?.startsWith(INVITE_TOKEN_PREFIX)) {
+      const token = payload.slice(INVITE_TOKEN_PREFIX.length);
+      if (token.trim().length > 0) return token;
+    }
+    return undefined;
+  }
+
+  const match = content.match(/^\/start\s+iv_(\S+)/);
+  return match?.[1] || undefined;
+}
+
+export interface InviteRedemptionInterceptParams {
+  sourceChannel: string;
+  messageContent: string;
+  commandIntent?: CommandIntent;
+  actorExternalUserId?: string;
+  actorChatId: string;
+  actorDisplayName?: string;
+  actorUsername?: string;
+  replyCallbackUrl?: string;
+  assistantId?: string;
+  /** Resolved gateway trust verdict for the sender (gates to non-members). */
+  trustVerdict?: TrustVerdict;
+}
+
+export type InviteRedemptionInterceptResult =
+  | { intercepted: false }
+  | {
+      intercepted: true;
+      outcome: "redeemed" | "already_member" | "failed";
+      /** Reply text when replyCallbackUrl was unavailable (e.g. email). */
+      pendingReplyText?: string;
+    };
+
+/**
+ * Intercept a bare 6-digit invite code or `/start iv_<token>` deep link from
+ * a non-member sender and redeem it at the gateway. Called from handleInbound
+ * after the verification intercept and trust-verdict resolution.
+ *
+ * - Only channels in the shared code-redemption allowlist are considered.
+ * - Only non-member senders (`unknown` / `unverified_contact`) are
+ *   intercepted — a member's bare 6-digit message is a normal message. A
+ *   resolution-failure sentinel also falls through (never redeem on a
+ *   verdict the resolver could not produce).
+ * - A code that matches no invite falls through to normal forwarding; a
+ *   matched-but-failed redemption (and a channel mismatch) intercepts with
+ *   the deterministic failure reply.
+ */
+export async function tryInviteRedemptionIntercept(
+  params: InviteRedemptionInterceptParams,
+): Promise<InviteRedemptionInterceptResult> {
+  const {
+    sourceChannel,
+    messageContent,
+    commandIntent,
+    actorExternalUserId,
+    actorChatId,
+    actorDisplayName,
+    actorUsername,
+    replyCallbackUrl,
+    assistantId,
+    trustVerdict,
+  } = params;
+
+  if (!isInviteCodeRedemptionEnabled(sourceChannel)) {
+    return { intercepted: false };
+  }
+
+  // For email, strip quoted reply content first (same as the verification
+  // intercept) so a bare code isn't buried under signatures/quotes.
+  const effectiveContent =
+    sourceChannel === "email"
+      ? extractEmailReplyBody(messageContent)
+      : messageContent;
+  const trimmed = effectiveContent.trim();
+  const token = extractInviteToken(commandIntent, trimmed);
+  const isCode = !token && /^\d{6}$/.test(trimmed);
+  if (!token && !isCode) {
+    return { intercepted: false };
+  }
+
+  // Non-member gate — mirrors the daemon's denyNonMember scope: members
+  // (guardian / trusted_contact) are never intercepted.
+  const trustClass = trustVerdict?.trustClass;
+  if (
+    !trustVerdict ||
+    trustVerdict.resolutionFailed ||
+    (trustClass !== "unknown" && trustClass !== "unverified_contact")
+  ) {
+    return { intercepted: false };
+  }
+
+  let result: InviteRedemptionEngineResult;
+  try {
+    result = token
+      ? await redeemInviteByToken({
+          rawToken: token,
+          sourceChannel,
+          externalUserId: actorExternalUserId,
+          externalChatId: actorChatId,
+          displayName: actorDisplayName,
+          username: actorUsername,
+        })
+      : await redeemInviteByCode({
+          code: trimmed,
+          sourceChannel,
+          externalUserId: actorExternalUserId,
+          externalChatId: actorChatId,
+          displayName: actorDisplayName,
+          username: actorUsername,
+        });
+  } catch (err) {
+    // Fail-soft: fall through to normal forwarding rather than dropping the
+    // message on an engine error.
+    log.error(
+      { err, sourceChannel },
+      "Invite redemption engine threw — falling through to normal forwarding",
+    );
+    return { intercepted: false };
+  }
+
+  if (result.status === "no_match") {
+    return { intercepted: false };
+  }
+
+  if (result.status === "redeemed") {
+    notifyDaemonInviteRedeemed(result.outcome);
+  }
+
+  log.info(
+    {
+      sourceChannel,
+      status: result.status,
+      ...(result.status === "failed" ? { reason: result.reason } : {}),
+      ...(result.status !== "failed"
+        ? { inviteId: result.outcome.inviteId }
+        : {}),
+    },
+    "Invite redemption intercepted at gateway ingress",
+  );
+
+  let pendingReplyText: string | undefined;
+  if (replyCallbackUrl) {
+    await deliverVerificationReply({
+      replyCallbackUrl,
+      chatId: actorChatId,
+      text: result.replyText,
+      assistantId,
+    });
+  } else {
+    pendingReplyText = result.replyText;
+  }
+
+  return {
+    intercepted: true,
+    outcome: result.status === "failed" ? "failed" : result.status,
+    pendingReplyText,
+  };
+}

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -223,12 +223,28 @@ async function finishRedemption(
     return failed("invalid_token");
   }
 
+  // ── Commit point ──
+  // The claim above consumed the use; from here the redemption must never
+  // regress to a thrown engine error (the intercept would fall through and
+  // forward the raw code to the runtime on an already-consumed invite).
+  // Assistant-mirror failures are soft inside the helper; anything else that
+  // throws post-claim is logged and the redemption still succeeds — the
+  // daemon `invite_redeemed` event and self-heal cover the mirror.
+
   // Preserve the target contact's curated displayName over the raw
   // transport-provided name (mirrors the daemon redemption service).
-  const targetContact = store.getContact(invite.contactId);
-  const displayName = targetContact?.displayName?.trim().length
-    ? targetContact.displayName
-    : params.displayName;
+  let displayName = params.displayName;
+  try {
+    const targetContact = store.getContact(invite.contactId);
+    if (targetContact?.displayName?.trim().length) {
+      displayName = targetContact.displayName;
+    }
+  } catch (err) {
+    log.warn(
+      { err, inviteId: invite.id },
+      "Invite redemption: target contact lookup failed post-claim",
+    );
+  }
 
   // ── ACL side effect ──
   // The same gateway store path the `upsert_verified_channel` IPC handler
@@ -236,16 +252,25 @@ async function finishRedemption(
   // member-write-relay passes: an invite may reactivate a revoked member;
   // blocked actors are still refused inside the helper.
   const address = externalUserId ?? externalChatId!;
-  const { verified } = await upsertVerifiedContactChannel({
-    sourceChannel,
-    externalUserId: address,
-    externalChatId: externalChatId ?? address,
-    displayName,
-    username,
-    verifiedVia: "invite",
-    contactId: invite.contactId,
-    allowRevokedReactivation: true,
-  });
+  let verified = true;
+  try {
+    ({ verified } = await upsertVerifiedContactChannel({
+      sourceChannel,
+      externalUserId: address,
+      externalChatId: externalChatId ?? address,
+      displayName,
+      username,
+      verifiedVia: "invite",
+      contactId: invite.contactId,
+      allowRevokedReactivation: true,
+      mirrorFailureMode: "soft",
+    }));
+  } catch (err) {
+    log.error(
+      { err, sourceChannel, inviteId: invite.id },
+      "Invite redemption: ACL upsert threw post-claim; use already consumed — treating as redeemed",
+    );
+  }
   if (!verified) {
     // The authoritative write was refused (a block landed under the race).
     // The claimed use is wasted — same semantics as the daemon engine.

--- a/gateway/src/webhook-pipeline.ts
+++ b/gateway/src/webhook-pipeline.ts
@@ -96,7 +96,7 @@ export function processInboundResult(
     return { ok: true, rejected: true };
   }
 
-  if (result.verificationIntercepted) {
+  if (result.verificationIntercepted || result.inviteIntercepted) {
     return { ok: true, rejected: false };
   }
 
@@ -114,4 +114,26 @@ export function processInboundResult(
  */
 export function isNewCommand(text: string): boolean {
   return text.trim().toLowerCase() === "/new";
+}
+
+/**
+ * Pending reply from a gateway verification/invite intercept, for channels
+ * where the gateway couldn't deliver it via a replyCallbackUrl (email). The
+ * `flag` names which intercept fired, for the webhook's JSON response.
+ */
+export function interceptedReply(
+  result: InboundResult,
+):
+  | { text: string; flag: "verificationIntercepted" | "inviteIntercepted" }
+  | undefined {
+  if (result.verificationIntercepted && result.verificationReplyText) {
+    return {
+      text: result.verificationReplyText,
+      flag: "verificationIntercepted",
+    };
+  }
+  if (result.inviteIntercepted && result.inviteReplyText) {
+    return { text: result.inviteReplyText, flag: "inviteIntercepted" };
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Gateway-native invite redemption engine (code + token) with atomic claim, blocked-row refusal, already-member no-consume, gateway ACL upsert (verifiedVia: invite)
- Inbound text intercept for 6-digit codes and /start iv_ tokens at gateway ingress (verdict-gated to non-members, no-forward on intercept)
- Best-effort invite_redeemed daemon IPC event mirrors the local info contact row

Part of plan: invites-gateway-native.md (PR 5 of 12)