### PR TITLE
fix(web): keep attachment previews on sent messages through the echo

### DIFF
--- a/clients/web/docs/CONVERSATION_SSE.md
+++ b/clients/web/docs/CONVERSATION_SSE.md
@@ -57,11 +57,16 @@ keeps replay, resync, and rebuild equivalent.
 
 `use-send-message` adds the user's row to `optimisticSends` (`addOptimisticSend`)
 the instant they hit send; the overlay renders it immediately. There is **no**
-id-swap against the server id — the assistant echoes the `clientMessageId` back on
-the persisted row, the overlay collapses the two on that nonce, and
-`user_message_echo` clears the optimistic copy (`clearOptimisticSend`). Queued
-sends live here too, with `queueStatus`/`queuePosition` maintained by the queue
-handlers via `setOptimisticSends`.
+id-swap against the server id on POST resolve — the assistant echoes the
+`clientMessageId` back on the persisted row and the overlay collapses the two on
+that nonce. `user_message_echo` retires the optimistic copy of a text-only send;
+a send that carries attachments is kept (upgraded to the server id, queue fields
+cleared) because the echo has no attachment payload — the optimistic row holds
+the only copy of the user's previews (blob URLs for pasted images) until the
+turn-end reseed pulls the hydrated server row and
+`pruneConfirmedOptimisticSends` retires it. Queued sends live here too, with
+`queueStatus`/`queuePosition` maintained by the queue handlers via
+`setOptimisticSends`.
 
 Nonce-less echoes (the field is optional; pre-idempotency assistants omit it)
 have no shared key for the overlay to collapse on, so `handleUserMessageEcho`

