### PR TITLE
fix(acp): surface real adapter error instead of generic "Internal error"

### DIFF
--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -72,3 +72,49 @@ describe("AcpAgentProcess.recentStderr", () => {
     expect(proc.recentStderr()).toBe("only line");
   });
 });
+
+describe("AcpAgentProcess.markStderr / stderrSince", () => {
+  test("stderrSince returns only lines produced after the mark", () => {
+    const proc = newProcess();
+    feed(proc, "before 1");
+    feed(proc, "before 2");
+
+    const mark = proc.markStderr();
+    feed(proc, "after 1");
+    feed(proc, "after 2");
+
+    expect(proc.stderrSince(mark)).toBe("after 1\nafter 2");
+  });
+
+  test("a mark taken after all lines excludes everything retained so far", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+
+    const mark = proc.markStderr();
+    expect(proc.stderrSince(mark)).toBe("");
+  });
+
+  test("stderrSince(0) returns all retained lines, like recentStderr", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+
+    expect(proc.stderrSince(0)).toBe(proc.recentStderr());
+  });
+
+  test("mark is monotonic across eviction: seq keeps counting evicted lines", () => {
+    const proc = newProcess();
+    // Overflow the byte cap so early lines are evicted, then mark and add one
+    // fresh line: only the post-mark line comes back, unaffected by eviction.
+    const kb = "z".repeat(1024);
+    for (let i = 0; i < 8; i++) {
+      feed(proc, `${i}:${kb}`);
+    }
+
+    const mark = proc.markStderr();
+    feed(proc, "fresh failure");
+
+    expect(proc.stderrSince(mark)).toBe("fresh failure");
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -77,10 +77,17 @@ export class AcpAgentProcess {
 
   /**
    * Ring of the most recent stderr lines, bounded to ~STDERR_RETENTION_BYTES.
-   * Read once on the failure path to surface the real adapter error.
+   * Read once on the failure path to surface the real adapter error. Each
+   * entry carries a monotonic `seq` so a caller can scope reads to lines
+   * produced after a checkpoint (see markStderr/stderrSince).
    */
-  private stderrRing: string[] = [];
+  private stderrRing: { seq: number; text: string }[] = [];
   private stderrRingBytes = 0;
+  /**
+   * Cumulative count of stderr lines ever retained, including ones later
+   * evicted. Assigned as each line's `seq`; markStderr() snapshots it.
+   */
+  private stderrSeq = 0;
 
   constructor(
     public readonly agentId: string,
@@ -144,14 +151,15 @@ export class AcpAgentProcess {
    * so a single oversized line is not fully dropped.
    */
   private retainStderr(text: string): void {
-    this.stderrRing.push(text);
+    this.stderrSeq += 1;
+    this.stderrRing.push({ seq: this.stderrSeq, text });
     this.stderrRingBytes += Buffer.byteLength(text);
     while (
       this.stderrRingBytes > STDERR_RETENTION_BYTES &&
       this.stderrRing.length > 1
     ) {
       const evicted = this.stderrRing.shift()!;
-      this.stderrRingBytes -= Buffer.byteLength(evicted);
+      this.stderrRingBytes -= Buffer.byteLength(evicted.text);
     }
   }
 
@@ -160,7 +168,29 @@ export class AcpAgentProcess {
    * it does not mutate or clear the buffer.
    */
   recentStderr(): string {
-    return this.stderrRing.join("\n");
+    return this.stderrSince(0);
+  }
+
+  /**
+   * Snapshots the current cumulative stderr line count. Pair with
+   * stderrSince() to read only stderr produced after this checkpoint, so a
+   * prompt's failure derives from its own stderr rather than lines retained
+   * from startup, resume, or an earlier (possibly cancelled) prompt.
+   */
+  markStderr(): number {
+    return this.stderrSeq;
+  }
+
+  /**
+   * Returns retained stderr lines produced after `mark` (a markStderr()
+   * checkpoint), joined by newlines. Best-effort: lines pushed after the mark
+   * but since evicted are simply absent; returns "" when nothing newer remains.
+   */
+  stderrSince(mark: number): string {
+    return this.stderrRing
+      .filter((e) => e.seq > mark)
+      .map((e) => e.text)
+      .join("\n");
   }
 
   /**

--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -62,6 +62,13 @@ describe("deriveFailureError", () => {
     );
   });
 
+  test("structured error duplicating the generic ack yields the clean ack, not the raw JSON", () => {
+    // The adapter acked "Internal error" and also emitted it as a JSON blob;
+    // return the clean ack rather than echoing the raw JSON line.
+    const stderr = `{"error":{"message":"Internal error"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("Internal error");
+  });
+
   test("falls back to the ack message when stderr has no JSON and no lines", () => {
     expect(deriveFailureError("Internal error", "   \n  \n")).toBe(
       "Internal error",

--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveFailureError } from "./failure-error.js";
+
+const CODEX_MESSAGE =
+  "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.";
+
+const ESC = String.fromCharCode(27); // ANSI escape (0x1B)
+
+// A realistic codex-acp stderr line: a JSON error blob wrapped in a coloured
+// log prefix and a trailing reset code.
+const ansiCodexStderr =
+  `${ESC}[2m2026-06-30T12:00:00Z${ESC}[0m ${ESC}[31mERROR${ESC}[0m codex_core: ` +
+  `request failed {"type":"error","status":400,"error":` +
+  `{"type":"invalid_request_error","message":"${CODEX_MESSAGE}"}}${ESC}[0m`;
+
+describe("deriveFailureError", () => {
+  test("extracts the inner error.message from codex-acp JSON stderr", () => {
+    const stderr =
+      `{"type":"error","status":400,"error":` +
+      `{"type":"invalid_request_error","message":"${CODEX_MESSAGE}"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(CODEX_MESSAGE);
+  });
+
+  test("strips ANSI codes and extracts error.message from a real log line", () => {
+    const result = deriveFailureError("Internal error", ansiCodexStderr);
+    expect(result).toBe(CODEX_MESSAGE);
+    expect(result).not.toContain(ESC);
+  });
+
+  test("parses JSON embedded in surrounding log text", () => {
+    const stderr = `2026-06-30 fatal: the adapter said {"error":{"message":"boom"}} and gave up`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("boom");
+  });
+
+  test("returns the LAST JSON error.message when several are present", () => {
+    const stderr =
+      `{"error":{"message":"first failure"}}\n` +
+      `{"error":{"message":"final failure"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("final failure");
+  });
+
+  test("empty stderr yields the ack message", () => {
+    expect(deriveFailureError("Internal error", "")).toBe("Internal error");
+  });
+
+  test("generic ack with informative non-JSON stderr yields the last stderr line, ANSI-stripped", () => {
+    const stderr = `starting up...\n${ESC}[31mfatal: could not connect to backend${ESC}[0m`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "fatal: could not connect to backend",
+    );
+  });
+
+  test("already-specific ack is preserved when stderr is empty", () => {
+    expect(deriveFailureError(CODEX_MESSAGE, "")).toBe(CODEX_MESSAGE);
+  });
+
+  test("already-specific ack is preserved (not double-appended) when stderr duplicates it", () => {
+    // codex often echoes the same message to stderr; we must not repeat it.
+    expect(deriveFailureError(CODEX_MESSAGE, CODEX_MESSAGE)).toBe(
+      CODEX_MESSAGE,
+    );
+  });
+
+  test("falls back to the ack message when stderr has no JSON and no lines", () => {
+    expect(deriveFailureError("Internal error", "   \n  \n")).toBe(
+      "Internal error",
+    );
+  });
+
+  test("ignores malformed JSON braces and uses the last stderr line", () => {
+    const stderr = "noise {not: valid json} more noise\nreal failure detail";
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "real failure detail",
+    );
+  });
+});

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -17,9 +17,10 @@ export function deriveFailureError(ackMessage: string, stderr: string): string {
   const clean = stderr.replace(ANSI_ESCAPE, "").trim();
 
   // Most precise: a structured adapter error. Prefer it even over a specific
-  // ack, but never return a value that just duplicates the ack.
+  // ack, but when it merely duplicates the ack, return the clean ack rather
+  // than falling through to echo the raw JSON blob as a stderr line.
   const jsonMessage = lastJsonErrorMessage(clean);
-  if (jsonMessage && jsonMessage !== ackMessage) return jsonMessage;
+  if (jsonMessage) return jsonMessage !== ackMessage ? jsonMessage : ackMessage;
 
   // An already-specific ack is preserved when stderr has no better detail.
   if (ackMessage.length > 0 && ackMessage !== "Internal error")

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -1,0 +1,94 @@
+/**
+ * Derives a human-meaningful failure message for a failed ACP prompt.
+ *
+ * ACP adapters (e.g. codex-acp) frequently ack a failure with a generic
+ * "Internal error" while printing the real cause to stderr as a JSON blob like
+ * `{"error":{"message":"..."}}`. This picks the most specific signal available:
+ * a structured stderr error, else the last stderr line, else the ack message.
+ *
+ * Pure and dependency-free.
+ */
+
+// CSI escape sequences (colour codes, cursor moves) that adapters interleave
+// with their log lines: ESC `[`, parameter/intermediate bytes, then final byte.
+const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+
+export function deriveFailureError(ackMessage: string, stderr: string): string {
+  const clean = stderr.replace(ANSI_ESCAPE, "").trim();
+
+  // Most precise: a structured adapter error. Prefer it even over a specific
+  // ack, but never return a value that just duplicates the ack.
+  const jsonMessage = lastJsonErrorMessage(clean);
+  if (jsonMessage && jsonMessage !== ackMessage) return jsonMessage;
+
+  // An already-specific ack is preserved when stderr has no better detail.
+  if (ackMessage.length > 0 && ackMessage !== "Internal error")
+    return ackMessage;
+
+  // Generic/empty ack: fall back to the last meaningful stderr line.
+  return lastNonEmptyLine(clean) ?? ackMessage;
+}
+
+/**
+ * Returns the `error.message` of the LAST JSON object embedded in `text` whose
+ * shape is `{"error":{"message":"..."}}`, or null. Objects may be surrounded by
+ * arbitrary log text.
+ */
+function lastJsonErrorMessage(text: string): string | null {
+  const objects = extractJsonObjects(text);
+  for (let i = objects.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(objects[i]) as {
+        error?: { message?: unknown };
+      };
+      const message = parsed.error?.message;
+      if (typeof message === "string" && message.length > 0) return message;
+    } catch {
+      // Not valid JSON; keep scanning earlier candidates.
+    }
+  }
+  return null;
+}
+
+/**
+ * Extracts top-level balanced `{...}` substrings, tracking string literals so
+ * braces inside JSON strings don't throw off the depth count.
+ */
+function extractJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}" && depth > 0) {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        objects.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return objects;
+}
+
+function lastNonEmptyLine(text: string): string | null {
+  const lines = text.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -18,6 +18,7 @@ import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
+import { deriveFailureError } from "./failure-error.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
 import { formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
@@ -1081,17 +1082,26 @@ export class AcpSessionManager {
         // Same guards: entry must exist, prompt must be current, and status
         // must not have been set to "cancelled".
         if (current && current.currentPrompt === promptPromise) {
+          // The ack message is often a generic "Internal error"; recover the
+          // real cause from the adapter's retained stderr.
+          const failureMessage = deriveFailureError(
+            err.message,
+            current.process.recentStderr(),
+          );
           if (current.state.status !== "cancelled") {
             current.state.status = "failed";
             current.state.completedAt = Date.now();
-            current.state.error = err.message;
+            current.state.error = failureMessage;
           }
           current.currentPrompt = null;
-          log.error({ acpSessionId, error: err.message }, "ACP prompt failed");
+          log.error(
+            { acpSessionId, error: err.message, failureMessage },
+            "ACP prompt failed",
+          );
           current.sendToVellum({
             type: "acp_session_error",
             acpSessionId,
-            error: err.message,
+            error: failureMessage,
           });
 
           // Persist the terminal row before teardown clears the buffer.

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -964,6 +964,10 @@ export class AcpSessionManager {
     message: string,
   ): Promise<unknown> {
     log.info({ acpSessionId, messageLen: message.length }, "ACP firing prompt");
+    // Checkpoint stderr before the prompt so a failure derives only from stderr
+    // this prompt produced — not lines retained from startup, resume, or an
+    // earlier (possibly cancelled) prompt.
+    const stderrMark = entry.process.markStderr();
     const promptPromise = entry.process
       .prompt(acpProtocolSessionId, message)
       .then((response) => {
@@ -1086,7 +1090,7 @@ export class AcpSessionManager {
           // real cause from the adapter's retained stderr.
           const failureMessage = deriveFailureError(
             err.message,
-            current.process.recentStderr(),
+            current.process.stderrSince(stderrMark),
           );
           if (current.state.status !== "cancelled") {
             current.state.status = "failed";


### PR DESCRIPTION
## Summary
- Add deriveFailureError() to extract the real adapter error from retained stderr and use it for state.error + the acp_session_error SSE, replacing the generic "Internal error".

Part of plan: acp-failure-surfacing.md (PR 2 of 4)