### PR TITLE
fix(attachments): store HEIC uploads as JPEG and render legacy HEIC in history

### DIFF
--- a/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
+++ b/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Wiring tests for HEIF/HEIC storage normalization: user-sourced ingress
+ * paths store a JPEG master (rewritten filename, mime, size, bytes) while
+ * register and assistant-outbound paths keep content verbatim.
+ *
+ * The converter module is mocked (keyed on the declared mime type) so these
+ * tests run identically with and without macOS sips; real conversion is
+ * covered in image-conversion.test.ts. mock.module is process-global — keep
+ * these cases in this file.
+ */
+
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({}),
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getAssistantDomain: () => "vellum.me",
+}));
+
+const FAKE_JPEG = Buffer.from("fake-jpeg-master-bytes");
+const FAKE_JPEG_B64 = FAKE_JPEG.toString("base64");
+
+mock.module("../util/image-conversion.js", () => ({
+  convertImageToJpeg: () => FAKE_JPEG,
+  isHeifImage: (bytes: Uint8Array) => bytes.length >= 12,
+  jpegFilenameFor: (filename: string) =>
+    `${filename.replace(/\.[^./\\]+$/, "")}.jpg`,
+  normalizeImageBytes: (mimeType: string, bytes: Uint8Array) =>
+    mimeType === "image/heic"
+      ? { mimeType: "image/jpeg", bytes: FAKE_JPEG, converted: true }
+      : { mimeType, bytes, converted: false },
+  normalizeImageBase64: (mimeType: string, dataBase64: string) =>
+    mimeType === "image/heic"
+      ? { mimeType: "image/jpeg", dataBase64: FAKE_JPEG_B64, converted: true }
+      : { mimeType, dataBase64, converted: false },
+}));
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  attachInlineAttachmentToMessage,
+  getAttachmentById,
+  getFilePathForAttachment,
+  uploadAttachment,
+  uploadAttachmentFromBytes,
+} from "../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  attachmentMetadataSchema,
+  ROUTES,
+} from "../runtime/routes/attachment-routes.js";
+import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { fakeHeifHeaderBytes } from "./heic-fixture.js";
+
+const uploadRoute = ROUTES.find((r) => r.operationId === "attachment_upload")!;
+const registerRoute = ROUTES.find(
+  (r) => r.operationId === "attachment_register",
+)!;
+
+const HEIC_BYTES = fakeHeifHeaderBytes();
+const HEIC_B64 = HEIC_BYTES.toString("base64");
+
+function jsonUploadArgs(body: Record<string, unknown>): RouteHandlerArgs {
+  return {
+    body,
+    rawBody: new TextEncoder().encode(JSON.stringify(body)),
+    headers: { "content-type": "application/json" },
+    queryParams: {},
+  };
+}
+
+describe("HEIC upload normalization wiring", () => {
+  beforeAll(async () => {
+    await initializeDb();
+  }, 30_000);
+
+  test("uploadAttachmentFromBytes stores a JPEG master for HEIC", () => {
+    const stored = uploadAttachmentFromBytes(
+      "IMG_5487.HEIC",
+      "image/heic",
+      HEIC_BYTES,
+    );
+
+    expect(stored.originalFilename).toBe("IMG_5487.jpg");
+    expect(stored.mimeType).toBe("image/jpeg");
+    expect(stored.sizeBytes).toBe(FAKE_JPEG.length);
+    const stagedPath = getFilePathForAttachment(stored.id);
+    expect(stagedPath).not.toBeNull();
+    expect(readFileSync(stagedPath!).equals(FAKE_JPEG)).toBe(true);
+  });
+
+  test("uploadAttachmentFromBytes leaves non-HEIC uploads verbatim", () => {
+    const stored = uploadAttachmentFromBytes(
+      "photo.png",
+      "image/png",
+      HEIC_BYTES,
+    );
+
+    expect(stored.originalFilename).toBe("photo.png");
+    expect(stored.mimeType).toBe("image/png");
+    expect(stored.sizeBytes).toBe(HEIC_BYTES.length);
+  });
+
+  test("uploadAttachment (base64) stores a JPEG master for HEIC", () => {
+    const stored = uploadAttachment("IMG_1.heic", "image/heic", HEIC_B64);
+
+    expect(stored.originalFilename).toBe("IMG_1.jpg");
+    expect(stored.mimeType).toBe("image/jpeg");
+    expect(stored.sizeBytes).toBe(FAKE_JPEG.length);
+    const row = getAttachmentById(stored.id);
+    expect(row?.dataBase64).toBe(FAKE_JPEG_B64);
+  });
+
+  test("uploadAttachment (base64) leaves non-HEIC uploads verbatim", () => {
+    const stored = uploadAttachment("photo.png", "image/png", HEIC_B64);
+
+    expect(stored.originalFilename).toBe("photo.png");
+    expect(stored.mimeType).toBe("image/png");
+    expect(stored.sizeBytes).toBe(HEIC_BYTES.length);
+  });
+
+  test("attachInlineAttachmentToMessage normalizes only when opted in", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "photos" }]),
+    );
+
+    const normalized = attachInlineAttachmentToMessage(
+      msg.id,
+      0,
+      "IMG_2.HEIC",
+      "image/heic",
+      HEIC_B64,
+      { normalizeImage: true },
+    );
+    expect(normalized.originalFilename).toBe("IMG_2.jpg");
+    expect(normalized.mimeType).toBe("image/jpeg");
+
+    // Assistant-outbound attachments are stored verbatim: no normalizeImage
+    // flag, no rewrite, even for HEIC content.
+    const verbatim = attachInlineAttachmentToMessage(
+      msg.id,
+      1,
+      "IMG_3.HEIC",
+      "image/heic",
+      HEIC_B64,
+    );
+    expect(verbatim.originalFilename).toBe("IMG_3.HEIC");
+    expect(verbatim.mimeType).toBe("image/heic");
+    expect(verbatim.sizeBytes).toBe(HEIC_BYTES.length);
+  });
+
+  test("JSON file-path upload converts the daemon-owned copy", async () => {
+    const sourceDir = mkdtempSync(join(tmpdir(), "vellum-heic-src-"));
+    const sourcePath = join(sourceDir, "IMG_4.HEIC");
+    writeFileSync(sourcePath, HEIC_BYTES);
+
+    const raw = await uploadRoute.handler(
+      jsonUploadArgs({
+        filename: "IMG_4.HEIC",
+        mimeType: "image/heic",
+        filePath: sourcePath,
+      }),
+    );
+    const result = attachmentMetadataSchema.parse(raw);
+
+    expect(result.filename).toBe("IMG_4.jpg");
+    expect(result.mimeType).toBe("image/jpeg");
+    expect(result.sizeBytes).toBe(FAKE_JPEG.length);
+    // The caller's source file is never mutated.
+    expect(readFileSync(sourcePath).equals(HEIC_BYTES)).toBe(true);
+    // The staged raw copy is replaced by the converted one.
+    const stagedPath = getFilePathForAttachment(result.id);
+    expect(stagedPath).not.toBeNull();
+    expect(stagedPath!.endsWith(".jpg")).toBe(true);
+    expect(readFileSync(stagedPath!).equals(FAKE_JPEG)).toBe(true);
+  });
+
+  test("attachment register keeps workspace files verbatim", async () => {
+    const registerDir = join(getWorkspaceDir(), "register-fixtures");
+    mkdirSync(registerDir, { recursive: true });
+    const registeredPath = join(registerDir, "IMG_5.HEIC");
+    writeFileSync(registeredPath, HEIC_BYTES);
+
+    const raw = await registerRoute.handler(
+      jsonUploadArgs({
+        path: registeredPath,
+        mimeType: "image/heic",
+        filename: "IMG_5.HEIC",
+      }),
+    );
+    const result = raw as {
+      originalFilename: string;
+      mimeType: string;
+    };
+
+    expect(result.originalFilename).toBe("IMG_5.HEIC");
+    expect(result.mimeType).toBe("image/heic");
+    // Registered files are referenced in place, never rewritten.
+    expect(existsSync(registeredPath)).toBe(true);
+    expect(readFileSync(registeredPath).equals(HEIC_BYTES)).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/heic-fixture.ts
+++ b/assistant/src/__tests__/heic-fixture.ts
@@ -1,0 +1,55 @@
+/**
+ * HEIC fixture helpers for image-conversion tests.
+ *
+ * Real HEIC bytes can only be produced where `sips` exists (macOS), so
+ * consumers gate those tests with `describe.skipIf(process.platform !==
+ * "darwin")`. The fake-header helper works everywhere and exercises the
+ * conversion-failure fallback: the ftyp sniff accepts it, sips rejects it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PNG_1PX_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+/**
+ * Create real HEIC bytes via macOS `sips` (1×1 PNG upscaled to 64×64, then
+ * HEIC-encoded). Returns null when sips is unavailable or fails.
+ */
+export function makeHeicFixtureBytes(): Buffer | null {
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "vellum-heic-fixture-"));
+    const pngPath = join(dir, "src.png");
+    const bigPngPath = join(dir, "big.png");
+    const heicPath = join(dir, "out.heic");
+    writeFileSync(pngPath, Buffer.from(PNG_1PX_BASE64, "base64"));
+    execFileSync("sips", ["-z", "64", "64", pngPath, "--out", bigPngPath], {
+      stdio: "pipe",
+    });
+    execFileSync(
+      "sips",
+      ["-s", "format", "heic", bigPngPath, "--out", heicPath],
+      { stdio: "pipe" },
+    );
+    return readFileSync(heicPath) as Buffer;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A syntactically valid HEIF ftyp header followed by nothing decodable.
+ * Sniffs as HEIF but fails conversion on every platform.
+ */
+export function fakeHeifHeaderBytes(brand = "heic"): Buffer {
+  const buf = Buffer.alloc(24);
+  buf.writeUInt32BE(24, 0);
+  buf.write("ftyp", 4, "ascii");
+  buf.write(brand, 8, "ascii");
+  return buf;
+}
+
+export const PNG_1PX_BYTES = Buffer.from(PNG_1PX_BASE64, "base64");

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the shared sips-backed image converter.
+ *
+ * Pure logic (ftyp sniffing, filename rewriting, passthrough behavior) runs
+ * everywhere; actual conversion requires macOS `sips`, so those cases are
+ * gated on darwin.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  convertImageToJpeg,
+  isHeifImage,
+  jpegFilenameFor,
+  normalizeImageBase64,
+  normalizeImageBytes,
+} from "../util/image-conversion.js";
+import {
+  fakeHeifHeaderBytes,
+  makeHeicFixtureBytes,
+  PNG_1PX_BYTES,
+} from "./heic-fixture.js";
+
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff]);
+
+function startsWithJpegMagic(bytes: Uint8Array): boolean {
+  return Buffer.from(bytes.slice(0, 3)).equals(JPEG_MAGIC);
+}
+
+describe("isHeifImage", () => {
+  test("accepts HEIF ftyp brands", () => {
+    for (const brand of ["heic", "heix", "heif", "mif1", "msf1", "hevc"]) {
+      expect(isHeifImage(fakeHeifHeaderBytes(brand))).toBe(true);
+    }
+  });
+
+  test("rejects AVIF brands (Chromium decodes AVIF natively)", () => {
+    expect(isHeifImage(fakeHeifHeaderBytes("avif"))).toBe(false);
+    expect(isHeifImage(fakeHeifHeaderBytes("avis"))).toBe(false);
+  });
+
+  test("rejects non-ISO-BMFF content", () => {
+    expect(isHeifImage(PNG_1PX_BYTES)).toBe(false);
+    expect(isHeifImage(Buffer.from("plain text content"))).toBe(false);
+  });
+
+  test("rejects buffers shorter than the sniff window", () => {
+    expect(isHeifImage(Buffer.alloc(0))).toBe(false);
+    expect(isHeifImage(Buffer.from("ftypheic"))).toBe(false);
+  });
+});
+
+describe("jpegFilenameFor", () => {
+  test("rewrites the extension to .jpg", () => {
+    expect(jpegFilenameFor("IMG_5487.HEIC")).toBe("IMG_5487.jpg");
+    expect(jpegFilenameFor("photo.heif")).toBe("photo.jpg");
+    expect(jpegFilenameFor("archive.tar.gz")).toBe("archive.tar.jpg");
+  });
+
+  test("keeps existing .jpg/.jpeg extensions", () => {
+    expect(jpegFilenameFor("photo.jpg")).toBe("photo.jpg");
+    expect(jpegFilenameFor("photo.JPEG")).toBe("photo.JPEG");
+  });
+
+  test("handles missing or empty names", () => {
+    expect(jpegFilenameFor("photo")).toBe("photo.jpg");
+    expect(jpegFilenameFor("")).toBe("attachment.jpg");
+    expect(jpegFilenameFor(".heic")).toBe("attachment.jpg");
+  });
+});
+
+describe("normalizeImageBytes passthrough", () => {
+  test("non-HEIF bytes pass through untouched", () => {
+    const result = normalizeImageBytes("image/png", PNG_1PX_BYTES);
+    expect(result.converted).toBe(false);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.bytes).toBe(PNG_1PX_BYTES);
+  });
+
+  test("HEIF header with undecodable payload passes through", () => {
+    // sips fails (or is absent off-macOS) → the original bytes are kept.
+    const fake = fakeHeifHeaderBytes();
+    const result = normalizeImageBytes("image/heic", fake);
+    expect(result.converted).toBe(false);
+    expect(result.mimeType).toBe("image/heic");
+    expect(result.bytes).toBe(fake);
+  });
+});
+
+describe("normalizeImageBase64 passthrough", () => {
+  test("non-HEIF payloads skip conversion", () => {
+    const b64 = PNG_1PX_BYTES.toString("base64");
+    const result = normalizeImageBase64("image/png", b64);
+    expect(result.converted).toBe(false);
+    expect(result.dataBase64).toBe(b64);
+  });
+});
+
+describe.skipIf(process.platform !== "darwin")(
+  "real HEIC conversion (sips)",
+  () => {
+    let heicBytes: Buffer;
+
+    beforeAll(() => {
+      const fixture = makeHeicFixtureBytes();
+      if (!fixture) {
+        throw new Error("sips failed to produce a HEIC fixture on darwin");
+      }
+      heicBytes = fixture;
+    });
+
+    test("fixture sniffs as HEIF", () => {
+      expect(isHeifImage(heicBytes)).toBe(true);
+    });
+
+    test("convertImageToJpeg produces JPEG bytes", () => {
+      const converted = convertImageToJpeg(heicBytes);
+      expect(converted).not.toBeNull();
+      expect(startsWithJpegMagic(converted!)).toBe(true);
+    });
+
+    test("conversion options produce distinct outputs (cache key isolation)", () => {
+      // A hash-only cache key would make the second call return the first
+      // call's cached full-resolution output.
+      const fullRes = convertImageToJpeg(heicBytes, { quality: 90 });
+      const downscaled = convertImageToJpeg(heicBytes, {
+        maxDimensionPx: 16,
+        quality: 90,
+      });
+      expect(fullRes).not.toBeNull();
+      expect(downscaled).not.toBeNull();
+      expect(fullRes!.equals(downscaled!)).toBe(false);
+    });
+
+    test("repeated conversion is stable (cache round-trip)", () => {
+      const first = convertImageToJpeg(heicBytes, { quality: 90 });
+      const second = convertImageToJpeg(heicBytes, { quality: 90 });
+      expect(first).not.toBeNull();
+      expect(second).not.toBeNull();
+      expect(first!.equals(second!)).toBe(true);
+    });
+
+    test("normalizeImageBytes converts to a JPEG master", () => {
+      const result = normalizeImageBytes("image/heic", heicBytes);
+      expect(result.converted).toBe(true);
+      expect(result.mimeType).toBe("image/jpeg");
+      expect(startsWithJpegMagic(result.bytes)).toBe(true);
+    });
+
+    test("normalizeImageBytes converts even when the declared mime is wrong", () => {
+      // Chromium reports empty file.type for .heic; clients coerce it to
+      // application/octet-stream. Detection is content-based.
+      const result = normalizeImageBytes("application/octet-stream", heicBytes);
+      expect(result.converted).toBe(true);
+      expect(result.mimeType).toBe("image/jpeg");
+    });
+
+    test("normalizeImageBase64 converts and re-encodes", () => {
+      const result = normalizeImageBase64(
+        "image/heic",
+        heicBytes.toString("base64"),
+      );
+      expect(result.converted).toBe(true);
+      expect(result.mimeType).toBe("image/jpeg");
+      expect(
+        startsWithJpegMagic(Buffer.from(result.dataBase64, "base64")),
+      ).toBe(true);
+    });
+  },
+);

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -5,6 +5,8 @@
  * - User message image attachments include base64 data for client thumbnail generation
  * - User message non-image attachments stay metadata-only (no base64 blob)
  * - Assistant message image attachments include base64 data (same as user messages)
