### PR TITLE
fix: coordinate split-track updates so one restart covers a full release (LUM-2603)

### DIFF
--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -19,12 +19,15 @@ const mockBunVersion = "1.3.11";
 // Set a known value so `path.join(process.resourcesPath, "bun")` works.
 Object.defineProperty(process, "resourcesPath", { value: mockResourcesPath, writable: true });
 
+let mockAppVersion = "0.10.4";
+
 mock.module("electron", () => ({
   app: {
     getPath: (name: string) => {
       if (name === "userData") return userDataPath;
       return "/tmp";
     },
+    getVersion: () => mockAppVersion,
     isPackaged: true,
   },
 }));
@@ -42,6 +45,8 @@ let readdirSyncError: Error | null = null;
 let writeFileSyncError: Error | null = null;
 // Contents returned by readFileSync (the install package.json stampPackageManager reads).
 let readFileSyncReturn = '{"dependencies":{"vellum":"latest"}}';
+// Per-path overrides for readFileSync. Falls back to `readFileSyncReturn`.
+const readFileSyncByPath: Record<string, string> = {};
 let readFileSyncError: Error | null = null;
 let renameSyncError: Error | null = null;
 const chmodSyncCalls: Array<[string, number]> = [];
@@ -70,9 +75,9 @@ mock.module("node:fs", () => ({
     if (readdirSyncError) throw readdirSyncError;
     return readdirSyncReturn;
   },
-  readFileSync: (_p: string, _enc?: string) => {
+  readFileSync: (p: string, _enc?: string) => {
     if (readFileSyncError) throw readFileSyncError;
-    return readFileSyncReturn;
+    return p in readFileSyncByPath ? readFileSyncByPath[p] : readFileSyncReturn;
   },
   renameSync: (src: string, dst: string) => {
     if (renameSyncError) throw renameSyncError;
@@ -138,8 +143,10 @@ afterEach(() => {
   readdirSyncError = null;
   writeFileSyncError = null;
   readFileSyncReturn = '{"dependencies":{"vellum":"latest"}}';
+  for (const key of Object.keys(readFileSyncByPath)) delete readFileSyncByPath[key];
   readFileSyncError = null;
   renameSyncError = null;
+  mockAppVersion = "0.10.4";
   chmodSyncCalls.length = 0;
   mkdirSyncCalls.length = 0;
   rmSyncCalls.length = 0;
@@ -746,6 +753,88 @@ describe("ensureCliInstalled", () => {
     existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await retry;
+  });
+});
+
+// --- stale CLI refresh (LUM-2603) ---
+
+describe("stale CLI refresh", () => {
+  const vellumPkgPath = `${latestInstallDir}/node_modules/vellum/package.json`;
+
+  test("floats an installed CLI that is behind the app version", async () => {
+    existsSyncDefault = true;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.10.3"}';
+    mockAppVersion = "0.10.4";
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(spawnCalls).toHaveLength(1);
+    const [cmd, args, opts] = spawnCalls[0];
+    expect(cmd).toBe(`${mockResourcesPath}/bun`);
+    expect(args).toEqual(["add", "vellum@latest", "--ignore-scripts"]);
+    expect((opts as { cwd: string }).cwd).toBe(latestInstallDir);
+  });
+
+  test("refreshes at most once per session", async () => {
+    existsSyncDefault = true;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.10.3"}';
+    mockAppVersion = "0.10.4";
+
+    const p1 = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await p1;
+    // Registry still serves 0.10.3 (npm lagging the app release) — the
+    // version gap persists, but no second install should spawn this session.
+    await ensureCliInstalled();
+
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("no refresh when the installed CLI matches the app version", async () => {
+    existsSyncDefault = true;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.10.4"}';
+    mockAppVersion = "0.10.4";
+
+    await ensureCliInstalled();
+
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("no refresh when the installed CLI is ahead of the app version", async () => {
+    existsSyncDefault = true;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.11.0"}';
+    mockAppVersion = "0.10.4";
+
+    await ensureCliInstalled();
+
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("a failed refresh keeps the existing install and resolves", async () => {
+    existsSyncDefault = true;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.10.3"}';
+    mockAppVersion = "0.10.4";
+
+    const promise = ensureCliInstalled();
+    lastChild.stderr.emit("data", Buffer.from("network error"));
+    lastChild.emit("close", 1);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test("skips refresh when the install dir has no package.json", async () => {
+    // `bun add` without a local package.json walks up the directory tree —
+    // leave this state to the (re)install path rather than refresh it.
+    existsSyncDefault = true;
+    existsSyncByPath[`${latestInstallDir}/package.json`] = false;
+    readFileSyncByPath[vellumPkgPath] = '{"version":"0.10.3"}';
+    mockAppVersion = "0.10.4";
+
+    await ensureCliInstalled();
+
+    expect(spawnCalls).toHaveLength(0);
   });
 });
 

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -333,6 +333,58 @@ function anchorInstallDir(installDir: string): void {
   );
 }
 
+/** Version of the installed `vellum` meta-package, or null when unreadable. */
+function getInstalledCliVersion(): string | null {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(
+        path.join(getCliInstallDir(), "node_modules", "vellum", "package.json"),
+        "utf8",
+      ),
+    );
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+// One refresh attempt per app session — enough to catch up after an app
+// update without re-hitting the registry on every CLI action.
+let cliRefreshAttempted = false;
+
+/**
+ * Whether the installed CLI should be floated forward. An app update bumps
+ * the app version while an unpinned install keeps whatever the dist-tag
+ * resolved to at install time, so the two drift apart until reinstalled
+ * (LUM-2603). Requires the install dir's package.json so `bun add` reuses
+ * the existing project instead of walking up the directory tree.
+ */
+function cliRefreshNeeded(): boolean {
+  if (PINNED_CLI_VERSION || cliRefreshAttempted) return false;
+  if (!existsSync(path.join(getCliInstallDir(), "package.json"))) return false;
+  const installed = getInstalledCliVersion();
+  return installed !== null && compareVersions(installed, app.getVersion()) < 0;
+}
+
+/**
+ * Float a stale install to the current dist-tag. Non-fatal — a failed
+ * refresh keeps the existing working install and retries next launch.
+ */
+async function refreshStaleCli(): Promise<void> {
+  const installDir = getCliInstallDir();
+  const spec = `vellum@${getCliDistTag()}`;
+  log.info(
+    `[cli-installer] installed CLI ${getInstalledCliVersion()} is behind app ${app.getVersion()}; refreshing to ${spec}`,
+  );
+  try {
+    await runBun(["add", spec, "--ignore-scripts"], installDir);
+    stampPackageManager(installDir);
+    writeCliLocator();
+  } catch (err) {
+    log.warn("[cli-installer] CLI refresh failed; keeping existing install:", err);
+  }
+}
+
 /** Spawn the bundled bun with `args` in `cwd` and await its exit. */
 function runBun(args: string[], cwd: string): Promise<void> {
   const bunPath = getBundledBunPath();
@@ -428,9 +480,10 @@ async function bunInstallCli(): Promise<void> {
 // Singleton promise prevents concurrent installs from corrupting node_modules.
 let cliInstallPromise: Promise<void> | null = null;
 
-/** Reset the install lock. Exposed for testing only. */
+/** Reset the install lock and refresh marker. Exposed for testing only. */
 export function _resetInstallLock(): void {
   cliInstallPromise = null;
+  cliRefreshAttempted = false;
 }
 
 /**
@@ -447,7 +500,18 @@ export async function ensureCliInstalled(): Promise<void> {
     // the upgrade path returns here without reinstalling, so an existing user's
     // package.json would otherwise stay unmarked and exposed to npm drift.
     // Skipped for local builds that run the repo CLI source.
-    if (getLocalCliEntry() === null) stampPackageManager(getCliInstallDir());
+    if (getLocalCliEntry() === null) {
+      stampPackageManager(getCliInstallDir());
+      // Float a stale install forward after an app update (LUM-2603). Shares
+      // the install lock so nothing spawns the CLI mid-rewrite.
+      if (cliRefreshNeeded()) {
+        cliRefreshAttempted = true;
+        cliInstallPromise ??= refreshStaleCli().finally(() => {
+          cliInstallPromise = null;
+        });
+      }
+      if (cliInstallPromise) await cliInstallPromise;
+    }
     return;
   }
 

--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -26,6 +26,7 @@ import {
   LOCAL_RUNTIME_RELEASES_FETCH_LIMIT,
   RUNTIME_RELEASES_REFETCH_INTERVAL_MS,
 } from "@/lib/local-runtime-upgrade";
+import { checkForUpdates } from "@/runtime/auto-update";
 import { isLocalModeHostAvailable } from "@/runtime/local-mode-host";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -212,6 +213,9 @@ export function RuntimeUpgradeBanner({
       } else {
         await localUpgrade.upgrade();
         toast.success("Update complete — assistant is healthy.");
+        // A release often pairs the runtime bump with an app-shell update;
+        // check now so one restart covers both (LUM-2603).
+        void checkForUpdates();
       }
       setDismissedScope(`${assistantId}:${targetVersion}`);
     } catch (err) {
@@ -337,6 +341,9 @@ function usePlatformRuntimeUpgrade({
           targetVersionRef.current = null;
           setIsPollingUpgrade(false);
           toast.success("Update complete — assistant is healthy.");
+          // Same pairing as the local path: pull any app-shell update now
+          // so one restart covers both (LUM-2603).
+          void checkForUpdates();
         });
         return false as const;
       }


### PR DESCRIPTION
Fixes [LUM-2603](https://linear.app/vellum/issue/LUM-2603): a release ships three independently-updating tracks — daemon runtime, Electron app shell, and the `cli/latest` npm install — with no coordination between them. That produces the reported two-restart upgrade dance and the CLI-version drift noted in the ticket comment (`assistant --version` at 0.10.3 while the daemon runs 0.10.4).

## Fix 1: stale CLI refresh (`cli-installer.ts`)

`ensureCliInstalled()` early-returned whenever a healthy bin existed, so an unpinned `cli/latest` kept whatever version the dist-tag resolved to at install time — forever. Corruption (the #36333 wipe path) was ironically the only upgrade mechanism.

Now, once per app session on the already-installed path, the installed `vellum` package version is compared against `app.getVersion()`; when behind, the install is floated forward with `bun add vellum@<dist-tag>`, then re-stamped and the locator rewritten.

- Shares the existing install lock, so nothing spawns the CLI mid-rewrite.
- Non-fatal: a failed refresh keeps the working install and retries next launch; one attempt per session so a lagging npm registry doesn't loop.
- Skips when the install dir has no `package.json` — `bun add` would walk up the directory tree and adopt an ancestor project (the #36963 escape) — leaving that state to the reinstall path.

## Fix 2: runtime banner triggers the Electron updater (`runtime-upgrade-banner.tsx`)

The Electron updater only checks at launch and every 4 hours, so when a runtime upgrade completed mid-session the paired app-shell update wasn't even discovered until the next launch — hence: restart once to discover, restart again to install.

Both upgrade-completion paths (local and platform-polling) now fire `checkForUpdates()` through the existing `runtime/auto-update.ts` bridge. The app-shell update downloads in the same session and the existing `UpdateToast` surfaces "Restart to install" on its own — one restart covers the whole release. No-op off Electron (web/iOS unaffected).

## Test plan

- `bun test src/main/cli-installer.test.ts` — 60 pass (6 new: floats when behind, once-per-session, no-op when equal/ahead, failure tolerance, missing-`package.json` guard).
- `local-mode`, `cli-path-flow`, `bundle-flow` suites pass.
- `bunx tsc --noEmit` clean in `clients/macos`; `bun run typecheck` clean in `clients/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)