### PR TITLE
refactor(gateway): consolidate mailgun/resend webhooks onto a shared email inbound pipeline

### DIFF
--- a/gateway/src/__tests__/email-inbound-pipeline.test.ts
+++ b/gateway/src/__tests__/email-inbound-pipeline.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Logger } from "pino";
+import type { GatewayConfig } from "../config.js";
+import { StringDedupCache } from "../dedup-cache.js";
+import type { VellumEmailPayload } from "../email/normalize.js";
+
+const handleInboundMock = mock(() =>
+  Promise.resolve({ forwarded: true, rejected: false } as Record<
+    string,
+    unknown
+  >),
+);
+const recordDenialReplyIfAllowedMock = mock(() => true);
+const resolveAssistantMock = mock(
+  () => ({ assistantId: "assistant-1" }) as Record<string, unknown>,
+);
+
+mock.module("../handlers/handle-inbound.js", () => ({
+  handleInbound: handleInboundMock,
+}));
+mock.module("../db/denial-reply-rate-limiter.js", () => ({
+  recordDenialReplyIfAllowed: recordDenialReplyIfAllowedMock,
+}));
+mock.module("../routing/resolve-assistant.js", () => ({
+  resolveAssistant: resolveAssistantMock,
+  isRejection: (routing: Record<string, unknown>) => "reason" in routing,
+}));
+
+const { runEmailInboundPipeline } =
+  await import("../email/inbound-pipeline.js");
+
+const silentLog = {
+  info: () => {},
+  warn: () => {},
+  debug: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+const config = {} as GatewayConfig;
+
+const payload: VellumEmailPayload = {
+  from: "alice@example.com",
+  fromName: "Alice",
+  to: "assistant@example.org",
+  subject: "Hello",
+  bodyText: "Hi there",
+  messageId: "<msg-1@example.com>",
+  conversationId: "<msg-1@example.com>",
+};
+
+function pipelineOpts(
+  overrides?: Partial<Parameters<typeof runEmailInboundPipeline>[0]>,
+) {
+  return {
+    config,
+    log: silentLog,
+    label: "Mailgun",
+    source: "mailgun",
+    dedupCache: new StringDedupCache(60_000),
+    dedupKey: "key-1",
+    vellumPayload: payload,
+    traceId: undefined,
+    sendReply: undefined,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  handleInboundMock.mockClear();
+  handleInboundMock.mockImplementation(() =>
+    Promise.resolve({ forwarded: true, rejected: false }),
+  );
+  recordDenialReplyIfAllowedMock.mockClear();
+  recordDenialReplyIfAllowedMock.mockImplementation(() => true);
+  resolveAssistantMock.mockClear();
+  resolveAssistantMock.mockImplementation(() => ({
+    assistantId: "assistant-1",
+  }));
+});
+
+describe("runEmailInboundPipeline", () => {
+  it("forwards to the runtime and marks the dedup key", async () => {
+    const dedupCache = new StringDedupCache(60_000);
+    dedupCache.reserve("key-1");
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({ dedupCache }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    // A marked key stays deduped: a second reserve is refused
+    expect(dedupCache.reserve("key-1")).toBe(false);
+  });
+
+  it("acknowledges without forwarding when routing rejects", async () => {
+    resolveAssistantMock.mockImplementation(() => ({ reason: "no-route" }));
+    const response = await runEmailInboundPipeline(pipelineOpts());
+    expect(response.status).toBe(200);
+    expect(handleInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a verification reply and short-circuits", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: false,
+        rejected: false,
+        verificationIntercepted: true,
+        verificationReplyText: "You are verified",
+      }),
+    );
+    const sent: Array<Record<string, unknown>> = [];
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({
+        sendReply: async (args) => {
+          sent.push(args);
+        },
+      }),
+    );
+    expect(await response.json()).toEqual({
+      ok: true,
+      verificationIntercepted: true,
+    });
+    expect(sent).toEqual([
+      {
+        kind: "verification",
+        from: "assistant@example.org",
+        to: "alice@example.com",
+        subject: "Re: Hello",
+        text: "You are verified",
+        inReplyTo: "<msg-1@example.com>",
+      },
+    ]);
+    // Verification replies are never gated by the denial rate limiter
+    expect(recordDenialReplyIfAllowedMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a rate-limited denial reply when the runtime denies", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: { denied: true, replyText: "Not allowed" },
+      }),
+    );
+    const sent: Array<Record<string, unknown>> = [];
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({
+        sendReply: async (args) => {
+          sent.push(args);
+        },
+      }),
+    );
+    expect(await response.json()).toEqual({
+      ok: true,
+      denied: true,
+      replyText: "Not allowed",
+    });
+    expect(recordDenialReplyIfAllowedMock).toHaveBeenCalledWith(
+      "email",
+      "alice@example.com",
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0].kind).toBe("denial");
+  });
+
+  it("skips the denial reply when the rate limiter refuses", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: { denied: true, replyText: "Not allowed" },
+      }),
+    );
+    recordDenialReplyIfAllowedMock.mockImplementation(() => false);
+    const sent: Array<Record<string, unknown>> = [];
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({
+        sendReply: async (args) => {
+          sent.push(args);
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("skips replies entirely without a sendReply sender", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: { denied: true, replyText: "Not allowed" },
+      }),
+    );
+    const response = await runEmailInboundPipeline(pipelineOpts());
+    expect(response.status).toBe(200);
+    expect(recordDenialReplyIfAllowedMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 and unreserves the dedup key on forwarding failure", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: false, rejected: false }),
+    );
+    const dedupCache = new StringDedupCache(60_000);
+    dedupCache.reserve("key-1");
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({ dedupCache }),
+    );
+    expect(response.status).toBe(500);
+    // Unreserved: the key can be reserved again for the retry delivery
+    expect(dedupCache.reserve("key-1")).toBe(true);
+  });
+});

