### PR TITLE
feat(plugins): validate an author-bundled icon.png (magic + dimensions + size)

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
@@ -122,6 +122,15 @@ describe("readValidatedPluginIcon", () => {
     expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
   });
 
+  test("rejects a signature-prefixed file whose first chunk is not IHDR", () => {
+    // Valid signature + in-range integers at offsets 16/20, but the first
+    // chunk type is IDAT — must not be treated as dimensions.
+    const buf = makePng(64, 64);
+    buf.write("IDAT", 12, "ascii");
+    writeIcon(buf);
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
   test("returns hasIcon:false when no icon.png exists", () => {
     expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
   });

--- a/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for {@link readValidatedPluginIcon} — the fail-closed `icon.png`
+ * validator. An icon is surfaced only when the file is a PNG (correct magic
+ * bytes) whose IHDR dimensions are within 128×128 and whose size is within
+ * 32 KB. Every other shape — missing, wrong magic, oversized dims/bytes,
+ * unreadable — is "no icon" (`{ hasIcon: false }`) and never throws.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { readValidatedPluginIcon } from "../plugin-icon-file.js";
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * Build a minimal PNG buffer with a valid signature and IHDR width/height.
+ * `padBytes` appends filler after the header so callers can produce an
+ * oversized-but-otherwise-valid file for the size-cap case.
+ */
+function makePng(width: number, height: number, padBytes = 0): Buffer {
+  const buf = Buffer.alloc(24 + Math.max(0, padBytes));
+  PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function sha16(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex").slice(0, 16);
+}
+
+let pluginDir: string;
+
+beforeEach(() => {
+  pluginDir = mkdtempSync(join(tmpdir(), "plugin-icon-"));
+});
+
+afterEach(() => {
+  rmSync(pluginDir, { recursive: true, force: true });
+});
+
+function writeIcon(bytes: Buffer): void {
+  writeFileSync(join(pluginDir, "icon.png"), bytes);
+}
+
+describe("readValidatedPluginIcon", () => {
+  test("accepts a valid <=128x128 <=32KB PNG with a content-hash version", () => {
+    // GIVEN a small, well-formed PNG at the fixed path
+    const bytes = makePng(64, 64);
+    writeIcon(bytes);
+
+    // WHEN we validate it
+    const result = readValidatedPluginIcon(pluginDir);
+
+    // THEN it is surfaced with a stable content-hash version and its path
+    expect(result.hasIcon).toBe(true);
+    expect(result.iconVersion).toBe(sha16(bytes));
+    expect(result.path).toBe(join(pluginDir, "icon.png"));
+  });
+
+  test("accepts exactly 128x128 (the dimension boundary)", () => {
+    writeIcon(makePng(128, 128));
+    expect(readValidatedPluginIcon(pluginDir).hasIcon).toBe(true);
+  });
+
+  test("returns a stable iconVersion across repeated reads of the same bytes", () => {
+    writeIcon(makePng(32, 48));
+    const first = readValidatedPluginIcon(pluginDir);
+    const second = readValidatedPluginIcon(pluginDir);
+    expect(first.iconVersion).toBe(second.iconVersion);
+  });
+
+  test("iconVersion changes when the bytes change", () => {
+    writeIcon(makePng(32, 32));
+    const before = readValidatedPluginIcon(pluginDir).iconVersion;
+    writeIcon(makePng(48, 48));
+    const after = readValidatedPluginIcon(pluginDir).iconVersion;
+    expect(before).not.toBe(after);
+  });
+
+  test("rejects a non-PNG file with wrong magic bytes (renamed JPEG/text)", () => {
+    // GIVEN a file with JPEG magic bytes renamed to icon.png
+    const jpeg = Buffer.alloc(24);
+    jpeg.writeUInt16BE(0xffd8, 0); // JPEG SOI marker
+    writeIcon(jpeg);
+
+    // THEN it is rejected without throwing
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects plain text renamed to icon.png", () => {
+    writeIcon(Buffer.from("<svg>not a png at all, just some text</svg>"));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects oversized dimensions (129x129)", () => {
+    writeIcon(makePng(129, 129));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects zero-dimension IHDR", () => {
+    writeIcon(makePng(0, 0));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a PNG larger than 32KB", () => {
+    // GIVEN a valid-header PNG padded past the 32 KB cap
+    writeIcon(makePng(64, 64, 33 * 1024));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a truncated file too short to hold an IHDR", () => {
+    writeIcon(PNG_SIGNATURE); // 8 bytes — signature only, no IHDR
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("returns hasIcon:false when no icon.png exists", () => {
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("returns hasIcon:false for a non-existent plugin directory", () => {
+    const missing = join(pluginDir, "does-not-exist");
+    expect(readValidatedPluginIcon(missing)).toEqual({ hasIcon: false });
+  });
+});

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -17,6 +17,7 @@ import { dirname, join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { parsePluginIcon } from "./plugin-artifact.js";
+import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 
 /**
  * Directory containing first-party default plugin packages. Each subdirectory
@@ -56,6 +57,10 @@ export interface InstalledPluginInfo {
    * JSON, unexpected type, etc.). Empty when the entry parses cleanly.
    */
   readonly issues: readonly string[];
+  /** Whether a valid author-bundled `icon.png` was found in the plugin dir. */
+  readonly hasIcon: boolean;
+  /** Content-hash version of the validated `icon.png`, when {@link hasIcon}. */
+  readonly iconVersion?: string;
 }
 
 /** Where the plugin comes from. */
@@ -132,9 +137,13 @@ function readPluginEntry(
   const pkgJsonPath = join(target, "package.json");
   const issues: string[] = [];
 
+  // Icon validation is independent of package.json parsing, so resolve it
+  // once and attach to every return below (including error paths).
+  const iconFields = pluginIconFields(target);
+
   if (!existsSync(pkgJsonPath)) {
     issues.push("missing package.json");
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   let raw: string;
@@ -144,7 +153,7 @@ function readPluginEntry(
     issues.push(
       `package.json unreadable: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   let parsed: unknown;
@@ -154,12 +163,12 @@ function readPluginEntry(
     issues.push(
       `package.json invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     issues.push("package.json is not an object");
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   const meta = parsed as Record<string, unknown>;
@@ -178,7 +187,21 @@ function readPluginEntry(
     ...(icon ? { icon } : {}),
   };
 
-  return { name, target, packageJson, issues };
+  return { name, target, packageJson, issues, ...iconFields };
+}
+
+/**
+ * Validate `<dir>/icon.png` and shape the result into the two fields surfaced
+ * on {@link InstalledPluginInfo}. `iconVersion` is omitted when no valid icon
+ * is present.
+ */
+function pluginIconFields(
+  dir: string,
+): Pick<InstalledPluginInfo, "hasIcon" | "iconVersion"> {
+  const icon = readValidatedPluginIcon(dir);
+  return icon.hasIcon
+    ? { hasIcon: true, iconVersion: icon.iconVersion }
+    : { hasIcon: false };
 }
 
 /**
@@ -231,6 +254,8 @@ export function listAllPlugins(
     (manifest) => {
       const target = join(pluginsDir, manifest.name);
       const disabled = existsSync(join(target, ".disabled"));
+      // A default plugin's files (including icon.png) live in the source tree,
+      // not the workspace stub dir that only holds the `.disabled` sentinel.
       return {
         name: manifest.name,
         target,
@@ -241,6 +266,7 @@ export function listAllPlugins(
         issues: [],
         source: "default" as const,
         disabled,
+        ...pluginIconFields(join(DEFAULT_PLUGINS_DIR, manifest.name)),
       };
     },
   );

--- a/assistant/src/cli/lib/plugin-icon-file.ts
+++ b/assistant/src/cli/lib/plugin-icon-file.ts
@@ -1,0 +1,88 @@
+/**
+ * Validate a plugin's optional author-bundled `icon.png`.
+ *
+ * A plugin may ship a raster icon at a fixed path — `icon.png` in the plugin
+ * root. The filename is fixed (no author-controlled path) so there is no
+ * traversal surface. Validation is fail-closed: any problem — missing file,
+ * wrong magic bytes, oversized bytes, oversized dimensions, unreadable —
+ * resolves to `{ hasIcon: false }` and never throws, so callers can surface
+ * "no icon" uniformly without per-source error handling.
+ *
+ * PNG-only by design: a single well-known container keeps the parser tiny
+ * (magic signature + IHDR) and adds no dependency.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Fixed icon filename in the plugin root — no author path, no traversal. */
+const ICON_FILENAME = "icon.png";
+/** Byte cap: reject anything larger (also bounds what we read into memory). */
+const MAX_ICON_BYTES = 32 * 1024;
+/** Dimension cap (px) enforced against the IHDR width/height. */
+const MAX_ICON_DIMENSION = 128;
+/** PNG signature: the first 8 bytes of every PNG file. */
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+/** Smallest prefix we need: 8-byte magic + 8-byte chunk header + IHDR w/h. */
+const MIN_HEADER_BYTES = 24;
+
+/** Result of validating a plugin's `icon.png`. */
+export interface ValidatedPluginIcon {
+  /** Whether a valid icon was found. `false` for every failure mode. */
+  readonly hasIcon: boolean;
+  /** First 16 hex chars of sha256(bytes) — a stable content version. */
+  readonly iconVersion?: string;
+  /** Absolute path to the validated `icon.png`. */
+  readonly path?: string;
+}
+
+/**
+ * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
+ * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
+ * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
+ * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ */
+export function readValidatedPluginIcon(
+  pluginDir: string,
+): ValidatedPluginIcon {
+  const iconPath = join(pluginDir, ICON_FILENAME);
+
+  let bytes: Buffer;
+  try {
+    const stat = statSync(iconPath);
+    // Size-gate before reading so an oversized file never enters memory.
+    // A missing file throws here and is caught as "no icon".
+    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
+      return { hasIcon: false };
+    }
+    bytes = readFileSync(iconPath);
+  } catch {
+    return { hasIcon: false };
+  }
+
+  if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
+    return { hasIcon: false };
+  }
+  if (!bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return { hasIcon: false };
+  }
+
+  // IHDR width/height: big-endian uint32 at byte offsets 16 and 20.
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_ICON_DIMENSION ||
+    height > MAX_ICON_DIMENSION
+  ) {
+    return { hasIcon: false };
+  }
+
+  const iconVersion = createHash("sha256")
+    .update(bytes)
+    .digest("hex")
+    .slice(0, 16);
+  return { hasIcon: true, iconVersion, path: iconPath };
+}

--- a/assistant/src/cli/lib/plugin-icon-file.ts
+++ b/assistant/src/cli/lib/plugin-icon-file.ts
@@ -24,6 +24,9 @@ const MAX_ICON_BYTES = 32 * 1024;
 const MAX_ICON_DIMENSION = 128;
 /** PNG signature: the first 8 bytes of every PNG file. */
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+/** The first chunk of a valid PNG is always IHDR with a 13-byte payload. */
+const PNG_IHDR_LENGTH = 13;
+const PNG_IHDR_TYPE = Buffer.from("IHDR", "ascii");
 /** Smallest prefix we need: 8-byte magic + 8-byte chunk header + IHDR w/h. */
 const MIN_HEADER_BYTES = 24;
 
@@ -65,6 +68,16 @@ export function readValidatedPluginIcon(
     return { hasIcon: false };
   }
   if (!bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return { hasIcon: false };
+  }
+
+  // The first chunk must be IHDR (length 13, type "IHDR") before its bytes
+  // can be read as dimensions — otherwise a non-PNG with the signature and
+  // small integers at offsets 16/20 would be accepted.
+  if (
+    bytes.readUInt32BE(8) !== PNG_IHDR_LENGTH ||
+    !bytes.subarray(12, 16).equals(PNG_IHDR_TYPE)
+  ) {
     return { hasIcon: false };
   }
 


### PR DESCRIPTION
## Summary
- Add `readValidatedPluginIcon`: fail-closed PNG validation (magic bytes + IHDR ≤128×128 + ≤32KB), content-hash iconVersion, no new dependency.
- Surface `hasIcon`/`iconVersion` on InstalledPluginInfo; no bytes embedded.

Part of plan: plugin-custom-icons.md (PR 8 of 12)