### PR TITLE
feat(calls): drive every setup outcome over the media-stream transport

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -107,6 +107,8 @@ mock.module("../calls/call-pointer-messages.js", () => ({
 
 // Mock the CallController to avoid pulling in the full conversation pipeline
 const mockStartInitialGreeting = jest.fn(async () => {});
+const mockStartPostVerificationGreeting = jest.fn(async () => {});
+const mockMarkNextCallerTurnAsOpeningAck = jest.fn();
 const mockHandleCallerUtterance = jest.fn(async () => {});
 const mockHandleInterrupt = jest.fn();
 const mockDestroy = jest.fn();
@@ -116,13 +118,14 @@ const mockHandleBargeIn = jest.fn(() => false);
 mock.module("../calls/call-controller.js", () => ({
   CallController: jest.fn().mockImplementation(() => ({
     startInitialGreeting: mockStartInitialGreeting,
+    startPostVerificationGreeting: mockStartPostVerificationGreeting,
+    markNextCallerTurnAsOpeningAck: mockMarkNextCallerTurnAsOpeningAck,
     handleCallerUtterance: mockHandleCallerUtterance,
     handleInterrupt: mockHandleInterrupt,
     handleBargeIn: mockHandleBargeIn,
     destroy: mockDestroy,
     getState: jest.fn(() => "idle"),
     setTrustContext: jest.fn(),
-    markNextCallerTurnAsOpeningAck: jest.fn(),
     getPendingConsultationQuestionId: jest.fn(),
     handleUserAnswer: jest.fn(),
     handleUserInstruction: jest.fn(),
@@ -182,9 +185,18 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 // Mock the inbound trust reader. handleStart awaits this and threads the
 // verdict into routeSetup so the media-stream transport enforces the same
 // gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
+// The optional gate lets a test hold mid-setup trust re-resolution open
+// (the setup flow's default resolver reads the verdict first) so it can
+// deliver transcripts during the deferral window.
 let mockInboundVerdict: unknown = null;
+let mockVerdictGate: Promise<void> | null = null;
 const mockGetInboundTrustVerdict = jest.fn(
-  async (_args?: Record<string, unknown>) => mockInboundVerdict,
+  async (_args?: Record<string, unknown>) => {
+    if (mockVerdictGate) {
+      await mockVerdictGate;
+    }
+    return mockInboundVerdict;
+  },
 );
 mock.module("../calls/inbound-trust-reader.js", () => ({
   getInboundTrustVerdict: mockGetInboundTrustVerdict,
@@ -228,12 +240,141 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
+// ── Setup-flow dependency mocks ─────────────────────────────────────────
+// MediaStreamCallSession drives every routeSetup outcome through a real
+// CallSetupFlow (and, for name capture, a real GuardianWaitController).
+// Mock the side-effectful modules those pull in: config-backed timing
+// constants, guardian labels, verification/invite services, the guardian
+// notifier, canonical-request polling, and wait heartbeats.
+
+// Config-backed call constants — small real-timer-friendly values.
+let mockTtsPlaybackDelayMs = 5;
+let mockAccessRequestPollIntervalMs = 5;
+let mockUserConsultationTimeoutMs = 500;
+mock.module("../calls/call-constants.js", () => ({
+  isDeniedNumber: jest.fn(() => false),
+  getMaxCallDurationMs: jest.fn(() => 3_600_000),
+  getUserConsultationTimeoutMs: jest.fn(() => mockUserConsultationTimeoutMs),
+  getTtsPlaybackDelayMs: jest.fn(() => mockTtsPlaybackDelayMs),
+  getAccessRequestPollIntervalMs: jest.fn(
+    () => mockAccessRequestPollIntervalMs,
+  ),
+  getGuardianWaitUpdateInitialIntervalMs: jest.fn(() => 10_000),
+  getGuardianWaitUpdateInitialWindowMs: jest.fn(() => 60_000),
+  getGuardianWaitUpdateSteadyMinIntervalMs: jest.fn(() => 20_000),
+  getGuardianWaitUpdateSteadyMaxIntervalMs: jest.fn(() => 40_000),
+  getSilenceTimeoutMs: jest.fn(() => 30_000),
+  getEndCallListenWindowMs: jest.fn(() => 15_000),
+}));
+
+// Guardian delivery reader (IPC-backed): label priming + cache warming.
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: jest.fn(async () => [
+    { channelType: "phone", status: "active", displayName: "Alex" },
+  ]),
+  getGuardianDeliveryFresh: jest.fn(async () => []),
+  peekCachedGuardianDelivery: jest.fn(() => null),
+  voiceGuardianDisplayName: jest.fn(() => "Alex"),
+  guardianForChannel: jest.fn(),
+  anyGuardian: jest.fn(),
+  invalidateGuardianDeliveryCache: jest.fn(),
+}));
+
+// Guardian/assistant display labels (filesystem-backed).
+mock.module("../prompts/user-reference.js", () => ({
+  DEFAULT_USER_REFERENCE: "my human",
+  resolveGuardianName: jest.fn(
+    (primed?: string | null) => primed ?? "my human",
+  ),
+}));
+mock.module("../daemon/identity-helpers.js", () => ({
+  getAssistantName: jest.fn(() => "Aria"),
+  resolveUserName: jest.fn(() => null),
+}));
+
+// Conversation persistence (used by callee verification code posting).
+const mockAddMessage = jest.fn(async () => ({}));
+mock.module("../persistence/conversation-crud.js", () => ({
+  addMessage: mockAddMessage,
+}));
+
+// Verification / invite services (gateway + verification-store backed).
+type MockVerificationResult =
+  | {
+      outcome: "success";
+      verificationType: "guardian" | "trusted_contact";
+      eventName: string;
+      ttsMessage?: string;
+    }
+  | { outcome: "failure"; eventName: string; ttsMessage: string; attempts: number }
+  | { outcome: "retry"; ttsMessage: string; attempt: number; maxAttempts: number };
+let mockVerificationResult: MockVerificationResult = {
+  outcome: "success",
+  verificationType: "guardian",
+  eventName: "voice_verification_succeeded",
+};
+const mockAttemptVerificationCode = jest.fn(async () => mockVerificationResult);
+type MockInviteResult =
+  | { outcome: "success"; memberId: string; inviteId: string; type: string }
+  | { outcome: "failure"; ttsMessage: string };
+let mockInviteResult: MockInviteResult = {
+  outcome: "success",
+  memberId: "member-1",
+  inviteId: "invite-1",
+  type: "trusted_contact",
+};
+const mockAttemptInviteCodeRedemption = jest.fn(async () => mockInviteResult);
+mock.module("../calls/relay-verification.js", () => ({
+  attemptVerificationCode: mockAttemptVerificationCode,
+  attemptInviteCodeRedemption: mockAttemptInviteCodeRedemption,
+  parseDigitsFromSpeech: jest.fn((text: string) => text.replace(/\D+/g, "")),
+}));
+
+// Guardian access-request notifier (name-capture sub-flow).
+type MockNotifyResult =
+  | { notified: true; created: boolean; requestId: string }
+  | { notified: false; reason: string };
+let mockNotifyResult: MockNotifyResult = {
+  notified: true,
+  created: true,
+  requestId: "req-1",
+};
+const mockNotifyGuardianOfAccessRequest = jest.fn(async () => mockNotifyResult);
+mock.module("../runtime/access-request-helper.js", () => ({
+  notifyGuardianOfAccessRequest: mockNotifyGuardianOfAccessRequest,
+}));
+
+// Canonical guardian-request store polled by the guardian wait controller.
+let mockCanonicalRequest: { status: string } | null = null;
+const mockGetCanonicalGuardianRequest = jest.fn(() => mockCanonicalRequest);
+mock.module("../contacts/canonical-guardian-store.js", () => ({
+  getCanonicalGuardianRequest: mockGetCanonicalGuardianRequest,
+}));
+
+// Wait-state helpers: no heartbeats in tests; capture callback handoffs.
+const mockEmitCallbackHandoff = jest.fn(
+  (args: { callbackHandoffNotified: boolean }) => ({
+    callbackHandoffNotified: args.callbackHandoffNotified,
+    notified: false,
+  }),
+);
+mock.module("../calls/relay-access-wait.js", () => ({
+  classifyWaitUtterance: jest.fn(() => "neutral"),
+  scheduleNextHeartbeat: jest.fn(() => null),
+  emitAccessRequestCallbackHandoff: mockEmitCallbackHandoff,
+}));
+
 // ---------------------------------------------------------------------------
 // Now import the module under test.
 // ---------------------------------------------------------------------------
 
+import { CallController } from "../calls/call-controller.js";
+import { addPointerMessage } from "../calls/call-pointer-messages.js";
 import { speakSystemPrompt } from "../calls/call-speech-output.js";
-import { registerCallController } from "../calls/call-state.js";
+import {
+  fireCallTranscriptNotifier,
+  registerCallController,
+} from "../calls/call-state.js";
 import { recordCallEvent, updateCallSession } from "../calls/call-store.js";
 import { finalizeCall } from "../calls/finalize-call.js";
 import {
@@ -361,22 +502,50 @@ beforeEach(() => {
   mockControllers.clear();
   activeMediaStreamSessions.clear();
   mockStartInitialGreeting.mockClear();
+  mockStartPostVerificationGreeting.mockClear();
+  mockMarkNextCallerTurnAsOpeningAck.mockClear();
   mockHandleCallerUtterance.mockClear();
   mockHandleInterrupt.mockClear();
   mockHandleBargeIn.mockClear();
   mockHandleBargeIn.mockReturnValue(false);
   mockDestroy.mockClear();
+  (CallController as unknown as jest.Mock).mockClear();
   (registerCallController as jest.Mock).mockClear();
+  (fireCallTranscriptNotifier as jest.Mock).mockClear();
   (recordCallEvent as jest.Mock).mockClear();
   (updateCallSession as jest.Mock).mockClear();
   (finalizeCall as jest.Mock).mockClear();
   (speakSystemPrompt as jest.Mock).mockClear();
+  (addPointerMessage as jest.Mock).mockClear();
   (routeSetup as jest.Mock).mockClear();
   mockGetChannelAdmissionPolicy.mockClear();
   mockAdmissionPolicy = null;
   mockAdmissionGate = null;
   mockGetInboundTrustVerdict.mockClear();
   mockInboundVerdict = null;
+  mockVerdictGate = null;
+  mockAddMessage.mockClear();
+  mockAttemptVerificationCode.mockClear();
+  mockVerificationResult = {
+    outcome: "success",
+    verificationType: "guardian",
+    eventName: "voice_verification_succeeded",
+  };
+  mockAttemptInviteCodeRedemption.mockClear();
+  mockInviteResult = {
+    outcome: "success",
+    memberId: "member-1",
+    inviteId: "invite-1",
+    type: "trusted_contact",
+  };
+  mockNotifyGuardianOfAccessRequest.mockClear();
+  mockNotifyResult = { notified: true, created: true, requestId: "req-1" };
+  mockGetCanonicalGuardianRequest.mockClear();
+  mockCanonicalRequest = null;
+  mockEmitCallbackHandoff.mockClear();
+  mockTtsPlaybackDelayMs = 5;
+  mockAccessRequestPollIntervalMs = 5;
+  mockUserConsultationTimeoutMs = 500;
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -958,157 +1127,7 @@ describe("media-stream setup outcome scenarios", () => {
     });
   });
 
-  describe("unsupported interactive setup flow", () => {
-    test("verification outcome records call_failed with preflight-bypass reason", async () => {
-      mockRouteSetupResult = {
-        outcome: {
-          action: "verification",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-verify-1", {
-        id: "call-unsup-verify-1",
-        conversationId: "conv-unsup-verify-1",
-        status: "initiated",
-        task: null,
-        startedAt: null,
-        fromNumber: "+14155551234",
-        toNumber: "+15550001111",
-      });
-
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-verify-1",
-      );
-      session.handleMessage(makeStartMessage());
-      await session.whenSetupSettled();
-
-      // Should record call_failed event with preflight-bypass note
-      expect(recordCallEvent).toHaveBeenCalledWith(
-        "call-unsup-verify-1",
-        "call_failed",
-        expect.objectContaining({
-          reason: expect.stringContaining("verification"),
-          transport: "media-stream",
-        }),
-      );
-
-      // Should set session status to failed
-      expect(updateCallSession).toHaveBeenCalledWith(
-        "call-unsup-verify-1",
-        expect.objectContaining({
-          status: "failed",
-          lastError: expect.stringContaining("preflight guard"),
-        }),
-      );
-
-      // Should NOT register a controller
-      expect(registerCallController).not.toHaveBeenCalled();
-    });
-
-    test("name_capture outcome speaks generic apology and tears down", async () => {
-      mockRouteSetupResult = {
-        outcome: {
-          action: "name_capture",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-name-1", {
-        id: "call-unsup-name-1",
-        conversationId: "conv-unsup-name-1",
-        status: "initiated",
-        task: null,
-        startedAt: null,
-        fromNumber: "+14155551234",
-        toNumber: "+15550001111",
-      });
-
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-name-1",
-      );
-      session.handleMessage(makeStartMessage());
-      await session.whenSetupSettled();
-
-      // speakSystemPrompt should be called with the generic apology
-      expect(speakSystemPrompt).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.stringContaining("additional verification"),
-      );
-
-      // Should run finalization inline
-      expect(finalizeCall).toHaveBeenCalledWith(
-        "call-unsup-name-1",
-        "conv-unsup-name-1",
-      );
-    });
-
-    test("callee_verification outcome fails with explicit reason", async () => {
-      mockRouteSetupResult = {
-        outcome: {
-          action: "callee_verification",
-          verificationConfig: { maxAttempts: 3, codeLength: 6 },
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: false,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-
-      const mockWs = createMockWs();
-      mockSessions.set("call-unsup-callee-1", {
-        id: "call-unsup-callee-1",
-        conversationId: "conv-unsup-callee-1",
-        status: "initiated",
-        task: null,
-        startedAt: null,
-        fromNumber: "+15550001111",
-        toNumber: "+14155551234",
-      });
-
-      const session = new MediaStreamCallSession(
-        mockWs.ws,
-        "call-unsup-callee-1",
-      );
-      session.handleMessage(makeStartMessage());
-      await session.whenSetupSettled();
-
-      // Should record the failure with the specific action
-      expect(recordCallEvent).toHaveBeenCalledWith(
-        "call-unsup-callee-1",
-        "call_failed",
-        expect.objectContaining({
-          reason: expect.stringContaining("callee_verification"),
-        }),
-      );
-
-      // Session should be failed
-      expect(updateCallSession).toHaveBeenCalledWith(
-        "call-unsup-callee-1",
-        expect.objectContaining({ status: "failed" }),
-      );
-    });
-
+  describe("normal_call reset after deny", () => {
     test("normal_call after deny scenario still creates controller", async () => {
       // Verify that after a deny-scenario test, resetting to normal_call
       // properly creates a controller (no cross-test pollution).
@@ -1663,6 +1682,582 @@ describe("media-stream setup outcome scenarios", () => {
       );
       expect(registerCallController).not.toHaveBeenCalled();
       expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Setup-flow integration scenarios
+// ---------------------------------------------------------------------------
+// Drive every interactive routeSetup outcome end to end through the real
+// CallSetupFlow (and, for name capture, the real GuardianWaitController)
+// over a fake WebSocket. These use real timers with small mocked timing
+// constants so terminal hangups and guardian-wait polling actually fire.
+
+describe("setup flows over the media-stream transport", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const FROM = "+14155550100";
+  const TO = "+15550001111";
+
+  const sleep = (ms = 15) => Bun.sleep(ms);
+
+  function setupCall(opts: {
+    callId: string;
+    outcome: { action: string; [key: string]: unknown };
+    resolved?: Partial<(typeof mockRouteSetupResult)["resolved"]>;
+    session?: Record<string, unknown>;
+  }) {
+    mockRouteSetupResult = {
+      outcome: opts.outcome,
+      resolved: {
+        assistantId: "self",
+        isInbound: true,
+        otherPartyNumber: FROM,
+        actorTrust: { trustClass: "unknown", memberRecord: null },
+        ...opts.resolved,
+      },
+    };
+    mockSessions.set(opts.callId, {
+      id: opts.callId,
+      conversationId: `conv-${opts.callId}`,
+      status: "initiated",
+      task: null,
+      startedAt: null,
+      fromNumber: FROM,
+      toNumber: TO,
+      ...opts.session,
+    });
+    const mockWs = createMockWs();
+    const session = new MediaStreamCallSession(mockWs.ws, opts.callId);
+    session.handleMessage(makeStartMessage());
+    return { session, mockWs };
+  }
+
+  /**
+   * Deliver a final caller transcript, mirroring the STT session's
+   * onTranscriptFinal callback wiring (driving real audio through the
+   * batch transcriber is out of scope for these tests).
+   */
+  function deliverTranscript(
+    session: MediaStreamCallSession,
+    text: string,
+  ): void {
+    (
+      session as unknown as {
+        handleTranscriptFinal(text: string, durationMs: number): void;
+      }
+    ).handleTranscriptFinal(text, 500);
+  }
+
+  function enterDigits(session: MediaStreamCallSession, digits: string): void {
+    for (const digit of digits) {
+      session.handleMessage(makeDtmfMessage(digit));
+    }
+  }
+
+  function callerSpokeEvents(callId: string) {
+    return mockEvents.filter(
+      (e) => e.callSessionId === callId && e.eventType === "caller_spoke",
+    );
+  }
+
+  describe("inbound verification", () => {
+    test("success routes DTMF to the flow, then proceeds to the initial greeting", async () => {
+      const { session } = setupCall({
+        callId: "call-verif-ok",
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: FROM,
+        },
+      });
+      await session.whenSetupSettled();
+
+      // The flow prompts for the code; no controller exists during setup.
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("six-digit verification code"),
+      );
+      expect(session.getSetupFlow()?.getState()).toBe("collecting_code");
+      expect(session.getController()).toBeNull();
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      enterDigits(session, "123456");
+      await sleep();
+
+      expect(mockAttemptVerificationCode).toHaveBeenCalledWith(
+        expect.objectContaining({ enteredCode: "123456", isOutbound: false }),
+      );
+      // The server records per-digit caller_spoke events for the flow.
+      expect(callerSpokeEvents("call-verif-ok")).toHaveLength(6);
+
+      // Flow completed: controller created + initial greeting fired.
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-verif-ok",
+        expect.anything(),
+      );
+      expect(
+        (CallController as unknown as jest.Mock).mock.calls[0]?.[3],
+      ).toMatchObject({ assistantId: "self" });
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+      expect(session.getSetupFlow()).toBeNull();
+      expect(session.getController()).not.toBeNull();
+      expect(finalizeCall).not.toHaveBeenCalled();
+
+      // Post-setup transcripts route to the controller.
+      deliverTranscript(session, "hello there");
+      await sleep(5);
+      expect(mockHandleCallerUtterance).toHaveBeenCalledWith("hello there");
+
+      session.destroy();
+    });
+
+    test("failure fails the session, finalizes exactly once, and hangs up", async () => {
+      mockVerificationResult = {
+        outcome: "failure",
+        eventName: "voice_verification_failed",
+        ttsMessage: "Verification failed. Goodbye.",
+        attempts: 3,
+      };
+      const { session, mockWs } = setupCall({
+        callId: "call-verif-fail",
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: FROM,
+        },
+      });
+      await session.whenSetupSettled();
+
+      enterDigits(session, "000000");
+      await sleep();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "Verification failed. Goodbye.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-verif-fail",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-verif-fail",
+        "conv-call-verif-fail",
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      // The flow schedules its own delayed endSession.
+      await sleep(30);
+      expect(mockWs.closed).toBe(true);
+
+      // Transport close after flow-side finalization must not double-finalize.
+      session.handleTransportClosed(1000, "session-ended");
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+
+      session.destroy();
+    });
+  });
+
+  describe("outbound verification", () => {
+    test("success posts the pointer and fires the post-verification greeting", async () => {
+      const { session } = setupCall({
+        callId: "call-outverif",
+        outcome: {
+          action: "outbound_verification",
+          assistantId: "self",
+          sessionId: "verif-sess-1",
+          toNumber: TO,
+        },
+        resolved: {
+          isInbound: false,
+          otherPartyNumber: TO,
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+        session: { initiatedFromConversationId: "conv-origin-1" },
+      });
+      await session.whenSetupSettled();
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      enterDigits(session, "654321");
+      await sleep();
+
+      expect(mockAttemptVerificationCode).toHaveBeenCalledWith(
+        expect.objectContaining({ enteredCode: "654321", isOutbound: true }),
+      );
+      expect(addPointerMessage).toHaveBeenCalledWith(
+        "conv-origin-1",
+        "verification_succeeded",
+        TO,
+        expect.objectContaining({ channel: "phone" }),
+      );
+      expect(mockStartPostVerificationGreeting).toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-outverif",
+        expect.anything(),
+      );
+
+      session.destroy();
+    });
+  });
+
+  describe("callee verification", () => {
+    test("posts the code to the origin conversation, retries a wrong code, greets on a match", async () => {
+      const { session } = setupCall({
+        callId: "call-callee",
+        outcome: {
+          action: "callee_verification",
+          verificationConfig: { maxAttempts: 3, codeLength: 4 },
+        },
+        resolved: {
+          isInbound: false,
+          otherPartyNumber: TO,
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+        session: { initiatedFromConversationId: "conv-origin-2" },
+      });
+      await session.whenSetupSettled();
+
+      // The generated code is posted to the initiating conversation.
+      expect(mockAddMessage).toHaveBeenCalledTimes(1);
+      const [postedConvId, , postedContent] = mockAddMessage.mock
+        .calls[0] as unknown as [string, string, string];
+      expect(postedConvId).toBe("conv-origin-2");
+      const code = /: (\d{4})/.exec(postedContent)?.[1];
+      expect(code).toBeDefined();
+
+      // A wrong code re-prompts without ending the call.
+      const wrongCode = code === "0000" ? "1111" : "0000";
+      enterDigits(session, wrongCode);
+      await sleep();
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "That code was incorrect. Please try again.",
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      // The right code proceeds to the initial greeting.
+      enterDigits(session, code!);
+      await sleep();
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-callee",
+        expect.anything(),
+      );
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+      expect(finalizeCall).not.toHaveBeenCalled();
+
+      session.destroy();
+    });
+  });
+
+  describe("invite redemption", () => {
+    test("success speaks the handoff, marks the opening ack, and replays deferred transcripts", async () => {
+      const { session } = setupCall({
+        callId: "call-invite",
+        outcome: {
+          action: "invite_redemption",
+          assistantId: "self",
+          fromNumber: FROM,
+          inviteeName: "Casey Example",
+        },
+      });
+      await session.whenSetupSettled();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("Welcome Casey."),
+      );
+
+      // Hold mid-setup trust re-resolution open so a transcript arrives
+      // during the deferral window.
+      let releaseVerdict!: () => void;
+      mockVerdictGate = new Promise<void>((resolve) => {
+        releaseVerdict = resolve;
+      });
+
+      enterDigits(session, "111222");
+      await sleep();
+      expect(mockAttemptInviteCodeRedemption).toHaveBeenCalledWith(
+        expect.objectContaining({ enteredCode: "111222" }),
+      );
+
+      // Caller speaks while the trust upgrade is in flight — deferred, but
+      // the transcript notifier still fires for UI subscribers.
+      deliverTranscript(session, "hi can you help me book a flight");
+      expect(fireCallTranscriptNotifier).toHaveBeenCalledWith(
+        "conv-call-invite",
+        "call-invite",
+        "caller",
+        "hi can you help me book a flight",
+      );
+      expect(mockHandleCallerUtterance).not.toHaveBeenCalled();
+
+      releaseVerdict();
+      await sleep();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("verified that you are Casey"),
+      );
+      expect(mockMarkNextCallerTurnAsOpeningAck).toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-invite",
+        expect.anything(),
+      );
+      // The deferred transcript replays into the controller after the opener.
+      expect(mockHandleCallerUtterance).toHaveBeenCalledWith(
+        "hi can you help me book a flight",
+      );
+
+      session.destroy();
+    });
+
+    test("failure speaks the failure copy and finalizes exactly once", async () => {
+      mockInviteResult = {
+        outcome: "failure",
+        ttsMessage: "That code is not valid. Goodbye.",
+      };
+      const { session, mockWs } = setupCall({
+        callId: "call-invite-fail",
+        outcome: {
+          action: "invite_redemption",
+          assistantId: "self",
+          fromNumber: FROM,
+          inviteeName: null,
+        },
+      });
+      await session.whenSetupSettled();
+
+      enterDigits(session, "999999");
+      await sleep();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "That code is not valid. Goodbye.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-invite-fail",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      await sleep(30);
+      expect(mockWs.closed).toBe(true);
+      session.handleTransportClosed(1000, "session-ended");
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+
+      session.destroy();
+    });
+  });
+
+  describe("name capture and guardian wait", () => {
+    function nameCaptureOutcome() {
+      return {
+        action: "name_capture",
+        assistantId: "self",
+        fromNumber: FROM,
+      };
+    }
+
+    test("waits for the guardian with NO controller, then approval hands off", async () => {
+      const { session } = setupCall({
+        callId: "call-name-ok",
+        outcome: nameCaptureOutcome(),
+      });
+      await session.whenSetupSettled();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("Can I get your name?"),
+      );
+      expect(session.getSetupFlow()?.getState()).toBe("capturing_name");
+
+      mockCanonicalRequest = { status: "pending" };
+      deliverTranscript(session, "Casey Example");
+      await sleep();
+
+      expect(mockNotifyGuardianOfAccessRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ actorDisplayName: "Casey Example" }),
+      );
+      // The transcript notifier fires for caller turns during setup.
+      expect(fireCallTranscriptNotifier).toHaveBeenCalledWith(
+        "conv-call-name-ok",
+        "call-name-ok",
+        "caller",
+        "Casey Example",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith("call-name-ok", {
+        status: "waiting_on_user",
+      });
+      // No controller exists during the wait — no silence nudges can fire.
+      expect(session.getSetupFlow()?.getState()).toBe(
+        "awaiting_guardian_decision",
+      );
+      expect(session.getController()).toBeNull();
+      expect(CallController as unknown as jest.Mock).not.toHaveBeenCalled();
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      // The guardian approves; the wait poll picks it up.
+      mockCanonicalRequest = { status: "approved" };
+      await sleep(40);
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "Great! Alex said I can speak with you. How can I help?",
+      );
+      expect(mockMarkNextCallerTurnAsOpeningAck).toHaveBeenCalled();
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-name-ok",
+        expect.anything(),
+      );
+      expect(session.getSetupFlow()).toBeNull();
+      expect(finalizeCall).not.toHaveBeenCalled();
+
+      session.destroy();
+    });
+
+    test("guardian denial speaks the goodbye copy and finalizes exactly once", async () => {
+      const { session, mockWs } = setupCall({
+        callId: "call-name-deny",
+        outcome: nameCaptureOutcome(),
+      });
+      await session.whenSetupSettled();
+
+      mockCanonicalRequest = { status: "pending" };
+      deliverTranscript(session, "Casey Example");
+      await sleep();
+
+      mockCanonicalRequest = { status: "denied" };
+      await sleep(40);
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "Sorry, Alex says I'm not allowed to speak with you. Goodbye.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-name-deny",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      await sleep(30);
+      expect(mockWs.closed).toBe(true);
+      session.handleTransportClosed(1000, "session-ended");
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+
+      session.destroy();
+    });
+
+    test("guardian-wait timeout speaks the timeout copy and finalizes exactly once", async () => {
+      mockUserConsultationTimeoutMs = 40;
+      const { session } = setupCall({
+        callId: "call-name-timeout",
+        outcome: nameCaptureOutcome(),
+      });
+      await session.whenSetupSettled();
+
+      mockCanonicalRequest = { status: "pending" };
+      deliverTranscript(session, "Casey Example");
+      await sleep();
+
+      await sleep(80);
+
+      expect(mockEmitCallbackHandoff).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "timeout" }),
+      );
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("Sorry, I can't get ahold of Alex right now."),
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-name-timeout",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      session.destroy();
+    });
+
+    test("disconnect mid-wait disposes the flow, emits the callback handoff, and finalizes once", async () => {
+      const { session } = setupCall({
+        callId: "call-name-drop",
+        outcome: nameCaptureOutcome(),
+      });
+      await session.whenSetupSettled();
+
+      mockCanonicalRequest = { status: "pending" };
+      deliverTranscript(session, "Casey Example");
+      await sleep();
+      expect(session.getSetupFlow()?.getState()).toBe(
+        "awaiting_guardian_decision",
+      );
+
+      session.handleTransportClosed(1006, "network dropped");
+
+      expect(mockEmitCallbackHandoff).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "transport_closed" }),
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-name-drop",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(session.getSetupFlow()).toBeNull();
+
+      // A late approval must not resurrect the torn-down call.
+      mockCanonicalRequest = { status: "approved" };
+      await sleep(40);
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+
+      session.destroy();
+    });
+  });
+
+  describe("unverified caller", () => {
+    test("hears the verification guidance and the call ends without a controller", async () => {
+      const { session, mockWs } = setupCall({
+        callId: "call-unverified",
+        outcome: {
+          action: "unverified_caller",
+          assistantId: "self",
+          fromNumber: FROM,
+          displayName: "Sam Example",
+          isGuardian: false,
+        },
+      });
+      await session.whenSetupSettled();
+
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("registered as Sam Example's phone"),
+      );
+      expect(
+        mockEvents.some(
+          (e) =>
+            e.callSessionId === "call-unverified" &&
+            e.eventType === "inbound_acl_unverified_caller",
+        ),
+      ).toBe(true);
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-unverified",
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledTimes(1);
+      expect(registerCallController).not.toHaveBeenCalled();
+
+      await sleep(30);
+      expect(mockWs.closed).toBe(true);
+
+      session.destroy();
     });
   });
 });

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -21,11 +21,18 @@
  * - WebSocket `open` -> extract callSessionId from upgrade params,
  *   create `MediaStreamCallSession`.
  * - Media stream `start` event -> capture streamSid/callSid, wire
