### PR TITLE
fix(gateway): classify Slack bot senders as assistant contacts, not human

### DIFF
--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -486,7 +486,11 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     // reach the gateway write; the authoritative gateway row may be
     // blocked/revoked and must not be reactivated.
     queryRows = [
-      { channelId: "assistant-ch", contactId: "co-10", channelStatus: "active" },
+      {
+        channelId: "assistant-ch",
+        contactId: "co-10",
+        channelStatus: "active",
+      },
     ];
     gwUpdateChanges = [0, 0];
 
@@ -613,7 +617,11 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
     // race). The assistant mirror must NOT be activated, so a blocked actor is
     // never left active locally.
     queryRows = [
-      { channelId: "ch-race", contactId: "co-race", channelStatus: "unverified" },
+      {
+        channelId: "ch-race",
+        contactId: "co-race",
+        channelStatus: "unverified",
+      },
     ];
     gwSelectStatus = "unverified"; // pre-check passes
     gwUpdateChanges = [0, 0]; // guarded gateway updates miss
@@ -774,7 +782,11 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
 
   test("without the flag a gateway-revoked channel is still refused", async () => {
     queryRows = [
-      { channelId: "ch-mirror", contactId: "co-mirror", channelStatus: "active" },
+      {
+        channelId: "ch-mirror",
+        contactId: "co-mirror",
+        channelStatus: "active",
+      },
     ];
     gwSelectStatus = "revoked";
 
@@ -814,7 +826,11 @@ describe("upsertVerifiedContactChannel — invite target-contact binding", () =>
     // The redeemer's channel currently lives under a different contact (the
     // guardian); the invite binds it to the target contact "mom".
     queryRows = [
-      { channelId: "ch-redeemer", contactId: "co-guardian", channelStatus: "active" },
+      {
+        channelId: "ch-redeemer",
+        contactId: "co-guardian",
+        channelStatus: "active",
+      },
     ];
 
     await upsertVerifiedContactChannel({
@@ -853,19 +869,23 @@ describe("upsertVerifiedContactChannel — invite target-contact binding", () =>
       col: "type",
       val: "telegram",
     });
-    expect(where.conds.some((c) => c.op === "eq" && c.col === "id")).toBe(false);
+    expect(where.conds.some((c) => c.op === "eq" && c.col === "id")).toBe(
+      false,
+    );
 
     // The verified gateway write lands under the bound (target) contact.
     expect(
-      gwUpdates.some(
-        (u) => (u.set as { status?: string }).status === "active",
-      ),
+      gwUpdates.some((u) => (u.set as { status?: string }).status === "active"),
     ).toBe(true);
   });
 
   test("activates the gateway channel even when the assistant mirror re-parent fails", async () => {
     queryRows = [
-      { channelId: "ch-redeemer", contactId: "co-guardian", channelStatus: "active" },
+      {
+        channelId: "ch-redeemer",
+        contactId: "co-guardian",
+        channelStatus: "active",
+      },
     ];
     // The assistant-DB mirror re-parent throws transiently.
     runThrowOnSql = "SET contact_id";
@@ -882,9 +902,7 @@ describe("upsertVerifiedContactChannel — invite target-contact binding", () =>
     // gateway source of truth is verified rather than left inactive.
     expect(result).toEqual({ verified: true });
     expect(
-      gwUpdates.some(
-        (u) => (u.set as { status?: string }).status === "active",
-      ),
+      gwUpdates.some((u) => (u.set as { status?: string }).status === "active"),
     ).toBe(true);
   });
 
@@ -961,7 +979,9 @@ describe("upsertVerifiedContactChannel — invite target-contact binding", () =>
       col: "type",
       val: "telegram",
     });
-    expect(where.conds.some((c) => c.op === "eq" && c.col === "id")).toBe(false);
+    expect(where.conds.some((c) => c.op === "eq" && c.col === "id")).toBe(
+      false,
+    );
   });
 });
 
