### PR TITLE
refactor(gateway): remove mark_channel_verified stub and stale dual-write docstrings

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -163,8 +163,6 @@ Verification SESSION state (pending sessions, codes, resend, rate-limit) is assi
 
 The verified outcome is written in-process by the gateway: the HTTP guardian-attest handler calls `ContactStore.markChannelVerified` directly (verifiedVia "manual"), and the inbound code-match path (`gateway/src/verification/text-verification.ts`) writes via `upsertVerifiedContactChannel` / `createGuardianBinding` (verifiedVia "challenge"). The revoke/downgrade outcome is relayed from the daemon via `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
 
-The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the outcome arrives via the inbound code-match path.
-
 ## Rate Limiting & Diagnostics
 
 Most `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -14,9 +14,6 @@
  *   inbound code-match path (`gateway/src/verification/text-verification.ts`).
  * - The revoke/downgrade OUTCOME is relayed from the daemon via
  *   `ipcCallPersistent("mark_channel_revoked", …)` to `ContactStore.markChannelRevoked`.
- * - The `mark_channel_verified` IPC method exists as the daemon/CLI relay surface (symmetric with
- *   `mark_channel_revoked`) but has no caller: the trusted-contact CLI path sends codes only, and the
- *   outcome arrives via the inbound code-match path.
  */
 
 import { z } from "zod";

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -1,10 +1,11 @@
 /**
- * Tests for the mark_channel_verified IPC handler in contact-handlers.
+ * Tests for the contact IPC write handlers (mark_channel_revoked,
+ * get_guardian_contact, upsert_verified_channel).
  *
- * The handler delegates to ContactStore.markChannelVerified and projects the
- * result into the contract-shaped envelope. The assistant DB proxy is mocked
- * behind a per-test fake so the not-found and assistant-mirror paths can be
- * exercised without a running daemon.
+ * The handlers delegate to ContactStore and project results into the
+ * contract-shaped envelopes. The assistant DB proxy is mocked behind a
+ * per-test fake so the assistant-mirror paths can be exercised without a
+ * running daemon.
  */
 
 import { describe, test, expect, beforeAll, beforeEach, afterAll, mock } from "bun:test";
@@ -82,10 +83,6 @@ import {
 } from "../db/connection.js";
 import { contacts, contactChannels } from "../db/schema.js";
 
-const markChannelVerifiedHandler = contactRoutes.find(
-  (r) => r.method === "mark_channel_verified",
-)!.handler;
-
 const markChannelRevokedHandler = contactRoutes.find(
   (r) => r.method === "mark_channel_revoked",
 )!.handler;
@@ -146,116 +143,6 @@ function seedChannel(opts: { id: string; contactId: string; status?: string }) {
     })
     .run();
 }
