### PR TITLE
feat(calls): add transport-agnostic call-setup-flow module (normal_call + deny)

### DIFF
--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  UnsupportedSetupFlowError,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowState,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type { MediaStreamOutput } from "../calls/media-stream-output.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { TrustClass } from "../runtime/trust-class.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CALL_SESSION_ID = "call-session-1";
+const PHONE_NUMBER = "+15555550100";
+
+function makeResolved(trustClass: TrustClass = "guardian"): SetupResolved {
+  return {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: PHONE_NUMBER,
+    actorTrust: {
+      canonicalSenderId: PHONE_NUMBER,
+      guardianBindingMatch: null,
+      memberRecord: null,
+      trustClass,
+      actorMetadata: {
+        identifier: PHONE_NUMBER,
+        displayName: undefined,
+        senderDisplayName: undefined,
+        memberDisplayName: undefined,
+        username: undefined,
+        channel: "phone",
+        trustStatus: trustClass,
+      },
+    },
+  };
+}
+
+function createFakeTransport() {
+  const spokenTokens: Array<{ token: string; last: boolean }> = [];
+  const playUrls: string[] = [];
+  const endReasons: Array<string | undefined> = [];
+  const transport: SetupFlowTransport = {
+    sendTextToken: (token, last) => {
+      spokenTokens.push({ token, last });
+    },
+    sendPlayUrl: (url) => {
+      playUrls.push(url);
+    },
+    endSession: (reason) => {
+      endReasons.push(reason);
+    },
+    getConnectionState: () => "connected",
+    requiresWavAudio: true,
+  };
+  return { transport, spokenTokens, playUrls, endReasons };
+}
+
+function createFlow(overrides?: Partial<CallSetupFlowDeps>) {
+  const fake = createFakeTransport();
+  const spoken: string[] = [];
+  const sessionUpdates: Array<Record<string, unknown>> = [];
+  const events: Array<{
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }> = [];
+  const results: SetupFlowResult[] = [];
+
+  const deps: CallSetupFlowDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spoken.push(text);
+    },
+    updateCallSession: (_id, updates) => {
+      sessionUpdates.push(updates as Record<string, unknown>);
+    },
+    recordCallEvent: (_callSessionId, eventType, payload) => {
+      events.push({ eventType, payload });
+    },
+    onComplete: (result) => {
+      results.push(result);
+    },
+    ttsPlaybackDelayMs: 0,
+    ...overrides,
+  };
+
+  const flow = new CallSetupFlow(CALL_SESSION_ID, fake.transport, deps);
+  return { flow, ...fake, spoken, sessionUpdates, events, results };
+}
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CallSetupFlow", () => {
+  describe("normal_call", () => {
+    test("completes with proceed-initial-greeting carrying the resolved trust", async () => {
+      const { flow, results, spoken, endReasons } = createFlow();
+      const resolved = makeResolved("guardian");
+
+      expect(flow.getState()).toBe("idle");
+      await flow.start({ action: "normal_call", isInbound: true }, resolved);
+
+      expect(flow.getState()).toBe("completed");
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.kind).toBe("proceed-initial-greeting");
+      if (result.kind !== "proceed-initial-greeting") {
+        throw new Error("expected proceed-initial-greeting");
+      }
+      expect(result.assistantId).toBe("self");
+      expect(result.trustContext.trustClass).toBe("guardian");
+      expect(result.trustContext.sourceChannel).toBe("phone");
+      expect(result.trustContext.requesterChatId).toBe(PHONE_NUMBER);
+
+      // No speech and no teardown on the normal path.
+      expect(spoken).toEqual([]);
+      expect(endReasons).toEqual([]);
+    });
+  });
+
+  describe("deny", () => {
+    const denyOutcome: SetupOutcome = {
+      action: "deny",
+      message: "This number is not authorized to use this assistant.",
+      logReason: "Inbound voice ACL: member policy deny",
+    };
+
+    test("records the ACL event, fails the session, speaks, and ends", async () => {
+      const { flow, results, spoken, events, sessionUpdates, endReasons } =
+        createFlow();
+      const resolved = makeResolved("unknown");
+
+      await flow.start(denyOutcome, resolved);
+
+      expect(events).toEqual([
+        {
+          eventType: "inbound_acl_denied",
+          payload: {
+            from: PHONE_NUMBER,
+            trustClass: "unknown",
+            channelId: undefined,
+            memberPolicy: undefined,
+          },
+        },
+      ]);
+      expect(sessionUpdates).toHaveLength(1);
+      expect(sessionUpdates[0].status).toBe("failed");
+      expect(sessionUpdates[0].lastError).toBe(denyOutcome.logReason);
+      expect(sessionUpdates[0].endedAt).toBeNumber();
+
+      expect(spoken).toEqual([denyOutcome.message]);
+      expect(flow.getState()).toBe("completed");
+      expect(results).toEqual([
+        { kind: "ended", reason: denyOutcome.logReason },
+      ]);
+
+      // Session teardown fires after the playback delay, not inline.
+      await sleep(0);
+      expect(endReasons).toEqual([denyOutcome.logReason]);
+    });
+
+    test("delays endSession until the playback delay elapses", async () => {
+      const { flow, endReasons } = createFlow({ ttsPlaybackDelayMs: 25 });
+
+      await flow.start(denyOutcome, makeResolved("unknown"));
+
+      expect(endReasons).toEqual([]);
+      await sleep(40);
+      expect(endReasons).toEqual([denyOutcome.logReason]);
+    });
+  });
+
+  describe("unsupported actions", () => {
+    test("throws UnsupportedSetupFlowError and stays idle", async () => {
+      const { flow, results } = createFlow();
+
+      await expect(
+        flow.start(
+          {
+            action: "name_capture",
+            assistantId: "self",
+            fromNumber: PHONE_NUMBER,
+          },
+          makeResolved("unknown"),
+        ),
+      ).rejects.toBeInstanceOf(UnsupportedSetupFlowError);
+
+      expect(flow.getState()).toBe("idle");
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("lifecycle guards", () => {
+    test("start() may only run once", async () => {
+      const { flow } = createFlow();
+      const resolved = makeResolved();
+
+      await flow.start({ action: "normal_call", isInbound: true }, resolved);
+      await expect(
+        flow.start({ action: "normal_call", isInbound: true }, resolved),
+      ).rejects.toThrow("may only be called once");
+    });
+
+    test("input methods are no-ops while idle and completed", async () => {
+      const { flow, results, spoken } = createFlow();
+
+      // Idle: inputs are swallowed.
+      flow.pushDtmfDigit("1");
+      flow.pushTranscriptFinal("hello");
+      expect(flow.getState()).toBe("idle");
+
+      await flow.start(
+        { action: "normal_call", isInbound: true },
+        makeResolved(),
+      );
+
+      // Completed: inputs are swallowed.
+      flow.pushDtmfDigit("2");
+      flow.pushTranscriptFinal("still here");
+      expect(flow.getState()).toBe("completed");
+      expect(results).toHaveLength(1);
+      expect(spoken).toEqual([]);
+    });
+  });
+
+  describe("type surfaces", () => {
+    test("MediaStreamOutput is assignable to SetupFlowTransport", () => {
+      // Compile-time assertion: the structural transport subset is
+      // satisfied by the media-stream output adapter.
+      const assertAssignable = (
+        output: MediaStreamOutput,
+      ): SetupFlowTransport => output;
+      expect(assertAssignable).toBeInstanceOf(Function);
+    });
+
+    test("all SetupFlowResult variants are representable", () => {
+      const trustContext: TrustContext = {
+        sourceChannel: "phone",
+        trustClass: "trusted_contact",
+      };
+      const variants: SetupFlowResult[] = [
+        { kind: "proceed-initial-greeting", assistantId: "self", trustContext },
+        {
+          kind: "proceed-post-verification-greeting",
+          assistantId: "self",
+          trustContext,
+        },
+        { kind: "proceed-handoff-spoken", assistantId: "self", trustContext },
+        { kind: "ended", reason: "test" },
+      ];
+      expect(variants.map((v) => v.kind)).toEqual([
+        "proceed-initial-greeting",
+        "proceed-post-verification-greeting",
+        "proceed-handoff-spoken",
+        "ended",
+      ]);
+    });
+
+    test("all SetupFlowState values are representable", () => {
+      const states: SetupFlowState[] = [
+        "idle",
+        "collecting_code",
+        "capturing_name",
+        "awaiting_guardian_decision",
+        "completed",
+      ];
+      expect(states).toHaveLength(5);
+    });
+  });
+});

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -1,0 +1,83 @@
+/**
+ * Types for the transport-agnostic call setup flow.
+ *
+ * The setup flow runs the pre-conversation phase of a phone call (ACL
+ * denial, verification, invite redemption, name capture) against any
+ * transport that can speak and end the session. Its result describes how
+ * the owning server should continue the call once setup completes.
+ */
+
+import type { TrustContext } from "../daemon/trust-context.js";
+
+// ── Transport surface ────────────────────────────────────────────────
+
+/**
+ * Structural subset of `CallTransport` (call-transport.ts) that the setup
+ * flow needs. `MediaStreamOutput` satisfies this interface (asserted at
+ * compile time in call-setup-flow.test.ts).
+ */
+export interface SetupFlowTransport {
+  sendTextToken(token: string, last: boolean): void;
+  sendPlayUrl(url: string): void;
+  endSession(reason?: string): void;
+  getConnectionState(): string;
+  readonly requiresWavAudio?: boolean;
+}
+
+// ── Input surface ────────────────────────────────────────────────────
+
+/**
+ * Caller input routed into the active setup sub-flow by the owning
+ * transport server. Both methods are no-ops while the flow is `idle` or
+ * `completed`.
+ */
+export interface SetupFlowInput {
+  pushDtmfDigit(digit: string): void;
+  pushTranscriptFinal(text: string): void;
+}
+
+// ── Flow state ───────────────────────────────────────────────────────
+
+/**
+ * Explicit setup-flow state. The flow is the sole source of truth for its
+ * state — it is never inferred from `transport.getConnectionState()`
+ * (which on `MediaStreamOutput` is only `"connected" | "closed"`).
+ */
+export type SetupFlowState =
+  | "idle"
+  | "collecting_code"
+  | "capturing_name"
+  | "awaiting_guardian_decision"
+  | "completed";
+
+// ── Terminal results ─────────────────────────────────────────────────
+
+/**
+ * Terminal setup-flow result, mirroring the distinct continuations of the
+ * relay setup path:
+ *
+ * - `proceed-initial-greeting` — the controller fires
+ *   `startInitialGreeting()`.
+ * - `proceed-post-verification-greeting` — the controller fires
+ *   `startPostVerificationGreeting()`.
+ * - `proceed-handoff-spoken` — the flow already spoke the handoff copy;
+ *   the controller calls `markNextCallerTurnAsOpeningAck()`.
+ * - `ended` — the flow terminated the call; no controller is created.
+ */
+export type SetupFlowResult =
+  | {
+      kind: "proceed-initial-greeting";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | {
+      kind: "proceed-post-verification-greeting";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | {
+      kind: "proceed-handoff-spoken";
+      assistantId: string;
+      trustContext: TrustContext;
+    }
+  | { kind: "ended"; reason: string };

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -1,0 +1,165 @@
+/**
+ * Transport-agnostic call setup flow.
+ *
+ * Runs the pre-conversation phase of a phone call — acting on the routing
+ * outcome produced by `routeSetup` (relay-setup-router.ts) — against any
+ * {@link SetupFlowTransport}. All side effects (speech, call-store writes,
+ * completion) flow through injected deps so the flow is unit-testable and
+ * independent of any wire protocol.
+ *
+ * Handles `normal_call` and `deny`. Other setup actions (verification,
+ * invite redemption, name capture) throw {@link UnsupportedSetupFlowError}.
+ */
+
+import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import { getTtsPlaybackDelayMs } from "./call-constants.js";
+import type {
+  SetupFlowInput,
+  SetupFlowResult,
+  SetupFlowState,
+  SetupFlowTransport,
+} from "./call-setup-flow-types.js";
+import type {
+  recordCallEvent as recordCallEventFn,
+  updateCallSession as updateCallSessionFn,
+} from "./call-store.js";
+import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
+
+// ── Errors ───────────────────────────────────────────────────────────
+
+/** Thrown when `start()` receives a setup action the flow does not implement. */
+export class UnsupportedSetupFlowError extends Error {
+  constructor(action: string) {
+    super(`Setup action '${action}' is not supported by CallSetupFlow`);
+    this.name = "UnsupportedSetupFlowError";
+  }
+}
+
+// ── Dependencies ─────────────────────────────────────────────────────
+
+/**
+ * Side-effect surface injected into the flow. Sub-flows extend this
+ * interface with additional accessors rather than reshaping the
+ * constructor.
+ */
+export interface CallSetupFlowDeps {
+  /** Speak a deterministic system prompt through the transport. */
+  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  updateCallSession(
+    id: string,
+    updates: Parameters<typeof updateCallSessionFn>[1],
+  ): void;
+  recordCallEvent(
+    callSessionId: string,
+    eventType: Parameters<typeof recordCallEventFn>[1],
+    payload?: Record<string, unknown>,
+  ): void;
+  /** Invoked exactly once when the flow reaches a terminal result. */
+  onComplete(result: SetupFlowResult): void;
+  /**
+   * Delay between speaking terminal copy and ending the session.
+   * Defaults to the configured TTS playback delay.
+   */
+  ttsPlaybackDelayMs?: number;
+}
+
+// ── Flow ─────────────────────────────────────────────────────────────
+
+export class CallSetupFlow implements SetupFlowInput {
+  private state: SetupFlowState = "idle";
+
+  constructor(
+    private readonly callSessionId: string,
+    private readonly transport: SetupFlowTransport,
+    private readonly deps: CallSetupFlowDeps,
+  ) {}
+
+  /** Explicit flow state — never inferred from the transport. */
+  getState(): SetupFlowState {
+    return this.state;
+  }
+
+  /**
+   * Act on a routing outcome. Runs at most once per flow instance;
+   * terminal continuation is delivered via `deps.onComplete`.
+   */
+  async start(outcome: SetupOutcome, resolved: SetupResolved): Promise<void> {
+    if (this.state !== "idle") {
+      throw new Error("CallSetupFlow.start() may only be called once");
+    }
+
+    switch (outcome.action) {
+      case "normal_call":
+        this.complete({
+          kind: "proceed-initial-greeting",
+          assistantId: resolved.assistantId,
+          trustContext: toTrustContext(
+            resolved.actorTrust,
+            resolved.otherPartyNumber,
+          ),
+        });
+        return;
+
+      case "deny":
+        await this.runDeny(outcome, resolved);
+        return;
+
+      default:
+        throw new UnsupportedSetupFlowError(outcome.action);
+    }
+  }
+
+  // ── SetupFlowInput ──────────────────────────────────────────────────
+
+  /** Feed a DTMF digit to the active sub-flow. No-op while idle/completed. */
+  pushDtmfDigit(_digit: string): void {
+    if (!this.acceptsInput()) {
+      return;
+    }
+  }
+
+  /** Feed a final caller transcript to the active sub-flow. No-op while idle/completed. */
+  pushTranscriptFinal(_text: string): void {
+    if (!this.acceptsInput()) {
+      return;
+    }
+  }
+
+  // ── Sub-flows ───────────────────────────────────────────────────────
+
+  /** Deny the call: record the ACL event, speak the denial, then hang up. */
+  private async runDeny(
+    outcome: Extract<SetupOutcome, { action: "deny" }>,
+    resolved: SetupResolved,
+  ): Promise<void> {
+    this.deps.recordCallEvent(this.callSessionId, "inbound_acl_denied", {
+      from: resolved.otherPartyNumber,
+      trustClass: resolved.actorTrust.trustClass,
+      channelId: resolved.actorTrust.memberRecord?.channel.id,
+      memberPolicy: resolved.actorTrust.memberRecord?.policy,
+    });
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "failed",
+      endedAt: Date.now(),
+      lastError: outcome.logReason,
+    });
+    await this.deps.speakSystemPrompt(this.transport, outcome.message);
+    // Let the spoken denial play out before tearing down the session.
+    setTimeout(
+      () => this.transport.endSession(outcome.logReason),
+      this.deps.ttsPlaybackDelayMs ?? getTtsPlaybackDelayMs(),
+    );
+    this.complete({ kind: "ended", reason: outcome.logReason });
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private acceptsInput(): boolean {
+    return this.state !== "idle" && this.state !== "completed";
+  }
+
+  private complete(result: SetupFlowResult): void {
+    this.state = "completed";
+    this.deps.onComplete(result);
+  }
+}

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -53,7 +53,7 @@ interface SetupContext {
 
 // ── Setup outcomes ───────────────────────────────────────────────────
 
-type SetupOutcome =
+export type SetupOutcome =
   | { action: "normal_call"; isInbound: boolean }
   | {
       action: "verification";


### PR DESCRIPTION
## Summary
- Adds CallSetupFlow, a transport-agnostic pre-conversation setup state machine, handling normal_call and deny
- Explicit SetupFlowState surface (never inferred from transport connection state) and a rich SetupFlowResult continuation union
- Foundation for porting all relay-server interactive sub-flows (verification, invite, name-capture, guardian wait) in later plan PRs

Part of plan: phone-media-stream-v2.md (PR 3 of 17)