### PR TITLE
fix(daemon): summarize-boundary treats tool_result+system_notice rows as continuations

### DIFF
--- a/assistant/src/__tests__/summarize-boundary.test.ts
+++ b/assistant/src/__tests__/summarize-boundary.test.ts
@@ -34,6 +34,19 @@ function userToolResult(id: string): MessageRow {
   );
 }
 
+// A tool_result row carrying an injected system_notice, the shape the agent
+// loop emits after a post-tool hook.
+function userToolResultWithSystemNotice(id: string): MessageRow {
+  return row(
+    id,
+    "user",
+    JSON.stringify([
+      { type: "tool_result", tool_use_id: "toolu-1", content: "ok" },
+      { type: "text", text: "<system_notice>progress check</system_notice>" },
+    ]),
+  );
+}
+
 // Two full turns: [user, assistant, user, assistant].
 const twoTurns: MessageRow[] = [
   userText("msg-1", "Hi, I am Alice"),
@@ -66,6 +79,28 @@ describe("resolveSummarizeBoundary", () => {
     ];
     // Anchoring on the tool-result row (or anything after it) snaps past it
     // to the real user message that started the turn.
+    expect(resolveSummarizeBoundary(rows, "msg-5", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+    expect(resolveSummarizeBoundary(rows, "msg-6", 0)).toEqual({
+      boundaryRowIndex: 2,
+    });
+  });
+
+  test("tool_result + system_notice user rows are continuations, not turn starts", () => {
+    const rows: MessageRow[] = [
+      userText("msg-1", "First question from Alice"),
+      assistantText("msg-2", "Working on it"),
+      userText("msg-3", "Second question"),
+      assistantText("msg-4", "Running a tool"),
+      userToolResultWithSystemNotice("msg-5"),
+      assistantText("msg-6", "Tool finished"),
+    ];
+    // The tool_result row also carries a system_notice text block, so it is not
+    // "entirely tool_result" — but it is still a mid-turn continuation. The
+    // backward snap must pass it and land on the real user message that started
+    // the turn, never leaving the kept tail beginning on an orphaned
+    // tool_result whose tool_use was summarized away.
     expect(resolveSummarizeBoundary(rows, "msg-5", 0)).toEqual({
       boundaryRowIndex: 2,
     });

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -938,9 +938,7 @@ export class Conversation {
     // message, matching the agent loop's per-turn `turnCount++`. Counted from
     // the full unsliced history so it survives compaction and is independent of
     // the viewer's trust class.
-    this.turnCount = allDbMessages.filter((m) =>
-      startsNewTurn(m.role, m.content),
-    ).length;
+    this.turnCount = allDbMessages.filter((m) => startsNewTurn(m)).length;
 
     const conv = getConversation(this.conversationId);
     this.conversationType = conv?.conversationType ?? undefined;

--- a/assistant/src/daemon/summarize-boundary.ts
+++ b/assistant/src/daemon/summarize-boundary.ts
@@ -1,35 +1,23 @@
+import { isToolResultOnlyUserMessage } from "../conversations/message-consolidation.js";
 import type { MessageRow } from "../persistence/conversation-crud.js";
 import { UserError } from "../util/errors.js";
-import { isToolResultBlock } from "./conversation-history.js";
 
 /**
- * Whether a persisted message starts a new conversation turn. A turn is
- * delimited by a "real" user message; a user message whose content is entirely
- * tool_result blocks is a continuation within the current turn, and assistant
- * messages never start one. Mirrors the turn-boundary definition used by
- * `getAssistantMessageIdsInTurn`/`getTurnTimeBounds` and the agent loop's
- * per-turn `turnCount++`, so counting these reconstructs `turnCount` on load.
+ * Whether a persisted message row starts a new conversation turn. A turn is
+ * delimited by a "real" user message; assistant rows never start one, and a
+ * user row whose content is exclusively tool_result (plus optional
+ * system_notice) blocks is a continuation within the current turn — the agent
+ * loop injects system_notice text alongside tool_results, and the
+ * display/write-path consolidation suppresses those rows as continuations.
+ * The block classification is delegated to {@link isToolResultOnlyUserMessage}
+ * so this predicate stays aligned with that suppression rule. Mirrors the
+ * turn-boundary definition used by `getAssistantMessageIdsInTurn`/
+ * `getTurnTimeBounds` and the agent loop's per-turn `turnCount++`, so counting
+ * these reconstructs `turnCount` on load.
  */
-export function startsNewTurn(role: string, content: string): boolean {
-  if (role !== "user") return false;
-  try {
-    const parsed = JSON.parse(content);
-    if (
-      Array.isArray(parsed) &&
-      parsed.length > 0 &&
-      parsed.every(
-        (block: unknown) =>
-          block != null &&
-          typeof block === "object" &&
-          isToolResultBlock(block as Record<string, unknown>),
-      )
-    ) {
-      return false;
-    }
-  } catch {
-    // Non-JSON content is a plain user message — a turn boundary.
-  }
-  return true;
+export function startsNewTurn(msg: MessageRow): boolean {
+  if (msg.role !== "user") return false;
+  return !isToolResultOnlyUserMessage(msg);
 }
 
 /**
@@ -59,10 +47,7 @@ export function resolveSummarizeBoundary(
   }
 
   let snappedIndex = targetIndex;
-  while (
-    snappedIndex >= 0 &&
-    !startsNewTurn(rows[snappedIndex].role, rows[snappedIndex].content)
-  ) {
+  while (snappedIndex >= 0 && !startsNewTurn(rows[snappedIndex])) {
     snappedIndex--;
   }
 


### PR DESCRIPTION
Follow-up to #36901 addressing Codex review feedback.

## Problem

`startsNewTurn()` in `summarize-boundary.ts` used `parsed.every(isToolResultBlock)`, so a user row carrying `[tool_result, <system_notice> text]` was misclassified as a turn **start**. The agent loop routinely injects `system_notice` text blocks alongside `tool_result`s (the post-tool-hook path), and the display/write-path consolidation (`isToolResultOnlyUserMessage` / the sibling `isUndoableUserMessage`) treats those rows as suppressed **continuations**.

Consequence: `resolveSummarizeBoundary`'s backward snap could stop on such a row, leaving the kept tail beginning with an orphaned `tool_result` whose `tool_use` was summarized away — a shape the provider request builder rejects, defeating the resolver's turn-safe purpose. The same misclassification also over-counted `turnCount` during `Conversation.loadFromDb` reconstruction whenever a post-tool hook injected a `system_notice`.

## Fix

Align `startsNewTurn` with the consolidation continuation semantics by **reusing** the existing single-source-of-truth predicate `isToolResultOnlyUserMessage` from `conversations/message-consolidation.ts` instead of duplicating block-classification logic. `startsNewTurn` now takes a `MessageRow` and returns `!isToolResultOnlyUserMessage(msg)` for user rows (assistant rows still never start a turn). This also drops the dependency on the heavy `conversation-history.js` module (`isToolResultBlock` is no longer imported here). The second caller in `conversation.ts` is updated to pass the row directly.

## Test

Added a regression test in `summarize-boundary.test.ts` for the `[tool_result + system_notice]` row shape: the boundary must snap past it to the real turn start. Verified it fails against the old `every(isToolResultBlock)` predicate and passes with the fix. Ran only that file (10 pass).

## Base branch

This PR targets the feature branch `siddseethepalli/summarize-up-to-here` (where #36901 and its follow-ups landed via the run-plan effort, umbrella PR #36929), **not** `main` — the resolver file does not yet exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)