### PR TITLE
fix(acp): self-review remediation (stale mocks, cancel route, slop)

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -75,6 +75,8 @@ function buildSessionWithFakeProcess(opts: {
     initialize: () => Promise.resolve(),
     createSession: () => Promise.resolve(opts.protocolSessionId),
     cancel: () => Promise.resolve(),
+    markStderr: () => 0,
+    stderrSince: () => "",
   };
 
   // Match spawn()'s wiring: pre-create the buffer and route emitted updates

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -129,6 +129,14 @@ class FakeAcpAgentProcess {
 
   async cancel(): Promise<void> {}
 
+  markStderr(): number {
+    return 0;
+  }
+
+  stderrSince(): string {
+    return "";
+  }
+
   kill(): void {
     this.killed = true;
   }

--- a/assistant/src/acp/__tests__/session-manager-usage.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage.test.ts
@@ -35,6 +35,12 @@ mock.module("../agent-process.js", () => ({
       return new Promise(() => {});
     }
     async cancel(): Promise<void> {}
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
     kill(): void {}
   },
 }));

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -37,6 +37,12 @@ mock.module("../agent-process.js", () => ({
     async cancel(sessionId: string): Promise<void> {
       cancelCalls.push(sessionId);
     }
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
     kill(): void {}
   },
 }));

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -20,9 +20,9 @@ function feed(proc: AcpAgentProcess, line: string): void {
   (proc as unknown as { retainStderr(text: string): void }).retainStderr(line);
 }
 
