### PR TITLE
feat(web): add a version gate for plugin icons

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useSupportsPluginIcons } from "@/lib/backwards-compat/use-supports-plugin-icons";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+function check(version: string | null): boolean {
+  setVersion(version);
+  const { result } = renderHook(() => useSupportsPluginIcons());
+  return result.current;
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("useSupportsPluginIcons", () => {
+  test("returns false when the version is unknown", () => {
+    expect(check(null)).toBe(false);
+    expect(check("")).toBe(false);
+  });
+
+  test("returns true at exactly MIN_VERSION (0.10.5)", () => {
+    expect(check("0.10.5")).toBe(true);
+  });
+
+  test("returns true for dev builds ahead of MIN_VERSION", () => {
+    expect(check("0.10.5-dev.202606211252.5cf8576")).toBe(true);
+  });
+
+  test("returns true for versions above MIN_VERSION", () => {
+    expect(check("0.10.6")).toBe(true);
+    expect(check("0.11.0")).toBe(true);
+    expect(check("1.0.0")).toBe(true);
+  });
+
+  test("returns false for versions below MIN_VERSION", () => {
+    expect(check("0.10.4")).toBe(false);
+    expect(check("0.9.0")).toBe(false);
+  });
+
+  test("returns false for unparseable versions", () => {
+    expect(check("not-a-version")).toBe(false);
+    expect(check("0.10")).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
@@ -1,0 +1,31 @@
+/**
+ * Backwards-compat gate: plugin custom icons.
+ *
+ * Plugins can carry a custom icon served by the daemon's plugin-icon
+ * endpoint. The web app renders that icon via an `<img>` pointed at the
+ * endpoint, so it must only do so when the active assistant is known to
+ * serve it — an older daemon 404s the request and the image breaks.
+ *
+ * The web app always serves the latest bundle, but the assistant can be
+ * any locally-installed version. Emoji/text icons degrade naturally via
+ * the optional field, so this gate only guards the `<img>` path.
+ *
+ * MIN_VERSION is a placeholder for the release that ships the icon
+ * endpoint; bump it to that release when it is cut.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.5";
+
+/**
+ * Returns `true` when the active assistant serves the plugin-icon
+ * endpoint. Subscribes to the identity store so consumers re-render when
+ * the assistant version crosses `MIN_VERSION`.
+ *
+ * Returns `false` while the identity store has no version yet, when the
+ * version is unparseable, or when it falls below `MIN_VERSION` — callers
+ * fall back to the non-`<img>` icon on the `false` branch.
+ */
+export function useSupportsPluginIcons(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
@@ -10,8 +10,8 @@
  * any locally-installed version. Emoji/text icons degrade naturally via
  * the optional field, so this gate only guards the `<img>` path.
  *
- * MIN_VERSION is a placeholder for the release that ships the icon
- * endpoint; bump it to that release when it is cut.
+ * MIN_VERSION is the minimum assistant version that serves the
+ * plugin-icon endpoint.
  */
 import { useAssistantSupports } from "./utils";
 


### PR DESCRIPTION
## Summary
- Add `useSupportsPluginIcons()` (mirrors `plugins-surface.ts`), MIN_VERSION 0.10.5 placeholder, gating the plugin-icon endpoint for older daemons.
- Test mirrors the vision-attachment-gate boundaries.

Part of plan: plugin-custom-icons.md (PR 7 of 12)