- *   output adapter, create controller.
+ *   output adapter, run setup routing and hand the outcome to a
+ *   `CallSetupFlow` (deny, verification, invite redemption, name
+ *   capture / guardian wait, unverified caller, normal call). The
+ *   controller is created only once the flow completes with a
+ *   `proceed-*` result.
  * - Media stream `media` events -> forwarded to STT session for
  *   turn detection and transcription.
- * - STT `onTranscriptFinal` -> routed to controller's
+ * - STT `onTranscriptFinal` -> routed to the active setup flow's
+ *   `pushTranscriptFinal()`, else the controller's
  *   `handleCallerUtterance()`.
+ * - STT `onDtmf` -> routed to the active setup flow's
+ *   `pushDtmfDigit()` for code-collection sub-flows.
  * - STT `onSpeechStart` -> barge-in: clears outbound audio queue
  *   and interrupts the in-flight LLM turn via the controller.
  * - Media stream `stop` event / WebSocket close -> finalize call.
@@ -34,10 +41,20 @@
 import type { ServerWebSocket } from "bun";
 
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
-import { toTrustContext } from "../runtime/actor-trust-resolver.js";
+import {
+  getGuardianDelivery,
+  getGuardianDeliveryFresh,
+  voiceGuardianDisplayName,
+} from "../contacts/guardian-delivery-reader.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
+import { addMessage } from "../persistence/conversation-crud.js";
+import { resolveGuardianName } from "../prompts/user-reference.js";
+import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
 import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import { CallSetupFlow, type CallSetupFlowDeps } from "./call-setup-flow.js";
