### PR TITLE
feat(calls): add STT+TTS credential-readiness resolver for telephony

### DIFF
--- a/assistant/src/__tests__/telephony-credential-preflight.test.ts
+++ b/assistant/src/__tests__/telephony-credential-preflight.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the telephony credential-readiness preflight resolver.
+ *
+ * The STT capability resolver, TTS capability resolver, TTS fallback
+ * scanner, and config loader are mocked so the readiness combination logic
+ * is exercised in isolation. `mock.module` is process-global in Bun and
+ * leaks into sibling files that run later in the same `bun test`
+ * invocation, so each stub delegates to the real implementation unless this
+ * file's tests are active (`preflightMocksActive`, toggled in
+ * beforeAll/afterAll). The real exports are snapshotted into plain objects
+ * NOW, before the stubs register — a module namespace is a live view, so
+ * reading the real export after the stub installs would resolve back to
+ * the stub (infinite recursion).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+let preflightMocksActive = false;
+
+const realSttResolveModule = {
+  ...(await import("../providers/speech-to-text/resolve.js")),
+};
+const realTtsCapabilityModule = {
+  ...(await import("../calls/telephony-tts-capability.js")),
+};
+const realCallTtsResolverModule = {
+  ...(await import("../calls/resolve-call-tts-provider.js")),
+};
+const realConfigLoaderModule = { ...(await import("../config/loader.js")) };
+
+// -- Mutable capability results -----------------------------------------------
+
+import type { TelephonyTtsCapability } from "../calls/telephony-tts-capability.js";
+import type { TelephonySttCapability } from "../providers/speech-to-text/resolve.js";
+import type { TtsProviderId } from "../tts/types.js";
+
+let sttCapability: TelephonySttCapability;
+let ttsCapability: TelephonyTtsCapability;
+let fallbackProviderId: TtsProviderId | null;
+let fallbackScanCalls: Array<TtsProviderId | undefined> = [];
+
+const testConfig = {
+  services: { stt: { provider: "acme-stt" } },
+} as unknown as ReturnType<typeof realConfigLoaderModule.getConfig>;
+
+mock.module("../providers/speech-to-text/resolve.js", () => ({
+  ...realSttResolveModule,
+  resolveTelephonySttCapability: async () =>
+    preflightMocksActive
+      ? sttCapability
+      : realSttResolveModule.resolveTelephonySttCapability(),
+}));
+
+mock.module("../calls/telephony-tts-capability.js", () => ({
+  ...realTtsCapabilityModule,
+  resolveTelephonyTtsCapability: async () =>
+    preflightMocksActive
+      ? ttsCapability
+      : realTtsCapabilityModule.resolveTelephonyTtsCapability(),
+}));
+
+mock.module("../calls/resolve-call-tts-provider.js", () => ({
+  ...realCallTtsResolverModule,
+  findPlayableTelephonyTtsFallback: async (
+    excludeProviderId?: TtsProviderId,
+  ) => {
+    if (!preflightMocksActive) {
+      return realCallTtsResolverModule.findPlayableTelephonyTtsFallback(
+        excludeProviderId,
+      );
+    }
+    fallbackScanCalls.push(excludeProviderId);
+    return fallbackProviderId;
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  ...realConfigLoaderModule,
+  getConfig: () =>
+    preflightMocksActive ? testConfig : realConfigLoaderModule.getConfig(),
+}));
+
+import { resolveTelephonyCredentialReadiness } from "../calls/telephony-credential-preflight.js";
+
+beforeAll(() => {
+  preflightMocksActive = true;
+});
+
+afterAll(() => {
+  preflightMocksActive = false;
+});
+
+beforeEach(() => {
+  sttCapability = {
+    status: "supported",
+    providerId: "deepgram",
+    telephonyMode: "realtime-ws",
+  };
+  ttsCapability = { status: "playable", providerId: "elevenlabs" };
+  fallbackProviderId = null;
+  fallbackScanCalls = [];
+});
+
+describe("resolveTelephonyCredentialReadiness", () => {
+  test("STT supported + TTS playable → ready", async () => {
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+    // A playable configured provider never triggers the fallback scan.
+    expect(fallbackScanCalls).toEqual([]);
+  });
+
+  test("STT missing-credentials → not-ready with an stt entry naming the provider", async () => {
+    sttCapability = {
+      status: "missing-credentials",
+      providerId: "deepgram",
+      credentialProvider: "deepgram",
+      reason: 'No API key configured for credential provider "deepgram"',
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "deepgram",
+        reason: 'No API key configured for credential provider "deepgram"',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain("speech-to-text");
+  });
+
+  test("STT unconfigured → not-ready with the configured provider id", async () => {
+    sttCapability = {
+      status: "unconfigured",
+      reason: 'STT provider "acme-stt" is not in the provider catalog',
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "acme-stt",
+        reason: 'STT provider "acme-stt" is not in the provider catalog',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"acme-stt"');
+  });
+
+  test("STT unsupported → not-ready", async () => {
+    sttCapability = {
+      status: "unsupported",
+      providerId: "openai-whisper",
+      reason: 'STT provider "openai-whisper" does not support telephony',
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "openai-whisper",
+        reason: 'STT provider "openai-whisper" does not support telephony',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"openai-whisper"');
+  });
+
+  test("TTS not-playable but a credentialed playable fallback exists → ready", async () => {
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "compressed-only" as TtsProviderId,
+      reason: "unsupported-format",
+    };
+    fallbackProviderId = "elevenlabs";
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+    // The scan excludes the configured provider.
+    expect(fallbackScanCalls).toEqual(["compressed-only" as TtsProviderId]);
+  });
+
+  test("TTS not-playable with no fallback → not-ready with a tts entry naming the provider", async () => {
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "elevenlabs",
+      reason: "missing-credentials",
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "elevenlabs",
+        reason:
+          'TTS provider "elevenlabs" is missing credentials and no playable fallback provider is available',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"elevenlabs"');
+    expect(readiness.userMessage).toContain("text-to-speech");
+  });
+
+  test("TTS unsupported-format with no fallback → not-ready with a tts entry", async () => {
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "compressed-only" as TtsProviderId,
+      reason: "unsupported-format",
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "compressed-only",
+        reason:
+          'TTS provider "compressed-only" cannot produce media-stream-playable audio and no playable fallback provider is available',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"compressed-only"');
+  });
+
+  test("both STT and TTS missing → both entries, message names both providers", async () => {
+    sttCapability = {
+      status: "missing-credentials",
+      providerId: "deepgram",
+      credentialProvider: "deepgram",
+      reason: 'No API key configured for credential provider "deepgram"',
+    };
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "elevenlabs",
+      reason: "missing-credentials",
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing.map((gap) => gap.kind)).toEqual(["stt", "tts"]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain('"elevenlabs"');
+    // Single sentence: suitable for both a tool error and a TwiML <Say>.
+    expect(readiness.userMessage).not.toContain("\n");
+    expect(readiness.userMessage.endsWith(".")).toBe(true);
+  });
+});

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -1,0 +1,147 @@
+/**
+ * Telephony credential-readiness preflight.
+ *
+ * Transport contract: on ConversationRelay, Twilio performs Deepgram/Google
+ * STT and TTS with Twilio-held keys, so calls work without the user holding
+ * any provider credentials. On the media-stream transport the daemon performs
+ * both legs itself — Twilio only carries mu-law audio frames — so a call can
+ * only work when the user holds credentials for a telephony-capable STT
+ * provider AND a media-stream-playable TTS provider (the configured one, or
+ * a credentialed playable fallback from the catalog).
+ *
+ * This resolver combines the two capability resolvers into a single
+ * ready / not-ready verdict with a user-facing message suitable for both a
+ * call-tool error result and TwiML <Say> copy. It creates no provider
+ * instances and performs no call-site wiring — callers gate outbound call
+ * placement and inbound TwiML on the verdict.
+ */
+
+import { getConfig } from "../config/loader.js";
+import type { TelephonySttCapability } from "../providers/speech-to-text/resolve.js";
+import { resolveTelephonySttCapability } from "../providers/speech-to-text/resolve.js";
+import { findPlayableTelephonyTtsFallback } from "./resolve-call-tts-provider.js";
+import type { TelephonyTtsNotPlayableReason } from "./telephony-tts-capability.js";
+import { resolveTelephonyTtsCapability } from "./telephony-tts-capability.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single credential/capability gap blocking telephony readiness. */
+export interface TelephonyCredentialGap {
+  kind: "stt" | "tts";
+  providerId: string;
+  reason: string;
+}
+
+/** Result of resolving whether telephony STT+TTS credentials are in order. */
+export type TelephonyCredentialReadiness =
+  | { status: "ready" }
+  | {
+      status: "not-ready";
+      missing: TelephonyCredentialGap[];
+      /**
+       * A single human-readable sentence naming the offending provider(s)
+       * and missing credential(s), suitable for both a tool error result
+       * and TwiML <Say> copy.
+       */
+      userMessage: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve whether the daemon can run both legs of a phone call.
+ *
+ * Readiness requires:
+ * - STT: `resolveTelephonySttCapability()` returns `"supported"`.
+ * - TTS: `resolveTelephonyTtsCapability()` returns `"playable"`, or a
+ *   credentialed playable fallback provider exists
+ *   ({@link findPlayableTelephonyTtsFallback}) — the call TTS resolver
+ *   swaps in that fallback at synthesis time, so readiness is satisfied
+ *   even when the configured provider is not playable.
+ */
+export async function resolveTelephonyCredentialReadiness(): Promise<TelephonyCredentialReadiness> {
+  const [stt, tts] = await Promise.all([
+    resolveTelephonySttCapability(),
+    resolveTelephonyTtsCapability(),
+  ]);
+
+  const missing: TelephonyCredentialGap[] = [];
+  const clauses: string[] = [];
+
+  if (stt.status !== "supported") {
+    const providerId =
+      "providerId" in stt ? stt.providerId : getConfig().services.stt.provider;
+    missing.push({ kind: "stt", providerId, reason: stt.reason });
+    clauses.push(sttGapClause(stt, providerId));
+  }
+
+  if (tts.status === "not-playable") {
+    const fallbackId = await findPlayableTelephonyTtsFallback(tts.providerId);
+    if (!fallbackId) {
+      const { gap, clause } = ttsGap(tts.providerId, tts.reason);
+      missing.push(gap);
+      clauses.push(clause);
+    }
+  }
+
+  if (missing.length === 0) {
+    return { status: "ready" };
+  }
+
+  return {
+    status: "not-ready",
+    missing,
+    userMessage: `Phone calls are unavailable because they require ${clauses.join(" and ")}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** User-message clause for an STT capability gap. */
+function sttGapClause(
+  capability: Exclude<TelephonySttCapability, { status: "supported" }>,
+  providerId: string,
+): string {
+  switch (capability.status) {
+    case "missing-credentials": {
+      return `an API key for the speech-to-text provider "${providerId}"`;
+    }
+    case "unsupported": {
+      return `a speech-to-text provider that supports phone calls (the configured "${providerId}" does not)`;
+    }
+    case "unconfigured": {
+      return `a recognized speech-to-text provider (the configured "${providerId}" is not in the provider catalog)`;
+    }
+  }
+}
+
+/** Gap entry and user-message clause for a TTS playability gap with no usable fallback. */
+function ttsGap(
+  providerId: string,
+  reason: TelephonyTtsNotPlayableReason,
+): { gap: TelephonyCredentialGap; clause: string } {
+  if (reason === "missing-credentials") {
+    return {
+      gap: {
+        kind: "tts",
+        providerId,
+        reason: `TTS provider "${providerId}" is missing credentials and no playable fallback provider is available`,
+      },
+      clause: `an API key for the text-to-speech provider "${providerId}" (no fallback provider has usable credentials)`,
+    };
+  }
+  return {
+    gap: {
+      kind: "tts",
+      providerId,
+      reason: `TTS provider "${providerId}" cannot produce media-stream-playable audio and no playable fallback provider is available`,
+    },
+    clause: `a text-to-speech provider that can produce call audio (the configured "${providerId}" cannot, and no fallback provider is usable)`,
+  };
+}


### PR DESCRIPTION
## Summary
- New resolveTelephonyCredentialReadiness() combines the STT and TTS telephony capability resolvers into a single ready/not-ready verdict with an actionable user message
- Pure module, no call sites yet — wired into outbound placement and inbound TwiML by the routing-flip PR

Part of plan: phone-media-stream-v2.md (PR 10 of 17)