### PR TITLE
fix(web): clear stuck "thinking" indicator when snapshot processing is the undefined sentinel

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-seed-processing.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-seed-processing.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+
+// ---------------------------------------------------------------------------
+// Module mocks.
+//
+// `use-history-pagination` is stubbed so the test drives the post-load
+// (data-apply) effect directly; `latestPage.processing` carries the daemon's
+// authoritative flag under test. The interactions API is stubbed to `{}` so
+// the effect's async pending-interaction restore makes no network call — the
+// synchronous `seedSnapshot` is all this test asserts on.
+// ---------------------------------------------------------------------------
+const realPaginationModule = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
+
+let currentProcessing: boolean | undefined;
+
+function latestPageStub(): PaginatedHistoryResult {
+  return {
+    messages: [],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 10,
+    processing: currentProcessing,
+    backgroundToolCompletions: [],
+  };
+}
+
+function paginationStub(): HistoryPaginationResult {
+  return {
+    messages: [],
+    latestPage: latestPageStub(),
+    subagentNotifications: undefined,
+    backgroundToolCompletions: undefined,
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+    hasMore: false,
+    isFetchingOlderPages: false,
+    isFetching: false,
+    fetchOlderPage: () => {},
+    invalidate: async () => {},
+    removeCache: () => {},
+    latestPageOldestTimestamp: null,
+    oldestLoadedTimestamp: null,
+    dataUpdatedAt: 1,
+  };
+}
+
+mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
+  ...realPaginationModule,
+  useHistoryPagination: () => paginationStub(),
+}));
+
+mock.module("@/domains/chat/api/interactions", () => ({
+  getPendingInteractions: async () => ({}),
+}));
+
+const { useConversationHistory } = await import(
+  "@/domains/chat/hooks/use-conversation-history"
+);
+
+const queryClient = new QueryClient();
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderHistory() {
+  return renderHook(
+    () =>
+      useConversationHistory({
+        assistantId: "asst-1",
+        assistantStateKind: "active",
+        activeConversationId: "conv-A",
+      }),
+    { wrapper: Wrapper },
+  );
+}
+
+beforeEach(() => {
+  currentProcessing = undefined;
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+
+describe("useConversationHistory — seed carries the authoritative processing flag", () => {
+  test("plants processing:false from the fetched page onto the snapshot", () => {
+    /**
+     * The `snapshotProcessing === false` close-gate and the stream reducer
+     * (`nextProcessingState`) can only work from a defined flag, and only the
+     * seed can plant one — a snapshot seeded without it is pinned to the
+     * `undefined` sentinel for its whole life, leaving a stuck "Thinking…"
+     * indicator unrecoverable without a page refresh.
+     */
+    currentProcessing = false;
+
+    renderHistory();
+
+    expect(useChatSessionStore.getState().snapshot?.processing).toBe(false);
+  });
+
+  test("plants processing:true so a later terminal fold can clear it", () => {
+    currentProcessing = true;
+
+    renderHistory();
+
+    expect(useChatSessionStore.getState().snapshot?.processing).toBe(true);
+  });
+
+  test("keeps the undefined sentinel for pages from older daemons", () => {
+    currentProcessing = undefined;
+
+    renderHistory();
+
+    const snapshot = useChatSessionStore.getState().snapshot;
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.processing).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -187,6 +187,12 @@ export function useConversationHistory({
       hasMore: pagination.hasMore,
       oldestTimestamp: pagination.oldestLoadedTimestamp,
       oldestMessageId: pagination.latestPage?.oldestMessageId ?? null,
+      // The daemon's authoritative per-conversation `processing` flag must
+      // ride every (re)seed: the stream reducer can only advance a defined
+      // flag (`nextProcessingState` pins `undefined` forever), and the
+      // `snapshotProcessing === false` close-gate in
+      // `shouldShowThinkingIndicator` / `canStopGeneration` starves without it.
+      processing: pagination.latestPage?.processing,
     });
 
     setIsLoadingHistory(false);

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -139,6 +139,22 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
+  test("reseeds when the snapshot never received an authoritative flag (undefined sentinel)", async () => {
+    // The rolling snapshot was seeded without the `processing` field, so
+    // `nextProcessingState` pinned it to the `undefined` sentinel and no delta
+    // fold could ever lift it — the close-gate is starved on a non-`false`
+    // value. A modern daemon reporting idle must still trigger the reseed that
+    // plants an authoritative `false`.
+    seedSnapshotProcessing(undefined);
+    seedServerFetch(false);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    const outcome = await result.current.reconcileActiveConversation();
+
+    expect(outcome.changed).toBe(false);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("does not reseed when the snapshot already reflects the idle turn", async () => {
     // Turn already idle locally — no stale spinner to clear, so no refetch.
     seedSnapshotProcessing(false);

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -135,19 +135,30 @@ export function useMessageReconciliation({
       );
 
       // Adopt the daemon's authoritative `processing` flag when it reports the
-      // conversation idle but our rolling snapshot still shows it processing.
-      // This is the sole path that samples the flag independently of the SSE
-      // stream, so it's the only place that learns a turn ended when the
+      // conversation idle but our rolling snapshot does not already reflect
+      // that. This is the sole path that samples the flag independently of the
+      // SSE stream, so it's the only place that learns a turn ended when the
       // terminal event (`message_complete` / `assistant_activity_state(idle)`)
       // was dropped on a disconnect. Propagating it lets the existing
       // authoritative CLOSE-gate in `shouldShowThinkingIndicator` /
       // `canStopGeneration` (`snapshotProcessing === false`) settle the turn —
-      // no client-side stuck-turn heuristic. `undefined` (older daemons) does
-      // nothing, preserving prior behavior.
+      // no client-side stuck-turn heuristic.
+      //
+      // The condition covers two stale-local states, both of which leave the
+      // close-gate starved on a value that is not `false`:
+      //   - `true`: a delta folded the flag on but the terminal event that
+      //     would fold it back off never arrived.
+      //   - `undefined`: the version sentinel. `nextProcessingState` returns
+      //     `undefined` forever once the snapshot seed lacked the flag, so no
+      //     amount of delta folding can ever lift it to a boolean — the reseed
+      //     is the only way to plant an authoritative `false` (which also cures
+      //     the sentinel so subsequent folds track the turn). A genuinely old
+      //     daemon can't reach here: it never emits a defined `serverProcessing
+      //     === false`, so the guard stays closed and prior behavior holds.
       const localSnapshotProcessing =
         useChatSessionStore.getState().snapshot?.processing;
       const serverClearedProcessing =
-        serverProcessing === false && localSnapshotProcessing === true;
+        serverProcessing === false && localSnapshotProcessing !== false;
 
       // Refresh the single source — history flows into the query cache and the
       // transcript (its union with the live turn) re-renders. No client-side


### PR DESCRIPTION
## Prompt / plan

User feedback (with debug bundle): _"I can still see the thinking and not stopping after the assistant is done. After refresh the thinking is gone."_

Triage of the attached bundle:
- The `"Thinking…"` indicator persisted after the assistant clearly finished; only a page refresh cleared it.
- The client experienced heavy SSE churn (repeated app background/resume), so the terminal event (`message_complete` / `assistant_activity_state(idle)`) that idles the turn `phase` was dropped mid-turn.
- Every one of ~15 reconciliation passes over ~3 minutes observed `serverProcessing=false, changed=false`, yet **none** cleared the indicator and there was no `reconciliation_processing_cleared` diagnostic — the server's authoritative "done" was discarded on every pass.

### Root cause

The client already drives the indicator off server state via the authoritative close-gate (`snapshotProcessing === false`) in `shouldShowThinkingIndicator` / `canStopGeneration`, and c34e20b added a reconcile-path reseed to feed it the fresh flag. But that reseed only fired when the local rolling snapshot showed `processing === true`.

In this bundle the snapshot's flag was the **`undefined` version sentinel**: `nextProcessingState` pins `processing` to `undefined` forever once a snapshot seed lacked the field, so no delta fold could ever lift it to a boolean. With `phase` stuck sending (dropped terminal event), neither the reseed gate (`=== true`) nor the close-gate (`=== false`) engaged — so the daemon's authoritative `false` had nowhere to land.

### Fix

Broaden the reseed condition from `localSnapshotProcessing === true` to `localSnapshotProcessing !== false`, covering both the stale-`true` and the never-seeded-`undefined` states. Adopting the server's `false` plants an authoritative flag on the snapshot (curing the sentinel so later folds track the turn) and lets the existing close-gate settle the indicator — no bespoke stuck-turn heuristic.

A genuinely old daemon can't reach this path: it never emits a defined `processing:false`, so the `serverProcessing === false` guard stays closed and prior behavior holds.

## Test plan

- `bun test src/domains/chat/hooks/use-message-reconciliation.test.tsx` — 5 pass, including a **new** case for the undefined-sentinel reseed. Existing stale-`true`, still-processing, already-idle, and old-daemon cases keep their coverage.
- Ran related suites: `use-event-stream-resume-reconcile`, `turn-selectors`, `rolling-snapshot`, `debug-api` — 93 pass.
- `bunx tsc --noEmit` — clean (exit 0).
- `eslint` on changed files — 0 errors (only pre-existing curly-brace warnings outside the edited region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XexB4GgzQPgJVDw62BKVze)_