### PR TITLE
test(assistant): isolate auto-analysis service test mocks from sibling suites

### DIFF
--- a/assistant/src/runtime/services/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/runtime/services/__tests__/auto-analysis-enqueue.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -42,11 +50,6 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
     flagEnabled,
 }));
 
-mock.module("../auto-analysis-guard.js", () => ({
-  AUTO_ANALYSIS_SOURCE: "auto-analysis",
-  isAutoAnalysisConversation: (_conversationId: string) => isAuto,
-}));
-
 mock.module(
   "../../../plugins/defaults/memory/memory-retrospective-enqueue.js",
   () => ({
@@ -78,6 +81,27 @@ mock.module("../../../persistence/jobs-store.js", () => ({
     });
   },
 }));
+
+// Scope the sibling `auto-analysis-guard` stub to this suite so it does not
+// leak into auto-analysis-guard.test.ts, which exercises the real
+// `isAutoAnalysisConversation` in the same Bun process. Bun's `mock.module` is
+// process-global and not undone by `mock.restore()`; the capture spreads into a
+// plain object to freeze the real export by value (a namespace reference is a
+// live view that `mock.module` mutates in place).
+const actualAutoAnalysisGuard = {
+  ...(await import("../auto-analysis-guard.js")),
+};
+
+beforeAll(() => {
+  mock.module("../auto-analysis-guard.js", () => ({
+    AUTO_ANALYSIS_SOURCE: "auto-analysis",
+    isAutoAnalysisConversation: (_conversationId: string) => isAuto,
+  }));
+});
+
+afterAll(() => {
+  mock.module("../auto-analysis-guard.js", () => actualAutoAnalysisGuard);
+});
 
 import {
   enqueueAutoAnalysisIfEnabled,

--- a/assistant/src/runtime/services/__tests__/conversation-analyze-job.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-analyze-job.test.ts
@@ -6,7 +6,15 @@
  * wiring.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -34,10 +42,6 @@ const mockAnalyzeConversation = mock(
   },
 );
 
-mock.module("../analyze-conversation.js", () => ({
-  analyzeConversation: mockAnalyzeConversation,
-}));
-
 // Mock auto-analysis-enqueue — track calls so we can verify requeue behavior.
 type EnqueueArgs = {
   conversationId: string;
@@ -48,9 +52,40 @@ const mockEnqueueAutoAnalysisIfEnabled = mock((args: EnqueueArgs) => {
   enqueueCalls.push(args);
 });
 
-mock.module("../auto-analysis-enqueue.js", () => ({
-  enqueueAutoAnalysisIfEnabled: mockEnqueueAutoAnalysisIfEnabled,
-}));
+// Scope the sibling-module stubs to this suite's lifecycle. Bun's `mock.module`
+// is process-global and is NOT undone by `mock.restore()`, so registering these
+// at the top level leaks the stubs into sibling suites that import the real
+// modules in the same Bun process (analyze-conversation.test.ts,
+// auto-analysis-enqueue.test.ts). Register the stubs in `beforeAll` and
+// re-register the real modules in `afterAll`.
+//
+// The captures spread into a plain object (`{ ...(await import()) }`) to freeze
+// the real exports by value. A module-namespace reference is a live view:
+// `mock.module` mutates it in place, so a bare `await import` would itself
+// return the stub once the stub is registered, and `afterAll` would "restore"
+// the stub instead of the real module.
+const actualAnalyzeConversation = {
+  ...(await import("../analyze-conversation.js")),
+};
+const actualAutoAnalysisEnqueue = {
+  ...(await import("../auto-analysis-enqueue.js")),
+};
+
+beforeAll(() => {
+  mock.module("../analyze-conversation.js", () => ({
+    ...actualAnalyzeConversation,
+    analyzeConversation: mockAnalyzeConversation,
+  }));
+  mock.module("../auto-analysis-enqueue.js", () => ({
+    ...actualAutoAnalysisEnqueue,
+    enqueueAutoAnalysisIfEnabled: mockEnqueueAutoAnalysisIfEnabled,
+  }));
+});
+
+afterAll(() => {
+  mock.module("../analyze-conversation.js", () => actualAnalyzeConversation);
+  mock.module("../auto-analysis-enqueue.js", () => actualAutoAnalysisEnqueue);
+});
 
 import { DEFAULT_CONFIG } from "../../../config/defaults.js";
 import type { AssistantConfig } from "../../../config/types.js";


### PR DESCRIPTION
Follow-up to #36447 addressing Codex review feedback.

## Problem

`conversation-analyze-job.test.ts` registered a process-global `mock.module("../analyze-conversation.js")` at the top level. Bun's `mock.module` persists for the entire test process, so when the `runtime/services/__tests__` directory runs together, `analyze-conversation.test.ts` imported the stub instead of the real module and 13 assertions failed (NOT_FOUND cases returned the stub's BAD_REQUEST; `runAgentLoop` was never called). Standalone, `analyze-conversation.test.ts` passed 17/0.

While fixing it I found the same bug class in a sibling file from the same PR: `auto-analysis-enqueue.test.ts` globally stubbed `../auto-analysis-guard.js`, poisoning `auto-analysis-guard.test.ts` (1 failure: `isAutoAnalysisConversation`). Before this change the directory ran **46 pass / 14 fail**.

## Fix

Scope each sibling-module stub to its suite's lifecycle:

- Capture a **frozen snapshot** of the real module (`{ ...(await import(...)) }`) before any stub is registered.
- Register the stub in `beforeAll`.
- Re-register the real module in `afterAll`.

Two non-obvious Bun behaviors drive this shape (both documented in the code comments):

1. `mock.restore()` does **not** undo `mock.module`, so restoring requires an explicit re-register (same pattern used in `persistence/__tests__/conversation-search-lexical.test.ts`).
2. A module-namespace reference is a **live view** that `mock.module` mutates in place — a bare `await import` would itself return the stub once the stub is registered, so the capture must spread into a plain object to freeze the real exports by value.

## Files

- `assistant/src/runtime/services/__tests__/conversation-analyze-job.test.ts` — isolate the `analyze-conversation.js` and `auto-analysis-enqueue.js` stubs.
- `assistant/src/runtime/services/__tests__/auto-analysis-enqueue.test.ts` — isolate the `auto-analysis-guard.js` stub.

All existing assertions are preserved; no production code changed.

## Verification

- `bun test src/runtime/services/__tests__/` → **60 pass / 0 fail** (was 46 / 14).
- Required pairing `conversation-analyze-job.test.ts analyze-conversation.test.ts` → 24 / 0 in **both** orderings.
- `auto-analysis-enqueue.test.ts auto-analysis-guard.test.ts` → 22 / 0 in both orderings.
- Each file green standalone; `bunx tsc --noEmit` clean for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)