### PR TITLE
fix(gateway): bound webhook body reads with a pre-auth streaming cap

### DIFF
--- a/gateway/src/http/read-limited-body.test.ts
+++ b/gateway/src/http/read-limited-body.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { readLimitedBody, readLimitedBodyBytes } from "./read-limited-body.js";
+
+function streamBody(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+/**
+ * A stream body carries no Content-Length header, mirroring a chunked
+ * transfer-encoding request — the case that slips past a header-only guard.
+ */
+function streamedRequest(chunks: Uint8Array[]): Request {
+  return new Request("http://gateway.test/webhook", {
+    method: "POST",
+    body: streamBody(chunks),
+    duplex: "half",
+  } as RequestInit & { duplex: "half" });
+}
+
+describe("readLimitedBodyBytes", () => {
+  test("returns the body bytes when under the cap", async () => {
+    const req = new Request("http://gateway.test/webhook", {
+      method: "POST",
+      body: "hello",
+    });
+    const result = await readLimitedBodyBytes(req, 1024);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(new TextDecoder().decode(result.bytes)).toBe("hello");
+    }
+  });
+
+  test("returns ok with empty bytes when there is no body", async () => {
+    const req = new Request("http://gateway.test/webhook", { method: "GET" });
+    const result = await readLimitedBodyBytes(req, 1024);
+    expect(result).toEqual({ status: "ok", bytes: new Uint8Array(0) });
+  });
+
+  test("rejects on an oversized Content-Length before reading", async () => {
+    const req = new Request("http://gateway.test/webhook", {
+      method: "POST",
+      body: "x".repeat(100),
+      headers: { "content-length": "100" },
+    });
+    const result = await readLimitedBodyBytes(req, 10);
+    expect(result.status).toBe("too_large");
+  });
+
+  test("caps a streamed body with no Content-Length as bytes accumulate", async () => {
+    const chunk = new Uint8Array(8);
+    const req = streamedRequest([chunk, chunk, chunk]); // 24 bytes
+    expect(req.headers.get("content-length")).toBeNull();
+    const result = await readLimitedBodyBytes(req, 16);
+    expect(result.status).toBe("too_large");
+  });
+
+  test("accepts a streamed body that stays within the cap", async () => {
+    const chunk = new Uint8Array([1, 2, 3, 4]);
+    const req = streamedRequest([chunk, chunk]); // 8 bytes
+    const result = await readLimitedBodyBytes(req, 16);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.bytes.byteLength).toBe(8);
+    }
+  });
+});
+
+describe("readLimitedBody", () => {
+  test("decodes a within-cap body to text", async () => {
+    const req = new Request("http://gateway.test/webhook", {
+      method: "POST",
+      body: "abc",
+    });
+    const result = await readLimitedBody(req, 1024);
+    expect(result).toEqual({ status: "ok", text: "abc" });
+  });
+
+  test("propagates too_large from the streamed byte cap", async () => {
+    const chunk = new Uint8Array(8);
+    const result = await readLimitedBody(streamedRequest([chunk, chunk]), 4);
+    expect(result.status).toBe("too_large");
+  });
+});

--- a/gateway/src/http/read-limited-body.ts
+++ b/gateway/src/http/read-limited-body.ts
@@ -3,10 +3,22 @@ export type ReadLimitedBodyResult =
   | { status: "too_large" }
   | { status: "unreadable" };
 
