### PR TITLE
feat(web): show author emoji in the Plugins-tab list rows

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -66,6 +66,7 @@ export function PluginListRow({
         <PluginIcon
           size="sm"
           external={item.external}
+          icon={item.icon}
           className={dimmed ? "opacity-50" : undefined}
         />
         <div className="min-w-0 flex-1">

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -43,6 +43,12 @@ export interface PluginListItem {
    * predate the enable/disable surface (version-skew safeguard).
    */
   enabled?: boolean;
+  /**
+   * Author-declared emoji (`package.json` `vellum.icon`), shown in the row
+   * icon. Installed rows only — the catalog endpoint carries none. `undefined`
+   * when the plugin declares no icon; the row falls back to 📦/🧩.
+   */
+  icon?: string;
 }
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
@@ -68,6 +74,7 @@ interface InstalledPluginSource {
   path?: string;
   issues?: string[];
   enabled?: boolean;
+  icon?: string;
 }
 
 interface CatalogPluginSource {

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -87,6 +87,17 @@ describe("mergePlugins", () => {
     expect(row.description).toBeUndefined();
     expect(row.version).toBeUndefined();
   });
+
+  test("carries an installed plugin's author icon onto the row", () => {
+    const [installedRow, catalogRow] = mergePlugins(
+      [installed({ name: "alpha", icon: "🚀" })],
+      [catalog({ name: "beta" })],
+    );
+
+    expect(installedRow.icon).toBe("🚀");
+    // Catalog rows carry no icon (the search endpoint has none).
+    expect(catalogRow.icon).toBeUndefined();
+  });
 });
 
 describe("matchesQuery", () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -29,6 +29,7 @@ export function mergePlugins(
     issues: p.issues,
     // Installed rows carry enablement; older daemons omit it (undefined).
     enabled: p.enabled,
+    icon: p.icon,
   }));
 
   const installedNames = new Set(installedItems.map((i) => i.name));


### PR DESCRIPTION
## Summary
- Thread the plugin `icon` (author emoji) through `PluginListItem` + `mergePlugins` into the Plugins-tab list rows, with the 📦/🧩 fallback.

Part of plan: plugin-custom-icons.md (PR 5 of 12)