--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
 import {
   pushSseEvent,
   registerSseClient,
@@ -98,12 +99,35 @@ describe("chat-session-store — snapshot + optimistic", () => {
     expect(store().snapshot).toBeNull();
   });
 
-  test("optimistic sends add and clear by clientMessageId", () => {
+  test("optimistic sends add and retire via setOptimisticSends", () => {
     const send: DisplayMessage = { ...textRow("u1", "hi"), role: "user", clientMessageId: "nonce-1" };
     store().addOptimisticSend(send);
     expect(store().optimisticSends.map((m) => m.clientMessageId)).toEqual(["nonce-1"]);
-    store().clearOptimisticSend("nonce-1");
+    store().setOptimisticSends((prev) => prev.filter((m) => m.clientMessageId !== "nonce-1"));
     expect(store().optimisticSends).toEqual([]);
+  });
+
+  test("seedSnapshot prunes optimistic sends the snapshot already represents", () => {
+    // A retained attachment-carrying send (upgraded to the server id by its
+    // echo) is retired once the reseeded snapshot carries the persisted row —
+    // matched by any shared identity key (server id or nonce).
+    store().addOptimisticSend({
+      ...textRow("msg-server-1", "pic"),
+      role: "user",
+      clientMessageId: "nonce-1",
+    });
+    store().addOptimisticSend({
+      ...textRow("u-unconfirmed", "later"),
+      role: "user",
+      clientMessageId: "nonce-2",
+    });
+
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("msg-server-1", "pic"), role: "user" }], 5),
+    );
+
+    expect(store().optimisticSends.map((m) => m.clientMessageId)).toEqual(["nonce-2"]);
   });
 
   test("switching conversation resets snapshot and optimistic sends", () => {
@@ -114,5 +138,75 @@ describe("chat-session-store — snapshot + optimistic", () => {
 
     expect(store().snapshot).toBeNull();
     expect(store().optimisticSends).toEqual([]);
+  });
+
+  test("attachment previews survive the echo → reseed lifecycle (LUM-2663)", () => {
+    // A pasted image's preview lives only on the optimistic send (blob URL).
+    // The echo folds a text-only row into the snapshot; the retained
+    // (id-upgraded) optimistic copy must keep winning the overlay so the
+    // preview never disappears, and the reseed retires it once the server row
+    // carries hydrated attachment data.
+    const attachment = {
+      id: "att-1",
+      filename: "shot.png",
+      mimeType: "image/png",
+      sizeBytes: 10,
+      previewUrl: "blob:preview",
+    };
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "earlier")], 5));
+    store().addOptimisticSend({
+      ...textRow("client-uuid", "look"),
+      role: "user",
+      clientMessageId: "nonce-1",
+      isOptimistic: true,
+      attachments: [attachment],
+    });
+
+    // The echo event folds a text-only user row into the snapshot…
+    store().applyEnvelopeToSnapshot(
+      envelope(6, CONV, {
+        type: "user_message_echo",
+        text: "look",
+        messageId: "msg-server-1",
+        clientMessageId: "nonce-1",
+      } as AssistantEvent),
+    );
+    // …while the handler upgrades the retained optimistic copy in place
+    // (mirrors handleUserMessageEcho's attachment-carrying branch).
+    store().setOptimisticSends((prev) =>
+      prev.map((m) =>
+        m.clientMessageId === "nonce-1"
+          ? { ...m, id: "msg-server-1", isOptimistic: false }
+          : m,
+      ),
+    );
+
+    const midTurn = selectTranscriptMessages(
+      store().snapshot!.messages,
+      store().optimisticSends,
+    );
+    const userRow = midTurn.find((m) => m.id === "msg-server-1");
+    expect(midTurn.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(userRow?.attachments?.[0]?.previewUrl).toBe("blob:preview");
+
+    // Turn-end reseed: the authoritative server row carries hydrated data and
+    // retires the overlay copy.
+    const serverRow: DisplayMessage = {
+      ...textRow("msg-server-1", "look"),
+      role: "user",
+      clientMessageId: "nonce-1",
+      attachments: [{ ...attachment, previewUrl: "data:image/png;base64,x" }],
+    };
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "earlier"), serverRow], 7));
+
+    expect(store().optimisticSends).toEqual([]);
+    const afterReseed = selectTranscriptMessages(
+      store().snapshot!.messages,
+      store().optimisticSends,
+    );
+    expect(
+      afterReseed.find((m) => m.id === "msg-server-1")?.attachments?.[0]
+        ?.previewUrl,
+    ).toBe("data:image/png;base64,x");
   });
 });

--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -140,6 +140,59 @@ describe("chat-session-store — snapshot + optimistic", () => {
     expect(store().optimisticSends).toEqual([]);
   });
 
