### PR TITLE
feat(persistence): auto-attribute slow Drizzle queries to their call site

### DIFF
--- a/assistant/src/persistence/__tests__/slow-query-log.test.ts
+++ b/assistant/src/persistence/__tests__/slow-query-log.test.ts
@@ -179,8 +179,31 @@ describe("slow-query-log", () => {
     expect(events).toHaveLength(2);
     expect(events[0].label).toBe("schedule::claimDue");
     expect(events[1].label).toBe("schedule::complete");
-    // Unlabeled queries carry no label field.
+    // A curated label suppresses the auto-derived caller.
+    expect(events[0].caller).toBeUndefined();
     expect(events[0].sql).toContain("INSERT INTO t");
+  });
+
+  test("an unlabeled query derives a caller from the stack", () => {
+    const events: SlowQueryEvent[] = [];
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    wrapSqliteForSlowQueryLogging(db, {
+      thresholdMs: 100,
+      now: fakeClock(0, 500),
+      onSlowQuery: (e) => events.push(e),
+    });
+
+    // No `.label()` — mirrors a Drizzle query, which has no chokepoint to label.
+    db.query("SELECT * FROM t").all();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].label).toBeUndefined();
+    // The caller points at this test file (the application frame that issued it),
+    // not at slow-query-log.ts or bun:sqlite internals.
+    expect(events[0].caller).toBeDefined();
+    expect(events[0].caller).toContain("slow-query-log.test.ts");
+    expect(events[0].caller).not.toContain("slow-query-log.ts");
   });
 
   test("wraps in place and returns the same Database instance", () => {

--- a/assistant/src/persistence/__tests__/slow-query-log.test.ts
+++ b/assistant/src/persistence/__tests__/slow-query-log.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
 import {
+  callerFromStack,
   SLOW_QUERY_THRESHOLD_MS,
   type SlowQueryEvent,
   wrapSqliteForSlowQueryLogging,
@@ -209,5 +210,57 @@ describe("slow-query-log", () => {
   test("wraps in place and returns the same Database instance", () => {
     const db = new Database(":memory:");
     expect(wrapSqliteForSlowQueryLogging(db)).toBe(db);
+  });
+});
+
+describe("callerFromStack", () => {
+  test("returns the first app frame in a source-tree run, skipping ORM/self", () => {
+    const stack = [
+      "Error",
+      "    at callerFromStack (/repo/assistant/src/persistence/slow-query-log.ts:110:20)",
+      "    at emit (/repo/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at all (/root/.bun/install/cache/drizzle-orm@0.45.2@@@1/bun-sqlite/session.js:79:23)",
+      "    at insertMessageCore (/repo/assistant/src/persistence/conversation-crud.ts:474:10)",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBe(
+      "persistence/conversation-crud.ts:insertMessageCore:474",
+    );
+  });
+
+  test("preserves the assistant's own src frames in a packaged install", () => {
+    // Local-runtime install: the daemon runs from
+    // node_modules/@vellumai/assistant/src, so app frames also contain
+    // node_modules. Third-party deps are still skipped; assistant src is not.
+    const stack = [
+      "Error",
+      "    at emit (/app/node_modules/@vellumai/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at all (/app/node_modules/drizzle-orm/bun-sqlite/session.js:79:23)",
+      "    at claimDueSchedules (/app/node_modules/@vellumai/assistant/src/schedule/schedule-store.ts:88:12)",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBe(
+      "schedule/schedule-store.ts:claimDueSchedules:88",
+    );
+  });
+
+  test("handles column-less frames (function omitted)", () => {
+    const stack = [
+      "Error",
+      "    at emit (/repo/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at all (/root/.bun/install/cache/drizzle-orm@0.45.2/bun-sqlite/session.js:79:23)",
+      "    at /repo/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts:231",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBe(
+      "plugins/defaults/memory/context-search/sources/conversations.ts:231",
+    );
+  });
+
+  test("returns undefined when no application frame is present", () => {
+    const stack = [
+      "Error",
+      "    at emit (/repo/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at all (/root/.bun/install/cache/drizzle-orm@0.45.2/bun-sqlite/session.js:79:23)",
+      "    at processTicksAndRejections (native:7:39)",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBeUndefined();
   });
 });

--- a/assistant/src/persistence/slow-query-log.ts
+++ b/assistant/src/persistence/slow-query-log.ts
@@ -77,20 +77,40 @@ export interface SlowQueryEvent {
   caller?: string;
 }
 
+/** This instrumentation module — never the query's call site. */
+const SELF_MODULE = "slow-query-log.ts";
+
 /**
- * Stack frames matching these substrings are instrumentation/ORM/runtime plumbing,
- * not the query's call site — skipped when deriving {@link SlowQueryEvent.caller}.
- * Dependency frames (Drizzle et al.) live under `node_modules` or Bun's global
- * install cache (`.bun/install/cache/drizzle-orm@x.y.z/…`), so both are skipped
- * to land on the first application (`src/`) frame that issued the query.
+ * Marks the assistant package's own source. In local-runtime installs the CLI
+ * runs the daemon from `<installDir>/node_modules/@vellumai/assistant/src/…`, so
+ * the assistant's own frames also contain `node_modules` — they must NOT be
+ * treated as third-party dependency frames when deriving the caller.
  */
-const CALLER_SKIP = [
-  "slow-query-log.ts",
-  "node_modules",
-  ".bun/install/cache",
-  "node:",
-  "bun:",
-];
+const ASSISTANT_SRC_MARKER = "@vellumai/assistant/src/";
+
+/**
+ * True for stack frames that are runtime/ORM/instrumentation plumbing rather
+ * than the application code that issued the query. Third-party dependency frames
+ * (Drizzle et al.) live under `node_modules/` or Bun's global install cache
+ * (`.bun/install/cache/drizzle-orm@x.y.z/…`) and are skipped — but the
+ * assistant's own packaged `src/` frames, which also live under `node_modules`,
+ * are preserved.
+ */
+function isPlumbingFrame(line: string): boolean {
+  // Runtime internals: `node:*` / `bun:*` modules and Bun's `native:` frames
+  // (moduleEvaluation, processTicksAndRejections, …).
+  if (
+    line.includes("node:") ||
+    line.includes("bun:") ||
+    line.includes("native:")
+  ) {
+    return true;
+  }
+  if (line.includes(SELF_MODULE)) return true;
+  const isDependency =
+    line.includes("node_modules/") || line.includes(".bun/install/cache/");
+  return isDependency && !line.includes(ASSISTANT_SRC_MARKER);
+}
 
 /** `src/`-relative path, or bare basename when the frame is outside `src/`. */
 function shortenStackFile(file: string): string {
@@ -101,19 +121,23 @@ function shortenStackFile(file: string): string {
 
 /**
  * Best-effort attribution for a query with no explicit label: the first stack
- * frame outside this module, Drizzle, and the runtime — i.e. the application
- * code that issued the query. Returns e.g. `persistence/conversation-crud.ts:insertMessageCore:474`.
- * Only called on the slow path (a query already past the threshold), so the
- * `Error().stack` cost is incurred rarely.
+ * frame outside this module, dependencies, and the runtime — i.e. the
+ * application code that issued the query. Returns e.g.
+ * `persistence/conversation-crud.ts:insertMessageCore:474`. Only called on the
+ * slow path (a query already past the threshold), so the `Error().stack` cost is
+ * incurred rarely. Accepts an explicit `stack` for testing.
+ *
+ * @internal exported only for unit tests.
  */
-function callerFromStack(): string | undefined {
-  const stack = new Error().stack;
+export function callerFromStack(
+  stack: string | undefined = new Error().stack,
+): string | undefined {
   if (!stack) return undefined;
   const lines = stack.split("\n");
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i];
     if (!line.includes("at ")) continue;
-    if (CALLER_SKIP.some((skip) => line.includes(skip))) continue;
+    if (isPlumbingFrame(line)) continue;
     // Bun renders frames as `at fn (file:line:col)`, `at file:line:col`, or
     // (for some optimized frames) `at file:line` with no function or column.
     const withFn = line.match(

--- a/assistant/src/persistence/slow-query-log.ts
+++ b/assistant/src/persistence/slow-query-log.ts
@@ -18,6 +18,13 @@
  * naming the specific query behind a freeze regardless of whether it came from
  * Drizzle or {@link ./raw-query}.
  *
+ * Attribution: raw-query callers attach a curated `.label()` (e.g.
+ * `"schedule:claimDue"`). Drizzle's fluent API has no chokepoint to label, so
+ * for any query without an explicit label the reporter derives a `caller` from
+ * the stack — `path:function:line` of the application frame that issued it —
+ * captured only on the slow path. Between the two, every slow query is
+ * attributable to its call site with no per-query annotation of Drizzle code.
+ *
  * This is pure instrumentation: return values, parameter binding, transactions,
  * savepoints, and error propagation are all preserved exactly. The fast path
  * adds only a `performance.now()` pair and a numeric compare — no allocation or
@@ -62,6 +69,65 @@ export interface SlowQueryEvent {
   rowCount?: number;
   /** Caller-supplied attribution tag, when the query was issued via `.label()`. */
   label?: string;
+  /**
+   * Auto-derived call site (`path:function:line`) for queries with no explicit
+   * `.label()` — notably every Drizzle query, which has no chokepoint to attach
+   * a label to. Captured from the stack only on the slow path.
+   */
+  caller?: string;
+}
+
+/**
+ * Stack frames matching these substrings are instrumentation/ORM/runtime plumbing,
+ * not the query's call site — skipped when deriving {@link SlowQueryEvent.caller}.
+ * Dependency frames (Drizzle et al.) live under `node_modules` or Bun's global
+ * install cache (`.bun/install/cache/drizzle-orm@x.y.z/…`), so both are skipped
+ * to land on the first application (`src/`) frame that issued the query.
+ */
+const CALLER_SKIP = [
+  "slow-query-log.ts",
+  "node_modules",
+  ".bun/install/cache",
+  "node:",
+  "bun:",
+];
+
+/** `src/`-relative path, or bare basename when the frame is outside `src/`. */
+function shortenStackFile(file: string): string {
+  const idx = file.lastIndexOf("/src/");
+  if (idx >= 0) return file.slice(idx + "/src/".length);
+  return file.split("/").pop() ?? file;
+}
+
+/**
+ * Best-effort attribution for a query with no explicit label: the first stack
+ * frame outside this module, Drizzle, and the runtime — i.e. the application
+ * code that issued the query. Returns e.g. `persistence/conversation-crud.ts:insertMessageCore:474`.
+ * Only called on the slow path (a query already past the threshold), so the
+ * `Error().stack` cost is incurred rarely.
+ */
+function callerFromStack(): string | undefined {
+  const stack = new Error().stack;
+  if (!stack) return undefined;
+  const lines = stack.split("\n");
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes("at ")) continue;
+    if (CALLER_SKIP.some((skip) => line.includes(skip))) continue;
+    // Bun renders frames as `at fn (file:line:col)`, `at file:line:col`, or
+    // (for some optimized frames) `at file:line` with no function or column.
+    const withFn = line.match(
+      /at (?:async )?([^\s(]+) \((.+?):(\d+)(?::\d+)?\)/,
+    );
+    if (withFn) {
+      return `${shortenStackFile(withFn[2])}:${withFn[1]}:${withFn[3]}`;
+    }
+    const noFn = line.match(/at (?:async )?(.+?):(\d+)(?::\d+)?$/);
+    if (noFn) {
+      return `${shortenStackFile(noFn[1])}:${noFn[2]}`;
+    }
+  }
+  return undefined;
 }
 
 /** Log a slow statement execution at WARN with its SQL and duration. */
@@ -132,12 +198,15 @@ export function wrapSqliteForSlowQueryLogging(
     durationMs: number,
     result: unknown,
   ): void => {
-    // Only ever called on the slow path, so building the payload here is fine.
+    // Only ever called on the slow path, so building the payload — including the
+    // stack walk for unlabeled (Drizzle) queries — is fine.
+    const caller = label === undefined ? callerFromStack() : undefined;
     onSlowQuery({
       durationMs,
       sql: sql.slice(0, SQL_PREVIEW_MAX),
       ...(Array.isArray(result) ? { rowCount: result.length } : {}),
       ...(label === undefined ? {} : { label }),
+      ...(caller === undefined ? {} : { caller }),
     });
   };
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to the raw-query label work (#36814, #36953): audit the rest of our Drizzle queries and give slow ones call-site attribution too.

## Audit

Anchoring to real Drizzle db handles (filtering out `Map`/`Set`/DOM noise), the Drizzle surface is **~390 query call sites across 73 non-test files** (`update` ~177, `insert` ~101, `delete` ~54, `select` ~33+, `transaction` ~25).

The wrapper already *times* all of these — but they logged SQL only, with no call-site attribution, because **Drizzle's fluent API has no chokepoint to attach a `.label()`** the way the raw helpers do (raw helpers could take a required `label` arg because I changed their signature; Drizzle can't).

## Approach — auto attribution instead of ~390 manual labels

Rather than build an AsyncLocalStorage labeling mechanism and wrap ~390 call sites (huge diff + ongoing maintenance), the reporter **derives the attribution automatically**: when a slow query has no explicit label, it walks `Error().stack` and records the first application frame as `caller` (e.g. `persistence/conversation-crud.ts:insertMessageCore:474`).

- **Slow-path only.** The stack walk happens inside `emit()`, which only runs when a query is already past the threshold — so the cost is incurred rarely and the fast path is unchanged.
- **Full coverage, zero churn.** Every Drizzle query, raw query, and future query is attributed with no per-call-site annotation.
- **Curated labels still win.** An explicit `.label()` (the raw-query helpers) is used as-is and suppresses the auto `caller`.
- **Robust frame skipping.** Dependency frames (Drizzle resolves to Bun's global install cache `~/.bun/install/cache/drizzle-orm@x.y.z/…`, not just `node_modules`), the instrumentation module, and `node:`/`bun:` runtime frames are skipped so the caller lands on real `src/` code. Bun renders some frames without a column or function name — the parser handles all three shapes.

Result: slow Drizzle queries now log `{ durationMs, sql, rowCount?, caller }`; labeled raw queries log `{ …, label }`.

## Test plan

- `slow-query-log.test.ts`: added coverage that an unlabeled query derives a `caller` pointing at the issuing app frame (not `slow-query-log.ts`/bun internals), and that a curated `.label()` suppresses the caller. Full file: 10/10 pass.
- Persistence suite: 49/49 pass. Typecheck clean (except the pre-existing, unrelated `packages/ces-client` workspace-resolution error that reproduces on `main`). Lint + Prettier clean.

If you'd prefer curated names on specific hot paths (schedule store, message insert, memory/history loads) on top of the auto caller, that's a small follow-up using the existing `.label()` primitive — but the auto caller already gives exact `file:function:line` everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117N3JqQpZFMMnrqn8NCPwq)_