### PR TITLE
feat(web): add "Summarize up to here" per-message hover action

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -62,6 +62,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
 const AddCreditsModal = lazy(() =>
   import("@/components/add-credits-modal").then((m) => ({
@@ -388,6 +389,7 @@ export function ActiveChatView() {
   const {
     handleForkConversation,
     handleForkConversationFromMenu,
+    handleSummarizeUpToMessage,
     handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,
@@ -398,6 +400,29 @@ export function ActiveChatView() {
     refreshConversations,
     switchConversation,
   });
+
+  // "Summarize up to here" confirm dialog. The hover action only records the
+  // target message; the POST fires from the dialog's confirm button — a
+  // misfired summarize mutates the assistant's live context with no undo, so
+  // it always goes through an explicit confirmation.
+  const [pendingSummarizeMessageId, setPendingSummarizeMessageId] =
+    useState<string | null>(null);
+  const [summarizePending, setSummarizePending] = useState(false);
+  const handleSummarizeUpToHere = useCallback((messageId: string) => {
+    setPendingSummarizeMessageId(messageId);
+  }, []);
+  const handleConfirmSummarize = useCallback(() => {
+    if (!pendingSummarizeMessageId) return;
+    setSummarizePending(true);
+    // Errors toast inside the handler; the dialog just closes.
+    void handleSummarizeUpToMessage(pendingSummarizeMessageId).finally(() => {
+      setSummarizePending(false);
+      setPendingSummarizeMessageId(null);
+    });
+  }, [pendingSummarizeMessageId, handleSummarizeUpToMessage]);
+  const handleCancelSummarize = useCallback(() => {
+    setPendingSummarizeMessageId(null);
+  }, []);
 
   // Manual "Refresh" menu item — re-fetch the latest history page through the
   // same TanStack Query invalidation the pull-to-refresh gesture uses, so the
@@ -464,6 +489,7 @@ export function ActiveChatView() {
 
     // Conversation secondary actions
     handleForkConversation,
+    onSummarizeUpToHere: handleSummarizeUpToHere,
     handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
 
     // History pagination
@@ -510,6 +536,15 @@ export function ActiveChatView() {
           />
         </LazyBoundary>
       ) : null}
+      <ConfirmDialog
+        open={pendingSummarizeMessageId !== null}
+        title="Summarize up to here?"
+        message="The assistant will summarize the conversation before this point and carry only the summary in its working memory going forward. Messages stay visible and are never deleted."
+        confirmLabel="Summarize"
+        isPending={summarizePending}
+        onConfirm={handleConfirmSummarize}
+        onCancel={handleCancelSummarize}
+      />
       <MobileChatOverlays />
     </>
   );

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -122,6 +122,8 @@ export interface ChatMainPanelProps {
 
   // Conversation secondary actions (orchestration dependency)
   handleForkConversation: (throughMessageId: string) => Promise<void>;
+  /** Opens the "Summarize up to here" confirm dialog for a message. */
+  onSummarizeUpToHere?: (messageId: string) => void;
   handleInspectMessage?: (messageId: string) => void;
 
   // History pagination (from useConversationLoader in ActiveChatView)
@@ -202,6 +204,7 @@ export function ChatMainPanel({
   handleSteerMessage,
   handleEditQueueTail,
   handleForkConversation,
+  onSummarizeUpToHere,
   handleInspectMessage,
   historyPagination,
   diskPressure,
@@ -839,6 +842,7 @@ export function ChatMainPanel({
     onConfirmationSubmit: handleConfirmationSubmit,
     onAllowAndCreateRule: handleAllowAndCreateRule,
     onForkConversation: handleForkConversationCallback,
+    onSummarizeUpToHere,
     onInspectMessage: handleInspectMessage,
     renderAvatar,
     onPullRefresh: handlePullRefresh,

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -32,4 +32,30 @@ describe("MessageHoverActions", () => {
 
     expect(html).toContain('title="Inspect"');
   });
+
+  test("renders summarize action when the callback is provided", () => {
+    const message: DisplayMessage = {
+      id: "m3",
+      role: "assistant",
+      timestamp: Date.UTC(2026, 0, 2, 12, 34),
+      ...textBody("hello"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} onSummarizeUpToHere={() => {}} />,
+    );
+
+    expect(html).toContain('title="Summarize up to here"');
+  });
+
+  test("omits summarize action when the callback is absent", () => {
+    const message: DisplayMessage = {
+      id: "m4",
+      role: "assistant",
+      timestamp: Date.UTC(2026, 0, 2, 12, 34),
+      ...textBody("hello"),
+    };
+    const html = renderToStaticMarkup(<MessageHoverActions message={message} />);
+
+    expect(html).not.toContain('title="Summarize up to here"');
+  });
 });

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -1,5 +1,5 @@
 
-import { Bookmark, Check, Copy, ExternalLink, FileCode, GitBranch } from "lucide-react";
+import { Bookmark, Check, Copy, ExternalLink, FileCode, GitBranch, ListCollapse } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -20,6 +20,8 @@ type MessageHoverActionsProps = {
   openInSlackUrl?: string;
   /** Callback when "Fork from here" is clicked. */
   onFork?: () => void;
+  /** Callback when "Summarize up to here" is clicked. */
+  onSummarizeUpToHere?: () => void;
   /** Callback when "Inspect" is clicked. */
   onInspect?: () => void;
 };
@@ -91,6 +93,7 @@ export function MessageHoverActions({
   conversationId,
   openInSlackUrl,
   onFork,
+  onSummarizeUpToHere,
   onInspect,
 }: MessageHoverActionsProps) {
   const { role } = message;
@@ -206,6 +209,17 @@ export function MessageHoverActions({
           className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
         >
           <GitBranch className="h-3.5 w-3.5" />
+        </button>
+      )}
+
+      {onSummarizeUpToHere && (
+        <button
+          type="button"
+          onClick={onSummarizeUpToHere}
+          title="Summarize up to here"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
+        >
+          <ListCollapse className="h-3.5 w-3.5" />
         </button>
       )}
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -15,9 +15,15 @@ import {
 } from "react";
 
 import { useNavigate } from "react-router";
+import { toast } from "@vellumai/design-library";
 
 import type { Conversation } from "@/types/conversation-types";
-import { conversationsByIdAnalyzePost, conversationsForkPost } from "@/generated/daemon/sdk.gen";
+import {
+  conversationsByIdAnalyzePost,
+  conversationsForkPost,
+  conversationsSummarizePost,
+} from "@/generated/daemon/sdk.gen";
+import { ApiError } from "@/utils/api-errors";
 import { isElectron } from "@/runtime/is-electron";
 import { openPopoutWindow } from "@/runtime/popout-window";
 import { routes } from "@/utils/routes";
@@ -47,6 +53,7 @@ export interface UseConversationSecondaryActionsParams {
 export interface UseConversationSecondaryActionsReturn {
   handleForkConversation: (throughMessageId: string) => Promise<void>;
   handleForkConversationFromMenu: () => void;
+  handleSummarizeUpToMessage: (beforeMessageId: string) => Promise<void>;
   handleAnalyzeConversation: (conversation: Conversation) => Promise<void>;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
@@ -122,6 +129,38 @@ export function useConversationSecondaryActions({
       }
     },
     [refreshConversations, navigate],
+  );
+
+  // Asks the daemon to summarize everything before `beforeMessageId` in the
+  // assistant's working memory. Fire-and-forget from the client's point of
+  // view: the daemon acknowledges with 202 and progress/result arrive through
+  // the existing turn SSE events, so there is no navigation, list refresh, or
+  // history invalidation here.
+  const handleSummarizeUpToMessage = useCallback(
+    async (beforeMessageId: string) => {
+      const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+      const activeConversationId = useConversationStore.getState().activeConversationId;
+      if (!assistantId || !activeConversationId) {
+        return;
+      }
+      haptic.light();
+
+      try {
+        await conversationsSummarizePost({
+          path: { assistant_id: assistantId },
+          body: { conversationId: activeConversationId, beforeMessageId },
+          throwOnError: true,
+        });
+      } catch (err) {
+        captureError(err, { context: "summarize_up_to_here" });
+        toast.error(
+          err instanceof ApiError && err.status === 409
+            ? "The assistant is busy — try again when the current response finishes"
+            : "Couldn't summarize the conversation",
+        );
+      }
+    },
+    [],
   );
 
   const handleForkConversationFromMenu = useCallback(() => {
@@ -228,6 +267,7 @@ export function useConversationSecondaryActions({
   return {
     handleForkConversation,
     handleForkConversationFromMenu,
+    handleSummarizeUpToMessage,
     handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,

--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -30,6 +30,7 @@ export interface LatestTurnRowProps {
     data?: Record<string, unknown>,
   ) => void;
   onForkConversation?: (messageId: string) => void;
+  onSummarizeUpToHere?: (messageId: string) => void;
   onInspectMessage?: (messageId: string) => void;
   renderOnboardingChoice?: () => ReactNode;
   onOpenRuleEditor?: (context: {
@@ -72,6 +73,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
+  onSummarizeUpToHere,
   onInspectMessage,
   renderOnboardingChoice,
   onOpenRuleEditor,
@@ -101,6 +103,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         assistantDisplayName={assistantDisplayName}
         onSurfaceAction={onSurfaceAction}
         onForkConversation={onForkConversation}
+        onSummarizeUpToHere={onSummarizeUpToHere}
         onInspectMessage={onInspectMessage}
         renderOnboardingChoice={renderOnboardingChoice}
         onOpenRuleEditor={onOpenRuleEditor}
@@ -124,6 +127,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             assistantDisplayName={assistantDisplayName}
             onSurfaceAction={onSurfaceAction}
             onForkConversation={onForkConversation}
+            onSummarizeUpToHere={onSummarizeUpToHere}
             onInspectMessage={onInspectMessage}
             renderOnboardingChoice={renderOnboardingChoice}
             onOpenRuleEditor={onOpenRuleEditor}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -46,6 +46,7 @@ export interface TranscriptMessageBodyProps {
     data?: Record<string, unknown>,
   ) => void;
   onForkConversation?: (messageId: string) => void;
+  onSummarizeUpToHere?: (messageId: string) => void;
   onInspectMessage?: (messageId: string) => void;
   onOpenRuleEditor?: (context: OpenRuleEditorContext) => void;
   /** Tool-call ids whose chip should display the "command not recognized"

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -98,6 +98,7 @@ export function TranscriptMessageBody({
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
+  onSummarizeUpToHere,
   onInspectMessage,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
@@ -136,6 +137,10 @@ export function TranscriptMessageBody({
   const forkMessageId = message.id;
   const forkHandler = forkMessageId && onForkConversation
     ? () => onForkConversation(forkMessageId)
+    : undefined;
+  const summarizeMessageId = message.id;
+  const summarizeHandler = summarizeMessageId && onSummarizeUpToHere
+    ? () => onSummarizeUpToHere(summarizeMessageId)
     : undefined;
   const inspectMessageId = message.id;
   const inspectHandler = inspectMessageId && onInspectMessage
@@ -691,6 +696,7 @@ export function TranscriptMessageBody({
           conversationId={conversationId}
           openInSlackUrl={slackMessageUrl}
           onFork={forkHandler}
+          onSummarizeUpToHere={summarizeHandler}
           onInspect={inspectHandler}
         />
       </div>

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -30,6 +30,7 @@ export interface TranscriptRowProps {
     data?: Record<string, unknown>,
   ) => void;
   onForkConversation?: (messageId: string) => void;
+  onSummarizeUpToHere?: (messageId: string) => void;
   onInspectMessage?: (messageId: string) => void;
   /** Render-prop for `kind: "onboardingChoice"` items. Onboarding depends on
    *  props from the parent (sendMessage, didOnboarding, etc.) and has a
@@ -82,6 +83,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
+  onSummarizeUpToHere,
   onInspectMessage,
   renderOnboardingChoice,
   onOpenRuleEditor,
@@ -107,6 +109,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           assistantDisplayName={assistantDisplayName}
           onSurfaceAction={onSurfaceAction}
           onForkConversation={onForkConversation}
+          onSummarizeUpToHere={onSummarizeUpToHere}
           onInspectMessage={onInspectMessage}
           onOpenRuleEditor={onOpenRuleEditor}
           unknownNudgeToolCallIds={unknownNudgeToolCallIds}

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -47,6 +47,8 @@ export interface TranscriptProps {
   ) => void;
   /** Callback for "Fork from here" from a message's hover actions. */
   onForkConversation?: (messageId: string) => void;
+  /** Callback for "Summarize up to here" from a message's hover actions. */
+  onSummarizeUpToHere?: (messageId: string) => void;
   /** Callback for "Inspect" from a message's hover actions. */
   onInspectMessage?: (messageId: string) => void;
 
@@ -239,6 +241,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       conversationId,
       onSurfaceAction: rest.onSurfaceAction,
       onForkConversation: rest.onForkConversation,
+      onSummarizeUpToHere: rest.onSummarizeUpToHere,
       onInspectMessage: rest.onInspectMessage,
       renderOnboardingChoice: rest.renderOnboardingChoice,
       assistantDisplayName: rest.assistantDisplayName,


### PR DESCRIPTION
## Summary
- New per-message hover action (ListCollapse icon, next to Fork) with a confirm dialog explaining the action
- Calls the new `conversationsSummarizePost` SDK endpoint; 409 → busy toast; live feedback rides existing turn SSE events (no cache invalidation needed)
- Threads `onSummarizeUpToHere` down the fork prop chain incl. latest-turn-row

Part of plan: summarize-up-to-here.md (PR 6 of 6)