### PR TITLE
fix(web): recover stuck "thinking" indicator from the server processing flag

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * `useMessageReconciliation` — the reconcile path adopts the daemon's
+ * authoritative `processing` flag.
+ *
+ * The load-bearing behavior for the "stuck on thinking until refresh" bug: when
+ * the reconcile fetch reports `processing: false` but the local rolling snapshot
+ * still shows the turn processing, the reconcile must reseed the snapshot
+ * (history invalidation) so the fresh `processing: false` reaches the
+ * `snapshotProcessing` CLOSE-gate in `shouldShowThinkingIndicator`. Content diffs
+ * are mocked out here so these tests isolate the processing-flag gate; the
+ * content-diff detection and the close-gate itself are covered by
+ * `reconcile-detection.test.ts` and `turn-selectors.test.ts`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+
+// Isolate the processing-flag gate: force "no new content" and "assistant
+// produced output" so `changed`/`assistantProgress` never drive invalidation.
+mock.module("@/domains/chat/utils/reconcile-detection", () => ({
+  serverSnapshotHasNewContent: () => false,
+  serverHasAssistantProgress: () => true,
+}));
+
+mock.module("@/domains/chat/utils/map-runtime-message", () => ({
+  mapRuntimeToDisplayMessage: (m: unknown) => m,
+}));
+
+// Server fetch is driven per-test — spied (not module-mocked) so the rest of
+// the messages module's exports stay real for other importers in the graph.
+import * as messagesApi from "@/domains/chat/api/messages";
+let fetchResult: unknown = undefined;
+spyOn(messagesApi, "fetchConversationMessages").mockImplementation(
+  async () => fetchResult as never,
+);
+
+const { useMessageReconciliation } = await import(
+  "@/domains/chat/hooks/use-message-reconciliation"
+);
+const { useStreamStore } = await import("@/domains/chat/stream-store");
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { __resetLocalSeqForTesting } = await import("@/lib/streaming/local-seq");
+
+const ASSISTANT_ID = "asst-1";
+const CONV_ID = "conv-A";
+
+function seedSnapshotProcessing(processing: boolean | undefined): void {
+  useChatSessionStore.setState({
+    snapshot: {
+      messages: [],
+      seq: 10,
+      processing,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      backgroundToolCompletions: [],
+    },
+  } as never);
+}
+
+function seedServerFetch(processing: boolean | undefined): void {
+  fetchResult = {
+    messages: [{ id: "a1", role: "assistant" }],
+    seq: 11,
+    processing,
+  };
+}
+
+/** Render the hook against a spied query client; returns the invalidate spy. */
+function renderReconciliation() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const invalidateSpy = mock(async () => {});
+  client.invalidateQueries = invalidateSpy as never;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+  const { result } = renderHook(
+    () => useMessageReconciliation({ latestPageOldestTimestamp: null }),
+    { wrapper },
+  );
+  return { result, invalidateSpy };
+}
+
+beforeEach(() => {
+  __resetLocalSeqForTesting();
+  useStreamStore.getState().setStreamContext({
+    assistantId: ASSISTANT_ID,
+    conversationId: CONV_ID,
+  });
+  useConversationStore.getState().setActiveConversationId(CONV_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  useStreamStore.getState().setStreamContext(null);
+  useConversationStore.getState().setActiveConversationId(null);
+  useChatSessionStore.setState({ snapshot: null } as never);
+  fetchResult = undefined;
+});
+
+describe("useMessageReconciliation — server processing flag drives reseed", () => {
+  test("reseeds when the server clears processing but the snapshot still shows it active", async () => {
+    seedSnapshotProcessing(true);
+    seedServerFetch(false);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    const outcome = await result.current.reconcileActiveConversation();
+
+    expect(outcome.changed).toBe(false);
+    // No content diff, but the server's `processing: false` must still trigger
+    // a reseed so the close-gate receives the fresh flag.
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reseed while the server is still processing and content matches", async () => {
+    seedSnapshotProcessing(true);
+    seedServerFetch(true);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    await result.current.reconcileActiveConversation();
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not reseed when the snapshot already reflects the idle turn", async () => {
+    // Turn already idle locally — no stale spinner to clear, so no refetch.
+    seedSnapshotProcessing(false);
+    seedServerFetch(false);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    await result.current.reconcileActiveConversation();
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  test("older daemons without the processing field keep phase-only behavior", async () => {
+    seedSnapshotProcessing(true);
+    seedServerFetch(undefined);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    await result.current.reconcileActiveConversation();
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -13,6 +13,7 @@ import { recordLocalSeq } from "@/lib/streaming/local-seq";
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
 import { conversationHistoryQueryKey } from "@/domains/chat/transcript/use-history-pagination";
+import { patchConversation } from "@/utils/conversation-cache";
 import {
   serverHasAssistantProgress,
   serverSnapshotHasNewContent,
@@ -95,6 +96,7 @@ export function useMessageReconciliation({
       serverMessages: ConversationMessage[],
       conversationId: string,
       serverSeq: number | null,
+      serverProcessing: boolean | undefined,
       authoritative = false,
     ): {
       changed: boolean;
@@ -132,17 +134,51 @@ export function useMessageReconciliation({
         0,
       );
 
+      // Adopt the daemon's authoritative `processing` flag when it reports the
+      // conversation idle but our rolling snapshot still shows it processing.
+      // This is the sole path that samples the flag independently of the SSE
+      // stream, so it's the only place that learns a turn ended when the
+      // terminal event (`message_complete` / `assistant_activity_state(idle)`)
+      // was dropped on a disconnect. Propagating it lets the existing
+      // authoritative CLOSE-gate in `shouldShowThinkingIndicator` /
+      // `canStopGeneration` (`snapshotProcessing === false`) settle the turn —
+      // no client-side stuck-turn heuristic. `undefined` (older daemons) does
+      // nothing, preserving prior behavior.
+      const localSnapshotProcessing =
+        useChatSessionStore.getState().snapshot?.processing;
+      const serverClearedProcessing =
+        serverProcessing === false && localSnapshotProcessing === true;
+
       // Refresh the single source — history flows into the query cache and the
       // transcript (its union with the live turn) re-renders. No client-side
-      // merge: the server snapshot is authoritative for persisted history.
-      if (changed || authoritative) {
+      // merge: the server snapshot is authoritative for persisted history. A
+      // reseed also carries the fresh `processing: false` onto the snapshot, so
+      // a server-cleared turn reconciles through the same path as new content.
+      if (changed || authoritative || serverClearedProcessing) {
         const assistantId =
           useStreamStore.getState().streamContext?.assistantId ?? null;
         if (assistantId) {
           void queryClient.invalidateQueries({
             queryKey: conversationHistoryQueryKey(assistantId, conversationId),
           });
+          if (serverClearedProcessing) {
+            // Mirror the terminal handlers' cache patch so the conversation-row
+            // half of the processing state (sidebar dot, `activeConversation
+            // ?.isProcessing`) can't stay latched `true` after the server has
+            // gone idle. See `handleMessageComplete`.
+            patchConversation(queryClient, assistantId, conversationId, {
+              isProcessing: false,
+            });
+          }
         }
+      }
+
+      if (serverClearedProcessing) {
+        recordDiagnostic("reconciliation_processing_cleared", {
+          conversationId,
+          changed,
+          assistantProgress,
+        });
       }
 
       recordDiagnostic("reconciliation_applied", {
@@ -150,6 +186,7 @@ export function useMessageReconciliation({
         assistantProgress,
         messagesAdded,
         authoritative,
+        serverProcessing,
         oldestPageTimestamp: initialPageOldestTsRef.current,
         server: summarizeRuntimeMessages(serverMessages),
       });
@@ -165,8 +202,12 @@ export function useMessageReconciliation({
       conversationId: string,
       serverSeq: number | null,
     ): boolean =>
-      reconcileFromServerDetailed(serverMessages, conversationId, serverSeq)
-        .changed,
+      reconcileFromServerDetailed(
+        serverMessages,
+        conversationId,
+        serverSeq,
+        undefined,
+      ).changed,
     [reconcileFromServerDetailed],
   );
 
@@ -176,6 +217,7 @@ export function useMessageReconciliation({
       snapshotTurnId: string | null,
       snapshotConversationId: string,
       serverSeq: number | null,
+      serverProcessing: boolean | undefined,
       authoritative = false,
     ): ReconcileActiveConversationResult => {
       const { changed, assistantProgress, messagesAdded } =
@@ -183,6 +225,7 @@ export function useMessageReconciliation({
           serverMessages,
           snapshotConversationId,
           serverSeq,
+          serverProcessing,
           authoritative,
         );
 
@@ -202,12 +245,12 @@ export function useMessageReconciliation({
       //   - Same turn id we snapshotted at fetch time, and the store
       //     still says we're sending.
       //
-      // Trade-off: in the (rare) case where SSE missed `message_complete`
-      // but the server's persisted view exactly matches what local
-      // already rendered, this rescue cannot fire. The user would need
-      // to reload — but that scenario is also genuinely indistinguishable
-      // from "live mid-stream paused between deltas", so the safe call
-      // is to never auto-idle without positive structural evidence.
+      // The case where SSE missed the terminal event but the server's
+      // persisted view already matches what local rendered (`changed`
+      // false) is handled separately, upstream: `reconcileFromServerDetailed`
+      // adopts the server's `processing: false` onto the snapshot, and the
+      // `snapshotProcessing` CLOSE-gate in `shouldShowThinkingIndicator`
+      // settles the indicator without a content diff.
       const wasStuck =
         changed &&
         assistantProgress &&
@@ -297,11 +340,13 @@ export function useMessageReconciliation({
             if (epoch !== useStreamStore.getState().streamEpoch) return;
             const serverMessages = snapshot?.messages ?? [];
             const serverSeq = snapshot?.seq ?? null;
+            const serverProcessing = snapshot?.processing;
             recordDiagnostic("reconciliation_fetch", {
               assistantId: ctx.assistantId,
               conversationId: ctx.conversationId,
               epoch,
               stableCount,
+              serverProcessing,
               server: summarizeRuntimeMessages(serverMessages),
             });
 
@@ -310,6 +355,7 @@ export function useMessageReconciliation({
               snapshotTurnId,
               ctx.conversationId,
               serverSeq,
+              serverProcessing,
             );
             if (changed) {
               stableCount = 0;
@@ -393,6 +439,7 @@ export function useMessageReconciliation({
         );
         const serverMessages = snapshot?.messages ?? [];
         const serverSeq = snapshot?.seq ?? null;
+        const serverProcessing = snapshot?.processing;
         if (useConversationStore.getState().activeConversationId !== ctx.conversationId) return empty;
         // If the epoch changed during the fetch (e.g. page went hidden
         // and back), this reconciliation is stale — bail out.
@@ -401,6 +448,7 @@ export function useMessageReconciliation({
           assistantId: ctx.assistantId,
           conversationId: ctx.conversationId,
           epoch: snapshotEpoch,
+          serverProcessing,
           server: summarizeRuntimeMessages(serverMessages),
         });
         return reconcileFetchedMessages(
@@ -408,6 +456,7 @@ export function useMessageReconciliation({
           snapshotTurnId,
           ctx.conversationId,
           serverSeq,
+          serverProcessing,
           authoritative,
         );
       } catch (err) {


### PR DESCRIPTION
## Prompt / plan

User report: **"Stuck on thinking state until I refreshed the page."**

Triage of the attached feedback bundle reconstructed the failure:

- The turn completed on the **daemon** at `14:19:20` (`stopReason: end_turn`, assistant message persisted).
- The **client's** SSE event stream stopped at `14:19:16`, mid-stream — the terminal event (`message_complete` / `assistant_activity_state(idle)`) was never delivered.
- The reconciliation loop then ran every ~5s for six minutes, each pass seeing the server report `processing: false` yet **never clearing the indicator**. A manual refresh recovered it.

### Root cause

The client already drives the indicator off server state: `shouldShowThinkingIndicator` / `canStopGeneration` have an authoritative close-gate on `snapshotProcessing === false` (turn-selectors.ts). The gap was **upstream** — nothing fed that gate the fresh flag.

The rolling snapshot's `processing` is refreshed only by (a) folding the SSE terminal event — dropped here — or (b) a history **reseed**, which the reconcile loop triggered only when content `changed`. Because the client had already folded every delta, `changed` was `false`, so the loop **fetched `processing: false` on every pass and discarded it**, starving the close-gate on a stale `true` for six minutes.

### Fix

In the reconcile path, when the server reports the conversation idle but the local snapshot still shows it processing:
- Reseed (history invalidation) so the fresh `processing: false` lands on the snapshot and the existing `snapshotProcessing` close-gate settles the turn — no bespoke stuck-turn heuristic.
- Mirror the terminal handlers' conversation-cache patch (`isProcessing: false`) for the sidebar/row half of the processing state.
- Absent `processing` (older daemons) is a no-op, preserving prior behavior.

The content-diff silent-stall rescue (`changed && assistantProgress`) is unchanged; this only adds the server-`processing`-driven path it couldn't cover.

## Test plan

- **New producer-side test** (`use-message-reconciliation.test.tsx`): the reseed fires exactly when the server clears processing on a locally-processing snapshot, and **not** while still processing, already idle, or when the field is absent.
- The close-gate consumer is already covered by `turn-selectors.test.ts`; content-diff detection by `reconcile-detection.test.ts`.
- Related suites pass individually: `reconcile-on-reopen.test.ts`, `use-event-stream-resume-reconcile.test.tsx`.
- `bunx tsc --noEmit`: 0 errors. `eslint` on changed files: 0 errors.
- Adds a `reconciliation_processing_cleared` diagnostic for future triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwfTXSQrDM7iZeZdtnbqRt