### PR TITLE
feat(plugins): serve a plugin icon PNG with caching headers

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21660,6 +21660,35 @@ paths:
           description: No plugin directory exists with the given name.
         "409":
           description: The plugin is already enabled.
+  /v1/plugins/{name}/icon:
+    get:
+      operationId: plugins_by_name_icon_get
+      summary: Serve a plugin's bundled icon
+      description:
+        Serve the installed plugin's validated author-bundled `icon.png` as `image/png`. The PNG is re-validated on
+        read (magic bytes + IHDR dimensions + size) and served with an immutable `Cache-Control` plus a content-hash
+        `ETag` — the `iconVersion` reported by `GET /v1/plugins` and `GET /v1/plugins/:name` — so clients cache
+        aggressively and only refetch when the hash changes. A plugin with no valid bundled icon returns 404; a
+        malformed name returns 400. Pair with the `hasIcon` / `iconVersion` fields on the list and detail responses to
+        decide whether to fetch.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: No installed plugin with the given name has an icon.
   /v1/plugins/{name}/inspect:
     get:
       operationId: plugins_by_name_inspect_get

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -50,7 +50,9 @@
  * here we mock them to isolate the route's wiring logic.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   type DiffPluginDeps,
@@ -71,6 +73,7 @@ import {
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  sanitizePluginName,
 } from "../../../cli/lib/install-from-github.js";
 import type { InstalledPluginInfo } from "../../../cli/lib/list-installed-plugins.js";
 import {
@@ -174,6 +177,10 @@ mock.module("../../../cli/lib/install-from-github.js", () => ({
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  // The icon route calls the real name guard directly (it builds a filesystem
+  // path from `:name` rather than delegating to a lib that sanitizes), so pass
+  // the real `sanitizePluginName` through — a traversal name must still 400.
+  sanitizePluginName,
   installPlugin: installSpy,
 }));
 
@@ -323,11 +330,13 @@ import {
   NotFoundError,
   ServiceUnavailableError,
 } from "../errors.js";
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import {
   loadCategoryMapBounded,
   normalizeMarketplaceCategory,
   ROUTES as PLUGINS_ROUTES,
 } from "../plugins-routes.js";
+import { RouteResponse } from "../types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
@@ -347,6 +356,7 @@ const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
 const enableHandler = findHandler("plugins_enable");
 const disableHandler = findHandler("plugins_disable");
+const iconHandler = findHandler("plugins_icon");
 
 async function invoke(args: RouteHandlerArgs = {}): Promise<{
   plugins: Array<Record<string, unknown>>;
@@ -2399,6 +2409,87 @@ describe("POST /v1/plugins/:name/disable", () => {
     });
 
     expect(() => invokeDisable({ pathParams: { name: "../escape" } })).toThrow(
+      BadRequestError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/plugins/:name/icon
+// ---------------------------------------------------------------------------
+
+const ICON_PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/** Minimal valid PNG: signature + IHDR width/height, within the 128×128 cap. */
+function makeIconPng(width = 64, height = 64): Buffer {
+  const buf = Buffer.alloc(24);
+  ICON_PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+/**
+ * Create `<workspacePlugins>/<name>/`, optionally writing `icon.png` into it.
+ * Returns the plugin directory so the caller can clean it up. Uses the real
+ * `getWorkspacePluginsDir()` (rooted at the per-test temp workspace), so the
+ * route's real `readValidatedPluginIcon` + `readFileSync` path is exercised.
+ */
+function makePluginDir(name: string, icon?: Buffer): string {
+  const dir = join(getWorkspacePluginsDir(), name);
+  mkdirSync(dir, { recursive: true });
+  if (icon) writeFileSync(join(dir, "icon.png"), icon);
+  return dir;
+}
+
+describe("GET /v1/plugins/:name/icon", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("serves the validated icon.png as image/png with caching headers", () => {
+    const bytes = makeIconPng(64, 64);
+    created.push(makePluginDir("with-icon", bytes));
+
+    const result = iconHandler({
+      pathParams: { name: "with-icon" },
+    }) as RouteResponse;
+
+    // Exact bytes flow through unmodified as an image/png body.
+    expect(result).toBeInstanceOf(RouteResponse);
+    expect(Buffer.from(result.body as Uint8Array)).toEqual(bytes);
+    expect(result.headers["Content-Type"]).toBe("image/png");
+    expect(result.headers["Content-Length"]).toBe(String(bytes.length));
+    // Immutable cache + nosniff: the bytes are content-addressed by the ETag.
+    expect(result.headers["Cache-Control"]).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(result.headers["X-Content-Type-Options"]).toBe("nosniff");
+    // ETag is the quoted content-hash iconVersion (16 hex chars).
+    expect(result.headers.ETag).toMatch(/^"[0-9a-f]{16}"$/);
+  });
+
+  test("404 (NotFoundError) when the installed plugin ships no valid icon", () => {
+    // Directory exists but carries no icon.png → validator returns hasIcon:false.
+    created.push(makePluginDir("no-icon"));
+
+    expect(() => iconHandler({ pathParams: { name: "no-icon" } })).toThrow(
+      NotFoundError,
+    );
+  });
+
+  test("400 (BadRequestError) on a traversal / malformed name", () => {
+    // The name guard rejects `../escape` before it can become a filesystem
+    // path, so no icon is ever read for an out-of-tree name.
+    expect(() => iconHandler({ pathParams: { name: "../escape" } })).toThrow(
       BadRequestError,
     );
   });

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -323,6 +323,7 @@ mock.module("../../../skills/categories-cache.js", () => ({
   getLocalCategorySlugs: () => SKILLS_CATEGORY_SLUGS,
 }));
 
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import {
   BadRequestError,
   ConflictError,
@@ -330,14 +331,13 @@ import {
   NotFoundError,
   ServiceUnavailableError,
 } from "../errors.js";
-import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import {
   loadCategoryMapBounded,
   normalizeMarketplaceCategory,
   ROUTES as PLUGINS_ROUTES,
 } from "../plugins-routes.js";
-import { RouteResponse } from "../types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+import { RouteResponse } from "../types.js";
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
   const route = PLUGINS_ROUTES.find((r) => r.operationId === operationId);
@@ -2468,9 +2468,10 @@ describe("GET /v1/plugins/:name/icon", () => {
     expect(Buffer.from(result.body as Uint8Array)).toEqual(bytes);
     expect(result.headers["Content-Type"]).toBe("image/png");
     expect(result.headers["Content-Length"]).toBe(String(bytes.length));
-    // Immutable cache + nosniff: the bytes are content-addressed by the ETag.
+    // Private immutable cache + nosniff: an authenticated per-workspace
+    // resource, content-addressed by the ETag; no shared cache may reuse it.
     expect(result.headers["Cache-Control"]).toBe(
-      "public, max-age=31536000, immutable",
+      "private, max-age=31536000, immutable",
     );
     expect(result.headers["X-Content-Type-Options"]).toBe("nosniff");
     // ETag is the quoted content-hash iconVersion (16 hex chars).

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -101,8 +101,8 @@ import {
   RouteError,
   ServiceUnavailableError,
 } from "./errors.js";
-import { RouteResponse } from "./types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import { RouteResponse } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -1404,7 +1404,10 @@ function handleGetPluginIcon({
   return new RouteResponse(new Uint8Array(bytes), {
     "Content-Type": "image/png",
     "Content-Length": String(bytes.length),
-    "Cache-Control": "public, max-age=31536000, immutable",
+    // `private`: the icon is an authenticated, workspace-specific resource, so
+    // no shared/proxy cache may reuse it across requests. The content-hash
+    // ETag + immutable still let the browser cache aggressively.
+    "Cache-Control": "private, max-age=31536000, immutable",
     ETag: `"${v.iconVersion}"`,
     "X-Content-Type-Options": "nosniff",
   });
@@ -1569,8 +1572,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     additionalResponses: {
       "404": {
-        description:
-          "No installed plugin with the given name has an icon.",
+        description: "No installed plugin with the given name has an icon.",
       },
     },
     handler: handleGetPluginIcon,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -23,6 +23,9 @@
  * `get_route_schema` so the gateway's IPC proxy stays in sync.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { z } from "zod";
 
 import {
@@ -40,6 +43,7 @@ import {
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  sanitizePluginName,
 } from "../../cli/lib/install-from-github.js";
 import {
   type InstalledPluginInfo,
@@ -50,6 +54,7 @@ import {
   getPluginDetails,
   PluginDetailsNotFoundError,
 } from "../../cli/lib/plugin-details.js";
+import { readValidatedPluginIcon } from "../../cli/lib/plugin-icon-file.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
   listPinHistory,
@@ -82,6 +87,7 @@ import {
 } from "../../cli/lib/upgrade-plugin.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   getOriginClientId,
@@ -95,6 +101,7 @@ import {
   RouteError,
   ServiceUnavailableError,
 } from "./errors.js";
+import { RouteResponse } from "./types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -1363,6 +1370,47 @@ function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// Handler — icon (bundled icon.png)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serve an installed plugin's validated author-bundled `icon.png` as
+ * `image/png`. Side-effect-free: the on-disk icon is re-validated on read and
+ * never mutated. `sanitizePluginName` rejects a traversal name (`../escape`)
+ * with a 400 before it becomes a filesystem path. The content-hash
+ * `iconVersion` is the `ETag` and the bytes are immutable-cacheable, so a byte
+ * change yields a new hash — clients refetch off the `hasIcon` / `iconVersion`
+ * fields on the list / detail responses.
+ */
+function handleGetPluginIcon({
+  pathParams = {},
+}: RouteHandlerArgs): RouteResponse {
+  let name: string;
+  try {
+    name = sanitizePluginName(pathParams.name ?? "");
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+
+  const v = readValidatedPluginIcon(join(getWorkspacePluginsDir(), name));
+  if (!v.hasIcon || !v.path) {
+    throw new NotFoundError("Plugin icon not found");
+  }
+
+  const bytes = readFileSync(v.path);
+  return new RouteResponse(new Uint8Array(bytes), {
+    "Content-Type": "image/png",
+    "Content-Length": String(bytes.length),
+    "Cache-Control": "public, max-age=31536000, immutable",
+    ETag: `"${v.iconVersion}"`,
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -1495,6 +1543,37 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleGetPluginDetails,
+  },
+  {
+    operationId: "plugins_icon",
+    endpoint: "plugins/:name/icon",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Serve a plugin's bundled icon",
+    description:
+      "Serve the installed plugin's validated author-bundled `icon.png` as `image/png`. The PNG is re-validated on read (magic bytes + IHDR dimensions + size) and served with an immutable `Cache-Control` plus a content-hash `ETag` — the `iconVersion` reported by `GET /v1/plugins` and `GET /v1/plugins/:name` — so clients cache aggressively and only refetch when the hash changes. A plugin with no valid bundled icon returns 404; a malformed name returns 400. Pair with the `hasIcon` / `iconVersion` fields on the list and detail responses to decide whether to fetch.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description: "Install name (kebab-case).",
+      },
+    ],
+    responseBody: {
+      contentType: "image/png",
+      schema: { type: "string", format: "binary" },
+    },
+    additionalResponses: {
+      "404": {
+        description:
+          "No installed plugin with the given name has an icon.",
+      },
+    },
+    handler: handleGetPluginIcon,
   },
   {
     operationId: "plugins_uninstall",

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -72,7 +72,8 @@ export type RouteResponseContentType =
   | "application/octet-stream"
   | "application/gzip"
   | "application/pdf"
-  | "application/zip";
+  | "application/zip"
+  | "image/png";
 
 /**
  * A route's success response body. Either:


### PR DESCRIPTION
## Summary
- Add `GET /v1/plugins/:name/icon` serving the validated icon.png as image/png with nosniff + immutable Cache-Control + ETag; 404 when absent, 400 on a bad name. Added `image/png` to RouteResponseContentType. Regenerated openapi.yaml.

Part of plan: plugin-custom-icons.md (PR 10 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)