### PR TITLE
fix(assistant): hide raw <background_event> wake-trigger bubble for all wake sources

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18005,7 +18005,7 @@ paths:
                           required:
                             - acpSessionId
                           additionalProperties: false
-                        backgroundToolNotification:
+                        backgroundEventNotification:
                           type: boolean
                         backgroundToolCompletion:
                           type: object

--- a/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
+++ b/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
@@ -4,7 +4,7 @@
  * A backgrounded bash/host_bash run posts a `<background_event
  * source="background-tool">` wake on completion, stamped with
  * `metadata.backgroundToolCompletion`. The history projection must surface
- * that structured record (and the `backgroundToolNotification` flag) so the
+ * that structured record (and the `backgroundEventNotification` flag) so the
  * web can rebuild a terminal inline card after a daemon restart.
  */
 
@@ -48,7 +48,7 @@ function resetTables() {
 
 interface ProjectedMessage {
   role: string;
-  backgroundToolNotification?: boolean;
+  backgroundEventNotification?: boolean;
   backgroundToolCompletion?: Record<string, unknown>;
 }
 
@@ -76,8 +76,8 @@ describe("handleListMessages background-tool completion projection", () => {
     };
     // Mirror persistWakeTriggerMessage: a user-role
     // `<background_event source="background-tool">` row carrying the structured
-    // completion. Not flagged `hidden`; the client suppresses it from the
-    // transcript via `backgroundToolNotification`.
+    // completion. The client suppresses it from the transcript via
+    // `backgroundEventNotification`.
     await addMessage(
       conv.id,
       "user",
@@ -110,7 +110,7 @@ describe("handleListMessages background-tool completion projection", () => {
       (m) => m.backgroundToolCompletion !== undefined,
     );
     expect(wakeRow).toBeDefined();
-    expect(wakeRow?.backgroundToolNotification).toBe(true);
+    expect(wakeRow?.backgroundEventNotification).toBe(true);
     expect(wakeRow?.backgroundToolCompletion).toEqual(completion);
   });
 
@@ -134,7 +134,7 @@ describe("handleListMessages background-tool completion projection", () => {
     expect(response.messages).toHaveLength(2);
     for (const message of response.messages) {
       expect(message.backgroundToolCompletion).toBeUndefined();
-      expect(message.backgroundToolNotification).toBeUndefined();
+      expect(message.backgroundEventNotification).toBeUndefined();
       expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
     }
   });

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -567,13 +567,13 @@ export const ConversationMessageSchema = z.object({
   contentBlocks: z.array(ConversationContentBlockSchema).optional(),
   subagentNotification: ConversationSubagentNotificationSchema.optional(),
   acpNotification: ConversationAcpNotificationSchema.optional(),
-  /** Set on the persisted `<background_event source="background-tool">` wake a
-   *  backgrounded bash/host_bash run posts on completion. Like the subagent/ACP
-   *  notifications, the row stays in state (the LLM reads it) but is filtered
-   *  from the rendered transcript — the inline card carries the status. */
-  backgroundToolNotification: z.boolean().optional(),
+  /** Set on any persisted `<background_event source="...">` wake trigger row.
+   *  Like the subagent/ACP notifications, the row stays in state (the LLM reads
+   *  it) but is filtered from the rendered transcript — the user-facing wake
+   *  card carries the status. */
+  backgroundEventNotification: z.boolean().optional(),
   /** Structured completion of a backgrounded bash/host_bash run, stamped on the
-   *  same persisted background-event wake row as `backgroundToolNotification`.
+   *  same persisted background-event wake row as `backgroundEventNotification`.
    *  Lets the web reconstruct a terminal inline card after a daemon restart
    *  (the in-memory completed ring does not survive restarts). `id` equals the
    *  spawning tool call's `{backgrounded,id}` id. */

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -62,13 +62,14 @@ const log = getLogger("conversation-process");
 
 /**
  * Daemon-injected run lifecycle notifications — subagent (`subagentNotification`),
- * ACP run (`acpNotification`), and backgrounded bash/host_bash completion (the
- * `<background_event source="background-tool">` wake) — are persisted into the
- * parent conversation so the orchestrator wakes and reads the run's result, but
- * they are internal scaffolding: the user sees the run through its inline
- * progress card, not a chat turn. Skip the `user_message_echo` broadcast for
- * these so they never render as a live user bubble; the persisted row is
- * filtered from the rendered transcript on the client.
+ * ACP run (`acpNotification`), and any wake trigger (the persisted
+ * `<background_event source="...">` row every wake reads) — are persisted into
+ * the parent conversation so the orchestrator wakes and reads the trigger, but
+ * they are internal scaffolding: the user sees the wake through its inline card
+ * ("Conversation Woke", or a terminal card for a backgrounded bash run), not a
+ * chat turn. Skip the `user_message_echo` broadcast for these so they never
+ * render as a live user bubble; the persisted row is filtered from the rendered
+ * transcript on the client.
  */
 function isHiddenRunNotificationMessage(
   metadata: Record<string, unknown> | undefined,
@@ -76,7 +77,7 @@ function isHiddenRunNotificationMessage(
   return (
     metadata?.subagentNotification != null ||
     metadata?.acpNotification != null ||
-    metadata?.backgroundEventSource === "background-tool"
+    typeof metadata?.backgroundEventSource === "string"
   );
 }
 

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -267,8 +267,9 @@ export async function persistWakeTailMessage(
  *
  * Mirrors {@link persistWakeTailMessage}'s channel/interface/provenance
  * metadata, but stamps `kind: "background-event"` (+ the originating `source`)
- * for identification, skips indexing (the body may carry untrusted command
- * output), and is NOT flagged hidden so the trigger shows in the transcript.
+ * for identification and skips indexing (the body may carry untrusted command
+ * output). The `backgroundEventSource` stamp lets clients hide this row from the
+ * rendered transcript — the user-facing wake card carries the status instead.
  */
 export async function persistWakeTriggerMessage(
   conversation: Conversation,
@@ -312,12 +313,10 @@ export async function persistWakeTriggerMessage(
       "wake trigger persist: syncMessageToDisk failed (non-fatal)",
     );
   }
-  // Tell connected clients the message list changed so they refetch and the
-  // visible trigger renders live. The normal user-send path publishes the same
-  // invalidation after persisting a user message; without it a wake that
-  // produces no assistant stream (silent no-op), or a conversation open in
-  // another client, would not show the <background_event> row until a manual
-  // reload.
+  // Tell connected clients the message list changed so they refetch. The
+  // trigger row itself is hidden from the transcript (clients drop rows carrying
+  // `backgroundEventSource`), but the refetch keeps other clients' state in sync
+  // and lets a wake that produces no assistant stream still settle cleanly.
   try {
     publishConversationMessagesChanged(conversation.conversationId);
   } catch (err) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -846,19 +846,19 @@ export function handleListMessages({
         }
       | undefined;
     let acpNotification: { acpSessionId: string; agent?: string } | undefined;
-    let backgroundToolNotification: boolean | undefined;
+    let backgroundEventNotification: boolean | undefined;
     let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
         if (typeof meta.sentAt === "number") sentAt = meta.sentAt;
-        // The backgrounded bash/host_bash completion wake persists a
-        // `<background_event source="background-tool">` row (see
-        // `persistWakeTriggerMessage`). Flag it so clients hide it from the
-        // transcript like a subagent/ACP notification — the inline card carries
-        // the status.
-        if (meta.backgroundEventSource === "background-tool") {
-          backgroundToolNotification = true;
+        // Every wake persists a `<background_event source="...">` trigger row
+        // (see `persistWakeTriggerMessage`) that the LLM reads. Flag any such
+        // row so clients hide it from the transcript like a subagent/ACP
+        // notification — the user-facing "Conversation Woke" card (or, for a
+        // backgrounded bash run, the inline terminal card) carries the status.
+        if (typeof meta.backgroundEventSource === "string") {
+          backgroundEventNotification = true;
         }
         // `persistWakeTriggerMessage` stamps the structured completion onto the
         // same wake row, letting the web rebuild a terminal inline card from
@@ -921,7 +921,7 @@ export function handleListMessages({
       sentAt,
       subagentNotification,
       acpNotification,
-      backgroundToolNotification,
+      backgroundEventNotification,
       backgroundToolCompletion,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
@@ -1116,8 +1116,8 @@ export function handleListMessages({
         ? { subagentNotification: m.subagentNotification }
         : {}),
       ...(m.acpNotification ? { acpNotification: m.acpNotification } : {}),
-      ...(m.backgroundToolNotification
-        ? { backgroundToolNotification: true }
+      ...(m.backgroundEventNotification
+        ? { backgroundEventNotification: true }
         : {}),
       ...(m.backgroundToolCompletion
         ? { backgroundToolCompletion: m.backgroundToolCompletion }

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -130,7 +130,7 @@ describe("buildTranscriptItems", () => {
       ...textBody(
         '<background_event source="background-tool">Background command completed (id=bg-1, exit=0):</background_event>',
       ),
-      isBackgroundToolNotification: true,
+      isBackgroundEventNotification: true,
     });
     const assistant = makeMessage({
       id: "m3",

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -93,16 +93,16 @@ export function buildTranscriptItems(
   const items: TranscriptItem[] = [];
 
   for (const message of messages) {
-    // Daemon-injected run lifecycle notifications (subagent + ACP + backgrounded
-    // bash/host_bash completion, user-role messages carrying subagentNotification
-    // / acpNotification / backgroundToolNotification metadata) stay in `messages`
+    // Daemon-injected run lifecycle notifications (subagent + ACP + any wake
+    // trigger, i.e. user-role messages carrying subagentNotification /
+    // acpNotification / backgroundEventNotification metadata) stay in `messages`
     // state so the LLM transcript and store rehydration still see them, but they
     // are internal scaffolding and are never rendered in the transcript — the run
-    // surfaces through its inline progress card.
+    // surfaces through its inline card instead.
     if (
       message.isSubagentNotification ||
       message.isAcpNotification ||
-      message.isBackgroundToolNotification
+      message.isBackgroundEventNotification
     ) {
       continue;
     }

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -148,10 +148,10 @@ export interface DisplayMessage {
   /** True for daemon-injected ACP-run lifecycle notifications; suppressed from
    *  the transcript like {@link isSubagentNotification}. */
   isAcpNotification?: boolean;
-  /** True for the backgrounded bash/host_bash completion wake
-   *  (`<background_event source="background-tool">`); suppressed from the
-   *  transcript like {@link isSubagentNotification} — the inline card shows it. */
-  isBackgroundToolNotification?: boolean;
+  /** True for any wake trigger row (`<background_event source="...">`, e.g.
+   *  defer/schedule/webhook/background-tool); suppressed from the transcript
+   *  like {@link isSubagentNotification} — the wake card shows it instead. */
+  isBackgroundEventNotification?: boolean;
 }
 
 /**

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -130,18 +130,18 @@ describe("mapRuntimeToDisplayMessage", () => {
     expect(mapRuntimeToDisplayMessage(m).isAcpNotification).toBe(true);
   });
 
-  test("flags a backgroundToolNotification message as isBackgroundToolNotification", () => {
+  test("flags a backgroundEventNotification message as isBackgroundEventNotification", () => {
     const plain = makeMessage({ id: "m-plain", role: "user" });
     expect(
-      mapRuntimeToDisplayMessage(plain).isBackgroundToolNotification,
+      mapRuntimeToDisplayMessage(plain).isBackgroundEventNotification,
     ).toBeUndefined();
 
     const m = makeMessage({
       id: "m-bg",
       role: "user",
-      backgroundToolNotification: true,
+      backgroundEventNotification: true,
     });
-    expect(mapRuntimeToDisplayMessage(m).isBackgroundToolNotification).toBe(
+    expect(mapRuntimeToDisplayMessage(m).isBackgroundEventNotification).toBe(
       true,
     );
   });

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -160,7 +160,7 @@ export function mapRuntimeToDisplayMessage(
   if (thinkingSegments) msg.thinkingSegments = thinkingSegments;
   if (m.subagentNotification) msg.isSubagentNotification = true;
   if (m.acpNotification) msg.isAcpNotification = true;
-  if (m.backgroundToolNotification) msg.isBackgroundToolNotification = true;
+  if (m.backgroundEventNotification) msg.isBackgroundEventNotification = true;
   if (m.slackMessage) msg.slackMessage = m.slackMessage;
   if (toolCalls) msg.toolCalls = toolCalls;
   if (timestamp != null) msg.timestamp = timestamp;

--- a/clients/web/src/domains/chat/utils/message-merge.test.ts
+++ b/clients/web/src/domains/chat/utils/message-merge.test.ts
@@ -392,7 +392,7 @@ describe("mergeAdjacentAssistantMessages · skip predicates", () => {
     const notification = makeAssistant({
       id: "a-2",
       ...textBody(""),
-      isBackgroundToolNotification: true,
+      isBackgroundEventNotification: true,
     });
     const result = mergeAdjacentAssistantMessages([real, notification]);
     expect(result).toHaveLength(2);

--- a/clients/web/src/domains/chat/utils/message-merge.ts
+++ b/clients/web/src/domains/chat/utils/message-merge.ts
@@ -174,8 +174,8 @@ function canFoldAdjacentAssistant(
     donor.isSubagentNotification ||
     survivor.isAcpNotification ||
     donor.isAcpNotification ||
-    survivor.isBackgroundToolNotification ||
-    donor.isBackgroundToolNotification
+    survivor.isBackgroundEventNotification ||
+    donor.isBackgroundEventNotification
   ) {
     return false;
   }


### PR DESCRIPTION
## Problem

When a conversation **defer** wakes back up, the transcript showed an ugly raw `<background_event source="defer">…</background_event>` text bubble **in addition** to the intended "Conversation Woke" UI card:

<img width="600" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

> (Screenshot: the raw `<background_event source="defer">` bubble sitting above the "Conversation Woke" card.)

## Root cause

Every wake persists a `<background_event source="...">` trigger row into history — that raw text is what the LLM reads to know why it woke. The client is supposed to hide that row from the rendered transcript (the "Conversation Woke" card is the user-facing representation). But the suppression was hard-coded to only match `source === "background-tool"`:

```ts
// conversation-routes.ts — before
if (meta.backgroundEventSource === "background-tool") {
  backgroundToolNotification = true; // hide it
}
```

A `defer` wake stamps `source: "defer"`, so it was never flagged hidden and fell through to the normal message-bubble renderer. The `schedule` and `webhook` wake sources had the same latent bug.

## Fix

- Generalize both server-side suppression gates (`conversation-routes.ts` list-messages projection + `conversation-process.ts` live `user_message_echo` echo) to hide **any** `background_event` wake-trigger row — they all render the "Conversation Woke" card (or, for backgrounded bash, the inline terminal card), so the raw text is always redundant.
- Rename the now-misnamed `backgroundToolNotification` → `backgroundEventNotification` across the daemon → wire (`conversation-message.ts`, `openapi.yaml`) → web-client path (`types.ts`, `map-runtime-message.ts`, `message-merge.ts`, `build-items.ts`), so the flag doesn't falsely label a defer row as a background tool.
- Updated stale doc comments (one previously claimed the trigger was intentionally left visible) and the four affected test files.

## Verification

- ✅ TypeScript clean on both assistant and web sides (touched files).
- ✅ All 67 web tests pass (`map-runtime-message`, `message-merge`, `build-items`).
- ⚠️ The assistant unit test couldn't run in my local checkout due to an unbuilt-workspace gap (`@vellumai/environments` unresolved in `platform.ts`, unrelated to this change) — CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)