### PR TITLE
fix(calls): harden telephony streaming STT (whisper batch gating, close fallback, stranded turn)

### DIFF
--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -899,6 +899,97 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    test("unexpected provider close mid-call falls back to batch for subsequent turns", async () => {
+      const onTranscriptFinal = jest.fn();
+      const { session, fake } = await startStreamingSession(
+        { onTranscriptFinal },
+        { turnDetector: { silenceThresholdMs: 300 } },
+      );
+
+      // Provider closes the stream without the session asking it to.
+      fake.emit({ type: "closed" });
+
+      // A subsequent caller turn must be transcribed via batch.
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+
+      expect(resolveBatchTranscriber).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello world",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
+    test("deliberate stop does not trigger batch fallback on close", async () => {
+      const onStop = jest.fn();
+      const onTranscriptFinal = jest.fn();
+      const { session, fake } = await startStreamingSession(
+        { onStop, onTranscriptFinal },
+        { turnDetector: { silenceThresholdMs: 300 } },
+      );
+
+      session.handleMessage(makeStopMessage());
+      fake.emit({ type: "closed" });
+
+      // Late media after the stop must not be batch-transcribed.
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+
+      expect(onStop).toHaveBeenCalledTimes(1);
+      expect(resolveTelephonySttCapability).not.toHaveBeenCalled();
+      expect(resolveBatchTranscriber).not.toHaveBeenCalled();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      session.dispose();
+    });
+
+    test("close after dispose does not trigger batch fallback", async () => {
+      const { session, fake } = await startStreamingSession();
+
+      session.dispose();
+      fake.emit({ type: "closed" });
+
+      expect(resolveTelephonySttCapability).not.toHaveBeenCalled();
+    });
+
+    test("turn completed during transcriber startup is transcribed on batch fallback", async () => {
+      const fake = new FakeStreamingTranscriber({ deferStart: true });
+      (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
+
+      const onTranscriptFinal = jest.fn();
+      const session = new MediaStreamSttSession(
+        { turnDetector: { silenceThresholdMs: 300 } },
+        { onTranscriptFinal },
+      );
+
+      session.handleMessage(makeStartMessage());
+      await flushAsync();
+
+      // Speech arrives and the local VAD completes the turn while the
+      // provider session is still starting.
+      session.handleMessage(makeMediaMessage());
+      jest.advanceTimersByTime(400);
+      await flushAsync();
+      expect(onTranscriptFinal).not.toHaveBeenCalled();
+
+      // Startup then fails — the completed turn must not be stranded.
+      fake.failStart(new Error("connect timeout"));
+      await flushAsync();
+
+      expect(onTranscriptFinal).toHaveBeenCalledTimes(1);
+      expect(onTranscriptFinal).toHaveBeenCalledWith(
+        "hello world",
+        expect.any(Number),
+      );
+
+      session.dispose();
+    });
+
     test("falls back to batch when the streaming transcriber fails to start", async () => {
       const fake = new FakeStreamingTranscriber({ deferStart: true });
       (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -1,8 +1,9 @@
 /**
  * STT session module for media-stream call ingestion.
  *
- * Transcribes inbound caller audio in one of two modes, selected once at
- * the `start` event and never mixed mid-session:
+ * Transcribes inbound caller audio in one of two modes, selected at the
+ * `start` event (streaming additionally falls back to batch if the
+ * provider closes the stream mid-call):
  *
  * - **Streaming** (default, `calls.voice.telephonyStreaming: true`) —
  *   inbound mu-law audio is decoded to 16 kHz PCM16 and fed to a
@@ -15,8 +16,9 @@
  *   oldest frames and is counted + logged at teardown).
  * - **Batch** — segmented audio turns (produced by
  *   {@link MediaTurnDetector}) are transcribed per turn via the batch
- *   transcriber. Used when the streaming flag is off or no streaming
- *   transcriber is available for the configured provider.
+ *   transcriber. Used when the streaming flag is off, no streaming
+ *   transcriber is available for the configured provider, or the
+ *   provider closed the streaming session unexpectedly mid-call.
  *
  * This module is **transport-neutral** — it exposes callback hooks
  * (`onSpeechStart`, `onTranscriptFinal`, `onDtmf`, `onStop`) rather than
@@ -95,11 +97,12 @@ const STREAMING_AUDIO_MIME_TYPE = `audio/pcm;rate=${STREAMING_SAMPLE_RATE}`;
 const DEFAULT_STREAMING_STARTUP_BUFFER_FRAMES = 500;
 
 /**
- * Transcription mode, selected once at the `start` event:
+ * Transcription mode, selected at the `start` event:
  * - `"batch"` — per-turn batch transcription via {@link MediaTurnDetector}.
  * - `"streaming-pending"` — streaming selected; provider session still
  *   starting, frames buffered.
- * - `"streaming"` — live streaming session active.
+ * - `"streaming"` — live streaming session active. Falls back to
+ *   `"batch"` if the provider closes the stream unexpectedly mid-call.
  */
 type SttSessionMode = "batch" | "streaming-pending" | "streaming";
 
@@ -175,6 +178,22 @@ export class MediaStreamSttSession {
   /** Live streaming transcriber (streaming mode only). */
   private streamingTranscriber: StreamingTranscriber | null = null;
 
+  /**
+   * Whether the session deliberately stopped the streaming transcriber
+   * (stream `stop` event or dispose). Distinguishes expected `closed`
+   * events from provider-initiated closes, which trigger batch fallback.
+   */
+  private deliberateStreamingStop = false;
+
+  /**
+   * Duration of a turn the local VAD completed while the mode was
+   * `streaming-pending`. Its audio stays in {@link currentTurnChunks};
+   * {@link enterBatchMode} transcribes it if streaming never
+   * materializes. Cleared when a new turn starts (which resets the
+   * chunk buffer) or when streaming settles.
+   */
+  private pendingCompletedTurnDurationMs: number | null = null;
+
   /** PCM16 frames buffered while the streaming transcriber starts up. */
   private startupFrames: Buffer[] = [];
 
@@ -207,6 +226,7 @@ export class MediaStreamSttSession {
         // Clear inter-turn silence that accumulated while idle so each
         // transcription request contains only speech-relevant chunks.
         this.currentTurnChunks = [];
+        this.pendingCompletedTurnDurationMs = null;
         this.callbacks.onSpeechStart?.();
       },
       onTurnEnd: (reason, durationMs) => {
@@ -254,6 +274,7 @@ export class MediaStreamSttSession {
    */
   dispose(): void {
     this.disposed = true;
+    this.deliberateStreamingStop = true;
     this.activeTranscriptionAbort?.abort();
     this.activeTranscriptionAbort = null;
     this.turnDetector.dispose();
@@ -353,6 +374,7 @@ export class MediaStreamSttSession {
     this.turnDetector.forceEnd();
     // Streaming: signal end-of-audio so the provider flushes any withheld
     // utterance text as a trailing final before closing.
+    this.deliberateStreamingStop = true;
     stopStreamingBestEffort(this.streamingTranscriber);
     this.logStartupDrops();
     this.callbacks.onStop?.();
@@ -421,17 +443,36 @@ export class MediaStreamSttSession {
 
     // The batch fallback is settled — drop its turn buffer.
     this.currentTurnChunks = [];
+    this.pendingCompletedTurnDurationMs = null;
   }
 
   /**
    * Settle on the batch path: clear streaming startup state and eagerly
    * resolve the telephony capability so it's cached by the time the
    * first turn completes.
+   *
+   * A turn that the local VAD already completed while streaming was
+   * pending is stranded — {@link handleTurnEnd} deferred it to streaming
+   * finals that will never arrive — so it is batch-transcribed here.
+   * (A turn still in progress needs no special handling: it ends later
+   * through the normal batch path with its buffered chunks intact.)
    */
   private enterBatchMode(): void {
     this.mode = "batch";
     this.startupFrames = [];
-    this.capabilityPromise = resolveTelephonySttCapability();
+    this.capabilityPromise ??= resolveTelephonySttCapability();
+
+    const durationMs = this.pendingCompletedTurnDurationMs;
+    this.pendingCompletedTurnDurationMs = null;
+    if (durationMs !== null && this.currentTurnChunks.length > 0) {
+      const chunks = this.currentTurnChunks;
+      this.currentTurnChunks = [];
+      log.info(
+        { streamSid: this.streamSid, chunkCount: chunks.length, durationMs },
+        "Transcribing turn completed during streaming startup via batch fallback",
+      );
+      void this.transcribeTurn(chunks, durationMs);
+    }
   }
 
   /**
@@ -463,6 +504,17 @@ export class MediaStreamSttSession {
         return;
       case "closed":
         this.streamingTranscriber = null;
+        // Provider-initiated close mid-call: without a live transcriber
+        // the streaming mode would silently drop all subsequent audio.
+        // Fall back to per-turn batch transcription (the local VAD/turn
+        // detector already runs in streaming mode).
+        if (this.mode === "streaming" && !this.deliberateStreamingStop) {
+          log.warn(
+            { streamSid: this.streamSid, callSid: this.callSid },
+            "Streaming transcriber closed unexpectedly mid-call — falling back to batch STT",
+          );
+          this.enterBatchMode();
+        }
         return;
     }
   }
@@ -501,8 +553,13 @@ export class MediaStreamSttSession {
     durationMs: number,
   ): Promise<void> {
     // Streaming modes take turn boundaries from the transcriber's
-    // utterance-boundary finals, not the local VAD.
+    // utterance-boundary finals, not the local VAD. A turn completed
+    // while streaming is still pending is recorded so a later batch
+    // fallback can transcribe its buffered audio.
     if (this.mode !== "batch") {
+      if (this.mode === "streaming-pending") {
+        this.pendingCompletedTurnDurationMs = durationMs;
+      }
       return;
     }
 
@@ -515,6 +572,14 @@ export class MediaStreamSttSession {
       return;
     }
 
+    await this.transcribeTurn(chunks, durationMs);
+  }
+
+  /** Batch-transcribe a completed turn's audio chunks. */
+  private async transcribeTurn(
+    chunks: string[],
+    durationMs: number,
+  ): Promise<void> {
     // Resolve telephony capability (cached after first call)
     if (!this.capabilityPromise) {
       this.capabilityPromise = resolveTelephonySttCapability();

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -830,7 +830,7 @@ describe("resolveStreamingTranscriber diarize preference", () => {
     expect(transcriber).toBeNull();
     expect(xaiCtorCalls).toHaveLength(0);
     expect(loggerWarnings).toHaveLength(1);
-    expect(loggerWarnings[0]!.message).toContain("per-segment finals");
+    expect(loggerWarnings[0]!.message).toContain("falling back to batch");
     expect(
       (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
     ).toBe("xai");
@@ -851,7 +851,7 @@ describe("resolveStreamingTranscriber diarize preference", () => {
     expect(options.utteranceEndMs).toBe(1000);
   });
 
-  test("utteranceBoundaryFinals with google-gemini still resolves (finals already pause-aligned)", async () => {
+  test("utteranceBoundaryFinals with google-gemini returns null (catalog telephonyMode is batch-only)", async () => {
     mockProviderKeys["gemini"] = "gemini-key";
     mockConfig = buildConfig({ provider: "google-gemini" });
 
@@ -859,17 +859,36 @@ describe("resolveStreamingTranscriber diarize preference", () => {
       utteranceBoundaryFinals: true,
     });
 
-    expect(transcriber).not.toBeNull();
-    expect(geminiCtorCalls).toHaveLength(1);
+    expect(transcriber).toBeNull();
+    expect(geminiCtorCalls).toHaveLength(0);
+    expect(loggerWarnings).toHaveLength(1);
+    expect(
+      (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
+    ).toBe("google-gemini");
   });
 
-  test("utteranceBoundaryFinals with openai-whisper still resolves (finals already pause-aligned)", async () => {
+  test("utteranceBoundaryFinals with openai-whisper returns null with a warning (finals fire only on stop — end-of-stream, not utterance boundary)", async () => {
     mockProviderKeys["openai"] = "openai-key";
     mockConfig = buildConfig({ provider: "openai-whisper" });
 
     const transcriber = await resolveStreamingTranscriber({
       utteranceBoundaryFinals: true,
     });
+
+    expect(transcriber).toBeNull();
+    expect(whisperCtorCalls).toHaveLength(0);
+    expect(loggerWarnings).toHaveLength(1);
+    expect(loggerWarnings[0]!.message).toContain("falling back to batch");
+    expect(
+      (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
+    ).toBe("openai-whisper");
+  });
+
+  test("openai-whisper still resolves a streaming transcriber without utteranceBoundaryFinals", async () => {
+    mockProviderKeys["openai"] = "openai-key";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveStreamingTranscriber();
 
     expect(transcriber).not.toBeNull();
     expect(whisperCtorCalls).toHaveLength(1);

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -261,15 +261,14 @@ export interface ResolveStreamingTranscriberOptions {
    */
   diarize?: DiarizePreference;
   /**
-   * Emit `final` events only at utterance boundaries on providers that
-   * otherwise commit multiple `is_final` segments per utterance
-   * (Deepgram — also enables its `utterance_end_ms` endpointing).
-   * Ignored by providers whose finals already align with pause
-   * boundaries (google-gemini emits finals at turn completion,
-   * openai-whisper on stop). Providers that can neither gate nor align
-   * (xAI emits a `final` per committed segment) resolve to `null` so
-   * the caller falls back to batch transcription. Used by telephony
-   * call ingestion. Default: false.
+   * Emit `final` events only at utterance boundaries. Supported only by
+   * providers whose catalog `telephonyMode` is `"realtime-ws"` (Deepgram,
+   * where it also enables `utterance_end_ms` endpointing). All other
+   * providers resolve to `null` so the caller falls back to per-turn
+   * batch transcription — e.g. openai-whisper fires `final` only from
+   * `stop()` (end-of-stream, not end-of-utterance) and xAI emits a
+   * `final` per committed segment. Used by telephony call ingestion.
+   * Default: false.
    */
   utteranceBoundaryFinals?: boolean;
 }
@@ -289,8 +288,8 @@ export interface ResolveStreamingTranscriberOptions {
  * - No credentials are configured for the resolved provider.
  * - No streaming adapter exists for the configured provider.
  * - `diarize` is `"required"` but the configured provider cannot diarize.
- * - `utteranceBoundaryFinals` is set but the configured provider commits
- *   per-segment finals with no boundary gating (xAI).
+ * - `utteranceBoundaryFinals` is set but the configured provider's catalog
+ *   `telephonyMode` is not `"realtime-ws"`.
  */
 export async function resolveStreamingTranscriber(
   options: ResolveStreamingTranscriberOptions = {},
@@ -310,6 +309,26 @@ export async function resolveStreamingTranscriber(
   // Verify the provider supports the daemon-streaming boundary.
   if (!supportsBoundary(provider as SttProviderId, "daemon-streaming")) {
     return null;
+  }
+
+  // Boundary-requiring callers (telephony) can only stream on providers
+  // whose catalog telephonyMode is "realtime-ws" (Deepgram gates finals on
+  // utterance boundaries). Everything else fires `final` either only from
+  // stop() — end-of-stream, not end-of-utterance (openai-whisper) — or per
+  // committed segment (xAI), so streaming would yield no replies until
+  // hangup, or mid-sentence replies. Resolve to null so the caller falls
+  // back to per-turn batch transcription.
+  if (options.utteranceBoundaryFinals) {
+    const telephonyMode = getProviderEntry(
+      provider as SttProviderId,
+    )?.telephonyMode;
+    if (telephonyMode !== "realtime-ws") {
+      log.warn(
+        { providerId: provider, telephonyMode },
+        "utterance-boundary finals requested but the configured STT provider has no realtime telephony streaming — falling back to batch transcription",
+      );
+      return null;
+    }
   }
 
   // Resolve diarization capability against the catalog. For `"required"`
@@ -363,9 +382,9 @@ interface CreateStreamingTranscriberOptions {
   diarize?: boolean;
   /**
    * Whether `final` events should be gated on utterance boundaries.
-   * Only forwarded to providers that commit multiple segments per
-   * utterance (Deepgram). Ignored by adapters whose finals already
-   * align with pause boundaries.
+   * Only forwarded to Deepgram; the resolver never sets this for
+   * providers without realtime telephony streaming (they resolve to
+   * `null` instead).
    */
   utteranceBoundaryFinals?: boolean;
 }
@@ -418,17 +437,6 @@ async function createStreamingTranscriber(
       });
     }
     case "xai": {
-      // The xAI adapter emits a `final` for every committed `is_final`
-      // segment; segments are not utterance-aligned and the adapter has no
-      // boundary gating, so a boundary-requiring caller (telephony) would
-      // reply mid-sentence. Resolve to null so it falls back to batch.
-      if (options.utteranceBoundaryFinals) {
-        log.warn(
-          { providerId },
-          "utterance-boundary finals requested but the xAI streaming adapter commits per-segment finals — falling back to batch transcription",
-        );
-        return null;
-      }
       const { XAIRealtimeTranscriber } = await import("./xai-realtime.js");
       return new XAIRealtimeTranscriber(apiKey, {
         sampleRate: options.sampleRate,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for phone-media-stream-v2.md.
- openai-whisper is gated out of telephony streaming (finals only fire on stop — end-of-stream, not utterance boundary); falls back to per-turn batch. Implemented as a catalog-driven gate: `resolveStreamingTranscriber({ utteranceBoundaryFinals: true })` resolves to null for any provider whose catalog `telephonyMode` is not `realtime-ws`, replacing the per-provider xAI branch. This also moves google-gemini telephony to batch, consistent with its `batch-only` catalog entry. Deepgram keeps streaming.
- Unexpected provider-initiated stream close now falls back to batch instead of leaving the call deaf (deliberate stop/dispose is distinguished by a flag)
- A turn completed during transcriber startup is transcribed on batch fallback instead of being stranded (recorded with its real VAD duration; silence-only buffered audio with no completed turn is not flushed)