### PR TITLE
refactor(assistant): source interaction telemetry from gateway verdicts and rich reads

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5165,7 +5165,9 @@ paths:
                           - type: number
                           - type: "null"
                       interactionCount:
-                        type: number
+                        anyOf:
+                          - type: number
+                          - type: "null"
                       createdAt:
                         type: number
                       updatedAt:
@@ -5206,7 +5208,9 @@ paths:
                                 - type: number
                                 - type: "null"
                             interactionCount:
-                              type: number
+                              anyOf:
+                                - type: number
+                                - type: "null"
                             lastInteraction:
                               anyOf:
                                 - type: number
@@ -5325,7 +5329,9 @@ paths:
                             - type: number
                             - type: "null"
                         interactionCount:
-                          type: number
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         createdAt:
                           type: number
                         updatedAt:
@@ -5366,7 +5372,9 @@ paths:
                                   - type: number
                                   - type: "null"
                               interactionCount:
-                                type: number
+                                anyOf:
+                                  - type: number
+                                  - type: "null"
                               lastInteraction:
                                 anyOf:
                                   - type: number
@@ -5454,7 +5462,9 @@ paths:
                           - type: number
                           - type: "null"
                       interactionCount:
-                        type: number
+                        anyOf:
+                          - type: number
+                          - type: "null"
                       createdAt:
                         type: number
                       updatedAt:
@@ -5495,7 +5505,9 @@ paths:
                                 - type: number
                                 - type: "null"
                             interactionCount:
-                              type: number
+                              anyOf:
+                                - type: number
+                                - type: "null"
                             lastInteraction:
                               anyOf:
                                 - type: number
@@ -5853,7 +5865,9 @@ paths:
                           - type: number
                           - type: "null"
                       interactionCount:
-                        type: number
+                        anyOf:
+                          - type: number
+                          - type: "null"
                       createdAt:
                         type: number
                       updatedAt:
@@ -5894,7 +5908,9 @@ paths:
                                 - type: number
                                 - type: "null"
                             interactionCount:
-                              type: number
+                              anyOf:
+                                - type: number
+                                - type: "null"
                             lastInteraction:
                               anyOf:
                                 - type: number
@@ -6047,7 +6063,9 @@ paths:
                         - type: number
                         - type: "null"
                     interactionCount:
-                      type: number
+                      anyOf:
+                        - type: number
+                        - type: "null"
                     createdAt:
                       type: number
                     updatedAt:
@@ -6088,7 +6106,9 @@ paths:
                               - type: number
                               - type: "null"
                           interactionCount:
-                            type: number
+                            anyOf:
+                              - type: number
+                              - type: "null"
                           lastInteraction:
                             anyOf:
                               - type: number

--- a/assistant/src/__tests__/contact-store-interaction-info.test.ts
+++ b/assistant/src/__tests__/contact-store-interaction-info.test.ts
@@ -102,7 +102,7 @@ describe("contact interaction INFO aggregation", () => {
     expect(phone?.lastSeenAt).toBe(1850);
   });
 
