### PR TITLE
feat(calls): implement name-capture, guardian-wait, and unverified-caller in call-setup-flow

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-invite.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-invite.test.ts
@@ -538,5 +538,32 @@ describe("CallSetupFlow invite redemption", () => {
       expect(result.trustContext.trustClass).toBe("unknown");
       expect(result.trustContext.requesterChatId).toBe(CALLER_NUMBER);
     });
+
+    test("dispose during re-resolution suppresses the handoff on the dead call", async () => {
+      let releaseTrust!: (ctx: TrustContext) => void;
+      const gated = new Promise<TrustContext>((resolve) => {
+        releaseTrust = resolve;
+      });
+      const { flow, spoken, events, notifierCalls, results } = createHarness({
+        resolveMidCallTrustContext: () => gated,
+      });
+
+      await flow.start(inviteOutcome("Alice"), makeResolved(true));
+      for (const digit of CODE) {
+        flow.pushDtmfDigit(digit);
+      }
+      await settle();
+
+      // Caller hangs up while trust re-resolution is still in flight.
+      flow.dispose("transport_closed");
+      releaseTrust(UPGRADED_TRUST);
+      await settle();
+
+      // Only the invite prompt was spoken — no synthetic handoff.
+      expect(spoken).toHaveLength(1);
+      expect(events.map((e) => e.eventType)).not.toContain("assistant_spoke");
+      expect(notifierCalls).toEqual([]);
+      expect(results).toHaveLength(0);
+    });
   });
 });

