### PR TITLE
feat(gateway-client): stamp member interactionCount on the trust verdict

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4130,6 +4130,12 @@ paths:
                             - type: "null"
                         memberDisplayName:
                           type: string
+                        interactionCount:
+                          type: number
+                        lastInteraction:
+                          anyOf:
+                            - type: number
+                            - type: "null"
                       required:
                         - trustClass
                         - canonicalSenderId

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -47,6 +47,8 @@ function insertChannel(args: {
   policy?: string;
   verifiedAt?: number | null;
   verifiedVia?: string | null;
+  interactionCount?: number;
+  lastInteraction?: number | null;
 }): void {
   const now = Date.now();
   getGatewayDb()
@@ -61,7 +63,8 @@ function insertChannel(args: {
       policy: args.policy ?? "allow",
       verifiedAt: args.verifiedAt ?? now,
       verifiedVia: args.verifiedVia ?? "challenge",
-      interactionCount: 0,
+      interactionCount: args.interactionCount ?? 0,
+      lastInteraction: args.lastInteraction ?? null,
       createdAt: now,
     })
     .run();
@@ -131,6 +134,8 @@ describe("resolveTrustVerdict", () => {
       externalChatId: "chat-member",
       status: "active",
       verifiedVia: "manual",
+      interactionCount: 7,
+      lastInteraction: 1699990000,
     });
 
     const verdict = await resolveTrustVerdict({
@@ -147,6 +152,9 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.externalChatId).toBe("chat-member");
     expect(verdict.memberDisplayName).toBe("Trusted Member");
     expect(verdict.verifiedVia).toBe("manual");
+    // Interaction telemetry carried straight off the member channel row.
+    expect(verdict.interactionCount).toBe(7);
+    expect(verdict.lastInteraction).toBe(1699990000);
     // Guardian fields still populated from the channel binding.
     expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
   });
@@ -184,6 +192,9 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.channelId).toBeUndefined();
     expect(verdict.status).toBeUndefined();
     expect(verdict.guardianExternalUserId).toBeUndefined();
+    // No member channel → no interaction telemetry.
+    expect(verdict.interactionCount).toBeUndefined();
+    expect(verdict.lastInteraction).toBeUndefined();
   });
 
   test("no actorExternalId → unknown, canonicalSenderId null", async () => {

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -91,6 +91,8 @@ export async function resolveTrustVerdict(
           policy: gwContactChannels.policy,
           verifiedAt: gwContactChannels.verifiedAt,
           verifiedVia: gwContactChannels.verifiedVia,
+          interactionCount: gwContactChannels.interactionCount,
+          lastInteraction: gwContactChannels.lastInteraction,
           memberDisplayName: gwContacts.displayName,
           memberRole: gwContacts.role,
           memberPrincipalId: gwContacts.principalId,
@@ -228,6 +230,8 @@ export async function resolveTrustVerdict(
     verdict.policy = memberRow.policy;
     verdict.verifiedAt = memberRow.verifiedAt;
     verdict.verifiedVia = memberRow.verifiedVia;
+    verdict.interactionCount = memberRow.interactionCount;
+    verdict.lastInteraction = memberRow.lastInteraction;
     verdict.memberDisplayName = memberRow.memberDisplayName;
   }
 

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -29,6 +29,8 @@ const fullVerdict: TrustVerdict = {
   policy: "allow",
   verifiedAt: 1699999999,
   verifiedVia: "voice",
+  interactionCount: 12,
+  lastInteraction: 1699999998,
   memberDisplayName: "Member Name",
 };
 
@@ -90,6 +92,26 @@ describe("TrustVerdictSchema", () => {
       trustClass: "unknown",
       canonicalSenderId: null,
     });
+  });
+
+  test("carries interaction telemetry and tolerates a null lastInteraction", () => {
+    const parsed = TrustVerdictSchema.parse({
+      trustClass: "trusted_contact",
+      canonicalSenderId: "+15555550100",
+      interactionCount: 0,
+      lastInteraction: null,
+    });
+    expect(parsed.interactionCount).toBe(0);
+    expect(parsed.lastInteraction).toBeNull();
+  });
+
+  test("leaves interaction telemetry undefined when absent", () => {
+    const parsed = TrustVerdictSchema.parse({
+      trustClass: "unknown",
+      canonicalSenderId: null,
+    });
+    expect(parsed.interactionCount).toBeUndefined();
+    expect(parsed.lastInteraction).toBeUndefined();
   });
 
   test("rejects an invalid trustClass", () => {

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -77,6 +77,12 @@ export const TrustVerdictSchema = z.object({
   verifiedAt: z.number().nullable().optional(),
   verifiedVia: z.string().nullable().optional(),
   memberDisplayName: z.string().optional(),
+
+  // Gateway-owned interaction telemetry (a trust signal, not an info field per
+  // the 2×2) — carried straight off the member `contact_channels` row.
+  // Present only when a member channel resolves; absent for unknown senders.
+  interactionCount: z.number().optional(),
+  lastInteraction: z.number().nullable().optional(),
 });
 
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;


### PR DESCRIPTION
## Summary
- Add optional interactionCount (and lastInteraction) to the TrustVerdict member fields, populated from the already-loaded gateway contact_channels row. Additive; no consumer changes.

Part of plan: contacts-acl-cleanup.md (PR 6 of 14)