--- a/gateway/src/email/inbound-pipeline.ts
+++ b/gateway/src/email/inbound-pipeline.ts
@@ -1,0 +1,232 @@
+import type { Logger } from "pino";
+import { buildEmailTransportMetadata } from "../channels/transport-hints.js";
+import type { GatewayConfig } from "../config.js";
+import { recordDenialReplyIfAllowed } from "../db/denial-reply-rate-limiter.js";
+import type { StringDedupCache } from "../dedup-cache.js";
+import { handleInbound } from "../handlers/handle-inbound.js";
+import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  handleCircuitBreakerError,
+  processInboundResult,
+} from "../webhook-pipeline.js";
+import type { VellumEmailPayload } from "./normalize.js";
+import { normalizeEmailWebhook } from "./normalize.js";
+
+/**
+ * Sends a reply email through the provider's API. `kind` selects the log
+ * wording ("verification" vs "denial"); `from` is the provider address the
+ * inbound email was delivered to, `to` the original sender. Senders log
+ * their own outcome — the pipeline proceeds regardless of send success.
+ */
+export type EmailReplySender = (args: {
+  kind: "verification" | "denial";
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+  inReplyTo?: string;
+}) => Promise<void>;
+
+export interface EmailInboundPipelineOptions {
+  config: GatewayConfig;
+  log: Logger;
+  /** Capitalized provider name used in log lines, e.g. "Mailgun". */
+  label: string;
+  /** `source` field for the received log line, e.g. "mailgun". */
+  source: string;
+  dedupCache: StringDedupCache;
+  /** Already-reserved dedup key; an empty string skips mark bookkeeping. */
+  dedupKey: string;
+  vellumPayload: VellumEmailPayload;
+  traceId: string | undefined;
+  /** Undefined when the provider has no send credentials — replies are skipped. */
+  sendReply: EmailReplySender | undefined;
+  /** Extra fields for the received/forwarded log lines (e.g. Resend emailId). */
+  logFields?: Record<string, unknown>;
+}
+
+/**
+ * Shared tail of the provider email webhooks (Mailgun, Resend): canonical
+ * email normalization, routing resolution, forwarding to the runtime, and
+ * verification/denial replies through the provider-specific `sendReply`.
+ * Callers have already verified the webhook signature and reserved
+ * `dedupKey` in `dedupCache`.
+ */
+export async function runEmailInboundPipeline(
+  opts: EmailInboundPipelineOptions,
+): Promise<Response> {
+  const {
+    config,
+    log,
+    label,
+    source,
+    dedupCache,
+    dedupKey,
+    vellumPayload,
+    traceId,
+    sendReply,
+    logFields,
+  } = opts;
+
+  const mark = () => {
+    if (dedupKey) {
+      dedupCache.mark(dedupKey);
+    }
+  };
+
+  const normalized = normalizeEmailWebhook(
+    vellumPayload as unknown as Record<string, unknown>,
+  );
+  if (!normalized) {
+    log.debug(
+      `normalizeEmailWebhook returned null for ${label} event, acknowledging`,
+    );
+    mark();
+    return Response.json({ ok: true });
+  }
+
+  const { event: gatewayEvent, eventId, recipientAddress } = normalized;
+  const senderAddress = gatewayEvent.actor.actorExternalId;
+
+  log.info(
+    {
+      source,
+      eventId,
+      ...logFields,
+      from: senderAddress,
+      to: recipientAddress,
+    },
+    `${label} webhook received`,
+  );
+
+  const routing = resolveAssistant(
+    config,
+    gatewayEvent.message.conversationExternalId,
+    senderAddress,
+  );
+
+  if (isRejection(routing)) {
+    log.warn(
+      {
+        from: senderAddress,
+        to: recipientAddress,
+        reason: routing.reason,
+      },
+      `Routing rejected inbound ${label} email`,
+    );
+    mark();
+    return Response.json({ ok: true });
+  }
+
+  const replySubject = `Re: ${vellumPayload.subject ?? "(no subject)"}`;
+
+  try {
+    const result = await handleInbound(config, gatewayEvent, {
+      transportMetadata: buildEmailTransportMetadata({
+        senderAddress,
+        recipientAddress,
+        subject: vellumPayload.subject,
+        inReplyTo: vellumPayload.inReplyTo,
+      }),
+      replyCallbackUrl: undefined,
+      traceId,
+      routingOverride: routing,
+      sourceMetadata: {
+        emailSubject: vellumPayload.subject ?? undefined,
+        emailRecipient: recipientAddress,
+        ...(vellumPayload.inReplyTo
+          ? { emailInReplyTo: vellumPayload.inReplyTo }
+          : {}),
+        ...(vellumPayload.references
+          ? { emailReferences: vellumPayload.references }
+          : {}),
+      },
+    });
+
+    // Verification success confirmations are always delivered — never
+    // gated by the denial-reply rate limiter.
+    if (result.verificationIntercepted && result.verificationReplyText) {
+      if (sendReply) {
+        await sendReply({
+          kind: "verification",
+          from: recipientAddress,
+          to: senderAddress,
+          subject: replySubject,
+          text: result.verificationReplyText,
+          inReplyTo: vellumPayload.messageId,
+        });
+      }
+      mark();
+      return Response.json({ ok: true, verificationIntercepted: true });
+    }
+
+    const processed = processInboundResult(
+      result,
+      dedupCache,
+      dedupKey,
+      () => {
+        log.warn(
+          { from: senderAddress, to: recipientAddress },
+          `${label} email routing rejected after forwarding attempt`,
+        );
+      },
+      log,
+    );
+
+    if (!processed.ok) {
+      return Response.json({ error: "Internal error" }, { status: 500 });
+    }
+
+    mark();
+
+    if (!result.rejected) {
+      log.info(
+        { status: "forwarded", eventId, ...logFields },
+        `${label} email message forwarded to runtime`,
+      );
+    }
+
+    // When the runtime denies the message (ACL rejection) and provides
+    // replyText, send a reply email so the unknown sender knows why their
+    // message was rejected. The runtime can't send email directly (no
+    // replyCallbackUrl for email), so the gateway handles it.
+    const runtimeBody = result.runtimeResponse ?? {};
+    if (
+      result.runtimeResponse?.denied &&
+      result.runtimeResponse.replyText &&
+      sendReply
+    ) {
+      if (recordDenialReplyIfAllowed("email", senderAddress)) {
+        await sendReply({
+          kind: "denial",
+          from: recipientAddress,
+          to: senderAddress,
+          subject: replySubject,
+          text: result.runtimeResponse.replyText,
+          inReplyTo: vellumPayload.messageId,
+        });
+      } else {
+        log.info(
+          { from: recipientAddress, to: senderAddress },
+          `Denial reply rate-limited, skipping ${label} send`,
+        );
+      }
+    }
+
+    return Response.json({ ok: true, ...runtimeBody });
+  } catch (err) {
+    const cbResponse = handleCircuitBreakerError(
+      err,
+      dedupCache,
+      dedupKey,
+      log,
+    );
+    if (cbResponse) {
+      return cbResponse;
+    }
+
+    log.error({ err, eventId }, `Failed to process inbound ${label} email`);
+    dedupCache.unreserve(dedupKey);
+    return Response.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/gateway/src/email/normalize.ts
+++ b/gateway/src/email/normalize.ts
@@ -57,6 +57,22 @@ export interface NormalizedEmailEvent {
 }
 
 /**
+ * Parse an RFC 5322 address like `"Alice <alice@example.com>"` into its
+ * components. Returns the raw email address and optional display name.
+ */
+export function parseEmailAddress(raw: string): {
+  address: string;
+  displayName?: string;
+} {
+  const match = raw.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    const name = match[1].trim().replace(/^["']|["']$/g, "");
+    return { address: match[2].trim(), displayName: name || undefined };
+  }
+  return { address: raw.trim() };
+}
+
+/**
  * Normalize a Vellum email webhook payload into a GatewayInboundEvent.
  *
  * Returns null if required fields are missing.

--- a/gateway/src/http/routes/mailgun-webhook.ts
+++ b/gateway/src/http/routes/mailgun-webhook.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { buildEmailTransportMetadata } from "../../channels/transport-hints.js";
+import type { Logger } from "pino";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -8,21 +8,13 @@ import {
   resolveCredentialWithRefresh,
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
-import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { StringDedupCache } from "../../dedup-cache.js";
+import type { EmailReplySender } from "../../email/inbound-pipeline.js";
+import { runEmailInboundPipeline } from "../../email/inbound-pipeline.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
-import { normalizeEmailWebhook } from "../../email/normalize.js";
-import { handleInbound } from "../../handlers/handle-inbound.js";
+import { parseEmailAddress } from "../../email/normalize.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBodyBytes } from "../read-limited-body.js";
-import {
-  resolveAssistant,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
-import {
-  handleCircuitBreakerError,
-  processInboundResult,
-} from "../../webhook-pipeline.js";
 
 const log = getLogger("mailgun-webhook");
 
@@ -70,22 +62,6 @@ function verifyMailgunSignature(
 }
 
 // ── Mailgun inbound payload parsing ─────────────────────────────────
-
-/**
- * Parse an RFC 5322 address like `"Alice <alice@example.com>"` into its
- * components. Returns the raw email address and optional display name.
- */
-function parseEmailAddress(raw: string): {
-  address: string;
-  displayName?: string;
-} {
-  const match = raw.match(/^(.+?)\s*<([^>]+)>$/);
-  if (match) {
-    const name = match[1].trim().replace(/^["']|["']$/g, "");
-    return { address: match[2].trim(), displayName: name || undefined };
-  }
-  return { address: raw.trim() };
-}
 
 /**
  * Parse form-encoded or JSON body into a flat field map. Takes already-read
@@ -179,6 +155,55 @@ function normalizeMailgunToVellumPayload(
     references,
     conversationId,
     timestamp: fields["timestamp"],
+  };
+}
+
+// ── Reply delivery ──────────────────────────────────────────────────
+
+/**
+ * Reply sender using the Mailgun Messages API. The sending domain is
+ * derived from the inbound recipient address (`from` side of the reply).
+ */
+function buildMailgunReplySender(
+  apiKey: string,
+  log: Logger,
+): EmailReplySender {
+  return async ({ kind, from, to, subject, text, inReplyTo }) => {
+    const domain = from.split("@")[1];
+    if (!domain) {
+      return;
+    }
+    try {
+      const form = new URLSearchParams();
+      form.set("from", from);
+      form.set("to", to);
+      form.set("subject", subject);
+      form.set("text", text);
+      if (inReplyTo) {
+        form.set("h:In-Reply-To", inReplyTo);
+      }
+
+      const sendResponse = await fetch(
+        `https://api.mailgun.net/v3/${domain}/messages`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Basic ${Buffer.from(`api:${apiKey}`).toString("base64")}`,
+          },
+          body: form,
+        },
+      );
+      if (sendResponse.ok) {
+        log.info({ from, to }, `Sent ${kind} reply via Mailgun`);
+      } else {
+        log.warn(
+          { status: sendResponse.status, from, to },
+          `Failed to send ${kind} reply via Mailgun`,
+        );
+      }
+    } catch (err) {
+      log.error({ err, from, to }, `Error sending ${kind} reply via Mailgun`);
+    }
   };
 }
 
@@ -278,250 +303,27 @@ export function createMailgunWebhookHandler(
       return Response.json({ ok: true });
     }
 
-    const normalized = normalizeEmailWebhook(
-      vellumPayload as unknown as Record<string, unknown>,
+    // ── Forward through the shared email pipeline ───────────────────
+
+    const apiKey = await resolveCredentialWithRefresh(
+      caches?.credentials,
+      credentialKey("mailgun", "api_key"),
     );
-    if (!normalized) {
-      tlog.debug(
-        "normalizeEmailWebhook returned null for Mailgun event, acknowledging",
-      );
-      if (token) dedupCache.mark(token);
-      return Response.json({ ok: true });
+    if (!apiKey) {
+      tlog.debug("Mailgun API key not configured — replies disabled");
     }
 
-    const { event: gatewayEvent, eventId, recipientAddress } = normalized;
-
-    tlog.info(
-      {
-        source: "mailgun",
-        eventId,
-        from: gatewayEvent.actor.actorExternalId,
-        to: recipientAddress,
-      },
-      "Mailgun webhook received",
-    );
-
-    // ── Routing ─────────────────────────────────────────────────────
-
-    const routing = resolveAssistant(
+    return runEmailInboundPipeline({
       config,
-      gatewayEvent.message.conversationExternalId,
-      gatewayEvent.actor.actorExternalId,
-    );
-
-    if (isRejection(routing)) {
-      tlog.warn(
-        {
-          from: gatewayEvent.actor.actorExternalId,
-          to: recipientAddress,
-          reason: routing.reason,
-        },
-        "Routing rejected inbound Mailgun email",
-      );
-      if (token) dedupCache.mark(token);
-      return Response.json({ ok: true });
-    }
-
-    // ── Forward to runtime ──────────────────────────────────────────
-
-    try {
-      const result = await handleInbound(config, gatewayEvent, {
-        transportMetadata: buildEmailTransportMetadata({
-          senderAddress: gatewayEvent.actor.actorExternalId,
-          recipientAddress,
-          subject: vellumPayload.subject,
-          inReplyTo: vellumPayload.inReplyTo,
-        }),
-        replyCallbackUrl: undefined,
-        traceId,
-        routingOverride: routing,
-        sourceMetadata: {
-          emailSubject: vellumPayload.subject ?? undefined,
-          emailRecipient: recipientAddress,
-          ...(vellumPayload.inReplyTo
-            ? { emailInReplyTo: vellumPayload.inReplyTo }
-            : {}),
-          ...(vellumPayload.references
-            ? { emailReferences: vellumPayload.references }
-            : {}),
-        },
-      });
-
-      const processed = processInboundResult(
-        result,
-        dedupCache,
-        token,
-        () => {
-          tlog.warn(
-            { from: gatewayEvent.actor.actorExternalId, to: recipientAddress },
-            "Mailgun email routing rejected after forwarding attempt",
-          );
-        },
-        tlog,
-      );
-
-      if (!processed.ok) {
-        return Response.json({ error: "Internal error" }, { status: 500 });
-      }
-
-      // ── Verification reply ──────────────────────────────────────
-      // Not gated by recordDenialReplyIfAllowed — verification success
-      // confirmations must always be delivered regardless of prior denial
-      // replies to this sender.
-      if (result.verificationIntercepted && result.verificationReplyText) {
-        const mailgunApiKeyForVerify = await resolveCredentialWithRefresh(
-          caches?.credentials,
-          credentialKey("mailgun", "api_key"),
-        );
-        if (mailgunApiKeyForVerify) {
-          const senderAddress = gatewayEvent.actor.actorExternalId;
-          const mailgunDomainForVerify = recipientAddress.split("@")[1];
-          if (mailgunDomainForVerify) {
-            try {
-              const form = new URLSearchParams();
-              form.set("from", recipientAddress);
-              form.set("to", senderAddress);
-              form.set(
-                "subject",
-                `Re: ${vellumPayload.subject ?? "(no subject)"}`,
-              );
-              form.set("text", result.verificationReplyText);
-              if (vellumPayload.messageId) {
-                form.set("h:In-Reply-To", vellumPayload.messageId);
-              }
-
-              const sendResponse = await fetch(
-                `https://api.mailgun.net/v3/${mailgunDomainForVerify}/messages`,
-                {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Basic ${Buffer.from(`api:${mailgunApiKeyForVerify}`).toString("base64")}`,
-                  },
-                  body: form,
-                },
-              );
-              if (sendResponse.ok) {
-                tlog.info(
-                  { from: recipientAddress, to: senderAddress },
-                  "Sent verification reply via Mailgun",
-                );
-              } else {
-                tlog.warn(
-                  {
-                    status: sendResponse.status,
-                    from: recipientAddress,
-                    to: senderAddress,
-                  },
-                  "Failed to send verification reply via Mailgun",
-                );
-              }
-            } catch (err) {
-              tlog.error(
-                { err, from: recipientAddress, to: senderAddress },
-                "Error sending verification reply via Mailgun",
-              );
-            }
-          }
-        }
-        dedupCache.mark(token);
-        return Response.json({ ok: true, verificationIntercepted: true });
-      }
-
-      dedupCache.mark(token);
-
-      if (!result.rejected) {
-        tlog.info(
-          { status: "forwarded", eventId },
-          "Mailgun email message forwarded to runtime",
-        );
-      }
-
-      // ── Denial reply ────────────────────────────────────────────
-      // When the runtime denies the message (ACL rejection) and provides
-      // replyText, send a reply email so the unknown sender knows why
-      // their message was rejected. The runtime can't send email directly
-      // (no replyCallbackUrl for email), so the gateway handles it.
-      const runtimeBody = result.runtimeResponse ?? {};
-      if (result.runtimeResponse?.denied && result.runtimeResponse.replyText) {
-        const mailgunApiKey = await resolveCredentialWithRefresh(
-          caches?.credentials,
-          credentialKey("mailgun", "api_key"),
-        );
-        if (mailgunApiKey) {
-          const senderAddress = gatewayEvent.actor.actorExternalId;
-          const mailgunDomain = recipientAddress.split("@")[1];
-          if (mailgunDomain) {
-            if (recordDenialReplyIfAllowed("email", senderAddress)) {
-              try {
-                const form = new URLSearchParams();
-                form.set("from", recipientAddress);
-                form.set("to", senderAddress);
-                form.set(
-                  "subject",
-                  `Re: ${vellumPayload.subject ?? "(no subject)"}`,
-                );
-                form.set("text", result.runtimeResponse.replyText);
-                if (vellumPayload.messageId) {
-                  form.set("h:In-Reply-To", vellumPayload.messageId);
-                }
-
-                const sendResponse = await fetch(
-                  `https://api.mailgun.net/v3/${mailgunDomain}/messages`,
-                  {
-                    method: "POST",
-                    headers: {
-                      Authorization: `Basic ${Buffer.from(`api:${mailgunApiKey}`).toString("base64")}`,
-                    },
-                    body: form,
-                  },
-                );
-                if (sendResponse.ok) {
-                  tlog.info(
-                    { from: recipientAddress, to: senderAddress },
-                    "Sent denial reply via Mailgun",
-                  );
-                } else {
-                  tlog.warn(
-                    {
-                      status: sendResponse.status,
-                      from: recipientAddress,
-                      to: senderAddress,
-                    },
-                    "Failed to send denial reply via Mailgun",
-                  );
-                }
-              } catch (err) {
-                tlog.error(
-                  { err, from: recipientAddress, to: senderAddress },
-                  "Error sending denial reply via Mailgun",
-                );
-              }
-            } else {
-              tlog.info(
-                { from: recipientAddress, to: senderAddress },
-                "Denial reply rate-limited, skipping Mailgun send",
-              );
-            }
-          }
-        } else {
-          tlog.debug("Mailgun API key not configured — skipping denial reply");
-        }
-      }
-
-      return Response.json({ ok: true, ...runtimeBody });
-    } catch (err) {
-      const cbResponse = handleCircuitBreakerError(
-        err,
-        dedupCache,
-        token,
-        tlog,
-      );
-      if (cbResponse) return cbResponse;
-
-      tlog.error({ err, eventId }, "Failed to process inbound Mailgun email");
-      dedupCache.unreserve(token);
-      return Response.json({ error: "Internal error" }, { status: 500 });
-    }
+      log: tlog,
+      label: "Mailgun",
+      source: "mailgun",
+      dedupCache,
+      dedupKey: token,
+      vellumPayload,
+      traceId,
+      sendReply: apiKey ? buildMailgunReplySender(apiKey, tlog) : undefined,
+    });
   };
 
   return { handler, dedupCache };

