### PR TITLE
fix(memory): uphold probeBackendDimension never-throws contract

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-identity.test.ts
@@ -13,11 +13,15 @@ let backendToReturn: {
   embed: (inputs: string[]) => Promise<number[][]>;
 } | null = null;
 let breakerOpen = false;
+let selectBackendThrows = false;
 
-const selectEmbeddingBackendMock = mock(async () => ({
-  backend: backendToReturn,
-  reason: backendToReturn ? null : "no backend",
-}));
+const selectEmbeddingBackendMock = mock(async () => {
+  if (selectBackendThrows) throw new Error("credential store unavailable");
+  return {
+    backend: backendToReturn,
+    reason: backendToReturn ? null : "no backend",
+  };
+});
 // probeBackendDimension delegates the measurement to resolveBackendDimension;
 // the mock mirrors the real resolver's "embed → vector length, null on throw"
 // contract so these tests drive behavior through the stub backend's embed().
@@ -69,6 +73,7 @@ const { probeBackendDimension, readConceptPageCollectionDim } =
 describe("probeBackendDimension", () => {
   beforeEach(() => {
     breakerOpen = false;
+    selectBackendThrows = false;
     backendToReturn = {
       provider: "openai",
       model: "text-embedding-3-small",
@@ -108,6 +113,14 @@ describe("probeBackendDimension", () => {
         throw new Error("provider unreachable");
       },
     };
+    expect(await probeBackendDimension(CONFIG)).toBeNull();
+  });
+
+  test("returns null (does not reject) when backend selection rejects", async () => {
+    // `selectEmbeddingBackend` resolves provider credentials, which reject on a
+    // non-timeout credential-store error. The probe must uphold its never-throws
+    // contract so the reconcile defers instead of crashing.
+    selectBackendThrows = true;
     expect(await probeBackendDimension(CONFIG)).toBeNull();
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-identity.ts
+++ b/assistant/src/persistence/embeddings/embedding-identity.ts
@@ -1,6 +1,7 @@
 import { QdrantClient } from "@qdrant/js-client-rest";
 
 import type { AssistantConfig } from "../../config/types.js";
+import { getLogger } from "../../util/logger.js";
 import {
   resolveBackendDimension,
   selectEmbeddingBackend,
@@ -8,6 +9,8 @@ import {
 import { isEmbeddingBillingBreakerOpen } from "./embedding-billing-breaker.js";
 import type { EmbeddingProviderName } from "./embedding-types.js";
 import { resolveQdrantUrl } from "./qdrant-client.js";
+
+const log = getLogger("embedding-identity");
 
 // Inlined rather than imported from `memory/v2/qdrant.ts`: the persistence
 // layer must not import from the memory feature layer (enforced by
@@ -28,6 +31,7 @@ export interface BackendDimensionProbe {
  * reconcile defers rather than committing on a measurement it could not take:
  *   - the billing breaker is open (treated as "backend down");
  *   - no backend is configured/selectable;
+ *   - backend selection throws (e.g. a transient credential-store error);
  *   - the measurement probe throws (provider unreachable).
  *
  * Delegates the dimension measurement to {@link resolveBackendDimension}, the
@@ -40,12 +44,20 @@ export async function probeBackendDimension(
 ): Promise<BackendDimensionProbe | null> {
   if (isEmbeddingBillingBreakerOpen()) return null;
 
-  const { backend } = await selectEmbeddingBackend(config);
-  if (!backend) return null;
+  try {
+    const { backend } = await selectEmbeddingBackend(config);
+    if (!backend) return null;
 
-  const dim = await resolveBackendDimension(backend);
-  if (dim == null) return null;
-  return { provider: backend.provider, model: backend.model, dim };
+    const dim = await resolveBackendDimension(backend);
+    if (dim == null) return null;
+    return { provider: backend.provider, model: backend.model, dim };
+  } catch (err) {
+    // `selectEmbeddingBackend` resolves provider credentials and can reject on a
+    // non-timeout credential-store error; the reconcile relies on a null return
+    // to defer, so honor the never-throws contract and treat it as degraded.
+    log.warn({ err }, "Embedding-dimension probe failed; treating as degraded");
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Follow-up to #36533 addressing Codex review feedback.

`probeBackendDimension()` documents a "returns null — never throws" contract that `reconcileEmbeddingIdentity` (and other callers) rely on to defer reconciliation when the backend is unavailable. It awaited `selectEmbeddingBackend(config)` outside any try/catch. That call resolves provider credentials via `getProviderKeyAsync`, which rejects on non-timeout credential-store errors (only timeouts are swallowed by `withCredentialTimeout`) — so a transient CES/encrypted-store error made the probe reject, crashing the whole reconcile instead of deferring degraded.

Wrap the backend selection + dimension measurement in the same non-throwing handling as the rest of the probe: catch → warn (matching neighboring `resolveBackendDimension`) → return null. `resolveBackendDimension`'s billing-breaker behavior is unchanged.

Adds a unit test asserting the probe returns null (not rejects) when backend selection rejects.

The other Codex comment on #36533 (billing blocks from direct probe calls) was already addressed in #36549.