### PR TITLE
feat(memory): record injection-gate runs to usage telemetry

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -144,6 +144,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../skills/catalog-cache.js",
     "../../../../skills/install-meta.js",
     "../../../../skills/skill-memory.js",
+    "../../../../telemetry/watchdog-events-store.js",
     "../../../../tools/skills/delete-managed.js",
     "../../../../util/abort-reasons.js",
     "../../../../util/errors.js",

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -79,8 +79,37 @@ mock.module("../dense.js", () => ({
   },
 }));
 
-const { orchestrate, DEFAULT_NEEDLE_K, DEFAULT_DENSE_K } =
-  await import("../orchestrate.js");
+// The watchdog telemetry store is stubbed with the same active-flag delegation
+// as the dense lane: gate tests capture the per-run gate telemetry; any other
+// test file sharing the process falls through to the real store. Spread the
+// real module so the query/type exports stay present.
+const realWatchdogStore = {
+  ...(await import("../../../../../telemetry/watchdog-events-store.js")),
+};
+let watchdogMockActive = false;
+let recordedGateEvents: Array<{
+  checkName: string;
+  value?: number | null;
+  detail?: Record<string, unknown> | null;
+}> = [];
+mock.module("../../../../../telemetry/watchdog-events-store.js", () => ({
+  ...realWatchdogStore,
+  recordWatchdogEvent: (
+    record: Parameters<typeof realWatchdogStore.recordWatchdogEvent>[0],
+  ) => {
+    if (!watchdogMockActive) {
+      return realWatchdogStore.recordWatchdogEvent(record);
+    }
+    recordedGateEvents.push(record);
+  },
+}));
+
+const {
+  orchestrate,
+  DEFAULT_NEEDLE_K,
+  DEFAULT_DENSE_K,
+  MEMORY_V3_INJECTION_GATE_CHECK_NAME,
+} = await import("../orchestrate.js");
 
 // ---------------------------------------------------------------------------
 // Fixtures: a tiny corpus of pages with bodies + `links:` frontmatter.
