### PR TITLE
feat(gateway): voice-invite detection + redemption IPC backed by gateway ingress_invites

### DIFF
--- a/assistant/src/calls/__tests__/gateway-invite-reader.test.ts
+++ b/assistant/src/calls/__tests__/gateway-invite-reader.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the gateway-backed voice-invite reader.
+ *
+ * Pins the asymmetric failure contract: detection returns `null` on ANY
+ * failure (fail-soft — the caller falls to the unverified path), while
+ * redemption returns the generic `invalid_or_expired` failure outcome on ANY
+ * failure (fail-closed — no local fallback). Also pins the forwarded method,
+ * params, and timeouts.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import type {
+  ActiveVoiceInvite,
+  InviteRedemptionOutcome,
+} from "@vellumai/gateway-client";
+
+import {
+  getActiveVoiceInvite,
+  redeemVoiceInviteViaGateway,
+} from "../gateway-invite-reader.js";
+
+const CALLER = "+15555550100";
+const CODE = "123456";
+
+const VALID_INVITE = {
+  inviteId: "inv-1",
+  inviteeName: "Friend Name",
+  guardianName: "Guardian Name",
+  codeDigits: 6,
+} satisfies ActiveVoiceInvite;
+
+const VALID_OUTCOME = {
+  inviteId: "inv-1",
+  contactId: "c1",
+  sourceChannel: "phone",
+  memberExternalUserId: CALLER,
+  memberExternalChatId: CALLER,
+  displayName: "Friend Name",
+  result: "redeemed",
+} satisfies InviteRedemptionOutcome;
+
+const FAILURE = { ok: false, reason: "invalid_or_expired" } as const;
+
+beforeEach(() => {
+  ipcHandlers.clear();
+  ipcCallLog.length = 0;
+});
+
+describe("getActiveVoiceInvite", () => {
+  test("returns the gateway-resolved invite on a valid response", async () => {
+    ipcHandlers.set("get_active_voice_invite", () => ({
+      invite: VALID_INVITE,
+    }));
+
+    expect(await getActiveVoiceInvite(CALLER)).toEqual(VALID_INVITE);
+  });
+
+  test("forwards the correct method, params, and timeout", async () => {
+    ipcHandlers.set("get_active_voice_invite", () => ({ invite: null }));
+
+    await getActiveVoiceInvite(CALLER);
+
+    const call = ipcCallLog.find((c) => c.method === "get_active_voice_invite");
+    expect(call?.params).toEqual({ callerExternalUserId: CALLER });
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns null when the gateway reports no invite", async () => {
+    ipcHandlers.set("get_active_voice_invite", () => ({ invite: null }));
+    expect(await getActiveVoiceInvite(CALLER)).toBeNull();
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    expect(await getActiveVoiceInvite(CALLER)).toBeNull();
+  });
+
+  test("returns null for a malformed invite shape", async () => {
+    ipcHandlers.set("get_active_voice_invite", () => ({
+      invite: { inviteId: 42 },
+    }));
+    expect(await getActiveVoiceInvite(CALLER)).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set("get_active_voice_invite", () => {
+      throw new Error("socket exploded");
+    });
+    expect(await getActiveVoiceInvite(CALLER)).toBeNull();
+  });
+
+  test("returns null without dialing IPC when fromNumber is missing", async () => {
+    expect(await getActiveVoiceInvite(undefined)).toBeNull();
+    expect(await getActiveVoiceInvite("")).toBeNull();
+    expect(ipcCallLog).toHaveLength(0);
+  });
+});
+
+describe("redeemVoiceInviteViaGateway", () => {
+  test("returns the success outcome on a valid response", async () => {
+    ipcHandlers.set("redeem_voice_invite", () => ({
+      ok: true,
+      outcome: VALID_OUTCOME,
+    }));
+
+    expect(await redeemVoiceInviteViaGateway(CALLER, CODE)).toEqual({
+      ok: true,
+      outcome: VALID_OUTCOME,
+    });
+  });
+
+  test("forwards the correct method and params", async () => {
+    ipcHandlers.set("redeem_voice_invite", () => FAILURE);
+
+    await redeemVoiceInviteViaGateway(CALLER, CODE);
+
+    const call = ipcCallLog.find((c) => c.method === "redeem_voice_invite");
+    expect(call?.params).toEqual({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+    expect(call?.timeoutMs).toBe(10_000);
+  });
+
+  test("passes through the gateway's generic failure", async () => {
+    ipcHandlers.set("redeem_voice_invite", () => FAILURE);
+    expect(await redeemVoiceInviteViaGateway(CALLER, CODE)).toEqual(FAILURE);
+  });
+
+  test("fails CLOSED when IPC transport fails (undefined)", async () => {
+    expect(await redeemVoiceInviteViaGateway(CALLER, CODE)).toEqual(FAILURE);
+  });
+
+  test("fails CLOSED on a malformed response", async () => {
+    ipcHandlers.set("redeem_voice_invite", () => ({ ok: true }));
+    expect(await redeemVoiceInviteViaGateway(CALLER, CODE)).toEqual(FAILURE);
+  });
+
+  test("fails CLOSED when the IPC call throws", async () => {
+    ipcHandlers.set("redeem_voice_invite", () => {
+      throw new Error("socket exploded");
+    });
+    expect(await redeemVoiceInviteViaGateway(CALLER, CODE)).toEqual(FAILURE);
+  });
+});

--- a/assistant/src/calls/gateway-invite-reader.ts
+++ b/assistant/src/calls/gateway-invite-reader.ts
@@ -1,0 +1,98 @@
+/**
+ * Gateway-backed voice-invite reader for the phone channel.
+ *
+ * Resolves voice-invite state from the gateway's canonical `ingress_invites`
+ * table via the `get_active_voice_invite` / `redeem_voice_invite` IPC routes.
+ *
+ * Failure semantics are asymmetric by design:
+ * - Detection fails SOFT — `null` on ANY failure (transport error,
+ *   `undefined`, malformed shape), so the caller falls to the unverified
+ *   path rather than stalling call setup.
+ * - Redemption fails CLOSED — any IPC failure is the generic
+ *   `invalid_or_expired` outcome. There is no local fallback: the gateway
+ *   row is the single lifecycle authority for voice invites.
+ */
+
+import {
+  type ActiveVoiceInvite,
+  ActiveVoiceInviteSchema,
+  InviteRedemptionOutcomeSchema,
+} from "@vellumai/gateway-client";
+import { z } from "zod";
+
+import { ipcCall } from "../ipc/gateway-client.js";
+
+// Short IPC timeout so detection resolves promptly rather than stalling call
+// setup on a gateway that accepts the socket but hangs.
+const DETECTION_IPC_TIMEOUT_MS = 2_000;
+// Redemption performs the atomic claim plus ACL/mirror writes; give it more
+// headroom — a timeout still fails closed.
+const REDEMPTION_IPC_TIMEOUT_MS = 10_000;
+
+const GetActiveVoiceInviteResponseSchema = z.object({
+  invite: ActiveVoiceInviteSchema.nullable(),
+});
+
+const RedeemVoiceInviteResponseSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), outcome: InviteRedemptionOutcomeSchema }),
+  z.object({ ok: z.literal(false), reason: z.literal("invalid_or_expired") }),
+]);
+
+export type GatewayVoiceRedemptionResult = z.infer<
+  typeof RedeemVoiceInviteResponseSchema
+>;
+
+const REDEMPTION_FAILURE: GatewayVoiceRedemptionResult = {
+  ok: false,
+  reason: "invalid_or_expired",
+};
+
+/**
+ * Resolve the active voice invite awaiting `fromNumber`, or `null` when there
+ * is none — or when the gateway can't answer (fail-soft).
+ */
+export async function getActiveVoiceInvite(
+  fromNumber: string | undefined,
+): Promise<ActiveVoiceInvite | null> {
+  if (!fromNumber) {
+    return null;
+  }
+  try {
+    const result = await ipcCall(
+      "get_active_voice_invite",
+      { callerExternalUserId: fromNumber },
+      DETECTION_IPC_TIMEOUT_MS,
+    );
+    const parsed = GetActiveVoiceInviteResponseSchema.safeParse(result);
+    if (!parsed.success) {
+      return null;
+    }
+    return parsed.data.invite;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Redeem a spoken voice code for `fromNumber` at the gateway. Any transport
+ * failure or malformed response is the generic failure outcome (fail-closed).
+ */
+export async function redeemVoiceInviteViaGateway(
+  fromNumber: string,
+  code: string,
+): Promise<GatewayVoiceRedemptionResult> {
+  try {
+    const result = await ipcCall(
+      "redeem_voice_invite",
+      { callerExternalUserId: fromNumber, code },
+      REDEMPTION_IPC_TIMEOUT_MS,
+    );
+    const parsed = RedeemVoiceInviteResponseSchema.safeParse(result);
+    if (!parsed.success) {
+      return REDEMPTION_FAILURE;
+    }
+    return parsed.data;
+  } catch {
+    return REDEMPTION_FAILURE;
+  }
+}

--- a/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for the gateway engine's voice-invite surface
+ * (verification/invite-redemption.ts): caller-scoped detection
+ * (getActiveVoiceInviteForCaller) and spoken-code redemption
+ * (redeemVoiceInvite) — candidate scoping, generic invalid_or_expired
+ * failure, lazy expiry sweep, the membership gate, the atomic claim, and
+ * the phone ACL side effect.
+ *
+ * The gateway DB is real (shared test preload); the assistant DB mirror is
+ * mocked out — it is a best-effort info mirror and not under test here.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { hashInviteCode } from "@vellumai/gateway-client";
+
+// The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
+// assistant-DB info mirror over IPC; stub it so tests never touch a socket.
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: async () => [],
+  assistantDbRun: async () => {},
+}));
+
+await import("./test-preload.js");
+
+const { initGatewayDb, getGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const { contacts, contactChannels, ingressInvites } =
+  await import("../db/schema.js");
+const { ContactStore } = await import("../db/contact-store.js");
+const { getActiveVoiceInviteForCaller, redeemVoiceInvite } =
+  await import("../verification/invite-redemption.js");
+
+const CALLER = "+15555550100";
+const OTHER_CALLER = "+15555550199";
+const CODE = "123456";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(id: string, displayName = `name-${id}`): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedPhoneChannel(args: {
+  id: string;
+  contactId: string;
+  address: string;
+  status: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: "phone",
+      address: args.address,
+      externalChatId: args.address,
+      status: args.status,
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+function seedVoiceInvite(
+  overrides: Partial<
+    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
+  > = {},
+): string {
+  const store = new ContactStore();
+  const id = overrides.id ?? crypto.randomUUID();
+  store.createInvite({
+    id,
+    sourceChannel: "phone",
+    voiceCodeHash: hashInviteCode(CODE),
+    voiceCodeDigits: 6,
+    expectedExternalUserId: CALLER,
+    friendName: "Friend Name",
+    guardianName: "Guardian Name",
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  });
+  return id;
+}
+
+function inviteRow(id: string) {
+  return new ContactStore().getInviteById(id)!;
+}
+
+function gwPhoneChannel(address: string) {
+  return getGatewayDb()
+    .select()
+    .from(contactChannels)
+    .all()
+    .find((ch) => ch.type === "phone" && ch.address === address);
+}
+
+describe("getActiveVoiceInviteForCaller", () => {
+  test("active invite: curated contact displayName wins, metadata only", () => {
+    seedContact("c1", "Curated Name");
+    const inviteId = seedVoiceInvite({ voiceCodeDigits: 4 });
+
+    const invite = getActiveVoiceInviteForCaller(CALLER);
+
+    expect(invite).toEqual({
+      inviteId,
+      inviteeName: "Curated Name",
+      guardianName: "Guardian Name",
+      codeDigits: 4,
+    });
+  });
+
+  test("falls back to friendName when the contact has no displayName; codeDigits defaults to 6", () => {
+    seedContact("c1", "");
+    const inviteId = seedVoiceInvite({
+      voiceCodeDigits: null,
+      guardianName: null,
+    });
+
+    const invite = getActiveVoiceInviteForCaller(CALLER);
+
+    expect(invite).toEqual({
+      inviteId,
+      inviteeName: "Friend Name",
+      guardianName: null,
+      codeDigits: 6,
+    });
+  });
+
+  test("no invite bound to the caller → null (another caller's invite is invisible)", () => {
+    seedContact("c1");
+    seedVoiceInvite({ expectedExternalUserId: OTHER_CALLER });
+
+    expect(getActiveVoiceInviteForCaller(CALLER)).toBeNull();
+  });
+
+  test("expired invite → null and lazily marked expired", () => {
+    seedContact("c1");
+    const inviteId = seedVoiceInvite({ expiresAt: Date.now() - 1 });
+
+    expect(getActiveVoiceInviteForCaller(CALLER)).toBeNull();
+    expect(inviteRow(inviteId).status).toBe("expired");
+  });
+});
+
+describe("redeemVoiceInvite", () => {
+  test("valid code: claims atomically, activates the phone channel, returns the outcome", async () => {
+    seedContact("c1", "Curated Name");
+    const inviteId = seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.outcome).toMatchObject({
+      inviteId,
+      contactId: "c1",
+      sourceChannel: "phone",
+      memberExternalUserId: CALLER,
+      memberExternalChatId: CALLER,
+      displayName: "Curated Name",
+      result: "redeemed",
+    });
+
+    const invite = inviteRow(inviteId);
+    expect(invite.useCount).toBe(1);
+    expect(invite.status).toBe("redeemed");
+    expect(invite.redeemedByExternalUserId).toBe(CALLER);
+
+    const channel = gwPhoneChannel(CALLER);
+    expect(channel?.status).toBe("active");
+    expect(channel?.verifiedVia).toBe("invite");
+    expect(channel?.contactId).toBe("c1");
+  });
+
+  test("falls back to friendName when the target contact has no curated displayName", async () => {
+    seedContact("c1", "");
+    seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result.status).toBe("redeemed");
+    if (result.status !== "redeemed") throw new Error("unreachable");
+    expect(result.outcome.displayName).toBe("Friend Name");
+  });
+
+  test("wrong code → invalid_or_expired, no use consumed", async () => {
+    seedContact("c1");
+    const inviteId = seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: "999999",
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+
+  test("code bound to a different caller → invalid_or_expired (candidate scoping)", async () => {
+    seedContact("c1");
+    const inviteId = seedVoiceInvite({ expectedExternalUserId: OTHER_CALLER });
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+    expect(inviteRow(inviteId).useCount).toBe(0);
+  });
+
+  test("expired invite → invalid_or_expired and lazily marked expired", async () => {
+    seedContact("c1");
+    const inviteId = seedVoiceInvite({ expiresAt: Date.now() - 1 });
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+    const invite = inviteRow(inviteId);
+    expect(invite.status).toBe("expired");
+    expect(invite.useCount).toBe(0);
+  });
+
+  test("already-active member: already_member, NO use consumed", async () => {
+    seedContact("c1");
+    seedPhoneChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: CALLER,
+      status: "active",
+    });
+    const inviteId = seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result.status).toBe("already_member");
+    if (result.status !== "already_member") throw new Error("unreachable");
+    expect(result.outcome.result).toBe("already_member");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(inviteRow(inviteId).status).toBe("active");
+  });
+
+  test("blocked phone channel is NEVER reactivated: generic failure, no use consumed", async () => {
+    seedContact("c1");
+    seedPhoneChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: CALLER,
+      status: "blocked",
+    });
+    const inviteId = seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(gwPhoneChannel(CALLER)?.status).toBe("blocked");
+  });
+
+  test("revoked phone channel IS reactivated by an invite", async () => {
+    seedContact("c1");
+    seedPhoneChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: CALLER,
+      status: "revoked",
+    });
+    const inviteId = seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result.status).toBe("redeemed");
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(gwPhoneChannel(CALLER)?.status).toBe("active");
+  });
+
+  test("atomic double-redeem: two concurrent redemptions → exactly one consumes the use", async () => {
+    seedContact("c1");
+    const inviteId = seedVoiceInvite({ maxUses: 1 });
+
+    const results = await Promise.all([
+      redeemVoiceInvite({ callerExternalUserId: CALLER, code: CODE }),
+      redeemVoiceInvite({ callerExternalUserId: CALLER, code: CODE }),
+    ]);
+
+    // Whichever interleaving occurs, at most one caller consumes the use; the
+    // loser fails the atomic claim (or resolves already_member after the
+    // winner's activation) — the row is never double-consumed.
+    const redeemed = results.filter((r) => r.status === "redeemed");
+    expect(redeemed.length).toBeLessThanOrEqual(1);
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(inviteRow(inviteId).status).toBe("redeemed");
+  });
+
+  test("sequential re-redemption of a consumed invite → invalid_or_expired", async () => {
+    seedContact("c1");
+    seedVoiceInvite({ maxUses: 1 });
+    await redeemVoiceInvite({ callerExternalUserId: CALLER, code: CODE });
+    // Reset the caller's channel so the retry isn't gated as already_member.
+    getGatewayDb().delete(contactChannels).run();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+  });
+
+  test("empty caller identity → invalid_or_expired", async () => {
+    seedContact("c1");
+    seedVoiceInvite();
+
+    const result = await redeemVoiceInvite({
+      callerExternalUserId: "",
+      code: CODE,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "invalid_or_expired" });
+  });
+});