--- a/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
@@ -1,0 +1,725 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CallSetupFlow,
+  type CallSetupFlowDeps,
+  type GuardianWaitHandle,
+} from "../calls/call-setup-flow.js";
+import type {
+  SetupFlowResult,
+  SetupFlowTransport,
+} from "../calls/call-setup-flow-types.js";
+import type {
+  GuardianWaitControllerDeps,
+  GuardianWaitDisposeReason,
+  GuardianWaitStartParams,
+} from "../calls/guardian-wait-controller.js";
+import type {
+  SetupOutcome,
+  SetupResolved,
+} from "../calls/relay-setup-router.js";
+import type { CallSession } from "../calls/types.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { TrustClass } from "../runtime/trust-class.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CALL_SESSION_ID = "call-session-1";
+const PHONE_NUMBER = "+15555550100";
+const TO_NUMBER = "+15555550101";
+const REQUEST_ID = "canonical-req-1";
+const CALLER_NAME = "John Smith";
+
+const UPGRADED_TRUST: TrustContext = {
+  sourceChannel: "phone",
+  trustClass: "trusted_contact",
+  requesterChatId: PHONE_NUMBER,
+};
+
+const nameCaptureOutcome: SetupOutcome = {
+  action: "name_capture",
+  assistantId: "self",
+  fromNumber: PHONE_NUMBER,
+};
+
+function unverifiedOutcome(isGuardian: boolean): SetupOutcome {
+  return {
+    action: "unverified_caller",
+    assistantId: "self",
+    fromNumber: PHONE_NUMBER,
+    displayName: "Sam Example",
+    isGuardian,
+  };
+}
+
+function makeResolved(trustClass: TrustClass = "unknown"): SetupResolved {
+  return {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: PHONE_NUMBER,
+    actorTrust: {
+      canonicalSenderId: PHONE_NUMBER,
+      guardianBindingMatch: null,
+      memberRecord: null,
+      trustClass,
+      actorMetadata: {
+        identifier: PHONE_NUMBER,
+        displayName: undefined,
+        senderDisplayName: undefined,
+        memberDisplayName: undefined,
+        username: undefined,
+        channel: "phone",
+        trustStatus: trustClass,
+      },
+    },
+  };
+}
+
+function makeSession(overrides?: Partial<CallSession>): CallSession {
+  return {
+    id: CALL_SESSION_ID,
+    conversationId: "conv-1",
+    provider: "twilio",
+    providerCallSid: null,
+    fromNumber: PHONE_NUMBER,
+    toNumber: TO_NUMBER,
+    task: null,
+    status: "in_progress",
+    callMode: null,
+    verificationSessionId: null,
+    inviteFriendName: null,
+    inviteGuardianName: null,
+    callerIdentityMode: null,
+    callerIdentitySource: null,
+    skipDisclosure: false,
+    initiatedFromConversationId: null,
+    startedAt: null,
+    endedAt: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+/** Fake wait controller capturing the flow's wiring for the tests to drive. */
+class FakeGuardianWait implements GuardianWaitHandle {
+  startParams: GuardianWaitStartParams | null = null;
+  transcripts: string[] = [];
+  disposeReasons: GuardianWaitDisposeReason[] = [];
+
+  constructor(readonly deps: GuardianWaitControllerDeps) {}
+
+  start(params: GuardianWaitStartParams): void {
+    this.startParams = params;
+  }
+
+  handleTranscript(text: string): void {
+    this.transcripts.push(text);
+  }
+
+  getState() {
+    return this.startParams
+      ? ("awaiting_guardian_decision" as const)
+      : ("idle" as const);
+  }
+
+  dispose(reason: GuardianWaitDisposeReason = "teardown"): void {
+    this.disposeReasons.push(reason);
+  }
+}
+
+type NotifyParams = Parameters<
+  NonNullable<CallSetupFlowDeps["notifyGuardianOfAccessRequest"]>
+>[0];
+type NotifyResult = Awaited<
+  ReturnType<NonNullable<CallSetupFlowDeps["notifyGuardianOfAccessRequest"]>>
+>;
+
+function createFlow(opts?: {
+  deps?: Partial<CallSetupFlowDeps>;
+  notifyResult?: NotifyResult | Error;
+}) {
+  const endReasons: Array<string | undefined> = [];
+  const transport: SetupFlowTransport = {
+    sendTextToken: () => {},
+    sendPlayUrl: () => {},
+    endSession: (reason) => {
+      endReasons.push(reason);
+    },
+    getConnectionState: () => "connected",
+  };
+
+  const spoken: string[] = [];
+  const sessionUpdates: Array<Record<string, unknown>> = [];
+  const events: Array<{
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }> = [];
+  const results: SetupFlowResult[] = [];
+  const notifyCalls: NotifyParams[] = [];
+  const notified: Array<{
+    conversationId: string;
+    callSessionId: string;
+    speaker: string;
+    text: string;
+  }> = [];
+  const trustResolutions: Array<{ assistantId: string; fromNumber: string }> =
+    [];
+  const finalized: Array<{ callSessionId: string; conversationId: string }> =
+    [];
+  const waits: FakeGuardianWait[] = [];
+
+  const session = makeSession();
+  const notifyResult: NotifyResult | Error = opts?.notifyResult ?? {
+    notified: true,
+    created: true,
+    requestId: REQUEST_ID,
+  };
+
+  const deps: CallSetupFlowDeps = {
+    speakSystemPrompt: async (_transport, text) => {
+      spoken.push(text);
+    },
+    updateCallSession: (_id, updates) => {
+      sessionUpdates.push(updates as Record<string, unknown>);
+    },
+    recordCallEvent: (_callSessionId, eventType, payload) => {
+      events.push({ eventType, payload });
+    },
+    onComplete: (result) => {
+      results.push(result);
+    },
+    ttsPlaybackDelayMs: 0,
+    getCallSession: () => session,
+    finalizeCall: (callSessionId, conversationId) => {
+      finalized.push({ callSessionId, conversationId });
+    },
+    fireCallTranscriptNotifier: (
+      conversationId,
+      callSessionId,
+      speaker,
+      text,
+    ) => {
+      notified.push({ conversationId, callSessionId, speaker, text });
+    },
+    resolveGuardianLabel: () => "Alex",
+    resolveAssistantLabel: () => "Aria",
+    notifyGuardianOfAccessRequest: async (params) => {
+      notifyCalls.push(params);
+      if (notifyResult instanceof Error) {
+        throw notifyResult;
+      }
+      return notifyResult;
+    },
+    createGuardianWaitController: (_callSessionId, _transport, waitDeps) => {
+      const wait = new FakeGuardianWait(waitDeps);
+      waits.push(wait);
+      return wait;
+    },
+    resolveMidCallTrustContext: async (assistantId, fromNumber) => {
+      trustResolutions.push({ assistantId, fromNumber });
+      return UPGRADED_TRUST;
+    },
+    nameCaptureTimeoutMs: 10_000,
+    ...opts?.deps,
+  };
+
+  const flow = new CallSetupFlow(CALL_SESSION_ID, transport, deps);
+  return {
+    flow,
+    endReasons,
+    spoken,
+    sessionUpdates,
+    events,
+    results,
+    notifyCalls,
+    notified,
+    trustResolutions,
+    finalized,
+    waits,
+  };
+}
+
+const sleep = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Start name capture and speak the caller's name, returning the fake wait. */
+async function startWait(f: ReturnType<typeof createFlow>) {
+  await f.flow.start(nameCaptureOutcome, makeResolved());
+  f.flow.pushTranscriptFinal(CALLER_NAME);
+  await sleep();
+  const wait = f.waits[0];
+  if (!wait) {
+    throw new Error("expected a guardian wait controller to be created");
+  }
+  return wait;
+}
+
+function eventTypes(events: Array<{ eventType: string }>): string[] {
+  return events.map((e) => e.eventType);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CallSetupFlow name capture", () => {
+  test("start records the started event, speaks the intro greeting, and captures the name", async () => {
+    const f = createFlow();
+
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    expect(f.flow.getState()).toBe("capturing_name");
+    expect(f.events).toEqual([
+      {
+        eventType: "inbound_acl_name_capture_started",
+        payload: { from: PHONE_NUMBER, trustClass: "unknown" },
+      },
+    ]);
+    expect(f.spoken).toEqual([
+      "Hi, this is Aria, Alex's assistant. Sorry, I don't recognize this number. I'll let Alex know you called and see if I have permission to speak with you. Can I get your name?",
+    ]);
+  });
+
+  test("intro greeting omits the assistant name when unavailable", async () => {
+    const f = createFlow({ deps: { resolveAssistantLabel: () => null } });
+
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    expect(f.spoken).toEqual([
+      "Hi, this is Alex's assistant. Sorry, I don't recognize this number. I'll let Alex know you called and see if I have permission to speak with you. Can I get your name?",
+    ]);
+  });
+
+  test("blank transcripts and DTMF are ignored while capturing the name", async () => {
+    const f = createFlow();
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    f.flow.pushTranscriptFinal("   ");
+    for (const digit of "123456") {
+      f.flow.pushDtmfDigit(digit);
+    }
+    await sleep();
+
+    expect(f.notifyCalls).toHaveLength(0);
+    expect(f.flow.getState()).toBe("capturing_name");
+  });
+
+  test("the caller's name creates the access request and hands off to the wait controller", async () => {
+    const f = createFlow();
+
+    const wait = await startWait(f);
+
+    expect(eventTypes(f.events)).toEqual([
+      "inbound_acl_name_capture_started",
+      "inbound_acl_name_captured",
+    ]);
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_name_captured")
+        ?.payload,
+    ).toEqual({ from: PHONE_NUMBER, callerName: CALLER_NAME });
+    expect(f.notifyCalls).toEqual([
+      {
+        canonicalAssistantId: "self",
+        sourceChannel: "phone",
+        conversationExternalId: PHONE_NUMBER,
+        actorExternalId: PHONE_NUMBER,
+        actorDisplayName: CALLER_NAME,
+      },
+    ]);
+    expect(wait.startParams).toEqual({
+      requestId: REQUEST_ID,
+      assistantId: "self",
+      fromNumber: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+    });
+    expect(f.flow.getState()).toBe("awaiting_guardian_decision");
+  });
+
+  test("wait-state utterances are routed to the controller", async () => {
+    const f = createFlow();
+    const wait = await startWait(f);
+
+    f.flow.pushTranscriptFinal("hello are you still there");
+    f.flow.pushTranscriptFinal("yes call me back please");
+
+    expect(wait.transcripts).toEqual([
+      "hello are you still there",
+      "yes call me back please",
+    ]);
+    // Wait-state DTMF stays ignored.
+    f.flow.pushDtmfDigit("5");
+    expect(f.results).toHaveLength(0);
+  });
+
+  test("approval runs the activation continuation and completes with proceed-handoff-spoken", async () => {
+    const f = createFlow();
+    const wait = await startWait(f);
+
+    await wait.deps.onApproved({
+      requestId: REQUEST_ID,
+      assistantId: "self",
+      fromNumber: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+      callbackOptIn: false,
+    });
+
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_approved")
+        ?.payload,
+    ).toEqual({
+      from: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+      requestId: REQUEST_ID,
+    });
+    expect(f.trustResolutions).toEqual([
+      { assistantId: "self", fromNumber: PHONE_NUMBER },
+    ]);
+    expect(f.sessionUpdates).toContainEqual({ status: "in_progress" });
+
+    const handoff = "Great! Alex said I can speak with you. How can I help?";
+    expect(f.spoken).toContain(handoff);
+    expect(
+      f.events.find((e) => e.eventType === "assistant_spoke")?.payload,
+    ).toEqual({ text: handoff });
+    expect(f.notified).toEqual([
+      {
+        conversationId: "conv-1",
+        callSessionId: CALL_SESSION_ID,
+        speaker: "assistant",
+        text: handoff,
+      },
+    ]);
+    expect(eventTypes(f.events)).toContain(
+      "inbound_acl_post_approval_handoff_spoken",
+    );
+    expect(f.results).toEqual([
+      {
+        kind: "proceed-handoff-spoken",
+        assistantId: "self",
+        trustContext: UPGRADED_TRUST,
+        deferredTranscripts: undefined,
+      },
+    ]);
+    expect(f.flow.hasFinalized()).toBe(false);
+  });
+
+  test("denial speaks the goodbye copy, fails the session, and ends", async () => {
+    const f = createFlow();
+    const wait = await startWait(f);
+
+    await wait.deps.onDenied({
+      requestId: REQUEST_ID,
+      assistantId: "self",
+      fromNumber: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+      callbackOptIn: false,
+    });
+
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_denied")
+        ?.payload,
+    ).toEqual({ from: PHONE_NUMBER, requestId: REQUEST_ID });
+    expect(f.sessionUpdates.at(-1)).toMatchObject({
+      status: "failed",
+      lastError: "Inbound voice ACL: guardian denied access request",
+    });
+    expect(f.spoken).toContain(
+      "Sorry, Alex says I'm not allowed to speak with you. Goodbye.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request denied" },
+    ]);
+    await sleep();
+    expect(f.endReasons).toEqual(["Access request denied"]);
+  });
+
+  test("timeout without callback opt-in speaks the base copy and ends", async () => {
+    const f = createFlow();
+    const wait = await startWait(f);
+
+    await wait.deps.onTimeout({
+      requestId: REQUEST_ID,
+      assistantId: "self",
+      fromNumber: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+      callbackOptIn: false,
+    });
+
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_timeout")
+        ?.payload,
+    ).toEqual({
+      from: PHONE_NUMBER,
+      requestId: REQUEST_ID,
+      callbackOptIn: false,
+    });
+    expect(f.sessionUpdates.at(-1)).toMatchObject({
+      status: "failed",
+      lastError: "Inbound voice ACL: guardian approval wait timed out",
+    });
+    expect(f.spoken).toContain(
+      "Sorry, I can't get ahold of Alex right now. I'll let them know you called.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request timed out" },
+    ]);
+    await sleep();
+    expect(f.endReasons).toEqual(["Access request timed out"]);
+  });
+
+  test("timeout with callback opt-in appends the callback note", async () => {
+    const f = createFlow();
+    const wait = await startWait(f);
+
+    await wait.deps.onTimeout({
+      requestId: REQUEST_ID,
+      assistantId: "self",
+      fromNumber: PHONE_NUMBER,
+      callerName: CALLER_NAME,
+      callbackOptIn: true,
+    });
+
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_timeout")
+        ?.payload,
+    ).toMatchObject({ callbackOptIn: true });
+    expect(f.spoken).toContain(
+      "Sorry, I can't get ahold of Alex right now. I'll let them know you called. I've noted that you'd like a callback — I'll pass that along to Alex.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request timed out" },
+    ]);
+  });
+
+  test("name-capture timeout fails the session, speaks the timeout copy, and ends", async () => {
+    const f = createFlow({ deps: { nameCaptureTimeoutMs: 5 } });
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    await sleep(15);
+
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_name_capture_timeout")
+        ?.payload,
+    ).toEqual({ from: PHONE_NUMBER });
+    expect(f.sessionUpdates.at(-1)).toMatchObject({
+      status: "failed",
+      lastError: "Inbound voice ACL: name capture timed out",
+    });
+    expect(f.spoken).toContain(
+      "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Name capture timed out" },
+    ]);
+    await sleep();
+    expect(f.endReasons).toEqual(["Name capture timed out"]);
+  });
+
+  test("a name arriving after capture completes does not double-handle", async () => {
+    const f = createFlow({ deps: { nameCaptureTimeoutMs: 5 } });
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+    await sleep(15);
+    expect(f.results).toHaveLength(1);
+
+    f.flow.pushTranscriptFinal(CALLER_NAME);
+    await sleep();
+
+    expect(f.notifyCalls).toHaveLength(0);
+    expect(f.results).toHaveLength(1);
+  });
+
+  test("access-request creation failure fails closed to the timeout copy", async () => {
+    const f = createFlow({ notifyResult: new Error("gateway down") });
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    f.flow.pushTranscriptFinal(CALLER_NAME);
+    await sleep();
+
+    expect(f.waits).toHaveLength(0);
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_timeout")
+        ?.payload,
+    ).toEqual({ from: PHONE_NUMBER, requestId: null, callbackOptIn: false });
+    expect(f.spoken).toContain(
+      "Sorry, I can't get ahold of Alex right now. I'll let them know you called.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request timed out" },
+    ]);
+  });
+
+  test("a notified:false result (no sender id) also fails closed", async () => {
+    const f = createFlow({
+      notifyResult: { notified: false, reason: "no_sender_id" },
+    });
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    f.flow.pushTranscriptFinal(CALLER_NAME);
+    await sleep();
+
+    expect(f.waits).toHaveLength(0);
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request timed out" },
+    ]);
+  });
+
+  test("a previously denied caller gets the denial copy, not the timeout copy", async () => {
+    const f = createFlow({
+      notifyResult: { notified: false, reason: "already_denied" },
+    });
+    await f.flow.start(nameCaptureOutcome, makeResolved());
+
+    f.flow.pushTranscriptFinal(CALLER_NAME);
+    await sleep();
+
+    expect(f.waits).toHaveLength(0);
+    expect(
+      f.events.find((e) => e.eventType === "inbound_acl_access_denied")
+        ?.payload,
+    ).toEqual({ from: PHONE_NUMBER, requestId: null });
+    expect(f.spoken).toContain(
+      "Sorry, Alex says I'm not allowed to speak with you. Goodbye.",
+    );
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Access request denied" },
+    ]);
+  });
+
+  describe("dispose", () => {
+    test("disconnect mid-wait disposes the controller and never emits a result", async () => {
+      const f = createFlow();
+      const wait = await startWait(f);
+
+      f.flow.dispose("transport_closed");
+
+      expect(wait.disposeReasons).toEqual(["transport_closed"]);
+      expect(f.flow.getState()).toBe("completed");
+      expect(f.flow.hasFinalized()).toBe(false);
+      expect(f.results).toHaveLength(0);
+
+      // Idempotent, and late input is swallowed.
+      f.flow.dispose("transport_closed");
+      f.flow.pushTranscriptFinal("hello?");
+      expect(wait.disposeReasons).toEqual(["transport_closed"]);
+      expect(wait.transcripts).toEqual([]);
+    });
+
+    test("disconnect mid-capture clears the name-capture timer", async () => {
+      const f = createFlow({ deps: { nameCaptureTimeoutMs: 5 } });
+      await f.flow.start(nameCaptureOutcome, makeResolved());
+
+      f.flow.dispose("transport_closed");
+      await sleep(15);
+
+      // No timeout copy, no terminal result, no session teardown after dispose.
+      expect(
+        eventTypes(f.events).includes("inbound_acl_name_capture_timeout"),
+      ).toBe(false);
+      expect(f.results).toHaveLength(0);
+      expect(f.endReasons).toEqual([]);
+    });
+
+    test("dispose during access-request creation suppresses the fail-closed teardown", async () => {
+      let releaseNotify!: (result: NotifyResult) => void;
+      const gated = new Promise<NotifyResult>((resolve) => {
+        releaseNotify = resolve;
+      });
+      const f = createFlow({
+        deps: { notifyGuardianOfAccessRequest: () => gated },
+      });
+      await f.flow.start(nameCaptureOutcome, makeResolved());
+      f.flow.pushTranscriptFinal(CALLER_NAME);
+      await sleep();
+
+      f.flow.dispose("transport_closed");
+      releaseNotify({ notified: true, created: true, requestId: REQUEST_ID });
+      await sleep();
+
+      expect(f.waits).toHaveLength(0);
+      expect(f.results).toHaveLength(0);
+    });
+
+    test("hasFinalized reports flow-side finalization so the close handler can skip", async () => {
+      // Drive a sub-flow that finalizes inside the flow (invite failure).
+      const f = createFlow({
+        deps: {
+          attemptInviteCodeRedemption: async () => ({
+            outcome: "failure" as const,
+            ttsMessage: "That code is not valid. Goodbye.",
+          }),
+        },
+      });
+      await f.flow.start(
+        {
+          action: "invite_redemption",
+          assistantId: "self",
+          fromNumber: PHONE_NUMBER,
+          inviteeName: null,
+        },
+        makeResolved(),
+      );
+      for (const digit of "123456") {
+        f.flow.pushDtmfDigit(digit);
+      }
+      await sleep();
+
+      expect(f.finalized).toEqual([
+        { callSessionId: CALL_SESSION_ID, conversationId: "conv-1" },
+      ]);
+      expect(f.flow.hasFinalized()).toBe(true);
+
+      // A transport close after the flow finalized must not finalize again.
+      f.flow.dispose("transport_closed");
+      expect(f.finalized).toHaveLength(1);
+    });
+  });
+});
+
+describe("CallSetupFlow unverified caller", () => {
+  test("guardian variant speaks the self-service verification guidance and ends", async () => {
+    const f = createFlow();
+
+    await f.flow.start(unverifiedOutcome(true), makeResolved());
+
+    expect(f.events).toEqual([
+      {
+        eventType: "inbound_acl_unverified_caller",
+        payload: { callSessionId: CALL_SESSION_ID, isGuardian: true },
+      },
+    ]);
+    expect(f.sessionUpdates.at(-1)).toMatchObject({
+      status: "failed",
+      lastError: "Inbound voice ACL: caller channel unverified",
+    });
+    expect(f.spoken).toEqual([
+      "This number is registered as Sam Example's phone but has not been verified yet. " +
+        "To verify, open your assistant's contacts page, click Verify next to the phone channel, " +
+        "and follow the prompts. Then call back once the verification session is active.",
+    ]);
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Inbound voice ACL: caller channel unverified" },
+    ]);
+    await sleep();
+    expect(f.endReasons).toEqual([
+      "Inbound voice ACL: caller channel unverified",
+    ]);
+  });
+
+  test("non-guardian variant directs the caller to the guardian", async () => {
+    const f = createFlow();
+
+    await f.flow.start(unverifiedOutcome(false), makeResolved());
+
+    expect(f.spoken).toEqual([
+      "This number is registered as Sam Example's phone but has not been verified yet. " +
+        "Please reach out to the account guardian to start a new verification session, " +
+        "then call back once the verification session is active.",
+    ]);
+    expect(f.results).toEqual([
+      { kind: "ended", reason: "Inbound voice ACL: caller channel unverified" },
+    ]);
+  });
+});

