### PR TITLE
fix(web): stop mid-turn transcript wipe from anchor-less /messages reseeds

### DIFF
--- a/clients/web/docs/CONVERSATION_SSE.md
+++ b/clients/web/docs/CONVERSATION_SSE.md
@@ -82,8 +82,13 @@ later can't be ring-replayed. The recovery path is a refetch:
 - Every committed `/messages` fetch **reseeds** the snapshot (`seedSnapshot`):
   it replays the buffered event tail with `seq > snapshot.seq` onto the fresh
   server snapshot (`resolveSnapshot`), so events that raced the fetch aren't
-  lost. A buffer gap (eviction, or no anchor) falls back to the fetched snapshot
-  alone.
+  lost. A buffer gap (eviction) falls back to the fetched snapshot alone.
+  An **anchor-less** fetch (`seq: null` — the daemon has persisted no stream
+  content yet, e.g. a fresh conversation's first turn racing the 1s
+  partial-persist debounce) is **dropped** when the live view has already
+  folded seq-stamped events: with no cursor to replay from, taking it
+  wholesale would wipe the streamed turn (the mid-turn "vanishing prefix"
+  flicker) until the turn-end reseed restored it.
 - The reseed also **prunes** any optimistic send the snapshot now represents
   (`pruneConfirmedOptimisticSends`), keyed by the same identity
   `selectTranscriptMessages` overlays on. Without this, a send whose echo/dequeue

--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -107,6 +107,64 @@ describe("chat-session-store — snapshot + optimistic", () => {
     expect(store().optimisticSends).toEqual([]);
   });
 
