### PR TITLE
feat(plugins): read an author `vellum.icon` emoji from plugin package.json

### DIFF
--- a/assistant/src/cli/lib/__tests__/list-installed-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/list-installed-plugins.test.ts
@@ -78,6 +78,42 @@ describe("listInstalledPlugins", () => {
     expect(result.every((p) => p.issues.length === 0)).toBe(true);
   });
 
+  test("surfaces a valid vellum.icon emoji on packageJson", () => {
+    mkdirSync(join(pluginsDir, "iconed"));
+    writeFileSync(
+      join(pluginsDir, "iconed", "package.json"),
+      JSON.stringify({
+        name: "iconed",
+        version: "1.0.0",
+        vellum: { icon: "🚀" },
+      }),
+    );
+
+    const result = listInstalledPlugins({ workspacePluginsDir: pluginsDir });
+    expect(result[0]!.packageJson?.icon).toBe("🚀");
+  });
+
+  test.each([
+    ["missing vellum block", { name: "p", version: "1.0.0" }],
+    ["non-string icon", { name: "p", version: "1.0.0", vellum: { icon: 42 } }],
+    ["empty icon", { name: "p", version: "1.0.0", vellum: { icon: "" } }],
+    [
+      "over-long icon",
+      { name: "p", version: "1.0.0", vellum: { icon: "x".repeat(17) } },
+    ],
+  ])("leaves icon undefined for %s", (_label, pkg) => {
+    mkdirSync(join(pluginsDir, "no-icon"));
+    writeFileSync(
+      join(pluginsDir, "no-icon", "package.json"),
+      JSON.stringify(pkg),
+    );
+
+    const result = listInstalledPlugins({ workspacePluginsDir: pluginsDir });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.packageJson?.icon).toBeUndefined();
+    expect(result[0]!.issues).toEqual([]);
+  });
+
   test("reports missing package.json as an issue rather than failing", () => {
     mkdirSync(join(pluginsDir, "barebones"));
 

--- a/assistant/src/cli/lib/__tests__/plugin-artifact.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-artifact.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parsePluginArtifact } from "../plugin-artifact.js";
+import { parsePluginArtifact, parsePluginIcon } from "../plugin-artifact.js";
 
 const VALID_SHA = "a".repeat(64);
 
@@ -179,5 +179,58 @@ describe("parsePluginArtifact", () => {
     // WHEN we parse a non-object package.json value
     // THEN nothing is surfaced
     expect(parsePluginArtifact(value)).toBeNull();
+  });
+});
+
+describe("parsePluginIcon", () => {
+  test("returns the emoji when vellum.icon is a short glyph", () => {
+    expect(parsePluginIcon({ vellum: { icon: "🚀" } })).toBe("🚀");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(parsePluginIcon({ vellum: { icon: "  🎯 " } })).toBe("🎯");
+  });
+
+  test("accepts a multi-code-point glyph within the bound", () => {
+    // A ZWJ family emoji is several code points but well under the cap.
+    const family = "👩‍👩‍👧‍👦";
+    expect(parsePluginIcon({ vellum: { icon: family } })).toBe(family);
+  });
+
+  test("accepts a value at exactly the 16-code-point bound", () => {
+    const sixteen = "a".repeat(16);
+    expect(parsePluginIcon({ vellum: { icon: sixteen } })).toBe(sixteen);
+  });
+
+  test.each([
+    ["no vellum block", { name: "x" }],
+    ["no icon field", { vellum: {} }],
+    ["icon is empty", { vellum: { icon: "" } }],
+    ["icon is whitespace-only", { vellum: { icon: "   " } }],
+    [
+      "icon is too long (>16 code points)",
+      { vellum: { icon: "x".repeat(17) } },
+    ],
+    ["icon is a number", { vellum: { icon: 42 } }],
+    ["icon is an object", { vellum: { icon: {} } }],
+    ["vellum is an array", { vellum: [] }],
+  ])("returns undefined for %s", (_label, pkg) => {
+    expect(parsePluginIcon(pkg)).toBeUndefined();
+  });
+
+  test.each([
+    ["null", null],
+    ["a string", "not-a-package"],
+    ["an array", []],
+    ["a number", 42],
+  ])("returns undefined when package.json is %s", (_label, value) => {
+    expect(parsePluginIcon(value)).toBeUndefined();
+  });
+
+  test("does not count a >16-code-point emoji sequence as valid", () => {
+    // 17 rocket emoji: 17 code points, over the cap.
+    expect(
+      parsePluginIcon({ vellum: { icon: "🚀".repeat(17) } }),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -16,6 +16,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { parsePluginIcon } from "./plugin-artifact.js";
 
 /**
  * Directory containing first-party default plugin packages. Each subdirectory
@@ -38,6 +39,8 @@ export interface PluginPackageMetadata {
   readonly version?: string;
   readonly description?: string;
   readonly peerDependencies?: Record<string, string>;
+  /** Author-supplied short glyph (emoji) from `vellum.icon`, when present. */
+  readonly icon?: string;
 }
 
 /** One installed plugin entry. */
@@ -160,6 +163,7 @@ function readPluginEntry(
   }
 
   const meta = parsed as Record<string, unknown>;
+  const icon = parsePluginIcon(meta);
   const packageJson: PluginPackageMetadata = {
     name: typeof meta.name === "string" ? meta.name : undefined,
     version: typeof meta.version === "string" ? meta.version : undefined,
@@ -171,6 +175,7 @@ function readPluginEntry(
       !Array.isArray(meta.peerDependencies)
         ? (meta.peerDependencies as Record<string, string>)
         : undefined,
+    ...(icon ? { icon } : {}),
   };
 
   return { name, target, packageJson, issues };
@@ -206,9 +211,7 @@ export function listAllPlugins(
   // ── User plugins ───────────────────────────────────────────────────────
   // Filter out default-plugin stub directories (created by `plugins disable
   // default-<name>`) so they don't show up as duplicate user entries.
-  const defaultNames = new Set(
-    readDefaultPluginManifests().map((m) => m.name),
-  );
+  const defaultNames = new Set(readDefaultPluginManifests().map((m) => m.name));
   const userPlugins: AllPluginInfo[] = listInstalledPlugins(opts)
     .filter((entry) => !defaultNames.has(entry.name))
     .map((entry) => ({
@@ -255,7 +258,12 @@ export function listAllPlugins(
   );
   // enabledDefault and disabledDefault keep repo array order (no sort).
 
-  return [...enabledUser, ...disabledUser, ...enabledDefault, ...disabledDefault];
+  return [
+    ...enabledUser,
+    ...disabledUser,
+    ...enabledDefault,
+    ...disabledDefault,
+  ];
 }
 
 interface DefaultPluginManifest {
@@ -309,7 +317,10 @@ function getPluginInstallDate(plugin: AllPluginInfo): number {
   const metaPath = join(plugin.target, "install-meta.json");
   try {
     if (existsSync(metaPath)) {
-      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>;
+      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
       if (typeof raw.installedAt === "string") {
         const ms = Date.parse(raw.installedAt);
         if (Number.isFinite(ms)) return ms;

--- a/assistant/src/cli/lib/plugin-artifact.ts
+++ b/assistant/src/cli/lib/plugin-artifact.ts
@@ -101,3 +101,33 @@ export function parsePluginArtifact(
     ...(label ? { label } : {}),
   };
 }
+
+/** Upper bound on `vellum.icon`, in Unicode code points. */
+const MAX_ICON_CODE_POINTS = 16;
+
+/**
+ * Read `vellum.icon` from an already-parsed `package.json` value and return
+ * it only when it is a short, non-empty glyph (an emoji or similar). The
+ * value is trimmed and bounded to {@link MAX_ICON_CODE_POINTS} code points so
+ * it can never carry markup or a URL. Any other shape — missing block, wrong
+ * type, empty, or too long — yields `undefined` rather than throwing.
+ */
+export function parsePluginIcon(packageJson: unknown): string | undefined {
+  if (
+    typeof packageJson !== "object" ||
+    packageJson === null ||
+    Array.isArray(packageJson)
+  ) {
+    return undefined;
+  }
+  const vellum = (packageJson as Record<string, unknown>).vellum;
+  if (typeof vellum !== "object" || vellum === null || Array.isArray(vellum)) {
+    return undefined;
+  }
+  const icon = (vellum as Record<string, unknown>).icon;
+  if (typeof icon !== "string") return undefined;
+  const trimmed = icon.trim();
+  const codePoints = [...trimmed].length;
+  if (codePoints < 1 || codePoints > MAX_ICON_CODE_POINTS) return undefined;
+  return trimmed;
+}


### PR DESCRIPTION
## Summary
- Parse optional `vellum.icon` (short emoji string, ≤16 code points) from a plugin's package.json in the disk reader, mirroring the `vellum.artifact` parser's fail-closed style.
- Surface it on `InstalledPluginInfo.packageJson.icon`; wire schema follows in a later PR.

Part of plan: plugin-custom-icons.md (PR 1 of 12)