### PR TITLE
feat(calls): add mu-law→PCM16 decode and resample helpers for media-stream STT

### DIFF
--- a/assistant/src/__tests__/media-stream-audio-transcode.test.ts
+++ b/assistant/src/__tests__/media-stream-audio-transcode.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  mulawToPcm16,
+  pcm16ToMulaw,
+  resamplePcm16,
+} from "../calls/media-stream-audio-transcode.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pcm16Buffer(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  samples.forEach((s, i) => buf.writeInt16LE(s, i * 2));
+  return buf;
+}
+
+function readSamples(pcm: Buffer): number[] {
+  const samples: number[] = [];
+  for (let i = 0; i + 1 < pcm.length; i += 2) {
+    samples.push(pcm.readInt16LE(i));
+  }
+  return samples;
+}
+
+// ---------------------------------------------------------------------------
+// mulawToPcm16
+// ---------------------------------------------------------------------------
+
+describe("mulawToPcm16", () => {
+  test("output length is 2x input length", () => {
+    const mulaw = new Uint8Array([0xff, 0x7f, 0x00, 0x80, 0x55]);
+    const pcm = mulawToPcm16(mulaw);
+    expect(pcm.length).toBe(mulaw.length * 2);
+  });
+
+  test("empty input decodes to empty output", () => {
+    expect(mulawToPcm16(new Uint8Array(0)).length).toBe(0);
+  });
+
+  test("mu-law silence (0xFF and 0x7F) decodes to 0", () => {
+    const pcm = mulawToPcm16(new Uint8Array([0xff, 0x7f]));
+    expect(readSamples(pcm)).toEqual([0, 0]);
+  });
+
+  test("round-trip PCM16 -> mu-law -> PCM16 has bounded error", () => {
+    const samples = [
+      0, 1, -1, 8, -8, 33, -33, 100, -100, 500, -500, 1000, -1000, 4000, -4000,
+      8191, -8191, 16000, -16000, 24000, -24000, 32000, -32000, 32635, -32635,
+    ];
+    const original = pcm16Buffer(samples);
+    const decoded = readSamples(mulawToPcm16(pcm16ToMulaw(original)));
+
+    expect(decoded.length).toBe(samples.length);
+    for (let i = 0; i < samples.length; i++) {
+      // Mu-law quantization error scales with magnitude (~4%), floor of 16.
+      const tolerance = Math.max(16, Math.abs(samples[i]) * 0.04);
+      expect(Math.abs(decoded[i] - samples[i])).toBeLessThanOrEqual(tolerance);
+    }
+  });
+
+  test("round-trip preserves sign", () => {
+    const original = pcm16Buffer([12345, -12345]);
+    const [pos, neg] = readSamples(mulawToPcm16(pcm16ToMulaw(original)));
+    expect(pos).toBeGreaterThan(0);
+    expect(neg).toBeLessThan(0);
+    expect(pos).toBe(-neg);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resamplePcm16
+// ---------------------------------------------------------------------------
+
+describe("resamplePcm16", () => {
+  test("8k -> 16k doubles the sample count", () => {
+    const input = pcm16Buffer([0, 100, 200, 300]);
+    const output = resamplePcm16(input, 8000, 16000);
+    expect(output.length).toBe(input.length * 2);
+  });
+
+  test("8k -> 16k interpolates linearly between samples", () => {
+    const output = resamplePcm16(pcm16Buffer([0, 100, 200]), 8000, 16000);
+    expect(readSamples(output)).toEqual([0, 50, 100, 150, 200, 200]);
+  });
+
+  test("same-rate input is returned unchanged", () => {
+    const input = pcm16Buffer([1, -2, 3]);
+    const output = resamplePcm16(input, 16000, 16000);
+    expect(output).toBe(input);
+  });
+
+  test("empty input yields empty output", () => {
+    expect(resamplePcm16(Buffer.alloc(0), 8000, 16000).length).toBe(0);
+  });
+
+  test("preserves extreme sample values without overflow", () => {
+    const output = resamplePcm16(pcm16Buffer([32767, -32768]), 8000, 16000);
+    const samples = readSamples(output);
+    expect(samples[0]).toBe(32767);
+    expect(samples[2]).toBe(-32768);
+    for (const s of samples) {
+      expect(s).toBeGreaterThanOrEqual(-32768);
+      expect(s).toBeLessThanOrEqual(32767);
+    }
+  });
+
+  test("throws on non-positive sample rates", () => {
+    expect(() => resamplePcm16(pcm16Buffer([0]), 0, 16000)).toThrow();
+    expect(() => resamplePcm16(pcm16Buffer([0]), 8000, -1)).toThrow();
+  });
+});

--- a/assistant/src/calls/media-stream-audio-transcode.ts
+++ b/assistant/src/calls/media-stream-audio-transcode.ts
@@ -1,5 +1,5 @@
 /**
- * Audio transcoding helpers for media-stream outbound playback.
+ * Audio transcoding helpers for media-stream playback and capture.
  *
  * Twilio media streams send and receive audio as base64-encoded mu-law
  * (audio/x-mulaw) at 8 kHz mono. This module provides utilities for:
@@ -7,6 +7,8 @@
  * 1. Converting linear PCM audio (from TTS providers) to mu-law encoding.
  * 2. Chunking a contiguous audio buffer into Twilio-compatible frame sizes.
  * 3. Encoding frames as base64 strings ready for the `media` outbound command.
+ * 4. Decoding inbound mu-law audio to PCM16 and resampling it for streaming
+ *    transcribers that expect 16 kHz linear PCM.
  *
  * The chunk size is aligned to Twilio's expected frame duration (~20 ms at
  * 8 kHz = 160 samples per frame). Larger payloads are split into multiple
@@ -130,5 +132,79 @@ export function chunkMulawToBase64Frames(mulawBuffer: Buffer): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// High-level: raw audio bytes to sendable base64 frames
+// Mu-law to linear PCM conversion (inbound direction)
 // ---------------------------------------------------------------------------
+
+/**
+ * Expand a single 8-bit mu-law byte to a 16-bit signed linear PCM sample.
+ *
+ * Implements the ITU-T G.711 mu-law decoding algorithm. Mu-law bytes are
+ * bitwise-inverted on the wire (Twilio's encoding), mirroring
+ * {@link linearToMulaw}.
+ */
+function mulawToLinear(mulawByte: number): number {
+  const b = ~mulawByte & 0xff;
+  const sign = b & 0x80;
+  const exponent = (b >> 4) & 0x07;
+  const mantissa = b & 0x0f;
+  const magnitude = (((mantissa << 3) + MULAW_BIAS) << exponent) - MULAW_BIAS;
+  return sign !== 0 ? -magnitude : magnitude;
+}
+
+/**
+ * Decode a buffer of 8-bit mu-law samples to 16-bit signed LE PCM.
+ *
+ * @param mulaw - Raw mu-law audio bytes (one sample per byte).
+ * @returns A Buffer of PCM16 LE audio (twice the length of the input).
+ */
+export function mulawToPcm16(mulaw: Uint8Array): Buffer {
+  const pcm = Buffer.alloc(mulaw.length * 2);
+  for (let i = 0; i < mulaw.length; i++) {
+    pcm.writeInt16LE(mulawToLinear(mulaw[i]), i * 2);
+  }
+  return pcm;
+}
+
+// ---------------------------------------------------------------------------
+// Resampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Resample 16-bit signed LE PCM audio between sample rates using linear
+ * interpolation. Same-rate input is returned unchanged. Primarily used to
+ * upsample 8 kHz telephony audio to the 16 kHz expected by streaming
+ * transcribers.
+ *
+ * @param pcm - PCM16 LE audio buffer. Every 2 bytes is one sample.
+ * @param fromRate - Input sample rate in Hz (e.g. 8000).
+ * @param toRate - Output sample rate in Hz (e.g. 16000).
+ * @returns A Buffer of PCM16 LE audio at the target rate.
+ */
+export function resamplePcm16(
+  pcm: Buffer,
+  fromRate: number,
+  toRate: number,
+): Buffer {
+  if (fromRate <= 0 || toRate <= 0) {
+    throw new Error(`Invalid sample rates: ${fromRate} -> ${toRate}`);
+  }
+  if (fromRate === toRate) return pcm;
+
+  const inputCount = Math.floor(pcm.length / 2);
+  if (inputCount === 0) return Buffer.alloc(0);
+
+  const outputCount = Math.floor((inputCount * toRate) / fromRate);
+  const out = Buffer.alloc(outputCount * 2);
+  const ratio = fromRate / toRate;
+
+  for (let i = 0; i < outputCount; i++) {
+    const srcPos = i * ratio;
+    const idx = Math.floor(srcPos);
+    const frac = srcPos - idx;
+    const s0 = pcm.readInt16LE(idx * 2);
+    const s1 = idx + 1 < inputCount ? pcm.readInt16LE((idx + 1) * 2) : s0;
+    out.writeInt16LE(Math.round(s0 + (s1 - s0) * frac), i * 2);
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
- Adds pure inbound-direction helpers to media-stream-audio-transcode: mulawToPcm16 (G.711 µ-law → 16-bit LE PCM) and resamplePcm16 (8k→16k linear interpolation + same-rate identity)
- Unit tests: round-trip bounded error, length invariants, silence decode

Part of plan: phone-media-stream-v2.md (PR 1 of 17)