### PR TITLE
fix(acp): make stderr JSON extraction robust to stray braces

### DIFF
--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -81,4 +81,18 @@ describe("deriveFailureError", () => {
       "real failure detail",
     );
   });
+
+  test("a stray unmatched brace before the JSON does not block extraction", () => {
+    const stderr =
+      `some log { unmatched brace here\n` +
+      `... {"type":"error","error":{"message":"The real error"}} ...`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("The real error");
+  });
+
+  test("braces inside a JSON string literal don't throw off the scan", () => {
+    const stderr = `{"error":{"message":"unexpected } brace {in} the text"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "unexpected } brace {in} the text",
+    );
+  });
 });

--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -95,4 +95,15 @@ describe("deriveFailureError", () => {
       "unexpected } brace {in} the text",
     );
   });
+
+  test("prefers the outer adapter error over a nested error.message", () => {
+    // JSON-RPC style: the real failure is the top-level error.message; a nested
+    // error.data.error.message must not shadow it.
+    const stderr =
+      `{"error":{"message":"outer adapter failure",` +
+      `"data":{"error":{"message":"inner debug detail"}}}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "outer adapter failure",
+    );
+  });
 });

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -51,6 +51,12 @@ function lastJsonErrorMessage(text: string): string | null {
     }
     try {
       const parsed = JSON.parse(candidate) as { error?: { message?: unknown } };
+      // A valid top-level object: skip past its end so we don't restart
+      // candidates at its nested braces. Otherwise a nested error.message
+      // (e.g. a JSON-RPC error.data payload) would shadow the outer adapter
+      // error. Only reached on a successful parse, so a stray unmatched brace
+      // that balances-but-fails-to-parse still lets inner objects be scanned.
+      i += candidate.length - 1;
       const message = parsed.error?.message;
       if (typeof message === "string" && message.length > 0) {
         found = message;

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -34,55 +34,67 @@ export function deriveFailureError(ackMessage: string, stderr: string): string {
  * Returns the `error.message` of the LAST JSON object embedded in `text` whose
  * shape is `{"error":{"message":"..."}}`, or null. Objects may be surrounded by
  * arbitrary log text.
+ *
+ * A candidate object is attempted at EACH `{`, so a stray unmatched `{` in the
+ * surrounding log text never balances and is skipped rather than swallowing a
+ * later valid object.
  */
 function lastJsonErrorMessage(text: string): string | null {
-  const objects = extractJsonObjects(text);
-  for (let i = objects.length - 1; i >= 0; i--) {
+  let found: string | null = null;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "{") {
+      continue;
+    }
+    const candidate = balancedObjectAt(text, i);
+    if (candidate === null) {
+      continue;
+    }
     try {
-      const parsed = JSON.parse(objects[i]) as {
-        error?: { message?: unknown };
-      };
+      const parsed = JSON.parse(candidate) as { error?: { message?: unknown } };
       const message = parsed.error?.message;
-      if (typeof message === "string" && message.length > 0) return message;
+      if (typeof message === "string" && message.length > 0) {
+        found = message;
+      }
     } catch {
-      // Not valid JSON; keep scanning earlier candidates.
+      // Not valid JSON at this position; keep scanning later braces.
     }
   }
-  return null;
+  return found;
 }
 
 /**
- * Extracts top-level balanced `{...}` substrings, tracking string literals so
- * braces inside JSON strings don't throw off the depth count.
+ * Returns the balanced `{...}` substring starting at `start`, tracking string
+ * literals so braces inside JSON strings don't throw off the depth count, or
+ * null if the braces never balance before the text ends.
  */
-function extractJsonObjects(text: string): string[] {
-  const objects: string[] = [];
+function balancedObjectAt(text: string, start: number): string | null {
   let depth = 0;
-  let start = -1;
   let inString = false;
   let escaped = false;
-  for (let i = 0; i < text.length; i++) {
+  for (let i = start; i < text.length; i++) {
     const ch = text[i];
     if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
       continue;
     }
     if (ch === '"') {
       inString = true;
     } else if (ch === "{") {
-      if (depth === 0) start = i;
       depth++;
-    } else if (ch === "}" && depth > 0) {
+    } else if (ch === "}") {
       depth--;
-      if (depth === 0 && start >= 0) {
-        objects.push(text.slice(start, i + 1));
-        start = -1;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
       }
     }
   }
-  return objects;
+  return null;
 }
 
 function lastNonEmptyLine(text: string): string | null {


### PR DESCRIPTION
## Summary
- Scan each candidate brace independently so a stray unmatched `{` before the adapter's JSON no longer swallows a later valid `{"error":{"message":...}}`.

Follow-up to PR #36872 (codex P3). Part of plan: acp-failure-surfacing.md