### PR TITLE
docs: describe media-stream-only telephony; purge ConversationRelay references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -407,8 +407,7 @@ subgraph "Text Q&A Session"
         GW_FORWARD["Runtime Client<br/>POST /channels/inbound"]
         GW_TWILIO_VOICE["Twilio Voice Webhook<br/>/webhooks/twilio/voice"]
         GW_TWILIO_STATUS["Twilio Status Webhook<br/>/webhooks/twilio/status"]
-        GW_TWILIO_CONNECT["Twilio Connect-Action<br/>/webhooks/twilio/connect-action"]
-        GW_TWILIO_RELAY["Twilio Relay WS<br/>/webhooks/twilio/relay<br/>(bidirectional proxy)"]
+        GW_TWILIO_MEDIA["Twilio Media Stream WS<br/>/webhooks/twilio/media-stream/:callSessionId/:token<br/>(bidirectional proxy)"]
         GW_WA_WEBHOOK["WhatsApp Webhook<br/>/webhooks/whatsapp<br/>(HMAC-SHA256 validated)"]
         GW_SLACK_SOCKET["Slack Socket Mode<br/>WebSocket via<br/>apps.connections.open"]
         GW_SLACK_NORMALIZE["Slack Normalize<br/>app_mention events<br/>+ bot-mention stripping"]
@@ -529,8 +528,7 @@ subgraph "Text Q&A Session"
     %% Gateway flow — Twilio voice webhooks
     GW_TWILIO_VOICE -->|"HTTP"| HTTP_RT
     GW_TWILIO_STATUS -->|"HTTP"| HTTP_RT
-    GW_TWILIO_CONNECT -->|"HTTP"| HTTP_RT
-    GW_TWILIO_RELAY -->|"WebSocket proxy"| HTTP_RT
+    GW_TWILIO_MEDIA -->|"WebSocket proxy"| HTTP_RT
 
     %% Gateway flow — WhatsApp channel (Meta Cloud API)
     GW_WA_WEBHOOK -->|"HMAC-SHA256 verify<br/>+ normalize + dedup<br/>+ route resolver"| GW_FORWARD

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -16,10 +16,10 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Guardian/non-guardian/unverified classification is centralized in `assistant/src/runtime/trust-context-resolver.ts`.
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/WhatsApp path) before run orchestration.
-  - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
+  - Inbound Twilio voice setup (media-stream `routeSetup`) to seed call-time actor context.
 - Runtime channel runs pass this as `trustContext`, and conversation runtime assembly includes actor context in the unified `<turn_context>` block (via `buildUnifiedTurnContextBlock()`) injected into provider-facing prompts.
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
-- Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
+- Voice-specific behavior (DTMF/speech verification flow, call-setup state machine) remains voice-local; only actor-role resolution is shared.
 
 ### Safe Storage Limits
 
@@ -483,10 +483,10 @@ A complementary access-granting flow where the guardian proactively creates a sh
 | Channel  | Status   | Prerequisites                                                                                                                                                 |
 | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Telegram | Shipped  | Bot username resolved from credential metadata or config                                                                                                      |
-| Voice    | Shipped  | Identity-bound voice code redemption via DTMF/speech in the relay state machine. Always-on canonical behavior with personalized friend/guardian name prompts. |
+| Voice    | Shipped  | Identity-bound voice code redemption via DTMF/speech in the call setup flow. Always-on canonical behavior with personalized friend/guardian name prompts. |
 | Slack    | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing                                                       |
 
-### Voice Invite Flow (invite_redemption_pending)
+### Voice Invite Flow (invite_redemption)
 
 Voice invites use a short numeric code (6 digits) instead of a URL token. The guardian creates an invite bound to the invitee's E.164 phone number; the invitee redeems it by entering the code during an inbound voice call.
 
@@ -497,11 +497,11 @@ Voice invites use a short numeric code (6 digits) instead of a URL token. The gu
 3. The one-time plaintext `voiceCode` is returned in the creation response. The raw token is NOT returned for voice invites — redemption uses the identity-bound code flow exclusively.
 4. Guardian communicates the code to the invitee out-of-band.
 
-**Call-time redemption subflow (`invite_redemption_pending`):**
+**Call-time redemption subflow (`invite_redemption`):**
 
-1. Unknown caller dials in. `relay-server.ts` resolves trust via `resolveActorTrust`. Caller is `unknown`, no pending guardian challenge.
-2. The relay asks the gateway for the active voice invite bound to the caller's phone number (`get_active_voice_invite` IPC via `calls/gateway-invite-reader.ts`; fail-soft — any gateway failure falls through to the unverified path).
-3. If an active, non-expired invite exists, the relay enters the `invite_redemption_pending` state (reuses the `verification_pending` connection state) and prompts the caller with personalized copy: `Welcome <friend-name>. Please enter the 6-digit code that <guardian-name> provided you to verify your identity.`
+1. Unknown caller dials in. The media-stream server resolves trust (gateway trust verdict first, `resolveActorTrust` fallback inside `routeSetup`). Caller is `unknown`, no pending guardian challenge.
+2. `routeSetup` asks the gateway for the active voice invite bound to the caller's phone number (`get_active_voice_invite` IPC via `calls/gateway-invite-reader.ts`; fail-soft — any gateway failure falls through to the unverified path).
+3. If an active, non-expired invite exists, the `CallSetupFlow` runs the `invite_redemption` sub-flow (collecting the code via DTMF or spoken digits) and prompts the caller with personalized copy: `Welcome <friend-name>. Please enter the 6-digit code that <guardian-name> provided you to verify your identity.`
 4. The gateway's `redeem_voice_invite` engine validates: identity match, code hash match, expiry, use count. On success, the phone channel is activated in the gateway ACL and the call transitions to the normal call flow.
 5. On invalid/expired code, the caller hears deterministic failure copy: `Sorry, the code you provided is incorrect or has since expired. Please ask <guardian-name> for a new code. Goodbye.` and the call ends immediately.
 
@@ -523,12 +523,12 @@ Voice invites use a short numeric code (6 digits) instead of a URL token. The gu
 | `src/daemon/guardian-invite-intent.ts`              | Intent detection — routes create/list/revoke requests into the contacts skill                                      |
 | `src/runtime/invite-service.ts`                     | Daemon-owned invite presentation (share link, guardian instruction, channel handle) over gateway-minted invites    |
 | `src/runtime/routes/contact-routes.ts`              | HTTP/IPC invite handlers — relay mint/list/revoke/redeem to the gateway's invite IPC routes                        |
-| `src/calls/relay-server.ts`                         | Voice relay state machine — `invite_redemption_pending` subflow (always-on canonical behavior)                     |
+| `src/calls/call-setup-flow.ts`                      | Transport-agnostic call setup flow — `invite_redemption` sub-flow (always-on canonical behavior)                   |
 | `src/calls/gateway-invite-reader.ts`                | Gateway IPC read of the active voice invite for a caller identity                                                  |
 
 ### Voice Inbound Security Model (Canonical)
 
-The voice inbound security model determines how unknown callers are handled when they dial in. Three paths exist, evaluated in priority order by `relay-server.ts` during the `handleSetup` phase. All guardian decisions route through `applyCanonicalGuardianDecision` in the canonical guardian request system.
+The voice inbound security model determines how unknown callers are handled when they dial in. Three paths exist, evaluated in priority order by `routeSetup` (`relay-setup-router.ts`) when the media-stream session starts. All guardian decisions route through `applyCanonicalGuardianDecision` in the canonical guardian request system.
 
 **Decision tree for inbound unknown callers:**
 
@@ -556,17 +556,17 @@ resolveActorTrust() → trustClass
 
 **Path 1: Voice invite code redemption (guardian-initiated)**
 
-The guardian proactively creates a voice invite bound to the caller's E.164 phone number. When the unknown caller dials in and has an active, non-expired invite, the relay enters the `invite_redemption_pending` subflow with personalized prompts using the friend's and guardian's names. This is always-on canonical behavior (no feature flag). See [Voice Invite Flow](#voice-invite-flow-invite_redemption_pending) above.
+The guardian proactively creates a voice invite bound to the caller's E.164 phone number. When the unknown caller dials in and has an active, non-expired invite, the setup flow enters the `invite_redemption` sub-flow with personalized prompts using the friend's and guardian's names. This is always-on canonical behavior (no feature flag). See [Voice Invite Flow](#voice-invite-flow-invite_redemption) above.
 
 **Path 2: Live in-call guardian approval (friend-initiated)**
 
-When no invite exists and no pending guardian challenge is active, the relay enters the name capture + guardian approval wait flow:
+When no invite exists and no pending guardian challenge is active, the setup flow enters the name capture + guardian approval wait flow:
 
-1. The relay transitions to `awaiting_name` state and prompts the caller for their name with a timeout.
+1. The setup flow transitions to `capturing_name` state and prompts the caller for their name with a timeout.
 2. On name capture, `notifyGuardianOfAccessRequest` creates a canonical guardian request (`kind: 'access_request'`) and notifies the guardian via the notification pipeline.
-3. The relay transitions to `awaiting_guardian_decision` and plays hold music/messaging while polling the canonical request status.
+3. The setup flow hands off to a `GuardianWaitController` (`awaiting_guardian_decision`), which speaks hold messaging and heartbeat updates while polling the canonical request status.
 4. The guardian approves or denies via any channel (Telegram, desktop). All decisions route through `applyCanonicalGuardianDecision`, which dispatches to the `access_request` resolver in `guardian-request-resolvers.ts`.
-5. On approval: the resolver directly activates the caller as a trusted contact (sets channel `status: 'active'`, `policy: 'allow'`), the poll detects the approved status, the relay transitions to the normal call flow with the caller's guardian context updated.
+5. On approval: the resolver directly activates the caller as a trusted contact (sets channel `status: 'active'`, `policy: 'allow'`), the poll detects the approved status, and the setup flow completes into the normal call flow with the caller's guardian context updated.
 6. On denial or timeout: the caller hears a denial message and the call ends.
 
 **Path 3: Inbound guardian verification (pending challenge)**
@@ -586,7 +586,9 @@ All guardian decisions for voice access requests flow through:
 
 | File                                           | Purpose                                                                                |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `src/calls/relay-server.ts`                    | Inbound call decision tree, name capture, guardian approval wait polling               |
+| `src/calls/relay-setup-router.ts`              | Inbound call decision tree (`routeSetup`)                                               |
+| `src/calls/call-setup-flow.ts`                 | Name capture, verification, and invite sub-flows over the media-stream transport        |
+| `src/calls/guardian-wait-controller.ts`        | Guardian approval wait — hold messaging, heartbeats, poll/timeout                       |
 | `src/runtime/access-request-helper.ts`         | Creates canonical access request and notifies guardian                                 |
 | `src/approvals/guardian-decision-primitive.ts` | `applyCanonicalGuardianDecision` — unified decision primitive                          |
 | `src/approvals/guardian-request-resolvers.ts`  | `access_request` resolver — voice direct activation, text-channel verification session |
@@ -603,37 +605,41 @@ Audio-to-text conversion occurs in six distinct runtime boundaries, each with it
 
 | Boundary                   | Runtime                                                                       | Provider (current)                           | Adapter module                                                                                                                                                                                                                                             | Caller                                                  |
 | -------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Telephony (hybrid)**     | Twilio-native ConversationRelay or daemon media-stream (provider-conditional) | Configured STT provider (via `services.stt`) | `src/calls/telephony-stt-routing.ts`                                                                                                                                                                                                                       | `src/calls/twilio-routes.ts`                            |
