### PR TITLE
fix(compaction): disjoint-regime seed decrement + Slack watermark inversion guard

### DIFF
--- a/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
+++ b/assistant/src/__tests__/compaction-summary-head-persisted-count.test.ts
@@ -358,6 +358,54 @@ describe("compactedPersistedMessages excludes the synthetic summary head", () =>
     expect(second.compactedPersistedMessages).toBe(2);
   });
 
+  test("a pass that compacts only the minted head leaves the remaining seed intact", async () => {
+    // GIVEN a fork in the disjoint regime — [minted head, remaining seed,
+    // rows] — with exactly one seeded message left
+    const messages: Message[] = [
+      createContextSummaryMessage("Inherited summary from the parent."),
+      userTurn(0, "inherited user context with no DB row"),
+      userTurn(1, "Alice's first persisted message"),
+      assistantTurn(2, "assistant replies"),
+      userTurn(3, "Alice follows up"),
+      assistantTurn(4, "assistant replies again"),
+    ];
+    const manager = buildManager(
+      makeProvider([FIXED_RESPONSE, FIXED_RESPONSE, FIXED_RESPONSE]),
+    );
+    manager.seedNonPersistedPrefix(2);
+    // First pass consumes the seed's inherited summary head, entering the
+    // disjoint regime with 1 seeded message behind a freshly minted head
+    const first = await manager.maybeCompact(messages, undefined, {
+      fixedTailStartIndex: 1,
+    });
+    expect(first.compacted).toBe(true);
+    expect(manager.nonPersistedPrefixCount).toBe(1);
+
+    // WHEN a pass compacts ONLY the minted head (cut at the seeded user
+    // message, history index 1) — no seed message is folded away
+    const second = await manager.maybeCompact(first.messages, undefined, {
+      fixedTailStartIndex: 1,
+    });
+
+    // THEN the head position is not charged against the seed
+    expect(second.compacted).toBe(true);
+    expect(second.compactedMessages).toBe(1);
+    expect(second.compactedPersistedMessages).toBe(0);
+    expect(manager.nonPersistedPrefixCount).toBe(1);
+
+    // AND the next pass still counts minted head + surviving seed as the
+    // non-persisted lead: compacting [head, seed, rows 1-2] (cut at row 3,
+    // history index 4) yields exactly 2 persisted rows — an over-consumed
+    // seed would report 3 and slice a kept row out on reload
+    const third = await manager.maybeCompact(second.messages, undefined, {
+      fixedTailStartIndex: 4,
+    });
+    expect(third.compacted).toBe(true);
+    expect(third.compactedMessages).toBe(4);
+    expect(third.compactedPersistedMessages).toBe(2);
+    expect(manager.nonPersistedPrefixCount).toBe(0);
+  });
+
   test("emergency compaction over a rehydrated summary head", async () => {
     // GIVEN a mid-turn overflow history led by a rehydrated summary head,
     // with the last tool pair anchoring the emergency split at index 2

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -638,6 +638,36 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(conversation.slackContextCompactionWatermarkTs).toBe("1000.000400");
   });
 
