### PR TITLE
Clarify misleading `monitoring start` message

### DIFF
--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -112,7 +112,7 @@ Examples:
               : `Resource monitor started (PID ${res.pid})`,
           );
           log.info(
-            "Enabled monitoring.enabled; it will be respawned on the next assistant start",
+            "Enabled monitoring.enabled; it will also be respawned automatically on future assistant starts",
           );
         });
 


### PR DESCRIPTION
## Why

`assistant monitoring start` printed:

```
Resource monitor started (PID 7428)
Enabled monitoring.enabled; it will be respawned on the next assistant start
```

The second line is misleading. The monitor is **already spawned right now** — the line directly above reports a live PID, and `assistant ps` shows `monitoring-worker [running]` immediately, without any assistant restart. Enabling `monitoring.enabled` only governs *persistence* (so the monitor is respawned automatically on future boots); it does not defer the current start. The phrasing "it will be respawned on the next assistant start" made it sound like starting was deferred to a restart, contradicting the "started (PID …)" line.

## What

Reword the follow-up line to:

> Enabled monitoring.enabled; it will also be respawned automatically on future assistant starts

The "also" makes clear the monitor is running now **and** the flag ensures it comes back on future starts — separating the immediate spawn from the persistence guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh6Pq5nqEMb4rP7w4b47YD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh6Pq5nqEMb4rP7w4b47YD)_