--- a/gateway/src/http/routes/resend-webhook.ts
+++ b/gateway/src/http/routes/resend-webhook.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { buildEmailTransportMetadata } from "../../channels/transport-hints.js";
+import type { Logger } from "pino";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -8,21 +8,13 @@ import {
   resolveCredentialWithRefresh,
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
-import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { StringDedupCache } from "../../dedup-cache.js";
+import type { EmailReplySender } from "../../email/inbound-pipeline.js";
+import { runEmailInboundPipeline } from "../../email/inbound-pipeline.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
-import { normalizeEmailWebhook } from "../../email/normalize.js";
-import { handleInbound } from "../../handlers/handle-inbound.js";
+import { parseEmailAddress } from "../../email/normalize.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBody } from "../read-limited-body.js";
-import {
-  resolveAssistant,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
-import {
-  handleCircuitBreakerError,
-  processInboundResult,
-} from "../../webhook-pipeline.js";
 
 const log = getLogger("resend-webhook");
 
@@ -166,22 +158,6 @@ async function fetchResendEmailContent(
 }
 
 /**
- * Parse an RFC 5322 address like `"Alice <alice@example.com>"` into its
- * components. Returns the raw email address and optional display name.
- */
-function parseEmailAddress(raw: string): {
-  address: string;
-  displayName?: string;
-} {
-  const match = raw.match(/^(.+?)\s*<([^>]+)>$/);
-  if (match) {
-    const name = match[1].trim().replace(/^["']|["']$/g, "");
-    return { address: match[2].trim(), displayName: name || undefined };
-  }
-  return { address: raw.trim() };
-}
-
-/**
  * Normalize a Resend `email.received` webhook event into a
  * `VellumEmailPayload` suitable for `normalizeEmailWebhook()`.
  */
@@ -229,6 +205,46 @@ function normalizeResendToVellumPayload(
     references,
     conversationId,
     timestamp: data.created_at,
+  };
+}
+
+// ── Reply delivery ──────────────────────────────────────────────────
+
+/** Reply sender using the Resend Emails API. */
+function buildResendReplySender(apiKey: string, log: Logger): EmailReplySender {
+  return async ({ kind, from, to, subject, text, inReplyTo }) => {
+    try {
+      const sendResponse = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from,
+          to: [to],
+          subject,
+          text,
+          ...(inReplyTo
+            ? {
+                headers: {
+                  "In-Reply-To": inReplyTo,
+                },
+              }
+            : {}),
+        }),
+      });
+      if (sendResponse.ok) {
+        log.info({ from, to }, `Sent ${kind} reply via Resend`);
+      } else {
+        log.warn(
+          { status: sendResponse.status, from, to },
+          `Failed to send ${kind} reply via Resend`,
+        );
+      }
+    } catch (err) {
+      log.error({ err, from, to }, `Error sending ${kind} reply via Resend`);
+    }
   };
 }
 
