### PR TITLE
feat(search): un-gate message-lexical indexing from memory.enabled

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -195,6 +195,7 @@ mock.module("../persistence/jobs-store.js", () => ({
     automatic: "automatic",
     manual: "manual",
   },
+  MESSAGE_LEXICAL_JOB_TYPES: [],
   resetRunningJobsToPending: mock(() => 0),
   SLOW_LLM_JOB_TYPES: [],
   upsertAutoAnalysisJob: mock(() => "job-auto-analysis"),

--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -35,19 +35,6 @@ mock.module("../persistence/conversation-search-lexical.js", () => ({
   },
 }));
 
-// Drives the real recall availability gate: when true the source yields no
-// evidence, because the lexical index write path is suppressed and the
-// collection is never populated. Defaults false so every other test exercises
-// the live path. Spread the real module so its other exports (job handlers,
-// enqueue helpers) stay intact for transitive importers.
-let suppressIndexing = false;
-const realLexicalModule =
-  await import("../persistence/job-handlers/message-lexical.js");
-mock.module("../persistence/job-handlers/message-lexical.js", () => ({
-  ...realLexicalModule,
-  isMemoryIndexingSuppressed: () => suppressIndexing,
-}));
-
 import {
   deleteMemoryCheckpoint,
   LEXICAL_BACKFILL_COMPLETE_KEY,
@@ -67,15 +54,13 @@ describe("searchConversationSource (qdrant lexical index)", () => {
     getDb().run("DELETE FROM messages");
     getDb().run("DELETE FROM conversations");
     lexicalCalls = [];
-    suppressIndexing = false;
-    // Content evidence is available once the index is populated: not
-    // suppressed + backfill complete. Most tests exercise that path, so mark
-    // the backfill complete; the gates are covered by their own tests.
+    // Content evidence is available once the index is populated (backfill
+    // complete). Most tests exercise that path, so mark the backfill
+    // complete; the gate is covered by its own test.
     setMemoryCheckpoint(LEXICAL_BACKFILL_COMPLETE_KEY, "1");
   });
 
   afterEach(() => {
-    suppressIndexing = false;
     deleteMemoryCheckpoint(LEXICAL_BACKFILL_COMPLETE_KEY);
     lexicalMockImpl = () => {
       throw new Error(
@@ -138,29 +123,6 @@ describe("searchConversationSource (qdrant lexical index)", () => {
     expect(lexicalCalls).toHaveLength(0);
     expect(shortResult.evidence).toEqual([]);
     expect(unicodeResult.evidence).toEqual([]);
-  });
-
-  test("returns no evidence when memory indexing is suppressed", async () => {
-    await seedConversation({
-      title: "Suppressed indexing notes",
-      content: "The suppressedtoken decision is recorded here.",
-    });
-
-    // The lexical index is never populated while indexing is suppressed, so
-    // the source must yield no evidence without consulting Qdrant.
-    suppressIndexing = true;
-    lexicalMockImpl = async () => {
-      throw new Error("searchMessageIdsLexical must not run while suppressed");
-    };
-
-    const result = await searchConversationSource(
-      "suppressedtoken",
-      makeContext(),
-      5,
-    );
-
-    expect(lexicalCalls).toHaveLength(0);
-    expect(result.evidence).toEqual([]);
   });
 
   test("returns no evidence until the backfill completion checkpoint is set", async () => {

--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -1,9 +1,9 @@
-// Integration coverage for the messages lexical-index dual-write wiring:
-//   - a real persist (`addMessage` → `onMessagePersisted`) enqueues one
-//     `index_message_lexical` job for the message when memory is enabled, and
-//     none when memory is disabled;
+// Integration coverage for the messages lexical-index write wiring:
+//   - a real persist (`addMessage`) enqueues one `index_message_lexical` job
+//     for the message, regardless of whether memory is enabled or disabled
+//     (message-content search is host infrastructure);
 //   - forking a conversation copies message rows WITHOUT routing through
-//     `onMessagePersisted`, so a fork enqueues ZERO `index_message_lexical`
+//     the persist path, so a fork enqueues ZERO `index_message_lexical`
 //     jobs (the fork-exclusion regression);
 //   - wiping a conversation enqueues one `purge_conversation_lexical` job.
 //
@@ -161,12 +161,16 @@ describe("messages lexical-index dual-write", () => {
     expect(lexicalJobMessageIds()).toContain(message.id);
   });
 
-  test("addMessage enqueues NO index_message_lexical job when memory is disabled", async () => {
+  test("addMessage still enqueues an index_message_lexical job when memory is disabled", async () => {
     setMemoryEnabled(false);
     const conv = createConversation("Disabled memory thread");
-    await addMessage(conv.id, "user", "should not be lexically indexed");
+    const message = await addMessage(
+      conv.id,
+      "user",
+      "lexically indexed regardless of memory state",
+    );
 
-    expect(countJobs("index_message_lexical")).toBe(0);
+    expect(lexicalJobMessageIds()).toContain(message.id);
   });
 
   test("enqueueLexicalIndexForMessage no-ops on an empty message id", () => {

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -87,7 +87,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../../persistence/db-connection.js",
     "../../../../../persistence/embeddings/embed.js",
     "../../../../../persistence/embeddings/embedding-backend.js",
-    "../../../../../persistence/job-handlers/message-lexical.js",
     "../../../../../persistence/raw-query.js",
     "../../../../../persistence/schema/index.js",
     "../../../../../security/untrusted-content.js",

--- a/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
+++ b/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
@@ -40,10 +40,9 @@ mock.module("../conversation-search-lexical.js", () => ({
   searchMessageIdsLexical: searchMessageIdsLexicalMock,
 }));
 
-// Content search is unavailable when memory is disabled (the lexical index is
-// only written while memory is enabled). Control `isMemoryEnabled` so most
-// tests run with it `true`, and one test flips it `false` to assert the
-// title-only behavior. Spread the real module to preserve its other exports
+// Message-content search is host infrastructure, independent of the memory
+// feature. Control `isMemoryEnabled` so one test can flip it `false` and
+// prove reads ignore it. Spread the real module to preserve its other exports
 // (many modules import from `jobs-store`).
 let memoryEnabled = true;
 const actualJobsStore = await import("../jobs-store.js");
@@ -307,22 +306,22 @@ describe("searchConversations · qdrant lexical index", () => {
     expect(results[0]!.matchingMessages).toEqual([]);
   });
 
-  test("returns title matches only when memory is disabled (content search unavailable)", async () => {
-    // The lexical index is only written while memory is enabled, so with
-    // memory off it is empty and a lookup would silently return no content
-    // matches. The index must not be consulted at all; only titles can match.
+  test("serves lexical content matches even when memory is disabled", async () => {
+    // Message-content search is host infrastructure: indexing runs and reads
+    // serve regardless of the memory feature's state, so disabling memory
+    // must not degrade search to title-only.
     memoryEnabled = false;
-    const contentOnly = createConversation("Notes");
-    insertMessage("m-1", contentOnly.id, "flux capacitor in content only");
-    const titleMatch = createConversation("Flux capacitor planning");
-    // Even if the index somehow returned a candidate, it must not be consulted.
+    const conv = createConversation("Notes");
+    insertMessage("m-1", conv.id, "flux capacitor in content only");
     lexicalReturns(["m-1"]);
 
     const results = await searchConversations("flux capacitor");
 
-    expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
-    expect(results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
-    expect(results[0]!.matchingMessages).toEqual([]);
+    expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => r.conversationId)).toEqual([conv.id]);
+    expect(results[0]!.matchingMessages.map((m) => m.messageId)).toEqual([
+      "m-1",
+    ]);
   });
 
   test("returns title matches only until the backfill completion checkpoint is set", async () => {

--- a/assistant/src/persistence/__tests__/jobs-worker-memory-disabled.test.ts
+++ b/assistant/src/persistence/__tests__/jobs-worker-memory-disabled.test.ts
@@ -1,0 +1,95 @@
+/**
+ * With `memory.enabled === false` the job worker still drains the
+ * MESSAGE-LEXICAL job types (host-owned message-search indexing that shares
+ * the queue) while every memory job stays pending — the slow and embed lanes
+ * get no budget and the fast lane is restricted to the lexical types.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import type { AssistantConfig } from "../../config/types.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let memoryEnabled = false;
+const testConfig = (): AssistantConfig => ({
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    enabled: memoryEnabled,
+  },
+});
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => testConfig(),
+  loadConfig: () => testConfig(),
+  invalidateConfigCache: () => {},
+}));
+
+import { getMemoryDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { enqueueMemoryJob } from "../jobs-store.js";
+import { registerJobHandler, runMemoryJobsOnce } from "../jobs-worker.js";
+import { memoryJobs } from "../schema/index.js";
+
+await initializeDb();
+
+const processed: string[] = [];
+registerJobHandler("index_message_lexical", async (job) => {
+  processed.push(job.type);
+});
+registerJobHandler("memory_v2_activation_recompute", async (job) => {
+  processed.push(job.type);
+});
+
+function jobStatuses(type: string): string[] {
+  return getMemoryDb()!
+    .select({ status: memoryJobs.status })
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, type))
+    .all()
+    .map((row) => row.status);
+}
+
+describe("runMemoryJobsOnce with memory disabled", () => {
+  beforeEach(() => {
+    getMemoryDb()!.delete(memoryJobs).run();
+    processed.length = 0;
+    memoryEnabled = false;
+  });
+
+  test("drains lexical jobs while leaving memory jobs pending", async () => {
+    enqueueMemoryJob("index_message_lexical", { messageId: "msg-1" });
+    // A fast-lane MEMORY job type: proves the restriction is by type, not
+    // just by zeroing the slow/embed lane budgets.
+    enqueueMemoryJob("memory_v2_activation_recompute", {});
+
+    const ran = await runMemoryJobsOnce();
+
+    expect(ran).toBe(1);
+    expect(processed).toEqual(["index_message_lexical"]);
+    expect(jobStatuses("index_message_lexical")).toEqual(["completed"]);
+    expect(jobStatuses("memory_v2_activation_recompute")).toEqual(["pending"]);
+  });
+
+  test("drains both once memory is re-enabled", async () => {
+    enqueueMemoryJob("index_message_lexical", { messageId: "msg-2" });
+    enqueueMemoryJob("memory_v2_activation_recompute", {});
+
+    memoryEnabled = true;
+    const ran = await runMemoryJobsOnce();
+
+    expect(ran).toBe(2);
+    expect(jobStatuses("index_message_lexical")).toEqual(["completed"]);
+    expect(jobStatuses("memory_v2_activation_recompute")).toEqual([
+      "completed",
+    ]);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -72,6 +72,7 @@ import {
   copyForkMessagesViaSubprocess,
   type ForkIdPair,
 } from "./fork-message-copy.js";
+import { enqueueLexicalIndexForMessage } from "./job-handlers/message-lexical.js";
 import { getMemoryPersistenceHooks } from "./memory-lifecycle-hooks.js";
 import {
   rawExec,
@@ -1684,6 +1685,12 @@ export async function addMessage(
   const message = inserted;
 
   if (!skipIndexing) {
+    // Message-content lexical indexing is host infrastructure, invoked
+    // directly (not through the memory hook seam, whose active side effects go
+    // inert while the memory plugin is disabled — search indexing must not).
+    // The direct write seams (streaming finalize, import, edit) enqueue for
+    // themselves; this covers the plain addMessage path.
+    enqueueLexicalIndexForMessage(message.id);
     try {
       const parsed = metadata
         ? messageMetadataSchema.safeParse(metadata)

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -15,7 +15,6 @@ import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { searchMessageIdsLexical } from "./conversation-search-lexical.js";
 import type { ConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
-import { isMemoryEnabled } from "./jobs-store.js";
 import { rawAll } from "./raw-query.js";
 import { conversations, messages } from "./schema/index.js";
 
@@ -282,7 +281,9 @@ export function getMessageRoleStatsByConversation(
   conversationIds: string[],
   role: string = "assistant",
 ): Map<string, { count: number; lastAt: number }> {
-  if (conversationIds.length === 0) return new Map();
+  if (conversationIds.length === 0) {
+    return new Map();
+  }
   const db = getDb();
   const rows = db
     .select({
@@ -433,7 +434,9 @@ export function isLastUserMessageToolResult(conversationId: string): boolean {
     .limit(1)
     .get();
 
-  if (!lastUserMsg) return false;
+  if (!lastUserMsg) {
+    return false;
+  }
 
   try {
     const parsed = JSON.parse(lastUserMsg.content);
@@ -493,20 +496,14 @@ function likeContainsPattern(query: string): string {
 /**
  * Whether the sparse Qdrant `messages_lexical` index — the only source of
  * message-content matches — is a safe read source. Content matching is
- * unavailable (title matches only) in two cases, each of which would
- * otherwise silently return too little (an empty result — not a throw):
- *   1. Memory is disabled — the per-message write path is suppressed, so the
- *      collection is never forward-filled. `!isMemoryEnabled()` is the
- *      layer-clean check available from `persistence/`.
- *   2. The one-time upgrade backfill has not finished — the collection is only
- *      partially populated, so older content is missing until it drains.
- *
- * The recall read site applies the same completion gate (via the shared
- * {@link isLexicalBackfillComplete}) on top of its own, stricter suppression
- * check (`isMemoryIndexingSuppressed`, which also covers a disabled plugin).
+ * unavailable (title matches only) until the one-time upgrade backfill has
+ * fully drained: a partially populated collection would silently miss older
+ * content (an empty result — not a throw). Indexing itself is unconditional
+ * host infrastructure, so completion is the only gate; the recall read site
+ * applies the same one via the shared {@link isLexicalBackfillComplete}.
  */
 function isMessageContentSearchAvailable(): boolean {
-  return isMemoryEnabled() && isLexicalBackfillComplete();
+  return isLexicalBackfillComplete();
 }
 
 /**
@@ -535,7 +532,9 @@ export async function searchConversations(
   query: string,
   opts?: { limit?: number; maxMessagesPerConversation?: number },
 ): Promise<ConversationSearchResult[]> {
-  if (!query.trim()) return [];
+  if (!query.trim()) {
+    return [];
+  }
 
   ensureGroupMigration();
   const db = getDb();
@@ -617,13 +616,18 @@ export async function searchConversations(
       qdrantCandidatesByConv = new Map();
       for (const candidate of candidates) {
         const convId = visibleConvByMessageId.get(candidate.messageId);
-        if (!convId) continue;
+        if (!convId) {
+          continue;
+        }
         const bucket = qdrantCandidatesByConv.get(convId);
         if (bucket) {
           bucket.push(candidate.messageId);
         } else {
-          if (qdrantCandidatesByConv.size >= CONVERSATION_SEARCH_DISTINCT_LIMIT)
+          if (
+            qdrantCandidatesByConv.size >= CONVERSATION_SEARCH_DISTINCT_LIMIT
+          ) {
             continue;
+          }
           qdrantCandidatesByConv.set(convId, [candidate.messageId]);
           contentConvIds.add(convId);
         }
@@ -661,9 +665,13 @@ export async function searchConversations(
       ),
     )
     .all();
-  for (const row of titleMatchConvs) contentConvIds.add(row.id);
+  for (const row of titleMatchConvs) {
+    contentConvIds.add(row.id);
+  }
 
-  if (contentConvIds.size === 0) return [];
+  if (contentConvIds.size === 0) {
+    return [];
+  }
 
   // Fetch the matching conversation rows, ordered by updatedAt, capped at limit.
   const convIds = [...contentConvIds];
@@ -682,7 +690,9 @@ export async function searchConversations(
     limit,
   );
 
-  if (matchingConversations.length === 0) return [];
+  if (matchingConversations.length === 0) {
+    return [];
+  }
 
   const results: ConversationSearchResult[] = [];
 

--- a/assistant/src/persistence/job-handlers/__tests__/message-lexical-backfill.test.ts
+++ b/assistant/src/persistence/job-handlers/__tests__/message-lexical-backfill.test.ts
@@ -192,10 +192,9 @@ function setMemoryEnabled(enabled: boolean): void {
 
 /**
  * Toggle the memory plugin's `.disabled` sentinel in the real workspace plugins
- * dir so `isMemoryIndexingSuppressed()` (via `isPluginDisabled(MEMORY_PLUGIN_NAME)`)
- * sees the change. Driving the real sentinel — not a process-global mock —
- * exercises the same suppression path the write/recall gates use and avoids
- * leaking a mock into sibling test files.
+ * dir. Driving the real sentinel — not a process-global mock — proves the
+ * backfill enqueue ignores the plugin's disabled state without leaking a mock
+ * into sibling test files.
  */
 function setMemoryPluginDisabled(disabled: boolean): void {
   const dir = join(getWorkspacePluginsDir(), MEMORY_PLUGIN_NAME);
@@ -430,29 +429,24 @@ describe("backfillLexicalIndexJob", () => {
       expect(pendingBackfillJobCount()).toBe(0);
     });
 
-    test("does NOT enqueue when memory is disabled", () => {
+    // Message-content search is host infrastructure: the backfill enqueues
+    // regardless of the memory feature's or memory plugin's state (the job
+    // worker drains the lexical types even while memory is disabled).
+    test("enqueues even when memory is disabled", () => {
       setMemoryEnabled(false);
 
       maybeEnqueueLexicalBackfillOnUpgrade();
 
-      expect(pendingBackfillJobCount()).toBe(0);
+      expect(pendingBackfillJobCount()).toBe(1);
     });
 
-    // Indexing is suppressed by the memory plugin's `.disabled` sentinel even
-    // while `memory.enabled` is true. The hook gates on the same
-    // `isMemoryIndexingSuppressed` signal as the write/recall paths, so it must
-    // skip: enqueuing (and later setting the completion marker) would leave a
-    // stale index that a lexical-backed read could serve while per-message writes
-    // stay suppressed.
-    test("does NOT enqueue when the memory plugin is disabled but memory.enabled is true", () => {
+    test("enqueues even when the memory plugin is disabled", () => {
       setMemoryEnabled(true);
       setMemoryPluginDisabled(true);
 
       maybeEnqueueLexicalBackfillOnUpgrade();
 
-      expect(pendingBackfillJobCount()).toBe(0);
-      // The completion marker must stay unset so reads stay on FTS.
-      expect(isLexicalBackfillComplete()).toBe(false);
+      expect(pendingBackfillJobCount()).toBe(1);
     });
 
     test("does NOT enqueue a duplicate when a backfill job is already pending", () => {

--- a/assistant/src/persistence/job-handlers/__tests__/message-lexical-enqueue.test.ts
+++ b/assistant/src/persistence/job-handlers/__tests__/message-lexical-enqueue.test.ts
@@ -1,10 +1,7 @@
-// When memory is DISABLED the memory job worker skips every job
-// (`runMemoryJobsOnce` returns early), so an enqueued cleanup job would sit
-// pending forever and its Qdrant points would leak. But Qdrant itself is still
-// up (daemon startup boots it unconditionally, independent of `memory.enabled`),
-// so the cleanup enqueue helpers run the purge/delete INLINE instead. These
-// tests verify that split: enqueue when enabled, inline Qdrant delete when
-// disabled — for the cleanup paths only.
+// Message-content lexical indexing is host infrastructure: the enqueue
+// helpers schedule jobs unconditionally — regardless of `memory.enabled` or
+// the memory plugin's `.disabled` sentinel — and never touch Qdrant inline.
+// (The job worker drains the lexical types even while memory is disabled.)
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -17,10 +14,10 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 // Spread the real lexical-index module and override only the singleton
-// accessors to return a fake that records the inline delete calls. Spreading
-// keeps the module's other exports (`MessagesLexicalIndex`, `messagePointId`)
-// intact so this partial mock cannot leak into sibling test files that import
-// them. Its deps (`@qdrant/js-client-rest`, `uuid`) resolve in the worktree.
+// accessors to return a fake that records any inline delete calls (there
+// should be none — the helpers are enqueue-only). Spreading keeps the module's
+// other exports intact so this partial mock cannot leak into sibling test
+// files that import them.
 const deleteByConversationCalls: string[] = [];
 const deleteByMessageIdCalls: string[] = [];
 const fakeIndex = {
@@ -93,7 +90,7 @@ function jobCount(type: string): number {
     .all().length;
 }
 
-// Let the fire-and-forget inline promise settle.
+// Let any stray fire-and-forget promise settle before asserting.
 const flush = () => new Promise((r) => setTimeout(r, 5));
 
 beforeEach(() => {
@@ -104,90 +101,63 @@ beforeEach(() => {
   setMemoryPluginDisabled(false);
 });
 
-describe("lexical cleanup when memory is enabled — enqueues a job", () => {
-  test("purge enqueues a job and does NOT delete inline", async () => {
+describe("lexical enqueues with memory enabled", () => {
+  test("index, purge, and delete each enqueue a job and never touch Qdrant inline", async () => {
+    enqueueLexicalIndexForMessage("msg-1");
     enqueuePurgeConversationLexical("conv-1");
+    enqueueDeleteMessageLexical("msg-2");
     await flush();
+    expect(jobCount("index_message_lexical")).toBe(1);
     expect(jobCount("purge_conversation_lexical")).toBe(1);
-    expect(deleteByConversationCalls).toEqual([]);
-  });
-
-  test("delete enqueues a job and does NOT delete inline", async () => {
-    enqueueDeleteMessageLexical("msg-1");
-    await flush();
     expect(jobCount("delete_message_lexical")).toBe(1);
+    expect(deleteByConversationCalls).toEqual([]);
     expect(deleteByMessageIdCalls).toEqual([]);
   });
 });
 
-describe("lexical cleanup when memory is DISABLED — runs inline", () => {
-  test("purge deletes the conversation inline and enqueues NO job", async () => {
+describe("lexical enqueues with memory DISABLED — unchanged", () => {
+  test("index, purge, and delete still enqueue jobs (the worker drains lexical types while memory is off)", async () => {
     setMemoryEnabled(false);
+    enqueueLexicalIndexForMessage("msg-9");
     enqueuePurgeConversationLexical("conv-9");
+    enqueueDeleteMessageLexical("msg-10");
     await flush();
-    expect(deleteByConversationCalls).toEqual(["conv-9"]);
-    expect(jobCount("purge_conversation_lexical")).toBe(0);
-  });
-
-  test("delete removes the message point inline and enqueues NO job", async () => {
-    setMemoryEnabled(false);
-    enqueueDeleteMessageLexical("msg-9");
-    await flush();
-    expect(deleteByMessageIdCalls).toEqual(["msg-9"]);
-    expect(jobCount("delete_message_lexical")).toBe(0);
-  });
-
-  test("empty ids no-op in both modes", async () => {
-    setMemoryEnabled(false);
-    enqueuePurgeConversationLexical("");
-    enqueueDeleteMessageLexical("");
-    await flush();
+    expect(jobCount("index_message_lexical")).toBe(1);
+    expect(jobCount("purge_conversation_lexical")).toBe(1);
+    expect(jobCount("delete_message_lexical")).toBe(1);
     expect(deleteByConversationCalls).toEqual([]);
     expect(deleteByMessageIdCalls).toEqual([]);
     // Sanity: config really is disabled for this test.
     expect(getConfig().memory.enabled).toBe(false);
   });
+
+  test("empty ids no-op", async () => {
+    setMemoryEnabled(false);
+    enqueueLexicalIndexForMessage("");
+    enqueuePurgeConversationLexical("");
+    enqueueDeleteMessageLexical("");
+    await flush();
+    expect(jobCount("index_message_lexical")).toBe(0);
+    expect(jobCount("purge_conversation_lexical")).toBe(0);
+    expect(jobCount("delete_message_lexical")).toBe(0);
+  });
 });
 
-// The INDEX/write path must honor the plugin's `.disabled` sentinel (the same
-// full disabled-state check the host applies in the guarded hook seam), because
-// the direct index-write callers (finalize/import/edit/consolidation) run
-// outside that guard. The CLEANUP paths must still run while disabled so points
-// written when enabled are not orphaned.
-describe("plugin disabled via the .disabled sentinel (config still enabled)", () => {
-  test("index write is suppressed — enqueues NO index_message_lexical job", async () => {
+describe("plugin disabled via the .disabled sentinel — unchanged", () => {
+  test("index write still enqueues (search indexing is not a plugin feature)", async () => {
     setMemoryPluginDisabled(true);
     enqueueLexicalIndexForMessage("msg-idx");
     await flush();
-    expect(jobCount("index_message_lexical")).toBe(0);
+    expect(jobCount("index_message_lexical")).toBe(1);
   });
 
-  test("index write resumes once the sentinel is removed", async () => {
-    setMemoryPluginDisabled(true);
-    enqueueLexicalIndexForMessage("msg-a");
-    setMemoryPluginDisabled(false);
-    enqueueLexicalIndexForMessage("msg-b");
-    await flush();
-    // Only the post-enable write was indexed.
-    const ids = getMemoryDb()!
-      .select({ payload: memoryJobs.payload })
-      .from(memoryJobs)
-      .where(eq(memoryJobs.type, "index_message_lexical"))
-      .all()
-      .map((r) => (JSON.parse(r.payload) as { messageId?: string }).messageId);
-    expect(ids).toEqual(["msg-b"]);
-  });
-
-  test("cleanup STILL runs while the plugin is disabled — enqueues purge + delete jobs", async () => {
+  test("cleanup still enqueues purge + delete jobs", async () => {
     setMemoryPluginDisabled(true);
     enqueuePurgeConversationLexical("conv-x");
     enqueueDeleteMessageLexical("msg-x");
     await flush();
-    // Config is still enabled, so cleanup takes the enqueue path (the worker
-    // does not gate on the `.disabled` sentinel, so these jobs drain).
     expect(jobCount("purge_conversation_lexical")).toBe(1);
     expect(jobCount("delete_message_lexical")).toBe(1);
-    // ...and it did not run inline (config enabled → enqueue, not inline).
     expect(deleteByConversationCalls).toEqual([]);
     expect(deleteByMessageIdCalls).toEqual([]);
   });

--- a/assistant/src/persistence/job-handlers/message-lexical-backfill.ts
+++ b/assistant/src/persistence/job-handlers/message-lexical-backfill.ts
@@ -20,10 +20,7 @@ import {
   type MemoryJob,
 } from "../jobs-store.js";
 import { messages } from "../schema/index.js";
-import {
-  isMemoryIndexingSuppressed,
-  resolveLexicalIndex,
-} from "./message-lexical.js";
+import { resolveLexicalIndex } from "./message-lexical.js";
 
 const log = getLogger("lexical-backfill");
 
@@ -53,22 +50,17 @@ const LEXICAL_BACKFILL_CHECKPOINT_ID_KEY = "lexical:messages:last_id";
  * philosophy of never blocking or doing expensive work at boot.
  *
  * Guards (all must pass to enqueue):
- * - Memory indexing must not be suppressed — memory enabled AND the memory
- *   plugin not disabled — using the same {@link isMemoryIndexingSuppressed}
- *   signal as the write/recall paths. When `memory.enabled === false` the memory
- *   job worker drains nothing (`runMemoryJobsOnce` returns early), so an enqueued
- *   backfill would sit pending forever and only accumulate dead rows. When the
- *   memory plugin is disabled via its `.disabled` sentinel, per-message index
- *   writes are suppressed, so completing a backfill would leave a stale index
- *   that a lexical-backed read could serve; gating on the same signal keeps the
- *   completion marker unset while writes are suppressed, so every read path stays
- *   on FTS in that state (the marker unifies them).
  * - The completion sentinel must be unset. Once the backfill has fully drained
  *   on this instance there is nothing to do; the marker makes this idempotent
  *   across restarts.
  * - No backfill job may already be pending or running. Without this, every
  *   restart during a long backfill would pile up a duplicate job. (The batches
  *   are idempotent, but redundant jobs waste worker cycles.)
+ *
+ * Unconditional beyond those guards: message-content search is host
+ * infrastructure, so the backfill runs regardless of the memory feature's or
+ * memory plugin's state (the job worker drains the lexical types even while
+ * memory is disabled).
  *
  * An instance that was already manually backfilled via the route but predates
  * the completion sentinel re-enqueues once here and re-runs the idempotent
@@ -80,9 +72,6 @@ const LEXICAL_BACKFILL_CHECKPOINT_ID_KEY = "lexical:messages:last_id";
  */
 export function maybeEnqueueLexicalBackfillOnUpgrade(): void {
   try {
-    if (isMemoryIndexingSuppressed()) {
-      return;
-    }
     if (isLexicalBackfillComplete()) {
       return;
     }

--- a/assistant/src/persistence/job-handlers/message-lexical.ts
+++ b/assistant/src/persistence/job-handlers/message-lexical.ts
@@ -1,8 +1,6 @@
 import { eq } from "drizzle-orm";
 
-import { getConfig } from "../../config/loader.js";
 import type { AssistantConfig } from "../../config/types.js";
-import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLogger } from "../../util/logger.js";
 import { getDb } from "../db-connection.js";
 import { generateSparseEmbedding } from "../embeddings/embedding-backend.js";
@@ -15,40 +13,10 @@ import {
 import { withQdrantBreaker } from "../embeddings/qdrant-circuit-breaker.js";
 import { resolveQdrantUrl } from "../embeddings/qdrant-client.js";
 import { asString } from "../job-utils.js";
-import {
-  enqueueMemoryJob,
-  isMemoryEnabled,
-  type MemoryJob,
-} from "../jobs-store.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { messages } from "../schema/index.js";
 
 const log = getLogger("messages-lexical-enqueue");
-
-/**
- * The lexical index's write path is enqueued alongside the memory plugin's
- * per-message indexing, so its suppression state tracks that plugin's name.
- */
-const MEMORY_PLUGIN_NAME = "default-memory";
-
-/**
- * True when per-message lexical index writes should be suppressed — either the
- * memory feature is off in config (`memory.enabled === false`) or the
- * `default-memory` plugin is disabled via its `.disabled` sentinel. This
- * mirrors the FULL disabled-state check the host applies in
- * `guardPersistenceHooksByDisabledState`, because the index-write call sites
- * (streaming finalize, import, edit, consolidation) call
- * {@link enqueueLexicalIndexForMessage} directly, outside that guard.
- *
- * On the write side this suppresses ONLY the index/write path — the cleanup
- * paths (purge/delete/clear) must still run while disabled so points written
- * when enabled are not orphaned. It doubles as the read-side population signal:
- * when suppression is active the lexical index is not being forward-filled, so
- * lexical-backed reads must treat the `messages_lexical` collection as
- * stale/empty rather than query it.
- */
-export function isMemoryIndexingSuppressed(): boolean {
-  return !isMemoryEnabled() || isPluginDisabled(MEMORY_PLUGIN_NAME);
-}
 
 /**
  * Resolve the messages lexical index singleton, lazily initializing it from
@@ -134,9 +102,8 @@ export async function indexMessageLexicalJob(
 }
 
 /**
- * Delete a conversation's points from the lexical index. Shared by the
- * `purge_conversation_lexical` job handler and the disabled-memory inline
- * cleanup path (see {@link enqueuePurgeConversationLexical}).
+ * Delete a conversation's points from the lexical index (the
+ * `purge_conversation_lexical` job body).
  */
 async function purgeConversationLexical(
   conversationId: string,
@@ -147,9 +114,8 @@ async function purgeConversationLexical(
 }
 
 /**
- * Delete a single message's point from the lexical index. Shared by the
- * `delete_message_lexical` job handler and the disabled-memory inline cleanup
- * path (see {@link enqueueDeleteMessageLexical}).
+ * Delete a single message's point from the lexical index (the
+ * `delete_message_lexical` job body).
  */
 async function deleteMessageLexical(
   messageId: string,
@@ -193,24 +159,18 @@ export async function deleteMessageLexicalJob(
  * drop every message but the last from the index. The upsert into Qdrant is
  * idempotent, so re-enqueuing the same message id is harmless.
  *
- * This is the INDEX/write path: it is gated on {@link isMemoryIndexingSuppressed}
- * — the same FULL disabled-state check the host applies in
- * `guardPersistenceHooksByDisabledState` (config `memory.enabled` AND the
- * `default-memory` `.disabled` sentinel) — so no index job is created while the
- * plugin is disabled. The direct callers (streaming finalize, import, edit,
- * consolidation) run outside that host guard, so the gate lives here.
+ * Unconditional: message-content search is host infrastructure, so indexing
+ * runs regardless of the memory feature's or memory plugin's state (the job
+ * worker drains the lexical types even while memory is disabled).
  *
- * Best-effort: the enqueue itself is a memory side effect off the message write
- * path, so a failure (e.g. the memory database is unavailable) is swallowed and
- * logged rather than propagated — a memory hiccup must not escalate a
- * successful message persist into a throw, mirroring the `indexMessageNow` call
- * sites this runs beside.
+ * Best-effort: the enqueue is a search side effect off the message write path,
+ * so a failure (e.g. the jobs database is unavailable) is swallowed and logged
+ * rather than propagated — an indexing hiccup must not escalate a successful
+ * message persist into a throw, mirroring the `indexMessageNow` call sites
+ * this runs beside.
  */
 export function enqueueLexicalIndexForMessage(messageId: string): void {
   if (!messageId) {
-    return;
-  }
-  if (isMemoryIndexingSuppressed()) {
     return;
   }
   try {
@@ -224,17 +184,9 @@ export function enqueueLexicalIndexForMessage(messageId: string): void {
 }
 
 /**
- * Purge a deleted/wiped conversation's points from the lexical index. This is a
- * cleanup path that must run even while the memory plugin is disabled, so points
- * written while it was enabled are not orphaned.
- *
- * When memory is enabled the work is enqueued as a `purge_conversation_lexical`
- * job (processed off the write path by the worker). When memory is DISABLED the
- * memory job worker skips every job (`runMemoryJobsOnce` returns early), so an
- * enqueued job would sit pending forever and the points would leak — but Qdrant
- * itself is still up (daemon startup boots it unconditionally, independent of
- * `memory.enabled`), so the purge is run INLINE instead, best-effort and
- * breaker-wrapped (a safe no-op if Qdrant is unreachable).
+ * Purge a deleted/wiped conversation's points from the lexical index, as a
+ * `purge_conversation_lexical` job processed off the write path (the worker
+ * drains the lexical types regardless of the memory feature's state).
  *
  * The purge targets Qdrant by `conversationId`, so it is correct even after the
  * conversation's message rows have been deleted. Callers on the wipe path must
@@ -242,24 +194,15 @@ export function enqueueLexicalIndexForMessage(messageId: string): void {
  * pending `conversationId`-keyed job — otherwise an enqueued purge is swept by
  * that same cancellation.
  *
- * Best-effort: a failed enqueue or inline purge is swallowed and logged rather
- * than propagated, so conversation deletion never fails on a memory hiccup.
+ * Best-effort: a failed enqueue is swallowed and logged rather than
+ * propagated, so conversation deletion never fails on an indexing hiccup.
  */
 export function enqueuePurgeConversationLexical(conversationId: string): void {
   if (!conversationId) {
     return;
   }
   try {
-    if (isMemoryEnabled()) {
-      enqueueMemoryJob("purge_conversation_lexical", { conversationId });
-    } else {
-      void purgeConversationLexical(conversationId, getConfig()).catch((err) =>
-        log.warn(
-          { err, conversationId },
-          "Inline lexical purge failed (memory disabled, non-fatal)",
-        ),
-      );
-    }
+    enqueueMemoryJob("purge_conversation_lexical", { conversationId });
   } catch (err) {
     log.warn(
       { err, conversationId },
@@ -269,29 +212,18 @@ export function enqueuePurgeConversationLexical(conversationId: string): void {
 }
 
 /**
- * Remove a deleted message's point from the lexical index. Used by
- * single-message delete paths (consolidation, undo) that remove a row without
- * wiping the whole conversation. Like the purge, a cleanup path: enqueues a
- * `delete_message_lexical` job when memory is enabled, and runs INLINE
- * (best-effort, breaker-wrapped) when memory is disabled — where the worker
- * would never process the job but Qdrant is still reachable. Best-effort so
- * message deletion never fails on a memory hiccup.
+ * Remove a deleted message's point from the lexical index, as a
+ * `delete_message_lexical` job. Used by single-message delete paths
+ * (consolidation, undo) that remove a row without wiping the whole
+ * conversation. Best-effort so message deletion never fails on an indexing
+ * hiccup.
  */
 export function enqueueDeleteMessageLexical(messageId: string): void {
   if (!messageId) {
     return;
   }
   try {
-    if (isMemoryEnabled()) {
-      enqueueMemoryJob("delete_message_lexical", { messageId });
-    } else {
-      void deleteMessageLexical(messageId, getConfig()).catch((err) =>
-        log.warn(
-          { err, messageId },
-          "Inline lexical delete failed (memory disabled, non-fatal)",
-        ),
-      );
-    }
+    enqueueMemoryJob("delete_message_lexical", { messageId });
   } catch (err) {
     log.warn(
       { err, messageId },

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -83,6 +83,19 @@ export const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_concept_page",
 ];
 
+/**
+ * Job types that power message-content lexical search — host infrastructure
+ * that shares the background job queue but is not a memory feature. The worker
+ * keeps draining exactly these types while memory is disabled, so message
+ * search stays indexed regardless of the memory feature's state.
+ */
+export const MESSAGE_LEXICAL_JOB_TYPES: MemoryJobType[] = [
+  "index_message_lexical",
+  "purge_conversation_lexical",
+  "delete_message_lexical",
+  "backfill_lexical_index",
+];
+
 export const SLOW_LLM_JOB_TYPES: MemoryJobType[] = [
   "graph_consolidate",
   "graph_pattern_scan",
@@ -561,14 +574,29 @@ export interface LaneBudgets {
   embed: number;
 }
 
-export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
-  if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) return [];
+/**
+ * Claim up to the per-lane budgets of pending jobs. When `restrictToTypes` is
+ * provided, only jobs of those types are eligible in every lane — the worker
+ * uses this to drain exclusively the message-lexical types while memory is
+ * disabled.
+ */
+export function claimMemoryJobs(
+  limits: LaneBudgets,
+  restrictToTypes?: readonly MemoryJobType[],
+): MemoryJob[] {
+  if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) {
+    return [];
+  }
 
   const db = memoryDb();
   const now = Date.now();
+  const restrictFilter = restrictToTypes
+    ? inArray(memoryJobs.type, [...restrictToTypes])
+    : undefined;
   const pendingFilter = and(
     eq(memoryJobs.status, "pending"),
     lte(memoryJobs.runAfter, now),
+    restrictFilter,
   );
 
   // Slow lane: long-running LLM jobs (graph extract/consolidate, analysis, etc.).
@@ -650,7 +678,9 @@ export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
       .set({ status: "running", startedAt: now, updatedAt: now })
       .where(and(eq(memoryJobs.id, row.id), eq(memoryJobs.status, "pending")))
       .run();
-    if (rawMemoryChanges() === 0) continue;
+    if (rawMemoryChanges() === 0) {
+      continue;
+    }
     claimed.push(
       parseRow({
         ...row,
@@ -694,7 +724,9 @@ const DEFER_MAX_DELAY_MS = 5 * 60 * 1000;
 export function deferMemoryJob(id: string): "deferred" | "failed" {
   const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
-  if (!row) return "failed";
+  if (!row) {
+    return "failed";
+  }
 
   const deferrals = row.deferrals + 1;
   const now = Date.now();
@@ -751,7 +783,9 @@ export function failMemoryJob(
   const maxAttempts = options?.maxAttempts ?? 5;
   const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
-  if (!row) return;
+  if (!row) {
+    return;
+  }
   const attempts = row.attempts + 1;
   const now = Date.now();
   if (attempts >= maxAttempts) {
@@ -804,7 +838,9 @@ export function failStalledJobs(timeoutMs: number): number {
   `,
     cutoff,
   );
-  if (stalled.length === 0) return 0;
+  if (stalled.length === 0) {
+    return 0;
+  }
 
   const db = memoryDb();
   for (const row of stalled) {

--- a/assistant/src/persistence/jobs-worker.ts
+++ b/assistant/src/persistence/jobs-worker.ts
@@ -41,6 +41,7 @@ import {
   MEMORY_V2_CONSOLIDATION_JOB_TRIGGERS,
   type MemoryJob,
   type MemoryJobType,
+  MESSAGE_LEXICAL_JOB_TYPES,
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "./jobs-store.js";
@@ -203,7 +204,9 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
  * stopMemoryWorkerProcess() in worker-control.ts.
  */
 export function stopMemoryJobsWorker(): void {
-  if (!instance) return;
+  if (!instance) {
+    return;
+  }
   instance.stop();
   instance = null;
 }
@@ -248,7 +251,9 @@ export function startInProcessMemoryJobsWorker(
   let currentIntervalMs = POLL_INTERVAL_MIN_MS;
 
   const tick = async () => {
-    if (stopped || tickRunning) return;
+    if (stopped || tickRunning) {
+      return;
+    }
     tickRunning = true;
     try {
       if (
@@ -293,17 +298,23 @@ export function startInProcessMemoryJobsWorker(
   };
 
   const scheduleTick = () => {
-    if (stopped) return;
+    if (stopped) {
+      return;
+    }
     timer = setTimeout(() => {
       void tick().then(() => {
-        if (!stopped) scheduleTick();
+        if (!stopped) {
+          scheduleTick();
+        }
       });
     }, currentIntervalMs);
     (timer as NodeJS.Timeout).unref?.();
   };
 
   void tick().then(() => {
-    if (!stopped) scheduleTick();
+    if (!stopped) {
+      scheduleTick();
+    }
   });
 
   return {
@@ -323,8 +334,13 @@ export async function runMemoryJobsOnce(
   options: { enableScheduledCleanup?: boolean } = {},
 ): Promise<number> {
   const config = getConfig();
-  if (config.memory.enabled === false) return 0;
-  const enableScheduledCleanup = options.enableScheduledCleanup === true;
+  // While memory is disabled the queue still drains the MESSAGE-LEXICAL job
+  // types — host-owned message-search indexing that shares this queue but is
+  // not a memory feature. Every memory lane and every maintenance enqueue
+  // stays idle in that state; only the lexical types are claimable.
+  const memoryEnabled = config.memory.enabled !== false;
+  const enableScheduledCleanup =
+    options.enableScheduledCleanup === true && memoryEnabled;
 
   const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
   if (diskPressureGate.action === "skip") {
@@ -352,19 +368,26 @@ export async function runMemoryJobsOnce(
 
   // Claim per-lane budgets so a backlog of slow LLM jobs cannot starve fast
   // jobs (and vice versa). The Qdrant circuit breaker still gates only the
-  // embed lane inside `claimMemoryJobs`.
-  const claimed = claimMemoryJobs({
-    slowLlm: cfgSlow,
-    fast: cfgFast,
-    embed: cfgEmbed,
-  });
+  // embed lane inside `claimMemoryJobs`. With memory disabled, the slow and
+  // embed lanes get no budget and the fast lane is restricted to the
+  // message-lexical types (they ride the fast lane).
+  const claimed = claimMemoryJobs(
+    {
+      slowLlm: memoryEnabled ? cfgSlow : 0,
+      fast: cfgFast,
+      embed: memoryEnabled ? cfgEmbed : 0,
+    },
+    memoryEnabled ? undefined : MESSAGE_LEXICAL_JOB_TYPES,
+  );
 
   if (claimed.length === 0) {
     if (enableScheduledCleanup) {
       maybeEnqueueScheduledCleanupJobs(config);
     }
     maybeEnqueueGraphMaintenanceJobs(config);
-    await maybeRunDbMaintenance();
+    if (memoryEnabled) {
+      await maybeRunDbMaintenance();
+    }
     return 0;
   }
 
@@ -448,7 +471,9 @@ async function runLanePool(
   concurrency: number,
   processGroup: ProcessGroup,
 ): Promise<number> {
-  if (jobs.length === 0) return 0;
+  if (jobs.length === 0) {
+    return 0;
+  }
 
   const groups = new Map<string, MemoryJob[]>();
   for (const job of jobs) {
@@ -487,7 +512,9 @@ async function runLanePool(
   // starts the instant any slot frees up.
   let nextIdx = 0;
   const startNext = (): Promise<void> | undefined => {
-    if (nextIdx >= typeGroups.length) return undefined;
+    if (nextIdx >= typeGroups.length) {
+      return undefined;
+    }
     const group = typeGroups[nextIdx++]!;
     return processGroup(group)
       .then(
@@ -631,9 +658,12 @@ function maybeEnqueueScheduledCleanupJobs(
   nowMs = Date.now(),
 ): boolean {
   const cleanup = config.memory.cleanup;
-  if (!cleanup.enabled) return false;
-  if (nowMs - getLastScheduledCleanupEnqueueMs() < cleanup.enqueueIntervalMs)
+  if (!cleanup.enabled) {
     return false;
+  }
+  if (nowMs - getLastScheduledCleanupEnqueueMs() < cleanup.enqueueIntervalMs) {
+    return false;
+  }
 
   const pruneConversationsJobId =
     cleanup.conversationRetentionDays > 0
@@ -726,7 +756,9 @@ export function maybeEnqueueGraphMaintenanceJobs(
   nowMs = Date.now(),
 ): void {
   const memoryEnabled = config.memory.enabled !== false;
-  if (!memoryEnabled) return;
+  if (!memoryEnabled) {
+    return;
+  }
 
   const v2Active = config.memory.v2.enabled;
 
@@ -809,7 +841,9 @@ export function maybeEnqueueGraphMaintenanceJobs(
           : {};
       enqueueMemoryJob(jobType, payload);
       setMemoryCheckpoint(key, String(nowMs));
-      if (jobType === consolidateEntry.jobType) enqueuedConsolidate = true;
+      if (jobType === consolidateEntry.jobType) {
+        enqueuedConsolidate = true;
+      }
     }
   }
 

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -6,7 +6,6 @@ import {
   hasLexicalTokens,
 } from "../../../../../persistence/conversation-queries.js";
 import { searchMessageIdsLexical } from "../../../../../persistence/conversation-search-lexical.js";
-import { isMemoryIndexingSuppressed } from "../../../../../persistence/job-handlers/message-lexical.js";
 import { rawAll } from "../../../../../persistence/raw-query.js";
 import {
   parseExternalContentEnvelope,
@@ -116,15 +115,13 @@ export async function searchConversationSource(
   }
 
   // The Qdrant lexical index — the only source of conversation evidence — is
-  // forward-filled by the memory write path, which is gated on
-  // `isMemoryIndexingSuppressed()`: while suppressed (memory disabled or the
-  // memory plugin disabled) the collection is never populated. And until the
-  // one-time upgrade backfill has fully drained, it holds only messages
-  // written since the write path went live. In both cases a qdrant read would
-  // silently miss content (an empty candidate set, not a throw), so the
-  // source yields no evidence instead of serving misleading partial results.
-  // The completion checkpoint is shared with the persistence read site.
-  if (isMemoryIndexingSuppressed() || !isLexicalBackfillComplete()) {
+  // populated unconditionally (host-owned message-search indexing), but until
+  // the one-time upgrade backfill has fully drained it holds only messages
+  // written since the write path went live. A qdrant read then would silently
+  // miss older content (an empty candidate set, not a throw), so the source
+  // yields no evidence instead of serving misleading partial results. The
+  // completion checkpoint is shared with the persistence read site.
+  if (!isLexicalBackfillComplete()) {
     return { evidence: [] };
   }
 

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -4,7 +4,6 @@ import { getConfig } from "../../../config/loader.js";
 import {
   clearMessagesLexicalIndex,
   enqueueDeleteMessageLexical,
-  enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
 } from "../../../persistence/job-handlers/message-lexical.js";
 import type {
@@ -42,21 +41,7 @@ import {
  */
 export const memoryPersistenceHooks: MemoryPersistenceHooks = {
   async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
-    try {
-      await indexMessageNow(
-        { ...event, scopeId: "default" },
-        getMemoryConfig(),
-      );
-    } finally {
-      // Dual-write into the lexical (Qdrant) index off the write path. The
-      // sparse lexical job is independent of the dense embedding path, so it
-      // must be scheduled even when segment indexing above throws (a transient
-      // embedding/Qdrant/config failure) — otherwise the message would be
-      // permanently missing from the lexical index. Self-gates on the memory
-      // plugin's active state; the upsert is idempotent so a redundant enqueue
-      // is harmless.
-      enqueueLexicalIndexForMessage(event.messageId);
-    }
+    await indexMessageNow({ ...event, scopeId: "default" }, getMemoryConfig());
   },
 
   onConversationForked(event: ConversationForkedEvent): void {


### PR DESCRIPTION
## What

Un-gates message-content lexical indexing from `memory.enabled` — the behavioral half of the #36731 decoupling (the structural half was #36879). Message search now works for **memory-disabled installs**, restoring the content search they had under SQLite FTS.

- **The job worker drains lexical jobs while memory is disabled.** `runMemoryJobsOnce` no longer early-returns on `memory.enabled === false`: the slow and embed lanes get zero budget, the fast lane is restricted to the four `MESSAGE_LEXICAL_JOB_TYPES` (new `claimMemoryJobs` type-restriction param), and every memory maintenance enqueue (scheduled cleanup, graph maintenance, db maintenance) stays idle — so nothing else about the memory-disabled state changes. The standalone worker process keeps its memory-disabled exit; the daemon's always-running in-process supervisor is the drainer.
- **Enqueues are unconditional.** `enqueueLexicalIndexForMessage` drops its suppression gate; the purge/delete cleanup helpers drop their enqueue-vs-inline split (always enqueue — the worker now drains them in every state) — deleting the inline-Qdrant fallback paths. The `isMemoryIndexingSuppressed` predicate is deleted outright, removing the last host-code dependency on the memory plugin's `.disabled` sentinel.
- **The startup backfill enqueues regardless of memory state**, still guarded by the completion checkpoint and the duplicate-job check.
- **Read gates are completion-only.** `isMessageContentSearchAvailable()` (user search) and the recall source both gate on `isLexicalBackfillComplete()` alone.
- **The addMessage write seam moves out of the memory hook.** `conversation-crud` calls `enqueueLexicalIndexForMessage` directly (under the same `skipIndexing` condition); the hook's `onMessagePersisted` impl keeps only its dense-memory indexing. This closes the staleness hole where a disabled memory plugin would silence the hook (via `guardPersistenceHooksByDisabledState`) while reads trusted the completion checkpoint. The deletion/clear lexical calls still route through the cleanup hook members, which are deliberately ungated; folding those into direct calls is deferred cosmetics.

**Net −128 lines across 15 files.**

## Why

Message-content search is host infrastructure — it powers regular sidebar/global search and must survive the memory feature being off. Post-#36855 (FTS removal) a memory-disabled install had title-only search because its Qdrant index was never populated; this PR makes the index unconditional, per the maintainer decision on the PR 10 rollout (accept the temporary gap, restore via the #36731 decoupling).

## Tests

- New `jobs-worker-memory-disabled.test.ts`: with memory disabled, a pending `index_message_lexical` job completes while a pending fast-lane **memory** job (`memory_v2_activation_recompute`) stays pending — proving the restriction is by type, not just lane budgets; both drain once memory is re-enabled.
- `lexical-cleanup-disabled.test.ts` → renamed `message-lexical-enqueue.test.ts`: the enqueue-vs-inline split assertions are replaced with unconditional-enqueue assertions (memory disabled and plugin-`.disabled` cases both enqueue, never touch Qdrant inline).
- Backfill suite: the two does-NOT-enqueue suppression tests flip to enqueue-even-when-disabled.
- Search suite: "title matches only when memory is disabled" flips to "serves lexical content matches even when memory is disabled".
- Recall suite: the suppression gate test (and its module-mock apparatus) is deleted with the gate; the backfill-completion gate test remains.
- Dual-write suite: addMessage enqueues exactly one lexical job with memory disabled; fork exclusion and wipe purge unchanged.
- Boundary guard: the recall source's import of the lexical module is gone (baseline entry dropped). Full typecheck green; all affected suites pass in isolation.

Closes out the #36731 follow-up (with #36879). Part of the messages_fts → Qdrant migration (#36792, #36842, #36855).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
