### PR TITLE
test(plugins): catch namespace imports in the plugin import boundary guard

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -393,22 +393,59 @@ function parseNamedSymbols(clause: string): string[] {
     .filter((name) => name.length > 0);
 }
 
+/** Sentinel returned by {@link symbolsImportedFrom} for a namespace import
+ *  (`import * as NS from "X"` / `import type * as NS from "X"`): it binds the
+ *  module's entire export surface, so it counts as importing every re-exported
+ *  symbol. `*` cannot collide with a real named-import identifier. */
+const NAMESPACE_IMPORT = "*";
+
 /** Symbols a plugin file imports from a host module whose specifier ends with
- *  `hostPathSuffix` (e.g. `providers/types.js`), across multi-line clauses. */
+ *  `hostPathSuffix` (e.g. `providers/types.js`), across multi-line clauses. A
+ *  namespace import yields the {@link NAMESPACE_IMPORT} sentinel — it reaches
+ *  the whole surface, so it must not slip past the anti-backslide check. */
 function symbolsImportedFrom(source: string, hostPathSuffix: string): string[] {
   const escaped = hostPathSuffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const regex = new RegExp(
-    String.raw`import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]*` +
-      escaped +
-      String.raw`)['"]`,
+  const from = String.raw`\s*from\s*['"]([^'"]*` + escaped + String.raw`)['"]`;
+  const namedRegex = new RegExp(
+    String.raw`import\s+(?:type\s+)?\{([^}]*)\}` + from,
+    "g",
+  );
+  const namespaceRegex = new RegExp(
+    String.raw`import\s+(?:type\s+)?\*\s+as\s+\w+` + from,
     "g",
   );
   const symbols: string[] = [];
   let match: RegExpExecArray | null;
-  while ((match = regex.exec(source)) !== null) {
+  while ((match = namedRegex.exec(source)) !== null) {
     symbols.push(...parseNamedSymbols(match[1]!));
   }
+  while (namespaceRegex.exec(source) !== null) {
+    symbols.push(NAMESPACE_IMPORT);
+  }
   return symbols;
+}
+
+/** Anti-backslide violations for one plugin file against one guarded host
+ *  module: any re-exported symbol imported by name, plus any namespace import
+ *  (which binds the whole surface, and thus every guarded symbol). */
+function guardedImportViolations(
+  file: PluginFile,
+  hostPathSuffix: string,
+  guarded: ReadonlySet<string>,
+): string[] {
+  const violations: string[] = [];
+  for (const symbol of symbolsImportedFrom(file.source, hostPathSuffix)) {
+    if (symbol === NAMESPACE_IMPORT) {
+      violations.push(
+        `  - ${file.relPath}: "import * as … from ${hostPathSuffix}" reaches all re-exported symbols`,
+      );
+    } else if (guarded.has(symbol)) {
+      violations.push(
+        `  - ${file.relPath}: "${symbol}" from ${hostPathSuffix}`,
+      );
+    }
+  }
+  return violations;
 }
 
 describe("plugin import boundary", () => {
@@ -484,26 +521,18 @@ describe("plugin import boundary", () => {
   test("plugins import plugin-api-provided types from @vellumai/plugin-api, not host modules", () => {
     const violations: string[] = [];
     for (const file of files) {
-      for (const symbol of symbolsImportedFrom(
-        file.source,
-        "providers/types.js",
-      )) {
-        if (PLUGIN_API_PROVIDER_TYPES.has(symbol)) {
-          violations.push(
-            `  - ${file.relPath}: "${symbol}" from providers/types.js`,
-          );
-        }
-      }
-      for (const symbol of symbolsImportedFrom(
-        file.source,
-        "config/schemas/llm.js",
-      )) {
-        if (PLUGIN_API_LLM_TYPES.has(symbol)) {
-          violations.push(
-            `  - ${file.relPath}: "${symbol}" from config/schemas/llm.js`,
-          );
-        }
-      }
+      violations.push(
+        ...guardedImportViolations(
+          file,
+          "providers/types.js",
+          PLUGIN_API_PROVIDER_TYPES,
+        ),
+        ...guardedImportViolations(
+          file,
+          "config/schemas/llm.js",
+          PLUGIN_API_LLM_TYPES,
+        ),
+      );
     }
 
     const message = [
@@ -516,5 +545,59 @@ describe("plugin import boundary", () => {
     ].join("\n");
 
     expect(violations, message).toEqual([]);
+  });
+});
+
+describe("anti-backslide symbol extraction", () => {
+  const fileWith = (source: string): PluginFile => ({
+    plugin: "compaction",
+    relPath: "src/plugins/defaults/compaction/example.ts",
+    absPath: "/example.ts",
+    source,
+  });
+
+  test("a re-exported type imported by name is flagged", () => {
+    const file = fileWith(
+      `import type { Message } from "../../../providers/types.js";`,
+    );
+    expect(
+      guardedImportViolations(
+        file,
+        "providers/types.js",
+        PLUGIN_API_PROVIDER_TYPES,
+      ),
+    ).not.toEqual([]);
+  });
+
+  test("the allowed ToolDefinition named import stays clean", () => {
+    const file = fileWith(
+      `import type { ToolDefinition } from "../../../providers/types.js";`,
+    );
+    expect(
+      guardedImportViolations(
+        file,
+        "providers/types.js",
+        PLUGIN_API_PROVIDER_TYPES,
+      ),
+    ).toEqual([]);
+  });
+
+  // A namespace import binds the whole surface (`NS.Message`), so it must be
+  // caught even though the anti-backslide check extracts no named symbols and
+  // the specifier is already in the ratchet baseline.
+  test("a namespace import of a guarded module is flagged", () => {
+    for (const source of [
+      `import * as ProviderTypes from "../../../providers/types.js";`,
+      `import type * as ProviderTypes from "../../../providers/types.js";`,
+    ]) {
+      expect(
+        guardedImportViolations(
+          fileWith(source),
+          "providers/types.js",
+          PLUGIN_API_PROVIDER_TYPES,
+        ),
+        source,
+      ).not.toEqual([]);
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #36424 addressing Codex review feedback.

The anti-backslide guard's symbol-extraction (`symbolsImportedFrom`) only matched named `import { ... } from` clauses. A plugin whose ratchet baseline already lists a guarded specifier (e.g. compaction baselines `../../../providers/types.js`) could add `import type * as ProviderTypes from "../../../providers/types.js"` and use `ProviderTypes.Message`: the ratchet sees an already-baselined specifier, and the anti-backslide check extracts no symbols — so the exact regression this guard exists to prevent slipped through for a valid TypeScript import form.

## Fix
- Extend `symbolsImportedFrom` to also recognize namespace import forms (`import * as NS from` and `import type * as NS from`). A namespace import binds the module's whole export surface, so it yields a `NAMESPACE_IMPORT` (`"*"`) sentinel that trips the anti-backslide check regardless of the guarded set.
- Ratchet semantics for named imports are unchanged.
- Consolidated the two near-identical anti-backslide loops into a single `guardedImportViolations` helper (DRY).
- Added regression tests covering the three branches: named guarded symbol → flagged, allowed `ToolDefinition` named import → clean, namespace import (both `import * as` and `import type * as`) → flagged.

## Verification
- `bun test src/__tests__/plugin-import-boundary-guard.test.ts` → 5 pass / 0 fail.
- End-to-end: temporarily injecting `import type * as ProviderTypes from "../../../providers/types.js"` into the real compaction plugin makes the integration guard fail as expected; reverting restores green.