### PR TITLE
fix: wire-key round-trips, status validation, and guard cleanups for default profiles

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -8,10 +8,16 @@
  *   ("quality-optimized", "balanced", "cost-optimized") are fully read-only
  *   across PATCH/SET/PUT — the only writable transition is re-enabling a
  *   disabled default.
+ *
+ * Plus the wire-only profile keys (`invariant`, `supportsVision`) stamped on
+ * config reads: PATCH/SET strip them so a GET → write round-trip succeeds.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Imported before the `mock.module` below so the mock can pass the real
+// implementation through instead of hand-copying it.
+import { setNestedValue } from "../config/loader.js";
 import { makeMockLogger } from "./helpers/mock-logger.js";
 
 mock.module("../util/logger.js", () => ({
@@ -90,22 +96,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {
     invalidateConfigCacheCalls += 1;
   },
-  setNestedValue: (
-    obj: Record<string, unknown>,
-    path: string,
-    value: unknown,
-  ) => {
-    const keys = path.split(".");
-    let current = obj;
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i]!;
-      if (current[key] == null || typeof current[key] !== "object") {
-        current[key] = {};
-      }
-      current = current[key] as Record<string, unknown>;
-    }
-    current[keys[keys.length - 1]!] = value;
-  },
+  setNestedValue,
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
   withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
 }));
@@ -683,6 +674,9 @@ describe("default-profile invariant guard — rejected writes", () => {
     expectNothingCommitted();
   });
 
+  // PUT and SET flow through the same commitConfigWrite guard as PATCH, so
+  // the per-field matrix above isn't repeated per route — one rejection per
+  // route proves the wiring.
   test("PUT { status: 'disabled' } on balanced is rejected", async () => {
     await expect(
       replaceRoute.handler({
@@ -690,26 +684,6 @@ describe("default-profile invariant guard — rejected writes", () => {
         body: { status: "disabled" },
       }),
     ).rejects.toThrow('Cannot disable default profile "balanced".');
-    expectNothingCommitted();
-  });
-
-  test("PUT { label: 'Renamed' } on balanced is rejected", async () => {
-    await expect(
-      replaceRoute.handler({
-        pathParams: { name: "balanced" },
-        body: { label: "Renamed" },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
-    expectNothingCommitted();
-  });
-
-  test("PUT { topP: 0.8 } on balanced is rejected", async () => {
-    await expect(
-      replaceRoute.handler({
-        pathParams: { name: "balanced" },
-        body: { topP: 0.8 },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
     expectNothingCommitted();
   });
 
@@ -722,26 +696,31 @@ describe("default-profile invariant guard — rejected writes", () => {
     expectNothingCommitted();
   });
 
-  test("SET llm.profiles.balanced.topP = 0.8 is rejected", async () => {
-    await expect(
-      setRoute.handler({
-        body: { path: "llm.profiles.balanced.topP", value: 0.8 },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
-    expectNothingCommitted();
-  });
-
-  test("SET llm.profiles = {} is rejected (would drop all defaults)", async () => {
-    await expect(
-      setRoute.handler({ body: { path: "llm.profiles", value: {} } }),
-    ).rejects.toThrow(/Cannot delete or replace default profile/);
-    expectNothingCommitted();
-  });
-
   test("SET llm = {} is rejected (would drop all defaults)", async () => {
     await expect(
       setRoute.handler({ body: { path: "llm", value: {} } }),
     ).rejects.toThrow(/Cannot delete or replace default profile/);
+    expectNothingCommitted();
+  });
+
+  test("PATCH { status: 'weird' } on balanced is rejected (junk status)", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { status: "weird" } } } },
+      }),
+    ).rejects.toThrow(
+      'Cannot set status "weird" on default profile "balanced". ' +
+        'Only re-enabling (status "active") is allowed.',
+    );
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles.balanced.status = 123 is rejected (junk status)", async () => {
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.balanced.status", value: 123 },
+      }),
+    ).rejects.toThrow('Cannot set status 123 on default profile "balanced"');
     expectNothingCommitted();
   });
 });
