### PR TITLE
refactor(gateway): extract shared credential-resolve and verify-with-refresh helpers

### DIFF
--- a/gateway/src/__tests__/credential-refresh.test.ts
+++ b/gateway/src/__tests__/credential-refresh.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import type { Logger } from "pino";
+import type { CredentialCache } from "../credential-cache.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../credential-refresh.js";
+
+const silentLog = { info: () => {} } as unknown as Logger;
+
+/**
+ * Fake CredentialCache returning the given values in call order and
+ * recording whether each read was forced.
+ */
+function fakeCache(reads: Array<string | undefined>): {
+  cache: CredentialCache;
+  calls: Array<{ force: boolean }>;
+} {
+  const calls: Array<{ force: boolean }> = [];
+  const cache = {
+    get: async (_key: string, opts?: { force?: boolean }) => {
+      calls.push({ force: opts?.force ?? false });
+      return reads[calls.length - 1];
+    },
+  } as unknown as CredentialCache;
+  return { cache, calls };
+}
+
+describe("resolveCredentialWithRefresh", () => {
+  it("returns undefined without a credential cache", async () => {
+    expect(await resolveCredentialWithRefresh(undefined, "k")).toBeUndefined();
+  });
+
+  it("returns the cached value without forcing", async () => {
+    const { cache, calls } = fakeCache(["secret"]);
+    expect(await resolveCredentialWithRefresh(cache, "k")).toBe("secret");
+    expect(calls).toEqual([{ force: false }]);
+  });
+
+  it("force-refreshes once when the cached read is empty", async () => {
+    const { cache, calls } = fakeCache([undefined, "late"]);
+    expect(await resolveCredentialWithRefresh(cache, "k")).toBe("late");
+    expect(calls).toEqual([{ force: false }, { force: true }]);
+  });
+
+  it("returns undefined when the forced read is empty too", async () => {
+    const { cache, calls } = fakeCache([undefined, undefined]);
+    expect(await resolveCredentialWithRefresh(cache, "k")).toBeUndefined();
+    expect(calls).toEqual([{ force: false }, { force: true }]);
+  });
+});
+
+describe("verifySecretWithRefresh", () => {
+  const opts = (cache: CredentialCache | undefined, valid: Set<string>) => ({
+    credentials: cache,
+    key: "k",
+    verify: (secret: string) => valid.has(secret),
+    log: silentLog,
+    label: "Test webhook secret",
+  });
+
+  it("returns false without a credential cache", async () => {
+    expect(
+      await verifySecretWithRefresh(opts(undefined, new Set(["s1"]))),
+    ).toBe(false);
+  });
+
+  it("verifies against the cached secret without forcing", async () => {
+    const { cache, calls } = fakeCache(["s1"]);
+    expect(await verifySecretWithRefresh(opts(cache, new Set(["s1"])))).toBe(
+      true,
+    );
+    expect(calls).toEqual([{ force: false }]);
+  });
+
+  it("force-refreshes and retries once when verification fails", async () => {
+    const { cache, calls } = fakeCache(["stale", "fresh"]);
+    expect(await verifySecretWithRefresh(opts(cache, new Set(["fresh"])))).toBe(
+      true,
+    );
+    expect(calls).toEqual([{ force: false }, { force: true }]);
+  });
+
+  it("force-refreshes when the cached secret is missing", async () => {
+    const { cache, calls } = fakeCache([undefined, "fresh"]);
+    expect(await verifySecretWithRefresh(opts(cache, new Set(["fresh"])))).toBe(
+      true,
+    );
+    expect(calls).toEqual([{ force: false }, { force: true }]);
+  });
+
+  it("returns false when the refreshed secret also fails", async () => {
+    const { cache } = fakeCache(["stale", "still-stale"]);
+    expect(await verifySecretWithRefresh(opts(cache, new Set(["other"])))).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the forced refresh returns nothing", async () => {
+    const { cache } = fakeCache(["stale", undefined]);
+    expect(await verifySecretWithRefresh(opts(cache, new Set(["other"])))).toBe(
+      false,
+    );
+  });
+});

