### PR TITLE
refactor(web): convert postChatMessage trailing params to an options object

### DIFF
--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -73,12 +73,14 @@ afterEach(() => {
 
 describe("postChatMessage — onboarding wire format", () => {
   test("includes googleConnected and googleScopes when provided", async () => {
-    await postChatMessage("assistant-1", "conv-key", "Hello", [], {
-      tools: [],
-      tasks: [],
-      tone: "warm",
-      googleConnected: true,
-      googleScopes: ["https://mail.google.com/"],
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      onboarding: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+        googleScopes: ["https://mail.google.com/"],
+      },
     });
 
     expect(capturedBody).not.toBeNull();
@@ -90,10 +92,8 @@ describe("postChatMessage — onboarding wire format", () => {
   });
 
   test("omits googleConnected and googleScopes when not provided", async () => {
-    await postChatMessage("assistant-1", "conv-key", "Hello", [], {
-      tools: [],
-      tasks: [],
-      tone: "grounded",
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      onboarding: { tools: [], tasks: [], tone: "grounded" },
     });
 
     const onboarding = (capturedBody as Record<string, unknown>)
@@ -114,14 +114,9 @@ describe("postChatMessage — onboarding wire format", () => {
 
 describe("postChatMessage — clientMessageId wire format", () => {
   test("sends the client nonce as the idempotency key when provided", async () => {
-    await postChatMessage(
-      "assistant-1",
-      "conv-key",
-      "Hello",
-      [],
-      undefined,
-      "nonce-123",
-    );
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      clientMessageId: "nonce-123",
+    });
 
     expect(capturedBody).not.toBeNull();
     expect((capturedBody as Record<string, unknown>).clientMessageId).toBe(
@@ -141,16 +136,9 @@ describe("postChatMessage — clientMessageId wire format", () => {
 
 describe("postChatMessage — enabledPlugins wire format", () => {
   test("includes an explicit plugin selection verbatim", async () => {
-    await postChatMessage(
-      "assistant-1",
-      "conv-key",
-      "Hello",
-      [],
-      undefined,
-      undefined,
-      undefined,
-      ["alpha", "zeta"],
-    );
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      enabledPlugins: ["alpha", "zeta"],
+    });
 
     expect(
       (capturedBody as Record<string, unknown>).enabledPlugins,
@@ -158,16 +146,9 @@ describe("postChatMessage — enabledPlugins wire format", () => {
   });
 
   test("includes an explicit empty selection (user disabled every plugin)", async () => {
-    await postChatMessage(
-      "assistant-1",
-      "conv-key",
-      "Hello",
-      [],
-      undefined,
-      undefined,
-      undefined,
-      [],
-    );
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      enabledPlugins: [],
+    });
 
     // An empty array is a genuine "no plugins for this chat" selection, not a
     // missing one — it must reach the daemon, unlike the omitted-default case.
@@ -185,16 +166,9 @@ describe("postChatMessage — enabledPlugins wire format", () => {
   });
 
   test("omits enabledPlugins when null", async () => {
-    await postChatMessage(
-      "assistant-1",
-      "conv-key",
-      "Hello",
-      [],
-      undefined,
-      undefined,
-      undefined,
-      null,
-    );
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      enabledPlugins: null,
+    });
 
     expect(
       (capturedBody as Record<string, unknown>).enabledPlugins,

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -463,11 +463,27 @@ export async function uploadChatAttachment(
   };
 }
 
+/** Optional fields for {@link postChatMessage}. */
+export interface PostChatMessageOptions {
+  /** Server-assigned attachment ids from `uploadChatAttachment`. */
+  attachmentIds?: string[];
+  /** PreChat onboarding context — see the `postChatMessage` docs. */
+  onboarding?: PreChatOnboardingContext;
+  /** Client-generated idempotency nonce for echo dedup. */
+  clientMessageId?: string;
+  /** Per-conversation model profile for a freshly minted conversation. */
+  inferenceProfile?: string | null;
+  /** Per-chat plugin selection for a freshly minted conversation. */
+  enabledPlugins?: string[] | null;
+  /** Persist the message but suppress it from the transcript. */
+  hidden?: boolean;
+}
+
 /**
  * Send a user message without polling for the response.
  * Returns the assistant/conversation IDs needed to subscribe to events.
  *
- * The optional `onboarding` parameter carries PreChat onboarding context that
+ * The optional `onboarding` field carries PreChat onboarding context that
  * should be attached only to the FIRST message after PreChat completion. Callers
  * are responsible for the consume-once semantics: include `onboarding` on the
  * initial post and omit it on every subsequent message in the conversation.
@@ -488,13 +504,16 @@ export async function postChatMessage(
   assistantId: string,
   conversationId: string | null,
   content: string,
-  attachmentIds: string[] = [],
-  onboarding?: PreChatOnboardingContext,
-  clientMessageId?: string,
-  inferenceProfile?: string | null,
-  enabledPlugins?: string[] | null,
-  isHidden?: boolean,
+  options: PostChatMessageOptions = {},
 ): Promise<PostMessageResult> {
+  const {
+    attachmentIds = [],
+    onboarding,
+    clientMessageId,
+    inferenceProfile,
+    enabledPlugins,
+    hidden,
+  } = options;
   // Wire-field selection picks exactly one of `conversationId` (0.8.6+
   // strict internal-id lookup) or `conversationKey` (legacy
   // create-or-lookup). See `lib/backwards-compat/conversation-id-wire-field.ts`.
@@ -564,7 +583,7 @@ export async function postChatMessage(
   // Persist the message but suppress it from the transcript (it still drives the
   // turn LLM-side). Used by the research-onboarding "Let's chat" handoff to
   // prime a proactive assistant greeting without showing the triggering message.
-  if (isHidden) {
+  if (hidden) {
     body.hidden = true;
   }
   const normalizedOnboarding = onboarding

--- a/clients/web/src/domains/chat/api/post-chat-message.test.ts
+++ b/clients/web/src/domains/chat/api/post-chat-message.test.ts
@@ -99,13 +99,15 @@ describe("postChatMessage onboarding payload", () => {
   });
 
   test("includes normalized onboarding and seeds profile files concurrently with the message post", async () => {
-    await postChatMessage("asst-1", "K", "hello", [], {
-      tools: ["github", "linear"],
-      tasks: ["code-building", "writing"],
-      tone: "friendly",
-      userName: "Ada",
-      occupation: "Software Engineer",
-      assistantName: "Vel",
+    await postChatMessage("asst-1", "K", "hello", {
+      onboarding: {
+        tools: ["github", "linear"],
+        tasks: ["code-building", "writing"],
+        tone: "friendly",
+        userName: "Ada",
+        occupation: "Software Engineer",
+        assistantName: "Vel",
+      },
     });
     // Profile seeding is fire-and-forget — flush the microtask queue so
     // the concurrent writes settle before we assert.
@@ -138,12 +140,14 @@ describe("postChatMessage onboarding payload", () => {
   });
 
   test("excludes userName when undefined (matches macOS `if let userName`)", async () => {
-    await postChatMessage("asst-1", "K", "hello", [], {
-      tools: ["github"],
-      tasks: ["plan"],
-      tone: "concise",
-      // userName intentionally omitted
-      assistantName: "Vel",
+    await postChatMessage("asst-1", "K", "hello", {
+      onboarding: {
+        tools: ["github"],
+        tasks: ["plan"],
+        tone: "concise",
+        // userName intentionally omitted
+        assistantName: "Vel",
+      },
     });
 
     const body = getRequestBody();
@@ -161,12 +165,14 @@ describe("postChatMessage onboarding payload", () => {
     // Codex P2 regression guard: a caller that intentionally sends "" to
     // represent a blank-but-present name must reach the wire untouched —
     // truthy checks would silently drop these and diverge from macOS.
-    await postChatMessage("asst-1", "K", "hello", [], {
-      tools: ["github"],
-      tasks: ["plan"],
-      tone: "concise",
-      userName: "",
-      assistantName: "",
+    await postChatMessage("asst-1", "K", "hello", {
+      onboarding: {
+        tools: ["github"],
+        tasks: ["plan"],
+        tone: "concise",
+        userName: "",
+        assistantName: "",
+      },
     });
 
     const body = getRequestBody();
@@ -180,10 +186,12 @@ describe("postChatMessage onboarding payload", () => {
   });
 
   test("includes empty tools/tasks arrays as valid wire payload", async () => {
-    await postChatMessage("asst-1", "K", "hello", [], {
-      tools: [],
-      tasks: [],
-      tone: "neutral",
+    await postChatMessage("asst-1", "K", "hello", {
+      onboarding: {
+        tools: [],
+        tasks: [],
+        tone: "neutral",
+      },
     });
 
     const body = getRequestBody();

--- a/clients/web/src/domains/chat/channel-setup-close-notify.ts
+++ b/clients/web/src/domains/chat/channel-setup-close-notify.ts
@@ -53,12 +53,7 @@ export async function notifyChannelSetupClosed(
       payload.assistantId,
       conversationId,
       buildChannelSetupClosedMessage(payload.channel),
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      /* isHidden */ true,
+      { hidden: true },
     );
     if (!result.ok) {
       captureError(

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -335,12 +335,14 @@ export function useSendMessage({
         requestAssistantId,
         useServerMint ? null : requestConversationId,
         content,
-        attachmentIds,
-        onboardingContext ?? undefined,
-        clientMessageId,
-        inferenceProfileForSend,
-        enabledPluginsForSend,
-        isHidden,
+        {
+          attachmentIds,
+          onboarding: onboardingContext ?? undefined,
+          clientMessageId,
+          inferenceProfile: inferenceProfileForSend,
+          enabledPlugins: enabledPluginsForSend,
+          hidden: isHidden,
+        },
       );
       if (
         useServerMint &&
@@ -791,9 +793,7 @@ export function useSendMessage({
             assistantId,
             activeConversationId,
             content,
-            attachmentIds,
-            undefined,
-            clientMessageId,
+            { attachmentIds, clientMessageId },
           );
           if (!postResult.ok) {
             revertQueuedMessage(userMessage.id);


### PR DESCRIPTION
## Prompt / plan

Follow-up requested in review of #36954 (also flagged by the vex-assistant-bot review there): `postChatMessage` had nine positional parameters, six of them trailing optionals, which forced call sites into positional `undefined` runs like `postChatMessage(a, c, content, [], undefined, undefined, undefined, undefined, true)` — one silently mis-assigned argument away from a bug whenever the signature grows.

The three required identifiers (`assistantId`, `conversationId`, `content`) stay positional; the six optionals move into a `PostChatMessageOptions` object (`attachmentIds`, `onboarding`, `clientMessageId`, `inferenceProfile`, `enabledPlugins`, `hidden`). Pure refactor — the body destructures the options and is otherwise unchanged, so the wire format is identical.

**Stacked on #36954** (base branch `claude/slack-wizard-auto-notify-avatar-id0jn7`) because that PR adds one of the three production call sites; GitHub will retarget this PR to `main` when the base merges.

Call sites updated: `use-send-message.ts` (×2), `channel-setup-close-notify.ts` (now just `{ hidden: true }`), and the option-exercising tests in `messages.test.ts` and `post-chat-message.test.ts`.

## Test plan

- `clients/web`: `bun test` on `src/domains/chat/api/messages.test.ts`, `src/domains/chat/api/post-chat-message.test.ts`, `src/domains/chat/channel-setup-close-notify.test.ts`, and `src/domains/chat/hooks/use-channel-setup-close-notify.test.tsx` — all pass (run singly per the files' `mock.module` isolation notes, as CI does).
- `bun run typecheck` clean; eslint reports 0 errors on touched files (remaining warnings pre-date this change).

## CLI verb checklist

No new routes — client-only refactor of an existing API wrapper's signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhboew7TA4oyViVE6ubWXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhboew7TA4oyViVE6ubWXY)_