### PR TITLE
refactor(migrations): inline raw SQL in migration 041 for self-containment

### DIFF
--- a/assistant/src/workspace/migrations/041-backfill-google-gmail-settings-scope.ts
+++ b/assistant/src/workspace/migrations/041-backfill-google-gmail-settings-scope.ts
@@ -1,4 +1,7 @@
-import { rawGet, rawRun } from "../../persistence/raw-query.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
 import type { WorkspaceMigration } from "./types.js";
 
 const GMAIL_SETTINGS_BASIC_SCOPE =
@@ -18,36 +21,52 @@ export const backfillGoogleGmailSettingsScopeMigration: WorkspaceMigration = {
   id: "041-backfill-google-gmail-settings-scope",
   description:
     "Backfill gmail.settings.basic scope for existing Google provider rows",
-  run(_workspaceDir: string): void {
-    let row: { defaultScopes: string } | null;
+  run(workspaceDir: string): void {
+    const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+    if (!existsSync(dbPath)) return; // DB not created yet — nothing to backfill.
+
+    let db: Database;
     try {
-      row = rawGet<{ defaultScopes: string }>(
-        `SELECT defaultScopes FROM oauth_providers WHERE provider = 'google'`,
-      );
+      db = new Database(dbPath);
     } catch {
-      // DB not initialized yet — nothing to backfill.
+      // Cannot open DB — nothing to backfill.
       return;
     }
 
-    if (!row) return; // No google provider row — seed will create it fresh.
-
-    let scopes: string[];
     try {
-      const parsed = JSON.parse(row.defaultScopes);
-      scopes = Array.isArray(parsed) ? parsed : [];
-    } catch {
-      scopes = [];
+      let row: { defaultScopes: string } | null;
+      try {
+        row =
+          (db
+            .query(
+              `SELECT defaultScopes FROM oauth_providers WHERE provider = 'google'`,
+            )
+            .get() as { defaultScopes: string }) ?? null;
+      } catch {
+        // DB not initialized yet — nothing to backfill.
+        return;
+      }
+
+      if (!row) return; // No google provider row — seed will create it fresh.
+
+      let scopes: string[];
+      try {
+        const parsed = JSON.parse(row.defaultScopes);
+        scopes = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        scopes = [];
+      }
+
+      if (scopes.includes(GMAIL_SETTINGS_BASIC_SCOPE)) return; // Already present.
+
+      scopes.push(GMAIL_SETTINGS_BASIC_SCOPE);
+
+      db.query(
+        `UPDATE oauth_providers SET defaultScopes = ?, updatedAt = ? WHERE provider = 'google'`,
+      ).run(JSON.stringify(scopes), new Date().toISOString());
+    } finally {
+      db.close();
     }
-
-    if (scopes.includes(GMAIL_SETTINGS_BASIC_SCOPE)) return; // Already present.
-
-    scopes.push(GMAIL_SETTINGS_BASIC_SCOPE);
-
-    rawRun(
-      `UPDATE oauth_providers SET defaultScopes = ?, updatedAt = ? WHERE provider = 'google'`,
-      JSON.stringify(scopes),
-      new Date().toISOString(),
-    );
   },
   down(_workspaceDir: string): void {
     // Forward-only: removing the scope would break Gmail settings functionality


### PR DESCRIPTION
Follow-up to #36448 addressing Codex review feedback.

Migration 041 imported rawGet/rawRun from ../../persistence/raw-query.js. The workspace migrations AGENTS.md requires each migration to be fully self-contained (only ./types.js, ./utils.js, ../../util/logger.js, and runtime built-ins may be imported), because coupling an append-only historical migration to live persistence code lets a future helper change break the migration when it runs on an older install.

This inlines the SQLite get/run logic via bun:sqlite directly, matching the established self-contained pattern already used by sibling migration 042 (existsSync guard, try/finally close).

Behavior is byte-for-byte equivalent:
- The original (intentionally legacy) SQL and control flow are preserved verbatim, including the Drizzle-property column names that do not exist in the real schema. On every real DB the SELECT throws no-such-column, the inner catch swallows it, and the migration completes as a no-op — exactly as before. Migration 042 performs the actual backfill with the correct column names.
- The existsSync guard prevents new Database from creating an empty DB file where none exists (a side effect the shared global-connection helper never had), and the finally block closes the connection.

Verified with a scratch harness against a realistic oauth_providers schema: run() makes no changes, creates no DB file when absent, does not throw when the table is missing, and down() is a no-op.

Only migration 041 is touched; migration 011 is handled by a sibling task.