### PR TITLE
fix: shared-contract redeem parsing, chatId member precheck, invite engine consolidation

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -17,12 +17,6 @@ mock.module("../calls/twilio-rest.js", () => ({
   hasTwilioCredentials: () => mockHasTwilioCredentials,
 }));
 
-mock.module("../channels/config.js", () => ({
-  getChannelInvitePolicy: () => ({
-    codeRedemptionEnabled: true,
-  }),
-}));
-
 mock.module("../config/env.js", () => ({
   getIngressPublicBaseUrl: () => undefined,
 }));

--- a/assistant/src/__tests__/channel-readiness-slack-remote.test.ts
+++ b/assistant/src/__tests__/channel-readiness-slack-remote.test.ts
@@ -35,10 +35,6 @@ mock.module("../config/env-registry.js", () => ({
   getIsPlatform: () => false,
 }));
 
-mock.module("../channels/config.js", () => ({
-  getChannelInvitePolicy: () => ({ codeRedemptionEnabled: false }),
-}));
-
 mock.module("../calls/twilio-rest.js", () => ({
   hasTwilioCredentials: () => false,
 }));

--- a/assistant/src/__tests__/phone.test.ts
+++ b/assistant/src/__tests__/phone.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { isValidE164, normalizePhoneNumber } from "../util/phone.js";
+import { normalizePhoneNumber } from "../util/phone.js";
 
 describe("normalizePhoneNumber", () => {
   test("already E.164 — returned as-is", () => {
@@ -53,19 +53,5 @@ describe("normalizePhoneNumber", () => {
 
   test("empty string — returns null", () => {
     expect(normalizePhoneNumber("")).toBeNull();
-  });
-});
-
-describe("isValidE164", () => {
-  test("valid E.164 number", () => {
-    expect(isValidE164("+15551234567")).toBe(true);
-  });
-
-  test("missing + prefix", () => {
-    expect(isValidE164("5551234567")).toBe(false);
-  });
-
-  test("too short", () => {
-    expect(isValidE164("+123")).toBe(false);
   });
 });

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -6,8 +6,6 @@
  * to compile until a policy is added below.
  */
 
-import { isInviteCodeRedemptionEnabled as sharedIsInviteCodeRedemptionEnabled } from "@vellumai/gateway-client";
-
 import type { ChannelId } from "./types.js";
 
 export type ConversationStrategy =
@@ -15,11 +13,6 @@ export type ConversationStrategy =
   | "continue_existing_conversation"
   | "not_deliverable"
   | "push_only";
-
-export interface ChannelInvitePolicy {
-  /** Whether inbound invite code redemption is supported on this channel. */
-  codeRedemptionEnabled: boolean;
-}
 
 export interface ChannelNotificationPolicy {
   notification: {
@@ -113,22 +106,4 @@ export function getConversationStrategy(
   channelId: ChannelId,
 ): ConversationStrategy {
   return CHANNEL_POLICIES[channelId].notification.conversationStrategy;
-}
-
-/**
- * Returns the invite policy for the given channel. Delegates to the shared
- * @vellumai/gateway-client allowlist so gateway and daemon share one source
- * of truth.
- */
-export function getChannelInvitePolicy(
-  channelId: ChannelId,
-): ChannelInvitePolicy {
-  return {
-    codeRedemptionEnabled: sharedIsInviteCodeRedemptionEnabled(channelId),
-  };
-}
-
-/** Whether invite code redemption is enabled for the given channel. */
-export function isInviteCodeRedemptionEnabled(channelId: ChannelId): boolean {
-  return sharedIsInviteCodeRedemptionEnabled(channelId);
 }

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -10,7 +10,7 @@
  * than flagged inside `ROUTES`.
  */
 
-import { InviteRedeemedNotificationSchema } from "@vellumai/gateway-client";
+import { InviteRedemptionOutcomeSchema } from "@vellumai/gateway-client";
 
 import { upsertContactChannel } from "../../contacts/contacts-write.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
@@ -25,7 +25,7 @@ import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
  * outcome is safe.
  */
 export function handleInviteRedeemed({ body = {} }: RouteHandlerArgs) {
-  const outcome = InviteRedeemedNotificationSchema.parse(body);
+  const outcome = InviteRedemptionOutcomeSchema.parse(body);
   upsertContactChannel({
     sourceChannel: outcome.sourceChannel,
     externalUserId: outcome.memberExternalUserId,

--- a/assistant/src/persistence/a2a-invite-store.ts
+++ b/assistant/src/persistence/a2a-invite-store.ts
@@ -7,8 +7,12 @@
  * never stored.
  */
 
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
+import {
+  generateInviteToken,
+  hashInviteToken,
+} from "@vellumai/gateway-client";
 import { and, eq } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
@@ -43,15 +47,6 @@ const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function hashToken(rawToken: string): string {
-  return createHash("sha256").update(rawToken).digest("hex");
-}
-
-function generateToken(): string {
-  // 32 bytes = 256 bits of entropy, base64url-encoded to a 43-character URL-safe string.
-  return randomBytes(32).toString("base64url");
-}
 
 function rowToInvite(row: typeof a2aInvites.$inferSelect): A2aInvite {
   return { ...row, status: row.status as A2aInviteStatus };
@@ -139,11 +134,11 @@ export function createA2aInvite(params: {
 }): { invite: A2aInvite; rawToken: string } {
   const db = getDb();
   const now = Date.now();
-  const rawToken = generateToken();
+  const rawToken = generateInviteToken();
 
   const row = {
     id: randomUUID(),
-    tokenHash: hashToken(rawToken),
+    tokenHash: hashInviteToken(rawToken),
     contactId: params.contactId,
     maxUses: params.maxUses ?? 1,
     useCount: 0,
@@ -168,7 +163,7 @@ export function claimA2aInvite(params: {
   token: string;
   redeemedByExternalUserId: string;
 }): { claimed: boolean; invite: A2aInvite | null; error?: string } {
-  const tokenHash = hashToken(params.token);
+  const tokenHash = hashInviteToken(params.token);
   const invite = findByTokenHash(tokenHash);
 
   if (!invite) {

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,3 +1,4 @@
+import { isInviteCodeRedemptionEnabled } from "@vellumai/gateway-client";
 import {
   normalizePublicBaseUrl,
   resolveTwilioPublicBaseUrl,
@@ -5,7 +6,6 @@ import {
 
 import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
-import { getChannelInvitePolicy } from "../channels/config.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getNestedValue, loadRawConfig } from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -168,7 +168,6 @@ const telegramProbe: ChannelProbe = {
 const emailProbe: ChannelProbe = {
   channel: "email",
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
-    const invitePolicy = getChannelInvitePolicy("email");
     return [
       check(
         "platform_email",
@@ -178,7 +177,7 @@ const emailProbe: ChannelProbe = {
       ),
       check(
         "invite_policy",
-        invitePolicy.codeRedemptionEnabled,
+        isInviteCodeRedemptionEnabled("email"),
         "Email invite code redemption is enabled",
         "Email invite code redemption is disabled",
       ),
@@ -218,7 +217,6 @@ const whatsappProbe: ChannelProbe = {
   channel: "whatsapp",
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const displayNumber = resolveWhatsAppDisplayNumber();
-    const invitePolicy = getChannelInvitePolicy("whatsapp");
     return [
       await checkCredential(
         "whatsapp_phone_number_id",
@@ -252,7 +250,7 @@ const whatsappProbe: ChannelProbe = {
       ),
       check(
         "invite_policy",
-        invitePolicy.codeRedemptionEnabled,
+        isInviteCodeRedemptionEnabled("whatsapp"),
         "WhatsApp invite code redemption is enabled",
         "WhatsApp invite code redemption is disabled",
       ),

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -50,9 +50,7 @@ function buildSharePayload(
 // Result types
 // ---------------------------------------------------------------------------
 
-export type IngressResult<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: string };
+type IngressResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
 // ---------------------------------------------------------------------------
 // Invite operations

--- a/assistant/src/util/phone.ts
+++ b/assistant/src/util/phone.ts
@@ -1,13 +1,9 @@
 /**
- * Phone number normalization and validation utilities.
+ * Phone number normalization utilities.
  *
  * Accepts common US and international phone number formats and normalizes
  * them to E.164 before validation, rate-limit lookups, or storage.
  */
-
-// Thin alias over the shared @vellumai/gateway-client invite contract so the
-// daemon and the gateway validate voice-invite phone bindings identically.
-export { isValidE164 } from "@vellumai/gateway-client";
 
 /**
  * Normalize a phone number string to E.164 format.

--- a/gateway/src/__tests__/contact-store-invites.test.ts
+++ b/gateway/src/__tests__/contact-store-invites.test.ts
@@ -201,11 +201,12 @@ describe("ContactStore ingress_invites", () => {
       redeemedByExternalChatId: "chat-ext",
     });
     expect(redeem.updated).toBe(true);
-    expect(redeem.row!.useCount).toBe(1);
-    expect(redeem.row!.status).toBe("redeemed");
-    expect(redeem.row!.redeemedByExternalUserId).toBe("u-ext");
-    expect(redeem.row!.redeemedByExternalChatId).toBe("chat-ext");
-    expect(redeem.row!.redeemedAt).not.toBeNull();
+    const row = store.getInviteById("inv1")!;
+    expect(row.useCount).toBe(1);
+    expect(row.status).toBe("redeemed");
+    expect(row.redeemedByExternalUserId).toBe("u-ext");
+    expect(row.redeemedByExternalChatId).toBe("chat-ext");
+    expect(row.redeemedAt).not.toBeNull();
 
     // Revoking a redeemed (non-active) invite is a no-op but returns the row.
     const revoked = store.revokeInvite("inv1");
@@ -227,19 +228,19 @@ describe("ContactStore ingress_invites", () => {
 
     const r1 = store.recordInviteRedemption({ inviteId: "inv1" });
     expect(r1.updated).toBe(true);
-    expect(r1.row!.useCount).toBe(1);
-    expect(r1.row!.status).toBe("active");
+    expect(store.getInviteById("inv1")!.useCount).toBe(1);
+    expect(store.getInviteById("inv1")!.status).toBe("active");
 
     const r2 = store.recordInviteRedemption({ inviteId: "inv1" });
     expect(r2.updated).toBe(true);
-    expect(r2.row!.useCount).toBe(2);
-    expect(r2.row!.status).toBe("redeemed");
+    expect(store.getInviteById("inv1")!.useCount).toBe(2);
+    expect(store.getInviteById("inv1")!.status).toBe("redeemed");
 
     // Exhausted (non-active) → further redemptions are gated out.
     const r3 = store.recordInviteRedemption({ inviteId: "inv1" });
     expect(r3.updated).toBe(false);
-    expect(r3.row!.useCount).toBe(2);
-    expect(r3.row!.status).toBe("redeemed");
+    expect(store.getInviteById("inv1")!.useCount).toBe(2);
+    expect(store.getInviteById("inv1")!.status).toBe("redeemed");
   });
 
   test("revokeInvite flips active → revoked, is idempotent, and returns null for unknown id", () => {
@@ -280,16 +281,15 @@ describe("ContactStore ingress_invites", () => {
 
     const redeem = store.recordInviteRedemption({ inviteId: "inv1" });
     expect(redeem.updated).toBe(false);
-    expect(redeem.row!.status).toBe("revoked");
-    expect(redeem.row!.useCount).toBe(0);
+    expect(store.getInviteById("inv1")!.status).toBe("revoked");
+    expect(store.getInviteById("inv1")!.useCount).toBe(0);
   });
 
-  test("recordInviteRedemption returns updated=false and null row for unknown id", () => {
+  test("recordInviteRedemption returns updated=false for unknown id", () => {
     const redeem = new ContactStore().recordInviteRedemption({
       inviteId: "nope",
     });
     expect(redeem.updated).toBe(false);
-    expect(redeem.row).toBeNull();
   });
 
   test("createInvite round-trips the widened secret + display columns", () => {
@@ -507,8 +507,8 @@ describe("ContactStore ingress_invites", () => {
     // recordInviteRedemption still gates on status='active'.
     const redeem = store.recordInviteRedemption({ inviteId: "inv1" });
     expect(redeem.updated).toBe(false);
-    expect(redeem.row!.status).toBe("expired");
-    expect(redeem.row!.useCount).toBe(0);
+    expect(store.getInviteById("inv1")!.status).toBe("expired");
+    expect(store.getInviteById("inv1")!.useCount).toBe(0);
   });
 
   test("markInviteExpired does not flip a revoked invite", () => {

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -252,13 +252,10 @@ type RevokeInviteFn = (inviteId: string) => InviteRow | null;
 let contactStoreRevokeInviteMock: ReturnType<typeof mock<RevokeInviteFn>> =
   mock(() => DEFAULT_INVITE);
 
-type RecordRedemptionFn = (params: unknown) => {
-  updated: boolean;
-  row: InviteRow | null;
-};
+type RecordRedemptionFn = (params: unknown) => { updated: boolean };
 let contactStoreRecordRedemptionMock: ReturnType<
   typeof mock<RecordRedemptionFn>
-> = mock(() => ({ updated: true, row: DEFAULT_INVITE }));
+> = mock(() => ({ updated: true }));
 
 type GetInviteByIdFn = (inviteId: string) => InviteRow | null;
 let contactStoreGetInviteByIdMock: ReturnType<typeof mock<GetInviteByIdFn>> =
@@ -374,25 +371,21 @@ let redeemInviteByTokenMock: ReturnType<typeof mock<RedeemTokenEngineFn>> =
     reason: "invalid_token",
     replyText: "This invite is no longer valid.",
   }));
-let notifyDaemonInviteRedeemedMock: ReturnType<
-  typeof mock<(outcome: EngineOutcome) => void>
-> = mock(() => {});
-
 mock.module("../verification/invite-redemption.js", () => ({
   redeemVoiceInvite: (...args: Parameters<RedeemVoiceEngineFn>) =>
     redeemVoiceInviteMock(...args),
   redeemInviteByToken: (...args: Parameters<RedeemTokenEngineFn>) =>
     redeemInviteByTokenMock(...args),
-  notifyDaemonInviteRedeemed: (outcome: EngineOutcome) =>
-    notifyDaemonInviteRedeemedMock(outcome),
   // Faithful stand-in for the real helper (curated contact displayName wins,
   // invite friendName falls back) — the trigger-call tests rely on it.
   resolveInviteeName: (
     store: { getContact: (id: string) => { displayName?: string } | undefined },
     invite: { contactId: string; friendName?: string | null },
+    fallback?: string,
   ) =>
     store.getContact(invite.contactId)?.displayName?.trim() ||
     invite.friendName?.trim() ||
+    fallback?.trim() ||
     null,
 }));
 
@@ -460,10 +453,7 @@ afterEach(() => {
   contactStoreListInvitesMock = mock(() => []);
   contactStoreCreateInviteMock = mock(() => DEFAULT_INVITE);
   contactStoreRevokeInviteMock = mock(() => DEFAULT_INVITE);
-  contactStoreRecordRedemptionMock = mock(() => ({
-    updated: true,
-    row: DEFAULT_INVITE,
-  }));
+  contactStoreRecordRedemptionMock = mock(() => ({ updated: true }));
   contactStoreGetInviteByIdMock = mock(() => DEFAULT_INVITE);
   contactStoreMarkInviteExpiredMock = mock(() => true);
   redeemVoiceInviteMock = mock(async () => ({
@@ -475,7 +465,6 @@ afterEach(() => {
     reason: "invalid_token",
     replyText: "This invite is no longer valid.",
   }));
-  notifyDaemonInviteRedeemedMock = mock(() => {});
 });
 
 describe("contacts control-plane proxy", () => {
@@ -2571,13 +2560,13 @@ describe("handleRedeemInvite (gateway-native)", () => {
       code: "123456",
       callerExternalUserId: "+15551234567",
     });
-    // The daemon info-mirror event fired; no assistant redeem relay ran.
-    expect(notifyDaemonInviteRedeemedMock).toHaveBeenCalledWith(VOICE_OUTCOME);
+    // No assistant redeem relay ran (the daemon info-mirror event is fired
+    // inside the engine, covered by the engine tests).
     expect(ipcCallAssistantMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("voice already_member returns no inviteId and fires no daemon event (nothing consumed)", async () => {
+  test("voice already_member returns no inviteId (nothing consumed)", async () => {
     redeemVoiceInviteMock = mock(async () => ({
       status: "already_member" as const,
       outcome: { ...VOICE_OUTCOME, result: "already_member" as const },
@@ -2595,7 +2584,6 @@ describe("handleRedeemInvite (gateway-native)", () => {
       type: "already_member",
       memberId: "ct_1",
     });
-    expect(notifyDaemonInviteRedeemedMock).not.toHaveBeenCalled();
   });
 
   test("voice failure maps to 400 BAD_REQUEST with the generic reason", async () => {
@@ -2609,7 +2597,6 @@ describe("handleRedeemInvite (gateway-native)", () => {
     const body = await res.json();
     expect(body.error.code).toBe("BAD_REQUEST");
     expect(body.error.message).toBe("invalid_or_expired");
-    expect(notifyDaemonInviteRedeemedMock).not.toHaveBeenCalled();
   });
 
   test("token path dispatches to the token engine and returns the sanitized invite + type", async () => {
@@ -2645,16 +2632,15 @@ describe("handleRedeemInvite (gateway-native)", () => {
     expect(body.invite.tokenHash).toBeUndefined();
     expect(body.invite.voiceCodeHash).toBeUndefined();
     expect(redeemInviteByTokenMock.mock.calls[0][0]).toMatchObject({
-      rawToken: "raw-token",
+      token: "raw-token",
       sourceChannel: "telegram",
       externalUserId: "u_1",
     });
     expect(contactStoreGetInviteByIdMock.mock.calls[0][0]).toBe("inv_1");
-    expect(notifyDaemonInviteRedeemedMock).toHaveBeenCalledTimes(1);
     expect(ipcCallAssistantMock).not.toHaveBeenCalled();
   });
 
-  test("token already_member relays the type unchanged and fires no daemon event", async () => {
+  test("token already_member relays the type unchanged", async () => {
     redeemInviteByTokenMock = mock(async () => ({
       status: "already_member" as const,
       outcome: {
@@ -2676,7 +2662,6 @@ describe("handleRedeemInvite (gateway-native)", () => {
     expect(body.ok).toBe(true);
     expect(body.type).toBe("already_member");
     expect(body.invite.id).toBe("inv_1");
-    expect(notifyDaemonInviteRedeemedMock).not.toHaveBeenCalled();
   });
 
   test("token engine failure maps the reason to 400 BAD_REQUEST", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
@@ -29,6 +29,18 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: async () => {},
 }));
 
+// Capture the best-effort invite_redeemed daemon event (fired by the engine
+// on every real redeem) instead of dialing the assistant socket.
+let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
+    ipcCallAssistantCalls.push({ method, body: opts?.body });
+    return {};
+  },
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+}));
+
 await import("./test-preload.js");
 
 const { initGatewayDb, getGatewayDb, resetGatewayDb } =
@@ -52,6 +64,7 @@ beforeEach(() => {
   db.delete(ingressInvites).run();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  ipcCallAssistantCalls = [];
 });
 
 afterAll(() => {
@@ -209,6 +222,13 @@ describe("redeemVoiceInvite", () => {
     expect(channel?.status).toBe("active");
     expect(channel?.verifiedVia).toBe("invite");
     expect(channel?.contactId).toBe("c1");
+
+    // The engine fires the daemon info-mirror event with the outcome verbatim.
+    const mirrored = ipcCallAssistantCalls.filter(
+      (c) => c.method === "invite_redeemed",
+    );
+    expect(mirrored).toHaveLength(1);
+    expect(mirrored[0].body).toEqual(result.outcome);
   });
 
   test("falls back to friendName when the target contact has no curated displayName", async () => {
@@ -286,6 +306,10 @@ describe("redeemVoiceInvite", () => {
     expect(result.outcome.result).toBe("already_member");
     expect(inviteRow(inviteId).useCount).toBe(0);
     expect(inviteRow(inviteId).status).toBe("active");
+    // Nothing consumed → no daemon info-mirror event.
+    expect(
+      ipcCallAssistantCalls.filter((c) => c.method === "invite_redeemed"),
+    ).toHaveLength(0);
   });
 
   test("blocked phone channel is NEVER reactivated: generic failure, no use consumed", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -23,6 +23,18 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbRun: () => assistantDbRunImpl(),
 }));
 
+// Capture the best-effort invite_redeemed daemon event (fired by the engine
+// on every real redeem) instead of dialing the assistant socket.
+let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
+    ipcCallAssistantCalls.push({ method, body: opts?.body });
+    return {};
+  },
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+}));
+
 await import("./test-preload.js");
 
 const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
@@ -51,7 +63,12 @@ beforeEach(() => {
   db.delete(contacts).run();
   assistantDbQueryImpl = async () => [];
   assistantDbRunImpl = async () => {};
+  ipcCallAssistantCalls = [];
 });
+
+function inviteRedeemedEvents() {
+  return ipcCallAssistantCalls.filter((c) => c.method === "invite_redeemed");
+}
 
 afterAll(() => {
   resetGatewayDb();
@@ -160,6 +177,10 @@ describe("redeemInviteByCode", () => {
     expect(channel?.status).toBe("active");
     expect(channel?.verifiedVia).toBe("invite");
     expect(channel?.contactId).toBe("c1");
+
+    // The engine fires the daemon info-mirror event with the outcome verbatim.
+    expect(inviteRedeemedEvents()).toHaveLength(1);
+    expect(inviteRedeemedEvents()[0].body).toEqual(result.outcome);
   });
 
   test("preserves the target contact's curated displayName in the outcome", async () => {
@@ -253,6 +274,33 @@ describe("redeemInviteByCode", () => {
     if (result.status !== "already_member") throw new Error("unreachable");
     expect(result.replyText).toBe("You already have access.");
     expect(result.outcome.result).toBe("already_member");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(inviteRow(inviteId).status).toBe("active");
+    // Nothing consumed → no daemon info-mirror event.
+    expect(inviteRedeemedEvents()).toHaveLength(0);
+  });
+
+  test("already_member for a chatId-only caller: NO use consumed", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c1",
+      address: "U_SENDER",
+      status: "active",
+    });
+    const inviteId = seedInvite();
+
+    // The seeded channel's externalChatId is "chat-1"; the sender carries only
+    // the delivery chat id (no actor external id).
+    const result = await redeemInviteByCode({
+      code: CODE,
+      sourceChannel: CHANNEL,
+      externalChatId: "chat-1",
+    });
+
+    expect(result.status).toBe("already_member");
+    if (result.status !== "already_member") throw new Error("unreachable");
+    expect(result.outcome.memberExternalUserId).toBe("U_SENDER");
     expect(inviteRow(inviteId).useCount).toBe(0);
     expect(inviteRow(inviteId).status).toBe("active");
   });
@@ -437,7 +485,7 @@ describe("redeemInviteByToken", () => {
     seedContact("c1");
     const inviteId = seedInvite();
 
-    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+    const result = await redeemInviteByToken({ token: TOKEN, ...IDENTITY });
 
     expect(result.status).toBe("redeemed");
     expect(inviteRow(inviteId).useCount).toBe(1);
@@ -449,7 +497,7 @@ describe("redeemInviteByToken", () => {
     seedInvite();
 
     const result = await redeemInviteByToken({
-      rawToken: "not-a-token",
+      token: "not-a-token",
       ...IDENTITY,
     });
 
@@ -464,7 +512,7 @@ describe("redeemInviteByToken", () => {
     const inviteId = seedInvite();
     new ContactStore().revokeInvite(inviteId);
 
-    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+    const result = await redeemInviteByToken({ token: TOKEN, ...IDENTITY });
 
     expect(result.status).toBe("failed");
     if (result.status !== "failed") throw new Error("unreachable");
@@ -476,7 +524,7 @@ describe("redeemInviteByToken", () => {
     seedContact("c1");
     const inviteId = seedInvite({ sourceChannel: "whatsapp" });
 
-    const result = await redeemInviteByToken({ rawToken: TOKEN, ...IDENTITY });
+    const result = await redeemInviteByToken({ token: TOKEN, ...IDENTITY });
 
     expect(result.status).toBe("failed");
     if (result.status !== "failed") throw new Error("unreachable");

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -884,7 +884,7 @@ export class ContactStore {
     inviteId: string;
     redeemedByExternalUserId?: string | null;
     redeemedByExternalChatId?: string | null;
-  }): { updated: boolean; row: IngressInviteRow | null } {
+  }): { updated: boolean } {
     const now = Date.now();
     // RETURNING lets us tell a gated-out update (no active row matched) from a
     // successful one without depending on the driver's `changes` count.
@@ -904,13 +904,10 @@ export class ContactStore {
           eq(ingressInvites.status, "active"),
         ),
       )
-      .returning()
+      .returning({ id: ingressInvites.id })
       .all();
 
-    return {
-      updated: updated.length > 0,
-      row: updated[0] ?? this.getInviteById(params.inviteId),
-    };
+    return { updated: updated.length > 0 };
   }
 
   getInviteById(inviteId: string): IngressInviteRow | null {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -41,8 +41,8 @@ import {
   ipcCallAssistant,
 } from "../../ipc/assistant-client.js";
 import { getLogger } from "../../logger.js";
+import { ensureInviteLive } from "../../verification/invite-liveness.js";
 import {
-  notifyDaemonInviteRedeemed,
   redeemInviteByToken,
   redeemVoiceInvite,
   resolveInviteeName,
@@ -373,10 +373,8 @@ export async function revokeInviteNative(
 /**
  * Redeem an invite natively through the gateway redemption engine
  * (verification/invite-redemption.ts): validation, membership gate, atomic
- * claim, and the verified-channel ACL upsert all run inside the gateway. A
- * successful redemption fires the best-effort `invite_redeemed` daemon
- * info-mirror event (`already_member` consumes nothing, so there is nothing
- * to mirror).
+ * claim, the verified-channel ACL upsert, and the best-effort
+ * `invite_redeemed` daemon info-mirror event all run inside the engine.
  *
  * Returns the transport-agnostic redeem payload:
  *   - voice: `{ ok, type, memberId, inviteId? }` (memberId = the invite's
@@ -401,9 +399,6 @@ export async function redeemInviteNative(
     if (result.status === "failed") {
       throw new InviteNativeError(result.reason, 400, "BAD_REQUEST");
     }
-    if (result.status === "redeemed") {
-      notifyDaemonInviteRedeemed(result.outcome);
-    }
     log.info(
       { inviteId: result.outcome.inviteId, type: result.status },
       "redeem_invite(voice): handled natively",
@@ -419,10 +414,12 @@ export async function redeemInviteNative(
   }
 
   const result = await redeemInviteByToken({
-    rawToken: input.token,
+    token: input.token,
     sourceChannel: input.sourceChannel,
     externalUserId: input.externalUserId,
     externalChatId: input.externalChatId,
+    displayName: input.displayName,
+    username: input.username,
     store,
   });
   if (result.status === "no_match" || result.status === "failed") {
@@ -430,9 +427,6 @@ export async function redeemInviteNative(
     // for a token; treat it as the same definitive invalid invite.
     const reason = result.status === "failed" ? result.reason : "invalid_token";
     throw new InviteNativeError(reason, 400, "BAD_REQUEST");
-  }
-  if (result.status === "redeemed") {
-    notifyDaemonInviteRedeemed(result.outcome);
   }
 
   const row = store.getInviteById(result.outcome.inviteId);
@@ -472,17 +466,12 @@ export async function triggerInviteCallNative(
       "NOT_FOUND",
     );
   }
-  if (invite.status !== "active") {
+  const liveness = ensureInviteLive(store, invite);
+  if (!liveness.live) {
     throw new InviteNativeError(
-      `Invite "${inviteId}" is not active`,
-      400,
-      "BAD_REQUEST",
-    );
-  }
-  if (invite.expiresAt <= Date.now()) {
-    store.markInviteExpired(invite.id);
-    throw new InviteNativeError(
-      `Invite "${inviteId}" has expired`,
+      liveness.reason === "expired"
+        ? `Invite "${inviteId}" has expired`
+        : `Invite "${inviteId}" is not active`,
       400,
       "BAD_REQUEST",
     );

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -10,6 +10,12 @@
  * caller (handler or test) can use these directly.
  */
 
+import {
+  RedeemInviteByTokenRequestSchema,
+  RedeemVoiceInviteRequestSchema,
+  type RedeemInviteByTokenRequest,
+  type RedeemVoiceInviteRequest,
+} from "@vellumai/gateway-client";
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
@@ -71,22 +77,28 @@ export function parseCreateInviteBody(
 // Redeem invite (voice-code vs token)
 // ---------------------------------------------------------------------------
 
-export interface VoiceRedeemInput {
+export interface VoiceRedeemInput extends RedeemVoiceInviteRequest {
   kind: "voice";
-  code: string;
-  callerExternalUserId: string;
   assistantId?: string;
 }
 
-export interface TokenRedeemInput {
+export interface TokenRedeemInput extends RedeemInviteByTokenRequest {
   kind: "token";
-  token: string;
-  externalUserId?: string;
-  externalChatId?: string;
-  sourceChannel: string;
 }
 
 export type RedeemInviteInput = VoiceRedeemInput | TokenRedeemInput;
+
+/** Map a token-schema failure to the stable redeem error messages. */
+function tokenIssueMessage(error: z.ZodError): string {
+  const issues = error.issues;
+  if (issues.some((issue) => issue.path[0] === "token")) {
+    return "token is required";
+  }
+  if (issues.some((issue) => issue.path[0] === "sourceChannel")) {
+    return "sourceChannel is required";
+  }
+  return firstIssueMessage(error);
+}
 
 export function parseRedeemInviteBody(
   body: unknown,
@@ -96,12 +108,8 @@ export function parseRedeemInviteBody(
   // Voice-code path: presence of `code` selects voice redemption (matching the
   // daemon, which branches on `body.code != null`).
   if (raw.code != null) {
-    const code = typeof raw.code === "string" ? raw.code : "";
-    const callerExternalUserId =
-      typeof raw.callerExternalUserId === "string"
-        ? raw.callerExternalUserId
-        : "";
-    if (!code || !callerExternalUserId) {
+    const parsed = RedeemVoiceInviteRequestSchema.safeParse(raw);
+    if (!parsed.success) {
       return {
         ok: false,
         message: "callerExternalUserId and code are required",
@@ -111,8 +119,7 @@ export function parseRedeemInviteBody(
       ok: true,
       value: {
         kind: "voice",
-        code,
-        callerExternalUserId,
+        ...parsed.data,
         assistantId:
           typeof raw.assistantId === "string" ? raw.assistantId : undefined,
       },
@@ -120,27 +127,11 @@ export function parseRedeemInviteBody(
   }
 
   // Token path.
-  const token = typeof raw.token === "string" ? raw.token : "";
-  if (!token) {
-    return { ok: false, message: "token is required" };
+  const parsed = RedeemInviteByTokenRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, message: tokenIssueMessage(parsed.error) };
   }
-  const sourceChannel =
-    typeof raw.sourceChannel === "string" ? raw.sourceChannel.trim() : "";
-  if (!sourceChannel) {
-    return { ok: false, message: "sourceChannel is required" };
-  }
-  return {
-    ok: true,
-    value: {
-      kind: "token",
-      token,
-      externalUserId:
-        typeof raw.externalUserId === "string" ? raw.externalUserId : undefined,
-      externalChatId:
-        typeof raw.externalChatId === "string" ? raw.externalChatId : undefined,
-      sourceChannel,
-    },
-  };
+  return { ok: true, value: { kind: "token", ...parsed.data } };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -84,7 +84,6 @@ import {
 } from "../http/routes/invite-validation.js";
 import {
   getActiveVoiceInviteForCaller,
-  notifyDaemonInviteRedeemed,
   redeemVoiceInvite,
 } from "../verification/invite-redemption.js";
 import type { IpcRoute } from "./server.js";
@@ -185,9 +184,9 @@ export const inviteRoutes: IpcRoute[] = [
     },
   },
   {
-    // Voice-code redemption through the gateway engine. Success fires the
-    // best-effort `invite_redeemed` daemon info-mirror event (already_member
-    // consumed nothing, so there is nothing to mirror).
+    // Voice-code redemption through the gateway engine. The engine fires the
+    // best-effort `invite_redeemed` daemon info-mirror event on a real redeem
+    // (already_member consumed nothing, so there is nothing to mirror).
     method: "redeem_voice_invite",
     schema: RedeemVoiceInviteRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
@@ -195,9 +194,6 @@ export const inviteRoutes: IpcRoute[] = [
       const result = await redeemVoiceInvite({ ...parsed, store: getStore() });
       if (result.status === "failed") {
         return { ok: false, reason: result.reason };
-      }
-      if (result.status === "redeemed") {
-        notifyDaemonInviteRedeemed(result.outcome);
       }
       return { ok: true, outcome: result.outcome };
     },

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -249,6 +249,16 @@ export interface VerifiedChannelRow {
   verifiedVia: string | null;
 }
 
+const VERIFIED_CHANNEL_PROJECTION = {
+  id: gwContactChannels.id,
+  contactId: gwContactChannels.contactId,
+  type: gwContactChannels.type,
+  address: gwContactChannels.address,
+  status: gwContactChannels.status,
+  verifiedAt: gwContactChannels.verifiedAt,
+  verifiedVia: gwContactChannels.verifiedVia,
+};
+
 /**
  * Read the authoritative gateway channel row by the logical key
  * (type, address) COLLATE NOCASE. Used to project an upsert result back to the
@@ -259,20 +269,34 @@ export function getGatewayChannelByKey(
   address: string,
 ): VerifiedChannelRow | null {
   const row = getGatewayDb()
-    .select({
-      id: gwContactChannels.id,
-      contactId: gwContactChannels.contactId,
-      type: gwContactChannels.type,
-      address: gwContactChannels.address,
-      status: gwContactChannels.status,
-      verifiedAt: gwContactChannels.verifiedAt,
-      verifiedVia: gwContactChannels.verifiedVia,
-    })
+    .select(VERIFIED_CHANNEL_PROJECTION)
     .from(gwContactChannels)
     .where(
       and(
         eq(gwContactChannels.type, type),
         sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Read the authoritative gateway channel row by `(type, externalChatId)`.
+ * Fallback member resolution for callers that only carry a delivery chat id
+ * (no actor external id).
+ */
+export function getGatewayChannelByExternalChatId(
+  type: string,
+  externalChatId: string,
+): VerifiedChannelRow | null {
+  const row = getGatewayDb()
+    .select(VERIFIED_CHANNEL_PROJECTION)
+    .from(gwContactChannels)
+    .where(
+      and(
+        eq(gwContactChannels.type, type),
+        eq(gwContactChannels.externalChatId, externalChatId),
       ),
     )
     .get();
@@ -309,12 +333,12 @@ export async function upsertVerifiedContactChannel(params: {
   contactId?: string;
   allowRevokedReactivation?: boolean;
   /**
-   * "soft": assistant-mirror (IPC) failures are logged, never thrown — the
+   * When true, assistant-mirror (IPC) failures are logged, never thrown — the
    * result reflects the gateway ACL write alone. Used post-claim by invite
    * redemption, where the mirror is best-effort and a throw would regress an
    * already-consumed invite to a non-intercepted path.
    */
-  mirrorFailureMode?: "soft";
+  softMirrorFailures?: boolean;
 }): Promise<{ verified: boolean }> {
   const now = Date.now();
   const {
@@ -326,7 +350,7 @@ export async function upsertVerifiedContactChannel(params: {
     allowRevokedReactivation,
   } = params;
   const verifiedVia = params.verifiedVia ?? "challenge";
-  const mirrorSoft = params.mirrorFailureMode === "soft";
+  const mirrorSoft = params.softMirrorFailures === true;
   const runMirror = async (
     op: () => Promise<unknown>,
     what: string,

--- a/gateway/src/verification/invite-liveness.ts
+++ b/gateway/src/verification/invite-liveness.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared invite liveness gate: status + expiry validation with lazy expiry
+ * sweeping against the gateway-canonical `ingress_invites` row.
+ */
+
+import type { ContactStore, IngressInviteRow } from "../db/contact-store.js";
+
+export type InviteLiveness =
+  /** Active and unexpired. */
+  | { live: true }
+  /** Already terminal (expired / revoked / redeemed). */
+  | { live: false; reason: "terminal"; status: string }
+  /** Active but past expiry — lazily flipped to status "expired". */
+  | { live: false; reason: "expired"; status: "expired" };
+
+/**
+ * Check that an invite is live (status "active" and unexpired). An active
+ * row past its expiry is lazily marked expired as a side effect.
+ */
+export function ensureInviteLive(
+  store: ContactStore,
+  invite: IngressInviteRow,
+  now: number = Date.now(),
+): InviteLiveness {
+  if (invite.status !== "active") {
+    return { live: false, reason: "terminal", status: invite.status };
+  }
+  if (invite.expiresAt <= now) {
+    store.markInviteExpired(invite.id);
+    return { live: false, reason: "expired", status: "expired" };
+  }
+  return { live: true };
+}

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -20,6 +20,8 @@ import {
   type ActiveVoiceInvite,
   type CommandIntent,
   type InviteRedemptionOutcome,
+  type RedeemInviteByCodeRequest,
+  type RedeemInviteByTokenRequest,
   type TrustVerdict,
 } from "@vellumai/gateway-client";
 
@@ -29,9 +31,11 @@ import { getLogger } from "../logger.js";
 import { extractEmailReplyBody } from "./code-parsing.js";
 import {
   upsertVerifiedContactChannel,
+  getGatewayChannelByExternalChatId,
   getGatewayChannelByKey,
 } from "./contact-helpers.js";
 import { canonicalizeInboundIdentity } from "./identity.js";
+import { ensureInviteLive } from "./invite-liveness.js";
 import { deliverVerificationReply } from "./reply-delivery.js";
 
 const log = getLogger("invite-redemption");
@@ -81,7 +85,8 @@ function failed(
   return { status: "failed", reason, replyText: INVITE_REPLY_TEMPLATES[reason] };
 }
 
-export interface RedeemIdentityParams {
+/** Sender identity fields shared by every redemption path. */
+interface RedeemIdentityParams {
   sourceChannel: string;
   externalUserId?: string;
   externalChatId?: string;
@@ -100,7 +105,7 @@ export interface RedeemIdentityParams {
  * `no_match` so a bare 6-digit message can fall through as normal content.
  */
 export async function redeemInviteByCode(
-  params: RedeemIdentityParams & { code: string; store?: ContactStore },
+  params: RedeemInviteByCodeRequest & { store?: ContactStore },
 ): Promise<InviteRedemptionEngineResult> {
   const store = params.store ?? new ContactStore();
   if (!params.externalUserId && !params.externalChatId) {
@@ -125,14 +130,14 @@ export async function redeemInviteByCode(
  * invalid invite — never a fall-through.
  */
 export async function redeemInviteByToken(
-  params: RedeemIdentityParams & { rawToken: string; store?: ContactStore },
+  params: RedeemInviteByTokenRequest & { store?: ContactStore },
 ): Promise<InviteRedemptionEngineResult> {
   const store = params.store ?? new ContactStore();
   if (!params.externalUserId && !params.externalChatId) {
     return failed("missing_identity");
   }
 
-  const invite = store.findInviteByTokenHash(hashInviteToken(params.rawToken));
+  const invite = store.findInviteByTokenHash(hashInviteToken(params.token));
   if (!invite) {
     return failed("invalid_token");
   }
@@ -158,12 +163,9 @@ async function finishRedemption(
 ): Promise<InviteRedemptionEngineResult> {
   const { sourceChannel, externalUserId, externalChatId, username } = params;
 
-  if (invite.status !== "active") {
-    return failed(reasonForStatus(invite.status));
-  }
-  if (invite.expiresAt <= Date.now()) {
-    store.markInviteExpired(invite.id);
-    return failed("expired");
+  const liveness = ensureInviteLive(store, invite);
+  if (!liveness.live) {
+    return failed(reasonForStatus(liveness.status));
   }
   if (invite.useCount >= invite.maxUses) {
     return failed("max_uses_reached");
@@ -174,16 +176,20 @@ async function finishRedemption(
 
   // ── Membership gate — gateway ACL rows only ──
   // Same (type, address) COLLATE NOCASE resolution the trust-verdict resolver
-  // uses. `already_member` never consumes a use, and a blocked gateway channel
-  // is NEVER reactivated by a code match (generic failure so membership
-  // status doesn't leak to callers holding a valid code).
+  // uses; a chatId-only caller falls back to the (type, externalChatId) key so
+  // an existing member never consumes a use for lack of an actor external id.
+  // `already_member` never consumes a use, and a blocked gateway channel is
+  // NEVER reactivated by a code match (generic failure so membership status
+  // doesn't leak to callers holding a valid code).
   const canonicalUserId = externalUserId
     ? (canonicalizeInboundIdentity(sourceChannel, externalUserId) ??
       externalUserId)
     : undefined;
   const existing = canonicalUserId
     ? getGatewayChannelByKey(sourceChannel, canonicalUserId)
-    : null;
+    : externalChatId
+      ? getGatewayChannelByExternalChatId(sourceChannel, externalChatId)
+      : null;
   // An existing channel under a different contact is not "already a member"
   // for this invite: the invite binds the sender to its target contact.
   const targetMismatch = !!existing && existing.contactId !== invite.contactId;
@@ -195,7 +201,7 @@ async function finishRedemption(
         inviteId: invite.id,
         contactId: existing.contactId,
         sourceChannel,
-        memberExternalUserId: canonicalUserId!,
+        memberExternalUserId: canonicalUserId ?? existing.address,
         ...(externalChatId ? { memberExternalChatId: externalChatId } : {}),
         result: "already_member",
       },
@@ -231,14 +237,12 @@ async function finishRedemption(
   // throws post-claim is logged and the redemption still succeeds — the
   // daemon `invite_redeemed` event and self-heal cover the mirror.
 
-  // Preserve the target contact's curated displayName over the raw
-  // transport-provided name (mirrors the daemon redemption service).
+  // The target contact's curated displayName wins over the raw
+  // transport-provided name.
   let displayName = params.displayName;
   try {
-    const targetContact = store.getContact(invite.contactId);
-    if (targetContact?.displayName?.trim().length) {
-      displayName = targetContact.displayName;
-    }
+    displayName =
+      resolveInviteeName(store, invite, params.displayName) ?? undefined;
   } catch (err) {
     log.warn(
       { err, inviteId: invite.id },
@@ -263,7 +267,7 @@ async function finishRedemption(
       verifiedVia: "invite",
       contactId: invite.contactId,
       allowRevokedReactivation: true,
-      mirrorFailureMode: "soft",
+      softMirrorFailures: true,
     }));
   } catch (err) {
     log.error(
@@ -281,21 +285,23 @@ async function finishRedemption(
     return failed("invalid_token");
   }
 
+  const outcome: InviteRedemptionOutcome = {
+    inviteId: invite.id,
+    contactId: invite.contactId,
+    sourceChannel,
+    memberExternalUserId: canonicalUserId ?? address,
+    ...(externalChatId ? { memberExternalChatId: externalChatId } : {}),
+    ...(displayName ? { displayName } : {}),
+    ...(username ? { username } : {}),
+    ...(invite.sourceConversationId
+      ? { sourceConversationId: invite.sourceConversationId }
+      : {}),
+    result: "redeemed",
+  };
+  notifyDaemonInviteRedeemed(outcome);
   return {
     status: "redeemed",
-    outcome: {
-      inviteId: invite.id,
-      contactId: invite.contactId,
-      sourceChannel,
-      memberExternalUserId: canonicalUserId ?? address,
-      ...(externalChatId ? { memberExternalChatId: externalChatId } : {}),
-      ...(displayName ? { displayName } : {}),
-      ...(username ? { username } : {}),
-      ...(invite.sourceConversationId
-        ? { sourceConversationId: invite.sourceConversationId }
-        : {}),
-      result: "redeemed",
-    },
+    outcome,
     replyText: INVITE_REPLY_TEMPLATES.redeemed,
   };
 }
@@ -313,23 +319,25 @@ function sweepExpiredVoiceInvites(
   now: number,
 ): void {
   for (const candidate of candidates) {
-    if (candidate.expiresAt <= now) {
-      store.markInviteExpired(candidate.id);
-    }
+    ensureInviteLive(store, candidate, now);
   }
 }
 
 /**
- * Resolve a voice invite's invitee display name: the target contact's curated
- * displayName preferred, the invite's free-text friendName as fallback.
+ * Resolve an invite's invitee display name: the target contact's curated
+ * displayName preferred, the invite's free-text friendName (voice invites)
+ * next, then the caller-supplied fallback (e.g. the transport-provided
+ * sender name).
  */
 export function resolveInviteeName(
   store: ContactStore,
   invite: IngressInviteRow,
+  fallback?: string,
 ): string | null {
   return (
     store.getContact(invite.contactId)?.displayName?.trim() ||
     invite.friendName?.trim() ||
+    fallback?.trim() ||
     null
   );
 }
@@ -375,8 +383,8 @@ const VOICE_FAILURE: VoiceInviteRedemptionResult = {
  * pre-checks (expired candidates are lazily swept). Validation, the membership
  * gate (`already_member` no-consume; blocked never reactivated), the atomic
  * claim, and the phone ACL upsert are shared with the code/token paths via
- * {@link finishRedemption} — the invite's friendName seeds the displayName,
- * with the target contact's curated name taking precedence inside the helper.
+ * {@link finishRedemption} — the invitee display name resolves inside the
+ * helper (curated contact name first, invite friendName next).
  *
  * Every failure collapses to the single generic `invalid_or_expired` so a
  * caller probing codes can't learn which invites exist, which numbers are
@@ -409,7 +417,6 @@ export async function redeemVoiceInvite(params: {
     sourceChannel: "phone",
     externalUserId: callerExternalUserId,
     externalChatId: callerExternalUserId,
-    displayName: invite.friendName ?? undefined,
   });
   if (result.status !== "redeemed" && result.status !== "already_member") {
     return VOICE_FAILURE;
@@ -423,12 +430,11 @@ export async function redeemVoiceInvite(params: {
 
 /**
  * Notify the daemon of a successful redemption so it mirrors the contact
- * info row locally. Fire-and-forget: the info mirror must never block or
- * fail the ACL path.
+ * info row locally. Fired by {@link finishRedemption} on every `redeemed`
+ * outcome (transports only map results to response envelopes).
+ * Fire-and-forget: the info mirror must never block or fail the ACL path.
  */
-export function notifyDaemonInviteRedeemed(
-  outcome: InviteRedemptionOutcome,
-): void {
+function notifyDaemonInviteRedeemed(outcome: InviteRedemptionOutcome): void {
   void ipcCallAssistant("invite_redeemed", { body: outcome }).catch((err) => {
     log.warn(
       { err, inviteId: outcome.inviteId },
@@ -550,7 +556,7 @@ export async function tryInviteRedemptionIntercept(
   try {
     result = token
       ? await redeemInviteByToken({
-          rawToken: token,
+          token,
           sourceChannel,
           externalUserId: actorExternalUserId,
           externalChatId: actorChatId,
@@ -577,10 +583,6 @@ export async function tryInviteRedemptionIntercept(
 
   if (result.status === "no_match") {
     return { intercepted: false };
-  }
-
-  if (result.status === "redeemed") {
-    notifyDaemonInviteRedeemed(result.outcome);
   }
 
   log.info(

--- a/packages/gateway-client/src/__tests__/invite-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/invite-contract.test.ts
@@ -18,9 +18,9 @@ import {
   hashInviteCode,
   hashInviteToken,
   INVITE_CODE_REDEMPTION_CHANNELS,
-  InviteRedeemedNotificationSchema,
   InviteRedemptionOutcomeSchema,
   isInviteCodeRedemptionEnabled,
+  isValidE164,
   RedeemInviteByCodeRequestSchema,
   RedeemInviteByTokenRequestSchema,
   RedeemVoiceInviteRequestSchema,
@@ -75,6 +75,20 @@ describe("generateInviteCode", () => {
   test("rejects out-of-range digit counts", () => {
     expect(() => generateInviteCode(3)).toThrow();
     expect(() => generateInviteCode(11)).toThrow();
+  });
+});
+
+describe("isValidE164", () => {
+  test("valid E.164 number", () => {
+    expect(isValidE164("+15551234567")).toBe(true);
+  });
+
+  test("missing + prefix", () => {
+    expect(isValidE164("5551234567")).toBe(false);
+  });
+
+  test("too short", () => {
+    expect(isValidE164("+123")).toBe(false);
   });
 });
 
@@ -136,12 +150,6 @@ describe("InviteRedemptionOutcomeSchema", () => {
       }),
     ).toThrow();
   });
-
-  test("InviteRedeemedNotificationSchema carries the outcome verbatim", () => {
-    expect(InviteRedeemedNotificationSchema.parse(fullOutcome)).toEqual(
-      fullOutcome,
-    );
-  });
 });
 
 describe("invite IPC request schemas", () => {
@@ -164,7 +172,7 @@ describe("invite IPC request schemas", () => {
 
   test("RedeemInviteByTokenRequestSchema round-trips full and minimal requests", () => {
     const full = {
-      rawToken: "raw-token",
+      token: "raw-token",
       sourceChannel: "slack",
       externalUserId: "U123",
       externalChatId: "D456",
@@ -172,7 +180,7 @@ describe("invite IPC request schemas", () => {
       username: "member",
     };
     expect(RedeemInviteByTokenRequestSchema.parse(full)).toEqual(full);
-    const minimal = { rawToken: "raw-token", sourceChannel: "slack" };
+    const minimal = { token: "raw-token", sourceChannel: "slack" };
     expect(RedeemInviteByTokenRequestSchema.parse(minimal)).toEqual(minimal);
     expect(() =>
       RedeemInviteByTokenRequestSchema.parse({ sourceChannel: "slack" }),

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -100,9 +100,6 @@ export {
   GetActiveVoiceInviteRequestSchema,
   hashInviteCode,
   hashInviteToken,
-  INVITE_CODE_REDEMPTION_CHANNELS,
-  INVITE_REDEMPTION_RESULT_VALUES,
-  InviteRedeemedNotificationSchema,
   InviteRedemptionOutcomeSchema,
   isInviteCodeRedemptionEnabled,
   isValidE164,
@@ -114,7 +111,6 @@ export {
 export type {
   ActiveVoiceInvite,
   GetActiveVoiceInviteRequest,
-  InviteRedeemedNotification,
   InviteRedemptionOutcome,
   InviteRedemptionResult,
   RedeemInviteByCodeRequest,

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -95,10 +95,7 @@ export function isInviteCodeRedemptionEnabled(channelType: string): boolean {
 // Redemption outcome
 // ---------------------------------------------------------------------------
 
-export const INVITE_REDEMPTION_RESULT_VALUES = [
-  "redeemed",
-  "already_member",
-] as const;
+const INVITE_REDEMPTION_RESULT_VALUES = ["redeemed", "already_member"] as const;
 
 export type InviteRedemptionResult =
   (typeof INVITE_REDEMPTION_RESULT_VALUES)[number];
@@ -107,7 +104,8 @@ export type InviteRedemptionResult =
  * Result of a successful invite redemption resolved by the gateway. Carries
  * the identity fields the daemon needs to mirror the activation locally
  * (`already_member` = the sender was already an active member, so no invite
- * use was consumed).
+ * use was consumed). Also the payload of the best-effort daemon IPC
+ * `invite_redeemed` info-mirror event, verbatim.
  */
 export const InviteRedemptionOutcomeSchema = z.object({
   inviteId: z.string(),
@@ -139,13 +137,20 @@ export type InviteRedemptionOutcome = z.infer<
 // - `RedeemVoiceInviteRequestSchema` — gateway IPC `redeem_voice_invite`.
 // - `GetActiveVoiceInviteRequestSchema` — gateway IPC
 //   `get_active_voice_invite`.
-// - `InviteRedeemedNotificationSchema` — daemon IPC `invite_redeemed`
-//   notification.
+//
+// Wire dispatch for `invites_redeem` (gateway IPC + HTTP redeem): the presence
+// of `code` selects voice redemption (validated by
+// `RedeemVoiceInviteRequestSchema`); otherwise the body is a link-token
+// redemption (validated by `RedeemInviteByTokenRequestSchema`).
 
-/** Gateway redemption-engine request for code redemption (6-digit code). */
+/**
+ * Gateway redemption-engine request for code redemption (6-digit code).
+ * Not an `invites_redeem` wire shape: bare-code redemption only happens via
+ * the gateway inbound intercept, which supplies the sender identity itself.
+ */
 export const RedeemInviteByCodeRequestSchema = z.object({
   code: z.string().min(1),
-  sourceChannel: z.string().min(1),
+  sourceChannel: z.string().trim().min(1),
   externalUserId: z.string().optional(),
   externalChatId: z.string().optional(),
   displayName: z.string().optional(),
@@ -156,10 +161,14 @@ export type RedeemInviteByCodeRequest = z.infer<
   typeof RedeemInviteByCodeRequestSchema
 >;
 
-/** Gateway redemption-engine request for token redemption (raw link token). */
+/**
+ * Gateway redemption-engine request for token redemption. `token` is the raw
+ * link token as sent on the `invites_redeem` wire by the CLI and the daemon
+ * relay.
+ */
 export const RedeemInviteByTokenRequestSchema = z.object({
-  rawToken: z.string().min(1),
-  sourceChannel: z.string().min(1),
+  token: z.string().min(1),
+  sourceChannel: z.string().trim().min(1),
   externalUserId: z.string().optional(),
   externalChatId: z.string().optional(),
   displayName: z.string().optional(),
@@ -170,7 +179,11 @@ export type RedeemInviteByTokenRequest = z.infer<
   typeof RedeemInviteByTokenRequestSchema
 >;
 
-/** Request for gateway IPC `redeem_voice_invite` (voice-channel spoken code). */
+/**
+ * Request for gateway IPC `redeem_voice_invite` (voice-channel spoken code).
+ * Also the `invites_redeem` voice wire shape, selected by the presence of
+ * `code`.
+ */
 export const RedeemVoiceInviteRequestSchema = z.object({
   callerExternalUserId: z.string().min(1),
   code: z.string().min(1),
@@ -201,14 +214,3 @@ export const ActiveVoiceInviteSchema = z.object({
 });
 
 export type ActiveVoiceInvite = z.infer<typeof ActiveVoiceInviteSchema>;
-
-/**
- * Daemon-bound `invite_redeemed` info-mirror event, fired best-effort by the
- * gateway after a successful redemption so the daemon can mirror the member
- * activation locally. Payload is the redemption outcome verbatim.
- */
-export const InviteRedeemedNotificationSchema = InviteRedemptionOutcomeSchema;
-
-export type InviteRedeemedNotification = z.infer<
-  typeof InviteRedeemedNotificationSchema
->;


### PR DESCRIPTION
## Summary
Fixes consolidation/correctness gaps found during plan review for invites-gateway-native.md:
- parseRedeemInviteBody now built on the shared zod contracts (token field reconciled); displayName/username threaded through redemption again
- already_member precheck covers externalChatId-only callers
- liveness gate, daemon-notify, and invitee-name resolution deduplicated into single helpers; mirrorFailureMode enum → boolean
- a2a-invite-store uses shared hash helpers; dead exports/wrappers removed