### PR TITLE
fix(gateway): authenticate inbound email senders before granting guardian/contact trust

### DIFF
--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -70,14 +70,12 @@ mock.module("../feature-flag-resolver.js", () => ({
 }));
 
 await import("./test-preload.js");
-const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
-  "../db/connection.js"
-);
-const { AdmissionPolicyStore } = await import("../db/admission-policy-store.js");
-const {
-  initAdmissionPolicyCache,
-  resetAdmissionPolicyCache,
-} = await import("../risk/admission-policy-cache.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { AdmissionPolicyStore } =
+  await import("../db/admission-policy-store.js");
+const { initAdmissionPolicyCache, resetAdmissionPolicyCache } =
+  await import("../risk/admission-policy-cache.js");
 const { contacts: gwContacts, contactChannels: gwContactChannels } =
   await import("../db/schema.js");
 const { handleInbound } = await import("../handlers/handle-inbound.js");
@@ -318,5 +316,112 @@ describe("handle-inbound trust verdict stamping", () => {
     expect(verdict.trustClass).toBe("unknown");
     // Matches a real resolve: whitespace-only id normalizes to absent.
     expect(verdict.canonicalSenderId).toBeNull();
+  });
+});
+
+describe("handle-inbound sender-authentication downgrade", () => {
+  const GUARDIAN_EMAIL = "guardian@example.com";
+
+  function makeEmailEvent(): GatewayInboundEvent {
+    return makeEvent({
+      sourceChannel: "email",
+      actor: {
+        actorExternalId: GUARDIAN_EMAIL,
+        displayName: "The Guardian",
+        username: GUARDIAN_EMAIL,
+      },
+      message: {
+        conversationExternalId: "thread-1",
+        externalMessageId: "extmsg-email-1",
+        content: "please run this",
+      },
+    });
+  }
+
+  function insertGuardianEmailContact(): void {
+    insertContact({
+      id: "c-guardian",
+      displayName: "The Guardian",
+      role: "guardian",
+      principalId: "principal-1",
+    });
+    insertChannel({
+      id: "ch-guardian",
+      contactId: "c-guardian",
+      type: "email",
+      address: GUARDIAN_EMAIL,
+      externalChatId: "thread-guardian",
+      status: "active",
+    });
+  }
+
+  test("forged guardian From: with senderAuthenticated=false → verdict downgraded to stranger", async () => {
+    // The address matches the active guardian binding, so absent the auth
+    // signal this classifies `guardian`. A spoofed From: that failed
+    // SPF/DKIM/DMARC must NOT inherit that trust.
+    insertGuardianEmailContact();
+
+    await handleInbound(makeConfig(), makeEmailEvent(), {
+      ...ROUTING,
+      senderAuthenticated: false,
+    });
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("unknown");
+    // Guardian + member fields are stripped so no residual trust is rebuilt.
+    expect(verdict.guardianExternalUserId).toBeUndefined();
+    expect(verdict.guardianPrincipalId).toBeUndefined();
+    expect(verdict.contactId).toBeUndefined();
+    // A real stranger, not a resolver failure — flows through the normal
+    // admission floor + verification lane.
+    expect(verdict.resolutionFailed).toBeUndefined();
+    // Canonical sender identity is preserved for logging / verification reply.
+    expect(verdict.canonicalSenderId).toBe(GUARDIAN_EMAIL);
+  });
+
+  test("authenticated guardian From: with senderAuthenticated=true → verdict stays guardian", async () => {
+    insertGuardianEmailContact();
+
+    await handleInbound(makeConfig(), makeEmailEvent(), {
+      ...ROUTING,
+      senderAuthenticated: true,
+    });
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("guardian");
+    expect(verdict.guardianExternalUserId).toBe(GUARDIAN_EMAIL);
+  });
+
+  test("absent signal (senderAuthenticated undefined) preserves the resolved verdict", async () => {
+    // Backward-compat: an older platform that sends no signal must not have
+    // its senders downgraded (enforcement only engages on an explicit false).
+    insertGuardianEmailContact();
+
+    await handleInbound(makeConfig(), makeEmailEvent(), ROUTING);
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("guardian");
+  });
+
+  test("forged trusted_contact From: with senderAuthenticated=false → downgraded to stranger", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      type: "email",
+      address: GUARDIAN_EMAIL,
+      externalChatId: "thread-member",
+      status: "active",
+    });
+
+    await handleInbound(makeConfig(), makeEmailEvent(), {
+      ...ROUTING,
+      senderAuthenticated: false,
+    });
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.contactId).toBeUndefined();
+    expect(verdict.status).toBeUndefined();
   });
 });

