### PR TITLE
test(web): use generic placeholder name in apply-personality test

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -21,10 +21,10 @@ describe("buildPersonalityMessage", () => {
         "playful-serious": 0,
         "polite-unfiltered": 60,
       },
-      "Akash",
+      "Alice",
     );
 
-    expect(msg).toContain("Akash wants to customize your personality.");
+    expect(msg).toContain("Alice wants to customize your personality.");
     expect(msg).toContain("Companion (0-100): 30");
     expect(msg).toContain("Coworker (0-100): 70");
     expect(msg).toContain("Voice Style (0 = Gen Z, 100 = Boomer): 80");


### PR DESCRIPTION
## Summary
- Replace the real personal name used as the `userName` fixture in `clients/web/src/domains/onboarding/apply-personality.test.ts` (pre-existing from #36511) with the generic placeholder "Alice", per the Generic Examples rule in AGENTS.md.
- Swept the file for other personal names: none remain — all other strings are generic ("The user") or file paths.

## Original prompt
Replace the real name "Akash" used as userName in clients/web/src/domains/onboarding/apply-personality.test.ts (pre-existing from #36511) with a generic placeholder per the Generic Examples rule; sweep the file for other personal names while there

🤖 Generated with [Claude Code](https://claude.com/claude-code)