### PR TITLE
refactor(assistant): house enabled-plugins persistence in setEnabledPlugins

### DIFF
--- a/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
+++ b/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
@@ -3,9 +3,9 @@
  * handler.
  *
  * Validates that when a message mints/targets a conversation:
- * - `enabledPlugins: [...]` is persisted (setConversationEnabledPlugins) AND
- *   applied to the live conversation (setEnabledPlugins), observable via
- *   getEffectiveEnabledPluginSet.
+ * - `enabledPlugins: [...]` is applied to the live conversation via
+ *   `setEnabledPlugins`, which persists to the row (setConversationEnabledPlugins)
+ *   under the hood, observable via getEffectiveEnabledPluginSet.
  * - `[]` scopes the chat to no plugins (empty set).
  * - explicit `null` clears to the default (no per-chat restriction).
  * - omitting the field leaves the stored value untouched (no persist call).
@@ -227,8 +227,11 @@ function makeConversation() {
     setProcessing: (value: boolean) => {
       processing = value;
     },
+    // Mirrors the real Conversation.setEnabledPlugins, which persists to the
+    // row via setConversationEnabledPlugins as it updates the live instance.
     setEnabledPlugins: (plugins: string[] | null) => {
       enabledPlugins = plugins;
+      setConversationEnabledPluginsMock("conv-plugins-test", plugins);
     },
     hasAnyPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -52,6 +52,7 @@ import {
   getConversation,
   getMessages,
   resolveOverrideProfile,
+  setConversationEnabledPlugins,
   setConversationHistoryStrippedAt,
   setConversationProcessingStartedAt,
 } from "../persistence/conversation-crud.js";
@@ -334,9 +335,10 @@ export class Conversation {
   /**
    * Per-conversation plugin scope mirrored from the DB row. `null` means no
    * per-chat restriction (all globally-enabled plugins apply). Hydrated on load
-   * and kept in sync by {@link setEnabledPlugins} so the live instance is the
-   * source of truth; later tool/skill/hook filters intersect their candidate
-   * set against this via `getEffectiveEnabledPluginSet`.
+   * and kept in sync by {@link setEnabledPlugins}, which also persists the value
+   * back to the row, so the live instance is the source of truth; later
+   * tool/skill/hook filters intersect their candidate set against this via
+   * `getEffectiveEnabledPluginSet`.
    * @internal
    */
   enabledPlugins: string[] | null = null;
@@ -1378,8 +1380,15 @@ export class Conversation {
     this.subagentAllowedTools = tools;
   }
 
+  /**
+   * Set the conversation's per-chat plugin scope, updating both the live
+   * instance (source of truth for the current turn) and the persisted
+   * `enabled_plugins` row so the scope survives a reload. `null` clears the
+   * per-chat restriction. Callers do not persist separately.
+   */
   setEnabledPlugins(plugins: string[] | null): void {
     this.enabledPlugins = plugins;
+    setConversationEnabledPlugins(this.conversationId, plugins);
   }
 
   setIsSubagent(value: boolean): void {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1381,14 +1381,17 @@ export class Conversation {
   }
 
   /**
-   * Set the conversation's per-chat plugin scope, updating both the live
-   * instance (source of truth for the current turn) and the persisted
-   * `enabled_plugins` row so the scope survives a reload. `null` clears the
-   * per-chat restriction. Callers do not persist separately.
+   * Set the conversation's per-chat plugin scope, updating both the persisted
+   * `enabled_plugins` row and the live instance (source of truth for the
+   * current turn). `null` clears the per-chat restriction. Callers do not
+   * persist separately.
+   *
+   * Persist first, then mutate the live instance: if the write throws, the
+   * live scope is left untouched rather than diverging from the row.
    */
   setEnabledPlugins(plugins: string[] | null): void {
-    this.enabledPlugins = plugins;
     setConversationEnabledPlugins(this.conversationId, plugins);
+    this.enabledPlugins = plugins;
   }
 
   setIsSubagent(value: boolean): void {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -108,7 +108,6 @@ import {
   isConversationProcessing,
   type MessageRow,
   provenanceFromTrustContext,
-  setConversationEnabledPlugins,
   setConversationInferenceProfile,
 } from "../../persistence/conversation-crud.js";
 import {
@@ -1605,10 +1604,8 @@ export async function handleSendMessage(
   }
 
   if (requestedEnabledPlugins !== undefined) {
-    setConversationEnabledPlugins(
-      mapping.conversationId,
-      requestedEnabledPlugins,
-    );
+    // setEnabledPlugins persists the scope to the conversation row as well as
+    // updating the live instance, so no separate DB write is needed here.
     conversation.setEnabledPlugins(requestedEnabledPlugins);
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1604,8 +1604,6 @@ export async function handleSendMessage(
   }
 
   if (requestedEnabledPlugins !== undefined) {
-    // setEnabledPlugins persists the scope to the conversation row as well as
-    // updating the live instance, so no separate DB write is needed here.
     conversation.setEnabledPlugins(requestedEnabledPlugins);
   }
 


### PR DESCRIPTION
## Why

Follow-up to review feedback on #36678.

The `POST /v1/messages` handler updated the per-chat plugin scope in two separate calls — one DB write (`setConversationEnabledPlugins`) and one live-instance update (`conversation.setEnabledPlugins`). The reviewer noted the conversation method should house the persistence under the hood.

## What

- `Conversation.setEnabledPlugins()` now persists the scope to the `enabled_plugins` row (via `setConversationEnabledPlugins`) in addition to updating the live instance, so the row and the live instance stay in sync through a single call.
- The route handler drops its now-redundant direct DB write and just calls `conversation.setEnabledPlugins(...)`.
- Updated the field/method docs and the route test's fake conversation to mirror the encapsulated persistence.

The subagent-inheritance path (`SubagentManager`) already calls `setEnabledPlugins` on a conversation whose row exists, so it now persists the inherited scope too — consistent and harmless (no-op UPDATE when the row is absent).

## Testing

- `bun test src/__tests__/conversation-routes-enabled-plugins.test.ts` — 5 pass
- `bun test conversation-crud-enabled-plugins conversation-tool-setup subagent-spawn-and-await` — 24 pass
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_