### PR TITLE
fix(onboarding): tighten background-hatch poll cadence to 1s

### DIFF
--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -14,13 +14,17 @@ import {
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
 
-// Mirrors the poll/backoff constants in
-// `@/domains/onboarding/pages/hatching-screen.tsx`. The research-onboarding
-// flow kicks this hatch off in the background the moment the user lands on the
-// onboarding page, so by the time they finish the intro/pitch steps and submit
-// their details the assistant is (usually) already healthy and the flow can
-// immediately fire its research turn.
-const POLL_INTERVAL_MS = 3000;
+// The research-onboarding flow kicks this hatch off in the background the moment
+// the user lands on the onboarding page, so by the time they finish the
+// intro/pitch steps and submit their details the assistant is (usually) already
+// healthy and the flow can immediately fire its research turn.
+//
+// We poll faster than the hatching-screen (which uses 3s): this flow races the
+// user through the steps, and a 3s gap between the assistant going healthy and
+// `ready` flipping is enough to leave the calendar step stuck on its "Almost
+// ready / Starting assistant…" state. 1s tightens that window without meaningful
+// extra load (the polls are cheap and stop the moment the hatch settles).
+const POLL_INTERVAL_MS = 1000;
 const MAX_HATCH_WAIT_MS = 300_000;
 
 const GENERIC_HATCH_ERROR =


### PR DESCRIPTION
## What

Drops the research-onboarding background-hatch poll interval from **3s → 1s** in `use-background-hatch.ts`.

## Why

The calendar step (`LetsChatTomorrowStep`) shows an "Almost ready / Starting assistant…" loading state while `waitingForAssistant = !assistantId || !assistantReady`. `assistantReady` (`useBackgroundHatch().ready`) only flips true after the three-phase hatch completes: hatch → poll `getAssistant` until `active` → poll `getAssistantHealthz` until reachable.

At a 3s cadence there's up to a 3s lag between the assistant actually going healthy and `ready` flipping. Because users race through the intro/pitch/personality steps, that gap was enough to land them on the calendar step still showing the loading state.

We can't start the hatch any earlier — it already fires on route mount, and it's correctly gated on `flagsHydrated`/`enabled` so a flag-off visitor never provisions an assistant. So the practical lever is the poll cadence.

## Change

- `POLL_INTERVAL_MS: 3000 → 1000` (applies to both the active-poll and healthz-poll loops).
- Updated the comment explaining the intentional divergence from the hatching-screen's 3s.

The polls are cheap and stop the moment the hatch settles, so no meaningful extra load. `MAX_HATCH_WAIT_MS` (5 min ceiling) is unchanged.

## Testing

- `use-background-hatch.test.ts`: 3 pass (no hardcoded-interval assertions).
- [ ] Worth a visual QA pass: run onboarding and confirm the calendar step lands ready sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)