### PR TITLE
feat(onboarding): persona spinner lines, keep assistant name, no empty-state flash

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -542,6 +542,13 @@ export function ChatMainPanel({
     !!activeConversationId &&
     !isLoadingHistory &&
     messages.length === 0 &&
+    // A turn already in flight (e.g. the onboarding auto-greet, or any send whose
+    // first token hasn't landed) is NOT an empty conversation — showing the
+    // "start a conversation" empty state here flashes it for a beat before the
+    // streaming reply materializes (notably across the onboarding draft→real
+    // conversation switch, which resets the snapshot mid-turn).
+    !activeConversationIsProcessing &&
+    !isAssistantStreaming &&
     !(assistantState.kind === "active" && assistantState.maintenanceMode?.enabled);
 
   const showDoctorAction =

--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -41,6 +41,9 @@ describe("buildPersonalityMessage", () => {
     expect(msg).toContain("Overwrite each file completely with file_write");
     expect(msg).toContain("not an edit");
     expect(msg).toContain("do not append");
+    // The rewrite reshapes personality only — it must not rename the assistant.
+    expect(msg).toContain("Keep your existing name exactly as it is");
+    expect(msg).toContain("Do not rename yourself");
     expect(msg).toContain("<system-message>");
     expect(msg).toContain("</system-message>");
   });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -89,6 +89,8 @@ Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect
 
 Overwrite each file completely with file_write: write the whole file fresh in one pass. This is a from-scratch rewrite, not an edit — do not append to what's already there, do not patch individual lines, and leave none of the current default wording behind. Fill in every IDENTITY.md placeholder (the _(not yet chosen)_ / _(not yet established)_ fields).
 
+Keep your existing name exactly as it is — this changes your personality, not who you are. Do not rename yourself, and if your name is already set, carry it through verbatim (don't treat it as a placeholder to fill).
+
 Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, every file should read top-to-bottom as this new personality, with nothing left in the generic default voice.
 </system-message>`;
 }

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -679,6 +679,9 @@ export function ResearchOnboardingRoute() {
             // rewrite have settled, so the results/chat never open on a persona
             // that's still being written.
             ready={!researchLoading && !personalityPending}
+            // Weave the persona lines into the carousel when a personality was
+            // configured this session (locked on the personality step's continue).
+            applyingPersonality={personalityLocked}
           />
         )}
         {step === "results" && (

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -16,7 +16,14 @@
  * loading / empty presentation while the turn is still streaming.
  */
 
-import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ArrowRight, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
@@ -219,12 +226,27 @@ export function MeetingCreatedStep({
 // Looking you up (loading carousel)
 // ---------------------------------------------------------------------------
 
-const LOOKING_MESSAGES = [
+// Rotating status lines shown while the research turn (and, when the user
+// configured one, the personality rewrite) settle in the background. They loop
+// until `ready`, so the copy is pure flavor — it never gates progress.
+const WEB_SEARCH_MESSAGES = [
   "Searching the web to get to know you…",
   "Reading public profiles…",
+  "Skimming the highlights…",
   "Connecting the dots…",
-  "Almost there…",
+  "Piecing it together…",
 ];
+
+// Extra lines woven in when a personality was configured this session, so the
+// wait also narrates the persona rewrite that's running in the background.
+const PERSONALITY_MESSAGES = [
+  "Updating my personality…",
+  "Finding my voice…",
+  "Getting into character…",
+];
+
+// Always the final line, so the carousel settles on it when both operations land.
+const LOOKING_CLOSING_MESSAGE = "Almost there…";
 
 /** How long each rotating message lingers before advancing to the next. */
 const LOOKING_MESSAGE_INTERVAL_MS = 2800;
@@ -235,6 +257,7 @@ export function LookingYouUpStep({
   onAdvance,
   onForward,
   ready,
+  applyingPersonality = false,
 }: {
   onDone: () => void;
   onBack: () => void;
@@ -243,30 +266,46 @@ export function LookingYouUpStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
   /**
-   * The research turn has settled (results are ready, or there were none). Until
-   * then the carousel keeps rotating — looping the messages — so we never land
-   * on an empty "this is what I found" page.
+   * Both background operations have settled — the research turn (results are
+   * ready, or there were none) AND, when configured, the personality rewrite.
+   * Until then the carousel keeps rotating — looping the messages — so we never
+   * land on an empty "this is what I found" page or a half-written persona.
    */
   ready: boolean;
+  /**
+   * A personality was configured this session, so its rewrite is running in the
+   * background too — weave the persona lines into the carousel.
+   */
+  applyingPersonality?: boolean;
 }) {
   const tone = DARK_TONE;
   const [index, setIndex] = useState(0);
 
+  // Web-search lines first, the persona lines next (only when one's being
+  // applied), then the shared closer — so the wait reads as one continuous
+  // "getting ready" rather than two disjoint phases.
+  const messages = useMemo(() => {
+    const lines = [...WEB_SEARCH_MESSAGES];
+    if (applyingPersonality) lines.push(...PERSONALITY_MESSAGES);
+    lines.push(LOOKING_CLOSING_MESSAGE);
+    return lines;
+  }, [applyingPersonality]);
+
   useEffect(() => {
     onAdvance?.(index);
-    const isLast = index >= LOOKING_MESSAGES.length - 1;
-    // Finish on the last message once research is ready; otherwise keep cycling
-    // (looping back to the start) until it lands.
+    const isLast = index >= messages.length - 1;
+    // Finish on the last message once both operations are ready; otherwise keep
+    // cycling (looping back to the start) until they land.
     if (ready && isLast) {
       const done = setTimeout(onDone, LOOKING_MESSAGE_INTERVAL_MS);
       return () => clearTimeout(done);
     }
     const next = setTimeout(
-      () => setIndex((i) => (i + 1) % LOOKING_MESSAGES.length),
+      () => setIndex((i) => (i + 1) % messages.length),
       LOOKING_MESSAGE_INTERVAL_MS,
     );
     return () => clearTimeout(next);
-  }, [index, ready, onDone, onAdvance]);
+  }, [index, ready, onDone, onAdvance, messages.length]);
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -285,7 +324,7 @@ export function LookingYouUpStep({
             exit={{ y: -12, opacity: 0 }}
             transition={{ duration: 0.35 }}
           >
-            {LOOKING_MESSAGES[index]}
+            {messages[index]}
           </motion.p>
         </AnimatePresence>
       </div>


### PR DESCRIPTION
Three onboarding-handoff tweaks (all in the research-onboarding flow).

## 1. More spinner lines (incl. personality) on the "looking you up" wait
Expanded the loading carousel with extra web-search lines and added persona-rewrite lines ("Updating my personality…", "Finding my voice…", "Getting into character…") that show **only when a personality was configured this session**. Wired via a new `applyingPersonality` prop on `LookingYouUpStep` (fed from `personalityLocked`).

The carousel already gates on `ready = !researchLoading && !personalityPending`, so it holds until **both** the web search and the personality rewrite settle before advancing — personality is still guaranteed to finish before chat.

## 2. Personality rewrite must not rename the assistant
The personality system-message rewrites the identity files (IDENTITY.md / SOUL.md / guardian.md). Added an explicit instruction to **keep the existing name** and not treat it as a placeholder to fill, so a persona change can't accidentally rename the assistant. New assertion added in `apply-personality.test.ts` (3 tests pass).

## 3. No empty-state flash when dropping into chat
`isEmptyConversation` in `chat-route-content.tsx` now also requires `!activeConversationIsProcessing && !isAssistantStreaming`.

Root cause: across the onboarding **draft→real conversation switch**, the session snapshot is reset mid-turn (`switchToConversation`), so history briefly returns empty while the greeting turn is still streaming — `isLoadingHistory=false` + `messages.length===0` flashed the "start a conversation" empty state for ~1s. A conversation with a turn in flight isn't empty, so we no longer render the empty state during it. General fix, self-clearing, not onboarding-specific.

## Testing
- `apply-personality.test.ts`: 3 pass.
- `tsc`/`eslint`: no new errors in the changed files (pre-existing generated-SDK `tsc` drift on `main` is unrelated).
- [ ] **Needs visual QA** for the empty-state flash — run onboarding to the "Let's chat" handoff and confirm the chat opens straight on the greeting with no blank empty-state flash, and that the persona spinner lines appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)