+| **Telephony (media-stream)** | Daemon process (Twilio Media Streams WebSocket)                             | Configured STT provider (via `services.stt`) | `src/calls/media-stream-stt-session.ts`, `src/providers/speech-to-text/resolve.ts`, streaming provider adapters                                                                                                                                            | `src/calls/media-stream-server.ts`                      |
 | **Daemon batch**           | Daemon process (REST API to provider)                                         | Configured STT provider (via `services.stt`) | `src/stt/daemon-batch-transcriber.ts`                                                                                                                                                                                                                      | `src/runtime/routes/inbound-stages/transcribe-audio.ts` |
 | **Conversation streaming** | Daemon process (WebSocket-based)                                              | Configured STT provider (via `services.stt`) | `src/stt/stt-stream-session.ts`, `src/providers/speech-to-text/deepgram-realtime.ts`, `src/providers/speech-to-text/google-gemini-live-stream.ts`, `src/providers/speech-to-text/openai-whisper-stream.ts`, `src/providers/speech-to-text/xai-realtime.ts` | Web/Electron dictation client via gateway WS proxy      |
 | **Live voice channel**     | Assistant process (gateway-authenticated WebSocket)                           | Configured STT provider (via `services.stt`) | `src/runtime/http-server.ts`, `src/live-voice/live-voice-session-manager.ts`, `src/live-voice/live-voice-session.ts`, `src/providers/speech-to-text/resolve.ts`, streaming provider adapters                                                               | Web/Electron live voice client via `/v1/live-voice`     |
 | **Client service-first**   | Web/Electron via gateway → daemon                                             | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`                                                                                                                                                                                                                         | Web/Electron dictation and voice clients                |
 
-**Telephony boundary (hybrid routing):**
+**Telephony boundary (media-stream):**
 
-Telephony STT uses a provider-conditional hybrid model driven by `services.stt.provider`. The routing resolver (`src/calls/telephony-stt-routing.ts`) maps the configured provider to a discriminated strategy at call setup time:
+Every phone call connects over Twilio Media Streams: the voice webhook emits `<Connect><Stream>` TwiML pointing to the gateway's media-stream proxy, and the daemon performs both STT and TTS itself — Twilio only carries mu-law audio frames. The `<Stream url="...">` encodes `callSessionId` and auth `token` as **URL path segments** (e.g. `.../media-stream/<callSessionId>/<token>`) because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. The gateway extracts metadata from path segments (with query-parameter fallback for backward compatibility) and proxies raw audio frames to the daemon.
 
-- **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. The Twilio-native provider name and default speech model are read from the provider catalog entry's `telephonyRouting.twilioNativeMapping` (e.g. Deepgram maps to `provider: "Deepgram"` with `defaultSpeechModel: "nova-3"`; Google maps to `provider: "Google"` with `defaultSpeechModel: undefined`).
+Transcription mode is selected once per session in `media-stream-stt-session.ts`:
 
-- **`media-stream-custom`** (OpenAI Whisper) — TwiML emits `<Connect><Stream>` pointing to the gateway's media-stream proxy. The `<Stream url="...">` encodes `callSessionId` and auth `token` as **URL path segments** (e.g. `.../media-stream/<callSessionId>/<token>`) because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. The gateway extracts metadata from path segments (with query-parameter fallback for backward compatibility) and proxies raw audio frames to the daemon, which transcribes server-side via the provider's batch API.
+- **Streaming** (default) — when `calls.voice.telephonyStreaming` is enabled and the configured provider resolves a streaming transcriber (`resolveStreamingTranscriber()`), inbound audio is decoded (mu-law → PCM16, resampled 8 kHz → 16 kHz) and fed to the provider's realtime adapter. Replies trigger only on utterance-boundary finals (for Deepgram, `speech_final`/`UtteranceEnd`, never mid-sentence `is_final` segments), and barge-in fires from local energy VAD, never from transcriber partials.
+- **Batch fallback** — otherwise the session segments turns with the energy-based `MediaTurnDetector` and transcribes each completed turn via the provider's batch API.
+
+A credential preflight (`resolveTelephonyCredentialReadiness()` in `src/calls/telephony-credential-preflight.ts`) gates every call: it requires a credentialed, telephony-capable STT provider **and** a media-stream-playable TTS provider (the configured one or a credentialed playable fallback). Inbound calls that fail the preflight receive `<Say>` setup-required copy plus `<Hangup/>` instead of a doomed stream; outbound placement fails before dialing via `preflightVoiceIngress()` with the same user-facing message.
 
 Key modules:
 
-| Module                                              | Purpose                                                                |
-| --------------------------------------------------- | ---------------------------------------------------------------------- |
-| `src/calls/telephony-stt-routing.ts`                | Maps `services.stt.provider` to a discriminated `TelephonySttStrategy` |
-| `src/calls/twilio-routes.ts`                        | Voice webhook handler; generates provider-conditional TwiML            |
-| `src/calls/media-stream-parser.ts`                  | Twilio Media Streams protocol parser                                   |
-| `src/calls/media-turn-detector.ts`                  | Energy-based VAD turn detector for raw audio                           |
-| `src/calls/media-stream-stt-session.ts`             | STT session that transcribes audio turns via `services.stt`            |
-| `src/calls/call-transport.ts`                       | Transport interface decoupling CallController from wire protocol       |
-| `src/calls/media-stream-output.ts`                  | Output adapter for sending TTS audio back via Media Streams            |
-| `src/calls/media-stream-server.ts`                  | WebSocket server binding media-stream lifecycle to call sessions       |
-| `gateway/src/http/routes/twilio-media-websocket.ts` | Gateway WebSocket proxy for Media Streams frames                       |
+| Module                                              | Purpose                                                                          |
+| --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `src/calls/twilio-routes.ts`                        | Voice webhook handler; generates `<Connect><Stream>` TwiML, enforces the inbound credential preflight |
+| `src/calls/telephony-credential-preflight.ts`       | Combined STT + TTS credential-readiness resolver                                 |
+| `src/calls/media-stream-parser.ts`                  | Twilio Media Streams protocol parser                                             |
+| `src/calls/media-turn-detector.ts`                  | Energy-based VAD turn detector for raw audio (batch mode)                        |
+| `src/calls/media-stream-stt-session.ts`             | STT session — streaming/batch mode selection and transcription via `services.stt` |
+| `src/calls/media-stream-audio-transcode.ts`         | Mu-law ↔ PCM16 codecs and resampling                                             |
+| `src/calls/call-transport.ts`                       | Transport interface decoupling CallController from wire protocol                 |
+| `src/calls/media-stream-output.ts`                  | Output adapter for sending TTS audio back via Media Streams                      |
+| `src/calls/media-stream-server.ts`                  | WebSocket server binding media-stream lifecycle to call sessions and setup flows |
+| `gateway/src/http/routes/twilio-media-websocket.ts` | Gateway WebSocket proxy for Media Streams frames                                 |
 
-Guard tests in `__tests__/twilio-routes-twiml.test.ts` and `__tests__/twilio-routes.test.ts` assert that TwiML generation matches the provider-conditional strategy for each supported provider.
+Guard tests in `__tests__/twilio-routes-twiml.test.ts` and `__tests__/twilio-routes.test.ts` assert that every supported STT provider yields `<Connect><Stream>` TwiML for both inbound and outbound calls.
 
-To add a new telephony STT provider: add a `telephonyRouting` entry to the provider's catalog entry in `provider-catalog.ts`. Set `strategyKind` to `"conversation-relay-native"` for Twilio-native providers (and include a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`), or `"media-stream-custom"` for providers that require daemon-side transcription. The routing resolver reads these fields from the catalog — no hardcoded maps to update.
+To add a new telephony STT provider: declare `telephonyMode` and `supportedBoundaries` on the provider's catalog entry in `provider-catalog.ts`. The telephony capability resolver (`resolveTelephonySttCapability()`) reads these fields plus credential availability from the catalog — no per-provider routing maps exist.
 
 **Daemon batch boundary:**
 
@@ -2198,12 +2204,12 @@ The `TtsUseCase` discriminator (`"phone-call"` or `"message-playback"`) lets pro
 
 **Synthesis orchestrator (`synthesize-text.ts`):** `synthesizeText()` is the top-level entry point. It resolves the globally configured provider via the config resolver, looks up the adapter in the registry, and delegates synthesis. Provider selection is always global — per-use-case policy only gates capabilities (e.g. format checks), never overrides the chosen provider.
 
-**Call strategy abstraction (`tts-call-strategy.ts`):** The call strategy layer determines how a TTS provider integrates with the Twilio ConversationRelay telephony path. Instead of inferring call behavior from runtime capabilities, `resolveCallStrategy(config)` reads the provider's `callMode` from the canonical catalog and returns a `TtsCallStrategy` with the provider ID and call mode. Two modes exist:
+**Call strategy abstraction (`tts-call-strategy.ts`):** The call strategy layer determines how a TTS provider integrates with the telephony path. Instead of inferring call behavior from runtime capabilities, `resolveCallStrategy(config)` reads the provider's `callMode` from the canonical catalog and returns a `TtsCallStrategy` with the provider ID and call mode. Two modes exist:
 
-- **`native-twilio`** — Twilio handles TTS natively via ConversationRelay. The profile needs a real `ttsProvider` name (e.g. `"ElevenLabs"`) and a provider-specific voice spec string. New native providers plug in by registering a `NativeTwilioVoiceSpecBuilder` via `registerNativeTwilioVoiceSpec()` — no edits to core call routing logic required.
+- **`native-twilio`** — Twilio synthesises audio itself via its built-in provider integrations. The profile needs a real `ttsProvider` name (e.g. `"ElevenLabs"`) and a provider-specific voice spec string built by a registered `NativeTwilioVoiceSpecBuilder`.
 - **`synthesized-play`** — The assistant synthesises audio via the provider's HTTP API and streams chunks to Twilio via `play` messages. Uses a placeholder TTS provider (`"Google"`) and an empty voice string because Twilio never drives TTS itself on this path.
 
