### PR TITLE
feat(gateway): recreate channel_verification_sessions as a gateway-owned table with a native session store

### DIFF
--- a/gateway/src/__tests__/data-migration-m0011-drop-gw-verification-sessions.test.ts
+++ b/gateway/src/__tests__/data-migration-m0011-drop-gw-verification-sessions.test.ts
@@ -1,20 +1,14 @@
 /**
- * Tests for m0011-drop-gw-verification-sessions.
+ * Tests for m0011-drop-gw-verification-sessions (retired to a no-op).
  *
- * Verifies that the gateway `channel_verification_sessions` mirror table is
- * dropped when present, that re-running is idempotent, that a fresh install
- * (table already absent) is a no-op that still reports "done", that down() is
- * a no-op, and that the migration is registered after m0010.
+ * The migration formerly dropped the gateway `channel_verification_sessions`
+ * write-only mirror. Combo 13 recreates that table as gateway-owned via the
+ * schema push, so the drop was retired: up() must leave the live table
+ * intact on installs that never recorded the key (fresh installs run data
+ * migrations after the schema push creates the table).
  */
 
-import {
-  describe,
-  test,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterAll,
-} from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 
 import "./test-preload.js";
 
@@ -37,52 +31,26 @@ afterAll(() => {
   resetGatewayDb();
 });
 
