### PR TITLE
fix(web): stop first-message flicker on server-minted conversations

### DIFF
--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import {
   handleAssistantTextDelta,
   handleAssistantThinkingDelta,
@@ -333,7 +335,26 @@ describe("handleMessageComplete", () => {
 });
 
 describe("handleUserMessageEcho", () => {
-  it("clears the optimistic send correlated by clientMessageId when present", () => {
+  const seededSnapshot: PaginatedHistoryResult = {
+    messages: [],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 1,
+  };
+
+  // The handler reads the real chat-session store to decide whether the paired
+  // snapshot fold has somewhere to land. Reset it around each case so state
+  // never leaks between tests.
+  beforeEach(() => {
+    useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+  });
+  afterEach(() => {
+    useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+  });
+
+  it("clears the optimistic send correlated by clientMessageId when the snapshot is seeded", () => {
+    useChatSessionStore.setState({ snapshot: seededSnapshot });
     const ctx = makeCtx();
     handleUserMessageEcho(
       {
@@ -345,6 +366,25 @@ describe("handleUserMessageEcho", () => {
       ctx,
     );
     expect(ctx.clearOptimisticSend).toHaveBeenCalledWith("client-1");
+  });
+
+  it("does NOT clear the optimistic send when the snapshot is unseeded (first-message flicker guard)", () => {
+    // Regression: the first message of a freshly server-minted conversation has
+    // no history snapshot yet, so `applyEnvelopeToSnapshot` no-ops. Clearing the
+    // overlay here would blank the message out until `seedSnapshot` lands. The
+    // reseed's `pruneConfirmedOptimisticSends` retires it instead.
+    expect(useChatSessionStore.getState().snapshot).toBeNull();
+    const ctx = makeCtx();
+    handleUserMessageEcho(
+      {
+        type: "user_message_echo",
+        text: "Hello",
+        messageId: "msg-1",
+        clientMessageId: "client-1",
+      },
+      ctx,
+    );
+    expect(ctx.clearOptimisticSend).not.toHaveBeenCalled();
   });
 
   it("retires the most recent optimistic user send when the echo carries no nonce", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -16,6 +16,7 @@ import type {
   UserMessageEchoEvent,
 } from "@vellumai/assistant-api";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 /**
  * Resolve the conversation id for SSE handlers — events that carry it on
@@ -270,12 +271,30 @@ export function handleMessageComplete(
  * collapse on, so fall back to retiring the most recent optimistic user send,
  * mirroring the legacy echo correlation. A no-op for echoes with no matching
  * optimistic row (other clients' sends, synthetic prompts).
+ *
+ * Retiring the optimistic row is gated on the snapshot being seeded. The fold
+ * that materializes the echoed server row (`applyEnvelopeToSnapshot`, dispatched
+ * from the same `sse.event` in `use-event-stream`) is itself a no-op until the
+ * snapshot exists — so on the FIRST message of a freshly server-minted
+ * conversation, whose history hasn't loaded yet, clearing the optimistic row
+ * here would drop the only rendered copy and blank the message out until
+ * `seedSnapshot` lands (the staging first-message flicker). When the snapshot is
+ * unseeded we leave the optimistic row in place and let
+ * `pruneConfirmedOptimisticSends` retire it atomically on the reseed — the
+ * persisted row carries the same `clientMessageId`, so it matches there.
  */
 export function handleUserMessageEcho(
   event: UserMessageEchoEvent,
   ctx: StreamHandlerContext,
 ): void {
   if (event.clientMessageId) {
+    // No snapshot yet → the paired fold can't materialize this row, so retiring
+    // the overlay now would leave a render gap (the staging first-message
+    // flicker). Defer to the reseed's `pruneConfirmedOptimisticSends`, which
+    // matches the persisted row on this same `clientMessageId`.
+    if (!useChatSessionStore.getState().snapshot) {
+      return;
+    }
     ctx.clearOptimisticSend(event.clientMessageId);
     return;
   }


### PR DESCRIPTION
## Prompt / plan

Investigating a report that "on staging, every first message of a conversation clears out then reappears" (a flicker). Traced the send/echo/snapshot data flow, confirmed the root cause with an independent trace, then applied the minimal targeted fix (Option A) and added a regression test.

### Root cause

The rendered transcript is `snapshot ⊕ optimisticSends`. For the **first** message of a brand-new conversation the `snapshot` is still `null` (its history hasn't loaded yet), so the message is on screen **only** as an optimistic send.

Two independent consumers react to the same `user_message_echo` SSE event, dispatched together in `use-event-stream`:

1. **The snapshot reducer** (`applyEnvelopeToSnapshot`) folds the echoed, now-persisted server row into the snapshot — but it's a **hard no-op while the snapshot is unseeded** (`chat-session-store.ts`).
2. **The echo handler** (`handleUserMessageEcho`) **unconditionally** retired the optimistic overlay row.

So on a freshly **server-minted** conversation (staging runs assistants ≥ `0.8.6`, which swap the local draft id for the server-minted id and start a *fresh* history query), the echo cleared the optimistic row while the fold no-op'd — leaving the transcript with neither copy. The message blanked out until `seedSnapshot` finally landed and re-materialized the persisted row. Production/legacy assistants keep the draft row `draft: true`, which gates the SSE echo-clear off entirely, so they never hit the window — hence "staging only".

### Fix

Gate the optimistic clear in `handleUserMessageEcho` on the snapshot being seeded. When it isn't, leave the optimistic row and let `seedSnapshot`'s `pruneConfirmedOptimisticSends` retire it on the reseed — the persisted row carries the same `clientMessageId`, so it matches there. Seeded-snapshot behavior (every follow-up message) is unchanged: the echo-clear and the fold still commit in the same dispatch. The no-nonce legacy fallback is left untouched.

## Test plan

- Added a regression test in `message-handlers.test.ts` for the echo-before-seed ordering: with an **unseeded** snapshot the optimistic row is **not** cleared; with a **seeded** snapshot it is cleared as before.
- `bun test src/domains/chat/utils/stream-handlers/message-handlers.test.ts` — 22 pass.
- Adjacent suites green: `chat-session-store-base`, `stream-updaters`, `select-transcript-messages` (88 pass).
- `bunx tsc --noEmit` clean; `eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bXAJXthHGU14dZ6LAZAtm)_