### PR TITLE
feat(daemon): attribute event-loop freezes via a watchdog section trail

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -15,6 +15,10 @@ import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.
 import { parseActualTokensFromError } from "../daemon/parse-actual-tokens-from-error.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { stripHistoricalWebSearchResults } from "../daemon/web-search-history.js";
+import {
+  timeSyncSection,
+  traceAsyncSection,
+} from "../persistence/slow-sync-log.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type {
   AgentLoopExitReason,
@@ -1507,15 +1511,20 @@ export class AgentLoop {
         // the existing correction) so the calibrator learns the true
         // bias against provider ground truth instead of ratcheting a
         // feedback loop against its own corrected output.
-        const toolTokenBudget =
-          currentTools.length > 0 ? estimateToolsTokens(currentTools) : 0;
-        const preSendEstimatedTokens = estimatePromptTokensRaw(
-          history,
-          runSystemPrompt,
-          {
-            providerName: getCalibrationProviderKey(this.provider),
-            toolTokenBudget,
+        const preSendEstimatedTokens = timeSyncSection(
+          "agent-loop:estimate-prompt-tokens",
+          () => {
+            const toolTokenBudget =
+              currentTools.length > 0 ? estimateToolsTokens(currentTools) : 0;
+            return estimatePromptTokensRaw(history, runSystemPrompt, {
+              providerName: getCalibrationProviderKey(this.provider),
+              toolTokenBudget,
+            });
           },
+          (estimatedTokens) => ({
+            estimatedTokens,
+            messageCount: history.length,
+          }),
         );
         lastPreSendEstimatedTokens = preSendEstimatedTokens;
         rlog.info({ turn: toolUseTurns }, "LLM call start");
@@ -1523,7 +1532,11 @@ export class AgentLoop {
         // Sanitize the outbound history right before sending: drop accumulated
         // media, collapse old AX-tree snapshots, and convert historical
         // web-search results to text. See {@link preModelCallSanitize}.
-        const providerHistory = preModelCallSanitize(history);
+        const providerHistory = timeSyncSection(
+          "agent-loop:pre-model-call-sanitize",
+          () => preModelCallSanitize(history),
+          (sanitized) => ({ messageCount: sanitized.length }),
+        );
 
         // A `pre-model-call` hook (below) can defer this turn's assistant
         // output; when set, the live text stream is held so an
@@ -1634,9 +1647,9 @@ export class AgentLoop {
             deferAssistantOutput: false,
             logger: rlog,
           };
-          const finalPreModelCtx = await runHook(
-            HOOKS.PRE_MODEL_CALL,
-            preModelCtx,
+          const finalPreModelCtx = await traceAsyncSection(
+            "agent-loop:pre-model-call-hook",
+            () => runHook(HOOKS.PRE_MODEL_CALL, preModelCtx),
           );
           // Emit a changed event when the hook mutated the prompt. Compare
           // against the pre-hook value from providerOptions, not
@@ -1705,9 +1718,8 @@ export class AgentLoop {
         latencyTracker?.mark("request_sent");
         let response: ProviderResponse;
         try {
-          response = await this.provider.sendMessage(
-            providerHistory,
-            providerOptions,
+          response = await traceAsyncSection("agent-loop:provider-send", () =>
+            this.provider.sendMessage(providerHistory, providerOptions),
           );
         } catch (llmCallError) {
           // Skip recording on abort — the user cancelled the request and
@@ -1803,7 +1815,10 @@ export class AgentLoop {
               decision: "stop",
               logger: rlog,
             };
-            const result = await runHook(HOOKS.POST_MODEL_CALL, ctx);
+            const result = await traceAsyncSection(
+              "agent-loop:post-model-call-hook",
+              () => runHook(HOOKS.POST_MODEL_CALL, ctx),
+            );
             return {
               finalized: { role: "assistant", content: result.content },
               decision: result.decision,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -48,6 +48,7 @@ import {
   recordRequestLog,
   setAgentLoopExitReasonOnLatestLog,
 } from "../persistence/llm-request-log-store.js";
+import { endSection, markSection } from "../persistence/slow-sync-log.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
 import { backfillMemoryRecallLogMessageId } from "../plugins/defaults/memory/memory-recall-log-store.js";
@@ -2399,6 +2400,11 @@ export async function dispatchAgentEvent(
   deps: EventHandlerDeps,
   event: AgentEvent,
 ): Promise<void> {
+  // Section-trail breadcrumb for event-loop freeze attribution: the dispatch
+  // is the single choke point for per-turn persistence work (message writes,
+  // usage/request-log rows, SSE fan-out), so a watchdog report during a
+  // handler names the event type that was being processed.
+  const sectionMark = markSection(`agent-event:${event.type}`);
   try {
     switch (event.type) {
       case "llm_call_started":
@@ -2706,5 +2712,7 @@ export async function dispatchAgentEvent(
     ) {
       throw err;
     }
+  } finally {
+    endSection(sectionMark);
   }
 }

--- a/assistant/src/daemon/event-loop-watchdog.ts
+++ b/assistant/src/daemon/event-loop-watchdog.ts
@@ -20,11 +20,12 @@
  * What it does NOT do: capture the JS stack of the blocking operation. JS is
  * single-threaded, so while the loop is blocked no callback — including this one
  * — can run; by the time the tick fires, the offending synchronous call has
- * returned and its stack is gone. The watchdog reports *that* and *how long* a
- * freeze happened, not *what* caused it. The report lands at unblock, so the
- * surrounding log lines (which job or turn was active) are the correlation
- * handle. For deterministic attribution of a specific subsystem, time that
- * subsystem's synchronous calls at their source.
+ * returned and its stack is gone. Instead, each freeze report carries the
+ * section trail (`persistence/slow-sync-log.ts`): the recent instrumented
+ * sections with their start/end ages relative to the report. The newest entry
+ * older than `blockedMs` that hadn't ended when the block began names — or
+ * brackets — the code that froze. For sub-threshold contributors, time the
+ * subsystem's synchronous calls at their source with `timeSyncSection`.
  *
  * A cumulative event-loop-delay histogram is separately exposed pull-based over
  * SSE diagnostics (`runtime/routes/events-routes.ts`); this watchdog is the
@@ -33,6 +34,10 @@
 
 import * as Sentry from "@sentry/node";
 
+import {
+  getSectionTrail,
+  type SectionTrailEntry,
+} from "../persistence/slow-sync-log.js";
 import { recordWatchdogEvent } from "../telemetry/watchdog-events-store.js";
 import { getLogger } from "../util/logger.js";
 
@@ -84,8 +89,17 @@ export function evaluateTick(
 export const EVENT_LOOP_BLOCKED_CHECK_NAME = "event_loop_blocked";
 
 function reportBlock(blockedMs: number, thresholdMs: number): void {
+  // Attribution breadcrumbs: the block began ~`blockedMs` before this report,
+  // so the newest trail entry started at least that long ago — and not yet
+  // ended by then — is the section that was running when the loop froze.
+  let sectionTrail: SectionTrailEntry[] = [];
+  try {
+    sectionTrail = getSectionTrail();
+  } catch {
+    // Diagnostics-only — never let it escape the timer callback.
+  }
   log.warn(
-    { blockedMs, thresholdMs, tickIntervalMs: TICK_INTERVAL_MS },
+    { blockedMs, thresholdMs, tickIntervalMs: TICK_INTERVAL_MS, sectionTrail },
     "event loop blocked",
   );
   // Persist a `watchdog` telemetry event so the platform can surface
@@ -101,6 +115,7 @@ function reportBlock(blockedMs: number, thresholdMs: number): void {
       detail: {
         threshold_ms: thresholdMs,
         tick_interval_ms: TICK_INTERVAL_MS,
+        section_trail: sectionTrail,
       },
     });
   } catch {
@@ -114,6 +129,7 @@ function reportBlock(blockedMs: number, thresholdMs: number): void {
         blocked_ms: blockedMs,
         threshold_ms: thresholdMs,
         tick_interval_ms: TICK_INTERVAL_MS,
+        section_trail: sectionTrail,
       });
       Sentry.captureMessage(EVENT_LOOP_BLOCKED_CHECK_NAME);
     });

--- a/assistant/src/persistence/__tests__/slow-sync-log.test.ts
+++ b/assistant/src/persistence/__tests__/slow-sync-log.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  endSection,
+  getSectionTrail,
+  markSection,
   reportSlowSync,
+  resetSectionTrailForTests,
   SLOW_SYNC_CHECK_NAME,
   SLOW_SYNC_THRESHOLD_MS,
   timeSyncSection,
+  traceAsyncSection,
 } from "../slow-sync-log.js";
 
 describe("slow-sync-log", () => {
@@ -61,5 +66,90 @@ describe("slow-sync-log", () => {
         rowCount: 4200,
       }),
     ).not.toThrow();
+  });
+});
+
+describe("section trail", () => {
+  beforeEach(() => {
+    resetSectionTrailForTests();
+  });
+
+  test("marks appear newest-first with ago values relative to now", () => {
+    const first = markSection("test:first");
+    endSection(first);
+    markSection("test:second");
+
+    const trail = getSectionTrail(performance.now() + 100);
+    expect(trail.map((e) => e.label)).toEqual(["test:second", "test:first"]);
+    // Both marks started before the reference "now".
+    for (const entry of trail) {
+      expect(entry.startedAgoMs).toBeGreaterThanOrEqual(100);
+    }
+    // Only the ended mark carries an end age.
+    expect(trail[0]?.endedAgoMs).toBeUndefined();
+    expect(trail[1]?.endedAgoMs).toBeGreaterThanOrEqual(100);
+  });
+
+  test("endSection returns the section's elapsed time", () => {
+    const mark = markSection("test:elapsed");
+    const elapsed = endSection(mark);
+    expect(elapsed).toBeGreaterThanOrEqual(0);
+    expect(mark.endedAt).toBeDefined();
+  });
+
+  test("trail is capacity-bounded, evicting oldest marks", () => {
+    for (let i = 0; i < 20; i++) {
+      endSection(markSection(`test:mark-${i}`));
+    }
+    const trail = getSectionTrail();
+    expect(trail.length).toBe(16);
+    // Newest-first: the most recent mark leads, the earliest four are evicted.
+    expect(trail[0]?.label).toBe("test:mark-19");
+    expect(trail[trail.length - 1]?.label).toBe("test:mark-4");
+  });
+
+  test("timeSyncSection leaves an ended mark in the trail", () => {
+    timeSyncSection("test:timed", () => 1);
+    const trail = getSectionTrail();
+    expect(trail[0]?.label).toBe("test:timed");
+    expect(trail[0]?.endedAgoMs).toBeDefined();
+  });
+
+  test("timeSyncSection ends its mark when the section throws", () => {
+    expect(() =>
+      timeSyncSection("test:timed-throw", () => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    const trail = getSectionTrail();
+    expect(trail[0]?.label).toBe("test:timed-throw");
+    expect(trail[0]?.endedAgoMs).toBeDefined();
+  });
+
+  test("traceAsyncSection returns the value and ends the mark across an await", async () => {
+    const result = await traceAsyncSection("test:async", async () => {
+      // While awaited, the mark is open.
+      expect(getSectionTrail()[0]?.label).toBe("test:async");
+      expect(getSectionTrail()[0]?.endedAgoMs).toBeUndefined();
+      await Promise.resolve();
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    const trail = getSectionTrail();
+    expect(trail[0]?.label).toBe("test:async");
+    expect(trail[0]?.endedAgoMs).toBeDefined();
+  });
+
+  test("traceAsyncSection ends the mark when the span rejects", async () => {
+    let thrown: unknown;
+    try {
+      await traceAsyncSection("test:async-throw", async () => {
+        throw new Error("boom");
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(getSectionTrail()[0]?.endedAgoMs).toBeDefined();
   });
 });

--- a/assistant/src/persistence/slow-sync-log.ts
+++ b/assistant/src/persistence/slow-sync-log.ts
@@ -9,16 +9,24 @@
  * being single-threaded itself, cannot capture *what* was running: by the
  * time its tick fires the blocking call has returned and its stack is gone.
  *
- * This module fills that gap. Wrap a known-heavy synchronous section with
- * {@link timeSyncSection} (or call {@link reportSlowSync} with a measured
- * duration); when it blocks past {@link SLOW_SYNC_THRESHOLD_MS} it logs a
- * structured warning naming the call site and records a `watchdog`
- * telemetry event, so the next freeze is attributable to a specific
- * operation instead of an anonymous gap in the logs.
+ * This module fills that gap two ways:
  *
- * The threshold is deliberately below the watchdog's own 5s floor so
- * sub-watchdog contributors are still named. Override with
- * `VELLUM_SLOW_SYNC_THRESHOLD_MS`.
+ * 1. **Threshold reports** — wrap a known-heavy synchronous section with
+ *    {@link timeSyncSection} (or call {@link reportSlowSync} with a measured
+ *    duration); when it blocks past {@link SLOW_SYNC_THRESHOLD_MS} it logs a
+ *    structured warning naming the call site and records a `watchdog`
+ *    telemetry event. The threshold is deliberately below the watchdog's own
+ *    5s floor so sub-watchdog contributors are still named. Override with
+ *    `VELLUM_SLOW_SYNC_THRESHOLD_MS`.
+ *
+ * 2. **Section trail** — a small in-memory ring of the most recently entered
+ *    instrumented sections ({@link markSection} / {@link traceAsyncSection};
+ *    {@link timeSyncSection} marks automatically). The event-loop watchdog
+ *    attaches {@link getSectionTrail} to every freeze report: because the
+ *    loop is single-threaded, the newest mark still un-ended at block start
+ *    (entries older than `blockedMs`) names — or tightly brackets — the code
+ *    that froze, even when the block sits in a section nobody thought to
+ *    time. Marks record only static labels, never content.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -41,6 +49,95 @@ export const SLOW_SYNC_THRESHOLD_MS = ((): number => {
  * grouping stays consistent; keep it in sync with any admin query.
  */
 export const SLOW_SYNC_CHECK_NAME = "slow_sync_operation";
+
+/** One recorded section entry: a static label plus monotonic start/end stamps. */
+export interface SectionMark {
+  label: string;
+  startedAt: number;
+  endedAt?: number;
+}
+
+/**
+ * How many section marks the trail retains. Sized so the sections between a
+ * container mark (e.g. an agent-event dispatch) and a freeze — typically a
+ * handful of nested query marks — don't evict the container before the
+ * watchdog reads the trail.
+ */
+const SECTION_TRAIL_CAPACITY = 16;
+
+const sectionTrail: SectionMark[] = [];
+
+/**
+ * Record that an instrumented section is starting. Returns the mark so the
+ * caller can stamp its completion with {@link endSection}. Cheap enough for
+ * hot paths: one small allocation and a bounded-array push.
+ */
+export function markSection(label: string): SectionMark {
+  const mark: SectionMark = { label, startedAt: performance.now() };
+  sectionTrail.push(mark);
+  if (sectionTrail.length > SECTION_TRAIL_CAPACITY) {
+    sectionTrail.shift();
+  }
+  return mark;
+}
+
+/** Stamp a mark's completion; returns the section's elapsed milliseconds. */
+export function endSection(mark: SectionMark): number {
+  mark.endedAt = performance.now();
+  return mark.endedAt - mark.startedAt;
+}
+
+/**
+ * Trail a section that spans an `await` (a hook chain, a provider call). The
+ * mark stays open for the span's full wall time — sections entered by work
+ * interleaving on the loop during the await appear as newer trail entries, so
+ * a freeze inside the span is still bracketed correctly. Wall time is NOT
+ * reported as a slow sync: an awaited span legitimately spends most of it
+ * off-loop.
+ */
+export async function traceAsyncSection<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const mark = markSection(label);
+  try {
+    return await fn();
+  } finally {
+    endSection(mark);
+  }
+}
+
+/** A trail entry made relative to "now" for freeze reports. */
+export interface SectionTrailEntry {
+  label: string;
+  startedAgoMs: number;
+  /** Absent while the section is still running (or never ended). */
+  endedAgoMs?: number;
+}
+
+/**
+ * Newest-first snapshot of recent section marks, ages relative to `now`.
+ * Reading it against a freeze report: the block began ~`blockedMs` ago, so
+ * the newest entry with `startedAgoMs >= blockedMs` that has no `endedAgoMs`
+ * (or ended after the block began) is the section that was running when the
+ * loop froze.
+ */
+export function getSectionTrail(
+  now: number = performance.now(),
+): SectionTrailEntry[] {
+  return [...sectionTrail].reverse().map((mark) => ({
+    label: mark.label,
+    startedAgoMs: Math.round(now - mark.startedAt),
+    ...(mark.endedAt !== undefined
+      ? { endedAgoMs: Math.round(now - mark.endedAt) }
+      : {}),
+  }));
+}
+
+/** Test isolation only — the trail is process-global module state. */
+export function resetSectionTrailForTests(): void {
+  sectionTrail.length = 0;
+}
 
 /**
  * Report a synchronous section that blocked the event loop for `elapsedMs`.
@@ -79,20 +176,21 @@ export function reportSlowSync(
 
 /**
  * Time a synchronous section, returning its value, and {@link reportSlowSync}
- * it when it blocks past the threshold. `detail` is evaluated only on
- * success, from the section's result, so it can report a computed count.
- * A thrown error is still reported (the failed op still blocked) and then
- * rethrown unchanged.
+ * it when it blocks past the threshold. Every section also lands in the
+ * section trail, so watchdog freeze reports can place it on the timeline.
+ * `detail` is evaluated only on success, from the section's result, so it can
+ * report a computed count. A thrown error is still reported (the failed op
+ * still blocked) and then rethrown unchanged.
  */
 export function timeSyncSection<T>(
   label: string,
   fn: () => T,
   detail?: (result: T) => Record<string, unknown>,
 ): T {
-  const start = performance.now();
+  const mark = markSection(label);
   try {
     const result = fn();
-    const elapsedMs = performance.now() - start;
+    const elapsedMs = endSection(mark);
     // Build `detail` only when actually reporting — the section runs on hot
     // query paths, so the thunk must not allocate on the sub-threshold path.
     if (elapsedMs >= SLOW_SYNC_THRESHOLD_MS) {
@@ -100,7 +198,7 @@ export function timeSyncSection<T>(
     }
     return result;
   } catch (err) {
-    reportSlowSync(label, performance.now() - start);
+    reportSlowSync(label, endSection(mark));
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- `slow-sync-log` gains a **section trail**: a 16-slot ring of `{label, startedAt, endedAt?}` marks (`markSection`/`endSection`, async-span wrapper `traceAsyncSection`; `timeSyncSection` marks automatically, so every existing probe doubles as a breadcrumb).
- The event-loop watchdog attaches the trail (labels + start/end ages relative to the report) to every `event loop blocked` report — log line, watchdog telemetry detail, and Sentry context. Since the loop is single-threaded, the newest mark still open at block start names or tightly brackets the code that froze.
- Marks at the per-turn choke points: the daemon agent-event dispatch (`agent-event:<type>` — the single funnel for message persistence, usage/request-log rows, and SSE fan-out), `agent-loop:pre-model-call-hook` / `agent-loop:post-model-call-hook`, `agent-loop:provider-send`, `agent-loop:pre-model-call-sanitize`, and `agent-loop:estimate-prompt-tokens` (the latter two are sync `timeSyncSection` probes and also get ≥1s threshold reports).

## Why this shape
Bracketing recent freezes against surrounding log lines shows the residual 5–6.7s blocks start a few hundred ms **after** `[agent-loop] LLM call complete` and end right at `Tool execution start` — i.e. in the post-response section (finalize hook, queued usage/request-log handlers, message-complete persistence), not before the provider call as previously assumed, and not in the already-instrumented DB reads/writes (zero slow-sync captures across those freezes). The dispatch-level mark attributes that window per event type without guessing which handler is at fault; drill-down probes can follow once a label is implicated.

## Original prompt
Continuation of the daemon event-loop-stall investigation: earlier instrumentation PRs (#36758, #36790) added `timeSyncSection` probes over conversation reads, search/raw queries, and the per-LLM-call writes, which ruled out the DB layer for the residual 5–6.7s freezes. This PR was asked to instrument the remaining per-turn synchronous path in the same low-risk shape so the next freeze names its culprit.