### PR TITLE
fix(compaction): sanitize summary-call history like main model calls

### DIFF
--- a/assistant/src/__tests__/compactor-media-strip.test.ts
+++ b/assistant/src/__tests__/compactor-media-strip.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getMessages: () => [],
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  getAttachmentMetadataForMessage: () => [],
+  getAttachmentContent: () => null,
+}));
+
+import { runAssistantDrivenCompaction } from "../context/compactor.js";
+import type { Message, Provider } from "../providers/types.js";
+
+const TAIL_TIMESTAMP =
+  "2026-05-21 (Thursday) 10:00:00 -05:00 (America/Chicago)";
+
+const compactionResponse = `
+<compaction_result>
+<summary>
+Earlier turns summarized here.
+</summary>
+
+<key_state>
+- Nothing critical pending.
+</key_state>
+
+<tail_start timestamp="${TAIL_TIMESTAMP}" preview="tail anchor message" />
+</compaction_result>
+`;
+
+const OLD_SCREENSHOT_DATA = "b64-old-screenshot-bytes";
+const LATEST_SCREENSHOT_DATA = "b64-latest-screenshot-bytes";
+const USER_ATTACHED_IMAGE_DATA = "b64-user-attached-bytes";
+
+const userTextWithTurnContext = (text: string, timestamp: string): Message => ({
+  role: "user",
+  content: [
+    {
+      type: "text",
+      text: `<turn_context>\ncurrent_time: ${timestamp}\n</turn_context>\n${text}`,
+    },
+  ],
+});
+
+const assistantToolUse = (id: string): Message => ({
+  role: "assistant",
+  content: [{ type: "tool_use", id, name: "screenshot", input: {} }],
+});
+
+const toolResultWithImage = (id: string, data: string): Message => ({
+  role: "user",
+  content: [
+    {
+      type: "tool_result",
+      tool_use_id: id,
+      content: "captured",
+      contentBlocks: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data },
+        },
+      ],
+    },
+  ],
+});
+
+const userWithAttachedImage = (): Message => ({
+  role: "user",
+  content: [
+    { type: "text", text: "here is a mockup" },
+    {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: USER_ATTACHED_IMAGE_DATA,
+      },
+    },
+  ],
+});
+
+function serializeBlocks(messages: Message[]): string {
+  return JSON.stringify(messages);
+}
+
+// Records the exact message list the provider is asked to summarize.
+function recordingProvider(sink: { sent: Message[] }): Provider {
+  return {
+    name: "mock-provider",
+    sendMessage: async (msgs: Message[]) => {
+      sink.sent = msgs;
+      return {
+        content: [{ type: "text", text: compactionResponse }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+// The summary request must carry the same media-stripped projection the agent
+// loop sends on its own model calls. An unsanitized history resends every
+// screenshot in the conversation; enough of them cross Anthropic's many-image
+// threshold, where a stricter per-image dimension cap rejects the whole
+// summary call (and trips the compaction circuit breaker).
+describe("compaction summary calls — old tool-result media stripping", () => {
+  test("runAssistantDrivenCompaction strips images from older tool results, keeps the latest turn's image and user-attached images, and leaves durable history untouched", async () => {
+    // GIVEN a screenshot-heavy history: older tool results with images, a
+    // user-attached image, and a most-recent tool result with an image
+    const messages: Message[] = [
+      userWithAttachedImage(),
+      assistantToolUse("tu_old_1"),
+      toolResultWithImage("tu_old_1", OLD_SCREENSHOT_DATA),
+      userTextWithTurnContext("tail anchor message", TAIL_TIMESTAMP),
+      assistantToolUse("tu_latest"),
+      toolResultWithImage("tu_latest", LATEST_SCREENSHOT_DATA),
+    ];
+
+    // AND a snapshot of the caller's array so we can assert it is not mutated
+    const inputSnapshot = serializeBlocks(messages);
+    const sink = { sent: [] as Message[] };
+
+    // WHEN compaction runs over that history
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-media-strip",
+      messages,
+      provider: recordingProvider(sink),
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      // Large budget so the request is not front-truncated — this test
+      // exercises the media-strip sanitizer, not the truncation fallback.
+      maxInputTokens: 100000,
+      previousEstimatedInputTokens: 90000,
+    });
+
+    // THEN older tool-result screenshots are replaced with a text marker
+    const sentSerialized = serializeBlocks(sink.sent);
+    expect(sentSerialized).not.toContain(OLD_SCREENSHOT_DATA);
+    expect(sentSerialized).toContain("binary data removed to save context");
+
+    // AND the most recent tool-result turn keeps its image (the model may
+    // still need it), as do images the user attached directly
+    expect(sentSerialized).toContain(LATEST_SCREENSHOT_DATA);
+    expect(sentSerialized).toContain(USER_ATTACHED_IMAGE_DATA);
+
+    // AND the caller's durable history array is left byte-for-byte untouched,
+    // so persisted messages keep the original rich blocks
+    expect(serializeBlocks(messages)).toBe(inputSnapshot);
+    expect(result.compacted).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -622,6 +622,13 @@ describe("web_search_tool_result structural guard", () => {
     "context/post-turn-tool-result-truncation.ts",
     "context/tool-result-spool.ts",
 
+    // Outbound sanitize bundle: the media-strip and AX-tree transforms
+    // operate on locally-executed tool results (media contentBlocks and
+    // <ax-tree> text), which web_search_tool_result blocks never carry.
+    // Web-search blocks are handled by the bundle's own third transform
+    // (stripHistoricalWebSearchResults), so nothing is silently dropped.
+    "context/outbound-sanitize.ts",
+
     // Anthropic provider type guards define API-specific discriminants.
     // It has a separate isWebSearchToolResultBlock for the other type.
     "providers/anthropic/client.ts",

--- a/assistant/src/__tests__/pre-model-call-sanitize.test.ts
+++ b/assistant/src/__tests__/pre-model-call-sanitize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { preModelCallSanitize } from "../agent/loop.js";
+import { preModelCallSanitize } from "../context/outbound-sanitize.js";
 import type { Message } from "../providers/types.js";
 
 /**

--- a/assistant/src/agent/ax-tree-compaction.test.ts
+++ b/assistant/src/agent/ax-tree-compaction.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  compactAxTreeHistory,
+  escapeAxTreeContent,
+} from "../context/outbound-sanitize.js";
 import type { Message } from "../providers/types.js";
-import { compactAxTreeHistory, escapeAxTreeContent } from "./loop.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -4,6 +4,7 @@ import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { recordEstimate } from "../context/estimator-calibration.js";
+import { preModelCallSanitize } from "../context/outbound-sanitize.js";
 import {
   estimatePromptTokensRaw,
   estimatePromptTokensWithTools,
@@ -14,7 +15,6 @@ import { spoolAndStubOversizedToolResults } from "../context/tool-result-spool.j
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { parseActualTokensFromError } from "../daemon/parse-actual-tokens-from-error.js";
 import type { TrustContext } from "../daemon/trust-context.js";
-import { stripHistoricalWebSearchResults } from "../daemon/web-search-history.js";
 import {
   timeSyncSection,
   traceAsyncSection,
@@ -2559,179 +2559,4 @@ export class AgentLoop {
       newMessages: history.slice(newMessagesStart),
     };
   }
-}
-
-/** Number of most-recent AX tree snapshots to keep in conversation history. */
-const MAX_AX_TREES_IN_HISTORY = 2;
-
-/** Regex that matches the `<ax-tree>...</ax-tree>` markers. */
-const AX_TREE_PATTERN = /<ax-tree>[\s\S]*?<\/ax-tree>/g;
-const AX_TREE_PLACEHOLDER = "<ax_tree_omitted />";
-
-/**
- * Escapes any literal `</ax-tree>` occurrences inside AX tree content so
- * that the non-greedy compaction regex (`AX_TREE_PATTERN`) does not stop
- * prematurely when the user happens to be viewing XML/HTML source that
- * contains the closing tag.  The escaped content does not need to be
- * unescaped because compaction replaces the entire block with a placeholder.
- */
-export function escapeAxTreeContent(content: string): string {
-  return content.replace(/<\/ax-tree>/gi, "&lt;/ax-tree&gt;");
-}
-
-/**
- * Returns a shallow copy of `messages` where all but the most recent
- * `MAX_AX_TREES_IN_HISTORY` `<ax-tree>` blocks have been replaced with a
- * short placeholder.  This keeps the conversation context small so that
- * TTFT does not grow linearly with step count in computer-use sessions.
- *
- * Counting is per-block, not per-message — a single user message can
- * contain multiple tool_result blocks each with their own AX tree snapshot.
- */
-export function compactAxTreeHistory(messages: Message[]): Message[] {
-  // Collect (messageIndex, blockIndex) for every tool_result block with <ax-tree>
-  const axBlocks: Array<{ msgIdx: number; blockIdx: number }> = [];
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (msg.role !== "user") continue;
-    for (let j = 0; j < msg.content.length; j++) {
-      const block = msg.content[j];
-      if (
-        block.type === "tool_result" &&
-        typeof block.content === "string" &&
-        block.content.includes("<ax-tree>")
-      ) {
-        axBlocks.push({ msgIdx: i, blockIdx: j });
-      }
-    }
-  }
-
-  if (axBlocks.length <= MAX_AX_TREES_IN_HISTORY) {
-    return messages;
-  }
-
-  // Build a set of "msgIdx:blockIdx" keys for blocks that should be stripped
-  const toStrip = new Set(
-    axBlocks
-      .slice(0, -MAX_AX_TREES_IN_HISTORY)
-      .map((b) => `${b.msgIdx}:${b.blockIdx}`),
-  );
-
-  return messages.map((msg, idx) => {
-    // Quick check: does this message have any blocks to strip?
-    const hasStripTarget = msg.content.some((_, j) =>
-      toStrip.has(`${idx}:${j}`),
-    );
-    if (!hasStripTarget) return msg;
-
-    return {
-      ...msg,
-      content: msg.content.map((block, j) => {
-        if (
-          toStrip.has(`${idx}:${j}`) &&
-          block.type === "tool_result" &&
-          typeof block.content === "string"
-        ) {
-          return {
-            ...block,
-            content: block.content.replace(
-              AX_TREE_PATTERN,
-              AX_TREE_PLACEHOLDER,
-            ),
-          };
-        }
-        return block;
-      }),
-    };
-  });
-}
-
-/**
- * Strip image contentBlocks from all tool_result blocks except those in the
- * most recent user message that contains tool_result blocks. This prevents
- * screenshots from accumulating in the context window — each image is seen
- * once by the LLM on the turn it was captured, then replaced with a text
- * placeholder on subsequent turns.
- *
- * We target the last user message with tool_results (not just the last user
- * message) because a plain-text user message may follow the tool-result
- * turn. Using the last user message unconditionally would leave the most
- * recent tool screenshots unprotected from stripping.
- */
-function stripOldMediaBlocks(history: Message[]): Message[] {
-  // Find the last user message that contains tool_result blocks.
-  let lastToolResultUserIdx = -1;
-  for (let i = history.length - 1; i >= 0; i--) {
-    if (
-      history[i].role === "user" &&
-      history[i].content.some((b) => b.type === "tool_result")
-    ) {
-      lastToolResultUserIdx = i;
-      break;
-    }
-  }
-
-  return history.map((msg, idx) => {
-    // Keep the most recent tool-result user message intact (current turn)
-    if (idx === lastToolResultUserIdx || msg.role !== "user") return msg;
-
-    // Check if any tool_result blocks carry embedded media (image or audio).
-    const isMedia = (cb: ContentBlock) =>
-      cb.type === "image" || cb.type === "file";
-    const hasMedia = msg.content.some(
-      (b) =>
-        b.type === "tool_result" &&
-        (b as ToolResultContent).contentBlocks?.some(isMedia),
-    );
-    if (!hasMedia) return msg;
-
-    // Strip media from tool_result blocks, replacing with a text marker. The
-    // model already saw/heard the media in the turn it was captured; resending
-    // the bytes every turn (a 12 MB audio clip isn't optimized like images)
-    // bloats the request until compaction.
-    return {
-      ...msg,
-      content: msg.content.map((b) => {
-        if (b.type !== "tool_result") return b;
-        const tr = b as ToolResultContent;
-        if (!tr.contentBlocks?.some(isMedia)) return b;
-        return {
-          ...tr,
-          contentBlocks: undefined,
-          content:
-            (tr.content || "") +
-            "\n[Media (image/audio) was captured and shown previously — binary data removed to save context.]",
-        };
-      }),
-    };
-  });
-}
-
-/**
- * Sanitize the outbound history immediately before a provider call, bundling
- * the pre-send transforms the loop applies to every request:
- * - {@link stripOldMediaBlocks} drops accumulated screenshot/audio bytes from
- *   older tool results — the model saw the media on the turn it was captured.
- * - {@link compactAxTreeHistory} collapses all but the most recent few
- *   `<ax-tree>` snapshots so TTFT does not grow linearly with step count.
- * - {@link stripHistoricalWebSearchResults} converts historical
- *   `web_search_tool_result` blocks to text summaries; Anthropic's opaque
- *   `encrypted_content` tokens expire / are route-scoped, and replaying a stale
- *   one is rejected with `Invalid encrypted_content in search_result block`.
- *
- * Transforms the outbound copy only — the durable history keeps the rich
- * originals and each send re-derives the sanitized projection (every transform
- * is idempotent). Because it runs unconditionally before every provider call,
- * it is the single place where oversized media and expired web-search tokens
- * are guaranteed to be removed from a request.
- *
- * This is outbound-request preparation and should eventually move to a default
- * `pre-model-call` plugin hook ({@link HOOKS.PRE_MODEL_CALL}) once that hook's
- * context carries the outbound message list; for now it lives inline next to
- * the provider call it guards.
- */
-export function preModelCallSanitize(history: Message[]): Message[] {
-  const mediaStripped = stripOldMediaBlocks(history);
-  const axCompacted = compactAxTreeHistory(mediaStripped);
-  return stripHistoricalWebSearchResults(axCompacted).messages;
 }

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -22,7 +22,6 @@ import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import type { CompactionConfig } from "../config/schemas/compaction.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { filterMessagesForUntrustedActor } from "../daemon/message-provenance.js";
-import { stripHistoricalWebSearchResults } from "../daemon/web-search-history.js";
 import {
   getAttachmentContent,
   getAttachmentMetadataForMessage,
@@ -40,6 +39,7 @@ import type {
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
+import { preModelCallSanitize } from "./outbound-sanitize.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
 import {
   estimatePromptTokens,
@@ -826,14 +826,20 @@ function extractTextFromResponse(content: ContentBlock[]): string {
     .join("\n");
 }
 
-// Build the outbound message list for a compaction provider call: convert
-// historical web_search_tool_result blocks to text, then append the
-// summarization instruction at the tail.
+// Build the outbound message list for a compaction provider call: apply the
+// same pre-send sanitization bundle as the agent loop's model calls
+// (`preModelCallSanitize` — old tool-result media stripped, AX trees
+// collapsed, historical web-search results converted to text), then append
+// the summarization instruction at the tail.
 //
-// Anthropic's opaque `encrypted_content` tokens are route-scoped and expire, so
-// replaying a stale one is rejected with `Invalid encrypted_content in
-// search_result block`. Sanitizing here — the single seam every compaction
-// provider call funnels through — keeps that error away from both the
+// Matching the loop's projection matters for two reasons. First, the summary
+// call's prefix stays byte-aligned with the agent's warm prompt cache — an
+// unsanitized history diverges from what the loop actually sent at the first
+// stripped block. Second, an unsanitized history carries every screenshot in
+// the conversation; enough images cross Anthropic's many-image threshold,
+// where a stricter per-image dimension cap applies and a single large
+// screenshot rejects the whole summary call. Sanitizing here — the single
+// seam every compaction provider call funnels through — covers both the
 // assistant-driven and emergency summarization calls. Only this outbound copy
 // is sanitized; tail resolution and the persisted compaction result read the
 // caller's original messages, so durable history keeps the rich blocks. The
@@ -842,7 +848,7 @@ function buildCompactionRequest(
   history: Message[],
   instruction: Message,
 ): Message[] {
-  return [...stripHistoricalWebSearchResults(history).messages, instruction];
+  return [...preModelCallSanitize(history), instruction];
 }
 
 // Token headroom a compaction summary call reserves on top of its history: room
@@ -945,11 +951,14 @@ export async function runAssistantDrivenCompaction(
   // Bound the summary call's own input to the context window. With no tool
   // pair to anchor an emergency split, an overflow recovery routes the full
   // history straight here, so the summary call must front-truncate itself or
-  // it overflows in turn. `args.messages` stays intact for tail resolution
-  // below — only the outbound request is truncated. A below-budget history is
-  // returned untouched, keeping the prefix aligned with the agent's warm cache.
+  // it overflows in turn. Truncation operates on the sanitized projection
+  // (what the request actually carries) so the budget estimate is honest —
+  // estimating on raw history would count media bytes the request strips.
+  // `args.messages` stays intact for tail resolution below — only the
+  // outbound request is truncated. A below-budget history is returned
+  // untouched, keeping the prefix aligned with the agent's warm cache.
   const summaryHistory = truncateHistoryToBudget({
-    messages: args.messages,
+    messages: preModelCallSanitize(args.messages),
     systemPrompt: args.systemPrompt,
     budgetTokens: compactionPrefixBudget(args.maxInputTokens),
     providerName: args.provider.tokenEstimationProvider ?? args.provider.name,
@@ -1371,9 +1380,14 @@ export async function runEmergencyCompaction(
   );
   // Bound the prefix to the context window so the summary call fits, reserving
   // budget for the instruction message and the emitted summary. Truncates from
-  // the front, keeping the recent portion the summary most needs.
+  // the front, keeping the recent portion the summary most needs. The prefix
+  // is sliced from the sanitized projection (sanitize-then-slice, matching the
+  // agent's own sends byte-for-byte for cache alignment) so the budget
+  // estimate counts what the request actually carries. All sanitize
+  // transforms are 1:1 per message, so `splitIndex` maps onto the sanitized
+  // array unchanged.
   const prefix = truncateHistoryToBudget({
-    messages: args.messages.slice(0, splitIndex),
+    messages: preModelCallSanitize(args.messages).slice(0, splitIndex),
     systemPrompt: args.systemPrompt,
     budgetTokens: compactionPrefixBudget(args.maxInputTokens),
     providerName: args.provider.tokenEstimationProvider ?? args.provider.name,

--- a/assistant/src/context/outbound-sanitize.ts
+++ b/assistant/src/context/outbound-sanitize.ts
@@ -1,0 +1,202 @@
+/**
+ * Outbound-request history sanitization shared by every provider call that
+ * sends conversation history: the agent loop's model calls and the
+ * compactor's summary calls. Each transform derives a sanitized projection of
+ * the outbound copy only — durable history keeps the rich originals, and every
+ * transform is idempotent so each send re-derives the same projection.
+ */
+
+import { stripHistoricalWebSearchResults } from "../daemon/web-search-history.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolResultContent,
+} from "../providers/types.js";
+
+/** Number of most-recent AX tree snapshots to keep in conversation history. */
+const MAX_AX_TREES_IN_HISTORY = 2;
+
+/** Regex that matches the `<ax-tree>...</ax-tree>` markers. */
+const AX_TREE_PATTERN = /<ax-tree>[\s\S]*?<\/ax-tree>/g;
+const AX_TREE_PLACEHOLDER = "<ax_tree_omitted />";
+
+/**
+ * Escapes any literal `</ax-tree>` occurrences inside AX tree content so
+ * that the non-greedy compaction regex (`AX_TREE_PATTERN`) does not stop
+ * prematurely when the user happens to be viewing XML/HTML source that
+ * contains the closing tag.  The escaped content does not need to be
+ * unescaped because compaction replaces the entire block with a placeholder.
+ */
+export function escapeAxTreeContent(content: string): string {
+  return content.replace(/<\/ax-tree>/gi, "&lt;/ax-tree&gt;");
+}
+
+/**
+ * Returns a shallow copy of `messages` where all but the most recent
+ * `MAX_AX_TREES_IN_HISTORY` `<ax-tree>` blocks have been replaced with a
+ * short placeholder.  This keeps the conversation context small so that
+ * TTFT does not grow linearly with step count in computer-use sessions.
+ *
+ * Counting is per-block, not per-message — a single user message can
+ * contain multiple tool_result blocks each with their own AX tree snapshot.
+ */
+export function compactAxTreeHistory(messages: Message[]): Message[] {
+  // Collect (messageIndex, blockIndex) for every tool_result block with <ax-tree>
+  const axBlocks: Array<{ msgIdx: number; blockIdx: number }> = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user") {
+      continue;
+    }
+    for (let j = 0; j < msg.content.length; j++) {
+      const block = msg.content[j];
+      if (
+        block.type === "tool_result" &&
+        typeof block.content === "string" &&
+        block.content.includes("<ax-tree>")
+      ) {
+        axBlocks.push({ msgIdx: i, blockIdx: j });
+      }
+    }
+  }
+
+  if (axBlocks.length <= MAX_AX_TREES_IN_HISTORY) {
+    return messages;
+  }
+
+  // Build a set of "msgIdx:blockIdx" keys for blocks that should be stripped
+  const toStrip = new Set(
+    axBlocks
+      .slice(0, -MAX_AX_TREES_IN_HISTORY)
+      .map((b) => `${b.msgIdx}:${b.blockIdx}`),
+  );
+
+  return messages.map((msg, idx) => {
+    // Quick check: does this message have any blocks to strip?
+    const hasStripTarget = msg.content.some((_, j) =>
+      toStrip.has(`${idx}:${j}`),
+    );
+    if (!hasStripTarget) {
+      return msg;
+    }
+
+    return {
+      ...msg,
+      content: msg.content.map((block, j) => {
+        if (
+          toStrip.has(`${idx}:${j}`) &&
+          block.type === "tool_result" &&
+          typeof block.content === "string"
+        ) {
+          return {
+            ...block,
+            content: block.content.replace(
+              AX_TREE_PATTERN,
+              AX_TREE_PLACEHOLDER,
+            ),
+          };
+        }
+        return block;
+      }),
+    };
+  });
+}
+
+/**
+ * Strip image contentBlocks from all tool_result blocks except those in the
+ * most recent user message that contains tool_result blocks. This prevents
+ * screenshots from accumulating in the context window — each image is seen
+ * once by the LLM on the turn it was captured, then replaced with a text
+ * placeholder on subsequent turns.
+ *
+ * We target the last user message with tool_results (not just the last user
+ * message) because a plain-text user message may follow the tool-result
+ * turn. Using the last user message unconditionally would leave the most
+ * recent tool screenshots unprotected from stripping.
+ */
+function stripOldMediaBlocks(history: Message[]): Message[] {
+  // Find the last user message that contains tool_result blocks.
+  let lastToolResultUserIdx = -1;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (
+      history[i].role === "user" &&
+      history[i].content.some((b) => b.type === "tool_result")
+    ) {
+      lastToolResultUserIdx = i;
+      break;
+    }
+  }
+
+  return history.map((msg, idx) => {
+    // Keep the most recent tool-result user message intact (current turn)
+    if (idx === lastToolResultUserIdx || msg.role !== "user") {
+      return msg;
+    }
+
+    // Check if any tool_result blocks carry embedded media (image or audio).
+    const isMedia = (cb: ContentBlock) =>
+      cb.type === "image" || cb.type === "file";
+    const hasMedia = msg.content.some(
+      (b) =>
+        b.type === "tool_result" &&
+        (b as ToolResultContent).contentBlocks?.some(isMedia),
+    );
+    if (!hasMedia) {
+      return msg;
+    }
+
+    // Strip media from tool_result blocks, replacing with a text marker. The
+    // model already saw/heard the media in the turn it was captured; resending
+    // the bytes every turn (a 12 MB audio clip isn't optimized like images)
+    // bloats the request until compaction.
+    return {
+      ...msg,
+      content: msg.content.map((b) => {
+        if (b.type !== "tool_result") {
+          return b;
+        }
+        const tr = b as ToolResultContent;
+        if (!tr.contentBlocks?.some(isMedia)) {
+          return b;
+        }
+        return {
+          ...tr,
+          contentBlocks: undefined,
+          content:
+            (tr.content || "") +
+            "\n[Media (image/audio) was captured and shown previously — binary data removed to save context.]",
+        };
+      }),
+    };
+  });
+}
+
+/**
+ * Sanitize the outbound history immediately before a provider call, bundling
+ * the pre-send transforms applied to every request that carries conversation
+ * history:
+ * - {@link stripOldMediaBlocks} drops accumulated screenshot/audio bytes from
+ *   older tool results — the model saw the media on the turn it was captured.
+ *   Beyond context bloat, unstripped history can carry enough images to cross
+ *   Anthropic's many-image threshold, where a stricter per-image dimension
+ *   cap applies and a single large screenshot rejects the whole request.
+ * - {@link compactAxTreeHistory} collapses all but the most recent few
+ *   `<ax-tree>` snapshots so TTFT does not grow linearly with step count.
+ * - {@link stripHistoricalWebSearchResults} converts historical
+ *   `web_search_tool_result` blocks to text summaries; Anthropic's opaque
+ *   `encrypted_content` tokens expire / are route-scoped, and replaying a stale
+ *   one is rejected with `Invalid encrypted_content in search_result block`.
+ *
+ * Transforms the outbound copy only — the durable history keeps the rich
+ * originals and each send re-derives the sanitized projection (every transform
+ * is idempotent). Both the agent loop's model calls and the compactor's
+ * summary calls funnel through this bundle, so their request prefixes stay
+ * byte-aligned (the summary call reuses the agent's warm prompt cache) and
+ * oversized media and expired web-search tokens are guaranteed to be removed
+ * from every request.
+ */
+export function preModelCallSanitize(history: Message[]): Message[] {
+  const mediaStripped = stripOldMediaBlocks(history);
+  const axCompacted = compactAxTreeHistory(mediaStripped);
+  return stripHistoricalWebSearchResults(axCompacted).messages;
+}

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -16,8 +16,8 @@
 
 import { v4 as uuid } from "uuid";
 
-import { escapeAxTreeContent } from "../agent/loop.js";
 import { loadConfig } from "../config/loader.js";
+import { escapeAxTreeContent } from "../context/outbound-sanitize.js";
 import type { ContentBlock } from "../providers/types.js";
 import {
   assistantEventHub,


### PR DESCRIPTION
## Problem

User feedback `019f238c-7223-7015-9f3a-367d91f09bef`: **"Auto-compaction paused — long conversation may overflow. Use /compact to compact manually"** banner, with manual `/compact` failing instantly ("Context compaction skipped — provider error") on a conversation stuck at ~159k/200k tokens.

## Root cause

The daemon logs on the managed pod show every compaction summary call rejected in under a second:

```
Anthropic API error (400): messages.21.content.48.image.source.base64.data:
At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels
```

The compactor's summary request sent **raw conversation history**, applying only the web-search strip. The agent loop's own model calls go through `preModelCallSanitize`, which *also* strips old tool-result media and collapses AX trees. In a screenshot-heavy agentic session (this user's conversation ran `file read`/screenshot tools for hours, including a 3596×1952 screenshot):

- **Main calls** sent the stripped projection — ~10 images per request (verified via `llm_request_logs`) — and kept succeeding.
- **Compaction calls** sent every image in the conversation, crossing the provider's many-image threshold where a stricter 2000px-per-image cap applies → deterministic instant 400 → `summaryFailed` ×3 → circuit breaker opens → banner. Manual `/compact` hits the same wall, so the conversation could never compact and would ride into overflow.

The offending image lives in an old merged tool-result message — exactly the content `stripOldMediaBlocks` exists to remove.

## Fix

- Move the pre-send sanitize bundle (`stripOldMediaBlocks` + `compactAxTreeHistory` + `stripHistoricalWebSearchResults`) out of `agent/loop.ts` into `context/outbound-sanitize.ts` (avoids an import cycle: agent/loop → compaction plugin → compactor → agent/loop).
- Route `buildCompactionRequest` — the single seam both the assistant-driven and emergency summary calls funnel through — through `preModelCallSanitize`, so compaction sends the same projection as the agent's own calls.
- Run the front-truncation budget estimate on the sanitized projection too, so the estimate counts what the request actually carries (raw history would overcount stripped media).

Side benefit: the summary call's prefix is now byte-aligned with the agent's warm prompt cache. The raw history previously diverged from the cached prefix at the first stripped block, defeating the intended cache reuse documented on `COMPACTION_CALL_SITE`.

## Validation

- Replayed the daemon's exact compaction request shape (adaptive thinking + effort + `tool_choice: none` + cache breakpoints + streaming, ~150k tokens with images) against the Anthropic API — the shape itself is accepted; only the unstripped image load trips the many-image cap on the managed transport.
- New regression test `compactor-media-strip.test.ts`: summary request strips old tool-result images, keeps the latest turn's image and user-attached images, durable history untouched.
- `bunx tsgo --noEmit` clean; compactor/compaction/loop/ax-tree test files pass (the 8-file batch has pre-existing cross-file `mock.module` leakage on main; all pass individually).

## Notes for review

- `stripOldMediaBlocks` keeps the most recent tool-result message's media and all direct user-attached images, so the summary model still sees current-turn context; older screenshots are represented by the image manifest text (retained-image re-attachment reads the DB, not the request, and is unaffected).
- Behavior change is compaction-request-only; durable history and tail resolution still read the caller's original messages.