### PR TITLE
feat(web): InChatPluginPill — top-right pill + active-plugins menu

### DIFF
--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for `InChatPluginPill`. Mounted via `@testing-library/react` (happy-dom).
+ * The design-library primitives are real; only the data hook, the mobile check,
+ * and the router are mocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { routes } from "@/utils/routes";
+
+const isMobileRef = { value: false };
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const navigateSpy = mock((_href: string) => {});
+mock.module("react-router", () => ({
+  useNavigate: () => navigateSpy,
+}));
+
+interface EffectivePlugin {
+  name: string;
+  label: string;
+  selected: boolean;
+}
+const effectiveRef = {
+  value: {
+    plugins: [] as EffectivePlugin[],
+    selectedCount: 0,
+    total: 0,
+    isDefault: true,
+  },
+};
+mock.module(
+  "@/domains/chat/components/inchat-plugin-pill/use-effective-chat-plugins",
+  () => ({ useEffectiveChatPlugins: () => effectiveRef.value }),
+);
+
+const { InChatPluginPill } = await import("./inchat-plugin-pill");
+
+function setEffective(
+  plugins: EffectivePlugin[],
+  overrides: Partial<(typeof effectiveRef)["value"]> = {},
+) {
+  const selected = plugins.filter((p) => p.selected);
+  effectiveRef.value = {
+    plugins,
+    selectedCount: overrides.selectedCount ?? selected.length,
+    total: overrides.total ?? plugins.length,
+    isDefault: overrides.isDefault ?? false,
+  };
+}
+
+function renderPill() {
+  return render(
+    <InChatPluginPill assistantId="asst-1" conversationId="conv-1" />,
+  );
+}
+
+beforeEach(() => {
+  isMobileRef.value = false;
+  navigateSpy.mockClear();
+  effectiveRef.value = {
+    plugins: [],
+    selectedCount: 0,
+    total: 0,
+    isDefault: true,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InChatPluginPill", () => {
+  test("renders nothing when no plugins are installed", () => {
+    setEffective([], { total: 0 });
+    const { container } = renderPill();
+    expect(container.textContent).toBe("");
+  });
+
+  test("pill shows the active plugin count (pluralized)", () => {
+    setEffective([
+      { name: "a", label: "Alpha", selected: true },
+      { name: "b", label: "Beta", selected: true },
+      { name: "c", label: "Gamma", selected: false },
+    ]);
+    renderPill();
+    expect(screen.getByText("2 plugins")).toBeTruthy();
+  });
+
+  test("pill uses the singular for one active plugin", () => {
+    setEffective([
+      { name: "a", label: "Alpha", selected: true },
+      { name: "b", label: "Beta", selected: false },
+    ]);
+    renderPill();
+    expect(screen.getByText("1 plugin")).toBeTruthy();
+  });
+
+  test("opening lists the active plugins (read-only) and Manage", () => {
+    setEffective([
+      { name: "a", label: "Alpha", selected: true },
+      { name: "b", label: "Beta", selected: false },
+      { name: "c", label: "Gamma", selected: true },
+    ]);
+    renderPill();
+
+    fireEvent.click(screen.getByText("2 plugins"));
+
+    // Active plugins are listed; inactive ones are not.
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Gamma")).toBeTruthy();
+    expect(screen.queryByText("Beta")).toBeNull();
+    expect(
+      screen.getByText("Changing plugin settings can incur high costs."),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Manage" })).toBeTruthy();
+  });
+
+  test("Manage navigates to the plugins page", () => {
+    setEffective([{ name: "a", label: "Alpha", selected: true }]);
+    renderPill();
+
+    fireEvent.click(screen.getByText("1 plugin"));
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledWith(routes.plugins);
+  });
+
+  test("empty active set still shows header + Manage + caption, no rows", () => {
+    setEffective(
+      [
+        { name: "a", label: "Alpha", selected: false },
+        { name: "b", label: "Beta", selected: false },
+      ],
+      { selectedCount: 0 },
+    );
+    renderPill();
+
+    fireEvent.click(screen.getByText("0 plugins"));
+
+    expect(screen.getByText("Plugins")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Manage" })).toBeTruthy();
+    expect(
+      screen.getByText("Changing plugin settings can incur high costs."),
+    ).toBeTruthy();
+    // No plugin rows for an empty active set.
+    expect(screen.queryByText("Alpha")).toBeNull();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
@@ -1,0 +1,138 @@
+import { Cog, Plug } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  BottomSheet,
+  Button,
+  PanelItem,
+  Popover,
+  Typography,
+} from "@vellumai/design-library";
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { routes } from "@/utils/routes";
+
+import { useEffectiveChatPlugins } from "./use-effective-chat-plugins";
+
+export interface InChatPluginPillProps {
+  assistantId: string;
+  conversationId: string;
+}
+
+/** Warns that per-chat plugin changes (made on the plugins page) can be costly. */
+const COST_CAPTION = "Changing plugin settings can incur high costs.";
+
+/**
+ * Top-right chat pill summarizing the conversation's active plugins. Clicking it
+ * opens a read-only list of those plugins plus a "Manage" shortcut to the
+ * plugins page — editing the set happens there, not in this menu. Mirrors
+ * `ConversationAssetsPill`'s top-right placement and desktop-popover /
+ * mobile-bottom-sheet split.
+ */
+export function InChatPluginPill({
+  assistantId,
+  conversationId,
+}: InChatPluginPillProps) {
+  const { plugins, selectedCount, total } = useEffectiveChatPlugins(
+    assistantId,
+    conversationId,
+  );
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+
+  const handleManage = useCallback(() => {
+    setOpen(false);
+    navigate(routes.plugins);
+  }, [navigate]);
+
+  // No plugins installed for this assistant — nothing to summarize.
+  if (total === 0) {
+    return null;
+  }
+
+  const active = plugins.filter((plugin) => plugin.selected);
+  const label = selectedCount === 1 ? "1 plugin" : `${selectedCount} plugins`;
+  const ariaLabel = `Chat plugins, ${selectedCount} active`;
+
+  // Read-only rows — the chat's active plugins, no toggle affordance.
+  const pluginRows = active.map((plugin) => (
+    <PanelItem key={plugin.name} icon={Plug} label={plugin.label} />
+  ));
+
+  const manageFooter = (
+    <div className="flex flex-col gap-2 px-3 pb-3 pt-1">
+      <Button variant="primary" leftIcon={<Cog />} onClick={handleManage}>
+        Manage
+      </Button>
+      <Typography
+        variant="label-small-default"
+        className="text-[var(--content-tertiary)]"
+      >
+        {COST_CAPTION}
+      </Typography>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Trigger asChild>
+          <Button
+            variant="ghost"
+            active
+            iconOnly={<Plug />}
+            tintColor="var(--content-default)"
+            aria-label={ariaLabel}
+          />
+        </BottomSheet.Trigger>
+        <BottomSheet.Content>
+          <BottomSheet.Header>
+            <BottomSheet.Title>Plugins</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="pt-0">
+            {pluginRows}
+            {manageFooter}
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    );
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button
+          variant="ghost"
+          active
+          leftIcon={<Plug />}
+          className="rounded-full"
+          tintColor="var(--content-default)"
+          aria-label={ariaLabel}
+        >
+          {label}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-60 p-0"
+      >
+        <div className="px-3 pb-1 pt-3">
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+          >
+            Plugins
+          </Typography>
+        </div>
+        {pluginRows.length > 0 ? (
+          <div className="max-h-[240px] overflow-y-auto px-2">{pluginRows}</div>
+        ) : null}
+        {manageFooter}
+      </Popover.Content>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
Read-only in-chat plugin pill per Figma 6120-159906: a rounded-full "{N} plugins" pill opening a menu that lists the chat's active plugins (display-only), a dark Manage button → routes.plugins, and the 'Changing plugin settings can incur high costs.' caption. Desktop popover / mobile bottom sheet, mirroring ConversationAssetsPill. Reads useEffectiveChatPlugins; not mounted yet (PR 6 registers it).

Part of plan: in-chat-plugin-pill.md (PR 5 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>