@@ -852,5 +831,79 @@ describe("default-profile invariant guard — allowed writes", () => {
     expect(savedProfile("balanced")).toEqual(
       (makeDefaultRawConfig() as Record<string, any>).llm.profiles.balanced,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-only profile keys (`invariant`, `supportsVision`) are stamped onto
+// config GET/PATCH responses but never persisted. Writes carrying them —
+// e.g. a `config get` → `config set` round-trip — must succeed with the
+// wire keys stripped, not 400 on phantom fields.
+// ---------------------------------------------------------------------------
+
+describe("wire-only profile keys are stripped from writes", () => {
+  test("PATCH re-enable carrying wire keys succeeds and persists neither key", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: {
+            balanced: {
+              status: "active",
+              invariant: true,
+              supportsVision: true,
+            },
+          },
+        },
+      },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect(profile.status).toBe("active");
+    expect("invariant" in profile).toBe(false);
+    expect("supportsVision" in profile).toBe(false);
+  });
+
+  test("SET llm.profiles.balanced with a wire-shaped entry (GET round-trip) succeeds", async () => {
+    const entry = structuredClone(
+      (rawConfig as Record<string, any>).llm.profiles.balanced,
+    ) as Record<string, unknown>;
+    entry.invariant = true;
+    entry.supportsVision = true;
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced", value: entry },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect("invariant" in profile).toBe(false);
+    expect("supportsVision" in profile).toBe(false);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
+  });
+
+  test("SET of a wire-only leaf path is dropped without writing", async () => {
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced.supportsVision", value: true },
+    });
+    expect(result).toEqual({ ok: true });
+    expectNothingCommitted();
+  });
+
+  test("PATCH with supportsVision on a custom profile does not persist it", async () => {
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: { "my-custom": { supportsVision: false, maxTokens: 2048 } },
+        },
+      },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    const profile = savedProfile("my-custom");
+    expect("supportsVision" in profile).toBe(false);
+    expect(profile.maxTokens).toBe(2048);
   });
 });

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -174,8 +174,9 @@ export const INVARIANT_PROFILE_NAMES = new Set(
 
 // Membership here marks a name as managed. The route layer applies managed
 // restrictions (blocking model/provider edits and deletion) only to entries
-// whose on-disk `source` is `managed`, so a user-owned profile sharing one of
-// these names is not locked. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// whose on-disk `source` is `managed`; `INVARIANT_PROFILE_NAMES` entries are
+// additionally frozen by name at the `commitConfigWrite` choke point,
+// regardless of `source`. `OS_BETA_PROFILE_KEY` is flag-gated: it is
 // materialized by the flag-gated profile reconcile, which refuses to touch a
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1017,31 +1017,8 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(savedProfile.status).toBe("disabled");
     });
 
