### PR TITLE
fix(daemon): run the shutdown WAL checkpoint off the event loop

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -7,6 +7,7 @@ import { stopCliIpcServer } from "../ipc/assistant-server.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
 import { stopMonitoring } from "../monitoring/control.js";
+import { runAsyncSqlite } from "../persistence/db-async-query.js";
 import { getSqlite, resetDb } from "../persistence/db-connection.js";
 import { stopQdrantManager } from "../persistence/embeddings/qdrant-manager.js";
 import { stopMemoryJobsWorker } from "../persistence/jobs-worker.js";
@@ -190,8 +191,33 @@ async function shutdown(): Promise<void> {
   } catch (err) {
     log.warn({ err }, "PRAGMA optimize at shutdown failed (non-fatal)");
   }
+  // Fold the WAL back into the main database so the next boot opens a small
+  // WAL instead of paying a multi-minute recovery (see
+  // `checkpointWalBeforeOpen` in db-init.ts). Runs through `runAsyncSqlite`
+  // (sqlite3 subprocess when available) because a synchronous checkpoint of a
+  // WAL at its high-water mark blocks the event loop, which keeps the
+  // force-exit timer above from ever firing. Off the loop, the timer stays
+  // armed — and if it fires mid-checkpoint, the subprocess survives
+  // `process.exit` and finishes the fold in the background.
   try {
-    getSqlite().exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    const checkpointResult = await runAsyncSqlite(
+      "PRAGMA wal_checkpoint(TRUNCATE)",
+      "shutdown:wal-checkpoint-truncate",
+    );
+    if (checkpointResult.ok) {
+      log.info(
+        {
+          backend: checkpointResult.backend,
+          elapsedMs: checkpointResult.elapsedMs,
+        },
+        "Shutdown WAL checkpoint complete",
+      );
+    } else {
+      log.warn(
+        { error: checkpointResult.error, backend: checkpointResult.backend },
+        "WAL checkpoint failed (non-fatal)",
+      );
+    }
   } catch (err) {
     log.warn({ err }, "WAL checkpoint failed (non-fatal)");
   }


### PR DESCRIPTION
## Summary
- Route the graceful-shutdown `PRAGMA wal_checkpoint(TRUNCATE)` in `shutdown-handlers.ts` through `runAsyncSqlite` (sqlite3 subprocess when available) instead of a synchronous `exec` on the shared main-thread connection — mirroring the two existing call sites in `db-maintenance.ts` and `checkpointWalBeforeOpen()` in `db-init.ts`.
- A synchronous checkpoint of a WAL at its high-water mark blocks the event loop, which disarms the 20s force-exit timer during the one shutdown step most likely to run long; if the checkpoint outlives the supervisor's kill grace (CLI gives 120s, docker default is 10s), SIGKILL lands mid-checkpoint and the next boot pays a multi-minute WAL fold. Off the loop, the force timer stays armed — and if it fires mid-checkpoint, the subprocess survives `process.exit` and finishes the fold in the background.
- On hosts without a `sqlite3` binary, `runAsyncSqlite` falls back to the same in-process blocking exec as before — never worse than prior behavior.

## Original prompt
Investigation in this session verified three daemon shutdown/startup WAL-checkpoint reliability gaps that cause boots to start with a huge WAL to fold: the graceful checkpoint runs synchronously on the main thread, the 20s force-exit path skips the checkpoint entirely, and signal handlers install second-to-last in startup. The user asked to fix them across multiple PRs. This is PR 1 of 3: make the graceful-shutdown checkpoint non-blocking via the async subprocess path db-maintenance and db-init already use.