### PR TITLE
feat(assistant): gateway-backed verification-session client over IPC

### DIFF
--- a/assistant/src/channels/__tests__/gateway-verification-sessions.test.ts
+++ b/assistant/src/channels/__tests__/gateway-verification-sessions.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Tests for the gateway-backed verification-session client.
+ *
+ * The IPC transport is stubbed; each wrapper is exercised for method/param
+ * mapping, contract-schema validation of responses, error propagation
+ * (lifecycle wrappers throw fail-closed; validate-consume returns the
+ * generic failure), and shape parity with the daemon session-service
+ * results.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { VerificationSessionWire } from "@vellumai/gateway-client";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcResponse: unknown;
+let ipcError: Error | null = null;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) {
+      throw ipcError;
+    }
+    return ipcResponse;
+  },
+);
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+const client = await import("../gateway-verification-sessions.js");
+const { composeApprovalMessage } = await import(
+  "../../runtime/approval-message-composer.js"
+);
+
+function makeWireSession(
+  overrides: Partial<VerificationSessionWire> = {},
+): VerificationSessionWire {
+  return {
+    id: "sess-1",
+    channel: "telegram",
+    challengeHash: "a".repeat(64),
+    expiresAt: 1_700_000_600_000,
+    status: "pending",
+    sourceConversationId: null,
+    consumedByExternalUserId: null,
+    consumedByChatId: null,
+    expectedExternalUserId: null,
+    expectedChatId: null,
+    expectedPhoneE164: null,
+    identityBindingStatus: null,
+    destinationAddress: null,
+    lastSentAt: null,
+    sendCount: 0,
+    nextResendAt: null,
+    codeDigits: 6,
+    maxAttempts: 3,
+    verificationPurpose: "guardian",
+    bootstrapTokenHash: null,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+const GENERIC_VERIFY_FAILED = composeApprovalMessage({
+  scenario: "guardian_verify_failed",
+  failureReason: "The verification code is invalid or has expired.",
+});
+
+beforeEach(() => {
+  ipcCalls = [];
+  ipcResponse = undefined;
+  ipcError = null;
+});
+
+describe("createInboundVerificationSession", () => {
+  test("returns the service result shape with a daemon-composed instruction", async () => {
+    const session = makeWireSession();
+    ipcResponse = {
+      session,
+      secret: "s3cret-hex",
+      verifyCommand: "s3cret-hex",
+      ttlSeconds: 600,
+    };
+
+    const result = await client.createInboundVerificationSession(
+      "telegram",
+      "conv-xyz",
+    );
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_create_inbound",
+        params: { channel: "telegram", sourceConversationId: "conv-xyz" },
+      },
+    ]);
+    expect(result).toEqual({
+      challengeId: "sess-1",
+      secret: "s3cret-hex",
+      verifyCommand: "s3cret-hex",
+      ttlSeconds: 600,
+      instruction: composeApprovalMessage({
+        scenario: "guardian_verify_challenge_setup",
+        channel: "telegram",
+        verifyCommand: "s3cret-hex",
+      }),
+    });
+    expect(result.instruction).toContain("s3cret-hex");
+  });
+
+  test("throws on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.createInboundVerificationSession("telegram"),
+    ).rejects.toThrow("gateway unavailable");
+  });
+
+  test("throws on a malformed response", async () => {
+    ipcResponse = { secret: "s3cret-hex" };
+    await expect(
+      client.createInboundVerificationSession("telegram"),
+    ).rejects.toThrow("verification_sessions_create_inbound");
+  });
+});
+
+describe("createOutboundSession", () => {
+  test("forwards params and returns the parsed create result", async () => {
+    ipcResponse = {
+      sessionId: "sess-2",
+      secret: "123456",
+      challengeHash: "b".repeat(64),
+      expiresAt: 1_700_000_600_000,
+      ttlSeconds: 600,
+    };
+
+    const result = await client.createOutboundSession({
+      channel: "phone",
+      expectedPhoneE164: "+15555550123",
+      destinationAddress: "+15555550123",
+      codeDigits: 6,
+      verificationPurpose: "guardian",
+    });
+
+    expect(ipcCalls[0]?.method).toBe("verification_sessions_create_outbound");
+    expect(ipcCalls[0]?.params).toEqual({
+      channel: "phone",
+      expectedPhoneE164: "+15555550123",
+      destinationAddress: "+15555550123",
+      codeDigits: 6,
+      verificationPurpose: "guardian",
+    });
+    expect(result).toEqual({
+      sessionId: "sess-2",
+      secret: "123456",
+      challengeHash: "b".repeat(64),
+      expiresAt: 1_700_000_600_000,
+      ttlSeconds: 600,
+    });
+  });
+
+  test("throws on a malformed response", async () => {
+    ipcResponse = { sessionId: "sess-2" };
+    await expect(
+      client.createOutboundSession({ channel: "phone" }),
+    ).rejects.toThrow("verification_sessions_create_outbound");
+  });
+
+  test("throws on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.createOutboundSession({ channel: "phone" }),
+    ).rejects.toThrow("gateway unavailable");
+  });
+});
+
+describe("session lookups", () => {
+  test("getPendingSession returns the wire session", async () => {
+    const session = makeWireSession();
+    ipcResponse = session;
+
+    const result = await client.getPendingSession("telegram");
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_get_pending",
+        params: { channel: "telegram" },
+      },
+    ]);
+    expect(result).toEqual(session);
+  });
+
+  test("getPendingSession returns null when no session exists", async () => {
+    ipcResponse = null;
+    expect(await client.getPendingSession("telegram")).toBeNull();
+  });
+
+  test("findActiveSession round-trips and returns null on null", async () => {
+    const session = makeWireSession({
+      status: "awaiting_response",
+      identityBindingStatus: "bound",
+      expectedPhoneE164: "+15555550123",
+    });
+    ipcResponse = session;
+    expect(await client.findActiveSession("phone")).toEqual(session);
+    expect(ipcCalls[0]).toEqual({
+      method: "verification_sessions_find_active",
+      params: { channel: "phone" },
+    });
+
+    ipcResponse = null;
+    expect(await client.findActiveSession("phone")).toBeNull();
+  });
+
+  test("lookups throw on a malformed session payload", async () => {
+    ipcResponse = { id: "sess-1" };
+    await expect(client.getPendingSession("telegram")).rejects.toThrow(
+      "verification_sessions_get_pending",
+    );
+    await expect(client.findActiveSession("telegram")).rejects.toThrow(
+      "verification_sessions_find_active",
+    );
+  });
+
+  test("lookups throw on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(client.getPendingSession("telegram")).rejects.toThrow(
+      "gateway unavailable",
+    );
+  });
+});
+
+describe("resolveBootstrapToken", () => {
+  test("relays the RAW token — hashing is gateway-side", async () => {
+    const session = makeWireSession({
+      status: "pending_bootstrap",
+      identityBindingStatus: "pending_bootstrap",
+      bootstrapTokenHash: "c".repeat(64),
+    });
+    ipcResponse = session;
+
+    const result = await client.resolveBootstrapToken(
+      "telegram",
+      "raw-deep-link-token",
+    );
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_resolve_bootstrap",
+        params: { channel: "telegram", token: "raw-deep-link-token" },
+      },
+    ]);
+    expect(result).toEqual(session);
+  });
+
+  test("returns null when no session matches", async () => {
+    ipcResponse = null;
+    expect(
+      await client.resolveBootstrapToken("telegram", "raw-deep-link-token"),
+    ).toBeNull();
+  });
+});
+
+describe("session mutations", () => {
+  test("bindSessionIdentity sends identity fields and resolves on ok", async () => {
+    ipcResponse = { ok: true };
+    await client.bindSessionIdentity("sess-1", "user-123", "chat-456");
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_bind_identity",
+        params: {
+          sessionId: "sess-1",
+          externalUserId: "user-123",
+          chatId: "chat-456",
+        },
+      },
+    ]);
+  });
+
+  test("updateSessionStatus maps extra consumed-by fields", async () => {
+    ipcResponse = { ok: true };
+    await client.updateSessionStatus("sess-1", "consumed", {
+      consumedByExternalUserId: "user-123",
+      consumedByChatId: "chat-456",
+    });
+    expect(ipcCalls[0]?.method).toBe("verification_sessions_update_status");
+    expect(ipcCalls[0]?.params).toEqual({
+      sessionId: "sess-1",
+      status: "consumed",
+      consumedByExternalUserId: "user-123",
+      consumedByChatId: "chat-456",
+    });
+  });
+
+  test("updateSessionStatus works without extra fields", async () => {
+    ipcResponse = { ok: true };
+    await client.updateSessionStatus("sess-1", "revoked");
+    expect(ipcCalls[0]?.params).toEqual({
+      sessionId: "sess-1",
+      status: "revoked",
+      consumedByExternalUserId: undefined,
+      consumedByChatId: undefined,
+    });
+  });
+
+  test("updateSessionDelivery sends delivery tracking fields", async () => {
+    ipcResponse = { ok: true };
+    await client.updateSessionDelivery("sess-1", 1_700_000_100_000, 2, null);
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_update_delivery",
+        params: {
+          sessionId: "sess-1",
+          lastSentAt: 1_700_000_100_000,
+          sendCount: 2,
+          nextResendAt: null,
+        },
+      },
+    ]);
+  });
+
+  test("revokePendingSessions sends the channel", async () => {
+    ipcResponse = { ok: true };
+    await client.revokePendingSessions("phone");
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_revoke_pending",
+        params: { channel: "phone" },
+      },
+    ]);
+  });
+
+  test("mutations throw on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.bindSessionIdentity("sess-1", "user-123", "chat-456"),
+    ).rejects.toThrow("gateway unavailable");
+    await expect(client.revokePendingSessions("phone")).rejects.toThrow(
+      "gateway unavailable",
+    );
+  });
+
+  test("mutations throw when the gateway does not ack ok", async () => {
+    ipcResponse = { ok: false };
+    await expect(
+      client.updateSessionStatus("sess-1", "revoked"),
+    ).rejects.toThrow("verification_sessions_update_status");
+  });
+
+  test("mutations throw on a malformed ack", async () => {
+    ipcResponse = { acknowledged: true };
+    await expect(
+      client.updateSessionDelivery("sess-1", 1, 1, null),
+    ).rejects.toThrow("verification_sessions_update_delivery");
+  });
+});
+
+describe("countRecentSendsToDestination", () => {
+  test("returns the count from the gateway", async () => {
+    ipcResponse = { count: 3 };
+    const count = await client.countRecentSendsToDestination(
+      "phone",
+      "+15555550123",
+      60_000,
+    );
+    expect(count).toBe(3);
+    expect(ipcCalls).toEqual([
+      {
+        method: "verification_sessions_count_recent_sends",
+        params: {
+          channel: "phone",
+          destinationAddress: "+15555550123",
+          windowMs: 60_000,
+        },
+      },
+    ]);
+  });
+
+  test("throws on a malformed response — the throttle must not fail open", async () => {
+    ipcResponse = { total: 3 };
+    await expect(
+      client.countRecentSendsToDestination("phone", "+15555550123", 60_000),
+    ).rejects.toThrow("verification_sessions_count_recent_sends");
+  });
+
+  test("throws on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.countRecentSendsToDestination("phone", "+15555550123", 60_000),
+    ).rejects.toThrow("gateway unavailable");
+  });
+});
+
+describe("validateAndConsumeVerification", () => {
+  test("passes through a successful consume for each purpose", async () => {
+    ipcResponse = { success: true, verificationType: "guardian" };
+    expect(
+      await client.validateAndConsumeVerification(
+        "phone",
+        "123456",
+        "+15555550123",
+        "+15555550123",
+      ),
+    ).toEqual({ success: true, verificationType: "guardian" });
+    expect(ipcCalls[0]).toEqual({
+      method: "verification_sessions_validate_consume",
+      params: {
+        channel: "phone",
+        secret: "123456",
+        actorExternalUserId: "+15555550123",
+        actorChatId: "+15555550123",
+      },
+    });
+
+    ipcResponse = { success: true, verificationType: "trusted_contact" };
+    expect(
+      await client.validateAndConsumeVerification(
+        "telegram",
+        "654321",
+        "user-123",
+        "chat-456",
+      ),
+    ).toEqual({ success: true, verificationType: "trusted_contact" });
+  });
+
+  test("composes the generic user-facing reason from a machine-readable failure", async () => {
+    ipcResponse = { success: false, reason: "rate_limited" };
+    const result = await client.validateAndConsumeVerification(
+      "telegram",
+      "000000",
+      "user-123",
+      "chat-456",
+    );
+    expect(result).toEqual({ success: false, reason: GENERIC_VERIFY_FAILED });
+    // Anti-oracle: the machine reason never leaks into the user-facing copy.
+    expect(GENERIC_VERIFY_FAILED).not.toContain("rate_limited");
+  });
+
+  test("fails closed without throwing on transport failure", async () => {
+    ipcError = new Error("gateway unavailable");
+    expect(
+      await client.validateAndConsumeVerification(
+        "phone",
+        "123456",
+        "+15555550123",
+        "+15555550123",
+      ),
+    ).toEqual({ success: false, reason: GENERIC_VERIFY_FAILED });
+  });
+
+  test("fails closed on a malformed response", async () => {
+    ipcResponse = { success: "yes" };
+    expect(
+      await client.validateAndConsumeVerification(
+        "phone",
+        "123456",
+        "+15555550123",
+        "+15555550123",
+      ),
+    ).toEqual({ success: false, reason: GENERIC_VERIFY_FAILED });
+  });
+});

