### PR TITLE
feat(assistant): typed contacts_info_batch + channel identity lookup IPC; retire raw info SELECTs

### DIFF
--- a/assistant/src/ipc/__tests__/contacts-info-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/contacts-info-ipc.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the daemon-side contact INFO-READ IPC handlers
+ * (ipc/routes/contacts-info-ipc-routes.ts). Each handler reads the real
+ * (isolated) assistant DB, so we seed rows via getSqlite() and invoke the
+ * handler with `{ body }` exactly as the IPC server would.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqlite } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import {
+  handleContactChannelIdentityLookup,
+  handleContactMirrorProbe,
+  handleContactsInfoBatch,
+  handleContactUserFileSlugs,
+} from "../routes/contacts-info-ipc-routes.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function insertContact(params: {
+  id: string;
+  displayName?: string;
+  notes?: string | null;
+  userFile?: string | null;
+  contactType?: "human" | "assistant";
+}): void {
+  const now = Date.now();
+  getSqlite().run(
+    "INSERT INTO contacts (id, display_name, notes, user_file, contact_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    [
+      params.id,
+      params.displayName ?? `name-${params.id}`,
+      params.notes ?? null,
+      params.userFile ?? null,
+      params.contactType ?? "human",
+      now,
+      now,
+    ],
+  );
+}
+
+function insertChannel(params: {
+  id: string;
+  contactId: string;
+  type?: string;
+  address: string;
+  externalChatId?: string | null;
+}): void {
+  const now = Date.now();
+  getSqlite().run(
+    "INSERT INTO contact_channels (id, contact_id, type, address, is_primary, external_chat_id, interaction_count, created_at, updated_at) VALUES (?, ?, ?, ?, 0, ?, 0, ?, ?)",
+    [
+      params.id,
+      params.contactId,
+      params.type ?? "telegram",
+      params.address,
+      params.externalChatId ?? null,
+      now,
+      now,
+    ],
+  );
+}
+
+function insertMetadata(params: {
+  contactId: string;
+  species: string;
+  metadata?: Record<string, unknown> | null;
+}): void {
+  getSqlite().run(
+    "INSERT INTO assistant_contact_metadata (contact_id, species, metadata) VALUES (?, ?, ?)",
+    [
+      params.contactId,
+      params.species,
+      params.metadata != null ? JSON.stringify(params.metadata) : null,
+    ],
+  );
+}
+
+beforeEach(() => {
+  resetTables();
+});
+
+// ── contacts_info_batch ──────────────────────────────────────────────────────
+
+describe("handleContactsInfoBatch", () => {
+  test("empty contactIds returns empty infos", () => {
+    const result = handleContactsInfoBatch({ body: { contactIds: [] } });
+    expect(result).toEqual({ infos: [] });
+  });
+
+  test("returns info fields and gates assistant metadata on contactType", () => {
+    insertContact({ id: "c1", notes: "friend", contactType: "human" });
+    insertContact({ id: "c2", contactType: "assistant" });
+    insertMetadata({ contactId: "c2", species: "vellum", metadata: { model: "opus" } });
+
+    const result = handleContactsInfoBatch({
+      body: { contactIds: ["c1", "c2", "missing"] },
+    }) as { infos: Array<Record<string, unknown>> };
+
+    expect(result.infos).toHaveLength(2);
+    const c1 = result.infos.find((i) => i.contactId === "c1")!;
+    expect(c1.notes).toBe("friend");
+    expect(c1.contactType).toBe("human");
+    expect(c1.assistantMetadata).toBeNull();
+
+    const c2 = result.infos.find((i) => i.contactId === "c2")!;
+    expect(c2.contactType).toBe("assistant");
+    expect(c2.assistantMetadata).toEqual({
+      species: "vellum",
+      metadata: { model: "opus" },
+    });
+  });
+
+  test("does not emit metadata for human contact with stale species row", () => {
+    insertContact({ id: "c1", contactType: "human" });
+    insertMetadata({ contactId: "c1", species: "vellum", metadata: { x: 1 } });
+
+    const result = handleContactsInfoBatch({
+      body: { contactIds: ["c1"] },
+    }) as { infos: Array<Record<string, unknown>> };
+    expect(result.infos[0].assistantMetadata).toBeNull();
+  });
+
+  test("malformed metadata JSON degrades to null metadata", () => {
+    insertContact({ id: "c1", contactType: "assistant" });
+    getSqlite().run(
+      "INSERT INTO assistant_contact_metadata (contact_id, species, metadata) VALUES (?, ?, ?)",
+      ["c1", "vellum", "{not valid json"],
+    );
+
+    const result = handleContactsInfoBatch({
+      body: { contactIds: ["c1"] },
+    }) as { infos: Array<Record<string, unknown>> };
+    expect(result.infos[0].assistantMetadata).toEqual({
+      species: "vellum",
+      metadata: null,
+    });
+  });
+
+  test("rejects a malformed body (non-array contactIds)", () => {
+    expect(() =>
+      handleContactsInfoBatch({ body: { contactIds: "nope" } as never }),
+    ).toThrow();
+  });
+});
+
+// ── contact_channel_identity_lookup ──────────────────────────────────────────
+
+describe("handleContactChannelIdentityLookup", () => {
+  test("resolves by (type, address) case-insensitively", () => {
+    insertContact({ id: "c1", displayName: "Alice" });
+    insertChannel({
+      id: "ch1",
+      contactId: "c1",
+      type: "email",
+      address: "Alice@Example.com",
+      externalChatId: "chat-1",
+    });
+
+    const result = handleContactChannelIdentityLookup({
+      body: { type: "email", address: "alice@example.com" },
+    }) as { channel: Record<string, unknown> | null };
+
+    expect(result.channel).toEqual({
+      id: "ch1",
+      contactId: "c1",
+      type: "email",
+      address: "Alice@Example.com",
+      externalChatId: "chat-1",
+      displayName: "Alice",
+    });
+  });
+
+  test("resolves by channelId", () => {
+    insertContact({ id: "c1", displayName: "Bob" });
+    insertChannel({ id: "ch1", contactId: "c1", type: "slack", address: "U123" });
+
+    const result = handleContactChannelIdentityLookup({
+      body: { channelId: "ch1" },
+    }) as { channel: Record<string, unknown> | null };
+    expect(result.channel?.type).toBe("slack");
+    expect(result.channel?.address).toBe("U123");
+    expect(result.channel?.displayName).toBe("Bob");
+  });
+
+  test("returns null when no channel matches", () => {
+    const result = handleContactChannelIdentityLookup({
+      body: { channelId: "nope" },
+    });
+    expect(result).toEqual({ channel: null });
+  });
+
+  test("rejects a selector with neither channelId nor (type,address)", () => {
+    expect(() =>
+      handleContactChannelIdentityLookup({ body: { type: "email" } }),
+    ).toThrow();
+  });
+});
+
+// ── contact_mirror_probe ─────────────────────────────────────────────────────
+
+describe("handleContactMirrorProbe", () => {
+  test("reports absence when the contact is not mirrored", () => {
+    const result = handleContactMirrorProbe({ body: { contactId: "gone" } });
+    expect(result).toEqual({
+      exists: false,
+      hasChannels: false,
+      notes: null,
+      userFile: null,
+      contactType: null,
+      hasMetadata: false,
+    });
+  });
+
+  test("reports info fields, channels, and metadata presence", () => {
+    insertContact({
+      id: "c1",
+      notes: "note",
+      userFile: "alice.md",
+      contactType: "assistant",
+    });
+    insertChannel({ id: "ch1", contactId: "c1", address: "addr" });
+    insertMetadata({ contactId: "c1", species: "vellum" });
+
+    const result = handleContactMirrorProbe({
+      body: { contactId: "c1" },
+    }) as Record<string, unknown>;
+    expect(result).toEqual({
+      exists: true,
+      hasChannels: true,
+      notes: "note",
+      userFile: "alice.md",
+      contactType: "assistant",
+      hasMetadata: true,
+    });
+  });
+
+  test("row present with no channels or metadata (bare seed contact)", () => {
+    insertContact({ id: "c1", contactType: "human" });
+    const result = handleContactMirrorProbe({
+      body: { contactId: "c1" },
+    }) as Record<string, unknown>;
+    expect(result.exists).toBe(true);
+    expect(result.hasChannels).toBe(false);
+    expect(result.hasMetadata).toBe(false);
+    expect(result.contactType).toBe("human");
+  });
+});
+
+// ── contact_user_file_slugs ──────────────────────────────────────────────────
+
+describe("handleContactUserFileSlugs", () => {
+  test("lists user_file slugs matching the prefix", () => {
+    insertContact({ id: "c1", userFile: "alice.md" });
+    insertContact({ id: "c2", userFile: "alice-2.md" });
+    insertContact({ id: "c3", userFile: "bob.md" });
+    insertContact({ id: "c4", userFile: null });
+
+    const result = handleContactUserFileSlugs({
+      body: { prefix: "alice" },
+    }) as { userFiles: string[] };
+    expect(result.userFiles.sort()).toEqual(["alice-2.md", "alice.md"]);
+  });
+
+  test("returns empty list when nothing matches", () => {
+    insertContact({ id: "c1", userFile: "zed.md" });
+    const result = handleContactUserFileSlugs({ body: { prefix: "alice" } });
+    expect(result).toEqual({ userFiles: [] });
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -51,6 +51,7 @@ import {
   writeStreamChunk,
   writeStreamEnd,
 } from "./ipc-framing.js";
+import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js";
 import { type DbProxyParams, handleDbProxy } from "./routes/db-proxy.js";
 import {
   type DbProxyTransactionParams,
@@ -211,9 +212,18 @@ export class AssistantIpcServer {
       this.methods.set(operationId, handler);
     }
 
+    // IPC-only contact INFO-READ methods (see ipc/routes/contacts-info-ipc-routes.ts).
+    // The gateway calls these to read assistant-owned info fields + channel
+    // identity, replacing raw db_proxy SELECTs. No HTTP surface; never in ROUTES.
+    for (const [operationId, handler] of Object.entries(
+      CONTACTS_INFO_IPC_METHODS,
+    )) {
+      this.methods.set(operationId, handler);
+    }
+
     this.methods.set("$cancel", (params) => {
       const targetId = (params as { targetId?: string }).targetId;
-      if (targetId) this.abortControllers.get(targetId)?.abort();
+      if (targetId) {this.abortControllers.get(targetId)?.abort();}
       return null;
     });
 
@@ -255,11 +265,11 @@ export class AssistantIpcServer {
   stop(): void {
     this.watchdog.stop();
 
-    for (const ctrl of this.abortControllers.values()) ctrl.abort();
+    for (const ctrl of this.abortControllers.values()) {ctrl.abort();}
     this.abortControllers.clear();
 
     for (const client of this.clients) {
-      if (!client.destroyed) client.destroy();
+      if (!client.destroyed) {client.destroy();}
     }
     this.clients.clear();
 
@@ -595,7 +605,7 @@ export class AssistantIpcServer {
     response: IpcResponse,
     binary?: Uint8Array,
   ): void {
-    if (socket.destroyed) return;
+    if (socket.destroyed) {return;}
     if (reader.isLegacy) {
       writeLegacyMessage(socket, response);
     } else {
@@ -643,7 +653,7 @@ export function injectLocalActorHeader(
   if (!headers["x-vellum-actor-principal-id"]) {
     try {
       const localActor = findLocalGuardianPrincipalIdFromStore();
-      if (localActor) headers["x-vellum-actor-principal-id"] = localActor;
+      if (localActor) {headers["x-vellum-actor-principal-id"] = localActor;}
     } catch (err) {
       log.debug(
         { err },

--- a/assistant/src/ipc/routes/contacts-info-ipc-routes.ts
+++ b/assistant/src/ipc/routes/contacts-info-ipc-routes.ts
@@ -1,0 +1,239 @@
+/**
+ * IPC-only contact INFO-READ methods called by the gateway over the assistant
+ * IPC socket (`ipcCallAssistant`).
+ *
+ * These replace the gateway's raw `db_proxy` SELECTs against the assistant DB
+ * with typed, zod-validated reads of the assistant-owned informational fields
+ * (`notes`, `user_file`, `contact_type`, `assistant_contact_metadata`) and
+ * contact-channel identity. ACL data stays gateway-owned; these methods never
+ * touch it.
+ *
+ * Like the invite IPC methods, they have no HTTP surface: they are registered
+ * directly on the IPC server (see `assistant-server.ts`) and never enter the
+ * shared `ROUTES` array, so they can never reach the gateway's HTTP IPC proxy
+ * route schema.
+ */
+
+import { and, eq, inArray, like, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "../../persistence/db-connection.js";
+import {
+  assistantContactMetadata,
+  contactChannels,
+  contacts,
+} from "../../persistence/schema/index.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+
+/**
+ * Derive the daemon-owned assistant-metadata block. Gated on
+ * `contactType === "assistant"` so a stale metadata row on a human contact is
+ * never emitted (matches the daemon rich-read contract). A malformed JSON blob
+ * degrades to `null` metadata rather than throwing.
+ */
+function toAssistantMetadata(
+  contactType: string | null,
+  species: string | null,
+  metadataText: string | null,
+): { species: string; metadata: Record<string, unknown> | null } | null {
+  if (contactType !== "assistant" || species == null) return null;
+  let metadata: Record<string, unknown> | null = null;
+  if (metadataText) {
+    try {
+      metadata = JSON.parse(metadataText) as Record<string, unknown>;
+    } catch {
+      metadata = null;
+    }
+  }
+  return { species, metadata };
+}
+
+// ---------------------------------------------------------------------------
+// contacts_info_batch
+// ---------------------------------------------------------------------------
+
+const ContactsInfoBatchParamsSchema = z.object({
+  contactIds: z.array(z.string()),
+});
+
+/**
+ * Batch read of the assistant-owned info fields for a set of contact IDs.
+ * Replaces the info-joiner's raw SELECT. Contacts absent from the assistant DB
+ * are simply omitted; the caller treats a missing entry as "info unavailable".
+ */
+export function handleContactsInfoBatch({ body = {} }: RouteHandlerArgs) {
+  const { contactIds } = ContactsInfoBatchParamsSchema.parse(body);
+  if (contactIds.length === 0) return { infos: [] };
+
+  const db = getDb();
+  const rows = db
+    .select({
+      id: contacts.id,
+      notes: contacts.notes,
+      userFile: contacts.userFile,
+      contactType: contacts.contactType,
+      species: assistantContactMetadata.species,
+      metadata: assistantContactMetadata.metadata,
+    })
+    .from(contacts)
+    .leftJoin(
+      assistantContactMetadata,
+      eq(assistantContactMetadata.contactId, contacts.id),
+    )
+    .where(inArray(contacts.id, contactIds))
+    .all();
+
+  const infos = rows.map((row) => ({
+    contactId: row.id,
+    notes: row.notes ?? null,
+    userFile: row.userFile ?? null,
+    contactType: row.contactType ?? null,
+    assistantMetadata: toAssistantMetadata(
+      row.contactType,
+      row.species,
+      row.metadata,
+    ),
+  }));
+  return { infos };
+}
+
+// ---------------------------------------------------------------------------
+// contact_channel_identity_lookup
+// ---------------------------------------------------------------------------
+
+const ChannelIdentityLookupParamsSchema = z
+  .object({
+    channelId: z.string().optional(),
+    type: z.string().optional(),
+    address: z.string().optional(),
+  })
+  .refine(
+    (v) => v.channelId != null || (v.type != null && v.address != null),
+    { message: "Provide channelId, or both type and address" },
+  );
+
+const CHANNEL_IDENTITY_PROJECTION = {
+  id: contactChannels.id,
+  contactId: contactChannels.contactId,
+  type: contactChannels.type,
+  address: contactChannels.address,
+  externalChatId: contactChannels.externalChatId,
+  displayName: contacts.displayName,
+};
+
+/**
+ * Resolve a contact-channel identity by `channelId` OR by logical
+ * `(type, address)` (COLLATE NOCASE). Replaces the raw identity SELECTs in the
+ * verification helpers and the gateway channel resolver. Returns the channel's
+ * identity fields (no ACL/status).
+ */
+export function handleContactChannelIdentityLookup({
+  body = {},
+}: RouteHandlerArgs) {
+  const params = ChannelIdentityLookupParamsSchema.parse(body);
+  const db = getDb();
+
+  const where =
+    params.channelId != null
+      ? eq(contactChannels.id, params.channelId)
+      : and(
+          eq(contactChannels.type, params.type!),
+          sql`${contactChannels.address} = ${params.address!} COLLATE NOCASE`,
+        );
+
+  const row = db
+    .select(CHANNEL_IDENTITY_PROJECTION)
+    .from(contactChannels)
+    .innerJoin(contacts, eq(contacts.id, contactChannels.contactId))
+    .where(where)
+    .get();
+
+  return { channel: row ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// contact_mirror_probe
+// ---------------------------------------------------------------------------
+
+const ContactMirrorProbeParamsSchema = z.object({ contactId: z.string() });
+
+/**
+ * Probe the assistant mirror for one contact: whether the row and any channels
+ * exist, the guardian-authored info fields, and whether an assistant-metadata
+ * row is present. Feeds the gateway orphan-veto and delete-target decisions.
+ */
+export function handleContactMirrorProbe({ body = {} }: RouteHandlerArgs) {
+  const { contactId } = ContactMirrorProbeParamsSchema.parse(body);
+  const db = getDb();
+
+  const contactRow = db
+    .select({
+      notes: contacts.notes,
+      userFile: contacts.userFile,
+      contactType: contacts.contactType,
+    })
+    .from(contacts)
+    .where(eq(contacts.id, contactId))
+    .get();
+
+  const channelRow = db
+    .select({ id: contactChannels.id })
+    .from(contactChannels)
+    .where(eq(contactChannels.contactId, contactId))
+    .limit(1)
+    .get();
+
+  const metadataRow = db
+    .select({ contactId: assistantContactMetadata.contactId })
+    .from(assistantContactMetadata)
+    .where(eq(assistantContactMetadata.contactId, contactId))
+    .limit(1)
+    .get();
+
+  return {
+    exists: contactRow != null,
+    hasChannels: channelRow != null,
+    notes: contactRow?.notes ?? null,
+    userFile: contactRow?.userFile ?? null,
+    contactType: contactRow?.contactType ?? null,
+    hasMetadata: metadataRow != null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// contact_user_file_slugs
+// ---------------------------------------------------------------------------
+
+const ContactUserFileSlugsParamsSchema = z.object({ prefix: z.string() });
+
+/**
+ * List the `user_file` slugs matching `prefix%`. Feeds the gateway's
+ * collision-suffixed slug allocation for a new contact.
+ */
+export function handleContactUserFileSlugs({ body = {} }: RouteHandlerArgs) {
+  const { prefix } = ContactUserFileSlugsParamsSchema.parse(body);
+  const db = getDb();
+  const rows = db
+    .select({ userFile: contacts.userFile })
+    .from(contacts)
+    .where(like(contacts.userFile, `${prefix}%`))
+    .all();
+  const userFiles = rows
+    .map((r) => r.userFile)
+    .filter((f): f is string => f != null);
+  return { userFiles };
+}
+
+/**
+ * IPC-only contact info-read methods, keyed by IPC operationId. Registered
+ * directly on the assistant IPC server (see `assistant-server.ts`).
+ */
+export const CONTACTS_INFO_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  contacts_info_batch: handleContactsInfoBatch,
+  contact_channel_identity_lookup: handleContactChannelIdentityLookup,
+  contact_mirror_probe: handleContactMirrorProbe,
+  contact_user_file_slugs: handleContactUserFileSlugs,
+};

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -72,6 +72,29 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbExec: mock(async () => undefined),
 }));
 
+// resolveGatewayChannel resolves the assistant channel's (type,address) via the
+// typed identity-lookup IPC; serve it from the same fake channel store.
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: mock(
+    async (selector: { channelId?: string }) => {
+      if (selector.channelId == null) return null;
+      const row = fakeAssistantDb.channels.get(selector.channelId);
+      return row
+        ? {
+            id: row.id,
+            contactId: row.contact_id,
+            type: row.type,
+            address: row.address,
+            externalChatId:
+              (row as { external_chat_id?: string | null }).external_chat_id ??
+              null,
+            displayName: null,
+          }
+        : null;
+    },
+  ),
+}));
+
 import { eq } from "drizzle-orm";
 
 import { contactRoutes } from "../ipc/contact-handlers.js";

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -22,9 +22,12 @@ import {
 
 import "./test-preload.js";
 
-// ── Fake assistant DB ───────────────────────────────────────────────────────
-// Honors the info-join query (SELECT ... FROM contacts LEFT JOIN
-// assistant_contact_metadata WHERE c.id IN (...)) and throws on demand.
+// ── Fake daemon IPC (contacts_info_batch) ────────────────────────────────────
+// The info read now goes over typed IPC (`contacts_info_batch`), so we mock
+// `ipcCallAssistant` behind `fakeAssistantDb` — the daemon applies the metadata
+// gating + JSON parse, so this fake returns already-shaped infos and throws on
+// demand to exercise the caller's soft-fail path. Mirrors the mock in
+// contacts-info-joiner.test.ts.
 
 type FakeInfoRow = {
   id: string;
@@ -44,41 +47,54 @@ const fakeAssistantDb = {
   },
 };
 
-mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
-    if (fakeAssistantDb.throwOnQuery) {
-      throw new Error("simulated assistant DB outage");
-    }
-    const lower = sql.toLowerCase();
-    if (lower.includes("from contacts") && lower.includes("in (")) {
-      const ids = (bind ?? []) as string[];
-      const out: Array<{
-        id: string;
-        notes: string | null;
-        userFile: string | null;
-        contactType: string | null;
-        species: string | null;
-        metadata: string | null;
-      }> = [];
-      for (const id of ids) {
-        const row = fakeAssistantDb.info.get(id);
-        if (row) {
-          out.push({
-            id: row.id,
-            notes: row.notes,
-            userFile: row.user_file,
-            contactType: row.contact_type,
-            species: row.species,
-            metadata: row.metadata,
-          });
-        }
+function shapeInfo(row: FakeInfoRow) {
+  let assistantMetadata: {
+    species: string;
+    metadata: Record<string, unknown> | null;
+  } | null = null;
+  if (row.contact_type === "assistant" && row.species != null) {
+    let metadata: Record<string, unknown> | null = null;
+    if (row.metadata) {
+      try {
+        metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+      } catch {
+        metadata = null;
       }
-      return out;
     }
-    return [];
-  }),
-  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
-  assistantDbExec: mock(async () => undefined),
+    assistantMetadata = { species: row.species, metadata };
+  }
+  return {
+    contactId: row.id,
+    notes: row.notes,
+    userFile: row.user_file,
+    contactType: row.contact_type,
+    assistantMetadata,
+  };
+}
+
+class FakeIpcHandlerError extends Error {}
+class FakeIpcTransportError extends Error {}
+
+mock.module("../ipc/assistant-client.js", () => ({
+  IpcHandlerError: FakeIpcHandlerError,
+  IpcTransportError: FakeIpcTransportError,
+  ipcCallAssistant: mock(
+    async (method: string, params?: Record<string, unknown>) => {
+      if (fakeAssistantDb.throwOnQuery) {
+        throw new Error("simulated assistant DB outage");
+      }
+      if (method === "contacts_info_batch") {
+        const contactIds = ((params?.body as { contactIds?: string[] })
+          ?.contactIds ?? []) as string[];
+        const infos = contactIds
+          .map((id) => fakeAssistantDb.info.get(id))
+          .filter((r): r is FakeInfoRow => r != null)
+          .map(shapeInfo);
+        return { infos };
+      }
+      return {};
+    },
+  ),
 }));
 
 import {

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -87,6 +87,30 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbExec: mock(async () => undefined),
 }));
 
+// resolveGatewayChannel now resolves the assistant channel's (type,address) via
+// the typed identity-lookup IPC instead of a raw SELECT. Serve it from the same
+// fake channel store.
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: mock(
+    async (selector: { channelId?: string; type?: string; address?: string }) => {
+      if (selector.channelId != null) {
+        const row = fakeAssistantDb.channels.get(selector.channelId);
+        return row
+          ? {
+              id: row.id,
+              contactId: row.contact_id,
+              type: row.type,
+              address: row.address,
+              externalChatId: row.external_chat_id ?? null,
+              displayName: null,
+            }
+          : null;
+      }
+      return null;
+    },
+  ),
+}));
+
 import { eq } from "drizzle-orm";
 
 import { ContactStore } from "../db/contact-store.js";

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -88,25 +88,38 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 }));
 
 // resolveGatewayChannel now resolves the assistant channel's (type,address) via
-// the typed identity-lookup IPC instead of a raw SELECT. Serve it from the same
-// fake channel store.
-mock.module("../ipc/contacts-info-client.js", () => ({
-  lookupContactChannelIdentity: mock(
-    async (selector: { channelId?: string; type?: string; address?: string }) => {
-      if (selector.channelId != null) {
-        const row = fakeAssistantDb.channels.get(selector.channelId);
-        return row
-          ? {
-              id: row.id,
-              contactId: row.contact_id,
-              type: row.type,
-              address: row.address,
-              externalChatId: row.external_chat_id ?? null,
-              displayName: null,
-            }
-          : null;
+// the typed identity-lookup IPC instead of a raw SELECT. Mock the low-level
+// `ipcCallAssistant` (rather than the higher-level contacts-info-client export)
+// so this module mock stays isolated to the assistant transport and does not
+// leak over the real contacts-info-client module in other suites sharing the
+// Bun process. Serve the lookup from the same fake channel store.
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: mock(
+    async (method: string, params?: Record<string, unknown>) => {
+      if (method === "contact_channel_identity_lookup") {
+        const selector = (params?.body ?? {}) as {
+          channelId?: string;
+          type?: string;
+          address?: string;
+        };
+        if (selector.channelId != null) {
+          const row = fakeAssistantDb.channels.get(selector.channelId);
+          return {
+            channel: row
+              ? {
+                  id: row.id,
+                  contactId: row.contact_id,
+                  type: row.type,
+                  address: row.address,
+                  externalChatId: row.external_chat_id ?? null,
+                  displayName: null,
+                }
+              : null,
+          };
+        }
+        return { channel: null };
       }
-      return null;
+      return {};
     },
   ),
 }));

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -2014,7 +2014,9 @@ describe("handleDeleteContact (gateway-native)", () => {
     // No gateway row (a dual-write gap on inbound seeding), but the assistant
     // mirror holds the contact — the list can surface it, so delete must clean
     // it up instead of 404ing and leaving it stuck in the UI.
-    assistantDbQueryMock = mock(async () => [{ id: "ct_orphan" }]);
+    ipcCallAssistantMock = mock(async (method: string) =>
+      method === "contact_mirror_probe" ? { exists: true } : {},
+    );
 
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleDeleteContact("ct_orphan");
@@ -2039,10 +2041,13 @@ describe("handleDeleteContact (gateway-native)", () => {
 
   test("still deletes a gateway contact when the assistant mirror is unavailable", async () => {
     seedGatewayContact("ct_mirror_down", "contact");
-    // The mirror lookup AND delete both throw (assistant DB unavailable). The
+    // The mirror probe AND delete both throw (assistant DB unavailable). The
     // delete must degrade to gateway-only rather than 500ing on the mirror.
-    assistantDbQueryMock = mock(async () => {
-      throw new Error("assistant DB unavailable");
+    ipcCallAssistantMock = mock(async (method: string) => {
+      if (method === "contact_mirror_probe") {
+        throw new Error("assistant DB unavailable");
+      }
+      return {};
     });
     assistantDbRunMock = mock(async () => {
       throw new Error("assistant DB unavailable");

--- a/gateway/src/__tests__/contacts-info-client.test.ts
+++ b/gateway/src/__tests__/contacts-info-client.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the typed gateway → daemon contact info-read IPC client and its
+ * thin callers, with `ipcCallAssistant` mocked (no daemon required).
+ *
+ * Verifies the wire shapes the gateway sends/receives and that
+ * `findContactChannelByAddress` maps the identity response onto its legacy
+ * ContactChannelRow shape.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import "./test-preload.js";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+const ipc = {
+  calls: [] as IpcCall[],
+  responder: (_method: string, _params?: Record<string, unknown>): unknown =>
+    ({}),
+  reset(): void {
+    this.calls = [];
+    this.responder = () => ({});
+  },
+};
+
+mock.module("../ipc/assistant-client.js", () => ({
+  IpcHandlerError: class extends Error {},
+  IpcTransportError: class extends Error {},
+  ipcCallAssistant: mock(
+    async (method: string, params?: Record<string, unknown>) => {
+      ipc.calls.push({ method, params });
+      return ipc.responder(method, params);
+    },
+  ),
+}));
+
+const {
+  fetchContactsInfoBatch,
+  lookupContactChannelIdentity,
+  probeContactMirror,
+  listContactUserFileSlugs,
+} = await import("../ipc/contacts-info-client.js");
+const { findContactChannelByAddress } = await import(
+  "../verification/contact-helpers.js"
+);
+
+beforeEach(() => {
+  ipc.reset();
+});
+
+describe("fetchContactsInfoBatch", () => {
+  test("short-circuits with no IPC call for empty input", async () => {
+    const result = await fetchContactsInfoBatch([]);
+    expect(result).toEqual([]);
+    expect(ipc.calls).toHaveLength(0);
+  });
+
+  test("sends contactIds under body and returns infos", async () => {
+    ipc.responder = () => ({
+      infos: [
+        {
+          contactId: "c1",
+          notes: "n",
+          userFile: null,
+          contactType: "human",
+          assistantMetadata: null,
+        },
+      ],
+    });
+    const result = await fetchContactsInfoBatch(["c1", "c2"]);
+    expect(ipc.calls[0]).toEqual({
+      method: "contacts_info_batch",
+      params: { body: { contactIds: ["c1", "c2"] } },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].contactId).toBe("c1");
+  });
+
+  test("tolerates a missing infos field", async () => {
+    ipc.responder = () => ({});
+    expect(await fetchContactsInfoBatch(["c1"])).toEqual([]);
+  });
+});
+
+describe("lookupContactChannelIdentity", () => {
+  test("passes a (type,address) selector and unwraps the channel", async () => {
+    ipc.responder = () => ({
+      channel: {
+        id: "ch1",
+        contactId: "c1",
+        type: "email",
+        address: "a@b.com",
+        externalChatId: null,
+        displayName: "Alice",
+      },
+    });
+    const result = await lookupContactChannelIdentity({
+      type: "email",
+      address: "a@b.com",
+    });
+    expect(ipc.calls[0]).toEqual({
+      method: "contact_channel_identity_lookup",
+      params: { body: { type: "email", address: "a@b.com" } },
+    });
+    expect(result?.id).toBe("ch1");
+  });
+
+  test("passes a channelId selector and returns null for a missing channel", async () => {
+    ipc.responder = () => ({ channel: null });
+    const result = await lookupContactChannelIdentity({ channelId: "nope" });
+    expect(ipc.calls[0].params).toEqual({ body: { channelId: "nope" } });
+    expect(result).toBeNull();
+  });
+});
+
+describe("probeContactMirror", () => {
+  test("passes contactId and returns the probe verbatim", async () => {
+    const probe = {
+      exists: true,
+      hasChannels: false,
+      notes: null,
+      userFile: null,
+      contactType: "human",
+      hasMetadata: false,
+    };
+    ipc.responder = () => probe;
+    const result = await probeContactMirror("c1");
+    expect(ipc.calls[0]).toEqual({
+      method: "contact_mirror_probe",
+      params: { body: { contactId: "c1" } },
+    });
+    expect(result).toEqual(probe);
+  });
+});
+
+describe("listContactUserFileSlugs", () => {
+  test("passes prefix and returns the slug list", async () => {
+    ipc.responder = () => ({ userFiles: ["alice.md", "alice-2.md"] });
+    const result = await listContactUserFileSlugs("alice");
+    expect(ipc.calls[0].params).toEqual({ body: { prefix: "alice" } });
+    expect(result).toEqual(["alice.md", "alice-2.md"]);
+  });
+});
+
+describe("findContactChannelByAddress (caller)", () => {
+  test("maps the identity response onto ContactChannelRow", async () => {
+    ipc.responder = () => ({
+      channel: {
+        id: "ch1",
+        contactId: "c1",
+        type: "telegram",
+        address: "addr-1",
+        externalChatId: "chat-1",
+        displayName: "Bob",
+      },
+    });
+    const row = await findContactChannelByAddress("telegram", "addr-1");
+    expect(row).toEqual({
+      channelId: "ch1",
+      contactId: "c1",
+      address: "addr-1",
+      externalChatId: "chat-1",
+      displayName: "Bob",
+    });
+  });
+
+  test("returns null when no channel matches", async () => {
+    ipc.responder = () => ({ channel: null });
+    expect(await findContactChannelByAddress("telegram", "gone")).toBeNull();
+  });
+});

--- a/gateway/src/__tests__/contacts-info-joiner.test.ts
+++ b/gateway/src/__tests__/contacts-info-joiner.test.ts
@@ -4,8 +4,9 @@
  *   - ContactStore.listContactsWithInfo / getContactWithInfo (join + soft-fail)
  *
  * The gateway DB is a real (file-backed) DB seeded per test; the assistant DB
- * proxy is mocked behind `fakeAssistantDb` so no daemon is required. Mirrors
- * the pattern in contact-store-mark-channel-verified.test.ts.
+ * info read now goes over typed IPC (`contacts_info_batch`), so we mock
+ * `ipcCallAssistant` behind `fakeAssistantDb` — the daemon applies the
+ * metadata gating + JSON parse, so this fake returns already-shaped infos.
  */
 
 import {
@@ -20,9 +21,9 @@ import {
 
 import "./test-preload.js";
 
-// ── Fake assistant DB ───────────────────────────────────────────────────────
-// Honors the info-join query (SELECT ... FROM contacts LEFT JOIN
-// assistant_contact_metadata WHERE c.id IN (...)) and throws on demand.
+// ── Fake daemon IPC (contacts_info_batch) ────────────────────────────────────
+// Honors the typed info-batch read (already-gated infos) and throws on demand
+// so the caller's soft-fail path can be exercised.
 
 type FakeInfoRow = {
   id: string;
@@ -36,7 +37,7 @@ type FakeInfoRow = {
 const fakeAssistantDb = {
   info: new Map<string, FakeInfoRow>(),
   throwOnQuery: false as boolean,
-  queryCalls: [] as { sql: string; bind?: unknown[] }[],
+  queryCalls: [] as { method: string; params?: unknown }[],
   reset(): void {
     this.info.clear();
     this.throwOnQuery = false;
@@ -44,45 +45,55 @@ const fakeAssistantDb = {
   },
 };
 
-mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: mock(async (sql: string, bind?: unknown[]) => {
-    fakeAssistantDb.queryCalls.push({ sql, bind });
-    if (fakeAssistantDb.throwOnQuery) {
-      throw new Error("simulated assistant DB outage");
-    }
-    const lower = sql.toLowerCase();
-    if (lower.includes("from contacts") && lower.includes("in (")) {
-      // Batched info query: bind is the list of contact IDs.
-      // Return rows aliased to match the SQL SELECT (camelCase), which is
-      // what AssistantInfoRow / contacts-info-joiner reads.
-      const ids = (bind ?? []) as string[];
-      const out: Array<{
-        id: string;
-        notes: string | null;
-        userFile: string | null;
-        contactType: string | null;
-        species: string | null;
-        metadata: string | null;
-      }> = [];
-      for (const id of ids) {
-        const row = fakeAssistantDb.info.get(id);
-        if (row) {
-          out.push({
-            id: row.id,
-            notes: row.notes,
-            userFile: row.user_file,
-            contactType: row.contact_type,
-            species: row.species,
-            metadata: row.metadata,
-          });
-        }
+function shapeInfo(row: FakeInfoRow) {
+  let assistantMetadata: {
+    species: string;
+    metadata: Record<string, unknown> | null;
+  } | null = null;
+  if (row.contact_type === "assistant" && row.species != null) {
+    let metadata: Record<string, unknown> | null = null;
+    if (row.metadata) {
+      try {
+        metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+      } catch {
+        metadata = null;
       }
-      return out;
     }
-    return [];
-  }),
-  assistantDbRun: mock(async () => ({ changes: 1, lastInsertRowid: 0 })),
-  assistantDbExec: mock(async () => undefined),
+    assistantMetadata = { species: row.species, metadata };
+  }
+  return {
+    contactId: row.id,
+    notes: row.notes,
+    userFile: row.user_file,
+    contactType: row.contact_type,
+    assistantMetadata,
+  };
+}
+
+class FakeIpcHandlerError extends Error {}
+class FakeIpcTransportError extends Error {}
+
+mock.module("../ipc/assistant-client.js", () => ({
+  IpcHandlerError: FakeIpcHandlerError,
+  IpcTransportError: FakeIpcTransportError,
+  ipcCallAssistant: mock(
+    async (method: string, params?: Record<string, unknown>) => {
+      fakeAssistantDb.queryCalls.push({ method, params });
+      if (fakeAssistantDb.throwOnQuery) {
+        throw new Error("simulated assistant DB outage");
+      }
+      if (method === "contacts_info_batch") {
+        const contactIds = ((params?.body as { contactIds?: string[] })
+          ?.contactIds ?? []) as string[];
+        const infos = contactIds
+          .map((id) => fakeAssistantDb.info.get(id))
+          .filter((r): r is FakeInfoRow => r != null)
+          .map(shapeInfo);
+        return { infos };
+      }
+      return {};
+    },
+  ),
 }));
 
 import { ContactStore } from "../db/contact-store.js";

--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -63,6 +63,56 @@ mock.module("../db/assistant-db-proxy.js", () => ({
   },
 }));
 
+// The orphan-GC mirror inspection now goes through typed IPC instead of raw
+// SELECTs; serve it from the same in-memory assistant DB.
+mock.module("../ipc/contacts-info-client.js", () => ({
+  async probeContactMirror(contactId: string) {
+    const contactRow = db()
+      .prepare(
+        "SELECT notes, user_file AS userFile, contact_type AS contactType FROM contacts WHERE id = ?",
+      )
+      .get(contactId) as
+      | { notes: string | null; userFile: string | null; contactType: string }
+      | undefined;
+    const channelRow = db()
+      .prepare("SELECT id FROM contact_channels WHERE contact_id = ? LIMIT 1")
+      .get(contactId);
+    const metaRow = db()
+      .prepare(
+        "SELECT contact_id FROM assistant_contact_metadata WHERE contact_id = ? LIMIT 1",
+      )
+      .get(contactId);
+    return {
+      exists: contactRow != null,
+      hasChannels: channelRow != null,
+      notes: contactRow?.notes ?? null,
+      userFile: contactRow?.userFile ?? null,
+      contactType: contactRow?.contactType ?? null,
+      hasMetadata: metaRow != null,
+    };
+  },
+  async lookupContactChannelIdentity(selector: {
+    channelId?: string;
+    type?: string;
+    address?: string;
+  }) {
+    const row = (
+      selector.channelId != null
+        ? db()
+            .prepare(
+              "SELECT cc.id AS id, cc.contact_id AS contactId, cc.type AS type, cc.address AS address, cc.external_chat_id AS externalChatId, c.display_name AS displayName FROM contact_channels cc JOIN contacts c ON c.id = cc.contact_id WHERE cc.id = ?",
+            )
+            .get(selector.channelId)
+        : db()
+            .prepare(
+              "SELECT cc.id AS id, cc.contact_id AS contactId, cc.type AS type, cc.address AS address, cc.external_chat_id AS externalChatId, c.display_name AS displayName FROM contact_channels cc JOIN contacts c ON c.id = cc.contact_id WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE LIMIT 1",
+            )
+            .get(String(selector.type), String(selector.address))
+    ) as Record<string, unknown> | undefined;
+    return row ?? null;
+  },
+}));
+
 import { eq } from "drizzle-orm";
 
 import { createGuardianBinding } from "../auth/guardian-bootstrap.js";

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -41,11 +41,22 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 
 // Spread the actual module so the real IpcHandlerError/IpcTransportError
 // classes (and untouched exports like ipcSuggestTrustRule) stay importable by
-// later-loaded files when suites share a bun process.
+// later-loaded files when suites share a bun process. `ipcCallAssistant` routes
+// through a mutable mock so a test can resolve an assistant-side channel via
+// `contact_channel_identity_lookup` (backward-compat path).
+type IpcCallFn = (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<unknown>;
+let ipcCallAssistantMock: ReturnType<typeof mock<IpcCallFn>> = mock(
+  async () => ({}),
+);
+
 const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
   ...actualAssistantClient,
-  ipcCallAssistant: mock(async () => ({})),
+  ipcCallAssistant: (...args: Parameters<IpcCallFn>) =>
+    ipcCallAssistantMock(...args),
 }));
 
 import { GatewayIpcServer } from "../ipc/server.js";
@@ -73,6 +84,7 @@ beforeEach(() => {
   // channel resolution, dual-write succeeds.
   assistantDbQueryMock = mock(async () => []);
   assistantDbRunMock = mock(async () => ({ changes: 1, lastInsertRowid: 0 }));
+  ipcCallAssistantMock = mock(async () => ({}));
 });
 
 afterAll(() => {
@@ -968,11 +980,23 @@ describe("IPC contact routes", () => {
     test("assistant-side channel ID resolves via backward-compat path", async () => {
       seedTestData();
       // The given ID is unknown to the gateway DB; the assistant DB resolves it
-      // to the logical key (contactId, type, address) of the existing gateway
-      // channel ch3, which updateChannelStatus then matches.
-      assistantDbQueryMock = mock(async () => [
-        { contactId: "c2", type: "email", address: "test@example.com" },
-      ]);
+      // via `contact_channel_identity_lookup` to the logical key (type, address)
+      // of the existing gateway channel ch3, which updateChannelStatus matches.
+      ipcCallAssistantMock = mock(async (method: string) => {
+        if (method === "contact_channel_identity_lookup") {
+          return {
+            channel: {
+              id: "assistant-side-id",
+              contactId: "c2",
+              type: "email",
+              address: "test@example.com",
+              externalChatId: null,
+              displayName: null,
+            },
+          };
+        }
+        return {};
+      });
       await startServerAndConnect();
 
       const res = await sendRequest(client, "update_contact_channel", {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -19,6 +19,11 @@ import {
   emptyContactInfo,
   fetchInfoForContacts,
 } from "./contacts-info-joiner.js";
+import {
+  fetchContactsInfoBatch,
+  lookupContactChannelIdentity,
+  listContactUserFileSlugs,
+} from "../ipc/contacts-info-client.js";
 import { getLogger } from "../logger.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 
@@ -621,17 +626,14 @@ export class ContactStore {
       .get();
     if (byId) return byId;
 
-    const assistantChannel = await assistantDbQuery<{
-      type: string;
-      address: string;
-    }>("SELECT type, address FROM contact_channels WHERE id = ?", [channelId]);
-    if (assistantChannel.length === 0) return undefined;
+    const assistantChannel = await lookupContactChannelIdentity({ channelId });
+    if (!assistantChannel) return undefined;
 
     // Resolve by the gateway's unique key (type, address). The gateway row may
     // live under a different contact than the assistant mirror — m0006 reconcile
     // skips mirroring when (type, address) already exists under any contact — so
     // contactId is not part of the lookup; the resolved row's contact is trusted.
-    const { type, address } = assistantChannel[0];
+    const { type, address } = assistantChannel;
     return this.db
       .select()
       .from(contactChannels)
@@ -1771,17 +1773,10 @@ export class ContactStore {
         .all()
         .map((r) => r.id);
       if (siblingIds.length) {
-        const placeholders = siblingIds.map(() => "?").join(", ");
-        const sibling = await assistantDbQuery<{ userFile: string | null }>(
-          `SELECT user_file AS userFile
-             FROM contacts
-            WHERE id IN (${placeholders})
-              AND user_file IS NOT NULL
-            LIMIT 1`,
-          siblingIds,
-        );
-        if (sibling.length && sibling[0].userFile) {
-          return sibling[0].userFile;
+        const infos = await fetchContactsInfoBatch(siblingIds);
+        const siblingFile = infos.find((i) => i.userFile != null)?.userFile;
+        if (siblingFile) {
+          return siblingFile;
         }
       }
     }
@@ -1793,13 +1788,8 @@ export class ContactStore {
         .replace(/^-+|-+$/g, "")
         .slice(0, 100) || "user";
 
-    const rows = await assistantDbQuery<{ userFile: string | null }>(
-      "SELECT user_file AS userFile FROM contacts WHERE user_file LIKE ?",
-      [`${slug}%`],
-    );
-    const taken = new Set(
-      rows.map((r) => r.userFile?.toLowerCase()).filter(Boolean),
-    );
+    const userFiles = await listContactUserFileSlugs(slug);
+    const taken = new Set(userFiles.map((f) => f.toLowerCase()));
 
     const base = `${slug}.md`;
     if (!taken.has(base)) return base;

--- a/gateway/src/db/contacts-info-joiner.ts
+++ b/gateway/src/db/contacts-info-joiner.ts
@@ -6,14 +6,14 @@
  * assistant DB owns purely informational data: `notes`, `userFile`,
  * `contactType`, and `assistant_contact_metadata` (species + metadata blob).
  *
- * This module performs a SINGLE batched query against the assistant DB (via
- * `assistantDbQuery`) for a set of contact IDs and returns the info fields
+ * This module performs a SINGLE typed IPC read against the assistant DB (via
+ * `contacts_info_batch`) for a set of contact IDs and returns the info fields
  * keyed by contact ID. The caller (ContactStore) is responsible for soft-fail
  * handling if this throws — the ACL shape must remain servable when the
  * assistant DB is unreachable.
  */
 
-import { type SqliteValue, assistantDbQuery } from "./assistant-db-proxy.js";
+import { fetchContactsInfoBatch } from "../ipc/contacts-info-client.js";
 
 export interface ContactInfoFields {
   notes: string | null;
@@ -23,15 +23,6 @@ export interface ContactInfoFields {
     species: string;
     metadata: Record<string, unknown> | null;
   } | null;
-}
-
-interface AssistantInfoRow {
-  id: string;
-  notes: string | null;
-  userFile: string | null;
-  contactType: string | null;
-  species: string | null;
-  metadata: string | null;
 }
 
 const EMPTY_INFO: ContactInfoFields = {
@@ -48,14 +39,13 @@ const EMPTY_INFO: ContactInfoFields = {
  * - Contacts present in the gateway but missing from the assistant DB are
  *   simply absent from the returned Map; the caller treats a missing entry as
  *   "info unavailable" (all-null fields).
- * - If `assistantDbQuery` throws, the error propagates — the caller decides
+ * - If the IPC read throws, the error propagates — the caller decides
  *   soft-fail vs hard-fail. Per the decision, the caller soft-fails so the
  *   ACL list remains servable.
  *
- * The query is a single SELECT with a dynamically-sized `IN (...)` clause,
- * left-joining `assistant_contact_metadata` so species/metadata come back in
- * the same round trip. `metadata` is stored as a JSON text blob and is parsed
- * here; a malformed blob becomes `null` (logged, not thrown).
+ * The read is a single `contacts_info_batch` IPC call; the daemon left-joins
+ * `assistant_contact_metadata` and applies the metadata gating + JSON parse, so
+ * `assistantMetadata` arrives already shaped.
  */
 export async function fetchInfoForContacts(
   contactIds: string[],
@@ -63,46 +53,14 @@ export async function fetchInfoForContacts(
   const result = new Map<string, ContactInfoFields>();
   if (contactIds.length === 0) return result;
 
-  const placeholders = contactIds.map(() => "?").join(", ");
-  const bind = contactIds as SqliteValue[];
-
-  const rows = await assistantDbQuery<AssistantInfoRow>(
-    `SELECT c.id            AS id,
-            c.notes         AS notes,
-            c.user_file     AS userFile,
-            c.contact_type  AS contactType,
-            m.species       AS species,
-            m.metadata      AS metadata
-       FROM contacts c
-       LEFT JOIN assistant_contact_metadata m ON m.contact_id = c.id
-      WHERE c.id IN (${placeholders})`,
-    bind,
-  );
-
-  for (const row of rows) {
-    let parsedMetadata: Record<string, unknown> | null = null;
-    if (row.metadata) {
-      try {
-        parsedMetadata = JSON.parse(row.metadata) as Record<string, unknown>;
-      } catch {
-        // Malformed JSON blob — degrade to null rather than failing the read.
-        parsedMetadata = null;
-      }
-    }
-
-    const info: ContactInfoFields = {
-      notes: row.notes ?? null,
-      userFile: row.userFile ?? null,
-      contactType: row.contactType ?? null,
-      // Gate metadata on contactType === "assistant" to match the daemon's
-      // contract (assistant/src/runtime/routes/contact-routes.ts:187). A
-      // stale metadata row on a human contact is not emitted.
-      assistantMetadata:
-        row.contactType === "assistant" && row.species != null
-          ? { species: row.species, metadata: parsedMetadata }
-          : null,
-    };
-    result.set(row.id, info);
+  const infos = await fetchContactsInfoBatch(contactIds);
+  for (const info of infos) {
+    result.set(info.contactId, {
+      notes: info.notes,
+      userFile: info.userFile,
+      contactType: info.contactType,
+      assistantMetadata: info.assistantMetadata,
+    });
   }
 
   return result;

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -21,10 +21,7 @@ import { eq } from "drizzle-orm";
 
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../../db/assistant-db-proxy.js";
+import { assistantDbRun } from "../../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../../db/connection.js";
 import {
   ContactStore,
@@ -42,6 +39,7 @@ import {
   IpcHandlerError,
   ipcCallAssistant,
 } from "../../ipc/assistant-client.js";
+import { probeContactMirror } from "../../ipc/contacts-info-client.js";
 import { getLogger } from "../../logger.js";
 import { ensureInviteLive } from "../../verification/invite-liveness.js";
 import {
@@ -1328,11 +1326,8 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       // DB is the source of truth; the mirror is only a cleanup target.
       let inMirror = false;
       try {
-        const mirrorRows = await assistantDbQuery<{ id: string }>(
-          "SELECT id FROM contacts WHERE id = ? LIMIT 1",
-          [contactId],
-        );
-        inMirror = mirrorRows.length > 0;
+        const probe = await probeContactMirror(contactId);
+        inMirror = probe.exists;
       } catch (err) {
         log.warn(
           { err, contactId },

--- a/gateway/src/ipc/contacts-info-client.ts
+++ b/gateway/src/ipc/contacts-info-client.ts
@@ -1,0 +1,101 @@
+/**
+ * Typed gateway → daemon IPC client for contact INFO reads.
+ *
+ * Wraps `ipcCallAssistant` for the daemon's contact info-read methods (see
+ * assistant/src/ipc/routes/contacts-info-ipc-routes.ts), replacing the raw
+ * `db_proxy` SELECTs the gateway used to run against the assistant DB. The
+ * assistant DB owns purely informational fields (`notes`, `user_file`,
+ * `contact_type`, `assistant_contact_metadata`) and channel identity; ACL data
+ * stays gateway-owned and is never read here.
+ *
+ * These helpers throw (IpcTransportError / IpcHandlerError) on failure — the
+ * callers own soft-fail handling so an info read never blocks the ACL path.
+ */
+
+import { ipcCallAssistant } from "./assistant-client.js";
+
+export interface ContactInfoBatchEntry {
+  contactId: string;
+  notes: string | null;
+  userFile: string | null;
+  contactType: string | null;
+  assistantMetadata: {
+    species: string;
+    metadata: Record<string, unknown> | null;
+  } | null;
+}
+
+/**
+ * Batch-read assistant-owned info fields for a set of contact IDs. Returns one
+ * entry per contact present in the assistant DB; contacts absent there are
+ * omitted. No query is issued for an empty input.
+ */
+export async function fetchContactsInfoBatch(
+  contactIds: string[],
+): Promise<ContactInfoBatchEntry[]> {
+  if (contactIds.length === 0) return [];
+  const result = (await ipcCallAssistant("contacts_info_batch", {
+    body: { contactIds },
+  })) as { infos?: ContactInfoBatchEntry[] };
+  return result.infos ?? [];
+}
+
+export interface ChannelIdentity {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+  externalChatId: string | null;
+  displayName: string | null;
+}
+
+/**
+ * Resolve a contact-channel identity by channel id, or by logical
+ * `(type, address)` key. Returns null when no channel matches.
+ */
+export async function lookupContactChannelIdentity(
+  selector: { channelId: string } | { type: string; address: string },
+): Promise<ChannelIdentity | null> {
+  const result = (await ipcCallAssistant("contact_channel_identity_lookup", {
+    body: selector,
+  })) as { channel?: ChannelIdentity | null };
+  return result.channel ?? null;
+}
+
+export interface ContactMirrorProbe {
+  /** Whether a `contacts` row exists in the assistant mirror. */
+  exists: boolean;
+  /** Whether the contact has any channels in the assistant mirror. */
+  hasChannels: boolean;
+  notes: string | null;
+  userFile: string | null;
+  contactType: string | null;
+  /** Whether an `assistant_contact_metadata` row exists for the contact. */
+  hasMetadata: boolean;
+}
+
+/**
+ * Probe the assistant mirror for a single contact — presence, channels, info
+ * fields, and metadata presence — for the gateway orphan-veto and delete-target
+ * decisions.
+ */
+export async function probeContactMirror(
+  contactId: string,
+): Promise<ContactMirrorProbe> {
+  return (await ipcCallAssistant("contact_mirror_probe", {
+    body: { contactId },
+  })) as ContactMirrorProbe;
+}
+
+/**
+ * List the assistant-DB `user_file` slugs matching `prefix%`, for the gateway's
+ * collision-suffixed slug allocation.
+ */
+export async function listContactUserFileSlugs(
+  prefix: string,
+): Promise<string[]> {
+  const result = (await ipcCallAssistant("contact_user_file_slugs", {
+    body: { prefix },
+  })) as { userFiles?: string[] };
+  return result.userFiles ?? [];
+}

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -1,8 +1,8 @@
 /**
  * Contact upsert/lookup helpers for gateway-owned verification.
  *
- * All operations go through assistantDbQuery/assistantDbRun (raw SQL via
- * IPC proxy). No IPC routes are used — only the direct SQL executor.
+ * Identity/info READS go through typed daemon IPC (contacts-info-client);
+ * mirror WRITES still go through assistantDbRun (raw SQL via IPC proxy).
  *
  * These helpers cover the subset of contact operations needed by the
  * verification intercept flow. They are intentionally simpler than the
@@ -20,6 +20,10 @@ import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
 } from "../db/schema.js";
+import {
+  lookupContactChannelIdentity,
+  probeContactMirror,
+} from "../ipc/contacts-info-client.js";
 import { getLogger } from "../logger.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { canonicalizeInboundIdentity } from "./identity.js";
@@ -49,18 +53,18 @@ export async function findContactChannelByAddress(
   channelType: string,
   address: string,
 ): Promise<ContactChannelRow | null> {
-  const rows = await assistantDbQuery<ContactChannelRow>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId,
-            cc.address,
-            cc.external_chat_id AS externalChatId,
-            c.display_name AS displayName
-     FROM contact_channels cc
-     JOIN contacts c ON c.id = cc.contact_id
-     WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     LIMIT 1`,
-    [channelType, address],
-  );
-  return rows[0] ?? null;
+  const channel = await lookupContactChannelIdentity({
+    type: channelType,
+    address,
+  });
+  if (!channel) return null;
+  return {
+    channelId: channel.id,
+    contactId: channel.contactId,
+    address: channel.address,
+    externalChatId: channel.externalChatId,
+    displayName: channel.displayName,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -288,29 +292,16 @@ export async function deleteContactIfOrphaned(
   const mirrorReachable = existsSync(socketPath);
   if (mirrorReachable) {
     try {
-      const mirrorChannels = await assistantDbQuery<{ id: string }>(
-        `SELECT id FROM contact_channels WHERE contact_id = ? LIMIT 1`,
-        [contactId],
-      );
-      if (mirrorChannels.length > 0) {
+      const probe = await probeContactMirror(contactId);
+      if (probe.hasChannels) {
         return;
       }
-      const mirrorRows = await assistantDbQuery<{
-        notes: string | null;
-        userFile: string | null;
-        contactType: string;
-      }>(
-        `SELECT notes, user_file AS userFile, contact_type AS contactType
-         FROM contacts WHERE id = ?`,
-        [contactId],
-      );
-      mirrorRowPresent = mirrorRows.length > 0;
+      mirrorRowPresent = probe.exists;
       if (mirrorRowPresent) {
-        const mirror = mirrorRows[0];
         const hasGuardianAuthoredData =
-          (mirror.notes && mirror.notes.trim().length > 0) ||
-          (mirror.userFile && mirror.userFile.trim().length > 0) ||
-          mirror.contactType !== "human";
+          (probe.notes && probe.notes.trim().length > 0) ||
+          (probe.userFile && probe.userFile.trim().length > 0) ||
+          probe.contactType !== "human";
         if (hasGuardianAuthoredData) {
           log.info(
             { contactId },
@@ -318,12 +309,7 @@ export async function deleteContactIfOrphaned(
           );
           return;
         }
-        const mirrorMetadata = await assistantDbQuery<{ contactId: string }>(
-          `SELECT contact_id AS contactId FROM assistant_contact_metadata
-           WHERE contact_id = ? LIMIT 1`,
-          [contactId],
-        );
-        if (mirrorMetadata.length > 0) {
+        if (probe.hasMetadata) {
           log.info(
             { contactId },
             "Keeping orphaned seed contact: assistant mirror carries contact metadata",


### PR DESCRIPTION
## Summary
- Add typed daemon IPC (contacts_info_batch, contact_channel_identity_lookup, contact_mirror_probe) and repoint gateway info-read callers off raw db_proxy SELECTs; soft-fail semantics preserved.

Part of plan: contacts-acl-cleanup.md (PR 10 of 14)