### PR TITLE
feat(runtime): add POST /v1/conversations/summarize (summarize up to a message)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9224,6 +9224,48 @@ paths:
                   - ok
                   - updated
                 additionalProperties: false
+  /v1/conversations/summarize:
+    post:
+      operationId: conversations_summarize_post
+      summary: Summarize a conversation up to a message
+      description:
+        Replace the conversation's context before the given message with a generated summary. The boundary snaps to
+        the start of the turn containing beforeMessageId; that turn and everything after stay verbatim. Messages are
+        never deleted.
+      tags:
+        - conversations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                beforeMessageId:
+                  type: string
+                  description: Summarize all messages before this one
+              required:
+                - conversationId
+                - beforeMessageId
+      responses:
+        "202":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                    const: true
+                  conversationId:
+                    type: string
+                required:
+                  - accepted
+                  - conversationId
+                additionalProperties: false
   /v1/conversations/switch:
     post:
       operationId: conversations_switch_post

--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for POST /v1/conversations/summarize ("summarize up to here").
+ *
+ * Validates that:
+ * - The route 202s immediately and runs summarization async, persisting a
+ *   result card via the canned-message path (assistant_text_delta +
+ *   message_complete) exactly like the /compact branch.
+ * - Busy conversations are rejected with 409 without touching processing.
+ * - Boundary UserErrors surface as a "Summarization skipped" card, not a
+ *   conversation_error.
+ * - Unexpected errors broadcast a retryable conversation_error.
+ * - Processing is cleared and the queue drained on every outcome.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { z } from "zod";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+const formatSummarizeUpToResultMock = mock(
+  (result: { compactedMessages: number }) =>
+    `**Conversation summarized**\nSummarized ${result.compactedMessages} earlier messages.`,
+);
+
+mock.module("../daemon/conversation-process.js", () => ({
+  formatSummarizeUpToResult: formatSummarizeUpToResultMock,
+}));
+
+mock.module("../daemon/handlers/conversations.js", () => ({
+  cancelGeneration: () => true,
+  clearAllConversations: async () => 0,
+  resolveMetaSlashCommand: async () => null,
+  switchConversation: async () => null,
+  undoLastMessage: async () => null,
+}));
+
+const addMessageMock = mock(
+  async (
+    _conversationId: string,
+    _role: string,
+    _content: string,
+    _options?: { metadata?: Record<string, unknown> },
+  ) => ({ id: "persisted-assistant-id", deduplicated: false }),
+);
+
+const getConversationMock = mock((id: string) =>
+  id === "conv-summarize-test" ? { id } : null,
+);
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  addMessage: addMessageMock,
+  archiveConversation: () => true,
+  batchSetDisplayOrders: () => {},
+  countConversationsByScheduleJobId: () => 0,
+  deleteConversation: () => ({ segmentIds: [], deletedSummaryIds: [] }),
+  forkConversation: () => ({ id: "forked" }),
+  getConversation: getConversationMock,
+  provenanceFromTrustContext: (ctx: unknown) =>
+    ctx
+      ? { provenanceTrustClass: (ctx as Record<string, unknown>).trustClass }
+      : { provenanceTrustClass: "unknown" },
+  setConversationSurfaced: () => null,
+  unarchiveConversation: () => true,
+  updateConversationTitle: () => {},
+  wipeConversation: () => ({
+    segmentIds: [],
+    deletedSummaryIds: [],
+    cancelledJobCount: 0,
+  }),
+}));
+
+mock.module("../persistence/conversation-key-store.js", () => ({
+  getOrCreateConversation: () => ({
+    conversationId: "conv-summarize-test",
+    created: false,
+  }),
+  resolveConversationId: (id: string) => id,
+  setConversationKeyIfAbsent: () => {},
+}));
+
+mock.module("../persistence/jobs-store.js", () => ({
+  enqueueMemoryJob: () => {},
+}));
+
+mock.module("../schedule/schedule-store.js", () => ({
+  deleteSchedule: async () => {},
+}));
+
+mock.module("../home/feed-writer.js", () => ({
+  stripConversationIds: async () => {},
+}));
+
+const broadcastEvents: Array<Record<string, unknown>> = [];
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: Record<string, unknown>) => {
+    broadcastEvents.push(msg);
+  },
+}));
+
+mock.module("../runtime/services/conversation-serializer.js", () => ({
+  buildConversationDetailResponse: () => null,
+}));
+
+const publishConversationMessagesChangedMock = mock(
+  (_conversationId: string, _originClientId?: string) => {},
+);
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationListAndMetadataChanged: () => {},
+  publishConversationListChanged: () => {},
+  publishConversationMessagesChanged: publishConversationMessagesChangedMock,
+  publishConversationTitleChanged: () => {},
+}));
+
+mock.module("../runtime/routes/inference-profile-session-handler.js", () => ({
+  setInferenceProfileSession: async () => ({}),
+}));
+
+mock.module("../runtime/routes/conversation-list-routes.js", () => ({
+  conversationSummarySchema: z.object({}),
+}));
+
+// Each test installs its fake conversation here for the store mock to serve.
+let activeConversation: ReturnType<typeof makeConversation>["conversation"];
+mock.module("../daemon/conversation-store.js", () => ({
+  destroyActiveConversation: () => {},
+  getOrCreateConversation: async () => activeConversation,
+}));
+
+import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
+import { UserError } from "../util/errors.js";
+import { callHandler } from "./helpers/call-route-handler.js";
+
+const summarizeRoute = ROUTES.find(
+  (r) => r.operationId === "summarizeConversation",
+)!;
+const summarizeHandler = async (
+  args: Parameters<typeof summarizeRoute.handler>[0],
+) => summarizeRoute.handler(args);
+
+function makeConversation(opts: { processing?: boolean } = {}) {
+  let processing = opts.processing ?? false;
+  const setProcessing = mock((value: boolean) => {
+    processing = value;
+  });
+  const summarizeUpToMessage = mock(async (_beforeMessageId: string) => ({
+    messages: [],
+    compacted: true,
+    previousEstimatedInputTokens: 12000,
+    estimatedInputTokens: 4000,
+    maxInputTokens: 200000,
+    thresholdTokens: 160000,
+    compactedMessages: 12,
+    compactedPersistedMessages: 12,
+    preservedTailMessages: 4,
+    summaryCalls: 1,
+    summaryInputTokens: 500,
+    summaryOutputTokens: 100,
+    summaryModel: "test-model",
+  }));
+  const emitActivityState = mock(
+    (_phase: string, _reason: string, _options?: { statusText?: string }) => {},
+  );
+  const drainQueue = mock(async () => {});
+  const messages: unknown[] = [];
+  const conversation = {
+    conversationId: "conv-summarize-test",
+    trustContext: undefined,
+    isProcessing: () => processing,
+    setProcessing,
+    summarizeUpToMessage,
+    emitActivityState,
+    drainQueue,
+    getMessages: () => messages,
+  };
+  return {
+    conversation,
+    setProcessing,
+    summarizeUpToMessage,
+    emitActivityState,
+    drainQueue,
+    messages,
+  };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/v1/conversations/summarize", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Flush the fire-and-forget async block (macrotask + queued microtasks). */
+async function settle() {
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+beforeEach(() => {
+  addMessageMock.mockClear();
+  getConversationMock.mockClear();
+  formatSummarizeUpToResultMock.mockClear();
+  publishConversationMessagesChangedMock.mockClear();
+  broadcastEvents.length = 0;
+});
+
+describe("POST /v1/conversations/summarize", () => {
+  test("202s immediately, then persists the result card and emits turn events", async () => {
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest({
+        conversationId: "conv-summarize-test",
+        beforeMessageId: "msg-42",
+      }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({
+      accepted: true,
+      conversationId: "conv-summarize-test",
+    });
+
+    await settle();
+
+    expect(ctx.summarizeUpToMessage).toHaveBeenCalledWith("msg-42");
+    expect(ctx.emitActivityState).toHaveBeenCalledWith(
+      "thinking",
+      "context_compacting",
+      { statusText: "Summarizing conversation" },
+    );
+
+    // Card persisted as an assistant message and pushed onto in-memory history.
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    const [convId, role, content] = addMessageMock.mock.calls[0];
+    expect(convId).toBe("conv-summarize-test");
+    expect(role).toBe("assistant");
+    expect(content).toContain("Conversation summarized");
+    expect(ctx.messages).toHaveLength(1);
+
+    // Turn-style SSE events: full text delta, then message_complete with the
+    // persisted assistant id (what the web client renders live).
+    const delta = broadcastEvents.find(
+      (e) => e.type === "assistant_text_delta",
+    );
+    expect(String(delta?.text)).toContain("Conversation summarized");
+    const complete = broadcastEvents.find((e) => e.type === "message_complete");
+    expect(complete?.messageId).toBe("persisted-assistant-id");
+    expect(publishConversationMessagesChangedMock).toHaveBeenCalledWith(
+      "conv-summarize-test",
+      undefined,
+    );
+
+    expect(ctx.conversation.isProcessing()).toBe(false);
+    expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
+  });
+
+  test("busy conversation → 409 without claiming processing", async () => {
+    const ctx = makeConversation({ processing: true });
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest({
+        conversationId: "conv-summarize-test",
+        beforeMessageId: "msg-42",
+      }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("currently responding");
+    expect(ctx.setProcessing).not.toHaveBeenCalled();
+    expect(ctx.summarizeUpToMessage).not.toHaveBeenCalled();
+  });
+
+  test("unknown conversation → 404", async () => {
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest({
+        conversationId: "conv-missing",
+        beforeMessageId: "msg-42",
+      }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(404);
+    expect(ctx.summarizeUpToMessage).not.toHaveBeenCalled();
+  });
+
+  test("boundary UserError → skipped card, no conversation_error", async () => {
+    const ctx = makeConversation();
+    ctx.summarizeUpToMessage.mockImplementationOnce(async () => {
+      throw new UserError("Nothing to summarize before this message");
+    });
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest({
+        conversationId: "conv-summarize-test",
+        beforeMessageId: "msg-1",
+      }),
+      undefined,
+      202,
+    );
+    expect(res.status).toBe(202);
+
+    await settle();
+
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    const [, role, content] = addMessageMock.mock.calls[0];
+    expect(role).toBe("assistant");
+    expect(content).toContain(
+      "Summarization skipped — Nothing to summarize before this message",
+    );
+    expect(
+      broadcastEvents.some((e) => e.type === "conversation_error"),
+    ).toBe(false);
+    expect(
+      broadcastEvents.some((e) => e.type === "message_complete"),
+    ).toBe(true);
+    expect(ctx.conversation.isProcessing()).toBe(false);
+    expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
+  });
+
+  test("unexpected error → retryable conversation_error, processing cleared", async () => {
+    const ctx = makeConversation();
+    ctx.summarizeUpToMessage.mockImplementationOnce(async () => {
+      throw new Error("summary call exploded");
+    });
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest({
+        conversationId: "conv-summarize-test",
+        beforeMessageId: "msg-42",
+      }),
+      undefined,
+      202,
+    );
+    expect(res.status).toBe(202);
+
+    await settle();
+
+    expect(addMessageMock).not.toHaveBeenCalled();
+    const error = broadcastEvents.find((e) => e.type === "conversation_error");
+    expect(error).toBeDefined();
+    expect(error?.code).toBe("UNKNOWN");
+    expect(error?.retryable).toBe(true);
+    expect(String(error?.userMessage)).toContain("summary call exploded");
+    expect(ctx.conversation.isProcessing()).toBe(false);
+    expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    [{ beforeMessageId: "msg-42" }, "conversationId"],
+    [{ conversationId: "conv-summarize-test" }, "beforeMessageId"],
+    [{ conversationId: 7, beforeMessageId: "msg-42" }, "conversationId"],
+    [
+      { conversationId: "conv-summarize-test", beforeMessageId: 7 },
+      "beforeMessageId",
+    ],
+  ])("invalid body %j → 400 mentioning %s", async (body, field) => {
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      summarizeHandler,
+      makeRequest(body as Record<string, unknown>),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { error: { message: string } };
+    expect(parsed.error.message).toContain(field);
+    expect(ctx.setProcessing).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -80,9 +80,11 @@ function isHiddenRunNotificationMessage(
   );
 }
 
+/** Locale-formatted count for the user-facing context stats cards. */
+const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");
+
 /** Format the result of a forced compaction into a user-facing message. */
 export function formatCompactResult(result: ContextWindowResult): string {
-  const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");
   if (!result.compacted) {
     return [
       `Context compaction skipped — ${result.reason ?? "nothing to compact"}.`,
@@ -104,9 +106,29 @@ export function formatCompactResult(result: ContextWindowResult): string {
   ].join("\n");
 }
 
+/**
+ * Format the result of a "summarize up to here" compaction into a user-facing
+ * card.
+ */
+export function formatSummarizeUpToResult(result: ContextWindowResult): string {
+  if (!result.compacted) {
+    return `Summarization skipped — ${result.reason ?? "nothing to summarize"}.`;
+  }
+  const saved =
+    result.previousEstimatedInputTokens - result.estimatedInputTokens;
+  return [
+    "**Conversation summarized**",
+    `Summarized ${fmt(result.compactedMessages)} earlier messages. ${fmt(
+      result.preservedTailMessages,
+    )} recent messages kept in full.`,
+    `Context: ${fmt(result.previousEstimatedInputTokens)} → ${fmt(
+      result.estimatedInputTokens,
+    )} tokens (${fmt(saved)} saved)`,
+  ].join("\n");
+}
+
 /** Format the result of a forced clean into a user-facing message. */
 export function formatCleanResult(result: CleanResult): string {
-  const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");
   const reclaimed =
     result.previousEstimatedInputTokens - result.estimatedInputTokens;
   return [

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -1,0 +1,30 @@
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+
+// ---------------------------------------------------------------------------
+// Temporary fix — remove when #31994 lands
+// ---------------------------------------------------------------------------
+//
+// The canned-response paths (canned greeting, inline approval reply, slash
+// command, /compact, /clean, summarize-up-to) bypass the agent loop and so
+// don't pick up the per-turn anchor id allocated in
+// conversation-agent-loop.ts. Their `message_complete` events therefore went
+// out without `messageId`, and the macOS client filter at
+// ChatActionHandler.swift:507 dropped those events when they raced past the
+// 50 ms streaming-buffer flush — leaving `isSending` stuck for the full 60 s
+// watchdog window.
+//
+// Centralized so the patch surface is one helper + N one-line callers rather
+// than N duplicated literals. When #31994 lands and stamps these sites with
+// `state.assistantTurnId` directly, grep for `emitCannedMessageComplete` to
+// find every call site and inline-then-delete.
+export function emitCannedMessageComplete(
+  send: (msg: ServerMessage) => void,
+  conversationId: string,
+  persistedAssistantId: string,
+): void {
+  send({
+    type: "message_complete",
+    conversationId,
+    messageId: persistedAssistantId,
+  });
+}

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -4,6 +4,7 @@
  * POST   /v1/conversations                 — create a new conversation
  * POST   /v1/conversations/switch         — switch to an existing conversation
  * POST   /v1/conversations/fork           — fork an existing conversation
+ * POST   /v1/conversations/summarize      — summarize context up to a message
  * PUT    /v1/conversations/:id/inference-profile — set per-conversation inference profile
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
@@ -20,7 +21,12 @@
 
 import { z } from "zod";
 
-import { destroyActiveConversation } from "../../daemon/conversation-store.js";
+import { createAssistantMessage } from "../../agent/message-types.js";
+import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
+import {
+  destroyActiveConversation,
+  getOrCreateConversation as getOrCreateConversationInstance,
+} from "../../daemon/conversation-store.js";
 import {
   cancelGeneration,
   clearAllConversations,
@@ -31,12 +37,14 @@ import {
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import { stripConversationIds } from "../../home/feed-writer.js";
 import {
+  addMessage,
   archiveConversation,
   batchSetDisplayOrders,
   countConversationsByScheduleJobId,
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
+  provenanceFromTrustContext,
   setConversationSurfaced,
   unarchiveConversation,
   updateConversationTitle,
@@ -51,15 +59,24 @@ import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { silentlyWithLog } from "../../util/silently.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { buildConversationDetailResponse } from "../services/conversation-serializer.js";
 import {
   publishConversationListAndMetadataChanged,
   publishConversationListChanged,
+  publishConversationMessagesChanged,
   publishConversationTitleChanged,
 } from "../sync/resource-sync-events.js";
+import { emitCannedMessageComplete } from "./canned-message-complete.js";
 import { conversationSummarySchema } from "./conversation-list-routes.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  InternalError,
+  NotFoundError,
+} from "./errors.js";
 import { setInferenceProfileSession } from "./inference-profile-session-handler.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -175,6 +192,109 @@ async function handleForkConversation({
     }
     throw err;
   }
+}
+
+async function handleSummarizeConversation({
+  body = {},
+  headers,
+}: RouteHandlerArgs) {
+  const rawConversationId = body.conversationId;
+  if (!rawConversationId || typeof rawConversationId !== "string") {
+    throw new BadRequestError("Missing conversationId");
+  }
+  const beforeMessageId = body.beforeMessageId;
+  if (!beforeMessageId || typeof beforeMessageId !== "string") {
+    throw new BadRequestError("Missing beforeMessageId");
+  }
+
+  const conversationId =
+    resolveConversationId(rawConversationId) ?? rawConversationId;
+  // Gate on DB existence first: `getOrCreateConversationInstance` would
+  // otherwise create a fresh conversation and mask the not-found case.
+  if (!getConversation(conversationId)) {
+    throw new NotFoundError(`Conversation ${rawConversationId} not found`);
+  }
+  const conversation = await getOrCreateConversationInstance(conversationId);
+
+  // Synchronous check-then-claim (no await between them) so a concurrent
+  // request cannot slip past the busy gate.
+  if (conversation.isProcessing()) {
+    throw new ConflictError(
+      "The assistant is currently responding — try again when it finishes",
+    );
+  }
+  conversation.setProcessing(true);
+
+  const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
+
+  const persistCard = async (text: string) => {
+    const assistantMsg = createAssistantMessage(text);
+    const persistedAssistant = await addMessage(
+      conversationId,
+      "assistant",
+      JSON.stringify(assistantMsg.content),
+      {
+        metadata: {
+          ...provenanceFromTrustContext(conversation.trustContext),
+          assistantMessageChannel: "vellum",
+        },
+      },
+    );
+    conversation.getMessages().push(assistantMsg);
+    broadcastMessage({
+      type: "assistant_text_delta",
+      text,
+      conversationId,
+    });
+    emitCannedMessageComplete(
+      broadcastMessage,
+      conversationId,
+      persistedAssistant.id,
+    );
+    publishConversationMessagesChanged(conversationId, originClientId);
+  };
+
+  // Fire-and-forget: return 202 immediately, run summarization async. The
+  // summary LLM call can exceed the client's HTTP timeout on large contexts.
+  // The `context_compacted` SSE event, usage recording, and memory hooks are
+  // all emitted inside the shared compaction write path — only the result
+  // card is the route's responsibility.
+  (async () => {
+    try {
+      conversation.emitActivityState("thinking", "context_compacting", {
+        statusText: "Summarizing conversation",
+      });
+      const result = await conversation.summarizeUpToMessage(beforeMessageId);
+      await persistCard(formatSummarizeUpToResult(result));
+    } catch (err) {
+      // Boundary/mapping UserErrors are expected user-facing outcomes, not
+      // failures: surface them as a skipped card rather than an error event.
+      if (err instanceof UserError) {
+        try {
+          await persistCard(`Summarization skipped — ${err.message}`);
+          return;
+        } catch (cardErr) {
+          err = cardErr;
+        }
+      }
+      log.error({ err, conversationId }, "Summarize command failed");
+      broadcastMessage({
+        type: "conversation_error",
+        conversationId,
+        code: "UNKNOWN",
+        userMessage: `Summarization failed: ${err instanceof Error ? err.message : String(err)}`,
+        retryable: true,
+      });
+    } finally {
+      conversation.setProcessing(false);
+      silentlyWithLog(
+        conversation.drainQueue(),
+        "summarize-command queue drain",
+      );
+    }
+  })();
+
+  return { accepted: true as const, conversationId };
 }
 
 async function handleSwitchConversation({ body = {} }: RouteHandlerArgs) {
@@ -591,6 +711,33 @@ export const ROUTES: RouteDefinition[] = [
       conversation: conversationSummarySchema,
     }),
     handler: handleForkConversation,
+  },
+  {
+    operationId: "summarizeConversation",
+    endpoint: "conversations/summarize",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Summarize a conversation up to a message",
+    description:
+      "Replace the conversation's context before the given message with a generated summary. " +
+      "The boundary snaps to the start of the turn containing beforeMessageId; that turn and " +
+      "everything after stay verbatim. Messages are never deleted.",
+    tags: ["conversations"],
+    requestBody: z.object({
+      conversationId: z.string(),
+      beforeMessageId: z
+        .string()
+        .describe("Summarize all messages before this one"),
+    }),
+    responseBody: z.object({
+      accepted: z.literal(true),
+      conversationId: z.string(),
+    }),
+    responseStatus: "202",
+    handler: handleSummarizeConversation,
   },
   {
     operationId: "switchConversation",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -153,6 +153,7 @@ import {
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
 import { withSourceChannel } from "../trust-context-resolver.js";
+import { emitCannedMessageComplete } from "./canned-message-complete.js";
 import {
   BadRequestError,
   InternalError,
@@ -307,34 +308,6 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
     typeof value === "string" &&
     VALID_RISK_THRESHOLDS.includes(value as RiskThreshold)
   );
-}
-
-// ---------------------------------------------------------------------------
-// Temporary fix — remove when #31994 lands
-// ---------------------------------------------------------------------------
-//
-// The canned-response paths in this file (canned greeting, inline approval
-// reply, slash command, /compact, /clean) bypass the agent loop and so don't
-// pick up the per-turn anchor id allocated in conversation-agent-loop.ts.
-// Their `message_complete` events therefore went out without `messageId`,
-// and the macOS client filter at ChatActionHandler.swift:507 dropped those
-// events when they raced past the 50 ms streaming-buffer flush — leaving
-// `isSending` stuck for the full 60 s watchdog window.
-//
-// Centralized so the patch surface is one helper + N one-line callers rather
-// than N duplicated literals. When #31994 lands and stamps these sites with
-// `state.assistantTurnId` directly, grep for `emitCannedMessageComplete` to
-// find every call site and inline-then-delete.
-function emitCannedMessageComplete(
-  send: (msg: ServerMessage) => void,
-  conversationId: string,
-  persistedAssistantId: string,
-): void {
-  send({
-    type: "message_complete",
-    conversationId,
-    messageId: persistedAssistantId,
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- New non-send `POST /v1/conversations/summarize` (`{ conversationId, beforeMessageId }` → 202 + async work), mirroring the /compact slash branch: activity state, canned 'Conversation summarized' card via turn SSE events, processing claim/release + queue drain
- Boundary UserErrors surface as 'Summarization skipped — …' cards; unexpected errors as conversation_error
- openapi.yaml regenerated

Part of plan: summarize-up-to-here.md (PR 5 of 6)