### PR TITLE
feat(gateway): stamp emailProvider provenance on inbound email sourceMetadata

### DIFF
--- a/gateway/src/__tests__/email-inbound-pipeline.test.ts
+++ b/gateway/src/__tests__/email-inbound-pipeline.test.ts
@@ -88,6 +88,12 @@ describe("runEmailInboundPipeline", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true });
     expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const forwardOptions = (
+      handleInboundMock.mock.calls[0] as unknown[]
+    )[2] as {
+      sourceMetadata: Record<string, unknown>;
+    };
+    expect(forwardOptions.sourceMetadata.emailProvider).toBe("mailgun");
     // A marked key stays deduped: a second reserve is refused
     expect(dedupCache.reserve("key-1")).toBe(false);
   });

--- a/gateway/src/email/inbound-pipeline.ts
+++ b/gateway/src/email/inbound-pipeline.ts
@@ -132,6 +132,7 @@ export async function runEmailInboundPipeline(
       traceId,
       routingOverride: routing,
       sourceMetadata: {
+        emailProvider: source,
         emailSubject: vellumPayload.subject ?? undefined,
         emailRecipient: recipientAddress,
         ...(vellumPayload.inReplyTo

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -159,6 +159,7 @@ export function createEmailWebhookHandler(
         routingOverride: routing,
         senderAuthenticated,
         sourceMetadata: {
+          emailProvider: "platform",
           emailSubject: (payload.subject as string | undefined) ?? undefined,
           emailRecipient: recipientAddress,
           ...(typeof payload.inReplyTo === "string"

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -91,6 +91,11 @@ export const SourceMetadataSchema = z
     trustVerdict: TrustVerdictSchema.optional(),
 
     // Email-specific fields
+    /**
+     * Ingress provider that delivered the email to the gateway
+     * (e.g. "mailgun", "resend", or "platform" for the Vellum relay).
+     */
+    emailProvider: z.string().optional(),
     /** Email subject line. */
     emailSubject: z.string().optional(),
     /** Email recipient address. */


### PR DESCRIPTION
## Summary
- All three email ingresses collapse to `sourceChannel: "email"`, so the runtime (and its diagnostics) cannot tell which provider delivered a message. `sourceMetadata` now carries `emailProvider`: the shared email pipeline stamps its `source` (`mailgun` / `resend`), and the platform relay webhook stamps `platform`.
- Contract change is one optional string field on the `.passthrough()` `SourceMetadata` schema in `@vellumai/gateway-client` — additive and backward compatible in both directions.

## Original prompt
A code review of the webhook handlers flagged "coarse source labels" — provider identity was dropped at normalization. This is the final PR of that review's fix sequence (#36910/#36911 bounded pre-auth reads, #36915 credential-refresh helpers, #36917 email pipeline consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)