### PR TITLE
fix: gateway-only trigger-call policy, email intercept reply compat, test mock hygiene

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5665,8 +5665,8 @@ paths:
       operationId: contacts_invites_by_id_call_post
       summary: Trigger invite call
       description:
-        Trigger an outbound call for a phone invite. The gateway validates its canonical invite row and supplies
-        the resolved call fields in the body.
+        "Trigger an outbound call for a phone invite. Gateway-only: the gateway validates its canonical invite row
+        and supplies the resolved call fields in the body."
       tags:
         - contacts
       parameters:

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -242,6 +242,37 @@ describe("ROUTES policy declarations", () => {
     expect(route!.policy!.allowedPrincipalTypes).toContain("local");
   });
 
+  test("contacts/invites/:id/call is gateway-only", async () => {
+    // The handler dials whatever number the body supplies — the invite
+    // validation lives in the gateway's triggerInviteCallNative, so an
+    // actor-reachable policy would be an arbitrary-outbound-call primitive.
+    const { ROUTES } = await import("../../routes/index.js");
+    const route = ROUTES.find((r) => r.operationId === "invites_trigger_call");
+    expect(route).toBeDefined();
+    expect(route!.policy).not.toBeNull();
+    expect(route!.policy!.allowedPrincipalTypes).toEqual(["svc_gateway"]);
+    expect(route!.policy!.requiredScopes).toContain("internal.write");
+
+    // An actor principal with settings.write is denied.
+    authDisabled = false;
+    const actorCtx = buildTestContext({
+      principalType: "actor",
+      scopes: ["settings.write"],
+    });
+    const denied = enforcePolicy(route!.endpoint, route!.policy!, actorCtx);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(403);
+
+    // The gateway service principal with internal.write is allowed.
+    const gatewayCtx = buildTestContext({
+      principalType: "svc_gateway",
+      scopes: ["internal.write"],
+    });
+    expect(
+      enforcePolicy(route!.endpoint, route!.policy!, gatewayCtx),
+    ).toBeNull();
+  });
+
   test("internal/oauth/connect/start is gateway-only", async () => {
     const { ROUTES } = await import("../../routes/index.js");
     const route = ROUTES.find(

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -222,6 +222,22 @@ describe("invite relay routes", () => {
       expect(result).toEqual({ ok: true, callSid: "CA123" });
     });
 
+    test("route is gateway-only and stays dispatchable over the gateway's direct IPC path", () => {
+      const route = ROUTES.find(
+        (r) => r.operationId === "invites_trigger_call",
+      );
+      expect(route).toBeDefined();
+      // Gateway-only policy: the handler dials whatever number the body
+      // supplies, so it must never be reachable by actor principals (see
+      // route-policy.test.ts for the enforcement assertions).
+      expect(route!.policy!.allowedPrincipalTypes).toEqual(["svc_gateway"]);
+      expect(route!.policy!.requiredScopes).toEqual(["internal.write"]);
+      // The gateway invokes it via ipcCallAssistant("invites_trigger_call"),
+      // which dispatches shared routes that pass the IPC-eligibility filter.
+      expect(route!.requireGuardian).toBeUndefined();
+      expect(route!.isPublic).toBeUndefined();
+    });
+
     test("surfaces a failed provider call as a 400", async () => {
       triggerInviteCallResult = { ok: false, error: "Invite not eligible" };
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -26,7 +26,7 @@ import type { ContactRole, ContactType } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { getLogger } from "../../util/logger.js";
-import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import {
   composeInvitePresentation,
   resolveInviteGuardianName,
@@ -652,14 +652,17 @@ export const ROUTES: RouteDefinition[] = [
     operationId: "invites_trigger_call",
     endpoint: "contacts/invites/:id/call",
     method: "POST",
+    // Gateway-only: the handler dials whatever number is in the body — the
+    // invite validation in the gateway's triggerInviteCallNative is the sole
+    // gate, so an actor-reachable policy would be an arbitrary-dial primitive.
     policy: {
-      requiredScopes: ["settings.write"],
-      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+      requiredScopes: ["internal.write"],
+      allowedPrincipalTypes: GATEWAY_PRINCIPALS,
     },
     handler: handleTriggerInviteCall,
     summary: "Trigger invite call",
     description:
-      "Trigger an outbound call for a phone invite. The gateway validates its canonical invite row and supplies the resolved call fields in the body.",
+      "Trigger an outbound call for a phone invite. Gateway-only: the gateway validates its canonical invite row and supplies the resolved call fields in the body.",
     tags: ["contacts"],
     requestBody: z.object({
       phoneNumber: z

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -52,7 +52,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 
 const ipcMock = mock(async () => ({ resolved: true }));
 
+// Spread the actual module so untouched exports (IpcHandlerError,
+// IpcTransportError, ipcSuggestTrustRule) stay importable by later-loaded
+// files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: ipcMock,
 }));
 

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -56,28 +56,14 @@ let ipcCallAssistantMock: ReturnType<typeof mock<IpcCallFn>> = mock(
   async () => ({}),
 );
 
-class IpcHandlerError extends Error {
-  readonly statusCode: number;
-  readonly code: string;
-  constructor(message: string, statusCode: number, code: string) {
-    super(message);
-    this.name = "IpcHandlerError";
-    this.statusCode = statusCode;
-    this.code = code;
-  }
-}
-class IpcTransportError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "IpcTransportError";
-  }
-}
-
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (and untouched exports like ipcSuggestTrustRule) stay importable by
+// later-loaded files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: (...args: Parameters<IpcCallFn>) =>
     ipcCallAssistantMock(...args),
-  IpcHandlerError,
-  IpcTransportError,
 }));
 
 // ── ContactStore mock ─────────────────────────────────────────────────────────

--- a/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
@@ -54,7 +54,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 // and so we can assert it fired.
 const ipcMock = mock(async () => ({}));
 
+// Spread the actual module so untouched exports (IpcHandlerError,
+// IpcTransportError, ipcSuggestTrustRule) stay importable by later-loaded
+// files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: ipcMock,
 }));
 

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -86,7 +86,12 @@ mock.module("../verification/text-verification.js", () => ({
     tryTextVerificationInterceptMock(...(args as [])),
 }));
 