--- a/gateway/src/credential-refresh.ts
+++ b/gateway/src/credential-refresh.ts
@@ -1,0 +1,59 @@
+import type { Logger } from "pino";
+import type { CredentialCache } from "./credential-cache.js";
+
+/**
+ * Resolve a credential from the cache, force-refreshing once when the
+ * cached read comes back empty — the credential may have been written
+ * after the TTL cache was last populated.
+ */
+export async function resolveCredentialWithRefresh(
+  credentials: CredentialCache | undefined,
+  key: string,
+): Promise<string | undefined> {
+  if (!credentials) {
+    return undefined;
+  }
+  const value = await credentials.get(key);
+  if (value) {
+    return value;
+  }
+  return credentials.get(key, { force: true });
+}
+
+/**
+ * Verify a webhook secret with a one-shot forced-refresh retry: verify
+ * against the cached secret first, and when that fails re-fetch the
+ * secret (bypassing the TTL cache) and retry once — the stored secret
+ * may have rotated since the cache was last populated.
+ *
+ * `label` names the check in the refresh-success log line, e.g.
+ * "Telegram webhook secret" logs "Telegram webhook secret verified
+ * after forced credential refresh".
+ */
+export async function verifySecretWithRefresh(opts: {
+  credentials: CredentialCache | undefined;
+  key: string;
+  verify: (secret: string) => boolean;
+  log: Logger;
+  label: string;
+}): Promise<boolean> {
+  const { credentials, key, verify, log, label } = opts;
+  if (!credentials) {
+    return false;
+  }
+
+  const secret = await credentials.get(key);
+  if (secret && verify(secret)) {
+    return true;
+  }
+
+  const fresh = await credentials.get(key, { force: true });
+  if (!fresh) {
+    return false;
+  }
+  const valid = verify(fresh);
+  if (valid) {
+    log.info(`${label} verified after forced credential refresh`);
+  }
+  return valid;
+}

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -3,6 +3,10 @@ import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { normalizeEmailWebhook } from "../../email/normalize.js";
 import { verifyEmailWebhookSignature } from "../../email/verify.js";
@@ -50,30 +54,13 @@ export function createEmailWebhookHandler(
     }
     const rawBody = bodyResult.text;
 
-    // Resolve webhook secret from credential cache
-    const webhookSecret = caches?.credentials
-      ? await caches.credentials.get(credentialKey("vellum", "webhook_secret"))
-      : undefined;
-
-    // If the initial cache read returned undefined but a credential cache is available,
-    // attempt one forced refresh before fail-closing — the credential may have been
-    // written after the TTL cache was last populated.
-    let effectiveSecret = webhookSecret;
-    if (!effectiveSecret && caches?.credentials) {
-      effectiveSecret = await caches.credentials.get(
-        credentialKey("vellum", "webhook_secret"),
-        { force: true },
-      );
-      if (effectiveSecret) {
-        tlog.info(
-          "Email webhook secret resolved after forced credential refresh",
-        );
-      }
-    }
-
     // Signature validation is required — reject when no secret is configured
     // rather than silently accepting unauthenticated payloads (fail-closed).
