### PR TITLE
feat(calls): stream media-stream audio through StreamingTranscriber with utterance-boundary finals

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -890,6 +890,7 @@ describe("AssistantConfigSchema", () => {
         language: "en-US",
         hints: [],
         interruptSensitivity: "low",
+        telephonyStreaming: true,
       },
       callerIdentity: {
         allowPerCallOverride: true,
@@ -997,6 +998,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.voice.language).toBe("en-US");
     expect(result.calls.voice.hints).toEqual([]);
     expect(result.calls.voice.interruptSensitivity).toBe("low");
+    expect(result.calls.voice.telephonyStreaming).toBe(true);
   });
 
   test("accepts valid calls.voice overrides", () => {
@@ -1004,10 +1006,25 @@ describe("AssistantConfigSchema", () => {
       calls: {
         voice: {
           language: "es-ES",
+          telephonyStreaming: false,
         },
       },
     });
     expect(result.calls.voice.language).toBe("es-ES");
+    expect(result.calls.voice.telephonyStreaming).toBe(false);
+  });
+
+  test("rejects non-boolean calls.voice.telephonyStreaming", () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { telephonyStreaming: "yes" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("calls.voice.telephonyStreaming")),
+      ).toBe(true);
+    }
   });
 
   test("transcriptionProvider is no longer part of the voice config schema", () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -12,10 +12,13 @@ import {
 // Module mocks — declared before imports of the module under test.
 // ---------------------------------------------------------------------------
 
-// Mock the STT resolve module (used by MediaStreamSttSession)
+// Mock the STT resolve module (used by MediaStreamSttSession).
+// resolveStreamingTranscriber yields no transcriber, so sessions settle on
+// the batch path regardless of the calls.voice.telephonyStreaming default.
 mock.module("../providers/speech-to-text/resolve.js", () => ({
   resolveTelephonySttCapability: jest.fn(),
   resolveBatchTranscriber: jest.fn(),
+  resolveStreamingTranscriber: jest.fn(async () => null),
 }));
 
 // Mock the logger to suppress output during tests

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -8,7 +8,12 @@ import {
   test,
 } from "bun:test";
 
-import type { BatchTranscriber, SttTranscribeRequest } from "../stt/types.js";
+import type {
+  BatchTranscriber,
+  StreamingTranscriber,
+  SttStreamServerEvent,
+  SttTranscribeRequest,
+} from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared before the module under test is imported.
@@ -18,6 +23,16 @@ import type { BatchTranscriber, SttTranscribeRequest } from "../stt/types.js";
 mock.module("../providers/speech-to-text/resolve.js", () => ({
   resolveTelephonySttCapability: jest.fn(),
   resolveBatchTranscriber: jest.fn(),
+  resolveStreamingTranscriber: jest.fn(),
+}));
+
+// Mock the config loader so the session's telephony-streaming flag read
+// never touches the real filesystem config.
+const configState = { telephonyStreaming: true };
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    calls: { voice: { telephonyStreaming: configState.telephonyStreaming } },
+  }),
 }));
 
 // Mock the logger to suppress output during tests
