### PR TITLE
fix(daemon): include the error message in the provider retry warning

### DIFF
--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -713,6 +713,7 @@ export class RetryProvider implements Provider {
               retryAfterHeader: retryAfter !== undefined,
               errorType,
               provider: this.name,
+              message: error instanceof Error ? error.message : String(error),
             },
             "Retrying after transient error",
           );


### PR DESCRIPTION
## Summary
- The `[retry] Retrying after transient error` warning in `RetryProvider` now logs the underlying error's message alongside `errorType`, using the `message:` field convention already used by the anthropic client's error logs.
- `errorType` is a coarse bucket derived from message patterns (e.g. `stream_corruption` covers four distinct SDK signatures), so without the raw message the specific failure was unrecoverable from daemon logs.

## Original prompt
While diagnosing a turn that silently restarted mid-stream (the provider SSE died mid-generation and `RetryProvider` re-sent the identical request), the daemon log's retry warning only showed `errorType: "stream_corruption"` — the actual SDK error message wasn't logged anywhere, so we couldn't tell which corruption pattern fired. Asked to update the retry warning to log the actual error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)