### PR TITLE
fix(notifications): Slack approval cards — no duplicated text, no approval-code copy

### DIFF
--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -9,10 +9,12 @@ import {
   buildGuardianRequestCodeInstruction,
   hasGuardianRequestCodeInstruction,
   parseGuardianQuestionPayload,
+  parseInteractiveApprovalPayload,
   resolveGuardianInstructionModeForRequest,
   resolveGuardianInstructionModeFromFields,
   resolveGuardianQuestionInstructionMode,
   stripConflictingGuardianRequestInstructions,
+  stripGuardianRequestCodeInstructions,
 } from "../notifications/guardian-question-mode.js";
 
 describe("guardian-question-mode", () => {
@@ -227,5 +229,60 @@ describe("guardian-question-mode", () => {
         "approval",
       ),
     ).toBe("");
+  });
+
+  test("stripGuardianRequestCodeInstructions removes both-mode directives and bare code mentions", () => {
+    const text = [
+      "Alice is asking to run ls /tmp.",
+      "Approval code: A1B2C3",
+      'Reference code: A1B2C3. Reply "A1B2C3 approve" or "A1B2C3 reject".',
+      'Reply "A1B2C3 <your answer>".',
+    ].join("\n");
+
+    expect(stripGuardianRequestCodeInstructions(text, "A1B2C3")).toBe(
+      "Alice is asking to run ls /tmp.",
+    );
+  });
+
+  test("stripGuardianRequestCodeInstructions leaves unrelated text and other codes intact", () => {
+    const text = 'Approval code: ZZZZZZ. Reply "A1B2C3 approve" if you agree.';
+    expect(stripGuardianRequestCodeInstructions(text, "A1B2C3")).toBe(text);
+  });
+
+  test("parseInteractiveApprovalPayload accepts approval-mode payloads with a requestId", () => {
+    expect(
+      parseInteractiveApprovalPayload({
+        requestKind: "tool_grant_request",
+        requestId: "req-1",
+        requestCode: "A1B2C3",
+        questionText: "Allow host bash?",
+        toolName: "host_bash",
+      }),
+    ).not.toBeNull();
+  });
+
+  test("parseInteractiveApprovalPayload rejects answer-mode and unparseable payloads", () => {
+    // Answer mode: free-text questions get no Approve/Reject buttons.
+    expect(
+      parseInteractiveApprovalPayload({
+        requestKind: "pending_question",
+        requestId: "req-2",
+        requestCode: "A1B2C3",
+        questionText: "What time works?",
+        callSessionId: "call-1",
+        activeGuardianRequestCount: 1,
+      }),
+    ).toBeNull();
+
+    // Strict-parse failure: missing required pending_question fields.
+    expect(
+      parseInteractiveApprovalPayload({
+        requestKind: "pending_question",
+        requestId: "req-3",
+        requestCode: "A1B2C3",
+        questionText: "Allow send_email?",
+        toolName: "send_email",
+      }),
+    ).toBeNull();
   });
 });

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -285,6 +285,100 @@ describe("notification decision fallback copy", () => {
     expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 reject"');
     expect(decision.renderedCopy.vellum?.body).not.toContain("<your answer>");
   });
