### PR TITLE
chore: commit explicit prettier config as a version-drift guardrail

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
## Summary
- Adds a root `.prettierrc.json` that pins Prettier's options explicitly (`trailingComma: "all"`, `printWidth: 80`, `tabWidth: 2`, `semi`, double quotes, `arrowParens: "always"`, `endOfLine: "lf"`).
- **Verified zero-churn**: the config produces byte-identical output to Prettier 3.8.1's current defaults on `gateway/src` (a full `--write` diff matched exactly, 92130 bytes both ways) and is default-equivalent for `assistant/`. It reformats nothing under the pinned version.
- **Why**: `gateway/` and `assistant/` both pin `prettier@3.8.1` and ship `format` / `format:check` scripts, but no Prettier config was committed anywhere — so formatting silently depended on whichever binary got resolved. A stale bun-cached `bunx prettier` resolves to **2.2.1**, whose `trailingComma` default is `"es5"`; running it strips trailing commas across function params and type args (and 2.2.1 fails to parse some modern syntax). Pinning the options makes formatting deterministic regardless of the resolved binary — even an old Prettier honors an explicit `trailingComma: "all"`.

**Scope note (not enforcement):** the repo is not currently Prettier-clean — 61 `gateway/` files diverge from even 3.8.1 defaults, and `format:check` is not gated in CI. This PR is a version-drift guardrail only; it does not reformat the codebase and does not add CI enforcement.

## Original prompt
A prior PR's diff was mangled when an accidental `bunx prettier --write` run resolved a stale Prettier 2.2.1 and stripped trailing commas from pre-existing code. Sidd asked to fix the Prettier setup so that can't happen again. Root cause: no committed Prettier config, so output depended on the resolved version's defaults. This commits the option set explicitly as a guardrail.