### PR TITLE
fix(security): stop cross-channel address collisions from conferring guardian class

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -165,13 +165,13 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
     expect(findContactChannelCalls.length).toBe(0);
   });
 
-  test("member-less guardian verdict is admitted and never fires an access request", async () => {
-    // A guardian classified by principal reaches this channel with NO
-    // per-channel member row: trustClass is "guardian" but the verdict
-    // carries no contactId/channelId/status/policy. The guardian
-    // short-circuit must admit them instead of routing them into the
-    // stranger branch, which fires notifyGuardianOfAccessRequest at the
-    // guardian themselves.
+  test("member-less guardian verdict fails safe: denied with no stranger-lane side effects", async () => {
+    // ATL-958 regression: the gateway proves guardian identity via a
+    // same-channel member row, so every guardian verdict carries one. A
+    // guardian verdict with NO member row is contradictory (e.g. a forged
+    // cross-channel classification) and must not be admitted — but it must
+    // not be routed through the stranger lane either, which would fire an
+    // access request carrying the claimed guardian identity.
     const result = await enforceIngressAcl(
       makeParams({
         sourceMetadata: withVerdict({
@@ -182,10 +182,15 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
       }),
     );
 
-    expect(result.earlyResponse).toBeUndefined();
+    expect(result.earlyResponse).toMatchObject({
+      accepted: true,
+      denied: true,
+      reason: "not_a_member",
+    });
     expect(result.resolvedMember).toBeNull();
     expect(accessRequestCalls.length).toBe(0);
     expect(deliverReplyCalls.length).toBe(0);
+    expect(createOutboundSessionCalls.length).toBe(0);
   });
 
   test("guardian verdict with an inactive (pending) member row is still admitted", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -241,20 +241,35 @@ export async function enforceIngressAcl(
   }
 
   // ── Guardian short-circuit ──
-  // A verdict classified `guardian` is admitted even when it carries no
-  // per-channel member row (`resolvedMember` null) or an inactive one. The
-  // gateway classifies guardians by principal, so a guardian speaking on a
-  // channel where they hold no same-channel binding must not fall through the
-  // member-vs-stranger gates below — those would misroute the guardian into
-  // the stranger lane and fire an access request at the guardian themselves.
+  // A verdict classified `guardian` is admitted even when its same-channel
+  // member row is inactive (e.g. pending): the gateway classifies guardians
+  // by principal, so a guardian speaking on a channel where they hold no
+  // active guardian binding must not fall through the member-vs-stranger
+  // gates below — those would misroute the guardian into the stranger lane
+  // and fire an access request at the guardian themselves.
   if (verdict.trustClass === "guardian") {
+    // The gateway proves guardian identity via a same-channel member row
+    // (the active binding address, or a row belonging to the guardian
+    // contact), so every guardian verdict carries a resolvable member row.
+    // A guardian verdict WITHOUT one is contradictory — cross-channel
+    // address collisions are not identity proofs and must never confer
+    // guardian capabilities. Fail safe: soft-deny with no stranger-lane
+    // side effects.
+    if (!resolvedMember) {
+      log.warn(
+        { sourceChannel, externalUserId: canonicalSenderId },
+        "Ingress ACL: guardian verdict without a member row, denying fail-safe",
+      );
+      return failClosedDeny();
+    }
+
     // The gateway never classifies a blocked/revoked same-channel row as
     // guardian (explicit per-channel governance wins over the principal
     // check), so a verdict claiming both is contradictory. Fail safe:
     // soft-deny with no stranger-lane side effects.
     if (
-      resolvedMember?.status === "blocked" ||
-      resolvedMember?.status === "revoked"
+      resolvedMember.status === "blocked" ||
+      resolvedMember.status === "revoked"
     ) {
       log.warn(
         {
@@ -272,7 +287,7 @@ export async function enforceIngressAcl(
     // classification. Deny with the accurate policy_deny reason but none of
     // the stranger-lane side effects — the canned "ask the guardian" reply
     // would be addressed at the guardian themselves.
-    if (resolvedMember?.policy === "deny") {
+    if (resolvedMember.policy === "deny") {
       log.info(
         { sourceChannel, externalUserId: canonicalSenderId },
         "Ingress ACL: guardian member row carries policy deny, denying",

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -297,11 +297,12 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.trustClass).toBe("guardian");
   });
 
-  test("guardian with no same-channel binding sends on another channel → guardian by principal", async () => {
-    // Guardian is bound (active) only on the vellum anchor channel; they send
-    // on telegram with the same identity. The same-channel binding lookup
-    // finds nothing, but the principal-level check maps the sender to the
-    // guardian contact — never the stranger lane.
+  test("memberless sender whose address collides with the guardian's address on another channel type stays unknown", async () => {
+    // ATL-958 regression: external identifiers are channel-local namespaces.
+    // A telegram sender with NO telegram member row whose id happens to equal
+    // the guardian's vellum address is NOT the guardian — raw cross-channel
+    // address equality must never confer the class (it would grant
+    // self-approval, unsandboxed shell, and memory access to a spoofable id).
     insertContact({
       id: "c-guardian",
       displayName: "Principal Guardian",
@@ -321,13 +322,11 @@ describe("resolveTrustVerdict", () => {
       actorExternalId: "GUARDIAN_ID",
     });
 
-    expect(verdict.trustClass).toBe("guardian");
-    expect(verdict.guardianPrincipalId).toBe("principal-1");
-    expect(verdict.guardianDisplayName).toBe("Principal Guardian");
-    // No same-channel binding → delivery fields stay absent.
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBeUndefined();
+    expect(verdict.guardianPrincipalId).toBeUndefined();
+    expect(verdict.guardianDisplayName).toBeUndefined();
     expect(verdict.guardianExternalUserId).toBeUndefined();
-    expect(verdict.guardianDeliveryChatId).toBeUndefined();
-    // No same-channel member row either.
     expect(verdict.contactId).toBeUndefined();
   });
 
@@ -398,38 +397,13 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.status).toBe("blocked");
   });
 
-  test("guardian identity with a NULL principal is unresolved → resolutionFailed, not guardian", async () => {
-    // Pre-cutover artifact: an active guardian row whose contact has no
-    // principal. Classifying `guardian` would confer self-approving
-    // capabilities with nothing to authorize decisions against; classifying
-    // plain `unknown` would route the guardian through the stranger lane.
-    // The verdict is could-not-vouch instead: the consumer soft-denies with
-    // no stranger-lane side effects.
-    insertContact({
-      id: "c-guardian",
-      displayName: "Principal-less Guardian",
-      role: "guardian",
-      // principalId intentionally absent (NULL).
-    });
-    insertChannel({
-      id: "ch-guardian-vellum",
-      contactId: "c-guardian",
-      type: "vellum",
-      address: "GUARDIAN_ID",
-      status: "active",
-    });
-
-    const verdict = await resolveTrustVerdict({
-      channelType: CHANNEL,
-      actorExternalId: "GUARDIAN_ID",
-    });
-
-    expect(verdict.trustClass).toBe("unknown");
-    expect(verdict.resolutionFailed).toBe(true);
-    expect(verdict.guardianPrincipalId).toBeUndefined();
-  });
-
-  test("guardian identity via a pending member row with a NULL principal is also unresolved", async () => {
+  test("guardian identity via a pending member row with a NULL principal is unresolved → resolutionFailed, not guardian", async () => {
+    // Pre-cutover artifact: the sender's same-channel row belongs to a
+    // guardian contact that has no principal. Classifying `guardian` would
+    // confer self-approving capabilities with nothing to authorize decisions
+    // against; classifying plain `unknown` would route the guardian through
+    // the stranger lane. The verdict is could-not-vouch instead: the
+    // consumer soft-denies with no stranger-lane side effects.
     insertContact({
       id: "c-guardian",
       displayName: "Principal-less Guardian",
@@ -476,8 +450,9 @@ describe("resolveTrustVerdict", () => {
       policy: "deny",
     });
 
-    // Sender matches the revoked vellum address on telegram (no telegram row):
-    // the principal-level check requires an ACTIVE guardian channel → unknown.
+    // Sender matches the revoked vellum address on telegram (no telegram
+    // row): a memberless sender is a stranger — and even with a row, the
+    // principal-level check requires an ACTIVE guardian channel → unknown.
     const verdict = await resolveTrustVerdict({
       channelType: CHANNEL,
       actorExternalId: "OLD_GUARDIAN_ID",

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -35,14 +35,18 @@ export interface ResolveTrustVerdictInput {
  * 4. Classify guardian > trusted_contact > unverified_contact > unknown.
  *
  * Guardian classification is by principal, not only by same-channel binding:
- * a sender whose identity maps to the guardian contact (via this channel's
- * member row, or via an active guardian channel on any channel type) is
- * classified `guardian` even without a same-channel guardian binding. A
- * blocked/revoked same-channel row always wins (stays `unknown`), a guardian
- * contact with no active channel anywhere never re-acquires the class, and a
- * matched guardian identity whose contact has NO principal is unresolved —
- * it yields a `resolutionFailed` verdict (consumer soft-denies, no
- * stranger-lane side effects) rather than `guardian` or `unknown`.
+ * a sender whose member row on THIS channel belongs to the guardian contact
+ * is classified `guardian` even without a same-channel guardian binding
+ * (e.g. the row is pending/unverified), provided that contact still holds an
+ * ACTIVE channel. Identity is proven only by the same-channel member row —
+ * external identifiers are channel-local namespaces, so a sender with no
+ * member row on this channel is a stranger regardless of address collisions
+ * with guardian channels on other channel types. A blocked/revoked
+ * same-channel row always wins (stays `unknown`), a guardian contact with no
+ * active channel anywhere never re-acquires the class, and a matched
+ * guardian identity whose contact has NO principal is unresolved — it yields
+ * a `resolutionFailed` verdict (consumer soft-denies, no stranger-lane side
+ * effects) rather than `guardian` or `unknown`.
  */
 export async function resolveTrustVerdict(
   input: ResolveTrustVerdictInput,
@@ -129,25 +133,23 @@ export async function resolveTrustVerdict(
 
   // --- Guardian-by-principal (sender maps to the guardian contact) ---
   // The same-channel address match above fails for a guardian speaking on a
-  // channel where they hold no active guardian binding. Never route the
-  // guardian through the stranger lane: when the sender's identity maps to
-  // the guardian contact — via this channel's member row, or (with no member
-  // row) via the sender's address on any channel type — and that contact
-  // still holds an ACTIVE channel, classify `guardian`. Requiring an active
-  // channel means a fully revoked guardian never re-acquires the class. A
-  // non-guardian member row wins over any cross-channel address collision,
-  // so no identity filter is built for it.
-  const guardianIdentityFilter = memberRow
-    ? memberRow.memberRole === "guardian"
+  // channel where their row is not the active guardian binding (e.g. a
+  // pending/unverified row). When the sender's member row on THIS channel
+  // belongs to the guardian contact and that contact still holds an ACTIVE
+  // channel, classify `guardian`. Requiring an active channel means a fully
+  // revoked guardian never re-acquires the class. Identity is proven ONLY by
+  // the same-channel member row: external identifiers are channel-local
+  // namespaces, so a raw address match against guardian channels of OTHER
+  // channel types is not an identity proof — a sender with no member row on
+  // this channel stays in the stranger lane no matter what their address
+  // equals elsewhere.
+  const guardianIdentityFilter =
+    memberRow && memberRow.memberRole === "guardian"
       ? eq(gwContacts.id, memberRow.contactId)
-      : null
-    : sql`${gwContactChannels.address} = ${canonicalSenderId} COLLATE NOCASE`;
+      : null;
 
   const guardianIdentityMatch =
-    !isGuardian &&
-    canonicalSenderId &&
-    !memberDeniedByStatus &&
-    guardianIdentityFilter
+    !isGuardian && !memberDeniedByStatus && guardianIdentityFilter
       ? (db
           .select({
             principalId: gwContacts.principalId,


### PR DESCRIPTION
## Prompt / plan

Fixes [ATL-958](https://linear.app/vellum/issue/ATL-958/security-cross-channel-address-match-grants-guardian-privileges) (critical Codex security finding).

**The bug:** the gateway trust-verdict resolver's guardian-by-principal path (`gateway/src/risk/trust-verdict-resolver.ts`) handled memberless senders by matching `contact_channels.address = canonicalSenderId` with **no channel-type constraint**. External identifiers are channel-local namespaces, so a sender on one channel whose id happened to equal the guardian's address on *another* channel type (e.g. an email `From:` address equal to the guardian's vellum/Telegram id) was classified `guardian`, carrying the real `guardianPrincipalId`. The runtime's guardian short-circuit then admitted the verdict even with `resolvedMember` null, granting guardian capabilities (tool self-approval, unsandboxed shell, memory access).

**The fix (two layers):**

1. **Gateway (root cause):** guardian-by-principal now requires the sender's member row **on the inbound channel** to belong to the guardian contact (and that contact must still hold an active channel, as before). The memberless cross-channel raw-address fallback is removed — a sender with no member row on the inbound channel stays in the stranger lane regardless of address collisions elsewhere. This matches the daemon's canonical resolver (`actor-trust-resolver.ts`), which never had a cross-channel fallback. The legitimate case the removed branch aimed at (guardian on a channel where they hold no row at all) now routes through the normal verification/access-request flow, which is the correct mechanism when identity cannot be proven.
2. **Runtime (defense in depth, per the symmetric-enforcement doctrine in `gateway/AGENTS.md`):** after the resolver fix, every `guardian` verdict carries a same-channel member row by construction, so the ingress ACL guardian short-circuit (`assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts`) now fail-safe soft-denies a guardian verdict with no resolvable member row (no stranger-lane side effects), same as the existing contradictory blocked/revoked-row check.

Unchanged (still intentional): a guardian whose same-channel row is pending/unverified is still classified `guardian` when the guardian contact holds an active channel; blocked/revoked rows still hard-win; NULL-principal guardian identities still yield `resolutionFailed` soft-deny.

## Test plan

- `gateway`: `bun test src/risk/__tests__/trust-verdict-resolver.test.ts src/__tests__/handle-inbound-trust-verdict.test.ts src/ipc/__tests__/trust-verdict-handlers.test.ts` — 34 pass. The test pinning the vulnerable behavior is replaced with an ATL-958 regression test asserting a memberless cross-channel address collision resolves `unknown` with no guardian fields; the memberless NULL-principal `resolutionFailed` test is removed (that path no longer exists — the same-channel member-row variant still covers the semantics).
- `assistant`: `bun test src/runtime/routes/inbound-stages/acl-enforcement.test.ts src/__tests__/inbound-trust-verdict.test.ts src/runtime/__tests__/trust-verdict-consumer.test.ts` — 64 pass. The member-less-guardian-admitted test is flipped to assert fail-safe deny with no access request, no canned reply, and no verification challenge.
- `bunx tsc --noEmit` (gateway) and `bun run typecheck:fast` (assistant) pass; eslint + prettier clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXbgcqVTuVihueotuNftKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXbgcqVTuVihueotuNftKE)_