### PR TITLE
feat(plugins): expose `icon` on GET /v1/plugins/:name

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21437,6 +21437,11 @@ paths:
                     description:
                       Prebuilt client artifact from `package.json` `vellum.artifact`, or null when the plugin ships none or its
                       descriptor is incomplete (e.g. a placeholder sha256).
+                  icon:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.
                 required:
                   - name
                   - installed
@@ -21448,6 +21453,7 @@ paths:
                   - readme
                   - ref
                   - artifact
+                  - icon
                 additionalProperties: false
         "400":
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -305,6 +305,36 @@ describe("getPluginDetails", () => {
     expect(details.version).toBe("2.0.0");
     expect(details.license).toBe("Apache-2.0");
     expect(details.description).toBe("manifest description");
+    // AND a package.json without vellum.icon surfaces icon as null
+    expect(details.icon).toBeNull();
+  });
+
+  test("surfaces the installed copy's vellum.icon", async () => {
+    // GIVEN an installed copy whose package.json declares vellum.icon
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0", vellum: { icon: "🦴" } }),
+    );
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+      listings: {},
+      raw: {},
+    });
+
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN the author emoji is surfaced from the installed package.json
+    expect(details.installed).toBe(true);
+    expect(details.icon).toBe("🦴");
   });
 
   test("throws PluginDetailsNotFoundError when nothing claims the name", async () => {

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -33,7 +33,11 @@ import {
   type FetchLike,
   sanitizePluginName,
 } from "./install-from-github.js";
-import { parsePluginArtifact, type PluginArtifact } from "./plugin-artifact.js";
+import {
+  parsePluginArtifact,
+  parsePluginIcon,
+  type PluginArtifact,
+} from "./plugin-artifact.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
@@ -58,6 +62,7 @@ interface PluginManifestFields {
   readonly homepage: string | null;
   readonly license: string | null;
   readonly artifact: PluginArtifact | null;
+  readonly icon: string | null;
 }
 
 /** Options that control which plugin to resolve and at what ref. */
@@ -106,6 +111,11 @@ export interface PluginDetails {
    * descriptor is incomplete (e.g. a placeholder `sha256`).
    */
   readonly artifact: PluginArtifact | null;
+  /**
+   * Author-declared emoji icon from the plugin's `package.json` `vellum.icon`,
+   * resolved from the installed copy first then the repo; `null` when none.
+   */
+  readonly icon: string | null;
 }
 
 /** No installed copy and no catalog/source entry claims the name. */
@@ -185,6 +195,7 @@ export async function getPluginDetails(
     readme,
     ref,
     artifact: local.manifest.artifact ?? remote.manifest.artifact,
+    icon: local.manifest.icon ?? remote.manifest.icon,
   };
 }
 
@@ -358,6 +369,7 @@ function emptyManifest(): PluginManifestFields {
     homepage: null,
     license: null,
     artifact: null,
+    icon: null,
   };
 }
 
@@ -382,6 +394,7 @@ function parseManifest(raw: string): PluginManifestFields {
     homepage: typeof meta.homepage === "string" ? meta.homepage : null,
     license: normalizeLicense(meta.license),
     artifact: parsePluginArtifact(parsed),
+    icon: parsePluginIcon(parsed) ?? null,
   };
 }
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -280,6 +280,12 @@ const pluginDetailsResponseSchema = z.object({
     .describe(
       "Prebuilt client artifact from `package.json` `vellum.artifact`, or null when the plugin ships none or its descriptor is incomplete (e.g. a placeholder sha256).",
     ),
+  icon: z
+    .string()
+    .nullable()
+    .describe(
+      "Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.",
+    ),
 });
 
 const pluginInstallRequestSchema = z.object({


### PR DESCRIPTION
## Summary
- Surface the author `vellum.icon` emoji on the plugin detail response (`pluginDetailsResponseSchema` + `getPluginDetails`, installed copy first then repo), regenerated `openapi.yaml`.

Part of plan: plugin-custom-icons.md (PR 3 of 12)