### PR TITLE
refactor(gateway): drop the write-only channel_verification_sessions mirror table

### DIFF
--- a/gateway/src/__tests__/data-migration-m0011-drop-gw-verification-sessions.test.ts
+++ b/gateway/src/__tests__/data-migration-m0011-drop-gw-verification-sessions.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for m0011-drop-gw-verification-sessions.
+ *
+ * Verifies that the gateway `channel_verification_sessions` mirror table is
+ * dropped when present, that re-running is idempotent, that a fresh install
+ * (table already absent) is a no-op that still reports "done", that down() is
+ * a no-op, and that the migration is registered after m0010.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { MIGRATIONS } from "../db/data-migrations/index.js";
+import {
+  up as m0011Up,
+  down as m0011Down,
+} from "../db/data-migrations/m0011-drop-gw-verification-sessions.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function rawDb() {
+  return getGatewayDb().$client;
+}
+
+function tableExists(): boolean {
+  const row = rawDb()
+    .prepare(
+      "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_verification_sessions'",
+    )
+    .get();
+  return row != null;
+}
+
+function createMirrorTable(): void {
+  rawDb().exec(
+    "CREATE TABLE IF NOT EXISTS channel_verification_sessions (id TEXT PRIMARY KEY, status TEXT)",
+  );
+}
+
+beforeEach(() => {
+  createMirrorTable();
+});
+
+describe("m0011-drop-gw-verification-sessions", () => {
+  test("drops the mirror table when present", () => {
+    expect(tableExists()).toBe(true);
+
+    expect(m0011Up()).toBe("done");
+
+    expect(tableExists()).toBe(false);
+  });
+
+  test("idempotent: re-running after the drop is a no-op", () => {
+    expect(m0011Up()).toBe("done");
+    expect(tableExists()).toBe(false);
+
+    expect(m0011Up()).toBe("done");
+    expect(tableExists()).toBe(false);
+  });
+
+  test("fresh install (table absent) is a no-op that reports done", () => {
+    rawDb().exec("DROP TABLE IF EXISTS channel_verification_sessions");
+    expect(tableExists()).toBe(false);
+
+    expect(m0011Up()).toBe("done");
+    expect(tableExists()).toBe(false);
+  });
+
+  test("down is a no-op (returns done)", () => {
+    expect(m0011Down()).toBe("done");
+  });
+
+  test("is registered after m0010", () => {
+    const keys = MIGRATIONS.map((m) => m.key);
+    const prevIndex = keys.indexOf("m0010-drop-assistant-ingress-invites");
+    const thisIndex = keys.indexOf("m0011-drop-gw-verification-sessions");
+
+    expect(prevIndex).toBeGreaterThanOrEqual(0);
+    expect(thisIndex).toBeGreaterThan(prevIndex);
+  });
+});

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -29,6 +29,7 @@ import * as m0007 from "./m0007-backfill-ingress-invites.js";
 import * as m0008 from "./m0008-upsert-acl-columns-from-assistant.js";
 import * as m0009 from "./m0009-invite-fields-backfill.js";
 import * as m0010 from "./m0010-drop-assistant-ingress-invites.js";
+import * as m0011 from "./m0011-drop-gw-verification-sessions.js";
 
 const log = getLogger("data-migrations");
 
@@ -52,6 +53,7 @@ export const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0009-invite-fields-backfill", mod: m0009 },
   // m0010 must stay after m0009: it drops the assistant table m0009 reads.
   { key: "m0010-drop-assistant-ingress-invites", mod: m0010 },
