### PR TITLE
fix: settings UI test/slop cleanup for default-profile lock

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -29,7 +29,6 @@ import * as daemonQueryGen from "@/generated/daemon/@tanstack/react-query.gen";
 // ---------------------------------------------------------------------------
 
 let toastSuccessCalls: string[] = [];
-let configPatchCalled = false;
 let configPatchBodies: unknown[] = [];
 let profilesState: Record<string, ProfileEntry> = {};
 
@@ -56,7 +55,6 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     },
   })),
   configPatch: async (options?: { body?: unknown }) => {
-    configPatchCalled = true;
     configPatchBodies.push(options?.body);
     return {
       data: {
@@ -189,7 +187,6 @@ function selectModel(label: string): void {
 
 beforeEach(() => {
   toastSuccessCalls = [];
-  configPatchCalled = false;
   configPatchBodies = [];
   profilesState = {};
 });
@@ -232,7 +229,7 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
     // The config mutation ran and the Settings surface fired one toast using
     // the entered label.
     await waitFor(() => {
-      expect(configPatchCalled).toBe(true);
+      expect(configPatchBodies.length).toBeGreaterThan(0);
     });
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(['Profile "My Profile" created']);
@@ -309,7 +306,7 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     fireEvent.click(findStatusToggle("Enable", "Default B")!);
 
     await waitFor(() => {
-      expect(configPatchCalled).toBe(true);
+      expect(configPatchBodies.length).toBeGreaterThan(0);
     });
     expect(configPatchBodies).toEqual([
       { llm: { profiles: { "default-b": { status: "active" } } } },

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -724,12 +724,7 @@ function ProfileEditorModalInner({
     !isInvariant || status !== "active" ? (
       <Toggle
         checked={status === "active"}
-        onChange={(v) => {
-          if (isInvariant && v !== true) {
-            return;
-          }
-          setStatus(v ? "active" : "disabled");
-        }}
+        onChange={(v) => setStatus(v ? "active" : "disabled")}
         label="Active"
       />
     ) : null;


### PR DESCRIPTION
## Summary
Fixes cleanup gaps identified during plan review for invariant-default-profiles.md.

- Remove unreachable enable-only guard in the invariant profile status toggle (render condition already enforces it)
- Drop redundant configPatchCalled boolean in manage-profiles-modal.test.tsx in favor of configPatchBodies.length
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->