### PR TITLE
fix(acp): bound retained stderr so the failure scan can't go quadratic

### DIFF
--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -56,12 +56,17 @@ describe("AcpAgentProcess.recentStderr", () => {
     expect(indices).toEqual(sorted);
   });
 
-  test("keeps at least the newest line even when it alone exceeds the cap", () => {
+  test("keeps the newest line but truncates it to the cap when it alone exceeds it", () => {
     const proc = newProcess();
     const huge = "y".repeat(8192);
     feed(proc, huge);
 
-    expect(proc.recentStderr()).toBe(huge);
+    // The newest line is preserved (not dropped) but capped so one oversized
+    // chunk can't blow the ring budget or make the failure-path stderr scan
+    // super-linear on huge input.
+    const retained = proc.recentStderr();
+    expect(retained.length).toBe(4096);
+    expect(retained).toBe("y".repeat(4096));
   });
 
   test("recentStderr is pure: repeated reads do not clear the buffer", () => {

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -56,17 +56,16 @@ describe("AcpAgentProcess.recentStderr", () => {
     expect(indices).toEqual(sorted);
   });
 
-  test("keeps the newest line but truncates it to the cap when it alone exceeds it", () => {
+  test("truncates an oversized line to the cap, keeping its tail (the diagnostic)", () => {
     const proc = newProcess();
-    const huge = "y".repeat(8192);
+    // The real adapter error sits at the END of the chunk; deriveFailureError
+    // reads from the tail, so truncation must drop the head, not the tail.
+    const huge = "H".repeat(6000) + "TAIL_DIAGNOSTIC";
     feed(proc, huge);
 
-    // The newest line is preserved (not dropped) but capped so one oversized
-    // chunk can't blow the ring budget or make the failure-path stderr scan
-    // super-linear on huge input.
     const retained = proc.recentStderr();
     expect(retained.length).toBe(4096);
-    expect(retained).toBe("y".repeat(4096));
+    expect(retained.endsWith("TAIL_DIAGNOSTIC")).toBe(true);
   });
 
   test("recentStderr is pure: repeated reads do not clear the buffer", () => {

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -151,9 +151,16 @@ export class AcpAgentProcess {
    * so a single oversized line is not fully dropped.
    */
   private retainStderr(text: string): void {
+    // Cap a single oversized line: the "keep newest" rule below never evicts it,
+    // so an untruncated multi-MB chunk would blow the ring budget and make the
+    // failure-path stderr scan (deriveFailureError) super-linear on huge input.
+    const line =
+      text.length > STDERR_RETENTION_BYTES
+        ? text.slice(0, STDERR_RETENTION_BYTES)
+        : text;
     this.stderrSeq += 1;
-    this.stderrRing.push({ seq: this.stderrSeq, text });
-    this.stderrRingBytes += Buffer.byteLength(text);
+    this.stderrRing.push({ seq: this.stderrSeq, text: line });
+    this.stderrRingBytes += Buffer.byteLength(line);
     while (
       this.stderrRingBytes > STDERR_RETENTION_BYTES &&
       this.stderrRing.length > 1

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -154,9 +154,11 @@ export class AcpAgentProcess {
     // Cap a single oversized line: the "keep newest" rule below never evicts it,
     // so an untruncated multi-MB chunk would blow the ring budget and make the
     // failure-path stderr scan (deriveFailureError) super-linear on huge input.
+    // Keep the TAIL: the adapter's error JSON / last line sits at the end, and
+    // deriveFailureError reads from the end, so dropping the head is lossless.
     const line =
       text.length > STDERR_RETENTION_BYTES
-        ? text.slice(0, STDERR_RETENTION_BYTES)
+        ? text.slice(-STDERR_RETENTION_BYTES)
         : text;
     this.stderrSeq += 1;
     this.stderrRing.push({ seq: this.stderrSeq, text: line });


### PR DESCRIPTION
## Summary
- Truncate a single oversized stderr line when retaining it, so recentStderr()/stderrSince() are always bounded and the failure-path scan (deriveFailureError) can't become O(n^2) on a huge chunk and block the event loop.

Follow-up to PR #36875 (codex P2 'avoid quadratic stderr scans'). Part of plan: acp-failure-surfacing.md