-
-function seedAssistantContact(id: string, role: string = "guardian"): void {
-  fakeAssistantDb.contacts.set(id, {
-    id,
-    display_name: `name-${id}`,
-    role,
-    principal_id: `prin-${id}`,
-    created_at: 100,
-    updated_at: 100,
-  });
-}
-
-function seedAssistantChannel(opts: {
-  id: string;
-  contactId: string;
-  status?: string;
-}): void {
-  fakeAssistantDb.channels.set(opts.id, {
-    id: opts.id,
-    contact_id: opts.contactId,
-    type: "vellum",
-    address: `addr-${opts.id}`,
-    is_primary: 0,
-    external_chat_id: null,
-    status: opts.status ?? "unverified",
-    policy: "allow",
-    verified_at: null,
-    verified_via: null,
-    invite_id: null,
-    revoked_reason: null,
-    blocked_reason: null,
-    last_seen_at: null,
-    interaction_count: 0,
-    last_interaction: null,
-    created_at: 100,
-    updated_at: 100,
-  });
-}
-
-describe("mark_channel_verified IPC handler", () => {
-  test("flips a seeded unverified channel to active + verified_via=challenge and returns the envelope", async () => {
-    seedContact("c1");
-    seedChannel({ id: "ch1", contactId: "c1", status: "unverified" });
-
-    const before = Date.now();
-    const res = (await markChannelVerifiedHandler({
-      contactChannelId: "ch1",
-    })) as {
-      ok: boolean;
-      didWrite: boolean;
-      channel: {
-        id: string;
-        contactId: string;
-        type: string;
-        address: string;
-        status: string;
-        verifiedAt: number | null;
-        verifiedVia: string | null;
-      };
-    };
-
-    // (b) response envelope is well-formed
-    expect(res.ok).toBe(true);
-    expect(res.didWrite).toBe(true);
-    expect(res.channel).toEqual({
-      id: "ch1",
-      contactId: "c1",
-      type: "vellum",
-      address: "addr-ch1",
-      status: "active",
-      verifiedAt: res.channel.verifiedAt,
-      verifiedVia: "challenge",
-    });
-
-    // (a) gateway DB row flipped to active / challenge / verified_at set
-    const row = getGatewayDb()
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, "ch1"))
-      .get();
-    expect(row!.status).toBe("active");
-    expect(row!.verifiedVia).toBe("challenge");
-    expect(row!.verifiedAt!).toBeGreaterThanOrEqual(before);
-  });
-
-  test("throws on a missing channel id (no silent success)", async () => {
-    await expect(
-      markChannelVerifiedHandler({ contactChannelId: "nonexistent" }),
-    ).rejects.toThrow(/not found/);
-  });
-
-  test("does not verify a channel absent from the gateway DB", async () => {
-    seedAssistantContact("c1");
-    seedAssistantChannel({ id: "ch1", contactId: "c1", status: "unverified" });
-
-    // The channel lives only in the assistant DB. The gateway DB is the source
-    // of truth and does not heal from the assistant, so verification reports
-    // not found and nothing lands in the gateway DB.
-    await expect(
-      markChannelVerifiedHandler({ contactChannelId: "ch1" }),
-    ).rejects.toThrow(/not found/);
-
-    const channelInGateway = getGatewayDb()
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.id, "ch1"))
-      .get();
-    expect(channelInGateway).toBeUndefined();
-  });
-});
 
 describe("mark_channel_revoked IPC handler", () => {
   test("downgrades a contact channel to revoked + reason and returns the envelope", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -517,10 +517,9 @@ export class ContactStore {
   }
 
   /**
-   * Update a channel's status and/or policy in the gateway DB, then
-   * best-effort dual-write to the assistant DB.
+   * Update a channel's status and/or policy in the gateway DB.
    *
-   * Returns the updated channel, or null if not found in either DB.
+   * Returns the updated channel, or null if not found.
    * Throws if a blocked channel is being revoked (caller maps to 409).
    *
    * `revokedReason` / `blockedReason` are set based on the new status:

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -14,8 +14,6 @@ import {
   ListContactsIpcParamsSchema,
   MarkChannelRevokedIpcParamsSchema,
   MarkChannelRevokedIpcResponseSchema,
-  MarkChannelVerifiedIpcParamsSchema,
-  MarkChannelVerifiedIpcResponseSchema,
   UpdateContactChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcResponseSchema,
@@ -206,35 +204,6 @@ export const contactRoutes: IpcRoute[] = [
       // server's buildErrorResponse mirrors into the wire envelope; unexpected
       // errors propagate as a generic IPC error (no fallback).
       return updateContactChannelCore(parsed);
-    },
-  },
-  {
-    method: "mark_channel_verified",
-    schema: MarkChannelVerifiedIpcParamsSchema,
-    handler: async (params?: Record<string, unknown>) => {
-      const { contactChannelId, verifiedVia } =
-        MarkChannelVerifiedIpcParamsSchema.parse(params);
-      const result = await getStore().markChannelVerified(
-        contactChannelId,
-        verifiedVia,
-      );
-      if (!result) {
-        throw new Error(`Channel "${contactChannelId}" not found`);
-      }
-      const { channel, didWrite } = result;
-      return MarkChannelVerifiedIpcResponseSchema.parse({
-        ok: true,
-        didWrite,
-        channel: {
-          id: channel.id,
-          contactId: channel.contactId,
-          type: channel.type,
-          address: channel.address,
-          status: channel.status,
-          verifiedAt: channel.verifiedAt,
-          verifiedVia: channel.verifiedVia,
-        },
-      });
     },
   },
   {


### PR DESCRIPTION
## Summary
- Delete the callerless mark_channel_verified IPC stub and correct stale dual-write docstrings; the function is gateway-only.

Part of plan: contacts-acl-cleanup.md (PR 2 of 14)