+ * - Stored HEIF/HEIC rows are hydrated as JPEG display data (Chromium cannot
+ *   decode HEIF); undecodable content falls back to the stored bytes
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -26,6 +28,8 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+import { randomUUID } from "node:crypto";
+
 import {
   linkAttachmentToMessage,
   uploadAttachment,
@@ -36,7 +40,9 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { rawRun } from "../persistence/raw-query.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+import { fakeHeifHeaderBytes, makeHeicFixtureBytes } from "./heic-fixture.js";
 
 await initializeDb();
 
@@ -56,8 +62,36 @@ function createTestArgs(conversationId: string) {
 
 interface AttachmentPayload {
   data?: string;
+  filename?: string;
   mimeType: string;
   thumbnailData?: string;
+}
+
+/**
+ * Insert an attachment row directly, bypassing upload-time HEIF
+ * normalization — simulates rows stored before normalization existed (or
+ * where conversion was unavailable).
+ */
+function insertLegacyAttachmentRow(
+  messageId: string,
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+): string {
+  const id = randomUUID();
+  rawRun(
+    `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    filename,
+    mimeType,
+    Buffer.from(dataBase64, "base64").length,
+    "image",
+    dataBase64,
+    Date.now(),
+  );
+  linkAttachmentToMessage(messageId, id, 0);
+  return id;
 }
 
 interface MessagePayload {
@@ -208,6 +242,64 @@ describe("handleListMessages attachments", () => {
       "output.png",
     );
   });
+});
+
+describe("handleListMessages HEIC display normalization", () => {
+  beforeEach(resetTables);
+
+  test("undecodable HEIC data is served unchanged (conversion fallback)", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "photo" }]),
+    );
+    const heicB64 = fakeHeifHeaderBytes().toString("base64");
+    insertLegacyAttachmentRow(msg.id, "IMG_1.HEIC", "image/heic", heicB64);
+
+    const response = handleListMessages(createTestArgs(conv.id));
+    const body = response as { messages: MessagePayload[] };
+
+    const attachments = body.messages[0].attachments!;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].mimeType).toBe("image/heic");
+    expect(attachments[0].data).toBe(heicB64);
+  });
+
+  describe.skipIf(process.platform !== "darwin")(
+    "real conversion (sips)",
+    () => {
+      test("legacy HEIC rows are hydrated as JPEG display data", async () => {
+        const heic = makeHeicFixtureBytes();
+        expect(heic).not.toBeNull();
+
+        const conv = createConversation();
+        const msg = await addMessage(
+          conv.id,
+          "user",
+          JSON.stringify([{ type: "text", text: "photo" }]),
+        );
+        insertLegacyAttachmentRow(
+          msg.id,
+          "IMG_2.HEIC",
+          "image/heic",
+          heic!.toString("base64"),
+        );
+
+        const response = handleListMessages(createTestArgs(conv.id));
+        const body = response as { messages: MessagePayload[] };
+
+        const attachments = body.messages[0].attachments!;
+        expect(attachments).toHaveLength(1);
+        expect(attachments[0].mimeType).toBe("image/jpeg");
+        // JPEG SOI marker (FF D8 FF) base64-encodes to "/9j/".
+        expect(attachments[0].data!.startsWith("/9j/")).toBe(true);
+        // Metadata keeps describing the stored original, which the content
+        // endpoint serves verbatim for downloads.
+        expect(attachments[0].filename).toBe("IMG_2.HEIC");
+      });
+    },
+  );
 });
 
 describe("handleListMessages no_response filtering", () => {

--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -1,18 +1,5 @@
-import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import { parseImageDimensions } from "../context/image-dimensions.js";
+import { convertImageToJpeg } from "../util/image-conversion.js";
 
 // Anthropic's documented max dimension — images larger than this are scaled
 // down server-side anyway, so pre-scaling is zero quality loss.
@@ -28,110 +15,6 @@ const MAX_TRANSPORT_BYTES = Math.floor(3.5 * 1024 * 1024); // ~3.5 MB raw
 
 const JPEG_QUALITY = 80;
 
-// Content-addressed disk cache to avoid re-running sips on the same image.
-const CACHE_MAX_ENTRIES = 500;
-
-function getCacheDir(): string {
-  return join(tmpdir(), "vellum-optimized-images");
-}
-
-function readFromCache(
-  key: string,
-): { data: string; mediaType: string } | null {
-  try {
-    const cachePath = join(getCacheDir(), `${key}.jpg`);
-    if (!existsSync(cachePath)) return null;
-    const buf = readFileSync(cachePath) as Buffer;
-    return { data: buf.toString("base64"), mediaType: "image/jpeg" };
-  } catch {
-    return null;
-  }
-}
-
-function writeToCache(key: string, optimizedBytes: Buffer): void {
-  try {
-    const dir = getCacheDir();
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, `${key}.jpg`), optimizedBytes);
-    evictIfNeeded(dir);
-  } catch {
-    // Cache write failure is non-fatal.
-  }
-}
-
-function evictIfNeeded(dir: string): void {
-  try {
-    const entries = readdirSync(dir)
-      .filter((f) => f.endsWith(".jpg"))
-      .map((f) => {
-        const full = join(dir, f);
-        return { path: full, mtimeMs: statSync(full).mtimeMs };
-      })
-      .sort((a, b) => a.mtimeMs - b.mtimeMs);
-    const excess = entries.length - CACHE_MAX_ENTRIES;
-    for (let i = 0; i < excess; i++) {
-      try {
-        unlinkSync(entries[i]!.path);
-      } catch {
-        /* ignore */
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-}
-
-function runSips(inputBytes: Buffer): Buffer | null {
-  const srcPath = join(tmpdir(), `vellum-img-opt-${Date.now()}-src`);
-  const outPath = join(tmpdir(), `vellum-img-opt-${Date.now()}-out.jpg`);
-  try {
-    writeFileSync(srcPath, inputBytes);
-    execFileSync(
-      "sips",
-      [
-        "--resampleHeightWidthMax",
-        String(MAX_DIMENSION),
-        "-s",
-        "format",
-        "jpeg",
-        "-s",
-        "formatOptions",
-        String(JPEG_QUALITY),
-        srcPath,
-        "--out",
-        outPath,
-      ],
-      { stdio: "pipe", timeout: 15_000 },
-    );
-    return readFileSync(outPath) as Buffer;
-  } catch {
-    return null;
-  } finally {
-    try {
-      unlinkSync(srcPath);
-    } catch {
-      /* ignore */
-    }
-    try {
-      unlinkSync(outPath);
-    } catch {
-      /* ignore */
-    }
-  }
-}
-
-/**
- * Downscale a base64 image to fit within Anthropic's recommended dimensions
- * (1568px max side). Returns the original data unchanged if the image is
- * already small enough or if optimization fails.
- *
- * Anthropic applies the same scaling server-side, so this is zero quality
- * loss — we just do it pre-flight to keep request payloads small and avoid
- * 413 "request too large" errors when many images accumulate in context.
- *
- * Results are cached on disk by content hash so repeated sends of the same
- * image (or daemon restarts) skip the sips call entirely.
- */
 /**
  * Decide whether an image needs to be rescaled before sending.
  *
@@ -157,6 +40,18 @@ export function shouldRescaleImage(
   return byteLength > OPTIMIZE_THRESHOLD_BYTES;
 }
 
+/**
+ * Downscale a base64 image to fit within Anthropic's recommended dimensions
+ * (1568px max side). Returns the original data unchanged if the image is
+ * already small enough or if optimization fails.
+ *
+ * Anthropic applies the same scaling server-side, so this is zero quality
+ * loss — we just do it pre-flight to keep request payloads small and avoid
+ * 413 "request too large" errors when many images accumulate in context.
+ *
+ * Conversion (and its content-addressed disk cache) is shared with attachment
+ * storage normalization — see `util/image-conversion.ts`.
+ */
 export function optimizeImageForTransport(
   base64Data: string,
   mediaType: string,
@@ -168,18 +63,13 @@ export function optimizeImageForTransport(
     return { data: base64Data, mediaType };
   }
 
-  // Content-addressed cache lookup.
-  const hash = createHash("sha256").update(rawBytes).digest("hex");
-  const cacheKey = hash.slice(0, 16);
-  const cached = readFromCache(cacheKey);
-  if (cached) return cached;
-
-  // Run sips (macOS). On other platforms this gracefully returns null.
-  const optimized = runSips(rawBytes);
+  const optimized = convertImageToJpeg(rawBytes, {
+    maxDimensionPx: MAX_DIMENSION,
+    quality: JPEG_QUALITY,
+  });
   if (!optimized) {
     return { data: base64Data, mediaType };
   }
 
-  writeToCache(cacheKey, optimized);
   return { data: optimized.toString("base64"), mediaType: "image/jpeg" };
 }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -613,7 +613,7 @@ export async function persistQueuedMessageBody(
           a.filename,
           a.mimeType,
           a.data,
-          { sourcePath: a.filePath },
+          { sourcePath: a.filePath, normalizeImage: true },
         );
       } catch (err) {
         if (err instanceof AttachmentUploadError) {

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -20,6 +20,11 @@ import { basename, dirname, extname, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import {
+  jpegFilenameFor,
+  normalizeImageBase64,
+  normalizeImageBytes,
+} from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { getConversationAttachmentsDirPath } from "./conversation-directories.js";
@@ -518,7 +523,8 @@ export function validateAttachmentUpload(
 /**
  * Write raw bytes to the staging directory and register as a file-backed
  * attachment. Used by the multipart/form-data and application/octet-stream
- * upload paths.
+ * upload paths. HEIF/HEIC images are stored as JPEG masters so every client
+ * surface can render them; other formats are stored verbatim.
  *
  * @param filename  Original filename from the client
  * @param mimeType  MIME type of the file
@@ -530,20 +536,26 @@ export function uploadAttachmentFromBytes(
   mimeType: string,
   bytes: Uint8Array,
 ): StoredAttachment {
+  let norm = normalizeImageBytes(mimeType, bytes);
+  if (norm.converted && norm.bytes.length > MAX_UPLOAD_BYTES) {
+    norm = { mimeType, bytes, converted: false };
+  }
+  const storedFilename = norm.converted ? jpegFilenameFor(filename) : filename;
+
   const dir = join(getWorkspaceDir(), "data", "attachments");
   mkdirSync(dir, { recursive: true });
 
-  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const sanitized = storedFilename.replace(/[^a-zA-Z0-9._-]/g, "_");
   const stagingFilename = `${Date.now()}-${uuid().slice(0, 8)}-${sanitized}`;
   const stagedPath = join(dir, stagingFilename);
 
-  writeFileSync(stagedPath, bytes);
+  writeFileSync(stagedPath, norm.bytes);
 
   return uploadFileBackedAttachment(
-    filename,
-    mimeType,
+    storedFilename,
+    norm.mimeType,
     stagedPath,
-    bytes.length,
+    norm.bytes.length,
   );
 }
 
@@ -703,13 +715,45 @@ function validateAttachmentPayload(
   return sizeBytes;
 }
 
+/**
+ * HEIF/HEIC payloads are stored as JPEG masters (filename extension
+ * rewritten) so every client surface can render them; anything else — and any
+ * conversion whose output would break the upload size limit — passes through
+ * verbatim.
+ */
+function normalizeUploadedImageBase64(
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+): { filename: string; mimeType: string; dataBase64: string } {
+  const norm = normalizeImageBase64(mimeType, dataBase64);
+  if (
+    !norm.converted ||
+    computeSizeBytesFromBase64(norm.dataBase64) > MAX_UPLOAD_BYTES
+  ) {
+    return { filename, mimeType, dataBase64 };
+  }
+  return {
+    filename: jpegFilenameFor(filename),
+    mimeType: norm.mimeType,
+    dataBase64: norm.dataBase64,
+  };
+}
+
 export function uploadAttachment(
   filename: string,
   mimeType: string,
   dataBase64: string,
   sourcePath?: string,
 ): StoredAttachment {
-  const sizeBytes = validateAttachmentPayload(dataBase64);
+  validateAttachmentPayload(dataBase64);
+
+  ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
+    filename,
+    mimeType,
+    dataBase64,
+  ));
+  const sizeBytes = computeSizeBytesFromBase64(dataBase64);
 
   const db = getDb();
   const now = Date.now();
@@ -754,8 +798,26 @@ export function attachInlineAttachmentToMessage(
   filename: string,
   mimeType: string,
   dataBase64: string,
-  options?: { sourcePath?: string; skipSizeLimit?: boolean },
+  options?: {
+    sourcePath?: string;
+    skipSizeLimit?: boolean;
+    /**
+     * Store HEIF/HEIC content as a JPEG master (with the filename extension
+     * rewritten) so every client surface can render it. User-sourced ingress
+     * opts in; assistant-produced attachments are stored verbatim — if the
+     * assistant deliberately emits a HEIC, rewriting it would be wrong.
+     */
+    normalizeImage?: boolean;
+  },
 ): StoredAttachment {
+  if (options?.normalizeImage) {
+    ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
+      filename,
+      mimeType,
+      dataBase64,
+    ));
+  }
+
   const sizeBytes = validateAttachmentPayload(dataBase64, {
     skipSizeLimit: options?.skipSizeLimit,
   });

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -2,11 +2,17 @@
  * Route handlers for attachment upload, download, and deletion.
  */
 import {
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
   realpathSync,
   statSync,
+  unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
 
@@ -26,6 +32,11 @@ import {
   getFilePathForAttachment,
   validateAttachmentUpload,
 } from "../../persistence/attachments-store.js";
+import {
+  isHeifImage,
+  jpegFilenameFor,
+  normalizeImageBytes,
+} from "../../util/image-conversion.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -44,6 +55,18 @@ const MAX_UPLOAD_BODY_BYTES = 150 * 1024 * 1024;
 
 /** 100 MB — maximum file size for file-backed uploads (matches client memorySafetyLimit). */
 const MAX_FILE_BACKED_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+/** Read the first `length` bytes of a file without loading the rest. */
+function readFileHead(path: string, length: number): Buffer {
+  const fd = openSync(path, "r");
+  try {
+    const head = Buffer.alloc(length);
+    const bytesRead = readSync(fd, head, 0, length, 0);
+    return head.subarray(0, bytesRead);
+  } finally {
+    closeSync(fd);
+  }
+}
 
 function resolveCanonicalPath(filePath: string): string {
   try {
@@ -315,6 +338,8 @@ function handleJsonUpload(
 
   if (filePath && typeof filePath === "string" && (!data || data === "")) {
     let resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
+    let storedFilename = filename;
+    let storedMimeType = mimeType;
 
     if (!resolvedPath) {
       const canonicalSource = resolveCanonicalPath(filePath);
@@ -335,8 +360,34 @@ function handleJsonUpload(
       );
       mkdirSync(workspaceAttachmentsDir, { recursive: true });
       const destFilename = `${Date.now()}-${filename.replace(/[^a-zA-Z0-9._-]/g, "_")}`;
-      const destPath = join(workspaceAttachmentsDir, destFilename);
+      let destPath = join(workspaceAttachmentsDir, destFilename);
       copyFileSync(canonicalSource, destPath);
+      // The staged copy is daemon-owned, so HEIF/HEIC content can be stored
+      // as a JPEG master without mutating the caller's file. Allowlisted
+      // in-place paths (recordings, conversation attachments) are registered
+      // verbatim — the daemon does not own those files. The head sniff keeps
+      // non-HEIF files (e.g. large videos) from being read into memory.
+      try {
+        if (isHeifImage(readFileHead(destPath, 12))) {
+          const norm = normalizeImageBytes(mimeType, readFileSync(destPath));
+          if (
+            norm.converted &&
+            norm.bytes.length <= MAX_FILE_BACKED_UPLOAD_BYTES
+          ) {
+            const convertedPath = join(
+              workspaceAttachmentsDir,
+              jpegFilenameFor(destFilename),
+            );
+            writeFileSync(convertedPath, norm.bytes);
+            unlinkSync(destPath);
+            destPath = convertedPath;
+            storedFilename = jpegFilenameFor(filename);
+            storedMimeType = norm.mimeType;
+          }
+        }
+      } catch {
+        // Conversion is best-effort; the raw copy is registered on failure.
+      }
       resolvedPath = resolveCanonicalPath(destPath);
     }
 
@@ -345,8 +396,8 @@ function handleJsonUpload(
     }
     const sizeBytes = statSync(resolvedPath).size;
     attachment = uploadFileBackedAttachment(
-      filename,
-      mimeType,
+      storedFilename,
+      storedMimeType,
       resolvedPath,
       sizeBytes,
     );

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -122,6 +122,7 @@ import { getConfiguredProvider } from "../../providers/provider-send-message.js"
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getSubagentManager } from "../../subagent/index.js";
+import { normalizeImageBase64 } from "../../util/image-conversion.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getWorkspaceDir,
@@ -952,13 +953,20 @@ export function handleListMessages({
         msgAttachments = linked.map((a) => {
           if (a.mimeType.startsWith("image/")) {
             const full = getAttachmentById(a.id, { hydrateFileData: true });
+            // Stored HEIF/HEIC content is hydrated as JPEG display data —
+            // Chromium-based clients cannot decode HEIF. Filename and
+            // sizeBytes keep describing the stored file, which
+            // /attachments/:id/content serves verbatim for downloads.
+            const display = full?.dataBase64
+              ? normalizeImageBase64(a.mimeType, full.dataBase64)
+              : null;
             return {
               id: a.id,
               filename: a.originalFilename,
-              mimeType: a.mimeType,
+              mimeType: display?.mimeType ?? a.mimeType,
               sizeBytes: a.sizeBytes,
               kind: a.kind,
-              ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
+              ...(display ? { data: display.dataBase64 } : {}),
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1723,6 +1723,7 @@ async function persistBackfilledSlackMessage(params: {
             downloaded.filename,
             downloaded.mimeType,
             downloaded.data,
+            { normalizeImage: true },
           );
           attachments.push({
             filename: downloaded.filename,

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -1,0 +1,268 @@
+/**
+ * JPEG conversion for images, backed by macOS `sips`.
+ *
+ * Two consumers share this converter:
+ *   - transport optimization (`agent/image-optimize.ts`) downscales large
+ *     images before provider calls;
+ *   - storage normalization (attachment ingress + history hydration) converts
+ *     HEIF/HEIC — which Chromium-based clients cannot decode — to JPEG.
+ *
+ * Conversion runs `sips` (a macOS builtin); on other platforms or on any
+ * failure it returns null and callers keep the original bytes. Results are
+ * cached on disk keyed by content hash + conversion options, so repeated
+ * conversions of the same image (or daemon restarts) skip the sips call.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { v4 as uuid } from "uuid";
+
+const DEFAULT_JPEG_QUALITY = 80;
+
+/** Full-resolution quality for stored attachment masters. */
+const STORAGE_JPEG_QUALITY = 90;
+
+const CACHE_MAX_ENTRIES = 500;
+
+function getCacheDir(): string {
+  return join(tmpdir(), "vellum-optimized-images");
+}
+
+function readFromCache(key: string): Buffer | null {
+  try {
+    const cachePath = join(getCacheDir(), `${key}.jpg`);
+    if (!existsSync(cachePath)) return null;
+    return readFileSync(cachePath) as Buffer;
+  } catch {
+    return null;
+  }
+}
+
+function writeToCache(key: string, convertedBytes: Buffer): void {
+  try {
+    const dir = getCacheDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${key}.jpg`), convertedBytes);
+    evictIfNeeded(dir);
+  } catch {
+    // Cache write failure is non-fatal.
+  }
+}
+
+function evictIfNeeded(dir: string): void {
+  try {
+    const entries = readdirSync(dir)
+      .filter((f) => f.endsWith(".jpg"))
+      .map((f) => {
+        const full = join(dir, f);
+        return { path: full, mtimeMs: statSync(full).mtimeMs };
+      })
+      .sort((a, b) => a.mtimeMs - b.mtimeMs);
+    const excess = entries.length - CACHE_MAX_ENTRIES;
+    for (let i = 0; i < excess; i++) {
+      try {
+        unlinkSync(entries[i]!.path);
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export interface ConvertToJpegOptions {
+  /** Downscale so neither side exceeds this; omit to keep full resolution. */
+  maxDimensionPx?: number;
+  /** JPEG quality 1-100 (default 80). */
+  quality?: number;
+}
+
+function runSips(
+  inputBytes: Uint8Array,
+  options: ConvertToJpegOptions,
+): Buffer | null {
+  const stamp = `${Date.now()}-${uuid().slice(0, 8)}`;
+  const srcPath = join(tmpdir(), `vellum-img-opt-${stamp}-src`);
+  const outPath = join(tmpdir(), `vellum-img-opt-${stamp}-out.jpg`);
+  try {
+    writeFileSync(srcPath, inputBytes);
+    const args =
+      options.maxDimensionPx != null
+        ? ["--resampleHeightWidthMax", String(options.maxDimensionPx)]
+        : [];
+    args.push(
+      "-s",
+      "format",
+      "jpeg",
+      "-s",
+      "formatOptions",
+      String(options.quality ?? DEFAULT_JPEG_QUALITY),
+      srcPath,
+      "--out",
+      outPath,
+    );
+    execFileSync("sips", args, { stdio: "pipe", timeout: 15_000 });
+    return readFileSync(outPath) as Buffer;
+  } catch {
+    return null;
+  } finally {
+    try {
+      unlinkSync(srcPath);
+    } catch {
+      /* ignore */
+    }
+    try {
+      unlinkSync(outPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Convert an image to JPEG, optionally downscaling. Returns null when
+ * conversion is unavailable (non-macOS) or fails; callers keep the original.
+ */
+export function convertImageToJpeg(
+  bytes: Uint8Array,
+  options: ConvertToJpegOptions = {},
+): Buffer | null {
+  const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+  // Options qualify the key so full-resolution storage conversions and
+  // downscaled transport conversions of the same source never collide.
+  const cacheKey = `${hash}-${options.maxDimensionPx ?? "full"}-q${options.quality ?? DEFAULT_JPEG_QUALITY}`;
+
+  const cached = readFromCache(cacheKey);
+  if (cached) return cached;
+
+  const converted = runSips(bytes, options);
+  if (!converted) return null;
+
+  writeToCache(cacheKey, converted);
+  return converted;
+}
+
+// HEIF container brands (ISO BMFF `ftyp` major brand). AVIF brands are
+// deliberately absent: Chromium decodes AVIF natively, so it needs no
+// normalization.
+const HEIF_FTYP_BRANDS = new Set([
+  "heic",
+  "heix",
+  "hevc",
+  "hevx",
+  "heif",
+  "heim",
+  "heis",
+  "hevm",
+  "hevs",
+  "mif1",
+  "msf1",
+]);
+
+/**
+ * Content-based HEIF/HEIC detection. MIME metadata is unreliable here:
+ * Chromium reports an empty `file.type` for `.heic`, which clients coerce to
+ * `application/octet-stream`.
+ */
+export function isHeifImage(bytes: Uint8Array): boolean {
+  if (bytes.length < 12) return false;
+  // ISO BMFF layout: bytes 4-8 are "ftyp", bytes 8-12 the major brand.
+  if (
+    bytes[4] !== 0x66 || // f
+    bytes[5] !== 0x74 || // t
+    bytes[6] !== 0x79 || // y
+    bytes[7] !== 0x70 // p
+  ) {
+    return false;
+  }
+  const brand = String.fromCharCode(
+    bytes[8]!,
+    bytes[9]!,
+    bytes[10]!,
+    bytes[11]!,
+  );
+  return HEIF_FTYP_BRANDS.has(brand);
+}
+
+/** Rewrites a filename's extension to `.jpg` (e.g. `IMG_5487.HEIC` → `IMG_5487.jpg`). */
+export function jpegFilenameFor(filename: string): string {
+  const fallback = "attachment";
+  const trimmed = filename.trim() || fallback;
+  if (/\.jpe?g$/i.test(trimmed)) return trimmed;
+  const withoutExtension = trimmed.replace(/\.[^./\\]+$/, "") || fallback;
+  return `${withoutExtension}.jpg`;
+}
+
+export interface NormalizedImageBytes {
+  mimeType: string;
+  bytes: Uint8Array;
+  converted: boolean;
+}
+
+/**
+ * Normalize image bytes for storage: HEIF/HEIC becomes a full-resolution JPEG
+ * master; everything else (and any conversion failure) passes through
+ * unchanged. Callers that persist a filename should rewrite it with
+ * {@link jpegFilenameFor} when `converted` is true.
+ */
+export function normalizeImageBytes(
+  mimeType: string,
+  bytes: Uint8Array,
+): NormalizedImageBytes {
+  if (!isHeifImage(bytes)) {
+    return { mimeType, bytes, converted: false };
+  }
+  const converted = convertImageToJpeg(bytes, {
+    quality: STORAGE_JPEG_QUALITY,
+  });
+  if (!converted) {
+    return { mimeType, bytes, converted: false };
+  }
+  return { mimeType: "image/jpeg", bytes: converted, converted: true };
+}
+
+export interface NormalizedImageBase64 {
+  mimeType: string;
+  dataBase64: string;
+  converted: boolean;
+}
+
+/**
+ * Base64 variant of {@link normalizeImageBytes}. Sniffs the decoded head
+ * first so non-HEIF payloads skip the full decode.
+ */
+export function normalizeImageBase64(
+  mimeType: string,
+  dataBase64: string,
+): NormalizedImageBase64 {
+  // 16 base64 chars decode to the 12 bytes the ftyp sniff needs.
+  const head = Buffer.from(dataBase64.slice(0, 16), "base64");
+  if (!isHeifImage(head)) {
+    return { mimeType, dataBase64, converted: false };
+  }
+  const normalized = normalizeImageBytes(
+    mimeType,
+    Buffer.from(dataBase64, "base64"),
+  );
+  if (!normalized.converted) {
+    return { mimeType, dataBase64, converted: false };
+  }
+  return {
+    mimeType: normalized.mimeType,
+    dataBase64: Buffer.from(normalized.bytes).toString("base64"),
+    converted: true,
+  };
+}


### PR DESCRIPTION
## Summary
- Dragging an iPhone `.HEIC` photo into the macOS/web app rendered a broken-image glyph: Chromium cannot decode HEIF, the daemon stored/served the bytes verbatim, and providers replaced the image with a text placeholder. This PR normalizes HEIF/HEIC to JPEG at every user-sourced upload ingress (multipart, octet-stream, JSON base64, JSON file-path copy, inline message data, Slack backfill) via a new shared `sips`-backed converter (`assistant/src/util/image-conversion.ts`, extracted from `agent/image-optimize.ts`, content-addressed cache with options-qualified keys). Detection is content-based (ftyp sniff) since Chromium reports an empty MIME for `.heic`.
- Legacy rows: `handleListMessages` hydrates stored HEIC as JPEG display data (same cached converter), so existing broken messages render after upgrade. `GET /attachments/:id/content` is untouched — downloads keep pristine original bytes. On non-macOS daemons conversion is unavailable and everything passes through verbatim (status quo).
- Guards: conversions that would exceed upload size limits fall back to the original; `POST /attachments/register` and assistant-produced attachments are never rewritten; AVIF is excluded (Chromium decodes it natively). New tests cover the converter (real sips gated to darwin), store/route wiring (mocked converter), and history hydration.

Note on GET idempotency: the history hydration writes only to the bounded content-addressed tmp-dir conversion cache (same class as the existing image-optimize cache), never DB state.

## Original prompt
User dragged a HEIC photo into the macOS Electron app chat and it rendered as a broken-image icon with just the filename. Investigation showed the raw HEIC is stored and served end-to-end while no surface converts it for Chromium, and the LLM never sees small HEICs either. This PR is the daemon half of the fix (upload normalization + legacy display transcode); a follow-up PR handles web-client polish (WebKit-side conversion, fresh-bubble preview, broken-glyph fallback).