+import type { SetupFlowResult } from "./call-setup-flow-types.js";
 import { speakSystemPrompt } from "./call-speech-output.js";
 import {
   fireCallTranscriptNotifier,
@@ -62,8 +79,30 @@ import {
   type MediaStreamSttSessionConfig,
 } from "./media-stream-stt-session.js";
 import { routeSetup } from "./relay-setup-router.js";
+import {
+  attemptInviteCodeRedemption,
+  attemptVerificationCode,
+} from "./relay-verification.js";
 
 const log = getLogger("media-stream-server");
+const UUID_SHAPED_NAME =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Resolve the assistant's display name from identity configuration.
+ * Returns the trimmed name, or null when unavailable or UUID-shaped.
+ */
+function resolveAssistantLabel(): string | null {
+  try {
+    const trimmed = getAssistantName()?.trim();
+    if (!trimmed || UUID_SHAPED_NAME.test(trimmed)) {
+      return null;
+    }
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Active sessions registry (keyed by callSessionId)
@@ -89,6 +128,15 @@ export class MediaStreamCallSession {
   private output: MediaStreamOutput;
   private sttSession: MediaStreamSttSession;
   private controller: CallController | null = null;
+  /**
+   * Active setup flow driving the pre-conversation phase (verification,
+   * invite redemption, name capture, guardian wait, deny). Non-null from
+   * setup routing until the flow completes; caller input routes into it
+   * instead of the controller while set.
+   */
+  private setupFlow: CallSetupFlow | null = null;
+  /** Guardian displayName primed from the gateway binding during setup. */
+  private primedGuardianDisplayName: string | undefined;
   private streamSid: string | null = null;
   private callSid: string | null = null;
   private disposed = false;
@@ -156,6 +204,13 @@ export class MediaStreamCallSession {
   }
 
   /**
+   * Get the active setup flow (for test assertions).
+   */
+  getSetupFlow(): CallSetupFlow | null {
+    return this.setupFlow;
+  }
+
+  /**
    * Resolves once the async setup routing started by the `start` frame has
    * settled. Test-only convenience — production code does not await this.
    */
@@ -198,6 +253,12 @@ export class MediaStreamCallSession {
    */
   handleTransportClosed(code?: number, reason?: string): void {
     if (this.disposed) return;
+
+    // Tear down an in-flight setup flow first: clears its timers and emits
+    // the guardian-wait callback handoff when the caller opted in.
+    const setupFlow = this.setupFlow;
+    this.setupFlow = null;
+    setupFlow?.dispose("transport_closed");
 
     const session = getCallSession(this.callSessionId);
     if (!session) return;
@@ -275,25 +336,13 @@ export class MediaStreamCallSession {
       }
     }
 
-    // Revoke any scoped approval grants bound to this call session.
-    // Revoke by both callSessionId and conversationId because the
-    // guardian-approval-interception minting path sets callSessionId: null
-    // but always sets conversationId.
-    try {
-      revokeScopedApprovalGrantsForContext({
-        callSessionId: this.callSessionId,
-      });
-      revokeScopedApprovalGrantsForContext({
-        conversationId: session.conversationId,
-      });
-    } catch (err) {
-      log.warn(
-        { err, callSessionId: this.callSessionId },
-        "Failed to revoke scoped grants on media-stream transport close",
-      );
-    }
+    this.revokeScopedGrants(session.conversationId);
 
-    finalizeCall(this.callSessionId, session.conversationId);
+    // A setup flow that reached a flow-terminal path already ran
+    // finalizeCall — keep finalization exactly-once.
+    if (!setupFlow?.hasFinalized()) {
+      finalizeCall(this.callSessionId, session.conversationId);
+    }
   }
 
   /**
@@ -304,6 +353,9 @@ export class MediaStreamCallSession {
     this.disposed = true;
 
     this.sttSession.dispose();
+
+    this.setupFlow?.dispose("teardown");
+    this.setupFlow = null;
 
     if (this.controller) {
       this.controller.destroy();
@@ -367,9 +419,9 @@ export class MediaStreamCallSession {
     // ── Setup-policy routing ────────────────────────────────────────
     // Run the same routeSetup() that the ConversationRelay path uses
     // to enforce ACL/deny/escalate, verification, and invite flows.
-    // The media-stream transport does not support interactive sub-flows
-    // (DTMF entry, name capture, guardian wait), so non-normal outcomes
-    // are rejected gracefully with a TTS message and session teardown.
+    // The resulting outcome is handed to a CallSetupFlow, which drives
+    // every interactive sub-flow (DTMF/spoken code entry, invite
+    // redemption, name capture, guardian wait) over this transport.
     const from = session?.fromNumber ?? "";
     const to = session?.toNumber ?? "";
 
@@ -377,7 +429,17 @@ export class MediaStreamCallSession {
     // (e.g. guardian_only) is enforced on this transport too — not just the
     // gateway webhook's no_one kill switch. The reader fails open to `null`
     // by contract, so a transport hiccup admits the caller.
-    const admissionPolicy = await getChannelAdmissionPolicy("phone");
+    //
+    // Concurrently, prime the guardian displayName used by setup-flow copy
+    // and warm the phone-channel guardian-delivery cache for routeSetup's
+    // SYNC resolveActorTrust fallback (gateway-side binding writes don't
+    // invalidate the daemon cache, so read fresh). All three are independent
+    // IPC reads on different cache keys.
+    const [admissionPolicy] = await Promise.all([
+      getChannelAdmissionPolicy("phone"),
+      this.primeGuardianDisplayName(),
+      getGuardianDeliveryFresh({ channelTypes: ["phone"] }),
+    ]);
 
     // The admission-policy read above yields the event loop; if Twilio closed
     // the WebSocket meanwhile, the close handler will have called destroy().
@@ -442,141 +504,161 @@ export class MediaStreamCallSession {
       "Media stream session started",
     );
 
-    switch (outcome.action) {
-      case "normal_call": {
-        // Create the call controller only for normal calls. Deny and
-        // unsupported-flow paths speak a message via the output adapter
-        // directly and don't need a controller. Creating it eagerly
-        // would start duration/silence timers that leak when the
-        // session is torn down before destroy() runs.
-        const initialTrustContext = toTrustContext(
-          resolved.actorTrust,
-          resolved.otherPartyNumber,
-        );
-        this.controller = new CallController(
-          this.callSessionId,
-          this.output,
-          session?.task ?? null,
-          {
-            assistantId: resolved.assistantId,
-            trustContext: initialTrustContext,
-          },
-        );
-        registerCallController(this.callSessionId, this.controller);
-
-        // Routing/ACL cleared — leave the setup-pending window so subsequent
-        // transcripts and barge-in are handled normally.
-        this.setupRouting = false;
-
-        // Fire the initial greeting.
-        this.controller.startInitialGreeting().catch((err) => {
-          log.error(
-            { err, callSessionId: this.callSessionId },
-            "Failed to start initial greeting on media-stream session",
-          );
-        });
-        return;
-      }
-
-      case "deny":
-        // Deny — speak the denial message and tear down.
-        log.warn(
-          {
-            callSessionId: this.callSessionId,
-            reason: outcome.logReason,
-          },
-          "Media-stream setup denied by ACL policy",
-        );
-        recordCallEvent(this.callSessionId, "inbound_acl_denied", {
-          from,
-          trustClass: resolved.actorTrust.trustClass,
-        });
-        updateCallSession(this.callSessionId, {
-          status: "failed",
-          endedAt: Date.now(),
-          lastError: outcome.logReason,
-        });
-        // Run finalization now because handleTransportClosed will see
-        // terminal status and exit early when the WebSocket closes.
-        this.runFinalizationAndGrantCleanup(session);
-        void speakSystemPrompt(this.output, outcome.message).finally(() => {
-          setTimeout(() => this.output.endSession(outcome.logReason), 3000);
-        });
-        return;
-
-      default:
-        // All interactive sub-flows (verification, invite_redemption,
-        // name_capture, callee_verification, outbound_verification) are
-        // not supported on the media-stream transport. The TwiML preflight
-        // in twilio-routes.ts should have caught this and fallen back to
-        // ConversationRelay — reaching here indicates the preflight was
-        // bypassed or a new setup action was added without updating the
-        // preflight guard. Speak a generic apology and end the session
-        // rather than silently bypassing policy enforcement.
-        log.error(
-          {
-            callSessionId: this.callSessionId,
-            action: outcome.action,
-          },
-          "Media-stream transport received unsupported setup flow — preflight guard should have prevented this",
-        );
-        recordCallEvent(this.callSessionId, "call_failed", {
-          reason: `Setup flow '${outcome.action}' not supported on media-stream transport (preflight guard bypass)`,
-          transport: "media-stream",
-        });
-        updateCallSession(this.callSessionId, {
-          status: "failed",
-          endedAt: Date.now(),
-          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport — preflight guard should have prevented this`,
-        });
-        // Run finalization now because handleTransportClosed will see
-        // terminal status and exit early when the WebSocket closes.
-        this.runFinalizationAndGrantCleanup(session);
-        void speakSystemPrompt(
-          this.output,
-          "Sorry, this call requires additional verification that isn't available right now. Please try calling back. Goodbye.",
-        ).finally(() => {
-          setTimeout(
-            () =>
-              this.output.endSession(
-                `Unsupported setup flow: ${outcome.action} (preflight guard bypass)`,
-              ),
-            3000,
-          );
-        });
-        return;
-    }
+    const flow = new CallSetupFlow(
+      this.callSessionId,
+      this.output,
+      this.buildSetupFlowDeps(session),
+    );
+    this.setupFlow = flow;
+    // Routing/ACL cleared — the flow owns the setup phase from here, so
+    // transcripts and DTMF route into it until it completes.
+    this.setupRouting = false;
+    await flow.start(outcome, resolved);
   }
 
-  // ── Finalization helper for early-teardown paths ─────────────────
+  // ── Setup flow wiring ─────────────────────────────────────────────
 
   /**
-   * Run scoped-grant revocation and call finalization inline. Used by
-   * the deny and unsupported-flow branches which set terminal status
-   * before `endSession()`. When the WebSocket subsequently closes,
-   * {@link handleTransportClosed} sees the terminal status and exits
-   * early — so we must perform cleanup here to avoid leaking grants
-   * and skipping `finalizeCall()` side-effects.
+   * Real side-effect surface for the {@link CallSetupFlow}. Pure-logic
+   * deps (verification code parsing, trust re-resolution, guardian wait
+   * construction) use the flow's real-implementation defaults.
    */
-  private runFinalizationAndGrantCleanup(
+  private buildSetupFlowDeps(
+    session: ReturnType<typeof getCallSession>,
+  ): CallSetupFlowDeps {
+    return {
+      speakSystemPrompt: (_transport, text) =>
+        speakSystemPrompt(this.output, text),
+      updateCallSession,
+      recordCallEvent,
+      onComplete: (result) => this.handleSetupFlowResult(result, session),
+      getCallSession,
+      // Flow-terminal paths set a terminal session status, so the
+      // transport-close handler skips its cleanup — revoke scoped grants
+      // here alongside finalization.
+      finalizeCall: (callSessionId, conversationId) => {
+        this.revokeScopedGrants(conversationId);
+        finalizeCall(callSessionId, conversationId);
+      },
+      addMessage,
+      addPointerMessage,
+      fireCallTranscriptNotifier,
+      resolveGuardianLabel: () =>
+        resolveGuardianName(this.primedGuardianDisplayName),
+      resolveAssistantLabel,
+      notifyGuardianOfAccessRequest,
+      attemptVerificationCode,
+      attemptInviteCodeRedemption,
+    };
+  }
+
+  /**
+   * Continue the call once the setup flow reaches a terminal result:
+   * create + register the call controller and fire the matching opener
+   * for `proceed-*` variants, or complete finalization for `ended`
+   * (the flow already spoke its terminal copy, set terminal status,
+   * and scheduled its own delayed `endSession`).
+   */
+  private handleSetupFlowResult(
+    result: SetupFlowResult,
     session: ReturnType<typeof getCallSession>,
   ): void {
+    const flow = this.setupFlow;
+    this.setupFlow = null;
+
+    if (result.kind === "ended") {
+      // handleTransportClosed will see the terminal status and exit early
+      // when the WebSocket closes, so run cleanup inline — unless a
+      // flow-terminal path already finalized (grants revoked there too).
+      if (!flow?.hasFinalized()) {
+        this.runFinalizationAndGrantCleanup(session);
+      }
+      return;
+    }
+
+    const controller = new CallController(
+      this.callSessionId,
+      this.output,
+      session?.task ?? null,
+      {
+        assistantId: result.assistantId,
+        trustContext: result.trustContext,
+      },
+    );
+    this.controller = controller;
+    registerCallController(this.callSessionId, controller);
+
+    const opener =
+      result.kind === "proceed-post-verification-greeting"
+        ? controller.startPostVerificationGreeting()
+        : result.kind === "proceed-handoff-spoken"
+          ? Promise.resolve(controller.markNextCallerTurnAsOpeningAck())
+          : controller.startInitialGreeting();
+
+    const deferredTranscripts = result.deferredTranscripts ?? [];
+    void opener
+      .then(async () => {
+        // Replay transcripts buffered during mid-setup trust re-resolution,
+        // in order, so the caller's first utterance runs under the upgraded
+        // trust context.
+        for (const text of deferredTranscripts) {
+          await controller.handleCallerUtterance(text);
+        }
+      })
+      .catch((err) => {
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          "Failed to start call flow after setup completion",
+        );
+      });
+  }
+
+  /**
+   * Prime the guardian displayName from the gateway binding so the
+   * synchronous setup-flow label path can read it without an IPC
+   * round-trip.
+   */
+  private async primeGuardianDisplayName(): Promise<void> {
+    const list = await getGuardianDelivery();
+    this.primedGuardianDisplayName = voiceGuardianDisplayName(list);
+  }
+
+  // ── Finalization helpers for early-teardown paths ─────────────────
+
+  /**
+   * Revoke any scoped approval grants bound to this call session.
+   * Revoke by both callSessionId and conversationId because the
+   * guardian-approval-interception minting path sets callSessionId: null
+   * but always sets conversationId.
+   */
+  private revokeScopedGrants(conversationId: string | undefined): void {
     try {
       revokeScopedApprovalGrantsForContext({
         callSessionId: this.callSessionId,
       });
-      if (session?.conversationId) {
-        revokeScopedApprovalGrantsForContext({
-          conversationId: session.conversationId,
-        });
+      if (conversationId) {
+        revokeScopedApprovalGrantsForContext({ conversationId });
       }
     } catch (err) {
       log.warn(
         { err, callSessionId: this.callSessionId },
-        "Failed to revoke scoped grants on early teardown path",
+        "Failed to revoke scoped grants for media-stream session",
       );
     }
+  }
 
+  /**
+   * Run scoped-grant revocation and call finalization inline. Used for
+   * setup-terminal paths which set terminal status before `endSession()`.
+   * When the WebSocket subsequently closes, {@link handleTransportClosed}
+   * sees the terminal status and exits early — so cleanup must happen
+   * here to avoid leaking grants and skipping `finalizeCall()`
+   * side-effects.
+   */
+  private runFinalizationAndGrantCleanup(
+    session: ReturnType<typeof getCallSession>,
+  ): void {
+    this.revokeScopedGrants(session?.conversationId);
     if (session?.conversationId) {
       finalizeCall(this.callSessionId, session.conversationId);
     }
@@ -630,6 +712,23 @@ export class MediaStreamCallSession {
 
     this.transcriptFinalsProduced++;
 
+    // While a setup flow is active it owns caller speech (name capture,
+    // spoken code entry, guardian-wait utterances). Fire the transcript
+    // notifier for UI subscribers, then route into the flow.
+    if (this.setupFlow) {
+      const setupSession = getCallSession(this.callSessionId);
+      if (setupSession) {
+        fireCallTranscriptNotifier(
+          setupSession.conversationId,
+          this.callSessionId,
+          "caller",
+          text,
+        );
+      }
+      this.setupFlow.pushTranscriptFinal(text);
+      return;
+    }
+
     if (!this.controller) {
       log.warn(
         { callSessionId: this.callSessionId },
@@ -682,6 +781,10 @@ export class MediaStreamCallSession {
       dtmfDigit: digit,
       transport: "media-stream",
     });
+
+    // While a setup flow is active, digits feed its code-collection
+    // sub-flows (the flow itself records no per-digit events).
+    this.setupFlow?.pushDtmfDigit(digit);
   }
 
   private handleStreamStop(): void {


### PR DESCRIPTION
## Summary
- MediaStreamCallSession now constructs a CallSetupFlow for every routeSetup outcome (verification, invite, name-capture/guardian-wait, unverified, deny, normal) — the unsupported-flow rejection branch is gone
- DTMF and final transcripts route to the active flow, then the controller; deferred transcripts replay after the opener; exactly-once finalization across flow-terminal and transport-close paths
- No controller exists during setup waits (no spurious silence nudges)

Part of plan: phone-media-stream-v2.md (PR 9 of 17)