### PR TITLE
fix(assistant): seed the seq alignment baseline on key-materialized conversations

### DIFF
--- a/assistant/src/__tests__/assistant-stream-state.test.ts
+++ b/assistant/src/__tests__/assistant-stream-state.test.ts
@@ -590,6 +590,24 @@ describe("assistant-stream-state", () => {
       expect(b.seq).toBe(1025);
     });
 
+    test("getCurrentSeq reports the persisted ceiling before the first stamp of a process", () => {
+      // GIVEN a process that stamped events (reserving a seq block on disk)
+      stampAndBuffer(mkEvent());
+
+      // WHEN the daemon restarts and nothing has been stamped yet
+      _simulateRestartForTesting();
+
+      // THEN the high-water read loads the reservation instead of reporting
+      // 0 — callers seeding baselines at creation (conversation rows) must
+      // never treat a warm workspace as a cold start.
+      expect(getCurrentSeq()).toBe(1024);
+
+      // AND the next stamped event still lands strictly above it.
+      const b = mkEvent();
+      stampAndBuffer(b);
+      expect(b.seq).toBe(1025);
+    });
+
     test("repeated restarts keep advancing monotonically", () => {
       stampAndBuffer(mkEvent());
       _simulateRestartForTesting();

--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -53,6 +53,12 @@ import {
   conversationKeys,
   conversations,
 } from "../persistence/schema/index.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  _resetStreamStateForTesting,
+  getCurrentSeq,
+  stampAndBuffer,
+} from "../runtime/assistant-stream-state.js";
 
 await initializeDb();
 
@@ -104,5 +110,49 @@ describe("conversation-key-store disk view", () => {
     expect(conversationRows).toHaveLength(1);
     expect(keyRows).toHaveLength(1);
     expect(readdirSync(conversationsDir)).toEqual([expectedDirName]);
+  });
+
+  test("seeds the seq alignment baseline from the global counter at creation", () => {
+    // Regression: this insert used to omit `seq`, so key-materialized
+    // conversations (the web's first-send path) reported `seq: null` on
+    // /messages for their entire first turn — the anchor-less snapshot that
+    // let mid-turn refetches wipe streamed transcript content on clients.
+    _resetStreamStateForTesting();
+    const event: AssistantEvent = {
+      id: "seed-evt",
+      conversationId: "other-conversation",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "assistant_text_delta",
+        conversationId: "other-conversation",
+        text: "x",
+      } as AssistantEvent["message"],
+    };
+    stampAndBuffer(event);
+    const baseline = getCurrentSeq();
+    expect(baseline).toBeGreaterThan(0);
+
+    const created = getOrCreateConversation("seed-key");
+    const row = getDb()
+      .select({ seq: conversations.seq })
+      .from(conversations)
+      .where(eq(conversations.id, created.conversationId))
+      .get();
+    expect(row?.seq).toBe(baseline);
+  });
+
+  test("stores NULL seq when nothing has been stamped yet (cold process)", () => {
+    // getCurrentSeq() === 0 means no event was ever emitted; clients must
+    // cold-start rather than align to seq 0, so the column stays NULL.
+    _resetStreamStateForTesting();
+    expect(getCurrentSeq()).toBe(0);
+
+    const created = getOrCreateConversation("cold-key");
+    const row = getDb()
+      .select({ seq: conversations.seq })
+      .from(conversations)
+      .where(eq(conversations.id, created.conversationId))
+      .get();
+    expect(row?.seq).toBeNull();
   });
 });

--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -56,6 +56,7 @@ import {
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
+  _simulateRestartForTesting,
   getCurrentSeq,
   stampAndBuffer,
 } from "../runtime/assistant-stream-state.js";
