### PR TITLE
feat(compaction): support a caller-fixed tail boundary in the assistant-driven compactor

### DIFF
--- a/assistant/src/__tests__/compactor-fixed-boundary.test.ts
+++ b/assistant/src/__tests__/compactor-fixed-boundary.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Caller-fixed tail boundary in `runAssistantDrivenCompaction`.
+ *
+ * With `fixedTailStartIndex` set, the caller pins the cut: the model writes
+ * the summary but does not choose a `<tail_start>`, and no token-budget
+ * forward-cut applies. Only the tool-pairing back-walk still adjusts the
+ * boundary, as defense-in-depth.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getMessages: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  getAttachmentMetadataForMessage: () => [],
+  getAttachmentContent: () => null,
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+}));
+
+import { runAssistantDrivenCompaction } from "../context/compactor.js";
+import type { Message, Provider } from "../providers/types.js";
+
+function turnTimestamp(turn: number): string {
+  const hour = String(10 + Math.floor(turn / 60)).padStart(2, "0");
+  const minute = String(turn % 60).padStart(2, "0");
+  return `2026-05-21 (Thursday) ${hour}:${minute}:00 -05:00 (America/Chicago)`;
+}
+
+function userTurn(turn: number, body: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `<turn_context>\ncurrent_time: ${turnTimestamp(
+          turn,
+        )}\n</turn_context>\n[U${turn}] ${body}`,
+      },
+    ],
+  };
+}
+
+function assistantTurn(turn: number, body: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: `[A${turn}] ${body}` }],
+  };
+}
+
+const SUMMARY =
+  "Alice and Bob discussed onboarding at user@example.com — summarized in my own voice.";
+
+/** Fixed-boundary responses carry no `<tail_start>` — the caller owns the cut. */
+const FIXED_RESPONSE = `<compaction_result>
+<summary>
+${SUMMARY}
+</summary>
+<key_state>
+- Nothing critical pending.
+</key_state>
+</compaction_result>`;
+
+function responseWithTailStart(tailTurn: number, preview: string): string {
+  return `<compaction_result>
+<summary>
+${SUMMARY}
+</summary>
+<key_state>
+- Nothing critical pending.
+</key_state>
+<tail_start timestamp="${turnTimestamp(tailTurn)}" preview="${preview}" />
+</compaction_result>`;
+}
+
+function makeProvider(response: string): {
+  provider: Provider;
+  callCount: () => number;
+} {
+  let calls = 0;
+  const provider: Provider = {
+    name: "mock-provider",
+    sendMessage: async () => {
+      calls++;
+      return {
+        content: [{ type: "text", text: response }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return { provider, callCount: () => calls };
+}
+
+function plainConversation(turns: number, body = "turn body"): Message[] {
+  const messages: Message[] = [];
+  for (let i = 0; i < turns; i++) {
+    messages.push(userTurn(i, `Alice says: ${body}`));
+    messages.push(assistantTurn(i, `Bob's assistant replies: ${body}`));
+  }
+  return messages;
+}
+
+describe("runAssistantDrivenCompaction — caller-fixed tail boundary", () => {
+  test("uses the fixed index verbatim when the response has no tail_start", async () => {
+    const messages = plainConversation(10);
+    const fixedIndex = 12; // user turn 6 — a clean user boundary.
+    const { provider } = makeProvider(FIXED_RESPONSE);
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: fixedIndex,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(fixedIndex);
+    expect(result.preservedTailMessages).toBe(messages.length - fixedIndex);
+    // Summary heads the rebuilt history; the tail follows verbatim.
+    expect(result.messages[0]?.role).toBe("assistant");
+    const tail = result.messages.slice(1);
+    expect(tail.length).toBe(messages.length - fixedIndex);
+    expect(tail[0]?.role).toBe("user");
+  });
+
+  test("ignores a model-emitted tail_start when the boundary is fixed", async () => {
+    const messages = plainConversation(10);
+    const fixedIndex = 12;
+    // The model volunteers a cut at turn 2 (index 4) — it must be ignored.
+    const { provider } = makeProvider(
+      responseWithTailStart(2, "Alice says: turn body"),
+    );
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: fixedIndex,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(fixedIndex);
+    expect(result.preservedTailMessages).toBe(messages.length - fixedIndex);
+  });
+
+  test("walks the fixed boundary back when it would split a tool_use/tool_result pair", async () => {
+    const toolUse: Message = {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "X", name: "Bash", input: {} }],
+    };
+    const toolResult: Message = {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "X", content: "ok" }],
+    };
+    // [u0, a0, u1, tool_use, tool_result, a1, u2, a2]
+    const messages: Message[] = [
+      userTurn(0, "Alice opens the conversation"),
+      assistantTurn(0, "greeting reply"),
+      userTurn(1, "Alice asks to run a command"),
+      toolUse,
+      toolResult,
+      assistantTurn(1, "command finished"),
+      userTurn(2, "Alice follows up"),
+      assistantTurn(2, "final reply"),
+    ];
+    const { provider } = makeProvider(FIXED_RESPONSE);
+
+    // Index 4 opens on the tool_result — cutting there would orphan tool_use X.
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: 4,
+    });
+
+    expect(result.compacted).toBe(true);
+    // The back-walk lands on index 2 (the user turn that opens the exchange).
+    expect(result.compactedMessages).toBe(2);
+    expect(result.preservedTailMessages).toBe(6);
+    const tail = result.messages.slice(1);
+    const opensWithToolResult =
+      tail[0]?.role === "user" &&
+      tail[0].content.some((b) => b.type === "tool_result");
+    expect(opensWithToolResult).toBe(false);
+  });
+
+  test("applies no budget forward-cut even when the preserved tail is enormous", async () => {
+    // Heavy bodies so the tail estimate dwarfs the target — the model-chosen
+    // path would advance the cut; the fixed path must not.
+    const messages = plainConversation(
+      40,
+      "a long body that carries real token weight in the estimate. ".repeat(4),
+    );
+    const fixedIndex = 4; // keep 76 heavy messages.
+    const { provider } = makeProvider(FIXED_RESPONSE);
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      // Unreachably tiny budget — must be ignored in fixed mode.
+      targetTokens: 1,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: fixedIndex,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.preservedTailMessages).toBe(messages.length - fixedIndex);
+    expect(result.tailFloorReached).toBe(false);
+    // No span was dropped, so the summary carries no truncation notice.
+    const summaryBlock = result.messages[0]?.content.find(
+      (b) => b.type === "text",
+    );
+    expect(
+      summaryBlock && "text" in summaryBlock ? summaryBlock.text : "",
+    ).not.toContain("Context budget enforcement");
+  });
+
+  test.each([
+    ["zero", 0],
+    ["past the end", 20],
+    ["non-integer", 3.5],
+  ])(
+    "returns a non-compacted result for an out-of-range fixed index (%s)",
+    async (_label, fixedIndex) => {
+      const messages = plainConversation(10);
+      const { provider, callCount } = makeProvider(FIXED_RESPONSE);
+
+      const result = await runAssistantDrivenCompaction({
+        conversationId: "conv-test",
+        messages,
+        provider,
+        systemPrompt: "system",
+        compaction: { enabled: true, autoThreshold: 0.7 },
+        maxInputTokens: 100_000,
+        previousEstimatedInputTokens: 90_000,
+        force: true,
+        fixedTailStartIndex: fixedIndex,
+      });
+
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toBe("fixed boundary out of range");
+      expect(result.messages).toBe(messages);
+      // Validation runs before the provider call — no summary pass is burned.
+      expect(callCount()).toBe(0);
+    },
+  );
+
+  test("counts compactedPersistedMessages against a non-persisted prefix", async () => {
+    // Message 0 is a synthetic inherited summary with no DB row.
+    const inheritedSummary: Message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Inherited summary from a parent fork." },
+      ],
+    };
+    const messages: Message[] = [
+      inheritedSummary,
+      ...plainConversation(5), // 10 persisted messages, indices 1..10
+    ];
+    const fixedIndex = 7; // user turn 3 — summarizes the prefix + 6 real rows.
+    const { provider } = makeProvider(FIXED_RESPONSE);
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: fixedIndex,
+      nonPersistedPrefixCount: 1,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(fixedIndex);
+    expect(result.compactedPersistedMessages).toBe(fixedIndex - 1);
+  });
+
+  test("surfaces the model's summary in summaryText", async () => {
+    const messages = plainConversation(6);
+    const { provider } = makeProvider(FIXED_RESPONSE);
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 100_000,
+      previousEstimatedInputTokens: 90_000,
+      force: true,
+      fixedTailStartIndex: 6,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryText).toContain(SUMMARY);
+    expect(result.keyState).toContain("Nothing critical pending");
+    const summaryBlock = result.messages[0]?.content.find(
+      (b) => b.type === "text",
+    );
+    expect(
+      summaryBlock && "text" in summaryBlock ? summaryBlock.text : "",
+    ).toContain(SUMMARY);
+  });
+});

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -170,6 +170,65 @@ active decisions, open questions, commitments, project states.
 </compaction_result>
 </compaction_instructions>`;
 
+/**
+ * Fixed-boundary compaction instruction. Used when the caller pins the cut
+ * via `fixedTailStartIndex` — the user chose where the summary ends, so the
+ * model writes the summary but does not pick a `tail_start`.
+ *
+ * Interpolation points: `{image_manifest}` (same as the default prompt) and
+ * `{boundary_description}` (a description of the first preserved message so
+ * the model knows exactly where "before" ends).
+ */
+export const FIXED_BOUNDARY_COMPACTION_PROMPT = `<compaction_instructions>
+The user has asked to summarize this conversation up to a fixed point they
+chose. Everything BEFORE that point is replaced by your summary; the boundary
+message and everything after it are preserved verbatim. You do not choose the
+cut — it is already fixed.
+
+The first message to be preserved verbatim is {boundary_description}.
+Summarize ONLY what comes before it.
+
+Write the summary in YOUR voice — as if you're remembering this conversation,
+not writing meeting notes about it. Prioritize:
+- Decisions made and commitments given
+- Key context that's still relevant going forward
+- Emotional moments that shaped the conversation's direction
+- Exact quotes when the specific wording matters
+- Project/task state changes
+
+Compress aggressively:
+- Repeated debugging or troubleshooting attempts → just the outcome
+- Tool call outputs → results only, not raw data
+- Intermediate states superseded by later states
+- Back-and-forth deliberation → just the conclusion
+
+IMAGE MANIFEST (images in this conversation):
+{image_manifest}
+
+If any images from the summarized portion are still relevant to the
+ongoing conversation, include them in retained_images by filename.
+
+Output your result in this exact format:
+
+<compaction_result>
+<summary>
+Your summary in your voice. Aim for 2000-4000 tokens — rich enough
+to preserve what matters, compact enough to free real space.
+</summary>
+
+<key_state>
+Short structured list of anything PENDING from this conversation:
+active decisions, open questions, commitments, project states.
+</key_state>
+
+<retained_images>
+<image file="filename.ext" />
+(only images from BEFORE the boundary that are still contextually important)
+(omit this section entirely if no images need retention)
+</retained_images>
+</compaction_result>
+</compaction_instructions>`;
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -211,6 +270,16 @@ export interface CompactionRunArgs {
    * DB counterparts.
    */
   nonPersistedPrefixCount?: number;
+  /**
+   * Index into `messages` of the first message to KEEP verbatim. When set,
+   * everything before it is summarized and the model does not choose the
+   * cut: the `<tail_start>` output contract, tail resolution, and the
+   * token-budget forward-cut are all skipped. The boundary is authoritative
+   * (the caller has already turn-snapped it); only the tool-pairing
+   * back-walk still applies, as defense-in-depth. Must be an integer in
+   * `[1, messages.length)` — otherwise the run returns `compacted: false`.
+   */
+  fixedTailStartIndex?: number;
 }
 
 export interface CompactionRunResult {
@@ -277,10 +346,14 @@ export interface ParsedCompactionResult {
  * Lenient by design — the model may wrap the block in narration, may omit
  * `<retained_images>`, and may produce slightly malformed inner tags. We
  * accept any of those. Returns `null` only when the required fields
- * (summary + tail_start.timestamp) are missing.
+ * (summary + tail_start.timestamp) are missing. With
+ * `requireTailStart: false` (the fixed-boundary mode, where the caller
+ * already owns the cut) an absent `<tail_start>` is tolerated and its
+ * fields come back empty.
  */
 export function parseCompactionResult(
   raw: string,
+  opts: { requireTailStart?: boolean } = {},
 ): ParsedCompactionResult | null {
   const openIdx = raw.indexOf(RESULT_TAG_OPEN);
   if (openIdx < 0) return null;
@@ -296,7 +369,12 @@ export function parseCompactionResult(
   const keyState = extractTagContent(inner, "key_state")?.trim() ?? "";
 
   const tail = extractTailStart(inner);
-  if (!tail || tail.timestamp.length === 0) return null;
+  if (
+    opts.requireTailStart !== false &&
+    (!tail || tail.timestamp.length === 0)
+  ) {
+    return null;
+  }
 
   const retainedImageFilenames = extractRetainedImages(inner);
 
@@ -304,8 +382,8 @@ export function parseCompactionResult(
     summary,
     keyState,
     retainedImageFilenames,
-    tailStartTimestamp: tail.timestamp,
-    tailStartPreview: tail.preview,
+    tailStartTimestamp: tail?.timestamp ?? "",
+    tailStartPreview: tail?.preview ?? "",
   };
 }
 
@@ -466,6 +544,23 @@ function extractFirstTextPreview(message: Message, maxChars = 120): string {
     return text.slice(0, maxChars);
   }
   return "";
+}
+
+/**
+ * Human-readable description of the first preserved message for the
+ * fixed-boundary instruction, so the model knows exactly where "before"
+ * ends: the message's `<turn_context>` timestamp when available, else a
+ * short preview of its text.
+ */
+function describeFixedBoundary(message: Message): string {
+  const timestamp = extractTurnContextTimestamp(message);
+  if (timestamp) {
+    return `the message whose turn_context timestamp is "${timestamp}"`;
+  }
+  const preview = extractFirstTextPreview(message, 80);
+  return preview.length > 0
+    ? `the ${message.role} message beginning: "${preview}"`
+    : `the first preserved ${message.role} message`;
 }
 
 // ---------------------------------------------------------------------------
@@ -749,7 +844,21 @@ export function buildInstructionMessage(
   customPrompt: string | null | undefined,
   imageManifest: string,
   tailBudgetTokens?: number,
+  fixedBoundaryDescription?: string,
 ): Message {
+  // Fixed-boundary mode always uses the fixed variant — custom prompts are
+  // authored against the tail-choosing `<tail_start>` contract, which does
+  // not apply when the caller pins the cut.
+  if (fixedBoundaryDescription != null) {
+    const text = FIXED_BOUNDARY_COMPACTION_PROMPT.replace(
+      "{image_manifest}",
+      imageManifest,
+    ).replace("{boundary_description}", fixedBoundaryDescription);
+    return {
+      role: "user",
+      content: [{ type: "text", text }],
+    };
+  }
   const template =
     customPrompt && customPrompt.trim().length > 0
       ? customPrompt
@@ -927,6 +1036,24 @@ export async function runAssistantDrivenCompaction(
     return emptyResult(args, thresholdTokens, "no messages to compact");
   }
 
+  // A caller-fixed boundary must land strictly inside the array: index 0
+  // would leave nothing to summarize, and anything past the end preserves
+  // nothing. Validated before the provider call so an invalid index never
+  // burns a full-context summary pass.
+  const fixedTailStartIndex = args.fixedTailStartIndex;
+  if (
+    fixedTailStartIndex != null &&
+    (!Number.isInteger(fixedTailStartIndex) ||
+      fixedTailStartIndex < 1 ||
+      fixedTailStartIndex >= args.messages.length)
+  ) {
+    log.warn(
+      { fixedTailStartIndex, messageCount: args.messages.length },
+      "Fixed compaction boundary out of range — skipping compaction",
+    );
+    return emptyResult(args, thresholdTokens, "fixed boundary out of range");
+  }
+
   // Build image manifest from the DB before invoking the model so the
   // instruction message carries a faithful picture of available images.
   // Filtered by actor trust so untrusted turns never see guardian-only
@@ -940,6 +1067,9 @@ export async function runAssistantDrivenCompaction(
     args.compaction.prompt ?? null,
     manifestText,
     args.targetTokens,
+    fixedTailStartIndex != null
+      ? describeFixedBoundary(args.messages[fixedTailStartIndex])
+      : undefined,
   );
 
   // Bound the summary call's own input to the context window. With no tool
@@ -990,7 +1120,9 @@ export async function runAssistantDrivenCompaction(
   recordCompactionRequestLog(args.conversationId, response, args.provider);
 
   const rawText = extractTextFromResponse(response.content);
-  const parsed = parseCompactionResult(rawText);
+  const parsed = parseCompactionResult(rawText, {
+    requireTailStart: fixedTailStartIndex == null,
+  });
   if (!parsed) {
     log.warn(
       { rawPreview: rawText.slice(0, 200) },
@@ -1012,34 +1144,43 @@ export async function runAssistantDrivenCompaction(
     };
   }
 
-  const timestamps = buildTimestampIndex(args.messages);
-  const resolvedTailIndex = resolveTailStartIndex(
-    args.messages,
-    timestamps,
-    parsed,
-  );
-  if (resolvedTailIndex == null) {
-    log.warn(
-      {
-        timestamp: parsed.tailStartTimestamp,
-        preview: parsed.tailStartPreview.slice(0, 60),
-      },
-      "Compaction tail_start did not match any message — aborting compaction",
+  // The caller's fixed boundary is authoritative — any `<tail_start>` the
+  // model emitted anyway is ignored. Without a fixed boundary, resolve the
+  // model's choice against the live messages.
+  let resolvedTailIndex: number;
+  if (fixedTailStartIndex != null) {
+    resolvedTailIndex = fixedTailStartIndex;
+  } else {
+    const timestamps = buildTimestampIndex(args.messages);
+    const modelTailIndex = resolveTailStartIndex(
+      args.messages,
+      timestamps,
+      parsed,
     );
-    return {
-      ...emptyResult(args, thresholdTokens, "tail_start unresolved"),
-      summaryFailed: false,
-      summaryInputTokens: response.usage.inputTokens,
-      summaryOutputTokens: response.usage.outputTokens,
-      summaryModel: response.model,
-      summaryCacheCreationInputTokens:
-        response.usage.cacheCreationInputTokens ?? 0,
-      summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-      summaryCallSite: COMPACTION_CALL_SITE,
-      summaryOverrideProfile: args.overrideProfile ?? null,
-      summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
-      summaryCalls: 1,
-    };
+    if (modelTailIndex == null) {
+      log.warn(
+        {
+          timestamp: parsed.tailStartTimestamp,
+          preview: parsed.tailStartPreview.slice(0, 60),
+        },
+        "Compaction tail_start did not match any message — aborting compaction",
+      );
+      return {
+        ...emptyResult(args, thresholdTokens, "tail_start unresolved"),
+        summaryFailed: false,
+        summaryInputTokens: response.usage.inputTokens,
+        summaryOutputTokens: response.usage.outputTokens,
+        summaryModel: response.model,
+        summaryCacheCreationInputTokens:
+          response.usage.cacheCreationInputTokens ?? 0,
+        summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
+        summaryCallSite: COMPACTION_CALL_SITE,
+        summaryOverrideProfile: args.overrideProfile ?? null,
+        summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
+        summaryCalls: 1,
+      };
+    }
+    resolvedTailIndex = modelTailIndex;
   }
 
   const pairedTailIndex = adjustTailIndexForToolPairing(
@@ -1107,6 +1248,10 @@ export async function runAssistantDrivenCompaction(
   // between the model's cut and the enforced cut is acknowledged with an
   // explicit truncation notice appended to the summary message (see below),
   // so the loss is visible in-context rather than silent.
+  //
+  // A caller-fixed boundary skips the enforcement entirely: the user's cut is
+  // authoritative and no token-budget forward-cut applies, however large the
+  // preserved tail.
   let tailIndex = pairedTailIndex;
   // Whether the deterministic forward-cut hit the tail floor while still over
   // `targetTokens` — propagated onto the success result so the window-manager's
@@ -1114,7 +1259,11 @@ export async function runAssistantDrivenCompaction(
   // next time, so it cannot do better). Only meaningful when a `targetTokens`
   // budget drove the forward-cut.
   let tailFloorReached = false;
-  if (args.targetTokens != null && pairedTailIndex > 0) {
+  if (
+    fixedTailStartIndex == null &&
+    args.targetTokens != null &&
+    pairedTailIndex > 0
+  ) {
     const providerName =
       args.provider.tokenEstimationProvider ?? args.provider.name;
     // Mirror the window-manager's post-compaction estimate (system prompt +


### PR DESCRIPTION
## Summary
- Adds `fixedTailStartIndex` to `CompactionRunArgs`: callers pin the compaction cut instead of the model choosing `<tail_start>`
- Fixed-boundary instruction variant (no tail picking, no budget forward-cut); tool-pairing back-walk retained as defense
- Groundwork for the user-facing summarize-up-to-here action

Part of plan: summarize-up-to-here.md (PR 1 of 6)