@@ -984,5 +1004,74 @@ describe("upsertContactChannel — channel address casing", () => {
 
     expect(queryCalls[0]!.sql).toContain("cc.address = ? COLLATE NOCASE");
     expect(queryCalls[0]!.params).toEqual(["slack", "U123EXAMPLE"]);
+  });
+});
+
+describe("upsertContactChannel — bot sender classification", () => {
+  test("creates a bot sender's contact as 'assistant' with a provenance note, not 'human'", async () => {
+    queryRows = [];
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UBOT99",
+      externalChatId: "D123EXAMPLE",
+      displayName: "Peer Assistant",
+      contactType: "assistant",
+      notes:
+        "Automated Slack bot — messages from this contact are sent by an app, not a person.",
+    });
+
+    const contactInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT OR IGNORE INTO contacts"),
+    );
+    expect(contactInsert).toBeTruthy();
+    expect(contactInsert!.sql).toContain("contact_type");
+    // params: [id, display_name, notes, contact_type, created_at, updated_at]
+    expect(contactInsert!.params[1]).toBe("Peer Assistant");
+    expect(contactInsert!.params[2]).toContain("Automated Slack bot");
+    expect(contactInsert!.params[3]).toBe("assistant");
+    expect(contactInsert!.params[3]).not.toBe("human");
+  });
+
+  test("creates a human sender's contact as 'human' with no notes by default", async () => {
+    queryRows = [];
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "U123EXAMPLE",
+      externalChatId: "D123EXAMPLE",
+      displayName: "Alice",
+    });
+
+    const contactInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT OR IGNORE INTO contacts"),
+    );
+    expect(contactInsert).toBeTruthy();
+    expect(contactInsert!.params[2]).toBeNull();
+    expect(contactInsert!.params[3]).toBe("human");
+  });
+
+  test("does not overwrite contact type or notes for an existing channel", async () => {
+    queryRows = [
+      {
+        channelId: "ch-bot",
+        contactId: "co-bot",
+        channelStatus: "unverified",
+      },
+    ];
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UBOT99",
+      contactType: "assistant",
+      notes: "Automated Slack bot",
+    });
+
+    const contactUpdate = runCalls.find((c) =>
+      c.sql.includes("UPDATE contacts"),
+    );
+    expect(contactUpdate).toBeTruthy();
+    expect(contactUpdate!.sql).not.toContain("contact_type");
+    expect(contactUpdate!.sql).not.toContain("notes");
   });
 });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -154,6 +154,7 @@ import {
   type SlackSocketModeClient,
 } from "./slack/socket-mode.js";
 import { downloadSlackFile } from "./slack/download.js";
