### PR TITLE
feat(memory): add memory.v3.gate.enabled config kill-switch for the v3 injection gate

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -27,6 +27,7 @@ describe("MemoryV3ConfigSchema", () => {
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
       entity: { enabled: true, idfFloor: 4, cap: 8 },
       gate: {
+        enabled: true,
         denseThreshold: 0.66,
         sparseThreshold: 0.35,
         sparseOnlyThreshold: 0.75,
@@ -137,6 +138,7 @@ describe("MemoryV3ConfigSchema", () => {
       gate: { denseThreshold: 0.6 },
     });
     expect(parsed.gate).toEqual({
+      enabled: true,
       denseThreshold: 0.6,
       sparseThreshold: 0.35,
       sparseOnlyThreshold: 0.75,
@@ -146,6 +148,16 @@ describe("MemoryV3ConfigSchema", () => {
       bm25NormK: null,
       bypassForCore: false,
     });
+  });
+
+  test("gate.enabled defaults true, accepts false, rejects non-booleans", () => {
+    expect(MemoryV3ConfigSchema.parse({}).gate.enabled).toBe(true);
+    expect(
+      MemoryV3ConfigSchema.parse({ gate: { enabled: false } }).gate.enabled,
+    ).toBe(false);
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ gate: { enabled: "yes" } }),
+    ).toThrow();
   });
 
   test("gate.topK rejects zero and non-integers", () => {

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -251,12 +251,18 @@ export const MemoryV3EntitySchema = z
 
 /**
  * Per-turn injection-gate tuning: thresholds the retrieval signals must clear
- * for the gate to open and run the selector. The gate's on/off is the
- * `memory-v3-injection-gate` feature flag (a separate concern), so this schema
- * carries no `enabled` field — only the tuning knobs.
+ * for the gate to open and run the selector. The gate runs only when the
+ * `memory-v3-injection-gate` feature flag (the rollout switch) AND the
+ * `enabled` kill-switch below are both on.
  */
 export const MemoryV3GateSchema = z
   .object({
+    enabled: z
+      .boolean({ error: "memory.v3.gate.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the injection gate may run at all. false forces the full selection process every turn regardless of the `memory-v3-injection-gate` feature flag; true (default) defers to the flag.",
+      ),
     denseThreshold: z
       .number({ error: "memory.v3.gate.denseThreshold must be a number" })
       .min(0)
@@ -321,7 +327,7 @@ export const MemoryV3GateSchema = z
       ),
   })
   .describe(
-    "Memory v3 per-turn injection gate tuning (thresholds; on/off is the `memory-v3-injection-gate` feature flag).",
+    "Memory v3 per-turn injection gate tuning (thresholds; the gate runs when the `memory-v3-injection-gate` feature flag AND `enabled` are both on).",
   );
 
 // NOTE: a retired `workingSet` sub-config (maxPages/evictWindow for the old

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/gate-flag.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/gate-flag.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for `gate-flag.ts` — the on/off predicate gating the memory-v3
  * per-turn injection gate. The assistant flag resolver is mocked so the test
- * asserts pure delegation: the predicate forwards `MEMORY_V3_INJECTION_GATE_FLAG`
- * and the config to `isAssistantFeatureFlagEnabled` and returns its boolean.
+ * asserts the composition: the predicate forwards `MEMORY_V3_INJECTION_GATE_FLAG`
+ * and the config to `isAssistantFeatureFlagEnabled` and ANDs its boolean with
+ * the `memory.v3.gate.enabled` config kill-switch.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -22,7 +23,9 @@ mock.module("../../../../../config/assistant-feature-flags.js", () => ({
 const { isMemoryV3InjectionGateEnabled, MEMORY_V3_INJECTION_GATE_FLAG } =
   await import("../gate-flag.js");
 
-const cfg = {} as AssistantConfig;
+// The predicate reads only `memory.v3.gate.enabled` from the config.
+const cfgWithGateEnabled = (enabled: boolean): AssistantConfig =>
+  ({ memory: { v3: { gate: { enabled } } } }) as AssistantConfig;
 
 describe("gate-flag", () => {
   beforeEach(() => {
@@ -33,9 +36,10 @@ describe("gate-flag", () => {
     expect(MEMORY_V3_INJECTION_GATE_FLAG).toBe("memory-v3-injection-gate");
   });
 
-  test("delegates to the resolver with the flag id + config and returns true", () => {
+  test("flag on + config enabled → true, resolver called with the flag id + config", () => {
     isAssistantFeatureFlagEnabled.mockReturnValue(true);
 
+    const cfg = cfgWithGateEnabled(true);
     expect(isMemoryV3InjectionGateEnabled(cfg)).toBe(true);
     expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledTimes(1);
     expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
@@ -47,10 +51,19 @@ describe("gate-flag", () => {
   test("returns false when the resolver returns false", () => {
     isAssistantFeatureFlagEnabled.mockReturnValue(false);
 
+    const cfg = cfgWithGateEnabled(true);
     expect(isMemoryV3InjectionGateEnabled(cfg)).toBe(false);
     expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
       MEMORY_V3_INJECTION_GATE_FLAG,
       cfg,
+    );
+  });
+
+  test("config kill-switch: flag on + gate.enabled false → false", () => {
+    isAssistantFeatureFlagEnabled.mockReturnValue(true);
+
+    expect(isMemoryV3InjectionGateEnabled(cfgWithGateEnabled(false))).toBe(
+      false,
     );
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -92,11 +92,15 @@ let selectorEnabledCfg = false;
 // Drives the `memory-v3-injection-gate` feature flag through the shared
 // assistant-feature-flags mock below (default off).
 let gateFlagEnabled = false;
+// Mutable `memory.v3.gate.enabled` config kill-switch carried by the mocked
+// config (default on, mirroring the schema default).
+let gateEnabledCfg = true;
 let messages: Array<{ role: string; content: string }> = [];
 
-// Schema defaults for `memory.v3.gate` (the tuning the mocked config carries and
-// the gate-config threading test asserts against). No `enabled` field — that is
-// the feature flag, threaded in by `observeTurn`.
+// Schema defaults for `memory.v3.gate` (the tuning the mocked config carries
+// and the gate-config threading test asserts against). Includes the default-on
+// `enabled` kill-switch; `observeTurn` overwrites `enabled` with the effective
+// flag AND config value.
 const GATE_DEFAULTS = MemoryV3GateSchema.parse({});
 
 // A synthetic skill capability slug the page index carries. Its rendered
@@ -224,9 +228,10 @@ mock.module("../../../../../config/loader.js", () => ({
         },
         edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
         entity: { enabled: true, idfFloor: 4, cap: 8 },
-        // Gate TUNING only (schema defaults, no `enabled`); `observeTurn` spreads
-        // this and adds the flag-derived `enabled` before passing to orchestrate.
-        gate: GATE_DEFAULTS,
+        // Gate tuning (schema defaults) with the mutable `enabled` kill-switch;
+        // `observeTurn` spreads this and overwrites `enabled` with the effective
+        // flag AND config value before passing to orchestrate.
+        gate: { ...GATE_DEFAULTS, enabled: gateEnabledCfg },
       },
       qdrant: { vectorSize: 8, onDisk: false },
     },
@@ -455,6 +460,7 @@ beforeEach(() => {
   extraRealConceptPages = 0;
   selectorEnabledCfg = false;
   gateFlagEnabled = false;
+  gateEnabledCfg = true;
   messages = [
     {
       role: "user",
@@ -701,6 +707,19 @@ describe("memory-v3 engine", () => {
     // Flag off → the gate is wired in but inert, and the tuning fields are the
     // schema defaults the config carries.
     expect(deps.gateConfig?.enabled).toBe(false);
+    expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: false });
+  });
+
+  test("flag on + gate.enabled:false config kill-switch → gate threads inert", async () => {
+    gateFlagEnabled = true;
+    gateEnabledCfg = false;
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { gateConfig?: unknown };
+    // The config kill-switch wins over the flag: the effective `enabled` is
+    // false, so selection always runs.
     expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: false });
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/gate-flag.ts
+++ b/assistant/src/plugins/defaults/memory/v3/gate-flag.ts
@@ -5,11 +5,16 @@ import type { AssistantConfig } from "../../../../config/schema.js";
 export const MEMORY_V3_INJECTION_GATE_FLAG =
   "memory-v3-injection-gate" as const;
 
-/** Whether the memory-v3 injection gate is enabled for this config. Resolved
- *  via the standard assistant flag resolver (gateway override → registry
- *  default → false). On/off only — thresholds live in `memory.v3.gate`. */
+/** Whether the memory-v3 injection gate is enabled for this config: the
+ *  feature flag (resolved via the standard assistant flag resolver — gateway
+ *  override → registry default → false) AND the `memory.v3.gate.enabled`
+ *  config kill-switch. `enabled: false` forces the full selection process
+ *  every turn even with the flag on. Thresholds live in `memory.v3.gate`. */
 export function isMemoryV3InjectionGateEnabled(
   config: AssistantConfig,
 ): boolean {
-  return isAssistantFeatureFlagEnabled(MEMORY_V3_INJECTION_GATE_FLAG, config);
+  return (
+    isAssistantFeatureFlagEnabled(MEMORY_V3_INJECTION_GATE_FLAG, config) &&
+    config.memory.v3.gate.enabled
+  );
 }

--- a/assistant/src/plugins/defaults/memory/v3/gate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/gate.ts
@@ -18,8 +18,8 @@
 //
 // This module is intentionally PURE — no async, no I/O, no logging, and no
 // imports beyond the two scored-hit types. `config.enabled` is the resolved
-// injection-gate flag value supplied by the caller, which also feeds in the
-// finder-lane hits.
+// effective enable (feature flag AND `memory.v3.gate.enabled`) supplied by the
+// caller, which also feeds in the finder-lane hits.
 
 import type { DenseHitScored } from "./dense.js";
 import type { SectionNeedleScoredHit } from "./section-needle.js";
@@ -37,7 +37,7 @@ export type V3GateReason =
   | "disabled";
 
 export interface V3GateConfig {
-  enabled: boolean; // effective enable — set from the feature flag in observeTurn
+  enabled: boolean; // effective enable — flag AND config kill-switch, resolved in observeTurn
   denseThreshold: number;
   sparseThreshold: number;
   sparseOnlyThreshold: number;

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -587,8 +587,9 @@ export async function observeTurn(
     if (cfg.memory.enabled === false) return null;
     const lanes = await getLanes(cfg);
     const v3 = cfg.memory.v3;
-    // Resolve the injection-gate flag once for the turn. The gate's tuning lives
-    // in `memory.v3.gate` (no `enabled`); the on/off comes from the feature flag.
+    // Resolve the effective gate enable once for the turn: the feature flag
+    // AND the `memory.v3.gate.enabled` config kill-switch. Tuning lives in
+    // `memory.v3.gate`.
     const gateEnabled = isMemoryV3InjectionGateEnabled(cfg);
     // Re-resolve the corpus-adaptive tuning each turn from the CURRENT config
     // (with the lane-build corpus-size signal) so a live config.json edit to a
@@ -623,9 +624,10 @@ export async function observeTurn(
         v3.selectorPromptPath,
         getWorkspaceDir(),
       ),
-      // Per-turn injection gate: the `memory.v3.gate` tuning plus the
-      // flag-derived `enabled`. The spread is the compile-time drift guard —
-      // if the gate schema and `V3GateConfig` diverge, this stops typechecking.
+      // Per-turn injection gate: the `memory.v3.gate` tuning with the raw
+      // config `enabled` overwritten by the effective enable (flag AND config).
+      // The spread is the compile-time drift guard — if the gate schema and
+      // `V3GateConfig` diverge, this stops typechecking.
       gateConfig: { ...v3.gate, enabled: gateEnabled },
     });
 


### PR DESCRIPTION
## Summary
- Adds `memory.v3.gate.enabled` (boolean, default `true`) to `MemoryV3GateSchema` — a per-workspace kill-switch for the memory-v3 per-turn injection gate.
- `isMemoryV3InjectionGateEnabled()` now resolves the effective enable as the `memory-v3-injection-gate` feature flag AND the config value, so `enabled: false` forces the full (expensive) selectPool selection every turn regardless of the flag; the flag keeps its rollout role and the default changes nothing.
- Updates the schema/gate/shadow-plugin comments that said on/off was the feature flag alone, and extends the schema, gate-flag, and shadow-plugin threading tests (including a flag-on + config-off case).

## Original prompt
The memory-v3 injection gate added yesterday skips the expensive selection process when finder-lane retrieval scores clear none of the tuned thresholds (denseThreshold / denseClusterThreshold / sparseOnlyThreshold etc.), with on/off controlled only by the `memory-v3-injection-gate` feature flag. Sidd asked for a config option controlling whether this gating happens at all, defaulting to true; when set to false, the expensive selection process must always run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)