### PR TITLE
fix(surfaces): resolve open_panel acks without surface-completion side effects

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1894,6 +1894,20 @@ export async function handleSurfaceAction(
       summary,
     };
 
+    // channel_setup pendings are protocol-level acknowledgments for the
+    // `open_panel` command, not user-facing surfaces: nothing was rendered
+    // in the transcript, so there is no completion to broadcast, persist,
+    // or count as an activation commit. Resolve and clean up only.
+    if (standalone.surfaceType === "channel_setup") {
+      cleanupStandaloneSurface(ctx, surfaceId);
+      standalone.resolve(result);
+      log.info(
+        { conversationId: ctx.conversationId, surfaceId, actionId, status },
+        "open_panel acknowledgment resolved",
+      );
+      return { accepted: true, conversationId: ctx.conversationId };
+    }
+
     broadcastMessage({
       type: "ui_surface_complete",
       conversationId: ctx.conversationId,


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37000, addressing the Devin review finding that landed just before merge: the `channel_setup` ack/nack was resolved through the full standalone-surface completion path in `handleSurfaceAction`, which (1) broadcast `ui_surface_complete` to every connected client, (2) ran `markSurfaceCompleted`'s message-history scan for a surface that is never in the transcript, and (3) ran the activation-moment hook — all for what is conceptually a protocol-level handshake.

Fix: short-circuit the standalone intercept when the pending entry's `surfaceType` is `channel_setup` — resolve the caller's promise and clean up (timer, pending map, surface state, tombstone), nothing else. The tool result seen by the model is unchanged.

## Test plan

- Existing `channel-setup-panel-ack.test.ts` suite passes unchanged (ack/nack resolution, cleanup, tombstone) — the short-circuit is behavior-preserving for the tool result and state cleanup, and the ack path no longer emits the `markSurfaceCompleted` "no such table"/no-op scan seen in prior test logs.
- `interactive-ui.test.ts` and `conversation-surfaces-action-delivery.test.ts` pass, confirming other standalone surfaces (confirmation/form) still go through the full completion path.
- `bun run typecheck:fast` clean; prettier/eslint clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sXxQuLt1Q7wdaw6s6eWL6

---
_Generated by [Claude Code](https://claude.ai/code/session_011sXxQuLt1Q7wdaw6s6eWL6)_