### PR TITLE
fix(flags): GA research-onboarding + personality-onboarding in the meta registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -374,17 +374,17 @@
       "id": "research-onboarding",
       "scope": "client",
       "key": "research-onboarding",
-      "label": "Research onboarding (spike)",
-      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Research onboarding",
+      "description": "Replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including the \"Create my personality\" step and a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. On by default (GA); after consent, new web users (non-native, non-local-mode) are routed into this flow instead of the standard hatching path.",
+      "defaultEnabled": true
     },
     {
       "id": "personality-onboarding",
       "scope": "client",
       "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Personality onboarding step",
+      "description": "Show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. On by default (GA); only takes effect where the research-onboarding flow itself is enabled.",
+      "defaultEnabled": true
     },
     {
       "id": "channel-trust-floors",


### PR DESCRIPTION
#36985 GA'd both flags in web's bundled registry copy but not in the canonical `meta/feature-flags` registry. `sync-bundled-copies` regenerates the bundled copies from the canonical file, so wherever it runs (postinstalls, CI sync steps) it reverts both flags to their spike state.

This aligns the canonical entries with the shipped GA values; after syncing, all copies are identical and the sync is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)