+import { slackBotContactNote } from "./slack/normalize.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { upsertContactChannel } from "./verification/contact-helpers.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
@@ -2084,6 +2085,8 @@ async function main() {
         const forward = async () => {
           // Seed contact channel for the Slack actor (dual-write, fire-and-forget).
           // Covers both DMs (externalChatId = DM channel) and workspace messages.
+          // Bot/app senders are classified as 'assistant' contacts with a
+          // provenance note instead of the default 'human'.
           if (normalized.event.actor.actorExternalId) {
             void upsertContactChannel({
               sourceChannel: "slack",
@@ -2096,6 +2099,12 @@ async function main() {
                 : {}),
               displayName: normalized.event.actor.displayName,
               username: normalized.event.actor.username,
+              ...(normalized.botSender
+                ? {
+                    contactType: "assistant" as const,
+                    notes: slackBotContactNote(normalized.botSender),
+                  }
+                : {}),
             }).catch(() => {});
           }
 

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeSlackAppMention,
   normalizeSlackMessageEdit,
   normalizeSlackMessageDelete,
+  slackBotContactNote,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
   type SlackReactionRemovedEvent,
@@ -1570,5 +1571,95 @@ describe("source.threadId propagation", () => {
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
     });
+  });
+});
+
+describe("bot sender classification", () => {
+  it("marks a DM from another bot as a bot sender", () => {
+    const config = makeConfig();
+    const event = makeDmEvent({
+      user: "UBOT99",
+      bot_id: "B0AGENT",
+      bot_profile: {
+        id: "B0AGENT",
+        name: "Peer Assistant",
+        app_id: "A0EXAMPLE",
+        team_id: "T0EXAMPLE",
+      },
+    });
+    const result = normalizeSlackDirectMessage(event, "evt-bot-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.actor.isBot).toBe(true);
+    expect(result!.botSender).toEqual({
+      botId: "B0AGENT",
+      botName: "Peer Assistant",
+      appId: "A0EXAMPLE",
+      teamId: "T0EXAMPLE",
+    });
+  });
+
+  it("marks a channel message from another bot as a bot sender", () => {
+    const config = makeConfig();
+    const event = makeChannelEvent({
+      user: "UBOT99",
+      bot_id: "B0AGENT",
+    });
+    const result = normalizeSlackChannelMessage(event, "evt-bot-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.actor.isBot).toBe(true);
+    expect(result!.botSender).toEqual({ botId: "B0AGENT" });
+  });
+
+  it("marks an app_mention from another bot as a bot sender", () => {
+    const config = makeConfig();
+    const event = makeAppMentionEvent({
+      user: "UBOT99",
+      bot_id: "B0AGENT",
+      bot_profile: { name: "Peer Assistant" },
+    });
+    const result = normalizeSlackAppMention(event, "evt-bot-3", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.actor.isBot).toBe(true);
+    expect(result!.botSender).toEqual({
+      botId: "B0AGENT",
+      botName: "Peer Assistant",
+    });
+  });
+
+  it("does not mark a human sender as a bot", () => {
+    const config = makeConfig();
+    const result = normalizeSlackDirectMessage(
+      makeDmEvent(),
+      "evt-bot-4",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.actor.isBot).toBeUndefined();
+    expect(result!.botSender).toBeUndefined();
+  });
+});
+
+describe("slackBotContactNote", () => {
+  it("includes bot name, app id, and workspace when available", () => {
+    expect(
+      slackBotContactNote({
+        botId: "B0AGENT",
+        botName: "Peer Assistant",
+        appId: "A0EXAMPLE",
+        teamId: "T0EXAMPLE",
+      }),
+    ).toBe(
+      'Automated Slack bot "Peer Assistant" (Slack app A0EXAMPLE, workspace T0EXAMPLE) — messages from this contact are sent by an app, not a person.',
+    );
+  });
+
+  it("degrades gracefully when only bot_id is known", () => {
+    expect(slackBotContactNote({ botId: "B0AGENT" })).toBe(
+      "Automated Slack bot — messages from this contact are sent by an app, not a person.",
+    );
   });
 });

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeSlackAppMention,
   normalizeSlackMessageEdit,
   normalizeSlackMessageDelete,
+  enrichNormalizedActor,
   slackBotContactNote,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
@@ -1661,5 +1662,75 @@ describe("slackBotContactNote", () => {
     expect(slackBotContactNote({ botId: "B0AGENT" })).toBe(
       "Automated Slack bot — messages from this contact are sent by an app, not a person.",
     );
+  });
+});
+
+describe("enrichNormalizedActor", () => {
+  it("classifies an is_bot-only sender as a bot after profile resolution", () => {
+    const config = makeConfig();
+    // No bot_id on the event and no cached profile — normalization alone
+    // cannot detect the bot.
+    const normalized = normalizeSlackDirectMessage(
+      makeDmEvent({ user: "UBOT99" }),
+      "evt-enrich-1",
+      config,
+    );
+    expect(normalized).not.toBeNull();
+    expect(normalized!.botSender).toBeUndefined();
+
+    enrichNormalizedActor(normalized!, {
+      displayName: "Peer Assistant",
+      username: "peer-assistant",
+      isBot: true,
+    });
+
+    expect(normalized!.event.actor.isBot).toBe(true);
+    expect(normalized!.event.actor.displayName).toBe("Peer Assistant");
+    expect(normalized!.botSender).toEqual({ botName: "Peer Assistant" });
+  });
+
+  it("does not classify a human sender as a bot", () => {
+    const config = makeConfig();
+    const normalized = normalizeSlackDirectMessage(
+      makeDmEvent(),
+      "evt-enrich-2",
+      config,
+    );
+    expect(normalized).not.toBeNull();
+
+    enrichNormalizedActor(normalized!, {
+      displayName: "Alice",
+      username: "alice",
+    });
+
+    expect(normalized!.event.actor.isBot).toBeUndefined();
+    expect(normalized!.event.actor.displayName).toBe("Alice");
+    expect(normalized!.botSender).toBeUndefined();
+  });
+
+  it("preserves an existing botSender derived from bot_id", () => {
+    const config = makeConfig();
+    const normalized = normalizeSlackDirectMessage(
+      makeDmEvent({
+        user: "UBOT99",
+        bot_id: "B0AGENT",
+        bot_profile: { name: "Peer Assistant", app_id: "A0EXAMPLE" },
+      }),
+      "evt-enrich-3",
+      config,
+    );
+    expect(normalized).not.toBeNull();
+
+    enrichNormalizedActor(normalized!, {
+      displayName: "Peer Assistant",
+      username: "peer-assistant",
+      isBot: true,
+    });
+
+    expect(normalized!.botSender).toEqual({
+      botId: "B0AGENT",
+      botName: "Peer Assistant",
+      appId: "A0EXAMPLE",
+    });
   });
 });

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -18,6 +18,8 @@ interface SlackUserInfo {
   timezoneOffsetSeconds?: number;
   isStranger?: boolean;
   isRestricted?: boolean;
+  /** The sender is a bot user (Slack `users.info` `is_bot`). */
+  isBot?: boolean;
 }
 
 export type SlackUserActorFields = Pick<
