### PR TITLE
[codex] Polish quote reply UI

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
@@ -10,6 +10,7 @@
 export interface ComposerKeyDownPolicy {
   input: string;
   canSendAttachments: boolean;
+  hasStagedQuotes?: boolean;
   sendDisabled: boolean;
   attachmentsUploadingCount: number;
   cmdEnterMode: boolean;
@@ -55,9 +56,14 @@ export function shouldSubmitOnEnter(
   // Cmd+Enter mode: only Cmd+Enter (Mac) or Ctrl+Enter (Win/Linux) submits;
   // bare Enter inserts a newline.
   if (policy.cmdEnterMode) {
-    if (!event.metaKey && !event.ctrlKey) return "ignore";
+    if (!event.metaKey && !event.ctrlKey) {
+      return "ignore";
+    }
   }
-  const hasContent = policy.input.trim() || policy.canSendAttachments;
+  const hasContent =
+    Boolean(policy.input.trim()) ||
+    policy.canSendAttachments ||
+    Boolean(policy.hasStagedQuotes);
   if (
     hasContent &&
     !policy.sendDisabled &&

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -25,6 +25,7 @@ import {
   computeGhostSuffix,
   shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 let mockIsMobile = false;
 mock.module("@/hooks/use-is-mobile", () => ({
@@ -230,6 +231,20 @@ describe("shouldSubmitOnEnter — guards still preventDefault but skip submit", 
       shouldSubmitOnEnter(ENTER, false, {
         input: "",
         canSendAttachments: true,
+        hasStagedQuotes: false,
+        sendDisabled: false,
+        attachmentsUploadingCount: 0,
+        cmdEnterMode: false,
+      }),
+    ).toBe("submit");
+  });
+
+  test("input is empty but staged quote context is ready", () => {
+    expect(
+      shouldSubmitOnEnter(ENTER, false, {
+        input: "",
+        canSendAttachments: false,
+        hasStagedQuotes: true,
         sendDisabled: false,
         attachmentsUploadingCount: 0,
         cmdEnterMode: false,
@@ -410,6 +425,10 @@ beforeEach(() => {
     attachmentLastError: null,
     restoredDraftConversationId: null,
   });
+  useQuoteReplyStore.setState({
+    stagedQuotes: [],
+    replyBubble: null,
+  });
 });
 
 /**
@@ -584,6 +603,21 @@ describe("ChatComposer — disabled submit guard", () => {
   test("empty input + no attachments disables the submit button", () => {
     const html = renderComposer({ input: "", canSendAttachments: false });
     expect(sendButtonHasDisabledAttr(html)).toBe(true);
+  });
+
+  test("empty input with staged quote context leaves the submit button enabled", () => {
+    useQuoteReplyStore.setState({
+      stagedQuotes: [
+        {
+          id: "quote-1",
+          quotedText: "quoted context",
+          replyText: "use this context",
+          sourceMessageId: "msg-1",
+        },
+      ],
+    });
+    const html = renderComposer({ input: "", canSendAttachments: false });
+    expect(sendButtonHasDisabledAttr(html)).toBe(false);
   });
 
   test("ready (input + not disabled + nothing uploading) leaves the button enabled", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -22,6 +22,7 @@ import {
     selectUploadingCount,
     useComposerStore,
 } from "@/domains/chat/composer-store";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
@@ -317,6 +318,10 @@ export function ChatComposer({
     isVoiceActive && !isLocallyGenerating && !isElectronHost;
   const hideTextareaForVoice =
     isNative && showInlineVoicePreview;
+  const hasStagedQuotes =
+    useQuoteReplyStore.use.stagedQuotes().length > 0;
+  const canSendMessageContent =
+    Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
 
   const ghostSuffix = useMemo(
     () =>
@@ -521,6 +526,7 @@ export function ChatComposer({
                       sendDisabled,
                       attachmentsUploadingCount,
                       cmdEnterMode,
+                      hasStagedQuotes,
                     },
                   );
                   if (decision === "ignore") {
@@ -597,8 +603,8 @@ export function ChatComposer({
               <div className="flex items-center gap-1">
                 {canStopGenerating ? (
                   <>
-                    {/* Desktop: always show stop. Mobile: show stop only when user has no input. */}
-                    {(!isMobile || (!input.trim() && !canSendAttachments)) && (
+                    {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
+                    {(!isMobile || !canSendMessageContent) && (
                       <Button
                         variant="primary"
                         iconOnly={
@@ -608,8 +614,8 @@ export function ChatComposer({
                         aria-label="Stop generating"
                       />
                     )}
-                    {/* Mobile: show send instead of stop when user has typed input (for message queueing). */}
-                    {isMobile && (input.trim() || canSendAttachments) && (
+                    {/* Mobile: show send instead of stop when content can be queued. */}
+                    {isMobile && canSendMessageContent && (
                       <Button
                         variant="primary"
                         iconOnly={
@@ -684,10 +690,10 @@ export function ChatComposer({
                         disabled={
                           sendDisabled ||
                           attachmentsUploadingCount > 0 ||
-                          (!input.trim() && !canSendAttachments)
+                          !canSendMessageContent
                         }
                         title={
-                          sendDisabled || (!input.trim() && !canSendAttachments)
+                          sendDisabled || !canSendMessageContent
                             ? "Type a message to send"
                             : attachmentsUploadingCount > 0
                               ? "Uploading attachments…"

--- a/clients/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -8,16 +8,16 @@ import {
   memo,
   useCallback,
 } from "react";
-
 import {
-    openMarkdownOAuthLinkInPopup,
-    shouldOpenMarkdownLinkInOAuthPopup,
-} from "@/domains/chat/utils/oauth-popup-links";
-import {
-    MarkdownMessage,
-    type MarkdownMessageProps,
+  MarkdownMessage,
+  type MarkdownMessageProps,
 } from "@vellumai/design-library";
 import { defaultUrlTransform } from "react-markdown";
+
+import {
+  openMarkdownOAuthLinkInPopup,
+  shouldOpenMarkdownLinkInOAuthPopup,
+} from "@/domains/chat/utils/oauth-popup-links";
 
 /** Returns true when `href` is a known `vellum://` attachment link. */
 export function isVellumLink(href: string | undefined): boolean {
@@ -83,6 +83,7 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
   content,
   className,
   hardLineBreaks,
+  blockquoteVariant,
   onVellumLinkClick,
 }: ChatMarkdownMessageProps) {
   const linkComponent = useCallback(
@@ -118,6 +119,7 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
       content={content}
       className={className}
       hardLineBreaks={hardLineBreaks}
+      blockquoteVariant={blockquoteVariant}
       linkComponent={linkComponent}
       urlTransform={vellumUrlTransform}
     />

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -533,19 +533,11 @@ export function ChatMainPanel({
 
   const sendDisabled = isSendDisabledFromTurn || typingDisabled;
 
-  const handleQuoteReplyNow = useCallback(
-    (quotedText: string, replyText: string) => {
-      if (sendDisabled) {
-        return;
-      }
-      const blockquote = quotedText
-        .split("\n")
-        .map((line) => `> ${line}`)
-        .join("\n");
-      void sendMessage(`${blockquote}\n\n${replyText}`);
-    },
-    [sendMessage, sendDisabled],
-  );
+  const handleQuoteAddedToChat = useCallback(() => {
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, [inputRef]);
 
   const isEmptyConversation =
     !!activeConversationId &&
@@ -1098,7 +1090,7 @@ export function ChatMainPanel({
       {sendErrorModalNode}
       {ruleEditorModalNode}
       <TextSelectionPopover containerRef={transcriptContainerRef} />
-      <QuoteReplyBubble onSendNow={handleQuoteReplyNow} />
+      <QuoteReplyBubble onAddToChat={handleQuoteAddedToChat} />
     </>
   );
 }

--- a/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
@@ -1,14 +1,13 @@
 /**
  * Overlay bubble that appears after the user starts a reply from a text
  * selection. Displays the quoted passage and a text input for the user's
- * reply, with two actions:
+ * reply, with one action:
  *
  * - **Add to Chat** — stages the quote+reply for inclusion in the next
  *   message the user sends from the composer.
- * - **Send Now** — immediately sends only the quote+reply as a new message.
  */
 
-import { MessageSquareQuote, Send, X } from "lucide-react";
+import { MessageSquareQuote, X } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
@@ -27,10 +26,10 @@ import {
 } from "@vellumai/design-library";
 
 interface QuoteReplyBubbleProps {
-  onSendNow: (quotedText: string, replyText: string) => void;
+  onAddToChat?: () => void;
 }
 
-export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
+export function QuoteReplyBubble({ onAddToChat }: QuoteReplyBubbleProps) {
   const replyBubble = useQuoteReplyStore.use.replyBubble();
   const closeReplyBubble = useQuoteReplyStore.use.closeReplyBubble();
   const addStagedQuote = useQuoteReplyStore.use.addStagedQuote();
@@ -57,15 +56,9 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
       replyText: replyText.trim(),
       sourceMessageId: replyBubble.sourceMessageId,
     });
-  }, [replyBubble, replyText, addStagedQuote]);
-
-  const handleSendNow = useCallback(() => {
-    if (!replyBubble || !replyText.trim()) {
-      return;
-    }
-    onSendNow(replyBubble.quotedText, replyText.trim());
+    onAddToChat?.();
     closeReplyBubble();
-  }, [replyBubble, replyText, onSendNow, closeReplyBubble]);
+  }, [replyBubble, replyText, addStagedQuote, onAddToChat, closeReplyBubble]);
 
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -73,12 +66,8 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
         e.preventDefault();
         handleAddToChat();
       }
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        handleSendNow();
-      }
     },
-    [handleAddToChat, handleSendNow],
+    [handleAddToChat],
   );
 
   if (!replyBubble) {
@@ -147,7 +136,7 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
             <Typography
               as="div"
               variant="body-small-default"
-              className="rounded-lg border-l-2 border-[var(--border-active)] bg-[var(--surface-lift)] px-3 py-2 text-[var(--content-secondary)]"
+              className="rounded-md border-l-2 border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-[var(--content-secondary)] [&_p]:mb-0"
             >
               {truncatedQuote}
             </Typography>
@@ -171,15 +160,6 @@ export function QuoteReplyBubble({ onSendNow }: QuoteReplyBubbleProps) {
                 disabled={!replyText.trim()}
               >
                 Add to Chat
-              </Button>
-              <Button
-                variant="primary"
-                size="compact"
-                onClick={handleSendNow}
-                disabled={!replyText.trim()}
-                rightIcon={<Send />}
-              >
-                Send Now
               </Button>
             </div>
           </Card.Body>

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -59,7 +59,20 @@ function installImmediateAnimationFrame() {
   };
 }
 
-function installSelection(anchorNode: Node) {
+function installSelection(
+  anchorNode: Node,
+  rect: DOMRect = {
+    top: 120,
+    left: 80,
+    width: 160,
+    height: 24,
+    right: 240,
+    bottom: 144,
+    x: 80,
+    y: 120,
+    toJSON: () => ({}),
+  },
+) {
   const originalGetSelection = window.getSelection;
   const selection = {
     isCollapsed: false,
@@ -67,17 +80,7 @@ function installSelection(anchorNode: Node) {
     anchorNode,
     toString: () => "competitive research",
     getRangeAt: () => ({
-      getBoundingClientRect: () => ({
-        top: 120,
-        left: 80,
-        width: 160,
-        height: 24,
-        right: 240,
-        bottom: 144,
-        x: 80,
-        y: 120,
-        toJSON: () => ({}),
-      }),
+      getBoundingClientRect: () => rect,
     }),
     removeAllRanges: () => {},
   } as unknown as Selection;
@@ -91,6 +94,20 @@ function installSelection(anchorNode: Node) {
     Object.defineProperty(window, "getSelection", {
       configurable: true,
       value: originalGetSelection,
+    });
+  };
+}
+
+function installViewportHeight(innerHeight: number) {
+  const originalInnerHeight = window.innerHeight;
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: innerHeight,
+  });
+  return () => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
     });
   };
 }
@@ -164,12 +181,12 @@ describe("TextSelectionPopover", () => {
         selectedText.firstChild ?? selectedText,
       );
       try {
-        fireEvent.mouseUp(selectedText);
+        document.dispatchEvent(new Event("selectionchange"));
+        await screen.findByRole("button", { name: "Reply" });
       } finally {
         restoreSelection();
       }
 
-      await screen.findByRole("button", { name: "Reply" });
       const popoverContent = document.body.querySelector(
         '[data-slot="popover-content"]',
       );
@@ -177,6 +194,47 @@ describe("TextSelectionPopover", () => {
         "bottom",
       );
     } finally {
+      restoreAnimationFrame();
+      restorePointer();
+    }
+  });
+
+  test("moves coarse-pointer Reply above selections when there is no space below", async () => {
+    const restorePointer = installCoarsePointer();
+    const restoreAnimationFrame = installImmediateAnimationFrame();
+    const restoreViewportHeight = installViewportHeight(160);
+    try {
+      const containerRef = createRef<HTMLDivElement | null>();
+      render(
+        <>
+          <div ref={containerRef}>
+            <div data-message-id="msg-1" data-message-role="assistant">
+              <span data-testid="selected-text">competitive research</span>
+            </div>
+          </div>
+          <TextSelectionPopover containerRef={containerRef} />
+        </>,
+      );
+
+      const selectedText = screen.getByTestId("selected-text");
+      const restoreSelection = installSelection(
+        selectedText.firstChild ?? selectedText,
+      );
+      try {
+        document.dispatchEvent(new Event("selectionchange"));
+        await screen.findByRole("button", { name: "Reply" });
+      } finally {
+        restoreSelection();
+      }
+
+      const popoverContent = document.body.querySelector(
+        '[data-slot="popover-content"]',
+      );
+      expect(popoverContent?.getAttribute("data-selection-placement")).toBe(
+        "top",
+      );
+    } finally {
+      restoreViewportHeight();
       restoreAnimationFrame();
       restorePointer();
     }

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -34,6 +34,20 @@ function installFinePointer() {
   };
 }
 
+function installCoarsePointer() {
+  const originalMatchMedia = window.matchMedia;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({ matches: true }),
+  });
+  return () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+  };
+}
+
 function installImmediateAnimationFrame() {
   const originalAnimationFrame = globalThis.requestAnimationFrame;
   globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -128,10 +142,49 @@ describe("TextSelectionPopover", () => {
       restorePointer();
     }
   });
+
+  test("shows Reply below coarse-pointer text selections", async () => {
+    const restorePointer = installCoarsePointer();
+    const restoreAnimationFrame = installImmediateAnimationFrame();
+    try {
+      const containerRef = createRef<HTMLDivElement | null>();
+      render(
+        <>
+          <div ref={containerRef}>
+            <div data-message-id="msg-1" data-message-role="assistant">
+              <span data-testid="selected-text">competitive research</span>
+            </div>
+          </div>
+          <TextSelectionPopover containerRef={containerRef} />
+        </>,
+      );
+
+      const selectedText = screen.getByTestId("selected-text");
+      const restoreSelection = installSelection(
+        selectedText.firstChild ?? selectedText,
+      );
+      try {
+        fireEvent.mouseUp(selectedText);
+      } finally {
+        restoreSelection();
+      }
+
+      await screen.findByRole("button", { name: "Reply" });
+      const popoverContent = document.body.querySelector(
+        '[data-slot="popover-content"]',
+      );
+      expect(popoverContent?.getAttribute("data-selection-placement")).toBe(
+        "bottom",
+      );
+    } finally {
+      restoreAnimationFrame();
+      restorePointer();
+    }
+  });
 });
 
 describe("QuoteReplyBubble", () => {
-  test("renders the reply editor with shared design-system primitives", async () => {
+  test("renders the reply editor with only Add to Chat", async () => {
     useQuoteReplyStore.setState({
       replyBubble: {
         quotedText:
@@ -141,7 +194,7 @@ describe("QuoteReplyBubble", () => {
       },
     });
 
-    render(<QuoteReplyBubble onSendNow={() => {}} />);
+    render(<QuoteReplyBubble />);
 
     await waitFor(() => {
       expect(
@@ -156,9 +209,41 @@ describe("QuoteReplyBubble", () => {
     expect(
       screen.getByRole("button", { name: "Add to Chat" }).getAttribute("data-slot"),
     ).toBe("button");
-    expect(
-      screen.getByRole("button", { name: "Send Now" }).getAttribute("data-slot"),
-    ).toBe("button");
+    expect(screen.queryByRole("button", { name: "Send Now" })).toBeNull();
+  });
+
+  test("Enter stages the reply, closes the bubble, and focuses the composer", async () => {
+    const composerInput = document.createElement("textarea");
+    document.body.appendChild(composerInput);
+    useQuoteReplyStore.setState({
+      replyBubble: {
+        quotedText: "quoted context",
+        sourceMessageId: "msg-1",
+        anchorRect: { top: 120, left: 180, width: 0, height: 0 },
+      },
+    });
+
+    render(
+      <QuoteReplyBubble
+        onAddToChat={() => composerInput.focus()}
+      />,
+    );
+
+    const replyInput = await screen.findByPlaceholderText("Type your reply…");
+    fireEvent.change(replyInput, { target: { value: "use this context" } });
+    fireEvent.keyDown(replyInput, { key: "Enter", shiftKey: false });
+
+    expect(useQuoteReplyStore.getState().stagedQuotes).toMatchObject([
+      {
+        quotedText: "quoted context",
+        replyText: "use this context",
+        sourceMessageId: "msg-1",
+      },
+    ]);
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Type your reply…")).toBeNull();
+    });
+    expect(document.activeElement).toBe(composerInput);
   });
 });
 

--- a/clients/web/src/domains/chat/components/text-selection-popover.tsx
+++ b/clients/web/src/domains/chat/components/text-selection-popover.tsx
@@ -3,8 +3,8 @@
  * assistant message bubble. Offers a single reply action for the selected
  * passage.
  *
- * Desktop-only — `isPointerCoarse()` gates the entire listener so touch
- * devices never see the popover (OS text selection UX conflicts).
+ * On coarse pointers the chip renders below the selected text so native
+ * selection menus have room above the cursor.
  */
 
 import { MessageSquareQuote } from "lucide-react";
@@ -16,9 +16,9 @@ import { Button, Popover } from "@vellumai/design-library";
 
 /**
  * Selector: the transcript container ref whose descendants contain
- * assistant message text. The popover listens for `mouseup` on this
- * container and checks whether the selection falls inside an assistant
- * message element (identified by `data-message-id` + `data-message-role`).
+ * assistant message text. The popover checks whether the active selection
+ * falls inside an assistant message element, identified by
+ * `data-message-id` + `data-message-role`.
  */
 interface TextSelectionPopoverProps {
   containerRef: RefObject<HTMLElement | null>;
@@ -30,16 +30,13 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
     messageId: string;
     top: number;
     left: number;
+    placement: "top" | "bottom";
   } | null>(null);
 
   const openReplyBubble = useQuoteReplyStore.use.openReplyBubble();
 
-  const handleMouseUp = useCallback(() => {
-    if (isPointerCoarse()) {
-      return;
-    }
-
-    // Defer to next microtask so the browser has finalized the selection.
+  const updatePopoverFromSelection = useCallback(() => {
+    const coarsePointer = isPointerCoarse();
     requestAnimationFrame(() => {
       const selection = window.getSelection();
       if (!selection || selection.isCollapsed || !selection.rangeCount) {
@@ -61,6 +58,10 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
       if (!messageEl) {
         return;
       }
+      const container = containerRef.current;
+      if (!container || !container.contains(messageEl)) {
+        return;
+      }
 
       const role = messageEl.getAttribute("data-message-role");
       if (role !== "assistant") {
@@ -74,15 +75,17 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
 
       const range = selection.getRangeAt(0);
       const rect = range.getBoundingClientRect();
+      const placement = coarsePointer ? "bottom" : "top";
 
       setPopover({
         text,
         messageId,
-        top: rect.top,
+        top: placement === "bottom" ? rect.bottom : rect.top,
         left: rect.left + rect.width / 2,
+        placement,
       });
     });
-  }, []);
+  }, [containerRef]);
 
   // Dismiss the popover when the selection is cleared.
   useEffect(() => {
@@ -103,6 +106,19 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
     };
   }, [popover]);
 
+  useEffect(() => {
+    const handler = () => {
+      if (isPointerCoarse()) {
+        updatePopoverFromSelection();
+      }
+    };
+
+    document.addEventListener("selectionchange", handler);
+    return () => {
+      document.removeEventListener("selectionchange", handler);
+    };
+  }, [updatePopoverFromSelection]);
+
   // Listen for mouseup on the document and validate the selection target is
   // within the transcript container. Using document-level listeners avoids
   // the stale-ref problem where containerRef.current is null on initial
@@ -115,7 +131,7 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
       }
       const target = e.target as Node | null;
       if (target && container.contains(target)) {
-        handleMouseUp();
+        updatePopoverFromSelection();
       }
     };
 
@@ -123,7 +139,7 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
     return () => {
       document.removeEventListener("mouseup", handler);
     };
-  }, [containerRef, handleMouseUp]);
+  }, [containerRef, updatePopoverFromSelection]);
 
   if (!popover) {
     return null;
@@ -164,9 +180,10 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
         />
       </Popover.Anchor>
       <Popover.Content
-        side="top"
+        side={popover.placement}
         align="center"
         sideOffset={8}
+        data-selection-placement={popover.placement}
         onOpenAutoFocus={(event) => event.preventDefault()}
         onCloseAutoFocus={(event) => event.preventDefault()}
         className="rounded-lg p-0"

--- a/clients/web/src/domains/chat/components/text-selection-popover.tsx
+++ b/clients/web/src/domains/chat/components/text-selection-popover.tsx
@@ -3,16 +3,20 @@
  * assistant message bubble. Offers a single reply action for the selected
  * passage.
  *
- * On coarse pointers the chip renders below the selected text so native
- * selection menus have room above the cursor.
+ * On coarse pointers the chip renders below the selected text when there is
+ * room, so native selection menus have space above the cursor.
  */
 
 import { MessageSquareQuote } from "lucide-react";
-import { type RefObject, useCallback, useEffect, useState } from "react";
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { Button, Popover } from "@vellumai/design-library";
 
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { isPointerCoarse } from "@/utils/pointer";
-import { Button, Popover } from "@vellumai/design-library";
+
+const COARSE_SELECTION_SETTLE_MS = 120;
+const POPOVER_SIDE_OFFSET = 8;
+const ESTIMATED_POPOVER_HEIGHT = 44;
 
 /**
  * Selector: the transcript container ref whose descendants contain
@@ -25,6 +29,9 @@ interface TextSelectionPopoverProps {
 }
 
 export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps) {
+  const coarseSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const [popover, setPopover] = useState<{
     text: string;
     messageId: string;
@@ -35,47 +42,61 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
 
   const openReplyBubble = useQuoteReplyStore.use.openReplyBubble();
 
+  const clearCoarseSelectionTimer = useCallback(() => {
+    if (coarseSelectionTimerRef.current) {
+      clearTimeout(coarseSelectionTimerRef.current);
+      coarseSelectionTimerRef.current = null;
+    }
+  }, []);
+
   const updatePopoverFromSelection = useCallback(() => {
     const coarsePointer = isPointerCoarse();
     requestAnimationFrame(() => {
       const selection = window.getSelection();
       if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        setPopover(null);
         return;
       }
 
       const text = selection.toString().trim();
       if (!text) {
+        setPopover(null);
         return;
       }
 
       // Walk up from the selection anchor to find the message wrapper.
       const anchorNode = selection.anchorNode;
       if (!anchorNode) {
+        setPopover(null);
         return;
       }
 
       const messageEl = findMessageElement(anchorNode);
       if (!messageEl) {
+        setPopover(null);
         return;
       }
       const container = containerRef.current;
       if (!container || !container.contains(messageEl)) {
+        setPopover(null);
         return;
       }
 
       const role = messageEl.getAttribute("data-message-role");
       if (role !== "assistant") {
+        setPopover(null);
         return;
       }
 
       const messageId = messageEl.getAttribute("data-message-id");
       if (!messageId) {
+        setPopover(null);
         return;
       }
 
       const range = selection.getRangeAt(0);
       const rect = range.getBoundingClientRect();
-      const placement = coarsePointer ? "bottom" : "top";
+      const placement = getSelectionPopoverPlacement(rect, coarsePointer);
 
       setPopover({
         text,
@@ -86,6 +107,8 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
       });
     });
   }, [containerRef]);
+
+  useEffect(() => clearCoarseSelectionTimer, [clearCoarseSelectionTimer]);
 
   // Dismiss the popover when the selection is cleared.
   useEffect(() => {
@@ -108,16 +131,28 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
 
   useEffect(() => {
     const handler = () => {
-      if (isPointerCoarse()) {
-        updatePopoverFromSelection();
+      if (!isPointerCoarse()) {
+        return;
       }
+
+      clearCoarseSelectionTimer();
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        setPopover(null);
+        return;
+      }
+
+      coarseSelectionTimerRef.current = setTimeout(() => {
+        coarseSelectionTimerRef.current = null;
+        updatePopoverFromSelection();
+      }, COARSE_SELECTION_SETTLE_MS);
     };
 
     document.addEventListener("selectionchange", handler);
     return () => {
       document.removeEventListener("selectionchange", handler);
     };
-  }, [updatePopoverFromSelection]);
+  }, [clearCoarseSelectionTimer, updatePopoverFromSelection]);
 
   // Listen for mouseup on the document and validate the selection target is
   // within the transcript container. Using document-level listeners avoids
@@ -125,6 +160,10 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
   // mount (before the Transcript element renders).
   useEffect(() => {
     const handler = (e: MouseEvent) => {
+      if (isPointerCoarse()) {
+        return;
+      }
+
       const container = containerRef.current;
       if (!container) {
         return;
@@ -146,6 +185,7 @@ export function TextSelectionPopover({ containerRef }: TextSelectionPopoverProps
   }
 
   const handleQuoteReply = () => {
+    clearCoarseSelectionTimer();
     openReplyBubble({
       quotedText: popover.text,
       sourceMessageId: popover.messageId,
@@ -219,4 +259,18 @@ function findMessageElement(node: Node): HTMLElement | null {
     current = current.parentNode;
   }
   return null;
+}
+
+function getSelectionPopoverPlacement(
+  rect: DOMRect,
+  coarsePointer: boolean,
+): "top" | "bottom" {
+  if (!coarsePointer) {
+    return "top";
+  }
+
+  const hasRoomBelow =
+    rect.bottom + POPOVER_SIDE_OFFSET + ESTIMATED_POPOVER_HEIGHT <=
+    window.innerHeight;
+  return hasRoomBelow ? "bottom" : "top";
 }

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -315,7 +315,12 @@ export function TranscriptMessageBody({
             }
             return (
               <div key={`inline-text-${si}`} className={segmentClass}>
-                <ChatMarkdownMessage content={seg.content} hardLineBreaks onVellumLinkClick={handleVellumLinkClick} />
+                <ChatMarkdownMessage
+                  content={seg.content}
+                  hardLineBreaks
+                  blockquoteVariant={isUser ? "quotePreview" : "default"}
+                  onVellumLinkClick={handleVellumLinkClick}
+                />
               </div>
             );
           })}
@@ -324,7 +329,12 @@ export function TranscriptMessageBody({
     }
     return (
       <div key={key} className={segmentClass}>
-        <ChatMarkdownMessage content={text} hardLineBreaks onVellumLinkClick={handleVellumLinkClick} />
+        <ChatMarkdownMessage
+          content={text}
+          hardLineBreaks
+          blockquoteVariant={isUser ? "quotePreview" : "default"}
+          onVellumLinkClick={handleVellumLinkClick}
+        />
       </div>
     );
   };

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -35,10 +35,24 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("text-body-medium-default");
   });
 
-  test("blockquotes render as compact quote previews", () => {
+  test("blockquotes render with default markdown quote styling", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {
         content: "> This is quoted.\n\nReply text.",
+      }),
+    );
+
+    expect(html).toContain("italic");
+    expect(html).toContain("text-stone-600");
+    expect(html).not.toContain("rounded-md");
+    expect(html).not.toContain("bg-[var(--surface-sunken)]");
+  });
+
+  test("quotePreview blockquotes render as compact quote previews", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "> This is quoted.\n\nReply text.",
+        blockquoteVariant: "quotePreview",
       }),
     );
 

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -35,6 +35,18 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("text-body-medium-default");
   });
 
+  test("blockquotes render as compact quote previews", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "> This is quoted.\n\nReply text.",
+      }),
+    );
+
+    expect(html).toContain("rounded-md");
+    expect(html).toContain("bg-[var(--surface-sunken)]");
+    expect(html).not.toContain(" italic ");
+  });
+
   test("ordered list beginning at a non-1 number preserves its start", () => {
     // A terse "3." answer is parsed as a one-item ordered list starting at 3.
     // Without forwarding `start`, the <ol> defaults to 1 and renders "1.".

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -324,7 +324,7 @@ function buildMarkdownComponents(
     // emphasis render upright instead of skewed (see splitEmojiRuns).
     em: ({ children }) => <em>{renderUprightEmoji(children)}</em>,
     blockquote: ({ children }) => (
-      <blockquote className="mb-2 border-l-2 border-stone-300 pl-3 italic text-stone-600 last:mb-0 dark:border-stone-600 dark:text-stone-400">
+      <blockquote className="mb-3 rounded-md border-l-2 border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-body-small-default text-[var(--content-secondary)] last:mb-0 [&_p]:mb-0">
         {children}
       </blockquote>
     ),

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -23,6 +23,7 @@ import "katex/dist/katex.min.css";
 import { cn } from "../utils/cn";
 
 const MAX_CODE_BLOCK_HEIGHT = 400;
+type BlockquoteVariant = "default" | "quotePreview";
 
 function CopyButton({ visible, onClick, copied }: {
   visible: boolean;
@@ -243,6 +244,7 @@ function renderUprightEmoji(children: ReactNode): ReactNode {
 
 function buildMarkdownComponents(
   LinkComponent: MarkdownLinkComponent,
+  blockquoteVariant: BlockquoteVariant,
 ): Components {
   return {
     // mb-6 (24px) equals one --text-chat-line-height, so a `\n\n` paragraph
@@ -324,7 +326,14 @@ function buildMarkdownComponents(
     // emphasis render upright instead of skewed (see splitEmojiRuns).
     em: ({ children }) => <em>{renderUprightEmoji(children)}</em>,
     blockquote: ({ children }) => (
-      <blockquote className="mb-3 rounded-md border-l-2 border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-body-small-default text-[var(--content-secondary)] last:mb-0 [&_p]:mb-0">
+      <blockquote
+        className={cn(
+          "mb-3 border-l-2 last:mb-0",
+          blockquoteVariant === "quotePreview"
+            ? "rounded-md border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-body-small-default text-[var(--content-secondary)] [&_p]:mb-0"
+            : "border-stone-300 pl-3 italic text-stone-600 dark:border-moss-500 dark:text-stone-400",
+        )}
+      >
         {children}
       </blockquote>
     ),
@@ -557,6 +566,11 @@ export interface MarkdownMessageProps {
   /** When true, single newlines render as hard line breaks. */
   hardLineBreaks?: boolean;
   /**
+   * Controls blockquote chrome. The default preserves ordinary markdown
+   * quote styling; quotePreview is for compact quoted-message previews.
+   */
+  blockquoteVariant?: BlockquoteVariant;
+  /**
    * Custom link component for rendering `<a>` elements inside markdown.
    * Receives `href` and `children` props. Defaults to a plain
    * `<a target="_blank" rel="noopener noreferrer">`.
@@ -580,6 +594,7 @@ export function MarkdownMessage({
   content,
   className,
   hardLineBreaks,
+  blockquoteVariant = "default",
   linkComponent,
   urlTransform,
 }: MarkdownMessageProps) {
@@ -588,7 +603,10 @@ export function MarkdownMessage({
     return hardLineBreaks ? hardBreakNewlines(escaped) : escaped;
   }, [content, hardLineBreaks]);
   const Link = linkComponent ?? DefaultLink;
-  const components = useMemo(() => buildMarkdownComponents(Link), [Link]);
+  const components = useMemo(
+    () => buildMarkdownComponents(Link, blockquoteVariant),
+    [Link, blockquoteVariant],
+  );
   return (
     <div data-slot="markdown-message" className={cn("text-chat text-[var(--content-default)]", className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath, remarkPreserveOrderedListNumbers]} rehypePlugins={[rehypeKatex]} components={components} urlTransform={urlTransform}>


### PR DESCRIPTION
## Summary

- Restyles quoted context in the reply modal and sent Markdown messages to use the compact inset quote preview.
- Removes the immediate "Send Now" reply action so replies are staged through "Add to Chat" only.
- Lets staged quote context count as sendable composer content, including the desktop Enter-to-send flow after the modal focuses the composer.
- Shows the Reply chip for coarse-pointer selections below the selected text to avoid native selection menus.

## Why

The quote/reply UI looked heavier than the desired compact quote treatment, and the reply modal had two send paths. This keeps the interaction focused: confirm context into the composer, then send from the normal chat entry area.

## Validation

- `cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx`
- `cd clients/web && bun test src/domains/chat/components/chat-composer/chat-composer.test.tsx`
- `cd packages/design-library && bun test src/components/markdown-message.test.tsx`
- `cd clients/web && bun run typecheck`