+  test("Slack: no watermark advance when a kept-tail row's channelTs falls behind the prefix max", async () => {
+    // Row order ≠ Slack channel order: the kept row m4 was delivered late,
+    // carrying an older channelTs (1000.000350) than the summarized prefix's
+    // max (m3's 1000.000400). Advancing the watermark to the prefix max
+    // would exclude m4 from every future projection while the summary does
+    // not cover it either — skip the advance and accept bounded duplication.
+    mockDbMessages = [
+      slackRow("m0", "user", "u1", "1000.000100"),
+      slackRow("m1", "assistant", "a1", "1000.000200"),
+      slackRow("m2", "user", "u2", "1000.000300"),
+      slackRow("m3", "assistant", "a2", "1000.000400"),
+      slackRow("m4", "user", "u3", "1000.000350"),
+      slackRow("m5", "assistant", "a3", "1000.000600"),
+    ];
+    const conversation = makeConversation();
+    conversation.setChannelCapabilities(slackCapabilities);
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "slack summary",
+    };
+
+    await conversation.summarizeUpToMessage("m4");
+
+    expect(slackWatermarkCalls).toHaveLength(0);
+    expect(conversation.slackContextCompactionWatermarkTs).toBeNull();
+  });
+
   test("non-Slack conversations persist no watermark on a fixed-boundary run", async () => {
     mockCompactResult = {
       ...makeNoopResult(),

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1216,26 +1216,38 @@ export function getSlackCompactionWatermarkForPrefix(
  * keeps the watermark monotonic: a summarize range whose Slack rows all sit
  * at or before the existing watermark is already excluded from the
  * projection, so persisting nothing is correct.
+ *
+ * Row order is not guaranteed to match Slack channel order (late-delivered
+ * rows), so a kept-tail row past the boundary can carry an OLDER `channelTs`
+ * than the prefix max. Advancing anyway would drop that row from every
+ * future projection (`isSlackTsAfter` keeps strictly-after) while the
+ * summary doesn't cover it either — silent loss. When any kept row's
+ * `channelTs` sits at or before the candidate, the advance is skipped
+ * entirely, degrading to bounded duplication of already-summarized rows: the
+ * conservative direction.
  */
 export function getSlackWatermarkAdvanceForRowPrefix(
   rows: MessageRow[],
   endExclusive: number,
   existingWatermarkTs: string | null,
 ): string | null {
-  const ts = maxSlackTs(
-    rows.slice(0, endExclusive).map(
-      (row) =>
-        readSlackMetadataFromMessageMetadata(row.metadata, {
-          allowFlatLegacy: true,
-        })?.channelTs ?? null,
-    ),
-  );
+  const channelTsForRow = (row: MessageRow): string | null =>
+    readSlackMetadataFromMessageMetadata(row.metadata, {
+      allowFlatLegacy: true,
+    })?.channelTs ?? null;
+  const ts = maxSlackTs(rows.slice(0, endExclusive).map(channelTsForRow));
   if (ts === null) return null;
   if (
     existingWatermarkTs !== null &&
     !isSlackTsAfter(ts, existingWatermarkTs)
   ) {
     return null;
+  }
+  for (const row of rows.slice(endExclusive)) {
+    const keptTs = channelTsForRow(row);
+    if (keptTs !== null && !isSlackTsAfter(keptTs, ts)) {
+      return null;
+    }
   }
   return ts;
 }

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -304,6 +304,26 @@ function isStructuralContextSummaryHead(message: Message | undefined): boolean {
   );
 }
 
+/**
+ * Length of the leading synthetic span of `messages`: the summary and
+ * retained-images messages minted by conversation rehydration or a prior
+ * compaction pass, detected by WeakSet identity with a structural-marker
+ * fallback for wrappers rebuilt by history repair. See
+ * {@link ContextWindowManager.resolveNonPersistedPrefixCount} for why the
+ * structural fallback's false-positive direction is conservative.
+ */
+function countSyntheticHead(messages: Message[]): number {
+  let syntheticHead = 0;
+  while (
+    syntheticHead < messages.length &&
+    (isStructuralContextSummaryHead(messages[syntheticHead]) ||
+      isSyntheticCompactionMessage(messages[syntheticHead]))
+  ) {
+    syntheticHead++;
+  }
+  return syntheticHead;
+}
+
 // ---------------------------------------------------------------------------
 // ContextWindowManager
 // ---------------------------------------------------------------------------
@@ -750,7 +770,7 @@ export class ContextWindowManager {
       if (!result.compacted) return result;
       return {
         ...result,
-        estimatedInputTokens: this.settleCompactionAttempt(result),
+        estimatedInputTokens: this.settleCompactionAttempt(result, messages),
       };
     }
 
@@ -781,7 +801,7 @@ export class ContextWindowManager {
     // messages, summary failed, disabled mid-way). Nothing to retry.
     if (!result.compacted) return result;
 
-    let estimatedInputTokens = this.settleCompactionAttempt(result);
+    let estimatedInputTokens = this.settleCompactionAttempt(result, messages);
 
     // If a single pass already cleared the auto-threshold, ship it.
     if (estimatedInputTokens < thresholdTokens) {
@@ -815,7 +835,10 @@ export class ContextWindowManager {
         ),
       });
       if (!nextResult.compacted) break;
-      const nextEstimate = this.settleCompactionAttempt(nextResult);
+      const nextEstimate = this.settleCompactionAttempt(
+        nextResult,
+        result.messages,
+      );
       result = mergeCompactionResults(result, nextResult);
       estimatedInputTokens = nextEstimate;
       if (estimatedInputTokens < thresholdTokens) {
@@ -869,7 +892,12 @@ export class ContextWindowManager {
     });
     // A productive emergency pass rebuilds the history front just like the
     // ordinary path, so it consumes the same non-persisted prefix bookkeeping.
-    if (result.compacted) this.consumeCompactionState(result.compactedMessages);
+    if (result.compacted) {
+      this.consumeCompactionState(
+        result.compactedMessages,
+        countSyntheticHead(messages),
+      );
+    }
     return result;
   }
 
@@ -919,14 +947,7 @@ export class ContextWindowManager {
    * already attributes correctly.
    */
   private resolveNonPersistedPrefixCount(messages: Message[]): number {
-    let syntheticHead = 0;
-    while (
-      syntheticHead < messages.length &&
-      (isStructuralContextSummaryHead(messages[syntheticHead]) ||
-        isSyntheticCompactionMessage(messages[syntheticHead]))
-    ) {
-      syntheticHead++;
-    }
+    const syntheticHead = countSyntheticHead(messages);
     if (this._seedLeadsHistory) {
       // The seeded prefix still heads the history, so any synthetic head the
       // walk found is the seed's own inherited summary — already inside the
@@ -942,15 +963,23 @@ export class ContextWindowManager {
   /**
    * Post-pass bookkeeping shared by every productive compaction attempt:
    * recompute the prompt estimate against the rebuilt history and settle
-   * the non-persisted prefix count the pass consumed. Returns the fresh
-   * estimate.
+   * the non-persisted prefix count the pass consumed. `passInputMessages` is
+   * the history the pass compacted FROM — its synthetic-head length tells
+   * the consume step which compacted positions were head, not seed. Returns
+   * the fresh estimate.
    */
-  private settleCompactionAttempt(result: ContextWindowResult): number {
+  private settleCompactionAttempt(
+    result: ContextWindowResult,
+    passInputMessages: Message[],
+  ): number {
     const estimatedInputTokens = this.recomputePostCompactionEstimate(
       result.messages,
       result.estimatedInputTokens,
     );
-    this.consumeCompactionState(result.compactedMessages);
+    this.consumeCompactionState(
+      result.compactedMessages,
+      countSyntheticHead(passInputMessages),
+    );
     return estimatedInputTokens;
   }
 
@@ -958,21 +987,29 @@ export class ContextWindowManager {
    * Decrement the non-persisted prefix bookkeeping after a productive
    * compaction. Called once per successful internal attempt so multi-attempt
    * runs keep the count honest as the leading injected messages get folded
-   * into the summary.
+   * into the summary. `syntheticHeadCount` is the synthetic-head length of
+   * the pass's input history.
    */
-  private consumeCompactionState(compactedMessages: number): void {
+  private consumeCompactionState(
+    compactedMessages: number,
+    syntheticHeadCount: number,
+  ): void {
+    // While the seed leads the history, every compacted leading position is
+    // a seed message (the seed subsumes its own inherited summary head). In
+    // the disjoint regime — [minted head, remaining seed, rows] — the leading
+    // syntheticHeadCount compacted positions are the head, so only positions
+    // past it charge the seed.
+    const seedMessagesCompacted = this._seedLeadsHistory
+      ? compactedMessages
+      : Math.max(0, compactedMessages - syntheticHeadCount);
     if (compactedMessages > 0) {
       // The pass rebuilt the history front with a minted summary head, so any
       // remaining seed now sits behind that head rather than at index 0.
       this._seedLeadsHistory = false;
     }
-    const compactedAway = Math.min(
-      this._nonPersistedPrefixCount,
-      compactedMessages,
-    );
     this._nonPersistedPrefixCount = Math.max(
       0,
-      this._nonPersistedPrefixCount - compactedAway,
+      this._nonPersistedPrefixCount - seedMessagesCompacted,
     );
   }
 }


### PR DESCRIPTION
## Summary
Round-3 review residuals for summarize-up-to-here.md — both non-conservative edge cases hardened.
- Seed consumption no longer charges synthetic-head positions against the fork/subagent seed (disjoint regime)
- Slack watermark advance skipped when any kept-tail row's channelTs would fall at/behind it (degrades to bounded duplication, never loss)