### PR TITLE
fix(memory): degrade v3 dense lane to [] when the dimension preflight rejects

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -28,12 +28,18 @@ const embedState = {
   calls: [] as string[][],
   throws: null as Error | null,
   dimensionAvailable: true,
+  dimensionThrows: null as Error | null,
 };
 mock.module(
   "../../../../../persistence/embeddings/embedding-backend.js",
   () => ({
     ...realEmbeddingBackend,
-    isEmbeddingDimensionAvailable: async () => embedState.dimensionAvailable,
+    isEmbeddingDimensionAvailable: async () => {
+      // Models the availability probe rejecting — e.g. a transient
+      // credential-store error surfacing through getProviderKeyAsync.
+      if (embedState.dimensionThrows) throw embedState.dimensionThrows;
+      return embedState.dimensionAvailable;
+    },
     embedWithBackend: async (_config: unknown, inputs: string[]) => {
       embedState.calls.push(inputs);
       if (embedState.throws) throw embedState.throws;
@@ -97,6 +103,7 @@ function resetState(): void {
   embedState.calls.length = 0;
   embedState.throws = null;
   embedState.dimensionAvailable = true;
+  embedState.dimensionThrows = null;
   state.points = [];
   state.queryThrows = null;
   state.queryCalls.length = 0;
@@ -191,6 +198,19 @@ describe("memory v3 dense lane", () => {
     expect(state.queryCalls).toHaveLength(0);
   });
 
+  test("a rejected availability probe degrades to [] without embedding", async () => {
+    // A transient credential-store error can reject the dimension preflight;
+    // the lane must still honor its `[]` contract so the orchestrator's
+    // unguarded Promise.all does not discard the sibling needle/reply lanes.
+    embedState.dimensionThrows = new Error("credential store unreachable");
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
   test("a failed embedding degrades to []", async () => {
     embedState.throws = new Error("embed backend down");
 
@@ -253,6 +273,16 @@ describe("denseLaneScored", () => {
 
   test("a committed-dimension/reachable-backend mismatch degrades to []", async () => {
     embedState.dimensionAvailable = false;
+
+    const hits = await denseLaneScored(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    expect(embedState.calls).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("a rejected availability probe degrades to []", async () => {
+    embedState.dimensionThrows = new Error("credential store unreachable");
 
     const hits = await denseLaneScored(CONFIG, "query", 5);
 

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -69,12 +69,17 @@ export async function denseLaneScored(
 ): Promise<DenseHitScored[]> {
   if (k <= 0) return [];
 
-  if (!(await isEmbeddingDimensionAvailable(config))) {
-    return [];
-  }
-
   let points: Array<{ payload?: unknown; score?: number }>;
   try {
+    // Inside the try so a rejecting probe (e.g. a transient credential-store
+    // error surfacing through getProviderKeyAsync) degrades to `[]` instead of
+    // throwing — the orchestrator calls this lane in an unguarded Promise.all
+    // that relies on the `[]` contract, so one throw would discard the sibling
+    // lanes too. The check itself skips the embed on a dimension mismatch.
+    if (!(await isEmbeddingDimensionAvailable(config))) {
+      return [];
+    }
+
     const { vectors } = await embedWithBackend(config, [query]);
     const vector = vectors[0];
     if (!vector || vector.length === 0) return [];


### PR DESCRIPTION
Follow-up to #36545 addressing Codex review feedback.

## Problem
In `denseLaneScored` (assistant/src/plugins/defaults/memory/v3/dense.ts), the `await isEmbeddingDimensionAvailable(config)` preflight ran BEFORE the try/catch. That probe can reject: it flows through `getProviderKeyAsync` → `getSecureKeyResultAsync` → `withCredentialTimeout`, which propagates non-timeout credential-store errors (only genuine timeouts return a fallback). A transient credential-store blip therefore rejected the dense lane instead of returning `[]` as the lane's contract documents.

`orchestrate.ts` calls the lane inside an unguarded `Promise.all` that relies on that `[]` contract, so one throw discarded the sibling needle/reply lanes too and failed memory retrieval for the turn.

## Fix
Move the dimension preflight inside the lane's try/catch. Any error — including a rejecting availability probe — now degrades to `return []`, while the preflight still short-circuits the embed round-trip on a committed-dimension mismatch (behavior unchanged for that case).

## Tests
Added a `dimensionThrows` hook to the embedding-backend mock and a regression test in each of the `denseLane` and `denseLaneScored` suites asserting the lane returns `[]` (with no embed/Qdrant round-trip) when the availability probe rejects. Verified the new tests fail without the fix. Full file: 16 pass.

## Scope
Other `isEmbeddingDimensionAvailable` call sites in the memory plugin (v2 `sim.ts`/`activation.ts`) are covered by the sibling never-throws-contract fix (#36533); left untouched per task scoping.