### PR TITLE
fix(inspector): drop failed-attempt latency marks on provider retry

### DIFF
--- a/assistant/src/daemon/turn-latency-tracker.test.ts
+++ b/assistant/src/daemon/turn-latency-tracker.test.ts
@@ -115,6 +115,99 @@ describe("TurnLatencyTracker", () => {
     expect(breakdown!.providerDurationMs).toBe(135);
   });
 
+  test("a failed first attempt is superseded by the successful retry", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start"); // queue = 10
+    clock = 110;
+    t.mark("prompt_hook_end"); // memory_context = 100
+    // First attempt: tools resolved and request sent, then the provider
+    // rejects (context overflow) — no first_token, no call_complete.
+    clock = 120;
+    t.mark("tools_resolved");
+    clock = 130;
+    t.mark("request_sent");
+    // Recovery runs, then the loop re-issues the call.
+    clock = 1000;
+    t.mark("tools_resolved");
+    clock = 1010;
+    t.mark("request_sent");
+    clock = 1200;
+    t.markFirstToken("text");
+    clock = 1260;
+    t.mark("call_complete");
+
+    const { breakdown } = t.serializeSince(0);
+    // ttft / provider-duration reflect ONLY the successful attempt (1010),
+    // not the failed attempt's request_sent (130).
+    expect(breakdown!.ttftMs).toBe(190);
+    expect(breakdown!.providerDurationMs).toBe(250);
+    // The failed attempt's per-call marks are gone: no duplicate phases.
+    expect(breakdown!.phases.map((p) => p.key)).toEqual([
+      "queue",
+      "memory_context",
+      "setup",
+      "request_prep",
+      "ttft",
+      "generation",
+    ]);
+    expect(phaseMap(breakdown!.phases).request_prep).toBe(10);
+  });
+
+  test("a failed retry mid tool-loop is superseded", () => {
+    const t = new TurnLatencyTracker();
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start");
+    clock = 110;
+    t.mark("prompt_hook_end");
+    clock = 120;
+    t.mark("tools_resolved");
+    clock = 130;
+    t.mark("request_sent");
+    clock = 430;
+    t.markFirstToken("thinking");
+    clock = 700;
+    t.mark("call_complete");
+    const first = t.serializeSince(0);
+
+    // Second call fails after streaming a partial token, then retries.
+    clock = 1000;
+    t.mark("tools_resolved");
+    clock = 1010;
+    t.mark("request_sent");
+    clock = 1100;
+    t.markFirstToken("text"); // partial stream before the failure
+    clock = 2000;
+    t.mark("tools_resolved");
+    clock = 2010;
+    t.mark("request_sent");
+    clock = 2200;
+    t.markFirstToken("text");
+    clock = 2260;
+    t.mark("call_complete");
+
+    const { breakdown } = t.serializeSince(first.cursor);
+    // Only the successful retry (2010) drives ttft / provider-duration; the
+    // failed attempt's request_sent (1010) and its stray first_token (1100)
+    // are dropped.
+    expect(breakdown!.ttftMs).toBe(190);
+    expect(breakdown!.providerDurationMs).toBe(250);
+    expect(breakdown!.firstTokenKind).toBe("text");
+    // No duplicate per-call phases from the failed attempt.
+    expect(breakdown!.phases.map((p) => p.key)).toEqual([
+      "setup",
+      "request_prep",
+      "ttft",
+      "generation",
+    ]);
+    expect(phaseMap(breakdown!.phases).request_prep).toBe(10);
+    expect(breakdown!.totalToFirstTokenMs).toBeUndefined();
+  });
+
   test("no marks serializes to null", () => {
     const t = new TurnLatencyTracker();
     expect(t.serializeSince(0).breakdown).toBeNull();

--- a/assistant/src/daemon/turn-latency-tracker.ts
+++ b/assistant/src/daemon/turn-latency-tracker.ts
@@ -56,7 +56,45 @@ export class TurnLatencyTracker {
 
   /** Stamp a point-in-time mark. Cheap (`Date.now()`); safe to over-call. */
   mark(name: LatencyMark): void {
+    // A retried provider call re-issues `request_sent`; drop the failed
+    // attempt's stale marks first so the retry's segment measures only itself.
+    if (name === "request_sent") this.supersedeFailedAttempt();
     this.marks.push({ name, at: Date.now() });
+  }
+
+  /**
+   * Discard the per-call marks of a prior provider attempt that never
+   * completed. A call retried within the same turn (context-overflow recovery,
+   * post-model-call repair on a rejection) leaves a `request_sent` with no
+   * `call_complete` and no `usage` event to serialize it and advance the
+   * cursor; the next successful segment would otherwise measure ttft /
+   * provider-duration / phases from the failed attempt's marks.
+   *
+   * Detection is cursor-free: a completed call always stamps `call_complete`
+   * before its `usage` event, so a `request_sent` with none after it belongs
+   * to a call that never returned. A retry re-stamps its setup `tools_resolved`
+   * before this `request_sent`, so that trailing mark is preserved as the
+   * successful segment's setup mark.
+   */
+  private supersedeFailedAttempt(): void {
+    let failedRequestSent = -1;
+    for (let i = this.marks.length - 1; i >= 0; i--) {
+      const name = this.marks[i]!.name;
+      if (name === "call_complete") return; // prior attempt finished — nothing stale
+      if (name === "request_sent") {
+        failedRequestSent = i;
+        break;
+      }
+    }
+    if (failedRequestSent === -1) return; // no prior attempt this turn
+    // Drop from the failed attempt's paired setup mark (its `tools_resolved`,
+    // if any) through its trailing marks, keeping a retry `tools_resolved`
+    // already stamped as the last mark.
+    let start = failedRequestSent;
+    if (this.marks[start - 1]?.name === "tools_resolved") start -= 1;
+    let end = this.marks.length;
+    if (this.marks[end - 1]!.name === "tools_resolved") end -= 1;
+    this.marks.splice(start, end - start);
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #36563 addressing Codex review feedback on `assistant/src/daemon/turn-latency-tracker.ts`.

When a provider call rejects and is retried within the same `AgentLoop.run` (context-overflow recovery, post-model-call repair on a rejection), the failed attempt stamps a `request_sent` mark but never a `call_complete` — no `usage` event fires to serialize it and advance `latencyCursor`. The next successful call's `usage` event then serialized from the stale cursor and picked up the FAILED attempt's `request_sent`, so the persisted successful row's `ttftMs`, `providerDurationMs`, and phase durations wrongly included the failed request + recovery time instead of just the successful call.

## Fix

`TurnLatencyTracker.mark("request_sent")` now supersedes a stale prior attempt: if the most recent `request_sent` has no `call_complete` after it (a call that never returned), its per-call marks are dropped before the retry's marks land. Detection is cursor-free — a completed call always stamps `call_complete` before its `usage` event — so it is robust across every retry path and collapses multiple consecutive failures. The retry's freshly-stamped setup `tools_resolved` is preserved as the successful segment's setup mark. Single-call and normal tool-loop behavior is unchanged (the scan hits `call_complete` first and no-ops).

## Tests

Extended `turn-latency-tracker.test.ts`: a failed first attempt then successful retry, and a failed retry mid tool-loop (with a partial streamed token before the failure). Both assert the serialized `ttftMs`/`providerDurationMs` and phase list reflect only the successful attempt. All 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)