+
+  test("slack approval copy is stripped of request-code instructions instead of enforced", async () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestId: "req-grant-slack-1",
+        questionText: "Approve tool: bash — ls /tmp (requested by Alice)",
+        requestCode: "A1B2C3",
+        requestKind: "tool_grant_request",
+        toolName: "bash",
+      },
+    });
+
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "slack",
+    ] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(true);
+    // Vellum keeps the code-reply directive.
+    expect(decision.renderedCopy.vellum?.body).toContain('"A1B2C3 approve"');
+    // Slack renders Approve/Reject buttons — no code anywhere in its copy.
+    expect(decision.renderedCopy.slack?.body).toBe(
+      "Approve tool: bash — ls /tmp (requested by Alice)",
+    );
+    expect(decision.renderedCopy.slack?.body).not.toContain("A1B2C3");
+  });
+
+  test("slack copy strips LLM-authored approval-code phrasing for approval requests", async () => {
+    configuredProvider = {
+      sendMessage: async () => ({ content: [] }),
+    };
+    extractedToolUse = {
+      name: "record_notification_decision",
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["slack"],
+        reasoningSummary: "LLM decision",
+        renderedCopy: {
+          slack: {
+            title: "Tool Grant Request",
+            body: "Alice is asking to run ls /tmp.",
+            deliveryText:
+              'Alice is asking to run ls /tmp.\nApproval code: A1B2C3\nReference code: A1B2C3. Reply "A1B2C3 approve" or "A1B2C3 reject".',
+          },
+        },
+        dedupeKey: "guardian-question-slack-llm-test",
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal({
+      contextPayload: {
+        requestId: "req-grant-slack-2",
+        questionText: "Approve tool: bash — ls /tmp (requested by Alice)",
+        requestCode: "A1B2C3",
+        requestKind: "tool_grant_request",
+        toolName: "bash",
+      },
+    });
+
+    const decision = await evaluateSignal(signal, [
+      "slack",
+    ] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.slack?.deliveryText).toBe(
+      "Alice is asking to run ls /tmp.",
+    );
+    expect(decision.renderedCopy.slack?.body).toBe(
+      "Alice is asking to run ls /tmp.",
+    );
+  });
+
+  test("slack answer-mode questions keep code instructions (no buttons render)", async () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestId: "req-pending-slack-1",
+        questionText: "What is the gate code?",
+        requestCode: "A1B2C3",
+        requestKind: "pending_question",
+        callSessionId: "call-1",
+        activeGuardianRequestCount: 1,
+      },
+    });
+
+    const decision = await evaluateSignal(signal, [
+      "slack",
+    ] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.renderedCopy.slack?.body).toContain(
+      '"A1B2C3 <your answer>"',
+    );
+  });
 });
 
 // ── Access-request instruction enforcement ──────────────────────────────

--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -10,7 +10,7 @@ import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
  * quoted-preview body, action callback ids, source/permalink and requester-id
  * context blocks, the security-warning context block, and guardian
  * verification note that `buildApprovalNotificationBlocks` emits for an
