### PR TITLE
feat(config): expose per-profile `invariant` flag on config reads

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -31951,6 +31951,8 @@ components:
             additionalProperties: false
         supportsVision:
           type: boolean
+        invariant:
+          type: boolean
       additionalProperties: {}
     ProviderConnection:
       type: object

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -165,6 +165,13 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
   topP: 0.95,
 };
 
+// The three default managed profiles are invariant: read-only to user-facing
+// writes except re-enabling a hatch-disabled one (enforced at
+// commitConfigWrite). os-beta is managed but NOT invariant.
+export const INVARIANT_PROFILE_NAMES = new Set(
+  Object.keys(MANAGED_PROFILE_TEMPLATES),
+);
+
 // Membership here marks a name as managed. The route layer applies managed
 // restrictions (blocking model/provider edits and deletion) only to entries
 // whose on-disk `source` is `managed`, so a user-owned profile sharing one of

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1084,3 +1084,69 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     });
   });
 });
+
+describe("config invariant flag enrichment", () => {
+  const configGetRoute = ROUTES.find((r) => r.operationId === "config_get")!;
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+
+  type WireProfiles = Record<string, Record<string, unknown>>;
+
+  function wireProfiles(body: unknown): WireProfiles {
+    return (body as { llm: { profiles: WireProfiles } }).llm.profiles;
+  }
+
+  beforeEach(() => {
+    savedRawConfig = null;
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            label: "Balanced",
+            status: "active",
+          },
+          "os-beta": {
+            source: "managed",
+            provider: "together",
+            model: "zai-org/GLM-5.2",
+            label: "OS Beta",
+            status: "active",
+          },
+          custom: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+  });
+
+  test("GET /v1/config marks default managed profiles invariant, not os-beta or custom", async () => {
+    const body = await configGetRoute.handler({});
+    const profiles = wireProfiles(body);
+
+    expect(profiles.balanced!.invariant).toBe(true);
+    expect(profiles["os-beta"]!).not.toHaveProperty("invariant");
+    expect(profiles.custom!).not.toHaveProperty("invariant");
+  });
+
+  test("PATCH /v1/config stamps the flag on the response but never persists it", async () => {
+    const body = await configPatchRoute.handler({
+      body: { memory: { enabled: true } },
+    });
+    const profiles = wireProfiles(body);
+    expect(profiles.balanced!.invariant).toBe(true);
+
+    const savedProfiles = (
+      savedRawConfig?.llm as { profiles: WireProfiles } | undefined
+    )?.profiles;
+    expect(savedProfiles).toBeDefined();
+    for (const profile of Object.values(savedProfiles!)) {
+      expect(profile).not.toHaveProperty("invariant");
+    }
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -118,7 +118,10 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
-import { MANAGED_PROFILE_NAMES } from "../../config/seed-inference-profiles.js";
+import {
+  INVARIANT_PROFILE_NAMES,
+  MANAGED_PROFILE_NAMES,
+} from "../../config/seed-inference-profiles.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 
 const RESERVED_PROFILE_NAMES = new Set([
@@ -579,6 +582,7 @@ function rejectMcpTransportHeaderWrite(patch: unknown): void {
 
 const WireProfileEntry = ProfileEntry.extend({
   supportsVision: z.boolean().optional(),
+  invariant: z.boolean().optional(),
 })
   .passthrough()
   .meta({ id: "ProfileEntry" });
@@ -780,7 +784,7 @@ function handleGetConfig() {
   try {
     const config = applyContextDefaultsToRawConfig(loadRawConfig());
     sanitizeMcpTransportHeadersForSettingsRead(config);
-    enrichProfilesWithVisionFlag(config);
+    enrichProfilesForWire(config);
     return config;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -789,12 +793,16 @@ function handleGetConfig() {
 }
 
 /**
- * Annotate each profile in `config.llm.profiles` with `supportsVision`
- * resolved from the model catalog. The flag is wire-only — it is never
- * persisted to disk. Unknown (provider, model) pairs default to `true`
- * (fail-open) so image upload remains available for custom / unlisted models.
+ * Annotate each profile in `config.llm.profiles` with wire-only flags — never
+ * persisted to disk:
+ *
+ * - `supportsVision`: resolved from the model catalog. Unknown (provider,
+ *   model) pairs default to `true` (fail-open) so image upload remains
+ *   available for custom / unlisted models.
+ * - `invariant`: `true` for the three default managed profiles
+ *   (`INVARIANT_PROFILE_NAMES`); absent otherwise.
  */
-function enrichProfilesWithVisionFlag(config: unknown): void {
+function enrichProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
   if (!root) return;
   const llm = readPlainObject(root.llm);
@@ -802,9 +810,12 @@ function enrichProfilesWithVisionFlag(config: unknown): void {
   const profiles = readPlainObject(llm.profiles);
   if (!profiles) return;
 
-  for (const profile of Object.values(profiles)) {
+  for (const [name, profile] of Object.entries(profiles)) {
     const entry = readPlainObject(profile);
     if (!entry) continue;
+    if (INVARIANT_PROFILE_NAMES.has(name)) {
+      entry.invariant = true;
+    }
     const provider = entry.provider;
     const model = entry.model;
     if (typeof provider !== "string" || typeof model !== "string") continue;
@@ -942,7 +953,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
 
   const merged = applyContextDefaultsToRawConfig(loadRawConfig());
   sanitizeMcpTransportHeadersForSettingsRead(merged);
-  enrichProfilesWithVisionFlag(merged);
+  enrichProfilesForWire(merged);
   return merged;
 }
 


### PR DESCRIPTION
## Summary
- Export INVARIANT_PROFILE_NAMES (the three default managed profiles) from seed-inference-profiles
- Stamp wire-only `invariant: true` on default profiles in config GET/PATCH responses (same pattern as supportsVision)
- Regenerate openapi.yaml and web client types (ProfileEntry gains `invariant?: boolean`)

Part of plan: invariant-default-profiles.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->