### PR TITLE
[codex] Fix empty greeting timezone context

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3400,6 +3400,9 @@ paths:
                 content:
                   type: string
                   description: User prompt content
+                clientTimezone:
+                  description: IANA timezone reported by the active client
+                  type: string
               required:
                 - conversationKey
                 - content

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -8,7 +8,7 @@
 
 import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be defined before importing the module under test
@@ -82,6 +82,25 @@ mock.module("../prompts/persona-resolver.js", () => ({
 
 mock.module("../runtime/routes/workspace-greetings.js", () => ({
   readWorkspaceGreetings: () => null,
+}));
+
+const mockConfig = {
+  ui: {
+    emptyStateGreetingCacheTtlMs: 0,
+    userTimezone: "",
+    detectedTimezone: "",
+  },
+  memory: {
+    retrieval: {
+      scratchpadInjection: {
+        enabled: false,
+      },
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
 }));
 
 // Mock getOrCreateConversation from conversation-store so the handler
@@ -179,7 +198,9 @@ function makeMockSession(
 }
 
 const route = ROUTES.find((r) => r.endpoint === "btw" && r.method === "POST");
-if (!route) throw new Error("btw route not found in ROUTES");
+if (!route) {
+  throw new Error("btw route not found in ROUTES");
+}
 
 async function callHandler(
   body: Record<string, unknown>,
@@ -202,7 +223,9 @@ async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
   const chunks: Uint8Array[] = [];
   while (true) {
     const { done, value } = await reader.read();
-    if (done) break;
+    if (done) {
+      break;
+    }
     chunks.push(value);
   }
   return new TextDecoder().decode(
@@ -218,6 +241,13 @@ async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
 // ---------------------------------------------------------------------------
 
 describe("POST /v1/btw", () => {
+  beforeEach(() => {
+    mockConfig.ui.emptyStateGreetingCacheTtlMs = 0;
+    mockConfig.ui.userTimezone = "";
+    mockConfig.ui.detectedTimezone = "";
+    mockConfig.memory.retrieval.scratchpadInjection.enabled = false;
+  });
+
   // -- Validation (400s) --
 
   test("throws BadRequestError for missing conversationKey", async () => {
@@ -342,6 +372,30 @@ describe("POST /v1/btw", () => {
     expect(provider.sendMessage).toHaveBeenCalledTimes(1);
     const [, options] = provider.sendMessage.mock.calls[0];
     expect(options!.config!.callSite).toBe("emptyStateGreeting");
+  });
+
+  test("greeting requests include fresh turn context using the client timezone", async () => {
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    mockGetOrCreateConversation.mockImplementationOnce(async () => session);
+
+    const { result } = await callHandler({
+      conversationKey: "greeting",
+      content: "Generate a greeting",
+      clientTimezone: "Europe/Skopje",
+    });
+    await readStream(result as ReadableStream<Uint8Array>);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const [messages] = provider.sendMessage.mock.calls[0] as [
+      Array<{ content: Array<{ type: string; text: string }> }>,
+      SendMessageOptions | undefined,
+    ];
+    const greetingPrompt = messages[2]!.content[0]!.text;
+    expect(greetingPrompt).toContain("Generate a greeting");
+    expect(greetingPrompt).toContain("<turn_context>");
+    expect(greetingPrompt).toContain("current_time:");
+    expect(greetingPrompt).toContain("(Europe/Skopje)");
   });
 
   test("generic requests pass the default callSite", async () => {

--- a/assistant/src/__tests__/empty-state-greeting-cache.test.ts
+++ b/assistant/src/__tests__/empty-state-greeting-cache.test.ts
@@ -56,6 +56,15 @@ describe("empty-state greeting cache", () => {
     expect(getCachedEmptyStateGreeting()).toBe("hey there");
   });
 
+  test("keeps cached greetings separate by timezone scope", () => {
+    setCachedEmptyStateGreeting("hey eastern", "America/New_York");
+    setCachedEmptyStateGreeting("hey central", "America/Chicago");
+
+    expect(getCachedEmptyStateGreeting("America/New_York")).toBe("hey eastern");
+    expect(getCachedEmptyStateGreeting("America/Chicago")).toBe("hey central");
+    expect(getCachedEmptyStateGreeting("Europe/Skopje")).toBeNull();
+  });
+
   test("returns null once the TTL is exceeded", () => {
     setCachedEmptyStateGreeting("stale");
     checkpointStore.set(

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -16,6 +16,11 @@ import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
+import {
+  canonicalizeTimeZone,
+  formatTurnTimestamp,
+  resolveTurnTimezoneContext,
+} from "../../daemon/date-context.js";
 import { readNowScratchpad } from "../../daemon/now-scratchpad.js";
 import { getConversationByKey } from "../../persistence/conversation-key-store.js";
 import { getAllToolDefinitions } from "../../tools/registry.js";
@@ -64,6 +69,20 @@ async function handleBtw({
   }
 
   const trimmedContent = content.trim();
+  const config = getConfig();
+  const clientTimezone =
+    typeof body?.clientTimezone === "string"
+      ? canonicalizeTimeZone(body.clientTimezone)
+      : null;
+  const timezoneOptions = {
+    configuredUserTimeZone: config.ui?.userTimezone ?? null,
+    clientTimezone,
+    detectedTimezone: config.ui?.detectedTimezone ?? null,
+  };
+  const greetingCacheScope =
+    conversationKey === GREETING_KEY
+      ? resolveTurnTimezoneContext(timezoneOptions).effectiveTimezone
+      : null;
 
   // ----- Empty-state greeting fast-path -----
   // User-authored `## Greetings` win; otherwise replay a cached greeting when
@@ -76,7 +95,7 @@ async function handleBtw({
       log.debug("Returning authored empty-state greeting");
       return streamText(pickRandom(authored));
     }
-    const cached = getCachedEmptyStateGreeting();
+    const cached = getCachedEmptyStateGreeting(greetingCacheScope);
     if (cached) {
       log.debug("Returning cached empty-state greeting");
       return streamText(cached);
@@ -85,13 +104,18 @@ async function handleBtw({
 
   // ----- Greeting context enrichment -----
   let effectiveContent = trimmedContent;
+  if (conversationKey === GREETING_KEY) {
+    effectiveContent = `${effectiveContent}\n\n<turn_context>\ncurrent_time: ${formatTurnTimestamp(
+      timezoneOptions,
+    )}\n</turn_context>`;
+  }
   if (
     conversationKey === GREETING_KEY &&
-    getConfig().memory.retrieval.scratchpadInjection.enabled
+    config.memory.retrieval.scratchpadInjection.enabled
   ) {
     const now = readNowScratchpad();
     if (now) {
-      effectiveContent = `${trimmedContent}\n\n<context>\n${now}\n</context>`;
+      effectiveContent = `${effectiveContent}\n\n<context>\nUse the <turn_context> current_time above for date/time-sensitive wording; the scratchpad below is for situational notes.\n${now}\n</context>`;
     }
   }
 
@@ -138,7 +162,7 @@ async function handleBtw({
 
           if (isGreeting && result.text) {
             // setCachedEmptyStateGreeting is a no-op when the TTL is 0.
-            setCachedEmptyStateGreeting(result.text);
+            setCachedEmptyStateGreeting(result.text, greetingCacheScope);
             log.debug("Cached empty-state greeting text");
           }
 
@@ -200,6 +224,10 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .describe("Conversation key to scope the call"),
       content: z.string().describe("User prompt content"),
+      clientTimezone: z
+        .string()
+        .optional()
+        .describe("IANA timezone reported by the active client"),
     }),
     handler: handleBtw,
   },

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -115,7 +115,7 @@ async function handleBtw({
   ) {
     const now = readNowScratchpad();
     if (now) {
-      effectiveContent = `${effectiveContent}\n\n<context>\nUse the <turn_context> current_time above for date/time-sensitive wording; the scratchpad below is for situational notes.\n${now}\n</context>`;
+      effectiveContent = `${effectiveContent}\n\n<context>\n${now}\n</context>`;
     }
   }
 

--- a/assistant/src/runtime/routes/empty-state-greeting-cache.ts
+++ b/assistant/src/runtime/routes/empty-state-greeting-cache.ts
@@ -20,6 +20,11 @@ import {
 const CHECKPOINT_KEY_TEXT = "empty_state:greeting:text";
 const CHECKPOINT_KEY_TIMESTAMP = "empty_state:greeting:cached_at";
 
+function scopedCheckpointKey(baseKey: string, scope?: string | null): string {
+  const normalizedScope = scope?.trim();
+  return normalizedScope ? `${baseKey}:${normalizedScope}` : baseKey;
+}
+
 function cacheTtlMs(): number {
   return getConfig().ui.emptyStateGreetingCacheTtlMs;
 }
@@ -29,17 +34,30 @@ function cacheTtlMs(): number {
  * Returns `null` when caching is disabled (TTL <= 0), the cache is empty,
  * or the entry has expired.
  */
-export function getCachedEmptyStateGreeting(): string | null {
+export function getCachedEmptyStateGreeting(
+  scope?: string | null,
+): string | null {
   const ttl = cacheTtlMs();
-  if (ttl <= 0) return null; // caching disabled — always regenerate
+  if (ttl <= 0) {
+    // Caching disabled — always regenerate.
+    return null;
+  }
 
   try {
-    const text = getMemoryCheckpoint(CHECKPOINT_KEY_TEXT);
-    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
-    if (!text || !timestampStr) return null;
+    const text = getMemoryCheckpoint(
+      scopedCheckpointKey(CHECKPOINT_KEY_TEXT, scope),
+    );
+    const timestampStr = getMemoryCheckpoint(
+      scopedCheckpointKey(CHECKPOINT_KEY_TIMESTAMP, scope),
+    );
+    if (!text || !timestampStr) {
+      return null;
+    }
 
     const cachedAt = Number(timestampStr);
-    if (Number.isNaN(cachedAt) || Date.now() - cachedAt > ttl) return null;
+    if (Number.isNaN(cachedAt) || Date.now() - cachedAt > ttl) {
+      return null;
+    }
 
     return text;
   } catch {
@@ -52,12 +70,21 @@ export function getCachedEmptyStateGreeting(): string | null {
  * No-ops when caching is disabled (TTL <= 0) so a zero-TTL workspace never
  * writes a stale entry.
  */
-export function setCachedEmptyStateGreeting(text: string): void {
-  if (cacheTtlMs() <= 0) return; // caching disabled — skip write
+export function setCachedEmptyStateGreeting(
+  text: string,
+  scope?: string | null,
+): void {
+  if (cacheTtlMs() <= 0) {
+    // Caching disabled — skip write.
+    return;
+  }
 
   try {
-    setMemoryCheckpoint(CHECKPOINT_KEY_TEXT, text);
-    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, String(Date.now()));
+    setMemoryCheckpoint(scopedCheckpointKey(CHECKPOINT_KEY_TEXT, scope), text);
+    setMemoryCheckpoint(
+      scopedCheckpointKey(CHECKPOINT_KEY_TIMESTAMP, scope),
+      String(Date.now()),
+    );
   } catch {
     // Cache write failure is non-fatal — next request will regenerate.
   }

--- a/clients/web/src/domains/chat/api/stream-greeting.test.ts
+++ b/clients/web/src/domains/chat/api/stream-greeting.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+let mockEffectiveTimezone = "Europe/Skopje";
+mock.module("@/utils/effective-timezone", () => ({
+  getEffectiveTimezone: () => mockEffectiveTimezone,
+}));
+
 // Controllable stub for the daemon client's POST. Captures the args and
 // returns whatever the current test sets up.
 let postArgs: unknown = null;
-let postImpl: () => Promise<{ data: unknown; response: Response }> = async () => ({
+let postImpl: () => Promise<{
+  data: unknown;
+  response: Response;
+}> = async () => ({
   data: null,
   response: new Response(null, { status: 200 }),
 });
@@ -23,7 +31,9 @@ function sseStream(frames: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
     start(controller) {
-      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(frame));
+      }
       controller.close();
     },
   });
@@ -36,12 +46,17 @@ const COMPLETE_FRAME = "event: btw_complete\ndata: {}\n\n";
 
 afterEach(() => {
   postArgs = null;
+  mockEffectiveTimezone = "Europe/Skopje";
 });
 
 describe("streamEmptyStateGreeting", () => {
   test("accumulates deltas and resolves with the full greeting", async () => {
     postImpl = async () => ({
-      data: sseStream([deltaFrame("hey "), deltaFrame("there"), COMPLETE_FRAME]),
+      data: sseStream([
+        deltaFrame("hey "),
+        deltaFrame("there"),
+        COMPLETE_FRAME,
+      ]),
       response: new Response(null, { status: 200 }),
     });
 
@@ -74,6 +89,21 @@ describe("streamEmptyStateGreeting", () => {
     expect(args.body.conversationKey).toBe("greeting");
     expect(args.body.content.length).toBeGreaterThan(0);
     expect(args.parseAs).toBe("stream");
+  });
+
+  test("includes the live effective timezone on the greeting request", async () => {
+    mockEffectiveTimezone = "America/New_York";
+    postImpl = async () => ({
+      data: sseStream([deltaFrame("yo"), COMPLETE_FRAME]),
+      response: new Response(null, { status: 200 }),
+    });
+
+    await streamEmptyStateGreeting({ assistantId: "asst-1" });
+
+    const args = postArgs as {
+      body: { clientTimezone?: string };
+    };
+    expect(args.body.clientTimezone).toBe("America/New_York");
   });
 
   test("rejects on a btw_error event", async () => {

--- a/clients/web/src/domains/chat/api/stream-greeting.ts
+++ b/clients/web/src/domains/chat/api/stream-greeting.ts
@@ -13,6 +13,7 @@
  */
 
 import { client } from "@/generated/daemon/client.gen";
+import { getEffectiveTimezone } from "@/utils/effective-timezone";
 
 /** Conversation key the daemon maps to the empty-state greeting call site. */
 const GREETING_CONVERSATION_KEY = "greeting";
@@ -45,12 +46,14 @@ export async function streamEmptyStateGreeting({
   signal,
   onDelta,
 }: StreamGreetingOptions): Promise<string> {
+  const clientTimezone = getEffectiveTimezone();
   const { data, response } = await client.post({
     url: "/v1/assistants/{assistant_id}/btw",
     path: { assistant_id: assistantId },
     body: {
       conversationKey: GREETING_CONVERSATION_KEY,
       content: GREETING_PROMPT,
+      ...(clientTimezone ? { clientTimezone } : {}),
     },
     headers: {
       "Content-Type": "application/json",
@@ -91,7 +94,9 @@ function parseSseFrame(frame: string): ParsedSseFrame | null {
       dataLines.push(line.slice("data:".length).trim());
     }
   }
-  if (dataLines.length === 0) return { event, data: null };
+  if (dataLines.length === 0) {
+    return { event, data: null };
+  }
   try {
     return { event, data: JSON.parse(dataLines.join("\n")) };
   } catch {
@@ -111,7 +116,9 @@ async function readGreetingStream(
   try {
     for (;;) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       buffer += decoder.decode(value, { stream: true });
 
       // SSE frames are separated by a blank line.
@@ -121,7 +128,9 @@ async function readGreetingStream(
         buffer = buffer.slice(sep + 2);
 
         const parsed = parseSseFrame(frame);
-        if (!parsed) continue;
+        if (!parsed) {
+          continue;
+        }
 
         if (parsed.event === "btw_text_delta") {
           const delta =


### PR DESCRIPTION
## Summary
- Send the web client's effective timezone with empty-state greeting `/btw` requests.
- Inject a fresh `<turn_context>` `current_time` into greeting sidechain prompts using the same timezone resolver as normal chat turns.
- Scope cached empty-state greetings by effective timezone so changing timezone does not replay stale greeting copy.
- Regenerate the assistant OpenAPI schema for the new optional `clientTimezone` body field.

## Root cause
Normal chat messages already carried timezone metadata, but the empty-chat greeting path uses `/btw` and bypassed normal turn-context injection. That path appended `NOW.md` context, so stale scratchpad time could influence the greeting even after the timezone setting changed. The greeting cache was also global instead of timezone-scoped.

## Validation
- `bun run lint -- src/__tests__/btw-routes.test.ts src/__tests__/empty-state-greeting-cache.test.ts src/runtime/routes/btw-routes.ts src/runtime/routes/empty-state-greeting-cache.ts`
- `bun test src/__tests__/empty-state-greeting-cache.test.ts src/__tests__/btw-routes.test.ts`
- `bun run typecheck:fast`
- `bun run lint -- src/domains/chat/api/stream-greeting.test.ts src/domains/chat/api/stream-greeting.ts`
- `bun test src/domains/chat/api/stream-greeting.test.ts`
- `bun run typecheck`
- `git diff --check`

Fixes LUM-2645