### PR TITLE
feat(plugins): expose hasIcon + iconVersion on plugin responses

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21269,6 +21269,16 @@ paths:
                         icon:
                           description: Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.
                           type: string
+                        hasIcon:
+                          description:
+                            Whether the plugin ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated).
+                            Drives whether a client fetches the bundled icon.
+                          type: boolean
+                        iconVersion:
+                          description:
+                            Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for
+                            the bundled-icon endpoint.
+                          type: string
                       required:
                         - id
                         - name
@@ -21442,6 +21452,18 @@ paths:
                       - type: string
                       - type: "null"
                     description: Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.
+                  hasIcon:
+                    type: boolean
+                    description:
+                      Whether the locally installed copy ships a valid author-bundled `icon.png` (PNG magic + dimensions + size
+                      validated). Always false when the plugin is not installed.
+                  iconVersion:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description:
+                      Content hash of the validated `icon.png`; null when `hasIcon` is false. Use it as a cache-buster for the
+                      bundled-icon endpoint.
                 required:
                   - name
                   - installed
@@ -21454,6 +21476,8 @@ paths:
                   - ref
                   - artifact
                   - icon
+                  - hasIcon
+                  - iconVersion
                 additionalProperties: false
         "400":
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -10,6 +10,7 @@
  *   - raw file downloads (a listing entry's `download_url`).
  */
 
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -92,6 +93,25 @@ function splitOnce(s: string, sep: string): [string, string] {
   const i = s.indexOf(sep);
   if (i === -1) return [s, ""];
   return [s.slice(0, i), s.slice(i + sep.length)];
+}
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/** Build a minimal, well-formed PNG with a valid signature and IHDR dimensions. */
+function makePng(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function sha16(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex").slice(0, 16);
 }
 
 let workspace: string;
@@ -335,6 +355,92 @@ describe("getPluginDetails", () => {
     // THEN the author emoji is surfaced from the installed package.json
     expect(details.installed).toBe(true);
     expect(details.icon).toBe("🦴");
+  });
+
+  test("surfaces hasIcon + iconVersion from the installed copy's icon.png", async () => {
+    // GIVEN an installed copy that ships a valid bundled icon.png
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0" }),
+    );
+    const png = makePng(64, 64);
+    writeFileSync(join(target, "icon.png"), png);
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+    });
+
+    // WHEN we resolve the detail view
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN the validated icon presence + content-hash version are surfaced
+    expect(details.installed).toBe(true);
+    expect(details.hasIcon).toBe(true);
+    expect(details.iconVersion).toBe(sha16(png));
+  });
+
+  test("reports hasIcon false + null iconVersion when no bundled icon.png", async () => {
+    // GIVEN an installed copy with no icon.png
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0" }),
+    );
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+    });
+
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN no icon is surfaced (fail-closed) — a client offers no bundled image
+    expect(details.hasIcon).toBe(false);
+    expect(details.iconVersion).toBeNull();
+  });
+
+  test("reports hasIcon false + null iconVersion for an uninstalled plugin", async () => {
+    // GIVEN a marketplace-only plugin with no installed copy
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [
+          {
+            name: "simple-memory",
+            source: {
+              source: "github",
+              repo: "example-org/simple-memory",
+              ref: "9999999999999999999999999999999999999999",
+            },
+          },
+        ],
+      },
+      listings: { "example-org/simple-memory": [] },
+    });
+
+    const details = await getPluginDetails(
+      { name: "simple-memory" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN a not-installed plugin has no bundled icon to validate
+    expect(details.installed).toBe(false);
+    expect(details.hasIcon).toBe(false);
+    expect(details.iconVersion).toBeNull();
   });
 
   test("throws PluginDetailsNotFoundError when nothing claims the name", async () => {

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -38,6 +38,7 @@ import {
   parsePluginIcon,
   type PluginArtifact,
 } from "./plugin-artifact.js";
+import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
@@ -116,6 +117,17 @@ export interface PluginDetails {
    * resolved from the installed copy first then the repo; `null` when none.
    */
   readonly icon: string | null;
+  /**
+   * Whether the locally installed copy ships a valid author-bundled `icon.png`
+   * (validated for PNG magic, dimensions, and size). `false` when the plugin is
+   * not installed or ships no valid icon.
+   */
+  readonly hasIcon: boolean;
+  /**
+   * Content hash of the validated `icon.png`; `null` when {@link hasIcon} is
+   * false. A cache-buster for the bundled-icon endpoint.
+   */
+  readonly iconVersion: string | null;
 }
 
 /** No installed copy and no catalog/source entry claims the name. */
@@ -148,6 +160,9 @@ export async function getPluginDetails(
 
   const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
   const local = readLocalPlugin(pluginsDir, name);
+  // Validate the installed copy's bundled icon.png (fail-closed: a missing or
+  // invalid icon — including a not-installed plugin — resolves to no icon).
+  const localIcon = readValidatedPluginIcon(join(pluginsDir, name));
 
   const marketplaceEntry = await findMarketplaceEntry(name, ref, fetchFn);
 
@@ -196,6 +211,8 @@ export async function getPluginDetails(
     ref,
     artifact: local.manifest.artifact ?? remote.manifest.artifact,
     icon: local.manifest.icon ?? remote.manifest.icon,
+    hasIcon: localIcon.hasIcon,
+    iconVersion: localIcon.iconVersion ?? null,
   };
 }
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -381,6 +381,10 @@ function pluginEntry(
     target: overrides.target ?? `/tmp/plugins/${overrides.name}`,
     packageJson: overrides.packageJson ?? null,
     issues: overrides.issues ?? [],
+    hasIcon: overrides.hasIcon ?? false,
+    ...(overrides.iconVersion !== undefined
+      ? { iconVersion: overrides.iconVersion }
+      : {}),
   };
 }
 
@@ -433,6 +437,8 @@ describe("GET /v1/plugins", () => {
       version: "1.2.3",
       path: "/workspace/plugins/alpha",
       category: null,
+      // No bundled `icon.png` on this fixture → hasIcon is false, iconVersion absent.
+      hasIcon: false,
     });
     // `issues` is omitted (not just undefined) when the entry is clean.
     expect("issues" in result.plugins[0]!).toBe(false);
@@ -528,6 +534,28 @@ describe("GET /v1/plugins", () => {
     expect(byId.get("with-icon")?.icon).toBe("🎨");
     // Absent icon is omitted from the wire object, not set to undefined/null.
     expect("icon" in byId.get("no-icon")!).toBe(false);
+  });
+
+  test("serializes hasIcon + iconVersion from the validated bundled icon.png", async () => {
+    installedFixture = [
+      pluginEntry({
+        name: "bundled",
+        packageJson: { name: "bundled", version: "1.0.0" },
+        hasIcon: true,
+        iconVersion: "deadbeefdeadbeef",
+      }),
+      pluginEntry({
+        name: "plain",
+        packageJson: { name: "plain", version: "1.0.0" },
+      }),
+    ];
+
+    const byId = new Map((await invoke()).plugins.map((p) => [p.id, p]));
+    expect(byId.get("bundled")?.hasIcon).toBe(true);
+    expect(byId.get("bundled")?.iconVersion).toBe("deadbeefdeadbeef");
+    // No valid icon → hasIcon false and iconVersion omitted (not null).
+    expect(byId.get("plain")?.hasIcon).toBe(false);
+    expect("iconVersion" in byId.get("plain")!).toBe(false);
   });
 
   test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {
@@ -1243,6 +1271,9 @@ function pluginDetails(overrides: Partial<PluginDetails> = {}): PluginDetails {
     readme: overrides.readme ?? null,
     ref: overrides.ref ?? "main",
     artifact: overrides.artifact ?? null,
+    icon: overrides.icon ?? null,
+    hasIcon: overrides.hasIcon ?? false,
+    iconVersion: overrides.iconVersion ?? null,
   };
 }
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -144,6 +144,18 @@ const pluginInfoSchema = z.object({
     .describe(
       "Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.",
     ),
+  hasIcon: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the plugin ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated). Drives whether a client fetches the bundled icon.",
+    ),
+  iconVersion: z
+    .string()
+    .optional()
+    .describe(
+      "Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for the bundled-icon endpoint.",
+    ),
 });
 
 const pluginsListResponseSchema = z.object({
@@ -285,6 +297,17 @@ const pluginDetailsResponseSchema = z.object({
     .nullable()
     .describe(
       "Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.",
+    ),
+  hasIcon: z
+    .boolean()
+    .describe(
+      "Whether the locally installed copy ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated). Always false when the plugin is not installed.",
+    ),
+  iconVersion: z
+    .string()
+    .nullable()
+    .describe(
+      "Content hash of the validated `icon.png`; null when `hasIcon` is false. Use it as a cache-buster for the bundled-icon endpoint.",
     ),
 });
 
@@ -671,6 +694,8 @@ interface PluginView {
   issues?: string[];
   category?: string | null;
   icon?: string;
+  hasIcon: boolean;
+  iconVersion?: string;
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -685,12 +710,16 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
     description: entry.packageJson?.description ?? null,
     version: entry.packageJson?.version ?? null,
     path: entry.target,
+    hasIcon: entry.hasIcon,
   };
   if (entry.issues.length > 0) {
     view.issues = [...entry.issues];
   }
   if (entry.packageJson?.icon !== undefined) {
     view.icon = entry.packageJson.icon;
+  }
+  if (entry.iconVersion !== undefined) {
+    view.iconVersion = entry.iconVersion;
   }
   return view;
 }


### PR DESCRIPTION
## Summary
- Surface `hasIcon`/`iconVersion` (from the validated bundled icon.png) on the plugin list + detail responses; no base64. Regenerated openapi.yaml.

Part of plan: plugin-custom-icons.md (PR 9 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)