- * access request.
+ * access request — plus the tool-approval card body/continuation split.
  */
 
 const APPROVAL: ApprovalUIMetadata = {
@@ -39,7 +39,9 @@ type Block = Record<string, unknown>;
 
 function card(blocks: unknown[]): Block {
   const c = (blocks as Block[]).find((b) => b.type === "card");
-  if (!c) throw new Error("no card block");
+  if (!c) {
+    throw new Error("no card block");
+  }
   return c;
 }
 
@@ -172,5 +174,90 @@ describe("Slack access-request card blocks", () => {
     expect(
       texts.some((t) => t.includes("haven't verified your identity on slack")),
     ).toBe(true);
+  });
+});
+
+const TOOL_APPROVAL: ApprovalUIMetadata = {
+  requestId: "req-456",
+  actions: [
+    { id: "approve_once", label: "Approve once" },
+    { id: "reject", label: "Reject" },
+  ],
+  plainTextFallback: 'Reply "ABC123 approve" or "ABC123 reject"',
+  permissionDetails: {
+    toolName: "bash",
+    riskLevel: "medium",
+    toolInput: { command: "ls /tmp" },
+    requesterIdentifier: "Alice",
+  },
+};
+
+function buildToolApprovalPayload(): ChannelDeliveryPayload {
+  return {
+    sourceEventName: "guardian.question",
+    copy: { title: "Guardian Question", body: "Approve tool: bash" },
+    urgency: "high",
+    approvalContext: TOOL_APPROVAL,
+  };
+}
+
+function sectionTexts(blocks: unknown[]): string[] {
+  return (blocks as Block[])
+    .filter((b) => b.type === "section")
+    .map((b) => text(b.text));
+}
+
+describe("Slack tool-approval card blocks", () => {
+  test("short message renders entirely in the card body with no companion section", () => {
+    const message = "Alice is requesting approval to run: ls /tmp";
+    const blocks = buildApprovalNotificationBlocks(
+      buildToolApprovalPayload(),
+      message,
+    );
+    expect(text(card(blocks).body)).toBe(message);
+    expect(sectionTexts(blocks)).toHaveLength(0);
+  });
+
+  test("card carries tool title and tool/requester subtitle", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(buildToolApprovalPayload(), "msg"),
+    );
+    expect(text(c.title)).toBe("Tool Approval");
+    expect(text(c.subtitle)).toBe("bash — requested by Alice");
+  });
+
+  test("long message continues in a section without repeating the card body", () => {
+    const message = Array.from(
+      { length: 40 },
+      (_, i) => `word${String(i).padStart(2, "0")}`,
+    ).join(" "); // 279 chars of distinct words
+    const blocks = buildApprovalNotificationBlocks(
+      buildToolApprovalPayload(),
+      message,
+    );
+
+    const body = text(card(blocks).body);
+    expect(body.length).toBeLessThanOrEqual(200);
+    expect(body.endsWith(" ↓")).toBe(true);
+
+    const sections = sectionTexts(blocks);
+    expect(sections).toHaveLength(1);
+    const continuation = sections[0];
+
+    // Body + continuation reassemble the full message with nothing repeated
+    // and nothing lost — the guardian reads each word exactly once.
+    const bodyWords = body.replace(/ ↓$/, "").split(" ");
+    const continuationWords = continuation.replace(/^… /, "").split(" ");
+    expect([...bodyWords, ...continuationWords].join(" ")).toBe(message);
+  });
+
+  test("split lands on a word boundary", () => {
+    const message = `${"a".repeat(190)} ${"b".repeat(60)}`;
+    const blocks = buildApprovalNotificationBlocks(
+      buildToolApprovalPayload(),
+      message,
+    );
+    expect(text(card(blocks).body)).toBe(`${"a".repeat(190)} ↓`);
+    expect(sectionTexts(blocks)[0]).toBe(`… ${"b".repeat(60)}`);
   });
 });

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -280,3 +280,82 @@ describe("sendSlackReply post path", () => {
     expect(callSlackApiMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("sendSlackReply approval fallback", () => {
+  const approval = {
+    requestId: "req-123",
+    actions: [
+      { id: "approve_once", label: "Approve once" },
+      { id: "reject", label: "Reject" },
+    ],
+    plainTextFallback: 'Reply "ABC123 approve" or "ABC123 reject"',
+  };
+  const blocks: KnownBlock[] = [
+    { type: "section", text: { type: "mrkdwn", text: "Approve tool: bash" } },
+  ];
+
+  beforeEach(() => {
+    callSlackApiMock.mockReset();
+    callSlackApiMock.mockImplementation(async () => ({ ok: true }));
+  });
+
+  test("block-free retry re-attaches plain-text reply instructions", async () => {
+    // Dropping an approval's blocks drops its buttons — the retry text must
+    // carry the reply instructions so the recipient can still act.
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("invalid_blocks");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000400",
+      }));
+
+    const result = await sendSlackReply("C123", "Approve tool: bash", {
+      blocks,
+      approval,
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1700000000.000400" });
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
+      channel: "C123",
+      text: 'Approve tool: bash\n\nReply "ABC123 approve" or "ABC123 reject"',
+    });
+  });
+
+  test("retry text is unchanged when it already contains the instructions", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("msg_blocks_too_long");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000500",
+      }));
+
+    const text = `Approve tool: bash\n\n${approval.plainTextFallback}`;
+    await sendSlackReply("C123", text, { blocks, approval });
+
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
+      channel: "C123",
+      text,
+    });
+  });
+
+  test("approval without usable instructions is never retried bare", async () => {
+    // A block-free approval with no reply instructions gives the recipient no
+    // way to respond — fail the delivery instead so it surfaces as an error.
+    callSlackApiMock.mockImplementationOnce(async () => {
+      throw new SlackApiError("invalid_blocks");
+    });
+
+    await expect(
+      sendSlackReply("C123", "Approve tool: bash", {
+        blocks,
+        approval: { ...approval, plainTextFallback: "  " },
+      }),
+    ).rejects.toThrow();
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -151,13 +151,15 @@ export interface SlackSendResult {
  * Those errors fault the Block Kit payload, not the target — the retry repeats
  * the *same* operation (same `chat.update` ts, same `chat.postMessage` thread)
  * without blocks, so it edits/posts in place rather than spawning a second
- * message. Any other error propagates to the caller.
+ * message. `fallbackText` replaces the message text on that retry (used to
+ * re-attach reply instructions whose Block Kit equivalent was dropped). Any
+ * other error propagates to the caller.
  */
 async function sendWithBlockFallback(
   method: string,
   baseBody: Record<string, unknown>,
   blocks: KnownBlock[],
-  options: { fallbackWithoutBlocks: boolean },
+  options: { fallbackWithoutBlocks: boolean; fallbackText?: string },
 ): Promise<SlackSendResult> {
   try {
     const result = await callSlackApi(
@@ -177,11 +179,34 @@ async function sendWithBlockFallback(
         { method, slackError: err.slackError },
         "Slack rejected blocks; retrying without blocks",
       );
-      const result = await callSlackApi(method, baseBody);
+      const retryBody =
+        options.fallbackText !== undefined
+          ? { ...baseBody, text: options.fallbackText }
+          : baseBody;
+      const result = await callSlackApi(method, retryBody);
       return { ok: true, ts: result.ts };
     }
     throw err;
   }
+}
+
+/**
+ * Text for the block-free retry of an approval prompt. Dropping an approval's
+ * blocks removes its Approve/Reject buttons, so the retry re-attaches the
+ * plain-text reply instructions to keep the message actionable. Returns
+ * `undefined` when the approval has no usable instructions — such a prompt
+ * must not be retried bare, since a message with no way to respond is worse
+ * than a failed delivery the delivery layer can surface.
+ */
+function buildApprovalFallbackText(
+  text: string,
+  approval: ApprovalUIMetadata,
+): string | undefined {
+  const instructions = approval.plainTextFallback.trim();
+  if (instructions.length === 0) {
+    return undefined;
+  }
+  return text.includes(instructions) ? text : `${text}\n\n${instructions}`;
 }
 
 /**
@@ -219,29 +244,40 @@ export async function sendSlackReply(
   }
 
   const postBase: Record<string, unknown> = { channel: chatId, text };
-  if (options?.threadTs) postBase.thread_ts = options.threadTs;
+  if (options?.threadTs) {
+    postBase.thread_ts = options.threadTs;
+  }
+
+  // Approval prompts carry their action buttons in `blocks`. When Slack
+  // rejects the payload, the block-free retry re-attaches the plain-text
+  // reply instructions so the recipient can still act by text reply; an
+  // approval without usable instructions is never retried bare.
+  const approvalFallbackText = options?.approval
+    ? buildApprovalFallbackText(text, options.approval)
+    : undefined;
+  const fallbackOptions = {
+    fallbackWithoutBlocks:
+      !options?.approval || approvalFallbackText !== undefined,
+    fallbackText: approvalFallbackText,
+  };
 
   if (options?.ephemeral) {
-    if (!options.user)
+    if (!options.user) {
       throw new Error("user is required for ephemeral messages");
+    }
     return sendWithBlockFallback(
       "chat.postEphemeral",
       { ...postBase, user: options.user },
       blocks,
-      { fallbackWithoutBlocks: !options.approval },
+      fallbackOptions,
     );
   }
 
-  // Approval prompts carry their action buttons in `blocks`; dropping them when
-  // Slack rejects the payload would post a card with no way to respond, so only
-  // non-approval posts fall back to a block-free retry.
   const result = await sendWithBlockFallback(
     "chat.postMessage",
     postBase,
     blocks,
-    {
-      fallbackWithoutBlocks: !options?.approval,
-    },
+    fallbackOptions,
   );
   log.info({ chatId, hasThreadTs: !!options?.threadTs }, "Slack message sent");
   return result;

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -57,7 +57,7 @@ Hard invariants that the LLM cannot override:
 
 **Post-generation enforcement** (`decision-engine.ts`):
 
-- **Guardian question request-code enforcement** — `enforceGuardianRequestCode()` ensures request-code instructions (approve/reject or free-text answer) appear in all `guardian.question` notification copy, even when the LLM omits them.
+- **Guardian question request-code enforcement** — `enforceGuardianRequestCode()` ensures request-code instructions (approve/reject or free-text answer) appear in all `guardian.question` notification copy, even when the LLM omits them. Exception: for approval-mode questions the Slack adapter renders an interactive card with Approve/Reject buttons, so Slack copy is instead **stripped** of request-code instructions and bare code mentions (`stripGuardianRequestCodeInstructions()`).
 - **Access-request instruction enforcement** — `enforceAccessRequestInstructions()` validates that `ingress.access_request` copy contains: (1) the request-code approve/reject directive, (2) the exact "open invite flow" phrase. If any required element is missing, the full deterministic contract text is appended. This prevents model-generated copy from dropping security-critical action directives.
 
 **Pre-send gate checks** (`deterministic-checks.ts`) — these all depend on the decision, so they run here, after it:

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -3,10 +3,10 @@
  * using native Card blocks for approval notifications.
  *
  * Approval notifications (access requests, tool approvals) render as a
- * single Slack Card block with Approve/Reject action buttons, plus
- * optional companion context blocks for details that exceed the card's
- * character limits. Non-approval notifications use standard Block Kit
- * text sections.
+ * single Slack Card block with Approve/Reject action buttons. Text that
+ * exceeds the card body's 200-character cap continues in a companion
+ * section block below the card. Non-approval notifications use standard
+ * Block Kit text sections.
  *
  * Card block reference:
  * https://docs.slack.dev/reference/block-kit/blocks/card-block
@@ -239,11 +239,40 @@ function buildAccessRequestCardBlocks(
 // Tool approval card
 // ---------------------------------------------------------------------------
 
+/** Slack caps a card block's `body` text at 200 characters. */
+const CARD_BODY_MAX_LENGTH = 200;
+
+/** Marker signalling the card body continues in the section below. */
+const CARD_BODY_CONTINUATION_MARKER = " ↓";
+
+/**
+ * Split message text so the head fits Slack's card body cap (marker
+ * included) and the tail continues in a companion section below the card.
+ * Splits on the last whitespace inside the budget when there is one, so
+ * neither piece cuts mid-word. Text within the cap needs no split.
+ */
+function splitAtCardBodyLimit(text: string): { head: string; tail?: string } {
+  if (text.length <= CARD_BODY_MAX_LENGTH) {
+    return { head: text };
+  }
+
+  const budget = CARD_BODY_MAX_LENGTH - CARD_BODY_CONTINUATION_MARKER.length;
+  const window = text.slice(0, budget + 1);
+  const lastWhitespace = window.search(/\s\S*$/);
+  const cut = lastWhitespace > 0 ? lastWhitespace : budget;
+
+  return {
+    head: text.slice(0, cut).trimEnd() + CARD_BODY_CONTINUATION_MARKER,
+    tail: text.slice(cut).trimStart(),
+  };
+}
+
 /**
  * Build Slack blocks for a tool approval notification using a native Card block.
  *
  * Layout:
  *   Card — title + subtitle (tool + requester) + body (notification text) + actions
+ *   Section — continuation of body text exceeding the card's 200-char cap
  */
 function buildToolApprovalCardBlocks(
   payload: ChannelDeliveryPayload,
@@ -262,17 +291,14 @@ function buildToolApprovalCardBlocks(
     subtitle = truncate(toolName, 150);
   }
 
-  const needsOverflow = messageText.length > 200;
+  const { head, tail } = splitAtCardBodyLimit(messageText);
   const card: CardBlock = {
     type: "card",
     title: {
       type: "mrkdwn",
       text: details ? "Tool Approval" : "Approval Request",
     },
-    body: {
-      type: "mrkdwn",
-      text: needsOverflow ? truncate(messageText, 197) + " ↓" : messageText,
-    },
+    body: { type: "mrkdwn", text: head },
     actions: buildCardActions(approval),
   };
   if (subtitle) {
@@ -280,12 +306,12 @@ function buildToolApprovalCardBlocks(
   }
   blocks.push(card);
 
-  // When the message exceeds the card body limit, show the full text in a
-  // companion section so the approver can see the complete command/context.
-  if (needsOverflow) {
+  // The companion section carries only the remainder — repeating the full
+  // text would render the same message twice (once in the card, once below).
+  if (tail) {
     blocks.push({
       type: "section",
-      text: { type: "mrkdwn", text: truncate(messageText, 3000) },
+      text: { type: "mrkdwn", text: truncate(`… ${tail}`, 3000) },
     });
   }
 

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -368,9 +368,14 @@ export class SlackAdapter implements ChannelAdapter {
     const messageText = resolveMessageText(payload);
 
     try {
+      // `approval` rides along with the prebuilt card blocks so the send
+      // layer treats a rejected Block Kit payload as an approval prompt:
+      // its block-free retry re-attaches `plainTextFallback` reply
+      // instructions instead of posting text with no way to respond.
       const result = payload.approvalContext
         ? await sendSlackReply(chatId, messageText, {
             blocks: buildApprovalNotificationBlocks(payload, messageText),
+            approval: payload.approvalContext,
           })
         : await sendSlackReply(chatId, messageText, { useBlocks: true });
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -29,10 +29,7 @@ import {
   updateDeliveryStatus,
 } from "./deliveries-store.js";
 import { resolveDestinations } from "./destination-resolver.js";
-import {
-  parseGuardianQuestionPayload,
-  resolveGuardianInstructionModeFromPayload,
-} from "./guardian-question-mode.js";
+import { parseInteractiveApprovalPayload } from "./guardian-question-mode.js";
 import { nonEmpty } from "./notification-utils.js";
 import type { NotificationSignal } from "./signal.js";
 import type {
@@ -85,18 +82,11 @@ function resolveApprovalContext(
   }
 
   if (signal.sourceEventName === "guardian.question") {
-    const parsed = parseGuardianQuestionPayload(payload);
+    const parsed = parseInteractiveApprovalPayload(payload);
     if (!parsed) {
       return undefined;
     }
-    const { mode } = resolveGuardianInstructionModeFromPayload(parsed);
-    if (mode !== "approval") {
-      return undefined;
-    }
-    const requestId = nonEmpty(parsed.requestId);
-    if (!requestId) {
-      return undefined;
-    }
+    const requestId = parsed.requestId;
 
     // Extract tool context so channel adapters can render structured
     // approval cards without re-parsing contextPayload.

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -49,8 +49,10 @@ import { createDecision } from "./decisions-store.js";
 import {
   buildGuardianRequestCodeInstruction,
   hasGuardianRequestCodeInstruction,
+  parseInteractiveApprovalPayload,
   resolveGuardianQuestionInstructionMode,
   stripConflictingGuardianRequestInstructions,
+  stripGuardianRequestCodeInstructions,
 } from "./guardian-question-mode.js";
 import { nonEmpty, readPayloadString } from "./notification-utils.js";
 import { getPreferenceSummary } from "./preference-summary.js";
@@ -145,6 +147,7 @@ function buildSystemPrompt(
     `  - Avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?"). Write the recipient-facing message directly.`,
     `  - Avoid intermediary-instruction phrasing like "consider telling the guardian", "ask the recipient to", or "the assistant should remind them". Rewrite it as final copy the recipient can act on directly.`,
     `  - For telegram: 1-2 concise sentences.`,
+    `  - For slack approval requests: the message renders inside an interactive card with Approve/Reject buttons. Describe only what needs approval — never include approval/reference codes, code-reply instructions, or directions to respond in another app.`,
     `- \`conversationSeedMessage\` is the opening message in the internal notification conversation and also the expanded detail shown in the home feed. It should be richer and more contextual than the popup body.`,
     `  - For vellum (desktop): use structured markdown for readability. Break content into bullet points, numbered lists, or short sections with **bold** labels. Avoid long unbroken paragraphs — scan-friendly formatting is preferred.`,
     `  - Never dump raw JSON. Include only human-readable context.`,
@@ -595,9 +598,42 @@ function ensureGuardianRequestCodeInCopy(
 }
 
 /**
+ * Remove request-code reply instructions from copy for a channel whose
+ * approval UI makes them redundant. Instruction-only fields keep their
+ * original text rather than becoming empty — downstream treats an empty
+ * body as missing copy.
+ */
+function stripGuardianRequestCodeInCopy(
+  copy: RenderedChannelCopy,
+  requestCode: string,
+): RenderedChannelCopy {
+  const strip = (text: string): string => {
+    const stripped = stripGuardianRequestCodeInstructions(text, requestCode);
+    return stripped.length > 0 ? stripped : text;
+  };
+
+  return {
+    ...copy,
+    body: strip(copy.body),
+    deliveryText: copy.deliveryText
+      ? strip(copy.deliveryText)
+      : copy.deliveryText,
+    conversationSeedMessage: copy.conversationSeedMessage
+      ? strip(copy.conversationSeedMessage)
+      : copy.conversationSeedMessage,
+  };
+}
+
+/**
  * Guardian questions that share a conversation require explicit request-code
  * targeting. Enforce request-code instructions in rendered copy so guardians
  * can always disambiguate replies even when model copy omits them.
+ *
+ * Slack is the exception for approval-mode questions: the Slack adapter
+ * renders those as an interactive card with Approve/Reject buttons (see
+ * `resolveApprovalContext` in broadcaster.ts, gated on the same
+ * `parseInteractiveApprovalPayload`), so code-reply instructions are
+ * redundant noise there and are stripped instead of enforced in.
  */
 function enforceGuardianRequestCode(
   decision: NotificationDecision,
@@ -615,6 +651,8 @@ function enforceGuardianRequestCode(
   const modeResolution = resolveGuardianQuestionInstructionMode(
     signal.contextPayload,
   );
+  const slackRendersApprovalButtons =
+    parseInteractiveApprovalPayload(signal.contextPayload) != null;
   const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
     ...decision.renderedCopy,
   };
@@ -624,11 +662,14 @@ function enforceGuardianRequestCode(
     if (!copy) {
       continue;
     }
-    nextCopy[channel] = ensureGuardianRequestCodeInCopy(
-      copy,
-      requestCode,
-      modeResolution.mode,
-    );
+    nextCopy[channel] =
+      channel === "slack" && slackRendersApprovalButtons
+        ? stripGuardianRequestCodeInCopy(copy, requestCode)
+        : ensureGuardianRequestCodeInCopy(
+            copy,
+            requestCode,
+            modeResolution.mode,
+          );
   }
 
   return {

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -406,27 +406,75 @@ function normalizeInstructionText(value: string): string {
     .trim();
 }
 
+function buildApprovalInstructionPattern(escapedCode: string): RegExp {
+  return new RegExp(
+    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+approve"\\s+or\\s+"${escapedCode}\\s+reject"\\.?`,
+    "ig",
+  );
+}
+
+function buildAnswerInstructionPattern(escapedCode: string): RegExp {
+  return new RegExp(
+    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+<your\\s+answer>"\\.?`,
+    "ig",
+  );
+}
+
 export function stripConflictingGuardianRequestInstructions(
   text: string,
   requestCode: string,
   mode: GuardianQuestionInstructionMode,
 ): string {
   const escapedCode = escapeRegExp(requestCode);
-  const approvalInstructionPattern = new RegExp(
-    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+approve"\\s+or\\s+"${escapedCode}\\s+reject"\\.?`,
-    "ig",
-  );
-  const answerInstructionPattern = new RegExp(
-    `(?:Reference\\s+code:\\s*${escapedCode}\\.?\\s*)?Reply\\s+"${escapedCode}\\s+<your\\s+answer>"\\.?`,
-    "ig",
-  );
-
   const next =
     mode === "answer"
-      ? text.replace(approvalInstructionPattern, "")
-      : text.replace(answerInstructionPattern, "");
+      ? text.replace(buildApprovalInstructionPattern(escapedCode), "")
+      : text.replace(buildAnswerInstructionPattern(escapedCode), "");
 
   return normalizeInstructionText(next);
+}
+
+/**
+ * Remove every request-code reply instruction (both modes) plus bare
+ * "Reference code: X." / "Approval code: X." mentions from copy destined
+ * for a surface that renders interactive Approve/Reject buttons, where
+ * code-reply instructions are redundant noise.
+ */
+export function stripGuardianRequestCodeInstructions(
+  text: string,
+  requestCode: string,
+): string {
+  const escapedCode = escapeRegExp(requestCode);
+  const next = text
+    .replace(buildApprovalInstructionPattern(escapedCode), "")
+    .replace(buildAnswerInstructionPattern(escapedCode), "")
+    .replace(
+      new RegExp(`(?:Reference|Approval)\\s+code:\\s*${escapedCode}\\.?`, "ig"),
+      "",
+    );
+
+  return normalizeInstructionText(next);
+}
+
+/**
+ * Parse a guardian.question payload that renders channel-native
+ * Approve/Reject actions on button-capable channels: it parses strictly,
+ * resolves to approval mode, and carries the requestId the action
+ * callbacks target. Returns `null` otherwise — those payloads render as
+ * plain text and rely on request-code replies.
+ */
+export function parseInteractiveApprovalPayload(
+  payload: Record<string, unknown>,
+): GuardianQuestionPayload | null {
+  const parsed = parseGuardianQuestionPayload(payload);
+  if (!parsed) {
+    return null;
+  }
+  const { mode } = resolveGuardianInstructionModeFromPayload(parsed);
+  if (mode !== "approval") {
+    return null;
+  }
+  return nonEmpty(parsed.requestId) ? parsed : null;
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Report from Slack: a tool-grant approval notification rendered its content twice — the interactive approval card *and* what looked like the plain-text fallback below it, in the same message. Follow-up feedback: the copy itself should also be simplified — remove the approval code and rely on the card's Approve/Reject buttons instead of telling the guardian to go to Vellum or reply with a code.

**Commit 1 — duplication fix.** The duplication was not the notification-fallback path: `buildToolApprovalCardBlocks` in `assistant/src/notifications/adapters/slack.ts` put the (truncated) approval text in the card body and, whenever the text exceeded Slack's 200-character card body cap (a hard API limit — see `CardBlock.body` in `@slack/types`), appended a companion `section` block containing the **full text again**. Tool-grant copy always exceeded the cap because it carried the code-reply instructions, so every tool approval rendered twice. The companion section is now a true continuation: long text splits at a word boundary, the card body ends with the `↓` marker, and the section renders only the remainder prefixed with `…`.

**Commit 2 — copy simplification.** Slack renders approval-mode guardian questions as an interactive card with Approve/Reject buttons, yet the copy always carried code instructions: `enforceGuardianRequestCode` appended the "Reference code: X. Reply …" directive to every channel's copy, and the decision LLM often added its own "Approval code: X / check the app" phrasing. Changes:

- `enforceGuardianRequestCode` now branches per channel: Slack approval copy is **stripped** of request-code instructions and bare `Reference/Approval code: X` mentions (new `stripGuardianRequestCodeInstructions`), while every other channel — and Slack answer-mode questions, which render no buttons — keeps the enforced directive.
- The decision-engine system prompt tells the model that Slack approval requests render inside a card with buttons, so the copy must not include codes or directions to respond in another app.
- The "renders Approve/Reject buttons" predicate is extracted into `parseInteractiveApprovalPayload` and shared by the broadcaster's approval-context resolution and the enforcement branch, so the two cannot drift.

This also shortens typical tool-grant copy back under the 200-char card cap, so most approvals now render as a single clean card with no continuation section at all.

## Test plan

- New regression tests in `slack-notification-approval-card.test.ts` pinning the tool-approval card contract: short messages render card-only; long messages reassemble exactly once across body + continuation; the split lands on a word boundary.
- New tests in `notification-decision-fallback.test.ts`: Slack approval copy is stripped of codes (template and LLM paths) while vellum keeps the directive; Slack answer-mode questions keep the code instructions.
- New unit tests in `guardian-question-mode.test.ts` for `stripGuardianRequestCodeInstructions` (both directive modes + bare code mentions, other codes untouched) and `parseInteractiveApprovalPayload`.
- Ran the surrounding suites individually (broadcaster, decision-engine, copy-composer, deterministic-checks, decision-strategy, telegram adapter, seed-content blocks — all green), `bun run typecheck:fast`, eslint + prettier on changed files. One pre-existing cross-file mock-leak failure reproduces on the clean tree when certain suites share a process; unrelated to this change.

## CLI verb checklist

No new routes — section deleted per template instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbTbJv7YEN8Xa2rvpbtLXp