### PR TITLE
feat(settings): lock default profiles in the AI settings UI

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
@@ -98,6 +98,7 @@ export function ProfileListItem({
   onStatusToggle,
 }: ProfileListItemProps) {
   const isManaged = profile.source === "managed";
+  const isInvariant = profile.invariant === true;
   const isActive = profile.status !== "disabled";
 
   return (
@@ -132,7 +133,11 @@ export function ProfileListItem({
             {isManaged && (
               <Tag
                 tone="positive"
-                title="Managed by Platform — auth is locked, but you can rename or disable this profile."
+                title={
+                  isInvariant
+                    ? "Managed by Platform — this default profile cannot be disabled, deleted, or renamed."
+                    : "Managed by Platform — auth is locked, but you can rename or disable this profile."
+                }
               >
                 Platform
               </Tag>
@@ -151,21 +156,26 @@ export function ProfileListItem({
 
         {/* Actions */}
         <div className="flex shrink-0 items-center gap-2">
-          <div
-            className="flex shrink-0 items-center"
-            title={
-              isActive
-                ? "Active — toggle to hide from pickers"
-                : "Disabled — toggle to show in pickers"
-            }
-          >
-            <Toggle
-              checked={isActive}
-              onChange={(next) => onStatusToggle(next)}
-              disabled={isToggling}
-              aria-label={`${isActive ? "Disable" : "Enable"} ${profile.label ?? profile.name}`}
-            />
-          </div>
+          {/* Invariant (default) profiles cannot be disabled, so an active one
+              gets no toggle. A disabled one keeps it so it can be re-enabled —
+              the daemon accepts the enable direction. */}
+          {(!isInvariant || !isActive) && (
+            <div
+              className="flex shrink-0 items-center"
+              title={
+                isActive
+                  ? "Active — toggle to hide from pickers"
+                  : "Disabled — toggle to show in pickers"
+              }
+            >
+              <Toggle
+                checked={isActive}
+                onChange={(next) => onStatusToggle(next)}
+                disabled={isToggling}
+                aria-label={`${isActive ? "Disable" : "Enable"} ${profile.label ?? profile.name}`}
+              />
+            </div>
+          )}
           <div className="flex w-[92px] items-center justify-end gap-2">
             <Button variant="ghost" size="compact" onClick={onEditClick}>
               {isManaged ? "View" : "Edit"}

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -30,6 +30,7 @@ import * as daemonQueryGen from "@/generated/daemon/@tanstack/react-query.gen";
 
 let toastSuccessCalls: string[] = [];
 let configPatchCalled = false;
+let configPatchBodies: unknown[] = [];
 let profilesState: Record<string, ProfileEntry> = {};
 
 mock.module("@vellumai/design-library/components/toast", () => ({
@@ -54,8 +55,9 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
       },
     },
   })),
-  configPatch: async () => {
+  configPatch: async (options?: { body?: unknown }) => {
     configPatchCalled = true;
+    configPatchBodies.push(options?.body);
     return {
       data: {
         llm: {
@@ -188,6 +190,7 @@ function selectModel(label: string): void {
 beforeEach(() => {
   toastSuccessCalls = [];
   configPatchCalled = false;
+  configPatchBodies = [];
   profilesState = {};
 });
 
@@ -234,5 +237,82 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(['Profile "My Profile" created']);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant (default) profiles — server-stamped `invariant: true`
+// ---------------------------------------------------------------------------
+
+describe("ManageProfilesModal — invariant default profiles in the list", () => {
+  // The list-item status toggle carries an "Enable <label>"/"Disable <label>"
+  // aria-label — the accessible handle these tests query by.
+  function findStatusToggle(action: "Enable" | "Disable", label: string) {
+    return document.querySelector<HTMLButtonElement>(
+      `[role="switch"][aria-label="${action} ${label}"]`,
+    );
+  }
+
+  function seedInvariantProfiles() {
+    profilesState = {
+      "default-a": {
+        label: "Default A",
+        source: "managed",
+        invariant: true,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      "default-b": {
+        label: "Default B",
+        source: "managed",
+        invariant: true,
+        status: "disabled",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      "custom-managed": {
+        label: "Custom Managed",
+        source: "managed",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    };
+  }
+
+  test("an active invariant profile has no status toggle; a disabled one and non-invariant profiles keep theirs", () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    // Active invariant profile: no disable affordance at all.
+    expect(findStatusToggle("Disable", "Default A")).toBeNull();
+    expect(findStatusToggle("Enable", "Default A")).toBeNull();
+
+    // Disabled invariant profile: the enable affordance remains.
+    expect(findStatusToggle("Enable", "Default B")).not.toBeNull();
+
+    // Managed profile without the flag: behaves as before.
+    expect(findStatusToggle("Disable", "Custom Managed")).not.toBeNull();
+  });
+
+  test("re-enabling a disabled invariant profile PATCHes status:'active' and nothing else", async () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(findStatusToggle("Enable", "Default B")!);
+
+    await waitFor(() => {
+      expect(configPatchCalled).toBe(true);
+    });
+    expect(configPatchBodies).toEqual([
+      { llm: { profiles: { "default-b": { status: "active" } } } },
+    ]);
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -265,15 +265,22 @@ function renderView(
   );
 }
 
+/** Finds a Toggle switch by its visible label (wired via aria-labelledby). */
+function findSwitchByLabel(label: string): HTMLButtonElement | null {
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="switch"]'),
+    ).find((el) => {
+      const labelId = el.getAttribute("aria-labelledby");
+      const labelEl = labelId ? document.getElementById(labelId) : null;
+      return labelEl?.textContent?.trim() === label;
+    }) ?? null
+  );
+}
+
 /** The Top P toggle is a switch labelled (via aria-labelledby) "Top P". */
-function topPSwitch(): HTMLElement {
-  const sw = Array.from(
-    document.querySelectorAll<HTMLElement>('[role="switch"]'),
-  ).find((el) => {
-    const labelId = el.getAttribute("aria-labelledby");
-    const labelEl = labelId ? document.getElementById(labelId) : null;
-    return labelEl?.textContent?.trim() === "Top P";
-  });
+function topPSwitch(): HTMLButtonElement {
+  const sw = findSwitchByLabel("Top P");
   if (!sw) throw new Error("expected a Top P switch");
   return sw;
 }
@@ -889,5 +896,98 @@ describe("ProfileEditorModal — Top P wiring", () => {
       expect(saveCalls[0].entry.provider).toBeUndefined();
       expect(saveCalls[0].entry.model).toBeUndefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant (default) profiles — server-stamped `invariant: true`
+// ---------------------------------------------------------------------------
+
+describe("ProfileEditorModal — invariant default profiles in view mode", () => {
+  // A server-stamped default profile. Anthropic opus → visibility.topP is
+  // true, so the Top P control renders and we can assert it is locked.
+  const invariantProfile = {
+    name: "default-a",
+    label: "Default A",
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    source: "managed",
+    invariant: true,
+    topP: 0.9,
+  };
+
+  test("an active invariant profile is fully read-only: no status toggle, disabled label and Top P, Save never armed", () => {
+    renderView(invariantProfile);
+
+    // No disable affordance: the Active toggle is not rendered at all.
+    expect(findSwitchByLabel("Active")).toBeNull();
+
+    // Label and Top P are locked.
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
+    expect(topPSwitch().disabled).toBe(true);
+
+    // Save opens disabled and clicking the locked Top P toggle can't arm it.
+    expect(getSaveBtn().disabled).toBe(true);
+    fireEvent.click(topPSwitch());
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+
+  test("a disabled invariant profile keeps an enable-only toggle; saving PATCHes exactly {status:'active'} as a merge", async () => {
+    const saveCalls: {
+      name: string;
+      entry: Record<string, unknown>;
+      options?: { mode?: "merge" | "replace" };
+    }[] = [];
+    const onSave = (
+      name: string,
+      entry: unknown,
+      options?: { mode?: "merge" | "replace" },
+    ) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown>, options });
+      return Promise.resolve();
+    };
+
+    renderView({ ...invariantProfile, status: "disabled" }, onSave);
+
+    // The re-enable affordance is present and Save starts disarmed.
+    const activeSwitch = findSwitchByLabel("Active");
+    expect(activeSwitch).not.toBeNull();
+    expect(getSaveBtn().disabled).toBe(true);
+
+    // Flip to active: Save arms, and the toggle disappears (the flip is
+    // one-directional — an active invariant profile can't be disabled).
+    fireEvent.click(activeSwitch!);
+    expect(getSaveBtn().disabled).toBe(false);
+    expect(findSwitchByLabel("Active")).toBeNull();
+
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    // The body is exactly {status:"active"} — no label, no topP.
+    expect(saveCalls[0].entry).toEqual({ status: "active" });
+    expect(saveCalls[0].options?.mode).toBe("merge");
+  });
+
+  test("a managed profile without the invariant flag keeps the toggle, editable label, and editable Top P", () => {
+    const { invariant: _invariant, ...nonInvariant } = invariantProfile;
+    renderView(nonInvariant);
+
+    expect(findSwitchByLabel("Active")).not.toBeNull();
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
+    expect(topPSwitch().disabled).toBe(false);
+  });
+
+  test("Save As New from an invariant profile yields a fully editable create form", () => {
+    renderView(invariantProfile);
+
+    fireEvent.click(getButton("Save As New"));
+
+    // The duplicate drops the invariant lock: name and key are editable and
+    // the Active toggle is back.
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
+    expect(getInputByPlaceholder("e.g. fast-cheap").disabled).toBe(false);
+    expect(findSwitchByLabel("Active")).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -170,6 +170,13 @@ function ProfileEditorModalInner({
     "create" | "edit" | "view"
   >(mode);
   const isReadOnly = effectiveMode === "view";
+  // Invariant (default) profiles are fully read-only in view mode: no label
+  // rename, no Top P override, no disabling — the only interactive control is
+  // the enable-only status toggle when the profile is disabled. Customization
+  // goes through "Save As New", which switches `effectiveMode` to "create" and
+  // therefore drops the invariant lock on the duplicate.
+  const isInvariant =
+    initialValues?.invariant === true && effectiveMode === "view";
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
 
   // Managed profiles open the editor in view mode (mode === "view") so they
@@ -257,13 +264,15 @@ function ProfileEditorModalInner({
   // view mode permits editing (label, status, Top P). Drives the view-mode
   // Save button's enabled state and the partial-update save path. Top P is
   // compared on both the enabled flag and the value so flipping the toggle or
-  // dragging the slider both arm Save.
+  // dragging the slider both arm Save. Invariant profiles only permit the
+  // status flip (disabled → active), so label and Top P never arm Save there.
   const hasViewModeChanges =
     isReadOnly &&
-    (label !== initialLabel ||
-      status !== initialStatus ||
-      topPEnabled !== initialTopPEnabled ||
-      (topPEnabled && topP !== initialTopP));
+    (status !== initialStatus ||
+      (!isInvariant &&
+        (label !== initialLabel ||
+          topPEnabled !== initialTopPEnabled ||
+          (topPEnabled && topP !== initialTopP))));
 
   // Advanced params — thinking
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean>(
@@ -514,16 +523,21 @@ function ProfileEditorModalInner({
       setSaving(true);
       setSaveError(null);
       try {
-        const entry: ProfileEntry = {
-          label: label.trim() || null,
-          status,
-        };
-        // Top P is the one advanced param managed profiles may override.
-        // Mirror the create/edit build-entry logic: enabled → number,
-        // cleared → null. Only when the selected provider/model surfaces the
-        // control. `mode: "merge"` means sending just this changed subset
-        // leaves the seed-owned fields intact.
-        if (visibility.topP) {
+        // Invariant profiles reach Save only via the enable flip, and the
+        // daemon rejects any other mutation on them — send exactly
+        // `{status: "active"}`, never label or topP.
+        const entry: ProfileEntry = isInvariant
+          ? { status: "active" }
+          : {
+              label: label.trim() || null,
+              status,
+            };
+        // Top P is the one advanced param non-invariant managed profiles may
+        // override. Mirror the create/edit build-entry logic: enabled →
+        // number, cleared → null. Only when the selected provider/model
+        // surfaces the control. `mode: "merge"` means sending just this
+        // changed subset leaves the seed-owned fields intact.
+        if (!isInvariant && visibility.topP) {
           entry.topP = topPEnabled ? topP : null;
         }
         await onSave(keyTrimmed, entry, { mode: "merge" });
@@ -654,6 +668,7 @@ function ProfileEditorModalInner({
         value={label}
         onChange={(e) => handleLabelChange(e.target.value)}
         placeholder="e.g. Fast & Cheap"
+        disabled={isInvariant}
         fullWidth
       />
     </div>
@@ -702,21 +717,32 @@ function ProfileEditorModalInner({
     </div>
   );
 
-  const activeToggle = (
-    <Toggle
-      checked={status === "active"}
-      onChange={(v) => setStatus(v ? "active" : "disabled")}
-      label="Active"
-    />
-  );
+  // An active invariant profile shows no status toggle (it cannot be
+  // disabled); a disabled one keeps an enable-only toggle, mirroring the
+  // manage-profiles list item and the daemon's one-directional status rule.
+  const activeToggle =
+    !isInvariant || status !== "active" ? (
+      <Toggle
+        checked={status === "active"}
+        onChange={(v) => {
+          if (isInvariant && v !== true) {
+            return;
+          }
+          setStatus(v ? "active" : "disabled");
+        }}
+        label="Active"
+      />
+    ) : null;
 
   const advancedParamsNode = (
     <ProfileAdvancedParams
       visibility={visibility}
       isReadOnly={isReadOnly}
-      // Top P is user policy on managed profiles too, so it stays editable in
-      // view mode while the other advanced params remain locked by isReadOnly.
-      topPReadOnly={false}
+      // Top P is user policy on non-invariant managed profiles, so it stays
+      // editable in view mode while the other advanced params remain locked
+      // by isReadOnly. Invariant (default) profiles lock it too — users
+      // customize via "Save As New".
+      topPReadOnly={isInvariant}
       model={model}
       selectedModel={selectedModel}
       defaultMaxOutputTokens={defaultMaxOutputTokens}


### PR DESCRIPTION
## Summary
- Derive default-profile lock state from the server-stamped `invariant` wire flag (no hardcoded profile names in the web client)
- Active default profiles: no disable toggle, read-only label and Top P; customization via Save As New
- Hatch-disabled default profiles keep an enable-only toggle (list + editor), matching the daemon's one-directional status rule

Part of plan: invariant-default-profiles.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->