### PR TITLE
fix: gate m0010 drop on m0009 checkpoint; guard m0006/m0008 against dropped invite_id column

### DIFF
--- a/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
+++ b/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
@@ -57,17 +57,22 @@ const fakeAssistantDb = {
   channels: new Map<string, FakeChannel>(),
   hasContactsTable: true,
   hasChannelsTable: true,
+  hasInviteIdColumn: true,
   reset(): void {
     this.contacts.clear();
     this.channels.clear();
     this.hasContactsTable = true;
     this.hasChannelsTable = true;
+    this.hasInviteIdColumn = true;
   },
 };
 
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mock(async (sql: string) => {
     const lower = sql.toLowerCase();
+    if (lower.includes("pragma_table_info('contact_channels')")) {
+      return fakeAssistantDb.hasInviteIdColumn ? [{ "1": 1 }] : [];
+    }
     if (lower.includes("sqlite_master")) {
       if (lower.includes("'contacts'")) {
         return fakeAssistantDb.hasContactsTable ? [{ "1": 1 }] : [];
@@ -78,7 +83,16 @@ mock.module("../db/assistant-db-proxy.js", () => ({
       return [];
     }
     if (lower.includes("from contact_channels")) {
-      return Array.from(fakeAssistantDb.channels.values());
+      // Mirror SQLite: referencing the dropped column errors; the NULL alias
+      // is not a column reference.
+      const columnRefs = lower.replaceAll("null as invite_id", "");
+      if (!fakeAssistantDb.hasInviteIdColumn && columnRefs.includes("invite_id")) {
+        throw new Error("no such column: invite_id");
+      }
+      const rows = Array.from(fakeAssistantDb.channels.values());
+      return fakeAssistantDb.hasInviteIdColumn
+        ? rows
+        : rows.map((ch) => ({ ...ch, invite_id: null }));
     }
     if (lower.includes("from contacts")) {
       return Array.from(fakeAssistantDb.contacts.values());
@@ -473,6 +487,29 @@ describe("m0008-upsert-acl-columns-from-assistant", () => {
     };
 
     expect(after2).toEqual(after1);
+  });
+
+  test("completes when assistant contact_channels lacks the invite_id column", async () => {
+    fakeAssistantDb.hasInviteIdColumn = false;
+    seedAssistantContact({ id: "c6", role: "guardian", principal_id: "p6" });
+    seedAssistantChannel({
+      id: "ch6",
+      contact_id: "c6",
+      type: "telegram",
+      address: "addr-6",
+      status: "verified",
+    });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+
+    const c = gwContact("c6")!;
+    expect(c.role).toBe("guardian");
+    expect(c.principal_id).toBe("p6");
+
+    const ch = gwChannelByAddress("telegram", "addr-6")!;
+    expect(ch.status).toBe("verified");
+    expect(ch.invite_id).toBeNull();
   });
 
   test("returns skip and writes nothing when the assistant DB is unreachable", async () => {

--- a/gateway/src/__tests__/data-migration-m0010-drop-assistant-ingress-invites.test.ts
+++ b/gateway/src/__tests__/data-migration-m0010-drop-assistant-ingress-invites.test.ts
@@ -1,14 +1,15 @@
 /**
  * Tests for m0010-drop-assistant-ingress-invites.
  *
- * Verifies that phantom a2a rows (copied into the gateway by m0007) are
- * purged from gateway `ingress_invites`, that the assistant
- * `assistant_ingress_invites` table is dropped via the IPC db proxy, that an
- * IPC failure returns "skip" (runner retries next boot) while the a2a purge
- * still applies, that the migration is idempotent, and that it is registered
- * after m0009 so the sequential runner backfills before dropping. Uses the
- * same fake-assistant-DB + real in-memory gateway-DB pattern as the
- * m0007/m0009 tests.
+ * Verifies that the whole migration is gated on m0009's one_time_migrations
+ * checkpoint (no purge, no drop until the backfill is recorded as done), that
+ * phantom a2a rows (copied into the gateway by m0007) are purged from gateway
+ * `ingress_invites`, that the assistant `assistant_ingress_invites` table is
+ * dropped via the IPC db proxy, that an IPC failure returns "skip" (runner
+ * retries next boot) while the a2a purge still applies, that the migration is
+ * idempotent, and that it is registered after m0009. Uses the same
+ * fake-assistant-DB + real in-memory gateway-DB pattern as the m0007/m0009
+ * tests.
  */
 
 import {
@@ -59,11 +60,12 @@ import {
   getGatewayDb,
   resetGatewayDb,
 } from "../db/connection.js";
-import { contacts, ingressInvites } from "../db/schema.js";
+import { contacts, ingressInvites, oneTimeMigrations } from "../db/schema.js";
 import { MIGRATIONS } from "../db/data-migrations/index.js";
 import {
   up as m0010Up,
   down as m0010Down,
+  M0009_CHECKPOINT_KEY,
 } from "../db/data-migrations/m0010-drop-assistant-ingress-invites.js";
 
 beforeAll(async () => {
@@ -74,7 +76,9 @@ beforeEach(() => {
   const db = getGatewayDb();
   db.delete(ingressInvites).run();
   db.delete(contacts).run();
+  db.delete(oneTimeMigrations).run();
   fakeAssistantDb.reset();
+  checkpointM0009();
 });
 
 afterAll(() => {
@@ -82,6 +86,17 @@ afterAll(() => {
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+function checkpointM0009(): void {
+  getGatewayDb()
+    .insert(oneTimeMigrations)
+    .values({ key: M0009_CHECKPOINT_KEY, ranAt: 1_000 })
+    .run();
+}
+
+function uncheckpointM0009(): void {
+  getGatewayDb().delete(oneTimeMigrations).run();
+}
 
 function seedGatewayContact(id: string): void {
   getGatewayDb()
@@ -128,6 +143,27 @@ function gatewayInviteIds(): string[] {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe("m0010-drop-assistant-ingress-invites", () => {
+  test("skips entirely (no purge, no drop) when m0009 is not checkpointed", async () => {
+    uncheckpointM0009();
+    seedGatewayContact("c1");
+    seedGatewayInvite({ id: "a2a-1", sourceChannel: "a2a" });
+    seedGatewayInvite({ id: "tg-1", sourceChannel: "telegram" });
+
+    const result = await m0010Up();
+
+    expect(result).toBe("skip");
+    // The backfill source table and the a2a rows are untouched.
+    expect(fakeAssistantDb.hasInvitesTable).toBe(true);
+    expect(fakeAssistantDb.dropCalls).toBe(0);
+    expect(gatewayInviteIds()).toEqual(["a2a-1", "tg-1"]);
+
+    // Once the checkpoint lands, the same boot-retry path completes.
+    checkpointM0009();
+    expect(await m0010Up()).toBe("done");
+    expect(fakeAssistantDb.hasInvitesTable).toBe(false);
+    expect(gatewayInviteIds()).toEqual(["tg-1"]);
+  });
+
   test("purges phantom a2a rows and drops the assistant table", async () => {
     seedGatewayContact("c1");
     seedGatewayInvite({ id: "a2a-1", sourceChannel: "a2a" });
@@ -184,9 +220,9 @@ describe("m0010-drop-assistant-ingress-invites", () => {
     expect(fakeAssistantDb.hasInvitesTable).toBe(false);
   });
 
-  test("is registered after m0009 so the backfill reads the table before the drop", () => {
+  test("is registered after m0009 and gates on m0009's registered checkpoint key", () => {
     const keys = MIGRATIONS.map((m) => m.key);
-    const backfillIndex = keys.indexOf("m0009-invite-fields-backfill");
+    const backfillIndex = keys.indexOf(M0009_CHECKPOINT_KEY);
     const dropIndex = keys.indexOf("m0010-drop-assistant-ingress-invites");
 
     expect(backfillIndex).toBeGreaterThanOrEqual(0);

--- a/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
+++ b/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
@@ -55,17 +55,22 @@ const fakeAssistantDb = {
   channels: new Map<string, FakeChannel>(),
   hasContactsTable: true,
   hasChannelsTable: true,
+  hasInviteIdColumn: true,
   reset(): void {
     this.contacts.clear();
     this.channels.clear();
     this.hasContactsTable = true;
     this.hasChannelsTable = true;
+    this.hasInviteIdColumn = true;
   },
 };
 
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: mock(async (sql: string) => {
     const lower = sql.toLowerCase();
+    if (lower.includes("pragma_table_info('contact_channels')")) {
+      return fakeAssistantDb.hasInviteIdColumn ? [{ "1": 1 }] : [];
+    }
     if (lower.includes("sqlite_master") && lower.includes("'contacts'")) {
       return fakeAssistantDb.hasContactsTable ? [{ "1": 1 }] : [];
     }
@@ -76,7 +81,16 @@ mock.module("../db/assistant-db-proxy.js", () => ({
       return Array.from(fakeAssistantDb.contacts.values());
     }
     if (lower.includes("from contact_channels")) {
-      return Array.from(fakeAssistantDb.channels.values());
+      // Mirror SQLite: referencing the dropped column errors; the NULL alias
+      // is not a column reference.
+      const columnRefs = lower.replaceAll("null as invite_id", "");
+      if (!fakeAssistantDb.hasInviteIdColumn && columnRefs.includes("invite_id")) {
+        throw new Error("no such column: invite_id");
+      }
+      const rows = Array.from(fakeAssistantDb.channels.values());
+      return fakeAssistantDb.hasInviteIdColumn
+        ? rows
+        : rows.map((ch) => ({ ...ch, invite_id: null }));
     }
     return [];
   }),
@@ -282,6 +296,22 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
 
     expect(gatewayContactIds()).toEqual(["new-c"]);
     expect(gatewayChannelIds()).toEqual(["ch-new"]);
+  });
+
+  test("completes when assistant contact_channels lacks the invite_id column", async () => {
+    fakeAssistantDb.hasInviteIdColumn = false;
+    seedAssistantContact({ id: "c1" });
+    seedAssistantChannel({ id: "ch1", contactId: "c1" });
+
+    const result = await m0006Up();
+
+    expect(result).toBe("done");
+    expect(gatewayContactIds()).toEqual(["c1"]);
+    expect(gatewayChannelIds()).toEqual(["ch1"]);
+    const ch = getGatewayDb().$client
+      .prepare("SELECT invite_id FROM contact_channels WHERE id = ?")
+      .get("ch1") as { invite_id: string | null };
+    expect(ch.invite_id).toBeNull();
   });
 
   test("returns done when assistant DB has no contacts table", async () => {

--- a/gateway/src/db/data-migrations/assistant-invite-id-column.ts
+++ b/gateway/src/db/data-migrations/assistant-invite-id-column.ts
@@ -1,0 +1,15 @@
+/**
+ * `contact_channels.invite_id` exists only on assistant DBs that predate its
+ * drop (assistant persistence migration 314). Migrations that read the column
+ * over the db proxy build their SELECT with this fragment so the row shape is
+ * preserved — `NULL AS invite_id` — when the column is absent.
+ */
+
+import { assistantDbQuery } from "../assistant-db-proxy.js";
+
+export async function assistantInviteIdSelect(): Promise<string> {
+  const rows = await assistantDbQuery(
+    `SELECT 1 FROM pragma_table_info('contact_channels') WHERE name = 'invite_id'`,
+  );
+  return rows.length > 0 ? "invite_id" : "NULL AS invite_id";
+}

--- a/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
@@ -17,6 +17,7 @@ import { Database } from "bun:sqlite";
 import { getGatewayDb } from "../connection.js";
 import { getLogger } from "../../logger.js";
 import { assistantDbQuery } from "../assistant-db-proxy.js";
+import { assistantInviteIdSelect } from "./assistant-invite-id-column.js";
 
 import type { MigrationResult } from "./index.js";
 
@@ -125,7 +126,8 @@ export async function up(): Promise<MigrationResult> {
   if (hasChannelsTable.length > 0) {
     const assistantChannels = await assistantDbQuery<AssistantChannelRow>(
       `SELECT id, contact_id, type, address, is_primary, external_chat_id,
-              status, policy, verified_at, verified_via, invite_id,
+              status, policy, verified_at, verified_via,
+              ${await assistantInviteIdSelect()},
               revoked_reason, blocked_reason, last_seen_at,
               interaction_count, last_interaction, created_at, updated_at
          FROM contact_channels`,

--- a/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
@@ -23,6 +23,7 @@ import { Database } from "bun:sqlite";
 import { getGatewayDb } from "../connection.js";
 import { getLogger } from "../../logger.js";
 import { assistantDbQuery } from "../assistant-db-proxy.js";
+import { assistantInviteIdSelect } from "./assistant-invite-id-column.js";
 
 import type { MigrationResult } from "./index.js";
 
@@ -84,7 +85,8 @@ export async function up(): Promise<MigrationResult> {
     );
     const assistantChannels = await assistantDbQuery<AssistantChannelRow>(
       `SELECT id, contact_id, type, address, is_primary, external_chat_id,
-              status, policy, verified_at, verified_via, invite_id,
+              status, policy, verified_at, verified_via,
+              ${await assistantInviteIdSelect()},
               revoked_reason, blocked_reason, created_at, updated_at
          FROM contact_channels`,
     );

--- a/gateway/src/db/data-migrations/m0010-drop-assistant-ingress-invites.ts
+++ b/gateway/src/db/data-migrations/m0010-drop-assistant-ingress-invites.ts
@@ -1,19 +1,23 @@
 /**
  * One-time migration: finalize gateway ownership of ingress invites.
  *
+ * Gated on m0009's `one_time_migrations` checkpoint: registration order alone
+ * only guarantees m0009 ran *before* this migration, not that it succeeded
+ * (the runner continues past a "skip"/throw). Both steps below run only once
+ * the full-field backfill is checkpointed, so a failed backfill can never
+ * lose its source table, and the a2a purge cannot delete gateway-native a2a
+ * rows created between boots while the backfill retries.
+ *
  * 1. Purges `source_channel = 'a2a'` rows from the gateway `ingress_invites`
  *    table. m0007 copied every assistant invite, but A2A invites live in the
  *    daemon's `a2a_invites` table, so the copies are phantoms in the
- *    gateway-native list/revoke surfaces. Runs unconditionally — even when
- *    the assistant table is already gone.
+ *    gateway-native list/revoke surfaces.
  * 2. Drops the assistant's `assistant_ingress_invites` table via the IPC db
- *    proxy. Registered after m0009 so the sequential runner guarantees the
- *    full-field backfill reads the table before this drop; m0009's
- *    missing-table bail therefore only occurs on fresh installs or once this
- *    drop has completed.
+ *    proxy; m0009's missing-table bail therefore only occurs on fresh
+ *    installs or once this drop has completed.
  *
  * "skip" when the IPC drop fails so the runner retries next boot; the a2a
- * purge is idempotent and re-runs harmlessly on retry.
+ * purge is idempotent and re-runs harmlessly on that retry.
  */
 
 import { Database } from "bun:sqlite";
@@ -30,8 +34,21 @@ function getRawGatewayDb(): Database {
   return (getGatewayDb() as unknown as { $client: Database }).$client;
 }
 
+/** `one_time_migrations` key the runner records when m0009 completes. */
+export const M0009_CHECKPOINT_KEY = "m0009-invite-fields-backfill";
+
 export async function up(): Promise<MigrationResult> {
   const gwDb = getRawGatewayDb();
+
+  const backfillDone = gwDb
+    .prepare(`SELECT 1 FROM one_time_migrations WHERE key = ?`)
+    .get(M0009_CHECKPOINT_KEY);
+  if (!backfillDone) {
+    log.info(
+      "m0010: m0009 checkpoint absent — skipping purge + drop until the backfill completes",
+    );
+    return "skip";
+  }
 
   const purgedA2a = gwDb
     .prepare(`DELETE FROM ingress_invites WHERE source_channel = 'a2a'`)


### PR DESCRIPTION
## Summary
Fixes two migration gaps from plan re-review for invites-gateway-native.md:
- m0010 now skips (drop + a2a purge) until m0009's one_time_migrations checkpoint exists — a failed backfill can no longer lose the source table
- m0006/m0008 tolerate the dropped contact_channels.invite_id column (fresh installs and old-release upgraders no longer skip-loop)