### PR TITLE
style(providers): brace control-flow statements in placeholder-sentinel files

### DIFF
--- a/assistant/src/providers/__tests__/placeholder-sentinels.test.ts
+++ b/assistant/src/providers/__tests__/placeholder-sentinels.test.ts
@@ -98,7 +98,9 @@ function streamTextDeltas(deltas: readonly string[]): string[] {
   let textBuffer = "";
   for (const delta of deltas) {
     textBuffer += delta;
-    if (couldBePlaceholderSentinelPrefix(textBuffer)) continue;
+    if (couldBePlaceholderSentinelPrefix(textBuffer)) {
+      continue;
+    }
     emitted.push(textBuffer);
     textBuffer = "";
   }

--- a/assistant/src/providers/placeholder-sentinels.ts
+++ b/assistant/src/providers/placeholder-sentinels.ts
@@ -32,7 +32,9 @@ const PLACEHOLDER_SENTINEL_BARE: ReadonlySet<string> = new Set(
 // control-stripping proxy can leave in its place.
 function stripLeadingEdgeNoise(text: string): string {
   let start = 0;
-  while (start < text.length && text.charCodeAt(start) <= 0x20) start += 1;
+  while (start < text.length && text.charCodeAt(start) <= 0x20) {
+    start += 1;
+  }
   return text.slice(start);
 }
 
@@ -40,7 +42,9 @@ function stripLeadingEdgeNoise(text: string): string {
 function stripSentinelEdgeNoise(text: string): string {
   const lead = stripLeadingEdgeNoise(text);
   let end = lead.length;
-  while (end > 0 && lead.charCodeAt(end - 1) <= 0x20) end -= 1;
+  while (end > 0 && lead.charCodeAt(end - 1) <= 0x20) {
+    end -= 1;
+  }
   return lead.slice(0, end);
 }
 


### PR DESCRIPTION
Follow-up to #36934 clearing the `curly` ESLint warnings that PR surfaced in the files it touched.

The project Control-Flow Braces convention requires braces on every `if`/`while` body. Adds them to the two `stripEdgeNoise` scanners in `placeholder-sentinels.ts` (pre-existing) and to the `streamTextDeltas` test helper `continue` guard in `placeholder-sentinels.test.ts`. Auto-fixable, no behavior change.