### PR TITLE
chore(macos): gitignore all of resources/

### DIFF
--- a/clients/macos/.gitignore
+++ b/clients/macos/.gitignore
@@ -1,14 +1,7 @@
 node_modules/
+resources/
 out/
 dist/
 build/
-resources/bun
-resources/hotkey-helper
-resources/vellum-mac-helper
-resources/vellum-mac-helper.app
-resources/web-dist
 native/hotkey-helper/.build/
 native/mac-helper/.build/
-resources/cli-lockfile
-resources/.vellum-mac-helper.source-hash
-resources/.vellum-mac-helper*.Info.plist


### PR DESCRIPTION
Everything under \`clients/macos/resources/\` is build output, but the ignore list enumerated artifacts by name, so newer ones — like the env-suffixed helper apps (\`Vellum Helper Local.app\`) — show up as untracked. Nothing in the directory is tracked; ignore it wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)