### PR TITLE
feat(gateway): gateway-native session service (secret minting) + verification_sessions_* IPC routes

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -188,6 +188,7 @@ import {
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { inviteRoutes } from "./ipc/invite-handlers.js";
+import { verificationSessionRoutes } from "./ipc/verification-session-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
@@ -2491,6 +2492,7 @@ async function main() {
     ...featureFlagRoutes,
     ...contactRoutes,
     ...inviteRoutes,
+    ...verificationSessionRoutes,
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,

--- a/gateway/src/ipc/__tests__/verification-session-routes.test.ts
+++ b/gateway/src/ipc/__tests__/verification-session-routes.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Socket-level tests for the verification_sessions_* lifecycle IPC routes.
+ *
+ * Each request travels over a real Unix-domain-socket round-trip against a
+ * real (temp-dir) gateway DB, exercising the routes exactly as the daemon
+ * relay hits them: schema validation on the server, session-store writes,
+ * and wire-shaped responses. The key security property pinned here: secrets
+ * are minted gateway-side and only their SHA-256 hashes are persisted.
+ *
+ * `verification_sessions_validate_consume` ships separately and is asserted
+ * absent.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { connect } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CreateInboundSessionIpcResponseSchema,
+  CreateOutboundSessionIpcResponseSchema,
+  VERIFICATION_SESSIONS_IPC_METHODS,
+  VerificationSessionSchema,
+  hashVerificationSecret,
+} from "@vellumai/gateway-client";
+import { eq } from "drizzle-orm";
+
+import "../../__tests__/test-preload.js";
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../../db/connection.js";
+import { channelVerificationSessions } from "../../db/schema.js";
+import { verificationSessionRoutes } from "../verification-session-handlers.js";
+import { GatewayIpcServer } from "../server.js";
+
+const METHODS = VERIFICATION_SESSIONS_IPC_METHODS;
+
+let server: GatewayIpcServer;
+let socketDir: string;
+let prevEnv: string | undefined;
+let reqSeq = 0;
+
+async function rpc(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const id = `req-${++reqSeq}`;
+  const line = JSON.stringify({ id, method, params });
+  return await new Promise((resolve, reject) => {
+    const sock = connect(server.getSocketPath());
+    let buf = "";
+    sock.on("connect", () => sock.write(line + "\n"));
+    sock.on("data", (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        sock.end();
+        resolve(JSON.parse(buf.slice(0, nl)));
+      }
+    });
+    sock.on("error", reject);
+  });
+}
+
+/** rpc() for calls expected to succeed; returns the unwrapped result. */
+async function call(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await rpc(method, params);
+  if (res.error !== undefined) {
+    throw new Error(`unexpected IPC error: ${String(res.error)}`);
+  }
+  return res.result;
+}
+
+function getRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(channelVerificationSessions)
+    .where(eq(channelVerificationSessions.id, id))
+    .get();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(channelVerificationSessions).run();
+
+  socketDir = mkdtempSync(join(tmpdir(), "vellum-ipc-test-"));
+  prevEnv = process.env.GATEWAY_IPC_SOCKET_DIR;
+  process.env.GATEWAY_IPC_SOCKET_DIR = socketDir;
+  // Disable the watchdog so the test has a single deterministic listener.
+  server = new GatewayIpcServer(verificationSessionRoutes, {
+    watchdogIntervalMs: 0,
+  });
+  server.start();
+  // Wait for the listener to bind.
+  const { existsSync } = await import("node:fs");
+  for (let i = 0; i < 100 && !existsSync(server.getSocketPath()); i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+});
+
+afterEach(() => {
+  server.stop();
+  if (prevEnv === undefined) delete process.env.GATEWAY_IPC_SOCKET_DIR;
+  else process.env.GATEWAY_IPC_SOCKET_DIR = prevEnv;
+  rmSync(socketDir, { recursive: true, force: true });
+  resetGatewayDb();
+});
+
+describe("route registration", () => {
+  test("registers exactly the 10 lifecycle methods, each with a schema", () => {
+    const lifecycleMethods = Object.values(METHODS).filter(
+      (m) => m !== METHODS.validateConsume,
+    );
+    expect(verificationSessionRoutes.map((r) => r.method).sort()).toEqual(
+      [...lifecycleMethods].sort(),
+    );
+    for (const route of verificationSessionRoutes) {
+      expect(route.schema).toBeDefined();
+    }
+  });
+
+  test("validate_consume is not registered yet → 404 UNKNOWN_METHOD", async () => {
+    const res = await rpc(METHODS.validateConsume, {
+      channel: "telegram",
+      secret: "s",
+      actorExternalUserId: "u",
+      actorChatId: "c",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+  });
+});
+
+describe("verification_sessions_create_outbound", () => {
+  test("mints a numeric secret whose SHA-256 matches the stored challenge_hash", async () => {
+    const result = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        expectedExternalUserId: "tg-user-1",
+        expectedChatId: "tg-chat-1",
+        destinationAddress: "@guardian",
+      }),
+    );
+
+    expect(result.secret).toMatch(/^\d{6}$/);
+    expect(hashVerificationSecret(result.secret)).toBe(result.challengeHash);
+    expect(result.ttlSeconds).toBe(600);
+
+    // Only the hash is persisted — the raw secret never touches the DB.
+    const row = getRow(result.sessionId);
+    expect(row?.challengeHash).toBe(result.challengeHash);
+    expect(row?.status).toBe("awaiting_response");
+    expect(JSON.stringify(row)).not.toContain(result.secret);
+  });
+
+  test("honors codeDigits for bound-identity sessions", async () => {
+    const result = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "phone",
+        expectedPhoneE164: "+15555550123",
+        codeDigits: 4,
+      }),
+    );
+    expect(result.secret).toMatch(/^\d{4}$/);
+    expect(getRow(result.sessionId)?.codeDigits).toBe(4);
+  });
+
+  test("pending_bootstrap sessions get a 32-byte hex secret", async () => {
+    const result = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        identityBindingStatus: "pending_bootstrap",
+        bootstrapTokenHash: hashVerificationSecret("raw-bootstrap-token"),
+      }),
+    );
+    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashVerificationSecret(result.secret)).toBe(result.challengeHash);
+
+    const row = getRow(result.sessionId);
+    expect(row?.status).toBe("pending_bootstrap");
+    expect(row?.identityBindingStatus).toBe("pending_bootstrap");
+  });
+
+  test("uses a caller-supplied sessionId when provided", async () => {
+    const result = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        sessionId: "pre-minted-id",
+      }),
+    );
+    expect(result.sessionId).toBe("pre-minted-id");
+    expect(getRow("pre-minted-id")).toBeDefined();
+  });
+});
+
+describe("verification_sessions_create_inbound", () => {
+  test("mints a hex secret, persists only the hash, returns the session DTO", async () => {
+    const result = CreateInboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createInbound, {
+        channel: "telegram",
+        sourceConversationId: "conv-1",
+      }),
+    );
+
+    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.verifyCommand).toBe(result.secret);
+    expect(result.ttlSeconds).toBe(600);
+    expect(result.session.status).toBe("pending");
+    expect(result.session.sourceConversationId).toBe("conv-1");
+    expect(result.session.challengeHash).toBe(
+      hashVerificationSecret(result.secret),
+    );
+
+    const row = getRow(result.session.id);
+    expect(row?.challengeHash).toBe(result.session.challengeHash);
+    expect(JSON.stringify(row)).not.toContain(result.secret);
+  });
+});
+
+describe("read routes: get_pending / find_active / resolve_bootstrap", () => {
+  test("get_pending returns the pending inbound session, null otherwise", async () => {
+    expect(await call(METHODS.getPending, { channel: "telegram" })).toBeNull();
+
+    const created = CreateInboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createInbound, { channel: "telegram" }),
+    );
+
+    const found = VerificationSessionSchema.parse(
+      await call(METHODS.getPending, { channel: "telegram" }),
+    );
+    expect(found).toEqual(created.session);
+
+    // Outbound sessions are not visible to get_pending, and other channels
+    // stay isolated.
+    expect(await call(METHODS.getPending, { channel: "slack" })).toBeNull();
+  });
+
+  test("find_active returns the outbound session, scoped by channel", async () => {
+    expect(await call(METHODS.findActive, { channel: "telegram" })).toBeNull();
+
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        expectedChatId: "chat-1",
+      }),
+    );
+
+    const found = VerificationSessionSchema.parse(
+      await call(METHODS.findActive, { channel: "telegram" }),
+    );
+    expect(found.id).toBe(created.sessionId);
+    expect(found.status).toBe("awaiting_response");
+
+    expect(await call(METHODS.findActive, { channel: "phone" })).toBeNull();
+  });
+
+  test("resolve_bootstrap hashes the raw token gateway-side", async () => {
+    const rawToken = "raw-deep-link-token";
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        identityBindingStatus: "pending_bootstrap",
+        bootstrapTokenHash: hashVerificationSecret(rawToken),
+      }),
+    );
+
+    const resolved = VerificationSessionSchema.parse(
+      await call(METHODS.resolveBootstrap, {
+        channel: "telegram",
+        token: rawToken,
+      }),
+    );
+    expect(resolved.id).toBe(created.sessionId);
+
+    expect(
+      await call(METHODS.resolveBootstrap, {
+        channel: "telegram",
+        token: "wrong-token",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("mutation routes: bind / update_status / update_delivery / revoke", () => {
+  test("bind_identity binds the expected identity and flips to bound", async () => {
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        identityBindingStatus: "pending_bootstrap",
+      }),
+    );
+
+    const ack = await call(METHODS.bindIdentity, {
+      sessionId: created.sessionId,
+      externalUserId: "tg-user-9",
+      chatId: "tg-chat-9",
+    });
+    expect(ack).toEqual({ ok: true });
+
+    const row = getRow(created.sessionId);
+    expect(row?.expectedExternalUserId).toBe("tg-user-9");
+    expect(row?.expectedChatId).toBe("tg-chat-9");
+    expect(row?.identityBindingStatus).toBe("bound");
+  });
+
+  test("update_status transitions the session and records the consumer", async () => {
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, { channel: "telegram" }),
+    );
+
+    const ack = await call(METHODS.updateStatus, {
+      sessionId: created.sessionId,
+      status: "consumed",
+      consumedByExternalUserId: "tg-user-2",
+      consumedByChatId: "tg-chat-2",
+    });
+    expect(ack).toEqual({ ok: true });
+
+    const row = getRow(created.sessionId);
+    expect(row?.status).toBe("consumed");
+    expect(row?.consumedByExternalUserId).toBe("tg-user-2");
+    expect(row?.consumedByChatId).toBe("tg-chat-2");
+  });
+
+  test("update_delivery + count_recent_sends round-trip", async () => {
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "phone",
+        expectedPhoneE164: "+15555550142",
+        destinationAddress: "+15555550142",
+      }),
+    );
+
+    const before = await call(METHODS.countRecentSends, {
+      channel: "phone",
+      destinationAddress: "+15555550142",
+      windowMs: 60_000,
+    });
+    expect(before).toEqual({ count: 0 });
+
+    const sentAt = Date.now();
+    const ack = await call(METHODS.updateDelivery, {
+      sessionId: created.sessionId,
+      lastSentAt: sentAt,
+      sendCount: 1,
+      nextResendAt: sentAt + 30_000,
+    });
+    expect(ack).toEqual({ ok: true });
+
+    const row = getRow(created.sessionId);
+    expect(row?.lastSentAt).toBe(sentAt);
+    expect(row?.sendCount).toBe(1);
+    expect(row?.nextResendAt).toBe(sentAt + 30_000);
+
+    const after = await call(METHODS.countRecentSends, {
+      channel: "phone",
+      destinationAddress: "+15555550142",
+      windowMs: 60_000,
+    });
+    expect(after).toEqual({ count: 1 });
+  });
+
+  test("revoke_pending revokes the pending inbound session", async () => {
+    const created = CreateInboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createInbound, { channel: "telegram" }),
+    );
+
+    const ack = await call(METHODS.revokePending, { channel: "telegram" });
+    expect(ack).toEqual({ ok: true });
+
+    expect(await call(METHODS.getPending, { channel: "telegram" })).toBeNull();
+    expect(getRow(created.session.id)?.status).toBe("revoked");
+  });
+});
+
+describe("schema rejection", () => {
+  test("malformed params → 400 BAD_REQUEST without touching the store", async () => {
+    const badCalls: Array<[string, Record<string, unknown>]> = [
+      [METHODS.createInbound, {}], // channel required
+      [METHODS.createOutbound, { channel: "" }], // non-empty channel
+      [METHODS.createOutbound, { channel: "telegram", codeDigits: 0 }],
+      [METHODS.getPending, {}],
+      [METHODS.resolveBootstrap, { channel: "telegram", token: "" }],
+      [METHODS.bindIdentity, { sessionId: "s-1", externalUserId: "u" }],
+      [METHODS.updateStatus, { sessionId: "s-1", status: "not-a-status" }],
+      [METHODS.updateDelivery, { sessionId: "s-1", lastSentAt: 1 }],
+      [
+        METHODS.countRecentSends,
+        { channel: "phone", destinationAddress: "+15555550142", windowMs: -1 },
+      ],
+      [METHODS.revokePending, { channel: 42 }],
+    ];
+
+    for (const [method, params] of badCalls) {
+      const res = await rpc(method, params);
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(String(res.error)).toContain("Invalid params");
+    }
+
+    // Nothing was written by any of the rejected calls.
+    const rows = getGatewayDb()
+      .select()
+      .from(channelVerificationSessions)
+      .all();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/gateway/src/ipc/verification-session-handlers.ts
+++ b/gateway/src/ipc/verification-session-handlers.ts
@@ -1,0 +1,168 @@
+/**
+ * IPC route definitions for the gateway-native verification session
+ * lifecycle (Combo 13).
+ *
+ * The gateway owns the `channel_verification_sessions` table: secrets are
+ * minted in the session service, only hashes are persisted, and the daemon
+ * relays its session lifecycle operations here via `ipcCallPersistent`.
+ * Raw secrets transit back in the create responses because message
+ * composition and channel delivery stay daemon-owned.
+ *
+ * These are the 10 lifecycle methods. `verification_sessions_validate_consume`
+ * (gateway-native validation, rate limiting, and in-engine role side effects)
+ * ships separately.
+ *
+ * Request/response shapes are pinned by the shared contract in
+ * `@vellumai/gateway-client` (verification-session-contract.ts); the daemon
+ * client validates responses against the same schemas. Read methods return
+ * the wire DTO or null; mutations return a minimal `{ ok: true }` ack.
+ */
+
+import {
+  BindSessionIdentityIpcParamsSchema,
+  CountRecentSendsIpcParamsSchema,
+  CreateInboundSessionIpcParamsSchema,
+  CreateOutboundSessionIpcParamsSchema,
+  FindActiveSessionIpcParamsSchema,
+  GetPendingSessionIpcParamsSchema,
+  ResolveBootstrapSessionIpcParamsSchema,
+  RevokePendingSessionsIpcParamsSchema,
+  UpdateSessionDeliveryIpcParamsSchema,
+  UpdateSessionStatusIpcParamsSchema,
+  VERIFICATION_SESSIONS_IPC_METHODS,
+  hashVerificationSecret,
+} from "@vellumai/gateway-client";
+
+import {
+  bindSessionIdentity,
+  countRecentSendsToDestination,
+  findActiveSession,
+  findPendingSessionForChannel,
+  findSessionByBootstrapTokenHash,
+  revokePendingSessions,
+  updateSessionDelivery,
+  updateSessionStatus,
+} from "../db/session-store.js";
+import {
+  createInboundVerificationSession,
+  createOutboundSession,
+} from "../verification/session-service.js";
+import type { IpcRoute } from "./server.js";
+
+export const verificationSessionRoutes: IpcRoute[] = [
+  {
+    // Mint a high-entropy inbound challenge; the raw secret returns to the
+    // daemon, which composes the instruction copy and delivers it.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.createInbound,
+    schema: CreateInboundSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel, sourceConversationId } =
+        CreateInboundSessionIpcParamsSchema.parse(params);
+      return createInboundVerificationSession(channel, sourceConversationId);
+    },
+  },
+  {
+    // Mint an outbound session (numeric code when identity is bound,
+    // 32-byte hex for pending_bootstrap); secret transits for delivery.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.createOutbound,
+    schema: CreateOutboundSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const input = CreateOutboundSessionIpcParamsSchema.parse(params);
+      return createOutboundSession(input);
+    },
+  },
+  {
+    // Pending inbound session for a channel ('pending' status only).
+    method: VERIFICATION_SESSIONS_IPC_METHODS.getPending,
+    schema: GetPendingSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel } = GetPendingSessionIpcParamsSchema.parse(params);
+      return findPendingSessionForChannel(channel);
+    },
+  },
+  {
+    // Most recent active outbound session (pending_bootstrap /
+    // awaiting_response).
+    method: VERIFICATION_SESSIONS_IPC_METHODS.findActive,
+    schema: FindActiveSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel } = FindActiveSessionIpcParamsSchema.parse(params);
+      return findActiveSession(channel);
+    },
+  },
+  {
+    // The daemon relays the RAW deep-link token; hashing happens here so
+    // the scheme stays pinned to the stored bootstrap_token_hash values.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.resolveBootstrap,
+    schema: ResolveBootstrapSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel, token } =
+        ResolveBootstrapSessionIpcParamsSchema.parse(params);
+      return findSessionByBootstrapTokenHash(
+        channel,
+        hashVerificationSecret(token),
+      );
+    },
+  },
+  {
+    // Telegram bootstrap completion: bind identity fields and flip
+    // identity_binding_status to bound.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.bindIdentity,
+    schema: BindSessionIdentityIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { sessionId, externalUserId, chatId } =
+        BindSessionIdentityIpcParamsSchema.parse(params);
+      bindSessionIdentity(sessionId, externalUserId, chatId);
+      return { ok: true };
+    },
+  },
+  {
+    method: VERIFICATION_SESSIONS_IPC_METHODS.updateStatus,
+    schema: UpdateSessionStatusIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { sessionId, status, consumedByExternalUserId, consumedByChatId } =
+        UpdateSessionStatusIpcParamsSchema.parse(params);
+      updateSessionStatus(sessionId, status, {
+        consumedByExternalUserId,
+        consumedByChatId,
+      });
+      return { ok: true };
+    },
+  },
+  {
+    method: VERIFICATION_SESSIONS_IPC_METHODS.updateDelivery,
+    schema: UpdateSessionDeliveryIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { sessionId, lastSentAt, sendCount, nextResendAt } =
+        UpdateSessionDeliveryIpcParamsSchema.parse(params);
+      updateSessionDelivery(sessionId, lastSentAt, sendCount, nextResendAt);
+      return { ok: true };
+    },
+  },
+  {
+    // Destination-level send throttle input: sends to one address across
+    // all sessions within a rolling window.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.countRecentSends,
+    schema: CountRecentSendsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel, destinationAddress, windowMs } =
+        CountRecentSendsIpcParamsSchema.parse(params);
+      return {
+        count: countRecentSendsToDestination(
+          channel,
+          destinationAddress,
+          windowMs,
+        ),
+      };
+    },
+  },
+  {
+    method: VERIFICATION_SESSIONS_IPC_METHODS.revokePending,
+    schema: RevokePendingSessionsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel } = RevokePendingSessionsIpcParamsSchema.parse(params);
+      revokePendingSessions(channel);
+      return { ok: true };
+    },
+  },
+];

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -1,0 +1,147 @@
+/**
+ * Gateway-native verification session service (Combo 13).
+ *
+ * Ports secret minting from the daemon's channel-verification-service:
+ * sessions are created here, secrets are minted here, and only SHA-256
+ * hashes are persisted (via the gateway session store). The raw secret
+ * transits back to the daemon in the create-IPC response because message
+ * composition and channel delivery stay daemon-owned — mirror of how
+ * invite mint returns data and the daemon composes presentation.
+ *
+ * Validate-and-consume is deliberately NOT here yet; it lands with the
+ * `verification_sessions_validate_consume` route (in-engine role side
+ * effects replace the outbound-voice-verification-sync poller).
+ */
+
+import { randomBytes, randomUUID } from "node:crypto";
+
+import { hashVerificationSecret } from "@vellumai/gateway-client";
+
+import type {
+  IdentityBindingStatus,
+  VerificationPurpose,
+  VerificationSession,
+} from "../db/session-store.js";
+import {
+  createInboundSession,
+  createOutboundSession as storeCreateOutboundSession,
+} from "../db/session-store.js";
+
+/** Challenge TTL in milliseconds (10 minutes). */
+export const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+export interface CreateInboundVerificationSessionResult {
+  session: VerificationSession;
+  secret: string;
+  verifyCommand: string;
+  ttlSeconds: number;
+}
+
+export interface CreateOutboundSessionResult {
+  sessionId: string;
+  secret: string;
+  challengeHash: string;
+  expiresAt: number;
+  ttlSeconds: number;
+}
+
+/**
+ * Generate a numeric secret with the specified number of digits
+ * (default 6), zero-padded, using cryptographic randomness.
+ */
+function generateNumericSecret(digits: number = 6): string {
+  const buf = randomBytes(4);
+  const num = buf.readUInt32BE(0);
+  const max = 10 ** digits;
+  return String(num % max).padStart(digits, "0");
+}
+
+/**
+ * Create a new inbound verification session for a guardian candidate.
+ *
+ * Inbound sessions are not identity-bound, so code secrecy is the only
+ * protection against brute-force guessing during the TTL window — a
+ * 32-byte hex secret provides ~2^128 entropy. Identity-bound outbound
+ * sessions use shorter numeric codes because the identity check adds a
+ * second layer of protection.
+ *
+ * Only the SHA-256 hash is persisted; the raw secret is returned so the
+ * daemon can compose and deliver the instruction copy.
+ */
+export function createInboundVerificationSession(
+  channel: string,
+  sourceConversationId?: string,
+): CreateInboundVerificationSessionResult {
+  const secret = randomBytes(32).toString("hex");
+
+  const session = createInboundSession({
+    id: randomUUID(),
+    channel,
+    challengeHash: hashVerificationSecret(secret),
+    expiresAt: Date.now() + CHALLENGE_TTL_MS,
+    sourceConversationId,
+  });
+
+  return {
+    session,
+    secret,
+    verifyCommand: secret,
+    ttlSeconds: CHALLENGE_TTL_MS / 1000,
+  };
+}
+
+/**
+ * Create an outbound verification session with expected identity pre-set.
+ *
+ * Channels where identity is pre-bound use numeric codes for ease of
+ * entry; unbound bootstrap sessions (`pending_bootstrap`) use high-entropy
+ * 32-byte hex secrets to prevent brute-force guessing during the TTL
+ * window. Only the hash is persisted; the secret transits back for
+ * daemon-owned delivery.
+ */
+export function createOutboundSession(params: {
+  channel: string;
+  expectedExternalUserId?: string;
+  expectedChatId?: string;
+  expectedPhoneE164?: string;
+  identityBindingStatus?: IdentityBindingStatus;
+  destinationAddress?: string;
+  codeDigits?: number;
+  maxAttempts?: number;
+  verificationPurpose?: VerificationPurpose;
+  bootstrapTokenHash?: string;
+  sessionId?: string;
+}): CreateOutboundSessionResult {
+  const isUnbound = params.identityBindingStatus === "pending_bootstrap";
+  const secret = isUnbound
+    ? randomBytes(32).toString("hex")
+    : generateNumericSecret(params.codeDigits ?? 6);
+  const challengeHash = hashVerificationSecret(secret);
+  const sessionId = params.sessionId ?? randomUUID();
+  const expiresAt = Date.now() + CHALLENGE_TTL_MS;
+
+  storeCreateOutboundSession({
+    id: sessionId,
+    channel: params.channel,
+    challengeHash,
+    expiresAt,
+    status: isUnbound ? "pending_bootstrap" : "awaiting_response",
+    expectedExternalUserId: params.expectedExternalUserId,
+    expectedChatId: params.expectedChatId,
+    expectedPhoneE164: params.expectedPhoneE164,
+    identityBindingStatus: params.identityBindingStatus ?? "bound",
+    destinationAddress: params.destinationAddress,
+    codeDigits: params.codeDigits,
+    maxAttempts: params.maxAttempts,
+    verificationPurpose: params.verificationPurpose,
+    bootstrapTokenHash: params.bootstrapTokenHash,
+  });
+
+  return {
+    sessionId,
+    secret,
+    challengeHash,
+    expiresAt,
+    ttlSeconds: CHALLENGE_TTL_MS / 1000,
+  };
+}


### PR DESCRIPTION
## Summary
- session-service.ts mints inbound/outbound verification secrets gateway-side (hashes only persisted)
- 10 lifecycle verification_sessions_* IPC routes registered on the gateway socket, Zod-validated via the shared contract
- Socket-level route tests; no daemon changes, no consumers flipped yet

Part of plan: verif-sessions-gateway-native.md (PR 4 of 12)