+  test("reseed keeps an attachment-carrying send until its snapshot twin is hydrated", () => {
+    // A stale in-flight /messages fetch can commit after the echo: the reseed
+    // replays the buffered echo into a text-only twin row. Pruning against
+    // that unhydrated twin would drop the only blob-preview copy — the send
+    // must survive until a snapshot row with attachments lands.
+    const send: DisplayMessage = {
+      ...textRow("msg-server-1", "pic"),
+      role: "user",
+      clientMessageId: "nonce-1",
+      attachments: [
+        {
+          id: "att-1",
+          filename: "shot.png",
+          mimeType: "image/png",
+          sizeBytes: 10,
+          previewUrl: "blob:preview",
+        },
+      ],
+    };
+    store().addOptimisticSend(send);
+
+    // Stale reseed: the twin row shares identity but has no attachments.
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("msg-server-1", "pic"), role: "user" }], 5),
+    );
+    expect(store().optimisticSends).toEqual([send]);
+
+    // Hydrated reseed: the twin now carries attachment data — send retires.
+    store().seedSnapshot(
+      CONV,
+      snapshot(
+        [
+          {
+            ...textRow("msg-server-1", "pic"),
+            role: "user",
+            attachments: [
+              {
+                id: "att-1",
+                filename: "shot.png",
+                mimeType: "image/png",
+                sizeBytes: 10,
+                previewUrl: "data:image/png;base64,x",
+              },
+            ],
+          },
+        ],
+        6,
+      ),
+    );
+    expect(store().optimisticSends).toEqual([]);
+  });
+
   test("attachment previews survive the echo → reseed lifecycle (LUM-2663)", () => {
     // A pasted image's preview lives only on the optimistic send (blob URL).
     // The echo folds a text-only row into the snapshot; the retained

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -269,19 +269,43 @@ function applyUpdater<T>(current: T, updater: T | ((prev: T) => T)): T {
  * overlay lets optimistic rows win by identity, so a confirmed send would
  * otherwise stay rendered as optimistic/queued indefinitely. Pruning by the same
  * match keys `selectTranscriptMessages` overlays on keeps the two in lockstep.
+ *
+ * An attachment-carrying send is only pruned once its snapshot twin also
+ * carries attachments. The send holds the only copy of the user's previews
+ * (blob URLs for pasted images); a matching snapshot row without attachments
+ * is a tail-replayed text-only echo — e.g. a stale in-flight `/messages`
+ * fetch that committed after the echo — not the hydrated server row, and
+ * pruning against it would drop the previews until the next refetch. The
+ * overlay keeps rendering the retained copy over the unhydrated twin.
  */
 function pruneConfirmedOptimisticSends(
   optimisticSends: DisplayMessage[],
   snapshotMessages: DisplayMessage[],
 ): DisplayMessage[] {
-  if (optimisticSends.length === 0) return optimisticSends;
-  const snapshotKeys = new Set<string>();
-  for (const m of snapshotMessages) {
-    for (const k of messageMatchKeys(m)) snapshotKeys.add(k);
+  if (optimisticSends.length === 0) {
+    return optimisticSends;
   }
-  const kept = optimisticSends.filter(
-    (m) => !messageMatchKeys(m).some((k) => snapshotKeys.has(k)),
-  );
+  const snapshotByKey = new Map<string, DisplayMessage>();
+  for (const m of snapshotMessages) {
+    for (const k of messageMatchKeys(m)) {
+      if (!snapshotByKey.has(k)) {
+        snapshotByKey.set(k, m);
+      }
+    }
+  }
+  const kept = optimisticSends.filter((m) => {
+    let twin: DisplayMessage | undefined;
+    for (const k of messageMatchKeys(m)) {
+      twin = snapshotByKey.get(k);
+      if (twin) {
+        break;
+      }
+    }
+    if (!twin) {
+      return true;
+    }
+    return Boolean(m.attachments?.length) && !twin.attachments?.length;
+  });
   return kept.length === optimisticSends.length ? optimisticSends : kept;
 }
 

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -60,9 +60,11 @@ export interface ChatSessionState {
   // (`applyEvent`). `null` until seeded. This is the single source the transcript
   // renders from, overlaid with `optimisticSends`.
   snapshot: PaginatedHistoryResult | null;
-  // Optimistic user sends not yet confirmed by their `user_message_echo`.
-  // Held apart from `snapshot` so it's clear they're unconfirmed until an event
-  // clears them; rebased onto a fresh `snapshot` on resync.
+  // Optimistic user sends overlaid on the snapshot. Held apart from `snapshot`
+  // so it's clear they're client-owned: the `user_message_echo` handler retires
+  // a text-only send (or upgrades an attachment-carrying one, whose blob-URL
+  // previews only this list holds), and the reseed prunes whatever the server
+  // snapshot already represents.
   optimisticSends: DisplayMessage[];
 
   error: ChatError | null;
@@ -133,10 +135,8 @@ export interface ChatSessionActions {
   /** Fold one live stream event into the snapshot (no-op until seeded; the
    *  seed's replay covers anything that arrived first). Idempotent by `seq`. */
   applyEnvelopeToSnapshot: (envelope: AssistantEventEnvelope) => void;
-  /** Add an optimistic user send; cleared when its echo lands. */
+  /** Add an optimistic user send; retired by its echo or the reseed prune. */
   addOptimisticSend: (message: DisplayMessage) => void;
-  /** Drop the optimistic send correlated by `clientMessageId`. */
-  clearOptimisticSend: (clientMessageId: string) => void;
   /** Mutate the optimistic-send list (queue status, id swap, removal). */
   setOptimisticSends: (
     updater: DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[]),
@@ -310,13 +310,6 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
   addOptimisticSend: (message) =>
     set((s) => ({ optimisticSends: [...s.optimisticSends, message] })),
-
-  clearOptimisticSend: (clientMessageId) =>
-    set((s) => ({
-      optimisticSends: s.optimisticSends.filter(
-        (m) => m.clientMessageId !== clientMessageId,
-      ),
-    })),
 
   setOptimisticSends: (updater) =>
     set((s) => ({ optimisticSends: applyUpdater(s.optimisticSends, updater) })),

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -232,7 +232,6 @@ export function useStreamEventHandler(
         streamContext: streamState.streamContext,
         assistantId: useResolvedAssistantsStore.getState().activeAssistantId,
         setOptimisticSends: store.setOptimisticSends,
-        clearOptimisticSend: store.clearOptimisticSend,
         turnActions: useTurnStore.getState(),
         getTurnState: () => useTurnStore.getState(),
         endTurn,

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -333,37 +333,143 @@ describe("handleMessageComplete", () => {
 });
 
 describe("handleUserMessageEcho", () => {
-  it("clears the optimistic send correlated by clientMessageId when present", () => {
+  /** Run the handler and apply the captured setOptimisticSends updater. */
+  function applyEcho(
+    event: Parameters<typeof handleUserMessageEcho>[0],
+    prev: DisplayMessage[],
+  ): DisplayMessage[] {
     const ctx = makeCtx();
-    handleUserMessageEcho(
+    handleUserMessageEcho(event, ctx);
+    expect(ctx.setOptimisticSends).toHaveBeenCalled();
+    const updater = (ctx.setOptimisticSends as unknown as ReturnType<typeof Object>)
+      .mock.calls[0][0] as (prev: DisplayMessage[]) => DisplayMessage[];
+    return updater(prev);
+  }
+
+  it("removes the attachment-less optimistic send correlated by clientMessageId", () => {
+    const next = applyEcho(
       {
         type: "user_message_echo",
         text: "Hello",
         messageId: "msg-1",
         clientMessageId: "client-1",
       },
-      ctx,
+      [
+        {
+          id: "client-1",
+          clientMessageId: "client-1",
+          role: "user",
+          isOptimistic: true,
+        } as DisplayMessage,
+        {
+          id: "client-2",
+          clientMessageId: "client-2",
+          role: "user",
+          isOptimistic: true,
+        } as DisplayMessage,
+      ],
     );
-    expect(ctx.clearOptimisticSend).toHaveBeenCalledWith("client-1");
+    expect(next.map((m) => m.id)).toEqual(["client-2"]);
+  });
+
+  it("keeps an attachment-carrying send, upgraded to the server id", () => {
+    // The echo event has no attachment payload, so the snapshot row it folds
+    // is text-only — the optimistic row holds the only copy of the previews
+    // and must survive until the reseed carries the hydrated server row.
+    const next = applyEcho(
+      {
+        type: "user_message_echo",
+        text: "look at this",
+        messageId: "msg-1",
+        clientMessageId: "client-1",
+      },
+      [
+        {
+          id: "client-1",
+          clientMessageId: "client-1",
+          role: "user",
+          isOptimistic: true,
+          queueStatus: "queued",
+          queuePosition: 1,
+          attachments: [
+            {
+              id: "att-1",
+              filename: "shot.png",
+              mimeType: "image/png",
+              sizeBytes: 10,
+              previewUrl: "blob:preview",
+            },
+          ],
+        } as DisplayMessage,
+      ],
+    );
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({
+      id: "msg-1",
+      clientMessageId: "client-1",
+      isOptimistic: false,
+    });
+    expect(next[0]!.queueStatus).toBeUndefined();
+    expect(next[0]!.queuePosition).toBeUndefined();
+    expect(next[0]!.attachments?.[0]?.previewUrl).toBe("blob:preview");
+  });
+
+  it("removes an attachment-carrying send on a synthetic echo with no messageId", () => {
+    // With no server id there is no snapshot row to collapse onto, so keeping
+    // the row would double-render once the reducer appends its own copy.
+    const next = applyEcho(
+      {
+        type: "user_message_echo",
+        text: "look at this",
+        clientMessageId: "client-1",
+      },
+      [
+        {
+          id: "client-1",
+          clientMessageId: "client-1",
+          role: "user",
+          isOptimistic: true,
+          attachments: [
+            {
+              id: "att-1",
+              filename: "shot.png",
+              mimeType: "image/png",
+              sizeBytes: 10,
+              previewUrl: "blob:preview",
+            },
+          ],
+        } as DisplayMessage,
+      ],
+    );
+    expect(next).toEqual([]);
+  });
+
+  it("leaves the list unchanged when no optimistic send matches the nonce", () => {
+    const prev = [
+      { id: "other", clientMessageId: "other", role: "user" } as DisplayMessage,
+    ];
+    const next = applyEcho(
+      {
+        type: "user_message_echo",
+        text: "Hello",
+        messageId: "msg-1",
+        clientMessageId: "client-1",
+      },
+      prev,
+    );
+    expect(next).toBe(prev);
   });
 
   it("retires the most recent optimistic user send when the echo carries no nonce", () => {
-    const ctx = makeCtx();
-    handleUserMessageEcho(
+    // No nonce to correlate on — the updater drops the last optimistic user
+    // row, leaving others intact.
+    const next = applyEcho(
       { type: "user_message_echo", text: "Hello", messageId: "msg-1" },
-      ctx,
+      [
+        { id: "keep", role: "assistant" } as DisplayMessage,
+        { id: "opt-1", role: "user", isOptimistic: true } as DisplayMessage,
+      ],
     );
-    // No nonce to correlate on — falls back to setOptimisticSends rather than
-    // clearOptimisticSend.
-    expect(ctx.clearOptimisticSend).not.toHaveBeenCalled();
-    expect(ctx.setOptimisticSends).toHaveBeenCalled();
-    // The updater drops the last optimistic user row, leaving others intact.
-    const updater = (ctx.setOptimisticSends as unknown as ReturnType<typeof Object>)
-      .mock.calls[0][0] as (prev: DisplayMessage[]) => DisplayMessage[];
-    const next = updater([
-      { id: "keep", role: "assistant" } as DisplayMessage,
-      { id: "opt-1", role: "user", isOptimistic: true } as DisplayMessage,
-    ]);
     expect(next.map((m) => m.id)).toEqual(["keep"]);
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -265,18 +265,50 @@ export function handleMessageComplete(
  * doesn't double-render it next to the now-persisted server row.
  *
  * The common path correlates on `clientMessageId` (the nonce the daemon echoes
- * back). When the echo carries no nonce — the field is optional and pre-
- * idempotency daemons omit it — there's no shared key for the overlay to
- * collapse on, so fall back to retiring the most recent optimistic user send,
- * mirroring the legacy echo correlation. A no-op for echoes with no matching
- * optimistic row (other clients' sends, synthetic prompts).
+ * back) and removes the optimistic copy — with one exception: a send that
+ * carries attachments is kept. The echo event has no attachment payload, so
+ * the snapshot row the reducer folds is text-only; the optimistic row holds
+ * the only copy of the user's previews (blob URLs for pasted images) until
+ * the turn-end reseed pulls the hydrated server row. The kept row is upgraded
+ * to the server id (so id-keyed actions resolve and the overlay collapses it
+ * onto the folded snapshot row) and its queue fields are cleared; the reseed's
+ * `pruneConfirmedOptimisticSends` retires it once the authoritative snapshot
+ * carries the persisted row with attachment data.
+ *
+ * When the echo carries no nonce — the field is optional and pre-idempotency
+ * daemons omit it — there's no shared key for the overlay to collapse on, so
+ * fall back to retiring the most recent optimistic user send, mirroring the
+ * legacy echo correlation. A no-op for echoes with no matching optimistic row
+ * (other clients' sends, synthetic prompts).
  */
 export function handleUserMessageEcho(
   event: UserMessageEchoEvent,
   ctx: StreamHandlerContext,
 ): void {
   if (event.clientMessageId) {
-    ctx.clearOptimisticSend(event.clientMessageId);
+    const nonce = event.clientMessageId;
+    const serverId = event.messageId;
+    ctx.setOptimisticSends((prev) => {
+      const idx = prev.findIndex((m) => m.clientMessageId === nonce);
+      if (idx === -1) {
+        return prev;
+      }
+      const row = prev[idx]!;
+      // A synthetic echo (no messageId) leaves nothing to upgrade to, and an
+      // attachment-less send has no preview to preserve — remove either.
+      if (serverId === undefined || !row.attachments?.length) {
+        return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      }
+      const next = [...prev];
+      next[idx] = {
+        ...row,
+        id: serverId,
+        isOptimistic: false,
+        queueStatus: undefined,
+        queuePosition: undefined,
+      };
+      return next;
+    });
     return;
   }
   ctx.setOptimisticSends((prev) => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -41,7 +41,6 @@ export function makeCtx(
     streamContext: { assistantId: "ast-1", conversationId: "conv-1" },
     assistantId: "ast-1",
     setOptimisticSends: mock(() => {}),
-    clearOptimisticSend: mock(() => {}),
     turnActions: {
       requestSend: mock(() => {}),
       acceptSend: mock(() => {}),

--- a/clients/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -41,13 +41,11 @@ export interface StreamHandlerContext {
   // only the control-plane (turn/interaction stores, reconciliation, cache
   // patches) plus the unconfirmed optimistic sends below.
   /** Mutate the optimistic-send list — queue handlers retarget here (queue
-   *  position / status / removal of a not-yet-confirmed user send). */
+   *  position / status / removal of a not-yet-confirmed user send), and the
+   *  echo handler retires or upgrades the confirmed send. */
   setOptimisticSends: (
     updater: DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[]),
   ) => void;
-  /** Drop the optimistic send correlated by `clientMessageId` once its
-   *  `user_message_echo` has folded the server row into the snapshot. */
-  clearOptimisticSend: (clientMessageId: string) => void;
 
   // --- Turn state ---
   turnActions: TurnActions;

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -489,6 +489,12 @@ export function applyUserMessageEcho(
     {
       id: serverId ?? crypto.randomUUID(),
       ...(serverId === undefined ? { isOptimistic: true } : {}),
+      // Carry the nonce so the folded row shares the persisted server row's
+      // identity keys — the transcript overlay and the reseed prune both
+      // correlate on it (see `messageMatchKeys`).
+      ...(event.clientMessageId
+        ? { clientMessageId: event.clientMessageId }
+        : {}),
       role: "user",
       textSegments: [event.text],
       contentOrder: [{ type: "text", id: "0" }],

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -1061,6 +1061,35 @@ describe("applyUserMessageEcho", () => {
     });
   });
 
+  it("stamps the nonce on the appended row when the echo carries one", () => {
+    /**
+     * On the originating client the optimistic row lives in the overlay, not
+     * the snapshot, so the echo appends a fresh snapshot row. That row must
+     * carry the nonce so it shares the persisted server row's identity keys —
+     * the transcript overlay collapses the retained optimistic copy onto it
+     * and the reseed prune correlates on the same keys.
+     */
+    // GIVEN a snapshot with no matching user row (the optimistic copy is in
+    // the overlay)
+    const prev: DisplayMessage[] = [makeAssistantMsg()];
+
+    // WHEN the echo arrives with a nonce and a server id
+    const result = applyUserMessageEcho(prev, {
+      text: "hello",
+      messageId: "msg-server-n",
+      clientMessageId: "nonce-n",
+    });
+
+    // THEN the appended row carries both identity keys
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      id: "msg-server-n",
+      clientMessageId: "nonce-n",
+      role: "user",
+    });
+    expect(result[1]!.isOptimistic).toBeUndefined();
+  });
+
   it("appends an optimistic row for a synthetic echo with no messageId", () => {
     /**
      * Surface-action prompts persist no distinct user row, so the echo


### PR DESCRIPTION
Part of [LUM-2663](https://linear.app/vellum/issue/LUM-2663/image-previews-disappear-after-pastesend-in-chat-only-persist-in-first) (filed as ATL-944): image previews disappear after paste+send in chat — they only persist in the first message of a chat.

## Prompt / plan

Investigated the Linear report (Slack: previews vanish on send, first message excepted) and traced the web client's optimistic-send → echo → reseed lifecycle.

**Root cause:** a pasted image's preview exists only on the optimistic send row (a local blob URL). The `user_message_echo` event carries no attachment payload, so the user row the rolling-snapshot reducer folds is text-only — and `handleUserMessageEcho` simultaneously retired the optimistic copy, dropping the only copy of the preview. The first message of a chat escaped only because its echo is missed while the draft conversation id is still resolving, so its optimistic row (with the preview) survived.

**Fix (client-side, no wire change):**
- `handleUserMessageEcho` now keeps an attachment-carrying optimistic send — upgraded to the server `messageId` (so id-keyed actions resolve and the transcript overlay collapses it onto the folded snapshot row) with queue fields cleared. The turn-end reseed's existing `pruneConfirmedOptimisticSends` retires it once the authoritative `/messages` snapshot carries the persisted row with hydrated attachment data (the daemon inlines image bytes for history). Attachment-less sends retire at echo exactly as before.
- `applyUserMessageEcho` stamps `clientMessageId` on the snapshot row it appends, so the folded row shares the persisted server row's identity keys for the overlay and the reseed prune.
- `pruneConfirmedOptimisticSends` retires an attachment-carrying send only once its snapshot twin also carries attachments, so a tail-replayed text-only echo row (a stale in-flight `/messages` fetch committing after the echo) can't drop the retained preview (addresses the Codex P2 review comment).
- Removed the now-unused `clearOptimisticSend` store action / handler-context member, and updated `docs/CONVERSATION_SSE.md` to describe the lifecycle.
- Merged with main's first-message flicker guard: the unseeded-snapshot gate runs first, then the attachment-retention nonce path.

## Test plan

- New/updated unit tests:
  - `message-handlers.test.ts`: echo retains + upgrades an attachment-carrying send; removes attachment-less sends; removes on synthetic (no `messageId`) echoes; no-op when no row matches; unseeded-snapshot flicker guard; nonce-less fallback unchanged.
  - `stream-updaters.test.ts`: the appended echo row carries the nonce.
  - `chat-session-store-base.test.ts`: full lifecycle regression — optimistic send with blob preview → echo fold + retained overlay row renders one user row that keeps the preview → reseed retires the overlay and the server row's data-URI preview takes over; prune keeps an attachment-carrying send until its snapshot twin is hydrated; plus a `pruneConfirmedOptimisticSends` unit test.
- `cd clients/web && bun test` on all touched suites (110/110 pass post-merge; adjacent transcript/queue/send suites also pass individually — a 5-file batch run shows 5 pre-existing cross-file-pollution failures that reproduce identically on a clean tree).
- `bunx tsc --noEmit` clean; `eslint` clean on touched files.

## CLI verb checklist

No new routes — client-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyK5P66WaQ4GS8L6tTZUnW