--- a/gateway/src/email/normalize.test.ts
+++ b/gateway/src/email/normalize.test.ts
@@ -126,4 +126,30 @@ describe("normalizeEmailWebhook", () => {
     const result = normalizeEmailWebhook(payload);
     expect(result!.event.raw).toEqual(payload);
   });
+
+  it("passes through senderAuthenticated=false so the trust downgrade engages", () => {
+    const result = normalizeEmailWebhook(
+      makePayload({ senderAuthenticated: false }),
+    );
+    expect(result!.senderAuthenticated).toBe(false);
+  });
+
+  it("passes through senderAuthenticated=true", () => {
+    const result = normalizeEmailWebhook(
+      makePayload({ senderAuthenticated: true }),
+    );
+    expect(result!.senderAuthenticated).toBe(true);
+  });
+
+  it("omits senderAuthenticated when absent (platform could not evaluate)", () => {
+    const result = normalizeEmailWebhook(makePayload());
+    expect(result!.senderAuthenticated).toBeUndefined();
+  });
+
+  it("ignores a non-boolean senderAuthenticated value", () => {
+    const result = normalizeEmailWebhook(
+      makePayload({ senderAuthenticated: "pass" }),
+    );
+    expect(result!.senderAuthenticated).toBeUndefined();
+  });
 });