--- a/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
@@ -642,6 +642,43 @@ describe("CallSetupFlow name capture", () => {
       expect(f.results).toHaveLength(0);
     });
 
+    test("dispose during post-approval trust re-resolution suppresses the handoff", async () => {
+      let releaseTrust!: (ctx: TrustContext) => void;
+      const gated = new Promise<TrustContext>((resolve) => {
+        releaseTrust = resolve;
+      });
+      const f = createFlow({
+        deps: { resolveMidCallTrustContext: () => gated },
+      });
+      const wait = await startWait(f);
+
+      const approval = wait.deps.onApproved({
+        requestId: REQUEST_ID,
+        assistantId: "self",
+        fromNumber: PHONE_NUMBER,
+        callerName: CALLER_NAME,
+        callbackOptIn: false,
+      });
+      await sleep();
+
+      // Caller hangs up while trust re-resolution is still in flight.
+      f.flow.dispose("transport_closed");
+      releaseTrust(UPGRADED_TRUST);
+      await approval;
+
+      // No synthetic handoff on the dead call: no speech, transcript
+      // event, notifier delivery, or terminal result.
+      expect(f.spoken).not.toContain(
+        "Great! Alex said I can speak with you. How can I help?",
+      );
+      expect(eventTypes(f.events)).not.toContain("assistant_spoke");
+      expect(eventTypes(f.events)).not.toContain(
+        "inbound_acl_post_approval_handoff_spoken",
+      );
+      expect(f.notified).toEqual([]);
+      expect(f.results).toHaveLength(0);
+    });
+
     test("hasFinalized reports flow-side finalization so the close handler can skip", async () => {
       // Drive a sub-flow that finalizes inside the flow (invite failure).
       const f = createFlow({

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -204,11 +204,7 @@ describe("CallSetupFlow", () => {
 
       await expect(
         flow.start(
-          {
-            action: "name_capture",
-            assistantId: "self",
-            fromNumber: PHONE_NUMBER,
-          },
+          { action: "not_a_real_action" } as unknown as SetupOutcome,
           makeResolved("unknown"),
         ),
       ).rejects.toBeInstanceOf(UnsupportedSetupFlowError);

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -972,6 +972,11 @@ export class CallSetupFlow implements SetupFlowInput {
       assistantId,
       fromNumber,
     );
+    // Same teardown race as the activation handoff: don't resurrect a
+    // session whose transport closed during trust re-resolution.
+    if (this.state === "completed") {
+      return;
+    }
     this.deps.updateCallSession(this.callSessionId, { status: "in_progress" });
     this.complete({
       kind: "proceed-post-verification-greeting",
@@ -986,7 +991,8 @@ export class CallSetupFlow implements SetupFlowInput {
    * (invite redemption, access-request approval, verification code).
    * Upgrades trust, delivers deterministic transition copy, and completes
    * with `proceed-handoff-spoken` so the controller marks the next caller
-   * turn as an opening ack.
+   * turn as an opening ack. Returns false when the flow reached a terminal
+   * state during trust re-resolution and no handoff was delivered.
    */
   private async continueAfterTrustedContactActivation(
     adeps: ActivationDeps,
@@ -1006,7 +1012,7 @@ export class CallSetupFlow implements SetupFlowInput {
        */
       inviteeName?: string | null;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     const { assistantId, fromNumber } = params;
 
     this.deps.updateCallSession(this.callSessionId, { status: "in_progress" });
@@ -1016,6 +1022,12 @@ export class CallSetupFlow implements SetupFlowInput {
       assistantId,
       fromNumber,
     );
+
+    // A transport close during trust re-resolution tears the flow down;
+    // never speak or record a synthetic handoff on a dead call.
+    if (this.state === "completed") {
+      return false;
+    }
 
     const guardianLabel = adeps.resolveGuardianLabel();
     let handoffText: string;
@@ -1057,6 +1069,7 @@ export class CallSetupFlow implements SetupFlowInput {
       trustContext,
       deferredTranscripts: this.drainDeferredTranscripts(),
     });
+    return true;
   }
 
   /**
@@ -1555,11 +1568,17 @@ export class CallSetupFlow implements SetupFlowInput {
       "Access request approved — caller activated and continuing call",
     );
 
-    await this.continueAfterTrustedContactActivation(ndeps, {
-      assistantId: ctx.assistantId,
-      fromNumber: ctx.fromNumber,
-      activationReason: "access_approved",
-    });
+    const handoffSpoken = await this.continueAfterTrustedContactActivation(
+      ndeps,
+      {
+        assistantId: ctx.assistantId,
+        fromNumber: ctx.fromNumber,
+        activationReason: "access_approved",
+      },
+    );
+    if (!handoffSpoken) {
+      return;
+    }
 
     this.deps.recordCallEvent(
       this.callSessionId,

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -8,9 +8,9 @@
  * independent of any wire protocol.
  *
  * Handles `normal_call`, `deny`, the three verification actions
- * (`verification`, `outbound_verification`, `callee_verification`), and
- * `invite_redemption`. Other setup actions (name capture) throw
- * {@link UnsupportedSetupFlowError}.
+ * (`verification`, `outbound_verification`, `callee_verification`),
+ * `invite_redemption`, `name_capture` (delegating the guardian-decision
+ * wait to {@link GuardianWaitController}), and `unverified_caller`.
  */
 
 import { randomInt } from "node:crypto";
@@ -18,6 +18,7 @@ import { randomInt } from "node:crypto";
 import { getGuardianDeliveryFresh } from "../contacts/guardian-delivery-reader.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { addMessage as addMessageFn } from "../persistence/conversation-crud.js";
+import { notifyGuardianOfAccessRequest as notifyGuardianOfAccessRequestImpl } from "../runtime/access-request-helper.js";
 import {
   resolveActorTrust,
   toTrustContext,
@@ -46,6 +47,12 @@ import type {
   updateCallSession as updateCallSessionFn,
 } from "./call-store.js";
 import type { finalizeCall as finalizeCallFn } from "./finalize-call.js";
+import {
+  GuardianWaitController,
+  type GuardianWaitControllerDeps,
+  type GuardianWaitDisposeReason,
+  type GuardianWaitResolutionContext,
+} from "./guardian-wait-controller.js";
 import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
 import {
@@ -57,6 +64,10 @@ import {
 const log = getLogger("call-setup-flow");
 
 const INVITE_CODE_LENGTH = 6;
+
+// 30-second name-capture window — enough time to speak a name but short
+// enough to avoid keeping the call open for callers who never respond.
+const NAME_CAPTURE_TIMEOUT_MS = 30_000;
 
 // ── Errors ───────────────────────────────────────────────────────────
 
@@ -131,7 +142,31 @@ export interface CallSetupFlowDeps {
     assistantId: string,
     fromNumber: string,
   ): Promise<TrustContext>;
+
+  // ── Name-capture sub-flow deps ──────────────────────────────────────
+  /**
+   * Create the canonical access request and notify the guardian. Defaults
+   * to access-request-helper's {@link notifyGuardianOfAccessRequestImpl}.
+   */
+  notifyGuardianOfAccessRequest?: typeof notifyGuardianOfAccessRequestImpl;
+  /**
+   * Guardian wait controller factory, injectable so tests can substitute
+   * a fake. Defaults to constructing a real {@link GuardianWaitController}.
+   */
+  createGuardianWaitController?(
+    callSessionId: string,
+    transport: SetupFlowTransport,
+    deps: GuardianWaitControllerDeps,
+  ): GuardianWaitHandle;
+  /** Overrides the 30s name-capture response timeout. */
+  nameCaptureTimeoutMs?: number;
 }
+
+/** Structural subset of {@link GuardianWaitController} the flow drives. */
+export type GuardianWaitHandle = Pick<
+  GuardianWaitController,
+  "start" | "handleTranscript" | "getState" | "dispose"
+>;
 
 /** Verification deps with defaults applied and optionality removed. */
 type VerificationDeps = Required<
@@ -159,6 +194,20 @@ type InviteDeps = Required<
     | "resolveGuardianLabel"
     | "resolveAssistantLabel"
     | "attemptInviteCodeRedemption"
+    | "resolveMidCallTrustContext"
+  >
+>;
+
+/** Name-capture deps with defaults applied and optionality removed. */
+type NameCaptureDeps = Required<
+  Pick<
+    CallSetupFlowDeps,
+    | "getCallSession"
+    | "fireCallTranscriptNotifier"
+    | "resolveGuardianLabel"
+    | "resolveAssistantLabel"
+    | "notifyGuardianOfAccessRequest"
+    | "createGuardianWaitController"
     | "resolveMidCallTrustContext"
   >
 >;
@@ -265,6 +314,13 @@ interface InviteRedemptionState {
   inviteeName: string | null;
 }
 
+interface AccessRequestState {
+  assistantId: string;
+  fromNumber: string;
+  callerName: string | null;
+  requestId: string | null;
+}
+
 export class CallSetupFlow implements SetupFlowInput {
   private state: SetupFlowState = "idle";
 
@@ -299,6 +355,24 @@ export class CallSetupFlow implements SetupFlowInput {
    */
   private inviteRedemptionInFlight = false;
 
+  // ── Name-capture / guardian-wait sub-flow state ─────────────────────
+  private ndeps: NameCaptureDeps | null = null;
+  private accessRequest: AccessRequestState | null = null;
+  private nameCaptureTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Busy guard: access-request creation and the capture-timeout teardown
+   * are async, and a final transcript arriving while either is pending
+   * must not be treated as a (second) name and fire a duplicate guardian
+   * notification.
+   */
+  private nameCaptureBusy = false;
+  private guardianWait: GuardianWaitHandle | null = null;
+
+  // ── Terminal bookkeeping ────────────────────────────────────────────
+  private endSessionTimer: ReturnType<typeof setTimeout> | null = null;
+  private finalized = false;
+  private disposed = false;
+
   constructor(
     private readonly callSessionId: string,
     private readonly transport: SetupFlowTransport,
@@ -308,6 +382,38 @@ export class CallSetupFlow implements SetupFlowInput {
   /** Explicit flow state — never inferred from the transport. */
   getState(): SetupFlowState {
     return this.state;
+  }
+
+  /**
+   * Whether a flow-terminal path already ran `finalizeCall`. The owning
+   * server's transport-close handler checks this to keep finalization
+   * exactly-once across flow-terminal and transport-close paths.
+   */
+  hasFinalized(): boolean {
+    return this.finalized;
+  }
+
+  /**
+   * Tear down a flow whose transport disconnected mid-setup: clears the
+   * name-capture and end-session timers and disposes the guardian wait
+   * controller (which emits the callback handoff when the caller opted in
+   * and the reason is `transport_closed`). Idempotent; never fires
+   * `onComplete`.
+   */
+  dispose(reason: GuardianWaitDisposeReason = "teardown"): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.clearNameCaptureTimer();
+    if (this.endSessionTimer) {
+      clearTimeout(this.endSessionTimer);
+      this.endSessionTimer = null;
+    }
+    this.guardianWait?.dispose(reason);
+    // Stop accepting input without emitting a terminal result — the
+    // transport is gone, so there is no continuation to run.
+    this.state = "completed";
   }
 
   /**
@@ -363,8 +469,16 @@ export class CallSetupFlow implements SetupFlowInput {
         this.startInviteRedemption(outcome, resolved);
         return;
 
+      case "name_capture":
+        this.startNameCapture(outcome, resolved);
+        return;
+
+      case "unverified_caller":
+        await this.runUnverifiedCaller(outcome);
+        return;
+
       default:
-        throw new UnsupportedSetupFlowError(outcome.action);
+        throw new UnsupportedSetupFlowError((outcome as SetupOutcome).action);
     }
   }
 
@@ -375,6 +489,8 @@ export class CallSetupFlow implements SetupFlowInput {
     if (!this.acceptsInput()) {
       return;
     }
+    // codeMode is null during name capture and the guardian wait, so DTMF
+    // is ignored in those states.
     if (this.codeMode == null) {
       return;
     }
@@ -398,6 +514,37 @@ export class CallSetupFlow implements SetupFlowInput {
     // result for the owning server to replay in order.
     if (this.trustReResolving) {
       this.deferredTranscripts.push(text);
+      return;
+    }
+    // During name capture, the caller's response is their name. A blank
+    // transcript (silence/noise) keeps waiting; the capture timeout still
+    // fires if the caller never provides one.
+    if (this.state === "capturing_name") {
+      const callerName = text.trim();
+      if (!callerName || this.nameCaptureBusy) {
+        return;
+      }
+      log.info(
+        { callSessionId: this.callSessionId, callerName },
+        "Name captured from unknown inbound caller",
+      );
+      this.nameCaptureBusy = true;
+      void this.handleNameCaptureResponse(callerName)
+        .catch((err) =>
+          log.error(
+            { err, callSessionId: this.callSessionId },
+            "Name capture handling failed",
+          ),
+        )
+        .finally(() => {
+          this.nameCaptureBusy = false;
+        });
+      return;
+    }
+    // During the guardian decision wait, caller speech is classified by the
+    // wait controller (reassurance, impatience, callback offer/opt-in).
+    if (this.state === "awaiting_guardian_decision") {
+      this.guardianWait?.handleTranscript(text);
       return;
     }
     if (this.codeMode == null) {
@@ -689,7 +836,7 @@ export class CallSetupFlow implements SetupFlowInput {
 
       const session = vdeps.getCallSession(this.callSessionId);
       if (session) {
-        vdeps.finalizeCall(this.callSessionId, session.conversationId);
+        this.finalizeOnce(vdeps.finalizeCall, session.conversationId);
 
         if (isOutbound && session.initiatedFromConversationId) {
           this.postPointerMessage(
@@ -763,7 +910,7 @@ export class CallSetupFlow implements SetupFlowInput {
 
       const session = vdeps.getCallSession(this.callSessionId);
       if (session) {
-        vdeps.finalizeCall(this.callSessionId, session.conversationId);
+        this.finalizeOnce(vdeps.finalizeCall, session.conversationId);
         if (session.initiatedFromConversationId) {
           this.postPointerMessage(
             vdeps,
@@ -1034,10 +1181,25 @@ export class CallSetupFlow implements SetupFlowInput {
 
   /** Tear the session down once the terminal copy has had time to play. */
   private endSessionAfterPlayback(reason: string): void {
-    setTimeout(
+    if (this.disposed) {
+      return;
+    }
+    this.endSessionTimer = setTimeout(
       () => this.transport.endSession(reason),
       this.deps.ttsPlaybackDelayMs ?? getTtsPlaybackDelayMs(),
     );
+  }
+
+  /** Run `finalizeCall` at most once per flow, whichever terminal path wins. */
+  private finalizeOnce(
+    finalize: typeof finalizeCallFn,
+    conversationId: string,
+  ): void {
+    if (this.finalized) {
+      return;
+    }
+    this.finalized = true;
+    finalize(this.callSessionId, conversationId);
   }
 
   // ── Invite redemption ───────────────────────────────────────────────
@@ -1182,7 +1344,7 @@ export class CallSetupFlow implements SetupFlowInput {
 
       const failSession = ideps.getCallSession(this.callSessionId);
       if (failSession) {
-        ideps.finalizeCall(this.callSessionId, failSession.conversationId);
+        this.finalizeOnce(ideps.finalizeCall, failSession.conversationId);
       }
 
       await this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
@@ -1191,13 +1353,427 @@ export class CallSetupFlow implements SetupFlowInput {
     }
   }
 
+  // ── Name capture + guardian wait ────────────────────────────────────
+
+  /**
+   * Enter the name-capture sub-flow for an unknown inbound caller: speak
+   * the intro greeting and arm the capture timeout. The caller's next
+   * final transcript is taken as their name.
+   */
+  private startNameCapture(
+    outcome: Extract<SetupOutcome, { action: "name_capture" }>,
+    resolved: SetupResolved,
+  ): void {
+    const ndeps = this.requireNameCaptureDeps();
+    this.ndeps = ndeps;
+    this.accessRequest = {
+      assistantId: outcome.assistantId,
+      fromNumber: outcome.fromNumber,
+      callerName: null,
+      requestId: null,
+    };
+    this.initialTrustContext = toTrustContext(
+      resolved.actorTrust,
+      resolved.otherPartyNumber,
+    );
+    this.state = "capturing_name";
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_name_capture_started",
+      {
+        from: outcome.fromNumber,
+        trustClass: resolved.actorTrust.trustClass,
+      },
+    );
+
+    const guardianLabel = ndeps.resolveGuardianLabel();
+    const assistantName = ndeps.resolveAssistantLabel();
+    const greeting = assistantName
+      ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
+      : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
+    void this.deps.speakSystemPrompt(this.transport, greeting);
+
+    const timeoutMs = this.deps.nameCaptureTimeoutMs ?? NAME_CAPTURE_TIMEOUT_MS;
+    this.nameCaptureTimer = setTimeout(() => {
+      if (this.state !== "capturing_name") {
+        return;
+      }
+      void this.handleNameCaptureTimeout();
+    }, timeoutMs);
+
+    log.info(
+      {
+        callSessionId: this.callSessionId,
+        assistantId: outcome.assistantId,
+        timeoutMs,
+      },
+      "Name capture started for unknown inbound caller",
+    );
+  }
+
+  /**
+   * Handle the caller's name: create the canonical access request, notify
+   * the guardian, and hand the wait off to a {@link GuardianWaitController}.
+   * Fails closed to the timeout copy when no request id comes back.
+   */
+  private async handleNameCaptureResponse(callerName: string): Promise<void> {
+    const ndeps = this.ndeps;
+    const accessRequest = this.accessRequest;
+    if (!ndeps || !accessRequest) {
+      return;
+    }
+
+    this.clearNameCaptureTimer();
+    accessRequest.callerName = callerName;
+
+    this.deps.recordCallEvent(this.callSessionId, "inbound_acl_name_captured", {
+      from: accessRequest.fromNumber,
+      callerName,
+    });
+
+    try {
+      const accessResult = await ndeps.notifyGuardianOfAccessRequest({
+        canonicalAssistantId: accessRequest.assistantId,
+        sourceChannel: "phone",
+        conversationExternalId: accessRequest.fromNumber,
+        actorExternalId: accessRequest.fromNumber,
+        actorDisplayName: callerName,
+      });
+
+      if (accessResult.notified) {
+        accessRequest.requestId = accessResult.requestId;
+        log.info(
+          {
+            callSessionId: this.callSessionId,
+            requestId: accessResult.requestId,
+            callerName,
+          },
+          "Guardian notified of voice access request with caller name",
+        );
+      } else if (accessResult.reason === "already_denied") {
+        // The guardian already denied this caller; they are intentionally not
+        // re-notified. Deliver the denial copy rather than the "I'll let them
+        // know" timeout copy, which would falsely promise a notification.
+        log.info(
+          { callSessionId: this.callSessionId },
+          "Voice caller previously denied — suppressing re-notification, delivering denial",
+        );
+        await this.handleAccessRequestDenied(ndeps, null);
+        return;
+      } else {
+        log.warn(
+          { callSessionId: this.callSessionId },
+          "Failed to notify guardian of voice access request — no sender ID",
+        );
+      }
+    } catch (err) {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to create access request for voice caller",
+      );
+    }
+
+    // A transport close during the async notification tears the flow down;
+    // don't start a wait (or speak timeout copy) on a dead transport.
+    if (this.state === "completed") {
+      return;
+    }
+
+    // No request id (notify threw or returned notified: false) — fail closed
+    // rather than leaving the caller stuck on hold with no poll target.
+    const requestId = accessRequest.requestId;
+    if (!requestId) {
+      log.warn(
+        { callSessionId: this.callSessionId },
+        "Access request ID is null after notification attempt — failing closed",
+      );
+      await this.handleAccessRequestTimeout(ndeps, {
+        requestId: null,
+        callbackOptIn: false,
+      });
+      return;
+    }
+
+    this.startAccessRequestWait(ndeps, requestId, accessRequest);
+  }
+
+  /**
+   * Hand the guardian-decision wait to a {@link GuardianWaitController}:
+   * it owns the hold message, heartbeats, polling, and timeout; the flow
+   * owns the resolution continuations.
+   */
+  private startAccessRequestWait(
+    ndeps: NameCaptureDeps,
+    requestId: string,
+    accessRequest: AccessRequestState,
+  ): void {
+    this.state = "awaiting_guardian_decision";
+
+    this.guardianWait = ndeps.createGuardianWaitController(
+      this.callSessionId,
+      this.transport,
+      {
+        speakSystemPrompt: this.deps.speakSystemPrompt,
+        updateCallSession: this.deps.updateCallSession,
+        recordCallEvent: this.deps.recordCallEvent,
+        resolveGuardianLabel: ndeps.resolveGuardianLabel,
+        firstHeartbeatDelayMs: this.deps.ttsPlaybackDelayMs,
+        onApproved: (ctx) => this.handleAccessRequestApproved(ndeps, ctx),
+        onDenied: (ctx) => this.handleAccessRequestDenied(ndeps, ctx.requestId),
+        onTimeout: (ctx) => this.handleAccessRequestTimeout(ndeps, ctx),
+      },
+    );
+    this.guardianWait.start({
+      requestId,
+      assistantId: accessRequest.assistantId,
+      fromNumber: accessRequest.fromNumber,
+      callerName: accessRequest.callerName,
+    });
+  }
+
+  /**
+   * Approved access request: the caller is now an activated trusted
+   * contact — run the shared activation continuation and hand off.
+   */
+  private async handleAccessRequestApproved(
+    ndeps: NameCaptureDeps,
+    ctx: GuardianWaitResolutionContext,
+  ): Promise<void> {
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_access_approved",
+      {
+        from: ctx.fromNumber,
+        callerName: ctx.callerName,
+        requestId: ctx.requestId,
+      },
+    );
+
+    log.info(
+      { callSessionId: this.callSessionId, from: ctx.fromNumber },
+      "Access request approved — caller activated and continuing call",
+    );
+
+    await this.continueAfterTrustedContactActivation(ndeps, {
+      assistantId: ctx.assistantId,
+      fromNumber: ctx.fromNumber,
+      activationReason: "access_approved",
+    });
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_post_approval_handoff_spoken",
+      { from: ctx.fromNumber },
+    );
+  }
+
+  /** Denied access request: deliver deterministic copy and hang up. */
+  private async handleAccessRequestDenied(
+    ndeps: NameCaptureDeps,
+    requestId: string | null,
+  ): Promise<void> {
+    const guardianLabel = ndeps.resolveGuardianLabel();
+
+    this.deps.recordCallEvent(this.callSessionId, "inbound_acl_access_denied", {
+      from: this.accessRequest?.fromNumber,
+      requestId,
+    });
+
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "failed",
+      endedAt: Date.now(),
+      lastError: "Inbound voice ACL: guardian denied access request",
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Access request denied — ending call",
+    );
+
+    await this.deps.speakSystemPrompt(
+      this.transport,
+      `Sorry, ${guardianLabel} says I'm not allowed to speak with you. Goodbye.`,
+    );
+    this.endSessionAfterPlayback("Access request denied");
+    this.complete({ kind: "ended", reason: "Access request denied" });
+  }
+
+  /**
+   * Access-request wait timeout (or fail-closed creation failure): deliver
+   * deterministic copy — including the callback note when the caller opted
+   * in — and hang up. The wait controller emits the callback handoff
+   * notification before invoking this.
+   */
+  private async handleAccessRequestTimeout(
+    ndeps: NameCaptureDeps,
+    params: {
+      requestId: string | null;
+      callbackOptIn: boolean;
+    },
+  ): Promise<void> {
+    const guardianLabel = ndeps.resolveGuardianLabel();
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_access_timeout",
+      {
+        from: this.accessRequest?.fromNumber,
+        requestId: params.requestId,
+        callbackOptIn: params.callbackOptIn,
+      },
+    );
+
+    const callbackNote = params.callbackOptIn
+      ? ` I've noted that you'd like a callback — I'll pass that along to ${guardianLabel}.`
+      : "";
+
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "failed",
+      endedAt: Date.now(),
+      lastError: "Inbound voice ACL: guardian approval wait timed out",
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Access request timed out — ending call",
+    );
+
+    await this.deps.speakSystemPrompt(
+      this.transport,
+      `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
+    );
+    this.endSessionAfterPlayback("Access request timed out");
+    this.complete({ kind: "ended", reason: "Access request timed out" });
+  }
+
+  /**
+   * Name-capture timeout: the caller never provided their name within the
+   * allotted window. Deliver deterministic copy and hang up.
+   */
+  private async handleNameCaptureTimeout(): Promise<void> {
+    // A transcript racing the timeout must not start a second terminal path.
+    this.nameCaptureBusy = true;
+    this.clearNameCaptureTimer();
+
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_name_capture_timeout",
+      { from: this.accessRequest?.fromNumber },
+    );
+
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "failed",
+      endedAt: Date.now(),
+      lastError: "Inbound voice ACL: name capture timed out",
+    });
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Name capture timed out — ending call",
+    );
+
+    await this.deps.speakSystemPrompt(
+      this.transport,
+      "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
+    );
+    this.endSessionAfterPlayback("Name capture timed out");
+    this.complete({ kind: "ended", reason: "Name capture timed out" });
+  }
+
+  private clearNameCaptureTimer(): void {
+    if (this.nameCaptureTimer) {
+      clearTimeout(this.nameCaptureTimer);
+      this.nameCaptureTimer = null;
+    }
+  }
+
+  /** Resolve the name-capture deps, applying defaults for the pure logic. */
+  private requireNameCaptureDeps(): NameCaptureDeps {
+    const d = this.deps;
+    const missing = (
+      [
+        ["getCallSession", d.getCallSession],
+        ["fireCallTranscriptNotifier", d.fireCallTranscriptNotifier],
+        ["resolveGuardianLabel", d.resolveGuardianLabel],
+        ["resolveAssistantLabel", d.resolveAssistantLabel],
+      ] as const
+    )
+      .filter(([, dep]) => dep == null)
+      .map(([name]) => name);
+    if (missing.length > 0) {
+      throw new Error(
+        `CallSetupFlow name-capture deps missing: ${missing.join(", ")}`,
+      );
+    }
+    return {
+      getCallSession: d.getCallSession!,
+      fireCallTranscriptNotifier: d.fireCallTranscriptNotifier!,
+      resolveGuardianLabel: d.resolveGuardianLabel!,
+      resolveAssistantLabel: d.resolveAssistantLabel!,
+      notifyGuardianOfAccessRequest:
+        d.notifyGuardianOfAccessRequest ?? notifyGuardianOfAccessRequestImpl,
+      createGuardianWaitController:
+        d.createGuardianWaitController ??
+        ((callSessionId, transport, deps) =>
+          new GuardianWaitController(callSessionId, transport, deps)),
+      resolveMidCallTrustContext:
+        d.resolveMidCallTrustContext ?? resolveMidCallTrustContext,
+    };
+  }
+
+  // ── Unverified caller ───────────────────────────────────────────────
+
+  /** Speak verification guidance to a known-but-unverified caller, then disconnect. */
+  private async runUnverifiedCaller(
+    outcome: Extract<SetupOutcome, { action: "unverified_caller" }>,
+  ): Promise<void> {
+    this.deps.recordCallEvent(
+      this.callSessionId,
+      "inbound_acl_unverified_caller",
+      {
+        callSessionId: this.callSessionId,
+        isGuardian: outcome.isGuardian,
+      },
+    );
+    this.deps.updateCallSession(this.callSessionId, {
+      status: "failed",
+      endedAt: Date.now(),
+      lastError: "Inbound voice ACL: caller channel unverified",
+    });
+    const action = outcome.isGuardian
+      ? `To verify, open your assistant's contacts page, click Verify next to the phone channel, ` +
+        `and follow the prompts. Then call back once the verification session is active.`
+      : `Please reach out to the account guardian to start a new verification session, ` +
+        `then call back once the verification session is active.`;
+    const message =
+      `This number is registered as ${outcome.displayName}'s phone but has not been verified yet. ` +
+      action;
+    await this.deps.speakSystemPrompt(this.transport, message);
+    this.endSessionAfterPlayback(
+      "Inbound voice ACL: caller channel unverified",
+    );
+    this.complete({
+      kind: "ended",
+      reason: "Inbound voice ACL: caller channel unverified",
+    });
+  }
+
   // ── Internals ───────────────────────────────────────────────────────
 
   private acceptsInput(): boolean {
     return this.state !== "idle" && this.state !== "completed";
   }
 
+  /**
+   * Deliver the terminal result exactly once. A flow already completed
+   * (or disposed on transport close) swallows late completions from
+   * racing terminal paths.
+   */
   private complete(result: SetupFlowResult): void {
+    if (this.state === "completed") {
+      return;
+    }
     this.state = "completed";
     this.deps.onComplete(result);
   }


### PR DESCRIPTION
## Summary
- Ports name-capture (30s timeout, access-request creation, GuardianWaitController handoff), guardian-wait resolution paths, and unverified-caller guidance from relay-server into CallSetupFlow
- Adds CallSetupFlow.dispose(reason) with exactly-once finalization across flow-terminal and transport-close paths
- Reuses the unified trusted-contact activation continuation for access_approved

Part of plan: phone-media-stream-v2.md (PR 8 of 17)