### PR TITLE
feat(daemon): add summarize-boundary resolver (message id → turn-snapped row boundary)

### DIFF
--- a/assistant/src/__tests__/summarize-boundary.test.ts
+++ b/assistant/src/__tests__/summarize-boundary.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveSummarizeBoundary } from "../daemon/summarize-boundary.js";
+import type { MessageRow } from "../persistence/conversation-crud.js";
+import { UserError } from "../util/errors.js";
+
+function row(id: string, role: string, content: string): MessageRow {
+  return {
+    id,
+    conversationId: "conv-xyz",
+    role,
+    content,
+    createdAt: 0,
+    metadata: null,
+    clientMessageId: null,
+  };
+}
+
+function userText(id: string, text: string): MessageRow {
+  return row(id, "user", JSON.stringify([{ type: "text", text }]));
+}
+
+function assistantText(id: string, text: string): MessageRow {
+  return row(id, "assistant", JSON.stringify([{ type: "text", text }]));
+}
+
+function userToolResult(id: string): MessageRow {
+  return row(
+    id,
+    "user",
+    JSON.stringify([
+      { type: "tool_result", tool_use_id: "toolu-1", content: "ok" },
+    ]),
+  );
+}
+
+// Two full turns: [user, assistant, user, assistant].
+const twoTurns: MessageRow[] = [
+  userText("msg-1", "Hi, I am Alice"),
+  assistantText("msg-2", "Hello Alice"),
+  userText("msg-3", "Tell me about Bob"),
+  assistantText("msg-4", "Bob is a placeholder"),
+];
+
+describe("resolveSummarizeBoundary", () => {
+  test("plain user-message anchor resolves to itself", () => {
+    expect(resolveSummarizeBoundary(twoTurns, "msg-3", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+  });
+
+  test("assistant-message anchor snaps back to its turn's user message", () => {
+    expect(resolveSummarizeBoundary(twoTurns, "msg-4", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+  });
+
+  test("tool-result-only user rows are skipped as anchors", () => {
+    const rows: MessageRow[] = [
+      userText("msg-1", "First question from Alice"),
+      assistantText("msg-2", "Working on it"),
+      userText("msg-3", "Second question"),
+      assistantText("msg-4", "Running a tool"),
+      userToolResult("msg-5"),
+      assistantText("msg-6", "Tool finished"),
+    ];
+    // Anchoring on the tool-result row (or anything after it) snaps past it
+    // to the real user message that started the turn.
+    expect(resolveSummarizeBoundary(rows, "msg-5", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+    expect(resolveSummarizeBoundary(rows, "msg-6", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+  });
+
+  test("unknown message id throws", () => {
+    expect(() => resolveSummarizeBoundary(twoTurns, "msg-999", 0)).toThrow(
+      new UserError("Message msg-999 does not belong to this conversation"),
+    );
+  });
+
+  test("anchor inside the already-compacted prefix throws", () => {
+    expect(() => resolveSummarizeBoundary(twoTurns, "msg-3", 2)).toThrow(
+      new UserError("Already summarized up to this point"),
+    );
+  });
+
+  test("anchor whose snapped boundary equals the compacted count throws", () => {
+    const rows: MessageRow[] = [
+      ...twoTurns,
+      userText("msg-5", "Third question"),
+      assistantText("msg-6", "Third answer"),
+    ];
+    // Snaps to index 4; rows [0, 4) are already compacted, so nothing new.
+    expect(() => resolveSummarizeBoundary(rows, "msg-6", 4)).toThrow(
+      new UserError("Already summarized up to this point"),
+    );
+  });
+
+  test("first-turn anchor throws (nothing before it to summarize)", () => {
+    expect(() => resolveSummarizeBoundary(twoTurns, "msg-1", 0)).toThrow(
+      new UserError("Nothing to summarize before this message"),
+    );
+    expect(() => resolveSummarizeBoundary(twoTurns, "msg-2", 0)).toThrow(
+      new UserError("Nothing to summarize before this message"),
+    );
+  });
+
+  test("no turn start at or before the anchor throws", () => {
+    const rows: MessageRow[] = [
+      userToolResult("msg-1"),
+      assistantText("msg-2", "Resuming from a tool result"),
+      userText("msg-3", "A real question"),
+    ];
+    expect(() => resolveSummarizeBoundary(rows, "msg-2", 0)).toThrow(
+      new UserError("Nothing to summarize before this message"),
+    );
+  });
+
+  test("unparseable content rows are treated as text turn starts", () => {
+    const rows: MessageRow[] = [
+      userText("msg-1", "Hello"),
+      assistantText("msg-2", "Hi"),
+      row("msg-3", "user", "plain text, not JSON"),
+      assistantText("msg-4", "Understood"),
+    ];
+    expect(resolveSummarizeBoundary(rows, "msg-4", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -189,7 +189,7 @@ const log = getLogger("conversation");
  * `getAssistantMessageIdsInTurn`/`getTurnTimeBounds` and the agent loop's
  * per-turn `turnCount++`, so counting these reconstructs `turnCount` on load.
  */
-function startsNewTurn(role: string, content: string): boolean {
+export function startsNewTurn(role: string, content: string): boolean {
   if (role !== "user") return false;
   try {
     const parsed = JSON.parse(content);

--- a/assistant/src/daemon/summarize-boundary.ts
+++ b/assistant/src/daemon/summarize-boundary.ts
@@ -1,0 +1,47 @@
+import type { MessageRow } from "../persistence/conversation-crud.js";
+import { UserError } from "../util/errors.js";
+import { startsNewTurn } from "./conversation.js";
+
+/**
+ * Resolves a client-addressed message id to a turn-snapped row boundary for
+ * "summarize up to here". The boundary snaps back to the start of the turn
+ * containing `beforeMessageId`, so the selected message's whole turn survives
+ * verbatim and the kept tail always begins with a real user message (the
+ * summary message is assistant-role, and history must alternate).
+ *
+ * Rows `[0, boundaryRowIndex)` are the summarize range in row-space.
+ *
+ * Throws {@link UserError} (messages are user-facing) when the id is unknown,
+ * when there is nothing before the snapped turn to summarize, or when the
+ * snapped boundary falls inside the already-compacted prefix
+ * (`[0, contextCompactedMessageCount)`).
+ */
+export function resolveSummarizeBoundary(
+  rows: MessageRow[],
+  beforeMessageId: string,
+  contextCompactedMessageCount: number,
+): { boundaryRowIndex: number } {
+  const targetIndex = rows.findIndex((row) => row.id === beforeMessageId);
+  if (targetIndex === -1) {
+    throw new UserError(
+      `Message ${beforeMessageId} does not belong to this conversation`,
+    );
+  }
+
+  let snappedIndex = targetIndex;
+  while (
+    snappedIndex >= 0 &&
+    !startsNewTurn(rows[snappedIndex].role, rows[snappedIndex].content)
+  ) {
+    snappedIndex--;
+  }
+
+  if (snappedIndex <= 0) {
+    throw new UserError("Nothing to summarize before this message");
+  }
+  if (snappedIndex <= contextCompactedMessageCount) {
+    throw new UserError("Already summarized up to this point");
+  }
+
+  return { boundaryRowIndex: snappedIndex };
+}


### PR DESCRIPTION
## Summary
- New `resolveSummarizeBoundary(rows, beforeMessageId, contextCompactedMessageCount)`: maps a client message id to a turn-snapped row boundary for summarize-up-to-here
- Snaps back to the enclosing turn start so the kept tail always begins with a real user message
- Exports the existing turn-start predicate from conversation.ts for reuse (no behavior change)

Part of plan: summarize-up-to-here.md (PR 2 of 6)