+// Spread the actual module so untouched exports (IpcHandlerError,
+// IpcTransportError, ipcSuggestTrustRule) stay importable by later-loaded
+// files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: (...args: Parameters<typeof ipcCallAssistantMock>) =>
     ipcCallAssistantMock(...args),
 }));

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -39,10 +39,13 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: (...args: Parameters<DbRunFn>) => assistantDbRunMock(...args),
 }));
 
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (and untouched exports like ipcSuggestTrustRule) stay importable by
+// later-loaded files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: mock(async () => ({})),
-  IpcHandlerError: class IpcHandlerError extends Error {},
-  IpcTransportError: class IpcTransportError extends Error {},
 }));
 
 import { GatewayIpcServer } from "../ipc/server.js";

--- a/gateway/src/__tests__/ipc-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-invite-routes.test.ts
@@ -37,15 +37,16 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 // Capture the best-effort invite_redeemed daemon event instead of dialing
 // the assistant socket.
 let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (and untouched exports like ipcSuggestTrustRule) stay importable by
+// later-loaded files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
     ipcCallAssistantCalls.push({ method, body: opts?.body });
     return {};
   },
-  // Not exercised here, but the mock must cover what transitive importers
-  // (contacts-control-plane-proxy) pull from this module.
-  IpcHandlerError: class IpcHandlerError extends Error {},
-  IpcTransportError: class IpcTransportError extends Error {},
 }));
 
 const { testWorkspaceDir } = await import("./test-preload.js");

--- a/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
@@ -36,15 +36,16 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 // Capture the best-effort invite_redeemed daemon event instead of dialing
 // the assistant socket.
 let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (and untouched exports like ipcSuggestTrustRule) stay importable by