@@ -261,9 +290,11 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
 
 beforeEach(() => {
   denseMockActive = true;
+  watchdogMockActive = true;
   providerStub = null;
   denseHits = [];
   denseCalls = [];
+  recordedGateEvents = [];
   lastPool = [];
   lastPoolLines = [];
   lastPrefixBlock = null;
@@ -272,6 +303,7 @@ beforeEach(() => {
 
 afterAll(() => {
   denseMockActive = false;
+  watchdogMockActive = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -1198,5 +1230,85 @@ describe("orchestrate — injection gate", () => {
 
     expect(selectCalls).toBe(1);
     expect(result.selections.map((s) => s.slug)).toContain("topic-a");
+  });
+
+  test("a scored gate run records ONE telemetry event carrying the decision", async () => {
+    const lanes = await buildLanes();
+    // Dense top-1 (0.9) clears denseThreshold (0.52) → dense_pass.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents).toHaveLength(1);
+    const event = recordedGateEvents[0]!;
+    expect(event.checkName).toBe(MEMORY_V3_INJECTION_GATE_CHECK_NAME);
+    expect(event.value).toBe(1);
+    expect(event.detail).toMatchObject({
+      pass: true,
+      reason: "dense_pass",
+      top_dense_score: 0.9,
+    });
+  });
+
+  test("a closed gate records pass:false with the failure reason", async () => {
+    const lanes = await buildLanes();
+    // No needle-term overlap and sub-threshold dense → fail_no_signal.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "zzzz nomatch"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents).toHaveLength(1);
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      pass: false,
+      reason: "fail_no_signal",
+    });
+  });
+
+  test("the dense-unavailable pass-open records reason dense_unavailable", async () => {
+    const lanes = await buildLanes();
+    // denseK: 0 → no live dense hits → the gate passes open without scoring.
+    const needle = {
+      query: () => [],
+      queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { needle, denseK: 0, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents).toHaveLength(1);
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      pass: true,
+      reason: "dense_unavailable",
+    });
+  });
+
+  test("no gate telemetry when the gate is disabled or omitted", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        gateConfig: gateConfigOf({ enabled: false }),
+      }),
+    );
+    await orchestrate(makeTurn(2, "apple"), depsOf(lanes));
+
+    expect(recordedGateEvents).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -55,6 +55,7 @@
  */
 
 import type { AssistantConfig } from "../../../../config/schema.js";
+import { recordWatchdogEvent } from "../../../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../../../../util/logger.js";
 import { denseLaneScored } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
@@ -81,6 +82,28 @@ import type {
 // Named to disambiguate from the unrelated `src/config/memory-v3-gate.ts`: this
 // logger names the per-turn INJECTION gate wired in below.
 const log = getLogger("memory-v3-injection-gate");
+
+/** `check_name` of the `watchdog` telemetry event recorded once per
+ *  injection-gate run. The platform's memory admin analytics count and filter
+ *  on this exact string — keep it stable. */
+export const MEMORY_V3_INJECTION_GATE_CHECK_NAME = "memory_v3_injection_gate";
+
+/** Record one injection-gate run to usage telemetry. `detail` keys are the
+ *  platform-side contract (snake_case, scores and reason codes only — never
+ *  conversation content). Never throws: the gate is pass-open by design, and a
+ *  telemetry failure must not cost the turn its memory either. */
+function recordGateRun(detail: Record<string, unknown>): void {
+  try {
+    recordWatchdogEvent({
+      checkName: MEMORY_V3_INJECTION_GATE_CHECK_NAME,
+      value: 1,
+      detail,
+    });
+  } catch {
+    // recordWatchdogEvent already no-ops on opt-out and a missing telemetry
+    // DB; anything past that is not worth failing the turn over.
+  }
+}
 
 /** Default number of BM25 needle articles to fold into the pool. */
 export const DEFAULT_NEEDLE_K = 12;
@@ -429,6 +452,7 @@ export async function orchestrate(
         },
         "memory-v3 injection gate: dense lane unavailable, passing open",
       );
+      recordGateRun({ pass: true, reason: "dense_unavailable" });
     } else {
       let gate: V3GateResult | null = null;
       try {
@@ -445,6 +469,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate threw; passing open (proceeding with selection)",
         );
+        recordGateRun({ pass: true, reason: "gate_error" });
       }
       if (gate) {
         log.info(
@@ -455,6 +480,13 @@ export async function orchestrate(
           },
           "memory-v3 injection gate decision",
         );
+        recordGateRun({
+          pass: gate.pass,
+          reason: gate.reason,
+          top_dense_score: gate.topDenseScore,
+          top_norm_sparse_score: gate.topNormSparseScore,
+          checked_articles: gate.checkedArticles,
+        });
         if (!gate.pass) {
           // A closed gate produces no finder lane and no matched sections; only
           // the `selections` differ between bypass (stable prefix) and hard-skip.


### PR DESCRIPTION
## Summary

Emits one `watchdog` telemetry event — `check_name: "memory_v3_injection_gate"`, `value: 1` — per memory-v3 injection-gate run, so the platform can count gate activity across all assistants.

- **Scored decisions** record `pass`, `reason`, `top_dense_score`, `top_norm_sparse_score`, `checked_articles` in `detail` (metadata only, no conversation content).
- **Pass-open paths** record their reason codes too: `dense_unavailable` (no live dense hits) and `gate_error` (gate threw).
- `checkV3Gate` stays pure — the emit lives in `orchestrate.ts` beside the existing decision logs, try/catch-wrapped so a telemetry failure can never cost a turn its memory. `recordWatchdogEvent` already honors the collectUsageData opt-out and writes to the dedicated telemetry DB.

No ingest/schema changes needed anywhere: `check_name` is an open string set through the platform's watchdog pipeline (serializer → GCS NDJSON → `watchdog_raw` external table → `stg_telemetry__watchdog`).

Companion platform PR adds the `/admin/memory` admin page charting these events (summary tiles, daily pass/close, reason breakdown).

## Rollout note

The `memory-v3-injection-gate` flag is now default-on remotely, so these events start flowing as soon as this ships — one event per turn on gate-enabled assistants, well within existing per-turn telemetry volume (`turn`, `tool_executed`).

## Testing

- `bun test src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts` — 48 pass (4 new: event shape on pass, close, dense-unavailable; no events when the gate is disabled/omitted)
- `tsgo --noEmit` clean; prettier applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)