### PR TITLE
feat(calls): implement DTMF/speech verification sub-flows in call-setup-flow

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-verification.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-verification.test.ts
@@ -1,0 +1,823 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { CallSession } from "../calls/types.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { TrustClass } from "../runtime/trust-class.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CALL_SESSION_ID = "call-session-1";
+const PHONE_NUMBER = "+15555550100";
+const TO_NUMBER = "+15555550101";
+const CORRECT_CODE = "123456";
+
+const UPGRADED_TRUST: TrustContext = {
+  sourceChannel: "phone",
+  trustClass: "guardian",
+  requesterChatId: PHONE_NUMBER,
+};
+
+function makeResolved(
+  trustClass: TrustClass = "unknown",
+  overrides?: Partial<SetupResolved>,
+): SetupResolved {
+  return {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: PHONE_NUMBER,
+    actorTrust: {
+      canonicalSenderId: PHONE_NUMBER,
+      guardianBindingMatch: null,
+      memberRecord: null,
+      trustClass,
+      actorMetadata: {
+        identifier: PHONE_NUMBER,
+        displayName: undefined,
+        senderDisplayName: undefined,
+        memberDisplayName: undefined,
+        username: undefined,
+        channel: "phone",
+        trustStatus: trustClass,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeSession(overrides?: Partial<CallSession>): CallSession {
+  return {
+    id: CALL_SESSION_ID,
+    conversationId: "conv-1",
+    provider: "twilio",
+    providerCallSid: null,
+    fromNumber: PHONE_NUMBER,
+    toNumber: TO_NUMBER,
+    task: null,
+    status: "in_progress",
+    callMode: null,
+    verificationSessionId: null,
+    inviteFriendName: null,
+    inviteGuardianName: null,
+    callerIdentityMode: null,
+    callerIdentitySource: null,
+    skipDisclosure: false,
+    initiatedFromConversationId: "conv-origin",
+    startedAt: null,
+    endedAt: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+const inboundVerificationOutcome: SetupOutcome = {
+  action: "verification",
+  assistantId: "self",
+  fromNumber: PHONE_NUMBER,
+};
+
+const outboundVerificationOutcome: SetupOutcome = {
+  action: "outbound_verification",
+  assistantId: "self",
+  sessionId: "vs-1",
+  toNumber: TO_NUMBER,
+};
+
+function calleeOutcome(maxAttempts = 3, codeLength = 4): SetupOutcome {
+  return {
+    action: "callee_verification",
+    verificationConfig: { maxAttempts, codeLength },
+  };
+}
+
+type AttemptParams = Parameters<
+  NonNullable<CallSetupFlowDeps["attemptVerificationCode"]>
+>[0];
+
+/** Mirror of relay-verification's attemptVerificationCode result contract. */
+function fakeAttemptVerification(opts: {
+  correctCode: string;
+  verificationType?: "guardian" | "trusted_contact";
+}): NonNullable<CallSetupFlowDeps["attemptVerificationCode"]> {
+  return async (params) => {
+    if (params.enteredCode === opts.correctCode) {
+      return {
+        outcome: "success",
+        verificationType: opts.verificationType ?? "guardian",
+        eventName: params.isOutbound
+          ? "outbound_voice_verification_succeeded"
+          : "voice_verification_succeeded",
+      };
+    }
+    const attempts = params.verificationAttempts + 1;
+    if (attempts >= params.verificationMaxAttempts) {
+      return {
+        outcome: "failure",
+        eventName: params.isOutbound
+          ? "outbound_voice_verification_failed"
+          : "voice_verification_failed",
+        ttsMessage: "Verification failed. Goodbye.",
+        attempts,
+      };
+    }
+    return {
+      outcome: "retry",
+      ttsMessage: "That code was incorrect. Please try again.",
+      attempt: attempts,
+      maxAttempts: params.verificationMaxAttempts,
+    };
+  };
+}
+
+function createFlow(opts?: {
+  deps?: Partial<CallSetupFlowDeps>;
+  session?: CallSession | null;
+}) {
+  const spokenTokens: Array<{ token: string; last: boolean }> = [];
+  const endReasons: Array<string | undefined> = [];
+  const transport: SetupFlowTransport = {
+    sendTextToken: (token, last) => {
+      spokenTokens.push({ token, last });
+    },
+    sendPlayUrl: () => {},
+    endSession: (reason) => {
+      endReasons.push(reason);
+    },
+    getConnectionState: () => "connected",
+  };
+
+  const spoken: string[] = [];
+  const sessionUpdates: Array<Record<string, unknown>> = [];
+  const events: Array<{
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }> = [];
+  const results: SetupFlowResult[] = [];
+  const attemptCalls: AttemptParams[] = [];
+  const pointerMessages: Array<{
+    conversationId: string;
+    event: string;
+    phoneNumber: string;
+    extra?: Record<string, unknown>;
+  }> = [];
+  const addedMessages: Array<{
+    conversationId: string;
+    role: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }> = [];
+  const finalized: Array<{ callSessionId: string; conversationId: string }> =
+    [];
+  const notified: Array<{
+    conversationId: string;
+    callSessionId: string;
+    speaker: string;
+    text: string;
+  }> = [];
+  const trustResolutions: Array<{ assistantId: string; fromNumber: string }> =
+    [];
+
+  const session = opts && "session" in opts ? opts.session! : makeSession();
+  const attempt = fakeAttemptVerification({ correctCode: CORRECT_CODE });
+
+  const deps: CallSetupFlowDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spoken.push(text);
+    },
+    updateCallSession: (_id, updates) => {
+      sessionUpdates.push(updates as Record<string, unknown>);
+    },
+    recordCallEvent: (_callSessionId, eventType, payload) => {
+      events.push({ eventType, payload });
+    },
+    onComplete: (result) => {
+      results.push(result);
+    },
+    ttsPlaybackDelayMs: 0,
+    getCallSession: () => session,
+    finalizeCall: (callSessionId, conversationId) => {
+      finalized.push({ callSessionId, conversationId });
+    },
+    addMessage: (async (
+      conversationId: string,
+      role: string,
+      content: string,
+      options?: { metadata?: Record<string, unknown> },
+    ) => {
+      addedMessages.push({
+        conversationId,
+        role,
+        content,
+        metadata: options?.metadata,
+      });
+    }) as unknown as CallSetupFlowDeps["addMessage"],
+    addPointerMessage: (async (
+      conversationId: string,
+      event: string,
+      phoneNumber: string,
+      extra?: Record<string, unknown>,
+    ) => {
+      pointerMessages.push({ conversationId, event, phoneNumber, extra });
+    }) as unknown as CallSetupFlowDeps["addPointerMessage"],
+    fireCallTranscriptNotifier: (
+      conversationId,
+      callSessionId,
+      speaker,
+      text,
+    ) => {
+      notified.push({ conversationId, callSessionId, speaker, text });
+    },
+    resolveGuardianLabel: () => "Alex",
+    resolveAssistantLabel: () => "Aria",
+    attemptVerificationCode: async (params) => {
+      attemptCalls.push(params);
+      return attempt(params);
+    },
+    resolveMidCallTrust: async (assistantId, fromNumber) => {
+      trustResolutions.push({ assistantId, fromNumber });
+      return UPGRADED_TRUST;
+    },
+    ...opts?.deps,
+  };
+
+  const flow = new CallSetupFlow(CALL_SESSION_ID, transport, deps);
+  return {
+    flow,
+    endReasons,
+    spoken,
+    sessionUpdates,
+    events,
+    results,
+    attemptCalls,
+    pointerMessages,
+    addedMessages,
+    finalized,
+    notified,
+    trustResolutions,
+  };
+}
+
+const sleep = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pushCode(flow: CallSetupFlow, code: string): void {
+  for (const digit of code) {
+    flow.pushDtmfDigit(digit);
+  }
+}
+
+function eventTypes(events: Array<{ eventType: string }>): string[] {
+  return events.map((e) => e.eventType);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CallSetupFlow verification sub-flows", () => {
+  describe("inbound guardian verification", () => {
+    test("start records the started event and prompts for the code", async () => {
+      const { flow, events, spoken } = createFlow();
+
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      expect(flow.getState()).toBe("collecting_code");
+      expect(events).toEqual([
+        {
+          eventType: "voice_verification_started",
+          payload: { assistantId: "self", maxAttempts: 3 },
+        },
+      ]);
+      expect(spoken).toEqual([
+        "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
+      ]);
+    });
+
+    test("correct DTMF code proceeds to initial greeting under re-resolved trust", async () => {
+      const { flow, results, events, attemptCalls, trustResolutions } =
+        createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      expect(attemptCalls).toHaveLength(1);
+      expect(attemptCalls[0]).toMatchObject({
+        verificationAssistantId: "self",
+        verificationFromNumber: PHONE_NUMBER,
+        enteredCode: CORRECT_CODE,
+        isOutbound: false,
+        codeDigits: 6,
+      });
+      expect(eventTypes(events)).toContain("voice_verification_succeeded");
+      expect(
+        events.find((e) => e.eventType === "voice_verification_succeeded")
+          ?.payload,
+      ).toEqual({ verificationType: "guardian" });
+      expect(trustResolutions).toEqual([
+        { assistantId: "self", fromNumber: PHONE_NUMBER },
+      ]);
+
+      expect(flow.getState()).toBe("completed");
+      expect(results).toEqual([
+        {
+          kind: "proceed-initial-greeting",
+          assistantId: "self",
+          trustContext: UPGRADED_TRUST,
+          deferredTranscripts: undefined,
+        },
+      ]);
+    });
+
+    test("spoken digits are parsed and verified", async () => {
+      const { flow, results, attemptCalls } = createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      flow.pushTranscriptFinal("one two three four five six");
+      await sleep();
+
+      expect(attemptCalls[0]?.enteredCode).toBe(CORRECT_CODE);
+      expect(results[0]?.kind).toBe("proceed-initial-greeting");
+    });
+
+    test("partial spoken digits re-prompt without attempting", async () => {
+      const { flow, spoken, attemptCalls } = createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      flow.pushTranscriptFinal("one two three");
+      await sleep();
+
+      expect(attemptCalls).toHaveLength(0);
+      expect(spoken).toContain(
+        "I heard 3 digits. Please enter all 6 digits of your code.",
+      );
+      expect(flow.getState()).toBe("collecting_code");
+    });
+
+    test("wrong code under max attempts re-prompts, then a correct code proceeds", async () => {
+      const { flow, results, spoken, attemptCalls } = createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, "000000");
+      await sleep();
+
+      expect(spoken).toContain("That code was incorrect. Please try again.");
+      expect(flow.getState()).toBe("collecting_code");
+      expect(results).toHaveLength(0);
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      // The retry attempt counter carries into the second validation call.
+      expect(attemptCalls[1]?.verificationAttempts).toBe(1);
+      expect(results[0]?.kind).toBe("proceed-initial-greeting");
+    });
+
+    test("exhausted attempts fail the session, finalize, speak goodbye, and end", async () => {
+      const { flow, results, spoken, events, sessionUpdates, finalized } =
+        createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      for (const code of ["000000", "111111", "222222"]) {
+        pushCode(flow, code);
+        await sleep();
+      }
+
+      expect(
+        events.find((e) => e.eventType === "voice_verification_failed")
+          ?.payload,
+      ).toEqual({ attempts: 3 });
+      expect(sessionUpdates.at(-1)).toMatchObject({
+        status: "failed",
+        lastError: "Guardian voice verification failed — max attempts exceeded",
+      });
+      expect(finalized).toEqual([
+        { callSessionId: CALL_SESSION_ID, conversationId: "conv-1" },
+      ]);
+      expect(spoken).toContain("Verification failed. Goodbye.");
+      expect(results).toEqual([
+        { kind: "ended", reason: "Verification failed — challenge rejected" },
+      ]);
+    });
+
+    test("further input after completion is ignored", async () => {
+      const { flow, attemptCalls } = createFlow();
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+      expect(flow.getState()).toBe("completed");
+
+      pushCode(flow, CORRECT_CODE);
+      flow.pushTranscriptFinal("one two three four five six");
+      await sleep();
+      expect(attemptCalls).toHaveLength(1);
+    });
+
+    test("trusted-contact success runs the activation continuation and hands off", async () => {
+      const { flow, results, spoken, events, sessionUpdates, notified } =
+        createFlow({
+          deps: {
+            attemptVerificationCode: fakeAttemptVerification({
+              correctCode: CORRECT_CODE,
+              verificationType: "trusted_contact",
+            }),
+          },
+        });
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      const handoff = "Great! Alex said I can speak with you. How can I help?";
+      expect(sessionUpdates).toContainEqual({ status: "in_progress" });
+      expect(spoken).toContain(handoff);
+      expect(
+        events.find((e) => e.eventType === "assistant_spoke")?.payload,
+      ).toEqual({ text: handoff });
+      expect(notified).toEqual([
+        {
+          conversationId: "conv-1",
+          callSessionId: CALL_SESSION_ID,
+          speaker: "assistant",
+          text: handoff,
+        },
+      ]);
+      expect(results).toEqual([
+        {
+          kind: "proceed-handoff-spoken",
+          assistantId: "self",
+          trustContext: UPGRADED_TRUST,
+          deferredTranscripts: undefined,
+        },
+      ]);
+    });
+
+    test("a transcript arriving during trust re-resolution is deferred and rides the result", async () => {
+      let releaseTrust!: (ctx: TrustContext) => void;
+      const gated = new Promise<TrustContext>((resolve) => {
+        releaseTrust = resolve;
+      });
+      const { flow, results, spoken } = createFlow({
+        deps: { resolveMidCallTrust: () => gated },
+      });
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      // Re-resolution is in flight — a final transcript must be buffered,
+      // not treated as spoken digits and not answered under stale trust.
+      expect(results).toHaveLength(0);
+      flow.pushTranscriptFinal("hello are you there");
+      await sleep();
+      expect(results).toHaveLength(0);
+      expect(spoken.some((t) => t.startsWith("I heard"))).toBe(false);
+
+      releaseTrust(UPGRADED_TRUST);
+      await sleep();
+
+      expect(results).toEqual([
+        {
+          kind: "proceed-initial-greeting",
+          assistantId: "self",
+          trustContext: UPGRADED_TRUST,
+          deferredTranscripts: ["hello are you there"],
+        },
+      ]);
+    });
+
+    test("trust re-resolution failure falls back to the setup-time trust", async () => {
+      const { flow, results } = createFlow({
+        deps: {
+          resolveMidCallTrust: async () => {
+            throw new Error("gateway blip");
+          },
+        },
+      });
+      await flow.start(inboundVerificationOutcome, makeResolved("guardian"));
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      if (result.kind !== "proceed-initial-greeting") {
+        throw new Error("expected proceed-initial-greeting");
+      }
+      expect(result.trustContext.trustClass).toBe("guardian");
+    });
+  });
+
+  describe("outbound guardian verification", () => {
+    test("start records the started event and speaks the call intro", async () => {
+      const { flow, events, spoken } = createFlow();
+
+      await flow.start(
+        outboundVerificationOutcome,
+        makeResolved("unknown", {
+          isInbound: false,
+          otherPartyNumber: TO_NUMBER,
+        }),
+      );
+
+      expect(flow.getState()).toBe("collecting_code");
+      expect(events).toEqual([
+        {
+          eventType: "outbound_voice_verification_started",
+          payload: {
+            assistantId: "self",
+            verificationSessionId: "vs-1",
+            maxAttempts: 3,
+          },
+        },
+      ]);
+      expect(spoken).toHaveLength(1);
+      expect(spoken[0]).toContain("guardian verification call");
+      expect(spoken[0]).toContain("6-digit verification code");
+    });
+
+    test("success posts the succeeded pointer and proceeds to the post-verification greeting", async () => {
+      const {
+        flow,
+        results,
+        events,
+        sessionUpdates,
+        pointerMessages,
+        attemptCalls,
+        trustResolutions,
+      } = createFlow();
+      await flow.start(
+        outboundVerificationOutcome,
+        makeResolved("unknown", {
+          isInbound: false,
+          otherPartyNumber: TO_NUMBER,
+        }),
+      );
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+
+      expect(attemptCalls[0]).toMatchObject({
+        isOutbound: true,
+        verificationFromNumber: TO_NUMBER,
+      });
+      expect(eventTypes(events)).toContain(
+        "outbound_voice_verification_succeeded",
+      );
+      expect(pointerMessages).toEqual([
+        {
+          conversationId: "conv-origin",
+          event: "verification_succeeded",
+          phoneNumber: TO_NUMBER,
+          extra: { channel: "phone" },
+        },
+      ]);
+      expect(trustResolutions).toEqual([
+        { assistantId: "self", fromNumber: TO_NUMBER },
+      ]);
+      expect(sessionUpdates).toContainEqual({ status: "in_progress" });
+      expect(results).toEqual([
+        {
+          kind: "proceed-post-verification-greeting",
+          assistantId: "self",
+          trustContext: UPGRADED_TRUST,
+          deferredTranscripts: undefined,
+        },
+      ]);
+    });
+
+    test("exhausted attempts post the failed pointer, finalize, and end", async () => {
+      const { flow, results, events, pointerMessages, finalized, endReasons } =
+        createFlow();
+      await flow.start(
+        outboundVerificationOutcome,
+        makeResolved("unknown", {
+          isInbound: false,
+          otherPartyNumber: TO_NUMBER,
+        }),
+      );
+
+      for (const code of ["000000", "111111", "222222"]) {
+        pushCode(flow, code);
+        await sleep();
+      }
+
+      expect(
+        events.find((e) => e.eventType === "outbound_voice_verification_failed")
+          ?.payload,
+      ).toEqual({ attempts: 3 });
+      expect(pointerMessages).toEqual([
+        {
+          conversationId: "conv-origin",
+          event: "verification_failed",
+          phoneNumber: TO_NUMBER,
+          extra: {
+            channel: "phone",
+            reason: "Max verification attempts exceeded",
+          },
+        },
+      ]);
+      expect(finalized).toEqual([
+        { callSessionId: CALL_SESSION_ID, conversationId: "conv-1" },
+      ]);
+      expect(results).toEqual([
+        { kind: "ended", reason: "Verification failed — challenge rejected" },
+      ]);
+      await sleep();
+      expect(endReasons).toEqual(["Verification failed — challenge rejected"]);
+    });
+  });
+
+  describe("callee verification", () => {
+    const calleeResolved = () =>
+      makeResolved("unknown", {
+        isInbound: false,
+        otherPartyNumber: TO_NUMBER,
+      });
+
+    /** Extract the generated code from the message posted to the origin conversation. */
+    function postedCode(
+      addedMessages: Array<{ content: string }>,
+      codeLength: number,
+    ): string {
+      const text = (
+        JSON.parse(addedMessages[0].content) as Array<{ text: string }>
+      )[0].text;
+      const match = text.match(new RegExp(`(\\d{${codeLength}})$`));
+      if (!match) {
+        throw new Error(`No code found in posted message: ${text}`);
+      }
+      return match[1];
+    }
+
+    test("start posts the code to the origin conversation and prompts with spoken digits", async () => {
+      const { flow, events, spoken, addedMessages } = createFlow();
+
+      await flow.start(calleeOutcome(3, 4), calleeResolved());
+
+      expect(flow.getState()).toBe("collecting_code");
+      expect(events).toEqual([
+        {
+          eventType: "callee_verification_started",
+          payload: { codeLength: 4, maxAttempts: 3 },
+        },
+      ]);
+
+      expect(addedMessages).toHaveLength(1);
+      expect(addedMessages[0].conversationId).toBe("conv-origin");
+      expect(addedMessages[0].content).toContain(
+        `Verification code for call to ${TO_NUMBER}:`,
+      );
+      const code = postedCode(addedMessages, 4);
+
+      // The TTS prompt speaks the same code digit by digit.
+      expect(spoken).toEqual([
+        `Please enter the verification code: ${code.split("").join(". ")}.`,
+      ]);
+    });
+
+    test("no code message is posted without an origin conversation", async () => {
+      const { flow, addedMessages } = createFlow({
+        session: makeSession({ initiatedFromConversationId: null }),
+      });
+
+      await flow.start(calleeOutcome(), calleeResolved());
+      expect(addedMessages).toHaveLength(0);
+    });
+
+    test("correct DTMF code proceeds under the setup-time trust without re-resolution", async () => {
+      const { flow, results, events, addedMessages, trustResolutions } =
+        createFlow();
+      await flow.start(calleeOutcome(3, 4), calleeResolved());
+      const code = postedCode(addedMessages, 4);
+
+      pushCode(flow, code);
+      await sleep();
+
+      expect(eventTypes(events)).toContain("callee_verification_succeeded");
+      expect(trustResolutions).toEqual([]);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      if (result.kind !== "proceed-initial-greeting") {
+        throw new Error("expected proceed-initial-greeting");
+      }
+      expect(result.assistantId).toBe("self");
+      expect(result.trustContext.trustClass).toBe("unknown");
+      expect(result.trustContext.requesterChatId).toBe(TO_NUMBER);
+    });
+
+    test("speech is ignored — the callee flow is DTMF-only", async () => {
+      const { flow, results, spoken, addedMessages } = createFlow();
+      await flow.start(calleeOutcome(3, 4), calleeResolved());
+      const code = postedCode(addedMessages, 4);
+      const promptCount = spoken.length;
+
+      // Speaking the correct code out loud must not verify or re-prompt.
+      flow.pushTranscriptFinal(code.split("").join(" "));
+      await sleep();
+
+      expect(results).toHaveLength(0);
+      expect(spoken).toHaveLength(promptCount);
+      expect(flow.getState()).toBe("collecting_code");
+    });
+
+    test("a wrong code re-prompts, and a subsequent correct code succeeds", async () => {
+      const { flow, results, spoken, addedMessages } = createFlow();
+      await flow.start(calleeOutcome(3, 4), calleeResolved());
+      const code = postedCode(addedMessages, 4);
+      const wrong = code === "0000" ? "1111" : "0000";
+
+      pushCode(flow, wrong);
+      await sleep();
+      expect(spoken).toContain("That code was incorrect. Please try again.");
+      expect(results).toHaveLength(0);
+
+      pushCode(flow, code);
+      await sleep();
+      expect(results[0]?.kind).toBe("proceed-initial-greeting");
+    });
+
+    test("max attempts fail the session, finalize, post the failed pointer, and end", async () => {
+      const {
+        flow,
+        results,
+        spoken,
+        events,
+        sessionUpdates,
+        finalized,
+        pointerMessages,
+        endReasons,
+        addedMessages,
+      } = createFlow();
+      await flow.start(calleeOutcome(2, 4), calleeResolved());
+      const code = postedCode(addedMessages, 4);
+      const wrong = code === "0000" ? "1111" : "0000";
+
+      pushCode(flow, wrong);
+      await sleep();
+      pushCode(flow, wrong);
+      await sleep();
+
+      expect(
+        events.find((e) => e.eventType === "callee_verification_failed")
+          ?.payload,
+      ).toEqual({ attempts: 2 });
+      expect(sessionUpdates.at(-1)).toMatchObject({
+        status: "failed",
+        lastError: "Callee verification failed — max attempts exceeded",
+      });
+      expect(finalized).toEqual([
+        { callSessionId: CALL_SESSION_ID, conversationId: "conv-1" },
+      ]);
+      expect(pointerMessages).toEqual([
+        {
+          conversationId: "conv-origin",
+          event: "failed",
+          phoneNumber: TO_NUMBER,
+          extra: { reason: "Callee verification failed" },
+        },
+      ]);
+      expect(spoken).toContain("Verification failed. Goodbye.");
+      expect(results).toEqual([
+        { kind: "ended", reason: "Verification failed" },
+      ]);
+      await sleep();
+      expect(endReasons).toEqual(["Verification failed"]);
+    });
+  });
+
+  describe("dep validation", () => {
+    test("start throws a descriptive error when verification deps are missing", async () => {
+      const { flow } = createFlow({
+        deps: {
+          getCallSession: undefined,
+          finalizeCall: undefined,
+          addMessage: undefined,
+          addPointerMessage: undefined,
+          fireCallTranscriptNotifier: undefined,
+          resolveGuardianLabel: undefined,
+          resolveAssistantLabel: undefined,
+        },
+      });
+
+      expect(
+        flow.start(inboundVerificationOutcome, makeResolved()),
+      ).rejects.toThrow(/verification deps missing: getCallSession/);
+    });
+  });
+});

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -63,21 +63,29 @@ export type SetupFlowState =
  * - `proceed-handoff-spoken` — the flow already spoke the handoff copy;
  *   the controller calls `markNextCallerTurnAsOpeningAck()`.
  * - `ended` — the flow terminated the call; no controller is created.
+ *
+ * `deferredTranscripts` carries final caller transcripts that arrived while
+ * mid-setup trust re-resolution was in flight. The owning server replays
+ * them (in order) into the call controller once it exists, so a verified
+ * caller's first utterance is answered under the upgraded trust.
  */
 export type SetupFlowResult =
   | {
       kind: "proceed-initial-greeting";
       assistantId: string;
       trustContext: TrustContext;
+      deferredTranscripts?: string[];
     }
   | {
       kind: "proceed-post-verification-greeting";
       assistantId: string;
       trustContext: TrustContext;
+      deferredTranscripts?: string[];
     }
   | {
       kind: "proceed-handoff-spoken";
       assistantId: string;
       trustContext: TrustContext;
+      deferredTranscripts?: string[];
     }
   | { kind: "ended"; reason: string };

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -7,23 +7,54 @@
  * completion) flow through injected deps so the flow is unit-testable and
  * independent of any wire protocol.
  *
- * Handles `normal_call` and `deny`. Other setup actions (verification,
- * invite redemption, name capture) throw {@link UnsupportedSetupFlowError}.
+ * Handles `normal_call`, `deny`, and the three verification actions
+ * (`verification`, `outbound_verification`, `callee_verification`). Other
+ * setup actions (invite redemption, name capture) throw
+ * {@link UnsupportedSetupFlowError}.
  */
 
-import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import { randomInt } from "node:crypto";
+
+import { getGuardianDeliveryFresh } from "../contacts/guardian-delivery-reader.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { addMessage as addMessageFn } from "../persistence/conversation-crud.js";
+import {
+  resolveActorTrust,
+  toTrustContext,
+} from "../runtime/actor-trust-resolver.js";
+import {
+  trustContextFromVerdict,
+  verdictHasMemberIdentity,
+  verdictMemberUnresolvable,
+} from "../runtime/trust-verdict-consumer.js";
+import {
+  composeVerificationVoice,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from "../runtime/verification-templates.js";
+import { getLogger } from "../util/logger.js";
 import { getTtsPlaybackDelayMs } from "./call-constants.js";
+import type { addPointerMessage as addPointerMessageFn } from "./call-pointer-messages.js";
 import type {
   SetupFlowInput,
   SetupFlowResult,
   SetupFlowState,
   SetupFlowTransport,
 } from "./call-setup-flow-types.js";
+import type { fireCallTranscriptNotifier as fireCallTranscriptNotifierFn } from "./call-state.js";
 import type {
+  getCallSession as getCallSessionFn,
   recordCallEvent as recordCallEventFn,
   updateCallSession as updateCallSessionFn,
 } from "./call-store.js";
+import type { finalizeCall as finalizeCallFn } from "./finalize-call.js";
+import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
+import {
+  attemptVerificationCode as attemptVerificationCodeImpl,
+  parseDigitsFromSpeech,
+} from "./relay-verification.js";
+
+const log = getLogger("call-setup-flow");
 
 // ── Errors ───────────────────────────────────────────────────────────
 
@@ -61,12 +92,143 @@ export interface CallSetupFlowDeps {
    * Defaults to the configured TTS playback delay.
    */
   ttsPlaybackDelayMs?: number;
+
+  // ── Verification sub-flow deps ─────────────────────────────────────
+  // Optional so callers exercising only normal_call/deny need not supply
+  // them. Verification sub-flows resolve all of them up front at start()
+  // and throw on a missing side-effect dep (see requireVerificationDeps).
+  getCallSession?(id: string): ReturnType<typeof getCallSessionFn>;
+  finalizeCall?: typeof finalizeCallFn;
+  addMessage?: typeof addMessageFn;
+  addPointerMessage?: typeof addPointerMessageFn;
+  fireCallTranscriptNotifier?: typeof fireCallTranscriptNotifierFn;
+  /** Human-readable guardian label for deterministic handoff copy. */
+  resolveGuardianLabel?(): string;
+  /** Assistant display name, or null when unavailable. */
+  resolveAssistantLabel?(): string | null;
+  /** Defaults to {@link attemptVerificationCodeImpl} (relay-verification). */
+  attemptVerificationCode?: typeof attemptVerificationCodeImpl;
+  /** Defaults to {@link resolveMidCallTrustContext}. */
+  resolveMidCallTrust?(
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<TrustContext>;
+}
+
+/** Verification deps with defaults applied and optionality removed. */
+type VerificationDeps = Required<
+  Pick<
+    CallSetupFlowDeps,
+    | "getCallSession"
+    | "finalizeCall"
+    | "addMessage"
+    | "addPointerMessage"
+    | "fireCallTranscriptNotifier"
+    | "resolveGuardianLabel"
+    | "resolveAssistantLabel"
+    | "attemptVerificationCode"
+    | "resolveMidCallTrust"
+  >
+>;
+
+// ── Module helpers ───────────────────────────────────────────────────
+
+/**
+ * Re-resolve caller trust after a mid-setup verification/activation. Prefers
+ * the gateway verdict (authoritative right after the gateway updated the
+ * binding); falls back to local resolution on a missing/failed/unusable
+ * verdict so a blip never drops the call. Mirrors the setup path's
+ * verdict-first-with-fallback condition.
+ */
+export async function resolveMidCallTrustContext(
+  assistantId: string,
+  fromNumber: string,
+): Promise<TrustContext> {
+  const verdict = await getInboundTrustVerdict({
+    channelType: "phone",
+    actorExternalId: fromNumber,
+  });
+
+  // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
+  // falls back to local: the caller was just activated, and invite redemption
+  // writes the channel assistant-side, so the gateway may not see the member
+  // yet — local resolution has it. A MEMBERFUL unknown verdict (blocked/revoked
+  // member, carrying contactId/channelId) is honored so its deny ACL is
+  // enforced; falling back could lose the gateway's member status if local
+  // state is stale.
+  const memberlessUnknown =
+    verdict?.trustClass === "unknown" && !verdictHasMemberIdentity(verdict);
+  const usable =
+    verdict &&
+    !verdict.resolutionFailed &&
+    !verdictMemberUnresolvable(verdict) &&
+    !memberlessUnknown;
+
+  if (usable) {
+    return trustContextFromVerdict(verdict, {
+      sourceChannel: "phone",
+      conversationExternalId: fromNumber,
+    });
+  }
+
+  // Warm the phone-channel guardian-delivery cache before the SYNC
+  // resolveActorTrust fallback, which reads the IO-free per-channel snapshot
+  // that daemon startup leaves cold for `phone`. Read fresh: gateway-side
+  // binding writes don't invalidate the daemon cache, so a stale empty
+  // snapshot would otherwise survive the TTL and misclassify the guardian.
+  await getGuardianDeliveryFresh({ channelTypes: ["phone"] });
+
+  return toTrustContext(
+    resolveActorTrust({
+      assistantId,
+      sourceChannel: "phone",
+      conversationExternalId: fromNumber,
+      actorExternalId: fromNumber,
+    }),
+    fromNumber,
+  );
+}
+
+/**
+ * Return the first whitespace-delimited token of a name, or `null` when the
+ * input is null/blank. Used for greetings so "Alice Example" -> "Alice".
+ */
+function firstToken(name: string | null | undefined): string | null {
+  if (!name) {
+    return null;
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.split(/\s+/)[0] ?? null;
 }
 
 // ── Flow ─────────────────────────────────────────────────────────────
 
+type VerificationMode =
+  | "inbound_verification"
+  | "outbound_verification"
+  | "callee_verification";
+
 export class CallSetupFlow implements SetupFlowInput {
   private state: SetupFlowState = "idle";
+
+  // ── Verification sub-flow state ─────────────────────────────────────
+  private vdeps: VerificationDeps | null = null;
+  private verificationMode: VerificationMode | null = null;
+  private digitBuffer = "";
+  private verificationAttempts = 0;
+  private verificationMaxAttempts = 3;
+  private verificationCodeLength = 6;
+  private verificationAssistantId = "";
+  private verificationFromNumber = "";
+  private outboundVerificationSessionId: string | null = null;
+  private calleeVerificationCode: string | null = null;
+  /** Setup-time trust, kept as the fallback when re-resolution fails. */
+  private initialTrustContext: TrustContext | null = null;
+  private trustReResolving = false;
+  private deferredTranscripts: string[] = [];
 
   constructor(
     private readonly callSessionId: string,
@@ -104,6 +266,30 @@ export class CallSetupFlow implements SetupFlowInput {
         await this.runDeny(outcome, resolved);
         return;
 
+      case "verification":
+        this.startInboundVerification(
+          outcome.assistantId,
+          outcome.fromNumber,
+          resolved,
+        );
+        return;
+
+      case "outbound_verification":
+        this.startOutboundVerification(
+          outcome.assistantId,
+          outcome.sessionId,
+          outcome.toNumber,
+          resolved,
+        );
+        return;
+
+      case "callee_verification":
+        await this.startCalleeVerification(
+          outcome.verificationConfig,
+          resolved,
+        );
+        return;
+
       default:
         throw new UnsupportedSetupFlowError(outcome.action);
     }
@@ -112,16 +298,53 @@ export class CallSetupFlow implements SetupFlowInput {
   // ── SetupFlowInput ──────────────────────────────────────────────────
 
   /** Feed a DTMF digit to the active sub-flow. No-op while idle/completed. */
-  pushDtmfDigit(_digit: string): void {
+  pushDtmfDigit(digit: string): void {
     if (!this.acceptsInput()) {
       return;
     }
+    if (this.verificationMode == null) {
+      return;
+    }
+    this.digitBuffer += digit;
+    if (this.digitBuffer.length < this.verificationCodeLength) {
+      return;
+    }
+    const enteredCode = this.digitBuffer.slice(0, this.verificationCodeLength);
+    this.digitBuffer = "";
+    this.submitVerificationCode(enteredCode);
   }
 
   /** Feed a final caller transcript to the active sub-flow. No-op while idle/completed. */
-  pushTranscriptFinal(_text: string): void {
+  pushTranscriptFinal(text: string): void {
     if (!this.acceptsInput()) {
       return;
+    }
+    // Defer (don't drop) transcripts while trust is being re-resolved so a
+    // verified caller's first utterance runs under the upgraded context, not
+    // the stale pre-verification one. The drained buffer rides the terminal
+    // result for the owning server to replay in order.
+    if (this.trustReResolving) {
+      this.deferredTranscripts.push(text);
+      return;
+    }
+    if (this.verificationMode == null) {
+      return;
+    }
+    // Callee verification is DTMF-only — the callee should be entering
+    // digits on their keypad, not speaking.
+    if (this.verificationMode === "callee_verification") {
+      return;
+    }
+    const spokenDigits = parseDigitsFromSpeech(text);
+    if (spokenDigits.length >= this.verificationCodeLength) {
+      this.submitVerificationCode(
+        spokenDigits.slice(0, this.verificationCodeLength),
+      );
+    } else if (spokenDigits.length > 0) {
+      void this.deps.speakSystemPrompt(
+        this.transport,
+        `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
+      );
     }
   }
 
@@ -144,12 +367,569 @@ export class CallSetupFlow implements SetupFlowInput {
       lastError: outcome.logReason,
     });
     await this.deps.speakSystemPrompt(this.transport, outcome.message);
-    // Let the spoken denial play out before tearing down the session.
+    this.endSessionAfterPlayback(outcome.logReason);
+    this.complete({ kind: "ended", reason: outcome.logReason });
+  }
+
+  // ── Verification sub-flows ──────────────────────────────────────────
+
+  /**
+   * Inbound guardian / trusted-contact verification: the caller has a
+   * pending voice challenge and must enter (or speak) their six-digit code.
+   */
+  private startInboundVerification(
+    assistantId: string,
+    fromNumber: string,
+    resolved: SetupResolved,
+  ): void {
+    this.enterCodeCollection("inbound_verification", resolved, {
+      maxAttempts: 3,
+      codeLength: 6,
+    });
+    this.verificationAssistantId = assistantId;
+    this.verificationFromNumber = fromNumber;
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "voice_verification_started",
+      {
+        assistantId,
+        maxAttempts: this.verificationMaxAttempts,
+      },
+    );
+
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
+    );
+  }
+
+  /**
+   * Outbound guardian verification: the system called the guardian's phone;
+   * prompt them to enter the verification code via DTMF or speech.
+   */
+  private startOutboundVerification(
+    assistantId: string,
+    verificationSessionId: string,
+    toNumber: string,
+    resolved: SetupResolved,
+  ): void {
+    this.enterCodeCollection("outbound_verification", resolved, {
+      maxAttempts: 3,
+      codeLength: 6,
+    });
+    this.verificationAssistantId = assistantId;
+    // For outbound guardian calls, the "to" number is the guardian's phone.
+    this.verificationFromNumber = toNumber;
+    this.outboundVerificationSessionId = verificationSessionId;
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "outbound_voice_verification_started",
+      {
+        assistantId,
+        verificationSessionId,
+        maxAttempts: this.verificationMaxAttempts,
+      },
+    );
+
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO, {
+        codeDigits: this.verificationCodeLength,
+      }),
+    );
+  }
+
+  /**
+   * Outbound callee verification: generate a random code, post it to the
+   * initiating conversation so the guardian can share it with the callee,
+   * and prompt the callee to enter it. DTMF-only — speech is ignored.
+   */
+  private async startCalleeVerification(
+    verificationConfig: { maxAttempts: number; codeLength: number },
+    resolved: SetupResolved,
+  ): Promise<void> {
+    const vdeps = this.enterCodeCollection(
+      "callee_verification",
+      resolved,
+      verificationConfig,
+    );
+    this.verificationAssistantId = resolved.assistantId;
+
+    const maxValue = Math.pow(10, this.verificationCodeLength);
+    const code = randomInt(0, maxValue)
+      .toString()
+      .padStart(this.verificationCodeLength, "0");
+    this.calleeVerificationCode = code;
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "callee_verification_started",
+      {
+        codeLength: this.verificationCodeLength,
+        maxAttempts: this.verificationMaxAttempts,
+      },
+    );
+
+    const spokenCode = code.split("").join(". ");
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      `Please enter the verification code: ${spokenCode}.`,
+    );
+
+    // Post the verification code to the initiating conversation so the
+    // guardian (user) can share it with the callee.
+    const session = vdeps.getCallSession(this.callSessionId);
+    if (session?.initiatedFromConversationId) {
+      const codeMsg = `\u{1F510} Verification code for call to ${session.toNumber}: ${code}`;
+      await vdeps.addMessage(
+        session.initiatedFromConversationId,
+        "assistant",
+        JSON.stringify([{ type: "text", text: codeMsg }]),
+        {
+          metadata: {
+            userMessageChannel: "phone",
+            assistantMessageChannel: "phone",
+            userMessageInterface: "phone",
+            assistantMessageInterface: "phone",
+          },
+        },
+      );
+    }
+  }
+
+  /** Shared entry bookkeeping for the code-collection sub-flows. */
+  private enterCodeCollection(
+    mode: VerificationMode,
+    resolved: SetupResolved,
+    config: { maxAttempts: number; codeLength: number },
+  ): VerificationDeps {
+    const vdeps = this.requireVerificationDeps();
+    this.vdeps = vdeps;
+    this.verificationMode = mode;
+    this.verificationAttempts = 0;
+    this.verificationMaxAttempts = config.maxAttempts;
+    this.verificationCodeLength = config.codeLength;
+    this.digitBuffer = "";
+    this.initialTrustContext = toTrustContext(
+      resolved.actorTrust,
+      resolved.otherPartyNumber,
+    );
+    this.state = "collecting_code";
+    return vdeps;
+  }
+
+  /** Route a fully collected code to the active verification sub-flow. */
+  private submitVerificationCode(enteredCode: string): void {
+    const handler =
+      this.verificationMode === "callee_verification"
+        ? this.handleCalleeCode(enteredCode)
+        : this.handleVerificationCode(enteredCode);
+    handler.catch((err) =>
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Verification code handling failed",
+      ),
+    );
+  }
+
+  /**
+   * Validate an entered code against the pending voice guardian challenge
+   * (inbound and outbound guardian verification).
+   */
+  private async handleVerificationCode(enteredCode: string): Promise<void> {
+    const vdeps = this.vdeps;
+    if (!vdeps) {
+      return;
+    }
+    const isOutbound = this.outboundVerificationSessionId != null;
+    const assistantId = this.verificationAssistantId;
+    const fromNumber = this.verificationFromNumber;
+
+    const result = await vdeps.attemptVerificationCode({
+      verificationAssistantId: assistantId,
+      verificationFromNumber: fromNumber,
+      enteredCode,
+      isOutbound,
+      codeDigits: this.verificationCodeLength,
+      verificationAttempts: this.verificationAttempts,
+      verificationMaxAttempts: this.verificationMaxAttempts,
+    });
+
+    // A concurrent attempt may have already reached a terminal result.
+    if (this.state === "completed") {
+      return;
+    }
+
+    if (result.outcome === "success") {
+      this.verificationMode = null;
+      this.digitBuffer = "";
+      this.verificationAttempts = 0;
+
+      this.deps.recordCallEvent(this.callSessionId, result.eventName, {
+        verificationType: result.verificationType,
+      });
+
+      if (isOutbound) {
+        await this.completeOutboundVerificationSuccess(
+          vdeps,
+          assistantId,
+          fromNumber,
+        );
+      } else if (result.verificationType === "trusted_contact") {
+        await this.continueAfterTrustedContactActivation({
+          assistantId,
+          fromNumber,
+          activationReason: "trusted_contact_verified",
+        });
+      } else {
+        // Inbound guardian verification — proceed to the normal call flow
+        // under the upgraded trust context.
+        const trustContext = await this.resolveTrustWithDeferral(
+          vdeps,
+          assistantId,
+          fromNumber,
+        );
+        this.complete({
+          kind: "proceed-initial-greeting",
+          assistantId,
+          trustContext,
+          deferredTranscripts: this.drainDeferredTranscripts(),
+        });
+      }
+      return;
+    }
+
+    if (result.outcome === "failure") {
+      this.verificationMode = null;
+      this.verificationAttempts = result.attempts;
+
+      this.deps.recordCallEvent(this.callSessionId, result.eventName, {
+        attempts: result.attempts,
+      });
+      this.deps.updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: "Guardian voice verification failed — max attempts exceeded",
+      });
+
+      const session = vdeps.getCallSession(this.callSessionId);
+      if (session) {
+        vdeps.finalizeCall(this.callSessionId, session.conversationId);
+
+        if (isOutbound && session.initiatedFromConversationId) {
+          this.postPointerMessage(
+            vdeps,
+            session.initiatedFromConversationId,
+            "verification_failed",
+            session.toNumber,
+            { channel: "phone", reason: "Max verification attempts exceeded" },
+          );
+        }
+      }
+
+      await this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+      this.endSessionAfterPlayback("Verification failed — challenge rejected");
+      this.complete({
+        kind: "ended",
+        reason: "Verification failed — challenge rejected",
+      });
+      return;
+    }
+
+    // Retry — re-prompt and keep collecting.
+    this.verificationAttempts = result.attempt;
+    void this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+  }
+
+  /** Compare an entered code against the generated callee verification code. */
+  private async handleCalleeCode(enteredCode: string): Promise<void> {
+    const vdeps = this.vdeps;
+    if (!vdeps || this.calleeVerificationCode == null) {
+      return;
+    }
+
+    if (enteredCode === this.calleeVerificationCode) {
+      this.verificationMode = null;
+      this.calleeVerificationCode = null;
+      this.verificationAttempts = 0;
+
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "callee_verification_succeeded",
+        {},
+      );
+      this.complete({
+        kind: "proceed-initial-greeting",
+        assistantId: this.verificationAssistantId,
+        trustContext: this.initialTrustContext!,
+      });
+      return;
+    }
+
+    this.verificationAttempts++;
+
+    if (this.verificationAttempts >= this.verificationMaxAttempts) {
+      this.verificationMode = null;
+
+      this.deps.recordCallEvent(
+        this.callSessionId,
+        "callee_verification_failed",
+        {
+          attempts: this.verificationAttempts,
+        },
+      );
+      // Mark failed immediately so a transport close during the goodbye TTS
+      // window cannot race this into a terminal "completed" status.
+      this.deps.updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: "Callee verification failed — max attempts exceeded",
+      });
+
+      const session = vdeps.getCallSession(this.callSessionId);
+      if (session) {
+        vdeps.finalizeCall(this.callSessionId, session.conversationId);
+        if (session.initiatedFromConversationId) {
+          this.postPointerMessage(
+            vdeps,
+            session.initiatedFromConversationId,
+            "failed",
+            session.toNumber,
+            { reason: "Callee verification failed" },
+          );
+        }
+      }
+
+      // Wait for synthesis to complete before starting the teardown timer
+      // so the caller hears the goodbye message.
+      try {
+        await this.deps.speakSystemPrompt(
+          this.transport,
+          "Verification failed. Goodbye.",
+        );
+      } catch (err) {
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          "System prompt TTS failed during verification teardown",
+        );
+      }
+      this.endSessionAfterPlayback("Verification failed");
+      this.complete({ kind: "ended", reason: "Verification failed" });
+      return;
+    }
+
+    void this.deps.speakSystemPrompt(
+      this.transport,
+      "That code was incorrect. Please try again.",
+    );
+  }
+
+  /**
+   * Outbound guardian verification success: pointer back to the originating
+   * conversation, trust upgrade, session to in_progress, then hand off to
+   * the post-verification greeting.
+   */
+  private async completeOutboundVerificationSuccess(
+    vdeps: VerificationDeps,
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<void> {
+    const session = vdeps.getCallSession(this.callSessionId);
+    if (session?.initiatedFromConversationId) {
+      this.postPointerMessage(
+        vdeps,
+        session.initiatedFromConversationId,
+        "verification_succeeded",
+        session.toNumber,
+        { channel: "phone" },
+      );
+    }
+
+    const trustContext = await this.resolveTrustWithDeferral(
+      vdeps,
+      assistantId,
+      fromNumber,
+    );
+    this.deps.updateCallSession(this.callSessionId, { status: "in_progress" });
+    this.complete({
+      kind: "proceed-post-verification-greeting",
+      assistantId,
+      trustContext,
+      deferredTranscripts: this.drainDeferredTranscripts(),
+    });
+  }
+
+  /**
+   * Shared post-activation handoff for all trusted-contact success paths
+   * (invite redemption, access-request approval, verification code).
+   * Upgrades trust, delivers deterministic transition copy, and completes
+   * with `proceed-handoff-spoken` so the controller marks the next caller
+   * turn as an opening ack.
+   */
+  private async continueAfterTrustedContactActivation(params: {
+    assistantId: string;
+    fromNumber: string;
+    activationReason?:
+      | "invite_redeemed"
+      | "access_approved"
+      | "trusted_contact_verified";
+    /**
+     * Display name resolved from the bound contact (or, for outbound invite
+     * calls, the session's recorded invitee name). Greeting uses only the
+     * first whitespace-delimited token; an empty/blank value triggers the
+     * neutral "Hi there" greeting rather than substituting the channel
+     * address.
+     */
+    inviteeName?: string | null;
+  }): Promise<void> {
+    const vdeps = this.vdeps ?? this.requireVerificationDeps();
+    const { assistantId, fromNumber } = params;
+
+    this.deps.updateCallSession(this.callSessionId, { status: "in_progress" });
+
+    const trustContext = await this.resolveTrustWithDeferral(
+      vdeps,
+      assistantId,
+      fromNumber,
+    );
+
+    const guardianLabel = vdeps.resolveGuardianLabel();
+    let handoffText: string;
+
+    if (params.activationReason === "invite_redeemed") {
+      const firstName = firstToken(params.inviteeName);
+      const assistantName = vdeps.resolveAssistantLabel();
+      if (firstName) {
+        handoffText = assistantName
+          ? `Great, I've verified that you are ${firstName}. It's nice to meet you! I'm ${assistantName}, ${guardianLabel}'s assistant. How can I help?`
+          : `Great, I've verified that you are ${firstName}. It's nice to meet you! How can I help?`;
+      } else {
+        handoffText = assistantName
+          ? `Hi there! I'm ${assistantName}, ${guardianLabel}'s assistant. How can I help?`
+          : `Hi there! How can I help?`;
+      }
+    } else {
+      handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
+    }
+
+    void this.deps.speakSystemPrompt(this.transport, handoffText);
+
+    this.deps.recordCallEvent(this.callSessionId, "assistant_spoke", {
+      text: handoffText,
+    });
+    const session = vdeps.getCallSession(this.callSessionId);
+    if (session) {
+      vdeps.fireCallTranscriptNotifier(
+        session.conversationId,
+        this.callSessionId,
+        "assistant",
+        handoffText,
+      );
+    }
+
+    this.complete({
+      kind: "proceed-handoff-spoken",
+      assistantId,
+      trustContext,
+      deferredTranscripts: this.drainDeferredTranscripts(),
+    });
+  }
+
+  /**
+   * Re-resolve mid-setup trust, deferring transcripts that arrive during the
+   * async window (see pushTranscriptFinal). Falls back to the setup-time
+   * trust context on failure so a resolution blip can never wedge the call.
+   */
+  private async resolveTrustWithDeferral(
+    vdeps: VerificationDeps,
+    assistantId: string,
+    fromNumber: string,
+  ): Promise<TrustContext> {
+    this.trustReResolving = true;
+    try {
+      return await vdeps.resolveMidCallTrust(assistantId, fromNumber);
+    } catch (err) {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Mid-setup trust re-resolution failed — keeping setup-time trust",
+      );
+      return this.initialTrustContext!;
+    } finally {
+      this.trustReResolving = false;
+    }
+  }
+
+  /** Post a call pointer message, tolerating an evicted origin conversation. */
+  private postPointerMessage(
+    vdeps: VerificationDeps,
+    conversationId: string,
+    event: Parameters<VerificationDeps["addPointerMessage"]>[1],
+    phoneNumber: string,
+    extra?: Parameters<VerificationDeps["addPointerMessage"]>[3],
+  ): void {
+    vdeps
+      .addPointerMessage(conversationId, event, phoneNumber, extra)
+      .catch((err) => {
+        log.warn(
+          { conversationId, err },
+          "Skipping pointer write — origin conversation may no longer exist",
+        );
+      });
+  }
+
+  /** Hand off transcripts buffered during trust re-resolution, in order. */
+  private drainDeferredTranscripts(): string[] | undefined {
+    if (this.deferredTranscripts.length === 0) {
+      return undefined;
+    }
+    const drained = this.deferredTranscripts;
+    this.deferredTranscripts = [];
+    return drained;
+  }
+
+  /** Resolve the verification deps, applying defaults for the pure logic. */
+  private requireVerificationDeps(): VerificationDeps {
+    const d = this.deps;
+    const missing = (
+      [
+        ["getCallSession", d.getCallSession],
+        ["finalizeCall", d.finalizeCall],
+        ["addMessage", d.addMessage],
+        ["addPointerMessage", d.addPointerMessage],
+        ["fireCallTranscriptNotifier", d.fireCallTranscriptNotifier],
+        ["resolveGuardianLabel", d.resolveGuardianLabel],
+        ["resolveAssistantLabel", d.resolveAssistantLabel],
+      ] as const
+    )
+      .filter(([, dep]) => dep == null)
+      .map(([name]) => name);
+    if (missing.length > 0) {
+      throw new Error(
+        `CallSetupFlow verification deps missing: ${missing.join(", ")}`,
+      );
+    }
+    return {
+      getCallSession: d.getCallSession!,
+      finalizeCall: d.finalizeCall!,
+      addMessage: d.addMessage!,
+      addPointerMessage: d.addPointerMessage!,
+      fireCallTranscriptNotifier: d.fireCallTranscriptNotifier!,
+      resolveGuardianLabel: d.resolveGuardianLabel!,
+      resolveAssistantLabel: d.resolveAssistantLabel!,
+      attemptVerificationCode:
+        d.attemptVerificationCode ?? attemptVerificationCodeImpl,
+      resolveMidCallTrust: d.resolveMidCallTrust ?? resolveMidCallTrustContext,
+    };
+  }
+
+  /** Tear the session down once the terminal copy has had time to play. */
+  private endSessionAfterPlayback(reason: string): void {
     setTimeout(
-      () => this.transport.endSession(outcome.logReason),
+      () => this.transport.endSession(reason),
       this.deps.ttsPlaybackDelayMs ?? getTtsPlaybackDelayMs(),
     );
-    this.complete({ kind: "ended", reason: outcome.logReason });
   }
 
   // ── Internals ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Ports inbound guardian/trusted-contact verification, outbound verification, and DTMF-only callee verification from relay-server into the transport-agnostic CallSetupFlow
- Preserves side effects exactly: code posting, pointer messages, notifier/call events, mid-setup trust re-resolution with prompt deferral, exactly-once finalization
- All effects injected via deps; covered by a dedicated test suite

Part of plan: phone-media-stream-v2.md (PR 5 of 17)