-  test("findContactInfoById surfaces the real interaction count", () => {
+  test("findContactInfoById returns the notes-only INFO shape (telemetry is gateway-owned)", () => {
     insertContact("ct_2", "Bob");
     insertChannel({
       id: "ch_c",
@@ -114,7 +114,11 @@ describe("contact interaction INFO aggregation", () => {
     });
 
     const info = findContactInfoById("ct_2");
-    expect(info?.interactionCount).toBe(5);
+    // Interaction telemetry is no longer surfaced here — it is gateway-owned
+    // (carried on the trust verdict / gateway rich reads).
+    expect(info).not.toBeNull();
+    expect(Object.keys(info!)).toEqual(["notes"]);
+    expect(info!.notes).toBeNull();
   });
 
   test("lastInteraction is null when no channel has interacted", () => {

--- a/assistant/src/__tests__/contacts-relay-reads.test.ts
+++ b/assistant/src/__tests__/contacts-relay-reads.test.ts
@@ -189,6 +189,30 @@ beforeEach(() => {
   guardianIds = new Set();
 });
 
+/**
+ * Pin the daemon-native gateway boundary: the query/filter is resolved LOCALLY,
+ * so the gateway is NEVER asked to RESOLVE it. The only permitted gateway IPC on
+ * these paths is the telemetry overlay (`hydrateTelemetryFromGateway`), and it
+ * must carry ONLY the already-resolved result-set `ids` — never the
+ * query/contactType/channelType/channelAddress/role/limit filter params. The
+ * exact `toEqual({ ids })` match guarantees no filter key leaked into the relay.
+ */
+function expectOnlyIdsScopedTelemetryHydration(expectedIds: string[]) {
+  expect(ipcCalls.map((c) => c.method)).toEqual(["contacts_list_rich"]);
+  expect(ipcCalls[0]?.params).toEqual({ ids: expectedIds });
+}
+
+/** Telemetry-overlay stub: gateway returns rich telemetry for the ids-scoped
+ * hydration read, keyed to the locally-resolved contact. */
+function telemetryHydrationStub(id: string, interactionCount: number): IpcStub {
+  return (method) => {
+    if (method === "contacts_list_rich") {
+      return { ok: true, contacts: [gatewayContact({ id, interactionCount })] };
+    }
+    return undefined;
+  };
+}
+
 describe("handleListContacts relay", () => {
   test("non-search read serves gateway contacts and does NOT read assistant DB", async () => {
     ipcStub = (method) => {
@@ -239,68 +263,113 @@ describe("handleListContacts relay", () => {
     expect(localCalls).toEqual([]);
   });
 
-  test("search params stay daemon-native and log the boundary note", async () => {
+  test("search params stay daemon-native; query stays local while ids-scoped gateway telemetry is overlaid", async () => {
+    // The query is resolved LOCALLY (searchContacts) and the boundary note is
+    // logged. The gateway is NOT asked to resolve the query — its only call is
+    // the ids-scoped telemetry overlay, which then hydrates interactionCount.
+    ipcStub = telemetryHydrationStub("search-1", 7);
+
     const result = await handleListContacts({ query: "alice" });
 
-    expect(ipcCalls).toEqual([]);
     expect(localCalls).toContain("searchContacts");
+    expectOnlyIdsScopedTelemetryHydration(["search-1"]);
     expect(result.contacts[0].id).toBe("search-1");
+    expect(result.contacts[0].interactionCount).toBe(7);
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
   });
 
-  test("contactType filter stays daemon-native and does NOT relay to the gateway", async () => {
+  test("contactType filter stays daemon-native; filter never relayed, only ids-scoped telemetry overlaid", async () => {
     // If contactType were relayed, the gateway would apply it AFTER its limit
-    // and could under-return. We serve it daemon-native instead (SQL filter
-    // before the limit). Assert no relay, local read, and the boundary note.
+    // and could under-return. We resolve it daemon-native instead (SQL filter
+    // BEFORE the limit). The gateway is consulted ONLY for the ids-scoped
+    // telemetry overlay — never to resolve the contactType filter.
+    ipcStub = telemetryHydrationStub("local-1", 3);
+
     const result = await handleListContacts({
       contactType: "assistant",
       limit: "50",
     });
 
-    expect(ipcCalls).toEqual([]);
     expect(localCalls).toEqual(["listContacts"]);
     // contactType + limit are pushed into the SQL-filtered daemon read (the
     // daemon-native listContacts filters contactType BEFORE applying limit).
     expect(listContactsArgs).toEqual([
       { limit: 50, contactType: "assistant" },
     ]);
+    expectOnlyIdsScopedTelemetryHydration(["local-1"]);
     expect(result.contacts[0].id).toBe("local-1");
     expect(result.contacts[0].contactType).toBe("assistant");
+    expect(result.contacts[0].interactionCount).toBe(3);
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
   });
 
   test("contactType filters daemon-native; role is gateway-owned and no longer a local predicate", async () => {
     await handleListContacts({ contactType: "human", role: "guardian" });
 
-    expect(ipcCalls).toEqual([]);
     expect(listContactsArgs).toEqual([{ limit: 50, contactType: "human" }]);
+    // `role` is neither pushed to the local SQL read NOR relayed to the gateway
+    // as a filter — the sole gateway call is the ids-scoped telemetry overlay.
+    expectOnlyIdsScopedTelemetryHydration(["local-1"]);
   });
 });
 
 describe("search_contacts route relay boundary", () => {
-  test("real query stays daemon-native and logs the boundary note", async () => {
+  test("real query stays daemon-native; query stays local while ids-scoped telemetry is overlaid", async () => {
+    // Query resolved locally; boundary note logged. The gateway is only asked
+    // for the ids-scoped telemetry overlay, never to resolve the query.
+    ipcStub = telemetryHydrationStub("search-1", 5);
+
     const contacts = await searchContactsRoute({ query: "alice" });
 
-    expect(ipcCalls).toEqual([]);
     expect(localCalls).toContain("searchContacts");
+    expectOnlyIdsScopedTelemetryHydration(["search-1"]);
     expect(contacts[0].id).toBe("search-1");
+    expect(
+      (contacts[0] as { interactionCount?: number | null }).interactionCount,
+    ).toBe(5);
     expect(debugLogs.some((m) => m.includes("daemon-native"))).toBe(true);
   });
 
-  test("real channelAddress stays daemon-native", async () => {
+  test("real channelAddress stays daemon-native; filter stays local, only ids-scoped telemetry overlaid", async () => {
+    ipcStub = telemetryHydrationStub("search-1", 5);
+
     const contacts = await searchContactsRoute({ channelAddress: "tg-001" });
 
-    expect(ipcCalls).toEqual([]);
     expect(localCalls).toContain("searchContacts");
+    // channelAddress never reaches the gateway — the sole call carries only ids.
+    expectOnlyIdsScopedTelemetryHydration(["search-1"]);
     expect(contacts[0].id).toBe("search-1");
   });
 
-  test("real channelType stays daemon-native", async () => {
+  test("real channelType stays daemon-native; filter stays local, only ids-scoped telemetry overlaid", async () => {
+    ipcStub = telemetryHydrationStub("search-1", 5);
+
     const contacts = await searchContactsRoute({ channelType: "telegram" });
 
-    expect(ipcCalls).toEqual([]);
     expect(localCalls).toContain("searchContacts");
+    // channelType never reaches the gateway — the sole call carries only ids.
+    expectOnlyIdsScopedTelemetryHydration(["search-1"]);
     expect(contacts[0].id).toBe("search-1");
+  });
+
+  test("telemetry hydration is FAIL-SOFT: a throwing gateway read still returns locally-resolved contacts with null telemetry", async () => {
+    ipcStub = (method) => {
+      if (method === "contacts_list_rich") {
+        throw new Error("gateway telemetry down");
+      }
+      return undefined;
+    };
+
+    const contacts = await searchContactsRoute({ query: "alice" });
+
+    // The query is resolved locally; the throwing telemetry overlay degrades to
+    // null rather than propagating, so the search STILL returns its local result.
+    expect(localCalls).toContain("searchContacts");
+    expectOnlyIdsScopedTelemetryHydration(["search-1"]);
+    expect(contacts[0].id).toBe("search-1");
+    expect(
+      (contacts[0] as { interactionCount?: number | null }).interactionCount,
+    ).toBeNull();
   });
 
   test("empty/whitespace query with no filters relays through the gateway", async () => {

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -33,15 +33,13 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
-// `resolveTurnInboundActorContext` reads INFO (contact notes / interaction
-// count) via a local contactId join. Stub the join so the actor-context tests
-// can stage it without standing up the contacts schema.
+// `resolveTurnInboundActorContext` reads the INFO `notes` field via a local
+// contactId join (interaction count now comes from the gateway verdict). Stub
+// the join so the actor-context tests can stage it without standing up the
+// contacts schema.
 const realContactStoreForAssemblyTest =
   await import("../contacts/contact-store.js");
-let contactInfoById: Record<
-  string,
-  { notes: string | null; interactionCount: number }
-> = {};
+let contactInfoById: Record<string, { notes: string | null }> = {};
 mock.module("../contacts/contact-store.js", () => ({
   ...realContactStoreForAssemblyTest,
   findContactInfoById: (contactId: string) =>
@@ -1592,15 +1590,13 @@ describe("resolveTurnInboundActorContext", () => {
   });
 
   /**
-   * INFO fields (contact notes, interaction count) are joined locally by the
-   * verdict-stamped contact ID, not re-resolved through the ACL store.
+   * The INFO `notes` field is joined locally by the verdict-stamped contact ID,
+   * while the interaction count is gateway-owned and carried on the verdict
+   * (never re-resolved through the ACL store or the local aggregation).
    */
-  test("populates INFO via the local contactId join", () => {
-    // GIVEN a contact whose INFO is available by id
-    contactInfoById["contact-42"] = {
-      notes: "prefers async updates",
-      interactionCount: 7,
-    };
+  test("notes come from the local join; interaction count from the verdict", () => {
+    // GIVEN a contact whose notes are available by id
+    contactInfoById["contact-42"] = { notes: "prefers async updates" };
     const trustContext: TrustContext = {
       sourceChannel: "telegram",
       trustClass: "trusted_contact",
@@ -1609,16 +1605,40 @@ describe("resolveTurnInboundActorContext", () => {
       requesterContactId: "contact-42",
       memberStatus: "active",
       memberPolicy: "allow",
+      // Gateway-owned interaction telemetry, stamped from the trust verdict.
+      requesterInteractionCount: 7,
     };
 
     // WHEN the inbound actor context is resolved
     const actorContext = resolveTurnInboundActorContext(trustContext);
 
-    // THEN INFO comes from the local join and ACL stays verdict-derived
+    // THEN notes come from the local join, the count from the verdict, and ACL
+    // stays verdict-derived
     expect(actorContext?.contactNotes).toBe("prefers async updates");
     expect(actorContext?.contactInteractionCount).toBe(7);
     expect(actorContext?.memberStatus).toBe("active");
     expect(resolveActorTrustCalls).toBe(0);
+  });
+
+  /**
+   * A verdict without member telemetry (unknown sender) leaves the interaction
+   * count undefined rather than reviving a local assistant-DB read.
+   */
+  test("interaction count is undefined when the verdict carries none", () => {
+    contactInfoById["contact-99"] = { notes: "some note" };
+    const trustContext: TrustContext = {
+      sourceChannel: "telegram",
+      trustClass: "trusted_contact",
+      requesterExternalUserId: "tg-999",
+      requesterChatId: "chat-9",
+      requesterContactId: "contact-99",
+      // No requesterInteractionCount stamped.
+    };
+
+    const actorContext = resolveTurnInboundActorContext(trustContext);
+
+    expect(actorContext?.contactNotes).toBe("some note");
+    expect(actorContext?.contactInteractionCount).toBeUndefined();
   });
 });
 

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -174,21 +174,20 @@ export const getContactInternal = getContact;
 /** INFO-only contact fields, joined locally by contact ID. */
 export interface ContactInfo {
   notes: string | null;
-  interactionCount: number;
 }
 
 /**
- * Look up a contact's INFO fields (notes, interaction count) by ID.
+ * Look up a contact's INFO `notes` field by ID.
  *
- * Carries no ACL state (status/policy/verification) — those are owned by the
- * gateway-stamped trust verdict. Returns null when the contact does not exist.
+ * Carries no ACL state (status/policy/verification) or interaction telemetry —
+ * those are owned by the gateway (ACL via the stamped trust verdict, telemetry
+ * via the verdict/rich reads). Returns null when the contact does not exist.
  */
 export function findContactInfoById(contactId: string): ContactInfo | null {
   const contact = getContact(contactId);
   if (!contact) return null;
   return {
     notes: contact.notes,
-    interactionCount: contact.interactionCount,
   };
 }
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -166,9 +166,10 @@ export function inboundActorContextFromTrustContext(
  *
  * Returns `null` when there is no trust context and on guardian (owner) turns —
  * the actor section is suppressed for the owner. ACL fields (trust class,
- * member status/policy, guardian binding) come from the verdict-derived trust
- * context; INFO fields (contact notes, interaction count) are joined locally by
- * contact ID. Derives purely from the passed trust context, so callers
+ * member status/policy, guardian binding) and the gateway-owned interaction
+ * count come from the verdict-derived trust context; the INFO `notes` field is
+ * joined locally by contact ID. Derives purely from the passed trust context,
+ * so callers
  * self-resolve it from the live conversation rather than threading it.
  */
 export function resolveTurnInboundActorContext(
@@ -181,11 +182,13 @@ export function resolveTurnInboundActorContext(
   if (resolved.trustClass === "guardian") {
     return null;
   }
+  // Interaction count is gateway-owned telemetry, carried on the verdict-derived
+  // trust context; notes remain an INFO field joined locally by contact ID.
+  resolved.contactInteractionCount = trustContext.requesterInteractionCount;
   if (trustContext.requesterContactId) {
     const info = findContactInfoById(trustContext.requesterContactId);
     if (info) {
       resolved.contactNotes = info.notes ?? undefined;
-      resolved.contactInteractionCount = info.interactionCount;
     }
   }
   return resolved;

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -44,6 +44,13 @@ export interface TrustContext {
   memberStatus?: string;
   /** Channel policy of the requester's channel (ACL). */
   memberPolicy?: string;
+  /**
+   * Prior-interaction count for the requester's member channel, sourced from
+   * the gateway trust verdict (gateway owns interaction telemetry). Undefined
+   * when the verdict carries no member telemetry (unknown sender) or when trust
+   * was resolved locally without a gateway verdict.
+   */
+  requesterInteractionCount?: number;
 }
 
 /**

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -128,6 +128,43 @@ describe("trustContextFromVerdict", () => {
     expect(result.memberPolicy).toBe("escalate");
   });
 
+  test("carries the verdict's gateway-owned interaction count onto the context", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      status: "active",
+      policy: "allow",
+      interactionCount: 9,
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterInteractionCount).toBe(9);
+  });
+
+  test("leaves interaction count undefined when the verdict carries none", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+
+    const result = trustContextFromVerdict(verdict, {
+      sourceChannel: "slack",
+      conversationExternalId: CONV,
+    });
+
+    expect(result.requesterInteractionCount).toBeUndefined();
+  });
+
   test("memberless verdict leaves ACL member fields undefined", () => {
     const verdict = {
       trustClass: "unknown",

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -304,7 +304,41 @@ describe("contacts read API relays from the gateway", () => {
   });
 });
 
-describe("filtered/native contact reads stay daemon-native", () => {
+// Gateway rich-read for the native contact (ct_2), with telemetry values
+// DISTINCT from the local nativeContact fixture so tests can prove the served
+// telemetry is gateway-sourced (hydrated), not the local aggregation.
+const nativeGatewayRead = {
+  id: "ct_2",
+  displayName: "Bob",
+  role: "contact",
+  notes: null,
+  contactType: "human",
+  lastInteraction: 9200,
+  interactionCount: 11,
+  createdAt: 1000,
+  updatedAt: 1500,
+  channels: [
+    {
+      id: "ch_2",
+      contactId: "ct_2",
+      type: "phone",
+      address: "+15550200",
+      isPrimary: true,
+      externalUserId: null,
+      status: "active",
+      policy: "allow",
+      verifiedAt: null,
+      verifiedVia: null,
+      lastSeenAt: 9100,
+      interactionCount: 11,
+      lastInteraction: 9200,
+      revokedReason: null,
+      blockedReason: null,
+    },
+  ],
+};
+
+describe("filtered/native contact reads: daemon filters, gateway hydrates telemetry", () => {
   const listRoute = ROUTES.find((r) => r.operationId === "listContacts")!;
   const listResponseSchema = listRoute.responseBody as z.ZodTypeAny;
   const searchRoute = ROUTES.find((r) => r.operationId === "search_contacts")!;
@@ -312,7 +346,9 @@ describe("filtered/native contact reads stay daemon-native", () => {
 
   beforeEach(() => {
     ipcCalls = [];
-    ipcResult = {};
+    // Telemetry hydration relays `contacts_list_rich` with an ids filter; return
+    // the gateway rich-read for ct_2 by default so hydration succeeds.
+    ipcResult = { ok: true, contacts: [nativeGatewayRead] };
     ipcError = undefined;
     ipcCallPersistentMock.mockClear();
     contactStoreReadGuard.mockClear();
@@ -322,28 +358,54 @@ describe("filtered/native contact reads stay daemon-native", () => {
     getGuardianContactIdsMock.mockClear();
   });
 
-  test("query-filtered list serves daemon-native INFO and validates against the response schema", async () => {
+  test("query-filtered list hydrates telemetry from the gateway (not local aggregation)", async () => {
     searchContactsResult = [nativeContact];
 
     const result = await handleListContacts({ query: "Bob", limit: "10" });
 
-    // No gateway relay for a true search.
-    expect(ipcCalls).toEqual([]);
+    // Filtering stays daemon-native; telemetry is hydrated via an ids-scoped
+    // gateway rich read.
     expect(searchContactsMock).toHaveBeenCalled();
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { ids: ["ct_2"] } },
+    ]);
 
     const [contact] = result.contacts;
-    // INFO telemetry is present (re-hydrated locally, not dropped).
-    expect(contact.interactionCount).toBe(4);
-    expect(contact.lastInteraction).toBe(4200);
+    // Telemetry comes from the gateway (11/9200/9100), NOT the local fixture
+    // (4/4200/4100).
+    expect(contact.interactionCount).toBe(11);
+    expect(contact.lastInteraction).toBe(9200);
     const channel = contact.channels[0] as Record<string, unknown>;
-    expect(channel.interactionCount).toBe(4);
-    expect(channel.lastSeenAt).toBe(4100);
+    expect(channel.interactionCount).toBe(11);
+    expect(channel.lastSeenAt).toBe(9100);
+    expect(channel.lastInteraction).toBe(9200);
     expect(channel.externalUserId).toBe("+15550200");
     // Non-guardian id derives role "contact" (no name override).
     expect((contact as { role: string }).role).toBe("contact");
     expect(contact.displayName).toBe("Bob");
-    // Channel-level ACL fields (status/policy) are gateway-owned and absent.
+    // Channel-level ACL fields (status/policy) are gateway-owned and absent on
+    // the daemon-native shape.
     expect("status" in channel).toBe(false);
+    expect(() => listResponseSchema.parse(result)).not.toThrow();
+  });
+
+  test("telemetry degrades to null (still validates) when the gateway hydration fails", async () => {
+    searchContactsResult = [nativeContact];
+    ipcError = new IpcCallError("gateway down", {
+      statusCode: 503,
+      errorCode: "UNAVAILABLE",
+    });
+
+    const result = await handleListContacts({ query: "Bob", limit: "10" });
+
+    // Search results are still returned; only telemetry is nulled.
+    const [contact] = result.contacts;
+    expect(contact.interactionCount).toBeNull();
+    expect(contact.lastInteraction).toBeNull();
+    const channel = contact.channels[0] as Record<string, unknown>;
+    expect(channel.interactionCount).toBeNull();
+    expect(channel.lastSeenAt).toBeNull();
+    expect(contact.displayName).toBe("Bob");
     expect(() => listResponseSchema.parse(result)).not.toThrow();
   });
 
@@ -371,15 +433,18 @@ describe("filtered/native contact reads stay daemon-native", () => {
     expect(contact.displayName).toBe("Bob");
   });
 
-  test("POST search with a filter validates against the response schema", async () => {
+  test("POST search with a filter hydrates telemetry and validates against the response schema", async () => {
     searchContactsResult = [nativeContact];
 
     const contacts = (await searchRoute.handler({
       body: { query: "Bob" },
-    })) as unknown[];
+    })) as Array<{ interactionCount: number | null }>;
 
-    expect(ipcCalls).toEqual([]);
     expect(searchContactsMock).toHaveBeenCalled();
+    expect(ipcCalls).toEqual([
+      { method: "contacts_list_rich", params: { ids: ["ct_2"] } },
+    ]);
+    expect(contacts[0].interactionCount).toBe(11);
     expect(() => searchResponseSchema.parse(contacts)).not.toThrow();
   });
 });

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -248,8 +248,8 @@ type ContactWithGatewayTelemetry = Omit<
  * batch-fetch it via `contacts_list_rich` keyed by the filtered id set and
  * overlay it, keeping the local assistant-DB aggregation out of the served
  * payload. Fail-soft: if the gateway read fails or omits a contact, that
- * contact's telemetry degrades to null rather than reviving the local
- * (PR9-slated-for-removal) aggregation.
+ * contact's telemetry degrades to null rather than falling back to the local
+ * assistant-DB aggregation.
  */
 async function hydrateTelemetryFromGateway(
   contacts: ContactWithChannels[],

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -12,6 +12,7 @@ import {
   RedeemInviteByTokenRequestSchema,
   RedeemVoiceInviteRequestSchema,
 } from "@vellumai/gateway-client";
+import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import {
   GetContactIpcResponseSchema,
   ListContactsIpcResponseSchema,
@@ -26,7 +27,12 @@ import {
   searchContacts,
 } from "../../contacts/contact-store.js";
 import { getGuardianContactIds } from "../../contacts/guardian-contact-reader.js";
-import type { ContactRole, ContactType } from "../../contacts/types.js";
+import type {
+  ContactChannel,
+  ContactRole,
+  ContactType,
+  ContactWithChannels,
+} from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { getLogger } from "../../util/logger.js";
@@ -151,9 +157,12 @@ function isContactType(value: string): value is ContactType {
 // (search / contactType) omit them, so they are `.optional()`. Contact-level
 // `role` is gateway-sourced: relayed reads trust the role on the `ContactRead`,
 // while daemon-native reads derive it from the gateway guardian id set at the
-// serve layer (see prepareContactResponse). INFO telemetry
-// (lastSeenAt/interactionCount/lastInteraction) is locally hydrated on every
-// read path and stays required.
+// serve layer (see prepareContactResponse). Interaction telemetry
+// (lastSeenAt/interactionCount/lastInteraction) is gateway-owned: relayed reads
+// carry it directly, and daemon-native reads batch-hydrate it from the gateway
+// (see hydrateTelemetryFromGateway). It degrades to null when the gateway is
+// unreachable or a daemon-found contact is absent from the gateway DB, so
+// `interactionCount` is nullable.
 const contactChannelSchema = z.object({
   id: z.string(),
   contactId: z.string(),
@@ -167,7 +176,7 @@ const contactChannelSchema = z.object({
   verifiedAt: z.number().nullable().optional(),
   verifiedVia: z.string().nullable().optional(),
   lastSeenAt: z.number().nullable(),
-  interactionCount: z.number(),
+  interactionCount: z.number().nullable(),
   lastInteraction: z.number().nullable(),
   revokedReason: z.string().nullable().optional(),
   blockedReason: z.string().nullable().optional(),
@@ -180,7 +189,7 @@ const contactSchema = z.object({
   notes: z.string().nullable().optional(),
   contactType: z.enum(["human", "assistant"]),
   lastInteraction: z.number().nullable().optional(),
-  interactionCount: z.number(),
+  interactionCount: z.number().nullable(),
   createdAt: z.number(),
   updatedAt: z.number(),
   channels: z.array(contactChannelSchema),
@@ -215,6 +224,74 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
   }
 }
 
+/**
+ * A daemon-native contact read whose gateway-owned interaction telemetry has
+ * been overlaid. `interactionCount` widens to nullable (contact + channel level)
+ * because the gateway hydration can fail-soft to null.
+ */
+type ContactWithGatewayTelemetry = Omit<
+  ContactWithChannels,
+  "interactionCount" | "channels"
+> & {
+  interactionCount: number | null;
+  channels: Array<
+    Omit<ContactChannel, "interactionCount"> & { interactionCount: number | null }
+  >;
+};
+
+/**
+ * Overlay gateway-owned interaction telemetry onto daemon-native contact reads
+ * (search / contactType-filtered), which bypass the gateway list relay. The
+ * daemon still owns the FILTERING (gateway-native search/contactType is
+ * design-blocked), but telemetry (contact + channel
+ * interactionCount/lastInteraction, channel lastSeenAt) is gateway-owned — so
+ * batch-fetch it via `contacts_list_rich` keyed by the filtered id set and
+ * overlay it, keeping the local assistant-DB aggregation out of the served
+ * payload. Fail-soft: if the gateway read fails or omits a contact, that
+ * contact's telemetry degrades to null rather than reviving the local
+ * (PR9-slated-for-removal) aggregation.
+ */
+async function hydrateTelemetryFromGateway(
+  contacts: ContactWithChannels[],
+): Promise<ContactWithGatewayTelemetry[]> {
+  if (contacts.length === 0) return [];
+
+  const gatewayById = new Map<string, ContactRead>();
+  try {
+    const result = await ipcCallPersistent("contacts_list_rich", {
+      ids: contacts.map((c) => c.id),
+    });
+    const { contacts: rich } = ListContactsIpcResponseSchema.parse(result);
+    for (const c of rich) gatewayById.set(c.id, c);
+  } catch (err) {
+    log.warn(
+      { err },
+      "hydrateTelemetryFromGateway: gateway telemetry read failed; serving null telemetry",
+    );
+  }
+
+  return contacts.map((c) => {
+    const gw = gatewayById.get(c.id);
+    const gwChannelById = new Map(
+      (gw?.channels ?? []).map((ch) => [ch.id, ch]),
+    );
+    return {
+      ...c,
+      interactionCount: gw?.interactionCount ?? null,
+      lastInteraction: gw?.lastInteraction ?? null,
+      channels: c.channels.map((ch) => {
+        const gwCh = gwChannelById.get(ch.id);
+        return {
+          ...ch,
+          lastSeenAt: gwCh?.lastSeenAt ?? null,
+          interactionCount: gwCh?.interactionCount ?? null,
+          lastInteraction: gwCh?.lastInteraction ?? null,
+        };
+      }),
+    };
+  });
+}
+
 export async function handleListContacts(queryParams: Record<string, string>) {
   const limit = Number(queryParams.limit ?? 50);
   const role = (queryParams.role as ContactRole) || undefined;
@@ -238,15 +315,20 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     log.debug(
       "handleListContacts: search served daemon-native (gateway-native search is design-blocked)",
     );
-    const contacts = searchContacts({
-      query,
-      channelAddress,
-      channelType,
-      contactType,
-      limit,
-    });
-    // Daemon-native read: role is the neutral default, so derive it.
-    const guardianIds = await getGuardianContactIds();
+    // Telemetry hydration and the guardian-id read (for role derivation) both
+    // hit the gateway and are independent — run them concurrently.
+    const [contacts, guardianIds] = await Promise.all([
+      hydrateTelemetryFromGateway(
+        searchContacts({
+          query,
+          channelAddress,
+          channelType,
+          contactType,
+          limit,
+        }),
+      ),
+      getGuardianContactIds(),
+    ]);
     return {
       ok: true,
       contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
@@ -261,9 +343,12 @@ export async function handleListContacts(queryParams: Record<string, string>) {
     log.debug(
       "handleListContacts: contactType-filtered read served daemon-native (gateway-native contactType filtering is design-blocked, pending ACL classification)",
     );
-    const contacts = listContacts(limit, contactType);
-    // Daemon-native read: role is the neutral default, so derive it.
-    const guardianIds = await getGuardianContactIds();
+    // Telemetry hydration and the guardian-id read (for role derivation) both
+    // hit the gateway and are independent — run them concurrently.
+    const [contacts, guardianIds] = await Promise.all([
+      hydrateTelemetryFromGateway(listContacts(limit, contactType)),
+      getGuardianContactIds(),
+    ]);
     return {
       ok: true,
       contacts: contacts.map((c) => prepareContactResponse(c, guardianIds)),
@@ -770,11 +855,13 @@ export const ROUTES: RouteDefinition[] = [
       log.debug(
         "search_contacts: search served daemon-native (gateway-native search is design-blocked)",
       );
-      // Daemon-native read: role is the neutral default, so derive it.
-      const guardianIds = await getGuardianContactIds();
-      return searchContacts(parsed).map((c) =>
-        prepareContactResponse(c, guardianIds),
-      );
+      // Telemetry hydration and the guardian-id read (for role derivation) both
+      // hit the gateway and are independent — run them concurrently.
+      const [contacts, guardianIds] = await Promise.all([
+        hydrateTelemetryFromGateway(searchContacts(parsed)),
+        getGuardianContactIds(),
+      ]);
+      return contacts.map((c) => prepareContactResponse(c, guardianIds));
     },
   },
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -105,6 +105,13 @@ export function trustContextFromVerdict(
     context.memberPolicy = member.policy;
   }
 
+  // Interaction telemetry is gateway-owned: carry the verdict's count straight
+  // through so turn assembly reads it from the verdict rather than the local
+  // assistant DB.
+  if (verdict.interactionCount !== undefined) {
+    context.requesterInteractionCount = verdict.interactionCount;
+  }
+
   return context;
 }
 

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -315,6 +315,50 @@ describe("ContactStore.listContactsRich", () => {
     expect(result).toEqual([]);
   });
 
+  test("ids filter restricts to the given contact ids, bypassing role/limit", async () => {
+    for (const id of ["a", "b", "c"]) {
+      seedGatewayContact({ id, role: "contact" });
+      seedGatewayChannel({
+        id: `ch-${id}`,
+        contactId: id,
+        interactionCount: id === "b" ? 5 : 1,
+        lastInteraction: id === "b" ? 42 : null,
+      });
+      seedAssistantInfo({ id, contactType: "human" });
+    }
+
+    const result = await new ContactStore().listContactsRich({
+      ids: ["b", "c"],
+      // role/limit are ignored when ids is present.
+      role: "guardian",
+      limit: 1,
+    });
+
+    expect(result.map((c) => c.id).sort()).toEqual(["b", "c"]);
+    const b = result.find((c) => c.id === "b")!;
+    expect(b.interactionCount).toBe(5);
+    expect(b.lastInteraction).toBe(42);
+  });
+
+  test("ids filter returns empty for an empty id set", async () => {
+    seedGatewayContact({ id: "a" });
+    seedAssistantInfo({ id: "a", contactType: "human" });
+    const result = await new ContactStore().listContactsRich({ ids: [] });
+    expect(result).toEqual([]);
+  });
+
+  test("ids filter dedupes and ignores unknown ids", async () => {
+    seedGatewayContact({ id: "a" });
+    seedGatewayChannel({ id: "ch-a", contactId: "a", interactionCount: 2 });
+    seedAssistantInfo({ id: "a", contactType: "human" });
+
+    const result = await new ContactStore().listContactsRich({
+      ids: ["a", "a", "ghost"],
+    });
+    expect(result.map((c) => c.id)).toEqual(["a"]);
+    expect(result[0].interactionCount).toBe(2);
+  });
+
   test("primary channel appears first regardless of creation order", async () => {
     seedGatewayContact({ id: "c1" });
     seedGatewayChannel({ id: "ch-old", contactId: "c1", createdAt: 100 });

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -149,28 +149,38 @@ export class ContactStore {
   async listContactsWithInfo(opts?: {
     limit?: number;
     role?: string;
+    ids?: string[];
   }): Promise<ContactWithInfo[]> {
-    const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
-    const conditions = [];
-    if (opts?.role) conditions.push(eq(contacts.role, opts.role));
+    // Explicit id set: the caller has already selected/filtered the contacts
+    // (e.g. daemon-native search) and only needs the gateway-owned shape for
+    // them. Skip the role/limit query entirely — the ids ARE the filter.
+    let contactIds: string[];
+    if (opts?.ids) {
+      contactIds = [...new Set(opts.ids)].slice(0, 200);
+      if (contactIds.length === 0) return [];
+    } else {
+      const effectiveLimit = Math.min(opts?.limit ?? 50, 200);
+      const conditions = [];
+      if (opts?.role) conditions.push(eq(contacts.role, opts.role));
 
-    // Step 1: Select contact IDs with the limit applied to CONTACTS (not
-    // joined channel rows). The daemon path limits contact rows before
-    // fetching channels — we match that to avoid returning fewer contacts
-    // than expected when contacts have multiple channels.
-    const contactRows = this.db
-      .select({ id: contacts.id })
-      .from(contacts)
-      .where(conditions.length === 1 ? conditions[0] : undefined)
-      .orderBy(
-        sql`${contacts.role} = 'guardian' DESC`,
-        desc(contacts.updatedAt),
-      )
-      .limit(effectiveLimit)
-      .all();
+      // Step 1: Select contact IDs with the limit applied to CONTACTS (not
+      // joined channel rows). The daemon path limits contact rows before
+      // fetching channels — we match that to avoid returning fewer contacts
+      // than expected when contacts have multiple channels.
+      const contactRows = this.db
+        .select({ id: contacts.id })
+        .from(contacts)
+        .where(conditions.length === 1 ? conditions[0] : undefined)
+        .orderBy(
+          sql`${contacts.role} = 'guardian' DESC`,
+          desc(contacts.updatedAt),
+        )
+        .limit(effectiveLimit)
+        .all();
 
-    if (contactRows.length === 0) return [];
-    const contactIds = contactRows.map((r) => r.id);
+      if (contactRows.length === 0) return [];
+      contactIds = contactRows.map((r) => r.id);
+    }
 
     // Step 2: Fetch contacts + their channels (no limit — all channels for
     // the selected contacts).
@@ -293,10 +303,12 @@ export class ContactStore {
    * channels joined to assistant-DB info fields.
    *
    * Filters: `role` (gateway DB), `limit` (default 50, capped 200 to mirror
-   * the daemon's listContacts). The daemon serves contactType-filtered list
-   * reads natively (filtering in SQL before the limit) so a tight limit doesn't
-   * under-return and an assistant-DB outage degrades rather than dropping every
-   * row — the relay never carries a contactType filter.
+   * the daemon's listContacts), or an explicit `ids` set (the daemon's telemetry
+   * hydration for its native search/contactType reads — bypasses role/limit).
+   * The daemon serves contactType-filtered list reads natively (filtering in SQL
+   * before the limit) so a tight limit doesn't under-return and an assistant-DB
+   * outage degrades rather than dropping every row — the relay never carries a
+   * contactType filter.
    *
    * Thin adapter over `listContactsWithInfo` (shared assembly/soft-fail logic),
    * projected down to the ContactRead subset.
@@ -307,10 +319,12 @@ export class ContactStore {
   async listContactsRich(opts?: {
     limit?: number;
     role?: string;
+    ids?: string[];
   }): Promise<ContactRead[]> {
     const withInfo = await this.listContactsWithInfo({
       limit: opts?.limit,
       role: opts?.role,
+      ids: opts?.ids,
     });
     return withInfo.map((c) => this.toContactRead(c));
   }

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -259,6 +259,11 @@ export const ListContactsIpcParamsSchema = z
   .object({
     limit: z.number().optional(),
     role: z.string().optional(),
+    // Restrict the read to these contact ids (any order). Used by the daemon to
+    // batch-hydrate gateway-owned telemetry onto daemon-native filtered/search
+    // results without re-implementing search in the gateway. When present,
+    // `role`/`limit` filtering is bypassed — the id set is the filter.
+    ids: z.array(z.string()).optional(),
   })
   .strict()
   .default({});


### PR DESCRIPTION
## Summary
- Daemon sources interactionCount/lastInteraction from the gateway trust verdict and gateway rich-reads instead of the local assistant DB.
- Turn context: `resolveTurnInboundActorContext` now reads the interaction count from the verdict-stamped trust context (`requesterInteractionCount`); `notes` still comes from the local INFO join. `findContactInfoById`/`ContactInfo` no longer surface interaction telemetry.
- Relayed list/get already trust gateway rich-read telemetry (no assistant-DB re-hydration); response telemetry fields are now nullable so daemon-native paths can degrade.
- Daemon-native search / contactType reads (gateway-native search is design-blocked) now batch-hydrate gateway-owned telemetry via a new optional `ids` filter on `contacts_list_rich` (option a). Chosen because a real consumer — the `contact_search` tool (assistant/src/config/bundled-skills/contacts/tools/contact-search.ts) — displays `interactionCount`; dropping it to null would degrade assistant-facing output. Fail-soft: telemetry degrades to null if the gateway read fails or a contact is absent from the gateway DB.
- The local `withChannels` interactionCount aggregation is retained (its removal is PR 9); this PR only stops CONSUMING it on the turn-context and list/get/search paths. The merge route is intentionally left on local telemetry (out of scope; PR 9 forces the change).
- Regenerated assistant/openapi.yaml (interactionCount widened to nullable on the contact routes).

Part of plan: contacts-acl-cleanup.md (PR 7 of 14)