### PR TITLE
feat(web): PluginIcon renders a bundled image with graceful fallback

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -41,6 +41,18 @@ describe("PluginIcon", () => {
     expect(container.textContent).toBe("🚀");
   });
 
+  test("retries the image when iconSrc changes after a failure", () => {
+    const { container, rerender } = render(
+      <PluginIcon iconSrc="/a.png" icon="🚀" />,
+    );
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    rerender(<PluginIcon iconSrc="/b.png" icon="🚀" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/b.png");
+  });
+
   test("falls back to 📦 when the image errors, no icon, external", () => {
     const { container } = render(<PluginIcon iconSrc="/x.png" external />);
     fireEvent.error(container.querySelector("img")!);

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,14 +1,16 @@
 /**
- * Tests for `PluginIcon`: the author `icon` emoji, glyph defaulting by
- * `external`, and the `sm` / `md` container sizing that matches `SkillIcon`.
+ * Tests for `PluginIcon`: the bundled `iconSrc` image (and its `onError`
+ * fallback), the author `icon` emoji, glyph defaulting by `external`, and the
+ * `sm` / `md` container sizing that matches `SkillIcon`.
  *
  * Mounted via `@testing-library/react` (happy-dom — see
- * `clients/web/test-setup.ts`).
+ * `clients/web/test-setup.ts`); fires a real `error` event on the `<img>` to
+ * exercise the `useState`-driven fallback.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon.js";
 
@@ -20,6 +22,39 @@ const PACKAGE = "\u{1F4E6}"; // 📦
 const PUZZLE = "\u{1F9E9}"; // 🧩
 
 describe("PluginIcon", () => {
+  test("renders a lazy, decorative <img> when iconSrc is provided", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" icon="🚀" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/x.png");
+    expect(img!.getAttribute("loading")).toBe("lazy");
+    expect(img!.getAttribute("alt")).toBe("");
+    expect(img!.getAttribute("aria-hidden")).toBe("true");
+    // The image wins over the emoji, so no glyph text renders alongside it.
+    expect(container.textContent).toBe("");
+  });
+
+  test("falls back to the icon emoji when the image errors", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" icon="🚀" />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe("🚀");
+  });
+
+  test("falls back to 📦 when the image errors, no icon, external", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" external />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(PACKAGE);
+  });
+
+  test("falls back to 🧩 when the image errors, no icon, not external", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(PUZZLE);
+  });
+
   test("renders the provided icon emoji", () => {
     const { container } = render(<PluginIcon icon="🚀" />);
     expect(container.textContent).toBe("🚀");

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { cn } from "@/utils/misc";
 
@@ -31,6 +31,12 @@ export function PluginIcon({
   className,
 }: PluginIconProps) {
   const [imageFailed, setImageFailed] = useState(false);
+  // Retry the image when the source changes (e.g. a new icon URL or a
+  // cache-busting version) so a past failure doesn't pin a reused instance
+  // to the fallback.
+  useEffect(() => {
+    setImageFailed(false);
+  }, [iconSrc]);
   const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
   const showImage = Boolean(iconSrc) && !imageFailed;
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
+
 import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
   icon?: string;
+  iconSrc?: string;
   size?: "sm" | "md";
   className?: string;
 }
@@ -13,19 +16,23 @@ const SIZE_CLASS = {
 } as const;
 
 /**
- * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
- * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
- * icon-image endpoint, so there is no remote-image branch. Renders the
- * author-provided `icon` emoji when present, otherwise the origin glyph:
- * 📦 for catalog (external), 🧩 otherwise.
+ * Icon for a plugin, mirroring `SkillIcon`'s container dimensions for
+ * Plugins-tab / Skills-tab parity. A dumb renderer: the caller decides
+ * `iconSrc` (only when a gate passes and the plugin ships an icon). Render
+ * precedence — a bundled `iconSrc` image, then the author-provided `icon`
+ * emoji, then the origin glyph (📦 for catalog/external, 🧩 otherwise). A
+ * failed image load falls through to the emoji/glyph chain.
  */
 export function PluginIcon({
   external = false,
   icon,
+  iconSrc,
   size = "sm",
   className,
 }: PluginIconProps) {
+  const [imageFailed, setImageFailed] = useState(false);
   const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
+  const showImage = Boolean(iconSrc) && !imageFailed;
 
   return (
     <span
@@ -35,7 +42,18 @@ export function PluginIcon({
         className,
       )}
     >
-      {glyph}
+      {showImage ? (
+        <img
+          src={iconSrc}
+          alt=""
+          aria-hidden
+          loading="lazy"
+          className="h-full w-full object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        glyph
+      )}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- `PluginIcon` accepts `iconSrc` and renders a lazy, decorative `<img>` with an `onError` fallback to the emoji/📦/🧩 chain.
- Dumb renderer; caller decides iconSrc (gated) in a later PR.

Part of plan: plugin-custom-icons.md (PR 11 of 12)