-**Phone call integration:** `resolveVoiceQualityProfile()` in `voice-quality.ts` uses `resolveCallStrategy()` to determine the call mode, then dispatches to the appropriate path. For `native-twilio`, it looks up the registered `NativeTwilioVoiceSpec` to build the voice string. For `synthesized-play`, it uses the placeholder profile. This replaces the previous `supportsStreaming`-based branching with explicit catalog-declared modes.
+**Phone call integration:** Phone calls run on the media-stream transport, where the daemon synthesises speech via the configured TTS provider and transcodes it to mu-law 8 kHz frames (`media-stream-output.ts`). Each catalog entry declares `mediaStreamPlayback.outputFormat` (`pcm`, `wav`, or `none`); `resolveTelephonyTtsCapability()` (`src/calls/telephony-tts-capability.ts`) combines that field with credential availability into a playable / not-playable verdict, and the call TTS resolver falls back to a credentialed playable provider rather than producing silence. `resolveVoiceQualityProfile()` in `voice-quality.ts` uses `resolveCallStrategy()` to determine the call mode and build the voice profile.
 
 **Adding a new TTS provider (catalog-first checklist):**
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -174,7 +174,7 @@ Guardian actor-role _classification_ (determining whether a sender is guardian, 
 
 ### Ingress Boundary Guarantees (Gateway-Only Mode)
 
-The runtime operates in **gateway-only mode**: all public-facing webhook paths are blocked at the runtime level. Direct access to Twilio webhook routes (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhooks/twilio/connect-action`) and their legacy equivalents (`/v1/calls/twilio/*`) returns `410 GATEWAY_ONLY`. This ensures external webhook traffic can only reach the runtime through the gateway, which performs signature validation before forwarding.
+The runtime operates in **gateway-only mode**: all public-facing webhook paths are blocked at the runtime level. Direct access to Twilio webhook routes (`/webhooks/twilio/voice`, `/webhooks/twilio/status`) and their legacy equivalents (`/v1/calls/twilio/*`) returns `410 GATEWAY_ONLY`. This ensures external webhook traffic can only reach the runtime through the gateway, which performs signature validation before forwarding.
 
 Internal forwarding routes (`/v1/internal/twilio/*`) are unaffected — these accept pre-validated payloads from the gateway over the private network.
 

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -12,8 +12,7 @@ Add a new entry to the `CATALOG` map with:
 - `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key, or `google-gemini` shares the `"gemini"` key), reuse that name; otherwise use the provider's own name (e.g. `"deepgram"` maps to `"deepgram"`).
 - `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports. Valid values are `"daemon-batch"` (post-recording transcription) and `"daemon-streaming"` (real-time streaming transcription during conversation).
 - `conversationStreamingMode` — how the provider handles streaming transcription in conversation mode: `"realtime-ws"` (provider supports real-time streaming natively via WebSocket), `"incremental-batch"` (streaming emulated via throttled polling), or `"none"` (no streaming support). Required for all providers.
-- `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
-- `telephonyRouting` — telephony routing metadata that drives Twilio call setup strategy selection. Declare `strategyKind` as `"conversation-relay-native"` or `"media-stream-custom"`. For native providers, include `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`.
+- `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`. The telephony capability resolver (`resolveTelephonySttCapability()` in `src/providers/speech-to-text/resolve.ts`) reads this field plus credential availability to decide whether phone calls can run with the provider.
 
 ## 2. Type-system registration
 
@@ -84,8 +83,8 @@ Clients derive shared-vs-exclusive key behavior from the catalog automatically: 
 
 Before submitting the PR, verify that:
 
-1. **No stale config references** — grep for any references to a separate telephony transcription config. The telephony routing module (`src/calls/telephony-stt-routing.ts`) reads `services.stt.provider` and maps it to the appropriate Twilio strategy (either `conversation-relay-native` for providers Twilio supports natively, or `media-stream-custom` for server-side transcription).
+1. **No stale config references** — grep for any references to a separate telephony transcription config. Telephony transcription runs daemon-side over the Twilio media-stream transport (`src/calls/media-stream-stt-session.ts`), which reads `services.stt.provider` like every other boundary.
 
-2. **Provider catalog `telephonyRouting` metadata** — the new provider's catalog entry (step 1) includes a `telephonyRouting` object that is the single source of truth for strategy selection in `telephony-stt-routing.ts`. This object declares the `strategyKind` (`"conversation-relay-native"` or `"media-stream-custom"`) and, for native providers, provides a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`. The routing module contains no hardcoded provider-to-Twilio maps — it reads these values directly from the catalog.
+2. **Provider catalog telephony metadata** — the new provider's catalog entry (step 1) declares `telephonyMode` and `supportedBoundaries`; these are the single source of truth for the telephony capability check (`resolveTelephonySttCapability()`) and for streaming-vs-batch mode selection in the media-stream STT session. No per-provider routing maps exist.
 
-3. **No duplicate wiring** — a provider should appear only once in `services.stt`. The telephony routing layer consumes the same provider ID; there is no second registration step for telephony.
+3. **No duplicate wiring** — a provider should appear only once in `services.stt`. The telephony layer consumes the same provider ID; there is no second registration step for telephony.

--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -126,10 +126,10 @@ Voice calls have a dedicated in-call guardian approval flow that differs from th
 
 **Flow:**
 
-1. Unknown caller dials in. `relay-server.ts` resolves trust — caller is `unknown`, no pending challenge, no active invite.
-2. Relay enters `awaiting_name` state and prompts the caller for their name (with a timeout).
+1. Unknown caller dials in. `routeSetup` (`relay-setup-router.ts`) resolves trust — caller is `unknown`, no pending challenge, no active invite.
+2. The `CallSetupFlow` enters `capturing_name` state and prompts the caller for their name (with a timeout).
 3. On name capture, `notifyGuardianOfAccessRequest` creates a canonical guardian request (`kind: 'access_request'`) and notifies the guardian.
-4. Relay transitions to `awaiting_guardian_decision` and polls `canonical_guardian_requests` for status changes.
+4. The flow hands off to a `GuardianWaitController` (`awaiting_guardian_decision`), which speaks hold messaging while polling `canonical_guardian_requests` for status changes.
 5. Guardian approves or denies via any channel. All decisions route through `applyCanonicalGuardianDecision`.
 6. On approval: the `access_request` resolver directly activates the caller as a trusted contact (`upsertContactChannel` with `status: 'active'`, `policy: 'allow'`) — no verification session needed since the caller is already authenticated by their phone number.
 7. On denial or timeout: the caller hears a denial message and the call ends.

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -70,8 +70,6 @@ class MockTwilioVoiceProvider {
 }
 mock.module("../calls/twilio-provider.js", () => ({
   TwilioVoiceProvider: MockTwilioVoiceProvider,
-  // The twilio-validation middleware imports the deprecated alias.
-  TwilioConversationRelayProvider: MockTwilioVoiceProvider,
 }));
 
 // Mock Twilio config

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -91,8 +91,6 @@ class MockTwilioVoiceProvider {
 }
 mock.module("../calls/twilio-provider.js", () => ({
   TwilioVoiceProvider: MockTwilioVoiceProvider,
-  // The twilio-validation middleware imports the deprecated alias.
-  TwilioConversationRelayProvider: MockTwilioVoiceProvider,
 }));
 
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -183,8 +183,8 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 }));
 
 // Mock the inbound trust reader. handleStart awaits this and threads the
-// verdict into routeSetup so the media-stream transport enforces the same
-// gateway ACL as ConversationRelay. Tests override mockInboundVerdict.
+// verdict into routeSetup so the media-stream transport enforces the
+// gateway ACL. Tests override mockInboundVerdict.
 // The optional gate lets a test hold mid-setup trust re-resolution open
 // (the setup flow's default resolver reads the verdict first) so it can
 // deliver transcripts during the deferral window.
@@ -1602,9 +1602,9 @@ describe("media-stream setup outcome scenarios", () => {
 
   // ── Gateway trust verdict ──────────────────────────────────────────
   // handleStart fetches getInboundTrustVerdict for the inbound caller and
-  // threads it into routeSetup, so the media-stream transport enforces the
-  // same gateway ACL as ConversationRelay. routeSetup itself decides
-  // verdict-vs-local; these tests assert the verdict is fetched and passed.
+  // threads it into routeSetup, so the media-stream transport enforces
+  // the gateway ACL. routeSetup itself decides verdict-vs-local; these
+  // tests assert the verdict is fetched and passed.
 
   describe("gateway trust verdict", () => {
     test("fetches the inbound caller's verdict and threads it into routeSetup", async () => {

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -28,7 +28,6 @@ describe("generateStreamTwiML", () => {
     expect(twiml).toContain(
       `url="wss://test.example.com/webhooks/twilio/media-stream/${callSessionId}"`,
     );
-    expect(twiml).not.toContain("<ConversationRelay");
     // No query params should be present
     expect(twiml).not.toContain("?callSessionId=");
   });
@@ -97,7 +96,7 @@ describe("generateStreamTwiML", () => {
     expect(twiml).not.toContain("attacker-session");
   });
 
-  test("does not include ConversationRelay STT attributes", () => {
+  test("does not include STT/TTS attributes on the Stream element", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
     expect(twiml).not.toContain("transcriptionProvider=");

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -230,7 +230,7 @@ mock.module("../security/secure-keys.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     readonly name = "twilio";
     static getAuthToken(): string | null {
       return null;
@@ -1026,7 +1026,6 @@ describe("twilio webhook routes", () => {
       expect(res.status).toBe(200);
       const twiml = await res.text();
       expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
       expect(twiml).toContain('<Parameter name="callSessionId"');
 
       // Verify session was created with the CallSid
@@ -1100,7 +1099,6 @@ describe("twilio webhook routes", () => {
       expect(res.status).toBe(200);
       const twiml = await res.text();
       expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
       expect(twiml).toContain(`/webhooks/twilio/media-stream/${session.id}`);
     });
   });
@@ -1118,7 +1116,7 @@ describe("twilio webhook routes", () => {
     ] as const;
 
     for (const provider of providers) {
-      test(`outbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+      test(`outbound: ${provider} -> Stream TwiML`, async () => {
         mockConfigObj.services.stt.provider = provider as any;
         const session = createTestSession(
           `conv-stt-${provider}-1`,
@@ -1133,7 +1131,6 @@ describe("twilio webhook routes", () => {
 
         const twiml = await res.text();
         expect(twiml).toContain("<Stream");
-        expect(twiml).not.toContain("<ConversationRelay");
         expect(twiml).not.toContain("transcriptionProvider=");
         // callSessionId is in the URL path, not as a query param
         expect(twiml).toContain(
@@ -1142,7 +1139,7 @@ describe("twilio webhook routes", () => {
         expect(twiml).not.toContain("?callSessionId=");
       });
 
-      test(`inbound: ${provider} -> Stream TwiML (no ConversationRelay)`, async () => {
+      test(`inbound: ${provider} -> Stream TwiML`, async () => {
         mockConfigObj.services.stt.provider = provider as any;
         const req = makeInboundVoiceRequest({
           CallSid: `CA_stt_${provider}_inbound_1`,
@@ -1155,7 +1152,6 @@ describe("twilio webhook routes", () => {
 
         const twiml = await res.text();
         expect(twiml).toContain("<Stream");
-        expect(twiml).not.toContain("<ConversationRelay");
         expect(twiml).not.toContain("transcriptionProvider=");
       });
     }
@@ -1228,7 +1224,6 @@ describe("twilio webhook routes", () => {
 
         const twiml = await res.text();
         expect(twiml).toContain("<Stream");
-        expect(twiml).not.toContain("<ConversationRelay");
       });
     }
 
@@ -1295,7 +1290,6 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain("<Hangup/>");
       expect(twiml).toContain("speech-to-text provider");
       expect(twiml).not.toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
 
       const session = getCallSessionByCallSid("CA_preflight_inbound_1");
       expect(session).not.toBeNull();
@@ -1383,7 +1377,6 @@ describe("twilio webhook routes", () => {
 
       const twiml = result.body as string;
       expect(twiml).toContain("<Stream");
-      expect(twiml).not.toContain("<ConversationRelay");
     });
 
     test("outbound forward (callSessionId in originalUrl) yields Stream TwiML", async () => {

--- a/assistant/src/__tests__/twilio-validation.test.ts
+++ b/assistant/src/__tests__/twilio-validation.test.ts
@@ -20,7 +20,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../calls/twilio-provider.js", () => ({
-  TwilioConversationRelayProvider: class {
+  TwilioVoiceProvider: class {
     static getAuthToken() {
       return "test-auth-token";
     }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -239,7 +239,7 @@ export class CallController {
   }
 
   /**
-   * Handle a final caller utterance from the ConversationRelay.
+   * Handle a final caller utterance from the call transport.
    * Caller utterances always trigger normal turns, even when a guardian
    * consultation is pending — the consultation is tracked separately.
    */
@@ -767,15 +767,15 @@ export class CallController {
     // Synthesized playback (and its native fallback) can await provider
     // latency; re-check the run wasn't superseded meanwhile so a stale turn
     // doesn't inject its end-of-turn marker (or fallback text) into the next
-    // turn's relay stream.
+    // turn's output stream.
     if (!this.isCurrentRun(runVersion)) return fullResponseText;
 
     // Signal end of this turn's speech.  An empty token with `last: true`
-    // tells ConversationRelay to start listening — it does NOT trigger TTS
+    // tells the transport to start listening — it does NOT trigger TTS
     // synthesis.  This is required even when a synthesized provider handled
-    // all audio playback, because ConversationRelay still needs the
-    // end-of-turn signal to transition from "assistant speaking" to
-    // "caller speaking" state.
+    // all audio playback, because the transport still needs the end-of-turn
+    // signal to transition from "assistant speaking" to "caller speaking"
+    // state.
     this.transport.sendTextToken("", true);
 
     // Mark the greeting's first response as awaiting ack
@@ -906,8 +906,8 @@ export class CallController {
           { err, provider: provider.id, errName, errCode },
           "TTS synthesis failed — falling back to native token TTS",
         );
-        // If synthesis fails before any audio has started, degrade to
-        // token-based speech on ConversationRelay so the caller still
+        // If synthesis fails before any audio has started on a non-WAV
+        // transport, degrade to token-based speech so the caller still
         // hears a response instead of silence. This fallback is only
         // used for providers whose catalog entry allows native fallback.
         // Skip it entirely for a superseded run so a stale response can't

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -75,7 +75,7 @@ export async function speakSystemPrompt(
 
 /**
  * Synthesize text via a streaming TTS provider and send the play URL
- * to the relay.
+ * to the transport.
  *
  * On synthesis failure the behavior depends on the transport:
  * - WAV-requiring transports (media-stream) retry once with a playable
@@ -84,10 +84,10 @@ export async function speakSystemPrompt(
  *   path. When no fallback exists (or the retry also fails), only an
  *   empty end-of-turn signal is sent so the transport transitions back
  *   to listening state.
- * - On the ConversationRelay transport, providers with a native Twilio
- *   TTS fallback (e.g. Fish Audio) fall back to `sendTextToken(text)` so
- *   the caller still hears the message; providers without one (e.g.
- *   Deepgram) log the error and send only the end-of-turn signal.
+ * - On non-WAV transports, providers with a native Twilio TTS fallback
+ *   (e.g. Fish Audio) fall back to `sendTextToken(text)` so the caller
+ *   still hears the message; providers without one (e.g. Deepgram) log
+ *   the error and send only the end-of-turn signal.
  */
 async function synthesizeAndPlay(
   relay: CallTransport,
@@ -151,11 +151,11 @@ async function synthesizeAndPlay(
     }
 
     // Signal end of this turn's speech.  An empty token with `last: true`
-    // tells ConversationRelay to start listening — it does NOT trigger TTS
+    // tells the transport to start listening — it does NOT trigger TTS
     // synthesis.  This is required even when a synthesized provider handled
-    // all audio playback, because ConversationRelay still needs the
-    // end-of-turn signal to transition from "assistant speaking" to
-    // "caller speaking" state.
+    // all audio playback, because the transport still needs the end-of-turn
+    // signal to transition from "assistant speaking" to "caller speaking"
+    // state.
     relay.sendTextToken("", true);
   } catch (err) {
     // Extract error class and code for diagnosable log entries.
@@ -221,10 +221,10 @@ async function synthesizeAndPlay(
         { err, provider: provider.id, errName, errCode },
         "System prompt TTS synthesis failed — native fallback disabled for this provider",
       );
-      // Send the end-of-turn signal so ConversationRelay transitions from
-      // "assistant speaking" to "caller speaking" state. Without this, the
-      // relay hangs waiting for the prompt to complete and the caller
-      // cannot interact.
+      // Send the end-of-turn signal so the transport transitions from
+      // "assistant speaking" to "caller speaking" state. Without this,
+      // the session hangs waiting for the prompt to complete and the
+      // caller cannot interact.
       relay.sendTextToken("", true);
       return;
     }

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -5,9 +5,7 @@
  * can send synthesized audio and lifecycle signals through a Twilio Media
  * Stream WebSocket connection.
  *
- * Unlike the ConversationRelay transport which sends text tokens for
- * Twilio's built-in TTS, the media-stream transport operates on raw
- * audio frames:
+ * The media-stream transport operates on raw audio frames:
  *
  * - `sendTextToken()` — Accumulates text tokens and, on `last: true`,
  *   synthesizes the accumulated text via the configured TTS provider,
@@ -110,10 +108,9 @@ export class MediaStreamOutput implements CallTransport {
    * Accumulate text tokens for TTS synthesis. When `last` is true, the
    * accumulated text is queued for synthesis and delivery as media frames.
    *
-   * An empty token with `last: true` signals end-of-turn without TTS.
-   * This mirrors ConversationRelay semantics where an empty last token
-   * transitions the relay from "assistant speaking" to "caller speaking".
-   * On the media-stream transport we send a mark instead.
+   * An empty token with `last: true` signals end-of-turn without TTS:
+   * a mark is sent so the session transitions from "assistant speaking"
+   * to "caller speaking".
    */
   sendTextToken(token: string, last: boolean): void {
     if (this.state === "closed") return;
@@ -130,8 +127,7 @@ export class MediaStreamOutput implements CallTransport {
       }
 
       // Always send an end-of-turn mark so the media-stream server
-      // can detect turn boundaries (analogous to ConversationRelay's
-      // empty last token).
+      // can detect turn boundaries.
       this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
     }
   }

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -417,11 +417,11 @@ export class MediaStreamCallSession {
     });
 
     // ── Setup-policy routing ────────────────────────────────────────
-    // Run the same routeSetup() that the ConversationRelay path uses
-    // to enforce ACL/deny/escalate, verification, and invite flows.
-    // The resulting outcome is handed to a CallSetupFlow, which drives
-    // every interactive sub-flow (DTMF/spoken code entry, invite
-    // redemption, name capture, guardian wait) over this transport.
+    // Run routeSetup() to enforce ACL/deny/escalate, verification, and
+    // invite flows. The resulting outcome is handed to a CallSetupFlow,
+    // which drives every interactive sub-flow (DTMF/spoken code entry,
+    // invite redemption, name capture, guardian wait) over this
+    // transport.
     const from = session?.fromNumber ?? "";
     const to = session?.toNumber ?? "";
 
@@ -454,10 +454,10 @@ export class MediaStreamCallSession {
       return;
     }
 
-    // Verdict-first caller trust so this transport enforces the same gateway
-    // ACL as ConversationRelay. routeSetup uses it when present and not
-    // resolutionFailed, else falls back to local resolution. The reader returns
-    // null on failure, keeping the local path on a gateway blip.
+    // Verdict-first caller trust so this transport enforces the gateway
+    // ACL. routeSetup uses it when present and not resolutionFailed, else
+    // falls back to local resolution. The reader returns null on failure,
+    // keeping the local path on a gateway blip.
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? from : to;
     const verdict = await getPhoneCallerVerdict(otherPartyNumber);

--- a/assistant/src/calls/media-turn-detector.ts
+++ b/assistant/src/calls/media-turn-detector.ts
@@ -2,12 +2,10 @@
  * Speech-aware turn detector for segmenting inbound audio from a
  * Twilio Media Stream into discrete utterance "turns".
  *
- * The Twilio ConversationRelay protocol performs VAD (voice activity
- * detection) on Twilio's side and delivers fully segmented transcripts
- * via `prompt` messages. The raw media-stream path, however, delivers a
- * continuous stream of audio chunks with no built-in turn boundaries.
- * This module bridges that gap by detecting turns based on speech
- * activity signals derived from the audio content:
+ * A Twilio Media Stream delivers a continuous stream of audio chunks
+ * with no built-in turn boundaries. This module supplies those
+ * boundaries by detecting turns based on speech activity signals
+ * derived from the audio content:
  *
  * 1. **Speech-to-silence transition** — when a period of speech is
  *    followed by silence frames exceeding `silenceThresholdMs`, the

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -134,8 +134,8 @@ export async function resolveCallTtsProvider(
         }
       }
     } else if (useSynthesizedPath && fishAudioUnusable) {
-      // ConversationRelay transport: degrade to the native token path
-      // (Twilio TTS) rather than letting the call stay silent.
+      // Non-WAV transport: degrade to the native token path (Twilio TTS)
+      // rather than letting the call stay silent.
       log.warn(
         { provider: providerId },
         "Synthesized call TTS disabled: fish-audio.referenceId is not configured; falling back to native token path",

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -1,13 +1,11 @@
 /**
  * Telephony credential-readiness preflight.
  *
- * Transport contract: on ConversationRelay, Twilio performs Deepgram/Google
- * STT and TTS with Twilio-held keys, so calls work without the user holding
- * any provider credentials. On the media-stream transport the daemon performs
- * both legs itself — Twilio only carries mu-law audio frames — so a call can
- * only work when the user holds credentials for a telephony-capable STT
- * provider AND a media-stream-playable TTS provider (the configured one, or
- * a credentialed playable fallback from the catalog).
+ * Transport contract: the daemon performs both telephony legs itself —
+ * Twilio only carries mu-law audio frames — so a call can only work when
+ * the user holds credentials for a telephony-capable STT provider AND a
+ * media-stream-playable TTS provider (the configured one, or a
+ * credentialed playable fallback from the catalog).
  *
  * This resolver combines the two capability resolvers into a single
  * ready / not-ready verdict with a user-facing message suitable for both a

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -130,7 +130,7 @@ export async function evaluateTelephonyTtsPlayability(
  * Single source of truth for the fish-audio usability invariant: the
  * telephony path supplies no per-request voiceId, so synthesis requires a
  * configured reference ID. Shared by {@link evaluateTelephonyTtsPlayability}
- * and the call TTS resolver's ConversationRelay degrade path.
+ * and the call TTS resolver's non-WAV degrade path.
  *
  * When fish-audio is the active `services.tts.provider`, its config is
  * read through the {@link resolveTtsConfig} provider-options layer — the

--- a/assistant/src/calls/tts-call-strategy.ts
+++ b/assistant/src/calls/tts-call-strategy.ts
@@ -1,15 +1,15 @@
 /**
  * Explicit call-path strategy for TTS providers.
  *
- * Determines how a TTS provider integrates with the Twilio
- * ConversationRelay call path by reading the provider's `callMode` from
- * the canonical catalog rather than inferring behavior from runtime
- * capabilities like `supportsStreaming`.
+ * Determines how a TTS provider integrates with the telephony call path
+ * by reading the provider's `callMode` from the canonical catalog rather
+ * than inferring behavior from runtime capabilities like
+ * `supportsStreaming`.
  *
  * Two strategies exist:
  *
- * - **native-twilio** -- Twilio handles TTS natively via
- *   ConversationRelay. The profile needs a real `ttsProvider` name
+ * - **native-twilio** -- Twilio synthesises audio itself via its built-in
+ *   provider integrations. The profile needs a real `ttsProvider` name
  *   (e.g. `"ElevenLabs"`) and a provider-specific voice spec string.
  *   New native providers plug in by registering a
  *   {@link NativeTwilioVoiceSpecBuilder} -- no edits to the core call
@@ -37,15 +37,14 @@ import type { TtsCallMode, TtsProviderId } from "../tts/types.js";
  * Builds the provider-specific voice spec string for a native Twilio
  * provider.
  *
- * The returned string is used as the `voice` attribute in the
- * ConversationRelay TwiML element. Its format is provider-specific --
- * e.g. ElevenLabs uses `voiceId-modelId-speed_stability_similarity`.
+ * The returned string is used as Twilio's TTS `voice` attribute. Its
+ * format is provider-specific -- e.g. ElevenLabs uses
+ * `voiceId-modelId-speed_stability_similarity`.
  *
  * @param providerConfig - Provider-specific config block from
  *   `services.tts.providers.<id>`.
- * @returns The voice spec string for the ConversationRelay `voice`
- *   attribute, or an empty string if the provider has no voice to
- *   specify.
+ * @returns The voice spec string for Twilio's TTS `voice` attribute, or
+ *   an empty string if the provider has no voice to specify.
  */
 export type NativeTwilioVoiceSpecBuilder = (
   providerConfig: Record<string, unknown>,

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -324,6 +324,3 @@ export class TwilioVoiceProvider implements VoiceProvider {
     return timingSafeEqual(a, b);
   }
 }
-
-// Deprecated alias; the twilio-validation middleware imports this name.
-export { TwilioVoiceProvider as TwilioConversationRelayProvider };

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -24,8 +24,6 @@ export interface VoiceQualityProfile {
  * We default to bare voiceId unless a model is explicitly configured.
  * This avoids forcing model/tuning suffixes that may be rejected for some
  * voice + model combinations.
- *
- * See: https://www.twilio.com/docs/voice/conversationrelay/voice-configuration
  */
 export function buildElevenLabsVoiceSpec(config: {
   voiceId: string;

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -26,7 +26,7 @@ When speaking on behalf of your user during calls, refer to yourself as an "assi
 
 # Overview
 
-The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. The text-to-speech voice is provided by the globally configured TTS provider (set via `services.tts.provider`, default: ElevenLabs). After Twilio setup, the assistant prompts the user to choose a voice from a curated list of supported options.
+The calling system connects both **outbound** and **inbound** voice calls over Twilio Media Streams: the assistant transcribes and synthesizes call audio itself using the configured STT provider (`services.stt.provider`) and TTS provider (`services.tts.provider`, default: ElevenLabs), so working API keys for both are required before calls can connect. After Twilio setup, the assistant prompts the user to choose a voice from a curated list of supported options.
 
 # Initial Setup
 

--- a/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
@@ -14,22 +14,22 @@ All call-related settings can be managed via `assistant config`:
 | `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection                                                                                                                                                                                                  | `true`                                                                                                   |
 | `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                                                                                                                                                   | _(empty)_                                                                                                |
 | `calls.voice.language`                      | Language code for TTS and transcription                                                                                                                                                                                                   | `en-US`                                                                                                  |
-| `services.stt.provider`                     | STT provider for transcription and telephony. Determines the Twilio integration path at call setup time (Deepgram/Google use native ConversationRelay; OpenAI Whisper and xAI use media-stream).                                          | `deepgram`                                                                                               |
+| `services.stt.provider`                     | STT provider for transcription and telephony. The assistant transcribes call audio itself over the Twilio media stream (streaming when the provider supports it, batch otherwise), so calls require a working API key for this provider.  | `deepgram`                                                                                               |
 | `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (`elevenlabs`, `fish-audio`, `deepgram`, `xai`). New providers can be added via the catalog without code changes to call routing.                        | `elevenlabs`                                                                                             |
 | `services.tts.providers.<id>.*`             | Provider-specific settings block. Each catalog provider has its own settings namespace under `services.tts.providers.<id>`. See voice settings in the desktop/iOS app or run `assistant config list` for available settings per provider. | _(per-provider defaults)_                                                                                |
 
 ## TTS provider call-path behavior
 
-Each TTS provider uses one of two call-path modes during phone calls:
+During phone calls the assistant synthesizes audio server-side via the configured provider's HTTP API, transcodes it to mu-law, and streams it to Twilio over the media stream. Each provider's catalog entry declares its playback format:
 
-| Provider     | Call mode          | Description                                                                                                                                                              |
-| ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `elevenlabs` | `native-twilio`    | Text tokens are forwarded to Twilio's ConversationRelay, which synthesizes audio via its built-in ElevenLabs integration.                                                |
-| `fish-audio` | `synthesized-play` | The assistant synthesizes audio server-side via Fish Audio's HTTP API and streams chunks to Twilio via play messages.                                                    |
-| `deepgram`   | `synthesized-play` | The assistant synthesizes audio server-side via Deepgram's HTTP API and streams chunks to Twilio via play messages. Uses the same API key as Deepgram speech-to-text.    |
-| `xai`        | `synthesized-play` | The assistant synthesizes audio server-side via xAI's HTTP API and streams chunks to Twilio via play messages. No native Twilio fallback (`allowNativeFallback: false`). |
+| Provider     | Playback format | Description                                                                                                                       |
+| ------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `elevenlabs` | `pcm`           | Synthesizes PCM audio via the ElevenLabs API.                                                                                     |
+| `fish-audio` | `wav`           | Synthesizes WAV audio via Fish Audio's HTTP API. Requires a configured `referenceId`.                                             |
+| `deepgram`   | `pcm`           | Synthesizes PCM audio via Deepgram's HTTP API. Uses the same API key as Deepgram speech-to-text.                                  |
+| `xai`        | `pcm`           | Synthesizes PCM audio via xAI's HTTP API.                                                                                         |
 
-Providers using `synthesized-play` add a small amount of latency compared to `native-twilio` because audio must be synthesized server-side before playback. The assistant handles chunk buffering and streaming automatically.
+Calls require a media-stream-playable TTS provider with a working API key. When the configured provider is not playable (unsupported format or missing credentials), the assistant falls back to a credentialed playable provider rather than letting the call go silent; if none exists, calls are blocked up front with a setup-required message.
 
 ## Adjusting settings
 

--- a/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ If it reports an available platform assistant, do not install or start ngrok for
 
 ## Call connects but no audio / one-way audio
 
-- The ConversationRelay WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check `assistant platform status --json`; a 503 from `https://velay.../<assistant-id>/...` usually means the assistant tunnel is not connected or the gateway did not complete the WebSocket open, not that ngrok is required.
+- The media-stream WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check `assistant platform status --json`; a 503 from `https://velay.../<assistant-id>/...` usually means the assistant tunnel is not connected or the gateway did not complete the WebSocket open, not that ngrok is required.
 - Verify the assistant is running
 
 ## "Number not eligible for caller identity"
@@ -68,8 +68,8 @@ Do not rotate ngrok to work around a managed Velay WebSocket failure. Fix the Ve
 ## Local Twilio Velay smoke tests
 
 - HTTP bridge: request `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/healthz` and `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/schema`. When testing a JSON webhook route under active development, POST a small JSON body through the same Velay public URL and confirm the gateway receives it.
-- Synthetic WebSocket: connect a local WebSocket client to `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/relay?callSessionId=session-123&token=<edge-token>` and confirm the upgrade reaches the gateway.
-- Real Twilio call: wait for the gateway to register with Velay, then place a call and confirm Twilio fetches `/webhooks/twilio/voice` and opens the relay or media-stream WebSocket through the Velay URL.
+- Synthetic WebSocket: connect a local WebSocket client to `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/media-stream/session-123/<edge-token>` and confirm the upgrade reaches the gateway.
+- Real Twilio call: wait for the gateway to register with Velay, then place a call and confirm Twilio fetches `/webhooks/twilio/voice` and opens the media-stream WebSocket through the Velay URL.
 
 ## Call drops after 30 seconds of silence
 
@@ -82,7 +82,10 @@ The system has a 30-second silence timeout. If nobody speaks for 30 seconds duri
 
 ## Twilio says "application error" right after answer
 
-- This often means ConversationRelay rejected voice configuration after TwiML fetch
-- Keep `services.tts.providers.elevenlabs.voiceModelId` empty first (bare `voiceId` mode)
-- If you set `voiceModelId`, try clearing it and retesting:
-  `assistant config set services.tts.providers.elevenlabs.voiceModelId ""`
+- This often means the voice webhook failed or returned invalid TwiML, or the media-stream WebSocket could not connect
+- Check the assistant logs for voice-webhook errors and confirm `ingress.publicBaseUrl` (or the Velay tunnel) is reachable from Twilio
+
+## Call answers with a spoken "setup required" message and hangs up
+
+- The credential preflight found a missing STT or TTS provider credential — the spoken message names what is missing
+- Store the required API key for the configured `services.stt.provider` / `services.tts.provider` and retry

--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -1,5 +1,5 @@
 // Default ElevenLabs voice — "Amelia" (expressive, enthusiastic, British English).
-// Used by both in-app TTS and phone calls (via Twilio ConversationRelay).
+// Used by both in-app TTS and phone calls.
 export const DEFAULT_ELEVENLABS_VOICE_ID = "ZF6FPAbjXT4488VcRRnw";
 
 /** Valid conversation timeout values (seconds). Shared with voice-config-update tool. */

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -2,7 +2,7 @@
  * Twilio webhook signature validation and related constants.
  */
 
-import { TwilioConversationRelayProvider } from "../../calls/twilio-provider.js";
+import { TwilioVoiceProvider } from "../../calls/twilio-provider.js";
 import { loadConfig } from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getLogger } from "../../util/logger.js";
@@ -55,7 +55,7 @@ export async function validateTwilioWebhook(
 ): Promise<{ body: string } | Response> {
   const rawBody = await req.text();
 
-  const authToken = await TwilioConversationRelayProvider.getAuthToken();
+  const authToken = await TwilioVoiceProvider.getAuthToken();
 
   if (!authToken) {
     log.error(
@@ -93,7 +93,7 @@ export async function validateTwilioWebhook(
     ? publicBaseUrl + parsedUrl.pathname + parsedUrl.search
     : req.url;
 
-  const isValid = TwilioConversationRelayProvider.verifyWebhookSignature(
+  const isValid = TwilioVoiceProvider.verifyWebhookSignature(
     publicUrl,
     params,
     signature,

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -30,10 +30,9 @@ export type TtsProviderId =
 /**
  * Describes how a TTS provider integrates with the telephony call path.
  *
- * - `native-twilio`    — Twilio handles TTS natively via ConversationRelay;
- *                         text tokens are forwarded to the relay and Twilio
- *                         synthesises audio using the provider's built-in
- *                         integration.
+ * - `native-twilio`    — Twilio handles TTS natively; text tokens are
+ *                         forwarded to Twilio, which synthesises audio
+ *                         using the provider's built-in integration.
  * - `synthesized-play` — The assistant synthesises audio via the provider's
  *                         HTTP API and streams chunks to Twilio via `play`
  *                         messages. Used when the provider is not natively

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -642,48 +642,35 @@ New users download `vellum-assistant.dmg` from the [releases page](https://githu
 
 ## Telephony STT Architecture
 
-Telephony speech-to-text is driven by the unified `services.stt.provider` configuration. The voice webhook generates provider-conditional TwiML at call setup time, selecting between two Twilio integration paths based on the active STT provider's capabilities.
+Telephony speech-to-text is driven by the unified `services.stt.provider` configuration. Every call connects over Twilio Media Streams: the voice webhook emits `<Connect><Stream>` TwiML, and the daemon transcribes the raw mu-law audio itself.
 
 ### Overview
 
-The telephony STT routing resolver (`assistant/src/calls/telephony-stt-routing.ts`) reads `services.stt.provider` from config and maps it to a discriminated strategy:
+The media-stream STT session (`assistant/src/calls/media-stream-stt-session.ts`) selects a transcription mode once per call:
 
-- **`conversation-relay-native`** — Providers natively supported by Twilio ConversationRelay (Deepgram, Google). TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription; the daemon receives transcribed text.
+- **Streaming** (default) — when `calls.voice.telephonyStreaming` is enabled and the configured provider resolves a streaming transcriber (`resolveStreamingTranscriber()`), inbound audio is decoded (mu-law → PCM16, resampled 8 kHz → 16 kHz) and fed to the provider's realtime adapter. Replies trigger only on utterance-boundary finals; barge-in fires from local energy VAD, never from transcriber partials.
 
-- **`media-stream-custom`** — Providers not natively supported by Twilio (OpenAI Whisper). TwiML emits `<Connect><Stream>` pointing to the daemon's media-stream server. Raw audio flows from Twilio through the gateway's WebSocket proxy to the daemon, which transcribes server-side via the provider's batch API.
+- **Batch fallback** — otherwise turns are segmented with the energy-based `MediaTurnDetector` and each completed turn is transcribed via the provider's batch API.
 
-Both paths share the same `CallController`, `voice-session-bridge`, and `RunOrchestrator` pipeline downstream of transcription. The only difference is where audio-to-text conversion happens (Twilio-side vs daemon-side).
+Both modes share the same `CallController`, `voice-session-bridge`, and `RunOrchestrator` pipeline downstream of transcription.
 
-### Provider-Conditional Routing
-
-| `services.stt.provider` | Strategy                    | TwiML Element                  | Audio Path                                         |
-| ------------------------ | --------------------------- | ------------------------------ | -------------------------------------------------- |
-| `deepgram`               | `conversation-relay-native` | `<Connect><ConversationRelay>` | Twilio transcribes natively; daemon receives text   |
-| `google-gemini`          | `conversation-relay-native` | `<Connect><ConversationRelay>` | Twilio transcribes natively; daemon receives text   |
-| `openai-whisper`         | `media-stream-custom`       | `<Connect><Stream>`            | Raw audio to daemon; server-side batch transcription |
-| `xai`                    | `media-stream-custom`       | `<Connect><Stream>`            | Raw audio to daemon; server-side batch transcription |
-
-Model normalization for Twilio-native providers:
-- Deepgram defaults `speechModel` to `"nova-3"` when unset.
-- Google leaves `speechModel` undefined when unset. The legacy Deepgram default `"nova-3"` is treated as unset for Google so workspaces that switched providers do not send a Deepgram model name to Google's API.
+A credential preflight (`resolveTelephonyCredentialReadiness()` in `assistant/src/calls/telephony-credential-preflight.ts`) gates every call: it requires a credentialed, telephony-capable STT provider and a media-stream-playable TTS provider. Inbound calls that fail the preflight receive `<Say>` setup-required copy plus `<Hangup/>`; outbound placement fails before dialing via `preflightVoiceIngress()`.
 
 Workspace migration `034-remove-calls-voice-transcription-provider` preserves existing Google STT preferences from the former `calls.voice.transcriptionProvider` key into `services.stt.provider`.
 
 ### Troubleshooting Matrix
 
-| Symptom | Likely Provider | Check | Expected Log |
-| ------- | --------------- | ----- | ------------ |
-| Call connects but no transcription | Deepgram / Google | Verify Deepgram or Google API key is configured in credential store | `[twilio-routes] telephony STT strategy resolved: conversation-relay-native` |
-| Call connects, TTS works, but STT silent | OpenAI Whisper | Verify OpenAI API key is configured; check media-stream server is reachable via gateway | `[twilio-routes] telephony STT strategy resolved: media-stream-custom` |
-| TwiML error / call drops immediately | Any | Check `services.stt.provider` is a recognized catalog entry | `[twilio-routes] unknown STT provider — cannot resolve telephony routing` |
-| Deepgram transcription uses wrong model | Deepgram | The routing resolver defaults Deepgram to `nova-3`; custom model overrides are set via `services.stt.providers.deepgram` config | `speechModel="nova-3"` in TwiML output |
-| Google transcription sends Deepgram model | Google | Model normalization should suppress `nova-3` for Google; verify migration 034 ran | `speechModel` attribute absent from TwiML |
-| Media-stream WebSocket fails to connect | OpenAI Whisper | Verify gateway `/webhooks/twilio/media-stream` route is deployed and reachable | `[gateway] media-stream WebSocket proxy connected` |
-| Audio heard but transcription garbled | OpenAI Whisper | Check audio transcode pipeline (`media-stream-audio-transcode.ts`); verify sample rate matches provider expectations | `[media-stream-stt-session] transcription result` |
+| Symptom | Check | Where to Look |
+| ------- | ----- | ------------- |
+| Inbound call answers with "setup required" and hangs up | STT or TTS credentials missing — the credential preflight failed | `telephony_credential_preflight_failed` call event with the `missing` provider details |
+| Outbound call fails before dialing | Same preflight; the tool error names the missing provider credential | Calling tool result / `preflightVoiceIngress()` failure message |
+| Call connects, TTS works, but STT silent | Verify the configured STT provider's API key; check the media-stream server is reachable via gateway | `media-stream-stt-session` logs |
+| Media-stream WebSocket fails to connect | Verify gateway `/webhooks/twilio/media-stream` route is deployed and reachable | `[gateway] media-stream WebSocket proxy connected` |
+| Audio heard but transcription garbled | Check audio transcode pipeline (`media-stream-audio-transcode.ts`); verify sample rate matches provider expectations | `[media-stream-stt-session] transcription result` |
 
 ### Twilio Media-Stream Troubleshooting
 
-This section covers debugging media-stream calls that use the `media-stream-custom` STT strategy (OpenAI Whisper). The media-stream path handles raw audio ingestion, speech-aware turn segmentation, and server-side transcription.
+This section covers debugging media-stream calls. The media-stream path handles raw audio ingestion, speech-aware turn segmentation, and daemon-side transcription.
 
 #### Key Log Markers
 
@@ -944,4 +931,4 @@ Use this checklist when rolling out conversation STT streaming to macOS and iOS.
 - [ ] Verify no regressions in voice mode (OpenAIVoiceService) -- voice mode does not use conversation streaming.
 - [ ] Verify gateway logs show `"Upstream STT stream WS connected"` for each streaming session.
 - [ ] Verify daemon logs show `"STT stream session started"` with the correct provider.
-- [ ] Verify no `<ConversationRelay>` or telephony STT paths are affected by conversation streaming changes.
+- [ ] Verify telephony media-stream STT paths are not affected by conversation streaming changes.

--- a/docs/service-communication-matrix.md
+++ b/docs/service-communication-matrix.md
@@ -32,20 +32,19 @@ This document enumerates every observed communication permutation between the th
 | 20 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Channel integration control-plane proxies |
 | 21 | Gateway -> Assistant | `http` | JWT Bearer (service token) | OAuth control-plane proxies |
 | 22 | Gateway -> Assistant | `http` | JWT Bearer (service token) | Channel verification session proxy |
-| 23 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Twilio ConversationRelay WebSocket proxy |
-| 24 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Browser relay WebSocket proxy |
-| 25 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Twilio MediaStream WebSocket proxy |
-| 26 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | STT stream WebSocket proxy |
-| 27 | Assistant -> Gateway | `http` | JWT Bearer (edge relay token) | Trust rules CRUD |
-| 28 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Feature flags IPC |
-| 29 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Contact data IPC |
-| 30 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
-| 31 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Threshold IPC |
-| 32 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
-| 33 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
-| 34 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
-| 35 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
-| 36 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
+| 23 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Browser relay WebSocket proxy |
+| 24 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | Twilio MediaStream WebSocket proxy |
+| 25 | Gateway -> Assistant | `websocket` | JWT Bearer (service token, query param) | STT stream WebSocket proxy |
+| 26 | Assistant -> Gateway | `http` | JWT Bearer (edge relay token) | Trust rules CRUD |
+| 27 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Feature flags IPC |
+| 28 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Contact data IPC |
+| 29 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Risk classification IPC |
+| 30 | Assistant -> Gateway | `ipc-unix-ndjson` | none (local socket) | Threshold IPC |
+| 31 | Assistant -> CES | `stdio-ndjson` | none (child process) | CES RPC (local mode) |
+| 32 | Assistant -> CES | `unix-socket-ndjson` | none (bootstrap socket) | CES RPC (managed mode) |
+| 33 | Assistant -> CES | `http` | CES_SERVICE_TOKEN Bearer | CES credential CRUD (HTTP) |
+| 34 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway credential reads (HTTP) |
+| 35 | Gateway -> CES | `http` | CES_SERVICE_TOKEN Bearer | Gateway CES log export (HTTP) |
 
 ## Gateway -> Assistant
 
@@ -316,18 +315,6 @@ This document enumerates every observed communication permutation between the th
 
 **Callee files:**
 - `assistant/src/runtime/http-server.ts`
-
-### Twilio ConversationRelay WebSocket proxy
-
-- **Protocol:** `websocket`
-- **Auth:** JWT Bearer (service token, query param)
-- **Description:** Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.
-
-**Caller files:**
-- `gateway/src/http/routes/twilio-relay-websocket.ts`
-
-**Callee files:**
-- `assistant/src/calls/relay-server.ts`
 
 ### Browser relay WebSocket proxy
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -10,7 +10,7 @@ This boundary is enforced at three layers:
 
 1. **Gateway routing:** The gateway's `fetch()` handler matches `/webhooks/*` paths to dedicated handlers before the runtime-proxy fallthrough. Webhook traffic is validated (signature checks, payload limits) and forwarded to internal runtime endpoints.
 2. **Runtime-proxy guard:** The runtime-proxy handler rejects any `/webhooks/*` path with a 404, preventing accidental forwarding of webhook traffic to the runtime even if a new webhook path is added to the gateway without a dedicated handler.
-3. **Runtime server:** The runtime HTTP server does not register any `/webhooks/telegram` routes. Direct Twilio webhook routes (`/webhooks/twilio/*`) return 410 with a `GATEWAY_ONLY` error code, and relay WebSocket upgrades are restricted to private network peers.
+3. **Runtime server:** The runtime HTTP server does not register any `/webhooks/telegram` routes. Direct Twilio webhook routes (`/webhooks/twilio/*`) return 410 with a `GATEWAY_ONLY` error code, and call WebSocket upgrades are restricted to private network peers.
 
 ```
 Internet
@@ -325,7 +325,7 @@ Local platform smoke-test flow:
 4. Re-hatch or restart the assistant so the gateway receives the new environment.
 5. Confirm gateway logs show `Velay tunnel connected` and `Velay tunnel registered`.
 6. Verify HTTP forwarding by requesting `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/healthz` and `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/schema`. When validating a JSON webhook route under active development, POST a small JSON body through the same Velay public URL and confirm it reaches the loopback gateway.
-7. Verify Twilio WebSocket forwarding with a synthetic local WebSocket client against `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/relay?callSessionId=...&token=...`, then with a real Twilio call after the gateway has registered with Velay.
+7. Verify Twilio WebSocket forwarding with a synthetic local WebSocket client against `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/media-stream/<callSessionId>/<token>`, then with a real Twilio call after the gateway has registered with Velay.
 
 ### URL Builders
 
@@ -336,8 +336,7 @@ All public-facing URLs are constructed by `assistant/src/inbound/public-ingress-
 | `getPublicBaseUrl()`           | Resolves the canonical base URL from `ingress.publicBaseUrl` in workspace config or module-level state (assistant-side; the gateway reads via `ConfigFileCache`) |
 | `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`, using `ingress.publicBaseUrl`                                                                                 |
 | `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`, using `ingress.publicBaseUrl`                                                                                                  |
-| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`, using `ingress.publicBaseUrl`                                                                                          |
-| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`, using `ingress.publicBaseUrl`                                                                                               |
+| `getTwilioMediaStreamUrl()`    | `ws(s)://.../webhooks/twilio/media-stream`, using `ingress.publicBaseUrl` (per-call path segments appended at TwiML build time)                                  |
 | `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                                                                                                |
 | `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                                                                                                      |
 
@@ -792,7 +791,7 @@ Any persistent-stream transport that does not buffer events for disconnected cli
 
 ## AI Phone Calls — Twilio Voice
 
-The Calls subsystem supports both **outbound** and **inbound** voice calls via Twilio. The Twilio integration path is provider-conditional: `services.stt.provider` determines whether calls use ConversationRelay (Twilio-native STT for Deepgram/Google) or Media Streams (daemon-side STT for OpenAI Whisper). The assistant uses an LLM-driven conversation loop to speak in real time. Voice is a first-class channel with its own per-call conversation (outbound key: `asst:${assistantId}:voice:call:${callSessionId}`, inbound key: `asst:${assistantId}:voice:inbound:${callSid}`). When the AI needs guardian input during a call, it dispatches ASK_GUARDIAN requests cross-channel to mac/telegram via the guardian dispatch engine. Answer resolution uses first-writer-wins semantics -- the first channel to respond provides the answer, and remaining channels receive a "already answered" notice.
+The Calls subsystem supports both **outbound** and **inbound** voice calls via Twilio. Every call connects over Twilio Media Streams (`<Connect><Stream>` TwiML): the daemon performs speech-to-text on the raw mu-law audio (streaming when the configured `services.stt` provider supports it, batch otherwise) and synthesizes speech via the configured `services.tts` provider, transcoded to mu-law frames. The assistant uses an LLM-driven conversation loop to speak in real time. Voice is a first-class channel with its own per-call conversation (outbound key: `asst:${assistantId}:voice:call:${callSessionId}`, inbound key: `asst:${assistantId}:voice:inbound:${callSid}`). When the AI needs guardian input during a call, it dispatches ASK_GUARDIAN requests cross-channel to mac/telegram via the guardian dispatch engine. Answer resolution uses first-writer-wins semantics -- the first channel to respond provides the answer, and remaining channels receive a "already answered" notice.
 
 ### Outbound Call Flow
 
@@ -804,7 +803,7 @@ sequenceDiagram
     participant TwilioAPI as Twilio REST API
     participant Gateway as Gateway (public)
     participant Routes as twilio-routes.ts (runtime)
-    participant WS as RelayConnection (WebSocket)
+    participant WS as MediaStreamCallSession (WebSocket)
     participant Ctrl as CallController
     participant Bridge as voice-session-bridge
     participant RunOrch as RunOrchestrator
@@ -827,18 +826,20 @@ sequenceDiagram
     Gateway->>Gateway: validateTwilioWebhookRequest()
     Gateway->>Routes: forward to runtime /v1/internal/twilio/voice-webhook (+ params, originalUrl)
     Routes->>CallStore: getCallSession()
-    Routes-->>Gateway: TwiML (ConversationRelay connect)
+    Routes->>Routes: credential preflight (STT + TTS readiness)
+    Routes-->>Gateway: TwiML (Connect/Stream media-stream connect)
     Gateway-->>TwilioAPI: TwiML response
 
-    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/relay
-    Gateway->>WS: proxy WS to runtime /v1/calls/relay
-    WS->>WS: setup message (callSid)
+    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/media-stream/{callSessionId}/{token}
+    Gateway->>WS: proxy WS to runtime /v1/calls/media-stream
+    WS->>WS: start event (streamSid, callSid)
+    WS->>WS: routeSetup() → setup outcome (CallSetupFlow for interactive outcomes)
     WS->>Ctrl: new CallController()
     Ctrl->>State: registerCallController()
 
     loop Conversation turns
-        TwilioAPI->>WS: prompt (caller utterance)
-        WS->>WS: extract speaker metadata + map speaker identity
+        TwilioAPI->>WS: media frames (mu-law audio)
+        WS->>WS: daemon STT (streaming or batch) → final transcript
         WS->>Ctrl: handleCallerUtterance(transcript, speakerContext)
         Ctrl->>Bridge: startVoiceTurn()
         Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'phone', eventSink})
@@ -847,7 +848,7 @@ sequenceDiagram
         LLM-->>Session: text tokens (streaming)
         Session-->>Bridge: eventSink.onTextDelta()
         Bridge-->>Ctrl: onTextDelta callback
-        Ctrl->>WS: sendTextToken() (for TTS)
+        Ctrl->>WS: sendTextToken() (daemon TTS → mu-law media frames)
         Ctrl->>CallStore: recordCallEvent()
     end
 
@@ -877,7 +878,7 @@ sequenceDiagram
 
 ### Inbound Call Flow
 
-Inbound calls are triggered when someone dials the assistant's Twilio phone number. The gateway resolves which assistant owns the number, the runtime bootstraps a session keyed by CallSid, and the relay connection optionally gates the call behind guardian voice verification before handing off to the CallController.
+Inbound calls are triggered when someone dials the assistant's Twilio phone number. The gateway resolves which assistant owns the number, the runtime bootstraps a session keyed by CallSid, and the call setup flow gates the call (guardian verification, invite redemption, or name capture + guardian approval wait, as routed by `routeSetup`) before handing off to the CallController.
 
 ```mermaid
 sequenceDiagram
@@ -887,7 +888,7 @@ sequenceDiagram
     participant Routes as twilio-routes.ts (runtime)
     participant CallDomain as CallDomain
     participant CallStore as CallStore (SQLite)
-    participant WS as RelayConnection (WebSocket)
+    participant WS as MediaStreamCallSession + CallSetupFlow (WebSocket)
     participant GuardianSvc as ChannelGuardianService
     participant Ctrl as CallController
     participant Bridge as voice-session-bridge
@@ -914,24 +915,25 @@ sequenceDiagram
     Routes->>CallDomain: createInboundVoiceSession(callSid, from, to, assistantId)
     CallDomain->>CallStore: getOrCreateConversation(voice:inbound:${callSid})
     CallDomain->>CallStore: createCallSession() — task=null for inbound
-    Routes-->>Gateway: TwiML (ConversationRelay connect)
+    Routes->>Routes: credential preflight (STT + TTS readiness; Say + Hangup when not ready)
+    Routes-->>Gateway: TwiML (Connect/Stream media-stream connect)
     Gateway-->>TwilioAPI: TwiML response
 
-    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/relay
-    Gateway->>WS: proxy WS to runtime /v1/calls/relay
-    WS->>WS: setup message (callSid)
+    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/media-stream/{callSessionId}/{token}
+    Gateway->>WS: proxy WS to runtime /v1/calls/media-stream
+    WS->>WS: start event (streamSid, callSid)
     WS->>WS: detect isInbound (`session.initiatedFromConversationId == null`)
+    WS->>WS: routeSetup() → setup outcome
 
     alt Pending voice guardian challenge exists
-        WS->>GuardianSvc: getPendingSession(assistantId, 'phone')
-        WS->>WS: enter verification_pending state
+        WS->>WS: CallSetupFlow enters collecting_code state
         WS->>Caller: TTS "Please enter your six-digit verification code"
         loop DTMF / spoken digit attempts (max 3)
             Caller->>WS: DTMF digits or spoken digits
             WS->>GuardianSvc: validateAndConsumeVerification(code)
             alt Code matches
                 GuardianSvc-->>WS: success + guardian binding created
-                WS->>Ctrl: startNormalCallFlow(isInbound=true)
+                WS->>Ctrl: new CallController() + initial greeting
             else Code incorrect + attempts remaining
                 WS->>Caller: TTS "That code was incorrect. Please try again."
             else Max attempts exceeded
@@ -941,7 +943,7 @@ sequenceDiagram
             end
         end
     else No pending guardian challenge
-        WS->>Ctrl: startNormalCallFlow(isInbound=true)
+        WS->>Ctrl: new CallController() + initial greeting
     end
 
     Ctrl->>Bridge: startVoiceTurn([CALL_OPENING])
@@ -952,10 +954,11 @@ sequenceDiagram
     LLM-->>Session: receptionist-style greeting
     Session-->>Bridge: eventSink.onTextDelta()
     Bridge-->>Ctrl: onTextDelta callback
-    Ctrl->>WS: sendTextToken() (TTS to caller)
+    Ctrl->>WS: sendTextToken() (daemon TTS → mu-law frames to caller)
 
     loop Conversation turns
-        Caller->>WS: prompt (caller utterance)
+        Caller->>WS: media frames (mu-law audio)
+        WS->>WS: daemon STT (streaming or batch) → final transcript
         WS->>Ctrl: handleCallerUtterance(transcript, speakerContext)
         Ctrl->>Bridge: startVoiceTurn()
         Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'phone', eventSink})
@@ -964,12 +967,12 @@ sequenceDiagram
         LLM-->>Session: text tokens (streaming)
         Session-->>Bridge: eventSink.onTextDelta()
         Bridge-->>Ctrl: onTextDelta callback
-        Ctrl->>WS: sendTextToken() (for TTS)
+        Ctrl->>WS: sendTextToken() (daemon TTS → mu-law media frames)
         Ctrl->>CallStore: recordCallEvent()
     end
 ```
 
-**Inbound vs. outbound detection**: The relay server determines call direction by checking `session.initiatedFromConversationId`. Outbound calls are initiated from an existing conversation (`initiatedFromConversationId` set). Inbound calls are bootstrapped from Twilio webhooks and therefore have `initiatedFromConversationId == null`.
+**Inbound vs. outbound detection**: The media-stream server determines call direction by checking `session.initiatedFromConversationId`. Outbound calls are initiated from an existing conversation (`initiatedFromConversationId` set). Inbound calls are bootstrapped from Twilio webhooks and therefore have `initiatedFromConversationId == null`.
 
 **Inbound system prompt**: The session pipeline (via voice-session-bridge) generates system prompts appropriate for the voice channel context. For inbound calls, this produces a receptionist-style prompt that greets the caller warmly and helps them with what they need.
 
@@ -989,11 +992,15 @@ sequenceDiagram
 | `assistant/src/calls/call-state-machine.ts`                      | Deterministic state transition validator with allowed-transition table and terminal-state enforcement                                                                                                                  |
 | `assistant/src/calls/call-recovery.ts`                           | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions                                                                                                                   |
 | `assistant/src/calls/twilio-provider.ts`                         | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency                                                                                                 |
-| `assistant/src/calls/twilio-routes.ts`                           | HTTP webhook handlers: voice webhook (returns TwiML with WS-A/WS-B guardrails), status callback, connect action                                                                                                        |
-| `assistant/src/calls/relay-server.ts`                            | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call                                                                                                                |
+| `assistant/src/calls/twilio-routes.ts`                           | HTTP webhook handlers: voice webhook (returns `<Connect><Stream>` TwiML, enforces the credential preflight with `<Say>` + `<Hangup/>` when not ready), status callback                                                 |
+| `assistant/src/calls/media-stream-server.ts`                     | WebSocket handler for Twilio Media Streams; manages one MediaStreamCallSession per call, runs `routeSetup`, and drives interactive setup outcomes through `CallSetupFlow`                                              |
+| `assistant/src/calls/call-setup-flow.ts`                         | Transport-agnostic call setup flow: verification, invite-redemption, name-capture, and unverified-caller sub-flows over DTMF/spoken input                                                                              |
+| `assistant/src/calls/guardian-wait-controller.ts`                | Guardian access-request wait orchestration: hold messaging, heartbeats, status polling, consultation timeout, callback handoff                                                                                         |
+| `assistant/src/calls/media-stream-stt-session.ts`                | Daemon-side STT for media-stream audio: streaming transcriber (utterance-boundary finals) with batch + VAD turn-detection fallback                                                                                     |
+| `assistant/src/calls/telephony-credential-preflight.ts`          | Combined STT + TTS credential-readiness resolver gating inbound TwiML and outbound call placement                                                                                                                      |
 | `assistant/src/calls/speaker-identification.ts`                  | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
 | `assistant/src/calls/call-controller.ts`                         | Session-backed voice controller: routes voice turns through the daemon session pipeline via voice-session-bridge, detects ASK_GUARDIAN and END_CALL control markers                                                    |
-| `assistant/src/calls/voice-session-bridge.ts`                    | Bridge between voice relay and the daemon session/run pipeline: wraps RunOrchestrator.startRun() with voice-specific defaults, translating agent-loop events into callbacks for real-time TTS streaming                |
+| `assistant/src/calls/voice-session-bridge.ts`                    | Bridge between the voice call controller and the daemon session/run pipeline: wraps RunOrchestrator.startRun() with voice-specific defaults, translating agent-loop events into callbacks for real-time TTS streaming  |
 | `assistant/src/calls/call-state.ts`                              | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and controller registry                                                     |
 | `assistant/src/calls/call-constants.ts`                          | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers                                                                                                       |
 | `assistant/src/calls/voice-provider.ts`                          | Abstract VoiceProvider interface for provider-agnostic call initiation                                                                                                                                                 |
@@ -1002,9 +1009,7 @@ sequenceDiagram
 | `assistant/src/calls/types.ts`                                   | TypeScript type definitions: CallSession, CallEvent, CallPendingQuestion, CallStatus, CallEventType                                                                                                                    |
 | `gateway/src/http/routes/twilio-voice-webhook.ts`                | Gateway route: validates Twilio signature, forwards voice webhook to runtime                                                                                                                                           |
 | `gateway/src/http/routes/twilio-status-webhook.ts`               | Gateway route: validates Twilio signature, forwards status callback to runtime                                                                                                                                         |
-| `gateway/src/http/routes/twilio-connect-action-webhook.ts`       | Gateway route: validates Twilio signature, forwards connect-action to runtime                                                                                                                                          |
-| `gateway/src/http/routes/twilio-relay-websocket.ts`              | Gateway route: WebSocket proxy for ConversationRelay frames between Twilio and runtime (used for Deepgram/Google native STT)                                                                                           |
-| `gateway/src/http/routes/twilio-media-websocket.ts`              | Gateway route: WebSocket proxy for Media Streams frames between Twilio and runtime (used for OpenAI Whisper media-stream STT)                                                                                          |
+| `gateway/src/http/routes/twilio-media-websocket.ts`              | Gateway route: WebSocket proxy for Media Streams frames between Twilio and runtime (all calls)                                                                                                                         |
 | `gateway/src/twilio/validate-webhook.ts`                         | Twilio webhook validation: HMAC-SHA1 signature verification, payload size limits, fail-closed when auth token missing                                                                                                  |
 
 ### Call State Machine
@@ -1077,11 +1082,9 @@ Internet-facing Twilio callbacks terminate at the gateway, which validates signa
 | ---------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------- |
 | `POST /webhooks/twilio/voice`                              | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/voice-webhook` (JSON: `{ params, originalUrl, assistantId? }`) |
 | `POST /webhooks/twilio/status`                             | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params }`)                                   |
-| `POST /webhooks/twilio/connect-action`                     | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params }`)                           |
-| `WS /webhooks/twilio/relay`                                | WebSocket upgrade                 | `WS /v1/calls/relay` (bidirectional proxy) — ConversationRelay path                      |
 | `WS /webhooks/twilio/media-stream/<callSessionId>/<token>` | WebSocket upgrade                 | `WS /v1/calls/media-stream` (bidirectional proxy) — Media Streams path                   |
 
-In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice webhook) should point to the gateway's `/webhooks/twilio/relay` (ConversationRelay) or `/webhooks/twilio/media-stream/<callSessionId>/<token>` (Media Streams) endpoint rather than directly to the runtime. The gateway proxies frames bidirectionally between Twilio and the runtime, preserving close and error semantics for proper cleanup.
+In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice webhook) points to the gateway's `/webhooks/twilio/media-stream/<callSessionId>/<token>` endpoint rather than directly to the runtime. The gateway proxies frames bidirectionally between Twilio and the runtime, preserving close and error semantics for proper cleanup.
 
 **Media Streams handshake metadata:** Twilio Media Streams does not reliably preserve URL query parameters across the WebSocket upgrade, so handshake metadata (`callSessionId` and auth `token`) is encoded as **URL path segments** (primary transport). The gateway also supports legacy query-parameter-based handshake as a fallback for backward compatibility. The metadata extractor in `twilio-media-websocket.ts` resolves values from path segments first, falling back to query parameters.
 
@@ -1089,7 +1092,7 @@ Signature validation is **fail-closed**: if the Twilio auth token is not configu
 
 **Webhook base URL resolution:** Public ingress URL construction is centralized in `public-ingress-urls.ts`:
 
-- Twilio voice/status/connect-action/relay/media-stream URLs use `ingress.publicBaseUrl`.
+- Twilio voice/status/media-stream URLs use `ingress.publicBaseUrl`.
 - Velay registration publishes its public assistant URL to `ingress.publicBaseUrl` with `ingress.publicBaseUrlManagedBy: "velay"`.
 - Telegram webhooks, OAuth callbacks, email callbacks, and normal JSON webhook URLs also use `ingress.publicBaseUrl`; Velay-managed URL changes are tagged so unrelated reconciliation can be skipped when appropriate.
 - Module-level assistant state remains a fallback for legacy tunnel start/stop flows.
@@ -1116,9 +1119,7 @@ This makes ingress URL updates smoother in local tunnel workflows because Twilio
 | POST   | `/v1/calls/:callSessionId/answer`      | Answer a pending question via HTTP (alternative to in-conversation bridge)                                                             |
 | POST   | `/v1/calls/:callSessionId/instruction` | Relay a steering instruction to an active call's controller (alternative to in-conversation bridge)                                    |
 | POST   | `/v1/internal/twilio/status`           | Internal status callback used by gateway; accepts JSON `{ params }`                                                                    |
-| POST   | `/v1/internal/twilio/connect-action`   | Internal connect action callback used by gateway; accepts JSON `{ params }`                                                            |
-| WS     | `/v1/calls/relay`                      | ConversationRelay WebSocket (bidirectional: prompt/interrupt/dtmf from Twilio, text tokens/end to Twilio) — Deepgram/Google path       |
-| WS     | `/v1/calls/media-stream`               | Media Streams WebSocket (raw audio from Twilio, daemon-side STT) — OpenAI Whisper path                                                 |
+| WS     | `/v1/calls/media-stream`               | Media Streams WebSocket (raw audio from Twilio, daemon-side STT/TTS) — all calls                                                       |
 
 ### Tools
 
@@ -1165,7 +1166,7 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.safety.denyCategories`     | string[] | `[]`                                          | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting).                                                                                             |
 | `llm.callSites.callAgent.model`   | string   | _(unset — falls back to `llm.default.model`)_ | Optional override for the LLM model used in voice call conversations.                                                                                                                           |
 | `calls.voice.language`            | string   | `'en-US'`                                     | Language code for TTS and transcription.                                                                                                                                                        |
-| `services.stt.provider`           | enum     | `'deepgram'`                                  | STT provider for all boundaries including telephony. Determines the Twilio integration path (ConversationRelay-native for `deepgram`/`google-gemini`, media-stream for `openai-whisper`/`xai`). |
+| `services.stt.provider`           | enum     | `'deepgram'`                                  | STT provider for all boundaries including telephony. The daemon transcribes media-stream call audio with this provider (streaming when supported, batch otherwise).                             |
 | `services.tts.provider`           | enum     | `'elevenlabs'`                                | Active TTS provider for speech synthesis (catalog-driven; see [TTS Provider Abstraction](../assistant/ARCHITECTURE.md#tts-provider-abstraction-servicestts)).                                   |
 | `services.tts.providers.<id>.*`   | object   | _(per-provider defaults)_                     | Provider-specific settings block. One block per catalog entry (e.g. `elevenlabs`, `fish-audio`).                                                                                                |
 
@@ -1188,20 +1189,19 @@ Voice and TTS settings are configurable via the `calls.voice` and `services.tts`
 
 The active TTS provider is determined by `services.tts.provider` (default: `"elevenlabs"`). Provider-specific settings (voice ID, model, tuning parameters) are read from `services.tts.providers.<id>`. The call mode (`native-twilio` or `synthesized-play`) is resolved from the canonical provider catalog via `resolveCallStrategy()` in `tts-call-strategy.ts` — it reads the provider's declared `callMode` rather than inferring behavior from runtime capabilities.
 
-For `native-twilio` providers (e.g. ElevenLabs), the voice quality profile looks up a registered `NativeTwilioVoiceSpecBuilder` to construct the provider-specific voice spec string for the ConversationRelay `voice` attribute. New native providers plug in by registering their own voice spec builder — no edits to core call routing logic required. For `synthesized-play` providers (e.g. Fish Audio), `ttsProvider` is set to `"Google"` as a placeholder in TwiML and actual audio is delivered via `play` messages — the assistant synthesises audio via the provider's HTTP API.
+For `native-twilio` providers (e.g. ElevenLabs), the voice quality profile looks up a registered `NativeTwilioVoiceSpecBuilder` to construct the provider-specific voice spec string for Twilio's TTS `voice` attribute. For `synthesized-play` providers (e.g. Fish Audio), the assistant synthesises audio via the provider's HTTP API and delivers it as `play` audio.
 
-The voice webhook in `twilio-routes.ts` calls `resolveVoiceQualityProfile()` for TTS settings and separately resolves the telephony STT strategy via `resolveTelephonySttRouting()`. The routing result determines which TwiML generator to use: `generateTwiML()` for Twilio-native ConversationRelay, or `generateStreamTwiML()` for the media-stream path. This separation keeps TTS and STT resolution independent — the voice quality profile controls the TTS provider, voice, and language, while the routing strategy controls the STT integration path.
+On the media-stream transport, call playback requires audio the daemon can transcode to mu-law: each TTS catalog entry declares `mediaStreamPlayback.outputFormat`, `resolveTelephonyTtsCapability()` combines that with credential availability, and the call TTS resolver falls back to a credentialed playable provider rather than producing silence.
 
 For full details on the catalog-driven TTS architecture, provider catalog, call strategy abstraction, and the provider-add checklist, see the [TTS Provider Abstraction](../assistant/ARCHITECTURE.md#tts-provider-abstraction-servicestts) section in the assistant architecture docs.
 
-### Telephony STT: Provider-Conditional Hybrid Routing
+### Telephony STT: Daemon-Side Media-Stream Transcription
 
-Telephony STT is unified under `services.stt.provider`. The voice webhook in `twilio-routes.ts` calls `resolveTelephonySttRouting()` to determine the Twilio integration path based on the active provider:
+Telephony STT is unified under `services.stt.provider`. The voice webhook in `twilio-routes.ts` emits `<Connect><Stream>` TwiML pointing to the gateway's media-stream proxy (`/webhooks/twilio/media-stream/<callSessionId>/<token>`); the gateway forwards raw audio frames to the daemon's media-stream server, which transcribes them itself:
 
-- **Deepgram / Google** (`conversation-relay-native` strategy) — TwiML emits `<Connect><ConversationRelay>` with Twilio-native `transcriptionProvider` and `speechModel` attributes. The gateway proxies ConversationRelay frames via `/webhooks/twilio/relay`. The daemon receives transcribed text, not raw audio.
+- **Streaming** (default) — when `calls.voice.telephonyStreaming` is enabled and the configured provider resolves a streaming transcriber, audio is decoded (mu-law → PCM16, 8 kHz → 16 kHz) and fed to the provider's realtime adapter; replies trigger only on utterance-boundary finals and barge-in fires from local energy VAD.
+- **Batch fallback** — otherwise turns are segmented with the energy-based VAD turn detector and transcribed via the provider's batch API.
 
-- **OpenAI Whisper** (`media-stream-custom` strategy) — TwiML emits `<Connect><Stream>` pointing to the gateway's media-stream proxy (`/webhooks/twilio/media-stream`). The gateway forwards raw audio frames to the daemon's media-stream server, which transcribes server-side.
-
-Both paths are active in production. The strategy selection happens at call setup time based on the current `services.stt.provider` value. See `docs/internal-reference.md` for a provider-specific troubleshooting matrix.
+A credential preflight (`resolveTelephonyCredentialReadiness()`) requires a credentialed telephony-capable STT provider and a media-stream-playable TTS provider before any call connects: inbound not-ready calls get `<Say>` setup-required copy plus `<Hangup/>`, and outbound placement fails before dialing. See `docs/internal-reference.md` for a provider-specific troubleshooting matrix.
 
 ---

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -80,7 +80,7 @@ When the voice webhook is called without a `callSessionId` query parameter, the 
 1. **`resolveAssistantByPhoneNumber(config, To)`** — Reverse lookup of the inbound `To` number against `assistantPhoneNumbers`. If the dialed number matches an assistant's configured phone number, that assistant handles the call.
 2. **Fallback to `resolveAssistant(From, From)`** — If no phone number match is found, the standard routing chain is used: `conversation_id` match, `actor_id` match, then the unmapped policy.
 3. **TwiML Reject for unmapped** — When the unmapped policy is `reject` (and no route matches), the gateway returns `<Reject reason="rejected"/>` TwiML directly to Twilio. Twilio plays a busy signal and hangs up. The call is never forwarded to the runtime.
-4. **Forward with assistantId** — When routing succeeds, the gateway forwards the voice webhook to the runtime at `POST /v1/internal/twilio/voice-webhook` with a JSON body containing `{ params, originalUrl, assistantId }`. The runtime calls `createInboundVoiceSession()` to bootstrap a session keyed by CallSid, then returns TwiML pointing Twilio to the ConversationRelay WebSocket.
+4. **Forward with assistantId** — When routing succeeds, the gateway forwards the voice webhook to the runtime at `POST /v1/internal/twilio/voice-webhook` with a JSON body containing `{ params, originalUrl, assistantId }`. The runtime calls `createInboundVoiceSession()` to bootstrap a session keyed by CallSid, then returns `<Connect><Stream>` TwiML pointing Twilio to the gateway's media-stream WebSocket proxy (after a daemon-side STT/TTS credential preflight; calls that fail it get `<Say>` setup-required copy plus `<Hangup/>`).
 
 ### Inbound call lifecycle (gateway perspective)
 
@@ -88,9 +88,9 @@ When the voice webhook is called without a `callSessionId` query parameter, the 
 Caller → Twilio → Gateway /webhooks/twilio/voice (no callSessionId)
   → resolveAssistantByPhoneNumber(To) || resolveAssistant(From) || TwiML Reject
   → forward to runtime /v1/internal/twilio/voice-webhook (JSON: { params, originalUrl, assistantId })
-  → runtime returns TwiML (ConversationRelay connect)
-  → Twilio opens WebSocket → Gateway /webhooks/twilio/relay → Runtime /v1/calls/relay
-  → RelayConnection detects inbound (`initiatedFromConversationId == null`), optional guardian verification gate, then receptionist-style LLM greeting
+  → runtime returns TwiML (<Connect><Stream> media-stream connect)
+  → Twilio opens WebSocket → Gateway /webhooks/twilio/media-stream/<callSessionId>/<token> → Runtime /v1/calls/media-stream
+  → media-stream server detects inbound (`initiatedFromConversationId == null`), runs the call setup flow (verification / invite / name-capture sub-flows as routed), then receptionist-style LLM greeting
 ```
 
 ## Callback Query Handling
@@ -151,8 +151,7 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/deliver/telegram`                        | POST            | Internal endpoint for the assistant runtime to deliver outbound messages/attachments to Telegram chats                                        |
 | `/webhooks/twilio/voice`                   | POST            | Twilio voice webhook (validated via HMAC-SHA1 signature)                                                                                      |
 | `/webhooks/twilio/status`                  | POST            | Twilio status callback (validated via HMAC-SHA1 signature)                                                                                    |
-| `/webhooks/twilio/connect-action`          | POST            | Twilio connect-action callback (validated via HMAC-SHA1 signature)                                                                            |
-| `/webhooks/twilio/relay`                   | WS              | Twilio ConversationRelay WebSocket (bidirectional proxy to runtime, requires `callSessionId` query param)                                     |
+| `/webhooks/twilio/media-stream/:callSessionId/:token` | WS   | Twilio Media Streams WebSocket (bidirectional proxy to runtime; handshake metadata in URL path segments)                                      |
 | `/webhooks/oauth/callback`                 | GET             | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime |
 | `/v1/channel-verification-sessions`        | POST            | Authenticated control-plane proxy for creating verification sessions (inbound challenge or outbound verification)                             |
 | `/v1/channel-verification-sessions`        | DELETE          | Authenticated control-plane proxy for cancelling active verification sessions                                                                 |
@@ -213,7 +212,7 @@ The assistant runtime uses this URL to construct all webhook and OAuth callback 
 
 ### Velay for Twilio Testing
 
-Velay is a managed ingress transport for assistant-hosted HTTP and WebSocket traffic. The gateway starts the Velay tunnel only after Twilio setup has been started in the workspace, or when existing Twilio config shows it was set up before. When Velay registration succeeds, the gateway writes the registered public assistant URL to `ingress.publicBaseUrl` and marks it with `ingress.publicBaseUrlManagedBy: "velay"`. Twilio URL builders use that public base URL for voice, status, relay, and media-stream endpoints.
+Velay is a managed ingress transport for assistant-hosted HTTP and WebSocket traffic. The gateway starts the Velay tunnel only after Twilio setup has been started in the workspace, or when existing Twilio config shows it was set up before. When Velay registration succeeds, the gateway writes the registered public assistant URL to `ingress.publicBaseUrl` and marks it with `ingress.publicBaseUrlManagedBy: "velay"`. Twilio URL builders use that public base URL for voice, status, and media-stream endpoints.
 
 Use Velay when testing Twilio voice webhooks or Twilio WebSocket upgrades through the platform-managed tunnel:
 
@@ -248,10 +247,10 @@ For a synthetic Twilio WebSocket smoke test, connect a local WebSocket client to
 
 ```bash
 bun -e 'const ws = new WebSocket(process.argv[1]); ws.onopen = () => { console.log("open"); ws.close(); }; ws.onerror = (event) => console.error(event);' \
-  "wss://<velay-host>/<assistant-id>/webhooks/twilio/relay?callSessionId=session-123&token=<edge-token>"
+  "wss://<velay-host>/<assistant-id>/webhooks/twilio/media-stream/session-123/<edge-token>"
 ```
 
-For a real Twilio call, expose local Velay with a public HTTPS/WSS tunnel and configure the platform Velay service with that origin as `VELAY_PUBLIC_BASE_URL`. After the assistant re-registers, Twilio should fetch `/webhooks/twilio/voice` and open `/webhooks/twilio/relay` or `/webhooks/twilio/media-stream/...` through the Velay URL. Use ngrok or another custom tunnel in `ingress.publicBaseUrl` only for local/self-hosted workflows that are not routed through Velay.
+For a real Twilio call, expose local Velay with a public HTTPS/WSS tunnel and configure the platform Velay service with that origin as `VELAY_PUBLIC_BASE_URL`. After the assistant re-registers, Twilio should fetch `/webhooks/twilio/voice` and open `/webhooks/twilio/media-stream/...` through the Velay URL. Use ngrok or another custom tunnel in `ingress.publicBaseUrl` only for local/self-hosted workflows that are not routed through Velay.
 
 ## Ingress Boundary Guarantees
 

--- a/packages/assistant-client/src/__tests__/assistant-client.test.ts
+++ b/packages/assistant-client/src/__tests__/assistant-client.test.ts
@@ -356,7 +356,7 @@ describe("buildWsUpstreamUrl", () => {
   test("produces log-safe URL with redacted token", () => {
     const result = buildWsUpstreamUrl({
       baseUrl: "http://localhost:7821",
-      path: "/v1/calls/relay",
+      path: "/v1/calls/media-stream",
       serviceToken: "secret-jwt-value",
       extraParams: { callSessionId: "sess-1" },
     });

--- a/scripts/service-communication/matrix-source.ts
+++ b/scripts/service-communication/matrix-source.ts
@@ -314,17 +314,6 @@ export const MATRIX_ENTRIES: MatrixEntry[] = [
   // Gateway -> Assistant (WebSocket)
   // =========================================================================
   {
-    label: "Twilio ConversationRelay WebSocket proxy",
-    caller: "gateway",
-    callee: "assistant",
-    protocol: "websocket",
-    auth: "JWT Bearer (service token, query param)",
-    description:
-      "Gateway proxies Twilio ConversationRelay WebSocket frames to the assistant's /v1/calls/relay endpoint.",
-    callerGlobs: ["gateway/src/http/routes/twilio-relay-websocket.ts"],
-    calleeGlobs: ["assistant/src/calls/relay-server.ts"],
-  },
-  {
     label: "Browser relay WebSocket proxy",
     caller: "gateway",
     callee: "assistant",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -39,7 +39,7 @@
     },
     "phone-calls": {
       "docsSlug": "phone-calls",
-      "sha256": "9342a16afba60f162b9f9b31333fa50dd808b5445ab6ea1991ed9a46615f1a7e"
+      "sha256": "99a65fbcc7b683812aba75beb5865526d70476a0ef826a2f5002e5582b7803b1"
     },
     "playbooks": {
       "docsSlug": "playbooks",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -175,7 +175,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "updatedAt": "2026-07-02T18:24:29.000Z"
     },
     {
       "id": "email-setup",
@@ -795,7 +795,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-02T00:41:12.000Z"
+      "updatedAt": "2026-07-02T00:54:25.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -95,7 +95,7 @@ curl -s "https://api.elevenlabs.io/v2/voices?search=warm+female&page_size=10" \
 
 ### Custom and cloned voices
 
-If the user has created a custom voice or voice clone in their ElevenLabs account, they can use its voice ID directly. These voices work in both in-app TTS and Twilio ConversationRelay.
+If the user has created a custom voice or voice clone in their ElevenLabs account, they can use its voice ID directly. These voices work in both in-app TTS and phone calls.
 
 ### Preview voices
 
@@ -128,17 +128,13 @@ Lower stability makes the voice more expressive but less predictable - good for 
 
 ## Voice Model Tuning
 
-By default, the system sends a **bare** `voiceId` to Twilio ConversationRelay (no model/tuning suffix). This is the safest default across voice IDs.
-
-To optionally force Twilio's extended voice spec, set a model ID:
+By default, synthesis uses ElevenLabs' `eleven_multilingual_v2` model. To use a different model (e.g. a lower-latency one), set a model ID:
 
 ```bash
-assistant config set services.tts.providers.elevenlabs.voiceModelId "flash_v2_5"
+assistant config set services.tts.providers.elevenlabs.voiceModelId "eleven_flash_v2_5"
 ```
 
-When `voiceModelId` is set, the emitted voice string becomes: `voiceId-model-speed_stability_similarity`.
-
-To clear and revert to the bare voiceId default:
+To clear and revert to the default model:
 
 ```bash
 assistant config set services.tts.providers.elevenlabs.voiceModelId ""


### PR DESCRIPTION
## Summary
- All architecture/onboarding/skill docs now describe the media-stream-only telephony flow (daemon STT/TTS, CallSetupFlow, credential preflight); Mermaid diagrams updated
- Drops the temporary TwilioConversationRelayProvider alias (twilio-validation.ts renamed to TwilioVoiceProvider) and the last CR code comments
- Final repo-wide ConversationRelay grep is clean outside intentional keeps

Note: bundled phone-calls skill docs changed — local daemons need a container rebuild for the skill changes to take effect.

Part of plan: phone-media-stream-v2.md (PR 17 of 17)