-export async function readLimitedBody(
+export type ReadLimitedBodyBytesResult =
+  | { status: "ok"; bytes: Uint8Array<ArrayBuffer> }
+  | { status: "too_large" }
+  | { status: "unreadable" };
+
+/**
+ * Read a request body into memory while enforcing a hard byte cap as the
+ * stream arrives. Unlike a Content-Length header check, this bounds the bytes
+ * actually buffered even when the header is absent, spoofed, or the request
+ * uses chunked transfer-encoding — so it is safe to call on unauthenticated
+ * ingress before any signature check.
+ */
+export async function readLimitedBodyBytes(
   req: Request,
   maxBytes: number,
-): Promise<ReadLimitedBodyResult> {
+): Promise<ReadLimitedBodyBytesResult> {
   const contentLength = req.headers.get("content-length");
   if (
     contentLength &&
@@ -16,7 +28,7 @@ export async function readLimitedBody(
     return { status: "too_large" };
   }
 
-  if (!req.body) return { status: "ok", text: "" };
+  if (!req.body) return { status: "ok", bytes: new Uint8Array(0) };
 
   const reader = req.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -46,5 +58,14 @@ export async function readLimitedBody(
     offset += chunk.byteLength;
   }
 
-  return { status: "ok", text: new TextDecoder().decode(bytes) };
+  return { status: "ok", bytes };
+}
+
+export async function readLimitedBody(
+  req: Request,
+  maxBytes: number,
+): Promise<ReadLimitedBodyResult> {
+  const result = await readLimitedBodyBytes(req, maxBytes);
+  if (result.status !== "ok") return result;
+  return { status: "ok", text: new TextDecoder().decode(result.bytes) };
 }

--- a/gateway/src/http/routes/mailgun-webhook.ts
+++ b/gateway/src/http/routes/mailgun-webhook.ts
@@ -10,6 +10,7 @@ import type { VellumEmailPayload } from "../../email/normalize.js";
 import { normalizeEmailWebhook } from "../../email/normalize.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
+import { readLimitedBodyBytes } from "../read-limited-body.js";
 import {
   resolveAssistant,
   isRejection,
@@ -83,19 +84,24 @@ function parseEmailAddress(raw: string): {
 }
 
 /**
- * Parse form-encoded or JSON body into a flat field map.
+ * Parse form-encoded or JSON body into a flat field map. Takes already-read
+ * bytes (size-capped upstream) and the content-type rather than the live
+ * request, so the body is never buffered a second time and the payload cap is
+ * enforced before parsing. Bytes are re-wrapped in a `Response` to reuse the
+ * platform's multipart/form parser without losing binary fidelity.
  */
 async function parseMailgunBody(
-  req: Request,
+  bytes: Uint8Array<ArrayBuffer>,
+  contentType: string,
 ): Promise<Record<string, string> | null> {
-  const contentType = req.headers.get("content-type") ?? "";
-
   if (
     contentType.includes("application/x-www-form-urlencoded") ||
     contentType.includes("multipart/form-data")
   ) {
     try {
-      const formData = await req.formData();
+      const formData = await new Response(bytes, {
+        headers: { "content-type": contentType },
+      }).formData();
       const fields: Record<string, string> = {};
       for (const [key, value] of formData.entries()) {
         if (typeof value === "string") {
@@ -110,7 +116,10 @@ async function parseMailgunBody(
 
   if (contentType.includes("application/json")) {
     try {
-      const json = (await req.json()) as Record<string, unknown>;
+      const json = (await new Response(bytes).json()) as Record<
+        string,
+        unknown
+      >;
       const fields: Record<string, string> = {};
       for (const [key, value] of Object.entries(json)) {
         if (typeof value === "string") {
@@ -186,20 +195,27 @@ export function createMailgunWebhookHandler(
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Payload size guard
-    const contentLength = req.headers.get("content-length");
-    if (
-      contentLength &&
-      Number(contentLength) > config.maxWebhookPayloadBytes
-    ) {
-      tlog.warn({ contentLength }, "Mailgun webhook payload too large");
+    // Cap body buffering before the (unauthenticated) signature check; a
+    // header-only guard is bypassable via chunked / absent Content-Length.
+    const bodyResult = await readLimitedBodyBytes(
+      req,
+      config.maxWebhookPayloadBytes,
+    );
+    if (bodyResult.status === "too_large") {
+      tlog.warn("Mailgun webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+    if (bodyResult.status === "unreadable") {
+      return Response.json({ error: "Failed to read body" }, { status: 400 });
     }
 
     // ── Parse body ──────────────────────────────────────────────────
     // Mailgun inbound routes POST form-encoded data, not JSON.
 
-    const fields = await parseMailgunBody(req);
+    const fields = await parseMailgunBody(
+      bodyResult.bytes,
+      req.headers.get("content-type") ?? "",
+    );
     if (!fields) {
       return Response.json({ error: "Failed to parse body" }, { status: 400 });
     }

--- a/gateway/src/http/routes/resend-webhook.ts
+++ b/gateway/src/http/routes/resend-webhook.ts
@@ -10,6 +10,7 @@ import type { VellumEmailPayload } from "../../email/normalize.js";
 import { normalizeEmailWebhook } from "../../email/normalize.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
+import { readLimitedBody } from "../read-limited-body.js";
 import {
   resolveAssistant,
   isRejection,
@@ -243,26 +244,20 @@ export function createResendWebhookHandler(
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Payload size guard
-    const contentLength = req.headers.get("content-length");
-    if (
-      contentLength &&
-      Number(contentLength) > config.maxWebhookPayloadBytes
-    ) {
-      tlog.warn({ contentLength }, "Resend webhook payload too large");
+    // Cap body buffering before the (unauthenticated) signature check; a
+    // header-only guard is bypassable via chunked / absent Content-Length.
+    const bodyResult = await readLimitedBody(
+      req,
+      config.maxWebhookPayloadBytes,
+    );
+    if (bodyResult.status === "too_large") {
+      tlog.warn("Resend webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
-
-    let rawBody: string;
-    try {
-      rawBody = await req.text();
-    } catch {
+    if (bodyResult.status === "unreadable") {
       return Response.json({ error: "Failed to read body" }, { status: 400 });
     }
-
-    if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
-      return Response.json({ error: "Payload too large" }, { status: 413 });
-    }
+    const rawBody = bodyResult.text;
 
     // ── Credential resolution ───────────────────────────────────────
     // We need two credentials:

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -7,6 +7,7 @@ import { credentialKey } from "../../credential-key.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
+import { readLimitedBody } from "../read-limited-body.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
 import {
   resolveAssistant,
@@ -87,30 +88,20 @@ export function createWhatsAppWebhookHandler(
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Payload size guard
-    const contentLength = req.headers.get("content-length");
-    if (
-      contentLength &&
-      Number(contentLength) > config.maxWebhookPayloadBytes
-    ) {
-      tlog.warn({ contentLength }, "WhatsApp webhook payload too large");
+    // Cap body buffering before the (unauthenticated) signature check; a
+    // header-only guard is bypassable via chunked / absent Content-Length.
+    const bodyResult = await readLimitedBody(
+      req,
+      config.maxWebhookPayloadBytes,
+    );
+    if (bodyResult.status === "too_large") {
+      tlog.warn("WhatsApp webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
-
-    let rawBody: string;
-    try {
-      rawBody = await req.text();
-    } catch {
+    if (bodyResult.status === "unreadable") {
       return Response.json({ error: "Failed to read body" }, { status: 400 });
     }
-
-    if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
-      tlog.warn(
-        { bodyLength: Buffer.byteLength(rawBody) },
-        "WhatsApp webhook payload too large",
-      );
-      return Response.json({ error: "Payload too large" }, { status: 413 });
-    }
+    const rawBody = bodyResult.text;
 
     // Resolve app secret from cache
     const appSecret = caches?.credentials


### PR DESCRIPTION
## Summary
- WhatsApp, Mailgun, and Resend webhook handlers now read the request body through the streaming-capped `readLimitedBody` / `readLimitedBodyBytes` helpers, which enforce a hard byte limit (`config.maxWebhookPayloadBytes`, 1 MB) **as the body streams in — before any HMAC signature check**.
- Previously the only pre-read guard was a `Content-Length` header check. That check is skipped entirely for chunked / absent-`Content-Length` requests, so an unauthenticated caller who knows the public webhook path could stream up to Bun's 512 MB `maxRequestBodySize` into memory before the signature was verified; concurrent requests turn that into memory pressure. The cap now bounds each read at the configured webhook limit regardless of the header.
- `readLimitedBodyBytes` is the shared byte-level primitive; `readLimitedBody` (text) delegates to it so the cap logic has a single source of truth. Mailgun's form/JSON parser takes the already-capped bytes (re-wrapped in a `Response` to reuse the platform multipart parser without losing binary fidelity) instead of reading the live request a second time. Telegram already verifies its secret header before reading the body, so it was already safe. Adds unit tests for the cap, including the no-`Content-Length` streaming-bypass case.

Framed as resource-exhaustion hardening, not a critical DoS: Bun caps each request at 512 MB, so the impact is bounded memory pressure under concurrency rather than an unbounded single-request OOM.

## Original prompt
While reviewing a security finding that the WhatsApp/Mailgun/Resend webhooks buffer the full request body before the HMAC check — guarded only by a spoofable/absent `Content-Length` — we confirmed it is a real (though bounded) pre-auth buffering gap, and that Telegram is safe because it authenticates on a header first. Sidd then asked to standardize the existing `readLimitedBody` streaming cap across the three handlers as resource-exhaustion hardening.