### PR TITLE
feat(onboarding): richer hidden kickoff prompt for first chat greeting

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -87,7 +87,9 @@ import {
  * but renders no user bubble, so the chat opens with the assistant proactively
  * greeting the user in the persona they just configured.
  */
-const LETS_CHAT_KICKOFF_MESSAGE = "hey, what's up";
+const LETS_CHAT_KICKOFF_MESSAGE = `You're about to begin your first conversation.
+Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
+Keep it short! Don't use \`recall\` or read any files.`;
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -89,7 +89,7 @@ import {
  */
 const LETS_CHAT_KICKOFF_MESSAGE = `You're about to begin your first conversation.
 Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
-Keep it short! Don't use \`recall\` or read any files.`;
+Keep it short! For this opening greeting only, don't use \`recall\` or read any files — just say hello. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {


### PR DESCRIPTION
## What

Updates the hidden kickoff message sent on the user's behalf at the end of the personality-onboarding flow — the message that drives the assistant's first reply as the user drops into chat (renders no user bubble, so the chat opens as a proactive greeting).

**Before:** `"hey, what's up"`

**After:**
> You're about to begin your first conversation.
> Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
> Keep it short! Don't use `recall` or read any files.

This gives the assistant an explicit brief for the first impression — warm, short, self-contained — instead of leaning on `recall` or file reads for its opening line.

## Where

`clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx` — the `LETS_CHAT_KICKOFF_MESSAGE` constant.

## Notes

- One-line constant change; no logic touched.
- Pre-existing `tsc` errors on `main` (stale generated-SDK drift in the plugins/home domains) are unrelated to this change and untouched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)