### PR TITLE
fix(web): hide manage-plugins UI behind assistant version 0.10.7

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
@@ -20,22 +20,23 @@ afterEach(() => {
 });
 
 // Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
-// boundary on each side of MIN_VERSION (0.10.5 — the release that ships the
-// route + GET serialization) plus the conservative-on-unknown policy,
+// boundary on each side of MIN_VERSION (0.10.7 — the manage-plugins surface is
+// held back until it is ready) plus the conservative-on-unknown policy,
 // exercised through the public hook.
 describe("useSupportsInchatPluginEdit", () => {
   test("reads false when the version is unknown", () => {
     expect(readGate(null)).toBe(false);
   });
 
-  test("reads false below 0.10.5 (incl. the 0.10.4 send-path release)", () => {
+  test("reads false below 0.10.7 (incl. 0.10.5, 0.10.6)", () => {
+    expect(readGate("0.10.6")).toBe(false);
+    expect(readGate("0.10.5")).toBe(false);
     expect(readGate("0.10.4")).toBe(false);
-    expect(readGate("0.10.3")).toBe(false);
     expect(readGate("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.10.5+", () => {
-    expect(readGate("0.10.5")).toBe(true);
+  test("reads true for assistants on 0.10.7+", () => {
+    expect(readGate("0.10.7")).toBe(true);
     expect(readGate("0.11.0")).toBe(true);
     expect(readGate("1.0.0")).toBe(true);
   });

--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
@@ -3,20 +3,21 @@
  *
  * The in-chat plugin pill reads a conversation's plugin scope, which the daemon
  * only serializes onto the conversation GET (and exposes for edit via
- * `PUT /conversations/:id/enabledplugins`) in the release below — the same
- * release that ships #36678's per-chat plugin support.
+ * `PUT /conversations/:id/enabledplugins`) in the release below.
  *
  * The web app always serves the latest bundle, but the assistant can be any
  * locally-installed version. On an older daemon the GET omits `enabledPlugins`,
  * so the pill would misrepresent per-chat state — keep it hidden until the
  * active assistant is known to support it. Conservative on unknown.
  *
- * NOTE: the pill stays hidden until the monorepo version reaches MIN_VERSION,
- * so bump the monorepo version to 0.10.5 when cutting this release.
+ * MIN_VERSION targets 0.10.7 — the manage-plugins surface (this in-chat pill
+ * plus the new-chat plugin picker) is not ready for release, so the gate holds
+ * at a version the monorepo has not yet cut, keeping the pill hidden on every
+ * shipped assistant until the surface lands.
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.5";
+export const MIN_VERSION = "0.10.7";
 
 /**
  * Returns `true` when the active assistant exposes the standalone

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 // Exhaustive truth-table for the underlying semver gate lives in
-// `utils.test.ts`. Here we verify the boundary on each side of 0.10.5
+// `utils.test.ts`. Here we verify the boundary on each side of 0.10.7
 // plus the conservative-on-unknown policy, exercised through the public
 // hook and the awaiting send-path variant. (The snapshot read is a
 // private helper; it is covered via these exported entry points.)
@@ -36,14 +36,15 @@ describe("useSupportsNewChatPlugins", () => {
     expect(readGateViaHook(null)).toBe(false);
   });
 
-  test("reads false for assistants below 0.10.5 (incl. 0.10.4)", () => {
+  test("reads false for assistants below 0.10.7 (incl. 0.10.5, 0.10.6)", () => {
+    expect(readGateViaHook("0.10.6")).toBe(false);
+    expect(readGateViaHook("0.10.5")).toBe(false);
     expect(readGateViaHook("0.10.4")).toBe(false);
-    expect(readGateViaHook("0.10.3")).toBe(false);
     expect(readGateViaHook("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.10.5+", () => {
-    expect(readGateViaHook("0.10.5")).toBe(true);
+  test("reads true for assistants on 0.10.7+", () => {
+    expect(readGateViaHook("0.10.7")).toBe(true);
     expect(readGateViaHook("0.11.0")).toBe(true);
     expect(readGateViaHook("1.0.0")).toBe(true);
   });
@@ -61,7 +62,7 @@ describe("resolveSupportsNewChatPlugins", () => {
   });
 
   test("resolves true for a supported daemon once the version is known", async () => {
-    setVersion("0.10.5");
+    setVersion("0.10.7");
     expect(await resolveSupportsNewChatPlugins()).toBe(true);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
@@ -19,10 +19,12 @@
  * on the send path so the decision awaits version hydration rather than
  * optimistically assuming support.
  *
- * MIN_VERSION targets 0.10.5 — the release that ships the daemon side of
- * per-chat plugin selection (alongside the in-chat plugin pill). #36678 merged
- * with this at 0.10.4 by accident; corrected here. Bump the monorepo version to
- * 0.10.5 when cutting this release so the picker/send-path enable on it.
+ * MIN_VERSION targets 0.10.7 — the manage-plugins surface (this new-chat
+ * picker plus the in-chat plugin pill) is not ready for release, so the
+ * gate holds at a version the monorepo has not yet cut. That keeps the
+ * picker and send-path inclusion hidden on every shipped assistant until
+ * the surface lands; bump MIN_VERSION to the release that finalizes
+ * per-chat plugin selection when it is ready.
  */
 import {
   assistantSupports,
@@ -30,7 +32,7 @@ import {
   whenAssistantVersionKnown,
 } from "./utils";
 
-export const MIN_VERSION = "0.10.5";
+export const MIN_VERSION = "0.10.7";
 
 /**
  * Returns `true` when the active assistant accepts the per-chat plugin


### PR DESCRIPTION
## Prompt / plan

> there was a manage plugins UI shipped to the frontend that isn't ready yet. Add a backwards compat flag for min version 0.10.7 to hide it for now — the one that appears in the new-conversations UI and single-chat UI.

The per-chat plugin management surface reached the always-latest web bundle before it's ready to ship. It's controlled by two existing `lib/backwards-compat` version gates:

- **`use-supports-new-chat-plugins`** — the plugin picker in the new-conversation composer (`NewChatPluginsSection` in `chat-route-content.tsx`) plus the send-path inclusion of the per-chat plugin set.
- **`use-supports-inchat-plugin-edit`** — the in-chat plugin pill in the single-chat header.

Both were gated at `0.10.5`. This bumps both `MIN_VERSION` constants to **`0.10.7`** — a version the monorepo (currently `0.10.4`) has not yet cut — so the gates report "unsupported" against every shipped assistant and the surface stays hidden until it's finished. No new gate module is introduced; this reuses the centralized version-gate mechanism documented in `clients/web/docs/BACKWARDS_COMPAT.md`. Bump `MIN_VERSION` to the release that finalizes the surface when it's ready.

## Test plan

- Updated the colocated gate tests to move the boundary to `0.10.7` (`0.10.5`/`0.10.6` now read `false`; `0.10.7+` read `true`), including the async send-path variant.
- `bun test src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts` → 10 pass / 0 fail.
- `bunx tsc --noEmit` — no errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fTQmA4d41WnFYMBCh1f4H

---
_Generated by [Claude Code](https://claude.ai/code/session_012fTQmA4d41WnFYMBCh1f4H)_