--- a/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for the voice-invite IPC routes (ipc/invite-handlers.ts):
+ * `get_active_voice_invite` (detection with/without an invite, expired
+ * filtering) and `redeem_voice_invite` (success / already_member / generic
+ * failure / double-redeem), including the best-effort `invite_redeemed`
+ * daemon info-mirror event on success.
+ *
+ * The gateway DB is real (shared test preload); the assistant DB mirror and
+ * the daemon IPC client are mocked so tests never touch the assistant socket.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { randomBytes } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+import { createConnection, type Socket } from "node:net";
+import { join } from "node:path";
+
+import { hashInviteCode } from "@vellumai/gateway-client";
+
+// The engine's ACL side effect dual-writes an assistant-DB info mirror over
+// IPC; stub it so tests never touch a socket.
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: async () => [],
+  assistantDbRun: async () => {},
+}));
+
+// Capture the best-effort invite_redeemed daemon event instead of dialing
+// the assistant socket.
+let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
+    ipcCallAssistantCalls.push({ method, body: opts?.body });
+    return {};
+  },
+  // Not exercised here, but the mock must cover what transitive importers
+  // (contacts-control-plane-proxy) pull from this module.
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+}));
+
+const { testWorkspaceDir } = await import("./test-preload.js");
+
+const { initGatewayDb, getGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const { contacts, contactChannels, ingressInvites } =
+  await import("../db/schema.js");
+const { ContactStore } = await import("../db/contact-store.js");
+const { GatewayIpcServer } = await import("../ipc/server.js");
+const { inviteRoutes } = await import("../ipc/invite-handlers.js");
+
+// Short name: the workspace tmp prefix leaves little headroom under the
+// AF_UNIX socket-path length limit.
+const socketPath = join(testWorkspaceDir, "gw-vi.sock");
+
+const CALLER = "+15555550100";
+const CODE = "123456";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(ingressInvites).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  ipcCallAssistantCalls = [];
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function connectClient(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(path, () => resolve(client));
+    client.on("error", reject);
+  });
+}
+
+function sendRequest(
+  client: Socket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ id: string; result?: unknown; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const id = randomBytes(4).toString("hex");
+    let buffer = "";
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        client.off("data", onData);
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+    client.on("data", onData);
+    client.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+}
+
+function seedContact(displayName = "Target Name"): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: "c1",
+      displayName,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedVoiceInvite(
+  overrides: Partial<
+    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
+  > = {},
+): string {
+  const id = overrides.id ?? crypto.randomUUID();
+  new ContactStore().createInvite({
+    id,
+    sourceChannel: "phone",
+    voiceCodeHash: hashInviteCode(CODE),
+    voiceCodeDigits: 6,
+    expectedExternalUserId: CALLER,
+    friendName: "Friend Name",
+    guardianName: "Guardian Name",
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  });
+  return id;
+}
+
+function inviteRow(id: string) {
+  return new ContactStore().getInviteById(id)!;
+}
+
+// ---------------------------------------------------------------------------
+// IPC route tests
+// ---------------------------------------------------------------------------
+
+describe("voice invite IPC routes", () => {
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let client: Socket;
+
+  beforeEach(async () => {
+    if (existsSync(socketPath)) rmSync(socketPath);
+    server = new GatewayIpcServer([...inviteRoutes]);
+    (server as unknown as { socketPath: string }).socketPath = socketPath;
+    server.start();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client = await connectClient(socketPath);
+  });
+
+  afterEach(() => {
+    client?.destroy();
+    server?.stop();
+  });
+
+  // ── get_active_voice_invite ────────────────────────────────────────────
+
+  test("get_active_voice_invite: validates params", async () => {
+    const res = await sendRequest(client, "get_active_voice_invite", {});
+    expect(res.error).toBeDefined();
+    expect(res.error).toContain("Invalid params");
+  });
+
+  test("get_active_voice_invite: no invite → { invite: null }", async () => {
+    const res = await sendRequest(client, "get_active_voice_invite", {
+      callerExternalUserId: CALLER,
+    });
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({ invite: null });
+  });
+
+  test("get_active_voice_invite: active invite → display metadata only", async () => {
+    seedContact("Curated Name");
+    const inviteId = seedVoiceInvite();
+
+    const res = await sendRequest(client, "get_active_voice_invite", {
+      callerExternalUserId: CALLER,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      invite: {
+        inviteId,
+        inviteeName: "Curated Name",
+        guardianName: "Guardian Name",
+        codeDigits: 6,
+      },
+    });
+  });
+
+  test("get_active_voice_invite: friendName fallback + codeDigits default", async () => {
+    seedContact("");
+    const inviteId = seedVoiceInvite({ voiceCodeDigits: null });
+
+    const res = await sendRequest(client, "get_active_voice_invite", {
+      callerExternalUserId: CALLER,
+    });
+
+    expect(res.result).toEqual({
+      invite: {
+        inviteId,
+        inviteeName: "Friend Name",
+        guardianName: "Guardian Name",
+        codeDigits: 6,
+      },
+    });
+  });
+
+  test("get_active_voice_invite: expired invite filtered and lazily marked", async () => {
+    seedContact();
+    const inviteId = seedVoiceInvite({ expiresAt: Date.now() - 1 });
+
+    const res = await sendRequest(client, "get_active_voice_invite", {
+      callerExternalUserId: CALLER,
+    });
+
+    expect(res.result).toEqual({ invite: null });
+    expect(inviteRow(inviteId).status).toBe("expired");
+  });
+
+  // ── redeem_voice_invite ────────────────────────────────────────────────
+
+  test("redeem_voice_invite: validates params", async () => {
+    const res = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+    });
+    expect(res.error).toBeDefined();
+    expect(res.error).toContain("Invalid params");
+  });
+
+  test("redeem_voice_invite: success → outcome + invite_redeemed daemon event", async () => {
+    seedContact("Curated Name");
+    const inviteId = seedVoiceInvite();
+
+    const res = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({
+      ok: true,
+      outcome: {
+        inviteId,
+        contactId: "c1",
+        sourceChannel: "phone",
+        memberExternalUserId: CALLER,
+        memberExternalChatId: CALLER,
+        displayName: "Curated Name",
+        result: "redeemed",
+      },
+    });
+    expect(inviteRow(inviteId).useCount).toBe(1);
+    expect(inviteRow(inviteId).status).toBe("redeemed");
+
+    expect(ipcCallAssistantCalls).toHaveLength(1);
+    expect(ipcCallAssistantCalls[0].method).toBe("invite_redeemed");
+    expect(ipcCallAssistantCalls[0].body).toMatchObject({
+      inviteId,
+      result: "redeemed",
+    });
+  });
+
+  test("redeem_voice_invite: already_member → no consume, no daemon event", async () => {
+    seedContact();
+    const now = Date.now();
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "ch-1",
+        contactId: "c1",
+        type: "phone",
+        address: CALLER,
+        externalChatId: CALLER,
+        status: "active",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+      })
+      .run();
+    const inviteId = seedVoiceInvite();
+
+    const res = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toMatchObject({
+      ok: true,
+      outcome: { result: "already_member" },
+    });
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(ipcCallAssistantCalls).toHaveLength(0);
+  });
+
+  test("redeem_voice_invite: wrong code → generic failure, no consume", async () => {
+    seedContact();
+    const inviteId = seedVoiceInvite();
+
+    const res = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+      code: "999999",
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.result).toEqual({ ok: false, reason: "invalid_or_expired" });
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(ipcCallAssistantCalls).toHaveLength(0);
+  });
+
+  test("redeem_voice_invite: double redeem → second attempt fails generically", async () => {
+    seedContact();
+    const inviteId = seedVoiceInvite({ maxUses: 1 });
+
+    const first = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+    expect(first.result).toMatchObject({ ok: true });
+
+    // Reset the caller's channel so the retry isn't gated as already_member.
+    getGatewayDb().delete(contactChannels).run();
+
+    const second = await sendRequest(client, "redeem_voice_invite", {
+      callerExternalUserId: CALLER,
+      code: CODE,
+    });
+    expect(second.result).toEqual({ ok: false, reason: "invalid_or_expired" });
+    expect(inviteRow(inviteId).useCount).toBe(1);
+  });
+});

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -273,22 +273,30 @@ describe("GatewayIpcServer — protocol/validation errors carry status codes", (
 });
 
 describe("invite CRUD IPC routes registration", () => {
-  test("registers the three CRUD methods alongside record_invite_redemption", () => {
+  test("registers the CRUD and voice-invite methods alongside record_invite_redemption", () => {
     const methods = inviteRoutes.map((r) => r.method);
     expect(methods).toContain("record_invite_redemption");
     expect(methods).toContain("invites_list");
     expect(methods).toContain("invites_create");
     expect(methods).toContain("invites_revoke");
-    // No redeem IPC method — redemption stays on record_invite_redemption.
+    expect(methods).toContain("get_active_voice_invite");
+    expect(methods).toContain("redeem_voice_invite");
+    // No generic redeem IPC method — text redemption happens at ingress.
     expect(methods).not.toContain("invites_redeem");
     // invites_trigger_call stays daemon-local on the assistant; relaying it
     // here would loop gateway→assistant→gateway.
     expect(methods).not.toContain("invites_trigger_call");
-    expect(inviteRoutes).toHaveLength(4);
+    expect(inviteRoutes).toHaveLength(6);
   });
 
-  test("every CRUD route carries a Zod param schema", () => {
-    for (const m of ["invites_list", "invites_create", "invites_revoke"]) {
+  test("every route carries a Zod param schema", () => {
+    for (const m of [
+      "invites_list",
+      "invites_create",
+      "invites_revoke",
+      "get_active_voice_invite",
+      "redeem_voice_invite",
+    ]) {
       expect(route(m).schema).toBeDefined();
     }
   });

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -31,6 +31,19 @@
  *     params : { id: string }
  *     returns: { invite: Record<string, unknown> }            (sanitized)
  *
+ *   get_active_voice_invite
+ *     params : { callerExternalUserId: string }
+ *     returns: { invite: ActiveVoiceInvite | null }           (display metadata
+ *              only — inviteId/inviteeName/guardianName/codeDigits; never the
+ *              code or its hash)
+ *
+ *   redeem_voice_invite
+ *     params : { callerExternalUserId: string; code: string }
+ *     returns: { ok: true; outcome: InviteRedemptionOutcome } on
+ *              redeemed/already_member, or
+ *              { ok: false; reason: "invalid_or_expired" }    (single generic
+ *              failure — never leaks which check refused)
+ *
  * (Note: invites_trigger_call is NOT relayed here — it stays daemon-local on the
  * assistant. The gateway HTTP call path validates its row then delegates the
  * provider call to the assistant via triggerInviteCallNative; relaying it back
@@ -43,6 +56,10 @@
  * ───────────────────────────────────────────────────────────────────────────
  */
 
+import {
+  GetActiveVoiceInviteRequestSchema,
+  RedeemVoiceInviteRequestSchema,
+} from "@vellumai/gateway-client";
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
@@ -55,6 +72,11 @@ import {
   createInviteSchema,
   listInviteQueryShape,
 } from "../http/routes/invite-validation.js";
+import {
+  getActiveVoiceInviteForCaller,
+  notifyDaemonInviteRedeemed,
+  redeemVoiceInvite,
+} from "../verification/invite-redemption.js";
 import type { IpcRoute } from "./server.js";
 
 let store: ContactStore | null = null;
@@ -144,6 +166,37 @@ export const inviteRoutes: IpcRoute[] = [
     handler: async (params?: Record<string, unknown>) => {
       const { id } = InviteIdParamsSchema.parse(params);
       return await revokeInviteNative(id);
+    },
+  },
+  {
+    // Voice-invite detection for an inbound caller: the active phone invite
+    // bound to the caller's number, projected to display metadata only.
+    method: "get_active_voice_invite",
+    schema: GetActiveVoiceInviteRequestSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { callerExternalUserId } =
+        GetActiveVoiceInviteRequestSchema.parse(params);
+      return {
+        invite: getActiveVoiceInviteForCaller(callerExternalUserId, getStore()),
+      };
+    },
+  },
+  {
+    // Voice-code redemption through the gateway engine. Success fires the
+    // best-effort `invite_redeemed` daemon info-mirror event (already_member
+    // consumed nothing, so there is nothing to mirror).
+    method: "redeem_voice_invite",
+    schema: RedeemVoiceInviteRequestSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const parsed = RedeemVoiceInviteRequestSchema.parse(params);
+      const result = await redeemVoiceInvite({ ...parsed, store: getStore() });
+      if (result.status === "failed") {
+        return { ok: false, reason: result.reason };
+      }
+      if (result.status === "redeemed") {
+        notifyDaemonInviteRedeemed(result.outcome);
+      }
+      return { ok: true, outcome: result.outcome };
     },
   },
 ];

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -1,9 +1,9 @@
 /**
  * Gateway-native invite redemption engine + inbound text intercept.
  *
- * Resolves a 6-digit invite code or invite link token against the
- * gateway-canonical `ingress_invites` table, validates lifecycle
- * (status / expiry / use count / channel), gates on existing gateway
+ * Resolves a 6-digit invite code, invite link token, or caller-bound voice
+ * code against the gateway-canonical `ingress_invites` table, validates
+ * lifecycle (status / expiry / use count / channel), gates on existing gateway
  * membership, claims the row atomically, and applies the verified-channel
  * ACL side effect — entirely inside the gateway. After a successful
  * redemption the daemon is notified best-effort (`invite_redeemed`) so it
@@ -17,6 +17,7 @@ import {
   hashInviteCode,
   hashInviteToken,
   isInviteCodeRedemptionEnabled,
+  type ActiveVoiceInvite,
   type CommandIntent,
   type InviteRedemptionOutcome,
   type TrustVerdict,
@@ -298,6 +299,113 @@ async function finishRedemption(
     },
     replyText: INVITE_REPLY_TEMPLATES.redeemed,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Voice invites (phone channel)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_VOICE_CODE_DIGITS = 6;
+
+/** Lazily flip expired-but-still-active candidates to status "expired". */
+function sweepExpiredVoiceInvites(
+  store: ContactStore,
+  candidates: IngressInviteRow[],
+  now: number,
+): void {
+  for (const candidate of candidates) {
+    if (candidate.expiresAt <= now) {
+      store.markInviteExpired(candidate.id);
+    }
+  }
+}
+
+/**
+ * Resolve the active voice invite awaiting a caller, projected to display
+ * metadata for the personalized voice prompt (never the code or its hash).
+ * The invitee name prefers the target contact's curated displayName over the
+ * invite's free-text friendName. Expired stragglers are lazily swept.
+ */
+export function getActiveVoiceInviteForCaller(
+  callerExternalUserId: string,
+  store: ContactStore = new ContactStore(),
+): ActiveVoiceInvite | null {
+  const candidates = store.findActiveVoiceInvites(callerExternalUserId);
+  const now = Date.now();
+  sweepExpiredVoiceInvites(store, candidates, now);
+
+  const invite = candidates.find((candidate) => candidate.expiresAt > now);
+  if (!invite) return null;
+
+  const inviteeName =
+    store.getContact(invite.contactId)?.displayName?.trim() ||
+    invite.friendName?.trim() ||
+    null;
+  return {
+    inviteId: invite.id,
+    inviteeName,
+    guardianName: invite.guardianName?.trim() || null,
+    codeDigits: invite.voiceCodeDigits ?? DEFAULT_VOICE_CODE_DIGITS,
+  };
+}
+
+export type VoiceInviteRedemptionResult =
+  | { status: "redeemed" | "already_member"; outcome: InviteRedemptionOutcome }
+  | { status: "failed"; reason: "invalid_or_expired" };
+
+const VOICE_FAILURE: VoiceInviteRedemptionResult = {
+  status: "failed",
+  reason: "invalid_or_expired",
+};
+
+/**
+ * Redeem a spoken voice invite code for a caller identified by phone number.
+ *
+ * Candidates are scoped to active phone invites bound to the caller
+ * (`expectedExternalUserId`), then matched by code hash with expiry/use-count
+ * pre-checks (expired candidates are lazily swept). Validation, the membership
+ * gate (`already_member` no-consume; blocked never reactivated), the atomic
+ * claim, and the phone ACL upsert are shared with the code/token paths via
+ * {@link finishRedemption} — the invite's friendName seeds the displayName,
+ * with the target contact's curated name taking precedence inside the helper.
+ *
+ * Every failure collapses to the single generic `invalid_or_expired` so a
+ * caller probing codes can't learn which invites exist, which numbers are
+ * bound, or which check refused them.
+ */
+export async function redeemVoiceInvite(params: {
+  callerExternalUserId: string;
+  code: string;
+  store?: ContactStore;
+}): Promise<VoiceInviteRedemptionResult> {
+  const store = params.store ?? new ContactStore();
+  const { callerExternalUserId, code } = params;
+  if (!callerExternalUserId) return VOICE_FAILURE;
+
+  const candidates = store.findActiveVoiceInvites(callerExternalUserId);
+  const codeHash = hashInviteCode(code);
+  const now = Date.now();
+  const invite = candidates.find(
+    (candidate) =>
+      candidate.voiceCodeHash === codeHash &&
+      candidate.expiresAt > now &&
+      candidate.useCount < candidate.maxUses,
+  );
+  if (!invite) {
+    sweepExpiredVoiceInvites(store, candidates, now);
+    return VOICE_FAILURE;
+  }
+
+  const result = await finishRedemption(store, invite, {
+    sourceChannel: "phone",
+    externalUserId: callerExternalUserId,
+    externalChatId: callerExternalUserId,
+    displayName: invite.friendName ?? undefined,
+  });
+  if (result.status !== "redeemed" && result.status !== "already_member") {
+    return VOICE_FAILURE;
+  }
+  return { status: result.status, outcome: result.outcome };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Gateway engine gains voice-code redemption (candidate scoping, generic failure, atomic claim, phone ACL upsert)
- New gateway IPC methods get_active_voice_invite + redeem_voice_invite
- New daemon reader calls/gateway-invite-reader.ts (detection fails soft, redemption fails closed); additive — call paths convert next PR

Part of plan: invites-gateway-native.md (PR 7 of 12)