### PR TITLE
fix(assistant): regenerate OpenAPI spec for inbound email emailProvider field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4133,6 +4133,8 @@ paths:
                       required:
                         - trustClass
                         - canonicalSenderId
+                    emailProvider:
+                      type: string
                     emailSubject:
                       type: string
                     emailRecipient:


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` so it includes the `emailProvider` field that #36918 added to the inbound email `sourceMetadata` contract (`packages/gateway-client/src/inbound-contract.ts`)
- Fixes the failing **OpenAPI Spec Check** job on `main` ([run 28581620000](https://github.com/vellum-ai/vellum-assistant/actions/runs/28581620000/job/84743041211)) — the check regenerates the spec and diffs it against the committed file
- Diff is the pure generator output (two lines); verified locally with `bun run generate:openapi -- --check`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/28581620000/job/84743041211

🤖 Generated with [Claude Code](https://claude.com/claude-code)