### PR TITLE
feat(gateway): verification_sessions_validate_consume — gateway-native validation, rate limiting, and binding side effects

### DIFF
--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -1,0 +1,609 @@
+/**
+ * Tests for the gateway-native validate+consume path
+ * (`validateAndConsumeSession`) and its in-engine role side effects.
+ *
+ * Runs against a real (temp-dir) gateway DB; only the assistant-side IPC
+ * boundary is mocked (db proxy, identity mirror, contact-info reads).
+ * Properties pinned here:
+ *
+ * - status-guarded single consume: a code is spendable exactly once, even
+ *   under concurrent attempts, and never yields two bindings;
+ * - anti-oracle failures: lockout, wrong code, expiry, identity mismatch,
+ *   and blocked actors all return the same machine-readable reason;
+ * - guardian phone binding happens synchronously at consume time (no
+ *   poller), with the ATL-514 recency guard and deliberate-rebind
+ *   semantics ported from outbound-voice-verification-sync;
+ * - trusted-contact consume upserts the verified channel idempotently and
+ *   fails closed on a blocked authoritative gateway row.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { and, eq } from "drizzle-orm";
+
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Assistant-side boundary mocks (must precede the dynamic imports below)
+// ---------------------------------------------------------------------------
+
+// db_proxy — backed by an in-process sqlite DB with the mirror tables the
+// consume path touches (rate-limit dual-writes, trusted-contact mirror
+// lookup).
+let testAssistantDb: Database | null = null;
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  async assistantDbQuery(sql: string, bind?: unknown[]) {
+    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
+    const stmt = testAssistantDb.prepare(sql);
+     
+    return bind ? stmt.all(...(bind as any[])) : stmt.all();
+  },
+  async assistantDbRun(sql: string, bind?: unknown[]) {
+    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
+    const stmt = testAssistantDb.prepare(sql);
+     
+    const result = bind ? stmt.run(...(bind as any[])) : stmt.run();
+    return {
+      changes: result.changes,
+      lastInsertRowid: Number(result.lastInsertRowid),
+    };
+  },
+  async assistantDbExec(sql: string) {
+    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
+    testAssistantDb.exec(sql);
+  },
+}));
+
+// Identity-mirror IPC — recorded and acked; the gateway DB stays the ACL
+// source of truth in these tests.
+const mirrorCalls: { method: string; params: unknown }[] = [];
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: async (method: string, params: unknown) => {
+    mirrorCalls.push({ method, params });
+    return {};
+  },
+  IpcHandlerError: class IpcHandlerError extends Error {},
+}));
+
+// Contact-info reads (daemon-backed) — no known contacts by default.
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: async () => null,
+  probeContactMirror: async () => ({ exists: false, hasChannels: false }),
+}));
+
+// The assistant socket is absent (orphan-GC probes and similar short-circuit).
+mock.module("../ipc/socket-path.js", () => ({
+  resolveIpcSocketPath: () => ({
+    path: "/nonexistent/assistant.sock",
+    source: "test",
+  }),
+}));
+
+const { getGatewayDb, initGatewayDb, resetGatewayDb } = await import(
+  "../db/connection.js"
+);
+const {
+  channelGuardianRateLimits,
+  channelVerificationSessions,
+  contactChannels,
+  contacts,
+} = await import("../db/schema.js");
+const {
+  VALIDATE_CONSUME_FAILURE_REASON,
+  createOutboundSession,
+  createPhoneGuardianBinding,
+  validateAndConsumeSession,
+} = await import("../verification/session-service.js");
+const { getRateLimit } = await import("../verification/rate-limit-helpers.js");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PHONE = "+15555550123";
+const OTHER_PHONE = "+15555550199";
+const OLD_GUARDIAN_PHONE = "+15555550100";
+
+const GENERIC_FAILURE = {
+  success: false,
+  reason: VALIDATE_CONSUME_FAILURE_REASON,
+} as const;
+
+function seedAssistantMirrorTables(db: Database): void {
+  db.exec(`
+    CREATE TABLE contacts (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      role TEXT NOT NULL DEFAULT 'contact',
+      principal_id TEXT,
+      user_file TEXT,
+      contact_type TEXT NOT NULL DEFAULT 'human'
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      verified_at INTEGER,
+      verified_via TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER
+    );
+    CREATE TABLE channel_guardian_rate_limits (
+      id TEXT PRIMARY KEY,
+      channel TEXT NOT NULL,
+      actor_external_user_id TEXT NOT NULL,
+      actor_chat_id TEXT NOT NULL,
+      attempt_timestamps_json TEXT NOT NULL DEFAULT '[]',
+      locked_until INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (channel, actor_external_user_id, actor_chat_id)
+    );
+  `);
+}
+
+/** Seed a guardian contact + phone channel directly in the gateway DB. */
+function seedGuardianPhoneBinding(opts: {
+  contactId: string;
+  address: string;
+  status: "active" | "revoked";
+  updatedAt: number;
+}): void {
+  const db = getGatewayDb();
+  db.insert(contacts)
+    .values({
+      id: opts.contactId,
+      displayName: `Guardian ${opts.contactId}`,
+      role: "guardian",
+      principalId: `principal-${opts.contactId}`,
+      createdAt: opts.updatedAt - 60_000,
+      updatedAt: opts.updatedAt,
+    })
+    .run();
+  db.insert(contactChannels)
+    .values({
+      id: `ch-${opts.contactId}`,
+      contactId: opts.contactId,
+      type: "phone",
+      address: opts.address,
+      externalChatId: opts.address,
+      isPrimary: true,
+      status: opts.status,
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: opts.updatedAt - 60_000,
+      updatedAt: opts.updatedAt,
+    })
+    .run();
+}
+
+function guardianPhoneBindings(): { address: string; status: string }[] {
+  return getGatewayDb()
+    .select({
+      address: contactChannels.address,
+      status: contactChannels.status,
+    })
+    .from(contacts)
+    .innerJoin(contactChannels, eq(contactChannels.contactId, contacts.id))
+    .where(
+      and(eq(contacts.role, "guardian"), eq(contactChannels.type, "phone")),
+    )
+    .all();
+}
+
+function activeGuardianPhoneBindings(): { address: string }[] {
+  return guardianPhoneBindings()
+    .filter((b) => b.status === "active")
+    .map((b) => ({ address: b.address }));
+}
+
+function sessionRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(channelVerificationSessions)
+    .where(eq(channelVerificationSessions.id, id))
+    .get();
+}
+
+function createPhoneGuardianSession(phone: string = PHONE) {
+  return createOutboundSession({
+    channel: "phone",
+    expectedPhoneE164: phone,
+    destinationAddress: phone,
+    verificationPurpose: "guardian",
+  });
+}
+
+function createPhoneTrustedContactSession(phone: string = PHONE) {
+  return createOutboundSession({
+    channel: "phone",
+    expectedPhoneE164: phone,
+    destinationAddress: phone,
+    verificationPurpose: "trusted_contact",
+  });
+}
+
+beforeEach(async () => {
+  testAssistantDb = new Database(":memory:");
+  seedAssistantMirrorTables(testAssistantDb);
+  mirrorCalls.length = 0;
+
+  resetGatewayDb();
+  await initGatewayDb();
+  const db = getGatewayDb();
+  db.delete(channelVerificationSessions).run();
+  db.delete(channelGuardianRateLimits).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+  testAssistantDb?.close();
+  testAssistantDb = null;
+});
+
+// ---------------------------------------------------------------------------
+// Guardian (outbound voice shape) — binding at consume time
+// ---------------------------------------------------------------------------
+
+describe("guardian consume — synchronous phone binding", () => {
+  test("success consumes the session and creates the binding with no polling dependency", async () => {
+    const { sessionId, secret } = createPhoneGuardianSession();
+
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(result).toEqual({ success: true, verificationType: "guardian" });
+
+    const row = sessionRow(sessionId);
+    expect(row?.status).toBe("consumed");
+    expect(row?.consumedByExternalUserId).toBe(PHONE);
+    expect(row?.consumedByChatId).toBe(PHONE);
+
+    // The binding exists immediately after the call returns — the poller's
+    // job happened in-engine, synchronously.
+    expect(activeGuardianPhoneBindings()).toEqual([{ address: PHONE }]);
+  });
+
+  test("replayed secret fails closed and never yields a second binding", async () => {
+    const { secret } = createPhoneGuardianSession();
+
+    expect(
+      (await validateAndConsumeSession("phone", secret, PHONE, PHONE)).success,
+    ).toBe(true);
+
+    // IPC re-delivery of the same consume: the status guard makes the
+    // session unmatchable, so the retry fails with the generic reason.
+    const replay = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(replay).toEqual(GENERIC_FAILURE);
+
+    // Re-running the side effect directly is also idempotent (binding for
+    // the same number already exists → skip).
+    await createPhoneGuardianBinding(PHONE, PHONE, Date.now());
+
+    expect(guardianPhoneBindings()).toEqual([
+      { address: PHONE, status: "active" },
+    ]);
+  });
+
+  test("concurrent consume: exactly one winner, exactly one binding", async () => {
+    const { secret } = createPhoneGuardianSession();
+
+    const results = await Promise.all([
+      validateAndConsumeSession("phone", secret, PHONE, PHONE),
+      validateAndConsumeSession("phone", secret, PHONE, PHONE),
+    ]);
+
+    expect(results.filter((r) => r.success)).toHaveLength(1);
+    expect(activeGuardianPhoneBindings()).toEqual([{ address: PHONE }]);
+  });
+
+  test("deliberate rebind: revokes a conflicting guardian binding for another number", async () => {
+    seedGuardianPhoneBinding({
+      contactId: "c-old",
+      address: OLD_GUARDIAN_PHONE,
+      status: "active",
+      updatedAt: Date.now() - 60_000,
+    });
+
+    const { secret } = createPhoneGuardianSession(PHONE);
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(result.success).toBe(true);
+
+    // Outbound verification is guardian-initiated, so the conflicting old
+    // binding is revoked rather than skipped (unlike the inbound path).
+    const bindings = guardianPhoneBindings();
+    expect(bindings).toContainEqual({
+      address: OLD_GUARDIAN_PHONE,
+      status: "revoked",
+    });
+    expect(activeGuardianPhoneBindings()).toEqual([{ address: PHONE }]);
+  });
+
+  test("ATL-514: a binding event newer than the consume blocks the (stale) binding", async () => {
+    // A guardian binding for this number was revoked AFTER this session will
+    // be consumed (clock-skewed future timestamp models the poller-lookback /
+    // retry replay shape). The consume itself succeeds — the session is
+    // legitimately spent — but the stale side effect must not reactivate the
+    // revoked binding.
+    seedGuardianPhoneBinding({
+      contactId: "c-revoked",
+      address: PHONE,
+      status: "revoked",
+      updatedAt: Date.now() + 60_000,
+    });
+
+    const { secret } = createPhoneGuardianSession(PHONE);
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(result.success).toBe(true);
+
+    expect(activeGuardianPhoneBindings()).toEqual([]);
+    expect(guardianPhoneBindings()).toEqual([
+      { address: PHONE, status: "revoked" },
+    ]);
+  });
+
+  test("guardian consume on a non-phone channel applies no side effect", async () => {
+    const { sessionId, secret } = createOutboundSession({
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-1",
+      expectedChatId: "tg-chat-1",
+      verificationPurpose: "guardian",
+    });
+
+    const result = await validateAndConsumeSession(
+      "telegram",
+      secret,
+      "tg-user-1",
+      "tg-chat-1",
+    );
+    expect(result).toEqual({ success: true, verificationType: "guardian" });
+    expect(sessionRow(sessionId)?.status).toBe("consumed");
+    expect(guardianPhoneBindings()).toEqual([]);
+    expect(mirrorCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting + anti-oracle failures
+// ---------------------------------------------------------------------------
+
+describe("rate limiting and anti-oracle failures", () => {
+  test("wrong code: generic failure, attempt recorded, session stays consumable", async () => {
+    const { sessionId, secret } = createPhoneGuardianSession();
+
+    const bad = await validateAndConsumeSession(
+      "phone",
+      "000000",
+      PHONE,
+      PHONE,
+    );
+    expect(bad).toEqual(GENERIC_FAILURE);
+
+    const rl = getRateLimit("phone", PHONE, PHONE);
+    expect(JSON.parse(rl?.attemptTimestampsJson ?? "[]")).toHaveLength(1);
+    expect(rl?.lockedUntil).toBeNull();
+    expect(sessionRow(sessionId)?.status).toBe("awaiting_response");
+
+    // Success afterwards resets the counter.
+    const ok = await validateAndConsumeSession("phone", secret, PHONE, PHONE);
+    expect(ok.success).toBe(true);
+    const reset = getRateLimit("phone", PHONE, PHONE);
+    expect(JSON.parse(reset?.attemptTimestampsJson ?? "[]")).toHaveLength(0);
+    expect(reset?.lockedUntil).toBeNull();
+  });
+
+  test("lockout after 5 invalid attempts: even the correct code fails while locked", async () => {
+    const { sessionId, secret } = createPhoneGuardianSession();
+
+    for (let i = 0; i < 5; i++) {
+      const res = await validateAndConsumeSession(
+        "phone",
+        "000000",
+        PHONE,
+        PHONE,
+      );
+      expect(res).toEqual(GENERIC_FAILURE);
+    }
+
+    const rl = getRateLimit("phone", PHONE, PHONE);
+    expect(rl?.lockedUntil).toBeGreaterThan(Date.now());
+
+    const locked = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(locked).toEqual(GENERIC_FAILURE);
+    expect(sessionRow(sessionId)?.status).toBe("awaiting_response");
+    expect(activeGuardianPhoneBindings()).toEqual([]);
+  });
+
+  test("identity mismatch: same generic failure as a wrong code, attempt recorded", async () => {
+    const { sessionId, secret } = createPhoneGuardianSession(PHONE);
+
+    const res = await validateAndConsumeSession(
+      "phone",
+      secret,
+      OTHER_PHONE,
+      OTHER_PHONE,
+    );
+    // Anti-oracle: indistinguishable from a wrong code.
+    expect(res).toEqual(GENERIC_FAILURE);
+
+    const rl = getRateLimit("phone", OTHER_PHONE, OTHER_PHONE);
+    expect(JSON.parse(rl?.attemptTimestampsJson ?? "[]")).toHaveLength(1);
+    expect(sessionRow(sessionId)?.status).toBe("awaiting_response");
+    expect(activeGuardianPhoneBindings()).toEqual([]);
+  });
+
+  test("expired session: generic failure, attempt recorded", async () => {
+    const { sessionId, secret } = createPhoneGuardianSession();
+    getGatewayDb()
+      .update(channelVerificationSessions)
+      .set({ expiresAt: Date.now() - 1_000 })
+      .where(eq(channelVerificationSessions.id, sessionId))
+      .run();
+
+    const res = await validateAndConsumeSession("phone", secret, PHONE, PHONE);
+    expect(res).toEqual(GENERIC_FAILURE);
+    const rl = getRateLimit("phone", PHONE, PHONE);
+    expect(JSON.parse(rl?.attemptTimestampsJson ?? "[]")).toHaveLength(1);
+    expect(sessionRow(sessionId)?.status).toBe("awaiting_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trusted contact — verified channel upsert
+// ---------------------------------------------------------------------------
+
+describe("trusted-contact consume — verified channel upsert", () => {
+  test("success upserts the verified gateway channel (no guardian binding)", async () => {
+    const { sessionId, secret } = createPhoneTrustedContactSession();
+
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+    expect(result).toEqual({
+      success: true,
+      verificationType: "trusted_contact",
+    });
+    expect(sessionRow(sessionId)?.status).toBe("consumed");
+
+    const channel = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, "phone"),
+          eq(contactChannels.address, PHONE),
+        ),
+      )
+      .get();
+    expect(channel?.status).toBe("active");
+    expect(channel?.policy).toBe("allow");
+    expect(channel?.verifiedVia).toBe("challenge");
+
+    const contact = getGatewayDb()
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, channel!.contactId))
+      .get();
+    expect(contact?.role).toBe("contact");
+    expect(guardianPhoneBindings()).toEqual([]);
+
+    // The identity mirror was told about the channel (ACL stays gateway-side).
+    expect(
+      mirrorCalls.some((c) => c.method === "contacts_mirror_upsert_channel"),
+    ).toBe(true);
+  });
+
+  test("re-verification is idempotent: one (type,address) channel row", async () => {
+    const first = createPhoneTrustedContactSession();
+    expect(
+      (await validateAndConsumeSession("phone", first.secret, PHONE, PHONE))
+        .success,
+    ).toBe(true);
+
+    const second = createPhoneTrustedContactSession();
+    expect(
+      (await validateAndConsumeSession("phone", second.secret, PHONE, PHONE))
+        .success,
+    ).toBe(true);
+
+    const rows = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, "phone"),
+          eq(contactChannels.address, PHONE),
+        ),
+      )
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("active");
+  });
+
+  test("blocked actor: correct code fails closed, channel stays blocked", async () => {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(contacts)
+      .values({
+        id: "c-blocked",
+        displayName: "Blocked",
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "ch-blocked",
+        contactId: "c-blocked",
+        type: "phone",
+        address: PHONE,
+        isPrimary: false,
+        status: "blocked",
+        policy: "deny",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const { sessionId, secret } = createPhoneTrustedContactSession();
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+
+    // Same generic failure (anti-oracle), the one-time code is spent, and
+    // the authoritative blocked row is untouched.
+    expect(result).toEqual(GENERIC_FAILURE);
+    expect(sessionRow(sessionId)?.status).toBe("consumed");
+    const channel = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch-blocked"))
+      .get();
+    expect(channel?.status).toBe("blocked");
+    expect(channel?.policy).toBe("deny");
+  });
+});

--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -95,6 +95,9 @@ const {
   createPhoneGuardianBinding,
   validateAndConsumeSession,
 } = await import("../verification/session-service.js");
+const { consumeSession: storeConsumeSession } = await import(
+  "../db/session-store.js"
+);
 const { getRateLimit } = await import("../verification/rate-limit-helpers.js");
 
 // ---------------------------------------------------------------------------
@@ -370,6 +373,30 @@ describe("guardian consume — synchronous phone binding", () => {
     expect(guardianPhoneBindings()).toEqual([
       { address: PHONE, status: "revoked" },
     ]);
+  });
+
+  test("ATL-514 anchor: the recency guard uses the persisted consume timestamp", async () => {
+    const { sessionId } = createPhoneGuardianSession(PHONE);
+
+    const result = storeConsumeSession(sessionId, PHONE, PHONE);
+    if (!result.consumed) throw new Error("expected consume to succeed");
+
+    // The returned timestamp is exactly the row's persisted updated_at.
+    expect(result.consumedAt).toBe(sessionRow(sessionId)!.updatedAt);
+
+    // A guardian revoke lands after the consume was persisted but before the
+    // binding side effect runs (IPC retry / replay shape). Anchored on the
+    // persisted timestamp the stale binding is rejected; a re-sampled clock
+    // would have looked newer than the revoke and rebound.
+    seedGuardianPhoneBinding({
+      contactId: "c-newer-revoke",
+      address: PHONE,
+      status: "revoked",
+      updatedAt: result.consumedAt + 1,
+    });
+    await createPhoneGuardianBinding(PHONE, PHONE, result.consumedAt);
+
+    expect(activeGuardianPhoneBindings()).toEqual([]);
   });
 
   test("blocked actor: correct code fails closed, existing guardian is not revoked", async () => {

--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -372,6 +372,66 @@ describe("guardian consume — synchronous phone binding", () => {
     ]);
   });
 
+  test("blocked actor: correct code fails closed, existing guardian is not revoked", async () => {
+    seedGuardianPhoneBinding({
+      contactId: "c-current",
+      address: OLD_GUARDIAN_PHONE,
+      status: "active",
+      updatedAt: Date.now() - 60_000,
+    });
+
+    const now = Date.now();
+    getGatewayDb()
+      .insert(contacts)
+      .values({
+        id: "c-blocked",
+        displayName: "Blocked",
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "ch-blocked",
+        contactId: "c-blocked",
+        type: "phone",
+        address: PHONE,
+        isPrimary: false,
+        status: "blocked",
+        policy: "deny",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const { sessionId, secret } = createPhoneGuardianSession(PHONE);
+    const result = await validateAndConsumeSession(
+      "phone",
+      secret,
+      PHONE,
+      PHONE,
+    );
+
+    // Same generic failure (anti-oracle), the one-time code is spent, the
+    // current guardian keeps the binding, and no binding is created for the
+    // blocked number.
+    expect(result).toEqual(GENERIC_FAILURE);
+    expect(sessionRow(sessionId)?.status).toBe("consumed");
+    expect(activeGuardianPhoneBindings()).toEqual([
+      { address: OLD_GUARDIAN_PHONE },
+    ]);
+    const channel = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch-blocked"))
+      .get();
+    expect(channel?.status).toBe("blocked");
+    expect(channel?.policy).toBe("deny");
+  });
+
   test("guardian consume on a non-phone channel applies no side effect", async () => {
     const { sessionId, secret } = createOutboundSession({
       channel: "telegram",

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -386,15 +386,18 @@ describe("findSessionByIdentity", () => {
 // ---------------------------------------------------------------------------
 
 describe("consumeSession", () => {
-  test("consumes an interceptable session and stamps the actor", () => {
+  test("consumes an interceptable session, stamps the actor, and returns the persisted timestamp", () => {
     insertRaw({ id: "s1", status: "awaiting_response" });
 
-    expect(consumeSession("s1", "user-1", "chat-1")).toBe(true);
+    const result = consumeSession("s1", "user-1", "chat-1");
+    if (!result.consumed) throw new Error("expected consume to succeed");
 
     const row = getRow("s1");
     expect(row?.status).toBe("consumed");
     expect(row?.consumedByExternalUserId).toBe("user-1");
     expect(row?.consumedByChatId).toBe("chat-1");
+    // consumedAt is the exact updated_at written by the consume UPDATE.
+    expect(result.consumedAt).toBe(row!.updatedAt);
   });
 
   test("exactly one of two racing consumers wins", () => {
@@ -403,8 +406,8 @@ describe("consumeSession", () => {
     const first = consumeSession("s1", "user-1", "chat-1");
     const second = consumeSession("s1", "user-2", "chat-2");
 
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(first.consumed).toBe(true);
+    expect(second).toEqual({ consumed: false });
 
     // The loser must not overwrite the winner's actor stamp.
     const row = getRow("s1");
@@ -412,7 +415,7 @@ describe("consumeSession", () => {
     expect(row?.consumedByChatId).toBe("chat-1");
   });
 
-  test("returns false for consumed/revoked/expired/verified/locked rows", () => {
+  test("does not consume consumed/revoked/expired/verified/locked rows", () => {
     for (const status of [
       "consumed",
       "revoked",
@@ -421,13 +424,17 @@ describe("consumeSession", () => {
       "locked",
     ] as SessionStatus[]) {
       insertRaw({ id: `s-${status}`, status });
-      expect(consumeSession(`s-${status}`, "user-1", "chat-1")).toBe(false);
+      expect(consumeSession(`s-${status}`, "user-1", "chat-1")).toEqual({
+        consumed: false,
+      });
       expect(getRow(`s-${status}`)?.status).toBe(status);
     }
   });
 
-  test("returns false for a nonexistent session", () => {
-    expect(consumeSession("missing", "user-1", "chat-1")).toBe(false);
+  test("does not consume a nonexistent session", () => {
+    expect(consumeSession("missing", "user-1", "chat-1")).toEqual({
+      consumed: false,
+    });
   });
 });
 

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -228,20 +228,28 @@ export function findPendingSessionForChannel(
   return row ? rowToSession(row) : null;
 }
 
+export type ConsumeSessionResult =
+  | { consumed: true; consumedAt: number }
+  | { consumed: false };
+
 /**
  * Mark a session consumed. The status guard ensures atomicity under
  * concurrent consumers — only the first wins; later attempts (or attempts
  * on already-consumed/revoked/expired-status rows) see zero changes and
- * return false, preserving one-time-code semantics.
+ * return `{consumed: false}`, preserving one-time-code semantics.
+ *
+ * On success, `consumedAt` is the exact `updated_at` written by the UPDATE,
+ * so callers anchoring recency checks (ATL-514) never re-sample the clock.
  */
 export function consumeSession(
   id: string,
   actorExternalUserId: string,
   actorChatId: string,
-): boolean {
+): ConsumeSessionResult {
   // Raw client because drizzle's bun-sqlite run() does not surface the
   // changes count needed for the single-consumer guarantee.
   const raw = (getGatewayDb() as unknown as { $client: Database }).$client;
+  const consumedAt = Date.now();
   const changes = raw
     .prepare(
       `UPDATE channel_verification_sessions
@@ -252,9 +260,9 @@ export function consumeSession(
        WHERE id = ?
          AND status IN (${INTERCEPTABLE_STATUSES_SQL})`,
     )
-    .run(actorExternalUserId, actorChatId, Date.now(), id).changes;
+    .run(actorExternalUserId, actorChatId, consumedAt, id).changes;
 
-  return changes > 0;
+  return changes > 0 ? { consumed: true, consumedAt } : { consumed: false };
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/ipc/__tests__/verification-session-routes.test.ts
+++ b/gateway/src/ipc/__tests__/verification-session-routes.test.ts
@@ -7,8 +7,9 @@
  * and wire-shaped responses. The key security property pinned here: secrets
  * are minted gateway-side and only their SHA-256 hashes are persisted.
  *
- * `verification_sessions_validate_consume` ships separately and is asserted
- * absent.
+ * `verification_sessions_validate_consume` registration/schema is pinned
+ * here; its validation, rate-limiting, and side-effect behavior is covered
+ * by gateway/src/__tests__/verification-session-consume.test.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -21,6 +22,7 @@ import {
   CreateInboundSessionIpcResponseSchema,
   CreateOutboundSessionIpcResponseSchema,
   VERIFICATION_SESSIONS_IPC_METHODS,
+  ValidateConsumeSessionIpcResponseSchema,
   VerificationSessionSchema,
   hashVerificationSecret,
 } from "@vellumai/gateway-client";
@@ -114,27 +116,13 @@ afterEach(() => {
 });
 
 describe("route registration", () => {
-  test("registers exactly the 10 lifecycle methods, each with a schema", () => {
-    const lifecycleMethods = Object.values(METHODS).filter(
-      (m) => m !== METHODS.validateConsume,
-    );
+  test("registers all 11 verification_sessions_* methods, each with a schema", () => {
     expect(verificationSessionRoutes.map((r) => r.method).sort()).toEqual(
-      [...lifecycleMethods].sort(),
+      Object.values(METHODS).sort(),
     );
     for (const route of verificationSessionRoutes) {
       expect(route.schema).toBeDefined();
     }
-  });
-
-  test("validate_consume is not registered yet → 404 UNKNOWN_METHOD", async () => {
-    const res = await rpc(METHODS.validateConsume, {
-      channel: "telegram",
-      secret: "s",
-      actorExternalUserId: "u",
-      actorChatId: "c",
-    });
-    expect(res.statusCode).toBe(404);
-    expect(res.errorCode).toBe("UNKNOWN_METHOD");
   });
 });
 
@@ -380,6 +368,45 @@ describe("mutation routes: bind / update_status / update_delivery / revoke", () 
   });
 });
 
+describe("verification_sessions_validate_consume", () => {
+  test("round-trip: wrong code fails generically; correct code consumes once", async () => {
+    // Behavioral depth (side effects, rate limiting, ATL-514) is covered by
+    // verification-session-consume.test.ts — this pins the wire shape.
+    const created = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        expectedExternalUserId: "tg-user-1",
+        expectedChatId: "tg-chat-1",
+      }),
+    );
+    const actor = {
+      channel: "telegram",
+      actorExternalUserId: "tg-user-1",
+      actorChatId: "tg-chat-1",
+    };
+
+    const bad = ValidateConsumeSessionIpcResponseSchema.parse(
+      await call(METHODS.validateConsume, { ...actor, secret: "000000" }),
+    );
+    expect(bad).toEqual({ success: false, reason: "invalid_or_expired" });
+
+    const ok = ValidateConsumeSessionIpcResponseSchema.parse(
+      await call(METHODS.validateConsume, { ...actor, secret: created.secret }),
+    );
+    expect(ok).toEqual({ success: true, verificationType: "guardian" });
+
+    const row = getRow(created.sessionId);
+    expect(row?.status).toBe("consumed");
+    expect(row?.consumedByExternalUserId).toBe("tg-user-1");
+
+    // One-time code: the replay fails.
+    const replay = ValidateConsumeSessionIpcResponseSchema.parse(
+      await call(METHODS.validateConsume, { ...actor, secret: created.secret }),
+    );
+    expect(replay.success).toBe(false);
+  });
+});
+
 describe("schema rejection", () => {
   test("malformed params → 400 BAD_REQUEST without touching the store", async () => {
     const badCalls: Array<[string, Record<string, unknown>]> = [
@@ -396,6 +423,8 @@ describe("schema rejection", () => {
         { channel: "phone", destinationAddress: "+15555550142", windowMs: -1 },
       ],
       [METHODS.revokePending, { channel: 42 }],
+      [METHODS.validateConsume, { channel: "phone", secret: "123456" }], // actor ids required
+      [METHODS.validateConsume, { channel: "phone", secret: "" }],
     ];
 
     for (const [method, params] of badCalls) {

--- a/gateway/src/ipc/verification-session-handlers.ts
+++ b/gateway/src/ipc/verification-session-handlers.ts
@@ -8,9 +8,10 @@
  * Raw secrets transit back in the create responses because message
  * composition and channel delivery stay daemon-owned.
  *
- * These are the 10 lifecycle methods. `verification_sessions_validate_consume`
- * (gateway-native validation, rate limiting, and in-engine role side effects)
- * ships separately.
+ * All 11 methods live here: the 10 lifecycle methods plus
+ * `verification_sessions_validate_consume` (gateway-native validation, rate
+ * limiting, and in-engine role side effects — the guardian binding / contact
+ * upsert happen at consume time, in the engine, never in the daemon).
  *
  * Request/response shapes are pinned by the shared contract in
  * `@vellumai/gateway-client` (verification-session-contract.ts); the daemon
@@ -30,6 +31,7 @@ import {
   UpdateSessionDeliveryIpcParamsSchema,
   UpdateSessionStatusIpcParamsSchema,
   VERIFICATION_SESSIONS_IPC_METHODS,
+  ValidateConsumeSessionIpcParamsSchema,
   hashVerificationSecret,
 } from "@vellumai/gateway-client";
 
@@ -46,6 +48,7 @@ import {
 import {
   createInboundVerificationSession,
   createOutboundSession,
+  validateAndConsumeSession,
 } from "../verification/session-service.js";
 import type { IpcRoute } from "./server.js";
 
@@ -163,6 +166,24 @@ export const verificationSessionRoutes: IpcRoute[] = [
       const { channel } = RevokePendingSessionsIpcParamsSchema.parse(params);
       revokePendingSessions(channel);
       return { ok: true };
+    },
+  },
+  {
+    // Gateway-native validate+consume: rate limiting, identity binding,
+    // status-guarded atomic consume, and in-engine role side effects. On
+    // failure `reason` is a machine-readable code (one code for all failure
+    // classes — anti-oracle); the daemon composes the user-facing copy.
+    method: VERIFICATION_SESSIONS_IPC_METHODS.validateConsume,
+    schema: ValidateConsumeSessionIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { channel, secret, actorExternalUserId, actorChatId } =
+        ValidateConsumeSessionIpcParamsSchema.parse(params);
+      return validateAndConsumeSession(
+        channel,
+        secret,
+        actorExternalUserId,
+        actorChatId,
+      );
     },
   },
 ];

--- a/gateway/src/verification/outbound-voice-verification-sync.ts
+++ b/gateway/src/verification/outbound-voice-verification-sync.ts
@@ -27,17 +27,17 @@
 
 import { existsSync } from "node:fs";
 
-import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { noteIpcReachable, noteIpcTransportError } from "../ipc/ipc-health.js";
 import { getLogger } from "../logger.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
-import {
-  getExistingGuardianBinding,
-  getMostRecentChannelGuardianTimestamp,
-  resolveCanonicalPrincipal,
-  revokeExistingChannelGuardian,
-} from "./binding-helpers.js";
+import { createPhoneGuardianBinding } from "./session-service.js";
+
+// The binding logic (ATL-514 recency check, deliberate-rebind semantics)
+// moved to the session service, which now also applies it synchronously at
+// consume time via verification_sessions_validate_consume. Re-exported here
+// for this module's tests until the poller is deleted.
+export { createPhoneGuardianBinding };
 
 const log = getLogger("outbound-voice-verification-sync");
 
@@ -151,72 +151,3 @@ async function syncOutboundVoiceVerifications(): Promise<void> {
   }
 }
 
-export async function createPhoneGuardianBinding(
-  phoneNumber: string,
-  chatId: string,
-  sessionUpdatedAt: number,
-): Promise<void> {
-  // Recency check (security backstop, ATL-514). The poller's lookback
-  // window can include sessions that were consumed legitimately at the
-  // time but have since been superseded — by manual revocation, or by a
-  // sibling binding path (e.g. inbound verification).
-  // `getExistingGuardianBinding` only checks active bindings, so without
-  // this guard we would reactivate a revoked binding or revoke an active
-  // one in favor of a stale session.
-  const lastBindingTs = await getMostRecentChannelGuardianTimestamp("phone");
-  if (lastBindingTs != null && sessionUpdatedAt <= lastBindingTs) {
-    log.warn(
-      { phoneNumber, sessionUpdatedAt, lastBindingTs },
-      "Outbound voice verification sync: session older than most recent binding event; skipping (replay-protection)",
-    );
-    return;
-  }
-
-  const canonicalPrincipal = await resolveCanonicalPrincipal(phoneNumber);
-  const existingBinding = await getExistingGuardianBinding("phone");
-
-  if (existingBinding) {
-    if (existingBinding.address === phoneNumber) {
-      // Idempotent — binding already exists for this number. Can happen
-      // on gateway restart when the in-memory cursor falls back to the
-      // 24h lookback and re-encounters an already-processed session, or
-      // if the poller fires twice before lastSyncAt advances.
-      log.info(
-        { phoneNumber },
-        "Outbound voice verification sync: binding already exists, skipping",
-      );
-      return;
-    }
-
-    // A different number holds the phone guardian binding — revoke it first.
-    //
-    // This is an intentional behavioral difference from the inbound path
-    // (twilio-voice-verify-callback.ts), which logs and skips on conflict.
-    // Outbound calls are guardian-initiated by definition: only the trusted
-    // guardian can command the assistant to dial a specific number with
-    // expected_phone_e164 set. So an outbound code-redemption is always a
-    // deliberate rebind. Inbound's conservative skip exists because anyone
-    // could call in with a stolen code; outbound has no such attack surface.
-    //
-    // The recency check above ensures we only rebind when the consumed
-    // session is newer than the current binding's last-touched timestamp.
-    log.warn(
-      { phoneNumber, existingGuardian: existingBinding.address },
-      "Outbound voice verification sync: revoking conflicting phone guardian binding",
-    );
-    await revokeExistingChannelGuardian("phone");
-  }
-
-  await createGuardianBinding({
-    channel: "phone",
-    externalUserId: phoneNumber,
-    deliveryChatId: chatId,
-    guardianPrincipalId: canonicalPrincipal,
-    verifiedVia: "challenge",
-  });
-
-  log.info(
-    { phoneNumber, canonicalPrincipal },
-    "Outbound voice verification sync: guardian phone binding created",
-  );
-}

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -246,16 +246,20 @@ export async function validateAndConsumeSession(
     return CONSUME_FAILURE;
   }
 
-  // Status-guarded atomic consume: a false return means a concurrent
+  // Status-guarded atomic consume: a non-consumed return means a concurrent
   // consumer already won, so this attempt fails (one-time-code semantics).
-  if (!consumeSession(session.id, actorExternalUserId, actorChatId)) {
+  const consumeResult = consumeSession(
+    session.id,
+    actorExternalUserId,
+    actorChatId,
+  );
+  if (!consumeResult.consumed) {
     log.warn(
       { sessionId: session.id },
       "Session already consumed by concurrent request",
     );
     return CONSUME_FAILURE;
   }
-  const consumedAt = Date.now();
 
   await resetRateLimit(channel, actorExternalUserId, actorChatId);
 
@@ -293,11 +297,12 @@ export async function validateAndConsumeSession(
 
     // Guardian purpose on the outbound voice shape (an expected phone number
     // is only ever set by startOutboundVoice) — exactly the filter the
-    // retired poller used. Bind synchronously at consume time.
+    // retired poller used. Bind synchronously at consume time, anchored on
+    // the persisted consume timestamp (never a fresh clock sample).
     await createPhoneGuardianBinding(
       actorExternalUserId,
       actorChatId,
-      consumedAt,
+      consumeResult.consumedAt,
     );
   }
 
@@ -310,8 +315,9 @@ export async function validateAndConsumeSession(
  * poller is deleted, by outbound-voice-verification-sync replays — both are
  * idempotent here).
  *
- * `sessionUpdatedAt` is the session's consume timestamp; it anchors the
- * recency check below.
+ * `sessionUpdatedAt` is the session's persisted consume timestamp (the
+ * `updated_at` written by the consume UPDATE); it anchors the recency check
+ * below.
  */
 export async function createPhoneGuardianBinding(
   phoneNumber: string,

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -38,6 +38,7 @@ import {
   resolveCanonicalPrincipal,
   revokeExistingChannelGuardian,
 } from "./binding-helpers.js";
+import { gatewayChannelStatus } from "./contact-helpers.js";
 import { checkIdentityMatch } from "./identity-match.js";
 import {
   isRateLimited,
@@ -203,7 +204,9 @@ const CONSUME_FAILURE: ValidateConsumeSessionResult = {
  * must never happen in the (potentially prompt-injected) daemon:
  * - guardian purpose on phone with an expected number (the outbound voice
  *   shape): create the phone guardian binding synchronously — this replaces
- *   the outbound-voice-verification-sync poller.
+ *   the outbound-voice-verification-sync poller. A blocked authoritative
+ *   gateway row rejects the verification first (mirrors the text guardian
+ *   path).
  * - trusted_contact purpose: upsert the verified contact channel; a
  *   blocked/revoked authoritative gateway row rejects the verification even
  *   though the code matched (mirrors text-verification).
@@ -273,6 +276,21 @@ export async function validateAndConsumeSession(
       return CONSUME_FAILURE;
     }
   } else if (channel === "phone" && session.expectedPhoneE164 != null) {
+    // Mirrors the text guardian path's gateway-status guard: a blocked
+    // authoritative row must not report success — createGuardianBinding
+    // leaves blocked rows untouched, so without this guard a blocked-number
+    // rebind would revoke the current guardian and bind nobody. Checked
+    // after consume (same ordering as the text path); revoked rows stay
+    // rebindable here — outbound rebinds are guardian-initiated and the
+    // ATL-514 recency guard covers staleness.
+    if (gatewayChannelStatus(channel, actorExternalUserId) === "blocked") {
+      log.warn(
+        { channel, actorExternalUserId },
+        "Guardian phone binding rejected: gateway channel is blocked",
+      );
+      return CONSUME_FAILURE;
+    }
+
     // Guardian purpose on the outbound voice shape (an expected phone number
     // is only ever set by startOutboundVoice) — exactly the filter the
     // retired poller used. Bind synchronously at consume time.

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -8,24 +8,45 @@
  * composition and channel delivery stay daemon-owned — mirror of how
  * invite mint returns data and the daemon composes presentation.
  *
- * Validate-and-consume is deliberately NOT here yet; it lands with the
- * `verification_sessions_validate_consume` route (in-engine role side
- * effects replace the outbound-voice-verification-sync poller).
+ * Validate-and-consume lives here too (the
+ * `verification_sessions_validate_consume` route): rate limiting, identity
+ * binding, the status-guarded atomic consume, and the in-engine role side
+ * effects (guardian phone binding / trusted-contact channel upsert) that
+ * replace the outbound-voice-verification-sync poller.
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
 
 import { hashVerificationSecret } from "@vellumai/gateway-client";
 
+import { createGuardianBinding } from "../auth/guardian-bootstrap.js";
 import type {
   IdentityBindingStatus,
   VerificationPurpose,
   VerificationSession,
 } from "../db/session-store.js";
 import {
+  consumeSession,
   createInboundSession,
   createOutboundSession as storeCreateOutboundSession,
+  findPendingSessionByHash,
 } from "../db/session-store.js";
+import { getLogger } from "../logger.js";
+import {
+  getExistingGuardianBinding,
+  getMostRecentChannelGuardianTimestamp,
+  resolveCanonicalPrincipal,
+  revokeExistingChannelGuardian,
+} from "./binding-helpers.js";
+import { checkIdentityMatch } from "./identity-match.js";
+import {
+  isRateLimited,
+  recordInvalidAttempt,
+  resetRateLimit,
+} from "./rate-limit-helpers.js";
+import { applyTrustedContactSideEffects } from "./text-verification.js";
+
+const log = getLogger("verification-session-service");
 
 /** Challenge TTL in milliseconds (10 minutes). */
 export const CHALLENGE_TTL_MS = 10 * 60 * 1000;
@@ -144,4 +165,201 @@ export function createOutboundSession(params: {
     expiresAt,
     ttlSeconds: CHALLENGE_TTL_MS / 1000,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Validate + consume
+// ---------------------------------------------------------------------------
+
+/**
+ * The single machine-readable failure reason for validate+consume.
+ *
+ * Anti-oracle: every failure path — rate-limit lockout, unknown/expired
+ * code, identity mismatch, concurrent consume, blocked actor — returns this
+ * same code so the response cannot leak WHY the attempt failed. The daemon
+ * composes the user-facing copy from it.
+ */
+export const VALIDATE_CONSUME_FAILURE_REASON = "invalid_or_expired";
+
+export type ValidateConsumeSessionResult =
+  | { success: true; verificationType: VerificationPurpose }
+  | { success: false; reason: string };
+
+const CONSUME_FAILURE: ValidateConsumeSessionResult = {
+  success: false,
+  reason: VALIDATE_CONSUME_FAILURE_REASON,
+};
+
+/**
+ * Validate and consume a verification challenge — gateway-native port of the
+ * daemon's `validateAndConsumeVerification`.
+ *
+ * Flow: rate-limit lockout check → hash lookup among interceptable,
+ * non-expired sessions → expected-identity binding check → status-guarded
+ * atomic consume (only the first concurrent consumer wins) → rate-limit
+ * reset → in-engine role side effects.
+ *
+ * Side effects are applied here, in the engine, because trust-graph writes
+ * must never happen in the (potentially prompt-injected) daemon:
+ * - guardian purpose on phone with an expected number (the outbound voice
+ *   shape): create the phone guardian binding synchronously — this replaces
+ *   the outbound-voice-verification-sync poller.
+ * - trusted_contact purpose: upsert the verified contact channel; a
+ *   blocked/revoked authoritative gateway row rejects the verification even
+ *   though the code matched (mirrors text-verification).
+ *
+ * On failure the invalid-attempt counter is incremented; after exceeding the
+ * threshold the actor is locked out for a cooldown. Success resets it.
+ */
+export async function validateAndConsumeSession(
+  channel: string,
+  secret: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+): Promise<ValidateConsumeSessionResult> {
+  // Lockout does not record another attempt (matches the daemon port).
+  if (isRateLimited(channel, actorExternalUserId, actorChatId)) {
+    return CONSUME_FAILURE;
+  }
+
+  // The store lookup enforces both interceptable status and expiry
+  // (expires_at > now), so an expired code lands here as "no match" —
+  // indistinguishable from a wrong code, as intended.
+  const session = findPendingSessionByHash(
+    channel,
+    hashVerificationSecret(secret),
+  );
+  if (!session) {
+    await recordInvalidAttempt(channel, actorExternalUserId, actorChatId);
+    return CONSUME_FAILURE;
+  }
+
+  // Expected-identity binding check (outbound sessions). checkIdentityMatch
+  // carries the daemon's rules verbatim: phone match, the shared-chatId
+  // caveat (externalUserId required when both are set), the
+  // externalUserId-only fallback, and the pending_bootstrap bypass.
+  if (!checkIdentityMatch(session, actorExternalUserId, actorChatId)) {
+    await recordInvalidAttempt(channel, actorExternalUserId, actorChatId);
+    return CONSUME_FAILURE;
+  }
+
+  // Status-guarded atomic consume: a false return means a concurrent
+  // consumer already won, so this attempt fails (one-time-code semantics).
+  if (!consumeSession(session.id, actorExternalUserId, actorChatId)) {
+    log.warn(
+      { sessionId: session.id },
+      "Session already consumed by concurrent request",
+    );
+    return CONSUME_FAILURE;
+  }
+  const consumedAt = Date.now();
+
+  await resetRateLimit(channel, actorExternalUserId, actorChatId);
+
+  if (session.verificationPurpose === "trusted_contact") {
+    // Mirrors text-verification: a blocked/revoked authoritative gateway row
+    // rejects the verification — the actor must not regain trusted status
+    // even though the code matched and the session is consumed.
+    const verified = await applyTrustedContactSideEffects({
+      sourceChannel: channel,
+      canonicalUserId: actorExternalUserId,
+      actorChatId,
+    });
+    if (!verified) {
+      log.warn(
+        { channel, actorExternalUserId },
+        "Trusted-contact verification rejected: gateway channel is blocked/revoked",
+      );
+      return CONSUME_FAILURE;
+    }
+  } else if (channel === "phone" && session.expectedPhoneE164 != null) {
+    // Guardian purpose on the outbound voice shape (an expected phone number
+    // is only ever set by startOutboundVoice) — exactly the filter the
+    // retired poller used. Bind synchronously at consume time.
+    await createPhoneGuardianBinding(
+      actorExternalUserId,
+      actorChatId,
+      consumedAt,
+    );
+  }
+
+  return { success: true, verificationType: session.verificationPurpose };
+}
+
+/**
+ * Create the guardian phone binding for a consumed outbound voice
+ * verification session. Called synchronously at consume time (and, until the
+ * poller is deleted, by outbound-voice-verification-sync replays — both are
+ * idempotent here).
+ *
+ * `sessionUpdatedAt` is the session's consume timestamp; it anchors the
+ * recency check below.
+ */
+export async function createPhoneGuardianBinding(
+  phoneNumber: string,
+  chatId: string,
+  sessionUpdatedAt: number,
+): Promise<void> {
+  // Recency check (security backstop, ATL-514) — retained as the
+  // idempotency/replay guard under IPC retries, poller replays, and gateway
+  // restarts: a consumed session can have been superseded by manual
+  // revocation or a sibling binding path (e.g. inbound verification).
+  // `getExistingGuardianBinding` only checks active bindings, so without
+  // this guard we would reactivate a revoked binding or revoke an active
+  // one in favor of a stale session.
+  const lastBindingTs = await getMostRecentChannelGuardianTimestamp("phone");
+  if (lastBindingTs != null && sessionUpdatedAt <= lastBindingTs) {
+    log.warn(
+      { phoneNumber, sessionUpdatedAt, lastBindingTs },
+      "Phone guardian binding: session older than most recent binding event; skipping (replay-protection)",
+    );
+    return;
+  }
+
+  const canonicalPrincipal = await resolveCanonicalPrincipal(phoneNumber);
+  const existingBinding = await getExistingGuardianBinding("phone");
+
+  if (existingBinding) {
+    if (existingBinding.address === phoneNumber) {
+      // Idempotent — binding already exists for this number. Can happen on
+      // an IPC retry of the consume, or when the poller re-encounters an
+      // already-processed session after a gateway restart.
+      log.info(
+        { phoneNumber },
+        "Phone guardian binding already exists, skipping",
+      );
+      return;
+    }
+
+    // A different number holds the phone guardian binding — revoke it first.
+    //
+    // This is an intentional behavioral difference from the inbound path
+    // (twilio-voice-verify-callback.ts), which logs and skips on conflict.
+    // Outbound calls are guardian-initiated by definition: only the trusted
+    // guardian can command the assistant to dial a specific number with
+    // expected_phone_e164 set. So an outbound code-redemption is always a
+    // deliberate rebind. Inbound's conservative skip exists because anyone
+    // could call in with a stolen code; outbound has no such attack surface.
+    //
+    // The recency check above ensures we only rebind when the consumed
+    // session is newer than the current binding's last-touched timestamp.
+    log.warn(
+      { phoneNumber, existingGuardian: existingBinding.address },
+      "Phone guardian binding: revoking conflicting phone guardian binding",
+    );
+    await revokeExistingChannelGuardian("phone");
+  }
+
+  await createGuardianBinding({
+    channel: "phone",
+    externalUserId: phoneNumber,
+    deliveryChatId: chatId,
+    guardianPrincipalId: canonicalPrincipal,
+    verifiedVia: "challenge",
+  });
+
+  log.info(
+    { phoneNumber, canonicalPrincipal },
+    "Guardian phone binding created",
+  );
 }

--- a/gateway/src/verification/text-verification.ts
+++ b/gateway/src/verification/text-verification.ts
@@ -378,7 +378,13 @@ async function applyGuardianSideEffects(params: {
   return true;
 }
 
-async function applyTrustedContactSideEffects(params: {
+/**
+ * Trusted-contact side effect for a consumed verification session:
+ * idempotent verified-channel upsert. Shared with the session service's
+ * validate+consume path so the write has exactly one implementation.
+ * Returns false when the authoritative gateway row is blocked/revoked.
+ */
+export async function applyTrustedContactSideEffects(params: {
   sourceChannel: string;
   canonicalUserId: string;
   actorChatId: string;


### PR DESCRIPTION
## Summary
- Ports validateAndConsumeVerification into the gateway session service: lockout check, hash lookup, expiry, identity-binding rules, status-guarded atomic consume, rate-limit reset
- In-engine side effects on consume: phone guardian binding (ATL-514 recency guard, deliberate-rebind) and trusted-contact channel upsert
- Exposes verification_sessions_validate_consume over the gateway socket; consume/race/lockout/rebind/idempotency tests

Part of plan: verif-sessions-gateway-native.md (PR 5 of 12)