### PR TITLE
feat(gateway-client): shared verification-session wire types + IPC request/response schemas

### DIFF
--- a/packages/gateway-client/src/__tests__/verification-session-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/verification-session-contract.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for the shared verification-session contract.
+ *
+ * The pinned hash vectors below define the hash compatibility contract:
+ * `hashVerificationSecret` must produce exactly these outputs because session
+ * hashes already stored in the assistant DB (and backfilled to the gateway)
+ * were produced with the same SHA-256-hex scheme. Do not update the vectors
+ * to "fix" a failure — a mismatch means the hash scheme broke.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  BindSessionIdentityIpcParamsSchema,
+  CountRecentSendsIpcParamsSchema,
+  CountRecentSendsIpcResponseSchema,
+  CreateInboundSessionIpcParamsSchema,
+  CreateInboundSessionIpcResponseSchema,
+  CreateOutboundSessionIpcParamsSchema,
+  CreateOutboundSessionIpcResponseSchema,
+  hashVerificationSecret,
+  ResolveBootstrapSessionIpcParamsSchema,
+  SessionLookupIpcResponseSchema,
+  UpdateSessionDeliveryIpcParamsSchema,
+  UpdateSessionStatusIpcParamsSchema,
+  ValidateConsumeSessionIpcParamsSchema,
+  ValidateConsumeSessionIpcResponseSchema,
+  VERIFICATION_SESSIONS_IPC_METHODS,
+  VerificationSessionSchema,
+  type VerificationSessionWire,
+} from "../verification-session-contract.js";
+
+describe("hashVerificationSecret — pinned compatibility vectors", () => {
+  test("matches channel-verification-service.ts hashSecret output", () => {
+    expect(hashVerificationSecret("123456")).toBe(
+      "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92",
+    );
+    expect(hashVerificationSecret("test-bootstrap-token")).toBe(
+      "99ecd312d2f24ffd7011532ba5579dae00103767862bd5b7a79e6efcef99e05e",
+    );
+    expect(hashVerificationSecret("a3f9")).toBe(
+      "a5099480221d1ba2eb1fae7248a0ab2cb15b52ffbe3f3945b3d7e609acd3b2fc",
+    );
+  });
+});
+
+describe("IPC method names", () => {
+  test("exposes 11 unique methods under the verification_sessions_ prefix", () => {
+    const methods = Object.values(VERIFICATION_SESSIONS_IPC_METHODS);
+    expect(methods).toHaveLength(11);
+    expect(new Set(methods).size).toBe(11);
+    for (const method of methods) {
+      // Distinct from the daemon's client-facing
+      // `channel_verification_sessions_*` operationIds.
+      expect(method).toMatch(/^verification_sessions_[a-z_]+$/);
+    }
+  });
+});
+
+const outboundSession: VerificationSessionWire = {
+  id: "sess-1",
+  channel: "telegram",
+  challengeHash: hashVerificationSecret("123456"),
+  expiresAt: 1_700_000_600_000,
+  status: "awaiting_response",
+  sourceConversationId: null,
+  consumedByExternalUserId: null,
+  consumedByChatId: null,
+  expectedExternalUserId: "tg-user-1",
+  expectedChatId: "tg-chat-1",
+  expectedPhoneE164: null,
+  identityBindingStatus: "bound",
+  destinationAddress: "@handle",
+  lastSentAt: 1_700_000_000_000,
+  sendCount: 1,
+  nextResendAt: 1_700_000_060_000,
+  codeDigits: 6,
+  maxAttempts: 3,
+  verificationPurpose: "guardian",
+  bootstrapTokenHash: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const inboundSession: VerificationSessionWire = {
+  ...outboundSession,
+  id: "sess-2",
+  status: "pending",
+  sourceConversationId: "conv-1",
+  expectedExternalUserId: null,
+  expectedChatId: null,
+  identityBindingStatus: null,
+  destinationAddress: null,
+  lastSentAt: null,
+  sendCount: 0,
+  nextResendAt: null,
+  verificationPurpose: "trusted_contact",
+};
+
+describe("VerificationSessionSchema", () => {
+  test("round-trips outbound and inbound sessions", () => {
+    expect(VerificationSessionSchema.parse(outboundSession)).toEqual(
+      outboundSession,
+    );
+    expect(VerificationSessionSchema.parse(inboundSession)).toEqual(
+      inboundSession,
+    );
+  });
+
+  test("rejects an unknown status", () => {
+    expect(() =>
+      VerificationSessionSchema.parse({
+        ...outboundSession,
+        status: "definitely_not_a_status",
+      }),
+    ).toThrow();
+  });
+
+  test("SessionLookupIpcResponseSchema accepts a session or null", () => {
+    expect(SessionLookupIpcResponseSchema.parse(outboundSession)).toEqual(
+      outboundSession,
+    );
+    expect(SessionLookupIpcResponseSchema.parse(null)).toBeNull();
+  });
+});
+
+describe("create session IPC schemas", () => {
+  test("create_inbound round-trips params and response", () => {
+    const params = { channel: "telegram", sourceConversationId: "conv-1" };
+    expect(CreateInboundSessionIpcParamsSchema.parse(params)).toEqual(params);
+    const minimal = { channel: "slack" };
+    expect(CreateInboundSessionIpcParamsSchema.parse(minimal)).toEqual(minimal);
+    expect(() =>
+      CreateInboundSessionIpcParamsSchema.parse({ channel: "" }),
+    ).toThrow();
+
+    const response = {
+      session: inboundSession,
+      secret: "raw-secret",
+      verifyCommand: "raw-secret",
+      ttlSeconds: 600,
+    };
+    expect(CreateInboundSessionIpcResponseSchema.parse(response)).toEqual(
+      response,
+    );
+  });
+
+  test("create_outbound round-trips full and minimal params + response", () => {
+    const full = {
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-1",
+      expectedChatId: "tg-chat-1",
+      expectedPhoneE164: "+15551234567",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "@handle",
+      codeDigits: 6,
+      maxAttempts: 3,
+      verificationPurpose: "trusted_contact",
+      bootstrapTokenHash: hashVerificationSecret("test-bootstrap-token"),
+      sessionId: "sess-1",
+    } as const;
+    expect(CreateOutboundSessionIpcParamsSchema.parse(full)).toEqual(full);
+    const minimal = { channel: "phone" };
+    expect(CreateOutboundSessionIpcParamsSchema.parse(minimal)).toEqual(
+      minimal,
+    );
+    expect(() =>
+      CreateOutboundSessionIpcParamsSchema.parse({
+        channel: "phone",
+        identityBindingStatus: "unbound",
+      }),
+    ).toThrow();
+
+    const response = {
+      sessionId: "sess-1",
+      secret: "123456",
+      challengeHash: hashVerificationSecret("123456"),
+      expiresAt: 1_700_000_600_000,
+      ttlSeconds: 600,
+    };
+    expect(CreateOutboundSessionIpcResponseSchema.parse(response)).toEqual(
+      response,
+    );
+  });
+});
+
+describe("lifecycle IPC param schemas", () => {
+  test("resolve_bootstrap requires channel and raw token", () => {
+    const params = { channel: "telegram", token: "raw-deep-link-token" };
+    expect(ResolveBootstrapSessionIpcParamsSchema.parse(params)).toEqual(
+      params,
+    );
+    expect(() =>
+      ResolveBootstrapSessionIpcParamsSchema.parse({ channel: "telegram" }),
+    ).toThrow();
+  });
+
+  test("bind_identity requires all three fields", () => {
+    const params = {
+      sessionId: "sess-1",
+      externalUserId: "tg-user-1",
+      chatId: "tg-chat-1",
+    };
+    expect(BindSessionIdentityIpcParamsSchema.parse(params)).toEqual(params);
+    expect(() =>
+      BindSessionIdentityIpcParamsSchema.parse({ sessionId: "sess-1" }),
+    ).toThrow();
+  });
+
+  test("update_status accepts consumed-by fields and rejects bad statuses", () => {
+    const params = {
+      sessionId: "sess-1",
+      status: "consumed",
+      consumedByExternalUserId: "tg-user-1",
+      consumedByChatId: "tg-chat-1",
+    } as const;
+    expect(UpdateSessionStatusIpcParamsSchema.parse(params)).toEqual(params);
+    const minimal = { sessionId: "sess-1", status: "revoked" } as const;
+    expect(UpdateSessionStatusIpcParamsSchema.parse(minimal)).toEqual(minimal);
+    expect(() =>
+      UpdateSessionStatusIpcParamsSchema.parse({
+        sessionId: "sess-1",
+        status: "nope",
+      }),
+    ).toThrow();
+  });
+
+  test("update_delivery accepts a null nextResendAt", () => {
+    const params = {
+      sessionId: "sess-1",
+      lastSentAt: 1_700_000_000_000,
+      sendCount: 2,
+      nextResendAt: null,
+    };
+    expect(UpdateSessionDeliveryIpcParamsSchema.parse(params)).toEqual(params);
+    expect(() =>
+      UpdateSessionDeliveryIpcParamsSchema.parse({
+        sessionId: "sess-1",
+        lastSentAt: 1_700_000_000_000,
+        sendCount: 2,
+      }),
+    ).toThrow();
+  });
+
+  test("count_recent_sends round-trips params and response", () => {
+    const params = {
+      channel: "telegram",
+      destinationAddress: "@handle",
+      windowMs: 900_000,
+    };
+    expect(CountRecentSendsIpcParamsSchema.parse(params)).toEqual(params);
+    expect(CountRecentSendsIpcResponseSchema.parse({ count: 3 })).toEqual({
+      count: 3,
+    });
+    expect(() =>
+      CountRecentSendsIpcResponseSchema.parse({ count: 3.5 }),
+    ).toThrow();
+  });
+});
+
+describe("validate_consume IPC schemas", () => {
+  test("params require channel and secret", () => {
+    const params = {
+      channel: "phone",
+      secret: "123456",
+      actorExternalUserId: "+15551234567",
+      actorChatId: "+15551234567",
+    };
+    expect(ValidateConsumeSessionIpcParamsSchema.parse(params)).toEqual(params);
+    expect(() =>
+      ValidateConsumeSessionIpcParamsSchema.parse({
+        channel: "phone",
+        secret: "",
+        actorExternalUserId: "x",
+        actorChatId: "y",
+      }),
+    ).toThrow();
+  });
+
+  test("response discriminates success from failure", () => {
+    const success = { success: true, verificationType: "guardian" } as const;
+    expect(ValidateConsumeSessionIpcResponseSchema.parse(success)).toEqual(
+      success,
+    );
+    const failure = {
+      success: false,
+      reason: "invalid_or_expired_code",
+    } as const;
+    expect(ValidateConsumeSessionIpcResponseSchema.parse(failure)).toEqual(
+      failure,
+    );
+    expect(() =>
+      ValidateConsumeSessionIpcResponseSchema.parse({
+        success: true,
+        reason: "invalid_or_expired_code",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -119,6 +119,62 @@ export type {
   RedeemVoiceInviteRequest,
 } from "./invite-contract.js";
 
+// Verification-session contract (shared gateway ↔ daemon) — hash helper,
+// status enums, wire DTO + verification_sessions_* IPC schemas
+export {
+  BindSessionIdentityIpcParamsSchema,
+  CountRecentSendsIpcParamsSchema,
+  CountRecentSendsIpcResponseSchema,
+  CreateInboundSessionIpcParamsSchema,
+  CreateInboundSessionIpcResponseSchema,
+  CreateOutboundSessionIpcParamsSchema,
+  CreateOutboundSessionIpcResponseSchema,
+  FindActiveSessionIpcParamsSchema,
+  GetPendingSessionIpcParamsSchema,
+  hashVerificationSecret,
+  IDENTITY_BINDING_STATUS_VALUES,
+  IdentityBindingStatusSchema,
+  ResolveBootstrapSessionIpcParamsSchema,
+  RevokePendingSessionsIpcParamsSchema,
+  SESSION_STATUS_VALUES,
+  SessionLookupIpcResponseSchema,
+  SessionMutationIpcResponseSchema,
+  SessionStatusSchema,
+  UpdateSessionDeliveryIpcParamsSchema,
+  UpdateSessionStatusIpcParamsSchema,
+  ValidateConsumeSessionIpcParamsSchema,
+  ValidateConsumeSessionIpcResponseSchema,
+  VERIFICATION_PURPOSE_VALUES,
+  VERIFICATION_SESSIONS_IPC_METHODS,
+  VerificationPurposeSchema,
+  VerificationSessionSchema,
+} from "./verification-session-contract.js";
+
+export type {
+  BindSessionIdentityIpcParams,
+  CountRecentSendsIpcParams,
+  CountRecentSendsIpcResponse,
+  CreateInboundSessionIpcParams,
+  CreateInboundSessionIpcResponse,
+  CreateOutboundSessionIpcParams,
+  CreateOutboundSessionIpcResponse,
+  FindActiveSessionIpcParams,
+  GetPendingSessionIpcParams,
+  IdentityBindingStatus,
+  ResolveBootstrapSessionIpcParams,
+  RevokePendingSessionsIpcParams,
+  SessionLookupIpcResponse,
+  SessionMutationIpcResponse,
+  SessionStatus,
+  UpdateSessionDeliveryIpcParams,
+  UpdateSessionStatusIpcParams,
+  ValidateConsumeSessionIpcParams,
+  ValidateConsumeSessionIpcResponse,
+  VerificationPurpose,
+  VerificationSessionsIpcMethod,
+  VerificationSessionWire,
+} from "./verification-session-contract.js";
+
 // Guardian delivery contract (daemon → gateway pull) — Zod schemas + derived types
 export {
   GuardianDeliverySchema,

--- a/packages/gateway-client/src/verification-session-contract.ts
+++ b/packages/gateway-client/src/verification-session-contract.ts
@@ -1,0 +1,362 @@
+/**
+ * Shared verification-session contracts for the gateway-native session
+ * lifecycle (Combo 13).
+ *
+ * The secret-hashing helper lives here so gateway-computed hashes match
+ * assistant-minted (and backfilled) hashes byte-for-byte — hash compatibility
+ * with rows already stored in the session table is load-bearing, so do not
+ * change the scheme. The wire DTO and the `verification_sessions_*` IPC
+ * request/response schemas are shared so gateway and daemon converge on one
+ * source of truth instead of drifting copies.
+ *
+ * Method names deliberately use the `verification_sessions_` prefix — the
+ * daemon's client-facing HTTP/CLI surface owns the distinct
+ * `channel_verification_sessions_*` operationIds.
+ */
+
+import { createHash } from "node:crypto";
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Hash helper
+// ---------------------------------------------------------------------------
+
+/**
+ * SHA-256 hash a verification secret (challenge code or bootstrap token) for
+ * storage comparison. Must remain stable: stored session rows hold
+ * `challenge_hash` / `bootstrap_token_hash` values produced by this scheme
+ * (`assistant/src/runtime/channel-verification-service.ts` hashSecret).
+ */
+export function hashVerificationSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const SESSION_STATUS_VALUES = [
+  "pending",
+  "consumed",
+  "pending_bootstrap",
+  "awaiting_response",
+  "verified",
+  "expired",
+  "revoked",
+  "locked",
+] as const;
+
+export const SessionStatusSchema = z.enum(SESSION_STATUS_VALUES);
+
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+export const VERIFICATION_PURPOSE_VALUES = [
+  "guardian",
+  "trusted_contact",
+] as const;
+
+export const VerificationPurposeSchema = z.enum(VERIFICATION_PURPOSE_VALUES);
+
+export type VerificationPurpose = z.infer<typeof VerificationPurposeSchema>;
+
+export const IDENTITY_BINDING_STATUS_VALUES = [
+  "pending_bootstrap",
+  "bound",
+] as const;
+
+export const IdentityBindingStatusSchema = z.enum(
+  IDENTITY_BINDING_STATUS_VALUES,
+);
+
+export type IdentityBindingStatus = z.infer<typeof IdentityBindingStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Wire DTO
+// ---------------------------------------------------------------------------
+
+/**
+ * Verification session as carried on the daemon ↔ gateway wire. Mirrors the
+ * daemon's `VerificationSession` interface
+ * (`assistant/src/channels/channel-verification-sessions.ts`) field-for-field
+ * so consumer flips are mechanical.
+ */
+export const VerificationSessionSchema = z.object({
+  id: z.string(),
+  channel: z.string(),
+  challengeHash: z.string(),
+  expiresAt: z.number(),
+  status: SessionStatusSchema,
+  sourceConversationId: z.string().nullable(),
+  consumedByExternalUserId: z.string().nullable(),
+  consumedByChatId: z.string().nullable(),
+  // Outbound session: expected-identity binding
+  expectedExternalUserId: z.string().nullable(),
+  expectedChatId: z.string().nullable(),
+  expectedPhoneE164: z.string().nullable(),
+  identityBindingStatus: IdentityBindingStatusSchema.nullable(),
+  // Outbound session: delivery tracking
+  destinationAddress: z.string().nullable(),
+  lastSentAt: z.number().nullable(),
+  sendCount: z.number().int(),
+  nextResendAt: z.number().nullable(),
+  // Session configuration
+  codeDigits: z.number().int(),
+  maxAttempts: z.number().int(),
+  verificationPurpose: VerificationPurposeSchema,
+  // Telegram bootstrap deep-link token hash
+  bootstrapTokenHash: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export type VerificationSessionWire = z.infer<typeof VerificationSessionSchema>;
+
+// ---------------------------------------------------------------------------
+// IPC methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Gateway IPC method names for the verification-session lifecycle. Keys match
+ * the daemon-side wrapper names; values are the wire method strings.
+ */
+export const VERIFICATION_SESSIONS_IPC_METHODS = {
+  createInbound: "verification_sessions_create_inbound",
+  createOutbound: "verification_sessions_create_outbound",
+  getPending: "verification_sessions_get_pending",
+  findActive: "verification_sessions_find_active",
+  resolveBootstrap: "verification_sessions_resolve_bootstrap",
+  bindIdentity: "verification_sessions_bind_identity",
+  updateStatus: "verification_sessions_update_status",
+  updateDelivery: "verification_sessions_update_delivery",
+  countRecentSends: "verification_sessions_count_recent_sends",
+  revokePending: "verification_sessions_revoke_pending",
+  validateConsume: "verification_sessions_validate_consume",
+} as const;
+
+export type VerificationSessionsIpcMethod =
+  (typeof VERIFICATION_SESSIONS_IPC_METHODS)[keyof typeof VERIFICATION_SESSIONS_IPC_METHODS];
+
+// ---------------------------------------------------------------------------
+// IPC request/response schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared response for session lookups (`verification_sessions_get_pending`,
+ * `_find_active`, `_resolve_bootstrap`): the wire DTO, or null when no
+ * matching session exists.
+ */
+export const SessionLookupIpcResponseSchema =
+  VerificationSessionSchema.nullable();
+
+export type SessionLookupIpcResponse = z.infer<
+  typeof SessionLookupIpcResponseSchema
+>;
+
+/** Shared minimal ack for session mutations. */
+export const SessionMutationIpcResponseSchema = z.object({
+  ok: z.boolean(),
+});
+
+export type SessionMutationIpcResponse = z.infer<
+  typeof SessionMutationIpcResponseSchema
+>;
+
+/** Request for `verification_sessions_create_inbound`. */
+export const CreateInboundSessionIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+  sourceConversationId: z.string().optional(),
+});
+
+export type CreateInboundSessionIpcParams = z.infer<
+  typeof CreateInboundSessionIpcParamsSchema
+>;
+
+/**
+ * Response for `verification_sessions_create_inbound`. Carries the raw
+ * secret: message composition and channel delivery are daemon-owned, so the
+ * secret must transit back (the daemon composes the instruction copy —
+ * mirror of how invite mint returns data and the daemon presents it).
+ */
+export const CreateInboundSessionIpcResponseSchema = z.object({
+  session: VerificationSessionSchema,
+  secret: z.string(),
+  verifyCommand: z.string(),
+  ttlSeconds: z.number(),
+});
+
+export type CreateInboundSessionIpcResponse = z.infer<
+  typeof CreateInboundSessionIpcResponseSchema
+>;
+
+/** Request for `verification_sessions_create_outbound`. */
+export const CreateOutboundSessionIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+  expectedExternalUserId: z.string().optional(),
+  expectedChatId: z.string().optional(),
+  expectedPhoneE164: z.string().optional(),
+  identityBindingStatus: IdentityBindingStatusSchema.optional(),
+  destinationAddress: z.string().optional(),
+  codeDigits: z.number().int().positive().optional(),
+  maxAttempts: z.number().int().positive().optional(),
+  verificationPurpose: VerificationPurposeSchema.optional(),
+  bootstrapTokenHash: z.string().optional(),
+  // Caller-supplied id (bootstrap flows pre-mint the id for deep links).
+  sessionId: z.string().optional(),
+});
+
+export type CreateOutboundSessionIpcParams = z.infer<
+  typeof CreateOutboundSessionIpcParamsSchema
+>;
+
+/**
+ * Response for `verification_sessions_create_outbound`. Mirrors the daemon's
+ * `CreateOutboundSessionResult` so consumer flips are mechanical; `secret`
+ * transits for daemon-owned delivery.
+ */
+export const CreateOutboundSessionIpcResponseSchema = z.object({
+  sessionId: z.string(),
+  secret: z.string(),
+  challengeHash: z.string(),
+  expiresAt: z.number(),
+  ttlSeconds: z.number(),
+});
+
+export type CreateOutboundSessionIpcResponse = z.infer<
+  typeof CreateOutboundSessionIpcResponseSchema
+>;
+
+const ChannelOnlyIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+});
+
+/** Request for `verification_sessions_get_pending` (status `pending` only). */
+export const GetPendingSessionIpcParamsSchema = ChannelOnlyIpcParamsSchema;
+
+export type GetPendingSessionIpcParams = z.infer<
+  typeof GetPendingSessionIpcParamsSchema
+>;
+
+/**
+ * Request for `verification_sessions_find_active` (statuses
+ * `pending_bootstrap`/`awaiting_response`, newest first).
+ */
+export const FindActiveSessionIpcParamsSchema = ChannelOnlyIpcParamsSchema;
+
+export type FindActiveSessionIpcParams = z.infer<
+  typeof FindActiveSessionIpcParamsSchema
+>;
+
+/**
+ * Request for `verification_sessions_resolve_bootstrap`. Carries the RAW
+ * deep-link token; the gateway hashes it (`hashVerificationSecret`) and looks
+ * up by `bootstrap_token_hash`.
+ */
+export const ResolveBootstrapSessionIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+  token: z.string().min(1),
+});
+
+export type ResolveBootstrapSessionIpcParams = z.infer<
+  typeof ResolveBootstrapSessionIpcParamsSchema
+>;
+
+/** Request for `verification_sessions_bind_identity`. */
+export const BindSessionIdentityIpcParamsSchema = z.object({
+  sessionId: z.string().min(1),
+  externalUserId: z.string().min(1),
+  chatId: z.string().min(1),
+});
+
+export type BindSessionIdentityIpcParams = z.infer<
+  typeof BindSessionIdentityIpcParamsSchema
+>;
+
+/** Request for `verification_sessions_update_status`. */
+export const UpdateSessionStatusIpcParamsSchema = z.object({
+  sessionId: z.string().min(1),
+  status: SessionStatusSchema,
+  consumedByExternalUserId: z.string().optional(),
+  consumedByChatId: z.string().optional(),
+});
+
+export type UpdateSessionStatusIpcParams = z.infer<
+  typeof UpdateSessionStatusIpcParamsSchema
+>;
+
+/** Request for `verification_sessions_update_delivery`. */
+export const UpdateSessionDeliveryIpcParamsSchema = z.object({
+  sessionId: z.string().min(1),
+  lastSentAt: z.number(),
+  sendCount: z.number().int(),
+  nextResendAt: z.number().nullable(),
+});
+
+export type UpdateSessionDeliveryIpcParams = z.infer<
+  typeof UpdateSessionDeliveryIpcParamsSchema
+>;
+
+/** Request for `verification_sessions_count_recent_sends`. */
+export const CountRecentSendsIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+  destinationAddress: z.string().min(1),
+  windowMs: z.number().positive(),
+});
+
+export type CountRecentSendsIpcParams = z.infer<
+  typeof CountRecentSendsIpcParamsSchema
+>;
+
+/** Response for `verification_sessions_count_recent_sends`. */
+export const CountRecentSendsIpcResponseSchema = z.object({
+  count: z.number().int(),
+});
+
+export type CountRecentSendsIpcResponse = z.infer<
+  typeof CountRecentSendsIpcResponseSchema
+>;
+
+/** Request for `verification_sessions_revoke_pending`. */
+export const RevokePendingSessionsIpcParamsSchema = ChannelOnlyIpcParamsSchema;
+
+export type RevokePendingSessionsIpcParams = z.infer<
+  typeof RevokePendingSessionsIpcParamsSchema
+>;
+
+/**
+ * Request for `verification_sessions_validate_consume` — the gateway-native
+ * validate+consume path (rate limiting, identity binding, status-guarded
+ * consume, in-engine role side effects).
+ */
+export const ValidateConsumeSessionIpcParamsSchema = z.object({
+  channel: z.string().min(1),
+  secret: z.string().min(1),
+  actorExternalUserId: z.string(),
+  actorChatId: z.string(),
+});
+
+export type ValidateConsumeSessionIpcParams = z.infer<
+  typeof ValidateConsumeSessionIpcParamsSchema
+>;
+
+/**
+ * Response for `verification_sessions_validate_consume`. On failure `reason`
+ * is a machine-readable code — user-facing copy is composed daemon-side.
+ */
+export const ValidateConsumeSessionIpcResponseSchema = z.discriminatedUnion(
+  "success",
+  [
+    z.object({
+      success: z.literal(true),
+      verificationType: VerificationPurposeSchema,
+    }),
+    z.object({
+      success: z.literal(false),
+      reason: z.string(),
+    }),
+  ],
+);
+
+export type ValidateConsumeSessionIpcResponse = z.infer<
+  typeof ValidateConsumeSessionIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Adds verification-session-contract.ts to @vellumai/gateway-client: status/purpose/binding Zod enums, VerificationSession wire DTO, hashVerificationSecret
- Request/response schemas + method-name constants for the 11 verification_sessions_* IPC methods
- Additive only; no daemon/gateway behavior change

Part of plan: verif-sessions-gateway-native.md (PR 2 of 12)