### PR TITLE
Enable send for staged quote replies

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
@@ -10,6 +10,7 @@
 export interface ComposerKeyDownPolicy {
   input: string;
   canSendAttachments: boolean;
+  hasStagedQuotes?: boolean;
   sendDisabled: boolean;
   attachmentsUploadingCount: number;
   cmdEnterMode: boolean;
@@ -55,9 +56,14 @@ export function shouldSubmitOnEnter(
   // Cmd+Enter mode: only Cmd+Enter (Mac) or Ctrl+Enter (Win/Linux) submits;
   // bare Enter inserts a newline.
   if (policy.cmdEnterMode) {
-    if (!event.metaKey && !event.ctrlKey) return "ignore";
+    if (!event.metaKey && !event.ctrlKey) {
+      return "ignore";
+    }
   }
-  const hasContent = policy.input.trim() || policy.canSendAttachments;
+  const hasContent =
+    !!policy.input.trim() ||
+    policy.canSendAttachments ||
+    policy.hasStagedQuotes === true;
   if (
     hasContent &&
     !policy.sendDisabled &&

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -25,6 +25,7 @@ import {
   computeGhostSuffix,
   shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 let mockIsMobile = false;
 mock.module("@/hooks/use-is-mobile", () => ({
@@ -236,6 +237,19 @@ describe("shouldSubmitOnEnter — guards still preventDefault but skip submit", 
       }),
     ).toBe("submit");
   });
+
+  test("input is empty but a staged quote reply is ready", () => {
+    expect(
+      shouldSubmitOnEnter(ENTER, false, {
+        input: "",
+        canSendAttachments: false,
+        hasStagedQuotes: true,
+        sendDisabled: false,
+        attachmentsUploadingCount: 0,
+        cmdEnterMode: false,
+      }),
+    ).toBe("submit");
+  });
 });
 
 describe("shouldSubmitOnEnter — non-Enter keys", () => {
@@ -409,6 +423,10 @@ beforeEach(() => {
     attachments: [],
     attachmentLastError: null,
     restoredDraftConversationId: null,
+  });
+  useQuoteReplyStore.setState({
+    stagedQuotes: [],
+    replyBubble: null,
   });
 });
 
@@ -584,6 +602,22 @@ describe("ChatComposer — disabled submit guard", () => {
   test("empty input + no attachments disables the submit button", () => {
     const html = renderComposer({ input: "", canSendAttachments: false });
     expect(sendButtonHasDisabledAttr(html)).toBe(true);
+  });
+
+  test("empty input with a staged quote reply leaves the submit button enabled", () => {
+    useQuoteReplyStore.setState({
+      stagedQuotes: [
+        {
+          id: "quote-1",
+          quotedText: "selected assistant text",
+          replyText: "please use this context",
+          sourceMessageId: "msg-1",
+        },
+      ],
+    });
+
+    const html = renderComposer({ input: "", canSendAttachments: false });
+    expect(sendButtonHasDisabledAttr(html)).toBe(false);
   });
 
   test("ready (input + not disabled + nothing uploading) leaves the button enabled", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -22,6 +22,7 @@ import {
     selectUploadingCount,
     useComposerStore,
 } from "@/domains/chat/composer-store";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
@@ -189,6 +190,10 @@ export function ChatComposer({
     attachmentsUploadingCount === 0 &&
     (selectUploadedIds(attachments).length > 0 ||
       selectPathReferencePaths(attachments).length > 0);
+  const stagedQuotes = useQuoteReplyStore.use.stagedQuotes();
+  const hasStagedQuotes = stagedQuotes.length > 0;
+  const hasSendableContent =
+    !!input.trim() || canSendAttachments || hasStagedQuotes;
 
   const voicePhase = useVoiceRecordingStore.use.phase();
   const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
@@ -518,6 +523,7 @@ export function ChatComposer({
                     {
                       input,
                       canSendAttachments,
+                      hasStagedQuotes,
                       sendDisabled,
                       attachmentsUploadingCount,
                       cmdEnterMode,
@@ -597,8 +603,8 @@ export function ChatComposer({
               <div className="flex items-center gap-1">
                 {canStopGenerating ? (
                   <>
-                    {/* Desktop: always show stop. Mobile: show stop only when user has no input. */}
-                    {(!isMobile || (!input.trim() && !canSendAttachments)) && (
+                    {/* Desktop: always show stop. Mobile: show stop only when there is no queued send content. */}
+                    {(!isMobile || !hasSendableContent) && (
                       <Button
                         variant="primary"
                         iconOnly={
@@ -608,8 +614,8 @@ export function ChatComposer({
                         aria-label="Stop generating"
                       />
                     )}
-                    {/* Mobile: show send instead of stop when user has typed input (for message queueing). */}
-                    {isMobile && (input.trim() || canSendAttachments) && (
+                    {/* Mobile: show send instead of stop when content can be queued. */}
+                    {isMobile && hasSendableContent && (
                       <Button
                         variant="primary"
                         iconOnly={
@@ -684,10 +690,10 @@ export function ChatComposer({
                         disabled={
                           sendDisabled ||
                           attachmentsUploadingCount > 0 ||
-                          (!input.trim() && !canSendAttachments)
+                          !hasSendableContent
                         }
                         title={
-                          sendDisabled || (!input.trim() && !canSendAttachments)
+                          sendDisabled || !hasSendableContent
                             ? "Type a message to send"
                             : attachmentsUploadingCount > 0
                               ? "Uploading attachments…"


### PR DESCRIPTION
## Summary
- Count staged quote replies as sendable composer content.
- Keep keyboard submit and mobile send/stop visibility in sync with the send button.
- Add composer regression coverage for staged quote replies.

## Original prompt
User reported that the reply-to-message UI left the send button disabled even when quote replies were already staged in context, and asked for the button to be enabled and a PR opened.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->