### PR TITLE
fix(attachments): hydrate legacy octet-stream HEIC rows in history

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -64,6 +64,7 @@ interface AttachmentPayload {
   data?: string;
   filename?: string;
   mimeType: string;
+  kind?: string;
   thumbnailData?: string;
 }
 
@@ -77,6 +78,7 @@ function insertLegacyAttachmentRow(
   filename: string,
   mimeType: string,
   dataBase64: string,
+  kind = "image",
 ): string {
   const id = randomUUID();
   rawRun(
@@ -86,7 +88,7 @@ function insertLegacyAttachmentRow(
     filename,
     mimeType,
     Buffer.from(dataBase64, "base64").length,
-    "image",
+    kind,
     dataBase64,
     Date.now(),
   );
@@ -266,6 +268,36 @@ describe("handleListMessages HEIC display normalization", () => {
     expect(attachments[0].data).toBe(heicB64);
   });
 
+  test("octet-stream HEIC stays metadata-only when conversion is unavailable", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "photo" }]),
+    );
+    // Web-uploader fallback for an empty File.type: HEIC bytes land under
+    // application/octet-stream and classify as a document. Fake header bytes
+    // never convert, so the row must stay metadata-only rather than ship
+    // unrenderable bytes as display data.
+    const heicB64 = fakeHeifHeaderBytes().toString("base64");
+    insertLegacyAttachmentRow(
+      msg.id,
+      "IMG_3.HEIC",
+      "application/octet-stream",
+      heicB64,
+      "document",
+    );
+
+    const response = handleListMessages(createTestArgs(conv.id));
+    const body = response as { messages: MessagePayload[] };
+
+    const attachments = body.messages[0].attachments!;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].mimeType).toBe("application/octet-stream");
+    expect(attachments[0].kind).toBe("document");
+    expect(attachments[0].data).toBeUndefined();
+  });
+
   describe.skipIf(process.platform !== "darwin")(
     "real conversion (sips)",
     () => {
@@ -297,6 +329,40 @@ describe("handleListMessages HEIC display normalization", () => {
         // Metadata keeps describing the stored original, which the content
         // endpoint serves verbatim for downloads.
         expect(attachments[0].filename).toBe("IMG_2.HEIC");
+      });
+
+      test("legacy octet-stream HEIC rows hydrate as JPEG display data", async () => {
+        const heic = makeHeicFixtureBytes();
+        expect(heic).not.toBeNull();
+
+        const conv = createConversation();
+        const msg = await addMessage(
+          conv.id,
+          "user",
+          JSON.stringify([{ type: "text", text: "photo" }]),
+        );
+        // Real HEIC bytes stored under application/octet-stream (empty
+        // File.type fallback) and classified as a document — the row is
+        // detected by its filename extension and converted for display.
+        insertLegacyAttachmentRow(
+          msg.id,
+          "IMG_4.HEIC",
+          "application/octet-stream",
+          heic!.toString("base64"),
+          "document",
+        );
+
+        const response = handleListMessages(createTestArgs(conv.id));
+        const body = response as { messages: MessagePayload[] };
+
+        const attachments = body.messages[0].attachments!;
+        expect(attachments).toHaveLength(1);
+        expect(attachments[0].mimeType).toBe("image/jpeg");
+        expect(attachments[0].data!.startsWith("/9j/")).toBe(true);
+        // The converted row presents as an image so clients render it inline.
+        expect(attachments[0].kind).toBe("image");
+        // The stored original filename is preserved for verbatim download.
+        expect(attachments[0].filename).toBe("IMG_4.HEIC");
       });
     },
   );

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -122,7 +122,10 @@ import { getConfiguredProvider } from "../../providers/provider-send-message.js"
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getSubagentManager } from "../../subagent/index.js";
-import { normalizeImageBase64 } from "../../util/image-conversion.js";
+import {
+  isHeicFilename,
+  normalizeImageBase64,
+} from "../../util/image-conversion.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getWorkspaceDir,
@@ -951,34 +954,36 @@ export function handleListMessages({
       );
       if (linked.length > 0) {
         msgAttachments = linked.map((a) => {
-          if (a.mimeType.startsWith("image/")) {
-            const full = getAttachmentById(a.id, { hydrateFileData: true });
-            // Stored HEIF/HEIC content is hydrated as JPEG display data —
-            // Chromium-based clients cannot decode HEIF. Filename and
-            // sizeBytes keep describing the stored file, which
-            // /attachments/:id/content serves verbatim for downloads.
-            const display = full?.dataBase64
-              ? normalizeImageBase64(a.mimeType, full.dataBase64)
+          // Hydrate image rows for inline thumbnails. Legacy HEIC can be
+          // stored under application/octet-stream (empty File.type fallback),
+          // so `.heic`/`.heif` rows are hydrated by filename too;
+          // normalizeImageBase64 sniffs the bytes and rewrites only genuine
+          // HEIF, which Chromium-based clients cannot decode. Filename and
+          // sizeBytes keep describing the stored original, which
+          // /attachments/:id/content serves verbatim for downloads.
+          const isImage = a.mimeType.startsWith("image/");
+          const isLegacyHeic = !isImage && isHeicFilename(a.originalFilename);
+          const full =
+            isImage || isLegacyHeic
+              ? getAttachmentById(a.id, { hydrateFileData: true })
               : null;
-            return {
-              id: a.id,
-              filename: a.originalFilename,
-              mimeType: display?.mimeType ?? a.mimeType,
-              sizeBytes: a.sizeBytes,
-              kind: a.kind,
-              ...(display ? { data: display.dataBase64 } : {}),
-              ...(a.thumbnailBase64
-                ? { thumbnailData: a.thumbnailBase64 }
-                : {}),
-              fileBacked: true,
-            };
-          }
+          const display = full?.dataBase64
+            ? normalizeImageBase64(a.mimeType, full.dataBase64)
+            : null;
+          // Image rows carry data even when unconverted (thumbnails); a
+          // non-image row only becomes renderable once conversion yields a
+          // JPEG, so it stays metadata-only when conversion is unavailable.
+          const useDisplay =
+            display && (isImage || display.converted) ? display : null;
           return {
             id: a.id,
             filename: a.originalFilename,
-            mimeType: a.mimeType,
+            mimeType: useDisplay?.mimeType ?? a.mimeType,
             sizeBytes: a.sizeBytes,
-            kind: a.kind,
+            kind: useDisplay?.converted
+              ? classifyKind(useDisplay.mimeType)
+              : a.kind,
+            ...(useDisplay ? { data: useDisplay.dataBase64 } : {}),
             ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
             fileBacked: true,
           };

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -197,6 +197,19 @@ export function isHeifImage(bytes: Uint8Array): boolean {
   return HEIF_FTYP_BRANDS.has(brand);
 }
 
+const HEIF_FILENAME_RE = /\.(heic|heif)$/i;
+
+/**
+ * Filename-extension HEIF/HEIC detection, for call sites that only hold
+ * attachment metadata (filename + MIME) and want to skip hydrating bytes for
+ * non-candidate rows. Complements {@link isHeifImage}: Chromium reports an
+ * empty MIME for `.heic`, so legacy rows can carry HEIC bytes under
+ * `application/octet-stream` while the extension survives.
+ */
+export function isHeicFilename(filename: string): boolean {
+  return HEIF_FILENAME_RE.test(filename.trim());
+}
+
 /** Rewrites a filename's extension to `.jpg` (e.g. `IMG_5487.HEIC` → `IMG_5487.jpg`). */
 export function jpegFilenameFor(filename: string): string {
   const fallback = "attachment";


### PR DESCRIPTION
Follow-up to #36878 addressing Codex review feedback.

## Problem
`handleListMessages` history hydration gated HEIC-to-JPEG display conversion on `mimeType.startsWith("image/")`. Legacy rows can hold HEIC bytes under `mime_type = application/octet-stream` (the web uploader fallback when `File.type` is empty), so those rows took the non-image path, never received JPEG display data, and stayed unrenderable in history.

## Fix
- Detect HEIC candidates by filename extension via a new `isHeicFilename` helper in `util/image-conversion.ts`, co-located with the byte-sniff `isHeifImage`. Octet-stream `.heic`/`.heif` rows are now hydrated too.
- The stored bytes still flow through the existing `normalizeImageBase64`, which sniffs the `ftyp` brand and rewrites only genuine HEIF content — a mislabeled non-HEIF file passes through untouched.
- Converted rows present as `image/jpeg` with `kind: image` so clients render them inline. Unconvertible or non-HEIF rows stay metadata-only, so behavior off-darwin and for documents is unchanged.
- The two previously duplicated return objects in the mapping are unified.

## Tests
Added to `list-messages-attachments.test.ts`: an octet-stream fallback case (cross-platform, stays metadata-only) and a real-conversion case (darwin-gated, hydrates to JPEG with `kind: image`).

## Second Codex comment (not applicable)
The "normalize direct HEIC payloads before persisting messages" comment on `conversation-messaging.ts` was reviewed and judged not applicable: `persistQueuedMessageBody` callers pass id-bearing upload-normalized attachments, and provider sends route images through `optimizeImageForTransport`, so the described HEIC-to-provider path is unreachable. No change made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)