### PR TITLE
refactor(migrations): make workspace migration 011 self-contained

### DIFF
--- a/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
@@ -1,320 +1,314 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+/**
+ * Tests for workspace migration `011-backfill-installation-id`.
+ *
+ * Backfills a per-user `installationId` into the lockfile entry, sourcing it
+ * from the `telemetry:installation_id` row in the assistant DB's
+ * `memory_checkpoints` table (or a fresh UUID when absent), then deletes the
+ * stale checkpoint row. The lockfile is read from the user's home directory;
+ * the checkpoint lives in `<workspace>/data/db/assistant.db`.
+ *
+ * `node:os.homedir` is mocked to a temp directory so the lockfile paths never
+ * resolve to the developer's real `~`. The checkpoint is exercised against a
+ * real temp SQLite database, so the migration's inlined `bun:sqlite` access —
+ * including the table-missing fallback paths — runs for real.
+ */
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-const existsSyncFn = mock((_path: string): boolean => false);
-const readFileSyncFn = mock((_path: string, _enc: string): string => "");
-const writeFileSyncFn = mock((_path: string, _data: string): void => undefined);
-const randomUUIDFn = mock((): string => "generated-uuid-1234");
-const getMemoryCheckpointFn = mock((_key: string): string | null => null);
-const deleteMemoryCheckpointFn = mock((_key: string): void => undefined);
-const getExternalAssistantIdFn = mock((): string | undefined => "my-assistant");
-const homedirFn = mock((): string => "/mock-home");
+let mockHome = "";
+const homedirFn = mock((): string => mockHome);
+mock.module("node:os", () => ({ homedir: homedirFn }));
 
-// ---------------------------------------------------------------------------
-// Mock modules — before importing module under test
-// ---------------------------------------------------------------------------
-
-mock.module("node:fs", () => ({
-  existsSync: existsSyncFn,
-  readFileSync: readFileSyncFn,
-  writeFileSync: writeFileSyncFn,
-}));
-
-mock.module("node:crypto", () => ({
-  randomUUID: randomUUIDFn,
-}));
-
-mock.module("node:os", () => ({
-  homedir: homedirFn,
-}));
-
-mock.module("../persistence/checkpoints.js", () => ({
-  getMemoryCheckpoint: getMemoryCheckpointFn,
-  deleteMemoryCheckpoint: deleteMemoryCheckpointFn,
-}));
-
-mock.module("../runtime/auth/external-assistant-id.js", () => ({
-  getExternalAssistantId: getExternalAssistantIdFn,
-}));
-
-// Import after mocking
 import { backfillInstallationIdMigration } from "../workspace/migrations/011-backfill-installation-id.js";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const CHECKPOINT_KEY = "telemetry:installation_id";
