### PR TITLE
Milestone 2: Lock managed profiles (cannot be deleted, disabled, or relabeled)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -31951,6 +31951,8 @@ components:
             additionalProperties: false
         supportsVision:
           type: boolean
+        invariant:
+          type: boolean
       additionalProperties: {}
     ProviderConnection:
       type: object

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1,7 +1,13 @@
 /**
- * Tests that managed inference profiles ("quality-optimized", "balanced",
- * "cost-optimized") cannot be edited via the PUT profile route or deleted
- * via the PATCH config route.
+ * Tests the two layers protecting managed inference profiles:
+ *
+ * - Route-level managed guards: managed profiles can't be deleted via PATCH
+ *   and the PUT profile route restricts them to the label/status/topP
+ *   allowlist.
+ * - The commitConfigWrite invariant guard: the default profiles
+ *   ("quality-optimized", "balanced", "cost-optimized") are fully read-only
+ *   across PATCH/SET/PUT — the only writable transition is re-enabling a
+ *   disabled default.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -14,6 +20,11 @@ mock.module("../util/logger.js", () => ({
 
 let savedRaw: Record<string, unknown> | null = null;
 let rawConfig: Record<string, unknown>;
+// Counters so tests can assert whether `commitConfigWrite` ran its post-write
+// side effects: rejected writes must leave both at 0, allowed writes bump
+// each exactly once.
+let invalidateConfigCacheCalls = 0;
+let initializeProvidersCalls = 0;
 
 function makeDefaultRawConfig(): Record<string, unknown> {
   return {
@@ -76,13 +87,33 @@ mock.module("../config/loader.js", () => ({
   },
   getConfig: () => rawConfig,
   getDeploymentContextDefaults: () => ({}),
-  invalidateConfigCache: () => {},
+  invalidateConfigCache: () => {
+    invalidateConfigCacheCalls += 1;
+  },
+  setNestedValue: (
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ) => {
+    const keys = path.split(".");
+    let current = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i]!;
+      if (current[key] == null || typeof current[key] !== "object") {
+        current[key] = {};
+      }
+      current = current[key] as Record<string, unknown>;
+    }
+    current[keys[keys.length - 1]!] = value;
+  },
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
   withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
 }));
 
 mock.module("../providers/registry.js", () => ({
-  initializeProviders: async () => {},
+  initializeProviders: async () => {
+    initializeProvidersCalls += 1;
+  },
 }));
 
 mock.module("../persistence/embeddings/embedding-backend.js", () => ({
@@ -108,10 +139,33 @@ const replaceRoute = ROUTES.find(
 
 const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
 
+const setRoute = ROUTES.find((r) => r.operationId === "config_set")!;
+
 beforeEach(() => {
   rawConfig = makeDefaultRawConfig();
   savedRaw = null;
+  invalidateConfigCacheCalls = 0;
+  initializeProvidersCalls = 0;
 });
+
+function expectNothingCommitted(): void {
+  expect(savedRaw).toBeNull();
+  expect(initializeProvidersCalls).toBe(0);
+  expect(invalidateConfigCacheCalls).toBe(0);
+}
+
+function expectOneCommitCycle(): void {
+  expect(savedRaw).not.toBeNull();
+  expect(initializeProvidersCalls).toBe(1);
+  expect(invalidateConfigCacheCalls).toBe(1);
+}
+
+function savedProfile(name: string): Record<string, unknown> {
+  return (savedRaw as Record<string, any>).llm.profiles[name] as Record<
+    string,
+    unknown
+  >;
+}
 
 // ---------------------------------------------------------------------------
 // PUT /v1/config/llm/profiles/:name — replace inference profile
@@ -126,7 +180,8 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       }),
     ).rejects.toThrow(
       'Cannot edit managed profile "quality-optimized" fields [provider, model]. ' +
-        "Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.",
+        "Default profiles are read-only (a disabled default can be re-enabled); " +
+        "duplicate to a custom profile to customize.",
     );
   });
 
@@ -172,11 +227,12 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
   // Null-as-clear sentinel: clients send `{ label: null }` or
   // `{ status: null }` to clear a managed profile's overrides back to the
   // seed defaults. The Zod `ProfileEntry` schema accepts null for both
-  // fields, and the managed-profile guard / `patchManagedProfileFields`
-  // propagate the clear through to disk. These tests lock the round-trip.
+  // fields. On non-invariant managed profiles (os-beta) the clear round-trips
+  // to disk; on the invariant default profiles only the status clear is
+  // allowed (re-enable) — every other field is frozen at commit time.
   // -------------------------------------------------------------------------
 
-  test("PUT { label: null } on managed profile clears the label on disk", async () => {
+  test("PUT { label: null } on a default profile is rejected (label is frozen)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -190,18 +246,13 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         },
       },
     };
-    const result = await replaceRoute.handler({
-      pathParams: { name: "balanced" },
-      body: { label: null },
-    });
-    expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
-    // Label key removed; seed fields preserved.
-    expect("label" in profile).toBe(false);
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-sonnet");
-    expect(profile.source).toBe("managed");
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { label: null },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
+    expectNothingCommitted();
   });
 
   test("PUT { status: null } on managed profile clears status (back to active-by-absence)", async () => {
@@ -230,15 +281,15 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expect(profile.model).toBe("claude-opus");
   });
 
-  test("PUT { label: null, status: null } clears both in a single request", async () => {
+  test("PUT { label: null, status: null } on managed os-beta clears both in a single request", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
         profiles: {
-          "cost-optimized": {
-            provider: "anthropic",
-            model: "claude-haiku",
-            label: "Speed (Custom)",
+          "os-beta": {
+            provider: "together",
+            model: "zai-org/GLM-5.2",
+            label: "OS Beta (Custom)",
             status: "disabled",
             source: "managed",
           },
@@ -246,26 +297,25 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       },
     };
     const result = await replaceRoute.handler({
-      pathParams: { name: "cost-optimized" },
+      pathParams: { name: "os-beta" },
       body: { label: null, status: null },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm
-      ?.profiles?.["cost-optimized"] as Record<string, unknown>;
+    const profile = savedProfile("os-beta");
     expect("label" in profile).toBe(false);
     expect(profile.status).toBeUndefined();
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-haiku");
+    expect(profile.provider).toBe("together");
+    expect(profile.model).toBe("zai-org/GLM-5.2");
   });
 
-  test("PUT { label: null, status: 'disabled' } mixes clear + set in one call", async () => {
+  test("PUT { label: null, status: 'disabled' } on managed os-beta mixes clear + set in one call", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
         profiles: {
-          balanced: {
-            provider: "anthropic",
-            model: "claude-sonnet",
+          "os-beta": {
+            provider: "together",
+            model: "zai-org/GLM-5.2",
             label: "Custom Label",
             source: "managed",
           },
@@ -273,51 +323,49 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       },
     };
     const result = await replaceRoute.handler({
-      pathParams: { name: "balanced" },
+      pathParams: { name: "os-beta" },
       body: { label: null, status: "disabled" },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
+    const profile = savedProfile("os-beta");
     expect("label" in profile).toBe(false);
     expect(profile.status).toBe("disabled");
   });
 
-  test("PUT { topP } on managed profile is accepted and persisted", async () => {
+  test("PUT { topP } on managed os-beta is accepted and persisted", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
         profiles: {
-          balanced: {
-            provider: "anthropic",
-            model: "claude-sonnet",
+          "os-beta": {
+            provider: "together",
+            model: "zai-org/GLM-5.2",
             source: "managed",
           },
         },
       },
     };
     const result = await replaceRoute.handler({
-      pathParams: { name: "balanced" },
+      pathParams: { name: "os-beta" },
       body: { topP: 0.9 },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
+    const profile = savedProfile("os-beta");
     // topP override persisted; seed fields preserved.
     expect(profile.topP).toBe(0.9);
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-sonnet");
+    expect(profile.provider).toBe("together");
+    expect(profile.model).toBe("zai-org/GLM-5.2");
     expect(profile.source).toBe("managed");
   });
 
-  test("PUT { topP: null } on managed profile clears the override on disk", async () => {
+  test("PUT { topP: null } on managed os-beta clears the override on disk", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
         profiles: {
-          balanced: {
-            provider: "anthropic",
-            model: "claude-sonnet",
+          "os-beta": {
+            provider: "together",
+            model: "zai-org/GLM-5.2",
             topP: 0.7,
             source: "managed",
           },
@@ -325,15 +373,14 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       },
     };
     const result = await replaceRoute.handler({
-      pathParams: { name: "balanced" },
+      pathParams: { name: "os-beta" },
       body: { topP: null },
     });
     expect(result).toEqual({ ok: true });
-    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
-      ?.balanced as Record<string, unknown>;
+    const profile = savedProfile("os-beta");
     expect("topP" in profile).toBe(false);
-    expect(profile.provider).toBe("anthropic");
-    expect(profile.model).toBe("claude-sonnet");
+    expect(profile.provider).toBe("together");
+    expect(profile.model).toBe("zai-org/GLM-5.2");
   });
 
   test("allows edits to a user-owned profile sharing a managed name (os-beta)", async () => {
@@ -540,5 +587,270 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
         body: { llm: { profiles: null } },
       }),
     ).rejects.toThrow("Cannot null llm.profiles");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitConfigWrite — default-profile invariant guard
+//
+// The three default profiles (balanced, quality-optimized, cost-optimized)
+// are read-only to every config-write route; the only writable transition is
+// re-enabling a disabled default. Enforced by
+// `assertInvariantProfilesPreserved` at the commitConfigWrite choke point,
+// so PATCH, SET, and PUT are all covered by the same checks.
+// ---------------------------------------------------------------------------
+
+describe("default-profile invariant guard — rejected writes", () => {
+  test("PATCH disabling balanced is rejected (active → disabled)", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { status: "disabled" } } } },
+      }),
+    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    expectNothingCommitted();
+  });
+
+  test("PATCH setting a label on balanced is rejected", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { label: "X" } } } },
+      }),
+    ).rejects.toThrow(
+      'Cannot edit default profile "balanced" fields [label]. ' +
+        "Default profiles are read-only; duplicate to a custom profile to customize.",
+    );
+    expectNothingCommitted();
+  });
+
+  test("PATCH { label: null } on balanced is rejected when a label exists", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.label = "Balanced";
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { label: null } } } },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
+    expectNothingCommitted();
+  });
+
+  test("PATCH { topP: 0.8 } on balanced is rejected", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { topP: 0.8 } } } },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    expectNothingCommitted();
+  });
+
+  test("PATCH { topP: null } on balanced is rejected when an on-disk override exists", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.topP = 0.7;
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { topP: null } } } },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    expectNothingCommitted();
+  });
+
+  test("PATCH deleting a user-sourced balanced entry is rejected by the invariant guard", async () => {
+    // A `source: "user"` entry passes the legacy managed-deletion guard, so
+    // this exercises the invariant guard's missing-entry check directly.
+    (rawConfig as Record<string, any>).llm.profiles.balanced.source = "user";
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: null } } },
+      }),
+    ).rejects.toThrow(
+      'Cannot delete or replace default profile "balanced". Default profiles are read-only.',
+    );
+    expectNothingCommitted();
+  });
+
+  test("PATCH overwriting balanced with a string is rejected", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: "junk" } } },
+      }),
+    ).rejects.toThrow('Cannot delete or replace default profile "balanced".');
+    expectNothingCommitted();
+  });
+
+  test("PATCH overwriting balanced with an array is rejected", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: ["disabled"] } } },
+      }),
+    ).rejects.toThrow('Cannot delete or replace default profile "balanced".');
+    expectNothingCommitted();
+  });
+
+  test("PUT { status: 'disabled' } on balanced is rejected", async () => {
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { status: "disabled" },
+      }),
+    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    expectNothingCommitted();
+  });
+
+  test("PUT { label: 'Renamed' } on balanced is rejected", async () => {
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { label: "Renamed" },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
+    expectNothingCommitted();
+  });
+
+  test("PUT { topP: 0.8 } on balanced is rejected", async () => {
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { topP: 0.8 },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles.balanced.status = 'disabled' is rejected", async () => {
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.balanced.status", value: "disabled" },
+      }),
+    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles.balanced.topP = 0.8 is rejected", async () => {
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.balanced.topP", value: 0.8 },
+      }),
+    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles = {} is rejected (would drop all defaults)", async () => {
+    await expect(
+      setRoute.handler({ body: { path: "llm.profiles", value: {} } }),
+    ).rejects.toThrow(/Cannot delete or replace default profile/);
+    expectNothingCommitted();
+  });
+
+  test("SET llm = {} is rejected (would drop all defaults)", async () => {
+    await expect(
+      setRoute.handler({ body: { path: "llm", value: {} } }),
+    ).rejects.toThrow(/Cannot delete or replace default profile/);
+    expectNothingCommitted();
+  });
+});
+
+describe("default-profile invariant guard — allowed writes", () => {
+  test("PATCH re-enables a disabled default profile (BYOK re-enable)", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { balanced: { status: "active" } } } },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    expect(savedProfile("balanced").status).toBe("active");
+  });
+
+  test("PATCH { status: null } clears a disabled default back to active-by-absence", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { balanced: { status: null } } } },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    expect(savedProfile("balanced").status ?? null).toBeNull();
+  });
+
+  test("PUT { status: 'active' } re-enables a disabled default profile", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await replaceRoute.handler({
+      pathParams: { name: "balanced" },
+      body: { status: "active" },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    expect(savedProfile("balanced").status).toBe("active");
+  });
+
+  test("SET llm.profiles.balanced.status = 'active' re-enables a disabled default profile", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced.status", value: "active" },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    expect(savedProfile("balanced").status).toBe("active");
+  });
+
+  test("SET llm passes when the value carries the invariant profiles unchanged (incl. frozen topP override)", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.topP = 0.7;
+    const nextLlm = structuredClone(
+      (rawConfig as Record<string, any>).llm,
+    ) as Record<string, unknown>;
+    nextLlm.activeProfile = "my-custom";
+    const result = await setRoute.handler({
+      body: { path: "llm", value: nextLlm },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    // The pre-existing topP override survives untouched.
+    expect(savedProfile("balanced").topP).toBe(0.7);
+    expect((savedRaw as Record<string, any>).llm.activeProfile).toBe(
+      "my-custom",
+    );
+  });
+
+  test("PUT label/status/topP edits on managed os-beta remain allowed (non-invariant)", async () => {
+    (rawConfig as Record<string, any>).llm.profiles["os-beta"] = {
+      provider: "together",
+      model: "zai-org/GLM-5.2",
+      source: "managed",
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "os-beta" },
+      body: { label: "My OS Beta", status: "disabled", topP: 0.5 },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("os-beta");
+    expect(profile.label).toBe("My OS Beta");
+    expect(profile.status).toBe("disabled");
+    expect(profile.topP).toBe(0.5);
+  });
+
+  test("PUT full edits on a custom profile remain allowed", async () => {
+    const result = await replaceRoute.handler({
+      pathParams: { name: "my-custom" },
+      body: { provider: "openai", model: "gpt-4o", maxTokens: 4096 },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("my-custom");
+    expect(profile.provider).toBe("openai");
+    expect(profile.model).toBe("gpt-4o");
+    expect(profile.maxTokens).toBe(4096);
+  });
+
+  test("PATCH non-profile llm writes are unaffected", async () => {
+    const result = await patchRoute.handler({
+      body: { llm: { activeProfile: "custom" } },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    expect((savedRaw as Record<string, any>).llm.activeProfile).toBe("custom");
+    // The invariant profiles are untouched by an unrelated llm write.
+    expect(savedProfile("balanced")).toEqual(
+      (makeDefaultRawConfig() as Record<string, any>).llm.profiles.balanced,
+    );
   });
 });

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -2,12 +2,14 @@
  * Tests the two layers protecting managed inference profiles:
  *
  * - Route-level managed guards: managed profiles can't be deleted via PATCH
- *   and the PUT profile route restricts them to the label/status/topP
- *   allowlist.
- * - The commitConfigWrite invariant guard: the default profiles
- *   ("quality-optimized", "balanced", "cost-optimized") are fully read-only
- *   across PATCH/SET/PUT — the only writable transition is re-enabling a
- *   disabled default.
+ *   and the PUT profile route accepts only a pure status re-enable body for
+ *   them.
+ * - The commitConfigWrite invariant guard: every managed profile name
+ *   ("quality-optimized", "balanced", "cost-optimized", "os-beta") is fully
+ *   read-only across PATCH/SET/PUT while its on-disk entry is
+ *   managed-source — the only writable transition is re-enabling a disabled
+ *   profile. A user-owned (`source: "user"`) entry sharing a managed name is
+ *   not locked.
  *
  * Plus the wire-only profile keys (`invariant`, `supportsVision`) stamped on
  * config reads: PATCH/SET strip them so a GET → write round-trip succeeds.
@@ -163,7 +165,7 @@ function savedProfile(name: string): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 
 describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
-  test("rejects edits to quality-optimized that touch non-label/status fields", async () => {
+  test("rejects provider/model edits to quality-optimized", async () => {
     await expect(
       replaceRoute.handler({
         pathParams: { name: "quality-optimized" },
@@ -171,7 +173,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       }),
     ).rejects.toThrow(
       'Cannot edit managed profile "quality-optimized" fields [provider, model]. ' +
-        "Default profiles are read-only (a disabled default can be re-enabled); " +
+        "Managed profiles are read-only (a disabled profile can be re-enabled); " +
         "duplicate to a custom profile to customize.",
     );
   });
@@ -218,12 +220,12 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
   // Null-as-clear sentinel: clients send `{ label: null }` or
   // `{ status: null }` to clear a managed profile's overrides back to the
   // seed defaults. The Zod `ProfileEntry` schema accepts null for both
-  // fields. On non-invariant managed profiles (os-beta) the clear round-trips
-  // to disk; on the invariant default profiles only the status clear is
-  // allowed (re-enable) — every other field is frozen at commit time.
+  // fields. Every managed name is invariant, so on managed-source entries
+  // only the status clear is allowed (re-enable) — every other field is
+  // frozen at commit time.
   // -------------------------------------------------------------------------
 
-  test("PUT { label: null } on a default profile is rejected (label is frozen)", async () => {
+  test("PUT { label: null } on a managed profile is rejected (label is frozen)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -242,7 +244,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         pathParams: { name: "balanced" },
         body: { label: null },
       }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
+    ).rejects.toThrow('Cannot edit managed profile "balanced" fields [label]');
     expectNothingCommitted();
   });
 
@@ -272,7 +274,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expect(profile.model).toBe("claude-opus");
   });
 
-  test("PUT { label: null, status: null } on managed os-beta clears both in a single request", async () => {
+  test("PUT { label: null, status: null } on managed os-beta is rejected (label is frozen)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -287,19 +289,18 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         },
       },
     };
-    const result = await replaceRoute.handler({
-      pathParams: { name: "os-beta" },
-      body: { label: null, status: null },
-    });
-    expect(result).toEqual({ ok: true });
-    const profile = savedProfile("os-beta");
-    expect("label" in profile).toBe(false);
-    expect(profile.status).toBeUndefined();
-    expect(profile.provider).toBe("together");
-    expect(profile.model).toBe("zai-org/GLM-5.2");
+    // The status clear alone is the re-enable direction and would pass, but
+    // the label clear touches a frozen field so the whole write is rejected.
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { label: null, status: null },
+      }),
+    ).rejects.toThrow('Cannot edit managed profile "os-beta" fields [label]');
+    expectNothingCommitted();
   });
 
-  test("PUT { label: null, status: 'disabled' } on managed os-beta mixes clear + set in one call", async () => {
+  test("PUT { status: 'disabled' } on managed os-beta is rejected (read-only)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -313,17 +314,18 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         },
       },
     };
-    const result = await replaceRoute.handler({
-      pathParams: { name: "os-beta" },
-      body: { label: null, status: "disabled" },
-    });
-    expect(result).toEqual({ ok: true });
-    const profile = savedProfile("os-beta");
-    expect("label" in profile).toBe(false);
-    expect(profile.status).toBe("disabled");
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { status: "disabled" },
+      }),
+    ).rejects.toThrow(
+      'Cannot edit managed profile "os-beta". Managed profiles are read-only',
+    );
+    expectNothingCommitted();
   });
 
-  test("PUT { topP } on managed os-beta is accepted and persisted", async () => {
+  test("PUT { topP } on managed os-beta is rejected (topP is frozen)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -336,20 +338,16 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         },
       },
     };
-    const result = await replaceRoute.handler({
-      pathParams: { name: "os-beta" },
-      body: { topP: 0.9 },
-    });
-    expect(result).toEqual({ ok: true });
-    const profile = savedProfile("os-beta");
-    // topP override persisted; seed fields preserved.
-    expect(profile.topP).toBe(0.9);
-    expect(profile.provider).toBe("together");
-    expect(profile.model).toBe("zai-org/GLM-5.2");
-    expect(profile.source).toBe("managed");
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { topP: 0.9 },
+      }),
+    ).rejects.toThrow('Cannot edit managed profile "os-beta" fields [topP]');
+    expectNothingCommitted();
   });
 
-  test("PUT { topP: null } on managed os-beta clears the override on disk", async () => {
+  test("PUT { topP: null } on managed os-beta is rejected (frozen even when clearing)", async () => {
     savedRaw = null;
     rawConfig = {
       llm: {
@@ -363,13 +361,37 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
         },
       },
     };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { topP: null },
+      }),
+    ).rejects.toThrow('Cannot edit managed profile "os-beta" fields [topP]');
+    expectNothingCommitted();
+  });
+
+  test("PUT { status: 'active' } re-enables a disabled managed os-beta profile", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "together",
+            model: "zai-org/GLM-5.2",
+            status: "disabled",
+            source: "managed",
+          },
+        },
+      },
+    };
     const result = await replaceRoute.handler({
       pathParams: { name: "os-beta" },
-      body: { topP: null },
+      body: { status: "active" },
     });
     expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
     const profile = savedProfile("os-beta");
-    expect("topP" in profile).toBe(false);
+    expect(profile.status).toBe("active");
     expect(profile.provider).toBe("together");
     expect(profile.model).toBe("zai-org/GLM-5.2");
   });
@@ -582,22 +604,23 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
 });
 
 // ---------------------------------------------------------------------------
-// commitConfigWrite — default-profile invariant guard
+// commitConfigWrite — managed-profile invariant guard
 //
-// The three default profiles (balanced, quality-optimized, cost-optimized)
-// are read-only to every config-write route; the only writable transition is
-// re-enabling a disabled default. Enforced by
-// `assertInvariantProfilesPreserved` at the commitConfigWrite choke point,
-// so PATCH, SET, and PUT are all covered by the same checks.
+// Every managed profile name (balanced, quality-optimized, cost-optimized,
+// os-beta) is read-only to every config-write route while its on-disk entry
+// is managed-source; the only writable transition is re-enabling a disabled
+// profile. A user-owned entry sharing a managed name is not locked. Enforced
+// by `assertInvariantProfilesPreserved` at the commitConfigWrite choke
+// point, so PATCH, SET, and PUT are all covered by the same checks.
 // ---------------------------------------------------------------------------
 
-describe("default-profile invariant guard — rejected writes", () => {
+describe("managed-profile invariant guard — rejected writes", () => {
   test("PATCH disabling balanced is rejected (active → disabled)", async () => {
     await expect(
       patchRoute.handler({
         body: { llm: { profiles: { balanced: { status: "disabled" } } } },
       }),
-    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    ).rejects.toThrow('Cannot disable managed profile "balanced".');
     expectNothingCommitted();
   });
 
@@ -607,8 +630,8 @@ describe("default-profile invariant guard — rejected writes", () => {
         body: { llm: { profiles: { balanced: { label: "X" } } } },
       }),
     ).rejects.toThrow(
-      'Cannot edit default profile "balanced" fields [label]. ' +
-        "Default profiles are read-only; duplicate to a custom profile to customize.",
+      'Cannot edit managed profile "balanced" fields [label]. ' +
+        "Managed profiles are read-only; duplicate to a custom profile to customize.",
     );
     expectNothingCommitted();
   });
@@ -619,7 +642,7 @@ describe("default-profile invariant guard — rejected writes", () => {
       patchRoute.handler({
         body: { llm: { profiles: { balanced: { label: null } } } },
       }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
+    ).rejects.toThrow('Cannot edit managed profile "balanced" fields [label]');
     expectNothingCommitted();
   });
 
@@ -628,7 +651,7 @@ describe("default-profile invariant guard — rejected writes", () => {
       patchRoute.handler({
         body: { llm: { profiles: { balanced: { topP: 0.8 } } } },
       }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    ).rejects.toThrow('Cannot edit managed profile "balanced" fields [topP]');
     expectNothingCommitted();
   });
 
@@ -638,21 +661,35 @@ describe("default-profile invariant guard — rejected writes", () => {
       patchRoute.handler({
         body: { llm: { profiles: { balanced: { topP: null } } } },
       }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
+    ).rejects.toThrow('Cannot edit managed profile "balanced" fields [topP]');
     expectNothingCommitted();
   });
 
-  test("PATCH deleting a user-sourced balanced entry is rejected by the invariant guard", async () => {
-    // A `source: "user"` entry passes the legacy managed-deletion guard, so
-    // this exercises the invariant guard's missing-entry check directly.
-    (rawConfig as Record<string, any>).llm.profiles.balanced.source = "user";
+  test("PATCH disabling a managed-source os-beta is rejected (active → disabled)", async () => {
+    (rawConfig as Record<string, any>).llm.profiles["os-beta"] = {
+      provider: "together",
+      model: "zai-org/GLM-5.2",
+      source: "managed",
+    };
     await expect(
       patchRoute.handler({
-        body: { llm: { profiles: { balanced: null } } },
+        body: { llm: { profiles: { "os-beta": { status: "disabled" } } } },
       }),
-    ).rejects.toThrow(
-      'Cannot delete or replace default profile "balanced". Default profiles are read-only.',
-    );
+    ).rejects.toThrow('Cannot disable managed profile "os-beta".');
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles.os-beta.label is rejected on a managed-source entry", async () => {
+    (rawConfig as Record<string, any>).llm.profiles["os-beta"] = {
+      provider: "together",
+      model: "zai-org/GLM-5.2",
+      source: "managed",
+    };
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.os-beta.label", value: "My OS Beta" },
+      }),
+    ).rejects.toThrow('Cannot edit managed profile "os-beta" fields [label]');
     expectNothingCommitted();
   });
 
@@ -661,7 +698,7 @@ describe("default-profile invariant guard — rejected writes", () => {
       patchRoute.handler({
         body: { llm: { profiles: { balanced: "junk" } } },
       }),
-    ).rejects.toThrow('Cannot delete or replace default profile "balanced".');
+    ).rejects.toThrow('Cannot delete or replace managed profile "balanced".');
     expectNothingCommitted();
   });
 
@@ -670,20 +707,23 @@ describe("default-profile invariant guard — rejected writes", () => {
       patchRoute.handler({
         body: { llm: { profiles: { balanced: ["disabled"] } } },
       }),
-    ).rejects.toThrow('Cannot delete or replace default profile "balanced".');
+    ).rejects.toThrow('Cannot delete or replace managed profile "balanced".');
     expectNothingCommitted();
   });
 
-  // PUT and SET flow through the same commitConfigWrite guard as PATCH, so
-  // the per-field matrix above isn't repeated per route — one rejection per
-  // route proves the wiring.
+  // SET flows through the same commitConfigWrite guard as PATCH, so the
+  // per-field matrix above isn't repeated per route — one rejection per
+  // route proves the wiring. PUT rejects non-re-enable managed bodies at its
+  // own gate, before the commit guard.
   test("PUT { status: 'disabled' } on balanced is rejected", async () => {
     await expect(
       replaceRoute.handler({
         pathParams: { name: "balanced" },
         body: { status: "disabled" },
       }),
-    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    ).rejects.toThrow(
+      'Cannot edit managed profile "balanced". Managed profiles are read-only',
+    );
     expectNothingCommitted();
   });
 
@@ -692,14 +732,14 @@ describe("default-profile invariant guard — rejected writes", () => {
       setRoute.handler({
         body: { path: "llm.profiles.balanced.status", value: "disabled" },
       }),
-    ).rejects.toThrow('Cannot disable default profile "balanced".');
+    ).rejects.toThrow('Cannot disable managed profile "balanced".');
     expectNothingCommitted();
   });
 
   test("SET llm = {} is rejected (would drop all defaults)", async () => {
     await expect(
       setRoute.handler({ body: { path: "llm", value: {} } }),
-    ).rejects.toThrow(/Cannot delete or replace default profile/);
+    ).rejects.toThrow(/Cannot delete or replace managed profile/);
     expectNothingCommitted();
   });
 
@@ -709,7 +749,7 @@ describe("default-profile invariant guard — rejected writes", () => {
         body: { llm: { profiles: { balanced: { status: "weird" } } } },
       }),
     ).rejects.toThrow(
-      'Cannot set status "weird" on default profile "balanced". ' +
+      'Cannot set status "weird" on managed profile "balanced". ' +
         'Only re-enabling (status "active") is allowed.',
     );
     expectNothingCommitted();
@@ -720,13 +760,13 @@ describe("default-profile invariant guard — rejected writes", () => {
       setRoute.handler({
         body: { path: "llm.profiles.balanced.status", value: 123 },
       }),
-    ).rejects.toThrow('Cannot set status 123 on default profile "balanced"');
+    ).rejects.toThrow('Cannot set status 123 on managed profile "balanced"');
     expectNothingCommitted();
   });
 });
 
 describe("default-profile invariant guard — allowed writes", () => {
-  test("PATCH re-enables a disabled default profile (BYOK re-enable)", async () => {
+  test("PATCH re-enables a disabled managed profile (BYOK re-enable)", async () => {
     (rawConfig as Record<string, any>).llm.profiles.balanced.status =
       "disabled";
     const result = await patchRoute.handler({
@@ -748,7 +788,7 @@ describe("default-profile invariant guard — allowed writes", () => {
     expect(savedProfile("balanced").status ?? null).toBeNull();
   });
 
-  test("PUT { status: 'active' } re-enables a disabled default profile", async () => {
+  test("PUT { status: 'active' } re-enables a disabled managed profile", async () => {
     (rawConfig as Record<string, any>).llm.profiles.balanced.status =
       "disabled";
     const result = await replaceRoute.handler({
@@ -760,7 +800,7 @@ describe("default-profile invariant guard — allowed writes", () => {
     expect(savedProfile("balanced").status).toBe("active");
   });
 
-  test("SET llm.profiles.balanced.status = 'active' re-enables a disabled default profile", async () => {
+  test("SET llm.profiles.balanced.status = 'active' re-enables a disabled managed profile", async () => {
     (rawConfig as Record<string, any>).llm.profiles.balanced.status =
       "disabled";
     const result = await setRoute.handler({
@@ -789,21 +829,33 @@ describe("default-profile invariant guard — allowed writes", () => {
     );
   });
 
-  test("PUT label/status/topP edits on managed os-beta remain allowed (non-invariant)", async () => {
+  test("PATCH deleting a user-sourced balanced entry is allowed (invariance is source-gated)", async () => {
+    // A `source: "user"` entry passes the managed-deletion guard AND the
+    // invariant guard — both key on the on-disk entry's managed source, so
+    // a user-owned profile sharing a managed name stays deletable.
+    (rawConfig as Record<string, any>).llm.profiles.balanced.source = "user";
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { balanced: null } } },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+  });
+
+  test("PUT full edits on a user-sourced os-beta entry are allowed (invariance is source-gated)", async () => {
     (rawConfig as Record<string, any>).llm.profiles["os-beta"] = {
-      provider: "together",
-      model: "zai-org/GLM-5.2",
-      source: "managed",
+      provider: "anthropic",
+      model: "claude-sonnet",
+      source: "user",
     };
     const result = await replaceRoute.handler({
       pathParams: { name: "os-beta" },
-      body: { label: "My OS Beta", status: "disabled", topP: 0.5 },
+      body: { provider: "openai", model: "gpt-4o", topP: 0.5 },
     });
     expect(result).toEqual({ ok: true });
     expectOneCommitCycle();
     const profile = savedProfile("os-beta");
-    expect(profile.label).toBe("My OS Beta");
-    expect(profile.status).toBe("disabled");
+    expect(profile.provider).toBe("openai");
+    expect(profile.model).toBe("gpt-4o");
     expect(profile.topP).toBe(0.5);
   });
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -8,10 +8,16 @@
  *   ("quality-optimized", "balanced", "cost-optimized") are fully read-only
  *   across PATCH/SET/PUT — the only writable transition is re-enabling a
  *   disabled default.
+ *
+ * Plus the wire-only profile keys (`invariant`, `supportsVision`) stamped on
+ * config reads: PATCH/SET strip them so a GET → write round-trip succeeds.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Imported before the `mock.module` below so the mock can pass the real
+// implementation through instead of hand-copying it.
+import { setNestedValue } from "../config/loader.js";
 import { makeMockLogger } from "./helpers/mock-logger.js";
 
 mock.module("../util/logger.js", () => ({
@@ -90,22 +96,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {
     invalidateConfigCacheCalls += 1;
   },
-  setNestedValue: (
-    obj: Record<string, unknown>,
-    path: string,
-    value: unknown,
-  ) => {
-    const keys = path.split(".");
-    let current = obj;
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i]!;
-      if (current[key] == null || typeof current[key] !== "object") {
-        current[key] = {};
-      }
-      current = current[key] as Record<string, unknown>;
-    }
-    current[keys[keys.length - 1]!] = value;
-  },
+  setNestedValue,
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
   withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
 }));
@@ -683,6 +674,9 @@ describe("default-profile invariant guard — rejected writes", () => {
     expectNothingCommitted();
   });
 
+  // PUT and SET flow through the same commitConfigWrite guard as PATCH, so
+  // the per-field matrix above isn't repeated per route — one rejection per
+  // route proves the wiring.
   test("PUT { status: 'disabled' } on balanced is rejected", async () => {
     await expect(
       replaceRoute.handler({
@@ -690,26 +684,6 @@ describe("default-profile invariant guard — rejected writes", () => {
         body: { status: "disabled" },
       }),
     ).rejects.toThrow('Cannot disable default profile "balanced".');
-    expectNothingCommitted();
-  });
-
-  test("PUT { label: 'Renamed' } on balanced is rejected", async () => {
-    await expect(
-      replaceRoute.handler({
-        pathParams: { name: "balanced" },
-        body: { label: "Renamed" },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [label]');
-    expectNothingCommitted();
-  });
-
-  test("PUT { topP: 0.8 } on balanced is rejected", async () => {
-    await expect(
-      replaceRoute.handler({
-        pathParams: { name: "balanced" },
-        body: { topP: 0.8 },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
     expectNothingCommitted();
   });
 
@@ -722,26 +696,31 @@ describe("default-profile invariant guard — rejected writes", () => {
     expectNothingCommitted();
   });
 
-  test("SET llm.profiles.balanced.topP = 0.8 is rejected", async () => {
-    await expect(
-      setRoute.handler({
-        body: { path: "llm.profiles.balanced.topP", value: 0.8 },
-      }),
-    ).rejects.toThrow('Cannot edit default profile "balanced" fields [topP]');
-    expectNothingCommitted();
-  });
-
-  test("SET llm.profiles = {} is rejected (would drop all defaults)", async () => {
-    await expect(
-      setRoute.handler({ body: { path: "llm.profiles", value: {} } }),
-    ).rejects.toThrow(/Cannot delete or replace default profile/);
-    expectNothingCommitted();
-  });
-
   test("SET llm = {} is rejected (would drop all defaults)", async () => {
     await expect(
       setRoute.handler({ body: { path: "llm", value: {} } }),
     ).rejects.toThrow(/Cannot delete or replace default profile/);
+    expectNothingCommitted();
+  });
+
+  test("PATCH { status: 'weird' } on balanced is rejected (junk status)", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: { status: "weird" } } } },
+      }),
+    ).rejects.toThrow(
+      'Cannot set status "weird" on default profile "balanced". ' +
+        'Only re-enabling (status "active") is allowed.',
+    );
+    expectNothingCommitted();
+  });
+
+  test("SET llm.profiles.balanced.status = 123 is rejected (junk status)", async () => {
+    await expect(
+      setRoute.handler({
+        body: { path: "llm.profiles.balanced.status", value: 123 },
+      }),
+    ).rejects.toThrow('Cannot set status 123 on default profile "balanced"');
     expectNothingCommitted();
   });
 });
@@ -852,5 +831,79 @@ describe("default-profile invariant guard — allowed writes", () => {
     expect(savedProfile("balanced")).toEqual(
       (makeDefaultRawConfig() as Record<string, any>).llm.profiles.balanced,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-only profile keys (`invariant`, `supportsVision`) are stamped onto
+// config GET/PATCH responses but never persisted. Writes carrying them —
+// e.g. a `config get` → `config set` round-trip — must succeed with the
+// wire keys stripped, not 400 on phantom fields.
+// ---------------------------------------------------------------------------
+
+describe("wire-only profile keys are stripped from writes", () => {
+  test("PATCH re-enable carrying wire keys succeeds and persists neither key", async () => {
+    (rawConfig as Record<string, any>).llm.profiles.balanced.status =
+      "disabled";
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: {
+            balanced: {
+              status: "active",
+              invariant: true,
+              supportsVision: true,
+            },
+          },
+        },
+      },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect(profile.status).toBe("active");
+    expect("invariant" in profile).toBe(false);
+    expect("supportsVision" in profile).toBe(false);
+  });
+
+  test("SET llm.profiles.balanced with a wire-shaped entry (GET round-trip) succeeds", async () => {
+    const entry = structuredClone(
+      (rawConfig as Record<string, any>).llm.profiles.balanced,
+    ) as Record<string, unknown>;
+    entry.invariant = true;
+    entry.supportsVision = true;
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced", value: entry },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect("invariant" in profile).toBe(false);
+    expect("supportsVision" in profile).toBe(false);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
+  });
+
+  test("SET of a wire-only leaf path is dropped without writing", async () => {
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced.supportsVision", value: true },
+    });
+    expect(result).toEqual({ ok: true });
+    expectNothingCommitted();
+  });
+
+  test("PATCH with supportsVision on a custom profile does not persist it", async () => {
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: { "my-custom": { supportsVision: false, maxTokens: 2048 } },
+        },
+      },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    const profile = savedProfile("my-custom");
+    expect("supportsVision" in profile).toBe(false);
+    expect(profile.maxTokens).toBe(2048);
   });
 });

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -944,6 +944,78 @@ describe("wire-only profile keys are stripped from writes", () => {
     expectNothingCommitted();
   });
 
+  // -------------------------------------------------------------------------
+  // Stale wire-only keys on disk: configs written before the write-side strip
+  // existed can carry `supportsVision` under a managed profile. The invariant
+  // guard ignores wire-only keys on both sides, so a GET → write round-trip
+  // (whose incoming copy is stripped) is not rejected for "removing" the
+  // stale key — and a full-entry SET drops it from disk.
+  // -------------------------------------------------------------------------
+
+  test("SET round-trip re-enabling a managed profile with stale on-disk supportsVision succeeds and drops the stale key", async () => {
+    const balanced = (rawConfig as Record<string, any>).llm.profiles.balanced;
+    balanced.supportsVision = true; // stale pre-strip persistence
+    balanced.status = "disabled";
+    const entry = structuredClone(balanced) as Record<string, unknown>;
+    entry.invariant = true; // wire stamp from GET
+    entry.status = "active"; // legal re-enable
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced", value: entry },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect(profile.status).toBe("active");
+    expect("supportsVision" in profile).toBe(false);
+    expect("invariant" in profile).toBe(false);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
+  });
+
+  test("pure no-op SET round-trip with stale on-disk supportsVision succeeds", async () => {
+    const balanced = (rawConfig as Record<string, any>).llm.profiles.balanced;
+    balanced.supportsVision = true; // stale pre-strip persistence
+    const entry = structuredClone(balanced) as Record<string, unknown>;
+    entry.invariant = true; // wire stamp from GET
+    const result = await setRoute.handler({
+      body: { path: "llm.profiles.balanced", value: entry },
+    });
+    expect(result).toEqual({ ok: true });
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect("supportsVision" in profile).toBe(false);
+    expect("invariant" in profile).toBe(false);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
+  });
+
+  test("PATCH re-enable carrying wire keys succeeds when the on-disk entry has stale supportsVision", async () => {
+    const balanced = (rawConfig as Record<string, any>).llm.profiles.balanced;
+    balanced.supportsVision = true; // stale pre-strip persistence
+    balanced.status = "disabled";
+    const result = await patchRoute.handler({
+      body: {
+        llm: {
+          profiles: {
+            balanced: {
+              status: "active",
+              invariant: true,
+              supportsVision: true,
+            },
+          },
+        },
+      },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    const profile = savedProfile("balanced");
+    expect(profile.status).toBe("active");
+    // The deep merge starts from the on-disk entry, so the stale key survives
+    // a PATCH (only a full-entry SET removes it) — but the write gains no
+    // `invariant` key and never 400s on the phantom-field diff.
+    expect("invariant" in profile).toBe(false);
+  });
+
   test("PATCH with supportsVision on a custom profile does not persist it", async () => {
     const result = await patchRoute.handler({
       body: {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -414,14 +414,14 @@ export const ProfileEntry = LLMConfigFragment.extend({
   source: ProfileSource.optional(),
   /**
    * `.nullable()` is intentional: the PUT `/v1/config/llm/profiles/:name`
-   * route uses `null` as the "clear this override" sentinel for managed
-   * profiles (see `patchManagedProfileFields` in
+   * route uses `null` as the "clear this field" sentinel (edit mode sends
+   * `label: null` for a cleared display name — see
+   * `handleReplaceInferenceProfile` in
    * `runtime/routes/conversation-query-routes.ts`). Without `.nullable()`,
    * Zod rejects `{ label: null }` at parse time before the route handler
-   * ever sees it, and the clear-back-to-seed path is unreachable from any
-   * client. `.min(1)` still applies to string values so empty strings
-   * remain rejected — `null` is the only non-string-non-undefined input
-   * accepted.
+   * ever sees it, and the clear path is unreachable from any client.
+   * `.min(1)` still applies to string values so empty strings remain
+   * rejected — `null` is the only non-string-non-undefined input accepted.
    */
   label: z.string().min(1).nullable().optional(),
   description: z.string().optional(),
