### PR TITLE
fix(daemon): complete hidden-prompt handling — title-hook gate, idle supersede bypass

### DIFF
--- a/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
+++ b/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
@@ -192,13 +192,22 @@ interface BusyConversationSpies {
   enqueuedMetadata: () => Record<string, unknown> | undefined;
   denyAllCount: () => number;
   abortCount: () => number;
+  agentLoopOptions: () => Record<string, unknown> | undefined;
 }
 
-/** A live, mid-turn conversation with a pending tool confirmation. */
-function makeBusyConversation(): BusyConversationSpies {
+/**
+ * A live conversation with a pending tool confirmation. `processing: true`
+ * models a mid-turn conversation (queue branch); `false` an idle one whose
+ * confirmation outlived its turn (e.g. a guardian approval awaiting a
+ * channel reply).
+ */
+function makeConversationWithPendingConfirmation(
+  processing: boolean,
+): BusyConversationSpies {
   let enqueuedMetadata: Record<string, unknown> | undefined;
   let denyAllCount = 0;
   let abortCount = 0;
+  let agentLoopOptions: Record<string, unknown> | undefined;
   const conversation = {
     conversationId: CONV_ID,
     messages: [],
@@ -222,7 +231,7 @@ function makeBusyConversation(): BusyConversationSpies {
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
     ensureActorScopedHistory: async () => {},
-    isProcessing: () => true,
+    isProcessing: () => processing,
     setProcessing: () => {},
     hasAnyPendingConfirmation: () => true,
     denyAllPendingConfirmations: () => {
@@ -236,7 +245,13 @@ function makeBusyConversation(): BusyConversationSpies {
       id: "persisted-user-id",
       deduplicated: false,
     }),
-    runAgentLoop: async () => undefined,
+    runAgentLoop: async (
+      _content: string,
+      _messageId: string,
+      options?: Record<string, unknown>,
+    ) => {
+      agentLoopOptions = options;
+    },
     setPreactivatedSkillIds: () => {},
     drainQueue: async () => {},
     warmPromptCache: () => {},
@@ -255,7 +270,12 @@ function makeBusyConversation(): BusyConversationSpies {
     enqueuedMetadata: () => enqueuedMetadata,
     denyAllCount: () => denyAllCount,
     abortCount: () => abortCount,
+    agentLoopOptions: () => agentLoopOptions,
   };
+}
+
+function makeBusyConversation(): BusyConversationSpies {
+  return makeConversationWithPendingConfirmation(true);
 }
 
 function makeRequest(extras: Record<string, unknown> = {}) {
@@ -343,5 +363,45 @@ describe("hidden sends queued behind an in-flight turn", () => {
     expect(spies.enqueuedMetadata()?.hidden).toBeUndefined();
     // The typed message supersedes: pending confirmations are auto-denied.
     expect(spies.denyAllCount()).toBe(1);
+  });
+});
+
+describe("hidden sends to an idle conversation with a pending confirmation", () => {
+  test("do NOT auto-deny the confirmation and mark the turn as a hidden prompt", async () => {
+    const spies = makeConversationWithPendingConfirmation(false);
+    setConversation(CONV_ID, spies.conversation);
+    registerConfirmation();
+
+    const res = await callHandler(
+      (args) => handleSendMessage(args, makeDeps(spies.conversation)),
+      makeRequest({ hidden: true }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    // The confirmation that outlived its turn (e.g. a guardian approval
+    // awaiting a channel reply) survives the machine signal...
+    expect(spies.denyAllCount()).toBe(0);
+    // ...and the turn is flagged so prompt-as-user-speech consumers (title
+    // generation) skip it.
+    expect(spies.agentLoopOptions()?.isHiddenPrompt).toBe(true);
+  });
+
+  test("visible sends to the same state keep the idle auto-deny cleanup", async () => {
+    const spies = makeConversationWithPendingConfirmation(false);
+    setConversation(CONV_ID, spies.conversation);
+    registerConfirmation();
+
+    const res = await callHandler(
+      (args) => handleSendMessage(args, makeDeps(spies.conversation)),
+      makeRequest({ content: "hello again" }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    expect(spies.denyAllCount()).toBe(1);
+    expect(spies.agentLoopOptions()?.isHiddenPrompt).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/title-generate-hook.test.ts
+++ b/assistant/src/__tests__/title-generate-hook.test.ts
@@ -185,6 +185,22 @@ describe("title-generate user-prompt-submit hook", () => {
     expect(call).not.toHaveProperty("onTitleUpdated");
   });
 
+  test("skips title generation for hidden machine-signal prompts", async () => {
+    // A hidden send (e.g. the channel-setup wizard-close marker) is not user
+    // speech — minting a title from it would surface invisible scaffolding
+    // text in the sidebar.
+    const ctx = makeCtx({
+      prompt:
+        "[User action on channel_setup surface: closed the slack setup wizard]",
+      isHiddenPrompt: true,
+    });
+
+    await userPromptSubmit(ctx);
+    await flushMacrotasks();
+
+    expect(queueGenerateConversationTitleMock).toHaveBeenCalledTimes(0);
+  });
+
   test("does not block: returns before the title job is scheduled", async () => {
     // GIVEN a fresh user prompt submission
     const ctx = makeCtx();

--- a/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/user-prompt-submit.ts
@@ -19,6 +19,11 @@ import { getConversation } from "../../../../persistence/conversation-crud.js";
 import { queueGenerateConversationTitle } from "../../../../persistence/conversation-title-service.js";
 
 const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
+  // Hidden machine signals (e.g. the channel-setup wizard-close marker) are
+  // not user speech — a title minted from one would surface invisible
+  // scaffolding text in the sidebar, and the LLM call is wasted.
+  if (ctx.isHiddenPrompt) return;
+
   // System conversations (background/scheduled) carry a deterministic title
   // from bootstrap. Their own job prompts arrive as non-interactive turns and
   // must not spend an LLM call on a title nobody reads — only a genuine user

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2061,7 +2061,11 @@ export async function handleSendMessage(
   // before dispatching, so an idle conversation with lingering confirmations
   // (e.g. the user never responded to a tool-approval prompt) must deny
   // them before starting the new turn.
-  if (conversation.hasAnyPendingConfirmation()) {
+  // Hidden sends are machine signals, not user decisions — like the queue
+  // branch's supersede bypass above, they must not deny confirmations that
+  // outlived a turn (e.g. a guardian approval still awaiting a channel
+  // reply). The next visible send performs the cleanup instead.
+  if (body.hidden !== true && conversation.hasAnyPendingConfirmation()) {
     for (const interaction of pendingInteractions.getByConversation(
       mapping.conversationId,
     )) {
@@ -2460,6 +2464,7 @@ export async function handleSendMessage(
       onEvent: broadcastMessage,
       isInteractive,
       isUserMessage: true,
+      ...(body.hidden === true ? { isHiddenPrompt: true } : {}),
     })
     .catch((err) => {
       log.error(


### PR DESCRIPTION
## Prompt / plan

Follow-up to #36954 (merged) for the two Codex P2 findings posted at its merge SHA:

1. **Title hook never read `isHiddenPrompt`.** #36954 threaded the flag through the `user-prompt-submit` hook context, but the default title hook still queued title generation unconditionally, and the immediate `POST /messages` path never set the flag (only the drain paths did) — so a hidden wizard-close marker could still spend an LLM call and title a conversation from invisible scaffolding text. The title hook now returns early for hidden prompts, and the immediate path passes `isHiddenPrompt` into `runAgentLoop`.

2. **Idle supersede bypass.** #36954's hidden-supersede bypass covered only the queue branch; an *idle* conversation with a confirmation that outlived its turn (e.g. a guardian approval still awaiting a channel reply) would still auto-deny it when a hidden send arrived. The idle cleanup block now skips hidden sends the same way — a machine signal is not user intent in either state; the next visible send performs the cleanup.

## Test plan

- `assistant`: `conversation-routes-hidden-queue.test.ts` extended with the idle-path matrix — hidden send preserves the pending confirmation and flags the turn (`isHiddenPrompt: true` reaches `runAgentLoop`); visible send keeps the idle auto-deny cleanup. `title-generate-hook.test.ts` gains a hidden-prompt regression test (no title job queued). Both suites pass; typecheck clean.

## CLI verb checklist

No new routes — extends the existing `POST /v1/messages` handler's hidden-send semantics and a default plugin hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhboew7TA4oyViVE6ubWXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhboew7TA4oyViVE6ubWXY)_