### PR TITLE
feat(tts): declare media-stream playability per TTS provider and fall back instead of going silent

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2936,11 +2936,11 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("Deepgram selected path resolves useSynthesizedPath to true", () => {
+  test("Deepgram selected path resolves useSynthesizedPath to true", async () => {
     const cfg = loadConfig();
     cfg.services.tts.provider = "deepgram";
 
-    const result = resolveCallTtsProvider();
+    const result = await resolveCallTtsProvider();
     expect(result.provider).not.toBeNull();
     expect(result.provider!.id).toBe("deepgram");
     expect(result.useSynthesizedPath).toBe(true);
@@ -3086,30 +3086,30 @@ describe("call-controller", () => {
   // ── Shared TTS provider resolution ──────────────────────────────────
 
   describe("resolveCallTtsProvider (shared helper)", () => {
-    test("returns native path with elevenlabs (non-streaming provider)", () => {
+    test("returns native path with elevenlabs (non-streaming provider)", async () => {
       // Default config has provider: "elevenlabs" which is registered as
       // non-streaming in registerTestTtsProviders()
-      const result = resolveCallTtsProvider();
+      const result = await resolveCallTtsProvider();
       expect(result.provider).not.toBeNull();
       expect(result.provider!.id).toBe("elevenlabs");
       expect(result.useSynthesizedPath).toBe(false);
       expect(result.audioFormat).toBe("mp3");
     });
 
-    test("returns fallback when provider registry is empty", () => {
+    test("returns fallback when provider registry is empty", async () => {
       _resetTtsProviderRegistry();
-      const result = resolveCallTtsProvider();
+      const result = await resolveCallTtsProvider();
       expect(result.provider).toBeNull();
       expect(result.useSynthesizedPath).toBe(false);
       expect(result.audioFormat).toBe("mp3");
     });
 
-    test("degrades fish-audio synthesized path when referenceId is missing", () => {
+    test("degrades fish-audio synthesized path when referenceId is missing", async () => {
       const cfg = loadConfig();
       cfg.services.tts.provider = "fish-audio";
       cfg.services.tts.providers["fish-audio"].referenceId = "";
 
-      const result = resolveCallTtsProvider();
+      const result = await resolveCallTtsProvider();
       expect(result.provider).toBeNull();
       expect(result.useSynthesizedPath).toBe(false);
       expect(result.audioFormat).toBe("mp3");
@@ -3133,18 +3133,18 @@ describe("call-controller", () => {
       controller.destroy();
     });
 
-    test("returns synthesized path with deepgram provider", () => {
+    test("returns synthesized path with deepgram provider", async () => {
       const cfg = loadConfig();
       cfg.services.tts.provider = "deepgram";
 
-      const result = resolveCallTtsProvider();
+      const result = await resolveCallTtsProvider();
       expect(result.provider).not.toBeNull();
       expect(result.provider!.id).toBe("deepgram");
       expect(result.useSynthesizedPath).toBe(true);
       expect(result.audioFormat).toBe("mp3");
     });
 
-    test("Deepgram does not apply fish-audio referenceId gate", () => {
+    test("Deepgram does not apply fish-audio referenceId gate", async () => {
       // Deepgram has no referenceId requirement. Verify the fish-audio
       // config gate does not apply to deepgram resolution.
       const cfg = loadConfig();
@@ -3152,7 +3152,7 @@ describe("call-controller", () => {
       // fish-audio referenceId left empty — should not affect deepgram.
       cfg.services.tts.providers["fish-audio"].referenceId = "";
 
-      const result = resolveCallTtsProvider();
+      const result = await resolveCallTtsProvider();
       expect(result.provider).not.toBeNull();
       expect(result.provider!.id).toBe("deepgram");
       expect(result.useSynthesizedPath).toBe(true);

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -215,6 +215,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/conversation-process.ts", // masked provider key display
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
+      "calls/telephony-tts-capability.ts", // TTS provider API key availability check (presence only)
       "credential-execution/ces-runtime.ts", // CES runtime owns the daemon CES connection (setCesClient/onCesClientChanged/reconnect wiring at startup)
       "runtime/routes/credential-prompt-routes.ts", // Route for secure credential prompt (stores secret via setSecureKeyAsync)
       "runtime/routes/credential-routes.ts", // CLI credential management routes (CLI-migrated to IPC)

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2297,6 +2297,9 @@ describe("relay-server", () => {
     expect(relay.isVerificationSessionActive()).toBe(true);
     expect(relay.getConnectionState()).toBe("verification_pending");
 
+    // Let the fire-and-forget speakSystemPrompt resolution settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     // Should have sent a retry prompt
     const textMessages = ws.sentMessages
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
@@ -2344,6 +2347,9 @@ describe("relay-server", () => {
     expect(updated).not.toBeNull();
     expect(updated!.status).toBe("failed");
     expect(updated!.lastError).toContain("Guardian voice verification failed");
+
+    // Let the fire-and-forget speakSystemPrompt resolution settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Should have sent goodbye message
     const textMessages = ws.sentMessages

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Guard tests for telephony TTS media-stream playability.
+ *
+ * Covers three layers:
+ * 1. `resolveTelephonyTtsCapability` — catalog `mediaStreamPlayback` format
+ *    plus credential availability produce the playable / not-playable verdict.
+ * 2. `resolveCallTtsProvider({ preferWav: true })` — a not-playable configured
+ *    provider is swapped for a playable credentialed fallback instead of
+ *    resolving into guaranteed media-stream silence.
+ * 3. `speakSystemPrompt` on a WAV-requiring transport — synthesis failure
+ *    retries once via the fallback provider before degrading to an
+ *    end-of-turn-only signal.
+ *
+ * The provider catalog, config loader, credential store, provider registry,
+ * audio store, and ingress URL modules are all mocked so the tests exercise
+ * the capability/fallback logic in isolation.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+//
+// `mock.module` is process-global in Bun and leaks into sibling files that
+// run later in the same `bun test` invocation (e.g. the real catalog tests
+// in `src/tts/__tests__/`). Each stub therefore delegates to the real
+// implementation unless this file's tests are active (`guardMocksActive`,
+// toggled in beforeAll/afterAll). The real exports are snapshotted into
+// plain objects NOW, before the stubs register — a module namespace is a
+// live view, so reading the real export after the stub installs would
+// resolve back to the stub (infinite recursion).
+
+let guardMocksActive = false;
+
+const realProviderCatalogModule = {
+  ...(await import("../tts/provider-catalog.js")),
+};
+const realConfigLoaderModule = { ...(await import("../config/loader.js")) };
+const realSecureKeysModule = { ...(await import("../security/secure-keys.js")) };
+const realProviderRegistryModule = {
+  ...(await import("../tts/provider-registry.js")),
+};
+const realAudioStoreModule = { ...(await import("../calls/audio-store.js")) };
+const realPublicIngressUrlsModule = {
+  ...(await import("../inbound/public-ingress-urls.js")),
+};
+
+// -- Fake provider catalog ---------------------------------------------------
+
+interface FakeCatalogEntry {
+  id: string;
+  displayName: string;
+  callMode: "native-twilio" | "synthesized-play";
+  allowNativeFallback: boolean;
+  capabilities: { supportsStreaming: boolean; supportedFormats: string[] };
+  mediaStreamPlayback: { outputFormat: "pcm" | "wav" | "none" };
+  secretRequirements: Array<{
+    credentialStoreKey: string;
+    displayName: string;
+    setCommand: string;
+  }>;
+}
+
+function makeEntry(
+  id: string,
+  callMode: "native-twilio" | "synthesized-play",
+  outputFormat: "pcm" | "wav" | "none",
+  allowNativeFallback: boolean,
+): FakeCatalogEntry {
+  return {
+    id,
+    displayName: id,
+    callMode,
+    allowNativeFallback,
+    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+    mediaStreamPlayback: { outputFormat },
+    secretRequirements: [
+      {
+        credentialStoreKey: `credential/${id}/api_key`,
+        displayName: `${id} API Key`,
+        setCommand: `assistant credentials set --service ${id} --field api_key <key>`,
+      },
+    ],
+  };
+}
+
+const fakeCatalog: FakeCatalogEntry[] = [
+  makeEntry("elevenlabs", "native-twilio", "pcm", true),
+  makeEntry("fish-audio", "synthesized-play", "wav", true),
+  makeEntry("deepgram", "synthesized-play", "pcm", false),
+  makeEntry("compressed-only", "synthesized-play", "none", false),
+];
+
+mock.module("../tts/provider-catalog.js", () => ({
+  ...realProviderCatalogModule,
+  listCatalogProviders: () =>
+    guardMocksActive
+      ? fakeCatalog
+      : realProviderCatalogModule.listCatalogProviders(),
+  listCatalogProviderIds: () =>
+    guardMocksActive
+      ? fakeCatalog.map((e) => e.id)
+      : realProviderCatalogModule.listCatalogProviderIds(),
+  getCatalogProvider: (id: string) => {
+    if (!guardMocksActive) {
+      return realProviderCatalogModule.getCatalogProvider(id);
+    }
+    const entry = fakeCatalog.find((e) => e.id === id);
+    if (!entry) {
+      throw new Error(`Unknown TTS provider "${id}" is not in the catalog.`);
+    }
+    return entry;
+  },
+}));
+
+// -- Mutable config ------------------------------------------------------------
+
+const testConfig = {
+  services: {
+    tts: {
+      provider: "elevenlabs",
+      providers: {
+        elevenlabs: {},
+        "fish-audio": { referenceId: "", format: "mp3" },
+        deepgram: { format: "mp3" },
+        "compressed-only": { format: "mp3" },
+      } as Record<string, { referenceId?: string; format?: string }>,
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  ...realConfigLoaderModule,
+  loadConfig: () =>
+    guardMocksActive ? testConfig : realConfigLoaderModule.loadConfig(),
+  getConfig: () =>
+    guardMocksActive ? testConfig : realConfigLoaderModule.getConfig(),
+  getConfigReadOnly: () =>
+    guardMocksActive
+      ? testConfig
+      : realConfigLoaderModule.getConfigReadOnly(),
+}));
+
+// -- Mutable credential store --------------------------------------------------
+
+let storedKeys: Record<string, string | undefined> = {};
+
+mock.module("../security/secure-keys.js", () => ({
+  ...realSecureKeysModule,
+  getProviderKeyAsync: async (provider: string) =>
+    guardMocksActive
+      ? storedKeys[provider]
+      : realSecureKeysModule.getProviderKeyAsync(provider),
+  getSecureKeyAsync: async (key: string) =>
+    guardMocksActive
+      ? storedKeys[key]
+      : realSecureKeysModule.getSecureKeyAsync(key),
+}));
+
+// -- Mutable provider registry ---------------------------------------------------
+
+const registeredProviders = new Map<string, unknown>();
+
+mock.module("../tts/provider-registry.js", () => ({
+  ...realProviderRegistryModule,
+  getTtsProvider: (id: string) => {
+    if (!guardMocksActive) {
+      return realProviderRegistryModule.getTtsProvider(id);
+    }
+    const provider = registeredProviders.get(id);
+    if (!provider) {
+      throw new Error(`Unknown TTS provider "${id}".`);
+    }
+    return provider;
+  },
+}));
+
+// -- Audio store + ingress URL (used by call-speech-output) ---------------------
+
+const finalizeCalls: string[] = [];
+let audioEntryCounter = 0;
+
+mock.module("../calls/audio-store.js", () => ({
+  ...realAudioStoreModule,
+  createStreamingEntry: (
+    format: Parameters<typeof realAudioStoreModule.createStreamingEntry>[0],
+  ) => {
+    if (!guardMocksActive) {
+      return realAudioStoreModule.createStreamingEntry(format);
+    }
+    const audioId = `audio-${++audioEntryCounter}-${format}`;
+    return {
+      audioId,
+      push: () => {},
+      finalize: () => finalizeCalls.push(audioId),
+    };
+  },
+}));
+
+mock.module("../inbound/public-ingress-urls.js", () => ({
+  ...realPublicIngressUrlsModule,
+  getPublicBaseUrl: (
+    config: Parameters<typeof realPublicIngressUrlsModule.getPublicBaseUrl>[0],
+  ) =>
+    guardMocksActive
+      ? "https://example.test"
+      : realPublicIngressUrlsModule.getPublicBaseUrl(config),
+}));
+
+import { speakSystemPrompt } from "../calls/call-speech-output.js";
+import type { CallTransport } from "../calls/call-transport.js";
+import {
+  findPlayableTelephonyTtsFallback,
+  resolveCallTtsProvider,
+} from "../calls/resolve-call-tts-provider.js";
+import {
+  evaluateTelephonyTtsPlayability,
+  resolveTelephonyTtsCapability,
+} from "../calls/telephony-tts-capability.js";
+import type { TtsProvider } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function registerStubProvider(
+  id: string,
+  synthesize: TtsProvider["synthesize"],
+): TtsProvider {
+  const provider: TtsProvider = {
+    id,
+    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+    synthesize,
+  };
+  registeredProviders.set(id, provider);
+  return provider;
+}
+
+function createRelay(requiresWavAudio: boolean) {
+  const sentTokens: Array<{ token: string; last: boolean }> = [];
+  const sentPlayUrls: string[] = [];
+  const relay: CallTransport = {
+    requiresWavAudio,
+    sendTextToken: (token, last) => {
+      sentTokens.push({ token, last });
+    },
+    sendPlayUrl: (url) => {
+      sentPlayUrls.push(url);
+    },
+    endSession: () => {},
+    getConnectionState: () => "connected",
+  } as CallTransport;
+  return { relay, sentTokens, sentPlayUrls };
+}
+
+beforeAll(() => {
+  guardMocksActive = true;
+});
+
+afterAll(() => {
+  guardMocksActive = false;
+});
+
+beforeEach(() => {
+  storedKeys = {};
+  registeredProviders.clear();
+  finalizeCalls.length = 0;
+  testConfig.services.tts.provider = "elevenlabs";
+  testConfig.services.tts.providers["fish-audio"].referenceId = "";
+});
+
+// ---------------------------------------------------------------------------
+// Capability resolver
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonyTtsCapability", () => {
+  test("pcm provider with a resolvable key is playable", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+
+    const capability = await resolveTelephonyTtsCapability();
+    expect(capability).toEqual({ status: "playable", providerId: "deepgram" });
+  });
+
+  test("wav provider with a resolvable key is playable", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    storedKeys["fish-audio"] = "fa-key";
+
+    const capability = await resolveTelephonyTtsCapability();
+    expect(capability).toEqual({
+      status: "playable",
+      providerId: "fish-audio",
+    });
+  });
+
+  test("provider with mediaStreamPlayback 'none' is not playable (unsupported-format)", async () => {
+    testConfig.services.tts.provider = "compressed-only";
+    storedKeys["compressed-only"] = "co-key";
+
+    const capability = await resolveTelephonyTtsCapability();
+    expect(capability).toEqual({
+      status: "not-playable",
+      providerId: "compressed-only",
+      reason: "unsupported-format",
+    });
+  });
+
+  test("pcm provider without a key is not playable (missing-credentials)", async () => {
+    testConfig.services.tts.provider = "deepgram";
+
+    const capability = await resolveTelephonyTtsCapability();
+    expect(capability).toEqual({
+      status: "not-playable",
+      providerId: "deepgram",
+      reason: "missing-credentials",
+    });
+  });
+
+  test("unknown provider is not playable (unsupported-format)", async () => {
+    const capability = await evaluateTelephonyTtsPlayability("nonexistent");
+    expect(capability).toEqual({
+      status: "not-playable",
+      providerId: "nonexistent",
+      reason: "unsupported-format",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback provider scan
+// ---------------------------------------------------------------------------
+
+describe("findPlayableTelephonyTtsFallback", () => {
+  test("prefers the ElevenLabs default when its key resolves", async () => {
+    storedKeys["elevenlabs"] = "el-key";
+    storedKeys["deepgram"] = "dg-key";
+
+    expect(await findPlayableTelephonyTtsFallback("compressed-only")).toBe(
+      "elevenlabs",
+    );
+  });
+
+  test("skips fish-audio without a referenceId and picks the next playable provider", async () => {
+    storedKeys["fish-audio"] = "fa-key";
+    storedKeys["deepgram"] = "dg-key";
+
+    expect(await findPlayableTelephonyTtsFallback("elevenlabs")).toBe(
+      "deepgram",
+    );
+
+    testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
+    expect(await findPlayableTelephonyTtsFallback("elevenlabs")).toBe(
+      "fish-audio",
+    );
+  });
+
+  test("returns null when no provider is playable and credentialed", async () => {
+    storedKeys["compressed-only"] = "co-key";
+
+    expect(await findPlayableTelephonyTtsFallback()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Call TTS resolver — media-stream playability guard
+// ---------------------------------------------------------------------------
+
+describe("resolveCallTtsProvider with preferWav", () => {
+  test("keeps the configured provider when it is playable and credentialed", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    registerStubProvider("deepgram", async () => {
+      return { audio: Buffer.from("x"), contentType: "audio/pcm" };
+    });
+
+    const result = await resolveCallTtsProvider({ preferWav: true });
+    expect(result.provider?.id).toBe("deepgram");
+    expect(result.useSynthesizedPath).toBe(true);
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("falls back to a playable credentialed provider when the configured provider has an unsupported format", async () => {
+    testConfig.services.tts.provider = "compressed-only";
+    storedKeys["compressed-only"] = "co-key";
+    storedKeys["elevenlabs"] = "el-key";
+    registerStubProvider("compressed-only", async () => {
+      throw new Error("should not be used");
+    });
+    registerStubProvider("elevenlabs", async () => {
+      return { audio: Buffer.from("x"), contentType: "audio/pcm" };
+    });
+
+    const result = await resolveCallTtsProvider({ preferWav: true });
+    expect(result.provider?.id).toBe("elevenlabs");
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("falls back when the configured provider is missing credentials", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["elevenlabs"] = "el-key";
+    registerStubProvider("deepgram", async () => {
+      throw new Error("should not be used");
+    });
+    registerStubProvider("elevenlabs", async () => {
+      return { audio: Buffer.from("x"), contentType: "audio/pcm" };
+    });
+
+    const result = await resolveCallTtsProvider({ preferWav: true });
+    expect(result.provider?.id).toBe("elevenlabs");
+  });
+
+  test("without preferWav the configured provider is not swapped", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    // No credentials at all — the CR transport path does not consult the
+    // media-stream playability capability.
+    registerStubProvider("deepgram", async () => {
+      return { audio: Buffer.from("x"), contentType: "audio/mpeg" };
+    });
+
+    const result = await resolveCallTtsProvider();
+    expect(result.provider?.id).toBe("deepgram");
+    expect(result.useSynthesizedPath).toBe(true);
+    expect(result.audioFormat).toBe("mp3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// speakSystemPrompt — media-stream synthesis failure retries the fallback
+// ---------------------------------------------------------------------------
+
+describe("speakSystemPrompt on a WAV-requiring transport", () => {
+  test("retries with the fallback provider instead of emitting only end-of-turn", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    const deepgramSynthesize = jest.fn(async () => {
+      throw new Error("deepgram synthesis down");
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(relay, "You have a new message.");
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
+
+    // The fallback synthesis produced playable audio.
+    expect(sentPlayUrls.length).toBe(1);
+
+    // End-of-turn is signalled, and the raw prompt text is never sent as a
+    // text token (which the media-stream transport would re-synthesize via
+    // the same failing provider).
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+
+  test("degrades to end-of-turn only when no fallback provider is available", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+
+    const deepgramSynthesize = jest.fn(async () => {
+      throw new Error("deepgram synthesis down");
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(relay, "You have a new message.");
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls.length).toBe(0);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+
+  test("does not retry more than once when the fallback provider also fails", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    const deepgramSynthesize = jest.fn(async () => {
+      throw new Error("deepgram synthesis down");
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      throw new Error("elevenlabs synthesis down");
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(relay, "You have a new message.");
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls.length).toBe(0);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+});

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -611,7 +611,7 @@ export class CallController {
     // the audio store entry and any downstream fetch/transcode receives
     // PCM that audioBufferToFrames can convert to mu-law.
     const { provider, useSynthesizedPath, audioFormat } =
-      resolveCallTtsProvider({
+      await resolveCallTtsProvider({
         preferWav: this.transport.requiresWavAudio,
       });
 

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -17,11 +17,15 @@
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
-import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import {
+  findPlayableTelephonyTtsFallback,
+  resolveCallTtsProvider,
+} from "./resolve-call-tts-provider.js";
 
 const log = getLogger("call-speech-output");
 
@@ -42,7 +46,7 @@ const log = getLogger("call-speech-output");
  * Twilio before the session ends. Interactive mid-call callers can
  * fire-and-forget with `void speakSystemPrompt(...)`.
  */
-export function speakSystemPrompt(
+export async function speakSystemPrompt(
   relay: CallTransport,
   text: string,
 ): Promise<void> {
@@ -50,14 +54,15 @@ export function speakSystemPrompt(
   // the audio store entry contains PCM that audioBufferToFrames can
   // transcode to mu-law. Without this, compressed formats (mp3, opus)
   // are fetched by processFetchUrlItem and produce garbled audio.
-  const { provider, useSynthesizedPath, audioFormat } = resolveCallTtsProvider({
-    preferWav: relay.requiresWavAudio,
-  });
+  const { provider, useSynthesizedPath, audioFormat } =
+    await resolveCallTtsProvider({
+      preferWav: relay.requiresWavAudio,
+    });
 
   if (!useSynthesizedPath || !provider) {
     // Native path — send text for Twilio's built-in TTS.
     relay.sendTextToken(text, true);
-    return Promise.resolve();
+    return;
   }
 
   // Synthesized path — synthesize audio and send play URL.
@@ -72,18 +77,24 @@ export function speakSystemPrompt(
  * Synthesize text via a streaming TTS provider and send the play URL
  * to the relay.
  *
- * On synthesis failure the behavior depends on the provider:
- * - Providers with a native Twilio TTS fallback (e.g. Fish Audio) fall
- *   back to `sendTextToken(text)` so the caller still hears the message.
- * - Providers without a native fallback (e.g. Deepgram) log the error
- *   and send only an empty end-of-turn signal — the caller hears nothing
- *   but the relay transitions back to listening state.
+ * On synthesis failure the behavior depends on the transport:
+ * - WAV-requiring transports (media-stream) retry once with a playable
+ *   fallback provider — native token TTS cannot rescue the prompt there
+ *   because text tokens are themselves synthesized via the same provider
+ *   path. When no fallback exists (or the retry also fails), only an
+ *   empty end-of-turn signal is sent so the transport transitions back
+ *   to listening state.
+ * - On the ConversationRelay transport, providers with a native Twilio
+ *   TTS fallback (e.g. Fish Audio) fall back to `sendTextToken(text)` so
+ *   the caller still hears the message; providers without one (e.g.
+ *   Deepgram) log the error and send only the end-of-turn signal.
  */
 async function synthesizeAndPlay(
   relay: CallTransport,
   provider: TtsProvider,
   text: string,
   format: "mp3" | "wav" | "opus",
+  isFallbackRetry = false,
 ): Promise<void> {
   let handle: ReturnType<typeof createStreamingEntry> | null = null;
   let playUrlSent = false;
@@ -154,6 +165,49 @@ async function synthesizeAndPlay(
         ? (err as Error & { code?: string }).code
         : undefined;
 
+    if (relay.requiresWavAudio) {
+      // WAV-requiring transport (media-stream): native token TTS routes
+      // back through the same synthesis path, so retry once with a
+      // playable fallback provider before degrading to end-of-turn only.
+      if (!isFallbackRetry) {
+        const fallbackId = await findPlayableTelephonyTtsFallback(
+          provider.id as TtsProviderId,
+        );
+        const fallbackProvider = fallbackId
+          ? lookupRegisteredProvider(fallbackId)
+          : null;
+        if (fallbackProvider) {
+          log.warn(
+            {
+              err,
+              provider: provider.id,
+              fallbackProvider: fallbackProvider.id,
+              errName,
+              errCode,
+            },
+            "System prompt TTS synthesis failed — retrying with fallback provider",
+          );
+          handle?.finalize();
+          handle = null;
+          return await synthesizeAndPlay(
+            relay,
+            fallbackProvider,
+            text,
+            format,
+            true,
+          );
+        }
+      }
+      log.error(
+        { err, provider: provider.id, errName, errCode },
+        "System prompt TTS synthesis failed on WAV-requiring transport — sending end-of-turn only",
+      );
+      // Send the end-of-turn signal so the transport transitions from
+      // "assistant speaking" to "caller speaking" state.
+      relay.sendTextToken("", true);
+      return;
+    }
+
     // `allowNativeFallback` controls whether the system prompt text
     // should be sent via native Twilio token-based TTS when synthesis
     // fails. When false (e.g. Deepgram), the design choice is to
@@ -186,5 +240,14 @@ async function synthesizeAndPlay(
     relay.sendTextToken(text, true);
   } finally {
     handle?.finalize();
+  }
+}
+
+/** Look up a registered provider, returning null instead of throwing. */
+function lookupRegisteredProvider(id: TtsProviderId): TtsProvider | null {
+  try {
+    return getTtsProvider(id);
+  } catch {
+    return null;
   }
 }

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -399,7 +399,7 @@ export class MediaStreamOutput implements CallTransport {
       // Request WAV so audioBufferToFrames gets PCM it can transcode
       // to mu-law. Compressed formats (mp3, opus) would be sent as raw
       // bytes and produce garbled audio.
-      const { provider, audioFormat } = resolveCallTtsProvider({
+      const { provider, audioFormat } = await resolveCallTtsProvider({
         preferWav: true,
       });
       if (!provider) {

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -8,10 +8,15 @@
  */
 
 import { loadConfig } from "../config/loader.js";
+import {
+  getCatalogProvider,
+  listCatalogProviderIds,
+} from "../tts/provider-catalog.js";
 import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
-import type { TtsProvider } from "../tts/types.js";
+import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import { evaluateTelephonyTtsPlayability } from "./telephony-tts-capability.js";
 import { resolveCallStrategy } from "./tts-call-strategy.js";
 
 const log = getLogger("resolve-call-tts-provider");
@@ -47,6 +52,11 @@ export interface ResolveCallTtsOptions {
    * because its {@link audioBufferToFrames} can only correctly
    * transcode WAV (PCM) to mu-law -- compressed formats (mp3, opus)
    * are sent as raw bytes and produce garbled audio.
+   *
+   * Also gates the media-stream playability guard: a configured provider
+   * that cannot produce playable PCM/WAV audio (or lacks credentials) is
+   * swapped for a playable fallback provider instead of resolving into a
+   * provider whose only possible media-stream outcome is silence.
    */
   preferWav?: boolean;
 }
@@ -66,45 +76,73 @@ export interface ResolveCallTtsOptions {
  * `callMode: "native-twilio"` stream text tokens directly to the relay
  * for Twilio's built-in TTS.
  *
+ * For WAV-requiring transports (`preferWav`, i.e. media-stream), the
+ * resolved provider is validated against the media-stream playability
+ * capability (format + credentials); a not-playable provider is replaced
+ * by {@link findPlayableTelephonyTtsFallback}.
+ *
  * Falls back to the native path with `mp3` format when the config is
  * missing a `services.tts` block or the provider is not registered
  * (e.g. unit tests or early startup).
  */
-export function resolveCallTtsProvider(
+export async function resolveCallTtsProvider(
   options?: ResolveCallTtsOptions,
-): ResolvedCallTts {
+): Promise<ResolvedCallTts> {
   try {
     const config = loadConfig();
     const resolved = resolveTtsConfig(config);
-    const provider = getTtsProvider(resolved.provider);
 
     // Use the catalog's callMode to decide the call path -- the same
     // decision path used by voice-quality.ts via resolveCallStrategy().
     const strategy = resolveCallStrategy(config);
-    const useSynthesizedPath = strategy.callMode === "synthesized-play";
 
-    // For synthesized providers, preflight provider-specific config
-    // invariants that would otherwise fail only at first synthesis call.
-    // If required config is missing, degrade to the native token path
-    // (Twilio TTS) rather than letting the call stay silent.
-    //
-    // Fish Audio requires a reference ID when no per-request voiceId is
-    // supplied (which is the telephony default).
-    if (useSynthesizedPath && resolved.provider === "fish-audio") {
-      const referenceId = (resolved.providerConfig as { referenceId?: string })
-        .referenceId;
-      if (!referenceId?.trim()) {
-        log.warn(
-          { provider: resolved.provider },
-          "Synthesized call TTS disabled: fish-audio.referenceId is not configured; falling back to native token path",
-        );
-        return {
-          provider: null,
-          useSynthesizedPath: false,
-          audioFormat: "mp3",
-        };
+    let providerId = resolved.provider;
+    let useSynthesizedPath = strategy.callMode === "synthesized-play";
+
+    // Preflight provider-specific config invariants that would otherwise
+    // fail only at first synthesis call. Fish Audio requires a reference
+    // ID when no per-request voiceId is supplied (the telephony default).
+    const fishAudioUnusable =
+      providerId === "fish-audio" && !hasReferenceId(resolved.providerConfig);
+
+    if (options?.preferWav) {
+      // Media-stream transport: every spoken turn is synthesized, so the
+      // provider must produce playable PCM/WAV with resolvable credentials.
+      // Swap in a playable fallback rather than resolving into a provider
+      // that can only be silent.
+      const capability = await evaluateTelephonyTtsPlayability(providerId);
+      if (capability.status === "not-playable" || fishAudioUnusable) {
+        const reason =
+          capability.status === "not-playable"
+            ? capability.reason
+            : "missing-fish-audio-reference-id";
+        const fallbackId = await findPlayableTelephonyTtsFallback(providerId);
+        if (fallbackId) {
+          log.warn(
+            { providerId, reason, fallbackProviderId: fallbackId },
+            "Configured TTS provider is not playable on the media-stream transport; falling back",
+          );
+          providerId = fallbackId;
+          useSynthesizedPath =
+            getCatalogProvider(fallbackId).callMode === "synthesized-play";
+        } else {
+          log.warn(
+            { providerId, reason },
+            "Configured TTS provider is not playable on the media-stream transport and no playable fallback provider is available",
+          );
+        }
       }
+    } else if (useSynthesizedPath && fishAudioUnusable) {
+      // ConversationRelay transport: degrade to the native token path
+      // (Twilio TTS) rather than letting the call stay silent.
+      log.warn(
+        { provider: providerId },
+        "Synthesized call TTS disabled: fish-audio.referenceId is not configured; falling back to native token path",
+      );
+      return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
     }
+
+    const provider = getTtsProvider(providerId);
 
     // Read the user-configured audio format from the resolved provider
     // config so the streaming store entry's content-type matches the
@@ -132,5 +170,57 @@ export function resolveCallTtsProvider(
     // (e.g. unit tests or early startup) -- fall back to the native
     // path where the provider object is not used.
     return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
+  }
+}
+
+/**
+ * Find a catalog provider that can produce playable media-stream audio
+ * with resolvable credentials.
+ *
+ * Preference order: the ElevenLabs default first (when its key resolves),
+ * then the remaining catalog providers in display order. Fish Audio is
+ * skipped when its required `referenceId` is not configured. Returns
+ * `null` when no provider qualifies.
+ */
+export async function findPlayableTelephonyTtsFallback(
+  excludeProviderId?: TtsProviderId,
+): Promise<TtsProviderId | null> {
+  const candidates = [
+    ...new Set<TtsProviderId>(["elevenlabs", ...listCatalogProviderIds()]),
+  ].filter((id) => id !== excludeProviderId);
+
+  for (const candidateId of candidates) {
+    const capability = await evaluateTelephonyTtsPlayability(candidateId);
+    if (capability.status !== "playable") {
+      continue;
+    }
+    if (candidateId === "fish-audio" && !fishAudioReferenceIdConfigured()) {
+      continue;
+    }
+    return candidateId;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Whether a provider config block carries a non-empty `referenceId`. */
+function hasReferenceId(providerConfig: unknown): boolean {
+  return Boolean(
+    (providerConfig as { referenceId?: string } | undefined)?.referenceId?.trim(),
+  );
+}
+
+/** Whether `services.tts.providers.fish-audio.referenceId` is configured. */
+function fishAudioReferenceIdConfigured(): boolean {
+  try {
+    const providers = loadConfig().services?.tts?.providers as
+      | Record<string, unknown>
+      | undefined;
+    return hasReferenceId(providers?.["fish-audio"]);
+  } catch {
+    return false;
   }
 }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -1,0 +1,132 @@
+/**
+ * Telephony TTS playability capability resolver.
+ *
+ * Validates whether a TTS provider can produce audio that is actually
+ * playable over the media-stream call transport. Playability requires:
+ *
+ * 1. The catalog entry's `mediaStreamPlayback.outputFormat` is `"pcm"` or
+ *    `"wav"` — the media-stream mu-law transcoder cannot decode compressed
+ *    formats (mp3, opus).
+ * 2. Every secret the catalog entry requires resolves to a value.
+ *
+ * This resolver does **not** create a provider instance — it only validates
+ * catalog metadata and credentials, mirroring `resolveTelephonySttCapability`
+ * in `providers/speech-to-text/resolve.ts`. Credential lookup is centralized
+ * here (an authorized secure-keys importer) so callers don't need to import
+ * secure-keys directly.
+ */
+
+import { getConfig } from "../config/loader.js";
+import {
+  getProviderKeyAsync,
+  getSecureKeyAsync,
+} from "../security/secure-keys.js";
+import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProviderId } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Why a provider cannot play over media-stream transports. */
+export type TelephonyTtsNotPlayableReason =
+  | "unsupported-format"
+  | "missing-credentials";
+
+/**
+ * Result of resolving whether a TTS provider is playable over the
+ * media-stream call transport.
+ */
+export type TelephonyTtsCapability =
+  | {
+      /** The provider produces playable audio and credentials resolve. */
+      status: "playable";
+      providerId: TtsProviderId;
+    }
+  | {
+      /** The provider cannot play over media-stream transports. */
+      status: "not-playable";
+      providerId: TtsProviderId;
+      reason: TelephonyTtsNotPlayableReason;
+    };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate whether the configured `services.tts.provider` is playable over
+ * the media-stream call transport.
+ *
+ * Callers can branch on the discriminated `status` field:
+ * - `"playable"` — the provider produces PCM/WAV and credentials resolve.
+ * - `"not-playable"` — see `reason` (`"unsupported-format"` when the
+ *   provider is unknown or only produces compressed audio,
+ *   `"missing-credentials"` when a required secret does not resolve).
+ */
+export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
+  const { provider } = resolveTtsConfig(getConfig());
+  return evaluateTelephonyTtsPlayability(provider);
+}
+
+/**
+ * Evaluate media-stream playability for a specific catalog provider.
+ *
+ * Shared by {@link resolveTelephonyTtsCapability} (configured provider) and
+ * the call TTS resolver's fallback scan (candidate providers).
+ */
+export async function evaluateTelephonyTtsPlayability(
+  providerId: TtsProviderId,
+): Promise<TelephonyTtsCapability> {
+  let entry: TtsProviderCatalogEntry;
+  try {
+    entry = getCatalogProvider(providerId);
+  } catch {
+    // Unknown providers have no declared playable format.
+    return { status: "not-playable", providerId, reason: "unsupported-format" };
+  }
+
+  if (entry.mediaStreamPlayback.outputFormat === "none") {
+    return {
+      status: "not-playable",
+      providerId: entry.id,
+      reason: "unsupported-format",
+    };
+  }
+
+  for (const secret of entry.secretRequirements) {
+    if (!(await secretResolves(secret.credentialStoreKey))) {
+      return {
+        status: "not-playable",
+        providerId: entry.id,
+        reason: "missing-credentials",
+      };
+    }
+  }
+
+  return { status: "playable", providerId: entry.id };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a catalog `credentialStoreKey` resolves to a value.
+ *
+ * API keys (`credential/{service}/api_key` or a bare service name) go
+ * through `getProviderKeyAsync` so env-var-only setups are honoured;
+ * other namespaced fields are looked up verbatim.
+ */
+async function secretResolves(credentialStoreKey: string): Promise<boolean> {
+  const parts = credentialStoreKey.split("/");
+  if (parts.length === 1) {
+    return Boolean(await getProviderKeyAsync(credentialStoreKey));
+  }
+  if (parts.length === 3 && parts[0] === "credential" && parts[2] === "api_key") {
+    return Boolean(await getProviderKeyAsync(parts[1]));
+  }
+  return Boolean(await getSecureKeyAsync(credentialStoreKey));
+}

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -53,6 +53,15 @@ describe("TTS provider catalog", () => {
     }
   });
 
+  test("every entry declares a valid mediaStreamPlayback output format", () => {
+    const validFormats = new Set(["pcm", "wav", "none"]);
+    for (const entry of entries) {
+      expect(validFormats.has(entry.mediaStreamPlayback.outputFormat)).toBe(
+        true,
+      );
+    }
+  });
+
   test("every entry has at least one secret requirement", () => {
     for (const entry of entries) {
       expect(entry.secretRequirements.length).toBeGreaterThan(0);
@@ -120,6 +129,10 @@ describe("ElevenLabs catalog entry", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
   });
 
+  test("plays over media-stream via PCM output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("pcm");
+  });
+
   test("requires a credential stored under 'credential/elevenlabs/api_key'", () => {
     const apiKeySecret = entry.secretRequirements.find(
       (s) => s.credentialStoreKey === "credential/elevenlabs/api_key",
@@ -146,6 +159,10 @@ describe("Fish Audio catalog entry", () => {
     expect(entry.capabilities.supportedFormats).toContain("opus");
   });
 
+  test("plays over media-stream via WAV output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("wav");
+  });
+
   test("requires an API key stored under 'credential/fish-audio/api_key'", () => {
     const apiKeySecret = entry.secretRequirements.find(
       (s) => s.credentialStoreKey === "credential/fish-audio/api_key",
@@ -170,6 +187,10 @@ describe("Deepgram catalog entry", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
     expect(entry.capabilities.supportedFormats).toContain("wav");
     expect(entry.capabilities.supportedFormats).toContain("opus");
+  });
+
+  test("plays over media-stream via PCM output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("pcm");
   });
 
   test("requires an API key stored under 'credential/deepgram/api_key'", () => {

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -56,6 +56,27 @@ interface TtsProviderCatalogCapabilities {
 }
 
 /**
+ * Output format the provider's adapter produces when a caller requests
+ * PCM output (`outputFormat: "pcm"`) for media-stream playback.
+ *
+ * The media-stream transport can only transcode raw PCM or WAV
+ * (PCM-in-container) to mu-law — compressed formats (mp3, opus) produce
+ * garbled audio. Providers whose adapter honours the PCM hint declare
+ * `"pcm"`; providers that substitute WAV declare `"wav"`; providers that
+ * can only produce compressed audio declare `"none"` and are not playable
+ * over media-stream transports.
+ */
+export type TtsMediaStreamOutputFormat = "pcm" | "wav" | "none";
+
+/**
+ * How the provider's synthesized audio plays over media-stream transports.
+ */
+export interface TtsMediaStreamPlayback {
+  /** Format the adapter produces for media-stream (PCM-hinted) requests. */
+  readonly outputFormat: TtsMediaStreamOutputFormat;
+}
+
+/**
  * Link to a provider's API-key management page, shown in settings UI.
  */
 interface TtsCredentialsGuide {
@@ -71,7 +92,7 @@ interface TtsCredentialsGuide {
  * metadata level — identity, display name, telephony call mode,
  * capabilities, secret requirements, and client-facing display metadata.
  */
-interface TtsProviderCatalogEntry {
+export interface TtsProviderCatalogEntry {
   /** Unique provider identifier matching {@link TtsProviderId}. */
   readonly id: TtsProviderId;
 
@@ -110,6 +131,9 @@ interface TtsProviderCatalogEntry {
   /** Static provider-level capabilities. */
   readonly capabilities: Readonly<TtsProviderCatalogCapabilities>;
 
+  /** How the provider's audio plays over media-stream transports. */
+  readonly mediaStreamPlayback: Readonly<TtsMediaStreamPlayback>;
+
   /** Secrets the provider requires to function. */
   readonly secretRequirements: readonly Readonly<TtsProviderSecretRequirement>[];
 }
@@ -143,6 +167,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3"],
     },
+    // The adapter honours the PCM hint via `pcm_16000` output.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/elevenlabs/api_key",
@@ -171,6 +197,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: true,
       supportedFormats: ["mp3", "wav", "opus"],
     },
+    // The adapter substitutes WAV for the PCM hint (no raw PCM support).
+    mediaStreamPlayback: { outputFormat: "wav" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/fish-audio/api_key",
@@ -199,6 +227,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3", "wav", "opus"],
     },
+    // The adapter honours the PCM hint via `linear16` + `container=none`.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/deepgram/api_key",
@@ -226,6 +256,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       supportsStreaming: false,
       supportedFormats: ["mp3", "wav"],
     },
+    // The adapter honours the PCM hint via the `pcm` codec.
+    mediaStreamPlayback: { outputFormat: "pcm" },
     secretRequirements: [
       {
         credentialStoreKey: "credential/xai/api_key",


### PR DESCRIPTION
## Summary
- Adds explicit mediaStreamPlayback metadata to the TTS catalog and a resolveTelephonyTtsCapability() resolver (format + credential availability)
- resolve-call-tts-provider falls back to a playable credentialed provider for WAV-requiring transports instead of resolving into silence
- synthesizeAndPlay retries the fallback provider on media-stream synthesis failure instead of emitting only end-of-turn

Part of plan: phone-media-stream-v2.md (PR 2 of 17)