-    if (!effectiveSecret) {
+    const webhookSecret = await resolveCredentialWithRefresh(
+      caches?.credentials,
+      credentialKey("vellum", "webhook_secret"),
+    );
+    if (!webhookSecret) {
       tlog.warn("Email webhook secret is not configured — rejecting request");
       return Response.json(
         { error: "Webhook secret not configured" },
@@ -81,32 +68,14 @@ export function createEmailWebhookHandler(
       );
     }
 
-    let signatureValid = verifyEmailWebhookSignature(
-      req.headers,
-      rawBody,
-      effectiveSecret,
-    );
-
-    // One-shot force retry: if verification failed and caches are available,
-    // force-refresh the webhook secret and retry once.
-    if (!signatureValid && caches?.credentials) {
-      const freshSecret = await caches.credentials.get(
-        credentialKey("vellum", "webhook_secret"),
-        { force: true },
-      );
-      if (freshSecret) {
-        signatureValid = verifyEmailWebhookSignature(
-          req.headers,
-          rawBody,
-          freshSecret,
-        );
-        if (signatureValid) {
-          tlog.info(
-            "Email webhook signature verified after forced credential refresh",
-          );
-        }
-      }
-    }
+    const signatureValid = await verifySecretWithRefresh({
+      credentials: caches?.credentials,
+      key: credentialKey("vellum", "webhook_secret"),
+      verify: (secret) =>
+        verifyEmailWebhookSignature(req.headers, rawBody, secret),
+      log: tlog,
+      label: "Email webhook signature",
+    });
 
     if (!signatureValid) {
       tlog.warn("Email webhook signature verification failed");

--- a/gateway/src/http/routes/mailgun-webhook.ts
+++ b/gateway/src/http/routes/mailgun-webhook.ts
@@ -4,6 +4,10 @@ import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
@@ -222,18 +226,8 @@ export function createMailgunWebhookHandler(
 
     // ── Credential resolution ───────────────────────────────────────
 
-    const resolveCredential = async (
-      key: string,
-    ): Promise<string | undefined> => {
-      if (!caches?.credentials) return undefined;
-      let value = await caches.credentials.get(key);
-      if (!value) {
-        value = await caches.credentials.get(key, { force: true });
-      }
-      return value;
-    };
-
-    const signingKey = await resolveCredential(
+    const signingKey = await resolveCredentialWithRefresh(
+      caches?.credentials,
       credentialKey("mailgun", "webhook_signing_key"),
     );
 
@@ -253,33 +247,13 @@ export function createMailgunWebhookHandler(
     const token = fields["token"] ?? "";
     const signature = fields["signature"] ?? "";
 
-    let signatureValid = verifyMailgunSignature(
-      signingKey,
-      timestamp,
-      token,
-      signature,
-    );
-
-    // One-shot force retry on verification failure
-    if (!signatureValid && caches?.credentials) {
-      const freshKey = await caches.credentials.get(
-        credentialKey("mailgun", "webhook_signing_key"),
-        { force: true },
-      );
-      if (freshKey) {
-        signatureValid = verifyMailgunSignature(
-          freshKey,
-          timestamp,
-          token,
-          signature,
-        );
-        if (signatureValid) {
-          tlog.info(
-            "Mailgun webhook signature verified after forced credential refresh",
-          );
-        }
-      }
-    }
+    const signatureValid = await verifySecretWithRefresh({
+      credentials: caches?.credentials,
+      key: credentialKey("mailgun", "webhook_signing_key"),
+      verify: (key) => verifyMailgunSignature(key, timestamp, token, signature),
+      log: tlog,
+      label: "Mailgun webhook signature",
+    });
 
     if (!signatureValid) {
       tlog.warn("Mailgun webhook signature verification failed");
@@ -395,7 +369,8 @@ export function createMailgunWebhookHandler(
       // confirmations must always be delivered regardless of prior denial
       // replies to this sender.
       if (result.verificationIntercepted && result.verificationReplyText) {
-        const mailgunApiKeyForVerify = await resolveCredential(
+        const mailgunApiKeyForVerify = await resolveCredentialWithRefresh(
+          caches?.credentials,
           credentialKey("mailgun", "api_key"),
         );
         if (mailgunApiKeyForVerify) {
@@ -468,7 +443,8 @@ export function createMailgunWebhookHandler(
       // (no replyCallbackUrl for email), so the gateway handles it.
       const runtimeBody = result.runtimeResponse ?? {};
       if (result.runtimeResponse?.denied && result.runtimeResponse.replyText) {
-        const mailgunApiKey = await resolveCredential(
+        const mailgunApiKey = await resolveCredentialWithRefresh(
+          caches?.credentials,
           credentialKey("mailgun", "api_key"),
         );
         if (mailgunApiKey) {

--- a/gateway/src/http/routes/resend-webhook.ts
+++ b/gateway/src/http/routes/resend-webhook.ts
@@ -4,6 +4,10 @@ import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
@@ -264,18 +268,8 @@ export function createResendWebhookHandler(
     //   resend/webhook_secret — for Svix signature verification
     //   resend/api_key        — for fetching email content from the API
 
-    const resolveCredential = async (
-      key: string,
-    ): Promise<string | undefined> => {
-      if (!caches?.credentials) return undefined;
-      let value = await caches.credentials.get(key);
-      if (!value) {
-        value = await caches.credentials.get(key, { force: true });
-      }
-      return value;
-    };
-
-    const webhookSecret = await resolveCredential(
+    const webhookSecret = await resolveCredentialWithRefresh(
+      caches?.credentials,
       credentialKey("resend", "webhook_secret"),
     );
 
@@ -289,27 +283,13 @@ export function createResendWebhookHandler(
 
     // ── Signature verification ──────────────────────────────────────
 
-    let signatureValid = verifySvixSignature(
-      req.headers,
-      rawBody,
-      webhookSecret,
-    );
-
-    // One-shot force retry on verification failure
-    if (!signatureValid && caches?.credentials) {
-      const freshSecret = await caches.credentials.get(
-        credentialKey("resend", "webhook_secret"),
-        { force: true },
-      );
-      if (freshSecret) {
-        signatureValid = verifySvixSignature(req.headers, rawBody, freshSecret);
-        if (signatureValid) {
-          tlog.info(
-            "Resend webhook signature verified after forced credential refresh",
-          );
-        }
-      }
-    }
+    const signatureValid = await verifySecretWithRefresh({
+      credentials: caches?.credentials,
+      key: credentialKey("resend", "webhook_secret"),
+      verify: (secret) => verifySvixSignature(req.headers, rawBody, secret),
+      log: tlog,
+      label: "Resend webhook signature",
+    });
 
     if (!signatureValid) {
       tlog.warn("Resend webhook signature verification failed");
@@ -349,7 +329,10 @@ export function createResendWebhookHandler(
     // The webhook payload only has metadata — we need the API to get
     // the actual email body and headers.
 
-    const apiKey = await resolveCredential(credentialKey("resend", "api_key"));
+    const apiKey = await resolveCredentialWithRefresh(
+      caches?.credentials,
+      credentialKey("resend", "api_key"),
+    );
 
     let emailContent: Awaited<ReturnType<typeof fetchResendEmailContent>> =
       null;

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -3,6 +3,7 @@ import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import { verifySecretWithRefresh } from "../../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { DedupCache } from "../../dedup-cache.js";
 import { ContentMismatchError } from "../../download-validation.js";
@@ -74,32 +75,13 @@ export function createTelegramWebhookHandler(
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
-    // Verify webhook secret from cache
-    const webhookSecret = caches?.credentials
-      ? await caches.credentials.get(
-          credentialKey("telegram", "webhook_secret"),
-        )
-      : undefined;
-
-    let secretVerified =
-      !!webhookSecret && verifyWebhookSecret(req.headers, webhookSecret);
-
-    // One-shot force retry: if verification failed and caches are available,
-    // force-refresh the webhook secret and retry once.
-    if (!secretVerified && caches?.credentials) {
-      const freshSecret = await caches.credentials.get(
-        credentialKey("telegram", "webhook_secret"),
-        { force: true },
-      );
-      if (freshSecret) {
-        secretVerified = verifyWebhookSecret(req.headers, freshSecret);
-        if (secretVerified) {
-          tlog.info(
-            "Telegram webhook secret verified after forced credential refresh",
-          );
-        }
-      }
-    }
+    const secretVerified = await verifySecretWithRefresh({
+      credentials: caches?.credentials,
+      key: credentialKey("telegram", "webhook_secret"),
+      verify: (secret) => verifyWebhookSecret(req.headers, secret),
+      log: tlog,
+      label: "Telegram webhook secret",
+    });
 
     if (!secretVerified) {
       tlog.warn("Telegram webhook request failed secret verification");

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -4,6 +4,10 @@ import type { GatewayConfig } from "../../config.js";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
@@ -103,30 +107,13 @@ export function createWhatsAppWebhookHandler(
     }
     const rawBody = bodyResult.text;
 
-    // Resolve app secret from cache
-    const appSecret = caches?.credentials
-      ? await caches.credentials.get(credentialKey("whatsapp", "app_secret"))
-      : undefined;
-
-    // If the initial cache read returned undefined but a credential cache is available,
-    // attempt one forced refresh before fail-closing — the credential may have been
-    // written after the TTL cache was last populated.
-    let effectiveAppSecret = appSecret;
-    if (!effectiveAppSecret && caches?.credentials) {
-      effectiveAppSecret = await caches.credentials.get(
-        credentialKey("whatsapp", "app_secret"),
-        { force: true },
-      );
-      if (effectiveAppSecret) {
-        tlog.info(
-          "WhatsApp app secret resolved after forced credential refresh",
-        );
-      }
-    }
-
     // Signature validation is required — reject requests when the app secret is not configured
     // rather than silently accepting unauthenticated payloads (fail-closed).
-    if (!effectiveAppSecret) {
+    const appSecret = await resolveCredentialWithRefresh(
+      caches?.credentials,
+      credentialKey("whatsapp", "app_secret"),
+    );
+    if (!appSecret) {
       tlog.warn("WhatsApp app secret is not configured — rejecting request");
       return Response.json(
         { error: "Webhook signature validation not configured" },
@@ -134,32 +121,14 @@ export function createWhatsAppWebhookHandler(
       );
     }
 
-    let signatureValid = verifyWhatsAppWebhookSignature(
-      req.headers,
-      rawBody,
-      effectiveAppSecret,
-    );
-
-    // One-shot force retry: if verification failed and caches are available,
-    // force-refresh the app secret and retry once.
-    if (!signatureValid && caches?.credentials) {
-      const freshAppSecret = await caches.credentials.get(
-        credentialKey("whatsapp", "app_secret"),
-        { force: true },
-      );
-      if (freshAppSecret) {
-        signatureValid = verifyWhatsAppWebhookSignature(
-          req.headers,
-          rawBody,
-          freshAppSecret,
-        );
-        if (signatureValid) {
-          tlog.info(
-            "WhatsApp webhook signature verified after forced credential refresh",
-          );
-        }
-      }
-    }
+    const signatureValid = await verifySecretWithRefresh({
+      credentials: caches?.credentials,
+      key: credentialKey("whatsapp", "app_secret"),
+      verify: (secret) =>
+        verifyWhatsAppWebhookSignature(req.headers, rawBody, secret),
+      log: tlog,
+      label: "WhatsApp webhook signature",
+    });
 
     if (!signatureValid) {
       tlog.warn("WhatsApp webhook signature verification failed");


### PR DESCRIPTION
## Summary
- Extracts two patterns duplicated near-verbatim across all five webhook handlers (telegram/whatsapp/mailgun/resend/email) into `gateway/src/credential-refresh.ts`: `resolveCredentialWithRefresh()` (cache read, force-refresh once when empty — the credential may have been written after the TTL cache was populated) and `verifySecretWithRefresh()` (verify against the cached secret, one-shot forced-refresh retry on failure — the secret may have rotated). mailgun/resend additionally shared a verbatim local `resolveCredential` closure, now deleted.
- Behavior-preserving: same responses, same fail-closed ordering, same "<label> verified after forced credential refresh" log lines. Two info-only log lines ("app secret/webhook secret resolved after forced credential refresh" in whatsapp/email) are dropped — the resolve helper is silent; the verify-success refresh log remains. whatsapp/email make one extra warm in-memory cache read between resolve and verify (2s-TTL map hit, negligible).
- Adds unit tests covering both helpers (cached hit, forced retry, fail-closed with no cache/no secret).

## Original prompt
A code review flagged that the channel webhook handlers each re-implement ingress concerns — size guard, signature-verify + credential-refresh-retry, dedup, routing, denial-reply. The size-guard piece landed in #36910/#36911; this PR is the credential-refresh piece. Remaining: consolidating the near-duplicate mailgun/resend email pipelines (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)