### PR TITLE
fix: chatId member-lookup precedence, shared-schema daemon relay, mock/doc residuals

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -516,14 +516,13 @@ Voice invites use a short numeric code (6 digits) instead of a URL token. The gu
 
 | File                                                | Purpose                                                                                                            |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `gateway/src/verification/invite-redemption.ts` (gateway) | Core redemption engine — token/code validation, atomic claim, ACL activation, discriminated-union outcomes  |
+| `gateway/src/verification/invite-redemption.ts` (gateway) | Core redemption engine + gateway-ingress token/code intercept — validation, atomic claim, ACL activation, discriminated-union outcomes  |
 | `src/runtime/channel-invite-transport.ts`           | Transport adapter registry with `buildShareableInvite` / `extractInboundToken` interface                           |
 | `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — `t.me/<bot>?start=iv_<token>` deep links, `/start iv_<token>` extraction                        |
 | `src/runtime/channel-invite-transports/voice.ts`    | Voice transport adapter — code-based redemption metadata                                                           |
 | `src/daemon/guardian-invite-intent.ts`              | Intent detection — routes create/list/revoke requests into the contacts skill                                      |
 | `src/runtime/invite-service.ts`                     | Daemon-owned invite presentation (share link, guardian instruction, channel handle) over gateway-minted invites    |
 | `src/runtime/routes/contact-routes.ts`              | HTTP/IPC invite handlers — relay mint/list/revoke/redeem to the gateway's invite IPC routes                        |
-| `src/runtime/routes/inbound-message-handler.ts`     | Invite token intercept in the inbound flow (unknown-contact and inactive-contact branches)                         |
 | `src/calls/relay-server.ts`                         | Voice relay state machine — `invite_redemption_pending` subflow (always-on canonical behavior)                     |
 | `src/calls/gateway-invite-reader.ts`                | Gateway IPC read of the active voice invite for a caller identity                                                  |
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5748,6 +5748,12 @@ paths:
                 sourceChannel:
                   type: string
                   description: Source channel (token-based)
+                displayName:
+                  type: string
+                  description: Sender display name (token-based)
+                username:
+                  type: string
+                  description: Sender username (token-based)
                 assistantId:
                   type: string
                   description: Assistant ID (voice-code)
@@ -5758,6 +5764,8 @@ paths:
                 - externalUserId
                 - externalChatId
                 - sourceChannel
+                - displayName
+                - username
                 - assistantId
       responses:
         "200":

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -156,7 +156,11 @@ describe("invite redeem relay routes", () => {
       body: JSON.stringify({
         token: "raw-token-1",
         externalUserId: "redeemer-1",
+        externalChatId: "chat-9",
         sourceChannel: "telegram",
+        displayName: "Alice Example",
+        username: "alice",
+        notAContractField: "dropped",
       }),
     });
 
@@ -167,12 +171,17 @@ describe("invite redeem relay routes", () => {
     expect(body.ok).toBe(true);
     expect((body.invite as Record<string, unknown>).id).toBe("inv-gw-1");
     expect(body.type).toBe("redeemed");
-    // The relay forwarded the token fields (and nothing voice-shaped).
+    // The relay forwards every shared-contract field — including the sender
+    // identity fields (displayName/username) the gateway engine stamps onto
+    // the new member — and nothing voice-shaped or off-contract.
     expect(redeemRelay.calls).toEqual([
       {
         token: "raw-token-1",
         sourceChannel: "telegram",
         externalUserId: "redeemer-1",
+        externalChatId: "chat-9",
+        displayName: "Alice Example",
+        username: "alice",
       },
     ]);
   });
@@ -189,7 +198,11 @@ describe("invite redeem relay routes", () => {
     const req = new Request("http://localhost/v1/contacts/invites/redeem", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ callerExternalUserId: "+15551234567", code }),
+      body: JSON.stringify({
+        callerExternalUserId: "+15551234567",
+        code,
+        assistantId: "asst-1",
+      }),
     });
 
     const res = await handleRedeemInvite(req);
@@ -203,7 +216,7 @@ describe("invite redeem relay routes", () => {
       inviteId: "inv-gw-2",
     });
     expect(redeemRelay.calls).toEqual([
-      { code, callerExternalUserId: "+15551234567" },
+      { code, callerExternalUserId: "+15551234567", assistantId: "asst-1" },
     ]);
   });
 
@@ -249,11 +262,6 @@ describe("invite redeem relay routes", () => {
   });
 
   test("POST /v1/contacts/invites/redeem — missing token returns 400 without relaying", async () => {
-    redeemRelay.error = new IpcCallError("token is required", {
-      statusCode: 400,
-      errorCode: "BAD_REQUEST",
-    });
-
     const req = new Request("http://localhost/v1/contacts/invites/redeem", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -263,11 +271,12 @@ describe("invite redeem relay routes", () => {
     const res = await handleRedeemInvite(req);
     const body = (await res.json()) as { ok: boolean; error: string };
 
-    // No `code` and no `token` → token path; the gateway's shared validation
-    // rejects with a 400 the relay surfaces verbatim.
+    // No `code` and no `token` → token path; the shared contract schema
+    // rejects daemon-side before any gateway round-trip.
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
     expect(body.error).toContain("token");
+    expect(redeemRelay.calls.length).toBe(0);
   });
 
   test("POST /v1/contacts/invites/redeem — voice code without caller identity is rejected daemon-side", async () => {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -9,6 +9,10 @@
  */
 
 import {
+  RedeemInviteByTokenRequestSchema,
+  RedeemVoiceInviteRequestSchema,
+} from "@vellumai/gateway-client";
+import {
   GetContactIpcResponseSchema,
   ListContactsIpcResponseSchema,
   UpdateContactChannelIpcResponseSchema,
@@ -371,23 +375,22 @@ export async function handleRevokeInvite({
 /**
  * Redeem a voice invite code.
  *
- * Backs the HTTP `invites_redeem` route (voice path). Relays to the gateway's
+ * Backs the HTTP `invites_redeem` route (voice path). Parses the body with
+ * the shared `RedeemVoiceInviteRequestSchema` wire contract (plus the
+ * daemon-specific `assistantId` passthrough) and relays to the gateway's
  * `invites_redeem` IPC — the gateway redemption engine owns validation, the
  * atomic claim, and the ACL write. Fail-closed: a gateway relay failure
  * surfaces as an error; there is no local redemption fallback.
  */
-export async function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
-  const callerExternalUserId = body.callerExternalUserId as string | undefined;
-  const code = body.code as string | undefined;
-
-  if (!callerExternalUserId || !code) {
+async function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
+  const parsed = RedeemVoiceInviteRequestSchema.safeParse(body);
+  if (!parsed.success) {
     throw new BadRequestError("callerExternalUserId and code are required");
   }
 
   try {
     return (await ipcCallPersistent("invites_redeem", {
-      code,
-      callerExternalUserId,
+      ...parsed.data,
       ...(typeof body.assistantId === "string"
         ? { assistantId: body.assistantId }
         : {}),
@@ -397,30 +400,41 @@ export async function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
   }
 }
 
+/** Map a token-branch schema failure to the stable redeem error messages. */
+function redeemTokenIssueMessage(error: z.ZodError): string {
+  for (const field of ["token", "sourceChannel"] as const) {
+    if (error.issues.some((issue) => issue.path[0] === field)) {
+      return `${field} is required`;
+    }
+  }
+  return error.issues[0]?.message ?? "Invalid redemption request";
+}
+
 /**
  * Redeem a token invite.
  *
- * Backs the HTTP `invites_redeem` route (token path). Relays to the gateway's
- * `invites_redeem` IPC — the gateway redemption engine owns validation, the
- * atomic claim, and the ACL write. Fail-closed: a gateway relay failure
- * surfaces as an error; there is no local redemption fallback.
+ * Backs the HTTP `invites_redeem` route (token path). Parses the body with
+ * the shared `RedeemInviteByTokenRequestSchema` wire contract and relays the
+ * parsed request verbatim — including the sender identity fields
+ * (`displayName` / `username`) the gateway engine stamps onto the new member —
+ * to the gateway's `invites_redeem` IPC. The gateway redemption engine owns
+ * validation, the atomic claim, and the ACL write. Fail-closed: a gateway
+ * relay failure surfaces as an error; there is no local redemption fallback.
  */
-export async function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
+async function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
+  const parsed = RedeemInviteByTokenRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(redeemTokenIssueMessage(parsed.error));
+  }
+
   try {
     // The `type` is surfaced so callers can tell a real redeem apart from an
     // `already_member` no-op (which consumes no invite use).
-    return (await ipcCallPersistent("invites_redeem", {
-      ...(typeof body.token === "string" ? { token: body.token } : {}),
-      ...(typeof body.sourceChannel === "string"
-        ? { sourceChannel: body.sourceChannel }
-        : {}),
-      ...(typeof body.externalUserId === "string"
-        ? { externalUserId: body.externalUserId }
-        : {}),
-      ...(typeof body.externalChatId === "string"
-        ? { externalChatId: body.externalChatId }
-        : {}),
-    })) as { ok: true; invite: Record<string, unknown>; type: string };
+    return (await ipcCallPersistent("invites_redeem", parsed.data)) as {
+      ok: true;
+      invite: Record<string, unknown>;
+      type: string;
+    };
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -613,6 +627,8 @@ export const ROUTES: RouteDefinition[] = [
       externalUserId: z.string().describe("External user ID (token-based)"),
       externalChatId: z.string().describe("External chat ID (token-based)"),
       sourceChannel: z.string().describe("Source channel (token-based)"),
+      displayName: z.string().describe("Sender display name (token-based)"),
+      username: z.string().describe("Sender username (token-based)"),
       assistantId: z.string().describe("Assistant ID (voice-code)"),
     }),
     responseBody: z.object({

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1,8 +1,9 @@
 /**
  * Channel inbound message handler: validates, records, and routes inbound
  * messages from all channels. Handles ingress ACL, edits, guardian
- * verification, guardian action answers, approval interception, and
- * invite token redemption.
+ * verification, guardian action answers, and approval interception.
+ * Invite token/code redemption is intercepted at gateway ingress before
+ * messages reach this handler.
  */
 import type { SourceMetadata } from "@vellumai/gateway-client";
 import {

--- a/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
@@ -24,21 +24,28 @@ import { hashInviteCode } from "@vellumai/gateway-client";
 
 // The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
 // assistant-DB info mirror over IPC; stub it so tests never touch a socket.
+// Spread the actual module so untouched exports (assistantDbExec,
+// assistantDbTransaction) stay importable by later-loaded files when suites
+// share a bun process.
+const actualAssistantDbProxy = await import("../db/assistant-db-proxy.js");
 mock.module("../db/assistant-db-proxy.js", () => ({
+  ...actualAssistantDbProxy,
   assistantDbQuery: async () => [],
   assistantDbRun: async () => {},
 }));
 
 // Capture the best-effort invite_redeemed daemon event (fired by the engine
-// on every real redeem) instead of dialing the assistant socket.
+// on every real redeem) instead of dialing the assistant socket. Spread the
+// actual module so the real IpcHandlerError/IpcTransportError classes (and
+// untouched exports) stay importable by later-loaded files.
 let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
     ipcCallAssistantCalls.push({ method, body: opts?.body });
     return {};
   },
-  IpcHandlerError: class IpcHandlerError extends Error {},
-  IpcTransportError: class IpcTransportError extends Error {},
 }));
 
 await import("./test-preload.js");

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -15,24 +15,30 @@ import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
 
 // The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
 // assistant-DB info mirror over IPC; stub it so tests never touch a socket.
-// The impls are mutable so tests can simulate a down/failing mirror.
+// The impls are mutable so tests can simulate a down/failing mirror. Spread
+// the actual module so untouched exports (assistantDbExec, assistantDbTransaction)
+// stay importable by later-loaded files when suites share a bun process.
 let assistantDbQueryImpl: () => Promise<unknown[]> = async () => [];
 let assistantDbRunImpl: () => Promise<void> = async () => {};
+const actualAssistantDbProxy = await import("../db/assistant-db-proxy.js");
 mock.module("../db/assistant-db-proxy.js", () => ({
+  ...actualAssistantDbProxy,
   assistantDbQuery: () => assistantDbQueryImpl(),
   assistantDbRun: () => assistantDbRunImpl(),
 }));
 
 // Capture the best-effort invite_redeemed daemon event (fired by the engine
-// on every real redeem) instead of dialing the assistant socket.
+// on every real redeem) instead of dialing the assistant socket. Spread the
+// actual module so the real IpcHandlerError/IpcTransportError classes (and
+// untouched exports) stay importable by later-loaded files.
 let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
   ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
     ipcCallAssistantCalls.push({ method, body: opts?.body });
     return {};
   },
-  IpcHandlerError: class IpcHandlerError extends Error {},
-  IpcTransportError: class IpcTransportError extends Error {},
 }));
 
 await import("./test-preload.js");
@@ -300,6 +306,43 @@ describe("redeemInviteByCode", () => {
 
     expect(result.status).toBe("already_member");
     if (result.status !== "already_member") throw new Error("unreachable");
+    expect(result.outcome.memberExternalUserId).toBe("U_SENDER");
+    expect(inviteRow(inviteId).useCount).toBe(0);
+    expect(inviteRow(inviteId).status).toBe("active");
+  });
+
+  test("chatId-only lookup with two rows sharing the chatId: the active invite-contact row wins over a stale foreign row → already_member, NO use consumed", async () => {
+    // (type, externalChatId) is non-unique. A stale revoked row under another
+    // contact shares the chat id with the sender's active membership row; the
+    // membership precheck must resolve the invite-contact active row, not
+    // whichever row the DB returns first.
+    seedContact("c1");
+    seedContact("c2");
+    seedChannel({
+      id: "ch-stale",
+      contactId: "c2",
+      address: "U_STALE",
+      status: "revoked",
+    });
+    seedChannel({
+      id: "ch-member",
+      contactId: "c1",
+      address: "U_SENDER",
+      status: "active",
+    });
+    const inviteId = seedInvite(); // targets c1
+
+    // Both seeded rows carry externalChatId "chat-1"; the sender is
+    // chatId-only (no actor external id).
+    const result = await redeemInviteByCode({
+      code: CODE,
+      sourceChannel: CHANNEL,
+      externalChatId: "chat-1",
+    });
+
+    expect(result.status).toBe("already_member");
+    if (result.status !== "already_member") throw new Error("unreachable");
+    expect(result.outcome.contactId).toBe("c1");
     expect(result.outcome.memberExternalUserId).toBe("U_SENDER");
     expect(inviteRow(inviteId).useCount).toBe(0);
     expect(inviteRow(inviteId).status).toBe("active");

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -285,12 +285,17 @@ export function getGatewayChannelByKey(
  * Read the authoritative gateway channel row by `(type, externalChatId)`.
  * Fallback member resolution for callers that only carry a delivery chat id
  * (no actor external id).
+ *
+ * `(type, externalChatId)` is non-unique, so among multiple matches the row
+ * bound to `preferredContactId` wins, then an `active` row — a stale
+ * revoked/foreign row must not shadow the membership-relevant one.
  */
 export function getGatewayChannelByExternalChatId(
   type: string,
   externalChatId: string,
+  preferredContactId?: string,
 ): VerifiedChannelRow | null {
-  const row = getGatewayDb()
+  const rows = getGatewayDb()
     .select(VERIFIED_CHANNEL_PROJECTION)
     .from(gwContactChannels)
     .where(
@@ -299,8 +304,14 @@ export function getGatewayChannelByExternalChatId(
         eq(gwContactChannels.externalChatId, externalChatId),
       ),
     )
-    .get();
-  return row ?? null;
+    .all();
+  if (rows.length === 0) {
+    return null;
+  }
+  const score = (row: VerifiedChannelRow) =>
+    (row.contactId === preferredContactId ? 2 : 0) +
+    (row.status === "active" ? 1 : 0);
+  return rows.reduce((best, row) => (score(row) > score(best) ? row : best));
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/verification/invite-redemption.ts
+++ b/gateway/src/verification/invite-redemption.ts
@@ -188,7 +188,11 @@ async function finishRedemption(
   const existing = canonicalUserId
     ? getGatewayChannelByKey(sourceChannel, canonicalUserId)
     : externalChatId
-      ? getGatewayChannelByExternalChatId(sourceChannel, externalChatId)
+      ? getGatewayChannelByExternalChatId(
+          sourceChannel,
+          externalChatId,
+          invite.contactId,
+        )
       : null;
   // An existing channel under a different contact is not "already a member"
   // for this invite: the invite binds the sender to its target contact.


### PR DESCRIPTION
## Summary
Fixes residual gaps from plan re-review for invites-gateway-native.md:
- chatId-only member lookup prefers invite-contact + active rows (already_member precheck no longer shadowed by stale rows)
- daemon invites_redeem relay parses via the shared contracts and forwards displayName/username; dead exports dropped
- engine test files adopt the spread-actual mock pattern; two stale intercept doc references fixed