### PR TITLE
fix(compaction): robust synthetic-head accounting across repaired histories and fork prefixes

### DIFF
--- a/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
+++ b/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
@@ -66,6 +66,7 @@ import {
   ContextWindowManager,
   createContextSummaryMessage,
 } from "../plugins/defaults/compaction/window-manager.js";
+import { repairHistory } from "../plugins/defaults/history-repair/terminal.js";
 import type { Message, Provider } from "../providers/types.js";
 
 function turnTimestamp(turn: number): string {
@@ -242,6 +243,54 @@ describe("compactedPersistedMessages excludes the synthetic summary head", () =>
     expect(second.compactedPersistedMessages).toBe(2);
   });
 
+  test("repaired history — the structural marker catches a rebuilt rehydrated head", async () => {
+    // GIVEN the same rehydrated history after the per-turn history-repair
+    // pass, which copies content into fresh message wrappers — WeakSet
+    // identity is lost and only the `<context_summary>` marker remains
+    const { messages } = repairHistory(historyWithSummaryHead());
+    expect(messages.length).toBe(8);
+    const manager = buildManager(makeProvider([FIXED_RESPONSE]));
+
+    // WHEN a fixed-boundary pass runs over the repaired array
+    const result = await manager.maybeCompact(messages, undefined, {
+      fixedTailStartIndex: 5,
+    });
+
+    // THEN the head is still excluded from the persisted count
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(5);
+    expect(result.compactedPersistedMessages).toBe(4);
+  });
+
+  test("repaired history — a compactor-minted head is excluded on the next pass", async () => {
+    // GIVEN a history compacted once in this process, then run through
+    // history repair (the per-turn default) before the next compaction —
+    // the compactor-minted head must carry the structural marker or this
+    // pass counts it as a persisted row
+    const manager = buildManager(
+      makeProvider([FIXED_RESPONSE, FIXED_RESPONSE]),
+    );
+    const first = await manager.maybeCompact(
+      historyWithSummaryHead(),
+      undefined,
+      { fixedTailStartIndex: 5 },
+    );
+    expect(first.compacted).toBe(true);
+    const { messages: repaired } = repairHistory(first.messages);
+    // [minted summary, row 7, row 8, row 9] — alternating roles, no merges
+    expect(repaired.length).toBe(4);
+
+    // WHEN a second fixed-boundary pass cuts at row 9 (history index 3)
+    const second = await manager.maybeCompact(repaired, undefined, {
+      fixedTailStartIndex: 3,
+    });
+
+    // THEN only rows 7-8 count as compacted-persisted
+    expect(second.compacted).toBe(true);
+    expect(second.compactedMessages).toBe(3);
+    expect(second.compactedPersistedMessages).toBe(2);
+  });
+
   test("fork-inherited prefix is not double-counted with the summary head", async () => {
     // GIVEN a forked conversation whose seeded non-persisted prefix (2)
     // already includes its inherited summary head
@@ -261,11 +310,52 @@ describe("compactedPersistedMessages excludes the synthetic summary head", () =>
       fixedTailStartIndex: 4,
     });
 
-    // THEN the prefix is subtracted once (max, not summed with the head):
+    // THEN the prefix is subtracted once (the seed subsumes its own head):
     // compactable = [summary, inherited, row, row] → 2 persisted rows
     expect(result.compacted).toBe(true);
     expect(result.compactedMessages).toBe(4);
     expect(result.compactedPersistedMessages).toBe(2);
+  });
+
+  test("partially consumed fork prefix — a later pass counts minted head plus remaining seed", async () => {
+    // GIVEN a fork whose seeded 2-message prefix was only partially consumed:
+    // the first pass folds just the inherited summary head, leaving one
+    // seeded message behind a freshly minted head
+    const messages: Message[] = [
+      createContextSummaryMessage("Inherited summary from the parent."),
+      userTurn(0, "inherited user context with no DB row"),
+      userTurn(1, "Alice's first persisted message"),
+      assistantTurn(2, "assistant replies"),
+      userTurn(3, "Alice follows up"),
+      assistantTurn(4, "assistant replies again"),
+    ];
+    const manager = buildManager(
+      makeProvider([FIXED_RESPONSE, FIXED_RESPONSE]),
+    );
+    manager.seedNonPersistedPrefix(2);
+    // Cut at the inherited user message (index 1) — a user boundary the
+    // tool-pairing back-walk leaves in place
+    const first = await manager.maybeCompact(messages, undefined, {
+      fixedTailStartIndex: 1,
+    });
+    expect(first.compacted).toBe(true);
+    expect(first.compactedMessages).toBe(1);
+    expect(first.compactedPersistedMessages).toBe(0);
+    // [minted summary, inherited user message, rows 1-4]
+    expect(first.messages.length).toBe(6);
+
+    // WHEN a second pass compacts past both the minted head and the
+    // remaining seeded message (cut at row 3 — history index 4)
+    const second = await manager.maybeCompact(first.messages, undefined, {
+      fixedTailStartIndex: 4,
+    });
+
+    // THEN the non-persisted lead is minted head + remaining seed = 2, so
+    // exactly rows 1-2 count as persisted — a max() of the two spans would
+    // under-count the lead and drop a kept row on reload
+    expect(second.compacted).toBe(true);
+    expect(second.compactedMessages).toBe(4);
+    expect(second.compactedPersistedMessages).toBe(2);
   });
 
   test("emergency compaction over a rehydrated summary head", async () => {

--- a/assistant/src/__tests__/compactor-low-watermark-cut.test.ts
+++ b/assistant/src/__tests__/compactor-low-watermark-cut.test.ts
@@ -46,7 +46,10 @@ mock.module("../persistence/llm-request-log-store.js", () => ({
   recordRequestLog: () => {},
 }));
 
-import { runAssistantDrivenCompaction } from "../context/compactor.js";
+import {
+  runAssistantDrivenCompaction,
+  wrapContextSummaryText,
+} from "../context/compactor.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import type { Message, Provider } from "../providers/types.js";
 
@@ -346,6 +349,9 @@ describe("runAssistantDrivenCompaction — low-watermark forward cut", () => {
     // persists and rehydrates from `result.summaryText`, so a notice that
     // lived only on the in-memory message would vanish on reload/fork.
     expect(result.summaryText).toContain("Context budget enforcement");
-    expect(result.summaryText).toBe(summaryTextOut);
+    // The in-history head is the durable text in the `<context_summary>`
+    // wrapper, so rehydration from the persisted column rebuilds the head
+    // byte-for-byte.
+    expect(summaryTextOut).toBe(wrapContextSummaryText(result.summaryText));
   });
 });

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -883,6 +883,23 @@ export function buildInstructionMessage(
 // Summary message construction
 // ---------------------------------------------------------------------------
 
+export const CONTEXT_SUMMARY_MARKER = "<context_summary>";
+export const CONTEXT_SUMMARY_CLOSE = "</context_summary>";
+
+/**
+ * Wrap durable summary text in the `<context_summary>` tags that identify a
+ * synthetic summary head. Every summary head in a live history carries this
+ * wrapper — the reload/fork rehydration path (`createContextSummaryMessage`
+ * in the compaction plugin) and the compactor-minted heads below — so
+ * persisted-count accounting can recognize a head structurally even after
+ * history repair rebuilds message wrappers and WeakSet identity is lost.
+ * The durable `summaryText` result field stays unwrapped; rehydration adds
+ * the wrapper back when it rebuilds the head from the DB column.
+ */
+export function wrapContextSummaryText(summary: string): string {
+  return `${CONTEXT_SUMMARY_MARKER}\n${summary}\n${CONTEXT_SUMMARY_CLOSE}`;
+}
+
 /**
  * Synthetic messages a compaction pass prepends to the rebuilt history —
  * the summary head and the retained-images message. They have no DB row,
@@ -1224,7 +1241,7 @@ export async function runAssistantDrivenCompaction(
   let finalSummaryText = summaryText;
   let summaryMessage: Message = {
     role: "assistant",
-    content: [{ type: "text", text: finalSummaryText }],
+    content: [{ type: "text", text: wrapContextSummaryText(finalSummaryText) }],
   };
 
   const {
@@ -1325,7 +1342,9 @@ export async function runAssistantDrivenCompaction(
       finalSummaryText = summaryText + truncationNote;
       summaryMessage = {
         role: "assistant",
-        content: [{ type: "text", text: finalSummaryText }],
+        content: [
+          { type: "text", text: wrapContextSummaryText(finalSummaryText) },
+        ],
       };
       log.info(
         {
@@ -1607,7 +1626,7 @@ export async function runEmergencyCompaction(
   const summaryText = buildSummaryMemoryText(parsed.summary, parsed.keyState);
   const summaryMessage: Message = {
     role: "assistant",
-    content: [{ type: "text", text: summaryText }],
+    content: [{ type: "text", text: wrapContextSummaryText(summaryText) }],
   };
 
   const compactedMessages: Message[] = [summaryMessage, ...keptTail];

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -27,9 +27,12 @@ import type { ContextWindowConfig } from "../../../config/types.js";
 import {
   type CompactionRunArgs,
   type CompactionRunResult,
+  CONTEXT_SUMMARY_CLOSE,
+  CONTEXT_SUMMARY_MARKER,
   isSyntheticCompactionMessage,
   runAssistantDrivenCompaction,
   runEmergencyCompaction,
+  wrapContextSummaryText,
 } from "../../../context/compactor.js";
 import {
   estimatePromptTokens,
@@ -52,8 +55,7 @@ import { resolveOverflowAction } from "./overflow-policy.js";
 
 const log = getLogger("context-window");
 
-export const CONTEXT_SUMMARY_MARKER = "<context_summary>";
-const CONTEXT_SUMMARY_CLOSE = "</context_summary>";
+export { CONTEXT_SUMMARY_MARKER };
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 // ---------------------------------------------------------------------------
@@ -258,12 +260,7 @@ export interface ContextWindowManagerOptions {
 export function createContextSummaryMessage(summary: string): Message {
   const message: Message = {
     role: "assistant",
-    content: [
-      {
-        type: "text",
-        text: `${CONTEXT_SUMMARY_MARKER}\n${summary}\n${CONTEXT_SUMMARY_CLOSE}`,
-      },
-    ],
+    content: [{ type: "text", text: wrapContextSummaryText(summary) }],
   };
   INTERNAL_CONTEXT_SUMMARY_MESSAGES.add(message);
   return message;
@@ -291,6 +288,22 @@ function extractText(content: ContentBlock[]): string {
     .join("\n");
 }
 
+/**
+ * Content-shaped detection of a synthetic summary head: assistant-role with
+ * text starting at the `<context_summary>` marker every summary head carries
+ * (`wrapContextSummaryText`). Used only for persisted-count accounting, where
+ * a false positive is conservative — see
+ * {@link ContextWindowManager.resolveNonPersistedPrefixCount}. Never use it to
+ * extract summary text; that is {@link getSummaryFromContextMessage}'s
+ * WeakSet-gated job.
+ */
+function isStructuralContextSummaryHead(message: Message | undefined): boolean {
+  return (
+    message?.role === "assistant" &&
+    extractText(message.content).trim().startsWith(CONTEXT_SUMMARY_MARKER)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // ContextWindowManager
 // ---------------------------------------------------------------------------
@@ -310,6 +323,15 @@ export class ContextWindowManager {
    * rows. Decremented after a successful compaction.
    */
   private _nonPersistedPrefixCount = 0;
+  /**
+   * Whether the seeded prefix still occupies the very front of the history.
+   * True from seeding until the first productive compaction pass: such a pass
+   * rebuilds the front with a freshly minted summary head that is NOT part of
+   * the seed, after which the head and any remaining seed are disjoint spans.
+   * {@link resolveNonPersistedPrefixCount} switches between "the seed subsumes
+   * its own synthetic head" and "minted head + remaining seed" on this flag.
+   */
+  private _seedLeadsHistory = false;
   /**
    * Reducer state for the in-progress overflow-recovery ladder, held across
    * the successive {@link reduceOverflowOneRung} calls of a single turn so the
@@ -366,6 +388,7 @@ export class ContextWindowManager {
    */
   seedNonPersistedPrefix(count: number): void {
     this._nonPersistedPrefixCount = count;
+    this._seedLeadsHistory = count > 0;
   }
 
   private get estimationProviderName(): string {
@@ -676,7 +699,8 @@ export class ContextWindowManager {
       });
     }
 
-    if (this.conversationId == null) {
+    const conversationId = this.conversationId;
+    if (conversationId == null) {
       // The compactor needs the conversation id to look up image
       // attachments and DB timestamps. If we don't have one (legacy test
       // path, ad-hoc instantiation), skip — never fabricate one.
@@ -690,11 +714,14 @@ export class ContextWindowManager {
       });
     }
 
-    // Shared compactor args for every pass in this call. `targetTokens` is
-    // intentionally absent — the fixed-boundary path never applies a budget
-    // forward-cut, and the auto path adds it per call site.
-    const baseArgs: CompactionRunArgs = {
-      conversationId: this.conversationId,
+    // Shared compactor args for every pass in this call. Built lazily — only
+    // on paths that actually invoke the compactor — so the below-threshold
+    // no-op (the common outcome of idle `maybeCompact` gate calls) never pays
+    // tool resolution or the prefix walk. `targetTokens` is intentionally
+    // absent — the fixed-boundary path never applies a budget forward-cut,
+    // and the auto path adds it per call site.
+    const buildBaseArgs = (): CompactionRunArgs => ({
+      conversationId,
       messages,
       provider: this.provider,
       systemPrompt: this.systemPrompt,
@@ -707,7 +734,7 @@ export class ContextWindowManager {
       overrideProfile: options?.overrideProfile ?? null,
       actorTrustClass: options?.actorTrustClass,
       nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
-    };
+    });
 
     // Caller-fixed boundary ("summarize up to here"): one compactor pass at
     // the user's chosen cut. No threshold gate (the user asked, regardless of
@@ -716,7 +743,7 @@ export class ContextWindowManager {
     // history past the boundary the user picked).
     if (options?.fixedTailStartIndex != null) {
       const result = await runAssistantDrivenCompaction({
-        ...baseArgs,
+        ...buildBaseArgs(),
         force: true,
         fixedTailStartIndex: options.fixedTailStartIndex,
       });
@@ -735,6 +762,7 @@ export class ContextWindowManager {
       });
     }
 
+    const baseArgs = buildBaseArgs();
     const targetTokens = this.resolveCompactionTargetTokens(thresholdTokens);
 
     // Retry budget for the compactor itself. Lives here (not in the
@@ -825,7 +853,7 @@ export class ContextWindowManager {
         "ContextWindowManager has no conversationId — cannot run emergency compaction",
       );
     }
-    return await runEmergencyCompaction({
+    const result = await runEmergencyCompaction({
       conversationId: this.conversationId,
       messages,
       provider: this.provider,
@@ -839,6 +867,10 @@ export class ContextWindowManager {
       overrideProfile: options.overrideProfile ?? null,
       nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
     });
+    // A productive emergency pass rebuilds the history front just like the
+    // ordinary path, so it consumes the same non-persisted prefix bookkeeping.
+    if (result.compacted) this.consumeCompactionState(result.compactedMessages);
+    return result;
   }
 
   /**
@@ -863,22 +895,48 @@ export class ContextWindowManager {
 
   /**
    * Leading non-persisted messages of `messages` for persisted-count
-   * accounting: the seeded fork-inherited prefix, or the synthetic
+   * accounting: the seeded fork-inherited prefix and/or the synthetic
    * summary/retained-images head minted by conversation rehydration
    * (`createContextSummaryMessage`) or a prior compaction pass — none of
-   * which have DB rows. `max`, not `+`: a fork-inherited prefix already
-   * counts its own inherited summary head.
+   * which have DB rows.
+   *
+   * The synthetic head is detected two ways. WeakSet identity
+   * ({@link isSyntheticCompactionMessage}) covers heads passed through as the
+   * exact minted objects; the structural marker check covers heads whose
+   * wrappers were rebuilt by history repair (repair copies content into fresh
+   * message objects every turn, so identity is lost). A structural false
+   * positive — an assistant message that merely starts with the marker — errs
+   * toward a LOWER persisted count, so the boundary advances less and more
+   * rows are kept verbatim: conservative, no data loss. That failure direction
+   * is why a content-shaped check is acceptable here while
+   * {@link getSummaryFromContextMessage} (which EXTRACTS summary text for
+   * reuse) rightly stays WeakSet-gated.
+   *
+   * The retained-images message needs no structural fallback: within the pass
+   * that minted it, it keeps WeakSet identity; after history repair it merges
+   * into the adjacent first tail user message (both user-role), and the merged
+   * message occupies that kept message's position, which the accounting
+   * already attributes correctly.
    */
   private resolveNonPersistedPrefixCount(messages: Message[]): number {
     let syntheticHead = 0;
     while (
       syntheticHead < messages.length &&
-      (getSummaryFromContextMessage(messages[syntheticHead]) != null ||
+      (isStructuralContextSummaryHead(messages[syntheticHead]) ||
         isSyntheticCompactionMessage(messages[syntheticHead]))
     ) {
       syntheticHead++;
     }
-    return Math.max(this._nonPersistedPrefixCount, syntheticHead);
+    if (this._seedLeadsHistory) {
+      // The seeded prefix still heads the history, so any synthetic head the
+      // walk found is the seed's own inherited summary — already inside the
+      // seed count, not an addition to it.
+      return Math.max(this._nonPersistedPrefixCount, syntheticHead);
+    }
+    // A compaction pass has rebuilt the front (or there is no seed): the
+    // minted head and any remaining seeded prefix are disjoint leading spans
+    // — `[head..., remaining seed..., persisted rows...]` — so they sum.
+    return syntheticHead + this._nonPersistedPrefixCount;
   }
 
   /**
@@ -903,6 +961,11 @@ export class ContextWindowManager {
    * into the summary.
    */
   private consumeCompactionState(compactedMessages: number): void {
+    if (compactedMessages > 0) {
+      // The pass rebuilt the history front with a minted summary head, so any
+      // remaining seed now sits behind that head rather than at index 0.
+      this._seedLeadsHistory = false;
+    }
     const compactedAway = Math.min(
       this._nonPersistedPrefixCount,
       compactedMessages,


### PR DESCRIPTION
## Summary
Round-2 review fixes for summarize-up-to-here.md.
- Summary-head exclusion now survives history-repair wrapper rebuilds (structural marker fallback; conservative failure direction)
- Compactor-minted heads carry the `<context_summary>` marker (matching the rehydrated form) so the structural check covers in-process second passes, not just reloaded heads
- Positional non-persisted prefix counting replaces max() (fork partial-consume cases)
- baseArgs construction deferred past the threshold gate again