### PR TITLE
fix(web): HEIC attachment polish — client-side convert, stored-metadata preview, chip fallback

### DIFF
--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -400,7 +400,15 @@ export type PostMessageResult =
   | { ok: false; status: number; error: { code?: string; detail?: string } };
 
 export type UploadAttachmentResult =
-  | { ok: true; id: string }
+  | {
+      ok: true;
+      id: string;
+      /** Stored metadata — may differ from the uploaded file when the
+       *  assistant normalizes the format (e.g. HEIC stored as JPEG). */
+      filename?: string;
+      mimeType?: string;
+      sizeBytes?: number;
+    }
   | { ok: false; status: number; error: { detail?: string } };
 
 /**
@@ -446,7 +454,13 @@ export async function uploadChatAttachment(
       error: { detail: "Upload response did not include an attachment id." },
     };
   }
-  return { ok: true, id };
+  return {
+    ok: true,
+    id,
+    ...(typeof data.filename === "string" ? { filename: data.filename } : {}),
+    ...(typeof data.mimeType === "string" ? { mimeType: data.mimeType } : {}),
+    ...(typeof data.sizeBytes === "number" ? { sizeBytes: data.sizeBytes } : {}),
+  };
 }
 
 /**

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the pure attachment-preparation gates. The async conversion path
+ * needs a real browser image decoder (canvas/createImageBitmap), so it is not
+ * exercised here.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  filenameForResizedImage,
+  IMAGE_AUTO_RESIZE_TARGET_BYTES,
+  isHeicAttachment,
+  shouldAutoResizeImageAttachment,
+  shouldPrepareImageAttachment,
+} from "@/domains/chat/components/chat-attachments/attachment-image-resize";
+
+const SMALL = 100 * 1024;
+const LARGE = IMAGE_AUTO_RESIZE_TARGET_BYTES + 1;
+
+describe("isHeicAttachment", () => {
+  test("matches by mime type", () => {
+    expect(isHeicAttachment({ name: "photo", type: "image/heic" })).toBe(true);
+    expect(isHeicAttachment({ name: "photo", type: "image/heif" })).toBe(true);
+    expect(isHeicAttachment({ name: "photo.png", type: "image/png" })).toBe(false);
+  });
+
+  test("matches by extension when the mime type is missing", () => {
+    // Chromium reports an empty file.type for .heic files.
+    expect(isHeicAttachment({ name: "IMG_5487.HEIC", type: "" })).toBe(true);
+    expect(isHeicAttachment({ name: "photo.heif", type: "" })).toBe(true);
+    expect(isHeicAttachment({ name: "photo.jpg", type: "" })).toBe(false);
+    expect(isHeicAttachment({ name: "myheic.png", type: "" })).toBe(false);
+  });
+});
+
+describe("shouldPrepareImageAttachment", () => {
+  test("HEIC is prepared regardless of size (compatibility conversion)", () => {
+    expect(
+      shouldPrepareImageAttachment({
+        name: "IMG_5487.HEIC",
+        type: "image/heic",
+        size: SMALL,
+      }),
+    ).toBe(true);
+  });
+
+  test("non-HEIC images keep the size gate", () => {
+    const smallPng = { name: "a.png", type: "image/png", size: SMALL };
+    const largePng = { name: "a.png", type: "image/png", size: LARGE };
+    expect(shouldPrepareImageAttachment(smallPng)).toBe(false);
+    expect(shouldPrepareImageAttachment(largePng)).toBe(true);
+    expect(shouldAutoResizeImageAttachment(smallPng)).toBe(false);
+  });
+
+  test("non-image files are never prepared", () => {
+    expect(
+      shouldPrepareImageAttachment({
+        name: "report.pdf",
+        type: "application/pdf",
+        size: LARGE,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filenameForResizedImage", () => {
+  test("rewrites the extension to .jpg", () => {
+    expect(filenameForResizedImage("IMG_5487.HEIC")).toBe("IMG_5487.jpg");
+    expect(filenameForResizedImage("photo.png")).toBe("photo.jpg");
+  });
+
+  test("keeps existing jpeg extensions", () => {
+    expect(filenameForResizedImage("photo.jpg")).toBe("photo.jpg");
+    expect(filenameForResizedImage("photo.JPEG")).toBe("photo.JPEG");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.ts
@@ -54,6 +54,26 @@ export function shouldAutoResizeImageAttachment(file: Pick<File, "name" | "size"
   return isAutoResizableImage(file) && file.size > IMAGE_AUTO_RESIZE_TARGET_BYTES;
 }
 
+export function isHeicAttachment(file: Pick<File, "name" | "type">): boolean {
+  const mimeType = file.type.trim().toLowerCase();
+  if (mimeType === "image/heic" || mimeType === "image/heif") {
+    return true;
+  }
+
+  const extension = file.name.split(".").pop()?.trim().toLowerCase();
+  return extension === "heic" || extension === "heif";
+}
+
+/**
+ * HEIC/HEIF is converted regardless of size — Chromium cannot decode it, so
+ * compatibility (not byte savings) is the goal. Conversion only succeeds where
+ * the browser decodes HEIC (WebKit: Safari, the iOS app); on Chromium it fails
+ * fast and the original uploads for the daemon to normalize.
+ */
+export function shouldPrepareImageAttachment(file: Pick<File, "name" | "size" | "type">): boolean {
+  return shouldAutoResizeImageAttachment(file) || isHeicAttachment(file);
+}
+
 export function filenameForResizedImage(name: string): string {
   const fallback = "attachment";
   const trimmedName = name.trim() || fallback;
@@ -68,7 +88,7 @@ export function filenameForResizedImage(name: string): string {
 export async function prepareImageAttachmentForUpload(
   file: File,
 ): Promise<ImageAttachmentResizeResult> {
-  if (!shouldAutoResizeImageAttachment(file)) {
+  if (!shouldPrepareImageAttachment(file)) {
     return { status: "unchanged", file };
   }
 
@@ -100,7 +120,10 @@ export async function prepareImageAttachmentForUpload(
     } catch {
       resizedBlob = null;
     }
-    if (!resizedBlob || resizedBlob.size >= file.size) {
+    // A JPEG re-encode of a small HEIC is often larger than the source; for
+    // HEIC the size regression is acceptable because the output must be
+    // renderable, not smaller.
+    if (!resizedBlob || (!isHeicAttachment(file) && resizedBlob.size >= file.size)) {
       return {
         status: "failed",
         error: "Couldn't resize this image for upload. Try a smaller image.",

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -4,7 +4,7 @@ import type { FC, KeyboardEvent, MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
+import { fetchAttachmentContentBlob } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
@@ -106,12 +106,8 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     // the same attachment reuses the fetched blob instead of refetching.
     queryKey: ["attachmentContent", assistantId, attachment.id],
     queryFn: async () => {
-      const { data, error } = await attachmentsByIdContentGet({
-        path: { assistant_id: assistantId!, id: attachment.id },
-        parseAs: "blob",
-        throwOnError: false,
-      });
-      if (error || !(data instanceof Blob)) {
+      const data = await fetchAttachmentContentBlob(assistantId!, attachment.id);
+      if (!data) {
         throw new Error("Failed to load file");
       }
       return data;

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -108,4 +108,24 @@ describe("BubbleAttachments", () => {
     const { container } = render(<BubbleAttachments attachments={[]} />);
     expect(container.innerHTML).toBe("");
   });
+
+  test("falls back to the square chip when the inline image fails to decode", () => {
+    const undecodable: DisplayAttachment = {
+      id: "img-3",
+      filename: "IMG_5487.HEIC",
+      mimeType: "image/heic",
+      sizeBytes: 1_024,
+      previewUrl: "blob:undecodable-heic",
+    };
+    const { container, getByRole, getByText } = render(
+      <BubbleAttachments attachments={[undecodable]} />,
+    );
+
+    fireEvent.error(getByRole("button", { name: "IMG_5487.HEIC" }));
+
+    // The browser's broken-image glyph is replaced by the chip: the filename
+    // becomes visible and no <img> remains mounted.
+    expect(getByText("IMG_5487.HEIC")).toBeTruthy();
+    expect(container.querySelector("img")).toBeNull();
+  });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,5 +1,5 @@
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
@@ -32,6 +32,14 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
 }) => {
   const { openPreview, previewModal } = useAttachmentPreview(assistantId, attachments);
 
+  // Ids whose previewUrl the browser failed to decode (e.g. a HEIC blob on a
+  // Chromium renderer). Those fall back to the chip instead of the browser's
+  // broken-image glyph.
+  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(new Set());
+  const markImageFailed = useCallback((id: string) => {
+    setFailedImageIds((prev) => new Set(prev).add(id));
+  }, []);
+
   const handleDownload = useCallback(
     (att: DisplayAttachment) => {
       void downloadAttachment(att, assistantId);
@@ -47,9 +55,11 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
     <>
       <div className="flex flex-col gap-2">
         {attachments.map((att) => {
+          const imageFailed = failedImageIds.has(att.id);
           const isInlineImage =
             classifyAttachment(att.mimeType, att.filename) === "image" &&
-            att.previewUrl != null;
+            att.previewUrl != null &&
+            !imageFailed;
 
           if (isInlineImage) {
             return (
@@ -68,6 +78,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
                     openPreview(att);
                   }
                 }}
+                onError={() => markImageFailed(att.id)}
                 className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-contain"
               />
             );
@@ -79,7 +90,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
               filename={att.filename}
               mimeType={att.mimeType}
               sizeBytes={att.sizeBytes}
-              previewUrl={att.previewUrl}
+              previewUrl={imageFailed ? null : att.previewUrl}
               onPreview={() => openPreview(att)}
               onDownload={() => handleDownload(att)}
             />

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
@@ -1,6 +1,35 @@
 import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
 
 /**
+ * Fetch an attachment's stored bytes from the daemon content endpoint.
+ * Returns null when the id can never resolve (synthetic `rehydrated:` ids
+ * from the text-parsing history fallback) or the fetch fails.
+ */
+export async function fetchAttachmentContentBlob(
+  assistantId: string,
+  attachmentId: string,
+): Promise<Blob | null> {
+  if (!attachmentId || attachmentId.startsWith("rehydrated:")) {
+    return null;
+  }
+
+  try {
+    const { data, error } = await attachmentsByIdContentGet({
+      path: { assistant_id: assistantId, id: attachmentId },
+      parseAs: "blob",
+      throwOnError: false,
+    });
+    if (!error && data instanceof Blob) {
+      return data;
+    }
+    return null;
+  } catch {
+    // Network failure, assistant offline, etc.
+    return null;
+  }
+}
+
+/**
  * Download an attachment directly without opening the preview modal. Prefers
  * the daemon content endpoint because `previewUrl` may be a JPEG thumbnail
  * rather than the actual file (e.g. video attachments with `thumbnailData`
@@ -17,20 +46,11 @@ export async function downloadAttachment(
 ): Promise<void> {
   const { saveFile } = await import("@/runtime/native-file");
 
-  if (assistantId && attachment.id && !attachment.id.startsWith("rehydrated:")) {
-    try {
-      const { data, error } = await attachmentsByIdContentGet({
-        path: { assistant_id: assistantId, id: attachment.id },
-        parseAs: "blob",
-        throwOnError: false,
-      });
-
-      if (!error && data instanceof Blob) {
-        await saveFile(data, attachment.filename);
-        return;
-      }
-    } catch {
-      // Network failure, assistant offline, etc. — fall through to previewUrl.
+  if (assistantId) {
+    const blob = await fetchAttachmentContentBlob(assistantId, attachment.id);
+    if (blob) {
+      await saveFile(blob, attachment.filename);
+      return;
     }
   }
 

--- a/clients/web/src/domains/chat/composer-store.test.ts
+++ b/clients/web/src/domains/chat/composer-store.test.ts
@@ -18,10 +18,26 @@ mock.module("@/utils/local-settings", () => ({
   },
 }));
 
-// Mock the upload dependency — we're testing draft logic, not uploads.
+// Mock the upload dependencies. Hoisted mock fns let the attachment tests
+// vary per-call results (server-canonical metadata, stored-blob fetches).
+import type { UploadAttachmentResult } from "@/domains/chat/api/messages";
+
+const uploadChatAttachmentMock = mock(
+  async (): Promise<UploadAttachmentResult> => ({ ok: true, id: "mock-id" }),
+);
 mock.module("@/domains/chat/api/messages", () => ({
-  uploadChatAttachment: mock(async () => ({ ok: true, id: "mock-id" })),
+  uploadChatAttachment: uploadChatAttachmentMock,
 }));
+const fetchAttachmentContentBlobMock = mock(
+  async (): Promise<Blob | null> => null,
+);
+mock.module(
+  "@/domains/chat/components/chat-attachments/download-attachment",
+  () => ({
+    fetchAttachmentContentBlob: fetchAttachmentContentBlobMock,
+    downloadAttachment: mock(async () => {}),
+  }),
+);
 mock.module(
   "@/domains/chat/components/chat-attachments/attachment-image-resize",
   () => ({
@@ -43,12 +59,29 @@ function getStore() {
 beforeEach(() => {
   getStore().fullReset();
   localSettingsStore.clear();
+  uploadChatAttachmentMock.mockClear();
+  fetchAttachmentContentBlobMock.mockClear();
 });
 
 afterEach(() => {
   getStore().fullReset();
   localSettingsStore.clear();
 });
+
+/** Poll until no attachment is in the transient "uploading" state. */
+async function waitForUploadsSettled(expectedCount: number): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    const atts = getStore().attachments;
+    if (
+      atts.length >= expectedCount &&
+      atts.every((att) => att.kind !== "uploading")
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Attachments never settled");
+}
 
 // ---------------------------------------------------------------------------
 // handleConversationSwitch — save outgoing / restore incoming
@@ -359,5 +392,99 @@ describe("setInput", () => {
     getStore().setInput("hello");
     getStore().setInput((prev) => prev + " world");
     expect(getStore().input).toBe("hello world");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addFiles — server-canonical upload metadata
+// ---------------------------------------------------------------------------
+
+describe("addFiles upload metadata", () => {
+  test("adopts stored metadata and previews the stored bytes when the assistant transcodes", async () => {
+    uploadChatAttachmentMock.mockResolvedValueOnce({
+      ok: true,
+      id: "att-1",
+      filename: "IMG_5487.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 111,
+    });
+    fetchAttachmentContentBlobMock.mockResolvedValueOnce(
+      new Blob(["jpeg-bytes"], { type: "image/jpeg" }),
+    );
+
+    getStore().addFiles(
+      [new File(["heic-bytes"], "IMG_5487.HEIC", { type: "image/heic" })],
+      "assistant-1",
+    );
+    await waitForUploadsSettled(1);
+
+    const att = getStore().attachments[0];
+    expect(att.kind).toBe("uploaded");
+    expect(att.filename).toBe("IMG_5487.jpg");
+    expect(att.mimeType).toBe("image/jpeg");
+    expect(att.sizeBytes).toBe(111);
+    expect(fetchAttachmentContentBlobMock).toHaveBeenCalledWith(
+      "assistant-1",
+      "att-1",
+    );
+  });
+
+  test("skips the stored-bytes fetch when the stored mime matches the local file", async () => {
+    uploadChatAttachmentMock.mockResolvedValueOnce({
+      ok: true,
+      id: "att-2",
+      filename: "photo.png",
+      mimeType: "image/png",
+      sizeBytes: 9,
+    });
+
+    getStore().addFiles(
+      [new File(["png-bytes"], "photo.png", { type: "image/png" })],
+      "assistant-1",
+    );
+    await waitForUploadsSettled(1);
+
+    const att = getStore().attachments[0];
+    expect(att.kind).toBe("uploaded");
+    expect(att.mimeType).toBe("image/png");
+    expect(fetchAttachmentContentBlobMock).not.toHaveBeenCalled();
+  });
+
+  test("still uploads with stored metadata when the stored-bytes fetch fails", async () => {
+    uploadChatAttachmentMock.mockResolvedValueOnce({
+      ok: true,
+      id: "att-3",
+      filename: "IMG_1.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 5,
+    });
+    fetchAttachmentContentBlobMock.mockResolvedValueOnce(null);
+
+    getStore().addFiles(
+      [new File(["heic-bytes"], "IMG_1.HEIC", { type: "image/heic" })],
+      "assistant-1",
+    );
+    await waitForUploadsSettled(1);
+
+    const att = getStore().attachments[0];
+    expect(att.kind).toBe("uploaded");
+    expect(att.filename).toBe("IMG_1.jpg");
+    expect(att.mimeType).toBe("image/jpeg");
+  });
+
+  test("keeps local metadata when the response omits stored fields", async () => {
+    uploadChatAttachmentMock.mockResolvedValueOnce({ ok: true, id: "att-4" });
+
+    getStore().addFiles(
+      [new File(["heic-bytes"], "IMG_2.HEIC", { type: "image/heic" })],
+      "assistant-1",
+    );
+    await waitForUploadsSettled(1);
+
+    const att = getStore().attachments[0];
+    expect(att.kind).toBe("uploaded");
+    expect(att.filename).toBe("IMG_2.HEIC");
+    expect(att.mimeType).toBe("image/heic");
+    expect(fetchAttachmentContentBlobMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/composer-store.ts
+++ b/clients/web/src/domains/chat/composer-store.ts
@@ -27,6 +27,7 @@ import {
   isAutoResizableImage,
   prepareImageAttachmentForUpload,
 } from "@/domains/chat/components/chat-attachments/attachment-image-resize";
+import { fetchAttachmentContentBlob } from "@/domains/chat/components/chat-attachments/download-attachment";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -406,9 +407,29 @@ const useComposerStoreBase = create<ComposerStore>()((set, get) => ({
             return;
           }
 
+          const localMime = uploadFile.type || "application/octet-stream";
+          const storedFilename = result.filename ?? (uploadFile.name || "attachment");
+          const storedMime = result.mimeType ?? localMime;
+          const storedSize = result.sizeBytes ?? uploadFile.size;
+
+          // When the assistant stores a different image format than the local
+          // file (HEIC normalized to JPEG), the local bytes may not be
+          // decodable by this renderer — preview the stored bytes instead.
+          let previewSource: Blob = uploadFile;
+          if (storedMime.startsWith("image/") && storedMime !== localMime) {
+            const storedBlob = await fetchAttachmentContentBlob(assistantId, result.id);
+            if (cancelledUploads.has(pending.localId)) {
+              cancelledUploads.delete(pending.localId);
+              return;
+            }
+            if (storedBlob) {
+              previewSource = storedBlob;
+            }
+          }
+
           let previewUrl: string | null = null;
           try {
-            previewUrl = URL.createObjectURL(uploadFile);
+            previewUrl = URL.createObjectURL(previewSource);
             previewUrls.set(pending.localId, previewUrl);
           } catch {
             previewUrl = null;
@@ -421,9 +442,9 @@ const useComposerStoreBase = create<ComposerStore>()((set, get) => ({
                     kind: "uploaded",
                     localId: pending.localId,
                     id: result.id,
-                    filename: uploadFile.name || "attachment",
-                    mimeType: uploadFile.type || "application/octet-stream",
-                    sizeBytes: uploadFile.size,
+                    filename: storedFilename,
+                    mimeType: storedMime,
+                    sizeBytes: storedSize,
                     previewUrl,
                   } satisfies UploadedAttachment)
                 : att,


### PR DESCRIPTION
## Summary
- Client half of the HEIC attachment fix (daemon half: #36878). `prepareImageAttachmentForUpload` now converts HEIC/HEIF **unconditionally** (previously only >3.5MB): on WebKit surfaces (Safari, the iOS app) the browser can decode HEIC so the upload is already JPEG — covering daemons where `sips` is unavailable; on Chromium it fails fast and the original uploads for the daemon to normalize. The JPEG-larger-than-HEIC size regression is accepted for HEIC since the goal is renderability.
- The upload API now surfaces the stored `filename`/`mimeType`/`sizeBytes` (fields the daemon already returned), and the composer adopts them; when the stored mime differs from the local file (daemon transcoded), the freshly-sent bubble previews the stored bytes fetched via the new shared `fetchAttachmentContentBlob` helper — extracted from `downloadAttachment` and now also used by the preview modal (removes a duplicated fetch).
- `BubbleAttachments` tracks per-attachment `<img>` decode failures via `onError` and falls back to the `MessageAttachmentSquare` chip, so no surface ever shows the browser's broken-image glyph (e.g. Chromium + a daemon that can't convert).

## Original prompt
User dragged an iPhone HEIC photo into the macOS Electron app and the message rendered a broken-image glyph with just the filename — Chromium cannot decode HEIF. PR #36878 fixed the daemon (upload-time HEIC→JPEG normalization + legacy history transcode); this PR completes the client side: WebKit-side conversion for non-macOS daemons, correct fresh-bubble previews after daemon transcode, and a graceful chip fallback for any undecodable image.