### PR TITLE
feat(calls): extract transport-agnostic GuardianWaitController for access-request waits

### DIFF
--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -1,0 +1,678 @@
+/**
+ * Tests for GuardianWaitController — the transport-agnostic access-request
+ * wait orchestrator.
+ *
+ * Covers:
+ * - start(): hold message, waiting_on_user session status, timer arming
+ * - approval / denial / timeout resolution via injected callbacks
+ * - heartbeat sequencing (initial window vs jittered steady) and reset-on-reply
+ * - wait-utterance classes incl. cooldown throttling and callback opt-in bypass
+ * - callback handoff exactly-once semantics (timeout vs disconnect races)
+ * - dispose() idempotence and timer cleanup
+ * - config fallbacks for missing/NaN timeout values
+ *
+ * All timer-driven behavior runs under fake timers — no real delays.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
+
+// ── Module mocks (must come before source imports) ───────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Config loader — drives the intervals relay-access-wait reads directly.
+const mockConfig = {
+  calls: {
+    userConsultTimeoutSeconds: 120 as number,
+    ttsPlaybackDelayMs: 0,
+    accessRequestPollIntervalMs: 50 as number,
+    guardianWaitUpdateInitialIntervalMs: 100,
+    guardianWaitUpdateInitialWindowMs: 300,
+    guardianWaitUpdateSteadyMinIntervalMs: 150,
+    guardianWaitUpdateSteadyMaxIntervalMs: 200,
+  },
+};
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+// Canonical guardian request store — in-memory map driven by tests.
+const canonicalRequests = new Map<string, CanonicalGuardianRequest>();
+mock.module("../contacts/canonical-guardian-store.js", () => ({
+  getCanonicalGuardianRequest: (id: string) =>
+    canonicalRequests.get(id) ?? null,
+}));
+
+// Callback handoff helper dependencies — cut the real notification graph.
+mock.module("../contacts/contact-store.js", () => ({
+  findContactChannel: () => null,
+}));
+mock.module("../runtime/member-verdict-cache.js", () => ({
+  getCachedMemberAcl: () => null,
+}));
+
+let emitSignalCalls: Array<Record<string, unknown>> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return Promise.resolve();
+  },
+}));
+
+// call-store — relay-access-wait's heartbeat helper records events here.
+let storeEvents: Array<{
+  eventType: string;
+  payload?: Record<string, unknown>;
+}> = [];
+mock.module("../calls/call-store.js", () => ({
+  recordCallEvent: (
+    _callSessionId: string,
+    eventType: string,
+    payload?: Record<string, unknown>,
+  ) => {
+    storeEvents.push({ eventType, payload });
+  },
+}));
+
+// ── Source imports (after mocks) ─────────────────────────────────────
+
+import type { SetupFlowTransport } from "../calls/call-setup-flow-types.js";
+import {
+  GuardianWaitController,
+  type GuardianWaitControllerDeps,
+  type GuardianWaitResolutionContext,
+  IN_WAIT_REPLY_COOLDOWN_MS,
+} from "../calls/guardian-wait-controller.js";
+import type { CanonicalGuardianRequest } from "../contacts/canonical-guardian-store.js";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const CALL_SESSION_ID = "call-session-1";
+const REQUEST_ID = "req-1";
+const START_PARAMS = {
+  requestId: REQUEST_ID,
+  assistantId: "self",
+  fromNumber: "+15555550100",
+  callerName: "Bob",
+};
+
+// Controller clock. Starts large so the first in-wait reply is outside the
+// cooldown window (lastInWaitReplyAt initializes to 0, matching the relay).
+let nowValue = 1_000_000;
+
+function seedRequest(status: CanonicalGuardianRequest["status"]): void {
+  canonicalRequests.set(REQUEST_ID, {
+    id: REQUEST_ID,
+    status,
+  } as CanonicalGuardianRequest);
+}
+
+function createController(overrides?: Partial<GuardianWaitControllerDeps>) {
+  const spoken: string[] = [];
+  const sessionUpdates: Array<Record<string, unknown>> = [];
+  const events: Array<{
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }> = [];
+  const approvals: GuardianWaitResolutionContext[] = [];
+  const denials: GuardianWaitResolutionContext[] = [];
+  const timeouts: GuardianWaitResolutionContext[] = [];
+  let connectionStateReads = 0;
+
+  const transport: SetupFlowTransport = {
+    sendTextToken: () => {},
+    sendPlayUrl: () => {},
+    endSession: () => {},
+    getConnectionState: () => {
+      connectionStateReads += 1;
+      return "connected";
+    },
+  };
+
+  const deps: GuardianWaitControllerDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spoken.push(text);
+    },
+    updateCallSession: (_id, updates) => {
+      sessionUpdates.push(updates as Record<string, unknown>);
+    },
+    recordCallEvent: (_callSessionId, eventType, payload) => {
+      events.push({ eventType, payload });
+    },
+    resolveGuardianLabel: () => "Alice",
+    onApproved: (ctx) => {
+      approvals.push(ctx);
+    },
+    onDenied: (ctx) => {
+      denials.push(ctx);
+    },
+    onTimeout: (ctx) => {
+      timeouts.push(ctx);
+    },
+    now: () => nowValue,
+    firstHeartbeatDelayMs: 0,
+    ...overrides,
+  };
+
+  const controller = new GuardianWaitController(
+    CALL_SESSION_ID,
+    transport,
+    deps,
+  );
+  return {
+    controller,
+    spoken,
+    sessionUpdates,
+    events,
+    approvals,
+    denials,
+    timeouts,
+    getConnectionStateReads: () => connectionStateReads,
+  };
+}
+
+/** Make an in-wait callback offer, then opt in. Bypasses no timers. */
+function optIntoCallback(controller: GuardianWaitController): void {
+  nowValue += IN_WAIT_REPLY_COOLDOWN_MS + 1;
+  controller.handleTranscript("hurry up, this is taking too long");
+  nowValue += 1;
+  controller.handleTranscript("yes, please call me back");
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  nowValue = 1_000_000;
+  canonicalRequests.clear();
+  emitSignalCalls = [];
+  storeEvents = [];
+  mockConfig.calls.userConsultTimeoutSeconds = 120;
+  mockConfig.calls.accessRequestPollIntervalMs = 50;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("GuardianWaitController", () => {
+  describe("start", () => {
+    test("speaks the hold message, marks the session waiting, and enters the wait state", () => {
+      const { controller, spoken, sessionUpdates } = createController();
+
+      expect(controller.getState()).toBe("idle");
+      controller.start(START_PARAMS);
+
+      expect(controller.getState()).toBe("awaiting_guardian_decision");
+      expect(controller.getResolution()).toBeNull();
+      expect(spoken).toEqual([
+        "Thank you. I've let Alice know. Please hold while I check if I have permission to speak with you.",
+      ]);
+      expect(sessionUpdates).toEqual([{ status: "waiting_on_user" }]);
+
+      controller.dispose();
+    });
+
+    test("may only be called once", () => {
+      const { controller } = createController();
+      controller.start(START_PARAMS);
+      expect(() => controller.start(START_PARAMS)).toThrow(
+        "may only be called once",
+      );
+      controller.dispose();
+    });
+
+    test("never reads wait state through the transport", () => {
+      const { controller, getConnectionStateReads } = createController();
+      controller.start(START_PARAMS);
+      controller.handleTranscript("hello?");
+      jest.advanceTimersByTime(500);
+      controller.dispose();
+      expect(getConnectionStateReads()).toBe(0);
+    });
+  });
+
+  describe("resolution", () => {
+    test("approval: poll observes approved and fires onApproved once", () => {
+      seedRequest("pending");
+      const { controller, approvals, denials, timeouts } = createController();
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(50);
+      expect(approvals).toHaveLength(0);
+
+      seedRequest("approved");
+      jest.advanceTimersByTime(50);
+
+      expect(approvals).toHaveLength(1);
+      expect(approvals[0]).toEqual({
+        requestId: REQUEST_ID,
+        assistantId: "self",
+        fromNumber: "+15555550100",
+        callerName: "Bob",
+        callbackOptIn: false,
+      });
+      expect(denials).toHaveLength(0);
+      expect(timeouts).toHaveLength(0);
+      expect(controller.getState()).toBe("resolved");
+      expect(controller.getResolution()).toBe("approved");
+
+      // Poll is cleared — no duplicate resolution on further ticks.
+      jest.advanceTimersByTime(1000);
+      expect(approvals).toHaveLength(1);
+    });
+
+    test("denial: poll observes denied and fires onDenied once", () => {
+      seedRequest("pending");
+      const { controller, approvals, denials, timeouts } = createController();
+      controller.start(START_PARAMS);
+
+      seedRequest("denied");
+      jest.advanceTimersByTime(50);
+
+      expect(denials).toHaveLength(1);
+      expect(approvals).toHaveLength(0);
+      expect(timeouts).toHaveLength(0);
+      expect(controller.getResolution()).toBe("denied");
+
+      jest.advanceTimersByTime(1000);
+      expect(denials).toHaveLength(1);
+    });
+
+    test("pending/expired statuses keep polling; timeout fires onTimeout", () => {
+      seedRequest("pending");
+      const { controller, timeouts } = createController({
+        consultTimeoutMs: 2000,
+      });
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(1999);
+      expect(timeouts).toHaveLength(0);
+
+      jest.advanceTimersByTime(1);
+      expect(timeouts).toHaveLength(1);
+      expect(timeouts[0].callbackOptIn).toBe(false);
+      expect(controller.getState()).toBe("resolved");
+      expect(controller.getResolution()).toBe("timeout");
+
+      // Timeout without opt-in emits no callback handoff.
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+
+    test("heartbeats and speech stop after resolution", () => {
+      seedRequest("pending");
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      seedRequest("approved");
+      jest.advanceTimersByTime(50);
+      const spokenAtResolution = spoken.length;
+
+      jest.advanceTimersByTime(10_000);
+      expect(spoken).toHaveLength(spokenAtResolution);
+    });
+  });
+
+  describe("heartbeats", () => {
+    test("fires at the initial interval inside the initial window", () => {
+      seedRequest("pending");
+      nowValue = Date.now();
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      // Margins are generous because bun's fake clock bases timer due
+      // times on real registration timestamps (a few ms of drift).
+      jest.advanceTimersByTime(80);
+      expect(spoken).toHaveLength(1); // hold message only
+
+      jest.advanceTimersByTime(40);
+      expect(spoken).toHaveLength(2);
+      expect(spoken[1]).toBe(
+        "Still waiting to hear back from Alice. Thank you for your patience.",
+      );
+      expect(
+        storeEvents.filter(
+          (e) => e.eventType === "voice_guardian_wait_heartbeat_sent",
+        ),
+      ).toHaveLength(1);
+
+      controller.dispose();
+    });
+
+    test("uses the jittered steady interval past the initial window and advances the sequence", () => {
+      seedRequest("pending");
+      // Stamp the wait start 10s in the past so elapsed exceeds the 300ms
+      // initial window and the steady interval range [150, 200) applies.
+      nowValue = Date.now() - 10_000;
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(140);
+      expect(spoken).toHaveLength(1);
+
+      jest.advanceTimersByTime(120);
+      expect(spoken).toHaveLength(2);
+
+      // The next heartbeat is rescheduled and uses the next message in the
+      // rotation.
+      jest.advanceTimersByTime(210);
+      expect(spoken).toHaveLength(3);
+      expect(spoken[2]).not.toBe(spoken[1]);
+
+      controller.dispose();
+    });
+
+    test("a caller reply resets the heartbeat timer", () => {
+      seedRequest("pending");
+      nowValue = Date.now();
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(60);
+      controller.handleTranscript("any update?");
+      expect(spoken).toHaveLength(2);
+      expect(spoken[1]).toContain("still here");
+
+      // The pre-reply timer (40ms remaining) was cleared; a fresh full
+      // interval applies from the reply.
+      jest.advanceTimersByTime(80);
+      expect(spoken).toHaveLength(2);
+      jest.advanceTimersByTime(40);
+      expect(spoken).toHaveLength(3);
+      expect(spoken[2]).toBe(
+        "Still waiting to hear back from Alice. Thank you for your patience.",
+      );
+
+      controller.dispose();
+    });
+  });
+
+  describe("wait utterances", () => {
+    test("classifies every utterance and ignores empty ones without speaking", () => {
+      const { controller, spoken, events } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("   ");
+      expect(events).toEqual([
+        {
+          eventType: "voice_guardian_wait_prompt_classified",
+          payload: { classification: "empty", transcript: "   " },
+        },
+      ]);
+      expect(spoken).toHaveLength(1); // hold message only
+
+      controller.dispose();
+    });
+
+    test("patience check gets immediate reassurance", () => {
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("are you still there?");
+      expect(spoken[1]).toBe(
+        "Yes, I'm still here. Still waiting to hear back from Alice.",
+      );
+
+      controller.dispose();
+    });
+
+    test("neutral utterance gets an acknowledgment", () => {
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("I was calling about the garden fence");
+      expect(spoken[1]).toBe(
+        "Thanks for that. I'm still waiting on Alice. I'll let you know as soon as I hear back.",
+      );
+
+      controller.dispose();
+    });
+
+    test("impatience triggers the callback offer once, then plain reassurance", () => {
+      const { controller, spoken, events } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("hurry up");
+      expect(spoken[1]).toContain("call you back");
+      expect(
+        events.filter(
+          (e) => e.eventType === "voice_guardian_wait_callback_offer_sent",
+        ),
+      ).toHaveLength(1);
+
+      nowValue += IN_WAIT_REPLY_COOLDOWN_MS + 1;
+      controller.handleTranscript("come on, hurry up");
+      expect(spoken[2]).toBe(
+        "I hear you, I'm sorry for the wait. Still trying to reach Alice.",
+      );
+      expect(
+        events.filter(
+          (e) => e.eventType === "voice_guardian_wait_callback_offer_sent",
+        ),
+      ).toHaveLength(1);
+
+      controller.dispose();
+    });
+
+    test("cooldown suppresses rapid-fire non-callback replies", () => {
+      const { controller, spoken } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("hello?");
+      expect(spoken).toHaveLength(2);
+
+      nowValue += IN_WAIT_REPLY_COOLDOWN_MS - 1;
+      controller.handleTranscript("hello again?");
+      expect(spoken).toHaveLength(2);
+
+      nowValue += 1;
+      controller.handleTranscript("still there?");
+      expect(spoken).toHaveLength(3);
+
+      controller.dispose();
+    });
+
+    test("callback opt-in and decline bypass the cooldown", () => {
+      const { controller, spoken, events } = createController();
+      controller.start(START_PARAMS);
+
+      controller.handleTranscript("hurry up"); // offer made
+      nowValue += 1; // well inside cooldown
+      controller.handleTranscript("yes, please call me back");
+      expect(spoken[2]).toContain("you'd like a callback");
+      expect(
+        events.some(
+          (e) => e.eventType === "voice_guardian_wait_callback_opt_in_set",
+        ),
+      ).toBe(true);
+
+      nowValue += 1; // still inside cooldown
+      controller.handleTranscript("actually no, I'll hold");
+      expect(spoken[3]).toBe(
+        "No problem, I'll keep holding. Still waiting on Alice.",
+      );
+      expect(
+        events.some(
+          (e) =>
+            e.eventType === "voice_guardian_wait_callback_opt_in_declined",
+        ),
+      ).toBe(true);
+
+      controller.dispose();
+    });
+
+    test("transcripts are ignored before start and after resolution/dispose", () => {
+      const { controller, events, spoken } = createController();
+
+      controller.handleTranscript("hello?");
+      expect(events).toHaveLength(0);
+
+      controller.start(START_PARAMS);
+      controller.dispose();
+      controller.handleTranscript("hello?");
+      expect(events).toHaveLength(0);
+      expect(spoken).toHaveLength(1);
+    });
+  });
+
+  describe("callback handoff exactly-once", () => {
+    test("timeout after opt-in emits the handoff once, before onTimeout", () => {
+      seedRequest("pending");
+      const { controller, timeouts } = createController({
+        consultTimeoutMs: 2000,
+      });
+      controller.start(START_PARAMS);
+      optIntoCallback(controller);
+
+      jest.advanceTimersByTime(2000);
+      expect(emitSignalCalls).toHaveLength(1);
+      expect(emitSignalCalls[0].dedupeKey).toBe(
+        `access-request-callback-handoff:${REQUEST_ID}`,
+      );
+      expect(timeouts).toHaveLength(1);
+      expect(timeouts[0].callbackOptIn).toBe(true);
+    });
+
+    test("disconnect racing timeout does not emit a second handoff", () => {
+      seedRequest("pending");
+      const { controller, timeouts } = createController({
+        consultTimeoutMs: 2000,
+      });
+      controller.start(START_PARAMS);
+      optIntoCallback(controller);
+
+      jest.advanceTimersByTime(2000);
+      expect(emitSignalCalls).toHaveLength(1);
+
+      // Transport closes right after the timeout resolved the wait.
+      controller.dispose("transport_closed");
+      expect(emitSignalCalls).toHaveLength(1);
+      expect(timeouts).toHaveLength(1);
+    });
+
+    test("disconnect mid-wait with opt-in emits the handoff; a later timeout cannot fire", () => {
+      seedRequest("pending");
+      const { controller, timeouts } = createController({
+        consultTimeoutMs: 2000,
+      });
+      controller.start(START_PARAMS);
+      optIntoCallback(controller);
+
+      controller.dispose("transport_closed");
+      expect(emitSignalCalls).toHaveLength(1);
+      expect(emitSignalCalls[0].contextPayload).toMatchObject({
+        reason: "transport_closed",
+        callbackOptIn: true,
+        callerName: "Bob",
+      });
+
+      jest.advanceTimersByTime(10_000);
+      expect(emitSignalCalls).toHaveLength(1);
+      expect(timeouts).toHaveLength(0);
+    });
+
+    test("disconnect mid-wait without opt-in emits nothing", () => {
+      seedRequest("pending");
+      const { controller } = createController();
+      controller.start(START_PARAMS);
+
+      controller.dispose("transport_closed");
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+
+    test("plain teardown never emits the handoff", () => {
+      seedRequest("pending");
+      const { controller } = createController();
+      controller.start(START_PARAMS);
+      optIntoCallback(controller);
+
+      controller.dispose();
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+  });
+
+  describe("dispose", () => {
+    test("clears every timer — nothing fires afterwards", () => {
+      seedRequest("pending");
+      const {
+        controller,
+        spoken,
+        approvals,
+        denials,
+        timeouts,
+      } = createController({ consultTimeoutMs: 2000 });
+      controller.start(START_PARAMS);
+
+      controller.dispose();
+      expect(controller.getState()).toBe("disposed");
+
+      seedRequest("approved");
+      jest.advanceTimersByTime(60_000);
+      expect(spoken).toHaveLength(1); // hold message only
+      expect(approvals).toHaveLength(0);
+      expect(denials).toHaveLength(0);
+      expect(timeouts).toHaveLength(0);
+      expect(
+        storeEvents.filter(
+          (e) => e.eventType === "voice_guardian_wait_heartbeat_sent",
+        ),
+      ).toHaveLength(0);
+    });
+
+    test("is idempotent and preserves a reached resolution", () => {
+      seedRequest("approved");
+      const { controller, approvals } = createController();
+      controller.start(START_PARAMS);
+      jest.advanceTimersByTime(50);
+      expect(approvals).toHaveLength(1);
+
+      controller.dispose();
+      controller.dispose("transport_closed");
+      expect(controller.getState()).toBe("resolved");
+      expect(controller.getResolution()).toBe("approved");
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+  });
+
+  describe("config fallbacks", () => {
+    test("NaN consult timeout falls back to the 120s schema default", () => {
+      seedRequest("pending");
+      mockConfig.calls.userConsultTimeoutSeconds = Number.NaN;
+      const { controller, timeouts } = createController();
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(119_999);
+      expect(timeouts).toHaveLength(0);
+      jest.advanceTimersByTime(1);
+      expect(timeouts).toHaveLength(1);
+    });
+
+    test("NaN poll interval falls back to the 500ms schema default", () => {
+      seedRequest("approved");
+      mockConfig.calls.accessRequestPollIntervalMs = Number.NaN;
+      const { controller, approvals } = createController();
+      controller.start(START_PARAMS);
+
+      jest.advanceTimersByTime(499);
+      expect(approvals).toHaveLength(0);
+      jest.advanceTimersByTime(1);
+      expect(approvals).toHaveLength(1);
+    });
+  });
+});

--- a/assistant/src/calls/guardian-wait-controller.ts
+++ b/assistant/src/calls/guardian-wait-controller.ts
@@ -1,0 +1,505 @@
+/**
+ * Transport-agnostic guardian access-request wait controller.
+ *
+ * Owns the in-call wait for a guardian's decision on a caller access
+ * request: the hold message, periodic heartbeat updates, canonical-request
+ * polling, the consultation timeout, and wait-state utterance handling
+ * (reassurance, impatience, callback offer/opt-in). Resolution is
+ * delivered through injected `onApproved` / `onDenied` / `onTimeout`
+ * callbacks; the consumer owns the terminal copy and session teardown.
+ *
+ * The controller is the sole source of truth for its wait state — it is
+ * never inferred from the transport. All side effects flow through
+ * injected deps so the controller is unit-testable and independent of any
+ * wire protocol. Pure wait helpers (`classifyWaitUtterance`,
+ * `scheduleNextHeartbeat`, `emitAccessRequestCallbackHandoff`) are reused
+ * from relay-access-wait.ts.
+ */
+
+import { getCanonicalGuardianRequest as getCanonicalGuardianRequestFn } from "../contacts/canonical-guardian-store.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getAccessRequestPollIntervalMs,
+  getTtsPlaybackDelayMs,
+  getUserConsultationTimeoutMs,
+} from "./call-constants.js";
+import type { SetupFlowTransport } from "./call-setup-flow-types.js";
+import type {
+  recordCallEvent as recordCallEventFn,
+  updateCallSession as updateCallSessionFn,
+} from "./call-store.js";
+import {
+  classifyWaitUtterance,
+  emitAccessRequestCallbackHandoff,
+  scheduleNextHeartbeat,
+} from "./relay-access-wait.js";
+
+const log = getLogger("guardian-wait-controller");
+
+/** Minimum gap between spoken replies to non-callback wait utterances. */
+export const IN_WAIT_REPLY_COOLDOWN_MS = 3000;
+
+// Schema defaults from config/schemas/calls.ts, used when config values
+// are missing or NaN.
+const DEFAULT_CONSULT_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_FIRST_HEARTBEAT_DELAY_MS = 3000;
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export type GuardianWaitState =
+  | "idle"
+  | "awaiting_guardian_decision"
+  | "resolved"
+  | "disposed";
+
+export type GuardianWaitResolution = "approved" | "denied" | "timeout";
+
+/**
+ * Dispose reason. `transport_closed` additionally emits the callback
+ * handoff notification when the caller opted into a callback and the wait
+ * was still unresolved.
+ */
+export type GuardianWaitDisposeReason = "transport_closed" | "teardown";
+
+/** Context passed to every resolution callback. */
+export interface GuardianWaitResolutionContext {
+  requestId: string;
+  assistantId: string;
+  fromNumber: string;
+  callerName: string | null;
+  callbackOptIn: boolean;
+}
+
+export interface GuardianWaitStartParams {
+  /** Canonical guardian access-request id to poll. */
+  requestId: string;
+  assistantId: string;
+  fromNumber: string;
+  callerName: string | null;
+}
+
+export interface GuardianWaitControllerDeps {
+  /** Speak a deterministic system prompt through the transport. */
+  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  updateCallSession(
+    id: string,
+    updates: Parameters<typeof updateCallSessionFn>[1],
+  ): void;
+  recordCallEvent(
+    callSessionId: string,
+    eventType: Parameters<typeof recordCallEventFn>[1],
+    payload?: Record<string, unknown>,
+  ): void;
+  /** Human-readable guardian label for wait copy. */
+  resolveGuardianLabel(): string;
+  onApproved(ctx: GuardianWaitResolutionContext): void | Promise<void>;
+  onDenied(ctx: GuardianWaitResolutionContext): void | Promise<void>;
+  onTimeout(ctx: GuardianWaitResolutionContext): void | Promise<void>;
+  /** Canonical-request reader; defaults to the real store. */
+  getCanonicalGuardianRequest?: typeof getCanonicalGuardianRequestFn;
+  /** Clock; defaults to Date.now. */
+  now?: () => number;
+  /** Overrides the `calls.accessRequestPollIntervalMs` config value. */
+  pollIntervalMs?: number;
+  /** Overrides the `calls.userConsultTimeoutSeconds` config value. */
+  consultTimeoutMs?: number;
+  /**
+   * Delay before the first heartbeat so the hold message finishes
+   * playing. Overrides the `calls.ttsPlaybackDelayMs` config value.
+   */
+  firstHeartbeatDelayMs?: number;
+  /** Overrides {@link IN_WAIT_REPLY_COOLDOWN_MS}. */
+  inWaitReplyCooldownMs?: number;
+}
+
+// ── Controller ───────────────────────────────────────────────────────
+
+export class GuardianWaitController {
+  private state: GuardianWaitState = "idle";
+  private resolution: GuardianWaitResolution | null = null;
+  private params: GuardianWaitStartParams | null = null;
+
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private waitStartedAt = 0;
+  private heartbeatSequence = 0;
+  private lastInWaitReplyAt = 0;
+
+  private callbackOfferMade = false;
+  private callbackOptIn = false;
+  private callbackHandoffNotified = false;
+
+  constructor(
+    private readonly callSessionId: string,
+    private readonly transport: SetupFlowTransport,
+    private readonly deps: GuardianWaitControllerDeps,
+  ) {}
+
+  /** Explicit controller state — never inferred from the transport. */
+  getState(): GuardianWaitState {
+    return this.state;
+  }
+
+  /** Resolution reached, or null while unresolved. */
+  getResolution(): GuardianWaitResolution | null {
+    return this.resolution;
+  }
+
+  /**
+   * Begin the wait: speak the hold message, mark the session
+   * `waiting_on_user`, and arm the heartbeat, poll, and timeout timers.
+   * May only be called once per controller instance.
+   */
+  start(params: GuardianWaitStartParams): void {
+    if (this.state !== "idle") {
+      throw new Error("GuardianWaitController.start() may only be called once");
+    }
+    this.params = params;
+    this.state = "awaiting_guardian_decision";
+
+    const guardianLabel = this.deps.resolveGuardianLabel();
+    void this.speak(
+      `Thank you. I've let ${guardianLabel} know. Please hold while I check if I have permission to speak with you.`,
+    );
+
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "waiting_on_user",
+    });
+
+    // The first heartbeat waits out the hold message's TTS playback. The
+    // wait start time is stamped now so heartbeat scheduling has a valid
+    // reference point even if this timer is cancelled early (e.g. by a
+    // wait-state reply during playback); the callback re-stamps it to
+    // exclude the TTS delay.
+    this.heartbeatSequence = 0;
+    this.waitStartedAt = this.now();
+    this.heartbeatTimer = setTimeout(() => {
+      this.waitStartedAt = this.now();
+      this.scheduleHeartbeat();
+    }, this.resolveFirstHeartbeatDelayMs());
+
+    const pollIntervalMs = this.resolvePollIntervalMs();
+    this.pollTimer = setInterval(() => {
+      this.pollCanonicalRequest();
+    }, pollIntervalMs);
+
+    const timeoutMs = this.resolveConsultTimeoutMs();
+    this.timeoutTimer = setTimeout(() => {
+      if (this.state !== "awaiting_guardian_decision") {
+        return;
+      }
+      log.info(
+        { callSessionId: this.callSessionId, requestId: params.requestId },
+        "Access request in-call wait timed out",
+      );
+      this.resolve("timeout");
+    }, timeoutMs);
+
+    log.info(
+      {
+        callSessionId: this.callSessionId,
+        requestId: params.requestId,
+        timeoutMs,
+        pollIntervalMs,
+      },
+      "Access request in-call wait started",
+    );
+  }
+
+  /**
+   * Handle a caller utterance during the wait: reassurance, impatience
+   * detection, and callback offer/opt-in. No-op unless waiting.
+   */
+  handleTranscript(text: string): void {
+    if (this.state !== "awaiting_guardian_decision") {
+      return;
+    }
+
+    const now = this.now();
+    const classification = classifyWaitUtterance(text, this.callbackOfferMade);
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "voice_guardian_wait_prompt_classified",
+      { classification, transcript: text },
+    );
+
+    if (classification === "empty") {
+      return;
+    }
+
+    const guardianLabel = this.deps.resolveGuardianLabel();
+
+    // Callback decisions are always processed regardless of cooldown —
+    // the caller is answering a direct question and dropping their
+    // response would silently discard their decision.
+    switch (classification) {
+      case "callback_opt_in": {
+        this.callbackOptIn = true;
+        this.lastInWaitReplyAt = now;
+        this.deps.recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_set",
+          {},
+        );
+        this.resetHeartbeatTimer();
+        void this.speak(
+          `Noted, I'll make sure ${guardianLabel} knows you'd like a callback. For now, I'll keep trying to reach them.`,
+        );
+        this.scheduleHeartbeat();
+        return;
+      }
+      case "callback_decline": {
+        this.callbackOptIn = false;
+        this.lastInWaitReplyAt = now;
+        this.deps.recordCallEvent(
+          this.callSessionId,
+          "voice_guardian_wait_callback_opt_in_declined",
+          {},
+        );
+        this.resetHeartbeatTimer();
+        void this.speak(
+          `No problem, I'll keep holding. Still waiting on ${guardianLabel}.`,
+        );
+        this.scheduleHeartbeat();
+        return;
+      }
+      default:
+        break;
+    }
+
+    // Enforce cooldown on non-callback utterances to prevent spam.
+    if (now - this.lastInWaitReplyAt < this.resolveInWaitReplyCooldownMs()) {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        "In-wait reply suppressed by cooldown",
+      );
+      return;
+    }
+    this.lastInWaitReplyAt = now;
+
+    // Immediate replies reset the heartbeat timer so a scheduled
+    // heartbeat doesn't double up with the reassurance.
+    this.resetHeartbeatTimer();
+    switch (classification) {
+      case "impatient": {
+        if (!this.callbackOfferMade) {
+          this.callbackOfferMade = true;
+          this.deps.recordCallEvent(
+            this.callSessionId,
+            "voice_guardian_wait_callback_offer_sent",
+            {},
+          );
+          void this.speak(
+            `I understand this is taking a while. I can have ${guardianLabel} call you back once I hear from them. Would you like that, or would you prefer to keep holding?`,
+          );
+        } else {
+          void this.speak(
+            `I hear you, I'm sorry for the wait. Still trying to reach ${guardianLabel}.`,
+          );
+        }
+        break;
+      }
+      case "patience_check": {
+        void this.speak(
+          `Yes, I'm still here. Still waiting to hear back from ${guardianLabel}.`,
+        );
+        break;
+      }
+      case "neutral":
+      default: {
+        void this.speak(
+          `Thanks for that. I'm still waiting on ${guardianLabel}. I'll let you know as soon as I hear back.`,
+        );
+        break;
+      }
+    }
+    this.scheduleHeartbeat();
+  }
+
+  /**
+   * Clear every timer. Idempotent. When `reason` is `transport_closed`
+   * and the wait is still unresolved with callback opt-in, emits the
+   * callback handoff notification first (at most once per controller).
+   */
+  dispose(reason: GuardianWaitDisposeReason = "teardown"): void {
+    if (
+      this.state === "awaiting_guardian_decision" &&
+      reason === "transport_closed"
+    ) {
+      this.emitCallbackHandoff("transport_closed");
+    }
+    this.clearTimers();
+    if (this.state === "idle" || this.state === "awaiting_guardian_decision") {
+      this.state = "disposed";
+    }
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private pollCanonicalRequest(): void {
+    if (this.state !== "awaiting_guardian_decision" || !this.params) {
+      this.clearTimers();
+      return;
+    }
+    const read =
+      this.deps.getCanonicalGuardianRequest ?? getCanonicalGuardianRequestFn;
+    const request = read(this.params.requestId);
+    if (!request) {
+      return;
+    }
+    if (request.status === "approved") {
+      this.resolve("approved");
+    } else if (request.status === "denied") {
+      this.resolve("denied");
+    }
+    // 'pending' continues polling; 'expired'/'cancelled' handled by timeout.
+  }
+
+  private resolve(resolution: GuardianWaitResolution): void {
+    if (this.state !== "awaiting_guardian_decision" || !this.params) {
+      return;
+    }
+    // Emit the callback handoff before clearing wait state so a caller
+    // who opted into a callback gets the guardian notification.
+    if (resolution === "timeout") {
+      this.emitCallbackHandoff("timeout");
+    }
+    this.clearTimers();
+    this.state = "resolved";
+    this.resolution = resolution;
+
+    const ctx: GuardianWaitResolutionContext = {
+      requestId: this.params.requestId,
+      assistantId: this.params.assistantId,
+      fromNumber: this.params.fromNumber,
+      callerName: this.params.callerName,
+      callbackOptIn: this.callbackOptIn,
+    };
+    const callback =
+      resolution === "approved"
+        ? this.deps.onApproved
+        : resolution === "denied"
+          ? this.deps.onDenied
+          : this.deps.onTimeout;
+    void Promise.resolve(callback(ctx)).catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId, resolution },
+        "Guardian wait resolution callback failed",
+      );
+    });
+  }
+
+  private emitCallbackHandoff(reason: "timeout" | "transport_closed"): void {
+    const result = emitAccessRequestCallbackHandoff({
+      reason,
+      callbackOptIn: this.callbackOptIn,
+      accessRequestId: this.params?.requestId ?? null,
+      callbackHandoffNotified: this.callbackHandoffNotified,
+      accessRequestAssistantId: this.params?.assistantId ?? null,
+      accessRequestFromNumber: this.params?.fromNumber ?? null,
+      accessRequestCallerName: this.params?.callerName ?? null,
+      callSessionId: this.callSessionId,
+    });
+    this.callbackHandoffNotified = result.callbackHandoffNotified;
+  }
+
+  private scheduleHeartbeat(): void {
+    this.heartbeatTimer = scheduleNextHeartbeat({
+      isWaitActive: () => this.state === "awaiting_guardian_decision",
+      accessRequestWaitStartedAt: this.waitStartedAt,
+      callSessionId: this.callSessionId,
+      consumeSequence: () => this.heartbeatSequence++,
+      resolveGuardianLabel: () => this.deps.resolveGuardianLabel(),
+      sendTextToken: (text, _last) => void this.speak(text),
+      scheduleNext: () => this.scheduleHeartbeat(),
+    });
+  }
+
+  private resetHeartbeatTimer(): void {
+    if (this.heartbeatTimer) {
+      clearTimeout(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer);
+      this.timeoutTimer = null;
+    }
+    this.resetHeartbeatTimer();
+  }
+
+  private speak(text: string): Promise<void> {
+    return this.deps.speakSystemPrompt(this.transport, text).catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Guardian wait speech failed",
+      );
+    });
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now();
+  }
+
+  private resolveConsultTimeoutMs(): number {
+    return finiteAtLeast(
+      this.deps.consultTimeoutMs ?? safeCall(getUserConsultationTimeoutMs),
+      1,
+      DEFAULT_CONSULT_TIMEOUT_MS,
+    );
+  }
+
+  private resolvePollIntervalMs(): number {
+    return finiteAtLeast(
+      this.deps.pollIntervalMs ?? safeCall(getAccessRequestPollIntervalMs),
+      1,
+      DEFAULT_POLL_INTERVAL_MS,
+    );
+  }
+
+  private resolveFirstHeartbeatDelayMs(): number {
+    return finiteAtLeast(
+      this.deps.firstHeartbeatDelayMs ?? safeCall(getTtsPlaybackDelayMs),
+      0,
+      DEFAULT_FIRST_HEARTBEAT_DELAY_MS,
+    );
+  }
+
+  private resolveInWaitReplyCooldownMs(): number {
+    return finiteAtLeast(
+      this.deps.inWaitReplyCooldownMs,
+      0,
+      IN_WAIT_REPLY_COOLDOWN_MS,
+    );
+  }
+}
+
+// ── Config guards ────────────────────────────────────────────────────
+
+function safeCall(getter: () => number): number | undefined {
+  try {
+    return getter();
+  } catch {
+    return undefined;
+  }
+}
+
+function finiteAtLeast(
+  value: number | undefined,
+  min: number,
+  fallback: number,
+): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= min
+    ? value
+    : fallback;
+}


### PR DESCRIPTION
## Summary
- New GuardianWaitController owns the access-request wait orchestration (hold message, heartbeats, canonical-request polling, consultation timeout) transport-agnostically
- Reuses relay-access-wait pure helpers; explicit state surface; injected clock for real-time-free tests; exactly-once callback-handoff semantics
- Consumed by the name-capture sub-flow in a later plan PR

Part of plan: phone-media-stream-v2.md (PR 7 of 17)