### PR TITLE
fix(daemon): fold the WAL from a detached subprocess on force-exit

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -7,8 +7,11 @@ import { stopCliIpcServer } from "../ipc/assistant-server.js";
 import { stopGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
 import { stopMonitoring } from "../monitoring/control.js";
-import { runAsyncSqlite } from "../persistence/db-async-query.js";
-import { getSqlite, resetDb } from "../persistence/db-connection.js";
+import {
+  runAsyncSqlite,
+  spawnDetachedWalCheckpoint,
+} from "../persistence/db-async-query.js";
+import { getSqlite, isDbOpen, resetDb } from "../persistence/db-connection.js";
 import { stopQdrantManager } from "../persistence/embeddings/qdrant-manager.js";
 import { stopMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { stopMemoryWorkerProcess } from "../persistence/worker-control.js";
@@ -75,6 +78,16 @@ async function shutdown(): Promise<void> {
   // bump only changes behavior for the stuck-shutdown path.
   const forceTimer = setTimeout(() => {
     log.warn("Graceful shutdown timed out, forcing exit");
+    // A stuck shutdown may never reach the graceful WAL checkpoint below —
+    // fold the WAL from a detached subprocess that survives this exit, so
+    // the next boot opens a small WAL instead of paying a multi-minute
+    // recovery. Skipped when the DB was never opened: there is nothing to
+    // fold, and sqlite3 would create an empty DB file.
+    if (isDbOpen() && !spawnDetachedWalCheckpoint()) {
+      log.warn(
+        "No sqlite3 CLI on host — WAL left at high-water mark on force-exit",
+      );
+    }
     stopBackgroundServicesAndCleanupPidFile();
     process.exit(1);
   }, 20_000);

--- a/assistant/src/persistence/db-async-query.ts
+++ b/assistant/src/persistence/db-async-query.ts
@@ -26,6 +26,7 @@
  * ms) should keep using the in-process drizzle / `bun:sqlite` handle
  * directly — the subprocess overhead would dominate.
  */
+import { spawn } from "node:child_process";
 import { Database } from "bun:sqlite";
 
 import { getLogger } from "../util/logger.js";
@@ -325,5 +326,46 @@ async function runInProcessBlocking(
     };
   } finally {
     transient?.close();
+  }
+}
+
+/**
+ * Fire-and-forget `PRAGMA wal_checkpoint(TRUNCATE)` against the main
+ * assistant DB in a detached `sqlite3` subprocess.
+ *
+ * For exit paths that cannot wait for a fold to finish (the force-exit
+ * timeout in `shutdown-handlers.ts`): the child runs in its own process
+ * group with no inherited stdio, so it survives the daemon's `process.exit`
+ * — and any group-directed follow-up signal from a supervisor — and
+ * finishes the fold in the background. A concurrent checkpointer just makes
+ * this one give up after its busy timeout; the fold is best-effort either
+ * way, with the pre-open checkpoint in `db-init.ts` as the backstop.
+ *
+ * Returns false when no `sqlite3` binary is on the host or the spawn fails —
+ * there is no in-process fallback because the caller is exiting.
+ */
+export function spawnDetachedWalCheckpoint(): boolean {
+  const sqlite3Path = findSqlite3();
+  if (!sqlite3Path) {
+    return false;
+  }
+  try {
+    const child = spawn(
+      sqlite3Path,
+      [
+        getDbPath(),
+        `PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}; PRAGMA wal_checkpoint(TRUNCATE);`,
+      ],
+      { detached: true, stdio: "ignore" },
+    );
+    // A post-spawn failure can't be acted on — the daemon is exiting — but an
+    // unlistened ChildProcess "error" event would throw as an uncaught
+    // exception.
+    child.on("error", () => {});
+    child.unref();
+    log.info({ pid: child.pid }, "Spawned detached WAL checkpoint subprocess");
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -121,6 +121,16 @@ export function getDb(): DrizzleDb {
 }
 
 /**
+ * Whether the main assistant DB connection is currently open. Lets exit paths
+ * decide between DB teardown work and skipping it entirely — `getDb()` /
+ * `getSqlite()` lazily open the connection, so probing with those would
+ * create the very state being checked for.
+ */
+export function isDbOpen(): boolean {
+  return getStoredDb<DrizzleDb>("main") !== null;
+}
+
+/**
  * Get the underlying bun:sqlite Database from the global Drizzle instance.
  *
  * Use this instead of the raw cast `(db as unknown as { $client: Database }).$client`.

--- a/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
@@ -16,13 +16,15 @@
  *   4. Errors from sqlite3 surface as `ok: false` with the stderr
  *      preserved in `error`.
  */
+import { statSync } from "node:fs";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 const { getSqlite } = await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
-const { runAsyncSqlite, _resetFallbackWarning } =
+const { runAsyncSqlite, _resetFallbackWarning, spawnDetachedWalCheckpoint } =
   await import("../../../../persistence/db-async-query.js");
 const { findSqlite3 } = await import("../../../../util/sqlite3-runtime.js");
+const { getDbPath } = await import("../../../../util/platform.js");
 
 await initializeDb();
 
@@ -168,5 +170,38 @@ describe("runAsyncSqlite", () => {
       expect(tickCount).toBeGreaterThanOrEqual(1);
     },
     60_000,
+  );
+});
+
+describe("spawnDetachedWalCheckpoint", () => {
+  test.if(sqlite3Available)(
+    "folds and truncates the WAL from a detached subprocess",
+    async () => {
+      const sqlite = getSqlite();
+      const walPath = `${getDbPath()}-wal`;
+
+      // Grow the WAL past zero without checkpointing.
+      sqlite.exec("CREATE TABLE IF NOT EXISTS detached_ckpt_probe (x TEXT)");
+      sqlite.exec("INSERT INTO detached_ckpt_probe VALUES ('row')");
+      expect(statSync(walPath).size).toBeGreaterThan(0);
+
+      expect(spawnDetachedWalCheckpoint()).toBe(true);
+
+      // The child is detached with no inherited stdio, so the only
+      // observable effect is the WAL file itself — poll for the truncate.
+      const deadline = Date.now() + 10_000;
+      let walSize = -1;
+      while (Date.now() < deadline) {
+        walSize = statSync(walPath).size;
+        if (walSize === 0) {
+          break;
+        }
+        await Bun.sleep(50);
+      }
+      expect(walSize).toBe(0);
+
+      sqlite.exec("DROP TABLE detached_ckpt_probe");
+    },
+    30_000,
   );
 });


