### PR TITLE
Surface ACP agent failures instead of masking them

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -185,7 +185,6 @@ describe("VellumAcpClientHandler", () => {
       expect(sent).toHaveLength(0);
       expect(handler.pendingRequestIds.size).toBe(0);
     });
-
   });
 });
 
@@ -264,6 +263,8 @@ describe("AcpSessionManager", () => {
         initialize: mock(() => Promise.resolve()),
         createSession: mock(() => Promise.resolve("proto-session")),
         cancel: mock(() => Promise.resolve()),
+        markStderr: () => 0,
+        stderrSince: () => "",
       };
       const fakeHandler = new VellumAcpClientHandler(
         "test-session",
@@ -324,6 +325,8 @@ describe("AcpSessionManager", () => {
       const fakeProcess = {
         prompt: () => promptPromise,
         kill: mock(() => {}),
+        markStderr: () => 0,
+        stderrSince: () => "",
       };
       const fakeHandler = new VellumAcpClientHandler(
         "test-session-2",

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -75,6 +75,8 @@ function buildSessionWithFakeProcess(opts: {
     initialize: () => Promise.resolve(),
     createSession: () => Promise.resolve(opts.protocolSessionId),
     cancel: () => Promise.resolve(),
+    markStderr: () => 0,
+    stderrSince: () => "",
   };
 
   // Match spawn()'s wiring: pre-create the buffer and route emitted updates

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -129,6 +129,14 @@ class FakeAcpAgentProcess {
 
   async cancel(): Promise<void> {}
 
+  markStderr(): number {
+    return 0;
+  }
+
+  stderrSince(): string {
+    return "";
+  }
+
   kill(): void {
     this.killed = true;
   }

--- a/assistant/src/acp/__tests__/session-manager-usage.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage.test.ts
@@ -35,6 +35,12 @@ mock.module("../agent-process.js", () => ({
       return new Promise(() => {});
     }
     async cancel(): Promise<void> {}
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
     kill(): void {}
   },
 }));

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -37,6 +37,12 @@ mock.module("../agent-process.js", () => ({
     async cancel(sessionId: string): Promise<void> {
       cancelCalls.push(sessionId);
     }
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
     kill(): void {}
   },
 }));

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { AcpAgentProcess } from "./agent-process.js";
+import type { AcpAgentConfig } from "./types.js";
+
+const config: AcpAgentConfig = { command: "noop", args: [] };
+
+// The client factory is never invoked in these tests (no spawn), so a stub is
+// sufficient.
+const clientFactory = (() => ({})) as never;
+
+function newProcess(): AcpAgentProcess {
+  return new AcpAgentProcess("test-agent", config, clientFactory);
+}
+
+// retainStderr is the private handler path the stderr "data" listener calls
+// after logging; feed it directly to keep the test deterministic (no real
+// child process or stream timing).
+function feed(proc: AcpAgentProcess, line: string): void {
+  (proc as unknown as { retainStderr(text: string): void }).retainStderr(line);
+}
+
+describe("AcpAgentProcess.recentStderr", () => {
+  test("returns empty string before any stderr is captured", () => {
+    expect(newProcess().recentStderr()).toBe("");
+  });
+
+  test("retains captured lines joined by newlines, in order", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+    feed(proc, "line 3");
+
+    expect(proc.recentStderr()).toBe("line 1\nline 2\nline 3");
+  });
+
+  test("evicts oldest lines once the byte cap is exceeded", () => {
+    const proc = newProcess();
+    // Each line is ~1 KB; a handful exceeds the ~4 KB cap and forces eviction
+    // of the earliest lines while preserving newest-line ordering.
+    const kb = "x".repeat(1024);
+    for (let i = 0; i < 8; i++) {
+      feed(proc, `${i}:${kb}`);
+    }
+
+    const retained = proc.recentStderr().split("\n");
+    // Oldest ("0:") evicted, newest ("7:") retained, still in insertion order.
+    expect(retained.at(0)).not.toContain("0:");
+    expect(retained.at(-1)).toContain("7:");
+    expect(Buffer.byteLength(proc.recentStderr())).toBeLessThanOrEqual(
+      4096 + kb.length,
+    );
+
+    const indices = retained.map((l) => Number(l.split(":")[0]));
+    const sorted = [...indices].sort((a, b) => a - b);
+    expect(indices).toEqual(sorted);
+  });
+
+  test("keeps at least the newest line even when it alone exceeds the cap", () => {
+    const proc = newProcess();
+    const huge = "y".repeat(8192);
+    feed(proc, huge);
+
+    expect(proc.recentStderr()).toBe(huge);
+  });
+
+  test("recentStderr is pure: repeated reads do not clear the buffer", () => {
+    const proc = newProcess();
+    feed(proc, "only line");
+
+    expect(proc.recentStderr()).toBe("only line");
+    expect(proc.recentStderr()).toBe("only line");
+  });
+});

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -20,9 +20,9 @@ function feed(proc: AcpAgentProcess, line: string): void {
   (proc as unknown as { retainStderr(text: string): void }).retainStderr(line);
 }
 
-describe("AcpAgentProcess.recentStderr", () => {
+describe("AcpAgentProcess.stderrSince(0)", () => {
   test("returns empty string before any stderr is captured", () => {
-    expect(newProcess().recentStderr()).toBe("");
+    expect(newProcess().stderrSince(0)).toBe("");
   });
 
   test("retains captured lines joined by newlines, in order", () => {
@@ -31,7 +31,7 @@ describe("AcpAgentProcess.recentStderr", () => {
     feed(proc, "line 2");
     feed(proc, "line 3");
 
-    expect(proc.recentStderr()).toBe("line 1\nline 2\nline 3");
+    expect(proc.stderrSince(0)).toBe("line 1\nline 2\nline 3");
   });
 
   test("evicts oldest lines once the byte cap is exceeded", () => {
@@ -43,11 +43,11 @@ describe("AcpAgentProcess.recentStderr", () => {
       feed(proc, `${i}:${kb}`);
     }
 
-    const retained = proc.recentStderr().split("\n");
+    const retained = proc.stderrSince(0).split("\n");
     // Oldest ("0:") evicted, newest ("7:") retained, still in insertion order.
     expect(retained.at(0)).not.toContain("0:");
     expect(retained.at(-1)).toContain("7:");
-    expect(Buffer.byteLength(proc.recentStderr())).toBeLessThanOrEqual(
+    expect(Buffer.byteLength(proc.stderrSince(0))).toBeLessThanOrEqual(
       4096 + kb.length,
     );
 
@@ -63,17 +63,17 @@ describe("AcpAgentProcess.recentStderr", () => {
     const huge = "H".repeat(6000) + "TAIL_DIAGNOSTIC";
     feed(proc, huge);
 
-    const retained = proc.recentStderr();
+    const retained = proc.stderrSince(0);
     expect(retained.length).toBe(4096);
     expect(retained.endsWith("TAIL_DIAGNOSTIC")).toBe(true);
   });
 
-  test("recentStderr is pure: repeated reads do not clear the buffer", () => {
+  test("stderrSince(0) is pure: repeated reads do not clear the buffer", () => {
     const proc = newProcess();
     feed(proc, "only line");
 
-    expect(proc.recentStderr()).toBe("only line");
-    expect(proc.recentStderr()).toBe("only line");
+    expect(proc.stderrSince(0)).toBe("only line");
+    expect(proc.stderrSince(0)).toBe("only line");
   });
 });
 
@@ -97,14 +97,6 @@ describe("AcpAgentProcess.markStderr / stderrSince", () => {
 
     const mark = proc.markStderr();
     expect(proc.stderrSince(mark)).toBe("");
-  });
-
-  test("stderrSince(0) returns all retained lines, like recentStderr", () => {
-    const proc = newProcess();
-    feed(proc, "line 1");
-    feed(proc, "line 2");
-
-    expect(proc.stderrSince(0)).toBe(proc.recentStderr());
   });
 
   test("mark is monotonic across eviction: seq keeps counting evicted lines", () => {

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -56,12 +56,16 @@ describe("AcpAgentProcess.recentStderr", () => {
     expect(indices).toEqual(sorted);
   });
 
-  test("keeps at least the newest line even when it alone exceeds the cap", () => {
+  test("truncates an oversized line to the cap, keeping its tail (the diagnostic)", () => {
     const proc = newProcess();
-    const huge = "y".repeat(8192);
+    // The real adapter error sits at the END of the chunk; deriveFailureError
+    // reads from the tail, so truncation must drop the head, not the tail.
+    const huge = "H".repeat(6000) + "TAIL_DIAGNOSTIC";
     feed(proc, huge);
 
-    expect(proc.recentStderr()).toBe(huge);
+    const retained = proc.recentStderr();
+    expect(retained.length).toBe(4096);
+    expect(retained.endsWith("TAIL_DIAGNOSTIC")).toBe(true);
   });
 
   test("recentStderr is pure: repeated reads do not clear the buffer", () => {

--- a/assistant/src/acp/agent-process.test.ts
+++ b/assistant/src/acp/agent-process.test.ts
@@ -72,3 +72,49 @@ describe("AcpAgentProcess.recentStderr", () => {
     expect(proc.recentStderr()).toBe("only line");
   });
 });
+
+describe("AcpAgentProcess.markStderr / stderrSince", () => {
+  test("stderrSince returns only lines produced after the mark", () => {
+    const proc = newProcess();
+    feed(proc, "before 1");
+    feed(proc, "before 2");
+
+    const mark = proc.markStderr();
+    feed(proc, "after 1");
+    feed(proc, "after 2");
+
+    expect(proc.stderrSince(mark)).toBe("after 1\nafter 2");
+  });
+
+  test("a mark taken after all lines excludes everything retained so far", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+
+    const mark = proc.markStderr();
+    expect(proc.stderrSince(mark)).toBe("");
+  });
+
+  test("stderrSince(0) returns all retained lines, like recentStderr", () => {
+    const proc = newProcess();
+    feed(proc, "line 1");
+    feed(proc, "line 2");
+
+    expect(proc.stderrSince(0)).toBe(proc.recentStderr());
+  });
+
+  test("mark is monotonic across eviction: seq keeps counting evicted lines", () => {
+    const proc = newProcess();
+    // Overflow the byte cap so early lines are evicted, then mark and add one
+    // fresh line: only the post-mark line comes back, unaffected by eviction.
+    const kb = "z".repeat(1024);
+    for (let i = 0; i < 8; i++) {
+      feed(proc, `${i}:${kb}`);
+    }
+
+    const mark = proc.markStderr();
+    feed(proc, "fresh failure");
+
+    expect(proc.stderrSince(mark)).toBe("fresh failure");
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -32,7 +32,8 @@ const AUTH_REQUIRED_CODE = -32000;
 
 /**
  * Rough byte cap for retained stderr. Oldest lines are evicted once the sum of
- * retained line lengths exceeds this, so recentStderr() stays bounded.
+ * retained line lengths exceeds this, so the stderr ring (read via stderrSince)
+ * stays bounded.
  */
 const STDERR_RETENTION_BYTES = 4096;
 
@@ -170,14 +171,6 @@ export class AcpAgentProcess {
       const evicted = this.stderrRing.shift()!;
       this.stderrRingBytes -= Buffer.byteLength(evicted.text);
     }
-  }
-
-  /**
-   * Returns the retained recent stderr lines joined by newlines. Pure: reading
-   * it does not mutate or clear the buffer.
-   */
-  recentStderr(): string {
-    return this.stderrSince(0);
   }
 
   /**

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -77,10 +77,17 @@ export class AcpAgentProcess {
 
   /**
    * Ring of the most recent stderr lines, bounded to ~STDERR_RETENTION_BYTES.
-   * Read once on the failure path to surface the real adapter error.
+   * Read once on the failure path to surface the real adapter error. Each
+   * entry carries a monotonic `seq` so a caller can scope reads to lines
+   * produced after a checkpoint (see markStderr/stderrSince).
    */
-  private stderrRing: string[] = [];
+  private stderrRing: { seq: number; text: string }[] = [];
   private stderrRingBytes = 0;
+  /**
+   * Cumulative count of stderr lines ever retained, including ones later
+   * evicted. Assigned as each line's `seq`; markStderr() snapshots it.
+   */
+  private stderrSeq = 0;
 
   constructor(
     public readonly agentId: string,
@@ -144,14 +151,15 @@ export class AcpAgentProcess {
    * so a single oversized line is not fully dropped.
    */
   private retainStderr(text: string): void {
-    this.stderrRing.push(text);
+    this.stderrSeq += 1;
+    this.stderrRing.push({ seq: this.stderrSeq, text });
     this.stderrRingBytes += Buffer.byteLength(text);
     while (
       this.stderrRingBytes > STDERR_RETENTION_BYTES &&
       this.stderrRing.length > 1
     ) {
       const evicted = this.stderrRing.shift()!;
-      this.stderrRingBytes -= Buffer.byteLength(evicted);
+      this.stderrRingBytes -= Buffer.byteLength(evicted.text);
     }
   }
 
@@ -160,7 +168,29 @@ export class AcpAgentProcess {
    * it does not mutate or clear the buffer.
    */
   recentStderr(): string {
-    return this.stderrRing.join("\n");
+    return this.stderrSince(0);
+  }
+
+  /**
+   * Snapshots the current cumulative stderr line count. Pair with
+   * stderrSince() to read only stderr produced after this checkpoint, so a
+   * prompt's failure derives from its own stderr rather than lines retained
+   * from startup, resume, or an earlier (possibly cancelled) prompt.
+   */
+  markStderr(): number {
+    return this.stderrSeq;
+  }
+
+  /**
+   * Returns retained stderr lines produced after `mark` (a markStderr()
+   * checkpoint), joined by newlines. Best-effort: lines pushed after the mark
+   * but since evicted are simply absent; returns "" when nothing newer remains.
+   */
+  stderrSince(mark: number): string {
+    return this.stderrRing
+      .filter((e) => e.seq > mark)
+      .map((e) => e.text)
+      .join("\n");
   }
 
   /**

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -31,6 +31,12 @@ const log = getLogger("acp");
 const AUTH_REQUIRED_CODE = -32000;
 
 /**
+ * Rough byte cap for retained stderr. Oldest lines are evicted once the sum of
+ * retained line lengths exceeds this, so recentStderr() stays bounded.
+ */
+const STDERR_RETENTION_BYTES = 4096;
+
+/**
  * Detects the ACP auth-required error. Checks the `code` property rather than
  * `instanceof acp.RequestError` so plain JSON-RPC error objects are also
  * recognized.
@@ -68,6 +74,13 @@ export class AcpAgentProcess {
    * afterwards.
    */
   private spawnedEnv: NodeJS.ProcessEnv | null = null;
+
+  /**
+   * Ring of the most recent stderr lines, bounded to ~STDERR_RETENTION_BYTES.
+   * Read once on the failure path to surface the real adapter error.
+   */
+  private stderrRing: string[] = [];
+  private stderrRingBytes = 0;
 
   constructor(
     public readonly agentId: string,
@@ -108,6 +121,7 @@ export class AcpAgentProcess {
       const text = chunk.toString().trim();
       if (text) {
         log.error({ agentId: this.agentId, stderr: text }, "ACP agent stderr");
+        this.retainStderr(text);
       }
     });
 
@@ -122,6 +136,31 @@ export class AcpAgentProcess {
         "ACP agent process error",
       );
     });
+  }
+
+  /**
+   * Appends a stderr line to the ring, evicting oldest lines once the retained
+   * total exceeds STDERR_RETENTION_BYTES. Always keeps at least the newest line
+   * so a single oversized line is not fully dropped.
+   */
+  private retainStderr(text: string): void {
+    this.stderrRing.push(text);
+    this.stderrRingBytes += Buffer.byteLength(text);
+    while (
+      this.stderrRingBytes > STDERR_RETENTION_BYTES &&
+      this.stderrRing.length > 1
+    ) {
+      const evicted = this.stderrRing.shift()!;
+      this.stderrRingBytes -= Buffer.byteLength(evicted);
+    }
+  }
+
+  /**
+   * Returns the retained recent stderr lines joined by newlines. Pure: reading
+   * it does not mutate or clear the buffer.
+   */
+  recentStderr(): string {
+    return this.stderrRing.join("\n");
   }
 
   /**

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -151,9 +151,18 @@ export class AcpAgentProcess {
    * so a single oversized line is not fully dropped.
    */
   private retainStderr(text: string): void {
+    // Cap a single oversized line: the "keep newest" rule below never evicts it,
+    // so an untruncated multi-MB chunk would blow the ring budget and make the
+    // failure-path stderr scan (deriveFailureError) super-linear on huge input.
+    // Keep the TAIL: the adapter's error JSON / last line sits at the end, and
+    // deriveFailureError reads from the end, so dropping the head is lossless.
+    const line =
+      text.length > STDERR_RETENTION_BYTES
+        ? text.slice(-STDERR_RETENTION_BYTES)
+        : text;
     this.stderrSeq += 1;
-    this.stderrRing.push({ seq: this.stderrSeq, text });
-    this.stderrRingBytes += Buffer.byteLength(text);
+    this.stderrRing.push({ seq: this.stderrSeq, text: line });
+    this.stderrRingBytes += Buffer.byteLength(line);
     while (
       this.stderrRingBytes > STDERR_RETENTION_BYTES &&
       this.stderrRing.length > 1

--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveFailureError } from "./failure-error.js";
+
+const CODEX_MESSAGE =
+  "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.";
+
+const ESC = String.fromCharCode(27); // ANSI escape (0x1B)
+
+// A realistic codex-acp stderr line: a JSON error blob wrapped in a coloured
+// log prefix and a trailing reset code.
+const ansiCodexStderr =
+  `${ESC}[2m2026-06-30T12:00:00Z${ESC}[0m ${ESC}[31mERROR${ESC}[0m codex_core: ` +
+  `request failed {"type":"error","status":400,"error":` +
+  `{"type":"invalid_request_error","message":"${CODEX_MESSAGE}"}}${ESC}[0m`;
+
+describe("deriveFailureError", () => {
+  test("extracts the inner error.message from codex-acp JSON stderr", () => {
+    const stderr =
+      `{"type":"error","status":400,"error":` +
+      `{"type":"invalid_request_error","message":"${CODEX_MESSAGE}"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(CODEX_MESSAGE);
+  });
+
+  test("strips ANSI codes and extracts error.message from a real log line", () => {
+    const result = deriveFailureError("Internal error", ansiCodexStderr);
+    expect(result).toBe(CODEX_MESSAGE);
+    expect(result).not.toContain(ESC);
+  });
+
+  test("parses JSON embedded in surrounding log text", () => {
+    const stderr = `2026-06-30 fatal: the adapter said {"error":{"message":"boom"}} and gave up`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("boom");
+  });
+
+  test("returns the LAST JSON error.message when several are present", () => {
+    const stderr =
+      `{"error":{"message":"first failure"}}\n` +
+      `{"error":{"message":"final failure"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("final failure");
+  });
+
+  test("empty stderr yields the ack message", () => {
+    expect(deriveFailureError("Internal error", "")).toBe("Internal error");
+  });
+
+  test("generic ack with informative non-JSON stderr yields the last stderr line, ANSI-stripped", () => {
+    const stderr = `starting up...\n${ESC}[31mfatal: could not connect to backend${ESC}[0m`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "fatal: could not connect to backend",
+    );
+  });
+
+  test("already-specific ack is preserved when stderr is empty", () => {
+    expect(deriveFailureError(CODEX_MESSAGE, "")).toBe(CODEX_MESSAGE);
+  });
+
+  test("already-specific ack is preserved (not double-appended) when stderr duplicates it", () => {
+    // codex often echoes the same message to stderr; we must not repeat it.
+    expect(deriveFailureError(CODEX_MESSAGE, CODEX_MESSAGE)).toBe(
+      CODEX_MESSAGE,
+    );
+  });
+
+  test("structured error duplicating the generic ack yields the clean ack, not the raw JSON", () => {
+    // The adapter acked "Internal error" and also emitted it as a JSON blob;
+    // return the clean ack rather than echoing the raw JSON line.
+    const stderr = `{"error":{"message":"Internal error"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("Internal error");
+  });
+
+  test("falls back to the ack message when stderr has no JSON and no lines", () => {
+    expect(deriveFailureError("Internal error", "   \n  \n")).toBe(
+      "Internal error",
+    );
+  });
+
+  test("ignores malformed JSON braces and uses the last stderr line", () => {
+    const stderr = "noise {not: valid json} more noise\nreal failure detail";
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "real failure detail",
+    );
+  });
+});

--- a/assistant/src/acp/failure-error.test.ts
+++ b/assistant/src/acp/failure-error.test.ts
@@ -81,4 +81,29 @@ describe("deriveFailureError", () => {
       "real failure detail",
     );
   });
+
+  test("a stray unmatched brace before the JSON does not block extraction", () => {
+    const stderr =
+      `some log { unmatched brace here\n` +
+      `... {"type":"error","error":{"message":"The real error"}} ...`;
+    expect(deriveFailureError("Internal error", stderr)).toBe("The real error");
+  });
+
+  test("braces inside a JSON string literal don't throw off the scan", () => {
+    const stderr = `{"error":{"message":"unexpected } brace {in} the text"}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "unexpected } brace {in} the text",
+    );
+  });
+
+  test("prefers the outer adapter error over a nested error.message", () => {
+    // JSON-RPC style: the real failure is the top-level error.message; a nested
+    // error.data.error.message must not shadow it.
+    const stderr =
+      `{"error":{"message":"outer adapter failure",` +
+      `"data":{"error":{"message":"inner debug detail"}}}}`;
+    expect(deriveFailureError("Internal error", stderr)).toBe(
+      "outer adapter failure",
+    );
+  });
 });

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -34,55 +34,73 @@ export function deriveFailureError(ackMessage: string, stderr: string): string {
  * Returns the `error.message` of the LAST JSON object embedded in `text` whose
  * shape is `{"error":{"message":"..."}}`, or null. Objects may be surrounded by
  * arbitrary log text.
+ *
+ * A candidate object is attempted at EACH `{`, so a stray unmatched `{` in the
+ * surrounding log text never balances and is skipped rather than swallowing a
+ * later valid object.
  */
 function lastJsonErrorMessage(text: string): string | null {
-  const objects = extractJsonObjects(text);
-  for (let i = objects.length - 1; i >= 0; i--) {
+  let found: string | null = null;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "{") {
+      continue;
+    }
+    const candidate = balancedObjectAt(text, i);
+    if (candidate === null) {
+      continue;
+    }
     try {
-      const parsed = JSON.parse(objects[i]) as {
-        error?: { message?: unknown };
-      };
+      const parsed = JSON.parse(candidate) as { error?: { message?: unknown } };
+      // A valid top-level object: skip past its end so we don't restart
+      // candidates at its nested braces. Otherwise a nested error.message
+      // (e.g. a JSON-RPC error.data payload) would shadow the outer adapter
+      // error. Only reached on a successful parse, so a stray unmatched brace
+      // that balances-but-fails-to-parse still lets inner objects be scanned.
+      i += candidate.length - 1;
       const message = parsed.error?.message;
-      if (typeof message === "string" && message.length > 0) return message;
+      if (typeof message === "string" && message.length > 0) {
+        found = message;
+      }
     } catch {
-      // Not valid JSON; keep scanning earlier candidates.
+      // Not valid JSON at this position; keep scanning later braces.
     }
   }
-  return null;
+  return found;
 }
 
 /**
- * Extracts top-level balanced `{...}` substrings, tracking string literals so
- * braces inside JSON strings don't throw off the depth count.
+ * Returns the balanced `{...}` substring starting at `start`, tracking string
+ * literals so braces inside JSON strings don't throw off the depth count, or
+ * null if the braces never balance before the text ends.
  */
-function extractJsonObjects(text: string): string[] {
-  const objects: string[] = [];
+function balancedObjectAt(text: string, start: number): string | null {
   let depth = 0;
-  let start = -1;
   let inString = false;
   let escaped = false;
-  for (let i = 0; i < text.length; i++) {
+  for (let i = start; i < text.length; i++) {
     const ch = text[i];
     if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
       continue;
     }
     if (ch === '"') {
       inString = true;
     } else if (ch === "{") {
-      if (depth === 0) start = i;
       depth++;
-    } else if (ch === "}" && depth > 0) {
+    } else if (ch === "}") {
       depth--;
-      if (depth === 0 && start >= 0) {
-        objects.push(text.slice(start, i + 1));
-        start = -1;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
       }
     }
   }
-  return objects;
+  return null;
 }
 
 function lastNonEmptyLine(text: string): string | null {

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -16,11 +16,9 @@ const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
 export function deriveFailureError(ackMessage: string, stderr: string): string {
   const clean = stderr.replace(ANSI_ESCAPE, "").trim();
 
-  // Most precise: a structured adapter error. Prefer it even over a specific
-  // ack, but when it merely duplicates the ack, return the clean ack rather
-  // than falling through to echo the raw JSON blob as a stderr line.
+  // Most precise: a structured adapter error — prefer it over the ack.
   const jsonMessage = lastJsonErrorMessage(clean);
-  if (jsonMessage) return jsonMessage !== ackMessage ? jsonMessage : ackMessage;
+  if (jsonMessage) return jsonMessage;
 
   // An already-specific ack is preserved when stderr has no better detail.
   if (ackMessage.length > 0 && ackMessage !== "Internal error")

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -1,0 +1,95 @@
+/**
+ * Derives a human-meaningful failure message for a failed ACP prompt.
+ *
+ * ACP adapters (e.g. codex-acp) frequently ack a failure with a generic
+ * "Internal error" while printing the real cause to stderr as a JSON blob like
+ * `{"error":{"message":"..."}}`. This picks the most specific signal available:
+ * a structured stderr error, else the last stderr line, else the ack message.
+ *
+ * Pure and dependency-free.
+ */
+
+// CSI escape sequences (colour codes, cursor moves) that adapters interleave
+// with their log lines: ESC `[`, parameter/intermediate bytes, then final byte.
+const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+
+export function deriveFailureError(ackMessage: string, stderr: string): string {
+  const clean = stderr.replace(ANSI_ESCAPE, "").trim();
+
+  // Most precise: a structured adapter error. Prefer it even over a specific
+  // ack, but when it merely duplicates the ack, return the clean ack rather
+  // than falling through to echo the raw JSON blob as a stderr line.
+  const jsonMessage = lastJsonErrorMessage(clean);
+  if (jsonMessage) return jsonMessage !== ackMessage ? jsonMessage : ackMessage;
+
+  // An already-specific ack is preserved when stderr has no better detail.
+  if (ackMessage.length > 0 && ackMessage !== "Internal error")
+    return ackMessage;
+
+  // Generic/empty ack: fall back to the last meaningful stderr line.
+  return lastNonEmptyLine(clean) ?? ackMessage;
+}
+
+/**
+ * Returns the `error.message` of the LAST JSON object embedded in `text` whose
+ * shape is `{"error":{"message":"..."}}`, or null. Objects may be surrounded by
+ * arbitrary log text.
+ */
+function lastJsonErrorMessage(text: string): string | null {
+  const objects = extractJsonObjects(text);
+  for (let i = objects.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(objects[i]) as {
+        error?: { message?: unknown };
+      };
+      const message = parsed.error?.message;
+      if (typeof message === "string" && message.length > 0) return message;
+    } catch {
+      // Not valid JSON; keep scanning earlier candidates.
+    }
+  }
+  return null;
+}
+
+/**
+ * Extracts top-level balanced `{...}` substrings, tracking string literals so
+ * braces inside JSON strings don't throw off the depth count.
+ */
+function extractJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}" && depth > 0) {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        objects.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return objects;
+}
+
+function lastNonEmptyLine(text: string): string | null {
+  const lines = text.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { VellumAcpClientHandler } from "./client-handler.js";
+import { AcpSessionManager } from "./session-manager.js";
+
+// Parent conversations registered per test; torn down in afterEach so the
+// shared registry does not leak state between cases.
+const registered: string[] = [];
+
+afterEach(() => {
+  for (const id of registered.splice(0)) {
+    deleteConversation(id);
+  }
+});
+
+/**
+ * A duck-typed parent conversation exposing only the three methods
+ * `notifyParent` touches. `enqueueMessage` returns not-queued by default so the
+ * persist + runAgentLoop branch runs and the metadata can be asserted; pass
+ * `enqueueQueued: true` to exercise the enqueue branch instead.
+ */
+function mockConversation(opts?: { enqueueQueued?: boolean }) {
+  const enqueueMessage = mock(() => ({
+    queued: opts?.enqueueQueued ?? false,
+    requestId: "req-1",
+    rejected: false,
+  }));
+  const persistUserMessage = mock(async () => ({
+    id: "msg-1",
+    deduplicated: false,
+  }));
+  let resolveLoop!: () => void;
+  const loopRan = new Promise<void>((r) => {
+    resolveLoop = r;
+  });
+  const runAgentLoop = mock(async () => {
+    resolveLoop();
+  });
+  const conversation = {
+    enqueueMessage,
+    persistUserMessage,
+    runAgentLoop,
+  } as unknown as Conversation;
+  return {
+    conversation,
+    enqueueMessage,
+    persistUserMessage,
+    runAgentLoop,
+    loopRan,
+  };
+}
+
+/** Fake AcpAgentProcess covering only the calls firePromptInBackground makes. */
+function fakeProcess(prompt: () => Promise<unknown>) {
+  return {
+    markStderr: () => 0,
+    stderrSince: () => "",
+    prompt,
+    kill: mock(() => {}),
+  };
+}
+
+/** Injects a running session directly into the manager (no child process). */
+function injectSession(
+  manager: AcpSessionManager,
+  acpSessionId: string,
+  parentConversationId: string,
+  process: ReturnType<typeof fakeProcess>,
+) {
+  const sendToVellum = mock(() => {});
+  const clientHandler = new VellumAcpClientHandler(
+    acpSessionId,
+    sendToVellum,
+    parentConversationId,
+  );
+  const entry = {
+    process,
+    state: {
+      id: acpSessionId,
+      agentId: "claude",
+      acpSessionId: "proto-1",
+      parentConversationId,
+      status: "running" as string,
+      startedAt: Date.now(),
+    },
+    clientHandler,
+    sendToVellum,
+    currentPrompt: null as unknown,
+    parentConversationId,
+    cwd: "/tmp",
+    command: "noop",
+  };
+  (manager as any).sessions.set(acpSessionId, entry);
+  return entry;
+}
+
+function fire(
+  manager: AcpSessionManager,
+  acpSessionId: string,
+  entry: ReturnType<typeof injectSession>,
+): Promise<unknown> {
+  const bg = (manager as any).firePromptInBackground(
+    acpSessionId,
+    entry,
+    "proto-1",
+    "do it",
+  );
+  entry.currentPrompt = bg;
+  return bg;
+}
+
+describe("AcpSessionManager parent notification", () => {
+  test("prompt failure notifies the parent once with the failed message + acpNotification metadata", async () => {
+    const manager = new AcpSessionManager(1);
+    const {
+      conversation,
+      enqueueMessage,
+      persistUserMessage,
+      runAgentLoop,
+      loopRan,
+    } = mockConversation();
+    setConversation("parent-fail", conversation);
+    registered.push("parent-fail");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-fail", "parent-fail", proc);
+
+    await fire(manager, "sess-fail", entry);
+    await loopRan;
+
+    // Exactly one notification (enqueue returned not-queued, so persist+loop).
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    const persistArg = persistUserMessage.mock.calls[0][0] as {
+      content: string;
+      metadata: unknown;
+    };
+    expect(persistArg.content).toBe('[ACP agent "claude" failed]\n\nboom');
+    expect(persistArg.metadata).toEqual({
+      acpNotification: { acpSessionId: "proto-1", agent: "claude" },
+    });
+
+    // Session was torn down on failure.
+    expect((manager.getStatus() as unknown[]).length).toBe(0);
+    expect(proc.kill).toHaveBeenCalled();
+  });
+
+  test("prompt success still notifies the parent exactly once", async () => {
+    const manager = new AcpSessionManager(1);
+    const {
+      conversation,
+      enqueueMessage,
+      persistUserMessage,
+      runAgentLoop,
+      loopRan,
+    } = mockConversation();
+    setConversation("parent-ok", conversation);
+    registered.push("parent-ok");
+
+    const proc = fakeProcess(() => Promise.resolve({ stopReason: "end_turn" }));
+    const entry = injectSession(manager, "sess-ok", "parent-ok", proc);
+
+    await fire(manager, "sess-ok", entry);
+    await loopRan;
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    const persistArg = persistUserMessage.mock.calls[0][0] as {
+      content: string;
+      metadata: unknown;
+    };
+    expect(
+      persistArg.content.startsWith('[ACP agent "claude" completed]'),
+    ).toBe(true);
+    expect(persistArg.metadata).toEqual({
+      acpNotification: { acpSessionId: "proto-1", agent: "claude" },
+    });
+  });
+
+  test("a cancelled session does not notify the parent on failure", async () => {
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-cancel", conversation);
+    registered.push("parent-cancel");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-cancel", "parent-cancel", proc);
+    // Simulate a user cancel landing before the rejection settles.
+    entry.state.status = "cancelled";
+
+    await fire(manager, "sess-cancel", entry);
+    // Any notification would have called enqueue synchronously inside the catch.
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("a cancelled session does not notify the parent on success", async () => {
+    // A prompt can win the cancel race by resolving normally; a user stop must
+    // still not wake the parent with a completion.
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-cancel-ok", conversation);
+    registered.push("parent-cancel-ok");
+
+    const proc = fakeProcess(() => Promise.resolve({ stopReason: "end_turn" }));
+    const entry = injectSession(
+      manager,
+      "sess-cancel-ok",
+      "parent-cancel-ok",
+      proc,
+    );
+    entry.state.status = "cancelled";
+
+    await fire(manager, "sess-cancel-ok", entry);
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("cancel marks the session cancelled before the protocol cancel resolves", async () => {
+    // Guards the cancel race: if the in-flight prompt rejects while
+    // process.cancel is still pending, the failure gate must already see
+    // "cancelled" so it does not wake the parent after a user stop.
+    const manager = new AcpSessionManager(1);
+    let resolveCancel!: () => void;
+    const cancelPending = new Promise<void>((r) => {
+      resolveCancel = r;
+    });
+    const proc = {
+      markStderr: () => 0,
+      stderrSince: () => "",
+      prompt: () => new Promise(() => {}),
+      kill: mock(() => {}),
+      cancel: mock(() => cancelPending),
+    };
+    const entry = injectSession(
+      manager,
+      "sess-race",
+      "parent-race",
+      proc as unknown as ReturnType<typeof fakeProcess>,
+    );
+
+    const cancelPromise = (manager as any).cancel("sess-race");
+    // Synchronously after kicking off cancel — before the protocol cancel
+    // resolves — the status is already "cancelled".
+    expect(entry.state.status).toBe("cancelled");
+    expect(proc.cancel).toHaveBeenCalled();
+
+    resolveCancel();
+    await cancelPromise;
+  });
+
+  test("cancel restores the previous status when the protocol cancel throws", async () => {
+    // If process.cancel rejects, the session was not actually cancelled, so the
+    // status must roll back to running (else the live prompt's eventual settle
+    // is wrongly suppressed) and the error must propagate to the caller.
+    const manager = new AcpSessionManager(1);
+    const proc = {
+      markStderr: () => 0,
+      stderrSince: () => "",
+      prompt: () => new Promise(() => {}),
+      kill: mock(() => {}),
+      cancel: mock(() => Promise.reject(new Error("adapter down"))),
+    };
+    const entry = injectSession(
+      manager,
+      "sess-cancel-throw",
+      "parent-cancel-throw",
+      proc as unknown as ReturnType<typeof fakeProcess>,
+    );
+    // A prompt is still in flight; cancel must not tear it down on failure.
+    entry.currentPrompt = new Promise(() => {});
+
+    await expect((manager as any).cancel("sess-cancel-throw")).rejects.toThrow(
+      "adapter down",
+    );
+    expect(entry.state.status).toBe("running");
+  });
+
+  test("a superseded prompt does not notify the parent", async () => {
+    const manager = new AcpSessionManager(1);
+    const { conversation, enqueueMessage } = mockConversation();
+    setConversation("parent-stale", conversation);
+    registered.push("parent-stale");
+
+    const proc = fakeProcess(() => Promise.reject(new Error("boom")));
+    const entry = injectSession(manager, "sess-stale", "parent-stale", proc);
+
+    const bg = (manager as any).firePromptInBackground(
+      entry.state.id,
+      entry,
+      "proto-1",
+      "do it",
+    );
+    // A concurrent steer superseded this prompt: currentPrompt no longer
+    // points at it, so the whole catch body (including notify) is skipped.
+    entry.currentPrompt = null;
+    await bg;
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    // The stale catch left the session in place (no teardown).
+    expect((manager.getStatus() as unknown[]).length).toBe(1);
+  });
+});

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -138,10 +138,11 @@ describe("AcpSessionManager parent notification", () => {
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
 
-    const persistArg = persistUserMessage.mock.calls[0][0] as {
-      content: string;
-      metadata: unknown;
-    };
+    const persistArg = (
+      persistUserMessage.mock.calls as unknown as Array<
+        [{ content: string; metadata: unknown }]
+      >
+    )[0][0];
     expect(persistArg.content).toBe('[ACP agent "claude" failed]\n\nboom');
     expect(persistArg.metadata).toEqual({
       acpNotification: { acpSessionId: "proto-1", agent: "claude" },
@@ -174,10 +175,11 @@ describe("AcpSessionManager parent notification", () => {
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
 
-    const persistArg = persistUserMessage.mock.calls[0][0] as {
-      content: string;
-      metadata: unknown;
-    };
+    const persistArg = (
+      persistUserMessage.mock.calls as unknown as Array<
+        [{ content: string; metadata: unknown }]
+      >
+    )[0][0];
     expect(
       persistArg.content.startsWith('[ACP agent "claude" completed]'),
     ).toBe(true);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -18,6 +18,7 @@ import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
+import { deriveFailureError } from "./failure-error.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
 import { formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
@@ -963,6 +964,10 @@ export class AcpSessionManager {
     message: string,
   ): Promise<unknown> {
     log.info({ acpSessionId, messageLen: message.length }, "ACP firing prompt");
+    // Checkpoint stderr before the prompt so a failure derives only from stderr
+    // this prompt produced — not lines retained from startup, resume, or an
+    // earlier (possibly cancelled) prompt.
+    const stderrMark = entry.process.markStderr();
     const promptPromise = entry.process
       .prompt(acpProtocolSessionId, message)
       .then((response) => {
@@ -1081,17 +1086,26 @@ export class AcpSessionManager {
         // Same guards: entry must exist, prompt must be current, and status
         // must not have been set to "cancelled".
         if (current && current.currentPrompt === promptPromise) {
+          // The ack message is often a generic "Internal error"; recover the
+          // real cause from the adapter's retained stderr.
+          const failureMessage = deriveFailureError(
+            err.message,
+            current.process.stderrSince(stderrMark),
+          );
           if (current.state.status !== "cancelled") {
             current.state.status = "failed";
             current.state.completedAt = Date.now();
-            current.state.error = err.message;
+            current.state.error = failureMessage;
           }
           current.currentPrompt = null;
-          log.error({ acpSessionId, error: err.message }, "ACP prompt failed");
+          log.error(
+            { acpSessionId, error: err.message, failureMessage },
+            "ACP prompt failed",
+          );
           current.sendToVellum({
             type: "acp_session_error",
             acpSessionId,
-            error: err.message,
+            error: failureMessage,
           });
 
           // Persist the terminal row before teardown clears the buffer.

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -740,9 +740,28 @@ export class AcpSessionManager {
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
-    await entry.process.cancel(entry.state.acpSessionId);
+    // Mark cancelled BEFORE awaiting the protocol cancel. If the in-flight
+    // prompt rejects during this window, its catch handler must already see
+    // "cancelled" so it neither overwrites the status with "failed" nor wakes
+    // the parent — no model activity may follow a user stop.
+    const prevStatus = entry.state.status;
+    const prevCompletedAt = entry.state.completedAt;
     entry.state.status = "cancelled";
     entry.state.completedAt = Date.now();
+    try {
+      await entry.process.cancel(entry.state.acpSessionId);
+    } catch (err) {
+      // The protocol cancel failed (e.g. the adapter connection is already
+      // down): the session was NOT actually cancelled, so restore the prior
+      // status. Otherwise the still-running prompt's eventual completion would
+      // be wrongly suppressed and persisted as cancelled. Rethrow so the caller
+      // reports failure and the client rolls back its optimistic cancel.
+      if (this.sessions.get(acpSessionId) === entry) {
+        entry.state.status = prevStatus;
+        entry.state.completedAt = prevCompletedAt;
+      }
+      throw err;
+    }
     // Re-check the map after the await: the in-flight prompt's handler may
     // have already torn the session down while process.cancel was pending.
     if (!entry.currentPrompt && this.sessions.get(acpSessionId) === entry) {
@@ -1028,55 +1047,22 @@ export class AcpSessionManager {
           // kill the agent process.
           this.teardownSession(acpSessionId, current);
 
-          // Notify parent session so the LLM sees the agent's output
+          // Notify parent session so the LLM sees the agent's output.
           const agentLabel = current.state.agentId;
           const responseText = current.clientHandler.responseText;
-          const sessionId = current.state.acpSessionId;
           const hint = claudeResumeHint(
             current.command,
             current.cwd,
-            sessionId,
+            current.state.acpSessionId,
           );
           const resumeHint = hint ? `\n\n${hint}` : "";
-          const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`;
-          // Tag the injected message so the daemon skips its user_message_echo
-          // and the client filters it from the rendered transcript — the user
-          // sees the run through its inline card, not a chat turn.
-          const acpNotification = {
-            acpSessionId: sessionId,
-            agent: agentLabel,
-          };
-          const parentConversation = findConversation(
-            current.parentConversationId,
-          );
-          if (parentConversation) {
-            const enqueueResult = parentConversation.enqueueMessage({
-              content: notifyMessage,
-              metadata: { acpNotification },
-            });
-            if (!enqueueResult.queued && !enqueueResult.rejected) {
-              parentConversation
-                .persistUserMessage({
-                  content: notifyMessage,
-                  metadata: { acpNotification },
-                })
-                .then(({ id: messageId }) =>
-                  parentConversation.runAgentLoop(notifyMessage, messageId),
-                )
-                .catch((err) => {
-                  log.error(
-                    {
-                      parentConversationId: current.parentConversationId,
-                      err,
-                    },
-                    "Failed to process ACP notification in parent",
-                  );
-                });
-            }
-          } else {
-            log.warn(
-              { parentConversationId: current.parentConversationId },
-              "ACP agent finished but parent conversation not found",
+          // Skip when cancelled: a prompt can win the cancel race by resolving
+          // normally, but a user stop must not enqueue a completion and wake the
+          // parent (mirrors the failure-path gate below).
+          if (current.state.status !== "cancelled") {
+            this.notifyParent(
+              current,
+              `[ACP agent "${agentLabel}" completed]\n\n${responseText}${resumeHint}`,
             );
           }
         }
@@ -1113,10 +1099,66 @@ export class AcpSessionManager {
 
           // Free the session slot and deny any pending permissions.
           this.teardownSession(acpSessionId, current);
+
+          // Wake the parent with the failure (mirrors the success path) so
+          // the assistant reports it instead of silently re-spawning. Skip
+          // when cancelled: a user-cancelled run tears down silently and must
+          // not inject a turn. teardownSession leaves state intact, so the
+          // agentId read below is still valid.
+          if (current.state.status !== "cancelled") {
+            this.notifyParent(
+              current,
+              `[ACP agent "${current.state.agentId}" failed]\n\n${failureMessage}`,
+            );
+          }
         }
       });
 
     return promptPromise;
+  }
+
+  /**
+   * Injects an ACP run's outcome into its parent conversation. Shared by the
+   * success and failure paths of firePromptInBackground so a hard failure
+   * reaches the parent (and its inline card) exactly like a completion does.
+   *
+   * The message carries `acpNotification` metadata so the daemon skips its
+   * user_message_echo and the client filters it from the rendered transcript —
+   * the user sees the run through its inline card, not a raw chat turn, while
+   * the LLM still receives the text.
+   *
+   * Reads `entry.state.acpSessionId`/`agentId`, which teardownSession leaves
+   * intact, so callers may invoke this after tearing the session down.
+   */
+  private notifyParent(entry: SessionEntry, message: string): void {
+    const acpNotification = {
+      acpSessionId: entry.state.acpSessionId,
+      agent: entry.state.agentId,
+    };
+    const parentConversation = findConversation(entry.parentConversationId);
+    if (!parentConversation) {
+      log.warn(
+        { parentConversationId: entry.parentConversationId },
+        "ACP agent finished but parent conversation not found",
+      );
+      return;
+    }
+    const enqueueResult = parentConversation.enqueueMessage({
+      content: message,
+      metadata: { acpNotification },
+    });
+    if (enqueueResult.queued || enqueueResult.rejected) return;
+    parentConversation
+      .persistUserMessage({ content: message, metadata: { acpNotification } })
+      .then(({ id: messageId }) =>
+        parentConversation.runAgentLoop(message, messageId),
+      )
+      .catch((err) => {
+        log.error(
+          { parentConversationId: entry.parentConversationId, err },
+          "Failed to process ACP notification in parent",
+        );
+      });
   }
 
   /**

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -13,7 +13,10 @@ import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
 import { prepareAgentEnv } from "../../acp/prepare-agent-env.js";
 import { formatResolveFailure } from "../../acp/resolve-agent.js";
-import { AcpResumeError } from "../../acp/session-manager.js";
+import {
+  AcpResumeError,
+  AcpSessionNotFoundError,
+} from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getConfig } from "../../config/loader.js";
 import type { UserDecision } from "../../permissions/types.js";
@@ -29,6 +32,7 @@ import {
   ConflictError,
   FailedDependencyError,
   ForbiddenError,
+  InternalError,
   NotFoundError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -387,8 +391,16 @@ async function cancelSession({ pathParams }: RouteHandlerArgs) {
   const manager = getAcpSessionManager();
   try {
     await manager.cancel(id);
-  } catch {
-    throw new NotFoundError("ACP session not found");
+  } catch (err) {
+    // Only a genuinely unknown session is a 404. A protocol-cancel failure on a
+    // still-live session is a real error, not a missing session, so it surfaces
+    // as a 500 rather than a misleading not-found.
+    if (err instanceof AcpSessionNotFoundError) {
+      throw new NotFoundError("ACP session not found");
+    }
+    throw new InternalError(
+      err instanceof Error ? err.message : "Failed to cancel ACP session",
+    );
   }
   return { acpSessionId: id, cancelled: true };
 }

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.test.tsx
@@ -71,6 +71,33 @@ describe("AcpChatTerminalBlock", () => {
     expect(screen.getByText("Run failed")).toBeDefined();
   });
 
+  test("failed single-line → icon centered on the first line, no mt-0.5", () => {
+    render(<AcpChatTerminalBlock status="failed" error="Run failed" />);
+    const iconBox = screen.getByTestId("acp-chat-terminal-failed-icon");
+    // Fixed line-height flex box (12px) centers the triangle on the text line.
+    expect(iconBox.className).toContain("items-center");
+    expect(iconBox.className).toContain("h-[12px]");
+    // The legacy top-align hack must be gone from both the box and the icon.
+    expect(iconBox.className).not.toContain("mt-0.5");
+    const icon = iconBox.querySelector("svg");
+    expect(icon?.getAttribute("class") ?? "").not.toContain("mt-0.5");
+  });
+
+  test("failed multi-line → keeps the triangle on the first line", () => {
+    render(
+      <AcpChatTerminalBlock
+        status="failed"
+        error={"Run failed on a very long line that wraps across\nmultiple lines"}
+      />,
+    );
+    const root = screen.getByTestId("acp-chat-terminal-block");
+    // Row stays top-aligned so the fixed icon box pins to the first line.
+    expect(root.className).toContain("items-start");
+    expect(
+      screen.getByTestId("acp-chat-terminal-failed-icon").className,
+    ).toContain("items-center");
+  });
+
   test("cancelled status → Cancelled", () => {
     render(<AcpChatTerminalBlock status="cancelled" />);
     const root = screen.getByTestId("acp-chat-terminal-block");

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
@@ -71,7 +71,16 @@ export function AcpChatTerminalBlock({
         data-terminal-kind="failed"
         className="flex items-start gap-2 rounded-lg bg-[var(--system-negative-weak)] px-3 py-2 text-body-small-default text-[var(--system-negative-strong)]"
       >
-        <AlertTriangle aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
+        {/* Row wraps for multi-line errors; the icon box matches the 12px
+            text-body-small line-height so the triangle centers on the first
+            line rather than the wrapped block's middle. */}
+        <span
+          aria-hidden
+          data-testid="acp-chat-terminal-failed-icon"
+          className="flex h-[12px] w-4 shrink-0 items-center justify-center"
+        >
+          <AlertTriangle className="h-4 w-4" />
+        </span>
         <span>{error ?? "Run failed"}</span>
       </div>
     );


### PR DESCRIPTION
## Summary
When an ACP child agent (codex / claude) fails mid-turn, the daemon previously flattened the real cause to a generic \`Internal error\`, dropped the informative adapter stderr, and never notified the parent conversation — so the failure was silent in chat (observed with codex: a 400 "gpt-5.3-codex is not supported when using Codex with a ChatGPT account" surfaced only as "Internal error", and "try again" blind-re-spawned). This branch:

- **Retains recent adapter stderr** in a bounded ring on \`AcpAgentProcess\` (\`markStderr\`/\`stderrSince\`, tail-truncated), so a failure can recover the real cause.
- **Surfaces the real error** via \`deriveFailureError()\` (ANSI-strip + robust embedded-JSON \`error.message\` extraction), used for \`state.error\`, the \`acp_session_error\` SSE, and the persisted history row.
- **Wakes the parent conversation** on ACP failure (and keeps success parity) via \`notifyParent()\`, gated on non-cancelled so a user stop never injects a turn; \`cancel()\` marks cancelled before the protocol await and rolls back on throw.
- **Fixes web styling**: the ACP failed-run terminal block is vertically centered (matches the cancelled/completed siblings; multi-line-safe first-line centering).

## Self-review result
GAPS FOUND → remediated. Fresh-eyes passes (plan-faithfulness, repo-integration, slop) found a CI-red regression (stale ACP test mocks missing \`markStderr\`/\`stderrSince\`), a cancel-route error-mapping mismatch, and two slop items; all fixed in #36888. Full ACP suite green (214 pass / 0 fail, per-file as CI runs).

## PRs merged into this feature branch
- #36863 retain recent adapter stderr
- #36864 vertically center the ACP failed-run error (web)
- #36872 surface real adapter error instead of "Internal error"
- #36875 robust stderr JSON extraction (stray braces / nested error)
- #36877 bound retained stderr (tail-truncate; no quadratic scan)
- #36876 notify parent conversation on ACP failure
- #36888 self-review remediation (stale mocks, cancel route, slop)

## Deferred follow-up (out of scope)
A dedicated \`acp_session_cancelled\` event (or snapshot refetch) so cancelled runs settle to Cancelled on all clients rather than the pre-existing optimistic flash — a cross daemon+web change, tracked separately.

Part of plan: acp-failure-surfacing.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)