### PR TITLE
feat(acp): notify parent conversation when an ACP agent fails

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -185,7 +185,6 @@ describe("VellumAcpClientHandler", () => {
       expect(sent).toHaveLength(0);
       expect(handler.pendingRequestIds.size).toBe(0);
     });
-
   });
 });
 
@@ -264,6 +263,8 @@ describe("AcpSessionManager", () => {
         initialize: mock(() => Promise.resolve()),
         createSession: mock(() => Promise.resolve("proto-session")),
         cancel: mock(() => Promise.resolve()),
+        markStderr: () => 0,
+        stderrSince: () => "",
       };
       const fakeHandler = new VellumAcpClientHandler(
         "test-session",
@@ -324,6 +325,8 @@ describe("AcpSessionManager", () => {
       const fakeProcess = {
         prompt: () => promptPromise,
         kill: mock(() => {}),
+        markStderr: () => 0,
+        stderrSince: () => "",
       };
       const fakeHandler = new VellumAcpClientHandler(
         "test-session-2",

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -202,6 +202,39 @@ describe("AcpSessionManager parent notification", () => {
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
+  test("cancel marks the session cancelled before the protocol cancel resolves", async () => {
+    // Guards the cancel race: if the in-flight prompt rejects while
+    // process.cancel is still pending, the failure gate must already see
+    // "cancelled" so it does not wake the parent after a user stop.
+    const manager = new AcpSessionManager(1);
+    let resolveCancel!: () => void;
+    const cancelPending = new Promise<void>((r) => {
+      resolveCancel = r;
+    });
+    const proc = {
+      markStderr: () => 0,
+      stderrSince: () => "",
+      prompt: () => new Promise(() => {}),
+      kill: mock(() => {}),
+      cancel: mock(() => cancelPending),
+    };
+    const entry = injectSession(
+      manager,
+      "sess-race",
+      "parent-race",
+      proc as unknown as ReturnType<typeof fakeProcess>,
+    );
+
+    const cancelPromise = (manager as any).cancel("sess-race");
+    // Synchronously after kicking off cancel — before the protocol cancel
+    // resolves — the status is already "cancelled".
+    expect(entry.state.status).toBe("cancelled");
+    expect(proc.cancel).toHaveBeenCalled();
+
+    resolveCancel();
+    await cancelPromise;
+  });
+
   test("a superseded prompt does not notify the parent", async () => {
     const manager = new AcpSessionManager(1);
     const { conversation, enqueueMessage } = mockConversation();

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -200,11 +200,6 @@ describe("AcpSessionManager parent notification", () => {
     await fire(manager, "sess-cancel", entry);
     // Any notification would have called enqueue synchronously inside the catch.
     expect(enqueueMessage).not.toHaveBeenCalled();
-    // Nor a terminal error event (would regress the optimistic Cancelled state).
-    const sentTypes = (entry.sendToVellum.mock.calls as unknown[][]).map(
-      (c) => (c[0] as { type?: string })?.type,
-    );
-    expect(sentTypes).not.toContain("acp_session_error");
   });
 
   test("a cancelled session does not notify the parent on success", async () => {
@@ -226,12 +221,6 @@ describe("AcpSessionManager parent notification", () => {
 
     await fire(manager, "sess-cancel-ok", entry);
     expect(enqueueMessage).not.toHaveBeenCalled();
-    // Nor a completed terminal event: it would regress the client's optimistic
-    // Cancelled state to Completed while history is stored as cancelled.
-    const sentTypes = (entry.sendToVellum.mock.calls as unknown[][]).map(
-      (c) => (c[0] as { type?: string })?.type,
-    );
-    expect(sentTypes).not.toContain("acp_session_completed");
   });
 
   test("cancel marks the session cancelled before the protocol cancel resolves", async () => {
@@ -265,6 +254,33 @@ describe("AcpSessionManager parent notification", () => {
 
     resolveCancel();
     await cancelPromise;
+  });
+
+  test("cancel restores the previous status when the protocol cancel throws", async () => {
+    // If process.cancel rejects, the session was not actually cancelled, so the
+    // status must roll back to running (else the live prompt's eventual settle
+    // is wrongly suppressed) and the error must propagate to the caller.
+    const manager = new AcpSessionManager(1);
+    const proc = {
+      markStderr: () => 0,
+      stderrSince: () => "",
+      prompt: () => new Promise(() => {}),
+      kill: mock(() => {}),
+      cancel: mock(() => Promise.reject(new Error("adapter down"))),
+    };
+    const entry = injectSession(
+      manager,
+      "sess-cancel-throw",
+      "parent-cancel-throw",
+      proc as unknown as ReturnType<typeof fakeProcess>,
+    );
+    // A prompt is still in flight; cancel must not tear it down on failure.
+    entry.currentPrompt = new Promise(() => {});
+
+    await expect((manager as any).cancel("sess-cancel-throw")).rejects.toThrow(
+      "adapter down",
+    );
+    expect(entry.state.status).toBe("running");
   });
 
   test("a superseded prompt does not notify the parent", async () => {

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { VellumAcpClientHandler } from "./client-handler.js";
+import { AcpSessionManager } from "./session-manager.js";
+
+// Parent conversations registered per test; torn down in afterEach so the
+// shared registry does not leak state between cases.
+const registered: string[] = [];
+
+afterEach(() => {
+  for (const id of registered.splice(0)) {
+    deleteConversation(id);
+  }
+});
+
+/**
+ * A duck-typed parent conversation exposing only the three methods
+ * `notifyParent` touches. `enqueueMessage` returns not-queued by default so the
+ * persist + runAgentLoop branch runs and the metadata can be asserted; pass
+ * `enqueueQueued: true` to exercise the enqueue branch instead.
+ */
+function mockConversation(opts?: { enqueueQueued?: boolean }) {
+  const enqueueMessage = mock(() => ({
+    queued: opts?.enqueueQueued ?? false,
+    requestId: "req-1",
+    rejected: false,
+  }));
+  const persistUserMessage = mock(async () => ({
+    id: "msg-1",
+    deduplicated: false,
+  }));
+  let resolveLoop!: () => void;
+  const loopRan = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+  const runAgentLoop = mock(async () => {
+    resolveLoop();
+  });
+  const conversation = {
+    enqueueMessage,
+    persistUserMessage,
+    runAgentLoop,
+  } as unknown as Conversation;
+  return {
+    conversation,
+    enqueueMessage,
+    persistUserMessage,
+    runAgentLoop,
+    loopRan,
+  };
+}
+
+/** Fake AcpAgentProcess covering only the calls firePromptInBackground makes. */
+function fakeProcess(prompt: () => Promise<unknown>) {
+  return {
+    markStderr: () => 0,
+    stderrSince: () => "",
+    prompt,
+    kill: mock(() => {}),
+  };
+}
+
+/** Injects a running session directly into the manager (no child process). */
+function injectSession(
+  manager: AcpSessionManager,
+  acpSessionId: string,
+  parentConversationId: string,
+  process: ReturnType<typeof fakeProcess>,
+) {
+  const sendToVellum = mock(() => {});
+  const clientHandler = new VellumAcpClientHandler(
+    acpSessionId,
+    sendToVellum,
+    parentConversationId,
+  );
+  const entry = {
+    process,
+    state: {
+      id: acpSessionId,
+      agentId: "claude",
+      acpSessionId: "proto-1",
+      parentConversationId,
+      status: "running" as string,
+      startedAt: Date.now(),
+    },
+    clientHandler,
+    sendToVellum,
+    currentPrompt: null as unknown,
+    parentConversationId,
+    cwd: "/tmp",
+    command: "noop",
+  };
+  (manager as any).sessions.set(acpSessionId, entry);
+  return entry;
+}
+
+function fire(
+  manager: AcpSessionManager,
+  acpSessionId: string,
+  entry: ReturnType<typeof injectSession>,
+): Promise<unknown> {
+  const bg = (manager as any).firePromptInBackground(
+    acpSessionId,
+    entry,
+    "proto-1",
+    "do it",
+  );
+  entry.currentPrompt = bg;
+  return bg;
+}
+
+describe("AcpSessionManager parent notification", () => {
+  test("prompt failure notifies the parent once with the failed message + acpNotification metadata", async () => {
+    const manager = new AcpSessionManager(1);
+    const {
+      conversation,
+      enqueueMessage,
+      persistUserMessage,
+      runAgentLoop,
+      loopRan,
+    } = mockConversation();
+    setConversation("parent-fail", conversation);
+    registered.push("parent-fail");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-fail", "parent-fail", proc);
+
+    await fire(manager, "sess-fail", entry);
+    await loopRan;
+
+    // Exactly one notification (enqueue returned not-queued, so persist+loop).
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    const persistArg = persistUserMessage.mock.calls[0][0] as {
+      content: string;
+      metadata: unknown;
+    };
+    expect(persistArg.content).toBe('[ACP agent "claude" failed]\n\nboom');
+    expect(persistArg.metadata).toEqual({
+      acpNotification: { acpSessionId: "proto-1", agent: "claude" },
+    });
+
+    // Session was torn down on failure.
+    expect((manager.getStatus() as unknown[]).length).toBe(0);
+    expect(proc.kill).toHaveBeenCalled();
+  });
+
+  test("prompt success still notifies the parent exactly once", async () => {
+    const manager = new AcpSessionManager(1);
+    const {
+      conversation,
+      enqueueMessage,
+      persistUserMessage,
+      runAgentLoop,
+      loopRan,
+    } = mockConversation();
+    setConversation("parent-ok", conversation);
+    registered.push("parent-ok");
+
+    const proc = fakeProcess(() => Promise.resolve({ stopReason: "end_turn" }));
+    const entry = injectSession(manager, "sess-ok", "parent-ok", proc);
+
+    await fire(manager, "sess-ok", entry);
+    await loopRan;
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    const persistArg = persistUserMessage.mock.calls[0][0] as {
+      content: string;
+      metadata: unknown;
+    };
+    expect(
+      persistArg.content.startsWith('[ACP agent "claude" completed]'),
+    ).toBe(true);
+    expect(persistArg.metadata).toEqual({
+      acpNotification: { acpSessionId: "proto-1", agent: "claude" },
+    });
+  });
+
+  test("a cancelled session does not notify the parent on failure", async () => {
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-cancel", conversation);
+    registered.push("parent-cancel");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-cancel", "parent-cancel", proc);
+    // Simulate a user cancel landing before the rejection settles.
+    entry.state.status = "cancelled";
+
+    await fire(manager, "sess-cancel", entry);
+    // Any notification would have called enqueue synchronously inside the catch.
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("a superseded prompt does not notify the parent", async () => {
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-stale", conversation);
+    registered.push("parent-stale");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-stale", "parent-stale", proc);
+
+    const bg = (manager as any).firePromptInBackground(
+      entry.state.id,
+      entry,
+      "proto-1",
+      "do it",
+    );
+    // A concurrent steer superseded this prompt: currentPrompt no longer
+    // points at it, so the whole catch body (including notify) is skipped.
+    entry.currentPrompt = null;
+    await bg;
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    // The stale catch left the session in place (no teardown).
+    expect((manager.getStatus() as unknown[]).length).toBe(1);
+  });
+});

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -202,6 +202,27 @@ describe("AcpSessionManager parent notification", () => {
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
+  test("a cancelled session does not notify the parent on success", async () => {
+    // A prompt can win the cancel race by resolving normally; a user stop must
+    // still not wake the parent with a completion.
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-cancel-ok", conversation);
+    registered.push("parent-cancel-ok");
+
+    const proc = fakeProcess(() => Promise.resolve({ stopReason: "end_turn" }));
+    const entry = injectSession(
+      manager,
+      "sess-cancel-ok",
+      "parent-cancel-ok",
+      proc,
+    );
+    entry.state.status = "cancelled";
+
+    await fire(manager, "sess-cancel-ok", entry);
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
   test("cancel marks the session cancelled before the protocol cancel resolves", async () => {
     // Guards the cancel race: if the in-flight prompt rejects while
     // process.cancel is still pending, the failure gate must already see

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -200,6 +200,11 @@ describe("AcpSessionManager parent notification", () => {
     await fire(manager, "sess-cancel", entry);
     // Any notification would have called enqueue synchronously inside the catch.
     expect(enqueueMessage).not.toHaveBeenCalled();
+    // Nor a terminal error event (would regress the optimistic Cancelled state).
+    const sentTypes = (entry.sendToVellum.mock.calls as unknown[][]).map(
+      (c) => (c[0] as { type?: string })?.type,
+    );
+    expect(sentTypes).not.toContain("acp_session_error");
   });
 
   test("a cancelled session does not notify the parent on success", async () => {
@@ -221,6 +226,12 @@ describe("AcpSessionManager parent notification", () => {
 
     await fire(manager, "sess-cancel-ok", entry);
     expect(enqueueMessage).not.toHaveBeenCalled();
+    // Nor a completed terminal event: it would regress the client's optimistic
+    // Cancelled state to Completed while history is stored as cancelled.
+    const sentTypes = (entry.sendToVellum.mock.calls as unknown[][]).map(
+      (c) => (c[0] as { type?: string })?.type,
+    );
+    expect(sentTypes).not.toContain("acp_session_completed");
   });
 
   test("cancel marks the session cancelled before the protocol cancel resolves", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1028,57 +1028,19 @@ export class AcpSessionManager {
           // kill the agent process.
           this.teardownSession(acpSessionId, current);
 
-          // Notify parent session so the LLM sees the agent's output
+          // Notify parent session so the LLM sees the agent's output.
           const agentLabel = current.state.agentId;
           const responseText = current.clientHandler.responseText;
-          const sessionId = current.state.acpSessionId;
           const hint = claudeResumeHint(
             current.command,
             current.cwd,
-            sessionId,
+            current.state.acpSessionId,
           );
           const resumeHint = hint ? `\n\n${hint}` : "";
-          const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`;
-          // Tag the injected message so the daemon skips its user_message_echo
-          // and the client filters it from the rendered transcript — the user
-          // sees the run through its inline card, not a chat turn.
-          const acpNotification = {
-            acpSessionId: sessionId,
-            agent: agentLabel,
-          };
-          const parentConversation = findConversation(
-            current.parentConversationId,
+          this.notifyParent(
+            current,
+            `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`,
           );
-          if (parentConversation) {
-            const enqueueResult = parentConversation.enqueueMessage({
-              content: notifyMessage,
-              metadata: { acpNotification },
-            });
-            if (!enqueueResult.queued && !enqueueResult.rejected) {
-              parentConversation
-                .persistUserMessage({
-                  content: notifyMessage,
-                  metadata: { acpNotification },
-                })
-                .then(({ id: messageId }) =>
-                  parentConversation.runAgentLoop(notifyMessage, messageId),
-                )
-                .catch((err) => {
-                  log.error(
-                    {
-                      parentConversationId: current.parentConversationId,
-                      err,
-                    },
-                    "Failed to process ACP notification in parent",
-                  );
-                });
-            }
-          } else {
-            log.warn(
-              { parentConversationId: current.parentConversationId },
-              "ACP agent finished but parent conversation not found",
-            );
-          }
         }
       })
       .catch((err: Error) => {
@@ -1113,10 +1075,66 @@ export class AcpSessionManager {
 
           // Free the session slot and deny any pending permissions.
           this.teardownSession(acpSessionId, current);
+
+          // Wake the parent with the failure (mirrors the success path) so
+          // the assistant reports it instead of silently re-spawning. Skip
+          // when cancelled: a user-cancelled run tears down silently and must
+          // not inject a turn. teardownSession leaves state intact, so the
+          // agentId read below is still valid.
+          if (current.state.status !== "cancelled") {
+            this.notifyParent(
+              current,
+              `[ACP agent "${current.state.agentId}" failed]\n\n${failureMessage}`,
+            );
+          }
         }
       });
 
     return promptPromise;
+  }
+
+  /**
+   * Injects an ACP run's outcome into its parent conversation. Shared by the
+   * success and failure paths of firePromptInBackground so a hard failure
+   * reaches the parent (and its inline card) exactly like a completion does.
+   *
+   * The message carries `acpNotification` metadata so the daemon skips its
+   * user_message_echo and the client filters it from the rendered transcript —
+   * the user sees the run through its inline card, not a raw chat turn, while
+   * the LLM still receives the text.
+   *
+   * Reads `entry.state.acpSessionId`/`agentId`, which teardownSession leaves
+   * intact, so callers may invoke this after tearing the session down.
+   */
+  private notifyParent(entry: SessionEntry, message: string): void {
+    const acpNotification = {
+      acpSessionId: entry.state.acpSessionId,
+      agent: entry.state.agentId,
+    };
+    const parentConversation = findConversation(entry.parentConversationId);
+    if (!parentConversation) {
+      log.warn(
+        { parentConversationId: entry.parentConversationId },
+        "ACP agent finished but parent conversation not found",
+      );
+      return;
+    }
+    const enqueueResult = parentConversation.enqueueMessage({
+      content: message,
+      metadata: { acpNotification },
+    });
+    if (enqueueResult.queued || enqueueResult.rejected) return;
+    parentConversation
+      .persistUserMessage({ content: message, metadata: { acpNotification } })
+      .then(({ id: messageId }) =>
+        parentConversation.runAgentLoop(message, messageId),
+      )
+      .catch((err) => {
+        log.error(
+          { parentConversationId: entry.parentConversationId, err },
+          "Failed to process ACP notification in parent",
+        );
+      });
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1018,11 +1018,18 @@ export class AcpSessionManager {
             { acpSessionId, stopReason: response.stopReason },
             "ACP prompt completed",
           );
-          current.sendToVellum({
-            type: "acp_session_completed",
-            acpSessionId,
-            stopReason: response.stopReason,
-          });
+          // Skip the completed terminal event when the session was already
+          // cancelled (a prompt can win the cancel race by resolving normally):
+          // emitting it would regress the client's optimistic Cancelled state to
+          // Completed while history persists as cancelled. persistTerminal below
+          // records the preserved "cancelled" status.
+          if (current.state.status !== "cancelled") {
+            current.sendToVellum({
+              type: "acp_session_completed",
+              acpSessionId,
+              stopReason: response.stopReason,
+            });
+          }
 
           // Persist the terminal row + buffered event log before tearing
           // down (teardown deletes the buffer entry).
@@ -1073,11 +1080,15 @@ export class AcpSessionManager {
             { acpSessionId, error: err.message, failureMessage },
             "ACP prompt failed",
           );
-          current.sendToVellum({
-            type: "acp_session_error",
-            acpSessionId,
-            error: failureMessage,
-          });
+          // Skip the error terminal event when already cancelled (same cancel
+          // race as the success path): a user stop must not surface an error.
+          if (current.state.status !== "cancelled") {
+            current.sendToVellum({
+              type: "acp_session_error",
+              acpSessionId,
+              error: failureMessage,
+            });
+          }
 
           // Persist the terminal row before teardown clears the buffer.
           this.persistTerminal(acpSessionId, current);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -744,9 +744,24 @@ export class AcpSessionManager {
     // prompt rejects during this window, its catch handler must already see
     // "cancelled" so it neither overwrites the status with "failed" nor wakes
     // the parent — no model activity may follow a user stop.
+    const prevStatus = entry.state.status;
+    const prevCompletedAt = entry.state.completedAt;
     entry.state.status = "cancelled";
     entry.state.completedAt = Date.now();
-    await entry.process.cancel(entry.state.acpSessionId);
+    try {
+      await entry.process.cancel(entry.state.acpSessionId);
+    } catch (err) {
+      // The protocol cancel failed (e.g. the adapter connection is already
+      // down): the session was NOT actually cancelled, so restore the prior
+      // status. Otherwise the still-running prompt's eventual completion would
+      // be wrongly suppressed and persisted as cancelled. Rethrow so the caller
+      // reports failure and the client rolls back its optimistic cancel.
+      if (this.sessions.get(acpSessionId) === entry) {
+        entry.state.status = prevStatus;
+        entry.state.completedAt = prevCompletedAt;
+      }
+      throw err;
+    }
     // Re-check the map after the await: the in-flight prompt's handler may
     // have already torn the session down while process.cancel was pending.
     if (!entry.currentPrompt && this.sessions.get(acpSessionId) === entry) {
@@ -1018,18 +1033,11 @@ export class AcpSessionManager {
             { acpSessionId, stopReason: response.stopReason },
             "ACP prompt completed",
           );
-          // Skip the completed terminal event when the session was already
-          // cancelled (a prompt can win the cancel race by resolving normally):
-          // emitting it would regress the client's optimistic Cancelled state to
-          // Completed while history persists as cancelled. persistTerminal below
-          // records the preserved "cancelled" status.
-          if (current.state.status !== "cancelled") {
-            current.sendToVellum({
-              type: "acp_session_completed",
-              acpSessionId,
-              stopReason: response.stopReason,
-            });
-          }
+          current.sendToVellum({
+            type: "acp_session_completed",
+            acpSessionId,
+            stopReason: response.stopReason,
+          });
 
           // Persist the terminal row + buffered event log before tearing
           // down (teardown deletes the buffer entry).
@@ -1080,15 +1088,11 @@ export class AcpSessionManager {
             { acpSessionId, error: err.message, failureMessage },
             "ACP prompt failed",
           );
-          // Skip the error terminal event when already cancelled (same cancel
-          // race as the success path): a user stop must not surface an error.
-          if (current.state.status !== "cancelled") {
-            current.sendToVellum({
-              type: "acp_session_error",
-              acpSessionId,
-              error: failureMessage,
-            });
-          }
+          current.sendToVellum({
+            type: "acp_session_error",
+            acpSessionId,
+            error: failureMessage,
+          });
 
           // Persist the terminal row before teardown clears the buffer.
           this.persistTerminal(acpSessionId, current);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -740,9 +740,13 @@ export class AcpSessionManager {
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
-    await entry.process.cancel(entry.state.acpSessionId);
+    // Mark cancelled BEFORE awaiting the protocol cancel. If the in-flight
+    // prompt rejects during this window, its catch handler must already see
+    // "cancelled" so it neither overwrites the status with "failed" nor wakes
+    // the parent — no model activity may follow a user stop.
     entry.state.status = "cancelled";
     entry.state.completedAt = Date.now();
+    await entry.process.cancel(entry.state.acpSessionId);
     // Re-check the map after the await: the in-flight prompt's handler may
     // have already torn the session down while process.cancel was pending.
     if (!entry.currentPrompt && this.sessions.get(acpSessionId) === entry) {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1041,10 +1041,15 @@ export class AcpSessionManager {
             current.state.acpSessionId,
           );
           const resumeHint = hint ? `\n\n${hint}` : "";
-          this.notifyParent(
-            current,
-            `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`,
-          );
+          // Skip when cancelled: a prompt can win the cancel race by resolving
+          // normally, but a user stop must not enqueue a completion and wake the
+          // parent (mirrors the failure-path gate below).
+          if (current.state.status !== "cancelled") {
+            this.notifyParent(
+              current,
+              `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`,
+            );
+          }
         }
       })
       .catch((err: Error) => {


### PR DESCRIPTION
## Summary
- Extract notifyParent() and call it from the failure path so ACP failures reach the parent conversation (tagged acpNotification), not just the SSE error event.

Part of plan: acp-failure-surfacing.md (PR 3 of 4)