@@ -34,6 +49,7 @@ mock.module("../util/logger.js", () => ({
 import { MediaStreamSttSession } from "../calls/media-stream-stt-session.js";
 import {
   resolveBatchTranscriber,
+  resolveStreamingTranscriber,
   resolveTelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 
@@ -110,6 +126,65 @@ function makeMockTranscriber(text = "hello world"): BatchTranscriber {
   };
 }
 
+/**
+ * Controllable fake streaming transcriber. `deferStart` keeps `start()`
+ * pending until `finishStart()` (or rejects on `failStart()`), letting
+ * tests exercise the startup frame buffer.
+ */
+class FakeStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+  sentAudio: { audio: Buffer; mimeType: string }[] = [];
+  stopCalled = false;
+
+  private startGate: Promise<void> = Promise.resolve();
+  private releaseStart: () => void = () => {};
+  private rejectStart: (err: Error) => void = () => {};
+
+  constructor(opts: { deferStart?: boolean } = {}) {
+    if (opts.deferStart) {
+      this.startGate = new Promise<void>((resolve, reject) => {
+        this.releaseStart = resolve;
+        this.rejectStart = reject;
+      });
+    }
+  }
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+    await this.startGate;
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    this.sentAudio.push({ audio, mimeType });
+  }
+
+  stop(): void {
+    this.stopCalled = true;
+  }
+
+  finishStart(): void {
+    this.releaseStart();
+  }
+
+  failStart(err: Error): void {
+    this.rejectStart(err);
+  }
+
+  emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}
+
+/** Flush the microtask queue (fake timers keep setTimeout frozen). */
+async function flushAsync(rounds = 20): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -117,6 +192,12 @@ function makeMockTranscriber(text = "hello world"): BatchTranscriber {
 describe("MediaStreamSttSession", () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    // Most tests exercise the batch path — flip the kill-switch off so the
+    // session selects batch mode deterministically. Streaming-mode tests
+    // set it back to true.
+    configState.telephonyStreaming = false;
 
     // Default: provider is supported and transcriber is available
     (resolveTelephonySttCapability as jest.Mock).mockResolvedValue({
@@ -127,6 +208,7 @@ describe("MediaStreamSttSession", () => {
     (resolveBatchTranscriber as jest.Mock).mockResolvedValue(
       makeMockTranscriber(),
     );
+    (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -581,6 +663,267 @@ describe("MediaStreamSttSession", () => {
       // No turn should have started, so no transcript emitted
       expect(onSpeechStart).not.toHaveBeenCalled();
       expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+  });
+
+  // ── Telephony streaming flag ─────────────────────────────────────
+
+  test("flag off: never resolves a streaming transcriber", async () => {
+    configState.telephonyStreaming = false;
+    const session = new MediaStreamSttSession({}, {});
+
+    session.handleMessage(makeStartMessage());
+    await flushAsync();
+
+    expect(resolveStreamingTranscriber).not.toHaveBeenCalled();
+    session.dispose();
+  });
+
+  // ── Streaming mode ────────────────────────────────────────────────
+
+  describe("streaming mode", () => {
+    beforeEach(() => {
+      configState.telephonyStreaming = true;
+    });
+
+    /** Start a session with an already-started streaming transcriber. */
+    async function startStreamingSession(
+      callbacks: ConstructorParameters<typeof MediaStreamSttSession>[1] = {},
+      config: ConstructorParameters<typeof MediaStreamSttSession>[0] = {},
+    ): Promise<{ session: MediaStreamSttSession; fake: FakeStreamingTranscriber }> {
+      const fake = new FakeStreamingTranscriber();
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession(config, callbacks);
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      return { session, fake };
+    }
+
+    test("resolves the streaming transcriber at 16 kHz with boundary finals", async () => {
+      const { session } = await startStreamingSession();
+
+      expect(resolveStreamingTranscriber).toHaveBeenCalledTimes(1);
+      expect(resolveStreamingTranscriber).toHaveBeenCalledWith({
+        sampleRate: 16_000,
+        utteranceBoundaryFinals: true,
+      });
+
+      session.dispose();
+    });
+
+    test("buffers frames until start() resolves, then flushes in order", async () => {
+      const fake = new FakeStreamingTranscriber({ deferStart: true });
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession({}, {});
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      // start() is still pending — frames must be buffered, not sent.
+      for (let i = 0; i < 3; i++) {
+        session.handleMessage(makeMediaMessage());
+      }
+      expect(fake.sentAudio).toHaveLength(0);
+
+      fake.finishStart();
+      await flushAsync();
+
+      // Buffered frames flushed: 20 mu-law bytes @8k -> 40 PCM16 bytes
+      // -> 80 bytes resampled to 16k.
+      expect(fake.sentAudio).toHaveLength(3);
+      expect(fake.sentAudio[0].audio.length).toBe(80);
+      expect(fake.sentAudio[0].mimeType).toBe("audio/pcm;rate=16000");
+
+      // Post-start frames go straight through.
+      session.handleMessage(makeMediaMessage());
+      expect(fake.sentAudio).toHaveLength(4);
+
+      expect(session.streamingStartupFramesDropped).toBe(0);
+      session.dispose();
+    });
+
+    test("startup buffer overflow drops oldest frames and counts them", async () => {
+      const fake = new FakeStreamingTranscriber({ deferStart: true });
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const session = new MediaStreamSttSession(
+        { streamingStartupBufferFrames: 2 },
+        {},
+      );
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      // Distinguish frames by payload length: frame i has 20+i mu-law
+      // bytes, so its resampled PCM is (20+i)*4 bytes.
+      for (let i = 0; i < 5; i++) {
+        const payload = Buffer.alloc(20 + i, 0x00).toString("base64");
+        session.handleMessage(makeMediaMessage(payload));
+      }
+
+      fake.finishStart();
+      await flushAsync();
+
+      expect(fake.sentAudio).toHaveLength(2);
+      // Oldest frames (i=0,1,2) dropped — the newest two (i=3,4) survive.
+      expect(fake.sentAudio.map((f) => f.audio.length)).toEqual([92, 96]);
+      expect(session.streamingStartupFramesDropped).toBe(3);
+
+      session.dispose();
+    });
+
+    test("onSpeechStart fires from local VAD, not transcriber partials", async () => {
+      const onSpeechStart = jest.fn();
+      const onTranscriptFinal = jest.fn();
+      const { session, fake } = await startStreamingSession({
+        onSpeechStart,
+        onTranscriptFinal,
+      });
+
+      // A partial arriving before any speech-bearing frame must not
+      // trigger barge-in or a reply.
+      fake.emit({ type: "partial", text: "hel" });
+      expect(onSpeechStart).not.toHaveBeenCalled();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Local VAD sees speech -> barge-in fires.
+      session.handleMessage(makeMediaMessage());
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("final events map to onTranscriptFinal; empty finals are suppressed", async () => {
+      const onTranscriptFinal = jest.fn();
+      const { session, fake } = await startStreamingSession({
+        onTranscriptFinal,
+      });
+
+      session.handleMessage(makeMediaMessage());
+      fake.emit({ type: "final", text: "hello caller" });
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello caller",
+        expect.any(Number),
+      );
+
+      fake.emit({ type: "final", text: "   " });
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("local VAD turn end never triggers batch transcription in streaming mode", async () => {
+      const onTranscriptFinal = jest.fn();
+      const { session } = await startStreamingSession(
+        { onTranscriptFinal },
+        { turnDetector: { silenceThresholdMs: 300 } },
+      );
+
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+
+      expect(resolveBatchTranscriber).not.toHaveBeenCalled();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+
+    test("transcriber errors map to onError", async () => {
+      const onError = jest.fn();
+      const { session, fake } = await startStreamingSession({ onError });
+
+      fake.emit({
+        type: "error",
+        category: "provider-error",
+        message: "socket dropped",
+      });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith("provider-error", "socket dropped");
+
+      session.dispose();
+    });
+
+    test("stop event stops the transcriber and fires onStop", async () => {
+      const onStop = jest.fn();
+      const { session, fake } = await startStreamingSession({ onStop });
+
+      session.handleMessage(makeStopMessage());
+
+      expect(fake.stopCalled).toBe(true);
+      expect(onStop).toHaveBeenCalledTimes(1);
+
+      session.dispose();
+    });
+
+    test("dispose() stops the transcriber and suppresses late events", async () => {
+      const onTranscriptFinal = jest.fn();
+      const { session, fake } = await startStreamingSession({
+        onTranscriptFinal,
+      });
+
+      session.dispose();
+      expect(fake.stopCalled).toBe(true);
+
+      fake.emit({ type: "final", text: "too late" });
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+    });
+
+    test("falls back to batch when no streaming transcriber is available", async () => {
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(null);
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello world",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
+    test("falls back to batch when the streaming transcriber fails to start", async () => {
+      const fake = new FakeStreamingTranscriber({ deferStart: true });
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      fake.failStart(new Error("connect timeout"));
+      await flushAsync();
+
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello world",
+        expect.any(Number),
+      );
 
       session.dispose();
     });

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -1,30 +1,52 @@
 /**
  * STT session module for media-stream call ingestion.
  *
- * Consumes segmented audio turns (produced by {@link MediaTurnDetector})
- * and invokes the PR-1 telephony STT capability resolver to transcribe
- * them via the configured `services.stt` provider.
+ * Transcribes inbound caller audio in one of two modes, selected once at
+ * the `start` event and never mixed mid-session:
  *
- * This module is **integration-neutral** — it exposes callback hooks
- * (`onSpeechStart`, `onTranscriptFinal`, `onDtmf`, `onStop`) and is
- * not wired to any active call ingress path. A future media-stream
- * call adapter PR will instantiate and connect it.
+ * - **Streaming** (default, `calls.voice.telephonyStreaming: true`) —
+ *   inbound mu-law audio is decoded to 16 kHz PCM16 and fed to a
+ *   {@link StreamingTranscriber} resolved for the configured
+ *   `services.stt` provider. Replies trigger on the provider's
+ *   utterance-boundary `final` events; barge-in (`onSpeechStart`) always
+ *   fires from the local energy VAD, never from transcriber partials.
+ *   Frames arriving while the provider session is still starting are
+ *   held in a bounded buffer and flushed on start (overflow drops the
+ *   oldest frames and is counted + logged at teardown).
+ * - **Batch** — segmented audio turns (produced by
+ *   {@link MediaTurnDetector}) are transcribed per turn via the batch
+ *   transcriber. Used when the streaming flag is off or no streaming
+ *   transcriber is available for the configured provider.
+ *
+ * This module is **transport-neutral** — it exposes callback hooks
+ * (`onSpeechStart`, `onTranscriptFinal`, `onDtmf`, `onStop`) rather than
+ * driving any call flow itself; `media-stream-server.ts` instantiates and
+ * connects it to the media-stream WebSocket ingress.
  *
  * Error handling:
  * - When the telephony resolver returns a non-supported status, the
  *   session reports the failure through `onError` and stops processing.
  * - Individual turn transcription failures (timeouts, provider errors)
  *   are reported through `onError` without tearing down the session.
+ * - Streaming transcriber errors are reported through `onError` with the
+ *   provider's normalized category.
  */
 
+import { getConfig } from "../config/loader.js";
 import {
+  resolveBatchTranscriber,
+  resolveStreamingTranscriber,
   resolveTelephonySttCapability,
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
-import { resolveBatchTranscriber } from "../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../stt/daemon-batch-transcriber.js";
-import type { SttCallContextHints } from "../stt/types.js";
+import type {
+  StreamingTranscriber,
+  SttCallContextHints,
+  SttStreamServerEvent,
+} from "../stt/types.js";
 import { getLogger } from "../util/logger.js";
+import { mulawToPcm16, resamplePcm16 } from "./media-stream-audio-transcode.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type {
   MediaStreamMediaEvent,
@@ -50,9 +72,36 @@ export interface MediaStreamSttSessionConfig {
 
   /** Optional call-context hints forwarded to the STT provider. */
   callContextHints?: SttCallContextHints;
+
+  /**
+   * Maximum number of media frames buffered while the streaming
+   * transcriber starts up. Default: 500 (~10 s of 20 ms frames).
+   */
+  streamingStartupBufferFrames?: number;
 }
 
 const DEFAULT_TRANSCRIPTION_TIMEOUT_MS = 10_000;
+
+/** Twilio media streams deliver 8 kHz mono mu-law audio. */
+const TELEPHONY_SOURCE_SAMPLE_RATE = 8_000;
+
+/** Sample rate expected by the daemon streaming transcribers. */
+const STREAMING_SAMPLE_RATE = 16_000;
+
+/** MIME type for the PCM16 frames fed to the streaming transcriber. */
+const STREAMING_AUDIO_MIME_TYPE = `audio/pcm;rate=${STREAMING_SAMPLE_RATE}`;
+
+/** Default bound for the startup frame buffer (~10 s of 20 ms frames). */
+const DEFAULT_STREAMING_STARTUP_BUFFER_FRAMES = 500;
+
+/**
+ * Transcription mode, selected once at the `start` event:
+ * - `"batch"` — per-turn batch transcription via {@link MediaTurnDetector}.
+ * - `"streaming-pending"` — streaming selected; provider session still
+ *   starting, frames buffered.
+ * - `"streaming"` — live streaming session active.
+ */
+type SttSessionMode = "batch" | "streaming-pending" | "streaming";
 
 // ---------------------------------------------------------------------------
 // Callback hooks
@@ -63,9 +112,13 @@ export interface MediaStreamSttSessionCallbacks {
   onSpeechStart?: () => void;
 
   /**
-   * Called when a completed turn has been transcribed successfully.
+   * Called when a completed caller utterance has been transcribed.
    *
-   * @param text - The transcribed text (trimmed). May be empty for silence.
+   * Batch mode: fires per detected turn; text may be empty for silence
+   * turns. Streaming mode: fires per utterance-boundary final from the
+   * provider; empty finals are suppressed.
+   *
+   * @param text - The transcribed text (trimmed).
    * @param durationMs - Approximate duration of the audio turn.
    */
   onTranscriptFinal?: (text: string, durationMs: number) => void;
@@ -116,6 +169,27 @@ export class MediaStreamSttSession {
   /** Session-level abort controller for the active transcription request. */
   private activeTranscriptionAbort: AbortController | null = null;
 
+  /** Transcription mode — selected once in {@link handleStart}. */
+  private mode: SttSessionMode = "batch";
+
+  /** Live streaming transcriber (streaming mode only). */
+  private streamingTranscriber: StreamingTranscriber | null = null;
+
+  /** PCM16 frames buffered while the streaming transcriber starts up. */
+  private startupFrames: Buffer[] = [];
+
+  /** Bound for {@link startupFrames}. */
+  private readonly startupBufferFrames: number;
+
+  /** Frames evicted from the startup buffer on overflow. */
+  private startupFramesDroppedCount = 0;
+
+  /** Whether the startup-drop metric has been logged at teardown. */
+  private startupDropsLogged = false;
+
+  /** Speech-bearing audio milliseconds since the last streaming final. */
+  private utteranceAudioMs = 0;
+
   constructor(
     config: MediaStreamSttSessionConfig = {},
     callbacks: MediaStreamSttSessionCallbacks = {},
@@ -124,6 +198,9 @@ export class MediaStreamSttSession {
     this.callbacks = callbacks;
     this.transcriptionTimeoutMs =
       config.transcriptionTimeoutMs ?? DEFAULT_TRANSCRIPTION_TIMEOUT_MS;
+    this.startupBufferFrames =
+      config.streamingStartupBufferFrames ??
+      DEFAULT_STREAMING_STARTUP_BUFFER_FRAMES;
 
     this.turnDetector = new MediaTurnDetector(config.turnDetector, {
       onTurnStart: () => {
@@ -172,7 +249,8 @@ export class MediaStreamSttSession {
   }
 
   /**
-   * Dispose of the session, clearing all timers and buffers.
+   * Dispose of the session, clearing all timers and buffers and stopping
+   * any active streaming transcriber.
    */
   dispose(): void {
     this.disposed = true;
@@ -180,6 +258,16 @@ export class MediaStreamSttSession {
     this.activeTranscriptionAbort = null;
     this.turnDetector.dispose();
     this.currentTurnChunks = [];
+    this.startupFrames = [];
+    const transcriber = this.streamingTranscriber;
+    this.streamingTranscriber = null;
+    stopStreamingBestEffort(transcriber);
+    this.logStartupDrops();
+  }
+
+  /** Frames dropped from the bounded streaming startup buffer. */
+  get streamingStartupFramesDropped(): number {
+    return this.startupFramesDroppedCount;
   }
 
   // ── Event handlers ─────────────────────────────────────────────────
@@ -189,19 +277,26 @@ export class MediaStreamSttSession {
     this.callSid = event.start.callSid;
     this.encoding = event.start.mediaFormat.encoding;
 
+    const streamingEnabled = getConfig().calls.voice.telephonyStreaming;
+
     log.info(
       {
         streamSid: this.streamSid,
         callSid: this.callSid,
         encoding: this.encoding,
         sampleRate: event.start.mediaFormat.sampleRate,
+        telephonyStreaming: streamingEnabled,
       },
       "Media stream STT session started",
     );
 
-    // Eagerly resolve capability so it's cached by the time the first
-    // turn completes.
-    this.capabilityPromise = resolveTelephonySttCapability();
+    if (streamingEnabled) {
+      this.mode = "streaming-pending";
+      void this.startStreaming();
+      return;
+    }
+
+    this.enterBatchMode();
   }
 
   private handleMedia(event: MediaStreamMediaEvent): void {
@@ -215,16 +310,188 @@ export class MediaStreamSttSession {
     // The detector call runs BEFORE the push so that the onTurnStart
     // callback can clear stale inter-turn silence from the buffer
     // without also wiping the first speech chunk of the new turn.
-    const hasSpeech = detectSpeechActivity(event.media.payload);
+    //
+    // The detector runs in every mode: in streaming mode it only drives
+    // barge-in (`onSpeechStart` fires from this local VAD, never from
+    // transcriber partials).
+    const raw = Buffer.from(event.media.payload, "base64");
+    const hasSpeech = detectSpeechActivity(raw);
     this.turnDetector.onMediaChunk(hasSpeech);
 
+    if (this.mode === "batch") {
+      this.currentTurnChunks.push(event.media.payload);
+      return;
+    }
+
+    // Approximate the utterance duration reported with streaming finals:
+    // count audio while the local VAD sees an active turn.
+    if (hasSpeech || this.turnDetector.isActive) {
+      this.utteranceAudioMs +=
+        raw.length / (TELEPHONY_SOURCE_SAMPLE_RATE / 1000);
+    }
+
+    const pcm = resamplePcm16(
+      mulawToPcm16(raw),
+      TELEPHONY_SOURCE_SAMPLE_RATE,
+      STREAMING_SAMPLE_RATE,
+    );
+
+    if (this.mode === "streaming") {
+      this.streamingTranscriber?.sendAudio(pcm, STREAMING_AUDIO_MIME_TYPE);
+      return;
+    }
+
+    // streaming-pending: the provider session is still starting. Buffer
+    // the PCM for the flush, and keep filling the turn buffer so a batch
+    // fallback still has the audio.
+    this.bufferStartupFrame(pcm);
     this.currentTurnChunks.push(event.media.payload);
   }
 
   private handleStop(): void {
     // Finalize any in-flight turn
     this.turnDetector.forceEnd();
+    // Streaming: signal end-of-audio so the provider flushes any withheld
+    // utterance text as a trailing final before closing.
+    stopStreamingBestEffort(this.streamingTranscriber);
+    this.logStartupDrops();
     this.callbacks.onStop?.();
+  }
+
+  // ── Streaming mode ─────────────────────────────────────────────────
+
+  /**
+   * Resolve and start the streaming transcriber, then flush the frames
+   * buffered during startup. Falls back to the batch path when no
+   * streaming transcriber is available or the provider session cannot be
+   * established — the mode is settled before streaming ever becomes
+   * active, so modes are never mixed mid-session.
+   */
+  private async startStreaming(): Promise<void> {
+    let transcriber: StreamingTranscriber | null = null;
+    try {
+      transcriber = await resolveStreamingTranscriber({
+        sampleRate: STREAMING_SAMPLE_RATE,
+        utteranceBoundaryFinals: true,
+      });
+    } catch (err) {
+      log.warn(
+        { error: err, streamSid: this.streamSid },
+        "Streaming transcriber resolution failed — falling back to batch STT",
+      );
+    }
+
+    if (this.disposed) {
+      stopStreamingBestEffort(transcriber);
+      return;
+    }
+
+    if (!transcriber) {
+      this.enterBatchMode();
+      return;
+    }
+
+    try {
+      await transcriber.start((event) => this.handleStreamingEvent(event));
+    } catch (err) {
+      log.warn(
+        { error: err, streamSid: this.streamSid },
+        "Streaming transcriber failed to start — falling back to batch STT",
+      );
+      if (!this.disposed) {
+        this.enterBatchMode();
+      }
+      return;
+    }
+
+    if (this.disposed) {
+      stopStreamingBestEffort(transcriber);
+      return;
+    }
+
+    this.streamingTranscriber = transcriber;
+    this.mode = "streaming";
+
+    // Flush audio buffered while the provider session was starting.
+    const buffered = this.startupFrames;
+    this.startupFrames = [];
+    for (const frame of buffered) {
+      transcriber.sendAudio(frame, STREAMING_AUDIO_MIME_TYPE);
+    }
+
+    // The batch fallback is settled — drop its turn buffer.
+    this.currentTurnChunks = [];
+  }
+
+  /**
+   * Settle on the batch path: clear streaming startup state and eagerly
+   * resolve the telephony capability so it's cached by the time the
+   * first turn completes.
+   */
+  private enterBatchMode(): void {
+    this.mode = "batch";
+    this.startupFrames = [];
+    this.capabilityPromise = resolveTelephonySttCapability();
+  }
+
+  /**
+   * Map streaming transcriber events onto the session callbacks.
+   *
+   * Partials are ignored for turn-taking: replies trigger only on the
+   * provider's utterance-boundary finals, and barge-in comes from the
+   * local VAD.
+   */
+  private handleStreamingEvent(event: SttStreamServerEvent): void {
+    if (this.disposed) {
+      return;
+    }
+
+    switch (event.type) {
+      case "partial":
+        return;
+      case "final": {
+        const durationMs = Math.round(this.utteranceAudioMs);
+        this.utteranceAudioMs = 0;
+        const text = event.text.trim();
+        if (text.length > 0) {
+          this.callbacks.onTranscriptFinal?.(text, durationMs);
+        }
+        return;
+      }
+      case "error":
+        this.callbacks.onError?.(event.category, event.message);
+        return;
+      case "closed":
+        this.streamingTranscriber = null;
+        return;
+    }
+  }
+
+  /**
+   * Append a decoded frame to the bounded startup buffer. On overflow the
+   * oldest frame is dropped and counted; the total is logged at teardown.
+   */
+  private bufferStartupFrame(pcm: Buffer): void {
+    this.startupFrames.push(pcm);
+    if (this.startupFrames.length > this.startupBufferFrames) {
+      this.startupFrames.shift();
+      this.startupFramesDroppedCount++;
+    }
+  }
+
+  /** Log the startup-buffer drop count once, if any frames were dropped. */
+  private logStartupDrops(): void {
+    if (this.startupDropsLogged || this.startupFramesDroppedCount === 0) {
+      return;
+    }
+    this.startupDropsLogged = true;
+    log.warn(
+      {
+        streamingStartupFramesDropped: this.startupFramesDroppedCount,
+        streamSid: this.streamSid,
+      },
+      "Dropped media frames during streaming transcriber startup",
+    );
   }
 
   // ── Turn completion ────────────────────────────────────────────────
@@ -233,6 +500,12 @@ export class MediaStreamSttSession {
     _reason: "silence" | "max-duration",
     durationMs: number,
   ): Promise<void> {
+    // Streaming modes take turn boundaries from the transcriber's
+    // utterance-boundary finals, not the local VAD.
+    if (this.mode !== "batch") {
+      return;
+    }
+
     const chunks = this.currentTurnChunks;
     this.currentTurnChunks = [];
 
@@ -335,6 +608,24 @@ export class MediaStreamSttSession {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stop a streaming transcriber, swallowing best-effort stop failures. */
+function stopStreamingBestEffort(
+  transcriber: StreamingTranscriber | null,
+): void {
+  if (!transcriber) {
+    return;
+  }
+  try {
+    transcriber.stop();
+  } catch (err) {
+    log.debug({ error: err }, "Streaming transcriber stop failed");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Speech activity detection
 // ---------------------------------------------------------------------------
 
@@ -345,25 +636,20 @@ export class MediaStreamSttSession {
  * around 0xFF (negative zero) and 0x7F (positive zero). Speech produces
  * samples with lower byte values (higher decoded amplitude).
  *
- * This function decodes the base64 payload, computes the average absolute
- * linear amplitude of the mu-law samples, and compares it against a
- * threshold. The threshold is tuned for Twilio's 8 kHz, 8-bit mu-law
- * stream where typical silence RMS is ~50-100 and speech is >300.
+ * This function computes the average absolute linear amplitude of the
+ * mu-law samples and compares it against a threshold. The threshold is
+ * tuned for Twilio's 8 kHz, 8-bit mu-law stream where typical silence
+ * RMS is ~50-100 and speech is >300.
  *
- * @param base64Payload - Base64-encoded mu-law audio chunk from Twilio.
+ * @param raw - Decoded mu-law audio chunk from Twilio.
  * @returns `true` if the chunk likely contains speech, `false` otherwise.
  */
-function detectSpeechActivity(base64Payload: string): boolean {
+function detectSpeechActivity(raw: Buffer): boolean {
   const SPEECH_ENERGY_THRESHOLD = 200;
 
-  let raw: Buffer;
-  try {
-    raw = Buffer.from(base64Payload, "base64");
-  } catch {
+  if (raw.length === 0) {
     return false;
   }
-
-  if (raw.length === 0) return false;
 
   // Compute average absolute linear amplitude from mu-law samples.
   let totalAmplitude = 0;

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -62,6 +62,14 @@ const CallsVoiceConfigSchema = z
       .describe(
         "How aggressively the STT provider detects the start of caller speech — low reduces false interrupts from background noise",
       ),
+    telephonyStreaming: z
+      .boolean({
+        error: "calls.voice.telephonyStreaming must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether phone-call audio is streamed to the STT provider in real time; disable to fall back to per-turn batch transcription",
+      ),
   })
   .describe("Voice and speech settings for phone calls");
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -558,6 +558,104 @@ describe("DeepgramRealtimeTranscriber", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
+  // Utterance-boundary finals (telephony gating)
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("utteranceBoundaryFinals", () => {
+    test("withholds is_final segments until speech_final, then emits one aggregated final", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(resultsFrame("this is a", { is_final: true }));
+      mockWs.simulateMessage(resultsFrame("long sentence", { is_final: true }));
+      expect(events.filter((e) => e.type === "final")).toHaveLength(0);
+
+      mockWs.simulateMessage(
+        resultsFrame("with a pause", { is_final: true, speech_final: true }),
+      );
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "this is a long sentence with a pause",
+      });
+    });
+
+    test("still emits partials while segments are withheld", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(resultsFrame("this is", { is_final: false }));
+      mockWs.simulateMessage(resultsFrame("this is a", { is_final: true }));
+      mockWs.simulateMessage(resultsFrame("long sen", { is_final: false }));
+
+      expect(events.filter((e) => e.type === "partial")).toHaveLength(2);
+      expect(events.filter((e) => e.type === "final")).toHaveLength(0);
+    });
+
+    test("UtteranceEnd flushes withheld segments as a single final", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(resultsFrame("trailing words", { is_final: true }));
+      mockWs.simulateMessage(utteranceEndFrame());
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({ type: "final", text: "trailing words" });
+    });
+
+    test("boundary signals over silence emit nothing", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(
+        resultsFrame("", { is_final: true, speech_final: true }),
+      );
+      mockWs.simulateMessage(utteranceEndFrame());
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("close flushes withheld segments before the closed event", async () => {
+      const { transcriber, events } = await startSession({
+        utteranceBoundaryFinals: true,
+      });
+
+      mockWs.simulateMessage(resultsFrame("cut off", { is_final: true }));
+      transcriber.stop();
+      mockWs.simulateClose(1000, "normal");
+
+      const finalIndex = events.findIndex((e) => e.type === "final");
+      const closedIndex = events.findIndex((e) => e.type === "closed");
+      expect(finalIndex).toBeGreaterThanOrEqual(0);
+      expect(closedIndex).toBeGreaterThan(finalIndex);
+      expect(events[finalIndex]).toEqual({ type: "final", text: "cut off" });
+    });
+
+    test("each utterance aggregates independently", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(resultsFrame("first part", { is_final: true }));
+      mockWs.simulateMessage(
+        resultsFrame("done", { is_final: true, speech_final: true }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("second utterance", {
+          is_final: true,
+          speech_final: true,
+        }),
+      );
+
+      const finals = events.filter((e) => e.type === "final") as {
+        type: "final";
+        text: string;
+      }[];
+      expect(finals.map((f) => f.text)).toEqual([
+        "first part done",
+        "second utterance",
+      ]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // Non-transcript frames
   // ─────────────────────────────────────────────────────────────────
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -123,6 +123,23 @@ export interface DeepgramRealtimeOptions {
    * composer) preserve their current lean URL + response shape.
    */
   diarize?: boolean;
+  /**
+   * Emit `final` events only at utterance boundaries. Default: false.
+   *
+   * Deepgram commits a long sentence as multiple `is_final` segments
+   * before the speaker pauses. When `true`, committed segment texts are
+   * withheld and accumulated, and a single aggregated `final` is emitted
+   * when Deepgram signals an utterance boundary (`speech_final` on a
+   * Results frame, or an `UtteranceEnd` frame), or when the session
+   * closes with text still pending. Boundary signals with no accumulated
+   * text emit nothing. Aggregated finals omit `speakerLabel` /
+   * `confidence` (segment-level scores do not compose across segments).
+   *
+   * Used by telephony call ingestion so replies trigger once per caller
+   * utterance. When `false`, every `is_final` segment emits its own
+   * `final` event (chat composer / live-voice behavior).
+   */
+  utteranceBoundaryFinals?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +266,19 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    */
   private readonly diarize: boolean;
 
+  /**
+   * Whether `final` events are gated on utterance boundaries — see
+   * {@link DeepgramRealtimeOptions.utteranceBoundaryFinals}.
+   */
+  private readonly utteranceBoundaryFinals: boolean;
+
+  /**
+   * Committed (`is_final`) segment texts withheld until the next
+   * utterance boundary. Only populated when
+   * {@link utteranceBoundaryFinals} is enabled.
+   */
+  private pendingFinalSegments: string[] = [];
+
   /** The live WebSocket connection, set during start(). */
   private ws: WsLike | null = null;
 
@@ -290,6 +320,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       options.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS;
     this.sampleRate = options.sampleRate ?? 16_000;
     this.diarize = options.diarize ?? false;
+    this.utteranceBoundaryFinals = options.utteranceBoundaryFinals ?? false;
   }
 
   // ── StreamingTranscriber interface ──────────────────────────────────
@@ -497,10 +528,11 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
     // `UtteranceEnd` is an endpointing signal — no transcript text, but
     // it confirms the previous is_final segment is a natural boundary.
-    // We don't need to emit an additional event since we already emit
-    // finals on is_final=true.
+    // In utterance-boundary mode it flushes any withheld segments; in
+    // pass-through mode finals were already emitted on is_final=true.
     if (frame.type === "UtteranceEnd") {
       log.debug("Received UtteranceEnd signal");
+      this.flushPendingUtterance();
       return;
     }
 
@@ -543,6 +575,16 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         : undefined;
 
     if (frame.is_final) {
+      if (this.utteranceBoundaryFinals) {
+        // Withhold committed segments until an utterance boundary.
+        if (text.length > 0) {
+          this.pendingFinalSegments.push(text);
+        }
+        if (frame.speech_final) {
+          this.flushPendingUtterance();
+        }
+        return;
+      }
       // Committed transcript — emit as final.
       this.emitEvent({
         type: "final",
@@ -631,8 +673,24 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   }
 
   /**
+   * Emit a single aggregated `final` for the withheld `is_final` segments
+   * of the current utterance. No-op when nothing is pending, so boundary
+   * signals over silence emit nothing.
+   */
+  private flushPendingUtterance(): void {
+    if (this.pendingFinalSegments.length === 0) {
+      return;
+    }
+    const text = this.pendingFinalSegments.join(" ");
+    this.pendingFinalSegments = [];
+    this.emitEvent({ type: "final", text });
+  }
+
+  /**
    * Emit a `closed` event and clean up all resources (timers, WebSocket).
-   * Idempotent — safe to call multiple times.
+   * Flushes any withheld utterance text first so boundary-gated sessions
+   * never lose committed transcript on close. Idempotent — safe to call
+   * multiple times.
    */
   private emitClosedAndCleanup(): void {
     if (this.closed) return;
@@ -641,6 +699,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.clearTimers();
     this.forceClose();
 
+    this.flushPendingUtterance();
     this.emitEvent({ type: "closed" });
     this.onEvent = null;
   }

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -260,6 +260,14 @@ export interface ResolveStreamingTranscriberOptions {
    * See {@link DiarizePreference} for semantics.
    */
   diarize?: DiarizePreference;
+  /**
+   * Emit `final` events only at utterance boundaries on providers that
+   * otherwise commit multiple `is_final` segments per utterance
+   * (Deepgram — also enables its `utterance_end_ms` endpointing).
+   * Ignored by providers whose finals already align with pause
+   * boundaries. Used by telephony call ingestion. Default: false.
+   */
+  utteranceBoundaryFinals?: boolean;
 }
 
 /**
@@ -323,8 +331,17 @@ export async function resolveStreamingTranscriber(
   return createStreamingTranscriber(apiKey, provider as SttProviderId, {
     sampleRate: options.sampleRate,
     diarize: enableDiarization,
+    utteranceBoundaryFinals: options.utteranceBoundaryFinals ?? false,
   });
 }
+
+/**
+ * Deepgram `utterance_end_ms` used when utterance-boundary finals are
+ * requested. Deepgram requires >= 1000 ms; this is the pause length after
+ * which an `UtteranceEnd` frame confirms the utterance is complete even
+ * when `speech_final` endpointing never fired (e.g. background noise).
+ */
+const UTTERANCE_BOUNDARY_END_MS = 1_000;
 
 /**
  * Options forwarded to individual streaming adapter constructors.
@@ -338,6 +355,13 @@ interface CreateStreamingTranscriberOptions {
    * support.
    */
   diarize?: boolean;
+  /**
+   * Whether `final` events should be gated on utterance boundaries.
+   * Only forwarded to providers that commit multiple segments per
+   * utterance (Deepgram). Ignored by adapters whose finals already
+   * align with pause boundaries.
+   */
+  utteranceBoundaryFinals?: boolean;
 }
 
 /**
@@ -361,6 +385,12 @@ async function createStreamingTranscriber(
       return new DeepgramRealtimeTranscriber(apiKey, {
         sampleRate: options.sampleRate,
         ...(options.diarize ? { diarize: true } : {}),
+        ...(options.utteranceBoundaryFinals
+          ? {
+              utteranceBoundaryFinals: true,
+              utteranceEndMs: UTTERANCE_BOUNDARY_END_MS,
+            }
+          : {}),
       });
     }
     case "google-gemini": {


### PR DESCRIPTION
## Summary
- Adds a streaming-STT mode to MediaStreamSttSession (resolveStreamingTranscriber, mulaw→PCM16 @16k), selected once at start behind new calls.voice.telephonyStreaming flag (default true)
- Bounded startup-frame buffering with drop metric; barge-in stays on local VAD; Deepgram finals gated on speech_final/UtteranceEnd utterance boundaries
- Batch path unchanged as fallback

## Deepgram boundary design choice
Utterance-boundary gating is implemented **in the Deepgram adapter** behind a new opt-in `utteranceBoundaryFinals` option (off by default), rather than in the session's event handler: the normalized `SttStreamServerEvent` final carries no boundary metadata, so gating in the adapter avoids widening the shared event contract and keeps `/v1/stt/stream` and live-voice consumers byte-for-byte unchanged. When enabled, `is_final` segment texts are withheld and one aggregated `final` is emitted on `speech_final`, `UtteranceEnd` (the resolver also sets `utterance_end_ms=1000` for this mode), or close-flush. Verified the other streaming adapters: google-gemini emits finals at turn completion and openai-whisper emits one deterministic final on stop (both pause-boundary already); xai emits per-`is_final` segment finals and is left unchanged — telephony (PR 11) targets Deepgram configs.

Part of plan: phone-media-stream-v2.md (PR 4 of 17)