+  test("seedSnapshot drops an anchor-less fetch once the live view has folded stream events", () => {
+    // Fresh-conversation first turn: the daemon's partial-persist debounce
+    // hasn't flushed yet, so a mid-turn /messages fetch returns `seq: null`.
+    // Taking it wholesale would wipe the streamed prefix (the "vanishing
+    // prefix" flicker); the live view must be kept instead.
+    store().seedSnapshot(CONV, snapshot([], null)); // initial seed, nothing folded yet
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", "Hey"));
+    store().applyEnvelopeToSnapshot(textDelta(7, CONV, "a1", " yourself."));
+
+    store().seedSnapshot(CONV, snapshot([], null)); // anchor-less mid-turn refetch
+
+    expect(store().snapshot?.messages.find((m) => m.id === "a1")?.textSegments).toEqual([
+      "Hey yourself.",
+    ]);
+    expect(store().snapshot?.seq).toBe(7);
+  });
+
+  test("seedSnapshot still accepts an anchor-less fetch while nothing has been folded", () => {
+    store().seedSnapshot(CONV, snapshot([], null));
+    const snap = snapshot([textRow("a1", "persisted")], null);
+    store().seedSnapshot(CONV, snap); // live view exists but has no seq — fetch wins
+    expect(store().snapshot).toBe(snap);
+  });
+
+  test("anchor-less refetch mid-stream no longer drops the streamed prefix (flicker repro)", () => {
+    // Regression shape from the field: deltas fold live; an anchor-less
+    // refetch lands mid-word; more deltas follow; the turn-end anchored
+    // reseed adopts the canonical row. The transcript must show the full
+    // text at every step after the refetch — never a suffix-only bubble.
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("u1", "hey"), role: "user" }], null),
+    );
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", "Hey"));
+    store().applyEnvelopeToSnapshot(textDelta(7, CONV, "a1", " yourself."));
+
+    // Mid-turn refetch: server still has only the user row, no anchor.
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("u1", "hey"), role: "user" }], null),
+    );
+    store().applyEnvelopeToSnapshot(textDelta(8, CONV, "a1", " You're up."));
+
+    const live = store().snapshot?.messages.find((m) => m.id === "a1");
+    expect(live?.textSegments).toEqual(["Hey yourself. You're up."]);
+
+    // Turn-end reseed carries the persisted row and a real anchor.
+    store().seedSnapshot(
+      CONV,
+      snapshot(
+        [{ ...textRow("u1", "hey"), role: "user" }, textRow("a1", "Hey yourself. You're up.")],
+        8,
+      ),
+    );
+    const final = store().snapshot?.messages.find((m) => m.id === "a1");
+    expect(final?.textSegments).toEqual(["Hey yourself. You're up."]);
+  });
+
   test("seedSnapshot prunes optimistic sends the snapshot already represents", () => {
     // A retained attachment-carrying send (upgraded to the server id by its
     // echo) is retired once the reseeded snapshot carries the persisted row —

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -130,7 +130,9 @@ export interface ChatSessionActions {
   /** Seed (or resync) the snapshot from a freshly fetched server snapshot,
    *  replaying the buffered event tail with `seq > snapshot.seq` onto it so
    *  events that raced the fetch aren't lost. A gap (evicted tail) falls back
-   *  to the fetched snapshot alone. */
+   *  to the fetched snapshot alone — except when the fetch is anchor-less
+   *  (`seq` null) while the live view has already folded seq-stamped events;
+   *  such a fetch is provably behind the stream and is dropped instead. */
   seedSnapshot: (conversationId: string, snapshot: PaginatedHistoryResult) => void;
   /** Fold one live stream event into the snapshot (no-op until seeded; the
    *  seed's replay covers anything that arrived first). Idempotent by `seq`. */
@@ -318,6 +320,27 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
   // --- Materialized snapshot ---
   seedSnapshot: (conversationId, snapshot) => {
+    // Anchor-less regression guard. `seq: null` means the daemon has not yet
+    // durably persisted any stream content for this conversation — typically a
+    // fresh conversation's first turn, where the partial-persist debounce
+    // (1s) outlives a short reply, so every mid-turn `/messages` fetch comes
+    // back with no anchor. With no anchor there is no cursor to replay the
+    // buffered tail from, so taking such a fetch wholesale would wipe every
+    // event the live view has already folded: the streamed text vanishes and
+    // the following deltas rebuild only the suffix until the turn-end reseed
+    // restores the full reply (the mid-turn "vanishing prefix" flicker). A
+    // live view that has folded seq-stamped events is a superset of anything
+    // an anchor-less fetch can hold, so keep it and drop the fetch. The
+    // snapshot reset on conversation switch guarantees a non-null live view
+    // belongs to `conversationId`.
+    const current = get().snapshot;
+    if (snapshot.seq == null && current !== null && typeof current.seq === "number") {
+      recordDiagnostic("history_seed_skipped_anchorless", {
+        conversationId,
+        liveSeq: current.seq,
+      });
+      return;
+    }
     const tail = getSseEnvelopesSince(conversationId, snapshot.seq ?? null);
     const resolved = resolveSnapshot(snapshot, tail);
     set((s) => ({


### PR DESCRIPTION
## Prompt / plan

User report: streaming a reply in a brand-new conversation flickers — one render shows the streamed prefix ("Hey yourse"), the next shows only the suffix with the prefix missing ("lf. You're up. …"), then the full text appears. Diagnosed from the attached web-client log export (SSE liveness ring + daemon logs + persisted conversation state).

**Root cause.** A fresh conversation's first reply streams faster (~360 ms in the capture) than the daemon's 1 s partial-persist debounce, so every `/messages` fetch that lands mid-turn returns `seq: null` — nothing durably persisted yet for that conversation. `seedSnapshot` treated that like any other no-tail case and took the fetched snapshot wholesale, wiping every streamed event the live view had already folded. The next delta reopened a fresh bubble, so the transcript flashed from the streamed prefix to a suffix-only render until the turn-end reseed restored the full reply. Several `/messages` fetches landed inside the sub-second stream in the captured repro (invalidations from the echo/title/sync events), producing exactly the observed frame sequence.

**Fix.** Guard the reseed in `seedSnapshot`: when the fetched snapshot carries no `seq` anchor while the live materialized view has already folded seq-stamped events, drop the fetch and keep the live view — it is a superset of anything an anchor-less snapshot can hold (the daemon has persisted nothing the stream didn't already deliver). The conversation-switch snapshot reset guarantees a non-null live view belongs to the active conversation, and the first turn-end fetch always carries a real anchor (finalize records the persisted seq synchronously at `message_complete`), so canonical server rows are still adopted as before. Also documents the rule in `CONVERSATION_SSE.md`.

## Test plan

- Replayed the user's actual captured SSE envelope log through the real store (ring buffer + `seedSnapshot` + fold), sweeping every (reseed point × daemon flush point) interleaving: **744 anomalous suffix-only transcript states without the guard, 0 with it**. All anomalies came from the anchor-less (`seq: null`) case; every anchored reseed was already clean.
- New regression tests in `chat-session-store-base.test.ts`: anchor-less refetch mid-stream keeps the folded text; anchor-less fetch still seeds when nothing has been folded; full flicker-repro shape (fold → anchor-less refetch → more deltas → anchored turn-end reseed) renders the complete text at every step.
- `bun test` on the store / rolling-snapshot / stream-handler / seed-processing / stream-debug suites (89 pass), `bunx tsc --noEmit` clean, eslint: no new warnings on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfPpstqJ4g4DBNFjoHZuHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPpstqJ4g4DBNFjoHZuHh)_