### PR TITLE
refactor(gateway): touchContactChannelStats writes only the gateway DB

### DIFF
--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -12,6 +12,7 @@
  * verification intercept is mocked per-test so the default path forwards.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { eq } from "drizzle-orm";
 import type { GatewayConfig } from "../config.js";
 import type {
   RuntimeInboundPayload,
@@ -423,5 +424,68 @@ describe("handle-inbound sender-authentication downgrade", () => {
     expect(verdict.trustClass).toBe("unknown");
     expect(verdict.contactId).toBeUndefined();
     expect(verdict.status).toBeUndefined();
+  });
+});
+
+describe("handle-inbound contact channel stats", () => {
+  function readChannel(id: string) {
+    return getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.id, id))
+      .get()!;
+  }
+
+  test("non-duplicate inbound bumps lastSeen + interaction on the gateway row", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_USER_1",
+      externalChatId: "chat-member",
+    });
+
+    await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    const channel = readChannel("ch-member");
+    expect(channel.interactionCount).toBe(1);
+    expect(channel.lastInteraction).not.toBeNull();
+    expect(channel.lastSeenAt).not.toBeNull();
+  });
+
+  test("duplicate inbound bumps lastSeen only, leaving interactionCount at 0", async () => {
+    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_USER_1",
+    });
+    forwardToRuntimeMock.mockImplementationOnce(async (_config, payload) => {
+      runtimePayloads.push(payload);
+      return { accepted: true, duplicate: true, eventId: "runtime-dup-1" };
+    });
+
+    await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    const channel = readChannel("ch-member");
+    expect(channel.interactionCount).toBe(0);
+    expect(channel.lastInteraction).toBeNull();
+    expect(channel.lastSeenAt).not.toBeNull();
+  });
+
+  test("resolves via externalChatId fallback when the address does not match", async () => {
+    insertContact({ id: "c-legacy", displayName: "Legacy Import" });
+    insertChannel({
+      id: "ch-legacy",
+      contactId: "c-legacy",
+      address: "SOME_OTHER_ADDRESS",
+      externalChatId: "C_CHAT_1",
+    });
+
+    await handleInbound(makeConfig(), makeEvent(), ROUTING);
+
+    const channel = readChannel("ch-legacy");
+    expect(channel.interactionCount).toBe(1);
+    expect(channel.lastSeenAt).not.toBeNull();
   });
 });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -510,6 +510,42 @@ export class ContactStore {
   }
 
   /**
+   * Resolve a channel id by its logical (type, address) key, falling back to
+   * (type, externalChatId) for legacy/imported contacts. Gateway DB only.
+   */
+  findChannelIdByAddress(
+    type: string,
+    address: string,
+    externalChatId?: string | null,
+  ): string | undefined {
+    const byAddress = this.db
+      .select({ id: contactChannels.id })
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, type),
+          sql`${contactChannels.address} = ${address} COLLATE NOCASE`,
+        ),
+      )
+      .limit(1)
+      .get();
+    if (byAddress) return byAddress.id;
+
+    if (externalChatId == null) return undefined;
+    return this.db
+      .select({ id: contactChannels.id })
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, type),
+          eq(contactChannels.externalChatId, externalChatId),
+        ),
+      )
+      .limit(1)
+      .get()?.id;
+  }
+
+  /**
    * Set lastSeenAt to now for a channel (gateway DB only).
    */
   touchChannelLastSeen(channelId: string): void {

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import {
   makeResolutionFailedVerdict,
   makeUnauthenticatedSenderVerdict,
@@ -6,8 +5,6 @@ import {
   type TrustVerdict,
 } from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
-import { ipcCallAssistant } from "../ipc/assistant-client.js";
-import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
 import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
@@ -330,10 +327,9 @@ export async function handleInbound(
         : "Inbound event forwarded to runtime",
     );
 
-    // ── Contact channel interaction tracking (dual-write) ──
-    // Reads from the assistant DB (source of truth during migration),
-    // writes to both assistant DB and gateway DB. Fire-and-forget so
-    // IPC failures here cannot leak as unhandled rejections.
+    // ── Contact channel interaction tracking ──
+    // Fire-and-forget so write failures here cannot leak as unhandled
+    // rejections.
     if (!response.denied) {
       void touchContactChannelStats(event, response.duplicate).catch(() => {});
     }
@@ -354,71 +350,34 @@ export async function handleInbound(
 }
 
 // ---------------------------------------------------------------------------
-// Contact channel interaction tracking (dual-write helper)
+// Contact channel interaction tracking
 // ---------------------------------------------------------------------------
 
-interface DbProxyResult {
-  rows?: Array<Record<string, unknown>>;
-}
-
 /**
- * Look up the contact channel in the assistant DB and dual-write
- * interaction stats to both the assistant and gateway databases.
+ * Resolve the contact channel from the gateway store and write interaction
+ * stats to the gateway DB.
  *
- * Caller wraps in `.catch(() => {})` so IPC failures cannot surface as
- * unhandled rejections.
+ * Caller wraps in `.catch(() => {})` so failures cannot surface as unhandled
+ * rejections.
  */
 async function touchContactChannelStats(
   event: GatewayInboundEvent,
   duplicate: boolean,
 ): Promise<void> {
-  // Skip if the assistant IPC socket is not available (e.g. in tests).
-  const { path: socketPath } = resolveIpcSocketPath("assistant");
-  if (!existsSync(socketPath)) return;
-
   const canonicalActorId =
     canonicalizeInboundIdentity(
       event.sourceChannel,
       event.actor.actorExternalId,
     ) ?? event.actor.actorExternalId;
 
-  // Look up channel in assistant DB (source of truth), with
-  // externalChatId fallback for legacy/imported contacts.
-  let result = (await ipcCallAssistant("db_proxy", {
-    sql: "SELECT id FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE LIMIT 1",
-    mode: "query",
-    bind: [event.sourceChannel, canonicalActorId],
-  })) as DbProxyResult;
-
-  if (!result.rows?.length) {
-    result = (await ipcCallAssistant("db_proxy", {
-      sql: "SELECT id FROM contact_channels WHERE type = ? AND external_chat_id = ? LIMIT 1",
-      mode: "query",
-      bind: [event.sourceChannel, event.message.conversationExternalId],
-    })) as DbProxyResult;
-  }
-
-  if (!result.rows?.length) return;
-
-  const channelId = result.rows[0].id as string;
-  const now = Date.now();
-
-  // Assistant DB writes
-  await ipcCallAssistant("db_proxy", {
-    sql: "UPDATE contact_channels SET last_seen_at = ?, updated_at = ? WHERE id = ?",
-    mode: "run",
-    bind: [now, now, channelId],
-  });
-  if (!duplicate) {
-    await ipcCallAssistant("db_proxy", {
-      sql: "UPDATE contact_channels SET last_interaction = ?, interaction_count = interaction_count + 1, updated_at = ? WHERE id = ?",
-      mode: "run",
-      bind: [now, now, channelId],
-    });
-  }
-
-  // Gateway DB writes
   const store = new ContactStore();
+  const channelId = store.findChannelIdByAddress(
+    event.sourceChannel,
+    canonicalActorId,
+    event.message.conversationExternalId,
+  );
+  if (!channelId) return;
+
   store.touchChannelLastSeen(channelId);
   if (!duplicate) {
     store.touchContactInteraction(channelId);


### PR DESCRIPTION
## Summary
- touchContactChannelStats resolves the channel from the gateway store and writes only the gateway DB; removes the assistant-DB db_proxy lookups + UPDATEs and stale migration comments.

Part of plan: contacts-acl-cleanup.md (PR 8 of 14)