### PR TITLE
fix(daemon): install signal handlers at the top of startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -154,6 +154,13 @@ export async function runDaemon(): Promise<void> {
   // legacy local opt-out hard-disable via closeSentry().
   initSentry();
 
+  // Signal handlers install before any blocking startup work — a boot that
+  // inherits a large WAL can spend minutes inside `initializeDb()`, and
+  // without handlers a SIGTERM in that window is the default hard kill.
+  // Handlers run a minimal exit path until `setStartupComplete()` below
+  // switches them to the full graceful shutdown.
+  installShutdownHandlers();
+
   ensureDataDir();
 
   // Recover from any streaming `.vbundle` import that was interrupted by a
@@ -719,12 +726,12 @@ export async function runDaemon(): Promise<void> {
 
   startHeartbeatService();
 
-  installShutdownHandlers();
-
   // The critical startup await-chain has completed and the daemon can serve
   // requests, so latch readiness before logging "Daemon started". Any fatal
   // failure earlier in startup propagates out of runDaemon before this line,
-  // so the latch is never set on a failed start.
+  // so the latch is never set on a failed start. The latch also switches the
+  // signal handlers installed at the top of startup from their minimal
+  // early-exit mode to the full graceful shutdown.
   setStartupComplete();
 
   log.info(

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -35,7 +35,8 @@ import { stopAppSourceWatcher } from "./app-source-watcher.js";
 import { stopConfigWatcher } from "./config-watcher.js";
 import { stopConversationEvictor } from "./conversation-evictor.js";
 import { stopConversations } from "./conversation-store.js";
-import { cleanupPidFile } from "./daemon-control.js";
+import { cleanupPidFile, cleanupPidFileIfOwner } from "./daemon-control.js";
+import { isStartupComplete } from "./daemon-readiness.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
 import { stopOrphanReaper } from "./orphan-reaper.js";
@@ -198,46 +199,51 @@ async function shutdown(): Promise<void> {
   // Optimize query planner statistics before closing so they persist for
   // the next session. Checkpoint WAL and close SQLite so no writes are
   // lost on exit. Each step is in its own try block so later steps still
-  // run if an earlier one throws (e.g. SQLITE_BUSY).
-  try {
-    getSqlite().exec("PRAGMA optimize");
-  } catch (err) {
-    log.warn({ err }, "PRAGMA optimize at shutdown failed (non-fatal)");
-  }
-  // Fold the WAL back into the main database so the next boot opens a small
-  // WAL instead of paying a multi-minute recovery (see
-  // `checkpointWalBeforeOpen` in db-init.ts). Runs through `runAsyncSqlite`
-  // (sqlite3 subprocess when available) because a synchronous checkpoint of a
-  // WAL at its high-water mark blocks the event loop, which keeps the
-  // force-exit timer above from ever firing. Off the loop, the timer stays
-  // armed — and if it fires mid-checkpoint, the subprocess survives
-  // `process.exit` and finishes the fold in the background.
-  try {
-    const checkpointResult = await runAsyncSqlite(
-      "PRAGMA wal_checkpoint(TRUNCATE)",
-      "shutdown:wal-checkpoint-truncate",
-    );
-    if (checkpointResult.ok) {
-      log.info(
-        {
-          backend: checkpointResult.backend,
-          elapsedMs: checkpointResult.elapsedMs,
-        },
-        "Shutdown WAL checkpoint complete",
-      );
-    } else {
-      log.warn(
-        { error: checkpointResult.error, backend: checkpointResult.backend },
-        "WAL checkpoint failed (non-fatal)",
-      );
+  // run if an earlier one throws (e.g. SQLITE_BUSY). Skipped entirely when
+  // the DB was never opened: there is nothing to persist, fold, or close,
+  // and the lazy `getSqlite()` accessor would open the database just to
+  // tear it down.
+  if (isDbOpen()) {
+    try {
+      getSqlite().exec("PRAGMA optimize");
+    } catch (err) {
+      log.warn({ err }, "PRAGMA optimize at shutdown failed (non-fatal)");
     }
-  } catch (err) {
-    log.warn({ err }, "WAL checkpoint failed (non-fatal)");
-  }
-  try {
-    resetDb();
-  } catch (err) {
-    log.warn({ err }, "Database close failed (non-fatal)");
+    // Fold the WAL back into the main database so the next boot opens a
+    // small WAL instead of paying a multi-minute recovery (see
+    // `checkpointWalBeforeOpen` in db-init.ts). Runs through `runAsyncSqlite`
+    // (sqlite3 subprocess when available) because a synchronous checkpoint
+    // of a WAL at its high-water mark blocks the event loop, which keeps the
+    // force-exit timer above from ever firing. Off the loop, the timer stays
+    // armed — and if it fires mid-checkpoint, the subprocess survives
+    // `process.exit` and finishes the fold in the background.
+    try {
+      const checkpointResult = await runAsyncSqlite(
+        "PRAGMA wal_checkpoint(TRUNCATE)",
+        "shutdown:wal-checkpoint-truncate",
+      );
+      if (checkpointResult.ok) {
+        log.info(
+          {
+            backend: checkpointResult.backend,
+            elapsedMs: checkpointResult.elapsedMs,
+          },
+          "Shutdown WAL checkpoint complete",
+        );
+      } else {
+        log.warn(
+          { error: checkpointResult.error, backend: checkpointResult.backend },
+          "WAL checkpoint failed (non-fatal)",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "WAL checkpoint failed (non-fatal)");
+    }
+    try {
+      resetDb();
+    } catch (err) {
+      log.warn({ err }, "Database close failed (non-fatal)");
+    }
   }
 
   await Sentry.flush(2000);
@@ -246,45 +252,79 @@ async function shutdown(): Promise<void> {
   process.exit(exitCode);
 }
 
+/**
+ * Minimal exit for signals and fatal errors that land before startup
+ * completes. The graceful `shutdown()` path assumes started subsystems and
+ * would interleave its teardown with the still-running startup sequence, so
+ * this path does only the work that matters mid-boot: fold the WAL when the
+ * DB is already open (detached, so the fold survives the exit) and remove
+ * the PID file when this process wrote it — ownership-checked so a duplicate
+ * daemon exiting early never deletes the live daemon's PID file.
+ */
+function exitDuringStartup(code: number): void {
+  if (isDbOpen()) {
+    spawnDetachedWalCheckpoint();
+  }
+  cleanupPidFileIfOwner(process.pid);
+  process.exit(code);
+}
+
+function handleShutdownSignal(signal: string, message: string): void {
+  log.warn({ signal, pid: process.pid, uptime: process.uptime() }, message);
+  if (!isStartupComplete()) {
+    log.warn(
+      { signal },
+      "Signal arrived before startup completed — exiting without graceful shutdown",
+    );
+    exitDuringStartup(0);
+    return;
+  }
+  void shutdown();
+}
+
+function handleFatalError(err: unknown, message: string): void {
+  log.error({ err }, message);
+  Sentry.captureException(err);
+  exitCode = 1;
+  if (!isStartupComplete()) {
+    exitDuringStartup(1);
+    return;
+  }
+  void shutdown();
+}
+
+/**
+ * Install signal and fatal-error handlers. Runs before any blocking startup
+ * work — a boot that inherits a large WAL can spend minutes in DB init, and
+ * without handlers a SIGTERM in that window is the default hard kill (no WAL
+ * fold, no PID cleanup). Handlers stay in the minimal `exitDuringStartup`
+ * mode until `setStartupComplete()` marks the daemon ready; from then on
+ * signals run the full graceful `shutdown()`.
+ */
 export function installShutdownHandlers(): void {
   process.on("SIGTERM", () => {
-    log.warn(
-      { signal: "SIGTERM", pid: process.pid, uptime: process.uptime() },
+    handleShutdownSignal(
+      "SIGTERM",
       "Received SIGTERM — process termination requested",
     );
-    void shutdown();
   });
 
   process.on("SIGINT", () => {
-    log.warn(
-      { signal: "SIGINT", pid: process.pid, uptime: process.uptime() },
-      "Received SIGINT — user interrupt",
-    );
-    void shutdown();
+    handleShutdownSignal("SIGINT", "Received SIGINT — user interrupt");
   });
 
   process.on("SIGHUP", () => {
-    log.warn(
-      { signal: "SIGHUP", pid: process.pid, uptime: process.uptime() },
-      "Received SIGHUP — terminal hangup",
-    );
-    void shutdown();
+    handleShutdownSignal("SIGHUP", "Received SIGHUP — terminal hangup");
   });
 
   process.on("unhandledRejection", (reason) => {
-    log.error(
-      { err: reason },
+    handleFatalError(
+      reason,
       "Unhandled promise rejection — initiating shutdown",
     );
-    Sentry.captureException(reason);
-    exitCode = 1;
-    void shutdown();
   });
 
   process.on("uncaughtException", (err) => {
-    log.error({ err }, "Uncaught exception — initiating shutdown");
-    Sentry.captureException(err);
-    exitCode = 1;
-    void shutdown();
+    handleFatalError(err, "Uncaught exception — initiating shutdown");
   });
 }


### PR DESCRIPTION
## Summary
- `installShutdownHandlers()` moves from second-to-last in `runDaemon()` to before any blocking startup work. The unprotected window was longest in exactly the pathological case: a boot that inherits a large WAL spends minutes inside `initializeDb()`, and a `vellum stop`/update or impatient restart during that window was a default hard kill (exit 143, no WAL fold, no PID cleanup) — perpetuating the large-WAL state the next boot pays for.
- Handlers are two-phase, keyed off the existing `isStartupComplete()` readiness latch: until startup completes they take a minimal exit path (`exitDuringStartup`) — detached WAL fold when the DB is already open, PID-file removal via ownership-checked `cleanupPidFileIfOwner()` so a duplicate daemon exiting early never deletes the live daemon's PID file, then exit 0 (signals) / 1 (fatal errors). Running the full `shutdown()` mid-startup would interleave subsystem teardown with the still-executing startup sequence.
- The graceful path's optimize/checkpoint/close block is now guarded by `isDbOpen()` — `getSqlite()` opens the connection lazily, so an unguarded shutdown would open the database just to tear it down. The three near-identical signal listener bodies and two fatal-error bodies are deduplicated into `handleShutdownSignal`/`handleFatalError`.
- Verified against a live daemon boot from a scratch workspace: SIGTERM 18ms into `initializing DB` → early-exit log + exit 0 (previously exit 143 with no logs); SIGTERM after `Daemon started` → full graceful sequence incl. `Shutdown WAL checkpoint complete` + exit 0.

## Original prompt
Investigation in this session verified three daemon shutdown/startup WAL-checkpoint reliability gaps that cause boots to start with a huge WAL to fold: the graceful checkpoint ran synchronously on the main thread (#36909), the 20s force-exit path skipped the checkpoint (#36916), and signal handlers installed second-to-last in startup so an early SIGTERM was a hard kill. The user asked to fix them across multiple PRs. This is PR 3 of 3.

## Known limitation
A signal arriving during module *import* (before `runDaemon()` begins, typically well under a second) still takes the default disposition — that window is not addressable from inside the process.