### PR DESCRIPTION
## Summary
- The 20s force-exit path in `shutdown-handlers.ts` exits without the WAL checkpoint **and** without `resetDb()`, so a wedged shutdown (Meet teardown alone has a 15s budget; MCP/Qdrant/browser/enrichment drains all run before the checkpoint step) leaves the WAL at its high-water mark for the next boot to fold. It attempts a fire-and-forget `PRAGMA wal_checkpoint(TRUNCATE)` via a new `spawnDetachedWalCheckpoint()` in `db-async-query.ts` before exiting.
- The child runs detached (own process group, `stdio: ignore`, unref'd) so it survives the daemon's `process.exit` and any group-directed follow-up signal from a supervisor, and finishes the fold in the background. Contention with an in-flight graceful checkpoint is benign — the loser gives up after its busy timeout, and the pre-open checkpoint in `db-init.ts` remains the backstop.
- Adds `isDbOpen()` to `db-connection.ts` to guard the spawn: `getDb()`/`getSqlite()` open the connection lazily, so probing with them would create the state being checked. Covered by a new test that grows the WAL, spawns the detached fold, and polls the `-wal` file down to zero bytes.

## Original prompt
Investigation in this session verified three daemon shutdown/startup WAL-checkpoint reliability gaps that cause boots to start with a huge WAL to fold: the graceful checkpoint ran synchronously on the main thread (fixed in #36909), the 20s force-exit path skips the checkpoint entirely, and signal handlers install second-to-last in startup. The user asked to fix them across multiple PRs. This is PR 2 of 3: give the force-exit path a checkpoint attempt that survives the exit.