### PR TITLE
fix(runtime): keep a wake's trust elevation out of the conversation store

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -88,6 +88,13 @@ interface WakeConversationProbe {
    */
   turnTrustContextSets: Array<{ ctx: unknown; order: number }>;
   /**
+   * `setTrustContext` writes to the persistent `conversation.trustContext`,
+   * in order. A trust-carrying wake's resolver leaves its trust here; the
+   * wake must put the prior value back so it doesn't linger for a later
+   * no-trust wake.
+   */
+  trustContextSets: unknown[];
+  /**
    * Every assignment to `conversation.wakePersonaOverride`, in order. A
    * wake that applies an override records `[override, undefined]` — the
    * trailing `undefined` proves the wake restored the field before
@@ -340,6 +347,10 @@ import type {
   AgentLoopRunResult,
 } from "../../agent/loop.js";
 import type { Conversation } from "../../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../../daemon/conversation-registry.js";
 import { ContextOverflowError, type Message } from "../../providers/types.js";
 import {
   __resetWakeChainForTests,
@@ -387,6 +398,8 @@ function makeWakeConversation(options: {
    * (always under the mocked 200k window).
    */
   estimatedInputTokens?: number;
+  /** Seed for the conversation's resting `trustContext`. */
+  initialTrustContext?: unknown;
 }): WakeConversation {
   const conversationId = options.conversationId ?? "conv-test";
   const probe: WakeConversationProbe = {
@@ -401,6 +414,7 @@ function makeWakeConversation(options: {
     processingDuringDrain: [],
     allowedToolSnapshots: [],
     turnTrustContextSets: [],
+    trustContextSets: [],
     personaOverrideSets: [],
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
@@ -413,6 +427,7 @@ function makeWakeConversation(options: {
   let activeAllowedTools = options.initialAllowedTools;
   let wakePersonaOverride: unknown;
   let currentTurnTrustContext: unknown;
+  let persistentTrustContext: unknown = options.initialTrustContext;
   const snapshotAllowedTools = (): string[] | undefined =>
     activeAllowedTools ? [...activeAllowedTools].sort() : undefined;
 
@@ -526,7 +541,14 @@ function makeWakeConversation(options: {
     },
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
-    trustContext: undefined,
+    get trustContext() {
+      return persistentTrustContext;
+    },
+    // Mirrors Conversation.setTrustContext (coerces null → undefined).
+    setTrustContext(ctx: unknown) {
+      persistentTrustContext = ctx ?? undefined;
+      probe.trustContextSets.push(ctx);
+    },
     buildCurrentSystemPrompt: () => "mock-system-prompt",
     modelOverride: undefined,
     ...(drainQueue ? { drainQueue } : {}),
@@ -1533,6 +1555,141 @@ describe("wakeAgentForOpportunity", () => {
       conversation.turnTrustContextSets.filter((s) => s.ctx != null),
     ).toHaveLength(0);
     expect(conversation.currentTurnTrustContext).toBeUndefined();
+  });
+
+  // ── Persistent-trust restore ────────────────────────────────────────
+  // The resolver leaves the wake's trust on the conversation. The wake must
+  // put the prior resting value back, or a later no-trust wake inherits it
+  // through tool setup's `currentTurnTrustContext ?? trustContext` fallback.
+
+  const GUARDIAN_TRUST = {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+  } as const;
+
+  // The wake reads the prior trust from the live registry, so a test that
+  // wants to exercise the restore registers its double there and simulates
+  // the resolver's write by setting the trust in resolveTarget.
+  const withRegisteredConversation = async (
+    conversation: WakeConversation,
+    run: () => Promise<unknown>,
+  ): Promise<void> => {
+    setConversation(conversation.conversationId, conversation as Conversation);
+    try {
+      await run();
+    } finally {
+      deleteConversation(conversation.conversationId);
+    }
+  };
+
+  test("restores the conversation's prior trust once the wake ends", async () => {
+    const priorTrust = {
+      sourceChannel: "slack",
+      trustClass: "trusted_contact",
+    } as const;
+    const conversation = makeWakeConversation({
+      conversationId: "conv-trust-restore",
+      initialTrustContext: priorTrust,
+    });
+
+    await withRegisteredConversation(conversation, () =>
+      wakeAgentForOpportunity(
+        {
+          conversationId: "conv-trust-restore",
+          hint: "x",
+          source: "t",
+          trustContext: GUARDIAN_TRUST,
+        },
+        {
+          resolveTarget: async () => {
+            conversation.setTrustContext(GUARDIAN_TRUST);
+            return conversation;
+          },
+        },
+      ),
+    );
+
+    // Resolver installs guardian, wake restores the prior value.
+    expect(conversation.trustContextSets).toEqual([GUARDIAN_TRUST, priorTrust]);
+    expect(conversation.trustContext).toEqual(priorTrust);
+  });
+
+  test("restores the prior trust even when the agent loop throws", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "conv-trust-restore-throw",
+      runImpl: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await withRegisteredConversation(conversation, () =>
+      wakeAgentForOpportunity(
+        {
+          conversationId: "conv-trust-restore-throw",
+          hint: "x",
+          source: "t",
+          trustContext: GUARDIAN_TRUST,
+        },
+        {
+          resolveTarget: async () => {
+            conversation.setTrustContext(GUARDIAN_TRUST);
+            return conversation;
+          },
+        },
+      ),
+    );
+
+    // Nothing was resting before the wake, so it goes back to unset.
+    expect(conversation.trustContext).toBeUndefined();
+  });
+
+  test("leaves a trust that was re-set mid-run alone (identity guard)", async () => {
+    const replaced = {
+      sourceChannel: "vellum",
+      trustClass: "unknown",
+    } as const;
+    const conversation = makeWakeConversation({
+      conversationId: "conv-trust-guard",
+      runImpl: async (input) => {
+        conversation.setTrustContext(replaced);
+        return runResult(input);
+      },
+    });
+
+    await withRegisteredConversation(conversation, () =>
+      wakeAgentForOpportunity(
+        {
+          conversationId: "conv-trust-guard",
+          hint: "x",
+          source: "t",
+          trustContext: GUARDIAN_TRUST,
+        },
+        {
+          resolveTarget: async () => {
+            conversation.setTrustContext(GUARDIAN_TRUST);
+            return conversation;
+          },
+        },
+      ),
+    );
+
+    // The wake sees a different reference than it installed, so it doesn't
+    // restore: two writes (resolver install, mid-run replacement), no third.
+    expect(conversation.trustContext).toEqual(replaced);
+    expect(conversation.trustContextSets).toHaveLength(2);
+  });
+
+  test("never touches the persistent trust when the wake carries none", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "conv-trust-none",
+    });
+
+    await wakeAgentForOpportunity(
+      { conversationId: "conv-trust-none", hint: "x", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(conversation.trustContextSets).toHaveLength(0);
   });
 
   test("two concurrent wakes on the same conversation are serialized", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -619,6 +619,18 @@ export async function wakeAgentForOpportunity(
   const startedAt = nowFn();
 
   return runSingleFlight(conversationId, async () => {
+    // Snapshot the conversation's resting trust before the resolver runs, so
+    // it can be restored after. The resolver leaves the wake's trust on the
+    // conversation, and a following no-trust wake would otherwise read it via
+    // tool setup's `currentTurnTrustContext ?? trustContext` fallback. Null
+    // when the conversation isn't resident yet (a fresh hydrate or a fork).
+    let priorPersistentTrust: TrustContext | null = null;
+    if (opts.trustContext) {
+      const { findConversation } =
+        await import("../daemon/conversation-registry.js");
+      priorPersistentTrust =
+        findConversation(conversationId)?.trustContext ?? null;
+    }
     const resolved = await resolveTarget(opts);
     if (resolved === "archived") {
       log.info(
@@ -640,6 +652,18 @@ export async function wakeAgentForOpportunity(
     }
     const conversation = resolved;
 
+    // Put the resting trust back on exit. The guard restores only our own
+    // elevation, so a trust re-set by another turn is left alone; it's also
+    // idempotent, so the several call sites below are safe.
+    const restorePersistentWakeTrust = (): void => {
+      if (
+        opts.trustContext &&
+        conversation.trustContext === opts.trustContext
+      ) {
+        conversation.setTrustContext(priorPersistentTrust);
+      }
+    };
+
     const { decision: diskPressureDecision, status: diskPressureStatus } =
       classifyWakeDiskPressurePolicy(opts);
     if (diskPressureDecision.action === "block") {
@@ -657,6 +681,7 @@ export async function wakeAgentForOpportunity(
         },
         "agent-wake: blocked by disk pressure cleanup mode",
       );
+      restorePersistentWakeTrust();
       return {
         invoked: false,
         producedToolCalls: false,
@@ -670,6 +695,7 @@ export async function wakeAgentForOpportunity(
         { conversationId, source },
         "agent-wake: conversation still processing after timeout; skipping",
       );
+      restorePersistentWakeTrust();
       return { invoked: false, producedToolCalls: false, reason: "timeout" };
     }
 
@@ -1424,6 +1450,8 @@ export async function wakeAgentForOpportunity(
 
       return { invoked: true, producedToolCalls };
     } finally {
+      // Put the conversation's resting trust back on every exit path.
+      restorePersistentWakeTrust();
       // The success path (above) already called setProcessing(false)
       // + drainQueue after tail persist. This catch-all handles the
       // error and early-return paths where no tail was produced — those


### PR DESCRIPTION
A wake runs one turn under an elevated trust. The trust was left on the conversation after the run — the existing cleanup only restored the per-turn context, not the resting trust. Tool setup falls back to the resting trust, so a later wake with no trust of its own ran with the leftover guardian trust.

The wake now snapshots the conversation's resting trust before it runs and puts it back when the run ends, guarded so it only undoes its own elevation and never clobbers a trust that another turn set in the meantime.

Fixes ATL-934. A separate, pre-existing issue — the conversation options map keeps trust across idle eviction, which a no-trust wake can then read — is tracked in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)