### PR TITLE
feat(calls): voice invite detection + redemption via gateway; trigger-call reads gateway row

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5664,7 +5664,9 @@ paths:
     post:
       operationId: contacts_invites_by_id_call_post
       summary: Trigger invite call
-      description: Trigger an outbound call for a phone invite.
+      description:
+        Trigger an outbound call for a phone invite. The gateway validates its canonical invite row and supplies
+        the resolved call fields in the body.
       tags:
         - contacts
       parameters:
@@ -5673,6 +5675,28 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phoneNumber:
+                  type: string
+                  description: E.164 number the invite call dials (invite's bound caller)
+                friendName:
+                  description: Invitee display name for the call greeting
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                guardianName:
+                  description: Guardian display label recorded on the invite
+                  anyOf:
+                    - type: string
+                    - type: "null"
+              required:
+                - phoneNumber
       responses:
         "200":
           description: Successful response

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -24,14 +24,20 @@ mock.module("../telegram/bot-username.js", () => ({
 }));
 
 // Mock startInviteCall from call-domain — test env lacks Twilio credentials.
+// Captures the last input so trigger-call tests can assert the gateway-supplied
+// fields flow through to the provider call.
 let mockStartInviteCallResult:
   | { ok: true; callSid: string }
   | { ok: false; error: string; status?: number } = {
   ok: true,
   callSid: "CA_test_sid_123",
 };
+let lastStartInviteCallInput: Record<string, unknown> | null = null;
 mock.module("../calls/call-domain.js", () => ({
-  startInviteCall: async () => mockStartInviteCallResult,
+  startInviteCall: async (input: Record<string, unknown>) => {
+    lastStartInviteCallInput = input;
+    return mockStartInviteCallResult;
+  },
 }));
 
 // Model the gateway: the redemption claim (record_invite_redemption) and the
@@ -109,8 +115,12 @@ async function handleRedeemInvite(req: Request) {
   }
 }
 