@@ -353,236 +369,20 @@ export function createResendWebhookHandler(
       return Response.json({ ok: true });
     }
 
-    // Feed into the standard email normalization pipeline
-    const normalized = normalizeEmailWebhook(
-      vellumPayload as unknown as Record<string, unknown>,
-    );
-    if (!normalized) {
-      tlog.debug(
-        "normalizeEmailWebhook returned null for Resend event, acknowledging",
-      );
-      dedupCache.mark(messageId);
-      return Response.json({ ok: true });
-    }
+    // ── Forward through the shared email pipeline ───────────────────
 
-    const { event: gatewayEvent, eventId, recipientAddress } = normalized;
-
-    tlog.info(
-      {
-        source: "resend",
-        eventId,
-        emailId,
-        from: gatewayEvent.actor.actorExternalId,
-        to: recipientAddress,
-      },
-      "Resend webhook received",
-    );
-
-    // ── Routing ─────────────────────────────────────────────────────
-
-    const routing = resolveAssistant(
+    return runEmailInboundPipeline({
       config,
-      gatewayEvent.message.conversationExternalId,
-      gatewayEvent.actor.actorExternalId,
-    );
-
-    if (isRejection(routing)) {
-      tlog.warn(
-        {
-          from: gatewayEvent.actor.actorExternalId,
-          to: recipientAddress,
-          reason: routing.reason,
-        },
-        "Routing rejected inbound Resend email",
-      );
-      dedupCache.mark(messageId);
-      return Response.json({ ok: true });
-    }
-
-    // ── Forward to runtime ──────────────────────────────────────────
-
-    try {
-      const result = await handleInbound(config, gatewayEvent, {
-        transportMetadata: buildEmailTransportMetadata({
-          senderAddress: gatewayEvent.actor.actorExternalId,
-          recipientAddress,
-          subject: vellumPayload.subject,
-          inReplyTo: vellumPayload.inReplyTo,
-        }),
-        replyCallbackUrl: undefined,
-        traceId,
-        routingOverride: routing,
-        sourceMetadata: {
-          emailSubject: vellumPayload.subject ?? undefined,
-          emailRecipient: recipientAddress,
-          ...(vellumPayload.inReplyTo
-            ? { emailInReplyTo: vellumPayload.inReplyTo }
-            : {}),
-          ...(vellumPayload.references
-            ? { emailReferences: vellumPayload.references }
-            : {}),
-        },
-      });
-
-      // ── Verification reply ──────────────────────────────────────
-      // Not gated by recordDenialReplyIfAllowed — verification success
-      // confirmations must always be delivered regardless of prior denial
-      // replies to this sender.
-      if (
-        result.verificationIntercepted &&
-        result.verificationReplyText &&
-        apiKey
-      ) {
-        const senderAddress = gatewayEvent.actor.actorExternalId;
-        try {
-          const sendResponse = await fetch("https://api.resend.com/emails", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              from: recipientAddress,
-              to: [senderAddress],
-              subject: `Re: ${vellumPayload.subject ?? "(no subject)"}`,
-              text: result.verificationReplyText,
-              ...(vellumPayload.messageId
-                ? {
-                    headers: {
-                      "In-Reply-To": vellumPayload.messageId,
-                    },
-                  }
-                : {}),
-            }),
-          });
-          if (sendResponse.ok) {
-            tlog.info(
-              { from: recipientAddress, to: senderAddress },
-              "Sent verification reply via Resend",
-            );
-          } else {
-            tlog.warn(
-              {
-                status: sendResponse.status,
-                from: recipientAddress,
-                to: senderAddress,
-              },
-              "Failed to send verification reply via Resend",
-            );
-          }
-        } catch (err) {
-          tlog.error(
-            { err, from: recipientAddress, to: senderAddress },
-            "Error sending verification reply via Resend",
-          );
-        }
-        dedupCache.mark(messageId);
-        return Response.json({ ok: true, verificationIntercepted: true });
-      }
-
-      const processed = processInboundResult(
-        result,
-        dedupCache,
-        messageId,
-        () => {
-          tlog.warn(
-            { from: gatewayEvent.actor.actorExternalId, to: recipientAddress },
-            "Resend email routing rejected after forwarding attempt",
-          );
-        },
-        tlog,
-      );
-
-      if (!processed.ok) {
-        return Response.json({ error: "Internal error" }, { status: 500 });
-      }
-
-      dedupCache.mark(messageId);
-
-      if (!result.rejected) {
-        tlog.info(
-          { status: "forwarded", eventId, emailId },
-          "Resend email message forwarded to runtime",
-        );
-      }
-
-      // ── Denial reply ────────────────────────────────────────────
-      // When the runtime denies the message (ACL rejection) and provides
-      // replyText, send a reply email so the unknown sender knows why
-      // their message was rejected. The runtime can't send email directly
-      // (no replyCallbackUrl for email), so the gateway handles it.
-      const runtimeBody = result.runtimeResponse ?? {};
-      if (
-        result.runtimeResponse?.denied &&
-        result.runtimeResponse.replyText &&
-        apiKey
-      ) {
-        const senderAddress = gatewayEvent.actor.actorExternalId;
-        if (recordDenialReplyIfAllowed("email", senderAddress)) {
-          try {
-            const sendResponse = await fetch("https://api.resend.com/emails", {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${apiKey}`,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                from: recipientAddress,
-                to: [senderAddress],
-                subject: `Re: ${vellumPayload.subject ?? "(no subject)"}`,
-                text: result.runtimeResponse.replyText,
-                ...(vellumPayload.messageId
-                  ? {
-                      headers: {
-                        "In-Reply-To": vellumPayload.messageId,
-                      },
-                    }
-                  : {}),
-              }),
-            });
-            if (sendResponse.ok) {
-              tlog.info(
-                { from: recipientAddress, to: senderAddress },
-                "Sent denial reply via Resend",
-              );
-            } else {
-              tlog.warn(
-                {
-                  status: sendResponse.status,
-                  from: recipientAddress,
-                  to: senderAddress,
-                },
-                "Failed to send denial reply via Resend",
-              );
-            }
-          } catch (err) {
-            tlog.error(
-              { err, from: recipientAddress, to: senderAddress },
-              "Error sending denial reply via Resend",
-            );
-          }
-        } else {
-          tlog.info(
-            { from: recipientAddress, to: senderAddress },
-            "Denial reply rate-limited, skipping Resend send",
-          );
-        }
-      }
-
-      return Response.json({ ok: true, ...runtimeBody });
-    } catch (err) {
-      const cbResponse = handleCircuitBreakerError(
-        err,
-        dedupCache,
-        messageId,
-        tlog,
-      );
-      if (cbResponse) return cbResponse;
-
-      tlog.error({ err, eventId }, "Failed to process inbound Resend email");
-      dedupCache.unreserve(messageId);
-      return Response.json({ error: "Internal error" }, { status: 500 });
-    }
+      log: tlog,
+      label: "Resend",
+      source: "resend",
+      dedupCache,
+      dedupKey: messageId,
+      vellumPayload,
+      traceId,
+      sendReply: apiKey ? buildResendReplySender(apiKey, tlog) : undefined,
+      logFields: { emailId },
+    });
   };
 
   return { handler, dedupCache };


### PR DESCRIPTION
## Summary
- The mailgun and resend webhook handlers were ~530/590-line near-duplicates. Their shared tail — canonical email normalization, routing, `handleInbound` forwarding (identical transport/source metadata), verification reply, denial reply (rate-limited via the shared `email` channel), circuit-breaker handling, dedup bookkeeping — now lives in `gateway/src/email/inbound-pipeline.ts` as `runEmailInboundPipeline()`. Provider-specific reply delivery is injected as an `EmailReplySender` closure (Mailgun form API / Resend JSON API), passed as `undefined` when the provider's API key isn't configured.
- The verbatim-duplicated `parseEmailAddress` moves to `gateway/src/email/normalize.ts`. Handlers keep only what genuinely differs: envelope parsing, signature schemes (Mailgun HMAC-in-body with 10min tolerance, Svix headers with 5min — intentionally per-provider), Resend's content fetch, and dedup key choice.
- Behavior-preserving with three invisible-externally deltas, called out for review: (1) the verification-reply branch now runs before `processInboundResult` in mailgun (a no-op for verification results, matching resend's order); (2) resend without an API key now returns `{verificationIntercepted: true}` instead of falling through to the forwarded-shape body (providers only check 2xx); (3) mailgun resolves its api_key once up front per inbound instead of per reply attempt (2s-TTL cached read). Adds unit tests for the pipeline (forward, routing-reject, verification, denial + rate-limit gating, 500/unreserve).
- The generic `email-webhook.ts` (platform relay) intentionally keeps its own flow — it returns reply text to the caller instead of sending, so forcing it into this pipeline would leak a mode flag through the abstraction.

## Original prompt
A code review flagged the channel webhook handlers' duplicated ingress logic, specifically calling mailgun/resend '~600-line near-duplicates'. The pre-auth body-read DoS landed in #36910/#36911 and the credential-refresh helpers in #36915; this PR is the final consolidation piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)