### PR TITLE
feat(daemon): add Conversation.summarizeUpToMessage with guardian trust and boundary mapping

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Tests for Conversation.summarizeUpToMessage ("summarize up to here").
+ *
+ * Verifies the row→history boundary mapping (including the leading
+ * context-summary message and the already-compacted row prefix), the guardian
+ * trust swap around the fresh history load, the fail-safe mapping
+ * verification, and that boundary-resolver UserErrors propagate untouched.
+ * The compaction plugin entry (`defaultCompact`) is mocked so no summary LLM
+ * runs — the assertions target the CompactionContext it receives.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent } from "../agent/loop.js";
+import type { CompactionContext } from "../plugins/defaults/compaction/compact.js";
+import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+import { UserError } from "../util/errors.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede Conversation import
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    llm: {
+      default: {
+        provider: "mock-provider",
+        model: "mock-model",
+        maxTokens: 4096,
+        effort: "high" as const,
+        speed: "standard",
+        temperature: null,
+        thinking: { enabled: false, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 100000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    memory: { v2: { enabled: false } },
+    conversations: { skipAutoRetitling: false },
+    timeouts: { permissionTimeoutSec: 1 },
+    skills: { entries: {}, allowBundled: true },
+    permissions: { mode: "workspace" },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => false,
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+// Mutable persisted state — each test seeds its own rows/conversation.
+interface MockRow {
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+  clientMessageId: string | null;
+}
+let mockDbMessages: MockRow[] = [];
+let mockConversation: Record<string, unknown> = {};
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+  // Persist the compaction outcome back into the mock conversation row so a
+  // second summarize sees the advanced compacted count (the repeat test).
+  updateConversationContextWindow: (
+    _conversationId: string,
+    contextSummary: string,
+    contextCompactedMessageCount: number,
+  ) => {
+    mockConversation.contextSummary = contextSummary;
+    mockConversation.contextCompactedMessageCount =
+      contextCompactedMessageCount;
+  },
+  setConversationHistoryStrippedAt: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => mockDbMessages,
+  getConversation: () => mockConversation,
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: () => ({ id: `msg-${Date.now()}` }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  resolveOverrideProfile: () => null,
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+// Captured defaultCompact invocations + per-test canned result.
+let compactCalls: CompactionContext[] = [];
+let mockCompactResult: ContextWindowResult = makeNoopResult();
+
+function makeNoopResult(): ContextWindowResult {
+  return {
+    messages: [],
+    compacted: false,
+    previousEstimatedInputTokens: 0,
+    estimatedInputTokens: 0,
+    maxInputTokens: 0,
+    thresholdTokens: 0,
+    compactedMessages: 0,
+    compactedPersistedMessages: 0,
+    summaryCalls: 0,
+    summaryInputTokens: 0,
+    summaryOutputTokens: 0,
+    summaryModel: "",
+    summaryText: "",
+  };
+}
+
+mock.module("../plugins/defaults/compaction/compact.js", () => ({
+  DEFAULT_COMPACTION_PLUGIN_NAME: "default-compaction",
+  defaultCompact: async (
+    context: CompactionContext,
+  ): Promise<ContextWindowResult> => {
+    compactCalls.push(context);
+    return mockCompactResult;
+  },
+  defaultEmergencyCompact: async (): Promise<ContextWindowResult> =>
+    mockCompactResult,
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    nonPersistedPrefixCount = 0;
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact(): Promise<ContextWindowResult> {
+      return mockCompactResult;
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: (summary: string) => ({
+    role: "user",
+    content: [{ type: "text", text: summary }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../persistence/llm-usage-store.js", () => ({
+  recordUsageEvent: () => ({ id: "mock-id", createdAt: Date.now() }),
+  listUsageEvents: () => [],
+}));
+
+mock.module("../runtime/services/auto-analysis-enqueue.js", () => ({
+  enqueueAutoAnalysisOnCompaction: () => {},
+}));
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(_options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<Message[]> {
+      return [];
+    }
+  },
+}));
+
+mock.module("../contacts/canonical-guardian-store.js", () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
+  listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
+  createCanonicalGuardianRequest: () => ({
+    id: "mock-cg-id",
+    code: "MOCK",
+    status: "pending",
+  }),
+  getCanonicalGuardianRequest: () => null,
+  getCanonicalGuardianRequestByCode: () => null,
+  updateCanonicalGuardianRequest: () => {},
+  resolveCanonicalGuardianRequest: () => {},
+  createCanonicalGuardianDelivery: () => ({ id: "mock-cgd-id" }),
+  listCanonicalGuardianDeliveries: () => [],
+  listPendingCanonicalGuardianRequestsByDestinationChat: () => [],
+  updateCanonicalGuardianDelivery: () => {},
+  generateCanonicalRequestCode: () => "MOCK-CODE",
+}));
+
+// ---------------------------------------------------------------------------
+// Import Conversation AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { Conversation } from "../daemon/conversation.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProvider() {
+  return {
+    name: "mock-provider",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+function makeConversation(): Conversation {
+  const conversation = new Conversation(
+    "conv-1",
+    makeProvider(),
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+  conversation.setTrustContext({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  });
+  return conversation;
+}
+
+let nextCreatedAt = 1;
+function row(id: string, role: string, text: string): MockRow {
+  return {
+    id,
+    conversationId: "conv-1",
+    role,
+    content: JSON.stringify([{ type: "text", text }]),
+    createdAt: nextCreatedAt++,
+    metadata: null,
+    clientMessageId: null,
+  };
+}
+
+/** u1,a1,u2,a2,u3,a3 — three plain turns, ids m0..m5. */
+function threeTurnRows(): MockRow[] {
+  return [
+    row("m0", "user", "u1"),
+    row("m1", "assistant", "a1"),
+    row("m2", "user", "u2"),
+    row("m3", "assistant", "a2"),
+    row("m4", "user", "u3"),
+    row("m5", "assistant", "a3"),
+  ];
+}
+
+function baseConversationRow(): Record<string, unknown> {
+  return {
+    id: "conv-1",
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Conversation.summarizeUpToMessage", () => {
+  beforeEach(() => {
+    compactCalls = [];
+    mockCompactResult = makeNoopResult();
+    mockDbMessages = threeTurnRows();
+    mockConversation = baseConversationRow();
+  });
+
+  test("maps the boundary row straight through when there is no context summary", async () => {
+    const conversation = makeConversation();
+
+    const result = await conversation.summarizeUpToMessage("m4");
+
+    expect(result).toBe(mockCompactResult);
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].force).toBe(true);
+    // Row index 4 with no compacted prefix and no summary message → 4.
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    expect(compactCalls[0].conversationId).toBe("conv-1");
+    // The full guardian-scoped history is what gets compacted.
+    expect(compactCalls[0].messages).toHaveLength(6);
+  });
+
+  test("offsets by the summary message and the compacted row prefix", async () => {
+    mockConversation.contextSummary = "earlier summary";
+    mockConversation.contextCompactedMessageCount = 2;
+    const conversation = makeConversation();
+
+    await conversation.summarizeUpToMessage("m4");
+
+    // History is [summary, u2, a2, u3, a3]; row 4 (u3) maps to
+    // 1 + (4 - 2) = 3.
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].fixedTailStartIndex).toBe(3);
+    expect(compactCalls[0].messages).toHaveLength(5);
+  });
+
+  test("snaps a mid-turn message id back to the start of its turn", async () => {
+    const conversation = makeConversation();
+
+    // m5 (assistant a3) is inside the turn started by m4 (u3).
+    await conversation.summarizeUpToMessage("m5");
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+  });
+
+  test("a second summarize maps indices against the advanced compacted prefix", async () => {
+    mockDbMessages = [
+      ...threeTurnRows(),
+      row("m6", "user", "u4"),
+      row("m7", "assistant", "a4"),
+    ];
+    const conversation = makeConversation();
+
+    // First summarize (up to u3): the mocked write-back path persists the
+    // summary and compacted count exactly like the real
+    // updateConversationContextWindow.
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "first summary",
+    };
+    await conversation.summarizeUpToMessage("m4");
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    expect(mockConversation.contextCompactedMessageCount).toBe(4);
+    expect(mockConversation.contextSummary).toBe("first summary");
+
+    // Second summarize (up to u4): history reloads as
+    // [summary, u3, a3, u4, a4]; row 6 maps to 1 + (6 - 4) = 3.
+    mockCompactResult = makeNoopResult();
+    await conversation.summarizeUpToMessage("m6");
+
+    expect(compactCalls).toHaveLength(2);
+    expect(compactCalls[1].fixedTailStartIndex).toBe(3);
+    expect(compactCalls[1].messages).toHaveLength(5);
+  });
+
+  test("swaps in the guardian trust context for the load and restores the prior context", async () => {
+    const conversation = makeConversation();
+    // Metadata-less rows have no untrusted provenance, so a non-guardian load
+    // would filter the history to empty.
+    const priorTrust = {
+      trustClass: "unknown" as const,
+      sourceChannel: "telegram" as const,
+    };
+    conversation.setTrustContext(priorTrust);
+
+    await conversation.summarizeUpToMessage("m4");
+
+    // Guardian-scoped load saw the full history…
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].messages).toHaveLength(6);
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    // …and the exact prior context is back afterward.
+    expect(conversation.trustContext).toBe(priorTrust);
+  });
+
+  test("restores the prior trust context when the boundary resolver throws", async () => {
+    const conversation = makeConversation();
+    const priorTrust = {
+      trustClass: "unknown" as const,
+      sourceChannel: "telegram" as const,
+    };
+    conversation.setTrustContext(priorTrust);
+
+    await expect(
+      conversation.summarizeUpToMessage("missing-id"),
+    ).rejects.toThrow(
+      "Message missing-id does not belong to this conversation",
+    );
+
+    expect(conversation.trustContext).toBe(priorTrust);
+    expect(conversation.trustContext).not.toBe(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    expect(compactCalls).toHaveLength(0);
+  });
+
+  test("boundary-resolver UserErrors propagate untouched", async () => {
+    const conversation = makeConversation();
+
+    let thrown: unknown;
+    try {
+      // m1 is inside the very first turn — nothing before it to summarize.
+      await conversation.summarizeUpToMessage("m1");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect((thrown as UserError).message).toBe(
+      "Nothing to summarize before this message",
+    );
+    expect(compactCalls).toHaveLength(0);
+  });
+
+  test("throws the retryable UserError and skips compaction when the mapping cannot be verified", async () => {
+    // History repair inserts a synthetic tool_result user message after the
+    // dangling tool_use, so in-memory indices run ahead of row indices and
+    // the mapped index lands on the wrong message.
+    mockDbMessages = [
+      row("m0", "user", "u1"),
+      {
+        ...row("m1", "assistant", ""),
+        content: JSON.stringify([
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+        ]),
+      },
+      row("m2", "assistant", "continued"),
+      row("m3", "user", "u2"),
+      row("m4", "assistant", "a2"),
+    ];
+    const conversation = makeConversation();
+
+    let thrown: unknown;
+    try {
+      await conversation.summarizeUpToMessage("m3");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect((thrown as UserError).message).toBe(
+      "Conversation history is being reorganized — try again in a moment",
+    );
+    expect(compactCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -100,6 +100,7 @@ import { getAllToolDefinitions, getTool } from "../tools/registry.js";
 import type { ToolLifecycleEvent } from "../tools/types.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import type { AbortReason } from "../util/abort-reasons.js";
+import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type { WorkspaceGitService } from "../workspace/git-service.js";
 import type { commitTurnChanges } from "../workspace/turn-commit.js";
@@ -177,6 +178,7 @@ import type { ConversationTransportMetadata } from "./message-types/conversation
 import { isHostProxyTransport } from "./message-types/conversations.js";
 import type { ConfirmationStateChanged } from "./message-types/messages.js";
 import { conversationMetadataSyncTag } from "./message-types/sync.js";
+import { resolveSummarizeBoundary } from "./summarize-boundary.js";
 import { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("conversation");
@@ -211,6 +213,32 @@ export function startsNewTurn(role: string, content: string): boolean {
   return true;
 }
 
+/**
+ * First text block of a persisted message row's content, mirroring
+ * `loadFromDb`'s parse: non-JSON / non-array content loads as a single text
+ * block holding the raw string. Returns null when the row's block array has
+ * no text block. Used to verify the row→history boundary mapping in
+ * {@link Conversation.summarizeUpToMessage}.
+ */
+function firstPersistedTextBlockText(content: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      const block = parsed.find(
+        (b): b is { type: "text"; text: string } =>
+          typeof b === "object" &&
+          b !== null &&
+          (b as { type?: unknown }).type === "text" &&
+          typeof (b as { text?: unknown }).text === "string",
+      );
+      return block?.text ?? null;
+    }
+  } catch {
+    // Non-JSON content loads as a raw text block.
+  }
+  return content;
+}
+
 export interface CleanResult {
   previousEstimatedInputTokens: number;
   estimatedInputTokens: number;
@@ -243,7 +271,11 @@ export type {
   QueueDrainReason,
   QueuePolicy,
 } from "./conversation-queue-manager.js";
-import { isPersonalMemoryAllowed, type TrustContext } from "./trust-context.js";
+import {
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  isPersonalMemoryAllowed,
+  type TrustContext,
+} from "./trust-context.js";
 
 export interface ConversationConstructorOptions {
   maxTokens?: number;
@@ -1790,6 +1822,91 @@ export class Conversation {
   }
 
   /**
+   * "Summarize up to here": summarize everything before the turn containing
+   * `beforeMessageId`, keeping that turn and everything after it verbatim.
+   * Runs the same durable compaction pipeline as {@link forceCompact} but
+   * with a caller-fixed tail boundary instead of the token-budget cut.
+   *
+   * Owner self-maintenance operates on the full (guardian) history, so an
+   * untrusted trust context is temporarily swapped for the internal guardian
+   * context and restored afterward — the same idiom as
+   * `resolveMetaSlashCommand`. Throws {@link UserError} (messages are
+   * user-facing) when the boundary cannot be resolved or the row→history
+   * index mapping cannot be verified.
+   */
+  async summarizeUpToMessage(
+    beforeMessageId: string,
+  ): Promise<ContextWindowResult> {
+    const priorTrustContext = this.trustContext;
+    if (!resolveCapabilities(priorTrustContext?.trustClass).canAccessMemory) {
+      this.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    }
+    try {
+      // Fresh guardian-scoped load so `this.messages` and the persisted rows
+      // describe the same history (rare user action; the reload cost is
+      // acceptable).
+      await this.loadFromDb();
+      const rows = getMessages(this.conversationId);
+      const { boundaryRowIndex } = resolveSummarizeBoundary(
+        rows,
+        beforeMessageId,
+        this.contextCompactedMessageCount,
+      );
+      // Row-space → history-space: `this.messages` starts past the
+      // already-compacted row prefix and carries one leading summary message
+      // when a non-blank context summary exists (matching the `loadFromDb`
+      // prepend condition).
+      const tailIndex =
+        (this.contextSummary?.trim() ? 1 : 0) +
+        (boundaryRowIndex - this.contextCompactedMessageCount);
+      const boundaryRow = rows[boundaryRowIndex];
+      const mapped: Message | undefined = this.messages[tailIndex];
+      const rowText = firstPersistedTextBlockText(boundaryRow.content);
+      // Injection rehydration PREPENDS blocks to user messages, so the row's
+      // text must appear somewhere among the in-memory message's text blocks
+      // — never assume block 0. A mismatch means the in-memory view diverged
+      // from the persisted rows (e.g. history repair inserted a synthetic
+      // message); fail safe rather than summarize at the wrong boundary.
+      const matches =
+        mapped !== undefined &&
+        mapped.role === boundaryRow.role &&
+        (rowText === null ||
+          mapped.content.some(
+            (b) => b.type === "text" && b.text.includes(rowText),
+          ));
+      if (!matches) {
+        log.warn(
+          {
+            conversationId: this.conversationId,
+            beforeMessageId,
+            boundaryRowIndex,
+            tailIndex,
+            rowRole: boundaryRow.role,
+            mappedRole: mapped?.role,
+            rowCount: rows.length,
+            historyLength: this.messages.length,
+            contextCompactedMessageCount: this.contextCompactedMessageCount,
+          },
+          "summarizeUpToMessage: row→history boundary mapping mismatch",
+        );
+        throw new UserError(
+          "Conversation history is being reorganized — try again in a moment",
+        );
+      }
+      return await this.runCompaction(true, undefined, {
+        fixedTailStartIndex: tailIndex,
+      });
+    } finally {
+      // Only undo the temporary guardian context this method installed. If
+      // trustContext was legitimately updated at an `await` boundary, the
+      // reference differs and is left alone.
+      if (this.trustContext === INTERNAL_GUARDIAN_TRUST_CONTEXT) {
+        this.setTrustContext(priorTrustContext ?? null);
+      }
+    }
+  }
+
+  /**
    * Auto-threshold compaction gate. Runs the same durable compaction
    * pipeline as {@link forceCompact} (summary call, circuit-breaker
    * accounting, Slack provenance, in-memory + DB commit) but honors the
@@ -1814,14 +1931,17 @@ export class Conversation {
   }
 
   /**
-   * Shared compaction pipeline behind {@link forceCompact} and
-   * {@link maybeCompact}. `force` skips the auto-threshold check inside the
-   * context-window manager (user-initiated `/compact`); without it the
-   * manager no-ops below the threshold.
+   * Shared compaction pipeline behind {@link forceCompact},
+   * {@link maybeCompact}, and {@link summarizeUpToMessage}. `force` skips the
+   * auto-threshold check inside the context-window manager (user-initiated
+   * `/compact`); without it the manager no-ops below the threshold.
+   * `opts.fixedTailStartIndex` pins the kept tail to a caller-chosen history
+   * index ("summarize up to here") instead of the token-budget cut.
    */
   private async runCompaction(
     force: boolean,
     sizing?: CompactionSizing,
+    opts?: { fixedTailStartIndex?: number },
   ): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
     const config = getConfig();
@@ -1872,6 +1992,7 @@ export class Conversation {
       force,
       overrideProfile,
       actorTrustClass: this.trustContext?.trustClass,
+      fixedTailStartIndex: opts?.fixedTailStartIndex,
     });
     // Track circuit-breaker state for every compaction that ran a summary
     // call — user-initiated `/compact`, other forced paths, and the wake's


### PR DESCRIPTION
## Summary
- New `Conversation.summarizeUpToMessage(beforeMessageId)`: guardian trust swap → fresh load → turn-snapped boundary → verified row→history index mapping → fixed-boundary compaction via the shared `runCompaction`/`applyCompactionResult` path
- `runCompaction` gains an options bag forwarding `fixedTailStartIndex` to `defaultCompact`; `forceCompact` unchanged
- Mapping verification fails safe (retryable error) rather than summarizing at a wrong boundary

Part of plan: summarize-up-to-here.md (PR 4 of 6)