### PR TITLE
fix(slack): space fused response segments in streamed replies

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -16,6 +16,7 @@ import type { AuthContext } from "../../runtime/auth/types.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { unwrapExternalContentForDisplay } from "../../security/untrusted-content.js";
 import { getLogger } from "../../util/logger.js";
+import { joinWithSpacing } from "../../util/text-spacing.js";
 import { estimateBase64Bytes } from "../assistant-attachments.js";
 import type { ConversationTransportMetadata } from "../message-protocol.js";
 import type { TrustContext } from "../trust-context.js";
@@ -329,29 +330,6 @@ export function renderHistoryContent(
   // attachment-ref order; otherwise the file block contributes no block.
   const contentBlocks: ConversationContentBlock[] = [];
   let currentTextBlock: { type: "text"; text: string } | null = null;
-
-  function joinWithSpacing(parts: string[]): string {
-    let result = parts[0] ?? "";
-    for (let i = 1; i < parts.length; i++) {
-      const prev = result[result.length - 1];
-      const next = parts[i][0];
-      // Only insert a space when neither side already has whitespace
-      if (
-        prev &&
-        next &&
-        prev !== " " &&
-        prev !== "\n" &&
-        prev !== "\t" &&
-        next !== " " &&
-        next !== "\n" &&
-        next !== "\t"
-      ) {
-        result += " ";
-      }
-      result += parts[i];
-    }
-    return result;
-  }
 
   function finalizeSegment(): void {
     if (hasOpenSegment) {

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -92,6 +92,11 @@ const slackStreamOps = (): Array<Record<string, unknown>> =>
     .map((call) => call.payload.slackStream as Record<string, unknown>)
     .filter(Boolean);
 
+const streamedMarkdown = (): string =>
+  slackStreamOps()
+    .map((op) => (op.markdownText as string | undefined) ?? "")
+    .join("");
+
 beforeEach(() => {
   deliverCalls.length = 0;
   deliverImpl = async () => ({ ok: true, ts: "stream-ts-1" });
@@ -500,6 +505,82 @@ describe("createSlackReplySession", () => {
       messageTs: "stream-ts-1",
       deliveredSegmentCount: 2,
     });
+  });
+
+  test("inserts a space between segments fused across a tool boundary", async () => {
+    // The model ends one segment with a period and opens the next with a
+    // capital letter, supplying no separating whitespace on either side.
+    // Concatenating them raw would fuse "Sentence one.Sentence two.".
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+    })!;
+
+    session.observeEvent(textDelta("Sentence one."));
+    session.observeEvent(toolUseStart("toolu_1"));
+    session.observeEvent(textDelta("Sentence two."));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    await session.finish();
+
+    expect(streamedMarkdown()).toBe("Sentence one. Sentence two.");
+  });
+
+  test("inserts a space between separate model responses", async () => {
+    // Multiple `message_complete` events fire within one streamed turn (one
+    // per model response). Text from the second response must not fuse onto
+    // the first.
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+    })!;
+
+    session.observeEvent(textDelta("First response."));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    session.observeEvent(textDelta("Second response."));
+    session.observeEvent(messageComplete("assistant-msg-2"));
+    await session.finish();
+
+    expect(streamedMarkdown()).toBe("First response. Second response.");
+  });
+
+  test("does not double-space a boundary the model already spaced", async () => {
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+    })!;
+
+    session.observeEvent(textDelta("Before the tool."));
+    session.observeEvent(toolUseStart("toolu_1"));
+    session.observeEvent(textDelta(" After the tool."));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    await session.finish();
+
+    expect(streamedMarkdown()).toBe("Before the tool. After the tool.");
+  });
+
+  test("does not fuse mid-word deltas within a single segment", async () => {
+    // Intra-segment token deltas carry the model's own spacing and must never
+    // be altered — only tool/message boundaries introduce a separating space.
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+    })!;
+
+    session.observeEvent(textDelta("super"));
+    session.observeEvent(textDelta("cali"));
+    session.observeEvent(textDelta("fragilistic"));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    await session.finish();
+
+    expect(streamedMarkdown()).toBe("supercalifragilistic");
   });
 
   test("opens the stream in plan mode and advances task cards", async () => {

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -13,6 +13,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import { renderSlackBlocks } from "../messaging/providers/slack/render.js";
 import { getLogger } from "../util/logger.js";
+import { needsBoundarySpace } from "../util/text-spacing.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import {
   hasDeliverableAssistantText,
@@ -132,6 +133,11 @@ export function createSlackReplySession(params: {
 
   let segmentBuffer = "";
   let deliveredSegmentCount = 0;
+  // Set when a tool-call or message boundary closes a text segment: the next
+  // segment's first delta is a fresh model response, so it is spaced off the
+  // prior segment when the model omitted the separating whitespace (matching
+  // `renderHistoryContent`'s `joinWithSpacing` on the durable delivery path).
+  let pendingSegmentBoundary = false;
 
   const taskProgressBySurfaceId = new Map<string, TaskProgressData>();
   let activeProgress: TaskProgressData | undefined;
@@ -305,6 +311,12 @@ export function createSlackReplySession(params: {
         return;
       }
       if (msg.type === "assistant_text_delta") {
+        if (pendingSegmentBoundary && msg.text.length > 0) {
+          if (needsBoundarySpace(rawText, msg.text)) {
+            rawText += " ";
+          }
+          pendingSegmentBoundary = false;
+        }
         rawText += msg.text;
         segmentBuffer += msg.text;
         scheduleFlush();
@@ -312,6 +324,7 @@ export function createSlackReplySession(params: {
       }
       if (msg.type === "tool_use_start" || msg.type === "message_complete") {
         countSegmentBoundary();
+        pendingSegmentBoundary = true;
       }
     },
 

--- a/assistant/src/util/__tests__/text-spacing.test.ts
+++ b/assistant/src/util/__tests__/text-spacing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { joinWithSpacing, needsBoundarySpace } from "../text-spacing.js";
+
+describe("needsBoundarySpace", () => {
+  test("true when both sides fuse two non-whitespace characters", () => {
+    expect(needsBoundarySpace("end.", "Next")).toBe(true);
+  });
+
+  test("false when the left side already ends in whitespace", () => {
+    expect(needsBoundarySpace("end. ", "Next")).toBe(false);
+    expect(needsBoundarySpace("end.\n", "Next")).toBe(false);
+    expect(needsBoundarySpace("end.\t", "Next")).toBe(false);
+  });
+
+  test("false when the right side already starts with whitespace", () => {
+    expect(needsBoundarySpace("end.", " Next")).toBe(false);
+    expect(needsBoundarySpace("end.", "\nNext")).toBe(false);
+  });
+
+  test("false when either side is empty", () => {
+    expect(needsBoundarySpace("", "Next")).toBe(false);
+    expect(needsBoundarySpace("end.", "")).toBe(false);
+    expect(needsBoundarySpace("", "")).toBe(false);
+  });
+});
+
+describe("joinWithSpacing", () => {
+  test("inserts a single space between fused segments", () => {
+    expect(joinWithSpacing(["Sentence one.", "Sentence two."])).toBe(
+      "Sentence one. Sentence two.",
+    );
+  });
+
+  test("preserves whitespace the parts already supply", () => {
+    expect(joinWithSpacing(["First half. ", "Second half."])).toBe(
+      "First half. Second half.",
+    );
+    expect(joinWithSpacing(["First.", " Second."])).toBe("First. Second.");
+    expect(joinWithSpacing(["Line one\n", "Line two"])).toBe(
+      "Line one\nLine two",
+    );
+  });
+
+  test("does not alter intra-part spacing", () => {
+    expect(joinWithSpacing(["a b c"])).toBe("a b c");
+  });
+
+  test("skips empty parts without inserting stray spaces", () => {
+    expect(joinWithSpacing(["Done.", "", "More."])).toBe("Done. More.");
+    expect(joinWithSpacing([])).toBe("");
+  });
+});

--- a/assistant/src/util/text-spacing.ts
+++ b/assistant/src/util/text-spacing.ts
@@ -1,0 +1,53 @@
+/**
+ * Boundary-aware text joining.
+ *
+ * A single assistant turn is emitted as a sequence of text blocks split by
+ * tool-call and message boundaries. The model frequently ends one block with a
+ * sentence-final period and no trailing whitespace, then opens the next block
+ * with a capital letter and no leading whitespace — because from the model's
+ * point of view each block is its own response. Concatenating those blocks raw
+ * fuses the boundary into `...end.Next...` with the space missing.
+ *
+ * These helpers insert a single separating space at such a boundary, and only
+ * there: when both sides carry a character at the join and neither is already
+ * whitespace. Blocks that already supply a boundary space (or are empty) join
+ * verbatim, so intra-block token streams — where the model's own spacing is
+ * authoritative — are never altered.
+ */
+
+/** Whitespace characters that count as an existing join boundary. */
+function isJoinWhitespace(ch: string | undefined): boolean {
+  return ch === " " || ch === "\n" || ch === "\t";
+}
+
+/**
+ * Whether concatenating `left` + `right` needs a single separating space:
+ * true only when both sides have a character at the join and neither of those
+ * characters is already whitespace. Returns `false` when either side is empty.
+ */
+export function needsBoundarySpace(left: string, right: string): boolean {
+  const prev = left[left.length - 1];
+  const next = right[0];
+  return (
+    prev !== undefined &&
+    next !== undefined &&
+    !isJoinWhitespace(prev) &&
+    !isJoinWhitespace(next)
+  );
+}
+
+/**
+ * Join text parts, inserting a single space between adjacent parts only when
+ * the boundary would otherwise fuse two non-whitespace characters. Parts that
+ * already carry a boundary space (or are empty) are joined verbatim.
+ */
+export function joinWithSpacing(parts: string[]): string {
+  let result = parts[0] ?? "";
+  for (let i = 1; i < parts.length; i++) {
+    if (needsBoundarySpace(result, parts[i])) {
+      result += " ";
+    }
+    result += parts[i];
+  }
+  return result;
+}


### PR DESCRIPTION
## Prompt / plan

Fixes [LUM-2687](https://linear.app/vellum/issue/LUM-2687/fix-missing-spaces-between-sentences-in-credence-responses) — "Credence often omits a space between a period and the next word in responses. This appears to happen when separate assistant responses are joined together."

**Root cause.** Native Slack reply streaming (`slack-reply-session.ts`) accumulates the assistant's answer with `rawText += msg.text`, concatenating every text delta directly. Within a single turn the agent loop emits multiple text blocks split by tool-call and `message_complete` boundaries (one `message_complete` per model response). Each block is, from the model's point of view, its own response — it frequently ends one with a sentence-final period and no trailing whitespace and opens the next with a capital letter and no leading whitespace. Streaming them into one Slack message fused the boundary into `...end.Next...` with the space missing.

The durable (non-streamed) delivery path never showed this because `renderHistoryContent` already inserts a boundary space via a local `joinWithSpacing` helper. The streaming path just didn't share that logic.

**Fix.** Extract the boundary-spacing logic out of `renderHistoryContent` into a shared `assistant/src/util/text-spacing.ts` (`needsBoundarySpace` / `joinWithSpacing`) — single source of truth for both paths — and apply it in the streaming session. A tool-call or message boundary now marks the next delta as a fresh segment, whose first token is spaced off the prior segment **only** when neither side already carries whitespace. Intra-segment token deltas, where the model's own spacing is authoritative, are left untouched, so no word is ever split.

### Changed files
- `assistant/src/util/text-spacing.ts` — new shared helper (extracted, behavior-preserving).
- `assistant/src/daemon/handlers/shared.ts` — `renderHistoryContent` imports the shared helper; local copy removed.
- `assistant/src/runtime/slack-reply-session.ts` — track a pending segment boundary and insert the separating space on the next delta.

## Test plan

- **New unit tests** `assistant/src/util/__tests__/text-spacing.test.ts` — cover `needsBoundarySpace` / `joinWithSpacing` (fused boundary, existing whitespace on either side, empty parts, intra-part spacing untouched).
- **New streaming regression tests** in `assistant/src/runtime/slack-reply-session.test.ts`:
  - space inserted between segments fused across a tool boundary (`"Sentence one.Sentence two."` → `"Sentence one. Sentence two."`),
  - space inserted between separate model responses (two `message_complete` events),
  - no double-space when the model already supplied the whitespace,
  - mid-word deltas within one segment are never fused apart (`super` + `cali` + `fragilistic` → `supercalifragilistic`).
- **Regression coverage** for the extraction: `bun test src/__tests__/server-history-render.test.ts src/__tests__/channel-reply-delivery.test.ts src/__tests__/list-messages-tool-merge.test.ts src/__tests__/list-messages-attachments.test.ts` (112 pass), plus `background-dispatch.test.ts` (22 pass).
- `bunx tsgo --noEmit` clean; `eslint` clean (0 errors); Prettier clean — all via the pre-commit hook.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqs8dxT3FNDnv3Uyf4DVuB)_