### PR TITLE
feat(web): show the in-chat plugin pill in the chat top-right slot

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests the top-right slot registration in `useChatHeaderRegistration`:
+ * specifically that `InChatPluginPill` is mounted next to `ConversationAssetsPill`
+ * only when the daemon supports per-chat plugin state. The hook's many store
+ * dependencies are stubbed; the two pills are rendered as identifiable markers so
+ * the captured slot node can be asserted.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+const slotRef = { value: null as ReactNode };
+const setTopBarRightSlot = mock((node: ReactNode) => {
+  slotRef.value = node;
+});
+const setHeaderSupplements = mock(() => {});
+mock.module("@/components/layout/chat-layout-slots-store", () => {
+  const store = () => null;
+  store.use = {
+    setTopBarRightSlot: () => setTopBarRightSlot,
+    setHeaderSupplements: () => setHeaderSupplements,
+  };
+  return { useChatLayoutSlotsStore: store };
+});
+
+mock.module("@/stores/resolved-assistants-store", () => {
+  const store = () => null;
+  store.use = { activeAssistantId: () => "asst-1" };
+  return { useResolvedAssistantsStore: store };
+});
+
+mock.module("@/stores/conversation-store", () => {
+  const store = () => null;
+  store.use = { activeConversationId: () => "conv-1" };
+  return { useConversationStore: store };
+});
+
+mock.module("@/domains/chat/transcript/use-transcript-messages", () => ({
+  useTranscriptMessages: () => [],
+}));
+
+mock.module("@/domains/chat/hooks/use-active-conversation", () => ({
+  useActiveConversation: () => ({ conversationId: "conv-1" }),
+}));
+
+mock.module("@/domains/chat/hooks/use-slack-conversation-display", () => ({
+  useSlackConversationDisplay: () => null,
+}));
+
+mock.module("@/domains/chat/hooks/use-open-app-from-chat", () => ({
+  useOpenAppFromChat: () => () => {},
+}));
+
+const supportsRef = { value: true };
+mock.module("@/lib/backwards-compat/use-supports-inchat-plugin-edit", () => ({
+  useSupportsInchatPluginEdit: () => supportsRef.value,
+}));
+
+mock.module("@/domains/chat/components/conversation-assets-pill", () => ({
+  ConversationAssetsPill: () =>
+    createElement("div", { "data-testid": "assets-pill" }),
+}));
+
+mock.module("@/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill", () => ({
+  InChatPluginPill: () =>
+    createElement("div", { "data-testid": "plugin-pill" }),
+}));
+
+const { useChatHeaderRegistration } = await import(
+  "./use-chat-header-registration"
+);
+
+function renderRegistration() {
+  return renderHook(() =>
+    useChatHeaderRegistration({
+      assetsRefreshKey: 0,
+      handleAnalyzeConversation: async () => {},
+      handleForkConversationFromMenu: () => {},
+      handleOpenInNewWindow: () => {},
+      handleInspectConversation: () => {},
+      handleCopyConversation: () => {},
+      onRefresh: () => {},
+    }),
+  );
+}
+
+beforeEach(() => {
+  supportsRef.value = true;
+  slotRef.value = null;
+  setTopBarRightSlot.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useChatHeaderRegistration top-right slot", () => {
+  test("mounts the plugin pill beside the assets pill when supported", () => {
+    supportsRef.value = true;
+    renderRegistration();
+
+    const { queryByTestId } = render(<>{slotRef.value}</>);
+    expect(queryByTestId("assets-pill")).not.toBeNull();
+    expect(queryByTestId("plugin-pill")).not.toBeNull();
+  });
+
+  test("omits the plugin pill on daemons that don't support it", () => {
+    supportsRef.value = false;
+    renderRegistration();
+
+    const { queryByTestId } = render(<>{slotRef.value}</>);
+    expect(queryByTestId("assets-pill")).not.toBeNull();
+    expect(queryByTestId("plugin-pill")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
@@ -5,7 +5,7 @@
  *
  * Owns:
  * - `headerSupplements` computation and slot registration
- * - `topBarRightSlot` (ConversationAssetsPill) computation and registration
+ * - `topBarRightSlot` (ConversationAssetsPill + InChatPluginPill) computation and registration
  * - Slack conversation display derivation for the header label
  */
 
@@ -25,6 +25,8 @@ import { isChannelConversation } from "@/domains/chat/utils/conversation-channel
 import { getChannelBindingDisplayText } from "@/domains/chat/utils/channel-conversation-display";
 import { getChannelLabel } from "@/utils/channel-presentation";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
+import { InChatPluginPill } from "@/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill";
+import { useSupportsInchatPluginEdit } from "@/lib/backwards-compat/use-supports-inchat-plugin-edit";
 import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
 import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
@@ -54,6 +56,9 @@ export function useChatHeaderRegistration({
   const messages = useTranscriptMessages();
   const setTopBarRightSlot = useChatLayoutSlotsStore.use.setTopBarRightSlot();
   const setHeaderSupplements = useChatLayoutSlotsStore.use.setHeaderSupplements();
+  // Older daemons omit `enabledPlugins` on the conversation GET, so the pill
+  // can't reflect per-chat state there — hide it until the daemon supports it.
+  const supportsPluginPill = useSupportsInchatPluginEdit();
 
   const activeConversation = useActiveConversation(assistantId, activeConversationId, true);
 
@@ -132,15 +137,23 @@ export function useChatHeaderRegistration({
   const topBarRightContent = useMemo(() => {
     if (!activeConversation?.conversationId || !assistantId) return null;
     return (
-      <ConversationAssetsPill
-        assistantId={assistantId}
-        conversationId={activeConversation.conversationId}
-        refreshKey={assetsRefreshKey}
-        onOpenApp={handleOpenAppFromChat}
-        onOpenDocument={handleOpenDocument}
-      />
+      <>
+        <ConversationAssetsPill
+          assistantId={assistantId}
+          conversationId={activeConversation.conversationId}
+          refreshKey={assetsRefreshKey}
+          onOpenApp={handleOpenAppFromChat}
+          onOpenDocument={handleOpenDocument}
+        />
+        {supportsPluginPill ? (
+          <InChatPluginPill
+            assistantId={assistantId}
+            conversationId={activeConversation.conversationId}
+          />
+        ) : null}
+      </>
     );
-  }, [activeConversation?.conversationId, assistantId, assetsRefreshKey, handleOpenAppFromChat, handleOpenDocument]);
+  }, [activeConversation?.conversationId, assistantId, assetsRefreshKey, handleOpenAppFromChat, handleOpenDocument, supportsPluginPill]);
 
   useEffect(() => {
     setTopBarRightSlot(topBarRightContent);


### PR DESCRIPTION
Mounts InChatPluginPill beside ConversationAssetsPill in the chat top-right slot (via use-chat-header-registration), gated on useSupportsInchatPluginEdit() so it's hidden on daemons that don't serialize enabledPlugins on the conversation GET. Completes the in-chat plugin pill feature.

Part of plan: in-chat-plugin-pill.md (PR 6 of 6).

Co-Authored-By: Claude <noreply@anthropic.com>