### PR TITLE
docs: fix stale DB-migration and slash-command paths

### DIFF
--- a/.cursor/skills/vellum-migration-checklist/SKILL.md
+++ b/.cursor/skills/vellum-migration-checklist/SKILL.md
@@ -19,9 +19,9 @@ Do not delete migration files. Migrations are append-only, even when their logic
 
 For DB migrations:
 
-1. Add a new file under `assistant/src/memory/migrations/`.
+1. Add a new file under `assistant/src/persistence/migrations/`.
 2. Make it idempotent and safe to retry after interruption.
-3. Register it in the migration index or registry used by DB init.
+3. Register it in the `migrationSteps` array in `assistant/src/persistence/steps.ts`.
 4. Update schema modules if the runtime schema changed.
 5. Add or update a focused `db-*migration*.test.ts` test.
 

--- a/.cursor/skills/vellum-test-selection/SKILL.md
+++ b/.cursor/skills/vellum-test-selection/SKILL.md
@@ -68,7 +68,7 @@ Add typecheck when edits touch:
 
 Add migration tests when edits touch:
 
-- `assistant/src/memory/migrations/`
+- `assistant/src/persistence/migrations/`
 - `assistant/src/workspace/migrations/`
 - persisted workspace files
 - database schema modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ When a Vellum [Linear](https://linear.app/) ticket exists for the work, link it 
 
 ## Keep Docs Up to Date
 
-- **Internal reference**: When modifying slash commands in `.claude/commands/`, update the "Claude Code Workflow" section in `docs/internal-reference.md` to match.
+- **Internal reference**: When modifying slash commands in `.claude/skills/`, update the "Claude Code Workflow" section in `docs/internal-reference.md` to match.
 - **Architecture**: When introducing, removing, or significantly modifying a service/module/data flow, update `ARCHITECTURE.md` and impacted domain docs. Mermaid diagrams must reflect current architecture.
 - **AGENTS.md**: When a PR establishes a new mandatory pattern or architectural constraint, update `AGENTS.md`. Only for project-wide rules — use code comments for module-scoped patterns.
 
@@ -157,11 +157,11 @@ We have real users — maintain backwards compatibility for all interfaces, pers
 | What changed | Migration type | Location |
 |---|---|---|
 | Workspace files (renames, moves, format changes under `$VELLUM_WORKSPACE_DIR/`) | Workspace migration | `assistant/src/workspace/migrations/` — append to `WORKSPACE_MIGRATIONS` in `registry.ts` |
-| Database schema or data (columns, indexes, backfills) | DB migration | `assistant/src/memory/migrations/` — add function and register in `db-init.ts` |
+| Database schema or data (columns, indexes, backfills) | DB migration | `assistant/src/persistence/migrations/` — add function and register in the `migrationSteps` array in `assistant/src/persistence/steps.ts` |
 
 Migrations must be **idempotent** (safe to re-run if interrupted) and **append-only** (never reorder or remove existing entries). Test migrations — see `assistant/src/__tests__/workspace-migration-*.test.ts` and `assistant/src/__tests__/db-*.test.ts` for patterns. Flag breaking changes in PR descriptions. If a migration is infeasible, call it out explicitly for human review.
 
-DB migration steps registered in `db-init.ts` are checkpointed by function name in the shared `memory_checkpoints` ledger (under the `step:` namespace) and run at most once per database, so each step needs a stable, non-empty name. Add a new migration as its own entry in the list — every step is imported directly and listed individually so it is checkpointed on its own. Never hide a growing set of migrations behind a single stably-named wrapper function (or spread a shared array of them into the list under one import): once that name is checkpointed the whole group is skipped, so anything added to it later never runs. Crash recovery runs unconditionally inside `runMigrationSteps` before the step loop. Rolling a migration back (`rollbackMemoryMigration`) discards all `step:` checkpoints, so a later upgrade re-runs every step and restores any schema a `down()` reversed.
+DB migration steps registered in `steps.ts` are checkpointed by function name in the shared `memory_checkpoints` ledger (under the `step:` namespace) and run at most once per database, so each step needs a stable, non-empty name. Add a new migration as its own entry in the list — every step is imported directly and listed individually so it is checkpointed on its own. Never hide a growing set of migrations behind a single stably-named wrapper function (or spread a shared array of them into the list under one import): once that name is checkpointed the whole group is skipped, so anything added to it later never runs. Crash recovery runs unconditionally inside `runMigrationSteps` before the step loop. Rolling a migration back (`rollbackMemoryMigration`) discards all `step:` checkpoints, so a later upgrade re-runs every step and restores any schema a `down()` reversed.
 
 ## Multi-Client Assistant State Sync
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -289,17 +289,17 @@ When a voice call's ASK_GUARDIAN consultation times out before the guardian resp
 
 **Key source files:**
 
-| File                                                    | Purpose                                                                                                                                                                                     |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/memory/guardian-action-store.ts`                   | Follow-up state machine with atomic transitions (`startFollowupFromExpiredRequest`, `progressFollowupState`, `finalizeFollowup`) and query helpers for pending/expired/follow-up deliveries |
-| `src/runtime/guardian-action-message-composer.ts`       | 2-tier text generation: daemon-injected LLM generator with deterministic fallback templates. Covers all scenarios from timeout acknowledgment through follow-up completion                  |
-| `src/runtime/guardian-action-followup-executor.ts`      | Action dispatch: resolves counterparty from call session, executes `call_back` (outbound call via `startCall`), finalizes follow-up state                                                   |
-| `src/daemon/guardian-action-generators.ts`              | Daemon-injected generator factory: `createGuardianActionCopyGenerator` (latency-optimized text rewriting for guardian-facing copy)                                                          |
-| `src/calls/call-controller.ts`                          | Voice timeout handling: marks requests as timed out, sends expiry notices, injects `[GUARDIAN_TIMEOUT]` instruction for generated voice response                                            |
-| `src/runtime/routes/inbound-message-handler.ts`         | Late reply interception for Telegram channels: matches late answers to expired requests, routes follow-up conversation turns, dispatches actions                                            |
-| `src/daemon/conversation-process.ts`                    | Late reply interception for mac channel: same logic as inbound-message-handler but using conversation-ID-based delivery lookup                                                              |
-| `src/calls/guardian-action-sweep.ts`                    | Periodic sweep for stale pending requests; sends expiry notices to guardian destinations                                                                                                    |
-| `src/memory/migrations/030-guardian-action-followup.ts` | Schema migration adding follow-up columns (`followup_state`, `late_answer_text`, `late_answered_at`, `followup_action`, `followup_completed_at`)                                            |
+| File                                                         | Purpose                                                                                                                                                                                     |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/memory/guardian-action-store.ts`                        | Follow-up state machine with atomic transitions (`startFollowupFromExpiredRequest`, `progressFollowupState`, `finalizeFollowup`) and query helpers for pending/expired/follow-up deliveries |
+| `src/runtime/guardian-action-message-composer.ts`            | 2-tier text generation: daemon-injected LLM generator with deterministic fallback templates. Covers all scenarios from timeout acknowledgment through follow-up completion                  |
+| `src/runtime/guardian-action-followup-executor.ts`           | Action dispatch: resolves counterparty from call session, executes `call_back` (outbound call via `startCall`), finalizes follow-up state                                                   |
+| `src/daemon/guardian-action-generators.ts`                   | Daemon-injected generator factory: `createGuardianActionCopyGenerator` (latency-optimized text rewriting for guardian-facing copy)                                                          |
+| `src/calls/call-controller.ts`                               | Voice timeout handling: marks requests as timed out, sends expiry notices, injects `[GUARDIAN_TIMEOUT]` instruction for generated voice response                                            |
+| `src/runtime/routes/inbound-message-handler.ts`              | Late reply interception for Telegram channels: matches late answers to expired requests, routes follow-up conversation turns, dispatches actions                                            |
+| `src/daemon/conversation-process.ts`                         | Late reply interception for mac channel: same logic as inbound-message-handler but using conversation-ID-based delivery lookup                                                              |
+| `src/calls/guardian-action-sweep.ts`                         | Periodic sweep for stale pending requests; sends expiry notices to guardian destinations                                                                                                    |
+| `src/persistence/migrations/030-guardian-action-followup.ts` | Schema migration adding follow-up columns (`followup_state`, `late_answer_text`, `late_answered_at`, `followup_action`, `followup_completed_at`)                                            |
 
 ### WhatsApp Channel (Meta Cloud API)
 
@@ -527,7 +527,7 @@ Voice invites use a short numeric code (4-10 digits, default 6) instead of a URL
 | `src/runtime/routes/inbound-message-handler.ts`     | Invite token intercept in the inbound flow (unknown-contact and inactive-contact branches)                         |
 | `src/calls/relay-server.ts`                         | Voice relay state machine — `invite_redemption_pending` subflow (always-on canonical behavior)                     |
 | `src/util/voice-code.ts`                            | Cryptographic voice code generation and SHA-256 hashing                                                            |
-| `src/memory/invite-store.ts`                        | Invite persistence including `findActiveVoiceInvites` for identity-bound lookup                                    |
+| `src/persistence/invite-store.ts`                   | Invite persistence including `findActiveVoiceInvites` for identity-bound lookup                                    |
 
 ### Voice Inbound Security Model (Canonical)
 
@@ -799,14 +799,14 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 
 **Skill-gating guarantee:** Skill feature-flag gating is **opt-in**: only skills whose SKILL.md frontmatter contains a `featureFlag` field are gated. Skills without the field are always available regardless of feature flag state. For skills that declare a `featureFlag`, when the corresponding flag is OFF the skill is unavailable everywhere — it cannot appear in client UIs, model context, or runtime tool execution. This is enforced at six independent points:
 
-| Enforcement Point                | Module                                                        | Effect                                                                                                                                                                                                      |
-| -------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1. Client skill list**         | `resolveSkillStates()` in `config/skill-state.ts`             | Skills with flag OFF are excluded from the resolved list returned to clients (macOS skill list, settings UI). The skill never appears in the client.                                                        |
-| **2. Capability memory seeding** | `seedSkillGraphNodes()` in `memory/graph/capability-seed.ts`  | Skills with flag OFF are excluded from capability memory seeding. The model cannot discover them via semantic recall.                                                                                       |
-| **3. `skill_load` tool**         | `executeSkillLoad()` in `tools/skills/load.ts`                | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
-| **4. Runtime tool projection**   | `projectSkillTools()` in `daemon/conversation-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
-| **5. Included child skills**     | `executeSkillLoad()` in `tools/skills/load.ts`                | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
-| **6. Skill install gate**        | `installSkill()` in `daemon/handlers/skills.ts`               | When a client requests skill installation, the function checks the skill's feature flag before proceeding. If the flag is OFF, the install is rejected with an error.                                       |
+| Enforcement Point                | Module                                                                        | Effect                                                                                                                                                                                                      |
+| -------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. Client skill list**         | `resolveSkillStates()` in `config/skill-state.ts`                             | Skills with flag OFF are excluded from the resolved list returned to clients (macOS skill list, settings UI). The skill never appears in the client.                                                        |
+| **2. Capability memory seeding** | `seedSkillGraphNodes()` in `plugins/defaults/memory/graph/capability-seed.ts` | Skills with flag OFF are excluded from capability memory seeding. The model cannot discover them via semantic recall.                                                                                       |
+| **3. `skill_load` tool**         | `executeSkillLoad()` in `tools/skills/load.ts`                                | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
+| **4. Runtime tool projection**   | `projectSkillTools()` in `daemon/conversation-skill-tools.ts`                 | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
+| **5. Included child skills**     | `executeSkillLoad()` in `tools/skills/load.ts`                                | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
+| **6. Skill install gate**        | `installSkill()` in `daemon/handlers/skills.ts`                               | When a client requests skill installation, the function checks the skill's feature flag before proceeding. If the flag is OFF, the install is rejected with an error.                                       |
 
 All six enforcement points derive the flag key via `skillFlagKey(skill)` — which returns `undefined` for ungated skills, short-circuiting the check — and then call `isAssistantFeatureFlagEnabled(flagKey, config)` for consistency.
 
@@ -814,17 +814,17 @@ All six enforcement points derive the flag key via `skillFlagKey(skill)` — whi
 
 **Key source files:**
 
-| File                                            | Purpose                                                                                                                                                                   |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/config/assistant-feature-flags.ts`         | Canonical resolver: `isAssistantFeatureFlagEnabled()`, registry loader                                                                                                    |
-| `src/config/skill-state.ts`                     | `skillFlagKey(skill)` — returns canonical flag key for skills with a `featureFlag` frontmatter field, `undefined` otherwise; `resolveSkillStates()` — enforcement point 1 |
-| `src/memory/graph/capability-seed.ts`           | `seedSkillGraphNodes()` — enforcement point 2                                                                                                                             |
-| `src/tools/skills/load.ts`                      | `executeSkillLoad()` — enforcement points 3 and 5                                                                                                                         |
-| `src/daemon/conversation-skill-tools.ts`        | `projectSkillTools()` — enforcement point 4                                                                                                                               |
-| `src/config/schema.ts`                          | `AssistantConfig` Zod schema definition (feature flag values are no longer stored here)                                                                                   |
-| `src/daemon/handlers/skills.ts`                 | `listSkills()` — uses `resolveSkillStates()` for client responses; `installSkill()` — enforcement point 6                                                                 |
-| `meta/feature-flags/feature-flag-registry.json` | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions                                                        |
-| `src/config/feature-flag-registry.json`         | Bundled copy of the unified registry for compiled binary resolution                                                                                                       |
+| File                                                   | Purpose                                                                                                                                                                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/config/assistant-feature-flags.ts`                | Canonical resolver: `isAssistantFeatureFlagEnabled()`, registry loader                                                                                                    |
+| `src/config/skill-state.ts`                            | `skillFlagKey(skill)` — returns canonical flag key for skills with a `featureFlag` frontmatter field, `undefined` otherwise; `resolveSkillStates()` — enforcement point 1 |
+| `src/plugins/defaults/memory/graph/capability-seed.ts` | `seedSkillGraphNodes()` — enforcement point 2                                                                                                                             |
+| `src/tools/skills/load.ts`                             | `executeSkillLoad()` — enforcement points 3 and 5                                                                                                                         |
+| `src/daemon/conversation-skill-tools.ts`               | `projectSkillTools()` — enforcement point 4                                                                                                                               |
+| `src/config/schema.ts`                                 | `AssistantConfig` Zod schema definition (feature flag values are no longer stored here)                                                                                   |
+| `src/daemon/handlers/skills.ts`                        | `listSkills()` — uses `resolveSkillStates()` for client responses; `installSkill()` — enforcement point 6                                                                 |
+| `meta/feature-flags/feature-flag-registry.json`        | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions                                                        |
+| `src/config/feature-flag-registry.json`                | Bundled copy of the unified registry for compiled binary resolution                                                                                                       |
 
 ---
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -286,19 +286,19 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 
 ### Key Files
 
-| File                                                        | Role                                                                               |
-| ----------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `assistant/src/runtime/routes/credential-routes.ts`         | `assistant credentials` CLI — store, list, delete, inspect, reveal handlers        |
-| `assistant/src/credential-execution/prompted-credential.ts` | Persists credentials collected through the secure `credentials prompt` flow        |
-| `assistant/src/security/secure-keys.ts`                     | Async secure key CRUD via CES and encrypted file store                             |
-| `assistant/src/tools/credentials/metadata-store.ts`         | JSON file metadata CRUD for credential records                                     |
-| `assistant/src/tools/credentials/broker.ts`                 | Brokered credential access with policy enforcement and transient send              |
-| `assistant/src/tools/credentials/policy-validate.ts`        | Policy input validation (allowedTools, allowedDomains)                             |
-| `assistant/src/permissions/secret-prompter.ts`              | HTTP secret_request/secret_response flow                                           |
-| `assistant/src/security/secret-scanner.ts`                  | Prefix + shape-based secret regex detection (used by display-time `redactSecrets`) |
-| `assistant/src/security/secret-ingress.ts`                  | Prefix-only ingress check on user messages                                         |
-| `assistant/src/util/log-redact.ts`                          | Pino log serializers — prefix-based redaction for logs                             |
-| `clients/web/src/domains/chat/components/secret-prompt-card.tsx` | UI for secure credential entry                                                    |
+| File                                                             | Role                                                                               |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `assistant/src/runtime/routes/credential-routes.ts`              | `assistant credentials` CLI — store, list, delete, inspect, reveal handlers        |
+| `assistant/src/credential-execution/prompted-credential.ts`      | Persists credentials collected through the secure `credentials prompt` flow        |
+| `assistant/src/security/secure-keys.ts`                          | Async secure key CRUD via CES and encrypted file store                             |
+| `assistant/src/tools/credentials/metadata-store.ts`              | JSON file metadata CRUD for credential records                                     |
+| `assistant/src/tools/credentials/broker.ts`                      | Brokered credential access with policy enforcement and transient send              |
+| `assistant/src/tools/credentials/policy-validate.ts`             | Policy input validation (allowedTools, allowedDomains)                             |
+| `assistant/src/permissions/secret-prompter.ts`                   | HTTP secret_request/secret_response flow                                           |
+| `assistant/src/security/secret-scanner.ts`                       | Prefix + shape-based secret regex detection (used by display-time `redactSecrets`) |
+| `assistant/src/security/secret-ingress.ts`                       | Prefix-only ingress check on user messages                                         |
+| `assistant/src/util/log-redact.ts`                               | Pino log serializers — prefix-based redaction for logs                             |
+| `clients/web/src/domains/chat/components/secret-prompt-card.tsx` | UI for secure credential entry                                                     |
 
 ---
 
@@ -363,13 +363,13 @@ sequenceDiagram
 
 ### Key Source Files
 
-| File                                                             | Role                                                                          |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `assistant/src/memory/scoped-approval-grants.ts`                 | CRUD, atomic CAS consume, expiry sweep, context-based revocation              |
-| `assistant/src/memory/migrations/033-scoped-approval-grants.ts`  | SQLite schema migration for the `scoped_approval_grants` table                |
-| `assistant/src/security/tool-approval-digest.ts`                 | Canonical JSON serialization + SHA-256 digest for tool signatures             |
-| `assistant/src/runtime/routes/guardian-approval-interception.ts` | Grant minting on guardian approve_once decisions (`tryMintToolApprovalGrant`) |
-| `assistant/src/calls/voice-session-bridge.ts`                    | Voice consumer: checks and consumes grants before auto-denying                |
+| File                                                                 | Role                                                                          |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `assistant/src/approvals/scoped-approval-grants.ts`                  | CRUD, atomic CAS consume, expiry sweep, context-based revocation              |
+| `assistant/src/persistence/migrations/033-scoped-approval-grants.ts` | SQLite schema migration for the `scoped_approval_grants` table                |
+| `assistant/src/security/tool-approval-digest.ts`                     | Canonical JSON serialization + SHA-256 digest for tool signatures             |
+| `assistant/src/runtime/routes/guardian-approval-interception.ts`     | Grant minting on guardian approve_once decisions (`tryMintToolApprovalGrant`) |
+| `assistant/src/calls/voice-session-bridge.ts`                        | Voice consumer: checks and consumes grants before auto-denying                |
 
 ### Test Coverage
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -535,7 +535,7 @@ VELLUM_DAEMON_URL=http://localhost:8741 open -a Vellum
 
 ### Claude Code Workflow
 
-This repo includes Claude Code slash commands (in `.claude/commands/`) for agent-driven development.
+This repo includes Claude Code slash commands for agent-driven development. Most are shared from the [`claude-skills`](https://github.com/vellum-ai/claude-skills) repo via symlinks; repo-local commands live in `.claude/skills/<name>/` as local skill directories (see `.claude/README.md`).
 
 #### Single-task commands
 


### PR DESCRIPTION
## Summary
- Root `AGENTS.md` (and its `CLAUDE.md` symlink) pointed DB migrations at `assistant/src/memory/migrations/` with registration in `db-init.ts` — neither is true anymore. The table row and the checkpointing paragraph now point at `assistant/src/persistence/migrations/` and the `migrationSteps` array in `assistant/src/persistence/steps.ts`. The same dead path is fixed in `.cursor/skills/vellum-migration-checklist`, `.cursor/skills/vellum-test-selection`, `assistant/ARCHITECTURE.md`, and `assistant/docs/architecture/security.md`.
- `docs/internal-reference.md` described slash commands as living in `.claude/commands/` — that directory is untracked local symlinks created by the claude-skills `setup` script. It now describes the real layout (shared commands symlinked from `claude-skills`, repo-local commands tracked in `.claude/skills/<name>/`), matching `.claude/README.md`. The corresponding `AGENTS.md` "Keep Docs Up to Date" bullet is updated the same way.
- Three more moved-file paths in the same doc tables are fixed: `scoped-approval-grants.ts` → `src/approvals/`, `invite-store.ts` → `src/persistence/`, `capability-seed.ts` → `src/plugins/defaults/memory/graph/`. Table re-padding in `ARCHITECTURE.md`/`security.md` is Prettier (pre-commit hook enforces it).

## Not fixed here
`assistant/ARCHITECTURE.md` still has two stale rows that need a content rewrite, not a path fix: `src/memory/guardian-action-store.ts` and `src/memory/guardian-approvals.ts` describe code that no longer exists anywhere in the repo (e.g. `startFollowupFromExpiredRequest` has zero hits). Left for a guardian-docs refresh.

## Original prompt
Fix the doc drifts around DB migrations: root CLAUDE.md points DB migrations at `assistant/src/memory/migrations/` (doesn't exist — it's `persistence/migrations/`) and `docs/internal-reference.md:538` still says `.claude/commands/`. A companion PR adds a uniqueness guard for duplicate migration filename prefixes. The user asked for the work to be split into separate PRs where natural.