### PR TITLE
fix(daemon): Slack watermark advances with fixed-boundary summarize + row-space card counts

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -291,6 +291,7 @@ mock.module("../contacts/canonical-guardian-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { Conversation } from "../daemon/conversation.js";
+import { formatSummarizeUpToResult } from "../daemon/conversation-process.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 
 // ---------------------------------------------------------------------------
@@ -561,7 +562,7 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(compactCalls[0].messages).toHaveLength(6);
   });
 
-  test("Slack: a fixed-boundary run persists no watermark; forced compaction still does", async () => {
+  test("Slack: a fixed-boundary run persists the watermark derived from the summarized rows; forced compaction still derives its own", async () => {
     mockDbMessages = slackThreeTurnRows();
     const conversation = makeConversation();
     conversation.setChannelCapabilities(slackCapabilities);
@@ -575,18 +576,81 @@ describe("Conversation.summarizeUpToMessage", () => {
 
     await conversation.summarizeUpToMessage("m4");
 
-    // The compacted prefix came from `this.messages`, not the Slack
-    // projection, so no Slack watermark can be derived from it.
-    expect(slackWatermarkCalls).toHaveLength(0);
+    // The watermark is the highest channelTs among the summarized rows
+    // rows[0..4) (m0..m3) — the next turn's Slack projection must exclude
+    // exactly the rows the new summary covers.
+    expect(slackWatermarkCalls).toHaveLength(1);
+    expect(slackWatermarkCalls[0][0]).toBe("conv-1");
+    expect(slackWatermarkCalls[0][1]).toBe("1000.000400");
 
-    // Contrast: the forced/auto path keeps its Slack behavior — it compacts
-    // the projection and persists a watermark derived from the compacted
+    // The forced/auto path keeps its Slack behavior — it compacts the
+    // projection and persists a watermark derived from the compacted
     // prefix's channelTs values.
     await conversation.forceCompact();
 
+    expect(slackWatermarkCalls).toHaveLength(2);
+    expect(slackWatermarkCalls[1][0]).toBe("conv-1");
+    expect(typeof slackWatermarkCalls[1][1]).toBe("string");
+  });
+
+  test("Slack: a fixed boundary advances an existing older watermark", async () => {
+    mockDbMessages = slackThreeTurnRows();
+    // A prior Slack auto-compaction left a watermark at m1's channelTs.
+    // Without an advance, rows m2/m3 would be injected twice on the next
+    // turn: once in the new summary and once verbatim in the projection.
+    mockConversation.slackContextCompactionWatermarkTs = "1000.000200";
+    const conversation = makeConversation();
+    conversation.setChannelCapabilities(slackCapabilities);
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "slack summary",
+    };
+
+    await conversation.summarizeUpToMessage("m4");
+
     expect(slackWatermarkCalls).toHaveLength(1);
-    expect(slackWatermarkCalls[0][0]).toBe("conv-1");
-    expect(typeof slackWatermarkCalls[0][1]).toBe("string");
+    expect(slackWatermarkCalls[0][1]).toBe("1000.000400");
+    expect(conversation.slackContextCompactionWatermarkTs).toBe("1000.000400");
+  });
+
+  test("Slack: a boundary at or before the existing watermark leaves it untouched", async () => {
+    mockDbMessages = slackThreeTurnRows();
+    // The existing watermark already covers every row in the summarize range
+    // (rows[0..4) top out at m3's 1000.000400), so those rows are already
+    // excluded from the projection — the watermark must never move backwards.
+    mockConversation.slackContextCompactionWatermarkTs = "1000.000400";
+    const conversation = makeConversation();
+    conversation.setChannelCapabilities(slackCapabilities);
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "slack summary",
+    };
+
+    await conversation.summarizeUpToMessage("m4");
+
+    expect(slackWatermarkCalls).toHaveLength(0);
+    expect(conversation.slackContextCompactionWatermarkTs).toBe("1000.000400");
+  });
+
+  test("non-Slack conversations persist no watermark on a fixed-boundary run", async () => {
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "plain summary",
+    };
+    const conversation = makeConversation();
+
+    await conversation.summarizeUpToMessage("m4");
+
+    expect(slackWatermarkCalls).toHaveLength(0);
   });
 
   test("throws the retryable UserError and skips compaction when the mapping cannot be verified", async () => {
@@ -619,5 +683,24 @@ describe("Conversation.summarizeUpToMessage", () => {
       "Conversation history is being reorganized — try again in a moment",
     );
     expect(compactCalls).toHaveLength(0);
+  });
+});
+
+describe("formatSummarizeUpToResult", () => {
+  test("renders row-space counts — the synthetic summary head is not a user-visible message", () => {
+    // A repeat summarize compacts the prior synthetic summary head along
+    // with 12 persisted rows, so the history-space count runs one ahead.
+    const card = formatSummarizeUpToResult({
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 13,
+      compactedPersistedMessages: 12,
+      preservedTailMessages: 4,
+      previousEstimatedInputTokens: 12_000,
+      estimatedInputTokens: 4_000,
+    });
+
+    expect(card).toContain("Summarized 12 earlier messages.");
+    expect(card).toContain("4 recent messages kept in full.");
   });
 });

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -136,7 +136,10 @@ export function formatSummarizeUpToResult(result: ContextWindowResult): string {
     result.previousEstimatedInputTokens - result.estimatedInputTokens;
   return [
     "**Conversation summarized**",
-    `Summarized ${fmt(result.compactedMessages)} earlier messages. ${fmt(
+    // Persisted (row-space) count — `compactedMessages` is history-space and
+    // counts the synthetic summary head on a repeat summarize, which is not
+    // a message the user ever saw. The kept tail never contains the head.
+    `Summarized ${fmt(result.compactedPersistedMessages)} earlier messages. ${fmt(
       result.preservedTailMessages,
     )} recent messages kept in full.`,
     `Context: ${fmt(result.previousEstimatedInputTokens)} → ${fmt(

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1205,6 +1205,41 @@ export function getSlackCompactionWatermarkForPrefix(
   );
 }
 
+/**
+ * Highest Slack `channelTs` carried by the persisted rows
+ * `rows[0..endExclusive)`, or `null` when it would not advance past
+ * `existingWatermarkTs`. Backs fixed-boundary summarization ("summarize up
+ * to here"), which compacts the in-memory history rather than the Slack
+ * chronological projection: the watermark is derived in row-space — the same
+ * space the boundary was resolved in — so the next turn's Slack projection
+ * excludes exactly the rows the new summary covers. The advance-only check
+ * keeps the watermark monotonic: a summarize range whose Slack rows all sit
+ * at or before the existing watermark is already excluded from the
+ * projection, so persisting nothing is correct.
+ */
+export function getSlackWatermarkAdvanceForRowPrefix(
+  rows: MessageRow[],
+  endExclusive: number,
+  existingWatermarkTs: string | null,
+): string | null {
+  const ts = maxSlackTs(
+    rows.slice(0, endExclusive).map(
+      (row) =>
+        readSlackMetadataFromMessageMetadata(row.metadata, {
+          allowFlatLegacy: true,
+        })?.channelTs ?? null,
+    ),
+  );
+  if (ts === null) return null;
+  if (
+    existingWatermarkTs !== null &&
+    !isSlackTsAfter(ts, existingWatermarkTs)
+  ) {
+    return null;
+  }
+  return ts;
+}
+
 function assembleSlackChronologicalContext(
   rows: SlackTranscriptInputRow[],
   capabilities: ChannelCapabilities,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -142,6 +142,7 @@ import { MessageQueue } from "./conversation-queue-manager.js";
 import {
   type ChannelCapabilities,
   getSlackCompactionWatermarkForPrefix,
+  getSlackWatermarkAdvanceForRowPrefix,
   type InboundActorContext,
   loadSlackChronologicalContext,
   stripInjectionsForCompaction,
@@ -1868,6 +1869,15 @@ export class Conversation {
       }
       return await this.runCompaction(true, undefined, {
         fixedTailStartIndex: tailIndex,
+        // Slack projections gate on the persisted watermark, not on
+        // `contextCompactedMessageCount` — without an advance, the summarized
+        // rows would reappear verbatim in the projection alongside the new
+        // summary. Null for non-Slack rows or a non-advancing boundary.
+        fixedBoundarySlackWatermarkTs: getSlackWatermarkAdvanceForRowPrefix(
+          rows,
+          boundaryRowIndex,
+          this.slackContextCompactionWatermarkTs,
+        ),
       });
     } finally {
       // Only undo the temporary guardian context this method installed. If
@@ -1909,12 +1919,18 @@ export class Conversation {
    * auto-threshold check inside the context-window manager (user-initiated
    * `/compact`); without it the manager no-ops below the threshold.
    * `opts.fixedTailStartIndex` pins the kept tail to a caller-chosen history
-   * index ("summarize up to here") instead of the token-budget cut.
+   * index ("summarize up to here") instead of the token-budget cut;
+   * `opts.fixedBoundarySlackWatermarkTs` is that path's row-space-derived
+   * Slack watermark (the auto/forced Slack path derives its own from the
+   * chronological projection).
    */
   private async runCompaction(
     force: boolean,
     sizing?: CompactionSizing,
-    opts?: { fixedTailStartIndex?: number },
+    opts?: {
+      fixedTailStartIndex?: number;
+      fixedBoundarySlackWatermarkTs?: string | null;
+    },
   ): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
     const config = getConfig();
@@ -1946,8 +1962,9 @@ export class Conversation {
     // `this.messages`; the Slack chronological projection is a different
     // array (watermark-sliced, actor-filtered, re-rendered) whose indices
     // don't correspond. Fixed-boundary runs therefore always compact
-    // `this.messages` and skip the Slack watermark (a null context makes
-    // `getSlackCompactionWatermarkForPrefix` return null below).
+    // `this.messages`; their Slack watermark arrives pre-derived in
+    // row-space via `opts.fixedBoundarySlackWatermarkTs` (a null context
+    // makes `getSlackCompactionWatermarkForPrefix` return null below).
     const slackChronologicalContext =
       opts?.fixedTailStartIndex == null &&
       this.channelCapabilities?.channel === "slack"
@@ -1989,10 +2006,12 @@ export class Conversation {
     }
     if (result.compacted) {
       await applyCompactionResult(this, result, this.sendToClient, null, {
-        slackContextCompactionWatermarkTs: getSlackCompactionWatermarkForPrefix(
-          slackChronologicalContext,
-          result.compactedMessages,
-        ),
+        slackContextCompactionWatermarkTs:
+          opts?.fixedBoundarySlackWatermarkTs ??
+          getSlackCompactionWatermarkForPrefix(
+            slackChronologicalContext,
+            result.compactedMessages,
+          ),
       });
     }
     return result;


### PR DESCRIPTION
## Summary
Round-2 review fixes for summarize-up-to-here.md.
- Fixed-boundary summarize on Slack conversations derives the watermark from the summarized row range (never backwards), eliminating duplicated context between old watermark and boundary
- Result card renders row-space message counts (no synthetic-head off-by-one in copy)