### PR TITLE
fix(web): no broken glyph in attachment preview modal for undecodable images

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 
@@ -99,5 +99,17 @@ describe("AttachmentPreviewModal content loading", () => {
     renderModal(ATTACHMENT);
 
     expect(await screen.findByText("Failed to load preview.")).toBeDefined();
+  });
+
+  test("falls back to the non-image card when the fetched image can't be decoded", async () => {
+    renderModal(ATTACHMENT);
+
+    const img = await screen.findByAltText("photo.png");
+    fireEvent.error(img);
+
+    // The broken image is replaced by the non-image fallback card (file icon +
+    // download), so an undecodable full-size image never shows a broken glyph.
+    expect(screen.queryByAltText("photo.png")).toBeNull();
+    expect(screen.getByText("Download")).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -135,6 +135,11 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
 
   const effectiveUrl = attachment.previewUrl ?? objectUrl;
 
+  // A full-size image whose bytes the browser can't decode (e.g. HEIC on
+  // Chromium, even after fetching the stored original) falls through to the
+  // non-image fallback card instead of rendering the broken-image glyph.
+  const [decodeFailedUrl, setDecodeFailedUrl] = useState<string | null>(null);
+
   // Loading until there's a usable URL: covers the fetch and the one-render gap
   // between the blob arriving and its object URL being created.
   const isLoadingPreview = shouldFetch && !objectUrl && !isError;
@@ -243,11 +248,12 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
       return <PdfPreview url={effectiveUrl} />;
     }
 
-    if (isImage && effectiveUrl) {
+    if (isImage && effectiveUrl && decodeFailedUrl !== effectiveUrl) {
       return (
         <img
           src={effectiveUrl}
           alt={attachment.filename}
+          onError={() => setDecodeFailedUrl(effectiveUrl)}
           className="max-h-[80vh] max-w-[90vw] rounded object-contain"
         />
       );

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -7,9 +7,13 @@ mock.module(
     AttachmentPreviewModal: ({
       attachment,
     }: {
-      attachment: { id: string };
+      attachment: { id: string; previewUrl: string | null };
     }) => (
-      <div data-testid="preview-modal" data-attachment-id={attachment.id} />
+      <div
+        data-testid="preview-modal"
+        data-attachment-id={attachment.id}
+        data-preview-url={String(attachment.previewUrl)}
+      />
     ),
   }),
 );
@@ -127,5 +131,28 @@ describe("BubbleAttachments", () => {
     // becomes visible and no <img> remains mounted.
     expect(getByText("IMG_5487.HEIC")).toBeTruthy();
     expect(container.querySelector("img")).toBeNull();
+  });
+
+  test("opens the preview with a sanitized (null) previewUrl after the inline image fails to decode", () => {
+    const undecodable: DisplayAttachment = {
+      id: "img-4",
+      filename: "IMG_9999.HEIC",
+      mimeType: "image/heic",
+      sizeBytes: 2_048,
+      previewUrl: "blob:undecodable-heic",
+    };
+    const { getByRole, getByTestId } = render(
+      <BubbleAttachments attachments={[undecodable]} />,
+    );
+
+    // Decode fails -> falls back to the chip.
+    fireEvent.error(getByRole("button", { name: "IMG_9999.HEIC" }));
+    // Clicking the fallback chip opens the modal with the dead previewUrl
+    // stripped, so the modal fetches stored bytes instead of the broken blob.
+    fireEvent.click(getByRole("button", { name: "IMG_9999.HEIC" }));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("img-4");
+    expect(modal.getAttribute("data-preview-url")).toBe("null");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -84,14 +84,22 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
             );
           }
 
+          // A failed inline decode leaves a dead previewUrl (e.g. an
+          // undecodable HEIC blob on Chromium). Sanitize it so the chip and
+          // the full-screen modal both fall back to fetching stored bytes
+          // instead of reusing the broken blob.
+          const previewAttachment = imageFailed
+            ? { ...att, previewUrl: null }
+            : att;
+
           return (
             <MessageAttachmentSquare
               key={att.id}
               filename={att.filename}
               mimeType={att.mimeType}
               sizeBytes={att.sizeBytes}
-              previewUrl={imageFailed ? null : att.previewUrl}
-              onPreview={() => openPreview(att)}
+              previewUrl={previewAttachment.previewUrl}
+              onPreview={() => openPreview(previewAttachment)}
               onDownload={() => handleDownload(att)}
             />
           );


### PR DESCRIPTION
Follow-up to #36882 addressing Codex review feedback.

When an inline bubble image failed to decode (e.g. a HEIC blob on Chromium), the bubble fell back to a chip but still opened `AttachmentPreviewModal` with the original attachment — whose dead `previewUrl` made the modal skip its stored-bytes fetch (`shouldFetch` gates on `!previewUrl`) and render the same broken `<img>` (no `onError`), contradicting the PR's "no surface shows the broken glyph" goal.

## Changes
- **`bubble-attachments.tsx`**: after an inline decode fails, open the preview with a sanitized attachment (`{ ...att, previewUrl: null }`) so the modal fetches stored bytes / shows its fallback instead of reusing the broken blob. Consolidates the chip's `previewUrl` and the modal-open into one sanitized object so they can't drift.
- **`attachment-preview-modal.tsx`**: add an `onError` fallback on the full-size `<img>`. The `/content` fetch can still serve undecodable original bytes (HEIC), so a decode failure now falls through to the modal's non-image fallback card (file icon + download) instead of a broken glyph. A per-URL guard re-attempts decode on gallery navigation.

## Tests
Extended both component test files (13 pass): bubble opens the modal with a stripped `previewUrl` after an inline decode failure; modal degrades to the non-image card when the fetched image can't be decoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)