@@ -161,6 +163,7 @@ export async function resolveSlackUser(
           tz?: string;
           tz_label?: string;
           tz_offset?: number;
+          is_bot?: boolean;
           is_stranger?: boolean;
           is_restricted?: boolean;
           is_ultra_restricted?: boolean;
@@ -191,6 +194,7 @@ export async function resolveSlackUser(
         data.user.is_ultra_restricted === true
           ? true
           : undefined;
+      const isBot = data.user.is_bot === true ? true : undefined;
 
       const info: SlackUserInfo = {
         displayName,
@@ -202,6 +206,7 @@ export async function resolveSlackUser(
           : {}),
         ...(isStranger !== undefined ? { isStranger } : {}),
         ...(isRestricted !== undefined ? { isRestricted } : {}),
+        ...(isBot !== undefined ? { isBot } : {}),
       };
       cacheSet(
         userInfoCache,
@@ -342,6 +347,17 @@ export interface SlackFile {
 }
 
 /**
+ * Slack `bot_profile` object attached to bot-authored messages
+ * (subset relevant to sender classification).
+ */
+export interface SlackBotProfile {
+  id?: string;
+  name?: string;
+  app_id?: string;
+  team_id?: string;
+}
+
+/**
  * Slack `app_mention` event shape (subset relevant to normalization).
  */
 export interface SlackAppMentionEvent {
@@ -356,6 +372,9 @@ export interface SlackAppMentionEvent {
   files?: SlackFile[];
   /** Team ID of the mentioning user's workspace. */
   team?: string;
+  /** Present when the message was authored by a bot/app. */
+  bot_id?: string;
+  bot_profile?: SlackBotProfile;
 }
 
 /**
@@ -373,6 +392,9 @@ export interface SlackDirectMessageEvent {
   client_msg_id?: string;
   event_ts?: string;
   files?: SlackFile[];
+  /** Present when the message was authored by a bot/app. */
+  bot_id?: string;
+  bot_profile?: SlackBotProfile;
 }
 
 /**
@@ -393,6 +415,9 @@ export interface SlackChannelMessageEvent {
   files?: SlackFile[];
   /** Team ID of the sending user's workspace. */
   team?: string;
+  /** Present when the message was authored by a bot/app. */
+  bot_id?: string;
+  bot_profile?: SlackBotProfile;
 }
 
 /**
@@ -516,6 +541,56 @@ function extractSlackFileMap(
     : undefined;
 }
 
+/**
+ * Descriptor for a bot/app sender, derived from the message's `bot_id` /
+ * `bot_profile` and the resolved user profile's `is_bot` flag. Present on a
+ * normalized event only when the sender is a bot.
+ */
+export interface SlackBotSenderInfo {
+  botId?: string;
+  botName?: string;
+  appId?: string;
+  teamId?: string;
+}
+
+/**
+ * Classify a Slack message sender as a bot/app.
+ *
+ * Slack marks bot-authored messages with `bot_id` (and usually a
+ * `bot_profile`); bot users are also flagged `is_bot` on `users.info`.
+ * Returns undefined for human senders.
+ */
+export function slackBotSenderInfo(
+  event: { bot_id?: string; bot_profile?: SlackBotProfile },
+  userInfo?: SlackUserInfo,
+): SlackBotSenderInfo | undefined {
+  if (!event.bot_id && userInfo?.isBot !== true) return undefined;
+  const botName = event.bot_profile?.name ?? userInfo?.displayName;
+  return {
+    ...(event.bot_id ? { botId: event.bot_id } : {}),
+    ...(botName ? { botName } : {}),
+    ...(event.bot_profile?.app_id ? { appId: event.bot_profile.app_id } : {}),
+    ...(event.bot_profile?.team_id
+      ? { teamId: event.bot_profile.team_id }
+      : {}),
+  };
+}
+
+/**
+ * Human-readable contact note for a bot sender. Slack does not expose which
+ * user owns/installed an app, so the note carries what Slack does provide:
+ * the bot's name, Slack app ID, and workspace ID.
+ */
+export function slackBotContactNote(botSender: SlackBotSenderInfo): string {
+  const details = [
+    ...(botSender.appId ? [`Slack app ${botSender.appId}`] : []),
+    ...(botSender.teamId ? [`workspace ${botSender.teamId}`] : []),
+  ];
+  const name = botSender.botName ? ` "${botSender.botName}"` : "";
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `Automated Slack bot${name}${suffix} — messages from this contact are sent by an app, not a person.`;
+}
+
 export type NormalizedSlackEvent = {
   event: GatewayInboundEvent;
   routing: RouteResult;
@@ -525,6 +600,8 @@ export type NormalizedSlackEvent = {
   channel: string;
   /** Original Slack file objects keyed by file ID, for download in the I/O layer. */
   slackFiles?: Map<string, SlackFile>;
+  /** Present when the sender is a bot/app rather than a person. */
+  botSender?: SlackBotSenderInfo;
 };
 
 /**
@@ -578,6 +655,7 @@ export function normalizeSlackDirectMessage(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
+  const botSender = slackBotSenderInfo(event, userInfo);
   const content = renderSlackInboundText(event.text, renderContext);
 
   return {
@@ -594,6 +672,7 @@ export function normalizeSlackDirectMessage(
       actor: {
         actorExternalId: event.user,
         ...(userInfo ? slackUserActorFields(userInfo) : {}),
+        ...(botSender ? { isBot: true } : {}),
       },
       source: {
         updateId: eventId,
@@ -607,6 +686,7 @@ export function normalizeSlackDirectMessage(
     ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
     channel: event.channel,
     ...(slackFiles ? { slackFiles } : {}),
+    ...(botSender ? { botSender } : {}),
   };
 }
 
@@ -645,6 +725,7 @@ export function normalizeSlackChannelMessage(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
+  const botSender = slackBotSenderInfo(event, userInfo);
 
   return {
     event: {
@@ -661,6 +742,7 @@ export function normalizeSlackChannelMessage(
         actorExternalId: event.user,
         ...(userInfo ? slackUserActorFields(userInfo) : {}),
         ...(event.team ? { teamId: event.team } : {}),
+        ...(botSender ? { isBot: true } : {}),
       },
       source: {
         updateId: eventId,
@@ -674,6 +756,7 @@ export function normalizeSlackChannelMessage(
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
     ...(slackFiles ? { slackFiles } : {}),
+    ...(botSender ? { botSender } : {}),
   };
 }
 
@@ -707,6 +790,7 @@ export function normalizeSlackAppMention(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
+  const botSender = slackBotSenderInfo(event, userInfo);
 
   return {
     event: {
@@ -723,6 +807,7 @@ export function normalizeSlackAppMention(
         actorExternalId: event.user,
         ...(userInfo ? slackUserActorFields(userInfo) : {}),
         ...(event.team ? { teamId: event.team } : {}),
+        ...(botSender ? { isBot: true } : {}),
       },
       source: {
         updateId: eventId,
@@ -735,6 +820,7 @@ export function normalizeSlackAppMention(
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
     ...(slackFiles ? { slackFiles } : {}),
+    ...(botSender ? { botSender } : {}),
   };
 }
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -10,7 +10,7 @@ import type { GatewayInboundEvent } from "../types.js";
 /**
  * Resolved Slack user info for populating actor fields.
  */
-interface SlackUserInfo {
+export interface SlackUserInfo {
   displayName: string;
   username: string;
   timezone?: string;
@@ -603,6 +603,36 @@ export type NormalizedSlackEvent = {
   /** Present when the sender is a bot/app rather than a person. */
   botSender?: SlackBotSenderInfo;
 };
+
+/**
+ * Merge a freshly resolved user profile into an already-normalized event.
+ *
+ * Normalization uses a cache-only user lookup, so a cold cache can leave the
+ * actor unenriched. Besides display/trust fields, this re-runs bot-sender
+ * classification against the original event: a bot user whose message carries
+ * no top-level `bot_id` is only detectable via the profile's `is_bot`, which
+ * is unavailable until this fetch completes.
+ */
+export function enrichNormalizedActor(
+  normalized: NormalizedSlackEvent,
+  userInfo: SlackUserInfo,
+): void {
+  const actor = normalized.event.actor;
+  Object.assign(actor, slackUserActorFields(userInfo));
+  if (!normalized.botSender) {
+    const botSender = slackBotSenderInfo(
+      normalized.event.raw as {
+        bot_id?: string;
+        bot_profile?: SlackBotProfile;
+      },
+      userInfo,
+    );
+    if (botSender) {
+      normalized.botSender = botSender;
+      actor.isBot = true;
+    }
+  }
+}
 
 /**
  * Normalize a Slack DM (`message` with `channel_type: "im"`) into the

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -28,9 +28,9 @@ import {
   normalizeSlackBlockActions,
   normalizeSlackReactionAdded,
   normalizeSlackReactionRemoved,
+  enrichNormalizedActor,
   resolveSlackChannel,
   resolveSlackUser,
-  slackUserActorFields,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
@@ -1391,7 +1391,9 @@ export class SlackSocketModeClient {
         ),
       ]);
       if (userInfo) {
-        Object.assign(actor, slackUserActorFields(userInfo));
+        // Also re-runs bot-sender classification: an is_bot-only bot (no
+        // top-level bot_id) is undetectable during cache-only normalization.
+        enrichNormalizedActor(normalized, userInfo);
       }
     }
 

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -708,9 +708,12 @@ export async function upsertVerifiedContactChannel(params: {
  *
  * - Existing channel: updates display name, external_chat_id.
  *   Status and policy live in the gateway DB and are left unchanged so
- *   blocked/revoked channels stay that way.
- * - New channel: inserts contact + channel. ACL columns (status, policy) are
- *   gateway-owned; the gateway DB seeds status='unverified', policy='allow'.
+ *   blocked/revoked channels stay that way. `contactType`/`notes` are also
+ *   left unchanged so guardian-authored edits are never clobbered.
+ * - New channel: inserts contact + channel, classified via `contactType`
+ *   (default 'human') and seeded with `notes` when provided. ACL columns
+ *   (status, policy) are gateway-owned; the gateway DB seeds
+ *   status='unverified', policy='allow'.
  *
  * Dual-writes to both the assistant DB (identity/info mirror) and the gateway
  * DB (ACL source of truth). Skips silently when the assistant IPC socket is
@@ -722,6 +725,10 @@ export async function upsertContactChannel(params: {
   externalChatId?: string;
   displayName?: string;
   username?: string;
+  /** Classification for a newly created contact (e.g. 'assistant' for bot senders). */
+  contactType?: "human" | "assistant";
+  /** Notes seeded onto a newly created contact (e.g. bot/app provenance). */
+  notes?: string;
 }): Promise<void> {
   const { path: socketPath } = resolveIpcSocketPath("assistant");
   if (!existsSync(socketPath)) return;
@@ -789,9 +796,17 @@ export async function upsertContactChannel(params: {
   const channelId = crypto.randomUUID();
 
   await assistantDbRun(
-    `INSERT OR IGNORE INTO contacts (id, display_name, created_at, updated_at)
-     VALUES (?, ?, ?, ?)`,
-    [contactId, contactDisplayName, now, now],
+    `INSERT OR IGNORE INTO contacts
+       (id, display_name, notes, contact_type, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      contactId,
+      contactDisplayName,
+      params.notes ?? null,
+      params.contactType ?? "human",
+      now,
+      now,
+    ],
   );
   // ACL columns are gateway-owned; the mirror carries identity/info only and
   // relies on the schema defaults (status='unverified', policy='allow').


### PR DESCRIPTION
## Prompt / plan

Bug report: contacts created from inbound Slack messages were always classified as `human`, even when the sender is a bot/app (e.g. another Vellum assistant). Follow-up ask: seed a note on bot contacts describing whose bot it is, using whatever Slack exposes.

Root cause: the Slack Socket Mode self-filter only drops *this* bot's own messages; messages from *other* bots (which carry `user` = their bot-user ID, `bot_id`, and no subtype) flow through normalization, and the gateway's inbound contact seeding (`upsertContactChannel`) inserted the contact without `contact_type`, so the assistant DB default `'human'` applied. The Slack normalizers never inspected `bot_id` / `bot_profile` / `users.info` `is_bot` (the Telegram normalizer already sets `actor.isBot`).

Fix:
- `gateway/src/slack/normalize.ts`: capture `bot_id` / `bot_profile` on DM, channel-message, and app_mention events and `is_bot` from `users.info`; derive a `SlackBotSenderInfo` descriptor (`slackBotSenderInfo`), stamp `actor.isBot`, and expose the descriptor on `NormalizedSlackEvent.botSender`. `slackBotContactNote()` renders a provenance note from it.
- `gateway/src/index.ts`: the Slack inbound seeding call passes `contactType: "assistant"` plus the provenance note when the sender is a bot.
- `gateway/src/verification/contact-helpers.ts`: `upsertContactChannel` accepts `contactType` / `notes`, applied on the **new-contact insert only** — existing contacts are never reclassified, so guardian-authored edits are preserved.

Note on "whose assistant it is": Slack's API does not expose which user owns/installed an app, so the note carries what Slack does provide — the bot's display name, Slack app ID, and workspace ID (from `bot_profile` / `users.info`). Example: `Automated Slack bot "Peer Assistant" (Slack app A0EXAMPLE, workspace T0EXAMPLE) — messages from this contact are sent by an app, not a person.`

Side effect worth reviewing: `deleteContactIfOrphaned` treats non-empty notes / non-`human` contact type as guardian-authored data and vetoes orphan GC. Seeded bot contacts now match that heuristic, so a bot stub stranded by a guardian channel claim would be kept instead of deleted — fail-safe (a leftover row, never data loss), and the scenario requires the bot's address to be claimed as a guardian channel, which the verification flow doesn't do.

## Test plan

- New unit tests in `gateway/src/slack/normalize.test.ts`: DM / channel message / app_mention with `bot_id` → `actor.isBot === true` and populated `botSender`; human sender → both absent; `slackBotContactNote` formatting with full and minimal info.
- New unit tests in `gateway/src/__tests__/upsert-verified-contact-channel.test.ts`: bot sender's contact is inserted with `contact_type = 'assistant'` (not `'human'`) and the note; default path still inserts `'human'` with `NULL` notes; existing-channel updates never touch `contact_type` / `notes`.
- `bun test src/slack/normalize.test.ts src/__tests__/upsert-verified-contact-channel.test.ts` (123 pass), plus socket-mode and handle-inbound suites (56 pass), `bunx tsc --noEmit`, `bun run lint`, prettier — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R35qxZenMysPgmvvGhxxNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R35qxZenMysPgmvvGhxxNk)_