### PR TITLE
feat(compaction): thread fixedTailStartIndex through ContextWindowManager and defaultCompact

### DIFF
--- a/assistant/src/__tests__/compaction-direct.test.ts
+++ b/assistant/src/__tests__/compaction-direct.test.ts
@@ -143,4 +143,51 @@ describe("defaultCompact", () => {
       actorTrustClass: "guardian",
     });
   });
+
+  test("forwards fixedTailStartIndex to the manager", async () => {
+    // GIVEN a manager and a fixed-boundary compaction context
+    const observed = registerManager("conv-fixed", makeResult());
+
+    // WHEN defaultCompact runs with a fixed tail boundary
+    await defaultCompact({
+      conversationId: "conv-fixed",
+      messages: [] as never,
+      force: true,
+      fixedTailStartIndex: 4,
+    });
+
+    // THEN the manager received the boundary in its options bag
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.options).toEqual({
+      force: true,
+      fixedTailStartIndex: 4,
+    });
+  });
+
+  test("rejects overflowSignal combined with fixedTailStartIndex", async () => {
+    // GIVEN a manager that records any compaction entry point
+    const calls: string[] = [];
+    fakeContextWindowManagers.set("conv-conflict", {
+      maybeCompact: async () => {
+        calls.push("maybeCompact");
+        return makeResult();
+      },
+      recoverContextOverflow: async () => {
+        calls.push("recoverContextOverflow");
+        return makeResult();
+      },
+    });
+
+    // WHEN defaultCompact runs with both an overflow signal and a fixed boundary
+    // THEN the request is rejected before reaching the manager
+    await expect(
+      defaultCompact({
+        conversationId: "conv-conflict",
+        messages: [] as never,
+        overflowSignal: { actualTokens: 250_000, isInteractive: true },
+        fixedTailStartIndex: 4,
+      }),
+    ).rejects.toThrow(/mutually exclusive/);
+    expect(calls).toEqual([]);
+  });
 });