+// later-loaded files when suites share a bun process.
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
     ipcCallAssistantCalls.push({ method, body: opts?.body });
     return {};
   },
-  // Not exercised here, but the mock must cover what transitive importers
-  // (contacts-control-plane-proxy) pull from this module.
-  IpcHandlerError: class IpcHandlerError extends Error {},
-  IpcTransportError: class IpcTransportError extends Error {},
 }));
 
 const { testWorkspaceDir } = await import("./test-preload.js");

--- a/gateway/src/http/routes/email-webhook.test.ts
+++ b/gateway/src/http/routes/email-webhook.test.ts
@@ -6,9 +6,18 @@ import { credentialKey } from "../../credential-key.js";
 
 // --- Mocks ----------------------------------------------------------------
 
+type MockInboundResult = {
+  forwarded: boolean;
+  rejected: boolean;
+  verificationIntercepted?: boolean;
+  verificationReplyText?: string;
+  inviteIntercepted?: boolean;
+  inviteReplyText?: string;
+};
+
 const handleInboundMock = mock(
   (_config: GatewayConfig, _normalized: unknown, _options?: unknown) =>
-    Promise.resolve({ forwarded: true, rejected: false }),
+    Promise.resolve<MockInboundResult>({ forwarded: true, rejected: false }),
 );
 
 const resetConversationMock = mock(() => Promise.resolve());
@@ -356,6 +365,70 @@ describe("email-webhook", () => {
     const status = dedupCache.reserve("<unique-dedup-id@example.com>");
     // Should return false because it's already reserved/marked
     expect(status).toBe(false);
+  });
+
+  // Intercept response-shape pins. The platform email relay
+  // (vellum-assistant-platform django/app/email/views.py) gates only on
+  // `denied` in the gateway body and returns everything else verbatim — it
+  // reads neither intercept flag nor `replyText`. The flags name which
+  // intercept fired; keep both shapes stable for relay-side consumers.
+  it("returns { ok, verificationIntercepted, replyText } for a verification intercept", async () => {
+    handleInboundMock.mockResolvedValue({
+      forwarded: false,
+      rejected: false,
+      verificationIntercepted: true,
+      verificationReplyText: "You're verified!",
+    });
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({
+      messageId: "<verification-intercept@example.com>",
+    });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      verificationIntercepted: true,
+      replyText: "You're verified!",
+    });
+  });
+
+  it("returns { ok, inviteIntercepted, replyText } for an invite intercept", async () => {
+    handleInboundMock.mockResolvedValue({
+      forwarded: false,
+      rejected: false,
+      inviteIntercepted: true,
+      inviteReplyText: "Invite redeemed — welcome!",
+    });
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({
+      messageId: "<invite-intercept@example.com>",
+    });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      inviteIntercepted: true,
+      replyText: "Invite redeemed — welcome!",
+    });
+  });
+
+  it("marks the event as processed after an intercept (no reprocessing on retry)", async () => {
+    handleInboundMock.mockResolvedValue({
+      forwarded: false,
+      rejected: false,
+      inviteIntercepted: true,
+      inviteReplyText: "Invite redeemed — welcome!",
+    });
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({
+      messageId: "<intercept-dedup@example.com>",
+    });
+    await handler(postRequest(body));
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    const res2 = await handler(postRequest(body));
+    expect(res2.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns 403 (not 409) when cache miss resolves on force-refresh but signature is invalid", async () => {

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -13,23 +13,12 @@ import "../../__tests__/test-preload.js";
 // Mock implementations
 // ---------------------------------------------------------------------------
 
-class MockIpcHandlerError extends Error {
-  readonly statusCode: number;
-  readonly code: string;
-  constructor(message: string, statusCode: number, code: string) {
-    super(message);
-    this.name = "IpcHandlerError";
-    this.statusCode = statusCode;
-    this.code = code;
-  }
-}
-
-class MockIpcTransportError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "IpcTransportError";
-  }
-}
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (thrown by tests below, caught via instanceof in the proxy) and
+// untouched exports like ipcSuggestTrustRule stay importable by later-loaded
+// files when suites share a bun process.
+const actualAssistantClient = await import("../../ipc/assistant-client.js");
+const { IpcHandlerError, IpcTransportError } = actualAssistantClient;
 
 // Single mock for `ipcCallAssistant` — used by both `refreshRouteSchema`
 // (to prime the cache) and `tryIpcProxy` (per-request IPC calls).
@@ -93,9 +82,8 @@ const defaultIpcImpl = (
 const ipcCallAssistantMock = mock(defaultIpcImpl);
 
 mock.module("../../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: ipcCallAssistantMock,
-  IpcHandlerError: MockIpcHandlerError,
-  IpcTransportError: MockIpcTransportError,
 }));
 
 // Stub validateEdgeToken — default: auth passes
