### PR TITLE
feat(calls): route all phone calls through media-stream TwiML with credential preflight

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -105,6 +105,12 @@ mock.module("../daemon/handlers/config-ingress.js", () => ({
   syncTwilioWebhooks: async () => ({ success: true }),
 }));
 
+// Credential readiness gate inside preflightVoiceIngress — ready by default.
+let mockCredentialReadiness: Record<string, unknown> = { status: "ready" };
+mock.module("../calls/telephony-credential-preflight.js", () => ({
+  resolveTelephonyCredentialReadiness: async () => mockCredentialReadiness,
+}));
+
 import {
   clearActiveCallLeases,
   getActiveCallLease,
@@ -131,6 +137,7 @@ beforeEach(() => {
   twilioInitiateCallArgs = [];
   mockIngressEnabled = true;
   mockIngressPublicBaseUrl = "https://test.example.com";
+  mockCredentialReadiness = { status: "ready" };
 });
 
 let ensuredConvIds = new Set<string>();
@@ -358,6 +365,46 @@ describe("startCall — pointer message regression", () => {
       expect(result.error).toContain("Public ingress");
     }
     expect(twilioInitiateCallCount).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const text = getLatestAssistantText(convId);
+    expect(text).not.toBeNull();
+    expect(text!).toContain("+15559876543");
+    expect(text!).toContain("failed");
+  });
+
+  test("fails fast when telephony credentials are not ready and never reaches Twilio dialing", async () => {
+    const convId = "conv-domain-creds-not-ready";
+    ensureConversation(convId);
+    mockCredentialReadiness = {
+      status: "not-ready",
+      missing: [
+        {
+          kind: "stt",
+          providerId: "deepgram",
+          reason: 'No API key configured for credential provider "deepgram"',
+        },
+      ],
+      userMessage:
+        'Phone calls are unavailable because they require an API key for the speech-to-text provider "deepgram".',
+    };
+
+    const result = await startCall({
+      phoneNumber: "+15559876543",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      // The tool-facing error names the offending provider.
+      expect(result.error).toContain('speech-to-text provider "deepgram"');
+    }
+    // No Twilio call was placed and no call session was created.
+    expect(twilioInitiateCallCount).toBe(0);
+    expect(listActiveCallLeases()).toHaveLength(0);
 
     await new Promise((r) => setTimeout(r, 50));
 

--- a/assistant/src/__tests__/telephony-credential-preflight.test.ts
+++ b/assistant/src/__tests__/telephony-credential-preflight.test.ts
@@ -222,6 +222,45 @@ describe("resolveTelephonyCredentialReadiness", () => {
     expect(readiness.userMessage).toContain("text-to-speech");
   });
 
+  test("fish-audio keyed but referenceId-less with no fallback → not-ready naming the reference ID", async () => {
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "fish-audio",
+      reason: "missing-fish-audio-reference-id",
+    };
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(fallbackScanCalls).toEqual(["fish-audio" as TtsProviderId]);
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "fish-audio",
+        reason:
+          'TTS provider "fish-audio" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId) and no playable fallback provider is available',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("Fish Audio voice reference ID");
+    expect(readiness.userMessage).toContain(
+      "services.tts.providers.fish-audio.referenceId",
+    );
+  });
+
+  test("fish-audio referenceId-less but a playable fallback exists → ready", async () => {
+    ttsCapability = {
+      status: "not-playable",
+      providerId: "fish-audio",
+      reason: "missing-fish-audio-reference-id",
+    };
+    fallbackProviderId = "elevenlabs";
+
+    const readiness = await resolveTelephonyCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+  });
+
   test("TTS unsupported-format with no fallback → not-ready with a tts entry", async () => {
     ttsCapability = {
       status: "not-playable",

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -292,14 +292,27 @@ describe("resolveTelephonyTtsCapability", () => {
     expect(capability).toEqual({ status: "playable", providerId: "deepgram" });
   });
 
-  test("wav provider with a resolvable key is playable", async () => {
+  test("wav provider with a resolvable key and referenceId is playable", async () => {
     testConfig.services.tts.provider = "fish-audio";
+    testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
     storedKeys["fish-audio"] = "fa-key";
 
     const capability = await resolveTelephonyTtsCapability();
     expect(capability).toEqual({
       status: "playable",
       providerId: "fish-audio",
+    });
+  });
+
+  test("fish-audio with a key but no referenceId is not playable (missing-fish-audio-reference-id)", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    storedKeys["fish-audio"] = "fa-key";
+
+    const capability = await resolveTelephonyTtsCapability();
+    expect(capability).toEqual({
+      status: "not-playable",
+      providerId: "fish-audio",
+      reason: "missing-fish-audio-reference-id",
     });
   });
 
@@ -394,6 +407,22 @@ describe("resolveCallTtsProvider with preferWav", () => {
     storedKeys["compressed-only"] = "co-key";
     storedKeys["elevenlabs"] = "el-key";
     registerStubProvider("compressed-only", async () => {
+      throw new Error("should not be used");
+    });
+    registerStubProvider("elevenlabs", async () => {
+      return { audio: Buffer.from("x"), contentType: "audio/pcm" };
+    });
+
+    const result = await resolveCallTtsProvider({ preferWav: true });
+    expect(result.provider?.id).toBe("elevenlabs");
+    expect(result.audioFormat).toBe("wav");
+  });
+
+  test("falls back when configured fish-audio has a key but no referenceId", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    storedKeys["fish-audio"] = "fa-key";
+    storedKeys["elevenlabs"] = "el-key";
+    registerStubProvider("fish-audio", async () => {
       throw new Error("should not be used");
     });
     registerStubProvider("elevenlabs", async () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -72,8 +72,10 @@ function resolveIngressBaseUrlFromConfig(ingressConfig: unknown): string {
   );
 }
 
-// Default routeSetup mock — returns normal_call. Tests that need different
-// outcomes override `mockRouteSetupResult` before calling the handler.
+// routeSetup mock — TwiML generation must never invoke it (setup routing
+// is owned by the media-stream server at stream start). Tests set
+// `mockRouteSetupResult` to interactive outcomes and assert the webhook
+// still returns Stream TwiML without consulting the router.
 let mockRouteSetupResult: {
   outcome: { action: string; [key: string]: unknown };
   resolved: {
@@ -102,16 +104,18 @@ mock.module("../calls/relay-setup-router.js", () => ({
   },
 }));
 
-// Mock the phone channel admission reader used by the media-stream preflight.
-// Tests override mockAdmissionPolicy to exercise floor classification.
+// Mock the phone channel admission reader and inbound trust reader.
+// TwiML generation must not consult either — both are stream-start
+// concerns owned by the media-stream server.
 let mockAdmissionPolicy: unknown = null;
+let admissionPolicyReads = 0;
 mock.module("../calls/channel-admission-reader.js", () => ({
-  getChannelAdmissionPolicy: async () => mockAdmissionPolicy,
+  getChannelAdmissionPolicy: async () => {
+    admissionPolicyReads++;
+    return mockAdmissionPolicy;
+  },
 }));
 
-// Mock the inbound trust reader used by the media-stream preflight. Captures
-// its args so tests can assert the inbound caller's verdict is fetched, and
-// returns mockInboundVerdict which is threaded into the preflight routeSetup.
 let mockInboundVerdict: unknown = null;
 let lastInboundVerdictArgs: Record<string, unknown> | null = null;
 mock.module("../calls/inbound-trust-reader.js", () => ({
@@ -126,6 +130,13 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
     };
     return mockInboundVerdict;
   },
+}));
+
+// Mock the STT+TTS credential-readiness preflight consulted at TwiML time.
+// Tests override `mockCredentialReadiness` to exercise the not-ready gate.
+let mockCredentialReadiness: Record<string, unknown> = { status: "ready" };
+mock.module("../calls/telephony-credential-preflight.js", () => ({
+  resolveTelephonyCredentialReadiness: async () => mockCredentialReadiness,
 }));
 
 mock.module("../config/env.js", () => ({
@@ -365,6 +376,7 @@ import {
 } from "../calls/call-store.js";
 import {
   buildWelcomeGreeting,
+  handleInternalVoiceWebhook,
   handleStatusCallback,
   handleVoiceWebhook,
 } from "../calls/twilio-routes.js";
@@ -488,9 +500,12 @@ describe("twilio webhook routes", () => {
     mockConfigObj.services.stt.provider = "deepgram" as any;
     // Reset admission policy + captured routeSetup context between tests
     mockAdmissionPolicy = null;
+    admissionPolicyReads = 0;
     lastRouteSetupCtx = null;
     mockInboundVerdict = null;
     lastInboundVerdictArgs = null;
+    // Reset credential readiness to ready
+    mockCredentialReadiness = { status: "ready" };
     // Reset routeSetup mock to default normal_call
     mockRouteSetupResult = {
       outcome: { action: "normal_call", isInbound: true },
@@ -845,11 +860,11 @@ describe("twilio webhook routes", () => {
     });
   });
 
-  // ── TwiML relay URL generation ──────────────────────────────────────
+  // ── TwiML stream URL generation ─────────────────────────────────────
   // Call handleVoiceWebhook directly since direct routes are blocked.
 
-  describe("voice webhook TwiML relay URL", () => {
-    test("TwiML relay URL uses placeholder for gateway resolution", async () => {
+  describe("voice webhook TwiML stream URL", () => {
+    test("TwiML stream URL uses placeholder for gateway resolution", async () => {
       const session = createTestSession("conv-twiml-1", "CA_twiml_1");
       const req = makeVoiceRequest(session.id, { CallSid: "CA_twiml_1" });
 
@@ -858,7 +873,7 @@ describe("twilio webhook routes", () => {
       expect(res.status).toBe(200);
       const twiml = await res.text();
       expect(twiml).toContain(
-        "wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/relay",
+        `wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream/${session.id}`,
       );
     });
 
@@ -1031,8 +1046,9 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain("callSessionId=");
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).toContain('<Parameter name="callSessionId"');
 
       // Verify session was created with the CallSid
       const session = getCallSessionByCallSid("CA_inbound_new_1");
@@ -1104,106 +1120,74 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain(`callSessionId=${session.id}`);
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).toContain(`/webhooks/twilio/media-stream/${session.id}`);
     });
   });
 
-  // ── services.stt-driven TwiML routing ───────────────────────────────
-  // These tests assert that the voice webhook TwiML path is determined
-  // by services.stt.provider via resolveTelephonySttRouting — the
-  // canonical telephony STT routing resolver.
+  // ── Provider-independent Stream TwiML ───────────────────────────────
+  // Every call runs over the media-stream transport regardless of the
+  // configured STT provider — the webhook always emits <Connect><Stream>.
 
-  describe("services.stt-driven TwiML routing", () => {
-    test("outbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      const session = createTestSession("conv-stt-dg-1", "CA_stt_dg_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_dg_1" });
+  describe("Stream TwiML for every STT provider", () => {
+    const providers = [
+      "deepgram",
+      "google-gemini",
+      "openai-whisper",
+      "xai",
+    ] as const;
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
+    for (const provider of providers) {
+      test(`outbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+        mockConfigObj.services.stt.provider = provider as any;
+        const session = createTestSession(
+          `conv-stt-${provider}-1`,
+          `CA_stt_${provider}_1`,
+        );
+        const req = makeVoiceRequest(session.id, {
+          CallSid: `CA_stt_${provider}_1`,
+        });
 
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-    });
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
 
-    test("inbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      const req = makeInboundVoiceRequest({
-        CallSid: "CA_stt_dg_inbound_1",
-        From: "+14155551234",
-        To: "+15550001111",
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+        expect(twiml).not.toContain("transcriptionProvider=");
+        // callSessionId is in the URL path, not as a query param
+        expect(twiml).toContain(
+          `wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream/${session.id}`,
+        );
+        expect(twiml).not.toContain("?callSessionId=");
       });
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
+      test(`inbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+        mockConfigObj.services.stt.provider = provider as any;
+        const req = makeInboundVoiceRequest({
+          CallSid: `CA_stt_${provider}_inbound_1`,
+          From: "+14155551234",
+          To: "+15550001111",
+        });
 
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-      expect(twiml).not.toContain("<Stream");
-    });
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
 
-    test("outbound: google-gemini -> ConversationRelay with transcriptionProvider=Google", async () => {
-      mockConfigObj.services.stt.provider = "google-gemini" as any;
-      const session = createTestSession("conv-stt-gg-1", "CA_stt_gg_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_gg_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Google"');
-    });
-
-    test("outbound: openai-whisper -> Stream TwiML with path-based metadata (no ConversationRelay)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const session = createTestSession("conv-stt-ow-1", "CA_stt_ow_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_ow_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-      expect(twiml).not.toContain("transcriptionProvider=");
-      // callSessionId is in the URL path, not as a query param
-      expect(twiml).toContain(
-        `wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/media-stream/${session.id}`,
-      );
-      expect(twiml).not.toContain("?callSessionId=");
-    });
-
-    test("inbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const req = makeInboundVoiceRequest({
-        CallSid: "CA_stt_ow_inbound_1",
-        From: "+14155551234",
-        To: "+15550001111",
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+        expect(twiml).not.toContain("transcriptionProvider=");
       });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-      expect(twiml).not.toContain("transcriptionProvider=");
-    });
+    }
 
     test("Stream TwiML includes auth token as Parameter", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
       const session = createTestSession(
-        "conv-stt-ow-token-1",
-        "CA_stt_ow_token_1",
+        "conv-stt-token-1",
+        "CA_stt_token_1",
       );
       const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_stt_ow_token_1",
+        CallSid: "CA_stt_token_1",
       });
 
       const res = await handleVoiceWebhook(req);
@@ -1213,97 +1197,74 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain('<Parameter name="token"');
       expect(twiml).toContain('<Parameter name="callSessionId"');
     });
-
-    test("routing is driven exclusively by services.stt.provider", async () => {
-      // Telephony STT routing reads services.stt.provider only.
-      // calls.voice.transcriptionProvider is a legacy config field that
-      // no longer participates in the call setup path.
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      const session = createTestSession(
-        "conv-stt-routing-1",
-        "CA_stt_routing_1",
-      );
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_routing_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Must be Stream (from services.stt), NOT ConversationRelay
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-    });
   });
 
-  // ── Media-stream preflight setup guardrails ──────────────────────────
-  // These tests assert that the TwiML preflight guard in
-  // buildVoiceWebhookTwiml rejects unsupported interactive setup actions
-  // for media-stream-custom calls before stream bootstrap, falling back
-  // to ConversationRelay for interactive flows.
+  // ── Setup outcomes never affect TwiML ────────────────────────────────
+  // Setup routing is owned by the media-stream server: it re-runs
+  // routeSetup when Twilio's `start` frame arrives and drives every
+  // outcome (verification, invite redemption, name capture, deny, normal)
+  // over the stream. TwiML generation neither consults the router nor
+  // branches on its outcome.
 
-  describe("media-stream preflight setup guardrails", () => {
-    test("media-stream: normal_call setup proceeds with Stream TwiML", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: { action: "normal_call", isInbound: true },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+15559998888",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
+  describe("setup outcomes never affect TwiML", () => {
+    const outcomes: Array<Record<string, unknown>> = [
+      { action: "normal_call", isInbound: true },
+      {
+        action: "deny",
+        message: "This number is not authorized.",
+        logReason: "Inbound voice ACL: blocked caller",
+      },
+      { action: "verification", assistantId: "self", fromNumber: "+14155551234" },
+      { action: "name_capture", assistantId: "self", fromNumber: "+14155551234" },
+      {
+        action: "invite_redemption",
+        assistantId: "self",
+        fromNumber: "+14155551234",
+        inviteeName: "Alice",
+      },
+    ];
 
-      const session = createTestSession("conv-ms-normal-1", "CA_ms_normal_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_normal_1" });
+    for (const outcome of outcomes) {
+      test(`${outcome.action as string} setup outcome still yields Stream TwiML`, async () => {
+        mockRouteSetupResult = {
+          outcome: outcome as { action: string },
+          resolved: {
+            assistantId: "self",
+            isInbound: true,
+            otherPartyNumber: "+14155551234",
+            actorTrust: { trustClass: "unknown", memberRecord: null },
+          },
+        };
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
+        const session = createTestSession(
+          `conv-outcome-${outcome.action as string}`,
+          `CA_outcome_${outcome.action as string}`,
+        );
+        const req = makeVoiceRequest(session.id, {
+          CallSid: `CA_outcome_${outcome.action as string}`,
+        });
 
-      const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
-    });
+        const res = await handleVoiceWebhook(req);
+        expect(res.status).toBe(200);
 
-    test("media-stream: resolves the phone admission floor and threads it into the preflight routeSetup", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+        const twiml = await res.text();
+        expect(twiml).toContain("<Stream");
+        expect(twiml).not.toContain("<ConversationRelay");
+      });
+    }
+
+    test("TwiML generation does not invoke routeSetup or the admission/trust readers", async () => {
       mockAdmissionPolicy = "guardian_only";
-      mockRouteSetupResult = {
-        outcome: { action: "normal_call", isInbound: true },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+15559998888",
-          actorTrust: { trustClass: "guardian", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-floor-1", "CA_ms_floor_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_floor_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      // The resolved floor was passed into the preflight routeSetup so its
-      // classification matches the real stream-start enforcement.
-      expect(lastRouteSetupCtx).not.toBeNull();
-      expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
-    });
-
-    test("media-stream inbound: fetches the caller's verdict (From) and threads it into the preflight routeSetup", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
       mockInboundVerdict = {
         channelType: "phone",
         actorExternalId: "+14155551234",
-        contactId: "contact-1",
-        channelId: "channel-1",
         status: "verified",
         policy: "allow",
         resolutionFailed: false,
       };
 
       const req = makeInboundVoiceRequest({
-        CallSid: "CA_ms_verdict_inbound_1",
+        CallSid: "CA_no_routing_at_twiml_1",
         From: "+14155551234",
         To: "+15550001111",
       });
@@ -1311,46 +1272,38 @@ describe("twilio webhook routes", () => {
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
-      // Inbound: verdict fetched for the caller (From) on the phone channel.
-      expect(lastInboundVerdictArgs).toEqual({
-        channelType: "phone",
-        actorExternalId: "+14155551234",
-      });
-      // Verdict threaded into the preflight routeSetup.
-      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
+      // Routing and its inputs are resolved at stream start, not TwiML time.
+      expect(lastRouteSetupCtx).toBeNull();
+      expect(admissionPolicyReads).toBe(0);
+      expect(lastInboundVerdictArgs).toBeNull();
     });
+  });
 
-    test("media-stream inbound: a blocked/denied member verdict is classified deny in the preflight", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockInboundVerdict = {
-        channelType: "phone",
-        actorExternalId: "+14155551234",
-        contactId: "contact-1",
-        channelId: "channel-1",
-        status: "blocked",
-        policy: "deny",
-        resolutionFailed: false,
-      };
-      // The real router returns `deny` for a blocked member verdict; the mock
-      // reflects that outcome. deny is supported on media-stream, so the
-      // preflight still emits Stream TwiML (denial spoken at stream start).
-      mockRouteSetupResult = {
-        outcome: {
-          action: "deny",
-          message:
-            "This number is not authorized to reach the assistant right now.",
-          logReason: "Inbound voice ACL: member blocked",
+  // ── Credential-readiness gate ─────────────────────────────────────────
+  // The daemon performs STT and TTS for every call; when credentials are
+  // missing the webhook returns audible <Say> setup-required TwiML plus
+  // <Hangup/> instead of connecting a doomed stream, and records the gap
+  // on the session.
+
+  describe("credential-readiness TwiML gate", () => {
+    const notReady = {
+      status: "not-ready",
+      missing: [
+        {
+          kind: "stt",
+          providerId: "deepgram",
+          reason: 'No API key configured for credential provider "deepgram"',
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
+      ],
+      userMessage:
+        'Phone calls are unavailable because they require an API key for the speech-to-text provider "deepgram".',
+    };
+
+    test("inbound not-ready returns <Say> + <Hangup/> and records the preflight event", async () => {
+      mockCredentialReadiness = notReady;
 
       const req = makeInboundVoiceRequest({
-        CallSid: "CA_ms_verdict_deny_1",
+        CallSid: "CA_preflight_inbound_1",
         From: "+14155551234",
         To: "+15550001111",
       });
@@ -1358,198 +1311,143 @@ describe("twilio webhook routes", () => {
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
-      // Verdict was threaded into routeSetup, which denied the caller.
-      expect(lastRouteSetupCtx?.verdict).toEqual(mockInboundVerdict);
       const twiml = await res.text();
-      expect(twiml).toContain("<Stream");
+      expect(twiml).toContain("<Say>");
+      expect(twiml).toContain("<Hangup/>");
+      expect(twiml).toContain("speech-to-text provider");
+      expect(twiml).not.toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
+
+      const session = getCallSessionByCallSid("CA_preflight_inbound_1");
+      expect(session).not.toBeNull();
+      const events = getCallEvents(session!.id);
+      const preflightEvents = events.filter(
+        (e) => e.eventType === "telephony_credential_preflight_failed",
+      );
+      expect(preflightEvents.length).toBe(1);
+      const payload = JSON.parse(preflightEvents[0]!.payloadJson) as {
+        missing: Array<{ kind: string; providerId: string }>;
+      };
+      expect(payload.missing).toHaveLength(1);
+      expect(payload.missing[0]!.kind).toBe("stt");
+      expect(payload.missing[0]!.providerId).toBe("deepgram");
     });
 
-    test("media-stream: floor-denied caller classified deny still produces Stream TwiML (deny handled at stream level)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockAdmissionPolicy = "guardian_only";
-      // With the floor wired, the real router returns `deny` for a
-      // below-floor trusted_contact caller; the mock reflects that.
-      mockRouteSetupResult = {
-        outcome: {
-          action: "deny",
-          message:
-            "This number is not authorized to reach the assistant right now.",
-          logReason: "Inbound voice admission floor: guardian_only",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155550000",
-          actorTrust: { trustClass: "trusted_contact", memberRecord: null },
-        },
-      };
+    test("outbound webhook not-ready returns <Say> + <Hangup/> and records the preflight event", async () => {
+      mockCredentialReadiness = notReady;
 
       const session = createTestSession(
-        "conv-ms-floor-deny-1",
-        "CA_ms_floor_deny_1",
+        "conv-preflight-out-1",
+        "CA_preflight_out_1",
       );
       const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_ms_floor_deny_1",
+        CallSid: "CA_preflight_out_1",
       });
 
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
-      // Policy was threaded; deny is supported on media-stream, so Stream
-      // TwiML is still produced (denial spoken + torn down at stream start).
-      expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
       const twiml = await res.text();
+      expect(twiml).toContain("<Say>");
+      expect(twiml).toContain("<Hangup/>");
+      expect(twiml).not.toContain("<Stream");
+
+      const events = getCallEvents(session.id);
+      expect(
+        events.filter(
+          (e) => e.eventType === "telephony_credential_preflight_failed",
+        ).length,
+      ).toBe(1);
+    });
+
+    test("ready readiness produces Stream TwiML with no preflight event", async () => {
+      const session = createTestSession(
+        "conv-preflight-ready-1",
+        "CA_preflight_ready_1",
+      );
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_preflight_ready_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<Say>");
+
+      const events = getCallEvents(session.id);
+      expect(
+        events.filter(
+          (e) => e.eventType === "telephony_credential_preflight_failed",
+        ).length,
+      ).toBe(0);
+    });
+  });
+
+  // ── Internal voice webhook (gateway forward) ─────────────────────────
+  // The gateway's <Gather> voice-verify success path forwards through
+  // /v1/internal/twilio/voice-webhook, which shares processVoiceWebhook.
+
+  describe("internal voice webhook (gateway forward)", () => {
+    test("inbound forward yields Stream TwiML", async () => {
+      const result = await handleInternalVoiceWebhook({
+        body: {
+          params: {
+            CallSid: "CA_internal_fwd_1",
+            From: "+14155551234",
+            To: "+15550001111",
+          },
+          originalUrl: "https://ingress.example.com/webhooks/twilio/voice",
+        },
+      });
+
+      const twiml = result.body as string;
       expect(twiml).toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
     });
 
-    test("media-stream: deny setup proceeds with Stream TwiML (deny is handled at stream level)", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "deny",
-          message: "This number is not authorized.",
-          logReason: "Inbound voice ACL: blocked caller",
+    test("outbound forward (callSessionId in originalUrl) yields Stream TwiML", async () => {
+      const session = createTestSession(
+        "conv-internal-fwd-2",
+        "CA_internal_fwd_2",
+      );
+      const result = await handleInternalVoiceWebhook({
+        body: {
+          params: { CallSid: "CA_internal_fwd_2" },
+          originalUrl: `https://ingress.example.com/webhooks/twilio/voice?callSessionId=${session.id}`,
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+15559998888",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
+      });
 
-      const session = createTestSession("conv-ms-deny-1", "CA_ms_deny_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_deny_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Deny is supported on media-stream — should still produce Stream TwiML
+      const twiml = result.body as string;
       expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).toContain(`/webhooks/twilio/media-stream/${session.id}`);
     });
 
-    test("media-stream: verification setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "verification",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
+    test("inbound forward not-ready yields <Say> + <Hangup/>", async () => {
+      mockCredentialReadiness = {
+        status: "not-ready",
+        missing: [
+          { kind: "tts", providerId: "elevenlabs", reason: "missing key" },
+        ],
+        userMessage:
+          'Phone calls are unavailable because they require an API key for the text-to-speech provider "elevenlabs".',
       };
 
-      const session = createTestSession("conv-ms-verify-1", "CA_ms_verify_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_verify_1" });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // Interactive verification cannot work on media-stream — must fall back
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-      expect(twiml).toContain('transcriptionProvider="Deepgram"');
-    });
-
-    test("media-stream: name_capture setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "name_capture",
-          assistantId: "self",
-          fromNumber: "+14155551234",
+      const result = await handleInternalVoiceWebhook({
+        body: {
+          params: {
+            CallSid: "CA_internal_fwd_3",
+            From: "+14155551234",
+            To: "+15550001111",
+          },
+          originalUrl: "https://ingress.example.com/webhooks/twilio/voice",
         },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-namecap-1", "CA_ms_namecap_1");
-      const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_ms_namecap_1",
       });
 
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-    });
-
-    test("media-stream: invite_redemption setup falls back to ConversationRelay", async () => {
-      mockConfigObj.services.stt.provider = "openai-whisper" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "invite_redemption",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-          inviteeName: "Alice",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-ms-invite-1", "CA_ms_invite_1");
-      const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_ms_invite_1",
-      });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      expect(twiml).toContain("<ConversationRelay");
-      expect(twiml).not.toContain("<Stream");
-    });
-
-    test("conversation-relay-native: unsupported setup does not trigger preflight (not media-stream)", async () => {
-      // When the STT provider is deepgram (conversation-relay-native),
-      // the preflight guard is not invoked — setup flows are handled
-      // natively by the relay server.
-      mockConfigObj.services.stt.provider = "deepgram" as any;
-      mockRouteSetupResult = {
-        outcome: {
-          action: "verification",
-          assistantId: "self",
-          fromNumber: "+14155551234",
-        },
-        resolved: {
-          assistantId: "self",
-          isInbound: true,
-          otherPartyNumber: "+14155551234",
-          actorTrust: { trustClass: "unknown", memberRecord: null },
-        },
-      };
-
-      const session = createTestSession("conv-cr-verify-1", "CA_cr_verify_1");
-      const req = makeVoiceRequest(session.id, {
-        CallSid: "CA_cr_verify_1",
-      });
-
-      const res = await handleVoiceWebhook(req);
-      expect(res.status).toBe(200);
-
-      const twiml = await res.text();
-      // ConversationRelay should be emitted regardless of setup outcome
-      expect(twiml).toContain("<ConversationRelay");
+      const twiml = result.body as string;
+      expect(twiml).toContain("<Say>");
+      expect(twiml).toContain("<Hangup/>");
       expect(twiml).not.toContain("<Stream");
     });
   });

--- a/assistant/src/__tests__/voice-ingress-preflight.test.ts
+++ b/assistant/src/__tests__/voice-ingress-preflight.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockLoadConfig: () => unknown;
 let mockGetIsPlatform: () => boolean;
+let mockCredentialReadiness: Record<string, unknown>;
+let credentialReadinessCalls = 0;
 
 mock.module("../config/loader.js", () => ({
   loadConfig: () => mockLoadConfig(),
@@ -11,7 +13,27 @@ mock.module("../config/env-registry.js", () => ({
   getIsPlatform: () => mockGetIsPlatform(),
 }));
 
+mock.module("../calls/telephony-credential-preflight.js", () => ({
+  resolveTelephonyCredentialReadiness: async () => {
+    credentialReadinessCalls++;
+    return mockCredentialReadiness;
+  },
+}));
+
 import { preflightVoiceIngress } from "../calls/voice-ingress-preflight.js";
+
+const NOT_READY = {
+  status: "not-ready",
+  missing: [
+    {
+      kind: "stt",
+      providerId: "deepgram",
+      reason: 'No API key configured for credential provider "deepgram"',
+    },
+  ],
+  userMessage:
+    'Phone calls are unavailable because they require an API key for the speech-to-text provider "deepgram".',
+};
 
 describe("voice ingress preflight", () => {
   beforeEach(() => {
@@ -19,6 +41,8 @@ describe("voice ingress preflight", () => {
       ingress: { enabled: true, publicBaseUrl: "https://example.com" },
     });
     mockGetIsPlatform = () => false;
+    mockCredentialReadiness = { status: "ready" };
+    credentialReadinessCalls = 0;
   });
 
   test("returns success immediately for platform-callback deployments", async () => {
@@ -51,5 +75,42 @@ describe("voice ingress preflight", () => {
         "https://twilio.example.com",
       );
     }
+  });
+
+  test("fails with the readiness user message when credentials are not ready", async () => {
+    mockCredentialReadiness = NOT_READY;
+
+    const result = await preflightVoiceIngress();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      expect(result.error).toContain('speech-to-text provider "deepgram"');
+    }
+  });
+
+  test("credential readiness gates platform-callback deployments too", async () => {
+    // The platform short-circuit covers only the ingress-URL half — the
+    // daemon still performs STT/TTS on platform deployments.
+    mockGetIsPlatform = () => true;
+    mockLoadConfig = () => ({ ingress: { enabled: false } });
+    mockCredentialReadiness = NOT_READY;
+
+    const result = await preflightVoiceIngress();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('speech-to-text provider "deepgram"');
+    }
+  });
+
+  test("runs the credential readiness check on the platform success path", async () => {
+    mockGetIsPlatform = () => true;
+    mockLoadConfig = () => ({ ingress: { enabled: false } });
+
+    const result = await preflightVoiceIngress();
+
+    expect(result.ok).toBe(true);
+    expect(credentialReadinessCalls).toBe(1);
   });
 });

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -16,7 +16,10 @@ import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
-import { evaluateTelephonyTtsPlayability } from "./telephony-tts-capability.js";
+import {
+  evaluateTelephonyTtsPlayability,
+  fishAudioReferenceIdConfigured,
+} from "./telephony-tts-capability.js";
 import { resolveCallStrategy } from "./tts-call-strategy.js";
 
 const log = getLogger("resolve-call-tts-provider");
@@ -103,19 +106,17 @@ export async function resolveCallTtsProvider(
     // fail only at first synthesis call. Fish Audio requires a reference
     // ID when no per-request voiceId is supplied (the telephony default).
     const fishAudioUnusable =
-      providerId === "fish-audio" && !hasReferenceId(resolved.providerConfig);
+      providerId === "fish-audio" && !fishAudioReferenceIdConfigured();
 
     if (options?.preferWav) {
       // Media-stream transport: every spoken turn is synthesized, so the
-      // provider must produce playable PCM/WAV with resolvable credentials.
-      // Swap in a playable fallback rather than resolving into a provider
-      // that can only be silent.
+      // provider must produce playable PCM/WAV with resolvable credentials
+      // and satisfied config invariants (the capability check covers the
+      // fish-audio referenceId rule). Swap in a playable fallback rather
+      // than resolving into a provider that can only be silent.
       const capability = await evaluateTelephonyTtsPlayability(providerId);
-      if (capability.status === "not-playable" || fishAudioUnusable) {
-        const reason =
-          capability.status === "not-playable"
-            ? capability.reason
-            : "missing-fish-audio-reference-id";
+      if (capability.status === "not-playable") {
+        const reason = capability.reason;
         const fallbackId = await findPlayableTelephonyTtsFallback(providerId);
         if (fallbackId) {
           log.warn(
@@ -178,9 +179,10 @@ export async function resolveCallTtsProvider(
  * with resolvable credentials.
  *
  * Preference order: the ElevenLabs default first (when its key resolves),
- * then the remaining catalog providers in display order. Fish Audio is
- * skipped when its required `referenceId` is not configured. Returns
- * `null` when no provider qualifies.
+ * then the remaining catalog providers in display order. The playability
+ * capability already applies the fish-audio `referenceId` invariant, so a
+ * referenceId-less fish-audio setup is never selected. Returns `null` when
+ * no provider qualifies.
  */
 export async function findPlayableTelephonyTtsFallback(
   excludeProviderId?: TtsProviderId,
@@ -191,36 +193,9 @@ export async function findPlayableTelephonyTtsFallback(
 
   for (const candidateId of candidates) {
     const capability = await evaluateTelephonyTtsPlayability(candidateId);
-    if (capability.status !== "playable") {
-      continue;
+    if (capability.status === "playable") {
+      return candidateId;
     }
-    if (candidateId === "fish-audio" && !fishAudioReferenceIdConfigured()) {
-      continue;
-    }
-    return candidateId;
   }
   return null;
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/** Whether a provider config block carries a non-empty `referenceId`. */
-function hasReferenceId(providerConfig: unknown): boolean {
-  return Boolean(
-    (providerConfig as { referenceId?: string } | undefined)?.referenceId?.trim(),
-  );
-}
-
-/** Whether `services.tts.providers.fish-audio.referenceId` is configured. */
-function fishAudioReferenceIdConfigured(): boolean {
-  try {
-    const providers = loadConfig().services?.tts?.providers as
-      | Record<string, unknown>
-      | undefined;
-    return hasReferenceId(providers?.["fish-audio"]);
-  } catch {
-    return false;
-  }
 }

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -126,22 +126,36 @@ function ttsGap(
   providerId: string,
   reason: TelephonyTtsNotPlayableReason,
 ): { gap: TelephonyCredentialGap; clause: string } {
-  if (reason === "missing-credentials") {
-    return {
-      gap: {
-        kind: "tts",
-        providerId,
-        reason: `TTS provider "${providerId}" is missing credentials and no playable fallback provider is available`,
-      },
-      clause: `an API key for the text-to-speech provider "${providerId}" (no fallback provider has usable credentials)`,
-    };
+  switch (reason) {
+    case "missing-credentials": {
+      return {
+        gap: {
+          kind: "tts",
+          providerId,
+          reason: `TTS provider "${providerId}" is missing credentials and no playable fallback provider is available`,
+        },
+        clause: `an API key for the text-to-speech provider "${providerId}" (no fallback provider has usable credentials)`,
+      };
+    }
+    case "missing-fish-audio-reference-id": {
+      return {
+        gap: {
+          kind: "tts",
+          providerId,
+          reason: `TTS provider "${providerId}" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId) and no playable fallback provider is available`,
+        },
+        clause: `a Fish Audio voice reference ID for the text-to-speech provider "${providerId}" (set services.tts.providers.fish-audio.referenceId; no fallback provider is usable)`,
+      };
+    }
+    case "unsupported-format": {
+      return {
+        gap: {
+          kind: "tts",
+          providerId,
+          reason: `TTS provider "${providerId}" cannot produce media-stream-playable audio and no playable fallback provider is available`,
+        },
+        clause: `a text-to-speech provider that can produce call audio (the configured "${providerId}" cannot, and no fallback provider is usable)`,
+      };
+    }
   }
-  return {
-    gap: {
-      kind: "tts",
-      providerId,
-      reason: `TTS provider "${providerId}" cannot produce media-stream-playable audio and no playable fallback provider is available`,
-    },
-    clause: `a text-to-speech provider that can produce call audio (the configured "${providerId}" cannot, and no fallback provider is usable)`,
-  };
 }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -125,19 +125,36 @@ export async function evaluateTelephonyTtsPlayability(
 }
 
 /**
- * Whether `services.tts.providers.fish-audio.referenceId` is configured.
+ * Whether the fish-audio `referenceId` is configured.
  *
  * Single source of truth for the fish-audio usability invariant: the
  * telephony path supplies no per-request voiceId, so synthesis requires a
  * configured reference ID. Shared by {@link evaluateTelephonyTtsPlayability}
  * and the call TTS resolver's ConversationRelay degrade path.
+ *
+ * When fish-audio is the active `services.tts.provider`, its config is
+ * read through the {@link resolveTtsConfig} provider-options layer — the
+ * same path the call TTS resolver has always used. When fish-audio is only
+ * a fallback candidate, the canonical `services.tts.providers.fish-audio`
+ * block is read directly.
  */
 export function fishAudioReferenceIdConfigured(): boolean {
   try {
-    const providers = getConfig().services?.tts?.providers as
-      | Record<string, { referenceId?: string } | undefined>
-      | undefined;
-    return Boolean(providers?.["fish-audio"]?.referenceId?.trim());
+    const config = getConfig();
+    const resolved = resolveTtsConfig(config);
+    const providerConfig =
+      resolved.provider === "fish-audio"
+        ? resolved.providerConfig
+        : (
+            config.services?.tts?.providers as
+              | Record<string, unknown>
+              | undefined
+          )?.["fish-audio"];
+    return Boolean(
+      (
+        providerConfig as { referenceId?: string } | undefined
+      )?.referenceId?.trim(),
+    );
   } catch {
     return false;
   }

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -8,6 +8,10 @@
  *    `"wav"` — the media-stream mu-law transcoder cannot decode compressed
  *    formats (mp3, opus).
  * 2. Every secret the catalog entry requires resolves to a value.
+ * 3. Provider-specific config invariants hold — Fish Audio requires a
+ *    configured `referenceId` (no per-request voiceId is supplied on the
+ *    telephony path), so a referenceId-less fish-audio setup synthesizes
+ *    nothing and is not playable.
  *
  * This resolver does **not** create a provider instance — it only validates
  * catalog metadata and credentials, mirroring `resolveTelephonySttCapability`
@@ -33,7 +37,8 @@ import type { TtsProviderId } from "../tts/types.js";
 /** Why a provider cannot play over media-stream transports. */
 export type TelephonyTtsNotPlayableReason =
   | "unsupported-format"
-  | "missing-credentials";
+  | "missing-credentials"
+  | "missing-fish-audio-reference-id";
 
 /**
  * Result of resolving whether a TTS provider is playable over the
@@ -64,7 +69,9 @@ export type TelephonyTtsCapability =
  * - `"playable"` — the provider produces PCM/WAV and credentials resolve.
  * - `"not-playable"` — see `reason` (`"unsupported-format"` when the
  *   provider is unknown or only produces compressed audio,
- *   `"missing-credentials"` when a required secret does not resolve).
+ *   `"missing-credentials"` when a required secret does not resolve,
+ *   `"missing-fish-audio-reference-id"` when fish-audio has no configured
+ *   `referenceId`).
  */
 export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapability> {
   const { provider } = resolveTtsConfig(getConfig());
@@ -106,7 +113,34 @@ export async function evaluateTelephonyTtsPlayability(
     }
   }
 
+  if (entry.id === "fish-audio" && !fishAudioReferenceIdConfigured()) {
+    return {
+      status: "not-playable",
+      providerId: entry.id,
+      reason: "missing-fish-audio-reference-id",
+    };
+  }
+
   return { status: "playable", providerId: entry.id };
+}
+
+/**
+ * Whether `services.tts.providers.fish-audio.referenceId` is configured.
+ *
+ * Single source of truth for the fish-audio usability invariant: the
+ * telephony path supplies no per-request voiceId, so synthesis requires a
+ * configured reference ID. Shared by {@link evaluateTelephonyTtsPlayability}
+ * and the call TTS resolver's ConversationRelay degrade path.
+ */
+export function fishAudioReferenceIdConfigured(): boolean {
+  try {
+    const providers = getConfig().services?.tts?.providers as
+      | Record<string, { referenceId?: string } | undefined>
+      | undefined;
+    return Boolean(providers?.["fish-audio"]?.referenceId?.trim());
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -1,24 +1,18 @@
 /**
  * HTTP route handlers for Twilio voice webhooks.
  *
- * - handleVoiceWebhook: initial voice webhook; returns TwiML to connect
- *   ConversationRelay (Twilio-native STT) or Stream (custom media-stream STT)
+ * - handleVoiceWebhook: initial voice webhook; returns `<Connect><Stream>`
+ *   TwiML so the daemon receives raw audio over the media-stream transport
+ *   and performs STT/TTS server-side for every call
  * - handleStatusCallback: call status updates (ringing, in-progress, completed, etc.)
  * - handleConnectAction: called when the ConversationRelay connection ends
  *
- * ## STT routing
- *
- * TwiML generation is driven by `services.stt.provider` via
- * {@link resolveTelephonySttRouting}. The resolver returns a discriminated
- * strategy that determines which TwiML path to use:
- *
- * - **`conversation-relay-native`** (deepgram, google-gemini) — emits
- *   `<Connect><ConversationRelay>` with Twilio-native `transcriptionProvider`
- *   and `speechModel` attributes.
- *
- * - **`media-stream-custom`** (openai-whisper) — emits
- *   `<Connect><Stream>` so the daemon receives raw audio and transcribes
- *   server-side.
+ * Setup-flow routing (verification, invite redemption, name capture, deny,
+ * normal) is resolved by the media-stream server when Twilio's `start`
+ * frame arrives — TwiML generation performs no routing of its own. Its
+ * only gate is the STT+TTS credential-readiness preflight: a call whose
+ * daemon cannot transcribe or speak gets audible `<Say>` setup-required
+ * TwiML and a `<Hangup/>` instead of a doomed stream.
  */
 
 import {
@@ -27,8 +21,6 @@ import {
   TWILIO_PUBLIC_BASE_URL_PLACEHOLDER,
 } from "@vellumai/service-contracts/twilio-ingress";
 
-import { loadConfig } from "../config/loader.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
   BadRequestError,
   GoneError,
@@ -54,11 +46,8 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
-import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
-import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
-import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
-import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
+import { resolveTelephonyCredentialReadiness } from "./telephony-credential-preflight.js";
 import type { CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
@@ -161,11 +150,10 @@ ${greetingAttr}
 }
 
 /**
- * Generate `<Connect><Stream>` TwiML for the media-stream STT path.
+ * Generate `<Connect><Stream>` TwiML for the media-stream transport.
  *
- * Used when the telephony STT routing resolver selects `media-stream-custom`
- * (e.g. OpenAI Whisper). Twilio opens a WebSocket to `streamUrl` and sends
- * raw audio frames; the daemon transcribes server-side.
+ * Twilio opens a WebSocket to `streamUrl` and sends raw audio frames; the
+ * daemon transcribes and synthesizes speech server-side.
  *
  * `callSessionId` and `token` are encoded as **path segments** on the
  * WebSocket URL so the gateway can validate and route the upgrade request
@@ -305,18 +293,7 @@ async function processVoiceWebhook(
       toNumber: callerTo,
     });
 
-    return buildVoiceWebhookTwiml(
-      session.id,
-      {
-        task: session.task,
-        toNumber: callerTo,
-        fromNumber: callerFrom,
-        direction: "inbound",
-        inviteFriendName: null,
-        inviteGuardianName: null,
-      },
-      session.verificationSessionId,
-    );
+    return buildVoiceWebhookTwiml(session.id, session.verificationSessionId);
   }
 
   // ── Outbound mode: callSessionId is present ─────────────────────
@@ -340,25 +317,14 @@ async function processVoiceWebhook(
     log.info({ callSessionId, callSid }, "Stored CallSid from voice webhook");
   }
 
-  return buildVoiceWebhookTwiml(
-    callSessionId,
-    {
-      task: session.task,
-      toNumber: session.toNumber,
-      fromNumber: session.fromNumber,
-      direction: "outbound",
-      inviteFriendName: session.inviteFriendName,
-      inviteGuardianName: session.inviteGuardianName,
-    },
-    session.verificationSessionId,
-  );
+  return buildVoiceWebhookTwiml(callSessionId, session.verificationSessionId);
 }
 
 // ── Route handlers ───────────────────────────────────────────────────
 
 /**
  * Receives the initial voice webhook when Twilio connects the call.
- * Returns TwiML XML that tells Twilio to open a ConversationRelay WebSocket.
+ * Returns TwiML XML that tells Twilio to open a media-stream WebSocket.
  *
  * Supports two flows:
  * - **Outbound** (callSessionId present in query): uses the existing session
@@ -385,154 +351,59 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 /**
  * Shared TwiML generation for both inbound and outbound voice webhooks.
  *
- * Resolves the telephony STT routing strategy from `services.stt.provider`
- * and branches:
+ * Every call connects over the media-stream transport. Setup-flow routing
+ * (`routeSetup`) is owned by the media-stream server, which resolves it
+ * when Twilio's `start` frame arrives — no routing happens at TwiML time.
  *
- * - **`conversation-relay-native`** — emits `<Connect><ConversationRelay>`
- *   TwiML with Twilio-native STT attributes (`transcriptionProvider`,
- *   `speechModel`). Used for deepgram and google-gemini.
- *
- * - **`media-stream-custom`** — emits `<Connect><Stream>` TwiML so the
- *   daemon receives raw audio for server-side transcription. Used for
- *   openai-whisper.
+ * The one TwiML-time gate is credential readiness: the daemon performs
+ * both STT and TTS on this transport, so when
+ * {@link resolveTelephonyCredentialReadiness} reports a gap the webhook
+ * returns `<Say>` setup-required copy plus `<Hangup/>` (audible via
+ * Twilio-hosted TTS even when the daemon's TTS is the broken half) and
+ * records a `telephony_credential_preflight_failed` call event instead of
+ * connecting a stream that cannot work.
  *
  * When `verificationSessionId` is provided, it is included as a
  * `<Parameter>` in the TwiML for observability and compatibility with
  * the Twilio setup payload. The persisted call session mode is the
- * primary signal for deterministic flow selection in the relay server.
+ * primary signal for deterministic flow selection at stream start.
  */
 async function buildVoiceWebhookTwiml(
   callSessionId: string,
-  sessionContext: {
-    task: string | null;
-    toNumber: string;
-    fromNumber: string;
-    direction: "inbound" | "outbound";
-    inviteFriendName: string | null;
-    inviteGuardianName: string | null;
-  } | null,
   verificationSessionId?: string | null,
 ): Promise<string> {
-  const cfg = loadConfig();
-  const profile = resolveVoiceQualityProfile(cfg);
-
-  log.info(
-    { callSessionId, ttsProvider: profile.ttsProvider, voice: profile.voice },
-    "Voice quality profile resolved",
-  );
-
-  // Resolve telephony STT strategy from services.stt.provider.
-  // The routing resolver handles speech-model defaults internally per provider.
-  const routingResult = resolveTelephonySttRouting();
-
-  // Derive Deepgram fallback values from the provider catalog so they stay
-  // in sync with the single source of truth. Hardcoded strings are kept only
-  // as a final safety net in case the catalog entry is missing.
-  const dgEntry = getProviderEntry("deepgram");
-  const fallbackProvider =
-    dgEntry?.telephonyRouting.twilioNativeMapping?.provider ?? "Deepgram";
-  const fallbackModel =
-    dgEntry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel ??
-    "nova-3";
-
-  if (routingResult.status === "unknown-provider") {
-    log.error(
-      {
-        callSessionId,
-        providerId: routingResult.providerId,
-        reason: routingResult.reason,
-      },
-      "Telephony STT routing failed — unknown provider; falling back to ConversationRelay with Deepgram",
-    );
-    // Graceful degradation: fall back to Deepgram ConversationRelay so
-    // calls don't fail entirely on a misconfigured provider.
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
-    );
-  }
-
-  const { strategy } = routingResult;
-
-  if (strategy.strategy === "conversation-relay-native") {
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      {
-        transcriptionProvider: strategy.transcriptionProvider,
-        speechModel: strategy.speechModel,
-      },
-    );
-  }
-
-  // media-stream-custom path — preflight check to reject interactive setup
-  // flows that the media-stream transport cannot support. The media-stream
-  // server has a defensive fallback for these cases, but catching them here
-  // avoids bootstrapping a WebSocket session that will immediately fail.
-  const session = getCallSession(callSessionId);
-  const from = sessionContext?.fromNumber ?? "";
-  const to = sessionContext?.toNumber ?? "";
-
-  // Resolve the phone channel's inbound admission floor so this preflight
-  // classification matches the real enforcement at stream start — a
-  // floor-denied caller is recognized as `deny` here, not `normal_call`.
-  // The reader fails open to `null` by contract, so a transport hiccup
-  // admits the caller.
-  const admissionPolicy = await getChannelAdmissionPolicy("phone");
-
-  // Verdict-first caller trust so this preflight matches handleSetup's ACL.
-  // routeSetup uses it when present and not resolutionFailed, else falls back
-  // to local resolution. The reader returns null on failure, keeping the
-  // local path on a gateway blip.
-  const isInbound = sessionContext?.direction !== "outbound";
-  const otherPartyNumber = isInbound ? from : to;
-  const verdict = await getPhoneCallerVerdict(otherPartyNumber);
-
-  const { outcome } = await routeSetup({
-    callSessionId,
-    session: session ?? null,
-    from,
-    to,
-    admissionPolicy,
-    verdict,
-  });
-
-  // The media-stream transport supports normal_call and deny (which speaks
-  // a message and tears down). All other outcomes require interactive
-  // sub-flows (DTMF entry, name capture, guardian wait) that media-stream
-  // cannot perform. Reject these deterministically before stream bootstrap.
-  if (outcome.action !== "normal_call" && outcome.action !== "deny") {
+  const readiness = await resolveTelephonyCredentialReadiness();
+  if (readiness.status === "not-ready") {
     log.warn(
-      {
-        callSessionId,
-        setupAction: outcome.action,
-        strategy: "media-stream-custom",
-      },
-      "Media-stream preflight rejected unsupported interactive setup flow — falling back to ConversationRelay with Deepgram",
+      { callSessionId, missing: readiness.missing },
+      "Telephony credential preflight failed — returning setup-required TwiML",
     );
-    // Fall back to ConversationRelay so the interactive flow can proceed
-    // through the relay server which supports it natively.
-    return buildConversationRelayTwiml(
-      callSessionId,
-      profile,
-      sessionContext,
-      verificationSessionId,
-      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
-    );
+    recordCallEvent(callSessionId, "telephony_credential_preflight_failed", {
+      missing: readiness.missing,
+    });
+    return buildSetupRequiredTwiml(readiness.userMessage);
   }
 
   return buildMediaStreamTwiml(callSessionId, verificationSessionId);
 }
 
 /**
+ * Build `<Say>` + `<Hangup/>` TwiML for calls blocked by the credential
+ * preflight, so the caller hears why the call cannot proceed.
+ */
+function buildSetupRequiredTwiml(userMessage: string): string {
+  const sayCopy = `${userMessage} Please finish voice setup and call again. Goodbye.`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say>${escapeXml(sayCopy)}</Say>
+  <Hangup/>
+</Response>`;
+}
+
+/**
  * Build ConversationRelay TwiML for Twilio-native STT providers.
  */
-async function buildConversationRelayTwiml(
+export async function buildConversationRelayTwiml(
   callSessionId: string,
   profile: ReturnType<typeof resolveVoiceQualityProfile>,
   sessionContext: {
@@ -585,7 +456,7 @@ async function buildConversationRelayTwiml(
 }
 
 /**
- * Build Stream TwiML for custom media-stream STT providers.
+ * Build Stream TwiML connecting the call to the daemon's media-stream server.
  */
 function buildMediaStreamTwiml(
   callSessionId: string,
@@ -606,10 +477,7 @@ function buildMediaStreamTwiml(
     customParameters,
   );
 
-  log.info(
-    { callSessionId, strategy: "media-stream-custom" },
-    "Returning Stream TwiML",
-  );
+  log.info({ callSessionId }, "Returning Stream TwiML");
 
   return twiml;
 }

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -16,6 +16,7 @@ export type CallEventType =
   | "user_instruction_relayed"
   | "call_ended"
   | "call_failed"
+  | "telephony_credential_preflight_failed"
   | "callee_verification_started"
   | "callee_verification_succeeded"
   | "callee_verification_failed"

--- a/assistant/src/calls/voice-ingress-preflight.ts
+++ b/assistant/src/calls/voice-ingress-preflight.ts
@@ -2,6 +2,7 @@ import { getIsPlatform } from "../config/env-registry.js";
 import { loadConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import { resolveTelephonyCredentialReadiness } from "./telephony-credential-preflight.js";
 
 const SERVICE_UNAVAILABLE_STATUS = 503 as const;
 
@@ -31,6 +32,14 @@ function fail(error: string): VoiceIngressPreflightFailure {
 
 export async function preflightVoiceIngress(): Promise<VoiceIngressPreflightResult> {
   const ingressConfig = loadConfig();
+
+  // The daemon performs both STT and TTS on the media-stream transport —
+  // in every deployment mode, platform-hosted included — so credential
+  // readiness gates outbound placement before any Twilio call is made.
+  const readiness = await resolveTelephonyCredentialReadiness();
+  if (readiness.status === "not-ready") {
+    return fail(readiness.userMessage);
+  }
 
   // Platform-callback deployments register routes with the platform and receive
   // stable callback URLs. No public ingress URL or local gateway is involved.

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -880,4 +880,64 @@ describe("resolveStreamingTranscriber diarize preference", () => {
     expect(transcriber).toBeNull();
     expect(xaiCtorCalls).toHaveLength(0);
   });
+
+  // -------------------------------------------------------------------------
+  // Utterance-boundary finals (telephony)
+  // -------------------------------------------------------------------------
+
+  test("utteranceBoundaryFinals with xai returns null with a warning (per-segment finals cannot be boundary-gated)", async () => {
+    mockProviderKeys["xai"] = "xai-key";
+    mockConfig = buildConfig({ provider: "xai" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+    });
+
+    expect(transcriber).toBeNull();
+    expect(xaiCtorCalls).toHaveLength(0);
+    expect(loggerWarnings).toHaveLength(1);
+    expect(loggerWarnings[0]!.message).toContain("per-segment finals");
+    expect(
+      (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
+    ).toBe("xai");
+  });
+
+  test("utteranceBoundaryFinals with Deepgram forwards the gating options", async () => {
+    mockProviderKeys["deepgram"] = "dg-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(deepgramCtorCalls).toHaveLength(1);
+    const options = deepgramCtorCalls[0]!.options as Record<string, unknown>;
+    expect(options.utteranceBoundaryFinals).toBe(true);
+    expect(options.utteranceEndMs).toBe(1000);
+  });
+
+  test("utteranceBoundaryFinals with google-gemini still resolves (finals already pause-aligned)", async () => {
+    mockProviderKeys["gemini"] = "gemini-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(geminiCtorCalls).toHaveLength(1);
+  });
+
+  test("utteranceBoundaryFinals with openai-whisper still resolves (finals already pause-aligned)", async () => {
+    mockProviderKeys["openai"] = "openai-key";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(whisperCtorCalls).toHaveLength(1);
+  });
 });

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -265,7 +265,11 @@ export interface ResolveStreamingTranscriberOptions {
    * otherwise commit multiple `is_final` segments per utterance
    * (Deepgram — also enables its `utterance_end_ms` endpointing).
    * Ignored by providers whose finals already align with pause
-   * boundaries. Used by telephony call ingestion. Default: false.
+   * boundaries (google-gemini emits finals at turn completion,
+   * openai-whisper on stop). Providers that can neither gate nor align
+   * (xAI emits a `final` per committed segment) resolve to `null` so
+   * the caller falls back to batch transcription. Used by telephony
+   * call ingestion. Default: false.
    */
   utteranceBoundaryFinals?: boolean;
 }
@@ -285,6 +289,8 @@ export interface ResolveStreamingTranscriberOptions {
  * - No credentials are configured for the resolved provider.
  * - No streaming adapter exists for the configured provider.
  * - `diarize` is `"required"` but the configured provider cannot diarize.
+ * - `utteranceBoundaryFinals` is set but the configured provider commits
+ *   per-segment finals with no boundary gating (xAI).
  */
 export async function resolveStreamingTranscriber(
   options: ResolveStreamingTranscriberOptions = {},
@@ -412,6 +418,17 @@ async function createStreamingTranscriber(
       });
     }
     case "xai": {
+      // The xAI adapter emits a `final` for every committed `is_final`
+      // segment; segments are not utterance-aligned and the adapter has no
+      // boundary gating, so a boundary-requiring caller (telephony) would
+      // reply mid-sentence. Resolve to null so it falls back to batch.
+      if (options.utteranceBoundaryFinals) {
+        log.warn(
+          { providerId },
+          "utterance-boundary finals requested but the xAI streaming adapter commits per-segment finals — falling back to batch transcription",
+        );
+        return null;
+      }
       const { XAIRealtimeTranscriber } = await import("./xai-realtime.js");
       return new XAIRealtimeTranscriber(apiKey, {
         sampleRate: options.sampleRate,


### PR DESCRIPTION
## Summary
- buildVoiceWebhookTwiml always emits <Connect><Stream> — the conversation-relay-native branch, unknown-provider CR fallback, and interactive-setup CR fallback are removed
- Inbound credential gate: not-ready configs get an audible <Say> setup-required + <Hangup> instead of a doomed stream; outbound gate blocks before dialing via preflightVoiceIngress with a provider-naming message (platform deployments included)
- CR TwiML builders left unreferenced for the deletion wave

Part of plan: phone-media-stream-v2.md (PR 11 of 17)