### PR TITLE
test(gateway): shared invite/contact fixtures and newline-IPC client helpers

### DIFF
--- a/gateway/src/__tests__/guardian-channel-create.test.ts
+++ b/gateway/src/__tests__/guardian-channel-create.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../db/connection.js";
 import { contacts, contactChannels } from "../db/schema.js";
 import { findGuardian } from "../http/routes/guardian-channel-create.js";
+import { seedContact } from "./helpers/contact-fixtures.js";
 
 beforeAll(async () => {
   await initGatewayDb();
@@ -37,25 +38,6 @@ beforeEach(() => {
 afterAll(() => {
   resetGatewayDb();
 });
-
-function seedContact(opts: {
-  id: string;
-  role: string;
-  principalId: string | null;
-}): void {
-  const now = Date.now();
-  getGatewayDb()
-    .insert(contacts)
-    .values({
-      id: opts.id,
-      displayName: `name-${opts.id}`,
-      role: opts.role,
-      principalId: opts.principalId,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .run();
-}
 
 describe("findGuardian", () => {
   test("returns the guardian seeded in the gateway DB", async () => {

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -16,8 +16,6 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
-
 import type { GatewayConfig } from "../config.js";
 import type {
   RuntimeInboundPayload,
@@ -117,8 +115,10 @@ const {
 const { contacts, contactChannels, ingressInvites } = await import(
   "../db/schema.js"
 );
-const { ContactStore } = await import("../db/contact-store.js");
 const { handleInbound } = await import("../handlers/handle-inbound.js");
+const { inviteRow, seedInvite } = await import(
+  "./helpers/contact-fixtures.js"
+);
 
 const CHANNEL = "telegram";
 const CODE = "123456";
@@ -159,24 +159,6 @@ function seedChannel(args: {
       createdAt: now,
     })
     .run();
-}
-
-function seedInvite(overrides: { sourceChannel?: string } = {}): string {
-  const id = crypto.randomUUID();
-  new ContactStore().createInvite({
-    id,
-    sourceChannel: overrides.sourceChannel ?? CHANNEL,
-    inviteCodeHash: hashInviteCode(CODE),
-    tokenHash: hashInviteToken(TOKEN),
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-  });
-  return id;
-}
-
-function inviteRow(id: string) {
-  return new ContactStore().getInviteById(id)!;
 }
 
 function makeConfig(): GatewayConfig {

--- a/gateway/src/__tests__/helpers/contact-fixtures.ts
+++ b/gateway/src/__tests__/helpers/contact-fixtures.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared contact / invite seed fixtures for gateway DB-backed suites.
+ *
+ * All DB access is deferred to call time (via `getGatewayDb()`), so importing
+ * this module has no side effects. Suites that mock DB-adjacent modules must
+ * still import this helper *after* their `mock.module` calls (i.e. via the same
+ * dynamic `await import` they use for `db/*`).
+ */
+import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
+
+import { getGatewayDb } from "../../db/connection.js";
+import { ContactStore } from "../../db/contact-store.js";
+import { contacts } from "../../db/schema.js";
+
+const INVITE_CODE = "123456";
+const INVITE_TOKEN = "tok_raw_abc123";
+const INVITE_CHANNEL = "telegram";
+const VOICE_CALLER = "+15555550100";
+
+type CreateInviteInput = Parameters<
+  InstanceType<typeof ContactStore>["createInvite"]
+>[0];
+
+/** Insert a contact row; unspecified fields fall back to `name-<id>`/contact/null. */
+export function seedContact(opts: {
+  id: string;
+  displayName?: string;
+  role?: string;
+  principalId?: string | null;
+  createdAt?: number;
+  updatedAt?: number;
+}): void {
+  const now = opts.createdAt ?? Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: opts.displayName ?? `name-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: opts.principalId ?? null,
+      createdAt: now,
+      updatedAt: opts.updatedAt ?? now,
+    })
+    .run();
+}
+
+/** Look up an invite row by id, asserting it exists. */
+export function inviteRow(id: string) {
+  return new ContactStore().getInviteById(id)!;
+}
+
+/** Seed a code+token text invite (defaults to the telegram channel). */
+export function seedInvite(overrides: Partial<CreateInviteInput> = {}): string {
+  const id = overrides.id ?? crypto.randomUUID();
+  new ContactStore().createInvite({
+    id,
+    sourceChannel: INVITE_CHANNEL,
+    inviteCodeHash: hashInviteCode(INVITE_CODE),
+    tokenHash: hashInviteToken(INVITE_TOKEN),
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  });
+  return id;
+}
+
+/** Seed a voice (phone-channel) invite bound to `VOICE_CALLER`. */
+export function seedVoiceInvite(
+  overrides: Partial<CreateInviteInput> = {},
+): string {
+  const id = overrides.id ?? crypto.randomUUID();
+  new ContactStore().createInvite({
+    id,
+    sourceChannel: "phone",
+    voiceCodeHash: hashInviteCode(INVITE_CODE),
+    voiceCodeDigits: 6,
+    expectedExternalUserId: VOICE_CALLER,
+    friendName: "Friend Name",
+    guardianName: "Guardian Name",
+    contactId: "c1",
+    maxUses: 1,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  });
+  return id;
+}

--- a/gateway/src/__tests__/helpers/ipc-newline-client.ts
+++ b/gateway/src/__tests__/helpers/ipc-newline-client.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared newline-framed IPC client for `GatewayIpcServer` unit tests.
+ *
+ * The server speaks one JSON object per `\n`-terminated line over a UNIX
+ * socket. `connectClient` opens a socket; `sendRequest` writes a request and
+ * resolves with the first response line. Imports only node built-ins, so it is
+ * free of import-time side effects and safe to static-import from any suite.
+ */
+import { randomBytes } from "node:crypto";
+import { createConnection, type Socket } from "node:net";
+
+export function connectClient(path: string): Promise<Socket> {
+  return new Promise<Socket>((resolve, reject) => {
+    const client: Socket = createConnection(path, () => resolve(client));
+    client.on("error", reject);
+  });
+}
+
+export function sendRequest(
+  client: Socket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{
+  id: string;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+  errorCode?: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const id = randomBytes(4).toString("hex");
+    let buffer = "";
+
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        client.off("data", onData);
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    };
+
+    client.on("data", onData);
+    client.write(JSON.stringify({ id, method, params }) + "\n");
+  });
+}

--- a/gateway/src/__tests__/inbound-register.test.ts
+++ b/gateway/src/__tests__/inbound-register.test.ts
@@ -23,6 +23,7 @@ import {
   resetGatewayDb,
 } from "../db/connection.js";
 import { contacts } from "../db/schema.js";
+import { seedContact } from "./helpers/contact-fixtures.js";
 
 beforeAll(async () => {
   await initGatewayDb();
@@ -35,25 +36,6 @@ beforeEach(() => {
 afterAll(() => {
   resetGatewayDb();
 });
-
-function seedContact(opts: {
-  id: string;
-  role: string;
-  principalId: string | null;
-}): void {
-  const now = Date.now();
-  getGatewayDb()
-    .insert(contacts)
-    .values({
-      id: opts.id,
-      displayName: `name-${opts.id}`,
-      role: opts.role,
-      principalId: opts.principalId,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .run();
-}
 
 describe("findGuardian", () => {
   test("finds a guardian seeded in the gateway DB", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine-voice.test.ts
@@ -20,8 +20,6 @@ import {
   test,
 } from "bun:test";
 
-import { hashInviteCode } from "@vellumai/gateway-client";
-
 // The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
 // assistant-DB info mirror over IPC; stub it so tests never touch a socket.
 // Spread the actual module so untouched exports (assistantDbExec,
@@ -54,9 +52,11 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } =
   await import("../db/connection.js");
 const { contacts, contactChannels, ingressInvites } =
   await import("../db/schema.js");
-const { ContactStore } = await import("../db/contact-store.js");
 const { getActiveVoiceInviteForCaller, redeemVoiceInvite } =
   await import("../verification/invite-redemption.js");
+const { inviteRow, seedVoiceInvite } = await import(
+  "./helpers/contact-fixtures.js"
+);
 
 const CALLER = "+15555550100";
 const OTHER_CALLER = "+15555550199";
@@ -113,33 +113,6 @@ function seedPhoneChannel(args: {
       createdAt: now,
     })
     .run();
-}
-
-function seedVoiceInvite(
-  overrides: Partial<
-    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
-  > = {},
-): string {
-  const store = new ContactStore();
-  const id = overrides.id ?? crypto.randomUUID();
-  store.createInvite({
-    id,
-    sourceChannel: "phone",
-    voiceCodeHash: hashInviteCode(CODE),
-    voiceCodeDigits: 6,
-    expectedExternalUserId: CALLER,
-    friendName: "Friend Name",
-    guardianName: "Guardian Name",
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-    ...overrides,
-  });
-  return id;
-}
-
-function inviteRow(id: string) {
-  return new ContactStore().getInviteById(id)!;
 }
 
 function gwPhoneChannel(address: string) {

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -13,8 +13,6 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 
 import { sql } from "drizzle-orm";
 
-import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
-
 // The engine's ACL side effect (upsertVerifiedContactChannel) dual-writes an
 // assistant-DB info mirror over IPC; stub it so tests never touch a socket.
 // The impls are mutable so tests can simulate a down/failing mirror. Spread
@@ -55,6 +53,9 @@ const { contacts, contactChannels, ingressInvites } = await import(
 const { ContactStore } = await import("../db/contact-store.js");
 const { redeemInviteByCode, redeemInviteByToken } = await import(
   "../verification/invite-redemption.js"
+);
+const { inviteRow, seedInvite } = await import(
+  "./helpers/contact-fixtures.js"
 );
 
 const CHANNEL = "telegram";
@@ -112,30 +113,6 @@ function seedChannel(args: {
       createdAt: now,
     })
     .run();
-}
-
-function seedInvite(
-  overrides: Partial<
-    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
-  > = {},
-): string {
-  const store = new ContactStore();
-  const id = overrides.id ?? crypto.randomUUID();
-  store.createInvite({
-    id,
-    sourceChannel: CHANNEL,
-    inviteCodeHash: hashInviteCode(CODE),
-    tokenHash: hashInviteToken(TOKEN),
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-    ...overrides,
-  });
-  return id;
-}
-
-function inviteRow(id: string) {
-  return new ContactStore().getInviteById(id)!;
 }
 
 function gwChannel(address: string) {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -10,8 +10,7 @@ import {
 } from "bun:test";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { randomBytes } from "node:crypto";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { eq } from "drizzle-orm";
 
 // ── Assistant DB proxy + IPC mocks ──────────────────────────────────────────
@@ -52,6 +51,7 @@ import { GatewayIpcServer } from "../ipc/server.js";
 import { contactRoutes } from "../ipc/contact-handlers.js";
 import { ContactStore } from "../db/contact-store.js";
 import { contacts, contactChannels } from "../db/schema.js";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 import {
   initGatewayDb,
   getGatewayDb,
@@ -82,49 +82,6 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function connectClient(path: string): Promise<Socket> {
-  return new Promise((resolve, reject) => {
-    const client = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{
-  id: string;
-  result?: unknown;
-  error?: string;
-  statusCode?: number;
-  errorCode?: string;
-}> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-
-    client.on("data", onData);
-    const msg = JSON.stringify({ id, method, params });
-    client.write(msg + "\n");
-  });
-}
 
 function seedTestData(): void {
   const db = getGatewayDb();

--- a/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
+++ b/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { randomBytes } from "node:crypto";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { testSecurityDir, testWorkspaceDir } from "./test-preload.js";
+
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 const protectedDir = testSecurityDir;
 const featureFlagStorePath = join(protectedDir, "feature-flags.json");
@@ -89,49 +90,6 @@ const { resetEnvOverridesCache } =
   await import("../feature-flag-env-overrides.js");
 const { GatewayIpcServer } = await import("../ipc/server.js");
 const { featureFlagRoutes } = await import("../ipc/feature-flag-handlers.js");
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Connect a raw TCP client to the IPC socket, returning a Socket. */
-function connectClient(path: string): Promise<Socket> {
-  return new Promise((resolve, reject) => {
-    const client = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-/** Send a JSON-RPC-style request and wait for the response. */
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-
-    client.on("data", onData);
-    const msg = JSON.stringify({ id, method, params });
-    client.write(msg + "\n");
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/gateway/src/__tests__/ipc-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-invite-routes.test.ts
@@ -20,12 +20,11 @@ import {
   mock,
   test,
 } from "bun:test";
-import { randomBytes } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { join } from "node:path";
 
-import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 // The engine's ACL side effect dual-writes an assistant-DB info mirror over
 // IPC; stub it so tests never touch a socket.
@@ -55,9 +54,11 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } =
   await import("../db/connection.js");
 const { contacts, contactChannels, ingressInvites } =
   await import("../db/schema.js");
-const { ContactStore } = await import("../db/contact-store.js");
 const { GatewayIpcServer } = await import("../ipc/server.js");
 const { inviteRoutes } = await import("../ipc/invite-handlers.js");
+const { inviteRow, seedInvite, seedVoiceInvite } = await import(
+  "./helpers/contact-fixtures.js"
+);
 
 // Short name: the workspace tmp prefix leaves little headroom under the
 // AF_UNIX socket-path length limit.
@@ -88,46 +89,6 @@ afterAll(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function connectClient(path: string): Promise<Socket> {
-  return new Promise((resolve, reject) => {
-    const client = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{
-  id: string;
-  result?: unknown;
-  error?: string;
-  statusCode?: number;
-  errorCode?: string;
-}> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-    client.on("data", onData);
-    client.write(JSON.stringify({ id, method, params }) + "\n");
-  });
-}
-
 /** Seed a parent contact (FK target for invites). */
 function seedContact(displayName = "Target Name"): void {
   const now = Date.now();
@@ -142,46 +103,6 @@ function seedContact(displayName = "Target Name"): void {
       updatedAt: now,
     })
     .run();
-}
-
-function seedTokenInvite(
-  overrides: Partial<
-    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
-  > = {},
-): string {
-  const id = overrides.id ?? crypto.randomUUID();
-  new ContactStore().createInvite({
-    id,
-    sourceChannel: CHANNEL,
-    inviteCodeHash: hashInviteCode(CODE),
-    tokenHash: hashInviteToken(TOKEN),
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-    ...overrides,
-  });
-  return id;
-}
-
-function seedVoiceInvite(): string {
-  const id = crypto.randomUUID();
-  new ContactStore().createInvite({
-    id,
-    sourceChannel: "phone",
-    voiceCodeHash: hashInviteCode(CODE),
-    voiceCodeDigits: 6,
-    expectedExternalUserId: CALLER,
-    friendName: "Friend Name",
-    guardianName: "Guardian Name",
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-  });
-  return id;
-}
-
-function inviteRow(id: string) {
-  return new ContactStore().getInviteById(id)!;
 }
 
 // ---------------------------------------------------------------------------
@@ -217,7 +138,7 @@ describe("invites_redeem IPC route", () => {
 
   test("token redeem: consumes the row and returns the sanitized invite + type", async () => {
     seedContact();
-    const inviteId = seedTokenInvite();
+    const inviteId = seedInvite();
 
     const res = await sendRequest(client, "invites_redeem", {
       token: TOKEN,
@@ -251,7 +172,7 @@ describe("invites_redeem IPC route", () => {
 
   test("token redeem: unknown token → 400 invalid_token, nothing consumed", async () => {
     seedContact();
-    const inviteId = seedTokenInvite();
+    const inviteId = seedInvite();
 
     const res = await sendRequest(client, "invites_redeem", {
       token: "not-the-token",
@@ -307,7 +228,7 @@ describe("invites_redeem IPC route", () => {
 
   test("token redeem for an already-active member → already_member, NO use consumed", async () => {
     seedContact();
-    const inviteId = seedTokenInvite();
+    const inviteId = seedInvite();
     const now = Date.now();
     getGatewayDb()
       .insert(contactChannels)

--- a/gateway/src/__tests__/ipc-server-multi-client.test.ts
+++ b/gateway/src/__tests__/ipc-server-multi-client.test.ts
@@ -1,55 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { randomBytes } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import "./test-preload.js";
 
 import { GatewayIpcServer, type IpcRoute } from "../ipc/server.js";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 // macOS caps Unix socket paths at sizeof(sun_path)-1 == 103 chars, so the
 // shared test-preload temp dir is too long. Mint our own short path under
 // the system tmpdir for this test.
 const shortRoot = mkdtempSync(join(tmpdir(), "vmc-"));
 const socketPath = join(shortRoot, "g.sock");
-
-function connectClient(path: string): Promise<Socket> {
-  return new Promise<Socket>((resolve, reject) => {
-    const client: Socket = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-
-    client.on("data", onData);
-    client.write(JSON.stringify({ id, method, params }) + "\n");
-  });
-}
 
 describe("GatewayIpcServer multi-client behavior", () => {
   let server: InstanceType<typeof GatewayIpcServer> | undefined;

--- a/gateway/src/__tests__/ipc-server-watchdog.test.ts
+++ b/gateway/src/__tests__/ipc-server-watchdog.test.ts
@@ -1,13 +1,13 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { randomBytes } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync, unlinkSync } from "node:fs";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import "./test-preload.js";
 
 import { GatewayIpcServer, type IpcRoute } from "../ipc/server.js";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 // Integration tests for GatewayIpcServer's watchdog wiring. The watchdog's
 // own unit tests (race guards, timer error handling, etc.) live in
@@ -28,42 +28,6 @@ afterAll(() => {
     // best-effort
   }
 });
-
-function connectClient(path: string): Promise<Socket> {
-  return new Promise<Socket>((resolve, reject) => {
-    const client: Socket = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-
-    client.on("data", onData);
-    client.write(JSON.stringify({ id, method, params }) + "\n");
-  });
-}
 
 const echoRoute: IpcRoute = {
   method: "echo",

--- a/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
+++ b/gateway/src/__tests__/ipc-slack-thread-routes.test.ts
@@ -7,8 +7,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { randomBytes } from "node:crypto";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 
 import {
   getGatewayDb,
@@ -19,6 +18,7 @@ import { SlackStore } from "../db/slack-store.js";
 import { slackActiveThreads } from "../db/schema.js";
 import { GatewayIpcServer } from "../ipc/server.js";
 import { slackThreadRoutes } from "../ipc/slack-thread-handlers.js";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 const CHANNEL_ID = "CFAKE00001";
 const OTHER_CHANNEL_ID = "COTHER0001";
@@ -36,42 +36,6 @@ beforeEach(() => {
 afterAll(() => {
   resetGatewayDb();
 });
-
-function connectClient(path: string): Promise<Socket> {
-  return new Promise((resolve, reject) => {
-    const client = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-
-    client.on("data", onData);
-    client.write(JSON.stringify({ id, method, params }) + "\n");
-  });
-}
 
 function activeThreadRows(): Array<{ threadTs: string; channelId: string }> {
   return new SlackStore(getGatewayDb()).listActiveThreadsWithChannel();

--- a/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
+++ b/gateway/src/__tests__/ipc-voice-invite-routes.test.ts
@@ -19,12 +19,11 @@ import {
   mock,
   test,
 } from "bun:test";
-import { randomBytes } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
-import { createConnection, type Socket } from "node:net";
+import { type Socket } from "node:net";
 import { join } from "node:path";
 
-import { hashInviteCode } from "@vellumai/gateway-client";
+import { connectClient, sendRequest } from "./helpers/ipc-newline-client.js";
 
 // The engine's ACL side effect dual-writes an assistant-DB info mirror over
 // IPC; stub it so tests never touch a socket.
@@ -54,9 +53,11 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } =
   await import("../db/connection.js");
 const { contacts, contactChannels, ingressInvites } =
   await import("../db/schema.js");
-const { ContactStore } = await import("../db/contact-store.js");
 const { GatewayIpcServer } = await import("../ipc/server.js");
 const { inviteRoutes } = await import("../ipc/invite-handlers.js");
+const { inviteRow, seedVoiceInvite } = await import(
+  "./helpers/contact-fixtures.js"
+);
 
 // Short name: the workspace tmp prefix leaves little headroom under the
 // AF_UNIX socket-path length limit.
@@ -85,40 +86,6 @@ afterAll(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function connectClient(path: string): Promise<Socket> {
-  return new Promise((resolve, reject) => {
-    const client = createConnection(path, () => resolve(client));
-    client.on("error", reject);
-  });
-}
-
-function sendRequest(
-  client: Socket,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<{ id: string; result?: unknown; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const id = randomBytes(4).toString("hex");
-    let buffer = "";
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const newlineIdx = buffer.indexOf("\n");
-      if (newlineIdx !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        client.off("data", onData);
-        try {
-          resolve(JSON.parse(line));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    };
-    client.on("data", onData);
-    client.write(JSON.stringify({ id, method, params }) + "\n");
-  });
-}
-
 function seedContact(displayName = "Target Name"): void {
   const now = Date.now();
   getGatewayDb()
@@ -131,32 +98,6 @@ function seedContact(displayName = "Target Name"): void {
       updatedAt: now,
     })
     .run();
-}
-
-function seedVoiceInvite(
-  overrides: Partial<
-    Parameters<InstanceType<typeof ContactStore>["createInvite"]>[0]
-  > = {},
-): string {
-  const id = overrides.id ?? crypto.randomUUID();
-  new ContactStore().createInvite({
-    id,
-    sourceChannel: "phone",
-    voiceCodeHash: hashInviteCode(CODE),
-    voiceCodeDigits: 6,
-    expectedExternalUserId: CALLER,
-    friendName: "Friend Name",
-    guardianName: "Guardian Name",
-    contactId: "c1",
-    maxUses: 1,
-    expiresAt: Date.now() + 60_000,
-    ...overrides,
-  });
-  return id;
-}
-
-function inviteRow(id: string) {
-  return new ContactStore().getInviteById(id)!;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract shared contact/invite fixtures and a newline-framed IPC client helper; adopt across duplicating gateway test files. Behavior-neutral, identical test counts.

Part of plan: contacts-acl-cleanup.md (PR 14 of 14)