@@ -139,6 +140,35 @@ describe("conversation-key-store disk view", () => {
       .where(eq(conversations.id, created.conversationId))
       .get();
     expect(row?.seq).toBe(baseline);
+  });
+
+  test("seeds from the persisted seq ceiling after a daemon restart", () => {
+    // A restarted process with a warm workspace has stamped nothing yet, but
+    // the reservation file proves every previously emitted seq is at or below
+    // its ceiling — a conversation created before the first stamp must seed
+    // from that ceiling, not report NULL as if the assistant were brand new.
+    _resetStreamStateForTesting();
+    const event: AssistantEvent = {
+      id: "restart-evt",
+      conversationId: "other-conversation",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "assistant_text_delta",
+        conversationId: "other-conversation",
+        text: "x",
+      } as AssistantEvent["message"],
+    };
+    stampAndBuffer(event);
+    _simulateRestartForTesting();
+
+    const created = getOrCreateConversation("restart-key");
+    const row = getDb()
+      .select({ seq: conversations.seq })
+      .from(conversations)
+      .where(eq(conversations.id, created.conversationId))
+      .get();
+    expect(row?.seq).toBe(getCurrentSeq());
+    expect(row?.seq).toBeGreaterThan(0);
   });
 
   test("stores NULL seq when nothing has been stamped yet (cold process)", () => {

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -218,15 +218,8 @@ export function getOrCreateConversation(
     const customTitle = opts?.title?.trim();
     const title = customTitle || GENERATING_TITLE;
     const memoryScopeId = "default";
-    // Snapshot↔stream alignment baseline, captured at the creation instant —
-    // the same seed `createConversation` writes. Without it the row starts at
-    // seq NULL and `/messages` stays anchor-less for the whole first turn
-    // (the 1s partial-persist debounce outlives a fast reply), which is what
-    // let mid-turn refetches wipe the streamed transcript on clients. Every
-    // event this conversation will ever emit is stamped above the current
-    // counter, so the current value is a correct baseline. 0 (nothing stamped
-    // yet this process) stays NULL so clients cold-start rather than align to
-    // seq 0.
+    // Snapshot↔stream alignment baseline, captured at the creation instant
+    // (same seed as `createConversation`; 0 is stored as NULL).
     const initialSeq = getCurrentSeq();
 
     tx.insert(conversations)

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { cleanupBootstrapFiles } from "../prompts/bootstrap-cleanup.js";
+import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db-connection.js";
@@ -217,11 +218,22 @@ export function getOrCreateConversation(
     const customTitle = opts?.title?.trim();
     const title = customTitle || GENERATING_TITLE;
     const memoryScopeId = "default";
+    // Snapshot↔stream alignment baseline, captured at the creation instant —
+    // the same seed `createConversation` writes. Without it the row starts at
+    // seq NULL and `/messages` stays anchor-less for the whole first turn
+    // (the 1s partial-persist debounce outlives a fast reply), which is what
+    // let mid-turn refetches wipe the streamed transcript on clients. Every
+    // event this conversation will ever emit is stamped above the current
+    // counter, so the current value is a correct baseline. 0 (nothing stamped
+    // yet this process) stays NULL so clients cold-start rather than align to
+    // seq 0.
+    const initialSeq = getCurrentSeq();
 
     tx.insert(conversations)
       .values({
         id: conversationId,
         title,
+        seq: initialSeq > 0 ? initialSeq : null,
         // A caller-supplied title is user-set: mark it non-auto (0) so the
         // async LLM title generator's `canReplaceTitle` check won't overwrite
         // it. Without one, omit the column so it takes its default

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -238,8 +238,10 @@ export function getReplayWindow(
 
 /**
  * Current high-water `seq` -- the value last assigned by
- * {@link stampAndBuffer}, or `0` when nothing has been stamped yet in
- * this process.
+ * {@link stampAndBuffer}, or the persisted reservation ceiling when this
+ * process hasn't stamped yet (every seq a previous process could have
+ * emitted is at or below that ceiling). `0` only on a true cold start
+ * with no reservation file.
  *
  * Read synchronously right after emitting an event to learn that event's
  * `seq`: `stampAndBuffer` runs inline on the publish path (before the
@@ -247,6 +249,7 @@ export function getReplayWindow(
  * returning and this read on the single-threaded event loop.
  */
 export function getCurrentSeq(): number {
+  loadSeqReservation();
   return state.nextSeq - 1;
 }
 
@@ -314,14 +317,23 @@ function seqReservationPath(): string {
  * still advanced so the write is retried at most once per block, not
  * per event), matching the daemon's degraded-mode philosophy.
  */
-function reserveSeqCapacity(): void {
-  if (!state.seqReservationLoaded) {
-    state.seqReservationLoaded = true;
-    state.reservedSeqCeiling = readReservedCeiling();
-    if (state.reservedSeqCeiling >= state.nextSeq) {
-      state.nextSeq = state.reservedSeqCeiling + 1;
-    }
+/**
+ * Load the persisted seq reservation once per process, advancing
+ * `nextSeq` past the ceiling so this process never re-assigns (or
+ * reports, via {@link getCurrentSeq}) a seq a previous process could
+ * have emitted.
+ */
+function loadSeqReservation(): void {
+  if (state.seqReservationLoaded) return;
+  state.seqReservationLoaded = true;
+  state.reservedSeqCeiling = readReservedCeiling();
+  if (state.reservedSeqCeiling >= state.nextSeq) {
+    state.nextSeq = state.reservedSeqCeiling + 1;
   }
+}
+
+function reserveSeqCapacity(): void {
+  loadSeqReservation();
 
   if (state.nextSeq <= state.reservedSeqCeiling) return;
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37065 (the web-side guard for the streaming-transcript flicker). Question under investigation: why does `/v1/messages` ever return `seq: null` in the first place?

**Answer:** it shouldn't for normal conversations — and `createConversation` already prevents it by seeding `conversations.seq` with the global high-water counter at insert (the schema comment documents exactly this). But the repo has a second, duplicated `conversations` insert in `conversation-key-store.ts`'s `getOrCreateConversation` — the path that materializes a conversation from a client-supplied `conversationKey`, which is how **every web first-send conversation is born** (`POST /messages` with no `conversationId` mints a random key on the `vellum` channel). That insert drifted: it omits `seq`, so the row starts at `NULL` and nothing advances it until the first partial-persist flush (1 s debounce) or turn finalize. A reply that streams faster than the debounce — like the ~360 ms reply in the captured repro — finishes its entire first turn with `/messages` advertising `seq: null`, the anchor-less snapshot that made mid-turn refetches destructive on clients.

Fix: seed the key-store insert with `getCurrentSeq()` exactly as `createConversation` does, keeping the 0-means-NULL cold-start convention. This is correct across restarts (the counter reserves seq blocks ahead of use in `data/stream-seq.json`, so a new process always stamps above every previously emitted seq), and every event the new conversation will ever emit is stamped above the captured baseline.

Remaining legitimate `seq: null` cases, intentionally unchanged: rows predating the seq column (heal on their next turn's finalize), disaster-recovery/backfill inserts (migration 028, CLI repair — no live stream to align with), and a truly cold process where nothing has ever been stamped. The merged web guard (#37065) covers those residual cases; this PR removes the systematic source for all clients, including macOS/iOS which don't have the web guard.

## Test plan

- New regression tests in `conversation-key-store-disk-view.test.ts`: a key-materialized conversation's `seq` column equals the global counter at creation; a cold process (nothing stamped) stores `NULL`. `cd assistant && bun test src/__tests__/conversation-key-store-disk-view.test.ts` → 3 pass.
- `bunx tsc --noEmit` clean; eslint on touched files: no new warnings; pre-commit + pre-push hooks (format, lint, typecheck) passed.

## CLI verb checklist

No new routes added — persistence-layer change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfPpstqJ4g4DBNFjoHZuHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPpstqJ4g4DBNFjoHZuHh)_