### PR TITLE
fix(security): classify workflows dir as code-injection sink, fail closed on name collisions (ATL-912)

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -27,6 +27,7 @@ import {
   getWorkspacePluginsDir,
   getWorkspaceRoutesDir,
   getWorkspaceToolsDir,
+  getWorkspaceWorkflowsDir,
 } from "../util/platform.js";
 import {
   type ApprovalContext,
@@ -311,6 +312,7 @@ function buildFileContext(): FileContext {
     pluginsDir: resolveRealPath(getWorkspacePluginsDir()),
     toolsDir: resolveRealPath(getWorkspaceToolsDir()),
     routesDir: resolveRealPath(getWorkspaceRoutesDir()),
+    workflowsDir: resolveRealPath(getWorkspaceWorkflowsDir()),
     actorTokenSigningKeyPath: join(protectedDir, "actor-token-signing-key"),
     skillSourceDirs: getSkillRoots(config.skills.load.extraDirs).map(
       resolveRealPath,

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -55,6 +55,7 @@ export interface FileContext {
   pluginsDir: string;
   toolsDir: string;
   routesDir: string;
+  workflowsDir: string;
   actorTokenSigningKeyPath: string;
   skillSourceDirs: string[];
 }

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -348,6 +348,17 @@ export function getWorkspaceRoutesDir(): string {
   return join(getWorkspaceDir(), "routes");
 }
 
+/**
+ * Returns $VELLUM_WORKSPACE_DIR/workflows — saved (named) workflow scripts.
+ *
+ * A file here becomes a saved workflow whose source is executed (in the sandbox,
+ * and unattended when triggered by a schedule), so the file risk classifier
+ * escalates writes under this path to High like `tools/` and `routes/`.
+ */
+export function getWorkspaceWorkflowsDir(): string {
+  return join(getWorkspaceDir(), "workflows");
+}
+
 /** Returns $VELLUM_WORKSPACE_DIR/deprecated — transitional files slated for removal. */
 export function getDeprecatedDir(): string {
   return join(getWorkspaceDir(), "deprecated");

--- a/assistant/src/workflows/library.test.ts
+++ b/assistant/src/workflows/library.test.ts
@@ -218,8 +218,8 @@ describe("getWorkflow", () => {
   });
 });
 
-describe("name collisions", () => {
-  test("a directory wins over a same-base-name flat file", () => {
+describe("name collisions (fail closed)", () => {
+  test("a base-name collision (dir + flat) resolves NEITHER", () => {
     writeWorkflow(
       "foo.workflow.ts",
       `export const meta = { name: "foo", description: "flat" };\nreturn "FLAT";`,
@@ -229,16 +229,12 @@ describe("name collisions", () => {
       `export const meta = { name: "foo", description: "dir" };\nreturn "DIR";`,
     );
 
-    const resolved = getWorkflow("foo")!;
-    expect(resolved.source).toContain("DIR");
-    expect(resolved.path.endsWith(join("foo", "workflow.ts"))).toBe(true);
-
-    const foos = listWorkflows().filter((e) => e.name === "foo");
-    expect(foos).toHaveLength(1);
-    expect(foos[0]!.description).toBe("dir");
+    // Neither the base name nor the (shared) meta.name resolves.
+    expect(getWorkflow("foo")).toBeNull();
+    expect(listWorkflows().filter((e) => e.name === "foo")).toHaveLength(0);
   });
 
-  test("the shadowed flat file's own meta.name no longer resolves", () => {
+  test("a base-name collision hides both sides' own meta.names", () => {
     writeWorkflow(
       "bar.workflow.ts",
       `export const meta = { name: "flat-name", description: "flat" };\nreturn "FLAT";`,
@@ -248,14 +244,33 @@ describe("name collisions", () => {
       `export const meta = { name: "dir-name", description: "dir" };\nreturn "DIR";`,
     );
 
-    expect(getWorkflow("dir-name")!.source).toContain("DIR");
+    expect(getWorkflow("dir-name")).toBeNull();
     expect(getWorkflow("flat-name")).toBeNull();
-    // Base-name fallback also lands on the directory.
-    expect(getWorkflow("bar")!.source).toContain("DIR");
-    expect(listWorkflows().map((e) => e.name)).toEqual(["dir-name"]);
+    expect(getWorkflow("bar")).toBeNull();
+    expect(listWorkflows()).toEqual([]);
   });
 
-  test("listWorkflows dedups a duplicate meta.name across different files", () => {
+  test("a base-name collision does not affect unrelated workflows", () => {
+    writeWorkflow(
+      "foo.workflow.ts",
+      `export const meta = { name: "foo", description: "flat" };\nreturn "FLAT";`,
+    );
+    writeDirWorkflow(
+      "foo",
+      `export const meta = { name: "foo", description: "dir" };\nreturn "DIR";`,
+    );
+    // A separate, non-colliding workflow still resolves normally.
+    writeWorkflow(
+      "safe.workflow.ts",
+      `export const meta = { name: "safe", description: "ok" };\nreturn "SAFE";`,
+    );
+
+    expect(getWorkflow("safe")!.source).toContain("SAFE");
+    expect(listWorkflows().map((e) => e.name)).toEqual(["safe"]);
+  });
+
+  test("a duplicate meta.name across different files resolves NEITHER", () => {
+    // Distinct base names, same meta.name → fail closed (no hijack by order).
     writeWorkflow(
       "a.workflow.ts",
       `export const meta = { name: "dup", description: "from-a" };\nreturn "A";`,
@@ -265,10 +280,10 @@ describe("name collisions", () => {
       `export const meta = { name: "dup", description: "from-b" };\nreturn "B";`,
     );
 
-    // One entry; the directory (yielded first) wins, consistent with getWorkflow.
-    const dups = listWorkflows().filter((e) => e.name === "dup");
-    expect(dups).toHaveLength(1);
-    expect(dups[0]!.description).toBe("from-b");
-    expect(getWorkflow("dup")!.source).toContain("B");
+    expect(getWorkflow("dup")).toBeNull();
+    expect(listWorkflows().filter((e) => e.name === "dup")).toHaveLength(0);
+    // Each file is still reachable by its unambiguous base name.
+    expect(getWorkflow("a")!.source).toContain("A");
+    expect(getWorkflow("b")!.source).toContain("B");
   });
 });

--- a/assistant/src/workflows/library.ts
+++ b/assistant/src/workflows/library.ts
@@ -4,9 +4,10 @@
  *
  * Saved workflows live at `<workspace>/workflows/`. The preferred layout is
  * directory-style `<name>/workflow.ts` (so a workflow and its state can sit in
- * one folder); flat `<name>.workflow.ts` is still supported but discouraged. On
- * a base-name collision the directory wins. Each is a normal workflow script: a
- * leading literal
+ * one folder); flat `<name>.workflow.ts` is still supported but discouraged. A
+ * base-name collision or a duplicate `meta.name` FAILS CLOSED — the ambiguous
+ * name resolves to nothing, so a planted file can't shadow a trusted workflow.
+ * Each is a normal workflow script: a leading literal
  * `export const meta = { name, description }` followed by the script body. The
  * library only reads the STATIC `meta` (via {@link extractWorkflowMeta}, a
  * pure-literal extractor that never executes the untrusted source — only the
@@ -22,7 +23,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceWorkflowsDir } from "../util/platform.js";
 import { extractWorkflowMeta, type WorkflowMeta } from "./engine.js";
 
 const log = getLogger("workflow-library");
@@ -48,11 +49,6 @@ export interface SavedWorkflowSource {
   path: string;
 }
 
-/** Absolute path to the saved-workflows directory (`<workspace>/workflows`). */
-function workflowsDir(): string {
-  return join(getWorkspaceDir(), "workflows");
-}
-
 /** Filename of the entry-point script inside a directory-style workflow. */
 const DIRECTORY_ENTRY = "workflow.ts";
 
@@ -69,66 +65,90 @@ interface RawWorkflowFile {
   source: string;
 }
 
+/** Read one saved workflow off disk; `null` (with a warning) if unreadable. */
+function readRawWorkflow(
+  baseName: string,
+  path: string,
+): RawWorkflowFile | null {
+  try {
+    return { baseName, path, source: readFileSync(path, "utf8") };
+  } catch (err) {
+    log.warn({ err, path }, "Failed to read saved workflow; skipping");
+    return null;
+  }
+}
+
+/** Log the fail-closed refusal to resolve a name declared by multiple files. */
+function logDuplicateMetaName(name: string, paths: string[]): void {
+  log.error(
+    { name, paths },
+    `Multiple saved workflows declare meta.name "${name}"; resolving none. ` +
+      `Delete or rename all but one to disambiguate.`,
+  );
+}
+
 /**
- * Yield every readable saved workflow in a STABLE order (the raw filesystem
- * listing order is not guaranteed, so callers that take "the first match" stay
- * deterministic). Directory-style `<name>/workflow.ts` is yielded first and
- * WINS: a flat `<name>.workflow.ts` with the same base name is shadowed (skipped
- * with a warning). Yields nothing if the directory does not exist — it is never
- * created. An unreadable entry is skipped with a logged warning.
+ * Yield every readable saved workflow in a STABLE order (sorted, so "the first
+ * match" is deterministic). Directory-style `<name>/workflow.ts` is yielded
+ * before flat `<name>.workflow.ts`.
+ *
+ * FAIL CLOSED on a base-name collision: if a base name exists as BOTH a
+ * directory and a flat file, neither is yielded — otherwise a planted
+ * `<name>/workflow.ts` could silently shadow a trusted flat workflow.
+ *
+ * Yields nothing if the directory does not exist. An unreadable entry is
+ * skipped with a logged warning.
  */
 function* readWorkflowFiles(): Generator<RawWorkflowFile> {
-  const dir = workflowsDir();
+  const dir = getWorkspaceWorkflowsDir();
   if (!existsSync(dir)) return;
   const entries = readdirSync(dir).sort();
-  const seen = new Set<string>();
 
-  // Directory-style first, so it wins over a same-base-name flat file.
+  // Resolve each form once, keyed by base name (sorted entries keep Map
+  // iteration deterministic).
+  const dirPaths = new Map<string, string>();
+  const flatPaths = new Map<string, string>();
   for (const entry of entries) {
-    if (entry.endsWith(WORKFLOW_SUFFIX)) continue;
-    const path = join(dir, entry, DIRECTORY_ENTRY);
-    if (!existsSync(path)) continue;
-    try {
-      const source = readFileSync(path, "utf8");
-      seen.add(entry);
-      yield { baseName: entry, path, source };
-    } catch (err) {
-      log.warn({ err, path }, "Failed to read saved workflow; skipping");
-    }
-  }
-
-  // Flat files second; skip any shadowed by a directory of the same base name.
-  for (const entry of entries) {
-    if (!entry.endsWith(WORKFLOW_SUFFIX)) continue;
-    const baseName = fileBaseName(entry);
-    const path = join(dir, entry);
-    if (seen.has(baseName)) {
-      log.warn(
-        { path },
-        `Flat workflow "${entry}" is shadowed by directory "${baseName}/"; skipping`,
-      );
+    if (entry.endsWith(WORKFLOW_SUFFIX)) {
+      flatPaths.set(fileBaseName(entry), join(dir, entry));
       continue;
     }
-    try {
-      const source = readFileSync(path, "utf8");
-      seen.add(baseName);
-      yield { baseName, path, source };
-    } catch (err) {
-      log.warn({ err, path }, "Failed to read saved workflow; skipping");
-    }
+    const entrypoint = join(dir, entry, DIRECTORY_ENTRY);
+    if (existsSync(entrypoint)) dirPaths.set(entry, entrypoint);
+  }
+
+  // Fail closed on a base-name collision (both forms present).
+  const collisions = new Set<string>();
+  for (const baseName of dirPaths.keys()) {
+    if (flatPaths.has(baseName)) collisions.add(baseName);
+  }
+  for (const baseName of collisions) {
+    log.error(
+      { dir, baseName },
+      `Saved workflow "${baseName}" exists as BOTH a directory "${baseName}/" and ` +
+        `a flat file "${baseName}${WORKFLOW_SUFFIX}"; resolving neither. Delete one to disambiguate.`,
+    );
+  }
+
+  // Directory-style first, then flat; a colliding base name is skipped in both.
+  for (const [baseName, path] of [...dirPaths, ...flatPaths]) {
+    if (collisions.has(baseName)) continue;
+    const raw = readRawWorkflow(baseName, path);
+    if (raw) yield raw;
   }
 }
 
 /**
- * List every saved workflow with a statically-extractable `meta`, deduplicated
- * by `meta.name` — the first in {@link readWorkflowFiles}' stable order wins, a
- * later duplicate is skipped with a warning (matching {@link getWorkflow}'s
- * winner). A file whose `meta` cannot be statically extracted is skipped with a
- * warning rather than failing the whole listing.
+ * List every saved workflow with a statically-extractable `meta` (a file whose
+ * `meta` can't be extracted is skipped, not fatal).
+ *
+ * FAIL CLOSED on a duplicate `meta.name`: if two files declare the same name,
+ * neither is listed — matching {@link getWorkflow}, so a planted file can't
+ * hijack the name by iteration order.
  */
 export function listWorkflows(): SavedWorkflowEntry[] {
-  const entries: SavedWorkflowEntry[] = [];
-  const seenNames = new Set<string>();
+  // Group by meta.name so a duplicate can drop all sharers (fail closed).
+  const byName = new Map<string, SavedWorkflowEntry[]>();
   for (const { path, source } of readWorkflowFiles()) {
     let meta: WorkflowMeta;
     try {
@@ -140,32 +160,43 @@ export function listWorkflows(): SavedWorkflowEntry[] {
       );
       continue;
     }
-    if (seenNames.has(meta.name)) {
-      log.warn(
-        { path, name: meta.name },
-        `Duplicate workflow name "${meta.name}"; skipping shadowed entry`,
+    const group = byName.get(meta.name) ?? [];
+    group.push({ name: meta.name, description: meta.description, path });
+    byName.set(meta.name, group);
+  }
+
+  const entries: SavedWorkflowEntry[] = [];
+  for (const [name, group] of byName) {
+    if (group.length > 1) {
+      logDuplicateMetaName(
+        name,
+        group.map((e) => e.path),
       );
       continue;
     }
-    seenNames.add(meta.name);
-    entries.push({ name: meta.name, description: meta.description, path });
+    entries.push(group[0]);
   }
   return entries;
 }
 
 /**
- * Resolve a saved workflow by name, deterministically — {@link readWorkflowFiles}
- * yields in a stable order with directory-over-flat precedence, so "the first
- * match" is well-defined. Matches `meta.name` first (the canonical identity),
- * then falls back to the base name (directory or flat-file). Returns the source
- * + path, or `null` if nothing matches.
+ * Resolve a saved workflow by name: `meta.name` first (canonical), then the
+ * base name (directory or flat file). Returns the source + path, or `null`.
+ *
+ * FAIL CLOSED on a duplicate `meta.name`: if two files declare the requested
+ * name, neither is returned, so a planted file can't hijack it by iteration
+ * order. Base-name collisions already fail closed in {@link readWorkflowFiles}.
  */
 export function getWorkflow(name: string): SavedWorkflowSource | null {
+  const nameMatches: SavedWorkflowSource[] = [];
   let fileMatch: SavedWorkflowSource | null = null;
   for (const { baseName, path, source } of readWorkflowFiles()) {
     // Prefer a `meta.name` match — it is the canonical identity.
     try {
-      if (extractWorkflowMeta(source).name === name) return { source, path };
+      if (extractWorkflowMeta(source).name === name) {
+        nameMatches.push({ source, path });
+        continue;
+      }
     } catch {
       // Fall through: a file with non-extractable meta can still match by name.
     }
@@ -174,5 +205,13 @@ export function getWorkflow(name: string): SavedWorkflowSource | null {
       fileMatch = { source, path };
     }
   }
-  return fileMatch;
+
+  if (nameMatches.length > 1) {
+    logDuplicateMetaName(
+      name,
+      nameMatches.map((m) => m.path),
+    );
+    return null;
+  }
+  return nameMatches[0] ?? fileMatch;
 }

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -27,6 +27,7 @@ const dummyFileContext: FileClassificationContext = {
   pluginsDir: "/tmp/test-plugins",
   toolsDir: "/tmp/test-tools",
   routesDir: "/tmp/test-routes",
+  workflowsDir: "/tmp/test-workflows",
   skillSourceDirs: [],
 };
 

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -262,6 +262,26 @@ describe("file classification", () => {
     expect(result.reason).toContain("routes");
   });
 
+  test("file_write to workflows dir is high risk", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/workflows/victim/workflow.ts",
+      workingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/tools",
+        routesDir: "/workspace/routes",
+        workflowsDir: "/workspace/workflows",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("workflows");
+  });
+
   test("host_file_transfer to_sandbox dest in tools dir is high risk", async () => {
     const result = await classify({
       tool: "host_file_transfer",

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -63,6 +63,7 @@ const ClassifyRiskSchema = z.object({
       pluginsDir: z.string().optional(),
       toolsDir: z.string().optional(),
       routesDir: z.string().optional(),
+      workflowsDir: z.string().optional(),
       actorTokenSigningKeyPath: z.string(),
       skillSourceDirs: z.array(z.string()),
     })
@@ -448,6 +449,7 @@ export async function handleClassifyRisk(
         pluginsDir: fileCtx?.pluginsDir ?? SENTINEL,
         toolsDir: fileCtx?.toolsDir ?? SENTINEL,
         routesDir: fileCtx?.routesDir ?? SENTINEL,
+        workflowsDir: fileCtx?.workflowsDir ?? SENTINEL,
         skillSourceDirs: fileCtx?.skillSourceDirs ?? [],
       };
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -23,6 +23,7 @@ const MOCK_HOOKS_DIR = join(MOCK_WORKSPACE_DIR, "hooks");
 const MOCK_PLUGINS_DIR = join(MOCK_WORKSPACE_DIR, "plugins");
 const MOCK_TOOLS_DIR = join(MOCK_WORKSPACE_DIR, "tools");
 const MOCK_ROUTES_DIR = join(MOCK_WORKSPACE_DIR, "routes");
+const MOCK_WORKFLOWS_DIR = join(MOCK_WORKSPACE_DIR, "workflows");
 
 /** Skill source paths managed per-test via the context's skillSourceDirs. */
 let testSkillSourceDirs: string[] = [];
@@ -35,6 +36,7 @@ function makeContext(): FileClassificationContext {
     pluginsDir: MOCK_PLUGINS_DIR,
     toolsDir: MOCK_TOOLS_DIR,
     routesDir: MOCK_ROUTES_DIR,
+    workflowsDir: MOCK_WORKFLOWS_DIR,
     skillSourceDirs: testSkillSourceDirs,
   };
 }
@@ -340,6 +342,60 @@ describe("FileRiskClassifier", () => {
       expect(result.reason).toBe("Writes to routes directory");
     });
 
+    // Workflows directory escalation: a file here is a saved workflow whose
+    // source is executed later, so a routine file_write is code injection.
+    test("workflows directory itself is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: MOCK_WORKFLOWS_DIR,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workflows directory");
+    });
+
+    test("directory-style entrypoint inside workflows dir is high", async () => {
+      testSkillSourceDirs = [];
+      const entrypoint = join(MOCK_WORKFLOWS_DIR, "victim", "workflow.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: entrypoint,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workflows directory");
+    });
+
+    test("flat workflow file inside workflows dir is high", async () => {
+      testSkillSourceDirs = [];
+      const flat = join(MOCK_WORKFLOWS_DIR, "victim.workflow.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: flat,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workflows directory");
+    });
+
+    test("path containing 'workflows' substring outside workflows dir is low", async () => {
+      // Guard against substring matching: /workspace/workflows-data/ must NOT escalate.
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: join(
+          homedir(),
+          ".vellum",
+          "workspace",
+          "workflows-data",
+          "x",
+        ),
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("low");
+    });
+
     // Container-style /workspace paths must be remapped to the working dir
     // before the containment check — otherwise "/workspace/tools/evil.ts"
     // resolves to the literal path (never matching the real tools dir) and
@@ -364,6 +420,17 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to routes directory");
+    });
+
+    test("/workspace-prefixed workflows path is remapped and high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/workflows/victim/workflow.ts",
+        workingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workflows directory");
     });
 
     test("relative tools path resolves against working dir and is high", async () => {

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -9,16 +9,17 @@
  * - file_read: Low by default, High if targeting the actor token signing key.
  * - file_write / file_edit: Low by default, High if targeting skill source
  *   code, the workspace hooks directory, the user plugins directory, the
- *   workspace tools directory, or the workspace routes directory.
+ *   workspace tools directory, the workspace routes directory, or the
+ *   workspace workflows directory.
  * - host_file_read: Medium (tool registry default; no special escalation).
  * - host_file_write / host_file_edit: Medium by default, High if targeting
  *   skill source code, the workspace hooks directory, the user plugins
- *   directory, the workspace tools directory, or the workspace routes
- *   directory.
+ *   directory, the workspace tools directory, the workspace routes
+ *   directory, or the workspace workflows directory.
  * - host_file_transfer: Medium by default, High if the host-side path
  *   targets skill source code, the workspace hooks directory, the user
- *   plugins directory, the workspace tools directory, or the workspace
- *   routes directory.
+ *   plugins directory, the workspace tools directory, the workspace
+ *   routes directory, or the workspace workflows directory.
  *
  * The tools and routes directories are escalated for the same reason as
  * plugins: any file written under `<workspace>/tools/` is dynamic-imported
@@ -27,6 +28,11 @@
  * dynamic-imported and executed as an HTTP route handler. A write to either
  * is a code-injection sink, so it must clear the same High-risk approval gate
  * as hooks and plugins.
+ *
+ * The workflows directory is escalated for the same reason: any file under
+ * `<workspace>/workflows/` is a saved workflow whose source is executed (in the
+ * sandbox, and unattended when triggered by a schedule), so it must clear the
+ * same High-risk gate.
  *
  * Gateway adaptation: accepts a FileClassificationContext parameter instead
  * of importing assistant platform utilities directly. The assistant is
@@ -70,6 +76,8 @@ export interface FileClassificationContext {
   toolsDir: string;
   /** Absolute path to the workspace routes directory (dynamic-imported HTTP route handlers). */
   routesDir: string;
+  /** Absolute path to the workspace workflows directory (saved workflow scripts). */
+  workflowsDir: string;
   /**
    * Absolute paths of all skill source root directories (managed, bundled,
    * and any extra dirs from config). The classifier checks whether a file
@@ -259,6 +267,25 @@ function isRoutesPath(
 }
 
 /**
+ * Check whether a resolved absolute path falls inside the workspace workflows
+ * directory (or IS the workflows directory itself). Mirrors {@link isToolsPath}:
+ * a file under `<workspace>/workflows/` is a saved workflow whose source is
+ * executed (unattended when triggered by a schedule), so a write here is
+ * code-injection risk.
+ */
+function isWorkflowsPath(
+  resolvedPath: string,
+  context: FileClassificationContext,
+): boolean {
+  const normalizedWorkflowsDir = normalizeDirPath(context.workflowsDir);
+  const workflowsDirNoTrailingSlash = normalizedWorkflowsDir.slice(0, -1);
+  return (
+    resolvedPath === workflowsDirNoTrailingSlash ||
+    resolvedPath.startsWith(normalizedWorkflowsDir)
+  );
+}
+
+/**
  * Check whether a resolved absolute path falls under any skill source
  * directory.
  */
@@ -341,10 +368,10 @@ function buildFileAllowlistOptions(
 
 /**
  * Classify a resolved (absolute) path against the code-injection sink
- * directories: skill source, hooks, plugins, tools, and routes. A write to
- * any of these plants code the daemon will dynamic-import and execute, so it
- * must clear the High-risk approval gate. Returns a High assessment when the
- * path lands in a sink, or `null` when it doesn't.
+ * directories: skill source, hooks, plugins, tools, routes, and workflows. A
+ * write to any of these plants code the daemon later executes, so it must clear
+ * the High-risk approval gate. Returns a High assessment when the path lands in
+ * a sink, or `null` when it doesn't.
  *
  * `verb` distinguishes the user-facing reason: "Writes" for write/edit tools,
  * "Transfers" for host_file_transfer.
@@ -368,6 +395,8 @@ function classifyCodeInjectionSink(
   if (isPluginsPath(resolvedPath, context)) return high("plugins directory");
   if (isToolsPath(resolvedPath, context)) return high("tools directory");
   if (isRoutesPath(resolvedPath, context)) return high("routes directory");
+  if (isWorkflowsPath(resolvedPath, context))
+    return high("workflows directory");
   return null;
 }
 
@@ -403,8 +432,9 @@ function classifyCodeInjectionSinkEither(
 /**
  * File risk classifier implementation.
  *
- * Classifies all six file tool types by risk level, with escalation paths
- * for skill source code, workspace hooks, and the actor token signing key.
+ * Classifies all seven file tool types by risk level, with escalation paths
+ * for the code-injection sinks (skill source, hooks, plugins, tools, routes,
+ * and workflows) and the actor token signing key.
  *
  * Unlike the assistant version, this classifier accepts a
  * FileClassificationContext parameter on classify() instead of importing


### PR DESCRIPTION
## Summary
- Escalate writes under `<workspace>/workflows/` to High risk. A saved workflow's source runs in the QuickJS sandbox and a schedule executes it unattended under the guardian trust context, so writing one installs persistent named code — the same threat model already escalated for `tools/`, `routes/`, `plugins/`, and `hooks/`.
- Fail closed on ambiguous workflow names: a base-name collision (directory + flat file) or a duplicate `meta.name` across files now resolves to nothing, instead of letting directory-over-flat precedence or iteration order silently pick a winner a planted file could shadow.

## Original prompt
Codex flagged (ATL-912) that the saved-workflow resolver yields directory-style workflows over same-name flat files, but the file risk classifier never treated workflow entrypoints as code-injection sinks — so an unapproved low-risk `file_write` could plant `workflows/<victim>/workflow.ts` and shadow a trusted workflow that later runs unattended via a schedule. Fix: classify the workflows directory as a High-risk sink like tools/routes/plugins/hooks, and fail closed on name collisions rather than silently shadowing.

Ref ATL-912.