### PR TITLE
fix(providers): hold whitespace-suffixed empty-turn sentinels until block stop

### DIFF
--- a/assistant/src/providers/__tests__/placeholder-sentinels.test.ts
+++ b/assistant/src/providers/__tests__/placeholder-sentinels.test.ts
@@ -71,10 +71,64 @@ describe("couldBePlaceholderSentinelPrefix", () => {
     expect(couldBePlaceholderSentinelPrefix(`\x00__PLACE`)).toBe(true);
   });
 
+  test("holds a complete sentinel carrying trailing edge whitespace", () => {
+    // A lone delta can carry the whole sentinel plus trailing noise; trimming
+    // only the leading edge would overshoot the bare form and flash it.
+    expect(couldBePlaceholderSentinelPrefix(`${BARE_EMPTY}\n`)).toBe(true);
+    expect(couldBePlaceholderSentinelPrefix(` ${BARE_EMPTY}\n`)).toBe(true);
+    expect(couldBePlaceholderSentinelPrefix(`\t${BARE_EMPTY}  `)).toBe(true);
+    expect(couldBePlaceholderSentinelPrefix(`${BARE_BLOCKS}\n`)).toBe(true);
+  });
+
   test("releases text that cannot become a sentinel", () => {
     expect(couldBePlaceholderSentinelPrefix(" hello")).toBe(false);
     expect(couldBePlaceholderSentinelPrefix("hello")).toBe(false);
     // Overshoots the sentinel — no longer a prefix.
     expect(couldBePlaceholderSentinelPrefix(`${BARE_EMPTY} x`)).toBe(false);
+  });
+});
+
+// Mirrors the Anthropic client's `stream.on("text")` buffering loop and its
+// `content_block_stop` flush (assistant/src/providers/anthropic/client.ts):
+// append each delta, hold while the buffer could still be a sentinel, otherwise
+// emit the whole buffer; at block stop, drop the residue only if it is a
+// sentinel. Returns the ordered list of text deltas the live UI would receive.
+function streamTextDeltas(deltas: readonly string[]): string[] {
+  const emitted: string[] = [];
+  let textBuffer = "";
+  for (const delta of deltas) {
+    textBuffer += delta;
+    if (couldBePlaceholderSentinelPrefix(textBuffer)) continue;
+    emitted.push(textBuffer);
+    textBuffer = "";
+  }
+  // content_block_stop: flush residual text buffer unless it is a sentinel.
+  if (textBuffer.length > 0 && !isPlaceholderSentinelText(textBuffer)) {
+    emitted.push(textBuffer);
+  }
+  return emitted;
+}
+
+describe("Anthropic stream sentinel buffering", () => {
+  test("a whitespace-suffixed sentinel in one delta is dropped at block stop, never emitted", () => {
+    // The regression: held through streaming, classified as a sentinel at block
+    // stop, so nothing reaches the live UI.
+    expect(streamTextDeltas([` ${BARE_EMPTY}\n`])).toEqual([]);
+    expect(streamTextDeltas([`${BARE_BLOCKS}\n`])).toEqual([]);
+  });
+
+  test("a sentinel prefix followed by real text still streams", () => {
+    // The prefix is held alone, then real content breaks it and the whole buffer
+    // flushes — genuine content is never withheld.
+    expect(streamTextDeltas([BARE_EMPTY, " and then real words"])).toEqual([
+      `${BARE_EMPTY} and then real words`,
+    ]);
+    expect(streamTextDeltas(["__PLACE", "HOLD me a table"])).toEqual([
+      "__PLACEHOLD me a table",
+    ]);
+  });
+
+  test("plain content streams delta-by-delta without batching", () => {
+    expect(streamTextDeltas(["Hello", " there"])).toEqual(["Hello", " there"]);
   });
 });

--- a/assistant/src/providers/placeholder-sentinels.ts
+++ b/assistant/src/providers/placeholder-sentinels.ts
@@ -56,14 +56,20 @@ export function isPlaceholderSentinelText(text: string): boolean {
 }
 
 /**
- * True when `text` could still grow into a sentinel: once leading whitespace and
- * control noise is stripped, the remainder is a prefix of a bare sentinel (the
- * empty string included, so a buffer of pure edge noise is still held). The
- * streaming guard uses this to avoid flashing a sentinel — or an echo whose
- * `\x00` guard arrived as whitespace — on the live UI before completion.
+ * True when `text` could still grow into a sentinel — or already is one carrying
+ * trailing edge noise. Once whitespace and control bytes are stripped from BOTH
+ * edges, the remainder must be a prefix of a bare sentinel: the empty string
+ * (pure edge noise) and a complete sentinel (a prefix of itself, so
+ * `"<sentinel>\n"`) both qualify and stay held until block stop, where
+ * `isPlaceholderSentinelText` drops them. The streaming guard uses this to keep
+ * a sentinel — or an echo whose `\x00` guard arrived as whitespace — off the
+ * live UI before completion.
+ *
+ * Genuine content is never withheld: any non-whitespace byte breaks the prefix,
+ * extending the trimmed remainder past every bare form, so the buffer flushes.
  */
 export function couldBePlaceholderSentinelPrefix(text: string): boolean {
-  const normalized = stripLeadingEdgeNoise(text);
+  const normalized = stripSentinelEdgeNoise(text);
   return PLACEHOLDER_SENTINEL_BARE_FORMS.some((form) =>
     form.startsWith(normalized),
   );


### PR DESCRIPTION
Follow-up to #36583 addressing the remaining open Codex review thread.

`couldBePlaceholderSentinelPrefix` normalized only the leading edge before its `startsWith` prefix check, so a single streamed delta carrying the full sentinel plus trailing edge-whitespace (e.g. " __PLACEHOLDER__[empty assistant turn]\n") failed the prefix match. The Anthropic stream handler emitted and cleared the buffer immediately, `content_block_stop` never applied `isPlaceholderSentinelText`, and the sentinel flashed in the live UI even though completion/persistence filters classified it correctly.

Fix: trim both edges (via the existing `stripSentinelEdgeNoise`) for the prefix decision, so a complete sentinel plus edge noise stays held until block stop where it is dropped. Genuine content is still released the moment a non-whitespace byte breaks the prefix, and normalization stays lenient for corrupted echoes.

Tests: extend `placeholder-sentinels.test.ts` with the whitespace-suffixed single-delta case (held, then dropped at block stop, not emitted) and a sentinel-prefix-then-real-text case (still streams), plus a small buffering simulation mirroring the client stream loop.