### PR TITLE
fix(compaction): summary-head off-by-one in fixed-boundary count + emergency-compaction parse

### DIFF
--- a/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
+++ b/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Persisted-count accounting when a synthetic context-summary message heads
+ * the history.
+ *
+ * The summary head (minted by `createContextSummaryMessage` on reload/fork
+ * inheritance, or by a prior compaction pass in the same process) has no DB
+ * row, so `compactedPersistedMessages` must exclude it — otherwise every
+ * compaction over an already-summarized history advances the persisted
+ * `contextCompactedMessageCount` one row too far and silently drops the
+ * first kept message on the next reload.
+ *
+ * Runs the real compactor arithmetic through `ContextWindowManager` with a
+ * canned provider response — only the provider call is seeded.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversationOrSubagent: () => ({
+    systemPrompt: "you are a test assistant",
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    compaction: { enabled: true, autoThreshold: 0.7, prompt: null },
+  }),
+}));
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getMessages: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  getAttachmentMetadataForMessage: () => [],
+  getAttachmentContent: () => null,
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+}));
+
+import {
+  ContextWindowManager,
+  createContextSummaryMessage,
+} from "../plugins/defaults/compaction/window-manager.js";
+import type { Message, Provider } from "../providers/types.js";
+
+function turnTimestamp(turn: number): string {
+  const minute = String(turn % 60).padStart(2, "0");
+  return `2026-05-21 (Thursday) 10:${minute}:00 -05:00 (America/Chicago)`;
+}
+
+function userTurn(turn: number, body: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `<turn_context>\ncurrent_time: ${turnTimestamp(
+          turn,
+        )}\n</turn_context>\n[U${turn}] ${body}`,
+      },
+    ],
+  };
+}
+
+function assistantTurn(turn: number, body: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: `[A${turn}] ${body}` }],
+  };
+}
+
+/** Fixed-boundary responses carry no `<tail_start>` — the caller owns the cut. */
+const FIXED_RESPONSE = `<compaction_result>
+<summary>
+Alice and Bob's earlier discussion, remembered in my own voice.
+</summary>
+<key_state>
+- Nothing critical pending.
+</key_state>
+</compaction_result>`;
+
+function responseWithTailStart(tailTurn: number, preview: string): string {
+  return `<compaction_result>
+<summary>
+Alice and Bob's earlier discussion, remembered in my own voice.
+</summary>
+<key_state>
+- Nothing critical pending.
+</key_state>
+<tail_start timestamp="${turnTimestamp(tailTurn)}" preview="${preview}" />
+</compaction_result>`;
+}
+
+/** Provider that answers each call with the next queued response. */
+function makeProvider(responses: string[]): Provider {
+  const queue = [...responses];
+  return {
+    name: "mock-provider",
+    sendMessage: async () => {
+      const response = queue.shift();
+      if (response === undefined) {
+        throw new Error("Provider called more times than responses queued");
+      }
+      return {
+        content: [{ type: "text", text: response }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+function buildManager(provider: Provider): ContextWindowManager {
+  return new ContextWindowManager({
+    provider,
+    config: {
+      enabled: true,
+      maxInputTokens: 200_000,
+      targetBudgetRatio: 0.3,
+      compactThreshold: 0.8,
+      summaryBudgetRatio: 0.05,
+      overflowRecovery: {
+        enabled: true,
+        safetyMarginRatio: 0.05,
+        maxAttempts: 3,
+        interactiveLatestTurnCompression: "summarize",
+        nonInteractiveLatestTurnCompression: "summarize",
+      },
+    },
+    conversationId: "conv-test",
+  });
+}
+
+/**
+ * The in-memory view of a conversation with 10 persisted rows whose first 3
+ * are already compacted: a rehydrated summary head followed by rows 3..9.
+ * History index = 1 + (row - 3); row 7 lives at index 5.
+ */
+function historyWithSummaryHead(): Message[] {
+  return [
+    createContextSummaryMessage("Prior summary covering rows 0-2."),
+    userTurn(3, "Alice asks about onboarding"),
+    assistantTurn(4, "assistant replies"),
+    userTurn(5, "Alice follows up"),
+    assistantTurn(6, "assistant replies again"),
+    userTurn(7, "Alice changes topic"),
+    assistantTurn(8, "assistant answers the new topic"),
+    userTurn(9, "Alice wraps up"),
+  ];
+}
+
+describe("compactedPersistedMessages excludes the synthetic summary head", () => {
+  test("fixed boundary over a rehydrated summary head", async () => {
+    // GIVEN 10 persisted rows with contextCompactedMessageCount 3 and a
+    // summary head, and the user picking row 7 ("summarize up to here") —
+    // history index 5
+    const messages = historyWithSummaryHead();
+    const manager = buildManager(makeProvider([FIXED_RESPONSE]));
+
+    // WHEN the fixed-boundary pass runs
+    const result = await manager.maybeCompact(messages, undefined, {
+      fixedTailStartIndex: 5,
+    });
+
+    // THEN the head is folded into the summary but not counted as a DB row:
+    // the persisted count advances 3 → 3 + 4 = 7 (rows 3..6), never 8
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(5);
+    expect(result.compactedPersistedMessages).toBe(4);
+    expect(result.preservedTailMessages).toBe(3);
+  });
+
+  test("model-chosen tail over a rehydrated summary head", async () => {
+    // GIVEN the same history, compacting via the model-chosen `<tail_start>`
+    // pointing at row 7 (history index 5)
+    const messages = historyWithSummaryHead();
+    const manager = buildManager(
+      makeProvider([responseWithTailStart(7, "Alice changes topic")]),
+    );
+
+    // WHEN a forced auto-path pass runs
+    const result = await manager.maybeCompact(messages, undefined, {
+      force: true,
+    });
+
+    // THEN the shared arithmetic excludes the head on this path too
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(5);
+    expect(result.compactedPersistedMessages).toBe(4);
+  });
+
+  test("second in-process pass over a compaction-minted summary head", async () => {
+    // GIVEN a history already compacted once in this process — its head is
+    // the summary message the compactor itself minted, not a reload artifact
+    const manager = buildManager(
+      makeProvider([FIXED_RESPONSE, FIXED_RESPONSE]),
+    );
+    const first = await manager.maybeCompact(
+      historyWithSummaryHead(),
+      undefined,
+      { fixedTailStartIndex: 5 },
+    );
+    expect(first.compacted).toBe(true);
+    // [minted summary, row 7, row 8, row 9]
+    expect(first.messages.length).toBe(4);
+
+    // WHEN a second fixed-boundary pass cuts at row 9 (history index 3, a
+    // clean user boundary the tool-pairing walk leaves in place)
+    const second = await manager.maybeCompact(first.messages, undefined, {
+      fixedTailStartIndex: 3,
+    });
+
+    // THEN only rows 7-8 count as compacted-persisted — the minted head does not
+    expect(second.compacted).toBe(true);
+    expect(second.compactedMessages).toBe(3);
+    expect(second.compactedPersistedMessages).toBe(2);
+  });
+
+  test("fork-inherited prefix is not double-counted with the summary head", async () => {
+    // GIVEN a forked conversation whose seeded non-persisted prefix (2)
+    // already includes its inherited summary head
+    const messages: Message[] = [
+      createContextSummaryMessage("Inherited summary from the parent."),
+      assistantTurn(0, "inherited assistant context with no DB row"),
+      userTurn(1, "Alice's first persisted message"),
+      assistantTurn(2, "assistant replies"),
+      userTurn(3, "Alice follows up"),
+      assistantTurn(4, "assistant replies again"),
+    ];
+    const manager = buildManager(makeProvider([FIXED_RESPONSE]));
+    manager.seedNonPersistedPrefix(2);
+
+    // WHEN a fixed-boundary pass compacts past the whole inherited prefix
+    const result = await manager.maybeCompact(messages, undefined, {
+      fixedTailStartIndex: 4,
+    });
+
+    // THEN the prefix is subtracted once (max, not summed with the head):
+    // compactable = [summary, inherited, row, row] → 2 persisted rows
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(4);
+    expect(result.compactedPersistedMessages).toBe(2);
+  });
+
+  test("emergency compaction over a rehydrated summary head", async () => {
+    // GIVEN a mid-turn overflow history led by a rehydrated summary head,
+    // with the last tool pair anchoring the emergency split at index 2
+    const messages: Message[] = [
+      createContextSummaryMessage("Prior summary covering rows 0-2."),
+      userTurn(3, "Alice asks for a command run"),
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "X", name: "Bash", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "X", content: "ok" }],
+      },
+    ];
+    // The emergency prompt requests no `<tail_start>` — the canned response
+    // mirrors a prompt-following model and must still parse.
+    const manager = buildManager(makeProvider([FIXED_RESPONSE]));
+
+    // WHEN emergency compaction runs
+    const result = await manager.emergencyCompact(messages, {
+      previousEstimatedInputTokens: 190_000,
+    });
+
+    // THEN the compacted prefix [head, row 3] counts one persisted row
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(2);
+    expect(result.compactedPersistedMessages).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/compactor-web-search-strip.test.ts
+++ b/assistant/src/__tests__/compactor-web-search-strip.test.ts
@@ -56,6 +56,20 @@ Earlier turns summarized here.
 </compaction_result>
 `;
 
+// The emergency prompt asks for summary + key_state only — no tail_start —
+// so the emergency test's canned response mirrors a prompt-following model.
+const emergencyCompactionResponse = `
+<compaction_result>
+<summary>
+Earlier turns summarized here.
+</summary>
+
+<key_state>
+- Nothing critical pending.
+</key_state>
+</compaction_result>
+`;
+
 const ENCRYPTED_TOKEN = "expired_encrypted_token_abc123";
 
 const userText = (text: string): Message => ({
@@ -114,13 +128,16 @@ function serializeBlocks(messages: Message[]): string {
 }
 
 // Records the exact message list the provider is asked to summarize.
-function recordingProvider(sink: { sent: Message[] }): Provider {
+function recordingProvider(
+  sink: { sent: Message[] },
+  response: string,
+): Provider {
   return {
     name: "mock-provider",
     sendMessage: async (msgs: Message[]) => {
       sink.sent = msgs;
       return {
-        content: [{ type: "text", text: compactionResponse }],
+        content: [{ type: "text", text: response }],
         model: "mock-model",
         usage: { inputTokens: 100, outputTokens: 50 },
         stopReason: "end_turn",
@@ -151,7 +168,7 @@ describe("compaction summary calls — historical web-search sanitization", () =
     const result = await runAssistantDrivenCompaction({
       conversationId: "conv-web-search",
       messages,
-      provider: recordingProvider(sink),
+      provider: recordingProvider(sink, compactionResponse),
       systemPrompt: "system",
       compaction: { enabled: true, autoThreshold: 0.7 },
       maxInputTokens: 1000,
@@ -192,7 +209,7 @@ describe("compaction summary calls — historical web-search sanitization", () =
     const result = await runEmergencyCompaction({
       conversationId: "conv-web-search-emergency",
       messages,
-      provider: recordingProvider(sink),
+      provider: recordingProvider(sink, emergencyCompactionResponse),
       systemPrompt: "system",
       compaction: { enabled: true, autoThreshold: 0.7 },
       // Large budget so the prefix is not front-truncated — this test exercises

--- a/assistant/src/__tests__/context-window-manager-compact-retry.test.ts
+++ b/assistant/src/__tests__/context-window-manager-compact-retry.test.ts
@@ -90,6 +90,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../context/compactor.js", () => ({
+  isSyntheticCompactionMessage: () => false,
   runAssistantDrivenCompaction: async (args: {
     messages: unknown;
     previousEstimatedInputTokens: number;

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -179,7 +179,7 @@ active decisions, open questions, commitments, project states.
  * `{boundary_description}` (a description of the first preserved message so
  * the model knows exactly where "before" ends).
  */
-export const FIXED_BOUNDARY_COMPACTION_PROMPT = `<compaction_instructions>
+const FIXED_BOUNDARY_COMPACTION_PROMPT = `<compaction_instructions>
 The user has asked to summarize this conversation up to a fixed point they
 chose. Everything BEFORE that point is replaced by your summary; the boundary
 message and everything after it are preserved verbatim. You do not choose the
@@ -884,6 +884,22 @@ export function buildInstructionMessage(
 // ---------------------------------------------------------------------------
 
 /**
+ * Synthetic messages a compaction pass prepends to the rebuilt history —
+ * the summary head and the retained-images message. They have no DB row,
+ * so the persisted-count accounting of a later pass over the same
+ * in-memory history must exclude them (see
+ * `CompactionRunArgs.nonPersistedPrefixCount`). WeakSet-gated: only the
+ * exact objects minted here are recognized, never lookalike content.
+ */
+const SYNTHETIC_COMPACTION_MESSAGES = new WeakSet<Message>();
+
+export function isSyntheticCompactionMessage(
+  message: Message | undefined,
+): boolean {
+  return message != null && SYNTHETIC_COMPACTION_MESSAGES.has(message);
+}
+
+/**
  * Stitch summary + key_state into the assistant-role memory message that
  * heads the compacted context. Kept as a single block so downstream
  * lifecycle code can rehydrate it with the existing `contextSummary` text
@@ -1361,7 +1377,11 @@ export async function runAssistantDrivenCompaction(
   );
 
   const compactedMessages: Message[] = [summaryMessage];
-  if (retainedImageMessage) compactedMessages.push(retainedImageMessage);
+  SYNTHETIC_COMPACTION_MESSAGES.add(summaryMessage);
+  if (retainedImageMessage) {
+    compactedMessages.push(retainedImageMessage);
+    SYNTHETIC_COMPACTION_MESSAGES.add(retainedImageMessage);
+  }
   compactedMessages.push(...tailMessages);
 
   const nonPersistedCompactedAway = Math.min(
@@ -1565,7 +1585,10 @@ export async function runEmergencyCompaction(
   recordCompactionRequestLog(args.conversationId, response, args.provider);
 
   const rawText = extractTextFromResponse(response.content);
-  const parsed = parseCompactionResult(rawText);
+  // The emergency prompt asks for summary + key_state only — the split
+  // point is already fixed at `splitIndex`, so no `<tail_start>` is
+  // requested and a prompt-following response must still parse.
+  const parsed = parseCompactionResult(rawText, { requireTailStart: false });
   if (!parsed) {
     log.warn(
       { rawPreview: rawText.slice(0, 200) },
@@ -1588,6 +1611,7 @@ export async function runEmergencyCompaction(
   };
 
   const compactedMessages: Message[] = [summaryMessage, ...keptTail];
+  SYNTHETIC_COMPACTION_MESSAGES.add(summaryMessage);
 
   const compactedCount = splitIndex;
   const nonPersistedAway = Math.min(

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -27,6 +27,7 @@ import type { ContextWindowConfig } from "../../../config/types.js";
 import {
   type CompactionRunArgs,
   type CompactionRunResult,
+  isSyntheticCompactionMessage,
   runAssistantDrivenCompaction,
   runEmergencyCompaction,
 } from "../../../context/compactor.js";
@@ -689,6 +690,25 @@ export class ContextWindowManager {
       });
     }
 
+    // Shared compactor args for every pass in this call. `targetTokens` is
+    // intentionally absent — the fixed-boundary path never applies a budget
+    // forward-cut, and the auto path adds it per call site.
+    const baseArgs: CompactionRunArgs = {
+      conversationId: this.conversationId,
+      messages,
+      provider: this.provider,
+      systemPrompt: this.systemPrompt,
+      tools: this.resolveTools?.(),
+      compaction,
+      maxInputTokens: this.config.maxInputTokens,
+      previousEstimatedInputTokens,
+      force: options?.force,
+      signal,
+      overrideProfile: options?.overrideProfile ?? null,
+      actorTrustClass: options?.actorTrustClass,
+      nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
+    };
+
     // Caller-fixed boundary ("summarize up to here"): one compactor pass at
     // the user's chosen cut. No threshold gate (the user asked, regardless of
     // fullness), no target budget (the boundary is not a budget outcome), and
@@ -696,28 +716,15 @@ export class ContextWindowManager {
     // history past the boundary the user picked).
     if (options?.fixedTailStartIndex != null) {
       const result = await runAssistantDrivenCompaction({
-        conversationId: this.conversationId,
-        messages,
-        provider: this.provider,
-        systemPrompt: this.systemPrompt,
-        tools: this.resolveTools?.(),
-        compaction,
-        maxInputTokens: this.config.maxInputTokens,
-        previousEstimatedInputTokens,
+        ...baseArgs,
         force: true,
-        signal,
-        overrideProfile: options.overrideProfile ?? null,
-        actorTrustClass: options.actorTrustClass,
-        nonPersistedPrefixCount: this._nonPersistedPrefixCount,
         fixedTailStartIndex: options.fixedTailStartIndex,
       });
       if (!result.compacted) return result;
-      const estimatedInputTokens = this.recomputePostCompactionEstimate(
-        result.messages,
-        result.estimatedInputTokens,
-      );
-      this.consumeCompactionState(result.compactedMessages);
-      return { ...result, estimatedInputTokens };
+      return {
+        ...result,
+        estimatedInputTokens: this.settleCompactionAttempt(result),
+      };
     }
 
     if (!options?.force && previousEstimatedInputTokens < thresholdTokens) {
@@ -730,23 +737,6 @@ export class ContextWindowManager {
 
     const targetTokens = this.resolveCompactionTargetTokens(thresholdTokens);
 
-    const baseArgs: CompactionRunArgs = {
-      conversationId: this.conversationId,
-      messages,
-      provider: this.provider,
-      systemPrompt: this.systemPrompt,
-      tools: this.resolveTools?.(),
-      compaction,
-      maxInputTokens: this.config.maxInputTokens,
-      targetTokens,
-      previousEstimatedInputTokens,
-      force: options?.force,
-      signal,
-      overrideProfile: options?.overrideProfile ?? null,
-      actorTrustClass: options?.actorTrustClass,
-      nonPersistedPrefixCount: this._nonPersistedPrefixCount,
-    };
-
     // Retry budget for the compactor itself. Lives here (not in the
     // orchestrator/agent loop) because the question "did this compactor
     // make enough progress?" is a compaction-internal concern. The agent
@@ -754,17 +744,16 @@ export class ContextWindowManager {
     // or signal `exhausted` so reducers escalate.
     const maxAttempts = this.config.overflowRecovery.maxAttempts;
 
-    let result = await runAssistantDrivenCompaction(baseArgs);
+    let result = await runAssistantDrivenCompaction({
+      ...baseArgs,
+      targetTokens,
+    });
 
     // Compactor early-returned without doing any work (e.g. no eligible
     // messages, summary failed, disabled mid-way). Nothing to retry.
     if (!result.compacted) return result;
 
-    let estimatedInputTokens = this.recomputePostCompactionEstimate(
-      result.messages,
-      result.estimatedInputTokens,
-    );
-    this.consumeCompactionState(result.compactedMessages);
+    let estimatedInputTokens = this.settleCompactionAttempt(result);
 
     // If a single pass already cleared the auto-threshold, ship it.
     if (estimatedInputTokens < thresholdTokens) {
@@ -790,16 +779,15 @@ export class ContextWindowManager {
     for (let attempt = 2; attempt <= maxAttempts; attempt++) {
       const nextResult = await runAssistantDrivenCompaction({
         ...baseArgs,
+        targetTokens,
         messages: result.messages,
         previousEstimatedInputTokens: previousEstimate,
-        nonPersistedPrefixCount: this._nonPersistedPrefixCount,
+        nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(
+          result.messages,
+        ),
       });
       if (!nextResult.compacted) break;
-      const nextEstimate = this.recomputePostCompactionEstimate(
-        nextResult.messages,
-        nextResult.estimatedInputTokens,
-      );
-      this.consumeCompactionState(nextResult.compactedMessages);
+      const nextEstimate = this.settleCompactionAttempt(nextResult);
       result = mergeCompactionResults(result, nextResult);
       estimatedInputTokens = nextEstimate;
       if (estimatedInputTokens < thresholdTokens) {
@@ -849,7 +837,7 @@ export class ContextWindowManager {
       force: true,
       signal,
       overrideProfile: options.overrideProfile ?? null,
-      nonPersistedPrefixCount: this._nonPersistedPrefixCount,
+      nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
     });
   }
 
@@ -871,6 +859,41 @@ export class ContextWindowManager {
       log.warn({ err }, "Post-compaction token estimate failed");
       return fallback;
     }
+  }
+
+  /**
+   * Leading non-persisted messages of `messages` for persisted-count
+   * accounting: the seeded fork-inherited prefix, or the synthetic
+   * summary/retained-images head minted by conversation rehydration
+   * (`createContextSummaryMessage`) or a prior compaction pass — none of
+   * which have DB rows. `max`, not `+`: a fork-inherited prefix already
+   * counts its own inherited summary head.
+   */
+  private resolveNonPersistedPrefixCount(messages: Message[]): number {
+    let syntheticHead = 0;
+    while (
+      syntheticHead < messages.length &&
+      (getSummaryFromContextMessage(messages[syntheticHead]) != null ||
+        isSyntheticCompactionMessage(messages[syntheticHead]))
+    ) {
+      syntheticHead++;
+    }
+    return Math.max(this._nonPersistedPrefixCount, syntheticHead);
+  }
+
+  /**
+   * Post-pass bookkeeping shared by every productive compaction attempt:
+   * recompute the prompt estimate against the rebuilt history and settle
+   * the non-persisted prefix count the pass consumed. Returns the fresh
+   * estimate.
+   */
+  private settleCompactionAttempt(result: ContextWindowResult): number {
+    const estimatedInputTokens = this.recomputePostCompactionEstimate(
+      result.messages,
+      result.estimatedInputTokens,
+    );
+    this.consumeCompactionState(result.compactedMessages);
+    return estimatedInputTokens;
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for summarize-up-to-here.md.
- Fixed-boundary compaction no longer counts the synthetic summary head as a persisted message (second summarize previously ate one kept row)
- Emergency compaction parses prompt-conforming responses (requireTailStart: false); fixture corrected
- Dedup fixed-path args construction; unexport unused prompt const