### PR TITLE
fix(calls): in-flight verification guard + cross-PR consolidation sweep

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -323,9 +323,6 @@ function createMockTransport(): MockTransport {
       state._endCalled = true;
       state._endReason = reason;
     },
-    getConnectionState() {
-      return "connected";
-    },
   } as MockTransport;
 }
 

--- a/assistant/src/__tests__/call-setup-flow-invite.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-invite.test.ts
@@ -61,7 +61,9 @@ function inviteOutcome(inviteeName: string | null): SetupOutcome {
   };
 }
 
-type RedemptionFn = NonNullable<CallSetupFlowDeps["attemptInviteCodeRedemption"]>;
+type RedemptionFn = NonNullable<
+  CallSetupFlowDeps["attemptInviteCodeRedemption"]
+>;
 
 const successRedemption: RedemptionFn = async () => ({
   outcome: "success",
@@ -89,8 +91,10 @@ function createHarness(overrides?: Partial<CallSetupFlowDeps>) {
     enteredCode: string;
     guardianLabel: string;
   }> = [];
-  const finalizeCalls: Array<{ callSessionId: string; conversationId: string }> =
-    [];
+  const finalizeCalls: Array<{
+    callSessionId: string;
+    conversationId: string;
+  }> = [];
   const notifierCalls: Array<{
     conversationId: string;
     callSessionId: string;
@@ -100,11 +104,9 @@ function createHarness(overrides?: Partial<CallSetupFlowDeps>) {
 
   const transport: SetupFlowTransport = {
     sendTextToken: () => {},
-    sendPlayUrl: () => {},
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    getConnectionState: () => "connected",
   };
 
   // Record every claim regardless of which redemption impl a test injects.
@@ -114,7 +116,7 @@ function createHarness(overrides?: Partial<CallSetupFlowDeps>) {
   } = overrides ?? {};
 
   const deps: CallSetupFlowDeps = {
-    speakSystemPrompt: async (_transport, text) => {
+    speakSystemPrompt: async (text) => {
       spoken.push(text);
     },
     updateCallSession: (_id, updates) => {
@@ -245,10 +247,7 @@ describe("CallSetupFlow invite redemption", () => {
         endReasons,
       } = createHarness();
 
-      await flow.start(
-        inviteOutcome("Carolina Flaherty"),
-        makeResolved(true),
-      );
+      await flow.start(inviteOutcome("Carolina Flaherty"), makeResolved(true));
       await enterCode(flow);
 
       expect(redemptionCalls).toEqual([

--- a/assistant/src/__tests__/call-setup-flow-midcall-trust.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-midcall-trust.test.ts
@@ -29,6 +29,7 @@ const realInboundTrustReader = {
 mock.module("../calls/inbound-trust-reader.js", () => ({
   ...realInboundTrustReader,
   getInboundTrustVerdict: async () => mockVerdict,
+  getPhoneCallerVerdict: async () => mockVerdict,
 }));
 
 // Records fallback-path cache warms.

--- a/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
@@ -120,12 +120,6 @@ class FakeGuardianWait implements GuardianWaitHandle {
     this.transcripts.push(text);
   }
 
-  getState() {
-    return this.startParams
-      ? ("awaiting_guardian_decision" as const)
-      : ("idle" as const);
-  }
-
   dispose(reason: GuardianWaitDisposeReason = "teardown"): void {
     this.disposeReasons.push(reason);
   }
@@ -145,11 +139,9 @@ function createFlow(opts?: {
   const endReasons: Array<string | undefined> = [];
   const transport: SetupFlowTransport = {
     sendTextToken: () => {},
-    sendPlayUrl: () => {},
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    getConnectionState: () => "connected",
   };
 
   const spoken: string[] = [];
@@ -180,7 +172,7 @@ function createFlow(opts?: {
   };
 
   const deps: CallSetupFlowDeps = {
-    speakSystemPrompt: async (_transport, text) => {
+    speakSystemPrompt: async (text) => {
       spoken.push(text);
     },
     updateCallSession: (_id, updates) => {
@@ -214,7 +206,7 @@ function createFlow(opts?: {
       }
       return notifyResult;
     },
-    createGuardianWaitController: (_callSessionId, _transport, waitDeps) => {
+    createGuardianWaitController: (_callSessionId, waitDeps) => {
       const wait = new FakeGuardianWait(waitDeps);
       waits.push(wait);
       return wait;

--- a/assistant/src/__tests__/call-setup-flow-verification.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-verification.test.ts
@@ -154,11 +154,9 @@ function createFlow(opts?: {
     sendTextToken: (token, last) => {
       spokenTokens.push({ token, last });
     },
-    sendPlayUrl: () => {},
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    getConnectionState: () => "connected",
   };
 
   const spoken: string[] = [];
@@ -196,7 +194,7 @@ function createFlow(opts?: {
   const attempt = fakeAttemptVerification({ correctCode: CORRECT_CODE });
 
   const deps: CallSetupFlowDeps = {
-    speakSystemPrompt: async (_transport, text) => {
+    speakSystemPrompt: async (text) => {
       spoken.push(text);
     },
     updateCallSession: (_id, updates) => {
@@ -226,14 +224,14 @@ function createFlow(opts?: {
         metadata: options?.metadata,
       });
     }) as unknown as CallSetupFlowDeps["addMessage"],
-    addPointerMessage: (async (
+    postPointerMessage: ((
       conversationId: string,
       event: string,
       phoneNumber: string,
       extra?: Record<string, unknown>,
     ) => {
       pointerMessages.push({ conversationId, event, phoneNumber, extra });
-    }) as unknown as CallSetupFlowDeps["addPointerMessage"],
+    }) as unknown as CallSetupFlowDeps["postPointerMessage"],
     fireCallTranscriptNotifier: (
       conversationId,
       callSessionId,
@@ -808,7 +806,7 @@ describe("CallSetupFlow verification sub-flows", () => {
           getCallSession: undefined,
           finalizeCall: undefined,
           addMessage: undefined,
-          addPointerMessage: undefined,
+          postPointerMessage: undefined,
           fireCallTranscriptNotifier: undefined,
           resolveGuardianLabel: undefined,
           resolveAssistantLabel: undefined,
@@ -818,6 +816,110 @@ describe("CallSetupFlow verification sub-flows", () => {
       expect(
         flow.start(inboundVerificationOutcome, makeResolved()),
       ).rejects.toThrow(/verification deps missing: getCallSession/);
+    });
+  });
+
+  describe("in-flight submission guard", () => {
+    test("a 12-digit DTMF burst fires exactly one validation attempt", async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const attempt = fakeAttemptVerification({ correctCode: CORRECT_CODE });
+      const calls: AttemptParams[] = [];
+      const { flow, results } = createFlow({
+        deps: {
+          attemptVerificationCode: async (params) => {
+            calls.push(params);
+            await gate;
+            return attempt(params);
+          },
+        },
+      });
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      // Duplicated DTMF burst: the correct code arrives twice back-to-back.
+      pushCode(flow, CORRECT_CODE + CORRECT_CODE);
+      await sleep();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.enteredCode).toBe(CORRECT_CODE);
+
+      release();
+      await sleep();
+
+      expect(calls).toHaveLength(1);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.kind).toBe("proceed-initial-greeting");
+    });
+
+    test("a spoken code during a pending validation is dropped", async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const attempt = fakeAttemptVerification({ correctCode: CORRECT_CODE });
+      const calls: AttemptParams[] = [];
+      const { flow, results } = createFlow({
+        deps: {
+          attemptVerificationCode: async (params) => {
+            calls.push(params);
+            await gate;
+            return attempt(params);
+          },
+        },
+      });
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      pushCode(flow, CORRECT_CODE);
+      await sleep();
+      expect(calls).toHaveLength(1);
+
+      // The same code re-spoken while the validation is pending must not
+      // launch a second attempt.
+      flow.pushTranscriptFinal("one two three four five six");
+      await sleep();
+      expect(calls).toHaveLength(1);
+
+      release();
+      await sleep();
+      expect(calls).toHaveLength(1);
+      expect(results).toHaveLength(1);
+    });
+
+    test("the attempt counter advances once per settled attempt", async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const attempt = fakeAttemptVerification({ correctCode: CORRECT_CODE });
+      const calls: AttemptParams[] = [];
+      const { flow } = createFlow({
+        deps: {
+          attemptVerificationCode: async (params) => {
+            calls.push(params);
+            await gate;
+            return attempt(params);
+          },
+        },
+      });
+      await flow.start(inboundVerificationOutcome, makeResolved());
+
+      // Duplicated wrong code: only the first submission validates.
+      pushCode(flow, "000000" + "000000");
+      flow.pushTranscriptFinal("zero zero zero zero zero zero");
+      await sleep();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.verificationAttempts).toBe(0);
+
+      release();
+      await sleep();
+
+      // The next submission sees a counter advanced exactly once.
+      pushCode(flow, "111111");
+      await sleep();
+      expect(calls).toHaveLength(2);
+      expect(calls[1]?.verificationAttempts).toBe(1);
     });
   });
 });

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -50,22 +50,17 @@ function makeResolved(trustClass: TrustClass = "guardian"): SetupResolved {
 
 function createFakeTransport() {
   const spokenTokens: Array<{ token: string; last: boolean }> = [];
-  const playUrls: string[] = [];
   const endReasons: Array<string | undefined> = [];
   const transport: SetupFlowTransport = {
     sendTextToken: (token, last) => {
       spokenTokens.push({ token, last });
     },
-    sendPlayUrl: (url) => {
-      playUrls.push(url);
-    },
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    getConnectionState: () => "connected",
     requiresWavAudio: true,
   };
-  return { transport, spokenTokens, playUrls, endReasons };
+  return { transport, spokenTokens, endReasons };
 }
 
 function createFlow(overrides?: Partial<CallSetupFlowDeps>) {
@@ -79,7 +74,7 @@ function createFlow(overrides?: Partial<CallSetupFlowDeps>) {
   const results: SetupFlowResult[] = [];
 
   const deps: CallSetupFlowDeps = {
-    speakSystemPrompt: async (_transport, text) => {
+    speakSystemPrompt: async (text) => {
       spoken.push(text);
     },
     updateCallSession: (_id, updates) => {
@@ -112,8 +107,7 @@ function createFlow(overrides?: Partial<CallSetupFlowDeps>) {
   return { flow, ...fake, spoken, sessionUpdates, events, results };
 }
 
-const sleep = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -223,6 +217,29 @@ describe("CallSetupFlow", () => {
       await expect(
         flow.start({ action: "normal_call", isInbound: true }, resolved),
       ).rejects.toThrow("may only be called once");
+    });
+
+    test("start() during an in-flight deny path throws", async () => {
+      // The deny path awaits TTS before completing, so the flow is still
+      // in `idle` state while the first start() is in flight.
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const { flow } = createFlow({ speakSystemPrompt: () => gate });
+      const denyOutcome: SetupOutcome = {
+        action: "deny",
+        message: "Denied.",
+        logReason: "test deny",
+      };
+
+      const first = flow.start(denyOutcome, makeResolved("unknown"));
+      await expect(
+        flow.start(denyOutcome, makeResolved("unknown")),
+      ).rejects.toThrow("may only be called once");
+
+      release();
+      await first;
     });
 
     test("input methods are no-ops while idle and completed", async () => {

--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -9,7 +9,6 @@
  * - wait-utterance classes incl. cooldown throttling and callback opt-in bypass
  * - callback handoff exactly-once semantics (timeout vs disconnect races)
  * - dispose() idempotence and timer cleanup
- * - config fallbacks for missing/NaN timeout values
  *
  * All timer-driven behavior runs under fake timers — no real delays.
  */
@@ -92,7 +91,6 @@ mock.module("../calls/call-store.js", () => ({
 
 // ── Source imports (after mocks) ─────────────────────────────────────
 
-import type { SetupFlowTransport } from "../calls/call-setup-flow-types.js";
 import {
   GuardianWaitController,
   type GuardianWaitControllerDeps,
@@ -133,20 +131,9 @@ function createController(overrides?: Partial<GuardianWaitControllerDeps>) {
   const approvals: GuardianWaitResolutionContext[] = [];
   const denials: GuardianWaitResolutionContext[] = [];
   const timeouts: GuardianWaitResolutionContext[] = [];
-  let connectionStateReads = 0;
-
-  const transport: SetupFlowTransport = {
-    sendTextToken: () => {},
-    sendPlayUrl: () => {},
-    endSession: () => {},
-    getConnectionState: () => {
-      connectionStateReads += 1;
-      return "connected";
-    },
-  };
 
   const deps: GuardianWaitControllerDeps = {
-    speakSystemPrompt: async (_transport, text) => {
+    speakSystemPrompt: async (text) => {
       spoken.push(text);
     },
     updateCallSession: (_id, updates) => {
@@ -170,11 +157,7 @@ function createController(overrides?: Partial<GuardianWaitControllerDeps>) {
     ...overrides,
   };
 
-  const controller = new GuardianWaitController(
-    CALL_SESSION_ID,
-    transport,
-    deps,
-  );
+  const controller = new GuardianWaitController(CALL_SESSION_ID, deps);
   return {
     controller,
     spoken,
@@ -183,7 +166,6 @@ function createController(overrides?: Partial<GuardianWaitControllerDeps>) {
     approvals,
     denials,
     timeouts,
-    getConnectionStateReads: () => connectionStateReads,
   };
 }
 
@@ -236,15 +218,6 @@ describe("GuardianWaitController", () => {
         "may only be called once",
       );
       controller.dispose();
-    });
-
-    test("never reads wait state through the transport", () => {
-      const { controller, getConnectionStateReads } = createController();
-      controller.start(START_PARAMS);
-      controller.handleTranscript("hello?");
-      jest.advanceTimersByTime(500);
-      controller.dispose();
-      expect(getConnectionStateReads()).toBe(0);
     });
   });
 
@@ -509,8 +482,7 @@ describe("GuardianWaitController", () => {
       );
       expect(
         events.some(
-          (e) =>
-            e.eventType === "voice_guardian_wait_callback_opt_in_declined",
+          (e) => e.eventType === "voice_guardian_wait_callback_opt_in_declined",
         ),
       ).toBe(true);
 
@@ -610,13 +582,8 @@ describe("GuardianWaitController", () => {
   describe("dispose", () => {
     test("clears every timer — nothing fires afterwards", () => {
       seedRequest("pending");
-      const {
-        controller,
-        spoken,
-        approvals,
-        denials,
-        timeouts,
-      } = createController({ consultTimeoutMs: 2000 });
+      const { controller, spoken, approvals, denials, timeouts } =
+        createController({ consultTimeoutMs: 2000 });
       controller.start(START_PARAMS);
 
       controller.dispose();
@@ -647,32 +614,6 @@ describe("GuardianWaitController", () => {
       expect(controller.getState()).toBe("resolved");
       expect(controller.getResolution()).toBe("approved");
       expect(emitSignalCalls).toHaveLength(0);
-    });
-  });
-
-  describe("config fallbacks", () => {
-    test("NaN consult timeout falls back to the 120s schema default", () => {
-      seedRequest("pending");
-      mockConfig.calls.userConsultTimeoutSeconds = Number.NaN;
-      const { controller, timeouts } = createController();
-      controller.start(START_PARAMS);
-
-      jest.advanceTimersByTime(119_999);
-      expect(timeouts).toHaveLength(0);
-      jest.advanceTimersByTime(1);
-      expect(timeouts).toHaveLength(1);
-    });
-
-    test("NaN poll interval falls back to the 500ms schema default", () => {
-      seedRequest("approved");
-      mockConfig.calls.accessRequestPollIntervalMs = Number.NaN;
-      const { controller, approvals } = createController();
-      controller.start(START_PARAMS);
-
-      jest.advanceTimersByTime(499);
-      expect(approvals).toHaveLength(0);
-      jest.advanceTimersByTime(1);
-      expect(approvals).toHaveLength(1);
     });
   });
 });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -230,19 +230,6 @@ describe("MediaStreamOutput", () => {
       output.endSession("second");
       expect(mock.closed).toBe(true);
     });
-
-    test("getConnectionState returns 'connected' initially", () => {
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
-      expect(output.getConnectionState()).toBe("connected");
-    });
-
-    test("getConnectionState returns 'closed' after endSession", () => {
-      const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
-      output.endSession();
-      expect(output.getConnectionState()).toBe("closed");
-    });
   });
 
   describe("sendAudioPayload", () => {
@@ -369,7 +356,6 @@ describe("MediaStreamOutput", () => {
       const mock = createMockWs();
       const output = new MediaStreamOutput(mock.ws, "stream-1");
       output.markClosed();
-      expect(output.getConnectionState()).toBe("closed");
       expect(mock.closed).toBe(false); // WebSocket not actually closed
       output.sendAudioPayload("dGVzdA=="); // Should be suppressed
       expect(mock.sent).toHaveLength(0);

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -101,7 +101,7 @@ mock.module("../calls/finalize-call.js", () => ({
 
 // Mock the call pointer messages
 mock.module("../calls/call-pointer-messages.js", () => ({
-  addPointerMessage: jest.fn(async () => {}),
+  postPointerMessageSafe: jest.fn(),
   formatDuration: jest.fn((ms: number) => `${Math.round(ms / 1000)}s`),
 }));
 
@@ -380,7 +380,7 @@ mock.module("../calls/relay-access-wait.js", () => ({
 
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { CallController } from "../calls/call-controller.js";
-import { addPointerMessage } from "../calls/call-pointer-messages.js";
+import { postPointerMessageSafe } from "../calls/call-pointer-messages.js";
 import { speakSystemPrompt } from "../calls/call-speech-output.js";
 import {
   fireCallTranscriptNotifier,
@@ -528,7 +528,7 @@ beforeEach(() => {
   (finalizeCall as jest.Mock).mockClear();
   (revokeScopedApprovalGrantsForContext as jest.Mock).mockClear();
   (speakSystemPrompt as jest.Mock).mockClear();
-  (addPointerMessage as jest.Mock).mockClear();
+  (postPointerMessageSafe as jest.Mock).mockClear();
   (routeSetup as jest.Mock).mockClear();
   mockGetChannelAdmissionPolicy.mockClear();
   mockAdmissionPolicy = null;
@@ -588,7 +588,6 @@ describe("MediaStreamCallSession", () => {
     const session = new MediaStreamCallSession(ws, "call-1");
     expect(session.callSessionId).toBe("call-1");
     expect(session.getOutput()).toBeDefined();
-    expect(session.getOutput().getConnectionState()).toBe("connected");
   });
 
   describe("start event handling", () => {
@@ -675,7 +674,7 @@ describe("MediaStreamCallSession", () => {
         expect.objectContaining({ status: "completed" }),
       );
       expect(finalizeCall).toHaveBeenCalledWith("call-1", "conv-1");
-      expect(addPointerMessage).toHaveBeenCalledWith(
+      expect(postPointerMessageSafe).toHaveBeenCalledWith(
         "conv-origin",
         "completed",
         "+15551234567",
@@ -705,7 +704,7 @@ describe("MediaStreamCallSession", () => {
         }),
       );
       expect(finalizeCall).toHaveBeenCalledWith("call-1", "conv-1");
-      expect(addPointerMessage).toHaveBeenCalledWith(
+      expect(postPointerMessageSafe).toHaveBeenCalledWith(
         "conv-origin",
         "failed",
         "+15551234567",
@@ -750,7 +749,6 @@ describe("MediaStreamCallSession", () => {
 
       session.destroy();
       expect(mockDestroy).toHaveBeenCalled();
-      expect(session.getOutput().getConnectionState()).toBe("closed");
     });
 
     test("destroy is idempotent", () => {
@@ -1914,7 +1912,7 @@ describe("setup flows over the media-stream transport", () => {
       expect(mockAttemptVerificationCode).toHaveBeenCalledWith(
         expect.objectContaining({ enteredCode: "654321", isOutbound: true }),
       );
-      expect(addPointerMessage).toHaveBeenCalledWith(
+      expect(postPointerMessageSafe).toHaveBeenCalledWith(
         "conv-origin-1",
         "verification_succeeded",
         TO,

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -46,7 +46,9 @@ const realProviderCatalogModule = {
   ...(await import("../tts/provider-catalog.js")),
 };
 const realConfigLoaderModule = { ...(await import("../config/loader.js")) };
-const realSecureKeysModule = { ...(await import("../security/secure-keys.js")) };
+const realSecureKeysModule = {
+  ...(await import("../security/secure-keys.js")),
+};
 const realProviderRegistryModule = {
   ...(await import("../tts/provider-registry.js")),
 };
@@ -146,9 +148,7 @@ mock.module("../config/loader.js", () => ({
   getConfig: () =>
     guardMocksActive ? testConfig : realConfigLoaderModule.getConfig(),
   getConfigReadOnly: () =>
-    guardMocksActive
-      ? testConfig
-      : realConfigLoaderModule.getConfigReadOnly(),
+    guardMocksActive ? testConfig : realConfigLoaderModule.getConfigReadOnly(),
 }));
 
 // -- Mutable credential store --------------------------------------------------
@@ -258,7 +258,6 @@ function createRelay(requiresWavAudio: boolean) {
       sentPlayUrls.push(url);
     },
     endSession: () => {},
-    getConnectionState: () => "connected",
   } as CallTransport;
   return { relay, sentTokens, sentPlayUrls };
 }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -31,7 +31,10 @@ import {
   getSilenceTimeoutMs,
   getUserConsultationTimeoutMs,
 } from "./call-constants.js";
-import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import {
+  formatDuration,
+  postPointerMessageSafe,
+} from "./call-pointer-messages.js";
 import {
   fireCallQuestionNotifier,
   fireCallTranscriptNotifier,
@@ -1240,22 +1243,14 @@ export class CallController {
       const durationMs = currentSession.startedAt
         ? Date.now() - currentSession.startedAt
         : 0;
-      addPointerMessage(
+      postPointerMessageSafe(
         currentSession.initiatedFromConversationId,
         "completed",
         currentSession.toNumber,
         {
           duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
         },
-      ).catch((err) => {
-        log.warn(
-          {
-            conversationId: currentSession.initiatedFromConversationId,
-            err,
-          },
-          "Skipping pointer write — origin conversation may no longer exist",
-        );
-      });
+      );
     }
     this.state = "idle";
   }
@@ -1524,22 +1519,14 @@ export class CallController {
           const durationMs = currentSession.startedAt
             ? Date.now() - currentSession.startedAt
             : 0;
-          addPointerMessage(
+          postPointerMessageSafe(
             currentSession.initiatedFromConversationId,
             "completed",
             currentSession.toNumber,
             {
               duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
             },
-          ).catch((err) => {
-            log.warn(
-              {
-                conversationId: currentSession.initiatedFromConversationId,
-                err,
-              },
-              "Skipping pointer write — origin conversation may no longer exist",
-            );
-          });
+          );
         }
       }, 3000);
     }, maxDurationMs);

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -25,7 +25,7 @@ import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { upsertActiveCallLease } from "./active-call-lease.js";
 import { isDeniedNumber } from "./call-constants.js";
-import { addPointerMessage } from "./call-pointer-messages.js";
+import { postPointerMessageSafe } from "./call-pointer-messages.js";
 import { getCallController, unregisterCallController } from "./call-state.js";
 import { isTerminalState } from "./call-state-machine.js";
 import {
@@ -47,21 +47,6 @@ import { preflightVoiceIngress } from "./voice-ingress-preflight.js";
 const log = getLogger("call-domain");
 
 const E164_REGEX = /^\+\d+$/;
-
-function postFailedCallPointer(
-  conversationId: string,
-  phoneNumber: string,
-  reason: string,
-): void {
-  addPointerMessage(conversationId, "failed", phoneNumber, {
-    reason,
-  }).catch((pointerErr) => {
-    log.warn(
-      { conversationId, err: pointerErr },
-      "Failed to post call-failed pointer message",
-    );
-  });
-}
 
 // ── Result types ─────────────────────────────────────────────────────
 
@@ -427,7 +412,9 @@ export async function startCall(
 
     const preflightResult = await preflightVoiceIngress();
     if (!preflightResult.ok) {
-      postFailedCallPointer(conversationId, phoneNumber, preflightResult.error);
+      postPointerMessageSafe(conversationId, "failed", phoneNumber, {
+        reason: preflightResult.error,
+      });
       return preflightResult;
     }
 
@@ -530,12 +517,7 @@ export async function startCall(
     );
 
     // Post a concise pointer message in the initiating conversation
-    addPointerMessage(conversationId, "started", phoneNumber).catch((err) => {
-      log.warn(
-        { conversationId, err },
-        "Failed to post call-started pointer message",
-      );
-    });
+    postPointerMessageSafe(conversationId, "started", phoneNumber);
 
     return {
       ok: true,
@@ -568,7 +550,9 @@ export async function startCall(
       });
     }
 
-    postFailedCallPointer(conversationId, phoneNumber, msg);
+    postPointerMessageSafe(conversationId, "failed", phoneNumber, {
+      reason: msg,
+    });
 
     return { ok: false, error: `Error initiating call: ${msg}`, status: 500 };
   }

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -161,6 +161,24 @@ export async function addPointerMessage(
 }
 
 /**
+ * Fire-and-forget pointer write that tolerates an evicted origin
+ * conversation: failures are logged at warn level and swallowed.
+ */
+export function postPointerMessageSafe(
+  conversationId: string,
+  event: PointerEvent,
+  phoneNumber: string,
+  extra?: Parameters<typeof addPointerMessage>[3],
+): void {
+  addPointerMessage(conversationId, event, phoneNumber, extra).catch((err) => {
+    log.warn(
+      { conversationId, err },
+      "Skipping pointer write — origin conversation may no longer exist",
+    );
+  });
+}
+
+/**
  * Format a duration in milliseconds into a human-friendly string.
  */
 export function formatDuration(ms: number): string {

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -13,35 +13,20 @@ import type { TrustContext } from "../daemon/trust-context.js";
 
 /**
  * Structural subset of `CallTransport` (call-transport.ts) that the setup
- * flow needs. `MediaStreamOutput` satisfies this interface (asserted at
- * compile time in call-setup-flow.test.ts).
+ * flow needs: speak and end the session. `MediaStreamOutput` satisfies
+ * this interface (asserted at compile time in call-setup-flow.test.ts).
  */
 export interface SetupFlowTransport {
   sendTextToken(token: string, last: boolean): void;
-  sendPlayUrl(url: string): void;
   endSession(reason?: string): void;
-  getConnectionState(): string;
   readonly requiresWavAudio?: boolean;
-}
-
-// ── Input surface ────────────────────────────────────────────────────
-
-/**
- * Caller input routed into the active setup sub-flow by the owning
- * transport server. Both methods are no-ops while the flow is `idle` or
- * `completed`.
- */
-export interface SetupFlowInput {
-  pushDtmfDigit(digit: string): void;
-  pushTranscriptFinal(text: string): void;
 }
 
 // ── Flow state ───────────────────────────────────────────────────────
 
 /**
  * Explicit setup-flow state. The flow is the sole source of truth for its
- * state — it is never inferred from `transport.getConnectionState()`
- * (which on `MediaStreamOutput` is only `"connected" | "closed"`).
+ * state — it is never inferred from the transport.
  */
 export type SetupFlowState =
   | "idle"

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -34,9 +34,8 @@ import {
 } from "../runtime/verification-templates.js";
 import { getLogger } from "../util/logger.js";
 import { getTtsPlaybackDelayMs } from "./call-constants.js";
-import type { addPointerMessage as addPointerMessageFn } from "./call-pointer-messages.js";
+import type { postPointerMessageSafe as postPointerMessageSafeFn } from "./call-pointer-messages.js";
 import type {
-  SetupFlowInput,
   SetupFlowResult,
   SetupFlowState,
   SetupFlowTransport,
@@ -53,7 +52,7 @@ import {
   type GuardianWaitDisposeReason,
   type GuardianWaitResolutionContext,
 } from "./guardian-wait-controller.js";
-import { getInboundTrustVerdict } from "./inbound-trust-reader.js";
+import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
 import type { SetupOutcome, SetupResolved } from "./relay-setup-router.js";
 import {
   attemptInviteCodeRedemption as attemptInviteCodeRedemptionImpl,
@@ -94,8 +93,8 @@ export interface SetupFlowCallSession {
  * constructor.
  */
 export interface CallSetupFlowDeps {
-  /** Speak a deterministic system prompt through the transport. */
-  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  /** Speak a deterministic system prompt through the call transport. */
+  speakSystemPrompt(text: string): Promise<void>;
   updateCallSession(
     id: string,
     updates: Parameters<typeof updateCallSessionFn>[1],
@@ -116,13 +115,14 @@ export interface CallSetupFlowDeps {
   // ── Verification / invite sub-flow deps ────────────────────────────
   // Optional so callers exercising only normal_call/deny need not supply
   // them. Each sub-flow resolves the deps it needs up front at start()
-  // and throws on a missing side-effect dep (see requireVerificationDeps
-  // and requireInviteDeps).
+  // via requireDeps, which applies defaults for the pure logic and throws
+  // on a missing side-effect dep.
   /** Look up the call session (used for its conversation/routing fields). */
   getCallSession?(id: string): SetupFlowCallSession | null;
   finalizeCall?: typeof finalizeCallFn;
   addMessage?: typeof addMessageFn;
-  addPointerMessage?: typeof addPointerMessageFn;
+  /** Fire-and-forget pointer write tolerating an evicted conversation. */
+  postPointerMessage?: typeof postPointerMessageSafeFn;
   fireCallTranscriptNotifier?: typeof fireCallTranscriptNotifierFn;
   /** Human-readable guardian label for prompts and handoff copy. */
   resolveGuardianLabel?(): string;
@@ -155,7 +155,6 @@ export interface CallSetupFlowDeps {
    */
   createGuardianWaitController?(
     callSessionId: string,
-    transport: SetupFlowTransport,
     deps: GuardianWaitControllerDeps,
   ): GuardianWaitHandle;
   /** Overrides the 30s name-capture response timeout. */
@@ -165,7 +164,7 @@ export interface CallSetupFlowDeps {
 /** Structural subset of {@link GuardianWaitController} the flow drives. */
 export type GuardianWaitHandle = Pick<
   GuardianWaitController,
-  "start" | "handleTranscript" | "getState" | "dispose"
+  "start" | "handleTranscript" | "dispose"
 >;
 
 /** Verification deps with defaults applied and optionality removed. */
@@ -175,7 +174,7 @@ type VerificationDeps = Required<
     | "getCallSession"
     | "finalizeCall"
     | "addMessage"
-    | "addPointerMessage"
+    | "postPointerMessage"
     | "fireCallTranscriptNotifier"
     | "resolveGuardianLabel"
     | "resolveAssistantLabel"
@@ -228,6 +227,50 @@ type ActivationDeps = Pick<
 // ── Module helpers ───────────────────────────────────────────────────
 
 /**
+ * Real-implementation defaults for the optional pure-logic deps. Built per
+ * call so the module live bindings are read at resolution time.
+ */
+function setupFlowDepDefaults(): Partial<CallSetupFlowDeps> {
+  return {
+    attemptVerificationCode: attemptVerificationCodeImpl,
+    attemptInviteCodeRedemption: attemptInviteCodeRedemptionImpl,
+    notifyGuardianOfAccessRequest: notifyGuardianOfAccessRequestImpl,
+    resolveMidCallTrustContext,
+    createGuardianWaitController: (callSessionId, deps) =>
+      new GuardianWaitController(callSessionId, deps),
+  };
+}
+
+/**
+ * Resolve a sub-flow's dep subset, applying {@link setupFlowDepDefaults}
+ * for omitted pure-logic deps and throwing a descriptive error naming any
+ * missing side-effect dep.
+ */
+function requireDeps<K extends keyof CallSetupFlowDeps>(
+  kind: string,
+  deps: CallSetupFlowDeps,
+  names: readonly K[],
+): Required<Pick<CallSetupFlowDeps, K>> {
+  const defaults = setupFlowDepDefaults();
+  const resolved: Partial<Record<keyof CallSetupFlowDeps, unknown>> = {};
+  const missing: string[] = [];
+  for (const name of names) {
+    const value = deps[name] ?? defaults[name];
+    if (value == null) {
+      missing.push(name);
+    } else {
+      resolved[name] = value;
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `CallSetupFlow ${kind} deps missing: ${missing.join(", ")}`,
+    );
+  }
+  return resolved as Required<Pick<CallSetupFlowDeps, K>>;
+}
+
+/**
  * Re-resolve caller trust after a mid-setup verification/activation. Prefers
  * the gateway verdict (authoritative right after the gateway updated the
  * binding); falls back to local resolution on a missing/failed/unusable
@@ -238,10 +281,7 @@ export async function resolveMidCallTrustContext(
   assistantId: string,
   fromNumber: string,
 ): Promise<TrustContext> {
-  const verdict = await getInboundTrustVerdict({
-    channelType: "phone",
-    actorExternalId: fromNumber,
-  });
+  const verdict = await getPhoneCallerVerdict(fromNumber);
 
   // Only a MEMBERLESS unknown verdict is treated as a stale gateway view and
   // falls back to local: the caller was just activated, and invite redemption
@@ -321,14 +361,25 @@ interface AccessRequestState {
   requestId: string | null;
 }
 
-export class CallSetupFlow implements SetupFlowInput {
+export class CallSetupFlow {
   private state: SetupFlowState = "idle";
+  /** Set before dispatch so `start()` runs at most once per instance. */
+  private started = false;
 
   // ── Code-collection state (shared by verification + invite) ────────
   private codeMode: CodeCollectionMode | null = null;
   /** Shared digit buffer for code collection (DTMF + spoken digits). */
   private digitBuffer = "";
   private codeLength = 6;
+  /**
+   * In-flight guard shared by every code-collection sub-flow: async
+   * validation reads and advances the attempt counter, so digits and
+   * spoken codes arriving while one submission is pending are dropped
+   * rather than launching a parallel attempt against the same counter.
+   * Set synchronously before dispatch and cleared when the attempt
+   * settles.
+   */
+  private codeSubmissionInFlight = false;
   /** Setup-time trust, kept as the fallback when re-resolution fails. */
   private initialTrustContext: TrustContext | null = null;
   private trustReResolving = false;
@@ -346,14 +397,6 @@ export class CallSetupFlow implements SetupFlowInput {
   // ── Invite-redemption sub-flow state ────────────────────────────────
   private ideps: InviteDeps | null = null;
   private invite: InviteRedemptionState | null = null;
-  /**
-   * In-flight dedupe guard: the gateway claim is async, and a repeated
-   * code (re-spoken / re-entered) arriving while it is pending must not
-   * fire a second redemption that would see the invite already consumed
-   * and wrongly fail the call. Set synchronously before awaiting and
-   * cleared in a finally.
-   */
-  private inviteRedemptionInFlight = false;
 
   // ── Name-capture / guardian-wait sub-flow state ─────────────────────
   private ndeps: NameCaptureDeps | null = null;
@@ -421,9 +464,13 @@ export class CallSetupFlow implements SetupFlowInput {
    * terminal continuation is delivered via `deps.onComplete`.
    */
   async start(outcome: SetupOutcome, resolved: SetupResolved): Promise<void> {
-    if (this.state !== "idle") {
+    // Mark started before dispatching: async paths (e.g. deny awaits TTS)
+    // stay in `idle` state until their terminal continuation, so the state
+    // check alone would admit a concurrent second start().
+    if (this.started || this.state !== "idle") {
       throw new Error("CallSetupFlow.start() may only be called once");
     }
+    this.started = true;
 
     switch (outcome.action) {
       case "normal_call":
@@ -482,7 +529,7 @@ export class CallSetupFlow implements SetupFlowInput {
     }
   }
 
-  // ── SetupFlowInput ──────────────────────────────────────────────────
+  // ── Caller input ────────────────────────────────────────────────────
 
   /** Feed a DTMF digit to the active sub-flow. No-op while idle/completed. */
   pushDtmfDigit(digit: string): void {
@@ -492,6 +539,11 @@ export class CallSetupFlow implements SetupFlowInput {
     // codeMode is null during name capture and the guardian wait, so DTMF
     // is ignored in those states.
     if (this.codeMode == null) {
+      return;
+    }
+    // Digits arriving while a submitted code is still validating are
+    // dropped — buffering them would launch a parallel attempt.
+    if (this.codeSubmissionInFlight) {
       return;
     }
     this.digitBuffer += digit;
@@ -550,6 +602,11 @@ export class CallSetupFlow implements SetupFlowInput {
     if (this.codeMode == null) {
       return;
     }
+    // Spoken codes arriving while a submitted code is still validating
+    // are dropped — they would launch a parallel attempt.
+    if (this.codeSubmissionInFlight) {
+      return;
+    }
     // Callee verification is DTMF-only — the callee should be entering
     // digits on their keypad, not speaking.
     if (this.codeMode === "callee_verification") {
@@ -560,7 +617,6 @@ export class CallSetupFlow implements SetupFlowInput {
       this.submitCode(spokenDigits.slice(0, this.codeLength));
     } else if (spokenDigits.length > 0) {
       void this.deps.speakSystemPrompt(
-        this.transport,
         `I heard ${spokenDigits.length} digits. Please enter all ${this.codeLength} digits of your code.`,
       );
     }
@@ -584,7 +640,7 @@ export class CallSetupFlow implements SetupFlowInput {
       endedAt: Date.now(),
       lastError: outcome.logReason,
     });
-    await this.deps.speakSystemPrompt(this.transport, outcome.message);
+    await this.deps.speakSystemPrompt(outcome.message);
     this.endSessionAfterPlayback(outcome.logReason);
     this.complete({ kind: "ended", reason: outcome.logReason });
   }
@@ -617,7 +673,6 @@ export class CallSetupFlow implements SetupFlowInput {
     );
 
     void this.deps.speakSystemPrompt(
-      this.transport,
       "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
     );
   }
@@ -652,7 +707,6 @@ export class CallSetupFlow implements SetupFlowInput {
     );
 
     void this.deps.speakSystemPrompt(
-      this.transport,
       composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO, {
         codeDigits: this.codeLength,
       }),
@@ -692,7 +746,6 @@ export class CallSetupFlow implements SetupFlowInput {
 
     const spokenCode = code.split("").join(". ");
     void this.deps.speakSystemPrompt(
-      this.transport,
       `Please enter the verification code: ${spokenCode}.`,
     );
 
@@ -740,18 +793,23 @@ export class CallSetupFlow implements SetupFlowInput {
 
   /** Route a fully collected code to the active code-collection sub-flow. */
   private submitCode(enteredCode: string): void {
+    this.codeSubmissionInFlight = true;
     const handler =
       this.codeMode === "invite_redemption"
         ? this.handleInviteCodeEntry(enteredCode)
         : this.codeMode === "callee_verification"
           ? this.handleCalleeCode(enteredCode)
           : this.handleVerificationCode(enteredCode);
-    handler.catch((err) =>
-      log.error(
-        { err, callSessionId: this.callSessionId },
-        "Setup code handling failed",
-      ),
-    );
+    handler
+      .catch((err) =>
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          "Setup code handling failed",
+        ),
+      )
+      .finally(() => {
+        this.codeSubmissionInFlight = false;
+      });
   }
 
   /**
@@ -839,17 +897,16 @@ export class CallSetupFlow implements SetupFlowInput {
         this.finalizeOnce(vdeps.finalizeCall, session.conversationId);
 
         if (isOutbound && session.initiatedFromConversationId) {
-          this.postPointerMessage(
-            vdeps,
+          vdeps.postPointerMessage(
             session.initiatedFromConversationId,
             "verification_failed",
-            session.toNumber,
+            session.toNumber ?? "",
             { channel: "phone", reason: "Max verification attempts exceeded" },
           );
         }
       }
 
-      await this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+      await this.deps.speakSystemPrompt(result.ttsMessage);
       this.endSessionAfterPlayback("Verification failed — challenge rejected");
       this.complete({
         kind: "ended",
@@ -860,7 +917,7 @@ export class CallSetupFlow implements SetupFlowInput {
 
     // Retry — re-prompt and keep collecting.
     this.verificationAttempts = result.attempt;
-    void this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+    void this.deps.speakSystemPrompt(result.ttsMessage);
   }
 
   /** Compare an entered code against the generated callee verification code. */
@@ -912,11 +969,10 @@ export class CallSetupFlow implements SetupFlowInput {
       if (session) {
         this.finalizeOnce(vdeps.finalizeCall, session.conversationId);
         if (session.initiatedFromConversationId) {
-          this.postPointerMessage(
-            vdeps,
+          vdeps.postPointerMessage(
             session.initiatedFromConversationId,
             "failed",
-            session.toNumber,
+            session.toNumber ?? "",
             { reason: "Callee verification failed" },
           );
         }
@@ -925,10 +981,7 @@ export class CallSetupFlow implements SetupFlowInput {
       // Wait for synthesis to complete before starting the teardown timer
       // so the caller hears the goodbye message.
       try {
-        await this.deps.speakSystemPrompt(
-          this.transport,
-          "Verification failed. Goodbye.",
-        );
+        await this.deps.speakSystemPrompt("Verification failed. Goodbye.");
       } catch (err) {
         log.error(
           { err, callSessionId: this.callSessionId },
@@ -941,7 +994,6 @@ export class CallSetupFlow implements SetupFlowInput {
     }
 
     void this.deps.speakSystemPrompt(
-      this.transport,
       "That code was incorrect. Please try again.",
     );
   }
@@ -958,11 +1010,10 @@ export class CallSetupFlow implements SetupFlowInput {
   ): Promise<void> {
     const session = vdeps.getCallSession(this.callSessionId);
     if (session?.initiatedFromConversationId) {
-      this.postPointerMessage(
-        vdeps,
+      vdeps.postPointerMessage(
         session.initiatedFromConversationId,
         "verification_succeeded",
-        session.toNumber,
+        session.toNumber ?? "",
         { channel: "phone" },
       );
     }
@@ -1048,7 +1099,7 @@ export class CallSetupFlow implements SetupFlowInput {
       handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
     }
 
-    void this.deps.speakSystemPrompt(this.transport, handoffText);
+    void this.deps.speakSystemPrompt(handoffText);
 
     this.deps.recordCallEvent(this.callSessionId, "assistant_spoke", {
       text: handoffText,
@@ -1096,24 +1147,6 @@ export class CallSetupFlow implements SetupFlowInput {
     }
   }
 
-  /** Post a call pointer message, tolerating an evicted origin conversation. */
-  private postPointerMessage(
-    vdeps: VerificationDeps,
-    conversationId: string,
-    event: Parameters<VerificationDeps["addPointerMessage"]>[1],
-    phoneNumber: string | undefined,
-    extra?: Parameters<VerificationDeps["addPointerMessage"]>[3],
-  ): void {
-    vdeps
-      .addPointerMessage(conversationId, event, phoneNumber ?? "", extra)
-      .catch((err) => {
-        log.warn(
-          { conversationId, err },
-          "Skipping pointer write — origin conversation may no longer exist",
-        );
-      });
-  }
-
   /** Hand off transcripts buffered during trust re-resolution, in order. */
   private drainDeferredTranscripts(): string[] | undefined {
     if (this.deferredTranscripts.length === 0) {
@@ -1126,70 +1159,30 @@ export class CallSetupFlow implements SetupFlowInput {
 
   /** Resolve the verification deps, applying defaults for the pure logic. */
   private requireVerificationDeps(): VerificationDeps {
-    const d = this.deps;
-    const missing = (
-      [
-        ["getCallSession", d.getCallSession],
-        ["finalizeCall", d.finalizeCall],
-        ["addMessage", d.addMessage],
-        ["addPointerMessage", d.addPointerMessage],
-        ["fireCallTranscriptNotifier", d.fireCallTranscriptNotifier],
-        ["resolveGuardianLabel", d.resolveGuardianLabel],
-        ["resolveAssistantLabel", d.resolveAssistantLabel],
-      ] as const
-    )
-      .filter(([, dep]) => dep == null)
-      .map(([name]) => name);
-    if (missing.length > 0) {
-      throw new Error(
-        `CallSetupFlow verification deps missing: ${missing.join(", ")}`,
-      );
-    }
-    return {
-      getCallSession: d.getCallSession!,
-      finalizeCall: d.finalizeCall!,
-      addMessage: d.addMessage!,
-      addPointerMessage: d.addPointerMessage!,
-      fireCallTranscriptNotifier: d.fireCallTranscriptNotifier!,
-      resolveGuardianLabel: d.resolveGuardianLabel!,
-      resolveAssistantLabel: d.resolveAssistantLabel!,
-      attemptVerificationCode:
-        d.attemptVerificationCode ?? attemptVerificationCodeImpl,
-      resolveMidCallTrustContext:
-        d.resolveMidCallTrustContext ?? resolveMidCallTrustContext,
-    };
+    return requireDeps("verification", this.deps, [
+      "getCallSession",
+      "finalizeCall",
+      "addMessage",
+      "postPointerMessage",
+      "fireCallTranscriptNotifier",
+      "resolveGuardianLabel",
+      "resolveAssistantLabel",
+      "attemptVerificationCode",
+      "resolveMidCallTrustContext",
+    ]);
   }
 
   /** Resolve the invite-redemption deps, applying defaults for the pure logic. */
   private requireInviteDeps(): InviteDeps {
-    const d = this.deps;
-    const missing = (
-      [
-        ["getCallSession", d.getCallSession],
-        ["finalizeCall", d.finalizeCall],
-        ["fireCallTranscriptNotifier", d.fireCallTranscriptNotifier],
-        ["resolveGuardianLabel", d.resolveGuardianLabel],
-        ["resolveAssistantLabel", d.resolveAssistantLabel],
-      ] as const
-    )
-      .filter(([, dep]) => dep == null)
-      .map(([name]) => name);
-    if (missing.length > 0) {
-      throw new Error(
-        `CallSetupFlow invite deps missing: ${missing.join(", ")}`,
-      );
-    }
-    return {
-      getCallSession: d.getCallSession!,
-      finalizeCall: d.finalizeCall!,
-      fireCallTranscriptNotifier: d.fireCallTranscriptNotifier!,
-      resolveGuardianLabel: d.resolveGuardianLabel!,
-      resolveAssistantLabel: d.resolveAssistantLabel!,
-      attemptInviteCodeRedemption:
-        d.attemptInviteCodeRedemption ?? attemptInviteCodeRedemptionImpl,
-      resolveMidCallTrustContext:
-        d.resolveMidCallTrustContext ?? resolveMidCallTrustContext,
-    };
+    return requireDeps("invite", this.deps, [
+      "getCallSession",
+      "finalizeCall",
+      "fireCallTranscriptNotifier",
+      "resolveGuardianLabel",
+      "resolveAssistantLabel",
+      "attemptInviteCodeRedemption",
+      "resolveMidCallTrustContext",
+    ]);
   }
 
   /** Tear the session down once the terminal copy has had time to play. */
@@ -1231,7 +1224,6 @@ export class CallSetupFlow implements SetupFlowInput {
     this.codeMode = "invite_redemption";
     this.codeLength = INVITE_CODE_LENGTH;
     this.digitBuffer = "";
-    this.inviteRedemptionInFlight = false;
     this.invite = {
       assistantId: outcome.assistantId,
       fromNumber: outcome.fromNumber,
@@ -1261,7 +1253,7 @@ export class CallSetupFlow implements SetupFlowInput {
     } else {
       promptText = `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
     }
-    void this.deps.speakSystemPrompt(this.transport, promptText);
+    void this.deps.speakSystemPrompt(promptText);
 
     log.info(
       { callSessionId: this.callSessionId, assistantId: outcome.assistantId },
@@ -1270,9 +1262,9 @@ export class CallSetupFlow implements SetupFlowInput {
   }
 
   /**
-   * Validate a fully-entered invite code, deduping concurrent attempts:
-   * a repeated code arriving while the async gateway redemption is still
-   * in flight is ignored.
+   * Validate a fully-entered invite code against the gateway claim.
+   * Concurrent attempts are deduped upstream by the shared
+   * code-submission in-flight guard.
    */
   private async handleInviteCodeEntry(enteredCode: string): Promise<void> {
     const invite = this.invite;
@@ -1280,27 +1272,7 @@ export class CallSetupFlow implements SetupFlowInput {
     if (!invite || !ideps) {
       return;
     }
-    if (this.inviteRedemptionInFlight) {
-      log.info(
-        { callSessionId: this.callSessionId },
-        "Ignoring repeated invite code — redemption already in flight",
-      );
-      return;
-    }
-    this.inviteRedemptionInFlight = true;
 
-    try {
-      await this.runInviteCodeRedemption(ideps, invite, enteredCode);
-    } finally {
-      this.inviteRedemptionInFlight = false;
-    }
-  }
-
-  private async runInviteCodeRedemption(
-    ideps: InviteDeps,
-    invite: InviteRedemptionState,
-    enteredCode: string,
-  ): Promise<void> {
     const result = await ideps.attemptInviteCodeRedemption({
       inviteRedemptionFromNumber: invite.fromNumber,
       enteredCode,
@@ -1360,7 +1332,7 @@ export class CallSetupFlow implements SetupFlowInput {
         this.finalizeOnce(ideps.finalizeCall, failSession.conversationId);
       }
 
-      await this.deps.speakSystemPrompt(this.transport, result.ttsMessage);
+      await this.deps.speakSystemPrompt(result.ttsMessage);
       this.endSessionAfterPlayback("Invite redemption failed");
       this.complete({ kind: "ended", reason: "Invite redemption failed" });
     }
@@ -1405,7 +1377,7 @@ export class CallSetupFlow implements SetupFlowInput {
     const greeting = assistantName
       ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
       : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
-    void this.deps.speakSystemPrompt(this.transport, greeting);
+    void this.deps.speakSystemPrompt(greeting);
 
     const timeoutMs = this.deps.nameCaptureTimeoutMs ?? NAME_CAPTURE_TIMEOUT_MS;
     this.nameCaptureTimer = setTimeout(() => {
@@ -1523,20 +1495,16 @@ export class CallSetupFlow implements SetupFlowInput {
   ): void {
     this.state = "awaiting_guardian_decision";
 
-    this.guardianWait = ndeps.createGuardianWaitController(
-      this.callSessionId,
-      this.transport,
-      {
-        speakSystemPrompt: this.deps.speakSystemPrompt,
-        updateCallSession: this.deps.updateCallSession,
-        recordCallEvent: this.deps.recordCallEvent,
-        resolveGuardianLabel: ndeps.resolveGuardianLabel,
-        firstHeartbeatDelayMs: this.deps.ttsPlaybackDelayMs,
-        onApproved: (ctx) => this.handleAccessRequestApproved(ndeps, ctx),
-        onDenied: (ctx) => this.handleAccessRequestDenied(ndeps, ctx.requestId),
-        onTimeout: (ctx) => this.handleAccessRequestTimeout(ndeps, ctx),
-      },
-    );
+    this.guardianWait = ndeps.createGuardianWaitController(this.callSessionId, {
+      speakSystemPrompt: this.deps.speakSystemPrompt,
+      updateCallSession: this.deps.updateCallSession,
+      recordCallEvent: this.deps.recordCallEvent,
+      resolveGuardianLabel: ndeps.resolveGuardianLabel,
+      firstHeartbeatDelayMs: this.deps.ttsPlaybackDelayMs,
+      onApproved: (ctx) => this.handleAccessRequestApproved(ndeps, ctx),
+      onDenied: (ctx) => this.handleAccessRequestDenied(ndeps, ctx.requestId),
+      onTimeout: (ctx) => this.handleAccessRequestTimeout(ndeps, ctx),
+    });
     this.guardianWait.start({
       requestId,
       assistantId: accessRequest.assistantId,
@@ -1611,7 +1579,6 @@ export class CallSetupFlow implements SetupFlowInput {
     );
 
     await this.deps.speakSystemPrompt(
-      this.transport,
       `Sorry, ${guardianLabel} says I'm not allowed to speak with you. Goodbye.`,
     );
     this.endSessionAfterPlayback("Access request denied");
@@ -1659,7 +1626,6 @@ export class CallSetupFlow implements SetupFlowInput {
     );
 
     await this.deps.speakSystemPrompt(
-      this.transport,
       `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
     );
     this.endSessionAfterPlayback("Access request timed out");
@@ -1693,7 +1659,6 @@ export class CallSetupFlow implements SetupFlowInput {
     );
 
     await this.deps.speakSystemPrompt(
-      this.transport,
       "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
     );
     this.endSessionAfterPlayback("Name capture timed out");
@@ -1709,36 +1674,15 @@ export class CallSetupFlow implements SetupFlowInput {
 
   /** Resolve the name-capture deps, applying defaults for the pure logic. */
   private requireNameCaptureDeps(): NameCaptureDeps {
-    const d = this.deps;
-    const missing = (
-      [
-        ["getCallSession", d.getCallSession],
-        ["fireCallTranscriptNotifier", d.fireCallTranscriptNotifier],
-        ["resolveGuardianLabel", d.resolveGuardianLabel],
-        ["resolveAssistantLabel", d.resolveAssistantLabel],
-      ] as const
-    )
-      .filter(([, dep]) => dep == null)
-      .map(([name]) => name);
-    if (missing.length > 0) {
-      throw new Error(
-        `CallSetupFlow name-capture deps missing: ${missing.join(", ")}`,
-      );
-    }
-    return {
-      getCallSession: d.getCallSession!,
-      fireCallTranscriptNotifier: d.fireCallTranscriptNotifier!,
-      resolveGuardianLabel: d.resolveGuardianLabel!,
-      resolveAssistantLabel: d.resolveAssistantLabel!,
-      notifyGuardianOfAccessRequest:
-        d.notifyGuardianOfAccessRequest ?? notifyGuardianOfAccessRequestImpl,
-      createGuardianWaitController:
-        d.createGuardianWaitController ??
-        ((callSessionId, transport, deps) =>
-          new GuardianWaitController(callSessionId, transport, deps)),
-      resolveMidCallTrustContext:
-        d.resolveMidCallTrustContext ?? resolveMidCallTrustContext,
-    };
+    return requireDeps("name-capture", this.deps, [
+      "getCallSession",
+      "fireCallTranscriptNotifier",
+      "resolveGuardianLabel",
+      "resolveAssistantLabel",
+      "notifyGuardianOfAccessRequest",
+      "createGuardianWaitController",
+      "resolveMidCallTrustContext",
+    ]);
   }
 
   // ── Unverified caller ───────────────────────────────────────────────
@@ -1768,7 +1712,7 @@ export class CallSetupFlow implements SetupFlowInput {
     const message =
       `This number is registered as ${outcome.displayName}'s phone but has not been verified yet. ` +
       action;
-    await this.deps.speakSystemPrompt(this.transport, message);
+    await this.deps.speakSystemPrompt(message);
     this.endSessionAfterPlayback(
       "Inbound voice ACL: caller channel unverified",
     );

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -31,11 +31,6 @@ export interface CallTransport {
   endSession(reason?: string): void;
 
   /**
-   * Return the current connection-level state.
-   */
-  getConnectionState(): string;
-
-  /**
    * When true, the transport requires WAV (PCM) audio for playback.
    *
    * The media-stream transport sets this because its mu-law transcoder

--- a/assistant/src/calls/guardian-wait-controller.ts
+++ b/assistant/src/calls/guardian-wait-controller.ts
@@ -23,7 +23,6 @@ import {
   getTtsPlaybackDelayMs,
   getUserConsultationTimeoutMs,
 } from "./call-constants.js";
-import type { SetupFlowTransport } from "./call-setup-flow-types.js";
 import type {
   recordCallEvent as recordCallEventFn,
   updateCallSession as updateCallSessionFn,
@@ -38,12 +37,6 @@ const log = getLogger("guardian-wait-controller");
 
 /** Minimum gap between spoken replies to non-callback wait utterances. */
 export const IN_WAIT_REPLY_COOLDOWN_MS = 3000;
-
-// Schema defaults from config/schemas/calls.ts, used when config values
-// are missing or NaN.
-const DEFAULT_CONSULT_TIMEOUT_MS = 120_000;
-const DEFAULT_POLL_INTERVAL_MS = 500;
-const DEFAULT_FIRST_HEARTBEAT_DELAY_MS = 3000;
 
 // ── Public types ─────────────────────────────────────────────────────
 
@@ -80,8 +73,8 @@ export interface GuardianWaitStartParams {
 }
 
 export interface GuardianWaitControllerDeps {
-  /** Speak a deterministic system prompt through the transport. */
-  speakSystemPrompt(transport: SetupFlowTransport, text: string): Promise<void>;
+  /** Speak a deterministic system prompt through the call transport. */
+  speakSystemPrompt(text: string): Promise<void>;
   updateCallSession(
     id: string,
     updates: Parameters<typeof updateCallSessionFn>[1],
@@ -134,7 +127,6 @@ export class GuardianWaitController {
 
   constructor(
     private readonly callSessionId: string,
-    private readonly transport: SetupFlowTransport,
     private readonly deps: GuardianWaitControllerDeps,
   ) {}
 
@@ -179,14 +171,16 @@ export class GuardianWaitController {
     this.heartbeatTimer = setTimeout(() => {
       this.waitStartedAt = this.now();
       this.scheduleHeartbeat();
-    }, this.resolveFirstHeartbeatDelayMs());
+    }, this.deps.firstHeartbeatDelayMs ?? getTtsPlaybackDelayMs());
 
-    const pollIntervalMs = this.resolvePollIntervalMs();
+    const pollIntervalMs =
+      this.deps.pollIntervalMs ?? getAccessRequestPollIntervalMs();
     this.pollTimer = setInterval(() => {
       this.pollCanonicalRequest();
     }, pollIntervalMs);
 
-    const timeoutMs = this.resolveConsultTimeoutMs();
+    const timeoutMs =
+      this.deps.consultTimeoutMs ?? getUserConsultationTimeoutMs();
     this.timeoutTimer = setTimeout(() => {
       if (this.state !== "awaiting_guardian_decision") {
         return;
@@ -272,7 +266,9 @@ export class GuardianWaitController {
     }
 
     // Enforce cooldown on non-callback utterances to prevent spam.
-    if (now - this.lastInWaitReplyAt < this.resolveInWaitReplyCooldownMs()) {
+    const cooldownMs =
+      this.deps.inWaitReplyCooldownMs ?? IN_WAIT_REPLY_COOLDOWN_MS;
+    if (now - this.lastInWaitReplyAt < cooldownMs) {
       log.debug(
         { callSessionId: this.callSessionId },
         "In-wait reply suppressed by cooldown",
@@ -439,7 +435,7 @@ export class GuardianWaitController {
   }
 
   private speak(text: string): Promise<void> {
-    return this.deps.speakSystemPrompt(this.transport, text).catch((err) => {
+    return this.deps.speakSystemPrompt(text).catch((err) => {
       log.error(
         { err, callSessionId: this.callSessionId },
         "Guardian wait speech failed",
@@ -450,56 +446,4 @@ export class GuardianWaitController {
   private now(): number {
     return this.deps.now?.() ?? Date.now();
   }
-
-  private resolveConsultTimeoutMs(): number {
-    return finiteAtLeast(
-      this.deps.consultTimeoutMs ?? safeCall(getUserConsultationTimeoutMs),
-      1,
-      DEFAULT_CONSULT_TIMEOUT_MS,
-    );
-  }
-
-  private resolvePollIntervalMs(): number {
-    return finiteAtLeast(
-      this.deps.pollIntervalMs ?? safeCall(getAccessRequestPollIntervalMs),
-      1,
-      DEFAULT_POLL_INTERVAL_MS,
-    );
-  }
-
-  private resolveFirstHeartbeatDelayMs(): number {
-    return finiteAtLeast(
-      this.deps.firstHeartbeatDelayMs ?? safeCall(getTtsPlaybackDelayMs),
-      0,
-      DEFAULT_FIRST_HEARTBEAT_DELAY_MS,
-    );
-  }
-
-  private resolveInWaitReplyCooldownMs(): number {
-    return finiteAtLeast(
-      this.deps.inWaitReplyCooldownMs,
-      0,
-      IN_WAIT_REPLY_COOLDOWN_MS,
-    );
-  }
-}
-
-// ── Config guards ────────────────────────────────────────────────────
-
-function safeCall(getter: () => number): number | undefined {
-  try {
-    return getter();
-  } catch {
-    return undefined;
-  }
-}
-
-function finiteAtLeast(
-  value: number | undefined,
-  min: number,
-  fallback: number,
-): number {
-  return typeof value === "number" && Number.isFinite(value) && value >= min
-    ? value
-    : fallback;
 }

--- a/assistant/src/calls/media-stream-audio-transcode.ts
+++ b/assistant/src/calls/media-stream-audio-transcode.ts
@@ -142,7 +142,7 @@ export function chunkMulawToBase64Frames(mulawBuffer: Buffer): string[] {
  * bitwise-inverted on the wire (Twilio's encoding), mirroring
  * {@link linearToMulaw}.
  */
-function mulawToLinear(mulawByte: number): number {
+export function mulawToLinear(mulawByte: number): number {
   const b = ~mulawByte & 0xff;
   const sign = b & 0x80;
   const exponent = (b >> 4) & 0x07;

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -171,14 +171,6 @@ export class MediaStreamOutput implements CallTransport {
     }
   }
 
-  /**
-   * Return the current connection-level state. The controller uses this
-   * to suppress silence nudges during guardian wait states.
-   */
-  getConnectionState(): string {
-    return this.state;
-  }
-
   // ── Media-stream specific methods ───────────────────────────────────
 
   /**

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -49,10 +49,12 @@ import {
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
-import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
-import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import {
+  formatDuration,
+  postPointerMessageSafe,
+} from "./call-pointer-messages.js";
 import { CallSetupFlow, type CallSetupFlowDeps } from "./call-setup-flow.js";
 import type { SetupFlowResult } from "./call-setup-flow-types.js";
 import { speakSystemPrompt } from "./call-speech-output.js";
@@ -79,10 +81,6 @@ import {
   type MediaStreamSttSessionConfig,
 } from "./media-stream-stt-session.js";
 import { routeSetup } from "./relay-setup-router.js";
-import {
-  attemptInviteCodeRedemption,
-  attemptVerificationCode,
-} from "./relay-verification.js";
 
 const log = getLogger("media-stream-server");
 const UUID_SHAPED_NAME =
@@ -302,19 +300,14 @@ export class MediaStreamCallSession {
         const durationMs = session.startedAt
           ? Date.now() - session.startedAt
           : 0;
-        addPointerMessage(
+        postPointerMessageSafe(
           session.initiatedFromConversationId,
           "completed",
           session.toNumber,
           {
             duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
           },
-        ).catch((err) => {
-          log.warn(
-            { conversationId: session.initiatedFromConversationId, err },
-            "Skipping pointer write — origin conversation may no longer exist",
-          );
-        });
+        );
       }
     } else {
       const detail =
@@ -331,17 +324,12 @@ export class MediaStreamCallSession {
       });
 
       if (session.initiatedFromConversationId) {
-        addPointerMessage(
+        postPointerMessageSafe(
           session.initiatedFromConversationId,
           "failed",
           session.toNumber,
           { reason: detail },
-        ).catch((err) => {
-          log.warn(
-            { conversationId: session.initiatedFromConversationId, err },
-            "Skipping pointer write — origin conversation may no longer exist",
-          );
-        });
+        );
       }
     }
 
@@ -454,12 +442,7 @@ export class MediaStreamCallSession {
     // the WebSocket meanwhile, the close handler will have called destroy().
     // Abort setup so we don't create a controller or speak on a disposed
     // session.
-    if (this.disposed) {
-      log.info(
-        { callSessionId: this.callSessionId },
-        "Media-stream session disposed during admission read — aborting setup",
-      );
-      this.setupRouting = false;
+    if (this.abortIfDisposed("admission read")) {
       return;
     }
 
@@ -473,12 +456,7 @@ export class MediaStreamCallSession {
 
     // The verdict read above yields the event loop; abort if the session was
     // disposed meanwhile, matching the admission-read guard above.
-    if (this.disposed) {
-      log.info(
-        { callSessionId: this.callSessionId },
-        "Media-stream session disposed during verdict read — aborting setup",
-      );
-      this.setupRouting = false;
+    if (this.abortIfDisposed("verdict read")) {
       return;
     }
 
@@ -494,12 +472,7 @@ export class MediaStreamCallSession {
 
     // routeSetup can yield the event loop (gateway voice-invite read); abort
     // if the session was disposed meanwhile, matching the guards above.
-    if (this.disposed) {
-      log.info(
-        { callSessionId: this.callSessionId },
-        "Media-stream session disposed during setup routing — aborting setup",
-      );
-      this.setupRouting = false;
+    if (this.abortIfDisposed("setup routing")) {
       return;
     }
 
@@ -528,16 +501,33 @@ export class MediaStreamCallSession {
   // ── Setup flow wiring ─────────────────────────────────────────────
 
   /**
+   * Abort a pending setup when the session was disposed across an await
+   * in {@link handleStart}: logs the stage and clears the setup-routing
+   * input gate. Returns true when setup must abort.
+   */
+  private abortIfDisposed(stage: string): boolean {
+    if (!this.disposed) {
+      return false;
+    }
+    log.info(
+      { callSessionId: this.callSessionId, stage },
+      "Media-stream session disposed during setup — aborting",
+    );
+    this.setupRouting = false;
+    return true;
+  }
+
+  /**
    * Real side-effect surface for the {@link CallSetupFlow}. Pure-logic
-   * deps (verification code parsing, trust re-resolution, guardian wait
-   * construction) use the flow's real-implementation defaults.
+   * deps (code validation, invite redemption, guardian notification,
+   * trust re-resolution, guardian wait construction) use the flow's
+   * real-implementation defaults.
    */
   private buildSetupFlowDeps(
     session: ReturnType<typeof getCallSession>,
   ): CallSetupFlowDeps {
     return {
-      speakSystemPrompt: (_transport, text) =>
-        speakSystemPrompt(this.output, text),
+      speakSystemPrompt: (text) => speakSystemPrompt(this.output, text),
       updateCallSession,
       recordCallEvent,
       onComplete: (result) => this.handleSetupFlowResult(result, session),
@@ -550,14 +540,11 @@ export class MediaStreamCallSession {
         finalizeCall(callSessionId, conversationId);
       },
       addMessage,
-      addPointerMessage,
+      postPointerMessage: postPointerMessageSafe,
       fireCallTranscriptNotifier,
       resolveGuardianLabel: () =>
         resolveGuardianName(this.primedGuardianDisplayName),
       resolveAssistantLabel,
-      notifyGuardianOfAccessRequest,
-      attemptVerificationCode,
-      attemptInviteCodeRedemption,
     };
   }
 

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -48,7 +48,11 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { getLogger } from "../util/logger.js";
-import { mulawToPcm16, resamplePcm16 } from "./media-stream-audio-transcode.js";
+import {
+  mulawToLinear,
+  mulawToPcm16,
+  resamplePcm16,
+} from "./media-stream-audio-transcode.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type {
   MediaStreamMediaEvent,
@@ -701,16 +705,16 @@ function stopStreamingBestEffort(
  * around 0xFF (negative zero) and 0x7F (positive zero). Speech produces
  * samples with lower byte values (higher decoded amplitude).
  *
- * This function computes the average absolute linear amplitude of the
- * mu-law samples and compares it against a threshold. The threshold is
+ * This function computes the average absolute G.711-decoded amplitude of
+ * the mu-law samples and compares it against a threshold. The threshold is
  * tuned for Twilio's 8 kHz, 8-bit mu-law stream where typical silence
- * RMS is ~50-100 and speech is >300.
+ * averages ~200-400 and speech >1200 on the full 16-bit linear scale.
  *
  * @param raw - Decoded mu-law audio chunk from Twilio.
  * @returns `true` if the chunk likely contains speech, `false` otherwise.
  */
 function detectSpeechActivity(raw: Buffer): boolean {
-  const SPEECH_ENERGY_THRESHOLD = 200;
+  const SPEECH_ENERGY_THRESHOLD = 800;
 
   if (raw.length === 0) {
     return false;
@@ -719,31 +723,11 @@ function detectSpeechActivity(raw: Buffer): boolean {
   // Compute average absolute linear amplitude from mu-law samples.
   let totalAmplitude = 0;
   for (let i = 0; i < raw.length; i++) {
-    totalAmplitude += mulawToLinearMagnitude(raw[i]);
+    totalAmplitude += Math.abs(mulawToLinear(raw[i]));
   }
   const avgAmplitude = totalAmplitude / raw.length;
 
   return avgAmplitude > SPEECH_ENERGY_THRESHOLD;
-}
-
-/**
- * Convert a single mu-law byte to its approximate absolute linear magnitude.
- *
- * mu-law decoding formula (ITU-T G.711):
- * - Bit 7 is the sign bit (0 = positive, 1 = negative).
- * - Bits 6-4 are the exponent (3 bits).
- * - Bits 3-0 are the mantissa (4 bits).
- *
- * The decoded value is: sign * ((mantissa << 1 | 0x21) << exponent) - 0x21
- * We return the absolute value since we only care about energy.
- */
-function mulawToLinearMagnitude(mulawByte: number): number {
-  // mu-law bytes are bitwise-inverted in Twilio's encoding
-  const b = ~mulawByte & 0xff;
-  const exponent = (b >> 4) & 0x07;
-  const mantissa = b & 0x0f;
-  const magnitude = ((mantissa << 1) | 0x21) << exponent;
-  return magnitude - 0x21;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Review-remediation for phone-media-stream-v2.md:
- In-flight guard for verification code submission (parallel attempts no longer share one attempt count) + start() at-most-once hardening
- Consolidation sweep: dead getConnectionState/sendPlayUrl transport members removed, SetupFlowTransport now a real subset, generic requireDeps, shared postPointerMessageSafe, deduped defaults/wrappers, disposed-guard helper