### PR TITLE
fix(gateway): stop dual-writing dropped telemetry columns to the assistant mirror

### DIFF
--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -112,9 +112,6 @@ function initAssistantDb(): Database {
       invite_id TEXT,
       revoked_reason TEXT,
       blocked_reason TEXT,
-      last_seen_at INTEGER,
-      interaction_count INTEGER NOT NULL DEFAULT 0,
-      last_interaction INTEGER,
       updated_at INTEGER,
       created_at INTEGER NOT NULL
     )
@@ -466,6 +463,51 @@ describe("handleContactPromptSubmit", () => {
 
     // A successful non-guardian upsert invalidates the daemon contact caches.
     expectEmittedContactsChanged(ipcMock);
+  });
+
+  test("non-guardian prompt — mirrors the new channel into the post-317 assistant DB (no dropped-column write)", async () => {
+    // Regression: the assistant DB dropped interaction_count/last_seen_at/
+    // last_interaction (migration 317). The dual-write mirror INSERT must write
+    // only surviving columns; a dropped-column reference would throw and be
+    // swallowed by the best-effort catch, silently stranding the mirror row.
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-mirror-317",
+        address: "carol@example.com",
+        channelType: "email",
+        role: "trusted-contact",
+        displayName: "Carol",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const gwChannelRows = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.address, "carol@example.com"))
+      .all();
+    expect(gwChannelRows).toHaveLength(1);
+
+    // The mirror INSERT succeeded against the post-317 schema: the assistant DB
+    // has the channel row under the same gateway contact + channel id.
+    const asChannels = testAssistantDb!
+      .prepare(
+        `SELECT id, contact_id AS contactId, type, address, is_primary AS isPrimary
+           FROM contact_channels WHERE address = ?`,
+      )
+      .all("carol@example.com") as {
+      id: string;
+      contactId: string;
+      type: string;
+      address: string;
+      isPrimary: number;
+    }[];
+    expect(asChannels).toHaveLength(1);
+    expect(asChannels[0].id).toBe(gwChannelRows[0].id);
+    expect(asChannels[0].contactId).toBe(gwChannelRows[0].contactId);
+    expect(asChannels[0].type).toBe("email");
+    expect(asChannels[0].isPrimary).toBe(1);
   });
 
   test("non-guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1780,8 +1780,8 @@ export class ContactStore {
           `INSERT INTO contact_channels
              (id, contact_id, type, address, is_primary,
               external_chat_id,
-              interaction_count, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+              created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           [
             channelId,
             contactId,

--- a/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
@@ -50,9 +50,6 @@ interface AssistantChannelRow {
   invite_id: string | null;
   revoked_reason: string | null;
   blocked_reason: string | null;
-  last_seen_at: number | null;
-  interaction_count: number;
-  last_interaction: number | null;
   created_at: number;
   updated_at: number | null;
 }
@@ -128,8 +125,7 @@ export async function up(): Promise<MigrationResult> {
       `SELECT id, contact_id, type, address, is_primary, external_chat_id,
               status, policy, verified_at, verified_via,
               ${await assistantInviteIdSelect()},
-              revoked_reason, blocked_reason, last_seen_at,
-              interaction_count, last_interaction, created_at, updated_at
+              revoked_reason, blocked_reason, created_at, updated_at
          FROM contact_channels`,
     );
 
@@ -191,7 +187,7 @@ export async function up(): Promise<MigrationResult> {
             status, policy, verified_at, verified_via, invite_id,
             revoked_reason, blocked_reason, last_seen_at,
             interaction_count, last_interaction, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, NULL, ?, ?)`,
       );
       const txn = gwDb.transaction(() => {
         for (const ch of missingChannels) {
@@ -218,9 +214,6 @@ export async function up(): Promise<MigrationResult> {
             ch.invite_id,
             ch.revoked_reason,
             ch.blocked_reason,
-            ch.last_seen_at,
-            ch.interaction_count,
-            ch.last_interaction,
             ch.created_at,
             ch.updated_at,
           );


### PR DESCRIPTION
## Summary
Migration 317 dropped interaction_count/last_seen_at/last_interaction from the assistant contact_channels, but the gateway dual-write mirror INSERT still wrote interaction_count, so post-317 every new-channel mirror INSERT threw 'no such column' and was silently swallowed. Remove the dropped column(s) from the assistant-DB-targeted raw SQL so the mirror write succeeds again.

Self-review remediation for plan contacts-acl-cleanup.md.