--- a/gateway/src/email/normalize.ts
+++ b/gateway/src/email/normalize.ts
@@ -31,6 +31,15 @@ export interface VellumEmailPayload {
   conversationId: string;
   /** ISO 8601 timestamp of the original email. */
   timestamp?: string;
+  /**
+   * Whether the platform authenticated the sender's `From:` address against
+   * the message's SPF/DKIM/DMARC results. `true` when authentication passed,
+   * `false` when it was evaluated and failed (spoofable sender), omitted when
+   * the platform could not evaluate (no auth-results header). The gateway
+   * downgrades an unauthenticated sender so a forged `From:` cannot inherit
+   * guardian/trusted_contact trust.
+   */
+  senderAuthenticated?: boolean;
 }
 
 export interface NormalizedEmailEvent {
@@ -39,6 +48,12 @@ export interface NormalizedEmailEvent {
   eventId: string;
   /** Original recipient address for routing. */
   recipientAddress: string;
+  /**
+   * The payload's {@link VellumEmailPayload.senderAuthenticated} signal,
+   * forwarded to the trust-verdict downgrade in `handleInbound`. Omitted when
+   * the payload carried no boolean value.
+   */
+  senderAuthenticated?: boolean;
 }
 
 /**
@@ -65,6 +80,10 @@ export function normalizeEmailWebhook(
     "";
 
   const fromName = payload.fromName as string | undefined;
+  const senderAuthenticated =
+    typeof payload.senderAuthenticated === "boolean"
+      ? payload.senderAuthenticated
+      : undefined;
 
   const event: GatewayInboundEvent = {
     version: "v1",
@@ -90,5 +109,6 @@ export function normalizeEmailWebhook(
     event,
     eventId: messageId,
     recipientAddress: to,
+    ...(senderAuthenticated !== undefined ? { senderAuthenticated } : {}),
   };
 }

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import {
   makeResolutionFailedVerdict,
+  makeUnauthenticatedSenderVerdict,
   type SourceMetadata,
   type TrustVerdict,
 } from "@vellumai/gateway-client";
@@ -51,6 +52,16 @@ export type HandleInboundOptions = {
   routingOverride?: RouteResult;
   /** Extra fields merged into sourceMetadata (e.g. commandIntent). */
   sourceMetadata?: Partial<SourceMetadata>;
+  /**
+   * Result of the ingress channel's sender-authentication check (email
+   * SPF/DKIM/DMARC). `false` means the sender's identity (e.g. the `From:`
+   * address) could not be authenticated and is spoofable — the resolved
+   * verdict is downgraded to a plain stranger so it cannot inherit
+   * guardian/trusted_contact trust from a matching address. `undefined` means
+   * the channel does not authenticate senders, or the provider carried no
+   * result, and preserves the resolved verdict.
+   */
+  senderAuthenticated?: boolean;
 };
 
 function normalizeTransportHints(hints: string[] | undefined): string[] {
@@ -179,6 +190,31 @@ export async function handleInbound(
     trustVerdict = makeResolutionFailedVerdict(
       canonicalSenderIdFor(event.sourceChannel, event.actor.actorExternalId),
     );
+  }
+
+  // ── Sender-authentication downgrade ──
+  // Trust is keyed on the actor's channel address, which some channels (email)
+  // carry from a spoofable `From:` header. When the ingress reports the sender
+  // failed channel authentication (SPF/DKIM/DMARC), never let a forged address
+  // that happens to match a guardian/contact record inherit that trust —
+  // collapse the verdict to a plain stranger so the admission floor and
+  // verification lane treat it as unknown. `undefined` means "not evaluated"
+  // (non-authenticating channel, or a payload with no result) and is a no-op.
+  if (options?.senderAuthenticated === false && trustVerdict) {
+    const priorClass = trustVerdict.trustClass;
+    trustVerdict = makeUnauthenticatedSenderVerdict(
+      trustVerdict.canonicalSenderId,
+    );
+    if (priorClass !== "unknown") {
+      log.warn(
+        {
+          sourceChannel: event.sourceChannel,
+          actorExternalId: event.actor.actorExternalId,
+          resolvedTrustClass: priorClass,
+        },
+        "Inbound sender failed channel authentication — downgrading trust to stranger",
+      );
+    }
   }
 
   try {

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -137,7 +137,8 @@ export function createEmailWebhookHandler(
       return Response.json({ ok: true });
     }
 
-    const { event, eventId, recipientAddress } = normalized;
+    const { event, eventId, recipientAddress, senderAuthenticated } =
+      normalized;
 
     // Dedup by event ID
     if (!dedupCache.reserve(eventId)) {
@@ -196,6 +197,7 @@ export function createEmailWebhookHandler(
         replyCallbackUrl: undefined, // Email replies use `assistant email send` tool (no /deliver/email)
         traceId,
         routingOverride: routing,
+        senderAuthenticated,
         sourceMetadata: {
           emailSubject: (payload.subject as string | undefined) ?? undefined,
           emailRecipient: recipientAddress,

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "bun:test";
 import { SourceMetadataSchema } from "../inbound-contract.js";
 import {
   makeResolutionFailedVerdict,
+  makeUnauthenticatedSenderVerdict,
   TrustVerdictSchema,
   type TrustVerdict,
 } from "../trust-verdict-contract.js";
@@ -71,6 +72,23 @@ describe("TrustVerdictSchema", () => {
       trustClass: "unknown",
       canonicalSenderId: null,
       resolutionFailed: true,
+    });
+  });
+
+  test("makeUnauthenticatedSenderVerdict builds a plain stranger (not resolutionFailed)", () => {
+    // Distinct from makeResolutionFailedVerdict: an unauthenticated sender is
+    // a real stranger and must flow through the normal admission/verification
+    // lane, so it carries no resolutionFailed flag and no guardian/member keys.
+    const verdict = makeUnauthenticatedSenderVerdict("+15555550100");
+    expect(verdict).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: "+15555550100",
+    });
+    expect(verdict.resolutionFailed).toBeUndefined();
+    expect(TrustVerdictSchema.parse(verdict)).toEqual(verdict);
+    expect(makeUnauthenticatedSenderVerdict(null)).toEqual({
+      trustClass: "unknown",
+      canonicalSenderId: null,
     });
   });
 

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -79,6 +79,7 @@ export type { AdmissionPolicy } from "./admission-policy-contract.js";
 export {
   isTrustClass,
   makeResolutionFailedVerdict,
+  makeUnauthenticatedSenderVerdict,
   ResolveInboundTrustRequestSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -94,6 +94,23 @@ export function makeResolutionFailedVerdict(
 }
 
 /**
+ * Downgraded verdict for an inbound sender whose channel identity could not be
+ * authenticated — e.g. an email whose `From:` failed SPF/DKIM/DMARC and so
+ * carries a spoofable address. A spoofable sender must never inherit
+ * guardian/trusted_contact trust from a matching address, so it is reduced to
+ * a plain `unknown` stranger: guardian and member/ACL fields are dropped so no
+ * residual trust is reconstructed downstream. Unlike
+ * {@link makeResolutionFailedVerdict} this is NOT `resolutionFailed` — the
+ * sender is a real stranger and should flow through the normal admission floor
+ * + verification lane, not the could-not-vouch soft-deny.
+ */
+export function makeUnauthenticatedSenderVerdict(
+  canonicalSenderId: string | null,
+): TrustVerdict {
+  return { trustClass: "unknown", canonicalSenderId };
+}
+
+/**
  * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
  * gateway resolver needs to classify the inbound sender. The response reuses
  * {@link TrustVerdictSchema}.


### PR DESCRIPTION
## Summary
- Inbound email trust is keyed on the `From:` address, which is spoofable. A forged already-verified guardian/contact address was classified `guardian`/`trusted_contact` (and guardian inbound skips the untrusted-content wrapper), so a spoofed email could reach the top trust tier — self-approve tools, unsandboxed shell, memory/privileged-doc access.
- Adds a `senderAuthenticated` signal to `VellumEmailPayload`, threaded through `normalizeEmailWebhook` → `email-webhook` → `handleInbound`. When the ingress reports the sender failed SPF/DKIM/DMARC (`false`), the resolved trust verdict is collapsed to a plain `unknown` stranger (`makeUnauthenticatedSenderVerdict`), stripping guardian/member fields so no residual trust is reconstructed downstream. The runtime consumes the gateway verdict verbatim, so this is the single enforcement chokepoint.
- Fail-safe rollout: an **absent** signal is a no-op (unchanged behavior), so this is order-independent with the companion platform PR that produces the signal. Enforcement engages only on an explicit `false`.
- Regression tests: forged guardian/`trusted_contact` email with `senderAuthenticated=false` → downgraded to `unknown`; `true`/absent preserve the resolved class; `normalizeEmailWebhook` passthrough; `makeUnauthenticatedSenderVerdict` contract.

## Companion PR
Requires **vellum-assistant-platform**: parse the Resend receiving-API `Authentication-Results` header (DMARC pass, or aligned DKIM pass) and populate `senderAuthenticated`. Until that ships (or if the provider omits the header), the signal is absent and behavior is unchanged.

## Original prompt
A security review flagged that inbound email does no SPF/DKIM/DMARC checking and classifies trust from the spoofable `From:` header, so a forged already-verified guardian/contact address is classified `guardian`/`trusted_contact` — the provider HMAC only proves the mail came from the provider, not that the sender is authentic. After confirming the finding against the code, the ask was to fix it: parse provider auth-results and fail-closed downgrade unauthenticated senders so a spoofed `From:` cannot reach the guardian/trusted_contact tiers, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)