@@ -434,9 +434,9 @@ export const ProfileEntry = LLMConfigFragment.extend({
   provider_connection: z.string().min(1).optional(),
   /**
    * Absent means active. `.nullable()` matches `label` so the PUT route's
-   * "send `null` to clear" sentinel works for status edits too — see
-   * `patchManagedProfileFields`, which has handled `status === null` since
-   * #30362 even though the schema didn't accept it until now.
+   * "send `null` to clear" sentinel works for status too — a managed
+   * re-enable body of `{status: null}` clears back to active-by-absence
+   * (see `applyManagedProfileReenable`).
    */
   status: ProfileStatusSchema.nullable().optional(),
   /**

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -165,6 +165,13 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
   topP: 0.95,
 };
 
+// The three default managed profiles are invariant: read-only to user-facing
+// writes except re-enabling a hatch-disabled one (enforced at
+// commitConfigWrite). os-beta is managed but NOT invariant.
+export const INVARIANT_PROFILE_NAMES = new Set(
+  Object.keys(MANAGED_PROFILE_TEMPLATES),
+);
+
 // Membership here marks a name as managed. The route layer applies managed
 // restrictions (blocking model/provider edits and deletion) only to entries
 // whose on-disk `source` is `managed`, so a user-owned profile sharing one of

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -165,18 +165,21 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
   topP: 0.95,
 };
 
-// The three default managed profiles are invariant: read-only to user-facing
-// writes except re-enabling a hatch-disabled one (enforced at
-// commitConfigWrite). os-beta is managed but NOT invariant.
-export const INVARIANT_PROFILE_NAMES = new Set(
-  Object.keys(MANAGED_PROFILE_TEMPLATES),
-);
+// All managed profiles, including the flag-gated os-beta, are invariant:
+// their MANAGED-SOURCE entries are read-only to user-facing writes except
+// re-enabling a disabled one (enforced at commitConfigWrite). A user-owned
+// profile sharing one of these names is NOT locked — invariance is gated on
+// the on-disk entry's `source` being `managed`.
+export const INVARIANT_PROFILE_NAMES = new Set([
+  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  OS_BETA_PROFILE_KEY,
+]);
 
 // Membership here marks a name as managed. The route layer applies managed
 // restrictions (blocking model/provider edits and deletion) only to entries
-// whose on-disk `source` is `managed`; `INVARIANT_PROFILE_NAMES` entries are
-// additionally frozen by name at the `commitConfigWrite` choke point,
-// regardless of `source`. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// whose on-disk `source` is `managed`; `INVARIANT_PROFILE_NAMES` marks the
+// names whose managed-source entries are additionally frozen at the
+// `commitConfigWrite` choke point. `OS_BETA_PROFILE_KEY` is flag-gated: it is
 // materialized by the flag-gated profile reconcile, which refuses to touch a
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([
@@ -208,9 +211,9 @@ export type SeedInferenceProfilesOptions = {
  *    `cost-optimized`): reconciled from the code templates on every boot —
  *    on-platform and off-platform alike — so Vellum can push model/config
  *    updates to customers in a release without a workspace migration. The
- *    templates own all profile content; `label`, `status`, and `topP` are user
- *    overrides that survive reseeds and are editable through the managed PUT
- *    route allowlist.
+ *    templates own all profile content; on-disk `label`, `status`, and `topP`
+ *    overrides survive reseeds (the BYOK label suffix and hatch-time disable
+ *    rely on this).
  *    Platform overlays (`preserveProfileNames`) take precedence for the boot
  *    they are supplied.
  *
@@ -267,12 +270,11 @@ export function seedInferenceProfiles(
   //    A whitelist of fields survives the reconcile: `label`, `status`, and
   //    `topP` are preserved from disk across reseeds so the BYOK hatch-time
   //    disable and any pre-existing overrides don't silently revert on every
-  //    boot. User edits of these fields (via the managed PUT route
-  //    `/v1/config/llm/profiles/:name`) are allowed only on non-invariant
-  //    managed profiles (os-beta); invariant default profiles reject all
-  //    edits except the disabled→active re-enable at the route layer's
-  //    commit guard. Carry by key-presence rather than truthiness so an
-  //    explicit `null` (cleared field) survives too.
+  //    boot. Managed-source profiles reject all user-facing edits except the
+  //    disabled→active re-enable (enforced at the route layer's commit
+  //    guard), so these preserved fields are frozen, not editable. Carry by
+  //    key-presence rather than truthiness so an explicit `null` (cleared
+  //    field) survives too.
   //
   //    BYOK seed defaults (off-platform only):
   //      • label: " (Managed)" suffix disambiguates managed profile labels
@@ -327,12 +329,11 @@ export function seedInferenceProfiles(
             : previous.label;
       }
       if ("status" in previous) next.status = previous.status;
-      // `topP` is user-editable on non-invariant managed profiles (see the
-      // managed-profile editable allowlist on the PUT route; invariant
-      // defaults reject the edit at the commit guard) — preserve any on-disk
-      // override across reseeds, including an explicit `null` clear, or it
-      // would silently revert to the template value on every boot. Carry by
-      // key-presence (not truthiness) so `null` survives too.
+      // A pre-existing on-disk `topP` override is frozen by the invariant
+      // guard but must still survive reseeds, including an explicit `null`
+      // clear — otherwise it would silently revert to the template value on
+      // every boot. Carry by key-presence (not truthiness) so `null`
+      // survives too.
       if ("topP" in previous) next.topP = previous.topP;
     }
     profiles[name] = next as ProfileEntry;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -264,14 +264,15 @@ export function seedInferenceProfiles(
   //    its first merge), so on subsequent boots the templates reconcile content
   //    as usual.
   //
-  //    A whitelist of user-editable fields survives the reconcile: `label`
-  //    (display rename), `status` (active/disabled toggle), and `topP`
-  //    (sampling override) — the only fields a user may override. The managed
-  //    PUT route `/v1/config/llm/profiles/:name` lets users patch these on
-  //    managed profiles without duplicating. We honor every one of these
-  //    overrides across reseeds or they'd silently revert on every boot.
-  //    Carry by key-presence rather than truthiness so an explicit `null` (user
-  //    cleared the field) survives too.
+  //    A whitelist of fields survives the reconcile: `label`, `status`, and
+  //    `topP` are preserved from disk across reseeds so the BYOK hatch-time
+  //    disable and any pre-existing overrides don't silently revert on every
+  //    boot. User edits of these fields (via the managed PUT route
+  //    `/v1/config/llm/profiles/:name`) are allowed only on non-invariant
+  //    managed profiles (os-beta); invariant default profiles reject all
+  //    edits except the disabled→active re-enable at the route layer's
+  //    commit guard. Carry by key-presence rather than truthiness so an
+  //    explicit `null` (cleared field) survives too.
   //
   //    BYOK seed defaults (off-platform only):
   //      • label: " (Managed)" suffix disambiguates managed profile labels
@@ -314,7 +315,7 @@ export function seedInferenceProfiles(
       next.status = "disabled";
     }
     if (previous) {
-      // Preserve user overrides on these whitelisted fields. The label path
+      // Preserve on-disk overrides of these whitelisted fields. The label path
       // also runs the BYOK upgrade migration described above: if the on-disk
       // label exactly equals the bare template default and we're in BYOK
       // mode, rewrite to the suffixed effective label so existing installs
@@ -326,11 +327,12 @@ export function seedInferenceProfiles(
             : previous.label;
       }
       if ("status" in previous) next.status = previous.status;
-      // `topP` is user-editable on managed profiles (see the managed-profile
-      // editable allowlist on the PUT route) — preserve a user override across
-      // reseeds, including an explicit `null` clear, or it would silently revert
-      // to the template value on every boot. Carry by key-presence (not
-      // truthiness) so `null` survives too.
+      // `topP` is user-editable on non-invariant managed profiles (see the
+      // managed-profile editable allowlist on the PUT route; invariant
+      // defaults reject the edit at the commit guard) — preserve any on-disk
+      // override across reseeds, including an explicit `null` clear, or it
+      // would silently revert to the template value on every boot. Carry by
+      // key-presence (not truthiness) so `null` survives too.
       if ("topP" in previous) next.topP = previous.topP;
     }
     profiles[name] = next as ProfileEntry;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -174,8 +174,9 @@ export const INVARIANT_PROFILE_NAMES = new Set(
 
 // Membership here marks a name as managed. The route layer applies managed
 // restrictions (blocking model/provider edits and deletion) only to entries
-// whose on-disk `source` is `managed`, so a user-owned profile sharing one of
-// these names is not locked. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// whose on-disk `source` is `managed`; `INVARIANT_PROFILE_NAMES` entries are
+// additionally frozen by name at the `commitConfigWrite` choke point,
+// regardless of `source`. `OS_BETA_PROFILE_KEY` is flag-gated: it is
 // materialized by the flag-gated profile reconcile, which refuses to touch a
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -940,22 +940,33 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
 
   describe("managed profile guard", () => {
     beforeEach(() => {
-      // Seed a managed profile alongside the existing custom one.
-      (rawConfigFixture.llm as { profiles: Record<string, unknown> }).profiles[
-        "balanced"
-      ] = {
+      // Seed an invariant default profile and the non-invariant managed
+      // os-beta profile alongside the existing custom one. Default profiles
+      // are fully read-only (only disabled → active status transitions
+      // pass); os-beta keeps the label/status/topP allowlist.
+      const profiles = (
+        rawConfigFixture.llm as { profiles: Record<string, unknown> }
+      ).profiles;
+      profiles["balanced"] = {
         source: "managed",
         provider: "anthropic",
         model: "claude-sonnet-4-6",
         label: "Balanced",
         status: "active",
       };
+      profiles["os-beta"] = {
+        source: "managed",
+        provider: "together",
+        model: "zai-org/GLM-5.2",
+        label: "OS Beta",
+        status: "active",
+      };
     });
 
-    test("allows label edit on managed profile, preserving seed fields", async () => {
+    test("allows label edit on managed os-beta profile, preserving seed fields", async () => {
       const result = await replaceProfileRoute.handler({
-        pathParams: { name: "balanced" },
-        body: { label: "My Balanced" },
+        pathParams: { name: "os-beta" },
+        body: { label: "My OS Beta" },
       });
 
       expect(result).toEqual({ ok: true });
@@ -963,18 +974,18 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         savedRawConfig?.llm as {
           profiles: Record<string, Record<string, unknown>>;
         }
-      ).profiles.balanced;
+      ).profiles["os-beta"]!;
 
-      expect(savedProfile.label).toBe("My Balanced");
+      expect(savedProfile.label).toBe("My OS Beta");
       // Seed fields preserved.
-      expect(savedProfile.provider).toBe("anthropic");
-      expect(savedProfile.model).toBe("claude-sonnet-4-6");
+      expect(savedProfile.provider).toBe("together");
+      expect(savedProfile.model).toBe("zai-org/GLM-5.2");
       expect(savedProfile.source).toBe("managed");
     });
 
-    test("allows status edit on managed profile", async () => {
+    test("allows status edit on managed os-beta profile", async () => {
       const result = await replaceProfileRoute.handler({
-        pathParams: { name: "balanced" },
+        pathParams: { name: "os-beta" },
         body: { status: "disabled" },
       });
 
@@ -983,15 +994,15 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         savedRawConfig?.llm as {
           profiles: Record<string, Record<string, unknown>>;
         }
-      ).profiles.balanced;
+      ).profiles["os-beta"]!;
 
       expect(savedProfile.status).toBe("disabled");
-      expect(savedProfile.provider).toBe("anthropic");
+      expect(savedProfile.provider).toBe("together");
     });
 
-    test("allows label+status edit together", async () => {
+    test("allows label+status edit together on managed os-beta profile", async () => {
       const result = await replaceProfileRoute.handler({
-        pathParams: { name: "balanced" },
+        pathParams: { name: "os-beta" },
         body: { label: "Renamed", status: "disabled" },
       });
 
@@ -1000,10 +1011,36 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         savedRawConfig?.llm as {
           profiles: Record<string, Record<string, unknown>>;
         }
-      ).profiles.balanced;
+      ).profiles["os-beta"]!;
 
       expect(savedProfile.label).toBe("Renamed");
       expect(savedProfile.status).toBe("disabled");
+    });
+
+    test("rejects label edit on an invariant default profile at commit time", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "balanced" },
+          body: { label: "My Balanced" },
+        }),
+      ).rejects.toThrow(
+        'Cannot edit default profile "balanced" fields [label]',
+      );
+      expect(savedRawConfig).toBeNull();
+      expect(initializeProvidersCalls).toBe(0);
+      expect(invalidateConfigCacheCalls).toBe(0);
+    });
+
+    test("rejects disabling an invariant default profile at commit time", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "balanced" },
+          body: { status: "disabled" },
+        }),
+      ).rejects.toThrow('Cannot disable default profile "balanced".');
+      expect(savedRawConfig).toBeNull();
+      expect(initializeProvidersCalls).toBe(0);
+      expect(invalidateConfigCacheCalls).toBe(0);
     });
 
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
@@ -1040,10 +1077,12 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
   });
 
   describe("commitConfigWrite side effects", () => {
-    test("status flip on managed profile triggers provider reinit + cache invalidation", async () => {
-      // Seed a managed profile that the user will disable. commitConfigWrite
-      // must reinit the provider registry so the status change is reflected
-      // in the running daemon immediately, not at the next watcher tick.
+    test("re-enabling a disabled default profile triggers provider reinit + cache invalidation", async () => {
+      // Seed a hatch-disabled default profile that the user re-enables — the
+      // only status transition the invariant guard permits on a default
+      // profile. commitConfigWrite must reinit the provider registry so the
+      // status change is reflected in the running daemon immediately, not at
+      // the next watcher tick.
       (rawConfigFixture.llm as { profiles: Record<string, unknown> }).profiles[
         "balanced"
       ] = {
@@ -1051,12 +1090,12 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
         label: "Balanced",
-        status: "active",
+        status: "disabled",
       };
 
       const result = await replaceProfileRoute.handler({
         pathParams: { name: "balanced" },
-        body: { status: "disabled" },
+        body: { status: "active" },
       });
 
       expect(result).toEqual({ ok: true });

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1017,31 +1017,8 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(savedProfile.status).toBe("disabled");
     });
 
-    test("rejects label edit on an invariant default profile at commit time", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "balanced" },
-          body: { label: "My Balanced" },
-        }),
-      ).rejects.toThrow(
-        'Cannot edit default profile "balanced" fields [label]',
-      );
-      expect(savedRawConfig).toBeNull();
-      expect(initializeProvidersCalls).toBe(0);
-      expect(invalidateConfigCacheCalls).toBe(0);
-    });
-
-    test("rejects disabling an invariant default profile at commit time", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "balanced" },
-          body: { status: "disabled" },
-        }),
-      ).rejects.toThrow('Cannot disable default profile "balanced".');
-      expect(savedRawConfig).toBeNull();
-      expect(initializeProvidersCalls).toBe(0);
-      expect(invalidateConfigCacheCalls).toBe(0);
-    });
+    // Commit-time rejection coverage for invariant default profiles lives in
+    // src/__tests__/managed-profile-guard.test.ts.
 
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
       // The handler is `async`, so synchronous BadRequest throws still

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1084,3 +1084,69 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     });
   });
 });
+
+describe("config invariant flag enrichment", () => {
+  const configGetRoute = ROUTES.find((r) => r.operationId === "config_get")!;
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+
+  type WireProfiles = Record<string, Record<string, unknown>>;
+
+  function wireProfiles(body: unknown): WireProfiles {
+    return (body as { llm: { profiles: WireProfiles } }).llm.profiles;
+  }
+
+  beforeEach(() => {
+    savedRawConfig = null;
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            label: "Balanced",
+            status: "active",
+          },
+          "os-beta": {
+            source: "managed",
+            provider: "together",
+            model: "zai-org/GLM-5.2",
+            label: "OS Beta",
+            status: "active",
+          },
+          custom: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+  });
+
+  test("GET /v1/config marks default managed profiles invariant, not os-beta or custom", async () => {
+    const body = await configGetRoute.handler({});
+    const profiles = wireProfiles(body);
+
+    expect(profiles.balanced!.invariant).toBe(true);
+    expect(profiles["os-beta"]!).not.toHaveProperty("invariant");
+    expect(profiles.custom!).not.toHaveProperty("invariant");
+  });
+
+  test("PATCH /v1/config stamps the flag on the response but never persists it", async () => {
+    const body = await configPatchRoute.handler({
+      body: { memory: { enabled: true } },
+    });
+    const profiles = wireProfiles(body);
+    expect(profiles.balanced!.invariant).toBe(true);
+
+    const savedProfiles = (
+      savedRawConfig?.llm as { profiles: WireProfiles } | undefined
+    )?.profiles;
+    expect(savedProfiles).toBeDefined();
+    for (const profile of Object.values(savedProfiles!)) {
+      expect(profile).not.toHaveProperty("invariant");
+    }
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -940,10 +940,10 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
 
   describe("managed profile guard", () => {
     beforeEach(() => {
-      // Seed an invariant default profile and the non-invariant managed
-      // os-beta profile alongside the existing custom one. Default profiles
-      // are fully read-only (only disabled → active status transitions
-      // pass); os-beta keeps the label/status/topP allowlist.
+      // Seed two managed-source profiles alongside the existing custom one.
+      // Every managed profile name (including the flag-gated os-beta) is
+      // invariant while its entry is managed-source: fully read-only except
+      // the disabled → active status transition.
       const profiles = (
         rawConfigFixture.llm as { profiles: Record<string, unknown> }
       ).profiles;
@@ -963,10 +963,40 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       };
     });
 
-    test("allows label edit on managed os-beta profile, preserving seed fields", async () => {
+    test("rejects label edit on managed os-beta profile (invariant)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "os-beta" },
+          body: { label: "My OS Beta" },
+        }),
+      ).rejects.toThrow(
+        /Cannot edit managed profile "os-beta" fields \[label\]/,
+      );
+      expect(savedRawConfig).toBeNull();
+    });
+
+    test("rejects disable on managed os-beta profile (invariant)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "os-beta" },
+          body: { status: "disabled" },
+        }),
+      ).rejects.toThrow(
+        'Cannot edit managed profile "os-beta". Managed profiles are read-only',
+      );
+      expect(savedRawConfig).toBeNull();
+    });
+
+    test("re-enables a disabled managed os-beta profile, preserving seed fields", async () => {
+      (
+        rawConfigFixture.llm as {
+          profiles: Record<string, Record<string, unknown>>;
+        }
+      ).profiles["os-beta"]!.status = "disabled";
+
       const result = await replaceProfileRoute.handler({
         pathParams: { name: "os-beta" },
-        body: { label: "My OS Beta" },
+        body: { status: "active" },
       });
 
       expect(result).toEqual({ ok: true });
@@ -976,49 +1006,15 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         }
       ).profiles["os-beta"]!;
 
-      expect(savedProfile.label).toBe("My OS Beta");
+      expect(savedProfile.status).toBe("active");
       // Seed fields preserved.
       expect(savedProfile.provider).toBe("together");
       expect(savedProfile.model).toBe("zai-org/GLM-5.2");
       expect(savedProfile.source).toBe("managed");
     });
 
-    test("allows status edit on managed os-beta profile", async () => {
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "os-beta" },
-        body: { status: "disabled" },
-      });
-
-      expect(result).toEqual({ ok: true });
-      const savedProfile = (
-        savedRawConfig?.llm as {
-          profiles: Record<string, Record<string, unknown>>;
-        }
-      ).profiles["os-beta"]!;
-
-      expect(savedProfile.status).toBe("disabled");
-      expect(savedProfile.provider).toBe("together");
-    });
-
-    test("allows label+status edit together on managed os-beta profile", async () => {
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "os-beta" },
-        body: { label: "Renamed", status: "disabled" },
-      });
-
-      expect(result).toEqual({ ok: true });
-      const savedProfile = (
-        savedRawConfig?.llm as {
-          profiles: Record<string, Record<string, unknown>>;
-        }
-      ).profiles["os-beta"]!;
-
-      expect(savedProfile.label).toBe("Renamed");
-      expect(savedProfile.status).toBe("disabled");
-    });
-
-    // Commit-time rejection coverage for invariant default profiles lives in
-    // src/__tests__/managed-profile-guard.test.ts.
+    // The full commit-time rejection matrix for invariant managed profiles
+    // lives in src/__tests__/managed-profile-guard.test.ts.
 
     test("rejects provider edit on managed profile with disallowed-keys error", async () => {
       // The handler is `async`, so synchronous BadRequest throws still
@@ -1033,16 +1029,16 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       );
     });
 
-    test("rejects mixed allowed+disallowed fields", async () => {
-      // label is allowed but maxTokens is not — must reject without partially
-      // applying label, so saver should never be invoked.
+    test("rejects mixed-field bodies without partially applying anything", async () => {
+      // Neither label nor maxTokens is writable on a managed profile — the
+      // reject must fire before any write, so the saver is never invoked.
       await expect(
         replaceProfileRoute.handler({
           pathParams: { name: "balanced" },
           body: { label: "Try", maxTokens: 999 },
         }),
       ).rejects.toThrow(
-        /Cannot edit managed profile "balanced" fields \[maxTokens\]/,
+        /Cannot edit managed profile "balanced" fields \[maxTokens, label\]/,
       );
       expect(savedRawConfig).toBeNull();
       // Reject path skips commitConfigWrite entirely — no provider reinit
@@ -1132,6 +1128,13 @@ describe("config invariant flag enrichment", () => {
             label: "OS Beta",
             status: "active",
           },
+          // A user-owned profile sharing a managed name: no invariant flag —
+          // the stamp is gated on `source: "managed"` to match the guard.
+          "cost-optimized": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+          },
           custom: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
@@ -1141,12 +1144,13 @@ describe("config invariant flag enrichment", () => {
     };
   });
 
-  test("GET /v1/config marks default managed profiles invariant, not os-beta or custom", async () => {
+  test("GET /v1/config marks managed-source profiles invariant (incl. os-beta), not user-owned ones", async () => {
     const body = await configGetRoute.handler({});
     const profiles = wireProfiles(body);
 
     expect(profiles.balanced!.invariant).toBe(true);
-    expect(profiles["os-beta"]!).not.toHaveProperty("invariant");
+    expect(profiles["os-beta"]!.invariant).toBe(true);
+    expect(profiles["cost-optimized"]!).not.toHaveProperty("invariant");
     expect(profiles.custom!).not.toHaveProperty("invariant");
   });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -145,10 +145,13 @@ const INFERENCE_PROFILE_UI_KEYS = new Set([
   "thinking",
 ]);
 
-// Fields a MANAGED profile may edit. Beyond `label` (display name) and
-// `status` (enabled/disabled), users can tune `topP` — the seed contract
-// owns provider/model/connection, but top_p is a per-profile sampling knob
-// the UI exposes on the managed Balanced profile.
+// Fields a NON-INVARIANT managed profile (os-beta) may edit: `label`
+// (display name), `status` (enabled/disabled), and `topP` — the seed
+// contract owns provider/model/connection, but top_p is a per-profile
+// sampling knob the UI exposes on the managed Balanced profile. Invariant
+// default profiles (`INVARIANT_PROFILE_NAMES`) are frozen at the
+// `commitConfigWrite` guard (`assertInvariantProfilesPreserved`); their
+// only permitted edit is the disabled→active re-enable.
 const MANAGED_PROFILE_EDITABLE_KEYS = new Set(["label", "status", "topP"]);
 
 function asMutablePlainObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -937,10 +937,15 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
  *   profile can never be disabled; a changed `status` must be `"active"`,
  *   `null`, or absent — re-enabling a disabled profile. Any other value is
  *   rejected.
+ * - Wire-only keys (`WIRE_ONLY_PROFILE_KEYS`) are ignored on both sides:
+ *   incoming writes have them stripped, but configs persisted before the
+ *   strip existed may still carry them on disk, and treating that stale key
+ *   as a removed field would reject every round-trip write until reboot
+ *   reseeds the profile.
  * - Every other field is frozen: any changed, added, or removed key across
- *   the union of both entries' keys (except `status`) is rejected. A
- *   pre-existing on-disk override (e.g. `topP`) is preserved but frozen —
- *   it passes the guard only while it doesn't change.
+ *   the union of both entries' keys (except `status` and the wire-only keys)
+ *   is rejected. A pre-existing on-disk override (e.g. `topP`) is preserved
+ *   but frozen — it passes the guard only while it doesn't change.
  */
 function assertInvariantProfilesPreserved(
   oldRaw: Record<string, unknown>,
@@ -990,7 +995,9 @@ function assertInvariantProfilesPreserved(
       ...new Set([...Object.keys(oldEntry), ...Object.keys(newEntry)]),
     ].filter(
       (key) =>
-        key !== "status" && !isDeepStrictEqual(oldEntry[key], newEntry[key]),
+        key !== "status" &&
+        !WIRE_ONLY_PROFILE_KEYS.has(key) &&
+        !isDeepStrictEqual(oldEntry[key], newEntry[key]),
     );
     if (changedKeys.length > 0) {
       throw new BadRequestError(

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -795,8 +795,39 @@ function handleGetConfig() {
 }
 
 /**
- * Annotate each profile in `config.llm.profiles` with wire-only flags — never
- * persisted to disk:
+ * Per-profile keys that exist only on the wire — stamped onto config
+ * responses by {@link enrichProfilesForWire}, never persisted to disk.
+ * {@link stripWireOnlyProfileKeys} removes them from incoming writes so a
+ * `config get` → `config set`/PATCH round-trip isn't rejected for phantom
+ * fields; keep the stamp and strip lists in lock-step.
+ */
+const WIRE_ONLY_PROFILE_KEYS = new Set(["invariant", "supportsVision"]);
+
+/**
+ * Delete the wire-only keys ({@link WIRE_ONLY_PROFILE_KEYS}) from every
+ * profile entry in a config-write fragment, in place.
+ */
+function stripWireOnlyProfileKeys(patch: unknown): void {
+  const root = readPlainObject(patch);
+  const llm = readPlainObject(root?.llm);
+  const profiles = readPlainObject(llm?.profiles);
+  if (!profiles) {
+    return;
+  }
+  for (const profile of Object.values(profiles)) {
+    const entry = readPlainObject(profile);
+    if (!entry) {
+      continue;
+    }
+    for (const key of WIRE_ONLY_PROFILE_KEYS) {
+      delete entry[key];
+    }
+  }
+}
+
+/**
+ * Annotate each profile in `config.llm.profiles` with wire-only flags
+ * (`WIRE_ONLY_PROFILE_KEYS`) — never persisted to disk:
  *
  * - `supportsVision`: resolved from the model catalog. Unknown (provider,
  *   model) pairs default to `true` (fail-open) so image upload remains
@@ -900,8 +931,8 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
  *   rejected by this single check, regardless of route.
  * - `status` is one-directional: effective status is
  *   `entry.status !== "disabled"` (absence/null = active). An active default
- *   can never be disabled; re-enabling a disabled default (including
- *   clearing `status` to null/absent) is allowed.
+ *   can never be disabled; a changed `status` must be `"active"`, `null`, or
+ *   absent — re-enabling a disabled default. Any other value is rejected.
  * - Every other field is frozen: any changed, added, or removed key across
  *   the union of both entries' keys (except `status`) is rejected. A
  *   pre-existing on-disk override (e.g. `topP`) is preserved but frozen —
@@ -936,10 +967,16 @@ function assertInvariantProfilesPreserved(
       );
     }
 
-    const oldActive = oldEntry.status !== "disabled";
-    const newActive = newEntry.status !== "disabled";
-    if (oldActive && !newActive) {
-      throw new BadRequestError(`Cannot disable default profile "${name}".`);
+    if (!isDeepStrictEqual(oldEntry.status, newEntry.status)) {
+      if (newEntry.status === "disabled") {
+        throw new BadRequestError(`Cannot disable default profile "${name}".`);
+      }
+      if (newEntry.status !== "active" && newEntry.status != null) {
+        throw new BadRequestError(
+          `Cannot set status ${JSON.stringify(newEntry.status)} on default profile "${name}". ` +
+            `Only re-enabling (status "active") is allowed.`,
+        );
+      }
     }
 
     const changedKeys = [
@@ -1024,6 +1061,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   ) {
     throw new BadRequestError("Body must be a non-empty JSON object");
   }
+  stripWireOnlyProfileKeys(body);
   rejectManagedProfileDeletion(body as Record<string, unknown>);
   rejectMcpTransportHeaderWrite(body);
 
@@ -1074,10 +1112,25 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
       "`value` is required (use `null` to clear a key)",
     );
   }
+  // A leaf-path SET targeting a wire-only profile key is dropped without
+  // writing — the same treatment PATCH gives wire-only keys embedded in a
+  // profile fragment.
+  const pathSegments = path.split(".");
+  if (
+    pathSegments[0] === "llm" &&
+    pathSegments[1] === "profiles" &&
+    pathSegments.length >= 4 &&
+    WIRE_ONLY_PROFILE_KEYS.has(pathSegments[3]!)
+  ) {
+    return { ok: true };
+  }
   // Build the equivalent patch shape so the managed-profile guard can
-  // inspect the touched subtree.
+  // inspect the touched subtree. `setNestedValue` places `value` into
+  // `patchShape` by reference, so stripping wire-only profile keys here
+  // also strips the object written to `raw` below.
   const patchShape: Record<string, unknown> = {};
   setNestedValue(patchShape, path, value);
+  stripWireOnlyProfileKeys(patchShape);
   rejectManagedProfileDeletion(patchShape);
   rejectMcpTransportHeaderWrite(patchShape);
 
@@ -1155,9 +1208,11 @@ async function handleReplaceInferenceProfile({
     // Managed profiles are daemon-seeded — provider, model, and the
     // connection binding all belong to the seed contract and can't be
     // reshaped by the user. The fields that ARE user policy (display label,
-    // enabled status, and the topP sampling knob) are allowed through so
-    // users can rename a managed profile, temporarily disable it, or tune
-    // top_p without duplicating it.
+    // enabled status, and the topP sampling knob) pass this allowlist so
+    // non-invariant managed profiles (os-beta) can be renamed, temporarily
+    // disabled, or tuned. Invariant default profiles are further locked by
+    // `assertInvariantProfilesPreserved` at commit time — for them the only
+    // writable transition is re-enabling a disabled profile.
     const requestedKeys = Object.keys(parsed.data);
     const disallowed = requestedKeys.filter(
       (k) => !MANAGED_PROFILE_EDITABLE_KEYS.has(k),
@@ -1219,9 +1274,17 @@ async function handleReplaceInferenceProfile({
 
   // When the UI sends provider but no provider_connection, derive the connection
   // now so the config deep-merge doesn't inherit a stale connection from the
-  // default layer.
+  // default layer. Invariant names are excluded: commitConfigWrite rejects
+  // every write to them except a pure status re-enable (which derives no
+  // connection), so creating a connection here would leave an orphaned DB
+  // row behind a guaranteed 400.
   const fragment = parsed.data as Record<string, unknown>;
-  if (!isManaged && fragment.provider && !fragment.provider_connection) {
+  if (
+    !isManaged &&
+    !INVARIANT_PROFILE_NAMES.has(name) &&
+    fragment.provider &&
+    !fragment.provider_connection
+  ) {
     const provider = fragment.provider as string;
     const db = getDb();
     const [active] = listConnections(db, { provider });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -917,11 +917,11 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
 /**
  * Enforce the default-profile invariants at the config-write choke point.
  *
- * Transitional: protects the *seeded* default profiles
- * (`INVARIANT_PROFILE_NAMES`) that live in workspace config. When the
- * code-defined default catalog lands (inference-config refactor M4), the
- * defaults stop living in workspace config, this guard becomes a no-op, and
- * it is removed in the M9 cleanup.
+ * Protects the *seeded* default profiles (`INVARIANT_PROFILE_NAMES`) that
+ * live in workspace config. The guard only has an effect while defaults are
+ * seeded there: it checks entries present in the OLD config, so if defaults
+ * stop being stored in workspace config it has nothing to protect and can be
+ * deleted along with the seeding.
  *
  * For each invariant name where the OLD raw config carries a plain-object
  * entry at `llm.profiles[name]`:

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -118,7 +118,10 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
-import { MANAGED_PROFILE_NAMES } from "../../config/seed-inference-profiles.js";
+import {
+  INVARIANT_PROFILE_NAMES,
+  MANAGED_PROFILE_NAMES,
+} from "../../config/seed-inference-profiles.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 
 const RESERVED_PROFILE_NAMES = new Set([
@@ -579,6 +582,7 @@ function rejectMcpTransportHeaderWrite(patch: unknown): void {
 
 const WireProfileEntry = ProfileEntry.extend({
   supportsVision: z.boolean().optional(),
+  invariant: z.boolean().optional(),
 })
   .passthrough()
   .meta({ id: "ProfileEntry" });
@@ -780,7 +784,7 @@ function handleGetConfig() {
   try {
     const config = applyContextDefaultsToRawConfig(loadRawConfig());
     sanitizeMcpTransportHeadersForSettingsRead(config);
-    enrichProfilesWithVisionFlag(config);
+    enrichProfilesForWire(config);
     return config;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -789,12 +793,16 @@ function handleGetConfig() {
 }
 
 /**
- * Annotate each profile in `config.llm.profiles` with `supportsVision`
- * resolved from the model catalog. The flag is wire-only — it is never
- * persisted to disk. Unknown (provider, model) pairs default to `true`
- * (fail-open) so image upload remains available for custom / unlisted models.
+ * Annotate each profile in `config.llm.profiles` with wire-only flags — never
+ * persisted to disk:
+ *
+ * - `supportsVision`: resolved from the model catalog. Unknown (provider,
+ *   model) pairs default to `true` (fail-open) so image upload remains
+ *   available for custom / unlisted models.
+ * - `invariant`: `true` for the three default managed profiles
+ *   (`INVARIANT_PROFILE_NAMES`); absent otherwise.
  */
-function enrichProfilesWithVisionFlag(config: unknown): void {
+function enrichProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
   if (!root) return;
   const llm = readPlainObject(root.llm);
@@ -802,9 +810,12 @@ function enrichProfilesWithVisionFlag(config: unknown): void {
   const profiles = readPlainObject(llm.profiles);
   if (!profiles) return;
 
-  for (const profile of Object.values(profiles)) {
+  for (const [name, profile] of Object.entries(profiles)) {
     const entry = readPlainObject(profile);
     if (!entry) continue;
+    if (INVARIANT_PROFILE_NAMES.has(name)) {
+      entry.invariant = true;
+    }
     const provider = entry.provider;
     const model = entry.model;
     if (typeof provider !== "string" || typeof model !== "string") continue;
@@ -942,7 +953,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
 
   const merged = applyContextDefaultsToRawConfig(loadRawConfig());
   sanitizeMcpTransportHeadersForSettingsRead(merged);
-  enrichProfilesWithVisionFlag(merged);
+  enrichProfilesForWire(merged);
   return merged;
 }
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -19,6 +19,8 @@
  * POST   /v1/messages/queued/:id/steer — steer to a queued message
  */
 
+import { isDeepStrictEqual } from "node:util";
+
 import { z } from "zod";
 
 import { LlmContextResponseSchema } from "../../api/responses/llm-context-response.js";
@@ -882,6 +884,80 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
 }
 
 /**
+ * Enforce the default-profile invariants at the config-write choke point.
+ *
+ * Transitional: protects the *seeded* default profiles
+ * (`INVARIANT_PROFILE_NAMES`) that live in workspace config. When the
+ * code-defined default catalog lands (inference-config refactor M4), the
+ * defaults stop living in workspace config, this guard becomes a no-op, and
+ * it is removed in the M9 cleanup.
+ *
+ * For each invariant name where the OLD raw config carries a plain-object
+ * entry at `llm.profiles[name]`:
+ *
+ * - The NEW raw config must still carry a plain-object entry at the same
+ *   path — deletion, non-object overwrite, and subtree replacement are all
+ *   rejected by this single check, regardless of route.
+ * - `status` is one-directional: effective status is
+ *   `entry.status !== "disabled"` (absence/null = active). An active default
+ *   can never be disabled; re-enabling a disabled default (including
+ *   clearing `status` to null/absent) is allowed.
+ * - Every other field is frozen: any changed, added, or removed key across
+ *   the union of both entries' keys (except `status`) is rejected. A
+ *   pre-existing on-disk override (e.g. `topP`) is preserved but frozen —
+ *   it passes the guard only while it doesn't change.
+ */
+function assertInvariantProfilesPreserved(
+  oldRaw: Record<string, unknown>,
+  newRaw: Record<string, unknown>,
+): void {
+  const oldProfiles = asMutablePlainObject(
+    asMutablePlainObject(oldRaw.llm)?.profiles,
+  );
+  if (!oldProfiles) {
+    return;
+  }
+  const newProfiles = asMutablePlainObject(
+    asMutablePlainObject(newRaw.llm)?.profiles,
+  );
+
+  for (const name of INVARIANT_PROFILE_NAMES) {
+    const oldEntry = asMutablePlainObject(oldProfiles[name]);
+    if (!oldEntry) {
+      continue;
+    }
+
+    const newEntry = newProfiles
+      ? asMutablePlainObject(newProfiles[name])
+      : null;
+    if (!newEntry) {
+      throw new BadRequestError(
+        `Cannot delete or replace default profile "${name}". Default profiles are read-only.`,
+      );
+    }
+
+    const oldActive = oldEntry.status !== "disabled";
+    const newActive = newEntry.status !== "disabled";
+    if (oldActive && !newActive) {
+      throw new BadRequestError(`Cannot disable default profile "${name}".`);
+    }
+
+    const changedKeys = [
+      ...new Set([...Object.keys(oldEntry), ...Object.keys(newEntry)]),
+    ].filter(
+      (key) =>
+        key !== "status" && !isDeepStrictEqual(oldEntry[key], newEntry[key]),
+    );
+    if (changedKeys.length > 0) {
+      throw new BadRequestError(
+        `Cannot edit default profile "${name}" fields [${changedKeys.join(", ")}]. ` +
+          `Default profiles are read-only; duplicate to a custom profile to customize.`,
+      );
+    }
+  }
+}
+
+/**
  * Persist a mutated raw config object to disk and synchronize the running
  * daemon (file-watcher, embedding cache, provider registry).
  *
@@ -892,6 +968,12 @@ async function commitConfigWrite(
   raw: Record<string, unknown>,
   opLabel: string,
 ): Promise<void> {
+  // `loadRawConfig()` reads fresh from disk and the save hasn't happened yet,
+  // so it is the pre-write state; raw-to-raw comparison avoids parsed-vs-raw
+  // false diffs. Runs before the watcher-suppress/save sequence so a
+  // rejection needs no suppress-flag or cache cleanup.
+  assertInvariantProfilesPreserved(loadRawConfig(), raw);
+
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write
   // ~200ms later, sees a stale fingerprint, and calls initializeProviders a
@@ -1081,9 +1163,14 @@ async function handleReplaceInferenceProfile({
       (k) => !MANAGED_PROFILE_EDITABLE_KEYS.has(k),
     );
     if (disallowed.length > 0) {
+      // Invariant (default) profiles are locked down further by
+      // `assertInvariantProfilesPreserved` at commit time — don't tell users
+      // label/status/topP are editable when they aren't.
+      const guidance = INVARIANT_PROFILE_NAMES.has(name)
+        ? "Default profiles are read-only (a disabled default can be re-enabled); duplicate to a custom profile to customize."
+        : "Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.";
       throw new BadRequestError(
-        `Cannot edit managed profile "${name}" fields [${disallowed.join(", ")}]. ` +
-          `Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.`,
+        `Cannot edit managed profile "${name}" fields [${disallowed.join(", ")}]. ${guidance}`,
       );
     }
   }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -145,15 +145,6 @@ const INFERENCE_PROFILE_UI_KEYS = new Set([
   "thinking",
 ]);
 
-// Fields a NON-INVARIANT managed profile (os-beta) may edit: `label`
-// (display name), `status` (enabled/disabled), and `topP` — the seed
-// contract owns provider/model/connection, but top_p is a per-profile
-// sampling knob the UI exposes on the managed Balanced profile. Invariant
-// default profiles (`INVARIANT_PROFILE_NAMES`) are frozen at the
-// `commitConfigWrite` guard (`assertInvariantProfilesPreserved`); their
-// only permitted edit is the disabled→active re-enable.
-const MANAGED_PROFILE_EDITABLE_KEYS = new Set(["label", "status", "topP"]);
-
 function asMutablePlainObject(value: unknown): Record<string, unknown> | null {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -835,8 +826,11 @@ function stripWireOnlyProfileKeys(patch: unknown): void {
  * - `supportsVision`: resolved from the model catalog. Unknown (provider,
  *   model) pairs default to `true` (fail-open) so image upload remains
  *   available for custom / unlisted models.
- * - `invariant`: `true` for the three default managed profiles
- *   (`INVARIANT_PROFILE_NAMES`); absent otherwise.
+ * - `invariant`: `true` for managed-source entries of the managed profile
+ *   names (`INVARIANT_PROFILE_NAMES`); absent otherwise. Source-gated to
+ *   match `assertInvariantProfilesPreserved` — a user-owned profile sharing
+ *   a managed name is fully editable, so it must render as a normal custom
+ *   profile.
  */
 function enrichProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
@@ -849,7 +843,7 @@ function enrichProfilesForWire(config: unknown): void {
   for (const [name, profile] of Object.entries(profiles)) {
     const entry = readPlainObject(profile);
     if (!entry) continue;
-    if (INVARIANT_PROFILE_NAMES.has(name)) {
+    if (INVARIANT_PROFILE_NAMES.has(name) && entry.source === "managed") {
       entry.invariant = true;
     }
     const provider = entry.provider;
@@ -918,24 +912,31 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
 }
 
 /**
- * Enforce the default-profile invariants at the config-write choke point.
+ * Enforce the managed-profile invariants at the config-write choke point.
  *
- * Protects the *seeded* default profiles (`INVARIANT_PROFILE_NAMES`) that
- * live in workspace config. The guard only has an effect while defaults are
- * seeded there: it checks entries present in the OLD config, so if defaults
- * stop being stored in workspace config it has nothing to protect and can be
- * deleted along with the seeding.
+ * Protects the *seeded* managed profiles (`INVARIANT_PROFILE_NAMES`) that
+ * live in workspace config. The guard only has an effect while managed
+ * profiles are seeded there: it checks entries present in the OLD config, so
+ * if they stop being stored in workspace config it has nothing to protect
+ * and can be deleted along with the seeding.
  *
- * For each invariant name where the OLD raw config carries a plain-object
- * entry at `llm.profiles[name]`:
+ * Invariance is gated on managed ownership: a name is enforced only when the
+ * OLD entry's `source` is `"managed"`. A user-owned profile sharing a
+ * managed name stays fully editable and deletable — for os-beta that state
+ * is real and supported, because the flag-gated reconcile refuses to
+ * overwrite a same-named user profile.
+ *
+ * For each invariant name where the OLD raw config carries a managed-source
+ * plain-object entry at `llm.profiles[name]`:
  *
  * - The NEW raw config must still carry a plain-object entry at the same
  *   path — deletion, non-object overwrite, and subtree replacement are all
  *   rejected by this single check, regardless of route.
  * - `status` is one-directional: effective status is
- *   `entry.status !== "disabled"` (absence/null = active). An active default
- *   can never be disabled; a changed `status` must be `"active"`, `null`, or
- *   absent — re-enabling a disabled default. Any other value is rejected.
+ *   `entry.status !== "disabled"` (absence/null = active). An active managed
+ *   profile can never be disabled; a changed `status` must be `"active"`,
+ *   `null`, or absent — re-enabling a disabled profile. Any other value is
+ *   rejected.
  * - Every other field is frozen: any changed, added, or removed key across
  *   the union of both entries' keys (except `status`) is rejected. A
  *   pre-existing on-disk override (e.g. `topP`) is preserved but frozen —
@@ -960,23 +961,26 @@ function assertInvariantProfilesPreserved(
     if (!oldEntry) {
       continue;
     }
+    if (oldEntry.source !== "managed") {
+      continue;
+    }
 
     const newEntry = newProfiles
       ? asMutablePlainObject(newProfiles[name])
       : null;
     if (!newEntry) {
       throw new BadRequestError(
-        `Cannot delete or replace default profile "${name}". Default profiles are read-only.`,
+        `Cannot delete or replace managed profile "${name}". Managed profiles are read-only.`,
       );
     }
 
     if (!isDeepStrictEqual(oldEntry.status, newEntry.status)) {
       if (newEntry.status === "disabled") {
-        throw new BadRequestError(`Cannot disable default profile "${name}".`);
+        throw new BadRequestError(`Cannot disable managed profile "${name}".`);
       }
       if (newEntry.status !== "active" && newEntry.status != null) {
         throw new BadRequestError(
-          `Cannot set status ${JSON.stringify(newEntry.status)} on default profile "${name}". ` +
+          `Cannot set status ${JSON.stringify(newEntry.status)} on managed profile "${name}". ` +
             `Only re-enabling (status "active") is allowed.`,
         );
       }
@@ -990,8 +994,8 @@ function assertInvariantProfilesPreserved(
     );
     if (changedKeys.length > 0) {
       throw new BadRequestError(
-        `Cannot edit default profile "${name}" fields [${changedKeys.join(", ")}]. ` +
-          `Default profiles are read-only; duplicate to a custom profile to customize.`,
+        `Cannot edit managed profile "${name}" fields [${changedKeys.join(", ")}]. ` +
+          `Managed profiles are read-only; duplicate to a custom profile to customize.`,
       );
     }
   }
@@ -1208,27 +1212,26 @@ async function handleReplaceInferenceProfile({
     );
   }
   if (isManaged) {
-    // Managed profiles are daemon-seeded — provider, model, and the
-    // connection binding all belong to the seed contract and can't be
-    // reshaped by the user. The fields that ARE user policy (display label,
-    // enabled status, and the topP sampling knob) pass this allowlist so
-    // non-invariant managed profiles (os-beta) can be renamed, temporarily
-    // disabled, or tuned. Invariant default profiles are further locked by
-    // `assertInvariantProfilesPreserved` at commit time — for them the only
-    // writable transition is re-enabling a disabled profile.
+    // Managed profiles are daemon-seeded and read-only — the commit guard
+    // (`assertInvariantProfilesPreserved`) rejects every write to them
+    // except re-enabling a disabled profile. Enforce the same contract up
+    // front: the only body a managed PUT accepts is a pure status re-enable
+    // (`{status: "active"}`, or `{status: null}` to clear back to
+    // active-by-absence). Rejecting here keeps the error message ahead of
+    // any side effects and mirrors the guard's wording.
     const requestedKeys = Object.keys(parsed.data);
-    const disallowed = requestedKeys.filter(
-      (k) => !MANAGED_PROFILE_EDITABLE_KEYS.has(k),
-    );
-    if (disallowed.length > 0) {
-      // Invariant (default) profiles are locked down further by
-      // `assertInvariantProfilesPreserved` at commit time — don't tell users
-      // label/status/topP are editable when they aren't.
-      const guidance = INVARIANT_PROFILE_NAMES.has(name)
-        ? "Default profiles are read-only (a disabled default can be re-enabled); duplicate to a custom profile to customize."
-        : "Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.";
+    const isStatusReenable =
+      requestedKeys.length === 1 &&
+      requestedKeys[0] === "status" &&
+      (parsed.data.status === "active" || parsed.data.status === null);
+    if (!isStatusReenable) {
+      const disallowed = requestedKeys.filter((k) => k !== "status");
+      const detail =
+        disallowed.length > 0 ? ` fields [${disallowed.join(", ")}]` : "";
       throw new BadRequestError(
-        `Cannot edit managed profile "${name}" fields [${disallowed.join(", ")}]. ${guidance}`,
+        `Cannot edit managed profile "${name}"${detail}. ` +
+          `Managed profiles are read-only (a disabled profile can be re-enabled); ` +
+          `duplicate to a custom profile to customize.`,
       );
     }
   }
@@ -1277,17 +1280,13 @@ async function handleReplaceInferenceProfile({
 
   // When the UI sends provider but no provider_connection, derive the connection
   // now so the config deep-merge doesn't inherit a stale connection from the
-  // default layer. Invariant names are excluded: commitConfigWrite rejects
-  // every write to them except a pure status re-enable (which derives no
-  // connection), so creating a connection here would leave an orphaned DB
-  // row behind a guaranteed 400.
+  // default layer. Managed entries are excluded: the managed gate above
+  // already rejected any provider-carrying fragment, so their only surviving
+  // body is a status re-enable, which derives no connection. A user-owned
+  // profile sharing a managed name is fully editable, so it takes the
+  // derivation like any other custom profile.
   const fragment = parsed.data as Record<string, unknown>;
-  if (
-    !isManaged &&
-    !INVARIANT_PROFILE_NAMES.has(name) &&
-    fragment.provider &&
-    !fragment.provider_connection
-  ) {
+  if (!isManaged && fragment.provider && !fragment.provider_connection) {
     const provider = fragment.provider as string;
     const db = getDb();
     const [active] = listConnections(db, { provider });
@@ -1314,12 +1313,12 @@ async function handleReplaceInferenceProfile({
 
   const raw = loadRawConfig();
   if (isManaged) {
-    // Partial overlay: keep every existing key intact, only update label
-    // and/or status from the fragment. Using `replaceInferenceProfileConfig`
-    // here would wipe the UI-owned seed fields (provider, model, advanced
-    // params) because that function assumes the body carries the full UI
-    // surface.
-    patchManagedProfileFields(raw, name, fragment);
+    // Partial overlay: keep every existing key intact, only apply the status
+    // re-enable (the sole body the managed gate above admits). Using
+    // `replaceInferenceProfileConfig` here would wipe the seed-owned fields
+    // (provider, model, advanced params) because that function assumes the
+    // body carries the full UI surface.
+    applyManagedProfileReenable(raw, name, fragment.status as "active" | null);
   } else {
     replaceInferenceProfileConfig(raw, name, fragment);
   }
@@ -1337,37 +1336,34 @@ async function handleReplaceInferenceProfile({
 }
 
 /**
- * Apply a `{label?, status?, topP?}` patch to a managed profile entry, preserving
+ * Apply the disabled→active re-enable to a managed profile entry, preserving
  * every other field already on disk (provider, model, advanced params, etc).
- * Caller is responsible for having already restricted the fragment to the
- * managed-allowed keys.
+ * `status: "active"` sets the key; `null` clears it (active-by-absence).
  */
-function patchManagedProfileFields(
+function applyManagedProfileReenable(
   raw: Record<string, unknown>,
   name: string,
-  fragment: Record<string, unknown>,
+  status: "active" | null,
 ): void {
   const existingLlm = asMutablePlainObject(raw.llm);
   const llm = existingLlm ?? {};
-  if (!existingLlm) raw.llm = llm;
+  if (!existingLlm) {
+    raw.llm = llm;
+  }
 
   const existingProfiles = asMutablePlainObject(llm.profiles);
   const profiles = existingProfiles ?? {};
-  if (!existingProfiles) llm.profiles = profiles;
+  if (!existingProfiles) {
+    llm.profiles = profiles;
+  }
 
-  const existingProfile = asMutablePlainObject(profiles[name]) ?? {};
-  const nextProfile: Record<string, unknown> = { ...existingProfile };
-  // For each managed-editable key: send `null` to clear, a value to set,
-  // omit to leave untouched. Iterating the allowlist keeps persistence in
-  // lock-step with the guard above — a key can't slip through the gate
-  // without also being written.
-  for (const key of MANAGED_PROFILE_EDITABLE_KEYS) {
-    if (!(key in fragment)) continue;
-    if (fragment[key] === null) {
-      delete nextProfile[key];
-    } else {
-      nextProfile[key] = fragment[key];
-    }
+  const nextProfile: Record<string, unknown> = {
+    ...(asMutablePlainObject(profiles[name]) ?? {}),
+  };
+  if (status === null) {
+    delete nextProfile.status;
+  } else {
+    nextProfile.status = status;
   }
   profiles[name] = nextProfile;
 }

--- a/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
@@ -133,11 +133,7 @@ export function ProfileListItem({
             {isManaged && (
               <Tag
                 tone="positive"
-                title={
-                  isInvariant
-                    ? "Managed by Platform — this default profile cannot be disabled, deleted, or renamed."
-                    : "Managed by Platform — auth is locked, but you can rename or disable this profile."
-                }
+                title="Managed by Platform — this profile cannot be disabled, deleted, or renamed."
               >
                 Platform
               </Tag>
@@ -156,7 +152,7 @@ export function ProfileListItem({
 
         {/* Actions */}
         <div className="flex shrink-0 items-center gap-2">
-          {/* Invariant (default) profiles cannot be disabled, so an active one
+          {/* Invariant (managed) profiles cannot be disabled, so an active one
               gets no toggle. A disabled one keeps it so it can be re-enabled —
               the daemon accepts the enable direction. */}
           {(!isInvariant || !isActive) && (
@@ -177,9 +173,10 @@ export function ProfileListItem({
             </div>
           )}
           <div className="flex w-[92px] items-center justify-end gap-2">
-            {/* Invariant (default) profiles open in view mode and cannot be
-                deleted regardless of `source` — the daemon freezes invariant
-                names, so a managed-style lock applies here too. */}
+            {/* Invariant profiles open in view mode and cannot be deleted.
+                The daemon stamps the wire flag only on managed-source
+                entries, so a user-owned profile sharing a managed name
+                renders as a normal editable profile. */}
             <Button variant="ghost" size="compact" onClick={onEditClick}>
               {isManaged || isInvariant ? "View" : "Edit"}
             </Button>
@@ -190,11 +187,9 @@ export function ProfileListItem({
               aria-label={`Delete ${profile.label ?? profile.name}`}
               disabled={isManaged || isInvariant || isDeleting}
               title={
-                isManaged
+                isManaged || isInvariant
                   ? "Managed profiles cannot be deleted"
-                  : isInvariant
-                    ? "Default profiles cannot be deleted"
-                    : undefined
+                  : undefined
               }
               onClick={onDeleteClick}
               tintColor="var(--system-negative-strong)"

--- a/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
@@ -98,6 +98,7 @@ export function ProfileListItem({
   onStatusToggle,
 }: ProfileListItemProps) {
   const isManaged = profile.source === "managed";
+  const isInvariant = profile.invariant === true;
   const isActive = profile.status !== "disabled";
 
   return (
@@ -132,7 +133,11 @@ export function ProfileListItem({
             {isManaged && (
               <Tag
                 tone="positive"
-                title="Managed by Platform — auth is locked, but you can rename or disable this profile."
+                title={
+                  isInvariant
+                    ? "Managed by Platform — this default profile cannot be disabled, deleted, or renamed."
+                    : "Managed by Platform — auth is locked, but you can rename or disable this profile."
+                }
               >
                 Platform
               </Tag>
@@ -151,21 +156,26 @@ export function ProfileListItem({
 
         {/* Actions */}
         <div className="flex shrink-0 items-center gap-2">
-          <div
-            className="flex shrink-0 items-center"
-            title={
-              isActive
-                ? "Active — toggle to hide from pickers"
-                : "Disabled — toggle to show in pickers"
-            }
-          >
-            <Toggle
-              checked={isActive}
-              onChange={(next) => onStatusToggle(next)}
-              disabled={isToggling}
-              aria-label={`${isActive ? "Disable" : "Enable"} ${profile.label ?? profile.name}`}
-            />
-          </div>
+          {/* Invariant (default) profiles cannot be disabled, so an active one
+              gets no toggle. A disabled one keeps it so it can be re-enabled —
+              the daemon accepts the enable direction. */}
+          {(!isInvariant || !isActive) && (
+            <div
+              className="flex shrink-0 items-center"
+              title={
+                isActive
+                  ? "Active — toggle to hide from pickers"
+                  : "Disabled — toggle to show in pickers"
+              }
+            >
+              <Toggle
+                checked={isActive}
+                onChange={(next) => onStatusToggle(next)}
+                disabled={isToggling}
+                aria-label={`${isActive ? "Disable" : "Enable"} ${profile.label ?? profile.name}`}
+              />
+            </div>
+          )}
           <div className="flex w-[92px] items-center justify-end gap-2">
             <Button variant="ghost" size="compact" onClick={onEditClick}>
               {isManaged ? "View" : "Edit"}

--- a/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-list-item.tsx
@@ -177,17 +177,24 @@ export function ProfileListItem({
             </div>
           )}
           <div className="flex w-[92px] items-center justify-end gap-2">
+            {/* Invariant (default) profiles open in view mode and cannot be
+                deleted regardless of `source` — the daemon freezes invariant
+                names, so a managed-style lock applies here too. */}
             <Button variant="ghost" size="compact" onClick={onEditClick}>
-              {isManaged ? "View" : "Edit"}
+              {isManaged || isInvariant ? "View" : "Edit"}
             </Button>
             <Button
               variant="ghost"
               size="compact"
               iconOnly={<Trash2 />}
               aria-label={`Delete ${profile.label ?? profile.name}`}
-              disabled={isManaged || isDeleting}
+              disabled={isManaged || isInvariant || isDeleting}
               title={
-                isManaged ? "Managed profiles cannot be deleted" : undefined
+                isManaged
+                  ? "Managed profiles cannot be deleted"
+                  : isInvariant
+                    ? "Default profiles cannot be deleted"
+                    : undefined
               }
               onClick={onDeleteClick}
               tintColor="var(--system-negative-strong)"

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -30,6 +30,7 @@ import * as daemonQueryGen from "@/generated/daemon/@tanstack/react-query.gen";
 
 let toastSuccessCalls: string[] = [];
 let configPatchCalled = false;
+let configPatchBodies: unknown[] = [];
 let profilesState: Record<string, ProfileEntry> = {};
 
 mock.module("@vellumai/design-library/components/toast", () => ({
@@ -54,8 +55,9 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
       },
     },
   })),
-  configPatch: async () => {
+  configPatch: async (options?: { body?: unknown }) => {
     configPatchCalled = true;
+    configPatchBodies.push(options?.body);
     return {
       data: {
         llm: {
@@ -188,6 +190,7 @@ function selectModel(label: string): void {
 beforeEach(() => {
   toastSuccessCalls = [];
   configPatchCalled = false;
+  configPatchBodies = [];
   profilesState = {};
 });
 
@@ -234,5 +237,82 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(['Profile "My Profile" created']);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant (default) profiles — server-stamped `invariant: true`
+// ---------------------------------------------------------------------------
+
+describe("ManageProfilesModal — invariant default profiles in the list", () => {
+  // The list-item status toggle carries an "Enable <label>"/"Disable <label>"
+  // aria-label — the accessible handle these tests query by.
+  function findStatusToggle(action: "Enable" | "Disable", label: string) {
+    return document.querySelector<HTMLButtonElement>(
+      `[role="switch"][aria-label="${action} ${label}"]`,
+    );
+  }
+
+  function seedInvariantProfiles() {
+    profilesState = {
+      "default-a": {
+        label: "Default A",
+        source: "managed",
+        invariant: true,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      "default-b": {
+        label: "Default B",
+        source: "managed",
+        invariant: true,
+        status: "disabled",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      "custom-managed": {
+        label: "Custom Managed",
+        source: "managed",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    };
+  }
+
+  test("an active invariant profile has no status toggle; a disabled one and non-invariant profiles keep theirs", () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    // Active invariant profile: no disable affordance at all.
+    expect(findStatusToggle("Disable", "Default A")).toBeNull();
+    expect(findStatusToggle("Enable", "Default A")).toBeNull();
+
+    // Disabled invariant profile: the enable affordance remains.
+    expect(findStatusToggle("Enable", "Default B")).not.toBeNull();
+
+    // Managed profile without the flag: behaves as before.
+    expect(findStatusToggle("Disable", "Custom Managed")).not.toBeNull();
+  });
+
+  test("re-enabling a disabled invariant profile PATCHes status:'active' and nothing else", async () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(findStatusToggle("Enable", "Default B")!);
+
+    await waitFor(() => {
+      expect(configPatchCalled).toBe(true);
+    });
+    expect(configPatchBodies).toEqual([
+      { llm: { profiles: { "default-b": { status: "active" } } } },
+    ]);
   });
 });

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -259,6 +259,16 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
         provider: "anthropic",
         model: "claude-opus-4-8",
       },
+      // Invariant but NOT managed — the daemon freezes invariant names
+      // regardless of `source`, so the UI must lock this one exactly like a
+      // managed default.
+      "default-user": {
+        label: "Default User",
+        source: "user",
+        invariant: true,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
       "default-b": {
         label: "Default B",
         source: "managed",
@@ -311,5 +321,56 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     expect(configPatchBodies).toEqual([
       { llm: { profiles: { "default-b": { status: "active" } } } },
     ]);
+  });
+
+  test("an invariant profile with source 'user' has a disabled delete button and a View action", () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    // Delete is locked exactly like a managed profile — the daemon rejects
+    // deleting invariant names regardless of source.
+    const deleteBtn = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Delete Default User"]',
+    );
+    expect(deleteBtn).not.toBeNull();
+    expect(deleteBtn!.disabled).toBe(true);
+
+    // The row action reads "View", not "Edit" — the editor opens read-only.
+    const row = deleteBtn!.closest("div.relative")!;
+    const actionBtn = Array.from(
+      row.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "View" || b.textContent?.trim() === "Edit");
+    expect(actionBtn?.textContent?.trim()).toBe("View");
+  });
+
+  test("opening an invariant source-'user' profile lands in view mode with locked controls", async () => {
+    seedInvariantProfiles();
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    const deleteBtn = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Delete Default User"]',
+    )!;
+    const row = deleteBtn.closest("div.relative")!;
+    const viewBtn = Array.from(
+      row.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "View")!;
+    fireEvent.click(viewBtn);
+
+    // The editor opened in view mode: the read-only footer offers Save As
+    // New, and the invariant lock disables the Display Name field.
+    await waitFor(() => {
+      expect(getButton("Save As New")).not.toBeNull();
+    });
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
+    // Save opens disarmed — nothing view mode permits editing has changed.
+    expect(getSaveBtn().disabled).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -238,10 +238,10 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
 });
 
 // ---------------------------------------------------------------------------
-// Invariant (default) profiles — server-stamped `invariant: true`
+// Invariant (managed) profiles — server-stamped `invariant: true`
 // ---------------------------------------------------------------------------
 
-describe("ManageProfilesModal — invariant default profiles in the list", () => {
+describe("ManageProfilesModal — invariant managed profiles in the list", () => {
   // The list-item status toggle carries an "Enable <label>"/"Disable <label>"
   // aria-label — the accessible handle these tests query by.
   function findStatusToggle(action: "Enable" | "Disable", label: string) {
@@ -259,13 +259,12 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
         provider: "anthropic",
         model: "claude-opus-4-8",
       },
-      // Invariant but NOT managed — the daemon freezes invariant names
-      // regardless of `source`, so the UI must lock this one exactly like a
-      // managed default.
-      "default-user": {
-        label: "Default User",
+      // A user-owned profile sharing a managed name. The daemon stamps
+      // `invariant` only on managed-source entries, so this one carries no
+      // flag and must render as a normal, fully editable custom profile.
+      "os-beta": {
+        label: "My OS Beta",
         source: "user",
-        invariant: true,
         provider: "anthropic",
         model: "claude-opus-4-8",
       },
@@ -274,12 +273,6 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
         source: "managed",
         invariant: true,
         status: "disabled",
-        provider: "anthropic",
-        model: "claude-opus-4-8",
-      },
-      "custom-managed": {
-        label: "Custom Managed",
-        source: "managed",
         provider: "anthropic",
         model: "claude-opus-4-8",
       },
@@ -301,8 +294,8 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     // Disabled invariant profile: the enable affordance remains.
     expect(findStatusToggle("Enable", "Default B")).not.toBeNull();
 
-    // Managed profile without the flag: behaves as before.
-    expect(findStatusToggle("Disable", "Custom Managed")).not.toBeNull();
+    // User-owned profile without the flag: two-way toggle as usual.
+    expect(findStatusToggle("Disable", "My OS Beta")).not.toBeNull();
   });
 
   test("re-enabling a disabled invariant profile PATCHes status:'active' and nothing else", async () => {
@@ -323,7 +316,7 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     ]);
   });
 
-  test("an invariant profile with source 'user' has a disabled delete button and a View action", () => {
+  test("a user-owned profile sharing a managed name gets an Edit action and an enabled delete button", () => {
     seedInvariantProfiles();
     render(
       <Wrapper>
@@ -331,23 +324,24 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
       </Wrapper>,
     );
 
-    // Delete is locked exactly like a managed profile — the daemon rejects
-    // deleting invariant names regardless of source.
+    // Delete stays available — the daemon gates invariance on managed
+    // ownership, so a user-owned entry named like a managed profile is
+    // fully deletable.
     const deleteBtn = document.querySelector<HTMLButtonElement>(
-      '[aria-label="Delete Default User"]',
+      '[aria-label="Delete My OS Beta"]',
     );
     expect(deleteBtn).not.toBeNull();
-    expect(deleteBtn!.disabled).toBe(true);
+    expect(deleteBtn!.disabled).toBe(false);
 
-    // The row action reads "View", not "Edit" — the editor opens read-only.
+    // The row action reads "Edit", not "View" — the editor opens editable.
     const row = deleteBtn!.closest("div.relative")!;
     const actionBtn = Array.from(
       row.querySelectorAll<HTMLButtonElement>("button"),
     ).find((b) => b.textContent?.trim() === "View" || b.textContent?.trim() === "Edit");
-    expect(actionBtn?.textContent?.trim()).toBe("View");
+    expect(actionBtn?.textContent?.trim()).toBe("Edit");
   });
 
-  test("opening an invariant source-'user' profile lands in view mode with locked controls", async () => {
+  test("opening a user-owned profile sharing a managed name lands in edit mode with editable controls", async () => {
     seedInvariantProfiles();
     render(
       <Wrapper>
@@ -356,21 +350,22 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     );
 
     const deleteBtn = document.querySelector<HTMLButtonElement>(
-      '[aria-label="Delete Default User"]',
+      '[aria-label="Delete My OS Beta"]',
     )!;
     const row = deleteBtn.closest("div.relative")!;
-    const viewBtn = Array.from(
+    const editBtn = Array.from(
       row.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((b) => b.textContent?.trim() === "View")!;
-    fireEvent.click(viewBtn);
+    ).find((b) => b.textContent?.trim() === "Edit")!;
+    fireEvent.click(editBtn);
 
-    // The editor opened in view mode: the read-only footer offers Save As
-    // New, and the invariant lock disables the Display Name field.
+    // The editor opened in edit mode: the Display Name field is editable and
+    // the read-only footer's Save As New affordance is absent.
     await waitFor(() => {
-      expect(getButton("Save As New")).not.toBeNull();
+      expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
     });
-    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
-    // Save opens disarmed — nothing view mode permits editing has changed.
-    expect(getSaveBtn().disabled).toBe(true);
+    const saveAsNew = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "Save As New");
+    expect(saveAsNew).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -29,7 +29,6 @@ import * as daemonQueryGen from "@/generated/daemon/@tanstack/react-query.gen";
 // ---------------------------------------------------------------------------
 
 let toastSuccessCalls: string[] = [];
-let configPatchCalled = false;
 let configPatchBodies: unknown[] = [];
 let profilesState: Record<string, ProfileEntry> = {};
 
@@ -56,7 +55,6 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     },
   })),
   configPatch: async (options?: { body?: unknown }) => {
-    configPatchCalled = true;
     configPatchBodies.push(options?.body);
     return {
       data: {
@@ -189,7 +187,6 @@ function selectModel(label: string): void {
 
 beforeEach(() => {
   toastSuccessCalls = [];
-  configPatchCalled = false;
   configPatchBodies = [];
   profilesState = {};
 });
@@ -232,7 +229,7 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
     // The config mutation ran and the Settings surface fired one toast using
     // the entered label.
     await waitFor(() => {
-      expect(configPatchCalled).toBe(true);
+      expect(configPatchBodies.length).toBeGreaterThan(0);
     });
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(['Profile "My Profile" created']);
@@ -309,7 +306,7 @@ describe("ManageProfilesModal — invariant default profiles in the list", () =>
     fireEvent.click(findStatusToggle("Enable", "Default B")!);
 
     await waitFor(() => {
-      expect(configPatchCalled).toBe(true);
+      expect(configPatchBodies.length).toBeGreaterThan(0);
     });
     expect(configPatchBodies).toEqual([
       { llm: { profiles: { "default-b": { status: "active" } } } },

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -211,9 +211,15 @@ export function ManageProfilesModal({
       </Modal.Root>
       <ProfileEditorModal
         isOpen={editorOpen}
+        // Managed profiles AND invariant (default-named) profiles open in
+        // view mode. The daemon freezes invariant names regardless of
+        // `source`, so an invariant profile with source !== "managed" must
+        // also take the view-mode partial-save path — edit mode's
+        // delete/recreate cycle would be rejected with a 400.
         mode={
           editingProfile
-            ? editingProfile.source === "managed"
+            ? editingProfile.source === "managed" ||
+              editingProfile.invariant === true
               ? "view"
               : "edit"
             : "create"

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.tsx
@@ -105,10 +105,10 @@ export function ManageProfilesModal({
     const mode = options?.mode ?? "replace";
     const isNew = !(name in profiles);
 
-    // Merge mode (view-mode managed-profile policy edits): send a single
-    // deep-merge PATCH so the caller's partial `entry` (typically just
-    // `{label, status}`) layers on top of the existing record without
-    // wiping seed-owned fields.
+    // Merge mode (view-mode managed-profile re-enable): send a single
+    // deep-merge PATCH so the caller's partial `entry` — the
+    // `{status: "active"}` re-enable — layers on top of the existing record
+    // without wiping seed-owned fields.
     if (mode === "merge" && !isNew) {
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
@@ -211,11 +211,11 @@ export function ManageProfilesModal({
       </Modal.Root>
       <ProfileEditorModal
         isOpen={editorOpen}
-        // Managed profiles AND invariant (default-named) profiles open in
-        // view mode. The daemon freezes invariant names regardless of
-        // `source`, so an invariant profile with source !== "managed" must
-        // also take the view-mode partial-save path — edit mode's
-        // delete/recreate cycle would be rejected with a 400.
+        // Managed profiles AND invariant-flagged profiles open in view mode.
+        // The daemon stamps `invariant` only on managed-source entries, so
+        // the two checks normally coincide; keeping both is defensive. A
+        // user-owned profile sharing a managed name carries neither marker
+        // and opens fully editable — the daemon accepts every write to it.
         mode={
           editingProfile
             ? editingProfile.source === "managed" ||

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
@@ -37,7 +37,6 @@ const MODEL = {
 interface FieldOverrides {
   visibility: ProfileParamVisibility;
   isReadOnly?: boolean;
-  topPReadOnly?: boolean;
   maxTokens?: number | null;
   contextWindowMaxInputTokens?: number | null;
   onMaxTokensChange?: (v: number | null) => void;
@@ -58,7 +57,6 @@ function renderParams(overrides: FieldOverrides) {
     <ProfileAdvancedParams
       visibility={overrides.visibility}
       isReadOnly={overrides.isReadOnly ?? false}
-      topPReadOnly={overrides.topPReadOnly}
       model="claude-opus-4"
       selectedModel={overrides.selectedModel ?? MODEL}
       defaultMaxOutputTokens={overrides.defaultMaxOutputTokens}
@@ -485,29 +483,8 @@ describe("ProfileAdvancedParams Top P control", () => {
     expect(onTopPChange).toHaveBeenCalled();
   });
 
-  test("topPReadOnly overrides isReadOnly to keep the Top P control editable", () => {
-    // GIVEN the params locked read-only EXCEPT Top P (managed view mode)
-    const onTopPEnabledChange = mock();
-    renderParams({
-      visibility: topPOnly,
-      isReadOnly: true,
-      topPReadOnly: false,
-      onTopPEnabledChange,
-    });
-
-    // THEN the Top P toggle is enabled despite isReadOnly...
-    const toggle = screen.getByRole("switch", {
-      name: "Top P",
-    }) as HTMLButtonElement;
-    expect(toggle.disabled).toBe(false);
-
-    // ...and toggling it still fires the change handler.
-    fireEvent.click(toggle);
-    expect(onTopPEnabledChange).toHaveBeenLastCalledWith(true);
-  });
-
-  test("falls back to isReadOnly for Top P when topPReadOnly is omitted", () => {
-    // GIVEN read-only params with no topPReadOnly override
+  test("locks the Top P toggle when read-only", () => {
+    // GIVEN read-only params with Top P visible
     const onTopPEnabledChange = mock();
     renderParams({
       visibility: topPOnly,
@@ -531,8 +508,8 @@ const effortAndSpeed: ProfileParamVisibility = {
 
 describe("ProfileAdvancedParams read-only segment controls", () => {
   test("disables every Effort and Speed segment when read-only", () => {
-    // GIVEN a locked (read-only) profile — e.g. an invariant default — with
-    // Effort and Speed visible
+    // GIVEN a locked (read-only) profile — e.g. an invariant managed
+    // profile — with Effort and Speed visible
     const onEffortChange = mock();
     const onSpeedChange = mock();
     renderParams({

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
@@ -49,6 +49,8 @@ interface FieldOverrides {
   onTopPEnabledChange?: (v: boolean) => void;
   topP?: number;
   onTopPChange?: (v: number) => void;
+  onEffortChange?: (v: string) => void;
+  onSpeedChange?: (v: string) => void;
 }
 
 function renderParams(overrides: FieldOverrides) {
@@ -70,9 +72,9 @@ function renderParams(overrides: FieldOverrides) {
       }
       onContextWindowChange={overrides.onContextWindowChange ?? (() => {})}
       effort="none"
-      onEffortChange={() => {}}
+      onEffortChange={overrides.onEffortChange ?? (() => {})}
       speed="standard"
-      onSpeedChange={() => {}}
+      onSpeedChange={overrides.onSpeedChange ?? (() => {})}
       verbosity="low"
       onVerbosityChange={() => {}}
       temperatureEnabled={false}
@@ -518,5 +520,62 @@ describe("ProfileAdvancedParams Top P control", () => {
       name: "Top P",
     }) as HTMLButtonElement;
     expect(toggle.disabled).toBe(true);
+  });
+});
+
+const effortAndSpeed: ProfileParamVisibility = {
+  ...VISIBILITY_NONE,
+  effort: true,
+  speed: true,
+};
+
+describe("ProfileAdvancedParams read-only segment controls", () => {
+  test("disables every Effort and Speed segment when read-only", () => {
+    // GIVEN a locked (read-only) profile — e.g. an invariant default — with
+    // Effort and Speed visible
+    const onEffortChange = mock();
+    const onSpeedChange = mock();
+    renderParams({
+      visibility: effortAndSpeed,
+      isReadOnly: true,
+      onEffortChange,
+      onSpeedChange,
+    });
+
+    // THEN every segment in both controls is disabled, so the controls cannot
+    // even change local UI state
+    const segments = screen.getAllByRole("radio") as HTMLButtonElement[];
+    expect(segments.length).toBeGreaterThan(0);
+    for (const segment of segments) {
+      expect(segment.disabled).toBe(true);
+    }
+
+    // AND clicking a non-selected segment fires no change handler
+    fireEvent.click(screen.getByRole("radio", { name: "high" }));
+    expect(onEffortChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("radio", { name: "fast" }));
+    expect(onSpeedChange).not.toHaveBeenCalled();
+  });
+
+  test("keeps Effort and Speed segments interactive when editable", () => {
+    // GIVEN an editable profile with Effort and Speed visible
+    const onEffortChange = mock();
+    const onSpeedChange = mock();
+    renderParams({
+      visibility: effortAndSpeed,
+      isReadOnly: false,
+      onEffortChange,
+      onSpeedChange,
+    });
+
+    // THEN no segment is disabled and clicks commit the new value
+    const segments = screen.getAllByRole("radio") as HTMLButtonElement[];
+    for (const segment of segments) {
+      expect(segment.disabled).toBe(false);
+    }
+    fireEvent.click(screen.getByRole("radio", { name: "high" }));
+    expect(onEffortChange).toHaveBeenLastCalledWith("high");
+    fireEvent.click(screen.getByRole("radio", { name: "fast" }));
+    expect(onSpeedChange).toHaveBeenLastCalledWith("fast");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -53,13 +53,6 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 interface ProfileAdvancedParamsProps {
   visibility: ProfileParamVisibility;
   isReadOnly: boolean;
-  /**
-   * Overrides `isReadOnly` for the Top P toggle/slider only. Top P is
-   * user-editable wherever it's visible — including managed-profile view mode,
-   * where the rest of the advanced params stay locked. Defaults to `isReadOnly`
-   * when omitted so callers that don't opt in keep the old behavior.
-   */
-  topPReadOnly?: boolean;
   model: string;
   /** Resolved catalog entry for the selected model (null if not in catalog). */
   selectedModel: {
@@ -253,7 +246,6 @@ function TokenBudgetField({
 export function ProfileAdvancedParams({
   visibility,
   isReadOnly,
-  topPReadOnly,
   model,
   selectedModel,
   defaultMaxOutputTokens,
@@ -303,10 +295,6 @@ export function ProfileAdvancedParams({
     contextWindowCeiling,
   );
 
-  // Top P stays editable even when the rest of the params are locked (managed
-  // view mode). Fall back to the shared `isReadOnly` when the caller omits the
-  // override.
-  const topPDisabled = topPReadOnly ?? isReadOnly;
 
   return (
     // space-y-4 matches the modal body's rhythm so each advanced param gets
@@ -432,7 +420,7 @@ export function ProfileAdvancedParams({
             checked={topPEnabled}
             onChange={(v) => onTopPEnabledChange(v)}
             label="Top P"
-            disabled={topPDisabled}
+            disabled={isReadOnly}
           />
           {topPEnabled && (
             <div className="flex items-center justify-between">
@@ -445,7 +433,7 @@ export function ProfileAdvancedParams({
                   min={0}
                   max={1}
                   step={0.01}
-                  disabled={topPDisabled}
+                  disabled={isReadOnly}
                   showValue
                   formatValue={(v) =>
                     typeof v === "number" ? v.toFixed(2) : String(v)

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -343,7 +343,11 @@ export function ProfileAdvancedParams({
             Effort
           </label>
           <SegmentControl
-            items={EFFORT_OPTIONS.map((v) => ({ value: v, label: v }))}
+            items={EFFORT_OPTIONS.map((v) => ({
+              value: v,
+              label: v,
+              disabled: isReadOnly,
+            }))}
             value={effort}
             onChange={(v) => onEffortChange(v)}
             ariaLabel="Effort"
@@ -358,7 +362,11 @@ export function ProfileAdvancedParams({
             Speed
           </label>
           <SegmentControl
-            items={SPEED_OPTIONS.map((v) => ({ value: v, label: v }))}
+            items={SPEED_OPTIONS.map((v) => ({
+              value: v,
+              label: v,
+              disabled: isReadOnly,
+            }))}
             value={speed}
             onChange={(v) => onSpeedChange(v)}
             ariaLabel="Speed"
@@ -373,7 +381,11 @@ export function ProfileAdvancedParams({
             Verbosity
           </label>
           <SegmentControl
-            items={VERBOSITY_OPTIONS.map((v) => ({ value: v, label: v }))}
+            items={VERBOSITY_OPTIONS.map((v) => ({
+              value: v,
+              label: v,
+              disabled: isReadOnly,
+            }))}
             value={verbosity}
             onChange={(v) => onVerbosityChange(v)}
             ariaLabel="Verbosity"
@@ -485,6 +497,7 @@ export function ProfileAdvancedParams({
             ).map((v) => ({
               value: v,
               label: `${v}`,
+              disabled: isReadOnly,
             }))}
             value={thinkingLevel}
             onChange={onThinkingLevelChange}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -265,15 +265,22 @@ function renderView(
   );
 }
 
+/** Finds a Toggle switch by its visible label (wired via aria-labelledby). */
+function findSwitchByLabel(label: string): HTMLButtonElement | null {
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="switch"]'),
+    ).find((el) => {
+      const labelId = el.getAttribute("aria-labelledby");
+      const labelEl = labelId ? document.getElementById(labelId) : null;
+      return labelEl?.textContent?.trim() === label;
+    }) ?? null
+  );
+}
+
 /** The Top P toggle is a switch labelled (via aria-labelledby) "Top P". */
-function topPSwitch(): HTMLElement {
-  const sw = Array.from(
-    document.querySelectorAll<HTMLElement>('[role="switch"]'),
-  ).find((el) => {
-    const labelId = el.getAttribute("aria-labelledby");
-    const labelEl = labelId ? document.getElementById(labelId) : null;
-    return labelEl?.textContent?.trim() === "Top P";
-  });
+function topPSwitch(): HTMLButtonElement {
+  const sw = findSwitchByLabel("Top P");
   if (!sw) throw new Error("expected a Top P switch");
   return sw;
 }
@@ -889,5 +896,98 @@ describe("ProfileEditorModal — Top P wiring", () => {
       expect(saveCalls[0].entry.provider).toBeUndefined();
       expect(saveCalls[0].entry.model).toBeUndefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant (default) profiles — server-stamped `invariant: true`
+// ---------------------------------------------------------------------------
+
+describe("ProfileEditorModal — invariant default profiles in view mode", () => {
+  // A server-stamped default profile. Anthropic opus → visibility.topP is
+  // true, so the Top P control renders and we can assert it is locked.
+  const invariantProfile = {
+    name: "default-a",
+    label: "Default A",
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    source: "managed",
+    invariant: true,
+    topP: 0.9,
+  };
+
+  test("an active invariant profile is fully read-only: no status toggle, disabled label and Top P, Save never armed", () => {
+    renderView(invariantProfile);
+
+    // No disable affordance: the Active toggle is not rendered at all.
+    expect(findSwitchByLabel("Active")).toBeNull();
+
+    // Label and Top P are locked.
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
+    expect(topPSwitch().disabled).toBe(true);
+
+    // Save opens disabled and clicking the locked Top P toggle can't arm it.
+    expect(getSaveBtn().disabled).toBe(true);
+    fireEvent.click(topPSwitch());
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+
+  test("a disabled invariant profile keeps an enable-only toggle; saving PATCHes exactly {status:'active'} as a merge", async () => {
+    const saveCalls: {
+      name: string;
+      entry: Record<string, unknown>;
+      options?: { mode?: "merge" | "replace" };
+    }[] = [];
+    const onSave = (
+      name: string,
+      entry: unknown,
+      options?: { mode?: "merge" | "replace" },
+    ) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown>, options });
+      return Promise.resolve();
+    };
+
+    renderView({ ...invariantProfile, status: "disabled" }, onSave);
+
+    // The re-enable affordance is present and Save starts disarmed.
+    const activeSwitch = findSwitchByLabel("Active");
+    expect(activeSwitch).not.toBeNull();
+    expect(getSaveBtn().disabled).toBe(true);
+
+    // Flip to active: Save arms, and the toggle disappears (the flip is
+    // one-directional — an active invariant profile can't be disabled).
+    fireEvent.click(activeSwitch!);
+    expect(getSaveBtn().disabled).toBe(false);
+    expect(findSwitchByLabel("Active")).toBeNull();
+
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    // The body is exactly {status:"active"} — no label, no topP.
+    expect(saveCalls[0].entry).toEqual({ status: "active" });
+    expect(saveCalls[0].options?.mode).toBe("merge");
+  });
+
+  test("a managed profile without the invariant flag keeps the toggle, editable label, and editable Top P", () => {
+    const { invariant: _invariant, ...nonInvariant } = invariantProfile;
+    renderView(nonInvariant);
+
+    expect(findSwitchByLabel("Active")).not.toBeNull();
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
+    expect(topPSwitch().disabled).toBe(false);
+  });
+
+  test("Save As New from an invariant profile yields a fully editable create form", () => {
+    renderView(invariantProfile);
+
+    fireEvent.click(getButton("Save As New"));
+
+    // The duplicate drops the invariant lock: name and key are editable and
+    // the Active toggle is back.
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
+    expect(getInputByPlaceholder("e.g. fast-cheap").disabled).toBe(false);
+    expect(findSwitchByLabel("Active")).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -830,81 +830,14 @@ describe("ProfileEditorModal — Top P wiring", () => {
     expect(saveCalls[0].entry.topP).toBeNull();
   });
 
-  describe("managed profile in view mode", () => {
-    // A managed (platform-seeded) Balanced profile. Anthropic opus →
-    // visibility.topP is true, so the Top P control renders even in view mode.
-    const managedProfile = {
-      name: "balanced",
-      label: "Balanced",
-      provider: "anthropic",
-      model: "claude-opus-4-8",
-      source: "managed",
-    };
-
-    test("the Top P control is editable even though the modal is read-only", () => {
-      renderView(managedProfile);
-
-      // The Top P toggle stays interactive while the rest of the editor is
-      // locked (provider/model dropdowns are disabled in view mode).
-      expect((topPSwitch() as HTMLButtonElement).disabled).toBe(false);
-    });
-
-    test("enabling Top P arms the otherwise close-only Save button", () => {
-      renderView(managedProfile);
-
-      // View mode opens with Save disabled (no policy fields touched yet).
-      expect(getSaveBtn().disabled).toBe(true);
-
-      // Turning Top P on is a tracked view-mode change → Save unlocks.
-      fireEvent.click(topPSwitch());
-      expect(getSaveBtn().disabled).toBe(false);
-    });
-
-    test("saving sends topP in a merge entry without seed-owned fields", async () => {
-      const saveCalls: {
-        name: string;
-        entry: Record<string, unknown>;
-        options?: { mode?: "merge" | "replace" };
-      }[] = [];
-      const onSave = (
-        name: string,
-        entry: unknown,
-        options?: { mode?: "merge" | "replace" },
-      ) => {
-        saveCalls.push({
-          name,
-          entry: entry as Record<string, unknown>,
-          options,
-        });
-        return Promise.resolve();
-      };
-
-      renderView(managedProfile, onSave);
-
-      // Enable Top P, then save.
-      fireEvent.click(topPSwitch());
-      fireEvent.click(getSaveBtn());
-
-      await waitFor(() => {
-        expect(saveCalls.length).toBe(1);
-      });
-      // The merge entry carries the new topP number...
-      expect(saveCalls[0].entry.topP).toBe(0.95);
-      expect(typeof saveCalls[0].entry.topP).toBe("number");
-      // ...as a deep-merge so seed-owned fields are never sent.
-      expect(saveCalls[0].options?.mode).toBe("merge");
-      expect(saveCalls[0].entry.provider).toBeUndefined();
-      expect(saveCalls[0].entry.model).toBeUndefined();
-    });
-  });
 });
 
 // ---------------------------------------------------------------------------
-// Invariant (default) profiles — server-stamped `invariant: true`
+// Invariant (managed) profiles — server-stamped `invariant: true`
 // ---------------------------------------------------------------------------
 
-describe("ProfileEditorModal — invariant default profiles in view mode", () => {
-  // A server-stamped default profile. Anthropic opus → visibility.topP is
+describe("ProfileEditorModal — invariant managed profiles in view mode", () => {
+  // A server-stamped managed profile. Anthropic opus → visibility.topP is
   // true, so the Top P control renders and we can assert it is locked.
   const invariantProfile = {
     name: "default-a",
@@ -970,20 +903,11 @@ describe("ProfileEditorModal — invariant default profiles in view mode", () =>
     expect(saveCalls[0].options?.mode).toBe("merge");
   });
 
-  test("a managed profile without the invariant flag keeps the toggle, editable label, and editable Top P", () => {
-    const { invariant: _invariant, ...nonInvariant } = invariantProfile;
-    renderView(nonInvariant);
-
-    expect(findSwitchByLabel("Active")).not.toBeNull();
-    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
-    expect(topPSwitch().disabled).toBe(false);
-  });
-
   test("an invariant profile opened in edit mode keeps the lock (defense-in-depth)", () => {
-    // The daemon freezes invariant names regardless of `source`, so even if
-    // a parent opens a non-managed invariant profile in edit mode the lock
-    // must hold: locked label and Top P, no delete/recreate save path.
-    renderEdit({ ...invariantProfile, source: "user" });
+    // The lock keys off the server-stamped wire flag alone, so even if a
+    // parent opens an invariant profile in edit mode the lock must hold:
+    // locked label and Top P, no delete/recreate save path.
+    renderEdit(invariantProfile);
 
     expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
     expect(topPSwitch().disabled).toBe(true);
@@ -1009,10 +933,7 @@ describe("ProfileEditorModal — invariant default profiles in view mode", () =>
       return Promise.resolve();
     };
 
-    renderEdit(
-      { ...invariantProfile, source: "user", status: "disabled" },
-      onSave,
-    );
+    renderEdit({ ...invariantProfile, status: "disabled" }, onSave);
 
     const activeSwitch = findSwitchByLabel("Active");
     expect(activeSwitch).not.toBeNull();

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -979,6 +979,55 @@ describe("ProfileEditorModal — invariant default profiles in view mode", () =>
     expect(topPSwitch().disabled).toBe(false);
   });
 
+  test("an invariant profile opened in edit mode keeps the lock (defense-in-depth)", () => {
+    // The daemon freezes invariant names regardless of `source`, so even if
+    // a parent opens a non-managed invariant profile in edit mode the lock
+    // must hold: locked label and Top P, no delete/recreate save path.
+    renderEdit({ ...invariantProfile, source: "user" });
+
+    expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(true);
+    expect(topPSwitch().disabled).toBe(true);
+
+    // The footer is the safe read-only footer: Save As New is offered and
+    // Save stays disarmed (no status change to flip on an active profile).
+    expect(getButton("Save As New")).not.toBeNull();
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+
+  test("an invariant profile in edit mode saves an enable flip as a {status:'active'} merge, never delete/recreate", async () => {
+    const saveCalls: {
+      name: string;
+      entry: Record<string, unknown>;
+      options?: { mode?: "merge" | "replace" };
+    }[] = [];
+    const onSave = (
+      name: string,
+      entry: unknown,
+      options?: { mode?: "merge" | "replace" },
+    ) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown>, options });
+      return Promise.resolve();
+    };
+
+    renderEdit(
+      { ...invariantProfile, source: "user", status: "disabled" },
+      onSave,
+    );
+
+    const activeSwitch = findSwitchByLabel("Active");
+    expect(activeSwitch).not.toBeNull();
+    fireEvent.click(activeSwitch!);
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    // The body is exactly {status:"active"} as a merge — the replace path
+    // (delete/recreate) is never taken for invariant profiles.
+    expect(saveCalls[0].entry).toEqual({ status: "active" });
+    expect(saveCalls[0].options?.mode).toBe("merge");
+  });
+
   test("Save As New from an invariant profile yields a fully editable create form", () => {
     renderView(invariantProfile);
 

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -724,12 +724,7 @@ function ProfileEditorModalInner({
     !isInvariant || status !== "active" ? (
       <Toggle
         checked={status === "active"}
-        onChange={(v) => {
-          if (isInvariant && v !== true) {
-            return;
-          }
-          setStatus(v ? "active" : "disabled");
-        }}
+        onChange={(v) => setStatus(v ? "active" : "disabled")}
         label="Active"
       />
     ) : null;

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -86,9 +86,9 @@ export interface ProfileEditorModalProps {
    *     delete-then-recreate cycle so omitted fields are reset to default.
    *   - `"merge"` (view mode): the parent skips the delete and sends a
    *     single deep-merge PATCH so unspecified fields (provider, model,
-   *     advanced params) survive. Required for managed-profile policy
-   *     edits — view mode sends only `{label, status}` and we must not
-   *     destroy the seed-owned fields.
+   *     advanced params) survive. View mode's only save is the managed
+   *     re-enable — `{status: "active"}` — and we must not destroy the
+   *     seed-owned fields.
    */
   onSave: (
     name: string,
@@ -169,29 +169,24 @@ function ProfileEditorModalInner({
   const [effectiveMode, setEffectiveMode] = useState<
     "create" | "edit" | "view"
   >(mode);
-  // Invariant (default) profiles are fully locked outside create mode: no
-  // label rename, no Top P override, no disabling — the only interactive
-  // control is the enable-only status toggle when the profile is disabled.
-  // The daemon freezes invariant names regardless of `source`, so the lock
-  // must hold even if the parent opens the editor in edit mode. Customization
-  // goes through "Save As New", which switches `effectiveMode` to "create" and
-  // therefore drops the invariant lock on the duplicate.
+  // Managed profiles are read-only: no rename, no reshaping, no disabling —
+  // the only interactive control is the enable-only status toggle when the
+  // profile is disabled. The lock keys off the server-stamped `invariant`
+  // wire flag (the daemon stamps it exactly on the managed-source entries it
+  // freezes), so it must hold even if the parent opens the editor in edit
+  // mode. Customization goes through "Save As New", which switches
+  // `effectiveMode` to "create" and therefore drops the lock on the
+  // duplicate.
   const isInvariant =
     initialValues?.invariant === true && effectiveMode !== "create";
   // The invariant lock forces read-only handling even in edit mode, so Save
   // takes the partial-merge path and never the delete/recreate cycle the
-  // daemon rejects for invariant profiles.
+  // daemon rejects for managed profiles.
   const isReadOnly = effectiveMode === "view" || isInvariant;
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
 
-  // Managed profiles open the editor in view mode (mode === "view") so they
-  // can't be reshaped (provider, model, advanced params) — those are
-  // daemon-seeded. But the user is still allowed to rename them (label)
-  // and disable them (status) without leaving view mode, since those two
-  // fields are user policy, not daemon contract. The Save button at the
-  // footer is gated by `hasViewModeChanges` below so unchanged view-mode
-  // sessions stay close-only.
-  const initialLabel = initialValues?.label ?? "";
+  // Baseline for `hasViewModeChanges`: the enable flip is the only edit
+  // read-only mode permits.
   const initialStatus: ProfileStatus = initialValues?.status ?? "active";
 
   const [label, setLabel] = useState(initialValues?.label ?? "");
@@ -256,28 +251,18 @@ function ProfileEditorModalInner({
       : 0.7,
   );
 
-  // Advanced params — top P. Top P is editable in view mode (managed
-  // profiles), so capture its initial enabled flag + value as the baseline
-  // `hasViewModeChanges` compares against.
-  const initialTopPEnabled = typeof initialValues?.topP === "number";
-  const initialTopP =
-    typeof initialValues?.topP === "number" ? initialValues.topP : 0.95;
-  const [topPEnabled, setTopPEnabled] = useState<boolean>(initialTopPEnabled);
-  const [topP, setTopP] = useState<number>(initialTopP);
+  // Advanced params — top P
+  const [topPEnabled, setTopPEnabled] = useState<boolean>(
+    typeof initialValues?.topP === "number",
+  );
+  const [topP, setTopP] = useState<number>(
+    typeof initialValues?.topP === "number" ? initialValues.topP : 0.95,
+  );
 
-  // True when in view mode and the user has touched one of the fields that
-  // view mode permits editing (label, status, Top P). Drives the view-mode
-  // Save button's enabled state and the partial-update save path. Top P is
-  // compared on both the enabled flag and the value so flipping the toggle or
-  // dragging the slider both arm Save. Invariant profiles only permit the
-  // status flip (disabled → active), so label and Top P never arm Save there.
-  const hasViewModeChanges =
-    isReadOnly &&
-    (status !== initialStatus ||
-      (!isInvariant &&
-        (label !== initialLabel ||
-          topPEnabled !== initialTopPEnabled ||
-          (topPEnabled && topP !== initialTopP))));
+  // True when read-only mode's one permitted edit — the enable flip
+  // (disabled → active) — has been made. Drives the view-mode Save button's
+  // enabled state and the re-enable save path.
+  const hasViewModeChanges = isReadOnly && status !== initialStatus;
 
   // Advanced params — thinking
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean>(
@@ -512,40 +497,17 @@ function ProfileEditorModalInner({
 
   async function handleSave() {
     if (isInvalid && !isReadOnly) return;
-    // View mode is reserved for managed profiles. The user can rename them
-    // (label) and disable them (status) without leaving view mode, but
-    // everything else (provider, model, advanced params, binding) belongs
-    // to the daemon seed and must NOT be in the request body — the daemon
-    // would reject the request as a managed-profile mutation otherwise.
-    //
-    // `mode: "merge"` tells the parent to skip its delete-then-recreate
-    // cycle and send a single deep-merge PATCH. Without this, the seed
-    // fields (provider, model, advanced params) would be destroyed by
-    // the recreate step that only writes back the partial `{label, status}`
-    // entry.
+    // Read-only (managed) profiles reach Save only via the enable flip — the
+    // daemon rejects every other mutation on them — so the body is exactly
+    // `{status: "active"}`. `mode: "merge"` tells the parent to skip its
+    // delete-then-recreate cycle and send a single deep-merge PATCH so the
+    // seed-owned fields (provider, model, advanced params) stay intact.
     if (isReadOnly) {
       if (!hasViewModeChanges) return;
       setSaving(true);
       setSaveError(null);
       try {
-        // Invariant profiles reach Save only via the enable flip, and the
-        // daemon rejects any other mutation on them — send exactly
-        // `{status: "active"}`, never label or topP.
-        const entry: ProfileEntry = isInvariant
-          ? { status: "active" }
-          : {
-              label: label.trim() || null,
-              status,
-            };
-        // Top P is the one advanced param non-invariant managed profiles may
-        // override. Mirror the create/edit build-entry logic: enabled →
-        // number, cleared → null. Only when the selected provider/model
-        // surfaces the control. `mode: "merge"` means sending just this
-        // changed subset leaves the seed-owned fields intact.
-        if (!isInvariant && visibility.topP) {
-          entry.topP = topPEnabled ? topP : null;
-        }
-        await onSave(keyTrimmed, entry, { mode: "merge" });
+        await onSave(keyTrimmed, { status: "active" }, { mode: "merge" });
       } catch {
         setSaveError("Failed to save profile. Please try again.");
       } finally {
@@ -673,7 +635,7 @@ function ProfileEditorModalInner({
         value={label}
         onChange={(e) => handleLabelChange(e.target.value)}
         placeholder="e.g. Fast & Cheap"
-        disabled={isInvariant}
+        disabled={isReadOnly}
         fullWidth
       />
     </div>
@@ -722,11 +684,11 @@ function ProfileEditorModalInner({
     </div>
   );
 
-  // An active invariant profile shows no status toggle (it cannot be
-  // disabled); a disabled one keeps an enable-only toggle, mirroring the
+  // An active read-only (managed) profile shows no status toggle (it cannot
+  // be disabled); a disabled one keeps an enable-only toggle, mirroring the
   // manage-profiles list item and the daemon's one-directional status rule.
   const activeToggle =
-    !isInvariant || status !== "active" ? (
+    !isReadOnly || status !== "active" ? (
       <Toggle
         checked={status === "active"}
         onChange={(v) => setStatus(v ? "active" : "disabled")}
@@ -738,11 +700,6 @@ function ProfileEditorModalInner({
     <ProfileAdvancedParams
       visibility={visibility}
       isReadOnly={isReadOnly}
-      // Top P is user policy on non-invariant managed profiles, so it stays
-      // editable in view mode while the other advanced params remain locked
-      // by isReadOnly. Invariant (default) profiles lock it too — users
-      // customize via "Save As New".
-      topPReadOnly={isInvariant}
       model={model}
       selectedModel={selectedModel}
       defaultMaxOutputTokens={defaultMaxOutputTokens}
@@ -997,10 +954,9 @@ function ProfileEditorModalInner({
             >
               Save As New
             </Button>
-            {/* Save in view mode persists ONLY label and status changes
-                (managed profile policy fields). The button is gated by
-                `hasViewModeChanges` so an unchanged view session can't
-                round-trip a no-op write. */}
+            {/* Save in view mode persists ONLY the status re-enable. The
+                button is gated by `hasViewModeChanges` so an unchanged view
+                session can't round-trip a no-op write. */}
             <Button
               variant="primary"
               onClick={() => void handleSave()}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -170,6 +170,13 @@ function ProfileEditorModalInner({
     "create" | "edit" | "view"
   >(mode);
   const isReadOnly = effectiveMode === "view";
+  // Invariant (default) profiles are fully read-only in view mode: no label
+  // rename, no Top P override, no disabling — the only interactive control is
+  // the enable-only status toggle when the profile is disabled. Customization
+  // goes through "Save As New", which switches `effectiveMode` to "create" and
+  // therefore drops the invariant lock on the duplicate.
+  const isInvariant =
+    initialValues?.invariant === true && effectiveMode === "view";
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
 
   // Managed profiles open the editor in view mode (mode === "view") so they
@@ -257,13 +264,15 @@ function ProfileEditorModalInner({
   // view mode permits editing (label, status, Top P). Drives the view-mode
   // Save button's enabled state and the partial-update save path. Top P is
   // compared on both the enabled flag and the value so flipping the toggle or
-  // dragging the slider both arm Save.
+  // dragging the slider both arm Save. Invariant profiles only permit the
+  // status flip (disabled → active), so label and Top P never arm Save there.
   const hasViewModeChanges =
     isReadOnly &&
-    (label !== initialLabel ||
-      status !== initialStatus ||
-      topPEnabled !== initialTopPEnabled ||
-      (topPEnabled && topP !== initialTopP));
+    (status !== initialStatus ||
+      (!isInvariant &&
+        (label !== initialLabel ||
+          topPEnabled !== initialTopPEnabled ||
+          (topPEnabled && topP !== initialTopP))));
 
   // Advanced params — thinking
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean>(
@@ -514,16 +523,21 @@ function ProfileEditorModalInner({
       setSaving(true);
       setSaveError(null);
       try {
-        const entry: ProfileEntry = {
-          label: label.trim() || null,
-          status,
-        };
-        // Top P is the one advanced param managed profiles may override.
-        // Mirror the create/edit build-entry logic: enabled → number,
-        // cleared → null. Only when the selected provider/model surfaces the
-        // control. `mode: "merge"` means sending just this changed subset
-        // leaves the seed-owned fields intact.
-        if (visibility.topP) {
+        // Invariant profiles reach Save only via the enable flip, and the
+        // daemon rejects any other mutation on them — send exactly
+        // `{status: "active"}`, never label or topP.
+        const entry: ProfileEntry = isInvariant
+          ? { status: "active" }
+          : {
+              label: label.trim() || null,
+              status,
+            };
+        // Top P is the one advanced param non-invariant managed profiles may
+        // override. Mirror the create/edit build-entry logic: enabled →
+        // number, cleared → null. Only when the selected provider/model
+        // surfaces the control. `mode: "merge"` means sending just this
+        // changed subset leaves the seed-owned fields intact.
+        if (!isInvariant && visibility.topP) {
           entry.topP = topPEnabled ? topP : null;
         }
         await onSave(keyTrimmed, entry, { mode: "merge" });
@@ -654,6 +668,7 @@ function ProfileEditorModalInner({
         value={label}
         onChange={(e) => handleLabelChange(e.target.value)}
         placeholder="e.g. Fast & Cheap"
+        disabled={isInvariant}
         fullWidth
       />
     </div>
@@ -702,21 +717,32 @@ function ProfileEditorModalInner({
     </div>
   );
 
-  const activeToggle = (
-    <Toggle
-      checked={status === "active"}
-      onChange={(v) => setStatus(v ? "active" : "disabled")}
-      label="Active"
-    />
-  );
+  // An active invariant profile shows no status toggle (it cannot be
+  // disabled); a disabled one keeps an enable-only toggle, mirroring the
+  // manage-profiles list item and the daemon's one-directional status rule.
+  const activeToggle =
+    !isInvariant || status !== "active" ? (
+      <Toggle
+        checked={status === "active"}
+        onChange={(v) => {
+          if (isInvariant && v !== true) {
+            return;
+          }
+          setStatus(v ? "active" : "disabled");
+        }}
+        label="Active"
+      />
+    ) : null;
 
   const advancedParamsNode = (
     <ProfileAdvancedParams
       visibility={visibility}
       isReadOnly={isReadOnly}
-      // Top P is user policy on managed profiles too, so it stays editable in
-      // view mode while the other advanced params remain locked by isReadOnly.
-      topPReadOnly={false}
+      // Top P is user policy on non-invariant managed profiles, so it stays
+      // editable in view mode while the other advanced params remain locked
+      // by isReadOnly. Invariant (default) profiles lock it too — users
+      // customize via "Save As New".
+      topPReadOnly={isInvariant}
       model={model}
       selectedModel={selectedModel}
       defaultMaxOutputTokens={defaultMaxOutputTokens}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -169,14 +169,19 @@ function ProfileEditorModalInner({
   const [effectiveMode, setEffectiveMode] = useState<
     "create" | "edit" | "view"
   >(mode);
-  const isReadOnly = effectiveMode === "view";
-  // Invariant (default) profiles are fully read-only in view mode: no label
-  // rename, no Top P override, no disabling — the only interactive control is
-  // the enable-only status toggle when the profile is disabled. Customization
+  // Invariant (default) profiles are fully locked outside create mode: no
+  // label rename, no Top P override, no disabling — the only interactive
+  // control is the enable-only status toggle when the profile is disabled.
+  // The daemon freezes invariant names regardless of `source`, so the lock
+  // must hold even if the parent opens the editor in edit mode. Customization
   // goes through "Save As New", which switches `effectiveMode` to "create" and
   // therefore drops the invariant lock on the duplicate.
   const isInvariant =
-    initialValues?.invariant === true && effectiveMode === "view";
+    initialValues?.invariant === true && effectiveMode !== "create";
+  // The invariant lock forces read-only handling even in edit mode, so Save
+  // takes the partial-merge path and never the delete/recreate cycle the
+  // daemon rejects for invariant profiles.
+  const isReadOnly = effectiveMode === "view" || isInvariant;
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
 
   // Managed profiles open the editor in view mode (mode === "view") so they
@@ -967,7 +972,11 @@ function ProfileEditorModalInner({
       </Modal.Body>
 
       <Modal.Footer>
-        {effectiveMode === "view" ? (
+        {/* `isReadOnly` (not `effectiveMode === "view"`) picks the footer so
+            an invariant profile opened in edit mode still gets the safe
+            footer: Close, Save As New, and a Save gated by
+            `hasViewModeChanges` that only ever takes the merge path. */}
+        {isReadOnly ? (
           <>
             <Button
               variant="outlined"


### PR DESCRIPTION
## Summary
Makes every managed profile — the three defaults (balanced, quality-optimized, cost-optimized) **and the flag-gated os-beta** — fully read-only: a single choke-point guard in `commitConfigWrite` rejects any delete/disable/relabel/edit through every config-write route (PATCH/SET/PUT); the only permitted user action is re-enabling a disabled managed profile (one-directional status rule, which preserves BYOK hatch behavior). Invariance is **source-gated**: it applies only to entries whose on-disk `source` is `"managed"`, so a user-owned profile that shares a managed name (a real, supported state for os-beta) stays fully editable and deletable. The settings UI derives lock state from a server-stamped wire-only `invariant` flag — no hardcoded profile names in the web client. Customization goes through "Save As New". The now-unreachable partial-editability machinery (PUT label/status/topP allowlist, web view-mode label/status save path) was deleted along with its tests.

## Self-review result
GAPS FOUND → fixed — 2 review rounds, 7 gaps fixed across 2 fix PRs (wire-key GET→SET round-trips, junk status validation, orphaned-connection prevention on PUT, stale comments, test consolidation). Round 2: PASS on all four passes. Post-review Codex feedback cycles addressed: invariant lock honored outside view mode, read-only advanced-param segment controls, present-tense guard comments.

## PRs merged into feature branch
- #37014: feat(config): expose per-profile `invariant` flag on config reads
- #37020: feat(settings): lock default profiles in the AI settings UI
- #37021: feat(config): enforce default-profile invariants in commitConfigWrite

### Fix PRs
- #37048: fix: settings UI test/slop cleanup for default-profile lock
- #37051: fix: wire-key round-trips, status validation, and guard cleanups for default profiles

### Direct commits (review feedback + scope addition)
- 5c930e08a8: honor invariant lock outside view mode
- ca9d4a6ada: present-tense guard comment
- 57c915da78: read-only advanced-param segment controls; stale comments
- 14fa2d662d: make os-beta invariant; source-gate invariance; delete partial-editability machinery

Part of plan: invariant-default-profiles.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)