-describe("AcpAgentProcess.recentStderr", () => {
+describe("AcpAgentProcess.stderrSince(0)", () => {
   test("returns empty string before any stderr is captured", () => {
-    expect(newProcess().recentStderr()).toBe("");
+    expect(newProcess().stderrSince(0)).toBe("");
   });
 
   test("retains captured lines joined by newlines, in order", () => {
@@ -31,7 +31,7 @@ describe("AcpAgentProcess.recentStderr", () => {
     feed(proc, "line 2");
     feed(proc, "line 3");
 
-    expect(proc.recentStderr()).toBe("line 1\nline 2\nline 3");
+    expect(proc.stderrSince(0)).toBe("line 1\nline 2\nline 3");
   });
 
   test("evicts oldest lines once the byte cap is exceeded", () => {
@@ -43,11 +43,11 @@ describe("AcpAgentProcess.recentStderr", () => {
       feed(proc, `${i}:${kb}`);
     }
 
-    const retained = proc.recentStderr().split("\n");
+    const retained = proc.stderrSince(0).split("\n");
     // Oldest ("0:") evicted, newest ("7:") retained, still in insertion order.
     expect(retained.at(0)).not.toContain("0:");
     expect(retained.at(-1)).toContain("7:");
-    expect(Buffer.byteLength(proc.recentStderr())).toBeLessThanOrEqual(
+    expect(Buffer.byteLength(proc.stderrSince(0))).toBeLessThanOrEqual(
       4096 + kb.length,
     );
 
@@ -63,17 +63,17 @@ describe("AcpAgentProcess.recentStderr", () => {
     const huge = "H".repeat(6000) + "TAIL_DIAGNOSTIC";
     feed(proc, huge);
 
-    const retained = proc.recentStderr();
+    const retained = proc.stderrSince(0);
     expect(retained.length).toBe(4096);
     expect(retained.endsWith("TAIL_DIAGNOSTIC")).toBe(true);
   });
 
-  test("recentStderr is pure: repeated reads do not clear the buffer", () => {
+  test("stderrSince(0) is pure: repeated reads do not clear the buffer", () => {
     const proc = newProcess();
     feed(proc, "only line");
 
-    expect(proc.recentStderr()).toBe("only line");
-    expect(proc.recentStderr()).toBe("only line");
+    expect(proc.stderrSince(0)).toBe("only line");
+    expect(proc.stderrSince(0)).toBe("only line");
   });
 });
 
@@ -97,14 +97,6 @@ describe("AcpAgentProcess.markStderr / stderrSince", () => {
 
     const mark = proc.markStderr();
     expect(proc.stderrSince(mark)).toBe("");
-  });
-
-  test("stderrSince(0) returns all retained lines, like recentStderr", () => {
-    const proc = newProcess();
-    feed(proc, "line 1");
-    feed(proc, "line 2");
-
-    expect(proc.stderrSince(0)).toBe(proc.recentStderr());
   });
 
   test("mark is monotonic across eviction: seq keeps counting evicted lines", () => {

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -32,7 +32,8 @@ const AUTH_REQUIRED_CODE = -32000;
 
 /**
  * Rough byte cap for retained stderr. Oldest lines are evicted once the sum of
- * retained line lengths exceeds this, so recentStderr() stays bounded.
+ * retained line lengths exceeds this, so the stderr ring (read via stderrSince)
+ * stays bounded.
  */
 const STDERR_RETENTION_BYTES = 4096;
 
@@ -170,14 +171,6 @@ export class AcpAgentProcess {
       const evicted = this.stderrRing.shift()!;
       this.stderrRingBytes -= Buffer.byteLength(evicted.text);
     }
-  }
-
-  /**
-   * Returns the retained recent stderr lines joined by newlines. Pure: reading
-   * it does not mutate or clear the buffer.
-   */
-  recentStderr(): string {
-    return this.stderrSince(0);
   }
 
   /**

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -16,11 +16,9 @@ const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
 export function deriveFailureError(ackMessage: string, stderr: string): string {
   const clean = stderr.replace(ANSI_ESCAPE, "").trim();
 
-  // Most precise: a structured adapter error. Prefer it even over a specific
-  // ack, but when it merely duplicates the ack, return the clean ack rather
-  // than falling through to echo the raw JSON blob as a stderr line.
+  // Most precise: a structured adapter error — prefer it over the ack.
   const jsonMessage = lastJsonErrorMessage(clean);
-  if (jsonMessage) return jsonMessage !== ackMessage ? jsonMessage : ackMessage;
+  if (jsonMessage) return jsonMessage;
 
   // An already-specific ack is preserved when stderr has no better detail.
   if (ackMessage.length > 0 && ackMessage !== "Internal error")

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -13,7 +13,10 @@ import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { formatResolveFailure } from "../../acp/resolve-agent.js";
-import { AcpResumeError } from "../../acp/session-manager.js";
+import {
+  AcpResumeError,
+  AcpSessionNotFoundError,
+} from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getConfig } from "../../config/loader.js";
 import type { UserDecision } from "../../permissions/types.js";
@@ -29,6 +32,7 @@ import {
   ConflictError,
   FailedDependencyError,
   ForbiddenError,
+  InternalError,
   NotFoundError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -387,8 +391,16 @@ async function cancelSession({ pathParams }: RouteHandlerArgs) {
   const manager = getAcpSessionManager();
   try {
     await manager.cancel(id);
-  } catch {
-    throw new NotFoundError("ACP session not found");
+  } catch (err) {
+    // Only a genuinely unknown session is a 404. cancel() now rethrows when
+    // the protocol cancel fails on a still-live session (it rolls back to
+    // running), so mapping that to not-found would lie; surface it as a 500.
+    if (err instanceof AcpSessionNotFoundError) {
+      throw new NotFoundError("ACP session not found");
+    }
+    throw new InternalError(
+      err instanceof Error ? err.message : "Failed to cancel ACP session",
+    );
   }
   return { acpSessionId: id, cancelled: true };
 }

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -392,9 +392,9 @@ async function cancelSession({ pathParams }: RouteHandlerArgs) {
   try {
     await manager.cancel(id);
   } catch (err) {
-    // Only a genuinely unknown session is a 404. cancel() now rethrows when
-    // the protocol cancel fails on a still-live session (it rolls back to
-    // running), so mapping that to not-found would lie; surface it as a 500.
+    // Only a genuinely unknown session is a 404. A protocol-cancel failure on a
+    // still-live session is a real error, not a missing session, so it surfaces
+    // as a 500 rather than a misleading not-found.
     if (err instanceof AcpSessionNotFoundError) {
       throw new NotFoundError("ACP session not found");
     }


### PR DESCRIPTION
## Summary
- Add markStderr/stderrSince to pre-existing ACP test process mocks (fixes CI-red from the new failure-diagnostics calls).
- cancelSession route: only map AcpSessionNotFoundError to 404; rethrow other errors (cancel() now rolls back + rethrows on protocol-cancel failure).
- Remove dead recentStderr() accessor (superseded by stderrSince); collapse a self-canceling ternary in deriveFailureError.

Self-review remediation. Part of plan: acp-failure-surfacing.md