--- a/assistant/src/channels/gateway-verification-sessions.ts
+++ b/assistant/src/channels/gateway-verification-sessions.ts
@@ -1,0 +1,291 @@
+/**
+ * Gateway-backed verification-session client.
+ *
+ * Typed async wrappers over the gateway's `verification_sessions_*` IPC
+ * routes. The gateway owns the `channel_verification_sessions` table and
+ * mints all secrets; the daemon relays lifecycle operations here and keeps
+ * message composition and channel delivery. Responses are validated against
+ * the shared contract schemas in `@vellumai/gateway-client` — the same
+ * schemas the gateway routes are pinned to.
+ *
+ * Export names mirror the daemon session service
+ * (`assistant/src/runtime/channel-verification-service.ts`) so call-site
+ * flips are mechanical: same names, same result shapes, sync → async.
+ *
+ * Error posture (fail-closed — there is no local fallback):
+ * - Lifecycle wrappers THROW on any transport failure or malformed
+ *   response. Control-plane callers surface the error to the user;
+ *   inbound-stage callers catch and degrade to a plain deny.
+ * - `validateAndConsumeVerification` never throws: any failure — transport
+ *   included — is the generic invalid-code result, preserving the consume
+ *   path's anti-oracle posture (no signal about WHY a code was rejected).
+ */
+
+import {
+  CountRecentSendsIpcResponseSchema,
+  CreateInboundSessionIpcResponseSchema,
+  type CreateOutboundSessionIpcParams,
+  CreateOutboundSessionIpcResponseSchema,
+  SessionLookupIpcResponseSchema,
+  SessionMutationIpcResponseSchema,
+  type SessionStatus,
+  ValidateConsumeSessionIpcResponseSchema,
+  VERIFICATION_SESSIONS_IPC_METHODS,
+  type VerificationSessionsIpcMethod,
+  type VerificationSessionWire,
+} from "@vellumai/gateway-client";
+import type { ZodType } from "zod";
+
+import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { composeApprovalMessage } from "../runtime/approval-message-composer.js";
+import type {
+  CreateOutboundSessionResult,
+  CreateVerificationSessionResult,
+  ValidateVerificationResult,
+} from "../runtime/channel-verification-service.js";
+
+export type {
+  CreateOutboundSessionResult,
+  CreateVerificationSessionResult,
+  ValidateVerificationResult,
+} from "../runtime/channel-verification-service.js";
+export type { VerificationSessionWire } from "@vellumai/gateway-client";
+
+/**
+ * Call a gateway session route and validate the response against its
+ * contract schema. Throws on transport failure or a malformed response.
+ */
+async function callGateway<T>(
+  method: VerificationSessionsIpcMethod,
+  params: Record<string, unknown>,
+  responseSchema: ZodType<T>,
+): Promise<T> {
+  const result = await ipcCallPersistent(method, params);
+  const parsed = responseSchema.safeParse(result);
+  if (!parsed.success) {
+    throw new Error(`Gateway returned a malformed ${method} response`);
+  }
+  return parsed.data;
+}
+
+/** Call a mutation route; throws unless the gateway acks `{ ok: true }`. */
+async function callMutation(
+  method: VerificationSessionsIpcMethod,
+  params: Record<string, unknown>,
+): Promise<void> {
+  const ack = await callGateway(method, params, SessionMutationIpcResponseSchema);
+  if (!ack.ok) {
+    throw new Error(`Gateway rejected ${method}`);
+  }
+}
+
+/**
+ * Create an inbound verification session for a guardian candidate. The
+ * gateway mints the high-entropy secret and persists only its hash; the
+ * `instruction` copy is composed daemon-side from the returned secret.
+ * Throws when the gateway is unreachable (fail-closed, user-visible).
+ */
+export async function createInboundVerificationSession(
+  channel: string,
+  conversationId?: string,
+): Promise<CreateVerificationSessionResult> {
+  const response = await callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.createInbound,
+    { channel, sourceConversationId: conversationId },
+    CreateInboundSessionIpcResponseSchema,
+  );
+  return {
+    challengeId: response.session.id,
+    secret: response.secret,
+    verifyCommand: response.verifyCommand,
+    ttlSeconds: response.ttlSeconds,
+    instruction: composeApprovalMessage({
+      scenario: "guardian_verify_challenge_setup",
+      channel,
+      verifyCommand: response.verifyCommand,
+    }),
+  };
+}
+
+/**
+ * Create an outbound verification session with expected identity pre-set.
+ * The gateway mints the secret (numeric when identity is bound, hex for
+ * `pending_bootstrap`); it transits back for daemon-owned delivery.
+ * Throws when the gateway is unreachable (fail-closed, user-visible).
+ */
+export async function createOutboundSession(
+  params: CreateOutboundSessionIpcParams,
+): Promise<CreateOutboundSessionResult> {
+  return callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.createOutbound,
+    params as unknown as Record<string, unknown>,
+    CreateOutboundSessionIpcResponseSchema,
+  );
+}
+
+/**
+ * Look up the pending (status `pending`, non-expired) inbound session for a
+ * channel. Throws when the gateway is unreachable — callers on soft paths
+ * catch and treat the read as inconclusive.
+ */
+export async function getPendingSession(
+  channel: string,
+): Promise<VerificationSessionWire | null> {
+  return callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.getPending,
+    { channel },
+    SessionLookupIpcResponseSchema,
+  );
+}
+
+/**
+ * Find the most recent active outbound session (`pending_bootstrap` /
+ * `awaiting_response`) for a channel. Throws when the gateway is
+ * unreachable — callers on soft paths catch and treat the read as
+ * inconclusive.
+ */
+export async function findActiveSession(
+  channel: string,
+): Promise<VerificationSessionWire | null> {
+  return callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.findActive,
+    { channel },
+    SessionLookupIpcResponseSchema,
+  );
+}
+
+/**
+ * Resolve a bootstrap deep-link token to its `pending_bootstrap` session.
+ * Takes the RAW token — hashing happens gateway-side so the scheme stays
+ * pinned to the stored `bootstrap_token_hash` values. Throws when the
+ * gateway is unreachable.
+ */
+export async function resolveBootstrapToken(
+  channel: string,
+  token: string,
+): Promise<VerificationSessionWire | null> {
+  return callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.resolveBootstrap,
+    { channel, token },
+    SessionLookupIpcResponseSchema,
+  );
+}
+
+/**
+ * Telegram bootstrap completion: bind the expected identity fields and flip
+ * `identity_binding_status` to bound. Throws on any failure (fail-closed).
+ */
+export async function bindSessionIdentity(
+  id: string,
+  externalUserId: string,
+  chatId: string,
+): Promise<void> {
+  await callMutation(VERIFICATION_SESSIONS_IPC_METHODS.bindIdentity, {
+    sessionId: id,
+    externalUserId,
+    chatId,
+  });
+}
+
+/**
+ * Transition a session's status. Throws on any failure (fail-closed).
+ */
+export async function updateSessionStatus(
+  id: string,
+  status: SessionStatus,
+  extraFields?: Partial<{
+    consumedByExternalUserId: string;
+    consumedByChatId: string;
+  }>,
+): Promise<void> {
+  await callMutation(VERIFICATION_SESSIONS_IPC_METHODS.updateStatus, {
+    sessionId: id,
+    status,
+    consumedByExternalUserId: extraFields?.consumedByExternalUserId,
+    consumedByChatId: extraFields?.consumedByChatId,
+  });
+}
+
+/**
+ * Update outbound delivery tracking fields on a session. Throws on any
+ * failure (fail-closed).
+ */
+export async function updateSessionDelivery(
+  id: string,
+  lastSentAt: number,
+  sendCount: number,
+  nextResendAt: number | null,
+): Promise<void> {
+  await callMutation(VERIFICATION_SESSIONS_IPC_METHODS.updateDelivery, {
+    sessionId: id,
+    lastSentAt,
+    sendCount,
+    nextResendAt,
+  });
+}
+
+/**
+ * Count sends to a destination across all sessions within a rolling window
+ * (destination-level send throttle input). Throws when the gateway is
+ * unreachable — the throttle must not fail open.
+ */
+export async function countRecentSendsToDestination(
+  channel: string,
+  destinationAddress: string,
+  windowMs: number,
+): Promise<number> {
+  const response = await callGateway(
+    VERIFICATION_SESSIONS_IPC_METHODS.countRecentSends,
+    { channel, destinationAddress, windowMs },
+    CountRecentSendsIpcResponseSchema,
+  );
+  return response.count;
+}
+
+/**
+ * Revoke all pending sessions for a channel (user cancelled verification).
+ * Throws on any failure (fail-closed).
+ */
+export async function revokePendingSessions(channel: string): Promise<void> {
+  await callMutation(VERIFICATION_SESSIONS_IPC_METHODS.revokePending, {
+    channel,
+  });
+}
+
+function genericVerifyFailedReason(): string {
+  return composeApprovalMessage({
+    scenario: "guardian_verify_failed",
+    failureReason: "The verification code is invalid or has expired.",
+  });
+}
+
+/**
+ * Validate and consume a verification challenge at the gateway (rate
+ * limiting, identity binding, status-guarded single consume, in-engine role
+ * side effects).
+ *
+ * Never throws. Every failure — including gateway-unreachable and malformed
+ * responses — returns the same generic invalid-code result: the consume
+ * path is fail-closed and anti-oracle, so the machine-readable gateway
+ * reason is deliberately not surfaced to the actor.
+ */
+export async function validateAndConsumeVerification(
+  channel: string,
+  secret: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+): Promise<ValidateVerificationResult> {
+  try {
+    const response = await callGateway(
+      VERIFICATION_SESSIONS_IPC_METHODS.validateConsume,
+      { channel, secret, actorExternalUserId, actorChatId },
+      ValidateConsumeSessionIpcResponseSchema,
+    );
+    if (response.success) {
+      return { success: true, verificationType: response.verificationType };
+    }
+    return { success: false, reason: genericVerifyFailedReason() };
+  } catch {
+    return { success: false, reason: genericVerifyFailedReason() };
+  }
+}


### PR DESCRIPTION
## Summary
- Typed async wrappers for all 11 verification_sessions_* IPC methods via ipcCallPersistent, contract-validated
- Fail-closed error posture (transport errors throw); daemon-side composeApprovalMessage keeps CreateVerificationSessionResult shape
- Additive only — no call sites flipped yet

Part of plan: verif-sessions-gateway-native.md (PR 6 of 12)