### PR TITLE
refactor(runtime): consolidate canned-card ritual; summarize card metadata + copy fixes

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -63,6 +63,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   batchSetDisplayOrders: () => {},
   countConversationsByScheduleJobId: () => 0,
   deleteConversation: () => ({ segmentIds: [], deletedSummaryIds: [] }),
+  extractImageSourcePaths: () => undefined,
   forkConversation: () => ({ id: "forked" }),
   getConversation: getConversationMock,
   provenanceFromTrustContext: (ctx: unknown) =>
@@ -247,10 +248,17 @@ describe("POST /v1/conversations/summarize", () => {
 
     // Card persisted as an assistant message and pushed onto in-memory history.
     expect(addMessageMock).toHaveBeenCalledTimes(1);
-    const [convId, role, content] = addMessageMock.mock.calls[0];
+    const [convId, role, content, options] = addMessageMock.mock.calls[0];
     expect(convId).toBe("conv-summarize-test");
     expect(role).toBe("assistant");
     expect(content).toContain("Conversation summarized");
+    // Metadata mirrors the /compact card shape (channel keys + provenance);
+    // interface keys are omitted because the route receives no interface id.
+    expect(options?.metadata).toEqual({
+      provenanceTrustClass: "unknown",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    });
     expect(ctx.messages).toHaveLength(1);
 
     // Turn-style SSE events: full text delta, then message_complete with the
@@ -335,12 +343,12 @@ describe("POST /v1/conversations/summarize", () => {
     expect(content).toContain(
       "Summarization skipped — Nothing to summarize before this message",
     );
-    expect(
-      broadcastEvents.some((e) => e.type === "conversation_error"),
-    ).toBe(false);
-    expect(
-      broadcastEvents.some((e) => e.type === "message_complete"),
-    ).toBe(true);
+    expect(broadcastEvents.some((e) => e.type === "conversation_error")).toBe(
+      false,
+    );
+    expect(broadcastEvents.some((e) => e.type === "message_complete")).toBe(
+      true,
+    );
     expect(ctx.conversation.isProcessing()).toBe(false);
     expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
   });

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -107,12 +107,30 @@ export function formatCompactResult(result: ContextWindowResult): string {
 }
 
 /**
+ * User-facing copy for the compactor's internal skip-reason strings, keyed by
+ * the exact `ContextWindowResult.reason` values reachable from the
+ * "summarize up to here" path. Unknown reasons fall back to the raw string.
+ */
+const SUMMARIZE_SKIP_REASON_COPY: Record<string, string> = {
+  "fixed boundary out of range": "nothing to summarize before this point",
+  "tail_start at head — nothing to compact":
+    "nothing to summarize before this point",
+  "no messages to compact": "nothing to summarize",
+  "compaction disabled": "summarization is disabled in the assistant's config",
+  "provider error": "the summary could not be generated — try again",
+  "unparseable response": "the summary could not be generated — try again",
+};
+
+/**
  * Format the result of a "summarize up to here" compaction into a user-facing
  * card.
  */
 export function formatSummarizeUpToResult(result: ContextWindowResult): string {
   if (!result.compacted) {
-    return `Summarization skipped — ${result.reason ?? "nothing to summarize"}.`;
+    const reason = result.reason
+      ? (SUMMARIZE_SKIP_REASON_COPY[result.reason] ?? result.reason)
+      : "nothing to summarize";
+    return `Summarization skipped — ${reason}.`;
   }
   const saved =
     result.previousEstimatedInputTokens - result.estimatedInputTokens;

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -1,4 +1,9 @@
+import { createAssistantMessage } from "../../agent/message-types.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { addMessage } from "../../persistence/conversation-crud.js";
+import type { Message } from "../../providers/types.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
+import { publishConversationMessagesChanged } from "../sync/resource-sync-events.js";
 
 // ---------------------------------------------------------------------------
 // Temporary fix — remove when #31994 lands
@@ -27,4 +32,45 @@ export function emitCannedMessageComplete(
     conversationId,
     messageId: persistedAssistantId,
   });
+}
+
+/**
+ * Persist a canned assistant "card" — a pre-composed reply that bypasses the
+ * agent loop (the /compact, /clean, and summarize-up-to result cards) — and
+ * emit the turn-style events clients expect for it: the full text as a single
+ * `assistant_text_delta`, `message_complete` with the persisted assistant id,
+ * and the messages-changed sync invalidation.
+ *
+ * Callers that interleave other broadcasts between the persist and the
+ * delta (the canned greeting and unknown-slash-command paths defer their
+ * broadcasts behind the HTTP response with a `user_message_echo` in
+ * between) cannot use this helper without reordering their events.
+ */
+export async function persistCannedAssistantCard(opts: {
+  conversation: { getMessages(): Message[] };
+  conversationId: string;
+  text: string;
+  metadata: Record<string, unknown>;
+  originClientId?: string;
+}): Promise<void> {
+  const { conversation, conversationId, text, metadata, originClientId } = opts;
+  const assistantMsg = createAssistantMessage(text);
+  const persistedAssistant = await addMessage(
+    conversationId,
+    "assistant",
+    JSON.stringify(assistantMsg.content),
+    { metadata },
+  );
+  conversation.getMessages().push(assistantMsg);
+  broadcastMessage({
+    type: "assistant_text_delta",
+    text,
+    conversationId,
+  });
+  emitCannedMessageComplete(
+    broadcastMessage,
+    conversationId,
+    persistedAssistant.id,
+  );
+  publishConversationMessagesChanged(conversationId, originClientId);
 }

--- a/assistant/src/runtime/routes/channel-metadata.ts
+++ b/assistant/src/runtime/routes/channel-metadata.ts
@@ -1,0 +1,49 @@
+import {
+  extractImageSourcePaths,
+  provenanceFromTrustContext,
+} from "../../persistence/conversation-crud.js";
+
+/**
+ * Assemble the standard channel metadata object for message persistence.
+ *
+ * Combines provenance (trust context), channel/interface routing, and
+ * optional per-message fields (automated flag, image source paths) into the
+ * Record that `addMessage` stores in the `metadata` column.
+ *
+ * `sourceInterface` may be undefined for routes that don't receive an
+ * interface id from the client (e.g. the summarize-up-to management route);
+ * the interface keys are omitted in that case.
+ */
+export function buildChannelMetadata(
+  sourceChannel: string,
+  sourceInterface: string | undefined,
+  opts?: {
+    trustContext?: Parameters<typeof provenanceFromTrustContext>[0];
+    provenanceOverride?: Record<string, unknown>;
+    automated?: boolean;
+    attachments?: ReadonlyArray<{
+      filename: string;
+      mimeType: string;
+      filePath?: string;
+    }>;
+  },
+): Record<string, unknown> {
+  const provenance =
+    opts?.provenanceOverride ?? provenanceFromTrustContext(opts?.trustContext);
+  const imageSourcePaths = opts?.attachments
+    ? extractImageSourcePaths(opts.attachments)
+    : undefined;
+  return {
+    ...provenance,
+    userMessageChannel: sourceChannel,
+    assistantMessageChannel: sourceChannel,
+    ...(sourceInterface !== undefined
+      ? {
+          userMessageInterface: sourceInterface,
+          assistantMessageInterface: sourceInterface,
+        }
+      : {}),
+    ...(opts?.automated ? { automated: true } : {}),
+    ...(imageSourcePaths ? { imageSourcePaths } : {}),
+  };
+}

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -21,7 +21,6 @@
 
 import { z } from "zod";
 
-import { createAssistantMessage } from "../../agent/message-types.js";
 import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
 import {
   destroyActiveConversation,
@@ -37,14 +36,12 @@ import {
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import { stripConversationIds } from "../../home/feed-writer.js";
 import {
-  addMessage,
   archiveConversation,
   batchSetDisplayOrders,
   countConversationsByScheduleJobId,
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
-  provenanceFromTrustContext,
   setConversationSurfaced,
   unarchiveConversation,
   updateConversationTitle,
@@ -66,10 +63,10 @@ import { buildConversationDetailResponse } from "../services/conversation-serial
 import {
   publishConversationListAndMetadataChanged,
   publishConversationListChanged,
-  publishConversationMessagesChanged,
   publishConversationTitleChanged,
 } from "../sync/resource-sync-events.js";
-import { emitCannedMessageComplete } from "./canned-message-complete.js";
+import { persistCannedAssistantCard } from "./canned-message-complete.js";
+import { buildChannelMetadata } from "./channel-metadata.js";
 import { conversationSummarySchema } from "./conversation-list-routes.js";
 import {
   BadRequestError,
@@ -227,32 +224,20 @@ async function handleSummarizeConversation({
 
   const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
 
-  const persistCard = async (text: string) => {
-    const assistantMsg = createAssistantMessage(text);
-    const persistedAssistant = await addMessage(
+  // The summarize action only ships from the vellum web/desktop client; the
+  // interface id is omitted because this management route (unlike the send
+  // path) does not receive one from the client.
+  const channelMeta = buildChannelMetadata("vellum", undefined, {
+    trustContext: conversation.trustContext,
+  });
+  const persistCard = (text: string) =>
+    persistCannedAssistantCard({
+      conversation,
       conversationId,
-      "assistant",
-      JSON.stringify(assistantMsg.content),
-      {
-        metadata: {
-          ...provenanceFromTrustContext(conversation.trustContext),
-          assistantMessageChannel: "vellum",
-        },
-      },
-    );
-    conversation.getMessages().push(assistantMsg);
-    broadcastMessage({
-      type: "assistant_text_delta",
       text,
-      conversationId,
+      metadata: channelMeta,
+      originClientId,
     });
-    emitCannedMessageComplete(
-      broadcastMessage,
-      conversationId,
-      persistedAssistant.id,
-    );
-    publishConversationMessagesChanged(conversationId, originClientId);
-  };
 
   // Fire-and-forget: return 202 immediately, run summarization async. The
   // summary LLM call can exceed the client's HTTP timeout on large contexts.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -99,7 +99,6 @@ import {
 } from "../../persistence/attachments-store.js";
 import {
   addMessage,
-  extractImageSourcePaths,
   getConversation,
   getConversationPersistedSeq,
   getMessages,
@@ -107,7 +106,6 @@ import {
   hasMessages,
   isConversationProcessing,
   type MessageRow,
-  provenanceFromTrustContext,
   setConversationInferenceProfile,
 } from "../../persistence/conversation-crud.js";
 import {
@@ -153,7 +151,11 @@ import {
   publishConversationMessagesChanged,
 } from "../sync/resource-sync-events.js";
 import { withSourceChannel } from "../trust-context-resolver.js";
-import { emitCannedMessageComplete } from "./canned-message-complete.js";
+import {
+  emitCannedMessageComplete,
+  persistCannedAssistantCard,
+} from "./canned-message-complete.js";
+import { buildChannelMetadata } from "./channel-metadata.js";
 import {
   BadRequestError,
   InternalError,
@@ -2180,7 +2182,6 @@ export async function handleSendMessage(
     // forceCompact() makes an LLM call that can exceed the client's
     // HTTP timeout on large contexts, causing a false "Failed to send".
     (async () => {
-      let assistantMessagePersisted = false;
       try {
         broadcastMessage({
           type: "user_message_echo",
@@ -2192,33 +2193,14 @@ export async function handleSendMessage(
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.emitActivityState("thinking", "context_compacting");
         const result = await conversation.forceCompact();
-        const responseText = formatCompactResult(result);
-
-        const assistantMsg = createAssistantMessage(responseText);
-        const persistedAssistant = await addMessage(
+        await persistCannedAssistantCard({
+          conversation,
           conversationId,
-          "assistant",
-          JSON.stringify(assistantMsg.content),
-          { metadata: channelMeta },
-        );
-        assistantMessagePersisted = true;
-        conversation.getMessages().push(assistantMsg);
-
-        broadcastMessage({
-          type: "assistant_text_delta",
-          text: responseText,
-          conversationId,
+          text: formatCompactResult(result),
+          metadata: channelMeta,
+          originClientId,
         });
-        emitCannedMessageComplete(
-          broadcastMessage,
-          conversationId,
-          persistedAssistant.id,
-        );
-        publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
-        if (assistantMessagePersisted) {
-          publishConversationMessagesChanged(conversationId, originClientId);
-        }
         log.error({ err, conversationId }, "Compact command failed");
         broadcastMessage({
           type: "conversation_error",
@@ -2275,7 +2257,6 @@ export async function handleSendMessage(
       const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
         trustContext: conversation.trustContext,
       });
-      let assistantMessagePersisted = false;
       try {
         broadcastMessage({
           type: "user_message_echo",
@@ -2287,33 +2268,14 @@ export async function handleSendMessage(
         publishConversationMessagesChanged(conversationId, originClientId);
 
         const result = await conversation.forceClean();
-        const responseText = formatCleanResult(result);
-
-        const assistantMsg = createAssistantMessage(responseText);
-        const persistedAssistant = await addMessage(
+        await persistCannedAssistantCard({
+          conversation,
           conversationId,
-          "assistant",
-          JSON.stringify(assistantMsg.content),
-          { metadata: channelMeta },
-        );
-        assistantMessagePersisted = true;
-        conversation.getMessages().push(assistantMsg);
-
-        broadcastMessage({
-          type: "assistant_text_delta",
-          text: responseText,
-          conversationId,
+          text: formatCleanResult(result),
+          metadata: channelMeta,
+          originClientId,
         });
-        emitCannedMessageComplete(
-          broadcastMessage,
-          conversationId,
-          persistedAssistant.id,
-        );
-        publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
-        if (assistantMessagePersisted) {
-          publishConversationMessagesChanged(conversationId, originClientId);
-        }
         log.error({ err, conversationId }, "Clean command failed");
         broadcastMessage({
           type: "conversation_error",
@@ -2681,47 +2643,6 @@ async function handleSearchConversations({
   });
 
   return { query, results };
-}
-
-// ---------------------------------------------------------------------------
-// Metadata helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Assemble the standard channel metadata object for message persistence.
- *
- * Combines provenance (trust context), channel/interface routing, and
- * optional per-message fields (automated flag, image source paths) into the
- * Record that `addMessage` stores in the `metadata` column.
- */
-function buildChannelMetadata(
-  sourceChannel: string,
-  sourceInterface: string,
-  opts?: {
-    trustContext?: Parameters<typeof provenanceFromTrustContext>[0];
-    provenanceOverride?: Record<string, unknown>;
-    automated?: boolean;
-    attachments?: ReadonlyArray<{
-      filename: string;
-      mimeType: string;
-      filePath?: string;
-    }>;
-  },
-): Record<string, unknown> {
-  const provenance =
-    opts?.provenanceOverride ?? provenanceFromTrustContext(opts?.trustContext);
-  const imageSourcePaths = opts?.attachments
-    ? extractImageSourcePaths(opts.attachments)
-    : undefined;
-  return {
-    ...provenance,
-    userMessageChannel: sourceChannel,
-    assistantMessageChannel: sourceChannel,
-    userMessageInterface: sourceInterface,
-    assistantMessageInterface: sourceInterface,
-    ...(opts?.automated ? { automated: true } : {}),
-    ...(imageSourcePaths ? { imageSourcePaths } : {}),
-  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for summarize-up-to-here.md.
- persistCannedAssistantCard shared helper replaces four hand-rolled copies of the canned-card sequence
- Summarize card metadata matches the /compact card's buildChannelMetadata shape
- Skipped-card reasons mapped to user-appropriate copy