--- a/assistant/src/__tests__/context-window-manager-compact-retry.test.ts
+++ b/assistant/src/__tests__/context-window-manager-compact-retry.test.ts
@@ -59,6 +59,9 @@ interface CompactionRunResult {
 let runCalls: Array<{
   messages: unknown;
   previousEstimatedInputTokens: number;
+  force: boolean | undefined;
+  targetTokens: number | undefined;
+  fixedTailStartIndex: number | undefined;
 }> = [];
 let runResults: CompactionRunResult[] = [];
 const estimateReturns: number[] = [];
@@ -90,10 +93,16 @@ mock.module("../context/compactor.js", () => ({
   runAssistantDrivenCompaction: async (args: {
     messages: unknown;
     previousEstimatedInputTokens: number;
+    force: boolean | undefined;
+    targetTokens: number | undefined;
+    fixedTailStartIndex: number | undefined;
   }): Promise<CompactionRunResult> => {
     runCalls.push({
       messages: args.messages,
       previousEstimatedInputTokens: args.previousEstimatedInputTokens,
+      force: args.force,
+      targetTokens: args.targetTokens,
+      fixedTailStartIndex: args.fixedTailStartIndex,
     });
     const idx = runCalls.length - 1;
     const result = runResults[idx];
@@ -374,6 +383,114 @@ describe("ContextWindowManager.maybeCompact retry budget", () => {
     expect(result.exhausted).toBe(true);
     expect(result.estimatedInputTokens).toBe(150_000);
     expect(result.compactedMessages).toBe(5);
+  });
+});
+
+describe("ContextWindowManager.maybeCompact fixed boundary", () => {
+  beforeEach(() => {
+    runCalls = [];
+    runResults = [];
+    estimateReturns.length = 0;
+  });
+
+  test("skips threshold gating and omits the target budget", async () => {
+    /**
+     * A fixed boundary is a user request, not a fullness response: the run
+     * fires even when the estimate is far below the auto threshold and no
+     * `force` option is passed, and the compactor receives no `targetTokens`
+     * (the boundary is not a budget outcome) but does receive `force` so its
+     * own threshold gate never trips.
+     */
+    // GIVEN an estimate far below the 140k threshold, then a post-compaction
+    // recompute of 50k
+    estimateReturns.push(10_000, 50_000);
+    runResults = [
+      compactResult({
+        estimatedInputTokens: 50_000,
+        summaryText: "fixed summary",
+        compactedPersistedMessages: 5,
+      }),
+    ];
+
+    // WHEN maybeCompact runs with only a fixed boundary
+    const manager = buildManager();
+    const result = await manager.maybeCompact(makeMessages(10), undefined, {
+      fixedTailStartIndex: 4,
+    });
+
+    // THEN exactly one compactor call fired with the boundary forwarded
+    expect(runCalls.length).toBe(1);
+    expect(runCalls[0]!.fixedTailStartIndex).toBe(4);
+    expect(runCalls[0]!.targetTokens).toBeUndefined();
+    expect(runCalls[0]!.force).toBe(true);
+    expect(runCalls[0]!.previousEstimatedInputTokens).toBe(10_000);
+
+    // AND the result maps the compactor output with a recomputed estimate
+    expect(result.compacted).toBe(true);
+    expect(result.summaryText).toBe("fixed summary");
+    expect(result.compactedPersistedMessages).toBe(5);
+    expect(result.estimatedInputTokens).toBe(50_000);
+    expect(result.exhausted).toBeUndefined();
+  });
+
+  test("single attempt even when the result stays above threshold", async () => {
+    /**
+     * The retry ladder never runs on the fixed path — a retry would
+     * re-summarize past the boundary the user picked.
+     */
+    // GIVEN a pass that stays above the 140k threshold
+    estimateReturns.push(180_000, 165_000);
+    runResults = [
+      compactResult({ estimatedInputTokens: 165_000 }),
+      // Never consumed — proves no retry fired:
+      compactResult({ estimatedInputTokens: 50_000 }),
+    ];
+
+    // WHEN maybeCompact runs with a fixed boundary and retries available
+    const manager = buildManager(3);
+    const result = await manager.maybeCompact(makeMessages(10), undefined, {
+      force: true,
+      fixedTailStartIndex: 6,
+    });
+
+    // THEN exactly one attempt ran and the result is not marked exhausted
+    expect(runCalls.length).toBe(1);
+    expect(result.compacted).toBe(true);
+    expect(result.estimatedInputTokens).toBe(165_000);
+    expect(result.exhausted).toBeUndefined();
+  });
+
+  test("failed pass returns as-is with no retry", async () => {
+    /**
+     * A `summaryFailed` early return passes straight through so the caller
+     * can surface the failure — the manager never burns a second summary
+     * call against the same user-chosen boundary.
+     */
+    // GIVEN a compactor pass that failed its summary call
+    estimateReturns.push(180_000);
+    runResults = [
+      compactResult({
+        compacted: false,
+        summaryFailed: true,
+        estimatedInputTokens: 180_000,
+        compactedMessages: 0,
+        summaryCalls: 1,
+      }),
+      // Never consumed:
+      compactResult({ estimatedInputTokens: 50_000 }),
+    ];
+
+    // WHEN maybeCompact runs with a fixed boundary
+    const manager = buildManager(3);
+    const result = await manager.maybeCompact(makeMessages(10), undefined, {
+      force: true,
+      fixedTailStartIndex: 4,
+    });
+
+    // THEN the failed result passes through after a single attempt
+    expect(runCalls.length).toBe(1);
+    expect(result.compacted).toBe(false);
+    expect(result.summaryFailed).toBe(true);
   });
 });
 

--- a/assistant/src/plugins/defaults/compaction/compact.ts
+++ b/assistant/src/plugins/defaults/compaction/compact.ts
@@ -51,6 +51,13 @@ export interface CompactionContext {
   /** Trust class of the actor whose turn triggered compaction. */
   actorTrustClass?: TrustClass;
   /**
+   * Summarize everything before this in-memory history index ("summarize up
+   * to here"). Single-attempt; bypasses the auto-threshold gate and the
+   * token-budget forward-cut. Mutually exclusive with `overflowSignal` —
+   * overflow recovery never targets a user-chosen boundary.
+   */
+  fixedTailStartIndex?: number;
+  /**
    * Set when this compaction is recovering from a provider context-overflow
    * rejection rather than the ordinary auto-threshold trip. Its presence
    * routes the request through the manager's reduction ladder (which escalates
@@ -75,6 +82,12 @@ export async function defaultCompact(
 ): Promise<ContextWindowResult> {
   const { conversationId, messages, signal, overflowSignal, ...options } =
     context;
+  if (overflowSignal && options.fixedTailStartIndex != null) {
+    throw new PluginExecutionError(
+      `default-compaction: overflowSignal and fixedTailStartIndex are mutually exclusive — overflow recovery never targets a user-chosen boundary (conversation ${conversationId})`,
+      DEFAULT_COMPACTION_PLUGIN_NAME,
+    );
+  }
   const manager = getContextWindowManager(conversationId);
   if (manager == null) {
     throw new PluginExecutionError(

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -157,6 +157,15 @@ export interface ContextWindowCompactOptions {
    * for untrusted actors.
    */
   actorTrustClass?: TrustClass;
+  /**
+   * Summarize everything before this in-memory history index ("summarize up
+   * to here"). Single-attempt: bypasses the auto-threshold gate, the retry
+   * ladder, and the token-budget forward-cut — the boundary is the user's
+   * choice, not a budget outcome. Forwarded to the compactor's
+   * `fixedTailStartIndex` (see {@link CompactionRunArgs.fixedTailStartIndex}
+   * for range validation).
+   */
+  fixedTailStartIndex?: number;
 }
 
 export interface EmergencyCompactOptions {
@@ -657,7 +666,6 @@ export class ContextWindowManager {
     const thresholdTokens = Math.floor(
       this.config.maxInputTokens * compaction.autoThreshold,
     );
-    const targetTokens = this.resolveCompactionTargetTokens(thresholdTokens);
 
     if (!compaction.enabled) {
       return noopResult(messages, previousEstimatedInputTokens, {
@@ -681,6 +689,37 @@ export class ContextWindowManager {
       });
     }
 
+    // Caller-fixed boundary ("summarize up to here"): one compactor pass at
+    // the user's chosen cut. No threshold gate (the user asked, regardless of
+    // fullness), no target budget (the boundary is not a budget outcome), and
+    // no retry ladder (a retry would re-summarize the already-summarized
+    // history past the boundary the user picked).
+    if (options?.fixedTailStartIndex != null) {
+      const result = await runAssistantDrivenCompaction({
+        conversationId: this.conversationId,
+        messages,
+        provider: this.provider,
+        systemPrompt: this.systemPrompt,
+        tools: this.resolveTools?.(),
+        compaction,
+        maxInputTokens: this.config.maxInputTokens,
+        previousEstimatedInputTokens,
+        force: true,
+        signal,
+        overrideProfile: options.overrideProfile ?? null,
+        actorTrustClass: options.actorTrustClass,
+        nonPersistedPrefixCount: this._nonPersistedPrefixCount,
+        fixedTailStartIndex: options.fixedTailStartIndex,
+      });
+      if (!result.compacted) return result;
+      const estimatedInputTokens = this.recomputePostCompactionEstimate(
+        result.messages,
+        result.estimatedInputTokens,
+      );
+      this.consumeCompactionState(result.compactedMessages);
+      return { ...result, estimatedInputTokens };
+    }
+
     if (!options?.force && previousEstimatedInputTokens < thresholdTokens) {
       return noopResult(messages, previousEstimatedInputTokens, {
         maxInputTokens: this.config.maxInputTokens,
@@ -688,6 +727,8 @@ export class ContextWindowManager {
         reason: "below auto threshold",
       });
     }
+
+    const targetTokens = this.resolveCompactionTargetTokens(thresholdTokens);
 
     const baseArgs: CompactionRunArgs = {
       conversationId: this.conversationId,


### PR DESCRIPTION
## Summary
- `ContextWindowCompactOptions.fixedTailStartIndex`: single-attempt fixed-boundary compaction path in `_maybeCompact` (no threshold gate, no retry ladder, no budget forward-cut)
- `CompactionContext.fixedTailStartIndex` passthrough in `defaultCompact`; overflow+fixed combination rejected
- Entry point for Conversation.summarizeUpToMessage (next PR)

Part of plan: summarize-up-to-here.md (PR 3 of 6)