### PR TITLE
fix(assistant): ignore .git dir in app source watcher

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -120,6 +120,17 @@ describe("AppSourceWatcher", () => {
     expect(onChangeSpy).not.toHaveBeenCalled();
   });
 
+  test(".git/ files are filtered out (apps-directory git repo churn)", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", ".git/objects/ab/cdef");
+    capturedWatchCallback!("change", ".git/index");
+    capturedWatchCallback!("change", ".git/refs/heads/main");
+    capturedWatchCallback!("change", ".git/logs/HEAD");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
   test("files directly in apps/ (no subdirectory) are filtered out", async () => {
     watcher.start(onChangeSpy);
     capturedWatchCallback!("change", "my-app.json");

--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -57,6 +57,15 @@ function resolveAppIdFromRelPath(relPath: string): string | null {
   const dirName = relPath.slice(0, slashIdx);
   const innerPath = relPath.slice(slashIdx + 1);
 
+  // Skip the apps-directory git repo. app-git-service initializes a git repo
+  // at the root of the apps directory (PR #6227) and commits after every app
+  // turn, so .git churns constantly (objects, index, refs, logs). Each such
+  // event would otherwise hit resolveAppIdByDirName -> existsSync, which is
+  // needless work on a path that can never be an app.
+  if (dirName === ".git") {
+    return null;
+  }
+
   // Skip non-source directories (include bare directory names for fs.watch events)
   if (
     innerPath === "records" ||


### PR DESCRIPTION
## Prompt / plan
The app source watcher (`assistant/src/daemon/app-source-watcher.ts`) recursively watches the apps directory (`workspace/data/apps/`) to detect source edits and trigger recompile + surface refresh.

That same directory is also a git repository: `app-git-service` (introduced in #6227) initializes a git repo at the root of the apps dir and commits after every app turn. As a result `.git/` churns constantly — objects, index, refs, logs. Every one of those filesystem events was flowing into `resolveAppIdFromRelPath`, which called `resolveAppIdByDirName(".git")` → `existsSync(".git.json")`, doing needless stat work on paths that can never map to an app. Under active app editing this makes the watcher expensive.

This change short-circuits any watched path whose top-level segment is `.git`, before any resolution work — matching the existing `dist/` and `records/` filters right above it.

## Test plan
- Added a regression test in `assistant/src/__tests__/app-source-watcher.test.ts` asserting that `.git/objects/...`, `.git/index`, `.git/refs/heads/main`, and `.git/logs/HEAD` events do not trigger the change callback.
- `bun test src/__tests__/app-source-watcher.test.ts` → 14 pass / 0 fail.
- Type check + lint pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJgTeKQ3kJeNu5BGDbd8Su)_