### PR TITLE
feat(plugins): expose `icon` on GET /v1/plugins

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21266,6 +21266,9 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        icon:
+                          description: Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.
+                          type: string
                       required:
                         - id
                         - name

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -3,7 +3,7 @@
  *
  * GET /v1/plugins (list):
  *   - Projection from `InstalledPluginInfo` → response shape (id, name,
- *     description, version, path; issues omitted when empty)
+ *     description, version, path; issues + icon omitted when absent)
  *   - `?q=` substring filter (case-insensitive across id/name/description)
  *   - Trimming + empty-string fallthrough on `?q=`
  *   - Empty install dir → `{ plugins: [], categoryCounts: {}, totalCount: 0 }`
@@ -510,6 +510,24 @@ describe("GET /v1/plugins", () => {
 
     const [entry] = (await invoke()).plugins;
     expect(entry?.issues).toEqual(["missing package.json"]);
+  });
+
+  test("serializes `icon` from vellum.icon, omitting it when absent", async () => {
+    installedFixture = [
+      pluginEntry({
+        name: "with-icon",
+        packageJson: { name: "with-icon", version: "1.0.0", icon: "🎨" },
+      }),
+      pluginEntry({
+        name: "no-icon",
+        packageJson: { name: "no-icon", version: "1.0.0" },
+      }),
+    ];
+
+    const byId = new Map((await invoke()).plugins.map((p) => [p.id, p]));
+    expect(byId.get("with-icon")?.icon).toBe("🎨");
+    // Absent icon is omitted from the wire object, not set to undefined/null.
+    expect("icon" in byId.get("no-icon")!).toBe(false);
   });
 
   test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -138,6 +138,12 @@ const pluginInfoSchema = z.object({
     .describe(
       "Marketplace category slug (Skills taxonomy); null when origin/category is unknown, e.g. non-marketplace installs.",
     ),
+  icon: z
+    .string()
+    .optional()
+    .describe(
+      "Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.",
+    ),
 });
 
 const pluginsListResponseSchema = z.object({
@@ -658,6 +664,7 @@ interface PluginView {
   path: string;
   issues?: string[];
   category?: string | null;
+  icon?: string;
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -675,6 +682,9 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   };
   if (entry.issues.length > 0) {
     view.issues = [...entry.issues];
+  }
+  if (entry.packageJson?.icon !== undefined) {
+    view.icon = entry.packageJson.icon;
   }
   return view;
 }


### PR DESCRIPTION
## Summary
- Surface the author `vellum.icon` emoji on the plugins list response (`pluginInfoSchema` + `projectPlugin`), regenerated `openapi.yaml`.

Part of plan: plugin-custom-icons.md (PR 2 of 12)