### PR TITLE
fix(memory): durable v1 Qdrant rebuild signal via on-disk sentinel

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -1,10 +1,29 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Per-suite tmp data dir so the rebuild sentinel never lands in the
+// developer's real ~/.vellum workspace.
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "qdrant-v1-migration-test-"));
+const REBUILD_SENTINEL_PATH = join(
+  TEST_DATA_DIR,
+  ".memory-v1-rebuild-required",
+);
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => TEST_DATA_DIR,
+  // Bun shares mocked modules across test files; peer tests import
+  // `getWorkspaceDir` from this same module, so re-export it here to avoid an
+  // `undefined` if this mock is the one that wins evaluation order.
+  getWorkspaceDir: () => TEST_DATA_DIR,
 }));
 
 // ── Mock Qdrant REST client ───────────────────────────────────────────
@@ -23,6 +42,7 @@ let mockCollectionExists: boolean;
 let mockCollectionSize: number;
 let mockUseNamedVectors: boolean;
 let mockSentinelPayload: Record<string, unknown> | null;
+let mockCreateCollectionThrows: Error | null;
 let callLog: MockCallLog;
 
 function resetMockState() {
@@ -30,6 +50,12 @@ function resetMockState() {
   mockCollectionSize = 384;
   mockUseNamedVectors = false;
   mockSentinelPayload = null;
+  mockCreateCollectionThrows = null;
+  // Drop any sentinel a prior test left behind so the no-drift default path
+  // doesn't accidentally report `migrated: true`.
+  if (existsSync(REBUILD_SENTINEL_PATH)) {
+    rmSync(REBUILD_SENTINEL_PATH);
+  }
   callLog = {
     collectionExists: 0,
     getCollection: 0,
@@ -68,6 +94,9 @@ mock.module("@qdrant/js-client-rest", () => ({
 
     async createCollection(_name: string, _config: unknown) {
       callLog.createCollection++;
+      if (mockCreateCollectionThrows) {
+        throw mockCreateCollectionThrows;
+      }
       mockCollectionExists = true;
     }
 
@@ -97,10 +126,17 @@ mock.module("@qdrant/js-client-rest", () => ({
   },
 }));
 
-import { VellumQdrantClient } from "../persistence/embeddings/qdrant-client.js";
+import {
+  clearRebuildSentinel,
+  VellumQdrantClient,
+} from "../persistence/embeddings/qdrant-client.js";
 
 beforeEach(() => {
   resetMockState();
+});
+
+afterAll(() => {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
 describe("Qdrant collection migration", () => {
@@ -267,5 +303,112 @@ describe("Qdrant collection migration", () => {
     expect(callLog.upsert).toBe(0);
     // Fresh collection, not a migration
     expect(result.migrated).toBe(false);
+  });
+});
+
+// The v1 collection lives outside the startup embedding reconcile, so a
+// destructive dimension/model recreate reports `migrated: true` and the
+// lifecycle hook enqueues `rebuild_index`. That signal is durable across a
+// crash or Qdrant failure mid-recreate via an on-disk sentinel written before
+// the delete — otherwise a delete-then-die would drop the v1 vectors silently.
+describe("Qdrant v1 rebuild sentinel (durable migration signal)", () => {
+  const makeClient = () =>
+    new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768,
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2",
+    });
+
+  test("preserves the rebuild signal across calls when createCollection fails after delete", async () => {
+    // Dimension drift triggers the destructive recreate; createCollection then
+    // throws, reproducing the exact data-loss window — the collection is gone
+    // but the in-memory `migrated` signal never reaches the caller.
+    mockCollectionExists = true;
+    mockUseNamedVectors = true;
+    mockCollectionSize = 384;
+    mockCreateCollectionThrows = new Error("Qdrant transient failure");
+
+    let firstError: unknown = null;
+    try {
+      await makeClient().ensureCollection();
+    } catch (err) {
+      firstError = err;
+    }
+    expect(firstError).not.toBeNull();
+    expect(callLog.deleteCollection).toBe(1);
+    // The sentinel written BEFORE the delete outlives the failed call.
+    expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(true);
+
+    // Next startup: the collection is missing (delete succeeded), so a fresh
+    // client recreates it empty — but must still report migrated:true from the
+    // sentinel so the lifecycle hook enqueues rebuild_index.
+    mockCreateCollectionThrows = null;
+    mockCollectionExists = false;
+    const result = await makeClient().ensureCollection();
+    expect(result.migrated).toBe(true);
+    expect(callLog.createCollection).toBeGreaterThanOrEqual(1);
+
+    // Lifecycle hook clears the sentinel after enqueueing rebuild_index.
+    await clearRebuildSentinel();
+    expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
+  });
+
+  test("a leftover sentinel + freshly created collection reports migrated:true", async () => {
+    // Crash-after-delete recovery: the sentinel is on disk and the collection
+    // is absent, so the ensure path recreates it empty yet signals the owed
+    // rebuild.
+    writeFileSync(REBUILD_SENTINEL_PATH, "");
+    mockCollectionExists = false;
+
+    const result = await makeClient().ensureCollection();
+
+    expect(callLog.createCollection).toBe(1);
+    expect(result.migrated).toBe(true);
+  });
+
+  test("a leftover sentinel surfaces migrated:true even when the collection is already compatible", async () => {
+    // Crash-after-recreate: the collection exists and matches, but the prior
+    // boot died before enqueuing rebuild_index and clearing the sentinel.
+    writeFileSync(REBUILD_SENTINEL_PATH, "");
+    mockCollectionExists = true;
+    mockUseNamedVectors = true;
+    mockCollectionSize = 768;
+    mockSentinelPayload = {
+      _meta: true,
+      embedding_model: "gemini:gemini-embedding-2",
+    };
+
+    const result = await makeClient().ensureCollection();
+
+    // No destructive work — it just carries the owed rebuild forward.
+    expect(callLog.deleteCollection).toBe(0);
+    expect(callLog.createCollection).toBe(0);
+    expect(result.migrated).toBe(true);
+  });
+
+  test("normal path: a compatible collection writes no sentinel and reports migrated:false", async () => {
+    mockCollectionExists = true;
+    mockUseNamedVectors = true;
+    mockCollectionSize = 768;
+    mockSentinelPayload = {
+      _meta: true,
+      embedding_model: "gemini:gemini-embedding-2",
+    };
+
+    const result = await makeClient().ensureCollection();
+
+    expect(callLog.deleteCollection).toBe(0);
+    expect(callLog.createCollection).toBe(0);
+    expect(result.migrated).toBe(false);
+    expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
+  });
+
+  test("clearRebuildSentinel is a no-op when no sentinel exists", async () => {
+    expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
+    await clearRebuildSentinel();
+    expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
   });
 });

--- a/assistant/src/persistence/embeddings/qdrant-client.ts
+++ b/assistant/src/persistence/embeddings/qdrant-client.ts
@@ -1,9 +1,14 @@
+import { existsSync } from "node:fs";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
 import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v4 as uuid } from "uuid";
 
 import { getQdrantHttpPortEnv, getQdrantUrlEnv } from "../../config/env.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
+import { getDataDir } from "../../util/platform.js";
 
 const log = getLogger("qdrant-client");
 
@@ -85,6 +90,57 @@ export function stripLegacySparseSuffix(sentinel: string): string {
   return sentinel.replace(/:sparse-v\d+$/, "");
 }
 
+/**
+ * Marker file written before the v1 collection's destructive dimension/model
+ * recreate, cleared by the startup lifecycle hook once the `rebuild_index` job
+ * has been enqueued.
+ *
+ * Closes a data-loss window in {@link VellumQdrantClient.ensureCollection}: the
+ * `migrated` signal that tells the lifecycle hook to enqueue `rebuild_index`
+ * otherwise lives only in a local variable returned after `deleteCollection` +
+ * `createCollection` both succeed. If Qdrant fails between the delete and the
+ * return — or the process crashes — that signal is lost: the next startup finds
+ * the collection missing, recreates it empty, reports `migrated: false`, and
+ * the v1 vectors stay dropped until each row is individually re-touched.
+ * Persisting the intent on disk *before* the delete lets it survive crashes and
+ * transient failures: every later `ensureCollection` reports `migrated: true`
+ * until the hook enqueues the rebuild and clears the sentinel. Mirrors the v2
+ * reembed sentinel in `plugins/defaults/memory/v2/qdrant.ts`.
+ *
+ * Distinct from the in-collection model-identity sentinel point handled by
+ * {@link VellumQdrantClient.readSentinel} / `writeSentinel` — that records the
+ * embedding model; this records "a rebuild is owed".
+ */
+const REBUILD_SENTINEL_FILENAME = ".memory-v1-rebuild-required";
+
+function rebuildSentinelPath(): string {
+  return join(getDataDir(), REBUILD_SENTINEL_FILENAME);
+}
+
+function rebuildSentinelExists(): boolean {
+  return existsSync(rebuildSentinelPath());
+}
+
+async function writeRebuildSentinel(): Promise<void> {
+  const path = rebuildSentinelPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, "");
+}
+
+/**
+ * Remove the rebuild sentinel after the startup lifecycle hook has enqueued the
+ * `rebuild_index` job. Idempotent — a missing file is not an error.
+ */
+export async function clearRebuildSentinel(): Promise<void> {
+  try {
+    await unlink(rebuildSentinelPath());
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
 let _instance: VellumQdrantClient | null = null;
 
 export function getQdrantClient(): VellumQdrantClient {
@@ -129,7 +185,11 @@ export class VellumQdrantClient {
   async ensureCollection(): Promise<{ migrated: boolean }> {
     if (this.collectionReady) return { migrated: false };
 
-    let migrated = false;
+    // A leftover sentinel means a prior boot deleted the collection but never
+    // got to enqueue the rebuild (createCollection threw, or the process died
+    // before the lifecycle hook ran). Carry that signal forward until the hook
+    // clears it, even when the collection now looks freshly created or intact.
+    let migrated = rebuildSentinelExists();
 
     try {
       const exists = await this.client.collectionExists(this.collection);
@@ -186,7 +246,7 @@ export class VellumQdrantClient {
               },
               "Qdrant collection uses unnamed vectors (legacy) — deleting and recreating with named vectors. Embeddings will be re-indexed.",
             );
-            await this.client.deleteCollection(this.collection);
+            await this.deleteCollectionForRebuild();
             migrated = true;
             // Fall through to collection creation below
           } else if (dimMismatch || modelMismatch) {
@@ -207,7 +267,7 @@ export class VellumQdrantClient {
               },
               "Qdrant collection incompatible (dimension/model change) — deleting and recreating. Embeddings will be regenerated on demand.",
             );
-            await this.client.deleteCollection(this.collection);
+            await this.deleteCollectionForRebuild();
             migrated = true;
             // Fall through to collection creation below
           } else {
@@ -217,7 +277,11 @@ export class VellumQdrantClient {
             if (needsSentinelRewrite && this.embeddingModel) {
               await this.writeSentinel(this.embeddingModel);
             }
-            return { migrated: false };
+            // `migrated` is false in steady state; it is only true here when a
+            // prior recreate wrote the sentinel but never cleared it, in which
+            // case the rebuild is still owed against this (possibly empty)
+            // collection.
+            return { migrated };
           }
         } catch (err) {
           log.warn(
@@ -227,7 +291,7 @@ export class VellumQdrantClient {
           if (await this.ensurePayloadIndexesSafe()) {
             this.collectionReady = true;
           }
-          return { migrated: false };
+          return { migrated };
         }
       }
     } catch {
@@ -300,6 +364,18 @@ export class VellumQdrantClient {
     }
 
     return { migrated };
+  }
+
+  /**
+   * Delete the collection as the first half of a destructive dimension/model
+   * recreate. Persists the rebuild sentinel BEFORE the delete so a crash or
+   * transient Qdrant failure between the delete and the recreate still triggers
+   * `rebuild_index` on the next ensure call. Callers set `migrated = true` and
+   * fall through to recreation.
+   */
+  private async deleteCollectionForRebuild(): Promise<void> {
+    await writeRebuildSentinel();
+    await this.client.deleteCollection(this.collection);
   }
 
   async upsert(

--- a/assistant/src/plugins/defaults/memory/startup.ts
+++ b/assistant/src/plugins/defaults/memory/startup.ts
@@ -20,7 +20,10 @@ import {
   initMessagesLexicalIndex,
   MESSAGES_LEXICAL_COLLECTION,
 } from "../../../persistence/embeddings/messages-lexical-index.js";
-import { initQdrantClient } from "../../../persistence/embeddings/qdrant-client.js";
+import {
+  clearRebuildSentinel,
+  initQdrantClient,
+} from "../../../persistence/embeddings/qdrant-client.js";
 import { createQdrantManager } from "../../../persistence/embeddings/qdrant-manager.js";
 import {
   enqueueMemoryJob,
@@ -102,6 +105,10 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
         const { migrated } = await qdrantClient.ensureCollection();
         if (migrated && isMemoryEnabled()) {
           enqueueMemoryJob("rebuild_index", {});
+          // Clear the on-disk sentinel the ensure-path writes before its
+          // destructive delete: now that rebuild_index is queued, the
+          // cross-boot signal can retire. No-op if no sentinel was written.
+          await clearRebuildSentinel();
           log.info(
             "Qdrant collection was migrated — enqueued rebuild_index job",
           );


### PR DESCRIPTION
## Summary

Follow-up to #36547 addressing Codex review feedback on `assistant/src/persistence/embeddings/qdrant-client.ts`.

`ensureCollection()` repairs v1 collection dimension/model drift by deleting and recreating the collection, signalling the rebuild via a `migrated` flag that the startup hook turns into a `rebuild_index` job. That flag lived only in a local variable returned after both `deleteCollection` and `createCollection` succeed. If Qdrant errored after the delete — or the process crashed before the method returned — the signal was lost: the next startup found the collection missing, recreated it empty with `migrated: false`, and never enqueued `rebuild_index`, silently dropping the v1 vectors until each row was individually re-touched.

## Fix

Mirror the v2 reembed sentinel (`plugins/defaults/memory/v2/qdrant.ts`):

- Write a durable on-disk sentinel (`<dataDir>/.memory-v1-rebuild-required`) **before** the destructive delete, via a new `deleteCollectionForRebuild()` helper so the write-before-delete invariant lives in one place.
- Initialize `migrated` from the sentinel's existence, so a leftover sentinel surfaces `migrated: true` on the next `ensureCollection` even when the collection now looks freshly created or already compatible.
- The startup hook clears the sentinel (`clearRebuildSentinel()`) after enqueuing `rebuild_index`.

## Tests

Extended `qdrant-collection-migration.test.ts` (mocks `getDataDir` to a temp dir): the sentinel survives a `createCollection` failure after delete and surfaces `migrated: true` on retry; leftover sentinel + missing/compatible collection → `migrated: true`; normal path writes no sentinel and stays `migrated: false`; `clearRebuildSentinel` is a no-op when absent. All 12 pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)