+const ASSISTANT_NAME = "my-assistant";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const BASE = "/mock-home";
-const LOCK_PATH = `${BASE}/.vellum.lock.json`;
-const LEGACY_LOCK_PATH = `${BASE}/.vellum.lockfile.json`;
-const WORKSPACE_DIR = `${BASE}/.vellum/workspace`;
+// The preload sets VELLUM_WORKSPACE_DIR under a per-process temp root; its
+// parent is a writable temp base we can carve fresh dirs out of.
+const TMP_BASE = dirname(process.env.VELLUM_WORKSPACE_DIR ?? "");
+
+let workspaceDir: string;
+let dbPath: string;
+let lockPath: string;
+let legacyLockPath: string;
+let originalAssistantName: string | undefined;
+
+beforeEach(() => {
+  originalAssistantName = process.env.VELLUM_ASSISTANT_NAME;
+  process.env.VELLUM_ASSISTANT_NAME = ASSISTANT_NAME;
+
+  mockHome = mkdtempSync(join(TMP_BASE, "vellum-migration-011-home-"));
+  workspaceDir = mkdtempSync(join(TMP_BASE, "vellum-migration-011-ws-"));
+  homedirFn.mockClear();
+
+  lockPath = join(mockHome, ".vellum.lock.json");
+  legacyLockPath = join(mockHome, ".vellum.lockfile.json");
+
+  const dbDir = join(workspaceDir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  dbPath = join(dbDir, "assistant.db");
+});
+
+afterEach(() => {
+  if (originalAssistantName === undefined) {
+    delete process.env.VELLUM_ASSISTANT_NAME;
+  } else {
+    process.env.VELLUM_ASSISTANT_NAME = originalAssistantName;
+  }
+  for (const dir of [mockHome, workspaceDir]) {
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createCheckpointsTable(): void {
+  const db = new Database(dbPath);
+  try {
+    db.run(`
+      CREATE TABLE memory_checkpoints (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+/** Seed the installation-ID checkpoint row, creating the table if needed. */
+function seedCheckpoint(value: string): void {
+  if (!existsSync(dbPath)) {
+    createCheckpointsTable();
+  }
+  const db = new Database(dbPath);
+  try {
+    db.run(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, 0)`,
+      [CHECKPOINT_KEY, value],
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/** Read the checkpoint value directly, or null when the table/row is absent. */
+function readCheckpoint(): string | null {
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  const db = new Database(dbPath);
+  try {
+    const row = db
+      .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+      .get(CHECKPOINT_KEY) as { value: string } | null;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/** Create an empty DB file with no tables. */
+function createEmptyDb(): void {
+  new Database(dbPath).close();
+}
 
 function makeLockfile(assistants: Array<Record<string, unknown>>): string {
   return JSON.stringify({ assistants });
 }
 
-function setupFs(fileContents: Record<string, string>): void {
-  existsSyncFn.mockImplementation((path: string) => path in fileContents);
-  readFileSyncFn.mockImplementation((path: string, _enc: string) => {
-    if (path in fileContents) return fileContents[path];
-    throw new Error(`ENOENT: ${path}`);
-  });
+function writeLock(path: string, content: string): void {
+  writeFileSync(path, content, "utf-8");
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+function readLockAssistants(path: string): Array<Record<string, unknown>> {
+  return JSON.parse(readFileSync(path, "utf-8")).assistants;
+}
 
 describe("011-backfill-installation-id migration", () => {
-  beforeEach(() => {
-    existsSyncFn.mockClear();
-    readFileSyncFn.mockClear();
-    writeFileSyncFn.mockClear();
-    randomUUIDFn.mockClear();
-    getMemoryCheckpointFn.mockClear();
-    deleteMemoryCheckpointFn.mockClear();
-    getExternalAssistantIdFn.mockClear();
-    homedirFn.mockClear();
-
-    // Defaults
-    homedirFn.mockReturnValue("/mock-home");
-    getExternalAssistantIdFn.mockReturnValue("my-assistant");
-    getMemoryCheckpointFn.mockReturnValue(null);
-    randomUUIDFn.mockReturnValue("generated-uuid-1234");
-  });
-
   test("no-op when no lockfile exists", () => {
-    setupFs({});
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
-
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(legacyLockPath)).toBe(false);
   });
 
   test("no-op when lockfile has no assistants array", () => {
-    setupFs({
-      [LOCK_PATH]: JSON.stringify({ version: 1 }),
-    });
+    writeLock(lockPath, JSON.stringify({ version: 1 }));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(lockPath, "utf-8"))).toEqual({ version: 1 });
   });
 
   test("no-op when lockfile is malformed JSON", () => {
-    setupFs({
-      [LOCK_PATH]: "{{not json",
-    });
+    writeLock(lockPath, "{{not json");
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(readFileSync(lockPath, "utf-8")).toBe("{{not json");
   });
 
   test("no-op when lockfile is an array", () => {
-    setupFs({
-      [LOCK_PATH]: JSON.stringify([1, 2, 3]),
-    });
+    writeLock(lockPath, JSON.stringify([1, 2, 3]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(lockPath, "utf-8"))).toEqual([1, 2, 3]);
   });
 
   test("no-op when no matching assistant entry found", () => {
-    getExternalAssistantIdFn.mockReturnValue("my-assistant");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([
-        { assistantId: "other-assistant", installationId: undefined },
-      ]),
-    });
+    writeLock(lockPath, makeLockfile([{ assistantId: "other-assistant" }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(readLockAssistants(lockPath)[0].installationId).toBeUndefined();
   });
 
   test("backfills installationId from SQLite checkpoint", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-install-id");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+    seedCheckpoint("sqlite-install-id");
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    expect(path).toBe(LOCK_PATH);
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("sqlite-install-id");
+    expect(readLockAssistants(lockPath)[0].installationId).toBe(
+      "sqlite-install-id",
+    );
   });
 
-  test("generates new UUID when no SQLite checkpoint exists", () => {
-    getMemoryCheckpointFn.mockReturnValue(null);
-    randomUUIDFn.mockReturnValue("new-uuid-5678");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+  test("generates a new UUID when the checkpoint row is absent", () => {
+    createCheckpointsTable(); // table exists, no row
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("new-uuid-5678");
+    expect(readLockAssistants(lockPath)[0].installationId).toMatch(UUID_RE);
   });
 
-  test("generates new UUID when SQLite table does not exist", () => {
-    getMemoryCheckpointFn.mockImplementation(() => {
-      throw new Error("no such table: memory_checkpoints");
-    });
-    randomUUIDFn.mockReturnValue("fallback-uuid");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+  test("generates a new UUID when the assistant DB does not exist", () => {
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("fallback-uuid");
+    expect(readLockAssistants(lockPath)[0].installationId).toMatch(UUID_RE);
+  });
+
+  test("falls back to a UUID and does not throw when the memory_checkpoints table is absent", () => {
+    createEmptyDb(); // DB file exists but has no memory_checkpoints table
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
+
+    expect(() =>
+      backfillInstallationIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readLockAssistants(lockPath)[0].installationId).toMatch(UUID_RE);
   });
 
   test("skips lockfile write when entry already has installationId", () => {
-    setupFs({
-      [LOCK_PATH]: makeLockfile([
-        { assistantId: "my-assistant", installationId: "existing-id" },
+    writeLock(
+      lockPath,
+      makeLockfile([
+        { assistantId: ASSISTANT_NAME, installationId: "existing-id" },
       ]),
-    });
+    );
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(readLockAssistants(lockPath)[0].installationId).toBe("existing-id");
   });
 
-  test("cleans up SQLite checkpoint when entry already has installationId", () => {
-    setupFs({
-      [LOCK_PATH]: makeLockfile([
-        { assistantId: "my-assistant", installationId: "existing-id" },
+  test("deletes the checkpoint row when entry already has installationId", () => {
+    seedCheckpoint("stale-id");
+    writeLock(
+      lockPath,
+      makeLockfile([
+        { assistantId: ASSISTANT_NAME, installationId: "existing-id" },
       ]),
-    });
-
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
-
-    expect(deleteMemoryCheckpointFn).toHaveBeenCalledWith(
-      "telemetry:installation_id",
     );
+
+    backfillInstallationIdMigration.run(workspaceDir);
+
+    expect(readCheckpoint()).toBeNull();
   });
 
-  test("cleans up SQLite checkpoint after writing lockfile", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+  test("deletes the checkpoint row after writing the lockfile", () => {
+    seedCheckpoint("sqlite-id");
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    expect(deleteMemoryCheckpointFn).toHaveBeenCalledWith(
-      "telemetry:installation_id",
-    );
-  });
-
-  test("handles deleteMemoryCheckpoint throwing gracefully", () => {
-    deleteMemoryCheckpointFn.mockImplementation(() => {
-      throw new Error("no such table");
-    });
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
-
-    // Should not throw
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
-
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(readLockAssistants(lockPath)[0].installationId).toBe("sqlite-id");
+    expect(readCheckpoint()).toBeNull();
   });
 
   test("reads from legacy .vellum.lockfile.json when primary is absent", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-    setupFs({
-      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+    seedCheckpoint("sqlite-id");
+    writeLock(legacyLockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    expect(path).toBe(LEGACY_LOCK_PATH);
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("sqlite-id");
+    expect(readLockAssistants(legacyLockPath)[0].installationId).toBe(
+      "sqlite-id",
+    );
+    expect(existsSync(lockPath)).toBe(false);
   });
 
   test("prefers primary lockfile over legacy when both exist", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+    seedCheckpoint("sqlite-id");
+    writeLock(lockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
+    writeLock(legacyLockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [path] = writeFileSyncFn.mock.calls[0] as [string, string];
-    expect(path).toBe(LOCK_PATH);
+    expect(readLockAssistants(lockPath)[0].installationId).toBe("sqlite-id");
+    expect(
+      readLockAssistants(legacyLockPath)[0].installationId,
+    ).toBeUndefined();
   });
 
   test("falls through to legacy lockfile when primary is malformed", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-    setupFs({
-      [LOCK_PATH]: "{{not json",
-      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
+    seedCheckpoint("sqlite-id");
+    writeLock(lockPath, "{{not json");
+    writeLock(legacyLockPath, makeLockfile([{ assistantId: ASSISTANT_NAME }]));
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    expect(path).toBe(LEGACY_LOCK_PATH);
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("sqlite-id");
-  });
-
-  test("always reads lockfile from homedir (per-user, not per-instance)", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-
-    setupFs({
-      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
-    });
-
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
-
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [path] = writeFileSyncFn.mock.calls[0] as [string, string];
-    expect(path).toBe(LOCK_PATH);
+    expect(readLockAssistants(legacyLockPath)[0].installationId).toBe(
+      "sqlite-id",
+    );
   });
 
   test("preserves other assistants in lockfile when writing", () => {
-    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
-    setupFs({
-      [LOCK_PATH]: JSON.stringify({
-        assistants: [
-          { assistantId: "other-assistant", installationId: "other-id" },
-          { assistantId: "my-assistant" },
-        ],
-      }),
-    });
+    seedCheckpoint("sqlite-id");
+    writeLock(
+      lockPath,
+      makeLockfile([
+        { assistantId: "other-assistant", installationId: "other-id" },
+        { assistantId: ASSISTANT_NAME },
+      ]),
+    );
 
-    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+    backfillInstallationIdMigration.run(workspaceDir);
 
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
-    const parsed = JSON.parse(data);
-    expect(parsed.assistants[0].installationId).toBe("other-id");
-    expect(parsed.assistants[1].installationId).toBe("sqlite-id");
+    const assistants = readLockAssistants(lockPath);
+    expect(assistants[0].installationId).toBe("other-id");
+    expect(assistants[1].installationId).toBe("sqlite-id");
   });
 
   test("has migration id 011-backfill-installation-id", () => {

--- a/assistant/src/workspace/migrations/011-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/011-backfill-installation-id.ts
@@ -2,13 +2,70 @@ import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 
-import {
-  deleteMemoryCheckpoint,
-  getMemoryCheckpoint,
-} from "../../persistence/checkpoints.js";
-import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id.js";
 import type { WorkspaceMigration } from "./types.js";
+
+const INSTALLATION_ID_CHECKPOINT_KEY = "telemetry:installation_id";
+
+/**
+ * Open the assistant SQLite database read-write, or return null when it does
+ * not exist yet (fresh install) or cannot be opened. The path mirrors
+ * getDbPath(): `<workspace>/data/db/assistant.db`.
+ */
+function openAssistantDb(workspaceDir: string): Database | null {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  try {
+    return new Database(dbPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the persisted installation ID from the `memory_checkpoints` table.
+ * Returns null when the database, table, or row is absent — a fresh install
+ * has no prior ID to recover. Never throws.
+ */
+function readInstallationIdCheckpoint(workspaceDir: string): string | null {
+  const db = openAssistantDb(workspaceDir);
+  if (!db) {
+    return null;
+  }
+  try {
+    const row = db
+      .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+      .get(INSTALLATION_ID_CHECKPOINT_KEY) as { value: string } | null;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Delete the installation-ID checkpoint row. Idempotent and never throws — a
+ * missing table or row is a successful no-op.
+ */
+function deleteInstallationIdCheckpoint(workspaceDir: string): void {
+  const db = openAssistantDb(workspaceDir);
+  if (!db) {
+    return;
+  }
+  try {
+    db.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(
+      INSTALLATION_ID_CHECKPOINT_KEY,
+    );
+  } catch {
+    // Table doesn't exist — nothing to clean up.
+  } finally {
+    db.close();
+  }
+}
 
 export const backfillInstallationIdMigration: WorkspaceMigration = {
   id: "011-backfill-installation-id",
@@ -25,17 +82,10 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
     // No-op: leaving installationId in the lockfile is safe and non-disruptive.
   },
 
-  run(_workspaceDir: string): void {
+  run(workspaceDir: string): void {
     // a. Read existing installation ID from SQLite, or generate a new one.
-    //    On fresh installs the memory_checkpoints table may not exist yet,
-    //    so treat errors as null.
-    let existingId: string | null = null;
-    try {
-      existingId = getMemoryCheckpoint("telemetry:installation_id");
-    } catch {
-      // Table doesn't exist yet — fresh install, no prior ID to recover.
-    }
-    const installationId = existingId || randomUUID();
+    const installationId =
+      readInstallationIdCheckpoint(workspaceDir) || randomUUID();
 
     // b. Read the lockfile — check both the current and legacy lockfile paths
     //    to support installs that haven't migrated the filename yet.
@@ -50,7 +100,9 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
     let lockPath: string | undefined;
     let lockData: Record<string, unknown> | undefined;
     for (const candidate of lockCandidates) {
-      if (!existsSync(candidate)) continue;
+      if (!existsSync(candidate)) {
+        continue;
+      }
       try {
         const raw = JSON.parse(readFileSync(candidate, "utf-8"));
         if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -62,26 +114,30 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
         // Malformed — try next candidate.
       }
     }
-    if (!lockPath || !lockData) return;
+    if (!lockPath || !lockData) {
+      return;
+    }
 
-    // c. Find the assistant entry that corresponds to this daemon instance
+    // c. Find the assistant entry that corresponds to this daemon instance.
+    //    The external assistant ID comes from the VELLUM_ASSISTANT_NAME env
+    //    var, set by CLI hatch and Docker setup.
     const assistants = lockData.assistants as
       | Array<Record<string, unknown>>
       | undefined;
-    if (!Array.isArray(assistants)) return;
+    if (!Array.isArray(assistants)) {
+      return;
+    }
 
-    const externalId = getExternalAssistantId();
+    const externalId = process.env.VELLUM_ASSISTANT_NAME || undefined;
     const entry = assistants.find((a) => a.assistantId === externalId);
-    if (!entry) return;
+    if (!entry) {
+      return;
+    }
 
     // d. If already has a truthy installationId, skip lockfile write (idempotent)
     if (entry.installationId) {
       // e is skipped for lockfile write, but still clean up SQLite
-      try {
-        deleteMemoryCheckpoint("telemetry:installation_id");
-      } catch {
-        // Table doesn't exist — nothing to clean up.
-      }
+      deleteInstallationIdCheckpoint(workspaceDir);
       return;
     }
 
@@ -90,10 +146,6 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
     writeFileSync(lockPath, JSON.stringify(lockData, null, 2) + "\n");
 
     // f. Delete the stale SQLite row
-    try {
-      deleteMemoryCheckpoint("telemetry:installation_id");
-    } catch {
-      // Table doesn't exist — nothing to clean up.
-    }
+    deleteInstallationIdCheckpoint(workspaceDir);
   },
 };


### PR DESCRIPTION
Follow-up to #36449 addressing Codex review feedback.

Workspace migration `011-backfill-installation-id` imported `getMemoryCheckpoint` / `deleteMemoryCheckpoint` from `../../persistence/checkpoints.js` and `getExternalAssistantId` from `../../runtime/auth/external-assistant-id.js`. That violates the migrations self-containment rule (`assistant/src/workspace/migrations/AGENTS.md`): only `./types.js`, `./utils.js`, `../../util/logger.js`, and runtime built-ins may be imported. Coupling an append-only historical migration to live persistence/runtime code means a future change there can break startup for older installs that still need to run this migration.

## Changes
- Inline the checkpoint read/delete against `<workspace>/data/db/assistant.db` using direct `bun:sqlite` access, matching the established pattern in sibling migrations (042/075/085). Behavior stays equivalent and idempotent: the read swallows a missing `memory_checkpoints` table (fresh install falls back to a generated UUID) and the delete no-ops on a missing table.
- Replace `getExternalAssistantId()` with a direct `process.env.VELLUM_ASSISTANT_NAME` read (its only behavior).
- Rewrite the test to exercise the real inlined `bun:sqlite` paths against a temp SQLite DB, mocking only `node:os.homedir` so the lockfile never resolves to the real home directory. Removes the now-dead mocks of the persistence/runtime modules.

The migration now depends only on runtime built-ins and `./types.js`.

## Verification
- `bun test src/__tests__/workspace-migration-backfill-installation-id.test.ts` — 17 pass
- `typecheck:fast` clean, eslint + prettier clean