-    test("rejects label edit on an invariant default profile at commit time", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "balanced" },
-          body: { label: "My Balanced" },
-        }),
-      ).rejects.toThrow(
-        'Cannot edit default profile "balanced" fields [label]',
-      );
-      expect(savedRawConfig).toBeNull();
-      expect(initializeProvidersCalls).toBe(0);
-      expect(invalidateConfigCacheCalls).toBe(0);
-    });
-
-    test("rejects disabling an invariant default profile at commit time", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "balanced" },
-          body: { status: "disabled" },
-        }),
-      ).rejects.toThrow('Cannot disable default profile "balanced".');
-      expect(savedRawConfig).toBeNull();
-      expect(initializeProvidersCalls).toBe(0);
-      expect(invalidateConfigCacheCalls).toBe(0);
-    });
+    // Commit-time rejection coverage for invariant default profiles lives in
+    // src/__tests__/managed-profile-guard.test.ts.
 
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
       // The handler is `async`, so synchronous BadRequest throws still

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -795,8 +795,39 @@ function handleGetConfig() {
 }
 
 /**
- * Annotate each profile in `config.llm.profiles` with wire-only flags — never
- * persisted to disk:
+ * Per-profile keys that exist only on the wire — stamped onto config
+ * responses by {@link enrichProfilesForWire}, never persisted to disk.
+ * {@link stripWireOnlyProfileKeys} removes them from incoming writes so a
+ * `config get` → `config set`/PATCH round-trip isn't rejected for phantom
+ * fields; keep the stamp and strip lists in lock-step.
+ */
+const WIRE_ONLY_PROFILE_KEYS = new Set(["invariant", "supportsVision"]);
+
+/**
+ * Delete the wire-only keys ({@link WIRE_ONLY_PROFILE_KEYS}) from every
+ * profile entry in a config-write fragment, in place.
+ */
+function stripWireOnlyProfileKeys(patch: unknown): void {
+  const root = readPlainObject(patch);
+  const llm = readPlainObject(root?.llm);
+  const profiles = readPlainObject(llm?.profiles);
+  if (!profiles) {
+    return;
+  }
+  for (const profile of Object.values(profiles)) {
+    const entry = readPlainObject(profile);
+    if (!entry) {
+      continue;
+    }
+    for (const key of WIRE_ONLY_PROFILE_KEYS) {
+      delete entry[key];
+    }
+  }
+}
+
+/**
+ * Annotate each profile in `config.llm.profiles` with wire-only flags
+ * (`WIRE_ONLY_PROFILE_KEYS`) — never persisted to disk:
  *
  * - `supportsVision`: resolved from the model catalog. Unknown (provider,
  *   model) pairs default to `true` (fail-open) so image upload remains
@@ -900,8 +931,8 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
  *   rejected by this single check, regardless of route.
  * - `status` is one-directional: effective status is
  *   `entry.status !== "disabled"` (absence/null = active). An active default
- *   can never be disabled; re-enabling a disabled default (including
- *   clearing `status` to null/absent) is allowed.
+ *   can never be disabled; a changed `status` must be `"active"`, `null`, or
+ *   absent — re-enabling a disabled default. Any other value is rejected.
  * - Every other field is frozen: any changed, added, or removed key across
  *   the union of both entries' keys (except `status`) is rejected. A
  *   pre-existing on-disk override (e.g. `topP`) is preserved but frozen —
@@ -936,10 +967,16 @@ function assertInvariantProfilesPreserved(
       );
     }
 
-    const oldActive = oldEntry.status !== "disabled";
-    const newActive = newEntry.status !== "disabled";
-    if (oldActive && !newActive) {
-      throw new BadRequestError(`Cannot disable default profile "${name}".`);
+    if (!isDeepStrictEqual(oldEntry.status, newEntry.status)) {
+      if (newEntry.status === "disabled") {
+        throw new BadRequestError(`Cannot disable default profile "${name}".`);
+      }
+      if (newEntry.status !== "active" && newEntry.status != null) {
+        throw new BadRequestError(
+          `Cannot set status ${JSON.stringify(newEntry.status)} on default profile "${name}". ` +
+            `Only re-enabling (status "active") is allowed.`,
+        );
+      }
     }
 
     const changedKeys = [
@@ -1024,6 +1061,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   ) {
     throw new BadRequestError("Body must be a non-empty JSON object");
   }
+  stripWireOnlyProfileKeys(body);
   rejectManagedProfileDeletion(body as Record<string, unknown>);
   rejectMcpTransportHeaderWrite(body);
 
@@ -1074,10 +1112,25 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
       "`value` is required (use `null` to clear a key)",
     );
   }
+  // A leaf-path SET targeting a wire-only profile key is dropped without
+  // writing — the same treatment PATCH gives wire-only keys embedded in a
+  // profile fragment.
+  const pathSegments = path.split(".");
+  if (
+    pathSegments[0] === "llm" &&
+    pathSegments[1] === "profiles" &&
+    pathSegments.length >= 4 &&
+    WIRE_ONLY_PROFILE_KEYS.has(pathSegments[3]!)
+  ) {
+    return { ok: true };
+  }
   // Build the equivalent patch shape so the managed-profile guard can
-  // inspect the touched subtree.
+  // inspect the touched subtree. `setNestedValue` places `value` into
+  // `patchShape` by reference, so stripping wire-only profile keys here
+  // also strips the object written to `raw` below.
   const patchShape: Record<string, unknown> = {};
   setNestedValue(patchShape, path, value);
+  stripWireOnlyProfileKeys(patchShape);
   rejectManagedProfileDeletion(patchShape);
   rejectMcpTransportHeaderWrite(patchShape);
 
@@ -1155,9 +1208,11 @@ async function handleReplaceInferenceProfile({
     // Managed profiles are daemon-seeded — provider, model, and the
     // connection binding all belong to the seed contract and can't be
     // reshaped by the user. The fields that ARE user policy (display label,
-    // enabled status, and the topP sampling knob) are allowed through so
-    // users can rename a managed profile, temporarily disable it, or tune
-    // top_p without duplicating it.
+    // enabled status, and the topP sampling knob) pass this allowlist so
+    // non-invariant managed profiles (os-beta) can be renamed, temporarily
+    // disabled, or tuned. Invariant default profiles are further locked by
+    // `assertInvariantProfilesPreserved` at commit time — for them the only
+    // writable transition is re-enabling a disabled profile.
     const requestedKeys = Object.keys(parsed.data);
     const disallowed = requestedKeys.filter(
       (k) => !MANAGED_PROFILE_EDITABLE_KEYS.has(k),
@@ -1219,9 +1274,17 @@ async function handleReplaceInferenceProfile({
 
   // When the UI sends provider but no provider_connection, derive the connection
   // now so the config deep-merge doesn't inherit a stale connection from the
-  // default layer.
+  // default layer. Invariant names are excluded: commitConfigWrite rejects
+  // every write to them except a pure status re-enable (which derives no
+  // connection), so creating a connection here would leave an orphaned DB
+  // row behind a guaranteed 400.
   const fragment = parsed.data as Record<string, unknown>;
-  if (!isManaged && fragment.provider && !fragment.provider_connection) {
+  if (
+    !isManaged &&
+    !INVARIANT_PROFILE_NAMES.has(name) &&
+    fragment.provider &&
+    !fragment.provider_connection
+  ) {
     const provider = fragment.provider as string;
     const db = getDb();
     const [active] = listConnections(db, { provider });


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for invariant-default-profiles.md.

- Strip wire-only keys (invariant, supportsVision) from incoming profile writes so config get→set round-trips succeed
- Validate status transitions on default profiles: a changed status must be active/null/absent (junk values rejected)
- Skip connection derivation for invariant names on PUT (no orphaned DB connection behind a guaranteed 400)
- Fix two stale comments contradicting the name-based guard; consolidate duplicated guard tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->