### PR TITLE
feat(memory): default the injection-gate flag on in the registry fallback

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -359,8 +359,8 @@
       "scope": "assistant",
       "key": "memory-v3-injection-gate",
       "label": "Memory v3 injection gate",
-      "description": "Per-turn injection gate for memory v3: after the BM25F needle + dense cosine finder lanes run, skip the selectPool LLM call (inject nothing) when finder-lane scores fall below the configured thresholds (memory.v3.gate). Default off.",
-      "defaultEnabled": false
+      "description": "Per-turn injection gate for memory v3: after the BM25F needle + dense cosine finder lanes run, skip the selectPool LLM call (inject nothing) when finder-lane scores fall below the configured thresholds (memory.v3.gate). Default on (flipped remotely July 2026); this registry value is the fallback when no platform snapshot is available.",
+      "defaultEnabled": true
     },
     {
       "id": "self-intro-greeting",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -359,8 +359,8 @@
       "scope": "assistant",
       "key": "memory-v3-injection-gate",
       "label": "Memory v3 injection gate",
-      "description": "Per-turn injection gate for memory v3: after the BM25F needle + dense cosine finder lanes run, skip the selectPool LLM call (inject nothing) when finder-lane scores fall below the configured thresholds (memory.v3.gate). Default off.",
-      "defaultEnabled": false
+      "description": "Per-turn injection gate for memory v3: after the BM25F needle + dense cosine finder lanes run, skip the selectPool LLM call (inject nothing) when finder-lane scores fall below the configured thresholds (memory.v3.gate). Default on (flipped remotely July 2026); this registry value is the fallback when no platform snapshot is available.",
+      "defaultEnabled": true
     },
     {
       "id": "self-intro-greeting",


### PR DESCRIPTION
## Summary

`memory-v3-injection-gate` was flipped default-on remotely (LaunchDarkly, July 2026). This aligns the in-repo registry fallback — `defaultEnabled: false → true` plus a description update — so assistants that can't reach a platform flag snapshot run the gate like the rest of the fleet instead of silently diverging (and going dark on the new /admin/memory gate telemetry).

No platform terraform change is needed: the LaunchDarkly module manages flag existence/metadata only and `ignore_changes` covers `defaults`/targeting, so the dashboard flip is authoritative and won't be reverted by terraform.

## ⚠️ Deliberately NOT synced via `sync-bundled-copies.ts`

The committed `clients/web` registry copy has **drifted from `meta/`**: `research-onboarding` and `personality-onboarding` are GA-on in the bundled copy but still spike/off in the canonical meta registry. Running the documented sync script would therefore silently revert that GA flip. This PR edits the gate entry in both files directly and leaves the onboarding entries untouched; the meta back-port for those two flags should be its own reviewed change (flagging to the onboarding owners). The `assistant/` and `gateway/` copies are gitignored build-time artifacts and pick this up automatically.

## Testing

- Both JSON files parse; diff is exactly the one flag entry in each (2 files, 4 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)