-function rawDb() {
-  return getGatewayDb().$client;
-}
-
 function tableExists(): boolean {
-  const row = rawDb()
-    .prepare(
+  const row = getGatewayDb()
+    .$client.prepare(
       "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_verification_sessions'",
     )
     .get();
   return row != null;
 }
 
-function createMirrorTable(): void {
-  rawDb().exec(
-    "CREATE TABLE IF NOT EXISTS channel_verification_sessions (id TEXT PRIMARY KEY, status TEXT)",
-  );
-}
-
-beforeEach(() => {
-  createMirrorTable();
-});
-
 describe("m0011-drop-gw-verification-sessions", () => {
-  test("drops the mirror table when present", () => {
+  test("up is a no-op that leaves the gateway-owned table intact", () => {
+    // Schema push at initGatewayDb created the recreated table.
     expect(tableExists()).toBe(true);
 
     expect(m0011Up()).toBe("done");
+    expect(tableExists()).toBe(true);
 
-    expect(tableExists()).toBe(false);
-  });
-
-  test("idempotent: re-running after the drop is a no-op", () => {
+    // Idempotent re-run.
     expect(m0011Up()).toBe("done");
-    expect(tableExists()).toBe(false);
-
-    expect(m0011Up()).toBe("done");
-    expect(tableExists()).toBe(false);
-  });
-
-  test("fresh install (table absent) is a no-op that reports done", () => {
-    rawDb().exec("DROP TABLE IF EXISTS channel_verification_sessions");
-    expect(tableExists()).toBe(false);
-
-    expect(m0011Up()).toBe("done");
-    expect(tableExists()).toBe(false);
+    expect(tableExists()).toBe(true);
   });
 
   test("down is a no-op (returns done)", () => {

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -1,0 +1,528 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import "../../__tests__/test-preload.js";
+import { getGatewayDb, initGatewayDb, resetGatewayDb } from "../connection.js";
+import { channelVerificationSessions } from "../schema.js";
+import {
+  bindSessionIdentity,
+  consumeSession,
+  countRecentSendsToDestination,
+  createInboundSession,
+  createOutboundSession,
+  findActiveSession,
+  findPendingSessionByHash,
+  findPendingSessionForChannel,
+  findSessionByBootstrapTokenHash,
+  findSessionByIdentity,
+  revokePendingSessions,
+  updateSessionDelivery,
+  updateSessionStatus,
+} from "../session-store.js";
+import type { SessionStatus, VerificationSession } from "../session-store.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const FUTURE = () => Date.now() + 10 * 60 * 1000;
+const PAST = () => Date.now() - 1000;
+
+let idSeq = 0;
+const nextId = () => `sess-${++idSeq}`;
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(channelVerificationSessions).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+function getRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(channelVerificationSessions)
+    .where(eq(channelVerificationSessions.id, id))
+    .get();
+}
+
+/** Insert a row directly, bypassing the store's revoke-prior-on-create. */
+function insertRaw(
+  overrides: Partial<typeof channelVerificationSessions.$inferInsert> & {
+    id: string;
+  },
+) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(channelVerificationSessions)
+    .values({
+      channel: "telegram",
+      challengeHash: `hash-${overrides.id}`,
+      expiresAt: FUTURE(),
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    })
+    .run();
+}
+
+function createOutbound(
+  overrides: Partial<Parameters<typeof createOutboundSession>[0]> = {},
+): VerificationSession {
+  const id = nextId();
+  return createOutboundSession({
+    id,
+    channel: "telegram",
+    challengeHash: `hash-${id}`,
+    expiresAt: FUTURE(),
+    status: "awaiting_response",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// createInboundSession
+// ---------------------------------------------------------------------------
+
+describe("createInboundSession", () => {
+  test("round-trips a pending session with configuration defaults", () => {
+    const session = createInboundSession({
+      id: "in-1",
+      channel: "telegram",
+      challengeHash: "hash-in-1",
+      expiresAt: FUTURE(),
+      sourceConversationId: "conv-1",
+    });
+
+    expect(session.status).toBe("pending");
+    expect(session.sourceConversationId).toBe("conv-1");
+    expect(session.codeDigits).toBe(6);
+    expect(session.maxAttempts).toBe(3);
+    expect(session.verificationPurpose).toBe("guardian");
+    expect(session.sendCount).toBe(0);
+
+    const found = findPendingSessionForChannel("telegram");
+    expect(found?.id).toBe("in-1");
+    expect(found).toEqual(session);
+  });
+
+  test("revokes prior pending sessions on the same channel", () => {
+    const first = createInboundSession({
+      id: "in-1",
+      channel: "telegram",
+      challengeHash: "hash-1",
+      expiresAt: FUTURE(),
+    });
+    createInboundSession({
+      id: "in-2",
+      channel: "telegram",
+      challengeHash: "hash-2",
+      expiresAt: FUTURE(),
+    });
+
+    expect(getRow(first.id)?.status).toBe("revoked");
+    expect(getRow("in-2")?.status).toBe("pending");
+  });
+
+  test("does not revoke pending sessions on other channels", () => {
+    createInboundSession({
+      id: "in-slack",
+      channel: "slack",
+      challengeHash: "hash-s",
+      expiresAt: FUTURE(),
+    });
+    createInboundSession({
+      id: "in-tg",
+      channel: "telegram",
+      challengeHash: "hash-t",
+      expiresAt: FUTURE(),
+    });
+
+    expect(getRow("in-slack")?.status).toBe("pending");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOutboundSession
+// ---------------------------------------------------------------------------
+
+describe("createOutboundSession", () => {
+  test("round-trips caller-supplied status and identity fields", () => {
+    const session = createOutbound({
+      status: "pending_bootstrap",
+      expectedPhoneE164: "+15551234567",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: "+15551234567",
+      codeDigits: 8,
+      maxAttempts: 5,
+      verificationPurpose: "trusted_contact",
+      bootstrapTokenHash: "boot-hash",
+    });
+
+    const row = getRow(session.id);
+    expect(row?.status).toBe("pending_bootstrap");
+    expect(row?.expectedPhoneE164).toBe("+15551234567");
+    expect(row?.identityBindingStatus).toBe("pending_bootstrap");
+    expect(row?.destinationAddress).toBe("+15551234567");
+    expect(row?.codeDigits).toBe(8);
+    expect(row?.maxAttempts).toBe(5);
+    expect(row?.verificationPurpose).toBe("trusted_contact");
+    expect(row?.bootstrapTokenHash).toBe("boot-hash");
+  });
+
+  test("revokes prior interceptable sessions on the same channel", () => {
+    for (const status of [
+      "pending",
+      "pending_bootstrap",
+      "awaiting_response",
+    ] as SessionStatus[]) {
+      insertRaw({ id: `prior-${status}`, status });
+    }
+    insertRaw({ id: "prior-consumed", status: "consumed" });
+
+    const session = createOutbound();
+
+    expect(getRow("prior-pending")?.status).toBe("revoked");
+    expect(getRow("prior-pending_bootstrap")?.status).toBe("revoked");
+    expect(getRow("prior-awaiting_response")?.status).toBe("revoked");
+    expect(getRow("prior-consumed")?.status).toBe("consumed");
+    expect(getRow(session.id)?.status).toBe("awaiting_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revokePendingSessions
+// ---------------------------------------------------------------------------
+
+describe("revokePendingSessions", () => {
+  test("revokes only pending sessions on the channel", () => {
+    insertRaw({ id: "p1", status: "pending" });
+    insertRaw({ id: "a1", status: "awaiting_response" });
+    insertRaw({ id: "other", channel: "slack", status: "pending" });
+
+    revokePendingSessions("telegram");
+
+    expect(getRow("p1")?.status).toBe("revoked");
+    expect(getRow("a1")?.status).toBe("awaiting_response");
+    expect(getRow("other")?.status).toBe("pending");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPendingSessionByHash
+// ---------------------------------------------------------------------------
+
+describe("findPendingSessionByHash", () => {
+  test("matches every interceptable status", () => {
+    for (const status of [
+      "pending",
+      "pending_bootstrap",
+      "awaiting_response",
+    ] as SessionStatus[]) {
+      insertRaw({ id: `s-${status}`, status, challengeHash: `h-${status}` });
+      expect(findPendingSessionByHash("telegram", `h-${status}`)?.id).toBe(
+        `s-${status}`,
+      );
+    }
+  });
+
+  test("ignores non-interceptable statuses", () => {
+    for (const status of [
+      "consumed",
+      "revoked",
+      "expired",
+      "verified",
+      "locked",
+    ] as SessionStatus[]) {
+      insertRaw({ id: `s-${status}`, status, challengeHash: `h-${status}` });
+      expect(findPendingSessionByHash("telegram", `h-${status}`)).toBeNull();
+    }
+  });
+
+  test("ignores expired sessions", () => {
+    insertRaw({ id: "stale", challengeHash: "h-stale", expiresAt: PAST() });
+    expect(findPendingSessionByHash("telegram", "h-stale")).toBeNull();
+  });
+
+  test("ignores other channels", () => {
+    insertRaw({ id: "s1", channel: "slack", challengeHash: "h1" });
+    expect(findPendingSessionByHash("telegram", "h1")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPendingSessionForChannel
+// ---------------------------------------------------------------------------
+
+describe("findPendingSessionForChannel", () => {
+  test("matches 'pending' only — outbound statuses are excluded", () => {
+    insertRaw({ id: "boot", status: "pending_bootstrap" });
+    insertRaw({ id: "await", status: "awaiting_response" });
+    expect(findPendingSessionForChannel("telegram")).toBeNull();
+
+    insertRaw({ id: "pend", status: "pending" });
+    expect(findPendingSessionForChannel("telegram")?.id).toBe("pend");
+  });
+
+  test("ignores expired sessions", () => {
+    insertRaw({ id: "stale", status: "pending", expiresAt: PAST() });
+    expect(findPendingSessionForChannel("telegram")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findActiveSession
+// ---------------------------------------------------------------------------
+
+describe("findActiveSession", () => {
+  test("matches pending_bootstrap and awaiting_response, not pending", () => {
+    insertRaw({ id: "pend", status: "pending" });
+    expect(findActiveSession("telegram")).toBeNull();
+
+    insertRaw({ id: "boot", status: "pending_bootstrap" });
+    expect(findActiveSession("telegram")?.id).toBe("boot");
+  });
+
+  test("returns the newest session first", () => {
+    const now = Date.now();
+    insertRaw({ id: "old", status: "awaiting_response", createdAt: now - 500 });
+    insertRaw({ id: "new", status: "awaiting_response", createdAt: now });
+    expect(findActiveSession("telegram")?.id).toBe("new");
+  });
+
+  test("ignores expired sessions", () => {
+    insertRaw({ id: "stale", status: "awaiting_response", expiresAt: PAST() });
+    expect(findActiveSession("telegram")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSessionByBootstrapTokenHash
+// ---------------------------------------------------------------------------
+
+describe("findSessionByBootstrapTokenHash", () => {
+  test("matches a non-expired pending_bootstrap session by token hash", () => {
+    insertRaw({
+      id: "boot",
+      status: "pending_bootstrap",
+      bootstrapTokenHash: "tok-1",
+    });
+    expect(findSessionByBootstrapTokenHash("telegram", "tok-1")?.id).toBe(
+      "boot",
+    );
+    expect(findSessionByBootstrapTokenHash("telegram", "tok-2")).toBeNull();
+  });
+
+  test("ignores bound and expired sessions", () => {
+    insertRaw({
+      id: "bound",
+      status: "awaiting_response",
+      bootstrapTokenHash: "tok-bound",
+    });
+    insertRaw({
+      id: "stale",
+      status: "pending_bootstrap",
+      bootstrapTokenHash: "tok-stale",
+      expiresAt: PAST(),
+    });
+    expect(findSessionByBootstrapTokenHash("telegram", "tok-bound")).toBeNull();
+    expect(findSessionByBootstrapTokenHash("telegram", "tok-stale")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSessionByIdentity
+// ---------------------------------------------------------------------------
+
+describe("findSessionByIdentity", () => {
+  test("returns null when no identity parameter is supplied", () => {
+    insertRaw({ id: "s1", status: "awaiting_response" });
+    expect(findSessionByIdentity("telegram")).toBeNull();
+  });
+
+  test("matches on any supplied identity field", () => {
+    insertRaw({
+      id: "s1",
+      status: "awaiting_response",
+      expectedExternalUserId: "user-1",
+      expectedChatId: "chat-1",
+      expectedPhoneE164: "+15550001111",
+    });
+
+    expect(findSessionByIdentity("telegram", "user-1")?.id).toBe("s1");
+    expect(findSessionByIdentity("telegram", undefined, "chat-1")?.id).toBe(
+      "s1",
+    );
+    expect(
+      findSessionByIdentity("telegram", undefined, undefined, "+15550001111")
+        ?.id,
+    ).toBe("s1");
+    expect(findSessionByIdentity("telegram", "user-other")).toBeNull();
+  });
+
+  test("ignores expired and non-active sessions", () => {
+    insertRaw({
+      id: "stale",
+      status: "awaiting_response",
+      expectedExternalUserId: "user-1",
+      expiresAt: PAST(),
+    });
+    insertRaw({
+      id: "done",
+      status: "consumed",
+      expectedExternalUserId: "user-2",
+    });
+    expect(findSessionByIdentity("telegram", "user-1")).toBeNull();
+    expect(findSessionByIdentity("telegram", "user-2")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// consumeSession
+// ---------------------------------------------------------------------------
+
+describe("consumeSession", () => {
+  test("consumes an interceptable session and stamps the actor", () => {
+    insertRaw({ id: "s1", status: "awaiting_response" });
+
+    expect(consumeSession("s1", "user-1", "chat-1")).toBe(true);
+
+    const row = getRow("s1");
+    expect(row?.status).toBe("consumed");
+    expect(row?.consumedByExternalUserId).toBe("user-1");
+    expect(row?.consumedByChatId).toBe("chat-1");
+  });
+
+  test("exactly one of two racing consumers wins", () => {
+    insertRaw({ id: "s1", status: "pending" });
+
+    const first = consumeSession("s1", "user-1", "chat-1");
+    const second = consumeSession("s1", "user-2", "chat-2");
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+
+    // The loser must not overwrite the winner's actor stamp.
+    const row = getRow("s1");
+    expect(row?.consumedByExternalUserId).toBe("user-1");
+    expect(row?.consumedByChatId).toBe("chat-1");
+  });
+
+  test("returns false for consumed/revoked/expired/verified/locked rows", () => {
+    for (const status of [
+      "consumed",
+      "revoked",
+      "expired",
+      "verified",
+      "locked",
+    ] as SessionStatus[]) {
+      insertRaw({ id: `s-${status}`, status });
+      expect(consumeSession(`s-${status}`, "user-1", "chat-1")).toBe(false);
+      expect(getRow(`s-${status}`)?.status).toBe(status);
+    }
+  });
+
+  test("returns false for a nonexistent session", () => {
+    expect(consumeSession("missing", "user-1", "chat-1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSessionStatus / updateSessionDelivery / bindSessionIdentity
+// ---------------------------------------------------------------------------
+
+describe("updateSessionStatus", () => {
+  test("transitions status and applies extra fields when supplied", () => {
+    insertRaw({ id: "s1", status: "awaiting_response" });
+
+    updateSessionStatus("s1", "verified", {
+      consumedByExternalUserId: "user-1",
+      consumedByChatId: "chat-1",
+    });
+
+    const row = getRow("s1");
+    expect(row?.status).toBe("verified");
+    expect(row?.consumedByExternalUserId).toBe("user-1");
+    expect(row?.consumedByChatId).toBe("chat-1");
+
+    updateSessionStatus("s1", "revoked");
+    const after = getRow("s1");
+    expect(after?.status).toBe("revoked");
+    expect(after?.consumedByExternalUserId).toBe("user-1");
+  });
+});
+
+describe("updateSessionDelivery", () => {
+  test("round-trips delivery tracking fields", () => {
+    insertRaw({ id: "s1", status: "awaiting_response" });
+    const sentAt = Date.now();
+
+    updateSessionDelivery("s1", sentAt, 2, sentAt + 60_000);
+
+    const row = getRow("s1");
+    expect(row?.lastSentAt).toBe(sentAt);
+    expect(row?.sendCount).toBe(2);
+    expect(row?.nextResendAt).toBe(sentAt + 60_000);
+  });
+});
+
+describe("bindSessionIdentity", () => {
+  test("binds identity fields and flips binding status to bound", () => {
+    insertRaw({
+      id: "s1",
+      status: "pending_bootstrap",
+      identityBindingStatus: "pending_bootstrap",
+    });
+
+    bindSessionIdentity("s1", "user-1", "chat-1");
+
+    const row = getRow("s1");
+    expect(row?.expectedExternalUserId).toBe("user-1");
+    expect(row?.expectedChatId).toBe("chat-1");
+    expect(row?.identityBindingStatus).toBe("bound");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countRecentSendsToDestination
+// ---------------------------------------------------------------------------
+
+describe("countRecentSendsToDestination", () => {
+  test("counts rows sent to the destination within the window", () => {
+    const now = Date.now();
+    const dest = "+15550001111";
+
+    insertRaw({
+      id: "recent-1",
+      destinationAddress: dest,
+      lastSentAt: now - 1000,
+    });
+    insertRaw({
+      id: "recent-2",
+      destinationAddress: dest,
+      lastSentAt: now - 2000,
+    });
+    insertRaw({
+      id: "old",
+      destinationAddress: dest,
+      lastSentAt: now - 60 * 60 * 1000,
+    });
+    insertRaw({
+      id: "other-dest",
+      destinationAddress: "+15559998888",
+      lastSentAt: now - 1000,
+    });
+    insertRaw({ id: "never-sent", destinationAddress: dest });
+
+    expect(
+      countRecentSendsToDestination("telegram", dest, 15 * 60 * 1000),
+    ).toBe(2);
+    expect(countRecentSendsToDestination("slack", dest, 15 * 60 * 1000)).toBe(
+      0,
+    );
+  });
+});

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -154,9 +154,9 @@ describe("createOutboundSession", () => {
   test("round-trips caller-supplied status and identity fields", () => {
     const session = createOutbound({
       status: "pending_bootstrap",
-      expectedPhoneE164: "+15551234567",
+      expectedPhoneE164: "+15555550123",
       identityBindingStatus: "pending_bootstrap",
-      destinationAddress: "+15551234567",
+      destinationAddress: "+15555550123",
       codeDigits: 8,
       maxAttempts: 5,
       verificationPurpose: "trusted_contact",
@@ -165,9 +165,9 @@ describe("createOutboundSession", () => {
 
     const row = getRow(session.id);
     expect(row?.status).toBe("pending_bootstrap");
-    expect(row?.expectedPhoneE164).toBe("+15551234567");
+    expect(row?.expectedPhoneE164).toBe("+15555550123");
     expect(row?.identityBindingStatus).toBe("pending_bootstrap");
-    expect(row?.destinationAddress).toBe("+15551234567");
+    expect(row?.destinationAddress).toBe("+15555550123");
     expect(row?.codeDigits).toBe(8);
     expect(row?.maxAttempts).toBe(5);
     expect(row?.verificationPurpose).toBe("trusted_contact");
@@ -350,7 +350,7 @@ describe("findSessionByIdentity", () => {
       status: "awaiting_response",
       expectedExternalUserId: "user-1",
       expectedChatId: "chat-1",
-      expectedPhoneE164: "+15550001111",
+      expectedPhoneE164: "+15555550111",
     });
 
     expect(findSessionByIdentity("telegram", "user-1")?.id).toBe("s1");
@@ -358,7 +358,7 @@ describe("findSessionByIdentity", () => {
       "s1",
     );
     expect(
-      findSessionByIdentity("telegram", undefined, undefined, "+15550001111")
+      findSessionByIdentity("telegram", undefined, undefined, "+15555550111")
         ?.id,
     ).toBe("s1");
     expect(findSessionByIdentity("telegram", "user-other")).toBeNull();
@@ -494,7 +494,7 @@ describe("bindSessionIdentity", () => {
 describe("countRecentSendsToDestination", () => {
   test("counts rows sent to the destination within the window", () => {
     const now = Date.now();
-    const dest = "+15550001111";
+    const dest = "+15555550111";
 
     insertRaw({
       id: "recent-1",
@@ -513,7 +513,7 @@ describe("countRecentSendsToDestination", () => {
     });
     insertRaw({
       id: "other-dest",
-      destinationAddress: "+15559998888",
+      destinationAddress: "+15555550188",
       lastSentAt: now - 1000,
     });
     insertRaw({ id: "never-sent", destinationAddress: dest });

--- a/gateway/src/db/data-migrations/m0011-drop-gw-verification-sessions.ts
+++ b/gateway/src/db/data-migrations/m0011-drop-gw-verification-sessions.ts
@@ -1,34 +1,21 @@
 /**
- * One-time migration: drop the gateway `channel_verification_sessions` table.
+ * One-time migration (retired to a no-op): formerly dropped the gateway
+ * `channel_verification_sessions` write-only mirror table.
  *
- * The assistant DB owns verification session state; the gateway copy took a
- * single write that never had a matching insert, so the table only ever held
- * empty carry-cost. A future gateway-SoT move recreates this table
- * deliberately with its own read/write paths.
- *
- * Runs on the gateway's own DB (plain SQL). Idempotent via IF EXISTS.
+ * Combo 13 recreates that table as gateway-owned (see db/schema.ts), and
+ * schema push runs at startup — before data migrations — so executing the
+ * drop on an install that never recorded this key (e.g. a fresh install)
+ * would delete the live table right after startup created it. Installs
+ * that already ran the drop recorded the key and never re-enter. The old
+ * mirror never held data, so skipping the drop loses nothing.
  */
-
-import { Database } from "bun:sqlite";
-
-import { getLogger } from "../../logger.js";
-import { getGatewayDb } from "../connection.js";
 
 import type { MigrationResult } from "./index.js";
 
-const log = getLogger("m0011-drop-gw-verification-sessions");
-
-function getRawGatewayDb(): Database {
-  return (getGatewayDb() as unknown as { $client: Database }).$client;
-}
-
 export function up(): MigrationResult {
-  getRawGatewayDb().exec("DROP TABLE IF EXISTS channel_verification_sessions");
-  log.info("Dropped gateway channel_verification_sessions mirror table");
   return "done";
 }
 
 export function down(): MigrationResult {
-  // No-op: the assistant DB owns session state; the gateway mirror is not restored.
   return "done";
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -349,6 +349,73 @@ export const channelAdmissionPolicy = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// Channel verification sessions (gateway-owned)
+// ---------------------------------------------------------------------------
+//
+// Recreated deliberately after m0011 dropped the old write-only mirror.
+// Column names mirror the assistant table 1:1 so the m0012 backfill can
+// copy rows unchanged. Accessed via db/session-store.ts.
+
+export const channelVerificationSessions = sqliteTable(
+  "channel_verification_sessions",
+  {
+    id: text("id").primaryKey(),
+    channel: text("channel").notNull(),
+    challengeHash: text("challenge_hash").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+    status: text("status").notNull().default("pending"),
+    sourceConversationId: text("source_conversation_id"),
+    consumedByExternalUserId: text("consumed_by_external_user_id"),
+    consumedByChatId: text("consumed_by_chat_id"),
+    // Outbound session: expected-identity binding
+    expectedExternalUserId: text("expected_external_user_id"),
+    expectedChatId: text("expected_chat_id"),
+    expectedPhoneE164: text("expected_phone_e164"),
+    identityBindingStatus: text("identity_binding_status").default("bound"),
+    // Outbound session: delivery tracking
+    destinationAddress: text("destination_address"),
+    lastSentAt: integer("last_sent_at"),
+    sendCount: integer("send_count").default(0),
+    nextResendAt: integer("next_resend_at"),
+    // Session configuration
+    codeDigits: integer("code_digits").default(6),
+    maxAttempts: integer("max_attempts").default(3),
+    // Distinguishes guardian verification from trusted contact verification
+    verificationPurpose: text("verification_purpose").default("guardian"),
+    // Telegram bootstrap deep-link token hash
+    bootstrapTokenHash: text("bootstrap_token_hash"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_gw_verification_sessions_lookup").on(
+      table.channel,
+      table.challengeHash,
+      table.status,
+    ),
+    index("idx_gw_verification_sessions_active").on(
+      table.channel,
+      table.status,
+    ),
+    index("idx_gw_verification_sessions_identity").on(
+      table.channel,
+      table.expectedExternalUserId,
+      table.expectedChatId,
+      table.status,
+    ),
+    index("idx_gw_verification_sessions_destination").on(
+      table.channel,
+      table.destinationAddress,
+    ),
+    index("idx_gw_verification_sessions_bootstrap").on(
+      table.channel,
+      table.bootstrapTokenHash,
+      table.status,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Guardian verification rate limits
 // ---------------------------------------------------------------------------
 

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -1,0 +1,542 @@
+/**
+ * Gateway-owned channel verification session store.
+ *
+ * Drizzle-backed port of the assistant's channel-verification-sessions
+ * store (Combo 13: verification sessions become gateway-native). Same
+ * semantics and status vocabulary; `consumeSession` is status-guarded so
+ * only the first concurrent consumer wins.
+ */
+
+import type { Database } from "bun:sqlite";
+import { and, count, desc, eq, gt, gte, inArray, or } from "drizzle-orm";
+
+import { getGatewayDb } from "./connection.js";
+import { channelVerificationSessions } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SessionStatus =
+  | "pending"
+  | "consumed"
+  | "pending_bootstrap"
+  | "awaiting_response"
+  | "verified"
+  | "expired"
+  | "revoked"
+  | "locked";
+export type IdentityBindingStatus = "pending_bootstrap" | "bound";
+export type VerificationPurpose = "guardian" | "trusted_contact";
+
+export interface VerificationSession {
+  id: string;
+  channel: string;
+  challengeHash: string;
+  expiresAt: number;
+  status: SessionStatus;
+  sourceConversationId: string | null;
+  consumedByExternalUserId: string | null;
+  consumedByChatId: string | null;
+  // Outbound session: expected-identity binding
+  expectedExternalUserId: string | null;
+  expectedChatId: string | null;
+  expectedPhoneE164: string | null;
+  identityBindingStatus: IdentityBindingStatus | null;
+  // Outbound session: delivery tracking
+  destinationAddress: string | null;
+  lastSentAt: number | null;
+  sendCount: number;
+  nextResendAt: number | null;
+  // Session configuration
+  codeDigits: number;
+  maxAttempts: number;
+  // Distinguishes guardian verification from trusted contact verification
+  verificationPurpose: VerificationPurpose;
+  // Telegram bootstrap deep-link token hash
+  bootstrapTokenHash: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Statuses that represent an interceptable (consumable) session:
+ * 'pending' (inbound), 'pending_bootstrap' / 'awaiting_response' (outbound).
+ */
+const INTERCEPTABLE_STATUSES: SessionStatus[] = [
+  "pending",
+  "pending_bootstrap",
+  "awaiting_response",
+];
+
+const INTERCEPTABLE_STATUSES_SQL = INTERCEPTABLE_STATUSES.map(
+  (s) => `'${s}'`,
+).join(", ");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToSession(
+  row: typeof channelVerificationSessions.$inferSelect,
+): VerificationSession {
+  return {
+    id: row.id,
+    channel: row.channel,
+    challengeHash: row.challengeHash,
+    expiresAt: row.expiresAt,
+    status: row.status as SessionStatus,
+    sourceConversationId: row.sourceConversationId,
+    consumedByExternalUserId: row.consumedByExternalUserId,
+    consumedByChatId: row.consumedByChatId,
+    expectedExternalUserId: row.expectedExternalUserId ?? null,
+    expectedChatId: row.expectedChatId ?? null,
+    expectedPhoneE164: row.expectedPhoneE164 ?? null,
+    identityBindingStatus:
+      (row.identityBindingStatus as IdentityBindingStatus) ?? null,
+    destinationAddress: row.destinationAddress ?? null,
+    lastSentAt: row.lastSentAt ?? null,
+    sendCount: row.sendCount ?? 0,
+    nextResendAt: row.nextResendAt ?? null,
+    codeDigits: row.codeDigits ?? 6,
+    maxAttempts: row.maxAttempts ?? 3,
+    verificationPurpose:
+      (row.verificationPurpose as VerificationPurpose) ?? "guardian",
+    bootstrapTokenHash: row.bootstrapTokenHash ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inbound verification sessions
+// ---------------------------------------------------------------------------
+
+export function createInboundSession(params: {
+  id: string;
+  channel: string;
+  challengeHash: string;
+  expiresAt: number;
+  sourceConversationId?: string;
+}): VerificationSession {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  // Revoke any prior pending sessions for the same channel
+  // to close the replay window — only the latest session should be valid.
+  db.update(channelVerificationSessions)
+    .set({ status: "revoked", updatedAt: now })
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, params.channel),
+        eq(channelVerificationSessions.status, "pending"),
+      ),
+    )
+    .run();
+
+  const row = {
+    id: params.id,
+    channel: params.channel,
+    challengeHash: params.challengeHash,
+    expiresAt: params.expiresAt,
+    status: "pending" as const,
+    sourceConversationId: params.sourceConversationId ?? null,
+    consumedByExternalUserId: null,
+    consumedByChatId: null,
+    expectedExternalUserId: null,
+    expectedChatId: null,
+    expectedPhoneE164: null,
+    identityBindingStatus: null,
+    destinationAddress: null,
+    lastSentAt: null,
+    sendCount: 0,
+    nextResendAt: null,
+    codeDigits: 6,
+    maxAttempts: 3,
+    verificationPurpose: "guardian" as const,
+    bootstrapTokenHash: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(channelVerificationSessions).values(row).run();
+
+  return rowToSession(row);
+}
+
+export function revokePendingSessions(channel: string): void {
+  const db = getGatewayDb();
+  db.update(channelVerificationSessions)
+    .set({ status: "revoked", updatedAt: Date.now() })
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.status, "pending"),
+      ),
+    )
+    .run();
+}
+
+export function findPendingSessionByHash(
+  channel: string,
+  challengeHash: string,
+): VerificationSession | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.challengeHash, challengeHash),
+        inArray(channelVerificationSessions.status, INTERCEPTABLE_STATUSES),
+        gt(channelVerificationSessions.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * Find any pending inbound (non-expired) session for a given channel.
+ * Scoped to 'pending' status only — outbound session states
+ * (pending_bootstrap, awaiting_response) are excluded so that an active
+ * outbound verification does not inadvertently force unrelated inbound
+ * callers into the verification flow.
+ */
+export function findPendingSessionForChannel(
+  channel: string,
+): VerificationSession | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.status, "pending"),
+        gt(channelVerificationSessions.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * Mark a session consumed. The status guard ensures atomicity under
+ * concurrent consumers — only the first wins; later attempts (or attempts
+ * on already-consumed/revoked/expired-status rows) see zero changes and
+ * return false, preserving one-time-code semantics.
+ */
+export function consumeSession(
+  id: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+): boolean {
+  // Raw client because drizzle's bun-sqlite run() does not surface the
+  // changes count needed for the single-consumer guarantee.
+  const raw = (getGatewayDb() as unknown as { $client: Database }).$client;
+  const changes = raw
+    .prepare(
+      `UPDATE channel_verification_sessions
+       SET status = 'consumed',
+           consumed_by_external_user_id = ?,
+           consumed_by_chat_id = ?,
+           updated_at = ?
+       WHERE id = ?
+         AND status IN (${INTERCEPTABLE_STATUSES_SQL})`,
+    )
+    .run(actorExternalUserId, actorChatId, Date.now(), id).changes;
+
+  return changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound verification sessions (identity-bound)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an outbound verification session with expected-identity binding.
+ * Auto-revokes prior pending/pending_bootstrap/awaiting_response sessions
+ * for the same channel to close the replay window.
+ */
+export function createOutboundSession(params: {
+  id: string;
+  channel: string;
+  challengeHash: string;
+  expiresAt: number;
+  status: SessionStatus;
+  sourceConversationId?: string;
+  expectedExternalUserId?: string | null;
+  expectedChatId?: string | null;
+  expectedPhoneE164?: string | null;
+  identityBindingStatus?: IdentityBindingStatus;
+  destinationAddress?: string | null;
+  codeDigits?: number;
+  maxAttempts?: number;
+  verificationPurpose?: VerificationPurpose;
+  bootstrapTokenHash?: string | null;
+}): VerificationSession {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  db.update(channelVerificationSessions)
+    .set({ status: "revoked", updatedAt: now })
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, params.channel),
+        inArray(channelVerificationSessions.status, INTERCEPTABLE_STATUSES),
+      ),
+    )
+    .run();
+
+  const row = {
+    id: params.id,
+    channel: params.channel,
+    challengeHash: params.challengeHash,
+    expiresAt: params.expiresAt,
+    status: params.status as string,
+    sourceConversationId: params.sourceConversationId ?? null,
+    consumedByExternalUserId: null,
+    consumedByChatId: null,
+    expectedExternalUserId: params.expectedExternalUserId ?? null,
+    expectedChatId: params.expectedChatId ?? null,
+    expectedPhoneE164: params.expectedPhoneE164 ?? null,
+    identityBindingStatus: params.identityBindingStatus ?? "bound",
+    destinationAddress: params.destinationAddress ?? null,
+    lastSentAt: null,
+    sendCount: 0,
+    nextResendAt: null,
+    codeDigits: params.codeDigits ?? 6,
+    maxAttempts: params.maxAttempts ?? 3,
+    verificationPurpose: params.verificationPurpose ?? "guardian",
+    bootstrapTokenHash: params.bootstrapTokenHash ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(channelVerificationSessions).values(row).run();
+
+  return rowToSession(row);
+}
+
+/**
+ * Find the most recent pending_bootstrap or awaiting_response session
+ * for a given channel.
+ */
+export function findActiveSession(channel: string): VerificationSession | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, [
+          "pending_bootstrap",
+          "awaiting_response",
+        ]),
+        gt(channelVerificationSessions.expiresAt, now),
+      ),
+    )
+    .orderBy(desc(channelVerificationSessions.createdAt))
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * Look up a pending_bootstrap session by its bootstrap token hash.
+ * Used by the Telegram /start gv_<token> bootstrap flow.
+ */
+export function findSessionByBootstrapTokenHash(
+  channel: string,
+  tokenHash: string,
+): VerificationSession | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.bootstrapTokenHash, tokenHash),
+        eq(channelVerificationSessions.status, "pending_bootstrap"),
+        gt(channelVerificationSessions.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * Identity-bound lookup for the consume path. Finds a session matching the
+ * given identity fields with an active status.
+ */
+export function findSessionByIdentity(
+  channel: string,
+  externalUserId?: string,
+  chatId?: string,
+  phoneE164?: string,
+): VerificationSession | null {
+  // Require at least one identity parameter to avoid accidentally matching
+  // an unrelated session when the caller has no parsed identity fields.
+  if (!externalUserId && !chatId && !phoneE164) {
+    return null;
+  }
+
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const identityConditions = [];
+  if (externalUserId) {
+    identityConditions.push(
+      eq(channelVerificationSessions.expectedExternalUserId, externalUserId),
+    );
+  }
+  if (chatId) {
+    identityConditions.push(
+      eq(channelVerificationSessions.expectedChatId, chatId),
+    );
+  }
+  if (phoneE164) {
+    identityConditions.push(
+      eq(channelVerificationSessions.expectedPhoneE164, phoneE164),
+    );
+  }
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, [
+          "pending_bootstrap",
+          "awaiting_response",
+        ]),
+        gt(channelVerificationSessions.expiresAt, now),
+        or(...identityConditions),
+      ),
+    )
+    .orderBy(desc(channelVerificationSessions.createdAt))
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * Transition a session's status with optional extra field updates.
+ */
+export function updateSessionStatus(
+  id: string,
+  status: SessionStatus,
+  extraFields?: Partial<{
+    consumedByExternalUserId: string;
+    consumedByChatId: string;
+  }>,
+): void {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  db.update(channelVerificationSessions)
+    .set({
+      status,
+      updatedAt: now,
+      ...(extraFields?.consumedByExternalUserId !== undefined
+        ? { consumedByExternalUserId: extraFields.consumedByExternalUserId }
+        : {}),
+      ...(extraFields?.consumedByChatId !== undefined
+        ? { consumedByChatId: extraFields.consumedByChatId }
+        : {}),
+    })
+    .where(eq(channelVerificationSessions.id, id))
+    .run();
+}
+
+/**
+ * Update outbound delivery tracking fields on a session.
+ */
+export function updateSessionDelivery(
+  id: string,
+  lastSentAt: number,
+  sendCount: number,
+  nextResendAt: number | null,
+): void {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  db.update(channelVerificationSessions)
+    .set({
+      lastSentAt,
+      sendCount,
+      nextResendAt,
+      updatedAt: now,
+    })
+    .where(eq(channelVerificationSessions.id, id))
+    .run();
+}
+
+/**
+ * Count actual sends to a specific destination across all sessions within a
+ * rolling time window. Uses COUNT of rows with a last_sent_at timestamp
+ * inside the window rather than SUM(send_count) to avoid double-counting
+ * cumulative session counters when resend creates new sessions that carry
+ * forward the cumulative count.
+ */
+export function countRecentSendsToDestination(
+  channel: string,
+  destinationAddress: string,
+  windowMs: number,
+): number {
+  const db = getGatewayDb();
+  const cutoff = Date.now() - windowMs;
+
+  const result = db
+    .select({ total: count() })
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.destinationAddress, destinationAddress),
+        gte(channelVerificationSessions.lastSentAt, cutoff),
+      ),
+    )
+    .get();
+
+  return result?.total ?? 0;
+}
+
+/**
+ * Telegram bootstrap completion: bind the expected identity fields and
+ * transition identity_binding_status from pending_bootstrap to bound.
+ */
+export function bindSessionIdentity(
+  id: string,
+  externalUserId: string,
+  chatId: string,
+): void {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  db.update(channelVerificationSessions)
+    .set({
+      expectedExternalUserId: externalUserId,
+      expectedChatId: chatId,
+      identityBindingStatus: "bound",
+      updatedAt: now,
+    })
+    .where(eq(channelVerificationSessions.id, id))
+    .run();
+}


### PR DESCRIPTION
## Summary
- Adds channelVerificationSessions table to the gateway schema (columns mirror the assistant table 1:1 for the m0012 backfill) with the 5 assistant indexes under gateway-conventional idx_gw_verification_sessions_* names
- Adds Drizzle-backed gateway session store (gateway/src/db/session-store.ts) porting the assistant store 1:1, with a status-guarded atomic consumeSession that returns false on 0 changes
- Retires m0011 (drop-gw-verification-sessions) to a no-op: schema push recreates the table at startup BEFORE data migrations, so on installs that never recorded the m0011 key (fresh installs) the old drop would delete the live gateway-owned table on first boot — and would break the m0012 backfill ordering in PR 3
- Store tests: CRUD round-trips, revoke-prior-on-create, interceptable-status + expiry filtering, single-consume race (first consumer wins, loser cannot overwrite the actor stamp)

Part of plan: verif-sessions-gateway-native.md (PR 1 of 12)