### PR TITLE
fix(calls): keep contact-origin call-status pointer turns off guardian elevation

### DIFF
--- a/assistant/src/__tests__/call-pointer-messages.test.ts
+++ b/assistant/src/__tests__/call-pointer-messages.test.ts
@@ -355,7 +355,7 @@ describe("addPointerMessage", () => {
     expect(processorCalled).toBe(true);
   });
 
-  test("trusted_contact provenance trust class is detected as trusted audience", async () => {
+  test("trusted_contact provenance uses the deterministic fallback, not the daemon turn", async () => {
     const convId = "conv-ptr-tc-provenance";
     ensureConversation(convId);
     // Add a user message with trusted_contact provenance metadata
@@ -369,12 +369,17 @@ describe("addPointerMessage", () => {
     });
 
     await addPointerMessage(convId, "completed", "+15559876543");
-    expect(processorCalled).toBe(true);
+    // A known contact is not the owner: routing through the daemon turn would
+    // run it under the internal guardian context and leak guardian-only history
+    // into the contact's conversation, so the deterministic fallback is used.
+    expect(processorCalled).toBe(false);
+    const text = getLatestAssistantText(convId);
+    expect(text).toContain("Call to +15559876543 completed");
   });
 
-  test("unverified_contact provenance round-trips through the metadata schema and is treated as trusted audience", async () => {
+  test("unverified_contact provenance round-trips through the metadata schema and uses the deterministic fallback", async () => {
     // Persisted unverified_contact metadata must survive the schema parse so
-    // downstream consumers (e.g. memory write gate, pointer audience trust)
+    // downstream consumers (e.g. memory write gate, pointer audience resolution)
     // see the durable trust snapshot rather than a silently-dropped undefined.
     const convId = "conv-ptr-uvc-provenance";
     ensureConversation(convId);
@@ -389,14 +394,18 @@ describe("addPointerMessage", () => {
       "unverified_contact",
     );
 
-    // And that pointer-audience trust treats it identically to trusted_contact.
+    // And that pointer-audience resolution treats it identically to
+    // trusted_contact: a non-owner audience that takes the deterministic
+    // fallback rather than the guardian-elevated daemon turn.
     let processorCalled = false;
     setProcessor(async () => {
       processorCalled = true;
     });
 
     await addPointerMessage(convId, "completed", "+15559876543");
-    expect(processorCalled).toBe(true);
+    expect(processorCalled).toBe(false);
+    const text = getLatestAssistantText(convId);
+    expect(text).toContain("Call to +15559876543 completed");
   });
 
   test("unknown provenance trust class does not grant trusted audience", () => {

--- a/assistant/src/__tests__/pointer-conversation-trust.test.ts
+++ b/assistant/src/__tests__/pointer-conversation-trust.test.ts
@@ -55,7 +55,12 @@ class FakeConversation {
   }
 }
 
-const CONTACT_CONTEXT: TrustContext = {
+const TRUSTED_CONTACT_CONTEXT: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "trusted_contact",
+};
+
+const UNVERIFIED_CONTACT_CONTEXT: TrustContext = {
   sourceChannel: "vellum",
   trustClass: "unverified_contact",
 };
@@ -82,16 +87,43 @@ describe("elevatePointerConversationToGuardian", () => {
     expect(conv.trustContext).toBeUndefined();
   });
 
-  test("restores the prior non-memory trust context after the turn", async () => {
-    const conv = new FakeConversation({ trustContext: CONTACT_CONTEXT });
+  test("does not elevate a trusted_contact context (no guardian history leak)", async () => {
+    const conv = new FakeConversation({
+      trustContext: TRUSTED_CONTACT_CONTEXT,
+    });
+    // A contact load filters guardian history to empty; it must stay empty.
     expect(conv.visibleHistory).toEqual([]);
 
     const restore = await elevatePointerConversationToGuardian(conv);
-    expect(conv.trustContext).toBe(INTERNAL_GUARDIAN_TRUST_CONTEXT);
-    expect(conv.visibleHistory).toEqual(["m1", "m2", "m3"]);
+
+    // No elevation and no rehydration — guardian-only history is never
+    // surfaced into a contact conversation.
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.ensureCalls).toBe(0);
+    expect(conv.trustContext).toBe(TRUSTED_CONTACT_CONTEXT);
+    expect(conv.visibleHistory).toEqual([]);
 
     restore();
-    expect(conv.trustContext).toBe(CONTACT_CONTEXT);
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.trustContext).toBe(TRUSTED_CONTACT_CONTEXT);
+  });
+
+  test("does not elevate an unverified_contact context (no guardian history leak)", async () => {
+    const conv = new FakeConversation({
+      trustContext: UNVERIFIED_CONTACT_CONTEXT,
+    });
+    expect(conv.visibleHistory).toEqual([]);
+
+    const restore = await elevatePointerConversationToGuardian(conv);
+
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.ensureCalls).toBe(0);
+    expect(conv.trustContext).toBe(UNVERIFIED_CONTACT_CONTEXT);
+    expect(conv.visibleHistory).toEqual([]);
+
+    restore();
+    expect(conv.setTrustContextCalls).toEqual([]);
+    expect(conv.trustContext).toBe(UNVERIFIED_CONTACT_CONTEXT);
   });
 
   test("no-ops for a conversation that already has memory access", async () => {

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -3,10 +3,12 @@
  * so the user sees call lifecycle events without the full transcript
  * (which lives in the dedicated voice conversation).
  *
- * Trust-aware: trusted audiences get pointer messages routed through the
- * daemon conversation as a conversation turn (the assistant generates the text).
- * Untrusted/unknown audiences always receive deterministic fallback text
- * written directly to the conversation store.
+ * Trust-aware: the owner's own conversations get pointer messages routed through
+ * the daemon conversation as an owner self-maintenance turn (the assistant
+ * generates the text). Contact and unknown audiences always receive
+ * deterministic fallback text written directly to the conversation store, so a
+ * guardian-elevated turn never rehydrates private history into a non-owner
+ * conversation.
  */
 
 import { runPointerMessageTurn } from "../daemon/pointer-turn-runner.js";
@@ -15,6 +17,7 @@ import {
   getConversationOriginChannel,
   getConversationRecentProvenanceTrustClass,
 } from "../persistence/conversation-crud.js";
+import { isContactTrustClass } from "../runtime/trust-class.js";
 import { getLogger } from "../util/logger.js";
 import {
   buildPointerInstruction,
@@ -38,34 +41,34 @@ type PointerAudienceMode = "auto" | "trusted" | "untrusted";
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve whether the audience for a pointer message is trusted.
+ * Resolve whether the pointer audience is the assistant's owner (guardian)
+ * rather than a contact or unknown caller.
  *
- * Trusted when:
- * - recent message provenance trust class is 'guardian', 'trusted_contact',
- *   or 'unverified_contact'
- * - conversation origin channel is 'vellum' (desktop app)
+ * Owner when:
+ * - recent message provenance trust class is 'guardian', or
+ * - conversation origin channel is 'vellum' (desktop app).
  *
- * Untrusted by default when insufficient evidence.
+ * Known non-guardian contacts ('trusted_contact' / 'unverified_contact') and
+ * unknown callers are NOT the owner: routing their pointer status through the
+ * daemon turn would run it under the internal guardian context, rehydrating
+ * guardian-only history that then leaks into the contact's own conversation.
+ * They take the deterministic fallback instead. Defaults to non-owner when
+ * evidence is insufficient.
  */
-function resolvePointerAudienceTrust(conversationId: string): boolean {
+function resolvePointerAudienceIsOwner(conversationId: string): boolean {
   try {
-    // Check provenance trust class on recent messages first — this catches
-    // identity-known non-guardian contacts (trusted and unverified) who
-    // initiate calls from gateway channels (e.g. WhatsApp) where the
-    // conversation itself isn't desktop-origin.
+    // Provenance is read from persisted message metadata, so it survives
+    // conversation eviction — a known contact is diverted to the deterministic
+    // fallback even on a cold load where the in-memory trust context is absent.
     const provenance =
       getConversationRecentProvenanceTrustClass(conversationId);
-    if (
-      provenance === "guardian" ||
-      provenance === "trusted_contact" ||
-      provenance === "unverified_contact"
-    )
-      return true;
+    if (isContactTrustClass(provenance)) return false;
+    if (provenance === "guardian") return true;
 
     const originChannel = getConversationOriginChannel(conversationId);
     if (originChannel === "vellum") return true;
   } catch {
-    // Conversation may not exist or DB may be unavailable — default untrusted.
+    // Conversation may not exist or DB may be unavailable — default to non-owner.
   }
 
   return false;
@@ -116,13 +119,13 @@ export async function addPointerMessage(
   const outcomeKeyword = eventOutcomeKeywords[event];
   if (outcomeKeyword) requiredFacts.push(outcomeKeyword);
 
-  const trustedAudience =
+  const ownerAudience =
     audienceMode === "trusted" ||
-    (audienceMode === "auto" && resolvePointerAudienceTrust(conversationId));
+    (audienceMode === "auto" && resolvePointerAudienceIsOwner(conversationId));
 
-  if (trustedAudience) {
+  if (ownerAudience) {
     // Route through the daemon conversation — the assistant generates the
-    // pointer text as a natural conversation turn, shaped by context,
+    // pointer text as a natural owner self-maintenance turn, shaped by context,
     // identity, and preferences.
     const instruction = buildPointerInstruction(context);
     try {
@@ -137,7 +140,7 @@ export async function addPointerMessage(
   } else {
     log.debug(
       { event, conversationId },
-      "Untrusted audience — using deterministic pointer copy",
+      "Non-owner audience — using deterministic pointer copy",
     );
   }
 

--- a/assistant/src/daemon/pointer-conversation-trust.ts
+++ b/assistant/src/daemon/pointer-conversation-trust.ts
@@ -2,9 +2,10 @@
  * Guardian-trust elevation for call-status pointer turns.
  *
  * Call-status pointer messages are generated as owner self-maintenance turns:
- * only guardian-gated audiences route through the daemon processor (see
- * `resolvePointerAudienceTrust` in `calls/call-pointer-messages.ts`), so the
- * generation should run under the internal guardian context.
+ * only the owner's own conversations route through the daemon processor (see
+ * `resolvePointerAudienceIsOwner` in `calls/call-pointer-messages.ts`; contact
+ * and unknown audiences take the deterministic fallback instead), so the
+ * generation runs under the internal guardian context.
  *
  * The subtlety is history: `Conversation.loadFromDb` filters the persisted
  * history to non-guardian provenance whenever the active trust context cannot
@@ -38,18 +39,31 @@ export interface GuardianElevatableConversation {
  * its history so guardian-authored history is not filtered to empty on a cold
  * load. Returns a function that restores the prior trust context.
  *
- * No-ops (returning a no-op restorer) when the conversation is already
- * memory-capable, or when it is mid-turn — mutating `trustContext` during an
- * active loop would elevate that turn's actor trust (mirrors the warm-path guard
- * in `conversation-store.ts`).
+ * Elevation is restricted to the owner's own conversation: an explicit guardian
+ * context, or a trust-less cold load (an evicted owner conversation whose actor
+ * trust has not been re-resolved). It no-ops (returning a no-op restorer) when
+ * the prior context belongs to a known contact (`trusted_contact` /
+ * `unverified_contact`) or any other non-owner actor — rehydrating guardian-only
+ * history into a contact's conversation would leak it. It also no-ops when the
+ * conversation is already memory-capable, or when it is mid-turn — mutating
+ * `trustContext` during an active loop would elevate that turn's actor trust
+ * (mirrors the warm-path guard in `conversation-store.ts`).
  */
 export async function elevatePointerConversationToGuardian(
   conversation: GuardianElevatableConversation,
 ): Promise<() => void> {
   const priorTrustContext = conversation.trustContext;
+  const priorTrustClass = priorTrustContext?.trustClass;
+  // Only the owner may be elevated: an explicit guardian context (already
+  // memory-capable, so the capability check below no-ops it) or a trust-less
+  // cold load. Contact and unknown actors are excluded so guardian-only history
+  // is never rehydrated into a non-owner conversation.
+  const isOwnerContext =
+    priorTrustClass === undefined || priorTrustClass === "guardian";
   const shouldElevate =
-    !conversation.isProcessing() &&
-    !resolveCapabilities(priorTrustContext?.trustClass).canAccessMemory;
+    isOwnerContext &&
+    !resolveCapabilities(priorTrustClass).canAccessMemory &&
+    !conversation.isProcessing();
   if (!shouldElevate) return () => {};
 
   conversation.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);


### PR DESCRIPTION
## Summary

Follow-up to #36415 addressing Codex review feedback (P1 on `assistant/src/daemon/pointer-conversation-trust.ts`).

#36415 elevated call-status pointer turns to the internal guardian context and rehydrated history so an evicted owner conversation would not ship a cache-missing turn. But `resolvePointerAudienceTrust` also routed `trusted_contact` / `unverified_contact` conversations through the daemon processor, and `elevatePointerConversationToGuardian` elevated **any** non-memory-capable prior context. Contact classes have `canAccessMemory = false`, so a completion/failure pointer for a trusted or unverified contact would rehydrate guardian-only history, run without contact trust guidance, and post the generated status back into the contact's own conversation — leaking guardian history/memory that `filterMessagesForUntrustedActor` normally hides.

## Fix

- **`call-pointer-messages.ts`**: only the owner's own conversations (guardian provenance or `vellum` desktop origin) route through the elevated daemon turn. Known contacts and unknown callers take the deterministic fallback. Provenance is read from persisted message metadata, so contacts are diverted correctly even on a cold (evicted) load where the in-memory trust context is absent. (`resolvePointerAudienceTrust` → `resolvePointerAudienceIsOwner`, reusing the existing `isContactTrustClass` helper.)
- **`pointer-conversation-trust.ts`**: restrict `elevatePointerConversationToGuardian` to guardian / trust-less (local-owner) prior contexts as the enforcing boundary — a contact or unknown prior context never elevates. #36415's owner cold-load fix is preserved: a trust-less context still elevates and rehydrates.

This is defense-in-depth: `call-pointer-messages.ts` closes the leak at the source (contacts never reach the elevated turn), and the elevation allowlist is the fail-closed backstop.

## Testing

- `pointer-conversation-trust.test.ts`: added cases asserting `trusted_contact` and `unverified_contact` contexts do **not** elevate or rehydrate guardian history; trust-less owner cold-load still elevates.
- `call-pointer-messages.test.ts`: updated the contact-provenance cases to assert the deterministic fallback is used (processor not invoked); guardian-provenance and `vellum`-origin still route through the processor.
- `bun test` on both files: 31 pass, 0 fail. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)