### PR TITLE
fix(onboarding): don't clobber users/guardian.md in the personality rewrite

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -34,7 +34,11 @@ describe("buildPersonalityMessage", () => {
     expect(msg).toContain("Seriousness (0 - 100): 0");
     expect(msg).toContain("Politeness (0 - 100): 40");
     expect(msg).toContain("Unfiltered Rawness/Crassness (0 - 100): 60");
-    expect(msg).toContain("Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md)");
+    expect(msg).toContain("Rewrite your own identity files (IDENTITY.md and SOUL.md)");
+    // The rewrite is scoped to the assistant's own identity — the user's
+    // profile (users/guardian.md) must be preserved, not clobbered by
+    // personality text.
+    expect(msg).toContain("Do not touch users/guardian.md");
     // The instruction forces a full overwrite rather than an append, so the
     // rewrite lands the persona in the assistant's voice instead of stacking a
     // patch on top of the default text.

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -5,9 +5,10 @@
  *
  * The personality step collects five 0–100 trait sliders. On continue we hand
  * them to the real hatched assistant as a system-message that asks it to
- * rewrite its identity files (IDENTITY.md / SOUL.md / users/guardian.md) in a
- * voice matching the new personality — the durable way to reshape its persona,
- * since those files feed every future conversation's system prompt.
+ * rewrite its own identity files (IDENTITY.md / SOUL.md) in a voice matching
+ * the new personality — the durable way to reshape its persona, since those
+ * files feed every future conversation's system prompt. The user's profile
+ * (users/guardian.md) is left untouched.
  *
  * Like the research turn (`research-runner.ts`) and the check-in
  * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
@@ -85,13 +86,13 @@ Seriousness (0 - 100): ${playfulSerious}
 Politeness (0 - 100): ${100 - politeUnfiltered}
 Unfiltered Rawness/Crassness (0 - 100): ${politeUnfiltered}
 
-Rewrite your identity files (IDENTITY.md, SOUL.md, users/guardian.md) to reflect your new personality — first person, in a voice and style that matches it.
+Rewrite your own identity files (IDENTITY.md and SOUL.md) to reflect your new personality — first person, in a voice and style that matches it. Do not touch users/guardian.md or anything else under users/: that is your user's profile (their name, work, preferences), not your identity.
 
 Overwrite each file completely with file_write: write the whole file fresh in one pass. This is a from-scratch rewrite, not an edit — do not append to what's already there, do not patch individual lines, and leave none of the current default wording behind. Fill in every IDENTITY.md placeholder (the _(not yet chosen)_ / _(not yet established)_ fields).
 
 Keep your existing name exactly as it is — this changes your personality, not who you are. Do not rename yourself, and if your name is already set, carry it through verbatim (don't treat it as a placeholder to fill).
 
-Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, every file should read top-to-bottom as this new personality, with nothing left in the generic default voice.
+Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, both files should read top-to-bottom as this new personality, with nothing left in the generic default voice.
 </system-message>`;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #36825 addressing Codex review feedback.

The onboarding personality step's system-message (`buildPersonalityMessage` in `apply-personality.ts`) instructed the assistant to fully overwrite `IDENTITY.md`, `SOUL.md`, **and `users/guardian.md`** with `file_write`. But `users/guardian.md` is the **user's** profile, not assistant identity: it holds the guardian's preferred name, role, work context, and tool preferences — seeded by workspace migrations 017/031 and written by `prechat-profile.ts` via a *preserving* upsert.

On the fresh-hatch path the profile is upserted after the rewrite, so it survives. The live risk is the **upgrade / re-onboarding path**: an existing `users/guardian.md` gets clobbered by assistant personality text, wiping the user's name/work/preferences.

## Fix

Scope the full-rewrite instruction to the assistant's own identity files (`IDENTITY.md`, `SOUL.md`) and explicitly tell the assistant to leave `users/guardian.md` (and everything under `users/`) untouched. The PR's original purpose is preserved — the personality step still performs a from-scratch full overwrite of the assistant identity rather than merging politely.

Per the repo's **Assistant-Driven Judgement** rule this is an instruction-only change; the client just posts the message and the assistant performs the writes, so no client-side deterministic guard is applicable. Test assertions in `apply-personality.test.ts` updated to lock the new scoping and the guardian.md preservation.

## Files

- `clients/web/src/domains/onboarding/apply-personality.ts` — prompt text + module docstring
- `clients/web/src/domains/onboarding/apply-personality.test.ts` — assertions