@@ -268,7 +256,7 @@ describe("tryIpcProxy", () => {
     ipcCallAssistantMock.mockImplementation((method: string) => {
       if (method === "get_route_schema") return Promise.resolve(ROUTE_SCHEMA);
       return Promise.reject(
-        new MockIpcHandlerError(
+        new IpcHandlerError(
           "Binary/streaming responses are not supported over the IPC transport; use HTTP",
           421,
           "BINARY_UNSUPPORTED_OVER_IPC",
@@ -338,7 +326,7 @@ describe("tryIpcProxy", () => {
 
   test("returns handler error status code from IpcHandlerError", async () => {
     ipcCallAssistantMock.mockImplementation(() => {
-      throw new MockIpcHandlerError("Not found", 404, "NOT_FOUND");
+      throw new IpcHandlerError("Not found", 404, "NOT_FOUND");
     });
 
     const req = makeRequest("/v1/health");
@@ -352,7 +340,7 @@ describe("tryIpcProxy", () => {
 
   test("returns 502 on transport error", async () => {
     ipcCallAssistantMock.mockImplementation(() => {
-      throw new MockIpcTransportError("Socket closed");
+      throw new IpcTransportError("Socket closed");
     });
 
     const req = makeRequest("/v1/health");

--- a/gateway/src/http/routes/trust-rules.suggest.test.ts
+++ b/gateway/src/http/routes/trust-rules.suggest.test.ts
@@ -21,7 +21,12 @@ const ipcSuggestTrustRuleMock = mock((_params: unknown) =>
   }),
 );
 
+// Spread the actual module so untouched exports (ipcCallAssistant,
+// IpcHandlerError, IpcTransportError) stay importable by later-loaded files
+// when suites share a bun process.
+const actualAssistantClient = await import("../../ipc/assistant-client.js");
 mock.module("../../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcSuggestTrustRule: ipcSuggestTrustRuleMock,
 }));
 

--- a/gateway/src/ipc/route-schema-cache.test.ts
+++ b/gateway/src/ipc/route-schema-cache.test.ts
@@ -24,10 +24,13 @@ const ipcCallAssistantMock = mock(
   },
 );
 
+// Spread the actual module so the real IpcHandlerError/IpcTransportError
+// classes (and untouched exports like ipcSuggestTrustRule) stay importable by
+// later-loaded files when suites share a bun process.
+const actualAssistantClient = await import("./assistant-client.js");
 mock.module("./assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: ipcCallAssistantMock,
-  IpcHandlerError: class extends Error {},
-  IpcTransportError: class extends Error {},
 }));
 
 const {


### PR DESCRIPTION
## Summary
Fixes three gaps found during plan review for invites-gateway-native.md:
- invites_trigger_call is now gateway-only (was an arbitrary-outbound-call primitive for settings.write actors)
- email-webhook invite intercept response verified/aligned with the platform relay's flag expectations
- gateway assistant-client module mocks re-export IpcHandlerError (removes ordering-dependent test breakage)