+  { key: "m0011-drop-gw-verification-sessions", mod: m0011 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0011-drop-gw-verification-sessions.ts
+++ b/gateway/src/db/data-migrations/m0011-drop-gw-verification-sessions.ts
@@ -1,0 +1,34 @@
+/**
+ * One-time migration: drop the gateway `channel_verification_sessions` table.
+ *
+ * The assistant DB owns verification session state; the gateway copy took a
+ * single write that never had a matching insert, so the table only ever held
+ * empty carry-cost. A future gateway-SoT move recreates this table
+ * deliberately with its own read/write paths.
+ *
+ * Runs on the gateway's own DB (plain SQL). Idempotent via IF EXISTS.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../logger.js";
+import { getGatewayDb } from "../connection.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0011-drop-gw-verification-sessions");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+export function up(): MigrationResult {
+  getRawGatewayDb().exec("DROP TABLE IF EXISTS channel_verification_sessions");
+  log.info("Dropped gateway channel_verification_sessions mirror table");
+  return "done";
+}
+
+export function down(): MigrationResult {
+  // No-op: the assistant DB owns session state; the gateway mirror is not restored.
+  return "done";
+}

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -376,41 +376,6 @@ export const channelGuardianRateLimits = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
-// Channel verification sessions (dual-write mirror of assistant table)
-// ---------------------------------------------------------------------------
-
-export const channelVerificationSessions = sqliteTable(
-  "channel_verification_sessions",
-  {
-    id: text("id").primaryKey(),
-    channel: text("channel").notNull(),
-    challengeHash: text("challenge_hash").notNull(),
-    expiresAt: integer("expires_at").notNull(),
-    status: text("status").notNull().default("pending"),
-    sourceConversationId: text("source_conversation_id"),
-    consumedByExternalUserId: text("consumed_by_external_user_id"),
-    consumedByChatId: text("consumed_by_chat_id"),
-    expectedExternalUserId: text("expected_external_user_id"),
-    expectedChatId: text("expected_chat_id"),
-    expectedPhoneE164: text("expected_phone_e164"),
-    identityBindingStatus: text("identity_binding_status").default("bound"),
-    destinationAddress: text("destination_address"),
-    lastSentAt: integer("last_sent_at"),
-    sendCount: integer("send_count").default(0),
-    nextResendAt: integer("next_resend_at"),
-    codeDigits: integer("code_digits").default(6),
-    maxAttempts: integer("max_attempts").default(3),
-    verificationPurpose: text("verification_purpose").default("guardian"),
-    bootstrapTokenHash: text("bootstrap_token_hash"),
-    createdAt: integer("created_at").notNull(),
-    updatedAt: integer("updated_at").notNull(),
-  },
-  (table) => [
-    index("idx_gw_cvs_channel_status").on(table.channel, table.status),
-  ],
-);
-
-// ---------------------------------------------------------------------------
 // Channel denial reply log (rate-limiting outbound denial replies)
 // ---------------------------------------------------------------------------
 

--- a/gateway/src/verification/session-helpers.ts
+++ b/gateway/src/verification/session-helpers.ts
@@ -2,18 +2,13 @@
  * Verification session helpers for gateway-owned verification.
  *
  * Session lookup, consumption, and status checks — all via raw SQL
- * through the assistant DB IPC proxy. Dual-writes to gateway DB on
- * session consumption.
+ * through the assistant DB IPC proxy. The assistant DB owns session state.
  */
-
-import { eq } from "drizzle-orm";
 
 import {
   assistantDbQuery,
   assistantDbRun,
 } from "../db/assistant-db-proxy.js";
-import { getGatewayDb } from "../db/connection.js";
-import { channelVerificationSessions as gwSessions } from "../db/schema.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("verification-sessions");
@@ -103,12 +98,12 @@ export async function findSessionByHash(
 }
 
 // ---------------------------------------------------------------------------
-// Session consumption (dual-write)
+// Session consumption
 // ---------------------------------------------------------------------------
 
 /**
- * Mark a verification session as consumed. Dual-writes to both assistant
- * and gateway DBs.
+ * Mark a verification session as consumed in the assistant DB, which owns
+ * session state.
  *
  * The UPDATE includes a status predicate so only the first concurrent
  * consumer wins — subsequent attempts see zero changes and return false,
@@ -121,7 +116,7 @@ export async function consumeSession(
 ): Promise<boolean> {
   const now = Date.now();
 
-  // Assistant DB (source of truth) — status guard ensures atomicity
+  // Status guard ensures atomicity under concurrent consumers.
   const result = await assistantDbRun(
     `UPDATE channel_verification_sessions
      SET status = 'consumed',
@@ -139,25 +134,6 @@ export async function consumeSession(
       "Session consume returned 0 changes — already consumed or status changed",
     );
     return false;
-  }
-
-  // Gateway DB dual-write
-  try {
-    const gwDb = getGatewayDb();
-    gwDb.update(gwSessions)
-      .set({
-        status: "consumed",
-        consumedByExternalUserId: actorExternalUserId,
-        consumedByChatId: actorChatId,
-        updatedAt: now,
-      })
-      .where(eq(gwSessions.id, sessionId))
-      .run();
-  } catch (gwErr) {
-    log.warn(
-      { err: gwErr, sessionId },
-      "Gateway DB session consume dual-write failed (best-effort)",
-    );
   }
 
   return true;


### PR DESCRIPTION
## Summary
- Remove the permanently-no-op gateway channel_verification_sessions mirror write + table; add m0011 to DROP it. The assistant DB owns session state.

Part of plan: contacts-acl-cleanup.md (PR 4 of 14)