### PR TITLE
feat(web): PluginIcon renders an optional author emoji

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Tests for `PluginIcon`: glyph defaulting by `external` and the `sm` / `md`
- * container sizing that matches `SkillIcon`.
+ * Tests for `PluginIcon`: the author `icon` emoji, glyph defaulting by
+ * `external`, and the `sm` / `md` container sizing that matches `SkillIcon`.
  *
  * Mounted via `@testing-library/react` (happy-dom — see
  * `clients/web/test-setup.ts`).
@@ -20,6 +20,11 @@ const PACKAGE = "\u{1F4E6}"; // 📦
 const PUZZLE = "\u{1F9E9}"; // 🧩
 
 describe("PluginIcon", () => {
+  test("renders the provided icon emoji", () => {
+    const { container } = render(<PluginIcon icon="🚀" />);
+    expect(container.textContent).toBe("🚀");
+  });
+
   test("defaults to 📦 when external", () => {
     const { container } = render(<PluginIcon external />);
     expect(container.textContent).toBe(PACKAGE);

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
+  icon?: string;
   size?: "sm" | "md";
   className?: string;
 }
@@ -14,16 +15,17 @@ const SIZE_CLASS = {
 /**
  * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
  * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
- * icon-image endpoint, so there is no remote-image branch. The glyph
- * follows the existing Plugins convention: 📦 for catalog (external),
- * 🧩 otherwise.
+ * icon-image endpoint, so there is no remote-image branch. Renders the
+ * author-provided `icon` emoji when present, otherwise the origin glyph:
+ * 📦 for catalog (external), 🧩 otherwise.
  */
 export function PluginIcon({
   external = false,
+  icon,
   size = "sm",
   className,
 }: PluginIconProps) {
-  const glyph = external ? "\u{1F4E6}" : "\u{1F9E9}";
+  const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
 
   return (
     <span


### PR DESCRIPTION
## Summary
- `PluginIcon` accepts an optional `icon` string and renders it (author emoji) when present, else the existing 📦/🧩 origin glyph.
- Pure component change; caller wiring lands in later PRs.

Part of plan: plugin-custom-icons.md (PR 4 of 12)