-async function handleTriggerInviteCall(inviteId: string) {
-  const result = await triggerInviteCall(inviteId);
+async function handleTriggerInviteCall(params: {
+  phoneNumber?: string;
+  friendName?: string | null;
+  guardianName?: string | null;
+}) {
+  const result = await triggerInviteCall(params);
   if (!result.ok) {
     return fakeResponse({ ok: false, error: result.error }, 400);
   }
@@ -374,57 +384,82 @@ describe("composeInvitePresentation", () => {
 // Trigger invite call endpoint
 // ---------------------------------------------------------------------------
 
+// Invite lifecycle validation (existence/active/expiry/phone) lives in the
+// gateway's triggerInviteCallNative — see the gateway proxy tests. The daemon
+// only performs the provider call from the gateway-supplied fields.
 describe("POST /v1/contacts/invites/:id/call", () => {
   beforeEach(() => {
     resetTables();
     mockStartInviteCallResult = { ok: true, callSid: "CA_test_sid_123" };
+    lastStartInviteCallInput = null;
   });
 
-  test("triggers a call for an active phone invite", async () => {
-    const { invite } = seedVoiceInvite("+15551234567");
-
-    const res = await handleTriggerInviteCall(invite.id);
+  test("places the call from the gateway-supplied fields", async () => {
+    const res = await handleTriggerInviteCall({
+      phoneNumber: "+15551234567",
+      friendName: "Alice",
+      guardianName: "Guardian Label",
+    });
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);
     expect(body.ok).toBe(true);
     expect(body.callSid).toBe("CA_test_sid_123");
+    expect(lastStartInviteCallInput).toEqual({
+      phoneNumber: "+15551234567",
+      friendName: "Alice",
+      guardianName: "Guardian Label",
+    });
   });
 
-  test("returns 400 for non-existent invite", async () => {
-    const res = await handleTriggerInviteCall("nonexistent-id");
+  test("returns 400 when phoneNumber is missing (no local invite fallback)", async () => {
+    // A live local invite row exists, but the daemon never re-reads it — the
+    // gateway row is the lifecycle authority and supplies the call fields.
+    seedVoiceInvite("+15551234567");
+
+    const res = await handleTriggerInviteCall({});
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
-    expect(body.error).toBe("Invite not found");
+    expect(body.error).toBe("phoneNumber is required");
+    expect(lastStartInviteCallInput).toBeNull();
   });
 
-  test("returns 400 for a revoked (non-active) invite", async () => {
-    const { invite } = seedVoiceInvite("+15551234567");
-
-    // Revoke the invite
-    revokeInvite(invite.id);
-
-    const res = await handleTriggerInviteCall(invite.id);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
-    expect(body.error).toBe("Invite is not active");
-  });
-
-  test("returns 400 for a non-phone invite", async () => {
-    const { invite } = createInvite({
-      sourceChannel: "telegram",
-      contactId: createTargetContact(),
+  test("empty friendName falls through to the neutral-greeting contract", async () => {
+    const res = await handleTriggerInviteCall({
+      phoneNumber: "+15551234567",
+      friendName: "   ",
+      guardianName: "Guardian Label",
     });
 
-    const res = await handleTriggerInviteCall(invite.id);
+    expect(res.status).toBe(200);
+    expect(lastStartInviteCallInput).toMatchObject({ friendName: "" });
+  });
+
+  test("null guardianName falls back to the resolved guardian name", async () => {
+    const res = await handleTriggerInviteCall({
+      phoneNumber: "+15551234567",
+      friendName: "Alice",
+      guardianName: null,
+    });
+
+    expect(res.status).toBe(200);
+    // resolveGuardianName() has no persona in this env, so the fallback
+    // resolves to the empty-string default rather than the null passthrough.
+    expect(typeof lastStartInviteCallInput?.guardianName).toBe("string");
+  });
+
+  test("surfaces a failed provider call as 400", async () => {
+    mockStartInviteCallResult = {
+      ok: false,
+      error: "phone_number must be in E.164 format",
+    };
+
+    const res = await handleTriggerInviteCall({ phoneNumber: "+15551234567" });
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
-    expect(body.error).toBe("Only phone invites support call triggering");
+    expect(body.error).toBe("phone_number must be in E.164 format");
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -546,6 +546,23 @@ function createMockWs(callSessionId: string): {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+// Invite redemption is dispatched fire-and-forget from the DTMF handler and
+// hops the event loop several times (gateway IPC reader → redemption service →
+// persistent IPC), so fixed sleeps race it on slow CI runners. Poll instead.
+async function waitFor(
+  condition: () => boolean,
+  label: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
 let ensuredConvIds = new Set<string>();
 function ensureConversation(id: string): void {
   if (ensuredConvIds.has(id)) return;
@@ -2558,9 +2575,11 @@ describe("relay-server", () => {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Should have transitioned to connected
+    // Redemption is dispatched fire-and-forget; poll for the terminal state.
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "redemption to connect the call",
+    );
     expect(relay.getConnectionState()).toBe("connected");
 
     // Verify events
@@ -2615,9 +2634,12 @@ describe("relay-server", () => {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
 
-    // Redemption is dispatched async (it now consults the gateway lifecycle
-    // pre-check over IPC), so flush the microtask/timer queue before asserting.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Redemption is dispatched async (it consults the gateway over IPC), so
+    // poll for the terminal state rather than racing it with a fixed sleep.
+    await waitFor(
+      () => getCallSession(session.id)?.status === "failed",
+      "redemption failure to mark the call failed",
+    );
 
     // Call should be marked as failed
     const updated = getCallSession(session.id);
@@ -2647,14 +2669,13 @@ describe("relay-server", () => {
       true,
     );
 
-    // Let the delayed endSession callback flush
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Verify end message was sent
-    const endMessages = ws.sentMessages
-      .map((raw) => JSON.parse(raw) as { type: string })
-      .filter((m) => m.type === "end");
-    expect(endMessages.length).toBe(1);
+    // Wait for the delayed endSession callback to send the end message.
+    const countEndMessages = () =>
+      ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string })
+        .filter((m) => m.type === "end").length;
+    await waitFor(() => countEndMessages() >= 1, "end message to be sent");
+    expect(countEndMessages()).toBe(1);
 
     relay.destroy();
   });
@@ -2707,8 +2728,8 @@ describe("relay-server", () => {
     for (const digit of code) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    // Let the async handler reach the awaited gateway claim.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Poll until the async handler reaches the awaited gateway claim.
+    await waitFor(() => inviteClaimCalls === 1, "first gateway claim");
     expect(inviteClaimCalls).toBe(1);
 
     // Second attempt with the SAME code arrives while the first is in flight.
@@ -2719,9 +2740,12 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(inviteClaimCalls).toBe(1);
 
-    // Now let the first redemption resolve.
+    // Now let the first redemption resolve and poll for activation.
     releaseClaim();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "redemption to connect the call after claim release",
+    );
 
     // Exactly one gateway claim ran across both attempts.
     expect(inviteClaimCalls).toBe(1);
@@ -2788,7 +2812,10 @@ describe("relay-server", () => {
     for (const digit of priorCode) {
       await prior.relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => prior.relay.getConnectionState() === "connected",
+      "prior redemption to connect the call",
+    );
     expect(prior.relay.getConnectionState()).toBe("connected");
     expect(inviteClaimCalls).toBe(1);
     prior.relay.destroy();
@@ -2824,7 +2851,10 @@ describe("relay-server", () => {
     for (const digit of freshCode) {
       await fresh.relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => fresh.relay.getConnectionState() === "connected",
+      "fresh redemption to connect the call",
+    );
 
     // A second claim ran for the fresh attempt — guard did not deadlock it.
     expect(inviteClaimCalls).toBe(2);
@@ -2967,7 +2997,10 @@ describe("relay-server", () => {
     for (const digit of code) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => getCallSession(session.id)?.status === "failed",
+      "fail-closed redemption to mark the call failed",
+    );
 
     const updated = getCallSession(session.id);
     expect(updated).not.toBeNull();
@@ -5050,7 +5083,10 @@ describe("relay-server", () => {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "redemption to connect the call",
+    );
 
     // Call should remain connected
     expect(relay.getConnectionState()).toBe("connected");
@@ -5176,7 +5212,10 @@ describe("relay-server", () => {
     for (const digit of code) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "redemption to connect the call",
+    );
 
     expect(relay.getConnectionState()).toBe("connected");
 
@@ -5239,7 +5278,10 @@ describe("relay-server", () => {
     for (const digit of code) {
       await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "redemption to connect the call",
+    );
 
     expect(relay.getConnectionState()).toBe("connected");
 
@@ -6207,7 +6249,10 @@ describe("relay-server", () => {
     // Let the redemption chain (gateway claim, caller-verdict read, DB write)
     // drain up to activation, which flips the state to "connected" before
     // entering the gated re-resolution.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(
+      () => relay.getConnectionState() === "connected",
+      "activation to flip the call to connected",
+    );
     // Activation already reached the terminal state before re-resolution.
     expect(relay.getConnectionState()).toBe("connected");
 
@@ -6224,7 +6269,10 @@ describe("relay-server", () => {
 
     releaseVerdict();
     await redemptionDone;
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitFor(
+      () => mockSendMessage.mock.calls.length > turnCountBefore,
+      "buffered prompt to run as a real turn",
+    );
 
     // Flushed onto the real-turn path: the prompt produced an LLM turn rather
     // than being dropped by the verification-pending branch.

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -38,18 +38,71 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// The voice redemption path now claims the gateway-canonical row over IPC
-// before mutating. Stub it so tests don't attempt a real socket connect; the
-// claim returns consumed (updated:true) so redemption proceeds.
+// Voice-invite detection and redemption go through the gateway over IPC
+// (`get_active_voice_invite` / `redeem_voice_invite`), and the redemption
+// engine claims the canonical row before mutating. Model the gateway against
+// the locally seeded invite rows so tests don't attempt a real socket connect.
 //
 // `inviteClaimCalls` counts gateway claims so concurrency tests can assert that
 // a repeated code does NOT launch a second claim. `inviteClaimGate`, when set,
 // holds the claim open mid-flight so a test can drive the race window where a
 // second code arrives while the first redemption is still awaiting the gateway.
+// `voiceInviteIpcError`, when set, makes the voice-invite IPC methods throw so
+// tests can pin fail-soft detection and fail-closed redemption.
 let inviteClaimCalls = 0;
 let inviteClaimGate: Promise<void> | null = null;
+let voiceInviteIpcError = false;
 mock.module("../ipc/gateway-client.js", () => ({
-  ipcCall: async () => undefined,
+  ipcCall: async (method: string, params?: Record<string, unknown>) => {
+    if (method === "get_active_voice_invite") {
+      if (voiceInviteIpcError) throw new Error("gateway unreachable");
+      // Model the gateway read from the seeded local rows: bound-contact
+      // displayName preferred, invite friendName fallback.
+      const { findActiveVoiceInvites } =
+        await import("../persistence/invite-store.js");
+      const { getContact } = await import("../contacts/contact-store.js");
+      const now = Date.now();
+      const invite = findActiveVoiceInvites({
+        expectedExternalUserId: params?.callerExternalUserId as string,
+      }).find((i) => !i.expiresAt || i.expiresAt > now);
+      if (!invite) return { invite: null };
+      return {
+        invite: {
+          inviteId: invite.id,
+          inviteeName:
+            getContact(invite.contactId)?.displayName?.trim() ||
+            invite.friendName?.trim() ||
+            null,
+          guardianName: invite.guardianName?.trim() || null,
+          codeDigits: invite.voiceCodeDigits ?? 6,
+        },
+      };
+    }
+    if (method === "redeem_voice_invite") {
+      if (voiceInviteIpcError) throw new Error("gateway unreachable");
+      // Model the gateway redemption engine with the local service (identical
+      // semantics: identity-bound candidates, code hash, expiry, atomic claim).
+      const { redeemVoiceInviteCode } =
+        await import("../runtime/invite-redemption-service.js");
+      const result = await redeemVoiceInviteCode({
+        callerExternalUserId: params?.callerExternalUserId as string,
+        sourceChannel: "phone",
+        code: params?.code as string,
+      });
+      if (!result.ok) return { ok: false, reason: "invalid_or_expired" };
+      return {
+        ok: true,
+        outcome: {
+          inviteId: result.type === "redeemed" ? result.inviteId : "inv-member",
+          contactId: result.memberId,
+          sourceChannel: "phone",
+          memberExternalUserId: params?.callerExternalUserId as string,
+          result: result.type,
+        },
+      };
+    }
+    return undefined;
+  },
   ipcCallPersistent: async (
     method: string,
     params?: Record<string, unknown>,
@@ -624,6 +677,7 @@ describe("relay-server", () => {
     activeRelayConnections.clear();
     inviteClaimCalls = 0;
     inviteClaimGate = null;
+    voiceInviteIpcError = false;
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
     mockGuardianDeliveryList = null;
@@ -2829,6 +2883,119 @@ describe("relay-server", () => {
     relay.destroy();
   });
 
+  test("inbound voice: gateway IPC error during invite detection fails SOFT to name capture (not invite_redemption)", async () => {
+    ensureConversation("conv-invite-detect-err");
+    const session = createCallSession({
+      conversationId: "conv-invite-detect-err",
+      provider: "twilio",
+      fromNumber: "+15558884444",
+      toNumber: "+15551111111",
+    });
+
+    // A live invite row exists for this caller, but the gateway read throws —
+    // detection must fall to the unverified-caller flow, never block setup.
+    const code = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact("Frank"),
+      maxUses: 1,
+      expectedExternalUserId: "+15558884444",
+      voiceCodeHash: hashVoiceCode(code),
+      voiceCodeDigits: 6,
+    });
+    voiceInviteIpcError = true;
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_detect_err",
+        from: "+15558884444",
+        to: "+15551111111",
+      }),
+    );
+
+    // Fail-soft: routed to name capture, not invite redemption.
+    expect(relay.getConnectionState()).toBe("awaiting_name");
+    const events = getCallEvents(session.id);
+    expect(
+      events.some((e) => e.eventType === "invite_redemption_started"),
+    ).toBe(false);
+    expect(
+      events.some((e) => e.eventType === "inbound_acl_name_capture_started"),
+    ).toBe(true);
+
+    relay.destroy();
+  });
+
+  test("inbound voice invite redemption: gateway IPC error during code entry fails CLOSED (no local fallback)", async () => {
+    ensureConversation("conv-invite-redeem-err");
+    const session = createCallSession({
+      conversationId: "conv-invite-redeem-err",
+      provider: "twilio",
+      fromNumber: "+15558881111",
+      toNumber: "+15551111111",
+    });
+
+    const code = generateVoiceCode(6);
+    createInvite({
+      sourceChannel: "phone",
+      contactId: createTargetContact("Gina"),
+      maxUses: 1,
+      expectedExternalUserId: "+15558881111",
+      voiceCodeHash: hashVoiceCode(code),
+      voiceCodeDigits: 6,
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_invite_redeem_err",
+        from: "+15558881111",
+        to: "+15551111111",
+      }),
+    );
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // Gateway goes down between detection and code entry. Even though the
+    // CORRECT code for a live local invite row is entered, redemption must
+    // fail closed — no local fallback redemption.
+    voiceInviteIpcError = true;
+    for (const digit of code) {
+      await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("failed");
+
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === "invite_redemption_failed")).toBe(
+      true,
+    );
+    expect(
+      events.some((e) => e.eventType === "invite_redemption_succeeded"),
+    ).toBe(false);
+    // No local claim ran — the redemption never bypassed the gateway.
+    expect(inviteClaimCalls).toBe(0);
+    // The generic failure copy was spoken.
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) =>
+        (m.token ?? "").includes("incorrect or has since expired"),
+      ),
+    ).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    relay.destroy();
+  });
+
   test("inbound voice: guardian's unverified channel gets self-verify guidance", async () => {
     ensureConversation("conv-unverified-guardian");
     const session = createCallSession({
@@ -5026,12 +5193,12 @@ describe("relay-server", () => {
     relay.destroy();
   });
 
-  test("invite redemption success: empty contact displayName with stale friendName column still greets 'Hi there'", async () => {
-    // Guards the Codex P2 on #35581 (discussion_r3453033493): when a bound
-    // contact's displayName is blank and the invite row carries a stale
-    // free-text friend_name, the greeting must NOT fall back to that stale
-    // label. contact_id is NOT NULL, so every invite is bound — empty
-    // displayName falls through to the neutral "Hi there" copy.
+  test("invite redemption success: empty contact displayName falls back to the invite friendName (gateway precedence)", async () => {
+    // The gateway's active-voice-invite read resolves inviteeName as bound
+    // contact displayName first, invite friendName second. A blank contact
+    // displayName therefore greets with the invite's friendName; only when
+    // BOTH are absent does the neutral "Hi there" copy apply (pinned by the
+    // fail-soft router tests).
     ensureConversation("conv-invite-stale-friend");
     mockUserReference = "my human";
     mockAssistantName = "";
@@ -5051,7 +5218,7 @@ describe("relay-server", () => {
       expectedExternalUserId: "+15557774444",
       voiceCodeHash: codeHash,
       voiceCodeDigits: 6,
-      friendName: "Stale Legacy Name",
+      friendName: "Fallback Friend",
     });
 
     mockSendMessage.mockImplementation(
@@ -5080,10 +5247,9 @@ describe("relay-server", () => {
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
       .filter((m) => m.type === "text");
     expect(
-      textMessages.some((m) => (m.token ?? "").startsWith("Hi there!")),
-    ).toBe(true);
-    expect(
-      textMessages.every((m) => !(m.token ?? "").includes("Stale Legacy Name")),
+      textMessages.some((m) =>
+        (m.token ?? "").includes("verified that you are Fallback"),
+      ),
     ).toBe(true);
 
     relay.destroy();

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -2,9 +2,9 @@
  * Tests for the inbound admission-floor enforcement in `routeSetup`.
  *
  * `routeSetup` reads several module-level singletons (config, trust resolver,
- * pending verification session, invite store, contact store). Those I/O
+ * pending verification session, gateway voice-invite reader). Those I/O
  * collaborators are mocked so the tables below can drive trust class, member
- * status, pending challenge, active invites, and the bound invite contact
+ * status, pending challenge, and the gateway's active-voice-invite view
  * directly — no database is touched.
  *
  * The admission floor is exercised through the REAL, pure `enforceAdmissionPolicy`:
@@ -60,21 +60,17 @@ mock.module("../../runtime/channel-verification-service.js", () => ({
   getPendingSession: () => pendingChallenge,
 }));
 
-// Controllable active voice invites.
-let activeInvites: Array<{
-  contactId: string;
-  friendName: string | null;
+// Controllable gateway active-voice-invite view. The real reader fails soft
+// to `null` on ANY gateway failure by contract, so `null` covers both "no
+// invite" and "gateway unreachable / IPC error".
+let activeVoiceInvite: {
+  inviteId: string;
+  inviteeName: string | null;
   guardianName: string | null;
-  expiresAt?: number;
-}> = [];
-mock.module("../../persistence/invite-store.js", () => ({
-  findActiveVoiceInvites: () => activeInvites,
-}));
-
-// Controllable bound contact for invite-redemption name resolution.
-let boundContact: { displayName?: string | null } | null = null;
-mock.module("../../contacts/contact-store.js", () => ({
-  getContact: () => boundContact,
+  codeDigits: number;
+} | null = null;
+mock.module("../gateway-invite-reader.js", () => ({
+  getActiveVoiceInvite: async () => activeVoiceInvite,
 }));
 
 const { routeSetup } = await import("../relay-setup-router.js");
@@ -170,8 +166,7 @@ function route(
 
 beforeEach(() => {
   pendingChallenge = null;
-  activeInvites = [];
-  boundContact = null;
+  activeVoiceInvite = null;
   resolveActorTrustMock.mockClear();
 });
 
@@ -231,9 +226,9 @@ describe("routeSetup — admission floor table", () => {
 
   for (const { policy, admits, denies } of cases) {
     for (const trustClass of denies) {
-      test(`${policy} denies ${trustClass}`, () => {
+      test(`${policy} denies ${trustClass}`, async () => {
         setTrust(trustClass);
-        const { outcome } = route(policy);
+        const { outcome } = await route(policy);
         expect(outcome.action).toBe("deny");
         if (outcome.action === "deny") {
           expect(outcome.logReason).toBe(
@@ -243,9 +238,9 @@ describe("routeSetup — admission floor table", () => {
       });
     }
     for (const trustClass of admits) {
-      test(`${policy} admits ${trustClass}`, () => {
+      test(`${policy} admits ${trustClass}`, async () => {
         setTrust(trustClass);
-        const { outcome } = route(policy);
+        const { outcome } = await route(policy);
         expect(outcome.action).not.toBe("deny");
       });
     }
@@ -257,17 +252,17 @@ describe("routeSetup — admission floor table", () => {
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — blocked / revoked", () => {
-  test("blocked caller is denied (pre-floor ACL check)", () => {
+  test("blocked caller is denied (pre-floor ACL check)", async () => {
     nextTrust = makeTrust("unknown", { status: "blocked" });
-    const { outcome } = route("strangers");
+    const { outcome } = await route("strangers");
     expect(outcome.action).toBe("deny");
   });
 
-  test("revoked member is denied under permissive floor", () => {
+  test("revoked member is denied under permissive floor", async () => {
     // Revoked → resolver classifies as unknown; the floor mock denies on
     // memberStatus regardless of the permissive policy.
     nextTrust = makeTrust("unknown", { status: "revoked" });
-    const { outcome } = route("strangers");
+    const { outcome } = await route("strangers");
     expect(outcome.action).toBe("deny");
   });
 });
@@ -277,33 +272,33 @@ describe("routeSetup — blocked / revoked", () => {
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — no policy preserves current behavior", () => {
-  test("unknown caller → name_capture", () => {
+  test("unknown caller → name_capture", async () => {
     nextTrust = makeTrust("unknown");
-    expect(route(null).outcome.action).toBe("name_capture");
-    expect(route(undefined).outcome.action).toBe("name_capture");
+    expect((await route(null)).outcome.action).toBe("name_capture");
+    expect((await route(undefined)).outcome.action).toBe("name_capture");
   });
 
-  test("unverified known caller → unverified_caller", () => {
+  test("unverified known caller → unverified_caller", async () => {
     nextTrust = makeTrust("unverified_contact", { status: "unverified" });
-    expect(route(null).outcome.action).toBe("unverified_caller");
+    expect((await route(null)).outcome.action).toBe("unverified_caller");
   });
 
-  test("trusted contact → normal_call", () => {
+  test("trusted contact → normal_call", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    expect(route(null).outcome.action).toBe("normal_call");
+    expect((await route(null)).outcome.action).toBe("normal_call");
   });
 
-  test("guardian → normal_call", () => {
+  test("guardian → normal_call", async () => {
     nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
-    expect(route(null).outcome.action).toBe("normal_call");
+    expect((await route(null)).outcome.action).toBe("normal_call");
   });
 
-  test("member policy deny still denies", () => {
+  test("member policy deny still denies", async () => {
     nextTrust = makeTrust("trusted_contact", {
       status: "active",
       policy: "deny",
     });
-    expect(route(null).outcome.action).toBe("deny");
+    expect((await route(null)).outcome.action).toBe("deny");
   });
 });
 
@@ -315,39 +310,39 @@ describe("routeSetup — no policy preserves current behavior", () => {
 // and connect directly. With a null policy the legacy identity flows persist.
 
 describe("routeSetup — permissive floor admits to normal_call", () => {
-  test("any_contact admits an unverified_contact to normal_call (not unverified_caller)", () => {
+  test("any_contact admits an unverified_contact to normal_call (not unverified_caller)", async () => {
     nextTrust = makeTrust("unverified_contact", { status: "unverified" });
-    const { outcome } = route("any_contact");
+    const { outcome } = await route("any_contact");
     expect(outcome.action).toBe("normal_call");
   });
 
-  test("strangers admits an unknown caller to normal_call (not name_capture)", () => {
+  test("strangers admits an unknown caller to normal_call (not name_capture)", async () => {
     nextTrust = makeTrust("unknown");
-    const { outcome } = route("strangers");
+    const { outcome } = await route("strangers");
     expect(outcome.action).toBe("normal_call");
   });
 
-  test("strangers admits an unverified_contact to normal_call", () => {
+  test("strangers admits an unverified_contact to normal_call", async () => {
     nextTrust = makeTrust("unverified_contact", { status: "unverified" });
-    const { outcome } = route("strangers");
+    const { outcome } = await route("strangers");
     expect(outcome.action).toBe("normal_call");
   });
 
-  test("null policy preserves legacy name_capture for unknown caller", () => {
+  test("null policy preserves legacy name_capture for unknown caller", async () => {
     nextTrust = makeTrust("unknown");
-    expect(route(null).outcome.action).toBe("name_capture");
+    expect((await route(null)).outcome.action).toBe("name_capture");
   });
 
-  test("null policy preserves legacy unverified_caller for unverified caller", () => {
+  test("null policy preserves legacy unverified_caller for unverified caller", async () => {
     nextTrust = makeTrust("unverified_contact", { status: "unverified" });
-    expect(route(null).outcome.action).toBe("unverified_caller");
+    expect((await route(null)).outcome.action).toBe("unverified_caller");
   });
 
-  test("trusted_contacts (default) still denies unknown and unverified", () => {
+  test("trusted_contacts (default) still denies unknown and unverified", async () => {
     nextTrust = makeTrust("unknown");
-    expect(route("trusted_contacts").outcome.action).toBe("deny");
+    expect((await route("trusted_contacts")).outcome.action).toBe("deny");
     nextTrust = makeTrust("unverified_contact", { status: "unverified" });
-    expect(route("trusted_contacts").outcome.action).toBe("deny");
+    expect((await route("trusted_contacts")).outcome.action).toBe("deny");
   });
 });
 
@@ -356,30 +351,65 @@ describe("routeSetup — permissive floor admits to normal_call", () => {
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — floor bypasses", () => {
-  test("active voice invite bypasses the floor (no_one policy)", () => {
+  test("active voice invite bypasses the floor (no_one policy)", async () => {
     nextTrust = makeTrust("unknown");
-    activeInvites = [
-      {
-        contactId: "contact-123",
-        friendName: "Friend",
-        guardianName: "Guardian",
-      },
-    ];
-    boundContact = { displayName: "Friend Name" };
-    const { outcome } = route("no_one");
+    activeVoiceInvite = {
+      inviteId: "inv-123",
+      inviteeName: "Friend Name",
+      guardianName: "Guardian",
+      codeDigits: 6,
+    };
+    const { outcome } = await route("no_one");
     expect(outcome.action).toBe("invite_redemption");
     if (outcome.action === "invite_redemption") {
       expect(outcome.inviteeName).toBe("Friend Name");
     }
   });
 
-  test("pending verification challenge bypasses the floor (no_one policy)", () => {
+  test("pending verification challenge bypasses the floor (no_one policy)", async () => {
     // A pending challenge for a known member routes to verification regardless
     // of the floor.
     nextTrust = makeTrust("trusted_contact", { status: "active" });
     pendingChallenge = { id: "vs_1" };
-    const { outcome } = route("no_one");
+    const { outcome } = await route("no_one");
     expect(outcome.action).toBe("verification");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-soft detection: the gateway reader resolves `null` on any gateway
+// failure, so an unknown caller falls to the legacy identity flows instead of
+// invite_redemption — detection never blocks setup on a gateway blip.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup — fail-soft voice-invite detection", () => {
+  test("null gateway invite view (no invite / gateway error) → name_capture, not invite_redemption", async () => {
+    nextTrust = makeTrust("unknown");
+    activeVoiceInvite = null;
+    const { outcome } = await route(null);
+    expect(outcome.action).toBe("name_capture");
+  });
+
+  test("null gateway invite view for an unverified member → unverified_caller, not invite_redemption", async () => {
+    nextTrust = makeTrust("unverified_contact", { status: "unverified" });
+    activeVoiceInvite = null;
+    const { outcome } = await route(null);
+    expect(outcome.action).toBe("unverified_caller");
+  });
+
+  test("null inviteeName from the gateway keeps the neutral-greeting contract", async () => {
+    nextTrust = makeTrust("unknown");
+    activeVoiceInvite = {
+      inviteId: "inv-124",
+      inviteeName: null,
+      guardianName: null,
+      codeDigits: 6,
+    };
+    const { outcome } = await route(null);
+    expect(outcome.action).toBe("invite_redemption");
+    if (outcome.action === "invite_redemption") {
+      expect(outcome.inviteeName).toBeNull();
+    }
   });
 });
 
@@ -414,8 +444,8 @@ function makeMemberVerdict(
 }
 
 describe("routeSetup — caller-trust source", () => {
-  test("present verdict builds trust from the verdict (no local resolve)", () => {
-    const { resolved, outcome } = route(
+  test("present verdict builds trust from the verdict (no local resolve)", async () => {
+    const { resolved, outcome } = await route(
       null,
       makeMemberVerdict("guardian", { status: "active" }),
     );
@@ -425,31 +455,31 @@ describe("routeSetup — caller-trust source", () => {
     expect(outcome.action).toBe("normal_call");
   });
 
-  test("resolutionFailed verdict falls back to local resolveActorTrust", () => {
+  test("resolutionFailed verdict falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
-    const { resolved } = route(null, makeVerdict({ resolutionFailed: true }));
+    const { resolved } = await route(null, makeVerdict({ resolutionFailed: true }));
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
     expect(resolved.actorTrust.trustClass).toBe("guardian");
   });
 
-  test("null verdict falls back to local resolveActorTrust", () => {
+  test("null verdict falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    const { resolved } = route(null, null);
+    const { resolved } = await route(null, null);
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
     expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
   });
 
-  test("absent verdict falls back to local resolveActorTrust", () => {
+  test("absent verdict falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("guardian", { status: "active", role: "guardian" });
-    route(null);
+    await route(null);
 
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
   });
 
-  test("admission floor still applies on the verdict path (guardian_only denies trusted_contact)", () => {
-    const { outcome } = route(
+  test("admission floor still applies on the verdict path (guardian_only denies trusted_contact)", async () => {
+    const { outcome } = await route(
       "guardian_only",
       makeMemberVerdict("trusted_contact", { status: "active" }),
     );
@@ -458,9 +488,9 @@ describe("routeSetup — caller-trust source", () => {
     expect(outcome.action).toBe("deny");
   });
 
-  test("admission floor still applies on the fallback path (guardian_only denies trusted_contact)", () => {
+  test("admission floor still applies on the fallback path (guardian_only denies trusted_contact)", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    const { outcome } = route(
+    const { outcome } = await route(
       "guardian_only",
       makeVerdict({ resolutionFailed: true }),
     );
@@ -477,8 +507,8 @@ describe("routeSetup — caller-trust source", () => {
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — verdict path enforces member ACL", () => {
-  test("blocked member via verdict is denied (not normal_call) under permissive floor", () => {
-    const { outcome } = route(
+  test("blocked member via verdict is denied (not normal_call) under permissive floor", async () => {
+    const { outcome } = await route(
       "strangers",
       makeMemberVerdict("unknown", { status: "blocked" }),
     );
@@ -487,8 +517,8 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     expect(outcome.action).toBe("deny");
   });
 
-  test("revoked member via verdict is denied under permissive floor", () => {
-    const { outcome } = route(
+  test("revoked member via verdict is denied under permissive floor", async () => {
+    const { outcome } = await route(
       "strangers",
       makeMemberVerdict("unknown", { status: "revoked" }),
     );
@@ -497,8 +527,8 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     expect(outcome.action).toBe("deny");
   });
 
-  test("policy deny member via verdict is denied (not normal_call)", () => {
-    const { outcome } = route(
+  test("policy deny member via verdict is denied (not normal_call)", async () => {
+    const { outcome } = await route(
       null,
       makeMemberVerdict("trusted_contact", {
         status: "active",
@@ -510,8 +540,8 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     expect(outcome.action).toBe("deny");
   });
 
-  test("policy escalate member via verdict is denied (live call can't await approval)", () => {
-    const { outcome } = route(
+  test("policy escalate member via verdict is denied (live call can't await approval)", async () => {
+    const { outcome } = await route(
       null,
       makeMemberVerdict("trusted_contact", {
         status: "active",
@@ -523,8 +553,8 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     expect(outcome.action).toBe("deny");
   });
 
-  test("trusted/active member via verdict still admits to normal_call", () => {
-    const { outcome } = route(
+  test("trusted/active member via verdict still admits to normal_call", async () => {
+    const { outcome } = await route(
       null,
       makeMemberVerdict("trusted_contact", {
         status: "active",
@@ -536,8 +566,8 @@ describe("routeSetup — verdict path enforces member ACL", () => {
     expect(outcome.action).toBe("normal_call");
   });
 
-  test("guardian via verdict still admits to normal_call", () => {
-    const { outcome } = route(
+  test("guardian via verdict still admits to normal_call", async () => {
+    const { outcome } = await route(
       null,
       makeMemberVerdict("guardian", { status: "active" }),
     );
@@ -555,9 +585,9 @@ describe("routeSetup — verdict path enforces member ACL", () => {
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — unresolvable member verdict falls back to local", () => {
-  test("member identity with missing status falls back to local resolveActorTrust", () => {
+  test("member identity with missing status falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    const { resolved } = route(
+    const { resolved } = await route(
       null,
       makeVerdict({
         trustClass: "trusted_contact",
@@ -572,9 +602,9 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     expect(resolved.actorTrust.trustClass).toBe("trusted_contact");
   });
 
-  test("member identity with unknown status falls back to local resolveActorTrust", () => {
+  test("member identity with unknown status falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    route(
+    await route(
       null,
       makeVerdict({
         trustClass: "trusted_contact",
@@ -588,9 +618,9 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
   });
 
-  test("member identity with unknown policy falls back to local resolveActorTrust", () => {
+  test("member identity with unknown policy falls back to local resolveActorTrust", async () => {
     nextTrust = makeTrust("trusted_contact", { status: "active" });
-    route(
+    await route(
       null,
       makeVerdict({
         trustClass: "trusted_contact",
@@ -604,15 +634,15 @@ describe("routeSetup — unresolvable member verdict falls back to local", () =>
     expect(resolveActorTrustMock).toHaveBeenCalledTimes(1);
   });
 
-  test("real stranger verdict (no member identity) still takes the verdict path", () => {
-    const { resolved } = route(null, makeVerdict({ trustClass: "unknown" }));
+  test("real stranger verdict (no member identity) still takes the verdict path", async () => {
+    const { resolved } = await route(null, makeVerdict({ trustClass: "unknown" }));
 
     expect(resolveActorTrustMock).not.toHaveBeenCalled();
     expect(resolved.actorTrust.trustClass).toBe("unknown");
   });
 
-  test("valid member verdict (good status+policy) still takes the verdict path", () => {
-    const { outcome } = route(
+  test("valid member verdict (good status+policy) still takes the verdict path", async () => {
+    const { outcome } = await route(
       null,
       makeMemberVerdict("trusted_contact", {
         status: "active",

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -411,7 +411,7 @@ export class MediaStreamCallSession {
       return;
     }
 
-    const { outcome, resolved } = routeSetup({
+    const { outcome, resolved } = await routeSetup({
       callSessionId: this.callSessionId,
       session: session ?? null,
       from,
@@ -420,6 +420,17 @@ export class MediaStreamCallSession {
       admissionPolicy,
       verdict,
     });
+
+    // routeSetup can yield the event loop (gateway voice-invite read); abort
+    // if the session was disposed meanwhile, matching the guards above.
+    if (this.disposed) {
+      log.info(
+        { callSessionId: this.callSessionId },
+        "Media-stream session disposed during setup routing — aborting setup",
+      );
+      this.setupRouting = false;
+      return;
+    }
 
     log.info(
       {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -228,8 +228,8 @@ export class RelayConnection {
   // Inbound voice invite redemption state
   private inviteRedemptionActive = false;
   // In-flight guard: true while an async redemption attempt is awaiting the
-  // gateway-backed claim, so a rapidly-repeated code is deduped rather than
-  // launching a second concurrent redeemVoiceInviteCode.
+  // gateway redemption, so a rapidly-repeated code is deduped rather than
+  // launching a second concurrent gateway redemption.
   private inviteRedemptionInFlight = false;
   private inviteRedemptionAssistantId: string | null = null;
   private inviteRedemptionFromNumber: string | null = null;
@@ -651,7 +651,7 @@ export class RelayConnection {
     admissionPolicy: AdmissionPolicy | null,
     verdict: TrustVerdict | null,
   ): Promise<void> {
-    const { outcome, resolved } = routeSetup({
+    const { outcome, resolved } = await routeSetup({
       callSessionId: this.callSessionId,
       session,
       from: msg.from,
@@ -1763,10 +1763,10 @@ export class RelayConnection {
     }
 
     // Dedup concurrent attempts: a repeated code (re-spoken / re-entered)
-    // arriving while the async gateway-backed claim is still in flight is
-    // ignored, so we never run a second redeemVoiceInviteCode that would see
-    // the invite already consumed and wrongly mark the call failed. The flag
-    // is set synchronously before awaiting and cleared in finally.
+    // arriving while the async gateway redemption is still in flight is
+    // ignored, so we never run a second redemption that would see the invite
+    // already consumed and wrongly mark the call failed. The flag is set
+    // synchronously before awaiting and cleared in finally.
     if (this.inviteRedemptionInFlight) {
       log.info(
         { callSessionId: this.callSessionId },
@@ -1789,7 +1789,6 @@ export class RelayConnection {
     }
 
     const result = await attemptInviteCodeRedemption({
-      inviteRedemptionAssistantId: this.inviteRedemptionAssistantId,
       inviteRedemptionFromNumber: this.inviteRedemptionFromNumber,
       enteredCode,
       guardianLabel: this.resolveGuardianLabel(),
@@ -1802,7 +1801,7 @@ export class RelayConnection {
 
       recordCallEvent(this.callSessionId, "invite_redemption_succeeded", {
         memberId: result.memberId,
-        ...(result.inviteId ? { inviteId: result.inviteId } : {}),
+        inviteId: result.inviteId,
       });
       log.info(
         {

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -9,8 +9,6 @@
 import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import { getConfig } from "../config/loader.js";
-import { getContact } from "../contacts/contact-store.js";
-import { findActiveVoiceInvites } from "../persistence/invite-store.js";
 import {
   type ActorTrustContext,
   resolveActorTrust,
@@ -26,6 +24,7 @@ import {
   verdictMemberUnresolvable,
 } from "../runtime/trust-verdict-consumer.js";
 import { getLogger } from "../util/logger.js";
+import { getActiveVoiceInvite } from "./gateway-invite-reader.js";
 import type { CallSession } from "./types.js";
 
 const log = getLogger("relay-setup-router");
@@ -76,9 +75,9 @@ type SetupOutcome =
       assistantId: string;
       fromNumber: string;
       /**
-       * Display name of the invitee. For inbound redemptions, resolved from the
-       * bound contact's `displayName`; falls back to the legacy `friend_name`
-       * column for pre-contact-binding invites. For outbound invite calls,
+       * Display name of the invitee. For inbound redemptions, supplied by the
+       * gateway's active-voice-invite read (bound contact `displayName`
+       * preferred, invite `friendName` fallback). For outbound invite calls,
        * carries the session-recorded `inviteFriendName`. When null/empty, the
        * relay uses a neutral "Hi there" greeting instead of substituting the
        * channel address.
@@ -109,15 +108,16 @@ export interface SetupResolved {
 /**
  * Determine the setup outcome for an incoming relay connection.
  *
- * This function is pure routing logic — it reads state but performs no
- * side effects (no call-session mutations, no event recording, no WS
- * messages). The caller (`RelayConnection.handleSetup`) is responsible
- * for acting on the returned outcome.
+ * This function is pure routing logic — it reads state (including the
+ * gateway's active-voice-invite view) but performs no side effects (no
+ * call-session mutations, no event recording, no WS messages). The caller
+ * (`RelayConnection.handleSetup`) is responsible for acting on the
+ * returned outcome.
  */
-export function routeSetup(ctx: SetupContext): {
+export async function routeSetup(ctx: SetupContext): Promise<{
   outcome: SetupOutcome;
   resolved: SetupResolved;
-} {
+}> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const isInbound = ctx.session?.initiatedFromConversationId == null;
   const otherPartyNumber = isInbound ? ctx.from : ctx.to;
@@ -302,44 +302,23 @@ export function routeSetup(ctx: SetupContext): {
       };
     }
 
-    // Check for active voice invites
-    let voiceInvites: ReturnType<typeof findActiveVoiceInvites> = [];
-    try {
-      voiceInvites = findActiveVoiceInvites({
-        expectedExternalUserId: ctx.from,
-      });
-    } catch (err) {
-      log.warn(
-        { err, callSessionId: ctx.callSessionId },
-        "Failed to check voice invites for unknown caller",
-      );
-    }
+    // Check for an active voice invite. The gateway row is the lifecycle
+    // authority; the reader fails soft to `null` on any gateway failure, so a
+    // gateway blip falls through to the unverified-caller flows below instead
+    // of stalling setup.
+    const voiceInvite = await getActiveVoiceInvite(ctx.from);
 
-    const now = Date.now();
-    const nonExpiredInvites = voiceInvites.filter(
-      (i) => !i.expiresAt || i.expiresAt > now,
-    );
-
-    if (nonExpiredInvites.length > 0) {
-      const matchedInvite = nonExpiredInvites[0];
+    if (voiceInvite) {
       log.info(
         { callSessionId: ctx.callSessionId, from: ctx.from },
         "Inbound voice ACL: unknown caller has active voice invite — entering redemption flow",
       );
-      // Resolve the invitee's name from the bound contact's displayName so
-      // the post-redemption greeting matches what the guardian sees in the
-      // contact graph. `contact_id` is NOT NULL on the invite row, so every
-      // invite is bound — when the contact has no displayName the greeting
-      // falls through to the neutral "Hi there" copy in relay-server.ts
-      // rather than a stale free-text `friend_name` label.
-      const boundContact = getContact(matchedInvite.contactId);
-      const inviteeName = boundContact?.displayName?.trim() || null;
       return {
         outcome: {
           action: "invite_redemption",
           assistantId,
           fromNumber: ctx.from,
-          inviteeName: inviteeName ?? null,
+          inviteeName: voiceInvite.inviteeName,
         },
         resolved,
       };

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -12,11 +12,11 @@ import {
   getGuardianBinding,
   validateAndConsumeVerification,
 } from "../runtime/channel-verification-service.js";
-import { redeemVoiceInviteCode } from "../runtime/invite-service.js";
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../runtime/verification-templates.js";
+import { redeemVoiceInviteViaGateway } from "./gateway-invite-reader.js";
 import type { CallEventType } from "./types.js";
 
 // ── parseDigitsFromSpeech ──────────────────────────────────────────────
@@ -221,7 +221,6 @@ export async function attemptVerificationCode(
 // ── Invite code redemption ─────────────────────────────────────────────
 
 interface InviteRedemptionParams {
-  inviteRedemptionAssistantId: string;
   inviteRedemptionFromNumber: string;
   enteredCode: string;
   /** Resolved guardian label used in the failure TTS message. */
@@ -233,7 +232,7 @@ type InviteRedemptionResult =
       outcome: "success";
       memberId: string;
       type: "redeemed" | "already_member";
-      inviteId?: string;
+      inviteId: string;
     }
   | {
       outcome: "failure";
@@ -241,33 +240,27 @@ type InviteRedemptionResult =
     };
 
 /**
- * Validate an entered invite code against active voice invites for the
- * caller. Returns a structured result so the caller can handle state
- * mutations and session updates.
+ * Redeem an entered invite code for the caller at the gateway — the single
+ * lifecycle authority for voice invites. Fails CLOSED: any gateway failure is
+ * the generic failure outcome with no local fallback. Returns a structured
+ * result so the caller can handle state mutations and session updates.
  */
 export async function attemptInviteCodeRedemption(
   params: InviteRedemptionParams,
 ): Promise<InviteRedemptionResult> {
-  const {
-    inviteRedemptionAssistantId,
+  const { inviteRedemptionFromNumber, enteredCode, guardianLabel } = params;
+
+  const result = await redeemVoiceInviteViaGateway(
     inviteRedemptionFromNumber,
     enteredCode,
-    guardianLabel,
-  } = params;
-
-  const result = await redeemVoiceInviteCode({
-    assistantId: inviteRedemptionAssistantId,
-    callerExternalUserId: inviteRedemptionFromNumber,
-    sourceChannel: "phone",
-    code: enteredCode,
-  });
+  );
 
   if (result.ok) {
     return {
       outcome: "success",
-      memberId: result.memberId,
-      type: result.type,
-      ...(result.type === "redeemed" ? { inviteId: result.inviteId } : {}),
+      memberId: result.outcome.contactId,
+      type: result.outcome.result,
+      inviteId: result.outcome.inviteId,
     };
   }
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -493,7 +493,7 @@ async function buildVoiceWebhookTwiml(
   const otherPartyNumber = isInbound ? from : to;
   const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
-  const { outcome } = routeSetup({
+  const { outcome } = await routeSetup({
     callSessionId,
     session: session ?? null,
     from,

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -12,11 +12,9 @@ import { startInviteCall } from "../calls/call-domain.js";
 import { isChannelId } from "../channels/types.js";
 import { getContact } from "../contacts/contact-store.js";
 import {
-  findById,
   findByTokenHash,
   hashToken,
   type IngressInvite,
-  markInviteExpired,
 } from "../persistence/invite-store.js";
 import {
   DECLINED_BY_USER_SENTINEL,
@@ -28,11 +26,7 @@ import {
   resolveAdapterHandle,
 } from "./channel-invite-transport.js";
 import { generateInviteInstruction } from "./invite-instruction-generator.js";
-import {
-  redeemInvite as redeemInviteTyped,
-  redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
-  type VoiceRedemptionOutcome,
-} from "./invite-redemption-service.js";
+import { redeemInvite as redeemInviteTyped } from "./invite-redemption-service.js";
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and message handlers
@@ -236,38 +230,35 @@ export async function composeInvitePresentation(params: {
   };
 }
 
-export async function triggerInviteCall(
-  inviteId: string,
-): Promise<IngressResult<{ callSid: string }>> {
-  if (!inviteId) return { ok: false, error: "inviteId is required" };
-  const invite = findById(inviteId);
-  if (!invite) return { ok: false, error: "Invite not found" };
-  if (invite.status !== "active")
-    return { ok: false, error: "Invite is not active" };
-  if (invite.expiresAt && invite.expiresAt <= Date.now()) {
-    markInviteExpired(invite.id);
-    return { ok: false, error: "Invite has expired" };
+/**
+ * Place the outbound provider call for a voice invite. Invite lifecycle
+ * validation (existence, active status, expiry, phone channel) is the
+ * gateway's responsibility — it reads its canonical row and relays the
+ * resolved call fields here; the daemon only performs the provider call.
+ */
+export async function triggerInviteCall(params: {
+  phoneNumber?: string;
+  friendName?: string | null;
+  guardianName?: string | null;
+}): Promise<IngressResult<{ callSid: string }>> {
+  const phoneNumber = params.phoneNumber?.trim();
+  if (!phoneNumber) {
+    return { ok: false, error: "phoneNumber is required" };
   }
-  if (invite.sourceChannel !== "phone")
-    return { ok: false, error: "Only phone invites support call triggering" };
-  if (!invite.expectedExternalUserId) {
-    return { ok: false, error: "Invite is missing required voice metadata" };
-  }
-  // Resolve the invitee's name from the bound contact's displayName.
-  // `contact_id` is NOT NULL on the invite row, so every invite is bound;
-  // an empty displayName falls through to the neutral "Hi there" greeting
-  // downstream rather than a stale free-text `friend_name` label.
-  const boundContact = getContact(invite.contactId);
-  const friendName = boundContact?.displayName?.trim() || "";
-  // Guardian label is resolved at runtime by the relay; mirror the legacy
-  // value into the session so STT hints continue to seed correctly.
-  const guardianName = invite.guardianName || resolveGuardianName() || "";
+  // An empty friendName falls through to the neutral "Hi there" greeting
+  // downstream rather than substituting the channel address.
+  const friendName = params.friendName?.trim() || "";
+  // Guardian label is resolved at runtime by the relay; mirror the value
+  // into the session so STT hints continue to seed correctly.
+  const guardianName = params.guardianName || resolveGuardianName() || "";
   const result = await startInviteCall({
-    phoneNumber: invite.expectedExternalUserId,
+    phoneNumber,
     friendName,
     guardianName,
   });
-  if (!result.ok) return { ok: false, error: result.error };
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
   return { ok: true, data: { callSid: result.callSid } };
 }
 
@@ -306,13 +297,4 @@ export async function redeemIngressInvite(params: {
     ok: true,
     data: { invite: inviteToResponse(inv), type: outcome.type },
   };
-}
-
-export function redeemVoiceInviteCode(params: {
-  assistantId?: string;
-  callerExternalUserId: string;
-  sourceChannel: "phone";
-  code: string;
-}): Promise<VoiceRedemptionOutcome> {
-  return redeemVoiceInviteCodeTyped(params);
 }

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -63,7 +63,7 @@ mock.module("../../../persistence/invite-store.js", () => ({
 // `triggerInviteCall` provider logic directly (never `ipcCallPersistent`).
 let triggerInviteCallResult: unknown = { ok: true, data: { callSid: "CA000" } };
 const triggerInviteCallMock = mock(
-  async (_id: string) => triggerInviteCallResult,
+  async (_params: Record<string, unknown>) => triggerInviteCallResult,
 );
 
 const actualInviteService = await import("../../invite-service.js");
@@ -220,14 +220,23 @@ describe("invite relay routes", () => {
   });
 
   describe("handleTriggerInviteCall (daemon-local carve-out)", () => {
-    test("invokes the local triggerInviteCall and does NOT relay to the gateway", async () => {
+    test("invokes the local triggerInviteCall with the gateway-supplied body fields and does NOT relay to the gateway", async () => {
       triggerInviteCallResult = { ok: true, data: { callSid: "CA123" } };
       const result = await handleTriggerInviteCall({
         pathParams: { id: "i7" },
+        body: {
+          phoneNumber: "+15551234567",
+          friendName: "Alice",
+          guardianName: "Guardian Label",
+        },
       });
 
       expect(triggerInviteCallMock).toHaveBeenCalledTimes(1);
-      expect(triggerInviteCallMock).toHaveBeenCalledWith("i7");
+      expect(triggerInviteCallMock).toHaveBeenCalledWith({
+        phoneNumber: "+15551234567",
+        friendName: "Alice",
+        guardianName: "Guardian Label",
+      });
       // Must NOT relay: relaying invites_trigger_call would loop
       // gateway→assistant→gateway (the gateway calls THIS to place the call).
       expect(ipcCalls).toEqual([]);
@@ -238,7 +247,10 @@ describe("invite relay routes", () => {
       triggerInviteCallResult = { ok: false, error: "Invite not eligible" };
 
       try {
-        await handleTriggerInviteCall({ pathParams: { id: "i7" } });
+        await handleTriggerInviteCall({
+          pathParams: { id: "i7" },
+          body: { phoneNumber: "+15551234567" },
+        });
         throw new Error("expected handler to throw");
       } catch (err) {
         const e = err as { statusCode?: number; message: string };

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -27,10 +27,10 @@ import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { redeemVoiceInviteCode } from "../invite-redemption-service.js";
 import {
   composeInvitePresentation,
   redeemIngressInvite,
-  redeemVoiceInviteCode,
   resolveInviteGuardianName,
   triggerInviteCall,
 } from "../invite-service.js";
@@ -437,14 +437,17 @@ export async function handleRedeemInvite(args: RouteHandlerArgs) {
   return handleRedeemTokenInvite(args);
 }
 
-// Stays daemon-local by design (like invites_redeem): the gateway's call path
-// validates its row then delegates the actual provider call to THIS handler via
-// ipcCallAssistant("invites_trigger_call"). Relaying back would loop
-// gateway→assistant→gateway. The provider call is a daemon capability.
-export async function handleTriggerInviteCall({
-  pathParams = {},
-}: RouteHandlerArgs) {
-  const result = await triggerInviteCall(pathParams.id);
+// Stays daemon-local by design (like invites_redeem): the gateway validates
+// its canonical invite row, then delegates the actual provider call to THIS
+// handler via ipcCallAssistant("invites_trigger_call") with the resolved call
+// fields in the body. Relaying back would loop gateway→assistant→gateway.
+// The provider call is a daemon capability.
+export async function handleTriggerInviteCall({ body = {} }: RouteHandlerArgs) {
+  const result = await triggerInviteCall({
+    phoneNumber: body.phoneNumber as string | undefined,
+    friendName: body.friendName as string | null | undefined,
+    guardianName: body.guardianName as string | null | undefined,
+  });
   if (!result.ok) {
     throw new BadRequestError(result.error);
   }
@@ -658,8 +661,24 @@ export const ROUTES: RouteDefinition[] = [
     },
     handler: handleTriggerInviteCall,
     summary: "Trigger invite call",
-    description: "Trigger an outbound call for a phone invite.",
+    description:
+      "Trigger an outbound call for a phone invite. The gateway validates its canonical invite row and supplies the resolved call fields in the body.",
     tags: ["contacts"],
+    requestBody: z.object({
+      phoneNumber: z
+        .string()
+        .describe("E.164 number the invite call dials (invite's bound caller)"),
+      friendName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Invitee display name for the call greeting"),
+      guardianName: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Guardian display label recorded on the invite"),
+    }),
     responseBody: z.object({
       ok: z.boolean(),
       callSid: z.string().describe("Call SID from the provider"),

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -264,6 +264,11 @@ type GetInviteByIdFn = (inviteId: string) => InviteRow | null;
 let contactStoreGetInviteByIdMock: ReturnType<typeof mock<GetInviteByIdFn>> =
   mock(() => DEFAULT_INVITE);
 
+type MarkInviteExpiredFn = (inviteId: string) => boolean;
+let contactStoreMarkInviteExpiredMock: ReturnType<
+  typeof mock<MarkInviteExpiredFn>
+> = mock(() => true);
+
 mock.module("../db/contact-store.js", () => ({
   NO_INVITE_CODE_HASH: "",
   ContactStore: class MockContactStore {
@@ -287,6 +292,9 @@ mock.module("../db/contact-store.js", () => ({
     }
     getInviteById(inviteId: string) {
       return contactStoreGetInviteByIdMock(inviteId);
+    }
+    markInviteExpired(inviteId: string) {
+      return contactStoreMarkInviteExpiredMock(inviteId);
     }
     async listContactsWithInfo(opts?: {
       limit?: number;
@@ -402,6 +410,7 @@ afterEach(() => {
     row: DEFAULT_INVITE,
   }));
   contactStoreGetInviteByIdMock = mock(() => DEFAULT_INVITE);
+  contactStoreMarkInviteExpiredMock = mock(() => true);
 });
 
 describe("contacts control-plane proxy", () => {
@@ -2590,11 +2599,28 @@ describe("handleRedeemInvite (gateway-native, thin relay)", () => {
 });
 
 describe("handleCallInvite (gateway-native)", () => {
-  test("relays the call for an active invite", async () => {
-    contactStoreGetInviteByIdMock = mock(() => ({
-      ...DEFAULT_INVITE,
-      status: "active",
-    }));
+  // An active, unexpired phone invite bound to a caller number — the callable
+  // fixture the gateway relays to the daemon.
+  const PHONE_INVITE: InviteRow = {
+    ...DEFAULT_INVITE,
+    sourceChannel: "phone",
+    expectedExternalUserId: "+15550100001",
+    friendName: "Friend Label",
+    guardianName: "Guardian Label",
+  };
+
+  function callInvite() {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    return handler.handleCallInvite(
+      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
+        method: "POST",
+      }),
+      "inv_1",
+    );
+  }
+
+  test("relays the call for an active phone invite with the resolved call fields", async () => {
+    contactStoreGetInviteByIdMock = mock(() => PHONE_INVITE);
     ipcCallAssistantMock = mock(async (method: string) => {
       if (method === "invites_trigger_call") {
         return { callSid: "CA123" };
@@ -2602,92 +2628,114 @@ describe("handleCallInvite (gateway-native)", () => {
       return {};
     });
 
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCallInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
-        method: "POST",
-      }),
-      "inv_1",
-    );
+    const res = await callInvite();
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.callSid).toBe("CA123");
-    // The id must land at pathParams.id on the assistant route handler
-    // (handleTriggerInviteCall reads pathParams.id, not body).
+    // The id lands at pathParams.id; the resolved call fields land in body.
+    // The mock contact has no displayName, so friendName falls back to the
+    // invite's friendName.
     expect(ipcCallAssistantMock.mock.calls[0]).toEqual([
       "invites_trigger_call",
-      { pathParams: { id: "inv_1" } },
+      {
+        pathParams: { id: "inv_1" },
+        body: {
+          phoneNumber: "+15550100001",
+          friendName: "Friend Label",
+          guardianName: "Guardian Label",
+        },
+      },
     ]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("relays to the assistant when no gateway row exists (assistant-only invite)", async () => {
-    // Legacy assistant-only invite: no gateway row, but a live daemon-local
-    // row — don't 404; relay and let the daemon-local trigger validate it.
-    contactStoreGetInviteByIdMock = mock(() => null);
-    ipcCallAssistantMock = mock(async (method: string) => {
-      if (method === "invites_trigger_call") {
-        return { callSid: "CA456" };
-      }
-      return {};
-    });
+  test("prefers the bound contact's displayName over the invite friendName", async () => {
+    contactStoreGetInviteByIdMock = mock(() => PHONE_INVITE);
+    contactStoreGetContactMock = mock(() => ({
+      id: "ct_1",
+      displayName: "Curated Name",
+    }));
+    ipcCallAssistantMock = mock(async () => ({ callSid: "CA124" }));
 
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCallInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
-        method: "POST",
-      }),
-      "inv_1",
-    );
+    const res = await callInvite();
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.callSid).toBe("CA456");
-    expect(ipcCallAssistantMock.mock.calls[0]).toEqual([
-      "invites_trigger_call",
-      { pathParams: { id: "inv_1" } },
-    ]);
+    const relayed = ipcCallAssistantMock.mock.calls[0][1] as {
+      body: Record<string, unknown>;
+    };
+    expect(relayed.body.friendName).toBe("Curated Name");
+  });
+
+  test("returns 404 when no gateway row exists (row is the lifecycle authority — no daemon fall-through)", async () => {
+    contactStoreGetInviteByIdMock = mock(() => null);
+
+    const res = await callInvite();
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.message).toMatch(/not found/);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("returns 400 when the invite is not active", async () => {
     contactStoreGetInviteByIdMock = mock(() => ({
-      ...DEFAULT_INVITE,
+      ...PHONE_INVITE,
       status: "revoked",
     }));
 
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCallInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
-        method: "POST",
-      }),
-      "inv_1",
-    );
+    const res = await callInvite();
 
     expect(res.status).toBe(400);
     expect((await res.json()).error.message).toMatch(/not active/);
     expect(ipcCallAssistantMock).not.toHaveBeenCalled();
   });
 
-  test("returns 500 when the call relay throws unexpectedly", async () => {
+  test("returns 400 and sweeps the row when the invite has expired", async () => {
     contactStoreGetInviteByIdMock = mock(() => ({
-      ...DEFAULT_INVITE,
-      status: "active",
+      ...PHONE_INVITE,
+      expiresAt: Date.now() - 1,
     }));
+
+    const res = await callInvite();
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/expired/);
+    expect(contactStoreMarkInviteExpiredMock).toHaveBeenCalledWith("inv_1");
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 for a non-phone invite", async () => {
+    contactStoreGetInviteByIdMock = mock(() => DEFAULT_INVITE); // telegram
+
+    const res = await callInvite();
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/phone invites/);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 for a phone invite missing the bound caller number", async () => {
+    contactStoreGetInviteByIdMock = mock(() => ({
+      ...PHONE_INVITE,
+      expectedExternalUserId: null,
+    }));
+
+    const res = await callInvite();
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toMatch(/voice metadata/);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when the call relay throws unexpectedly", async () => {
+    contactStoreGetInviteByIdMock = mock(() => PHONE_INVITE);
     ipcCallAssistantMock = mock(async () => {
       throw new Error("ipc transport failure");
     });
 
-    const handler = createContactsControlPlaneProxyHandler(makeConfig());
-    const res = await handler.handleCallInvite(
-      new Request("http://localhost:7830/v1/contacts/invites/inv_1/call", {
-        method: "POST",
-      }),
-      "inv_1",
-    );
+    const res = await callInvite();
 
     expect(res.status).toBe(500);
     expect(fetchMock).not.toHaveBeenCalled();

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -41,6 +41,7 @@ import {
   ipcCallAssistant,
 } from "../../ipc/assistant-client.js";
 import { getLogger } from "../../logger.js";
+import { resolveInviteeName } from "../../verification/invite-redemption.js";
 import {
   parseCreateInviteBody,
   parseListInviteQuery,
@@ -364,34 +365,68 @@ export async function revokeInviteNative(
 }
 
 /**
- * Trigger the provider-specific outbound call for an invite. When the gateway
- * row exists (lifecycle source of truth) it gates on `active`. When it's
- * absent — a legacy assistant-only invite — it falls through and lets the
- * daemon-local trigger validate its own row. Returns the provider call sid.
- * Throws InviteNativeError(400) when a present gateway row isn't active,
- * InviteNativeError(500) on relay failure, and propagates an assistant
- * IpcHandlerError unchanged.
+ * Trigger the provider-specific outbound call for an invite. The gateway row
+ * is the lifecycle source of truth: the invite must exist, be `active`,
+ * unexpired, and be a phone invite with a bound caller number. The resolved
+ * call fields (number + display names) are relayed to the daemon, which only
+ * places the provider call. Returns the provider call sid. Throws
+ * InviteNativeError(404) when the invite id is unknown, InviteNativeError(400)
+ * when the invite isn't callable, InviteNativeError(500) on relay failure, and
+ * propagates an assistant IpcHandlerError unchanged.
  */
 export async function triggerInviteCallNative(
   inviteId: string,
 ): Promise<{ callSid: string }> {
-  const invite = new ContactStore().getInviteById(inviteId);
-  // Absent gateway row → legacy assistant-only invite. Don't 404: fall through
-  // and relay; `handleTriggerInviteCall` validates its own local row
-  // (active/inactive) and places the call or surfaces its own error.
-  if (invite && invite.status !== "active") {
+  const store = new ContactStore();
+  const invite = store.getInviteById(inviteId);
+  if (!invite) {
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+  if (invite.status !== "active") {
     throw new InviteNativeError(
       `Invite "${inviteId}" is not active`,
       400,
       "BAD_REQUEST",
     );
   }
+  if (invite.expiresAt <= Date.now()) {
+    store.markInviteExpired(invite.id);
+    throw new InviteNativeError(
+      `Invite "${inviteId}" has expired`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (invite.sourceChannel !== "phone") {
+    throw new InviteNativeError(
+      "Only phone invites support call triggering",
+      400,
+      "BAD_REQUEST",
+    );
+  }
+  if (!invite.expectedExternalUserId) {
+    throw new InviteNativeError(
+      "Invite is missing required voice metadata",
+      400,
+      "BAD_REQUEST",
+    );
+  }
 
   try {
-    // `invites_trigger_call` reads the id from pathParams.id (the assistant IPC
-    // server spreads params into RouteHandlerArgs) — send pathParams, not body.
+    // `invites_trigger_call` reads params from RouteHandlerArgs (the assistant
+    // IPC server spreads params): pathParams.id for the route path, body for
+    // the resolved call fields.
     const result = (await ipcCallAssistant("invites_trigger_call", {
       pathParams: { id: inviteId },
+      body: {
+        phoneNumber: invite.expectedExternalUserId,
+        friendName: resolveInviteeName(store, invite),
+        guardianName: invite.guardianName ?? null,
+      },
     } as unknown as Record<string, unknown>)) as { callSid: string };
     log.info(
       { inviteId, callSid: result.callSid },

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -320,10 +320,24 @@ function sweepExpiredVoiceInvites(
 }
 
 /**
+ * Resolve a voice invite's invitee display name: the target contact's curated
+ * displayName preferred, the invite's free-text friendName as fallback.
+ */
+export function resolveInviteeName(
+  store: ContactStore,
+  invite: IngressInviteRow,
+): string | null {
+  return (
+    store.getContact(invite.contactId)?.displayName?.trim() ||
+    invite.friendName?.trim() ||
+    null
+  );
+}
+
+/**
  * Resolve the active voice invite awaiting a caller, projected to display
  * metadata for the personalized voice prompt (never the code or its hash).
- * The invitee name prefers the target contact's curated displayName over the
- * invite's free-text friendName. Expired stragglers are lazily swept.
+ * Expired stragglers are lazily swept.
  */
 export function getActiveVoiceInviteForCaller(
   callerExternalUserId: string,
@@ -336,13 +350,9 @@ export function getActiveVoiceInviteForCaller(
   const invite = candidates.find((candidate) => candidate.expiresAt > now);
   if (!invite) return null;
 
-  const inviteeName =
-    store.getContact(invite.contactId)?.displayName?.trim() ||
-    invite.friendName?.trim() ||
-    null;
   return {
     inviteId: invite.id,
-    inviteeName,
+    inviteeName: resolveInviteeName(store, invite),
     guardianName: invite.guardianName?.trim() || null,
     codeDigits: invite.voiceCodeDigits ?? DEFAULT_VOICE_CODE_DIGITS,
   };


### PR DESCRIPTION
## Summary
- relay-setup-router detects voice invites via gateway IPC (fail-soft); relay-verification redeems via gateway (fail-closed, no local fallback)
- triggerInviteCall consumes gateway-supplied invite fields; daemon-local re-read and gateway fall-through removed

Part of plan: invites-gateway-native.md (PR 8 of 12)