### PR TITLE
feat(calls): implement invite-redemption sub-flow in call-setup-flow

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-invite.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-invite.test.ts
@@ -1,0 +1,542 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CALL_SESSION_ID = "call-session-1";
+const CALLER_NUMBER = "+15555550100";
+const CONVERSATION_ID = "conv-invite-1";
+const CODE = "123456";
+
+const UPGRADED_TRUST: TrustContext = {
+  sourceChannel: "phone",
+  trustClass: "trusted_contact",
+  requesterChatId: CALLER_NUMBER,
+};
+
+function makeResolved(isInbound: boolean): SetupResolved {
+  return {
+    assistantId: "self",
+    isInbound,
+    otherPartyNumber: CALLER_NUMBER,
+    actorTrust: {
+      canonicalSenderId: CALLER_NUMBER,
+      guardianBindingMatch: null,
+      memberRecord: null,
+      trustClass: "unknown",
+      actorMetadata: {
+        identifier: CALLER_NUMBER,
+        displayName: undefined,
+        senderDisplayName: undefined,
+        memberDisplayName: undefined,
+        username: undefined,
+        channel: "phone",
+        trustStatus: "unknown",
+      },
+    },
+  };
+}
+
+function inviteOutcome(inviteeName: string | null): SetupOutcome {
+  return {
+    action: "invite_redemption",
+    assistantId: "self",
+    fromNumber: CALLER_NUMBER,
+    inviteeName,
+  };
+}
+
+type RedemptionFn = CallSetupFlowDeps["attemptInviteCodeRedemption"];
+
+const successRedemption: RedemptionFn = async () => ({
+  outcome: "success",
+  memberId: "contact-abc",
+  type: "redeemed",
+  inviteId: "invite-xyz",
+});
+
+const failureRedemption: RedemptionFn = async ({ guardianLabel }) => ({
+  outcome: "failure",
+  ttsMessage: `Sorry, the code you provided is incorrect or has since expired. Please ask ${guardianLabel} for a new code. Goodbye.`,
+});
+
+function createHarness(overrides?: Partial<CallSetupFlowDeps>) {
+  const spoken: string[] = [];
+  const endReasons: Array<string | undefined> = [];
+  const sessionUpdates: Array<Record<string, unknown>> = [];
+  const events: Array<{
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }> = [];
+  const results: SetupFlowResult[] = [];
+  const redemptionCalls: Array<{
+    inviteRedemptionFromNumber: string;
+    enteredCode: string;
+    guardianLabel: string;
+  }> = [];
+  const finalizeCalls: Array<{ callSessionId: string; conversationId: string }> =
+    [];
+  const notifierCalls: Array<{
+    conversationId: string;
+    callSessionId: string;
+    speaker: "caller" | "assistant";
+    text: string;
+  }> = [];
+
+  const transport: SetupFlowTransport = {
+    sendTextToken: () => {},
+    sendPlayUrl: () => {},
+    endSession: (reason) => {
+      endReasons.push(reason);
+    },
+    getConnectionState: () => "connected",
+  };
+
+  // Record every claim regardless of which redemption impl a test injects.
+  const {
+    attemptInviteCodeRedemption: redemptionImpl = successRedemption,
+    ...restOverrides
+  } = overrides ?? {};
+
+  const deps: CallSetupFlowDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spoken.push(text);
+    },
+    updateCallSession: (_id, updates) => {
+      sessionUpdates.push(updates as Record<string, unknown>);
+    },
+    recordCallEvent: (_callSessionId, eventType, payload) => {
+      events.push({ eventType, payload });
+    },
+    onComplete: (result) => {
+      results.push(result);
+    },
+    ttsPlaybackDelayMs: 0,
+    attemptInviteCodeRedemption: async (params) => {
+      redemptionCalls.push(params);
+      return redemptionImpl(params);
+    },
+    resolveGuardianLabel: () => "Bob",
+    resolveAssistantLabel: () => "Vellum",
+    getCallSession: () => ({ conversationId: CONVERSATION_ID }),
+    finalizeCall: (callSessionId, conversationId) => {
+      finalizeCalls.push({ callSessionId, conversationId });
+    },
+    fireCallTranscriptNotifier: (
+      conversationId,
+      callSessionId,
+      speaker,
+      text,
+    ) => {
+      notifierCalls.push({ conversationId, callSessionId, speaker, text });
+    },
+    resolveMidCallTrustContext: async () => UPGRADED_TRUST,
+    ...restOverrides,
+  };
+
+  const flow = new CallSetupFlow(CALL_SESSION_ID, transport, deps);
+  return {
+    flow,
+    spoken,
+    endReasons,
+    sessionUpdates,
+    events,
+    results,
+    redemptionCalls,
+    finalizeCalls,
+    notifierCalls,
+  };
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function enterCode(flow: CallSetupFlow, code = CODE) {
+  for (const digit of code) {
+    flow.pushDtmfDigit(digit);
+  }
+  await settle();
+  await settle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CallSetupFlow invite redemption", () => {
+  describe("prompt copy", () => {
+    test("inbound prompt greets the invitee by first name with the guardian label", async () => {
+      const { flow, spoken, events } = createHarness();
+
+      await flow.start(inviteOutcome("Alice Example"), makeResolved(true));
+
+      expect(flow.getState()).toBe("collecting_code");
+      expect(spoken).toEqual([
+        "Welcome Alice. Please enter the 6-digit code that Bob provided you to verify your identity.",
+      ]);
+      expect(events).toEqual([
+        {
+          eventType: "invite_redemption_started",
+          payload: { assistantId: "self", codeLength: 6, maxAttempts: 1 },
+        },
+      ]);
+    });
+
+    test("inbound prompt falls back to 'there' when the invitee name is missing", async () => {
+      const { flow, spoken } = createHarness();
+
+      await flow.start(inviteOutcome(null), makeResolved(true));
+
+      expect(spoken).toEqual([
+        "Welcome there. Please enter the 6-digit code that Bob provided you to verify your identity.",
+      ]);
+    });
+
+    test("outbound prompt introduces the assistant by name", async () => {
+      const { flow, spoken } = createHarness({
+        resolveGuardianLabel: () => "Hank",
+      });
+
+      await flow.start(inviteOutcome("Grace"), makeResolved(false));
+
+      expect(spoken).toEqual([
+        "Hi Grace, this is Vellum, Hank's assistant. To get started, please enter the 6-digit code that Hank shared with you.",
+      ]);
+    });
+
+    test("outbound prompt omits the assistant name when unavailable", async () => {
+      const { flow, spoken } = createHarness({
+        resolveGuardianLabel: () => "Hank",
+        resolveAssistantLabel: () => null,
+      });
+
+      await flow.start(inviteOutcome("Grace"), makeResolved(false));
+
+      expect(spoken).toEqual([
+        "Hi Grace, this is Hank's assistant. To get started, please enter the 6-digit code that Hank shared with you.",
+      ]);
+    });
+  });
+
+  describe("successful redemption", () => {
+    test("valid DTMF code redeems at the gateway and hands off with proceed-handoff-spoken", async () => {
+      const {
+        flow,
+        spoken,
+        events,
+        results,
+        sessionUpdates,
+        redemptionCalls,
+        notifierCalls,
+        endReasons,
+      } = createHarness();
+
+      await flow.start(
+        inviteOutcome("Carolina Flaherty"),
+        makeResolved(true),
+      );
+      await enterCode(flow);
+
+      expect(redemptionCalls).toEqual([
+        {
+          inviteRedemptionFromNumber: CALLER_NUMBER,
+          enteredCode: CODE,
+          guardianLabel: "Bob",
+        },
+      ]);
+      expect(events).toContainEqual({
+        eventType: "invite_redemption_succeeded",
+        payload: { memberId: "contact-abc", inviteId: "invite-xyz" },
+      });
+      expect(sessionUpdates).toContainEqual({ status: "in_progress" });
+
+      // Greeting uses the bound contact displayName's first token only.
+      const handoff =
+        "Great, I've verified that you are Carolina. It's nice to meet you! I'm Vellum, Bob's assistant. How can I help?";
+      expect(spoken).toContain(handoff);
+      expect(events).toContainEqual({
+        eventType: "assistant_spoke",
+        payload: { text: handoff },
+      });
+      expect(notifierCalls).toEqual([
+        {
+          conversationId: CONVERSATION_ID,
+          callSessionId: CALL_SESSION_ID,
+          speaker: "assistant",
+          text: handoff,
+        },
+      ]);
+
+      expect(flow.getState()).toBe("completed");
+      expect(results).toEqual([
+        {
+          kind: "proceed-handoff-spoken",
+          assistantId: "self",
+          trustContext: UPGRADED_TRUST,
+        },
+      ]);
+      // The call stays alive — no session teardown on success.
+      expect(endReasons).toEqual([]);
+    });
+
+    test("spoken digits redeem like DTMF", async () => {
+      const { flow, redemptionCalls, results } = createHarness();
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      flow.pushTranscriptFinal("one two three four five six");
+      await settle();
+      await settle();
+
+      expect(redemptionCalls).toEqual([
+        {
+          inviteRedemptionFromNumber: CALLER_NUMBER,
+          enteredCode: "123456",
+          guardianLabel: "Bob",
+        },
+      ]);
+      expect(results).toHaveLength(1);
+      expect(results[0].kind).toBe("proceed-handoff-spoken");
+    });
+
+    test("already_member outcome also proceeds to the handoff", async () => {
+      const { flow, results, events } = createHarness({
+        attemptInviteCodeRedemption: async () => ({
+          outcome: "success",
+          memberId: "contact-abc",
+          type: "already_member",
+          inviteId: "invite-xyz",
+        }),
+      });
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      await enterCode(flow);
+
+      expect(
+        events.some((e) => e.eventType === "invite_redemption_succeeded"),
+      ).toBe(true);
+      expect(results).toHaveLength(1);
+      expect(results[0].kind).toBe("proceed-handoff-spoken");
+    });
+  });
+
+  describe("greeting personalization", () => {
+    test("blank invitee name triggers the neutral 'Hi there' greeting, never the phone number", async () => {
+      const { flow, spoken } = createHarness();
+
+      await flow.start(inviteOutcome("   "), makeResolved(true));
+      await enterCode(flow);
+
+      expect(spoken).toContain(
+        "Hi there! I'm Vellum, Bob's assistant. How can I help?",
+      );
+      expect(spoken.every((text) => !text.includes(CALLER_NUMBER))).toBe(true);
+    });
+
+    test("blank invitee name without an assistant name uses the plain neutral copy", async () => {
+      const { flow, spoken } = createHarness({
+        resolveAssistantLabel: () => null,
+      });
+
+      await flow.start(inviteOutcome(null), makeResolved(true));
+      await enterCode(flow);
+
+      expect(spoken).toContain("Hi there! How can I help?");
+    });
+
+    test("named invitee without an assistant name omits the introduction", async () => {
+      const { flow, spoken } = createHarness({
+        resolveAssistantLabel: () => null,
+      });
+
+      await flow.start(inviteOutcome("Grace Hopper"), makeResolved(true));
+      await enterCode(flow);
+
+      expect(spoken).toContain(
+        "Great, I've verified that you are Grace. It's nice to meet you! How can I help?",
+      );
+    });
+  });
+
+  describe("failed redemption", () => {
+    test("invalid code speaks the exact failure copy, finalizes, and ends the call", async () => {
+      const {
+        flow,
+        spoken,
+        events,
+        results,
+        sessionUpdates,
+        finalizeCalls,
+        endReasons,
+      } = createHarness({
+        attemptInviteCodeRedemption: failureRedemption,
+        resolveGuardianLabel: () => "Dave",
+      });
+
+      await flow.start(inviteOutcome("Carol"), makeResolved(true));
+      await enterCode(flow, "000000");
+
+      expect(spoken).toContain(
+        "Sorry, the code you provided is incorrect or has since expired. Please ask Dave for a new code. Goodbye.",
+      );
+      expect(events).toContainEqual({
+        eventType: "invite_redemption_failed",
+        payload: { attempts: 1 },
+      });
+
+      expect(sessionUpdates).toHaveLength(1);
+      expect(sessionUpdates[0].status).toBe("failed");
+      expect(sessionUpdates[0].lastError).toBe(
+        "Voice invite redemption failed — invalid or expired code",
+      );
+      expect(sessionUpdates[0].endedAt).toBeNumber();
+
+      expect(finalizeCalls).toEqual([
+        {
+          callSessionId: CALL_SESSION_ID,
+          conversationId: CONVERSATION_ID,
+        },
+      ]);
+
+      expect(flow.getState()).toBe("completed");
+      expect(results).toEqual([
+        { kind: "ended", reason: "Invite redemption failed" },
+      ]);
+
+      // Session teardown fires after the playback delay.
+      await settle();
+      expect(endReasons).toEqual(["Invite redemption failed"]);
+    });
+
+    test("input after a terminal failure is ignored", async () => {
+      const { flow, redemptionCalls, results } = createHarness({
+        attemptInviteCodeRedemption: failureRedemption,
+      });
+
+      await flow.start(inviteOutcome("Carol"), makeResolved(true));
+      await enterCode(flow, "000000");
+      expect(redemptionCalls).toHaveLength(1);
+
+      await enterCode(flow);
+      flow.pushTranscriptFinal("one two three four five six");
+      await settle();
+
+      expect(redemptionCalls).toHaveLength(1);
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe("in-flight dedupe", () => {
+    test("a repeated code while the gateway claim is pending never double-fires redemption", async () => {
+      let releaseClaim: () => void = () => {};
+      const claimGate = new Promise<void>((resolve) => {
+        releaseClaim = resolve;
+      });
+      let claimCalls = 0;
+
+      const { flow, results, events } = createHarness({
+        attemptInviteCodeRedemption: async (params) => {
+          claimCalls += 1;
+          await claimGate;
+          return successRedemption(params);
+        },
+      });
+
+      await flow.start(inviteOutcome("Eve"), makeResolved(true));
+
+      // First attempt reaches the awaited gateway claim.
+      for (const digit of CODE) {
+        flow.pushDtmfDigit(digit);
+      }
+      await settle();
+      expect(claimCalls).toBe(1);
+
+      // Second burst with the same code arrives while the claim is pending —
+      // it must be dropped, not queued.
+      for (const digit of CODE) {
+        flow.pushDtmfDigit(digit);
+      }
+      await settle();
+      expect(claimCalls).toBe(1);
+
+      releaseClaim();
+      await settle();
+      await settle();
+
+      expect(claimCalls).toBe(1);
+      expect(
+        events.some((e) => e.eventType === "invite_redemption_succeeded"),
+      ).toBe(true);
+      expect(
+        events.some((e) => e.eventType === "invite_redemption_failed"),
+      ).toBe(false);
+      expect(results).toHaveLength(1);
+      expect(results[0].kind).toBe("proceed-handoff-spoken");
+    });
+  });
+
+  describe("code collection", () => {
+    test("partial spoken digits re-prompt without attempting redemption", async () => {
+      const { flow, spoken, redemptionCalls } = createHarness();
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      flow.pushTranscriptFinal("one two three");
+      await settle();
+
+      expect(redemptionCalls).toEqual([]);
+      expect(spoken).toContain(
+        "I heard 3 digits. Please enter all 6 digits of your code.",
+      );
+      expect(flow.getState()).toBe("collecting_code");
+    });
+
+    test("non-digit speech during collection is ignored", async () => {
+      const { flow, spoken, redemptionCalls } = createHarness();
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      const promptCount = spoken.length;
+      flow.pushTranscriptFinal("hello, is anyone there?");
+      await settle();
+
+      expect(redemptionCalls).toEqual([]);
+      expect(spoken).toHaveLength(promptCount);
+    });
+  });
+
+  describe("trust re-resolution", () => {
+    test("falls back to the setup-time trust context when re-resolution fails", async () => {
+      const { flow, results } = createHarness({
+        resolveMidCallTrustContext: async () => {
+          throw new Error("gateway unavailable");
+        },
+      });
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      await enterCode(flow);
+
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      if (result.kind !== "proceed-handoff-spoken") {
+        throw new Error("expected proceed-handoff-spoken");
+      }
+      // Fail-soft: the call continues under the setup-time trust rather
+      // than wedging on the re-resolution error.
+      expect(result.trustContext.sourceChannel).toBe("phone");
+      expect(result.trustContext.trustClass).toBe("unknown");
+      expect(result.trustContext.requesterChatId).toBe(CALLER_NUMBER);
+    });
+  });
+});

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -92,6 +92,19 @@ function createFlow(overrides?: Partial<CallSetupFlowDeps>) {
       results.push(result);
     },
     ttsPlaybackDelayMs: 0,
+    attemptInviteCodeRedemption: async () => ({
+      outcome: "failure" as const,
+      ttsMessage: "unused",
+    }),
+    resolveGuardianLabel: () => "Bob",
+    resolveAssistantLabel: () => null,
+    getCallSession: () => ({ conversationId: "conv-1" }),
+    finalizeCall: () => {},
+    fireCallTranscriptNotifier: () => {},
+    resolveMidCallTrustContext: async () => ({
+      sourceChannel: "phone" as const,
+      trustClass: "trusted_contact" as const,
+    }),
     ...overrides,
   };
 

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -7,11 +7,13 @@
  * completion) flow through injected deps so the flow is unit-testable and
  * independent of any wire protocol.
  *
- * Handles `normal_call` and `deny`. Other setup actions (verification,
- * invite redemption, name capture) throw {@link UnsupportedSetupFlowError}.
+ * Handles `normal_call`, `deny`, and `invite_redemption`. Other setup
+ * actions (verification, name capture) throw {@link UnsupportedSetupFlowError}.
  */
 
+import type { TrustContext } from "../daemon/trust-context.js";
 import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import { getLogger } from "../util/logger.js";
 import { getTtsPlaybackDelayMs } from "./call-constants.js";
 import type {
   SetupFlowInput,
@@ -19,11 +21,35 @@ import type {
   SetupFlowState,
   SetupFlowTransport,
 } from "./call-setup-flow-types.js";
+import type { fireCallTranscriptNotifier as fireCallTranscriptNotifierFn } from "./call-state.js";
 import type {
   recordCallEvent as recordCallEventFn,
   updateCallSession as updateCallSessionFn,
 } from "./call-store.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
+import {
+  type attemptInviteCodeRedemption as attemptInviteCodeRedemptionFn,
+  parseDigitsFromSpeech,
+} from "./relay-verification.js";
+
+const log = getLogger("call-setup-flow");
+
+const INVITE_CODE_LENGTH = 6;
+
+/**
+ * Return the first whitespace-delimited token of a name, or `null` when the
+ * input is null/blank. Used for greetings so "Alice Example" -> "Alice".
+ */
+function firstToken(name: string | null | undefined): string | null {
+  if (!name) {
+    return null;
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.split(/\s+/)[0] ?? null;
+}
 
 // ── Errors ───────────────────────────────────────────────────────────
 
@@ -61,12 +87,57 @@ export interface CallSetupFlowDeps {
    * Defaults to the configured TTS playback delay.
    */
   ttsPlaybackDelayMs?: number;
+
+  // ── Invite-redemption sub-flow dependencies ─────────────────────────
+
+  /** Gateway-native invite claim (relay-verification.ts). */
+  attemptInviteCodeRedemption: typeof attemptInviteCodeRedemptionFn;
+  /** Human-readable guardian label for prompts and handoff copy. */
+  resolveGuardianLabel(): string;
+  /** Assistant display name, or null when unavailable/UUID-shaped. */
+  resolveAssistantLabel(): string | null;
+  /** Look up the call session (used for its conversationId). */
+  getCallSession(id: string): { conversationId: string } | null;
+  /** Persist the call-completion message and fire completion notifiers. */
+  finalizeCall(callSessionId: string, conversationId: string): void;
+  fireCallTranscriptNotifier: typeof fireCallTranscriptNotifierFn;
+  /**
+   * Re-resolve caller trust after a successful activation (verdict-first
+   * with local fallback). Errors fail soft to the setup-time trust.
+   */
+  resolveMidCallTrustContext(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<TrustContext>;
+}
+
+// ── Sub-flow state ───────────────────────────────────────────────────
+
+interface InviteRedemptionState {
+  assistantId: string;
+  fromNumber: string;
+  inviteeName: string | null;
+  /** Setup-time trust, used when post-activation re-resolution fails. */
+  fallbackTrustContext: TrustContext;
 }
 
 // ── Flow ─────────────────────────────────────────────────────────────
 
 export class CallSetupFlow implements SetupFlowInput {
   private state: SetupFlowState = "idle";
+
+  // ── Invite-redemption sub-flow state ────────────────────────────────
+  /** Shared digit buffer for code collection (DTMF + spoken digits). */
+  private digitBuffer = "";
+  /**
+   * In-flight dedupe guard: the gateway claim is async, and a repeated
+   * code (re-spoken / re-entered) arriving while it is pending must not
+   * fire a second redemption that would see the invite already consumed
+   * and wrongly fail the call. Set synchronously before awaiting and
+   * cleared in a finally.
+   */
+  private inviteRedemptionInFlight = false;
+  private invite: InviteRedemptionState | null = null;
 
   constructor(
     private readonly callSessionId: string,
@@ -104,6 +175,10 @@ export class CallSetupFlow implements SetupFlowInput {
         await this.runDeny(outcome, resolved);
         return;
 
+      case "invite_redemption":
+        this.startInviteRedemption(outcome, resolved);
+        return;
+
       default:
         throw new UnsupportedSetupFlowError(outcome.action);
     }
@@ -112,16 +187,37 @@ export class CallSetupFlow implements SetupFlowInput {
   // ── SetupFlowInput ──────────────────────────────────────────────────
 
   /** Feed a DTMF digit to the active sub-flow. No-op while idle/completed. */
-  pushDtmfDigit(_digit: string): void {
+  pushDtmfDigit(digit: string): void {
     if (!this.acceptsInput()) {
       return;
+    }
+    if (this.state === "collecting_code" && this.invite) {
+      this.digitBuffer += digit;
+      if (this.digitBuffer.length >= INVITE_CODE_LENGTH) {
+        const enteredCode = this.digitBuffer.slice(0, INVITE_CODE_LENGTH);
+        this.digitBuffer = "";
+        void this.handleInviteCodeEntry(enteredCode);
+      }
     }
   }
 
   /** Feed a final caller transcript to the active sub-flow. No-op while idle/completed. */
-  pushTranscriptFinal(_text: string): void {
+  pushTranscriptFinal(text: string): void {
     if (!this.acceptsInput()) {
       return;
+    }
+    if (this.state === "collecting_code" && this.invite) {
+      const spokenDigits = parseDigitsFromSpeech(text);
+      if (spokenDigits.length >= INVITE_CODE_LENGTH) {
+        void this.handleInviteCodeEntry(
+          spokenDigits.slice(0, INVITE_CODE_LENGTH),
+        );
+      } else if (spokenDigits.length > 0) {
+        void this.deps.speakSystemPrompt(
+          this.transport,
+          `I heard ${spokenDigits.length} digits. Please enter all ${INVITE_CODE_LENGTH} digits of your code.`,
+        );
+      }
     }
   }
 
@@ -150,6 +246,204 @@ export class CallSetupFlow implements SetupFlowInput {
       this.deps.ttsPlaybackDelayMs ?? getTtsPlaybackDelayMs(),
     );
     this.complete({ kind: "ended", reason: outcome.logReason });
+  }
+
+  // ── Invite redemption ───────────────────────────────────────────────
+
+  /**
+   * Enter the invite-redemption sub-flow for a caller with an active voice
+   * invite. Prompts the caller to enter their 6-digit invite code via DTMF
+   * or speech; the code is validated in a single attempt.
+   */
+  private startInviteRedemption(
+    outcome: Extract<SetupOutcome, { action: "invite_redemption" }>,
+    resolved: SetupResolved,
+  ): void {
+    this.invite = {
+      assistantId: outcome.assistantId,
+      fromNumber: outcome.fromNumber,
+      inviteeName: outcome.inviteeName,
+      fallbackTrustContext: toTrustContext(
+        resolved.actorTrust,
+        resolved.otherPartyNumber,
+      ),
+    };
+    this.digitBuffer = "";
+    this.inviteRedemptionInFlight = false;
+    this.state = "collecting_code";
+
+    this.deps.recordCallEvent(this.callSessionId, "invite_redemption_started", {
+      assistantId: outcome.assistantId,
+      codeLength: INVITE_CODE_LENGTH,
+      maxAttempts: 1,
+    });
+
+    const displayFriend = firstToken(outcome.inviteeName) ?? "there";
+    const displayGuardian = this.deps.resolveGuardianLabel();
+
+    let promptText: string;
+    if (!resolved.isInbound) {
+      const assistantName = this.deps.resolveAssistantLabel();
+      promptText = assistantName
+        ? `Hi ${displayFriend}, this is ${assistantName}, ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`
+        : `Hi ${displayFriend}, this is ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`;
+    } else {
+      promptText = `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
+    }
+    void this.deps.speakSystemPrompt(this.transport, promptText);
+
+    log.info(
+      { callSessionId: this.callSessionId, assistantId: outcome.assistantId },
+      `${resolved.isInbound ? "Inbound" : "Outbound"} voice invite redemption started`,
+    );
+  }
+
+  /**
+   * Validate a fully-entered invite code, deduping concurrent attempts:
+   * a repeated code arriving while the async gateway redemption is still
+   * in flight is ignored.
+   */
+  private async handleInviteCodeEntry(enteredCode: string): Promise<void> {
+    const invite = this.invite;
+    if (!invite) {
+      return;
+    }
+    if (this.inviteRedemptionInFlight) {
+      log.info(
+        { callSessionId: this.callSessionId },
+        "Ignoring repeated invite code — redemption already in flight",
+      );
+      return;
+    }
+    this.inviteRedemptionInFlight = true;
+
+    try {
+      await this.runInviteCodeRedemption(invite, enteredCode);
+    } finally {
+      this.inviteRedemptionInFlight = false;
+    }
+  }
+
+  private async runInviteCodeRedemption(
+    invite: InviteRedemptionState,
+    enteredCode: string,
+  ): Promise<void> {
+    const result = await this.deps.attemptInviteCodeRedemption({
+      inviteRedemptionFromNumber: invite.fromNumber,
+      enteredCode,
+      guardianLabel: this.deps.resolveGuardianLabel(),
+    });
+
+    if (result.outcome === "success") {
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "invite_redemption_succeeded",
+        { memberId: result.memberId, inviteId: result.inviteId },
+      );
+      log.info(
+        {
+          callSessionId: this.callSessionId,
+          memberId: result.memberId,
+          type: result.type,
+        },
+        "Voice invite redemption succeeded",
+      );
+
+      await this.completeInviteActivation(invite);
+    } else {
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "invite_redemption_failed",
+        { attempts: 1 },
+      );
+      log.warn(
+        { callSessionId: this.callSessionId },
+        "Voice invite redemption failed — invalid or expired code",
+      );
+
+      this.deps.updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: "Voice invite redemption failed — invalid or expired code",
+      });
+
+      const failSession = this.deps.getCallSession(this.callSessionId);
+      if (failSession) {
+        this.deps.finalizeCall(this.callSessionId, failSession.conversationId);
+      }
+
+      await this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+      setTimeout(
+        () => this.transport.endSession("Invite redemption failed"),
+        this.deps.ttsPlaybackDelayMs ?? getTtsPlaybackDelayMs(),
+      );
+      this.complete({ kind: "ended", reason: "Invite redemption failed" });
+    }
+  }
+
+  /**
+   * Post-redemption trusted-contact activation: mark the session live,
+   * re-resolve the caller's (now upgraded) trust, speak the personalized
+   * handoff copy, and hand control back with `proceed-handoff-spoken`.
+   *
+   * Greeting rules: only the first whitespace-delimited token of the
+   * invitee name is used; an empty/blank name triggers the neutral
+   * "Hi there" copy rather than substituting the channel address.
+   */
+  private async completeInviteActivation(
+    invite: InviteRedemptionState,
+  ): Promise<void> {
+    this.deps.updateCallSession(this.callSessionId, { status: "in_progress" });
+
+    let trustContext: TrustContext;
+    try {
+      trustContext = await this.deps.resolveMidCallTrustContext(
+        invite.assistantId,
+        invite.fromNumber,
+      );
+    } catch (err) {
+      log.warn(
+        { callSessionId: this.callSessionId, err },
+        "Post-redemption trust re-resolution failed — using setup-time trust",
+      );
+      trustContext = invite.fallbackTrustContext;
+    }
+
+    const guardianLabel = this.deps.resolveGuardianLabel();
+    const assistantName = this.deps.resolveAssistantLabel();
+    const firstName = firstToken(invite.inviteeName);
+
+    let handoffText: string;
+    if (firstName) {
+      handoffText = assistantName
+        ? `Great, I've verified that you are ${firstName}. It's nice to meet you! I'm ${assistantName}, ${guardianLabel}'s assistant. How can I help?`
+        : `Great, I've verified that you are ${firstName}. It's nice to meet you! How can I help?`;
+    } else {
+      handoffText = assistantName
+        ? `Hi there! I'm ${assistantName}, ${guardianLabel}'s assistant. How can I help?`
+        : `Hi there! How can I help?`;
+    }
+
+    void this.deps.speakSystemPrompt(this.transport, handoffText);
+
+    this.deps.recordCallEvent(this.callSessionId, "assistant_spoke", {
+      text: handoffText,
+    });
+    const session = this.deps.getCallSession(this.callSessionId);
+    if (session) {
+      this.deps.fireCallTranscriptNotifier(
+        session.conversationId,
+        this.callSessionId,
+        "assistant",
+        handoffText,
+      );
+    }
+
+    this.complete({
+      kind: "proceed-handoff-spoken",
+      assistantId: invite.assistantId,
+      trustContext,
+    });
   }
 
   // ── Internals ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Ports the voice invite-redemption sub-flow from relay-server into the transport-agnostic CallSetupFlow (gateway-native claim via redeemVoiceInviteCode)
- Preserves the in-flight dedupe guard, personalized greeting rules, failure copy, and invite_redemption_* events
- Covered by a dedicated test suite

Part of plan: phone-media-stream-v2.md (PR 6 of 17)