### PR TITLE
refactor(assistant): control-plane verification flows create/manage sessions via the gateway

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -73,6 +73,14 @@ mock.module("../ipc/gateway-client.js", () => ({
     method: string,
     params?: Record<string, unknown>,
   ) => {
+    // Session lifecycle goes through the gateway session client now;
+    // delegate to the local-service sim so these tests keep seeding and
+    // asserting against the local test DB.
+    const { handleVerificationSessionsIpc, isVerificationSessionsIpcMethod } =
+      await import("./helpers/verification-sessions-ipc-sim.js");
+    if (isVerificationSessionsIpcMethod(method)) {
+      return handleVerificationSessionsIpc(method, params);
+    }
     if (method === "mark_channel_revoked") {
       const { revokeChannelById } =
         await import("./helpers/seed-contact-channel.js");

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -84,6 +84,24 @@ globalThis.fetch = (async (
   return originalFetch(input, init as never);
 }) as unknown as typeof fetch;
 
+// Gateway IPC mock — session lifecycle now goes through the gateway session
+// client; delegate verification_sessions_* methods to the local-service sim
+// so the flows under test keep reading/writing the local test DB.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    const { handleVerificationSessionsIpc, isVerificationSessionsIpcMethod } =
+      await import("./helpers/verification-sessions-ipc-sim.js");
+    if (isVerificationSessionsIpcMethod(method)) {
+      return handleVerificationSessionsIpc(method, params);
+    }
+    return { ok: true };
+  },
+  ipcCall: async () => null,
+}));
+
 // Guardian-delivery reader mock — the inbound challenge guard reads guardian
 // existence from the gateway. These tests seed no binding, so report an empty
 // list (not bound) rather than a null that would fail closed as already-bound.
@@ -303,8 +321,8 @@ describe("startOutbound", () => {
 // ===========================================================================
 
 describe("resendOutbound", () => {
-  test("returns no_active_session when no session exists", () => {
-    const result = resendOutbound({ channel: "phone" });
+  test("returns no_active_session when no session exists", async () => {
+    const result = await resendOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
@@ -327,7 +345,7 @@ describe("resendOutbound", () => {
       );
     }
 
-    const resendResult = resendOutbound({ channel: "phone" });
+    const resendResult = await resendOutbound({ channel: "phone" });
     expect(resendResult.success).toBe(true);
     expect(resendResult.verificationSessionId).toBeDefined();
     expect(resendResult.sendCount).toBe(2);
@@ -349,7 +367,7 @@ describe("resendOutbound", () => {
       );
     }
 
-    const resendResult = resendOutbound({
+    const resendResult = await resendOutbound({
       channel: "phone",
       originConversationId: "conv-resend-voice-origin",
     });
@@ -374,7 +392,7 @@ describe("resendOutbound", () => {
       );
     }
 
-    const resendResult = resendOutbound({
+    const resendResult = await resendOutbound({
       channel: "phone",
       originConversationId: "conv-resend-voice-origin",
     });
@@ -398,8 +416,8 @@ describe("resendOutbound", () => {
 // ===========================================================================
 
 describe("cancelOutbound", () => {
-  test("returns no_active_session when no session exists", () => {
-    const result = cancelOutbound({ channel: "phone" });
+  test("returns no_active_session when no session exists", async () => {
+    const result = await cancelOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
@@ -411,7 +429,7 @@ describe("cancelOutbound", () => {
     });
     expect(startResult.success).toBe(true);
 
-    const cancelResult = cancelOutbound({ channel: "phone" });
+    const cancelResult = await cancelOutbound({ channel: "phone" });
     expect(cancelResult.success).toBe(true);
     expect(cancelResult.channel).toBe("phone");
   });
@@ -612,7 +630,7 @@ describe("origin conversation linkage", () => {
     }
 
     // Resend with origin conversation ID
-    const resendResult = resendOutbound({
+    const resendResult = await resendOutbound({
       channel: "phone",
       originConversationId: "conv-resend-origin-linkage",
     });

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -20,6 +20,24 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
+// Gateway IPC mock — session lifecycle goes through the gateway session
+// client; delegate verification_sessions_* methods to the local-service sim
+// so these tests keep reading/writing the local test DB.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    const { handleVerificationSessionsIpc, isVerificationSessionsIpcMethod } =
+      await import("./helpers/verification-sessions-ipc-sim.js");
+    if (isVerificationSessionsIpcMethod(method)) {
+      return handleVerificationSessionsIpc(method, params);
+    }
+    return { ok: true };
+  },
+  ipcCall: async () => null,
+}));
+
 const _conversationMocks = new Map<string, unknown>();
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => _conversationMocks.get(id),

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -13,19 +13,10 @@
 
 import { VERIFICATION_SESSIONS_IPC_METHODS } from "@vellumai/gateway-client";
 
-import {
-  bindSessionIdentity,
-  countRecentSendsToDestination,
-  createInboundVerificationSession,
-  createOutboundSession,
-  findActiveSession,
-  getPendingSession,
-  resolveBootstrapToken,
-  revokePendingSessions,
-  updateSessionDelivery,
-  updateSessionStatus,
-  validateAndConsumeVerification,
-} from "../../runtime/channel-verification-service.js";
+// Lazy import per AGENTS.md "Test machinery isolation": production runtime
+// must not load at helper-import time, only at call time inside a test.
+type VerificationService =
+  typeof import("../../runtime/channel-verification-service.js");
 
 const METHOD_SET = new Set<string>(
   Object.values(VERIFICATION_SESSIONS_IPC_METHODS),
@@ -35,10 +26,26 @@ export function isVerificationSessionsIpcMethod(method: string): boolean {
   return METHOD_SET.has(method);
 }
 
-export function handleVerificationSessionsIpc(
+export async function handleVerificationSessionsIpc(
   method: string,
   params: Record<string, unknown> = {},
-): unknown {
+): Promise<unknown> {
+  const svc: VerificationService = await import(
+    "../../runtime/channel-verification-service.js"
+  );
+  const {
+    bindSessionIdentity,
+    countRecentSendsToDestination,
+    createInboundVerificationSession,
+    createOutboundSession,
+    findActiveSession,
+    getPendingSession,
+    resolveBootstrapToken,
+    revokePendingSessions,
+    updateSessionDelivery,
+    updateSessionStatus,
+    validateAndConsumeVerification,
+  } = svc;
   const M = VERIFICATION_SESSIONS_IPC_METHODS;
   const p = params as Record<string, never>;
   switch (method) {

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -1,0 +1,117 @@
+/**
+ * Test-only handler for `verification_sessions_*` gateway IPC methods.
+ *
+ * Delegates to the daemon's local session service — the gateway store ported
+ * those semantics 1:1 — so integration tests keep seeding and asserting
+ * against the local test DB while production code paths go through the
+ * gateway session client. Wire in an `ipcCallPersistent` mock:
+ *
+ *   if (isVerificationSessionsIpcMethod(method)) {
+ *     return handleVerificationSessionsIpc(method, params);
+ *   }
+ */
+
+import { VERIFICATION_SESSIONS_IPC_METHODS } from "@vellumai/gateway-client";
+
+import {
+  bindSessionIdentity,
+  countRecentSendsToDestination,
+  createInboundVerificationSession,
+  createOutboundSession,
+  findActiveSession,
+  getPendingSession,
+  resolveBootstrapToken,
+  revokePendingSessions,
+  updateSessionDelivery,
+  updateSessionStatus,
+  validateAndConsumeVerification,
+} from "../../runtime/channel-verification-service.js";
+
+const METHOD_SET = new Set<string>(
+  Object.values(VERIFICATION_SESSIONS_IPC_METHODS),
+);
+
+export function isVerificationSessionsIpcMethod(method: string): boolean {
+  return METHOD_SET.has(method);
+}
+
+export function handleVerificationSessionsIpc(
+  method: string,
+  params: Record<string, unknown> = {},
+): unknown {
+  const M = VERIFICATION_SESSIONS_IPC_METHODS;
+  const p = params as Record<string, never>;
+  switch (method) {
+    case M.createInbound: {
+      const result = createInboundVerificationSession(
+        p.channel,
+        p.sourceConversationId,
+      );
+      const session = getPendingSession(p.channel);
+      if (!session) {
+        throw new Error("sim: no pending session after inbound create");
+      }
+      return {
+        session,
+        secret: result.secret,
+        verifyCommand: result.verifyCommand,
+        ttlSeconds: result.ttlSeconds,
+      };
+    }
+    case M.createOutbound:
+      return createOutboundSession(
+        params as Parameters<typeof createOutboundSession>[0],
+      );
+    case M.getPending:
+      return getPendingSession(p.channel);
+    case M.findActive:
+      return findActiveSession(p.channel);
+    case M.resolveBootstrap:
+      return resolveBootstrapToken(p.channel, p.token);
+    case M.bindIdentity:
+      bindSessionIdentity(p.sessionId, p.externalUserId, p.chatId);
+      return { ok: true };
+    case M.updateStatus: {
+      const extra: Partial<{
+        consumedByExternalUserId: string;
+        consumedByChatId: string;
+      }> = {};
+      if (p.consumedByExternalUserId != null) {
+        extra.consumedByExternalUserId = p.consumedByExternalUserId;
+      }
+      if (p.consumedByChatId != null) {
+        extra.consumedByChatId = p.consumedByChatId;
+      }
+      updateSessionStatus(p.sessionId, p.status, extra);
+      return { ok: true };
+    }
+    case M.updateDelivery:
+      updateSessionDelivery(
+        p.sessionId,
+        p.lastSentAt,
+        p.sendCount,
+        p.nextResendAt ?? null,
+      );
+      return { ok: true };
+    case M.countRecentSends:
+      return {
+        count: countRecentSendsToDestination(
+          p.channel,
+          p.destinationAddress,
+          p.windowMs,
+        ),
+      };
+    case M.revokePending:
+      revokePendingSessions(p.channel);
+      return { ok: true };
+    case M.validateConsume:
+      return validateAndConsumeVerification(
+        p.channel,
+        p.secret,
+        p.actorExternalUserId,
+        p.actorChatId,
+      );
+    default:
+      throw new Error(`sim: unhandled verification_sessions method ${method}`);
+  }
+}

--- a/assistant/src/__tests__/introduction-card-resolver.test.ts
+++ b/assistant/src/__tests__/introduction-card-resolver.test.ts
@@ -75,13 +75,22 @@ mock.module("../contacts/member-write-relay.js", () => ({
   revokeMemberChannel: async () => null,
 }));
 
-// Verification sessions: record mints instead of writing session state.
+// Verification sessions: record mints instead of writing session state. The
+// resolver mints via the gateway session client.
 const sessionMints: Array<Record<string, unknown>> = [];
 mock.module("../runtime/channel-verification-service.js", () => ({
   CHALLENGE_TTL_MS: 10 * 60 * 1000,
-  createOutboundSession: (params: Record<string, unknown>) => {
+}));
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  createOutboundSession: async (params: Record<string, unknown>) => {
     sessionMints.push(params);
-    return { sessionId: "session-1", secret: "123456" };
+    return {
+      sessionId: "session-1",
+      secret: "123456",
+      challengeHash: "hash",
+      expiresAt: Date.now() + 600_000,
+      ttlSeconds: 600,
+    };
   },
 }));
 

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -71,9 +71,16 @@ mock.module("../runtime/channel-verification-service.js", () => ({
     }
     return null;
   },
-  createOutboundSession: () => ({
-    conversationId: "test-session",
+}));
+
+// Gateway session client — the resolver mints verification sessions here.
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  createOutboundSession: async () => ({
+    sessionId: "test-session",
     secret: "123456",
+    challengeHash: "hash",
+    expiresAt: Date.now() + 600_000,
+    ttlSeconds: 600,
   }),
 }));
 

--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -10,9 +10,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-const mockFindActiveSession = mock(() => null as unknown);
-mock.module("../runtime/channel-verification-service.js", () => ({
-  findActiveSession: mockFindActiveSession,
+const mockFindActiveSession = mock((): unknown => null);
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  findActiveSession: async () => mockFindActiveSession(),
 }));
 
 const mockDeliverVerificationSlack = mock(() => {});
@@ -99,12 +99,12 @@ const dummySideEffectCtx = {
   ctx: {} as SideEffectContext["ctx"],
 } satisfies SideEffectContext;
 
-function callWithBashHook(
+async function callWithBashHook(
   command: string,
   content: string,
   isError = false,
-): void {
-  runPostExecutionSideEffects(
+): Promise<void> {
+  await runPostExecutionSideEffects(
     "bash",
     { command },
     { content, isError },
@@ -125,7 +125,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     mockLogError.mockReset();
   });
 
-  test("legitimate verification dispatches DM", () => {
+  test("legitimate verification dispatches DM", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U123",
       status: "awaiting_response",
@@ -139,7 +139,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
       },
     });
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       output,
     );
@@ -152,7 +152,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
   });
 
-  test("no active session — DM not dispatched", () => {
+  test("no active session — DM not dispatched", async () => {
     mockFindActiveSession.mockReturnValue(null);
 
     const output = JSON.stringify({
@@ -163,7 +163,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
       },
     });
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       output,
     );
@@ -175,7 +175,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
   });
 
-  test("userId mismatch — DM not dispatched", () => {
+  test("userId mismatch — DM not dispatched", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U999",
       status: "awaiting_response",
@@ -189,7 +189,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
       },
     });
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       output,
     );
@@ -201,7 +201,32 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
   });
 
-  test("command without verification substring — hook is no-op", () => {
+  test("gateway session lookup failure — DM not dispatched (fail closed)", async () => {
+    mockFindActiveSession.mockImplementation(() => {
+      throw new Error("gateway unreachable");
+    });
+
+    const output = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U123",
+        text: "code",
+        assistantId: "aid",
+      },
+    });
+
+    await callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      output,
+    );
+
+    expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "U123" }),
+      expect.stringContaining("gateway session lookup failed"),
+    );
+  });
+
+  test("command without verification substring — hook is no-op", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U123",
       status: "awaiting_response",
@@ -215,18 +240,18 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
       },
     });
 
-    callWithBashHook("echo hello", output);
+    await callWithBashHook("echo hello", output);
 
     expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
   });
 
-  test("output without _pendingSlackDm — hook is no-op", () => {
+  test("output without _pendingSlackDm — hook is no-op", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U123",
       status: "awaiting_response",
     });
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       JSON.stringify({ success: true, sessionId: "s1" }),
     );
@@ -234,7 +259,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
   });
 
-  test("multi-line JSON output — dispatches from correct line", () => {
+  test("multi-line JSON output — dispatches from correct line", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U123",
       status: "awaiting_response",
@@ -250,7 +275,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     });
     const multiLineOutput = `${cancelResult}\n${createResult}`;
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       multiLineOutput,
     );
@@ -263,7 +288,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
   });
 
-  test("multi-line — rejected first line does not block valid second line", () => {
+  test("multi-line — rejected first line does not block valid second line", async () => {
     mockFindActiveSession.mockReturnValue({
       destinationAddress: "U200",
       status: "awaiting_response",
@@ -285,7 +310,7 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     });
     const multiLineOutput = `${staleResult}\n${validResult}`;
 
-    callWithBashHook(
+    await callWithBashHook(
       "assistant channel-verification-sessions create ...",
       multiLineOutput,
     );

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -108,6 +108,17 @@ mock.module("../runtime/channel-verification-service.js", () => ({
   }),
 }));
 
+// Gateway session client — the resolver mints verification sessions here now.
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  createOutboundSession: async () => ({
+    sessionId: "test-session",
+    secret: "123456",
+    challengeHash: "hash",
+    expiresAt: Date.now() + 600_000,
+    ttlSeconds: 600,
+  }),
+}));
+
 // Mock gateway client — capture delivery calls. `failDeliveryWhen` lets a test
 // simulate a delivery failure for a specific payload (e.g. a DM that can't be
 // opened) so fallback paths can be exercised.

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -58,6 +58,24 @@ mock.module("../runtime/gateway-client.js", () => ({
   },
 }));
 
+// Gateway IPC mock — session lifecycle goes through the gateway session
+// client; delegate verification_sessions_* methods to the local-service sim
+// so these tests keep reading/writing the local test DB.
+mock.module("../ipc/gateway-client.js", () => ({
+  ipcCallPersistent: async (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => {
+    const { handleVerificationSessionsIpc, isVerificationSessionsIpcMethod } =
+      await import("./helpers/verification-sessions-ipc-sim.js");
+    if (isVerificationSessionsIpcMethod(method)) {
+      return handleVerificationSessionsIpc(method, params);
+    }
+    return { ok: true };
+  },
+  ipcCall: async () => null,
+}));
+
 // Mock the approval conversation / copy generators so they return canned text.
 mock.module("../runtime/approval-message-composer.js", () => ({
   composeApprovalMessage: () => "mock approval message",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -12,6 +12,7 @@
  */
 
 import { answerCall } from "../calls/call-domain.js";
+import { createOutboundSession } from "../channels/gateway-verification-sessions.js";
 import {
   type CanonicalGuardianRequest,
   type CanonicalRequestStatus,
@@ -40,7 +41,6 @@ import {
   type ApprovalAction,
   DENYING_ACTION_SET,
 } from "../runtime/channel-approval-types.js";
-import { createOutboundSession } from "../runtime/channel-verification-service.js";
 import { deliverChannelReply } from "../runtime/gateway-client.js";
 import {
   parseRequesterSignals,
@@ -988,7 +988,7 @@ const accessRequestResolver: GuardianRequestResolver = {
 
     // Non-voice approvals: mint an identity-bound verification session so the
     // requester can verify their identity.
-    const session = createOutboundSession({
+    const session = await createOutboundSession({
       channel,
       expectedExternalUserId: requesterExternalUserId,
       expectedChatId: requesterChatId,

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -405,7 +405,7 @@ export function createToolExecutor(
         ctx.approvedViaPromptThisTurn = true;
       }
 
-      runPostExecutionSideEffects(toolName, toolInput, result, { ctx });
+      void runPostExecutionSideEffects(toolName, toolInput, result, { ctx });
 
       return result;
     }
@@ -419,7 +419,9 @@ export function createToolExecutor(
       ctx.approvedViaPromptThisTurn = true;
     }
 
-    runPostExecutionSideEffects(executionName, executionInput, result, { ctx });
+    void runPostExecutionSideEffects(executionName, executionInput, result, {
+      ctx,
+    });
 
     return result;
   };

--- a/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-channels.test.ts
@@ -43,6 +43,25 @@ mock.module("../../../contacts/notify-contacts-changed.js", () => ({
 mock.module("../../../ipc/gateway-client.js", () => ({
   ipcCallPersistent: async (method: string, payload: unknown) => {
     ipcCalls.push({ method, payload });
+    // Gateway session client methods (stubbed gateway responses).
+    if (method === "verification_sessions_count_recent_sends") {
+      return { count: 0 };
+    }
+    if (method === "verification_sessions_create_outbound") {
+      return {
+        sessionId: "sess",
+        secret: "code",
+        challengeHash: "hash",
+        expiresAt: Date.now() + 1000,
+        ttlSeconds: 600,
+      };
+    }
+    if (
+      method === "verification_sessions_update_delivery" ||
+      method === "verification_sessions_revoke_pending"
+    ) {
+      return { ok: true };
+    }
     if (method === "contacts_get_rich") {
       if (mockGwContactChannels == null) return { ok: true, contact: null };
       return {
@@ -92,15 +111,7 @@ mock.module("../../../ipc/gateway-client.js", () => ({
 
 mock.module("../../../runtime/channel-verification-service.js", () => ({
   getGuardianBinding: () => mockBinding,
-  revokePendingSessions: () => {},
-  createOutboundSession: () => ({
-    sessionId: "sess",
-    secret: "code",
-    expiresAt: Date.now() + 1000,
-  }),
-  countRecentSendsToDestination: () => 0,
   isGuardianBoundForChannel: async () => false,
-  updateSessionDelivery: () => {},
 }));
 
 mock.module("../../../runtime/verification-outbound-actions.js", () => ({

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -4,6 +4,15 @@ import type { GuardianDelivery } from "@vellumai/gateway-client";
 import { MarkChannelRevokedIpcResponseSchema } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
+import {
+  countRecentSendsToDestination,
+  createInboundVerificationSession,
+  createOutboundSession,
+  findActiveSession,
+  getPendingSession,
+  revokePendingSessions,
+  updateSessionDelivery,
+} from "../../channels/gateway-verification-sessions.js";
 import type { ChannelId } from "../../channels/types.js";
 import {
   findContactChannel,
@@ -27,15 +36,8 @@ import {
   createReadinessService,
 } from "../../runtime/channel-readiness-service.js";
 import {
-  countRecentSendsToDestination,
-  createInboundVerificationSession,
-  createOutboundSession,
-  findActiveSession,
   getGuardianBinding,
-  getPendingSession,
   isGuardianBoundForChannel,
-  revokePendingSessions,
-  updateSessionDelivery,
 } from "../../runtime/channel-verification-service.js";
 import {
   cancelOutbound,
@@ -129,7 +131,7 @@ export async function createInboundChallenge(
     };
   }
 
-  const result = createInboundVerificationSession(
+  const result = await createInboundVerificationSession(
     resolvedChannel,
     conversationId,
   );
@@ -174,11 +176,13 @@ export async function getVerificationStatus(
       guardianUsername = ext.username;
     }
   }
-  const hasPendingChallenge = getPendingSession(resolvedChannel) != null;
-
-  // Include active outbound session state so the UI can resume
-  // after app restart and detect bootstrap completion.
-  const activeOutboundSession = findActiveSession(resolvedChannel);
+  // Active outbound session state is included so the UI can resume after app
+  // restart and detect bootstrap completion.
+  const [pendingSession, activeOutboundSession] = await Promise.all([
+    getPendingSession(resolvedChannel),
+    findActiveSession(resolvedChannel),
+  ]);
+  const hasPendingChallenge = pendingSession != null;
   const outboundFields: Record<string, unknown> = {};
   if (activeOutboundSession) {
     outboundFields.verificationSessionId = activeOutboundSession.id;
@@ -214,12 +218,12 @@ export async function revokeVerificationForChannel(
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
-  // Session teardown stays assistant-side — it is session state, not the ACL
-  // outcome. Cancel any active outbound session and pending challenges first
-  // (the macOS app uses action: "revoke" to cancel an in-flight challenge even
-  // before a binding exists, e.g. during verification setup).
-  cancelOutbound({ channel: resolvedChannel });
-  revokePendingSessions(resolvedChannel);
+  // Session teardown relays to the gateway (session SoT). Cancel any active
+  // outbound session and pending challenges first (the macOS app uses
+  // action: "revoke" to cancel an in-flight challenge even before a binding
+  // exists, e.g. during verification setup).
+  await cancelOutbound({ channel: resolvedChannel });
+  await revokePendingSessions(resolvedChannel);
 
   // Capture binding before revoking so we can downgrade the guardian's
   // channel — without this, the guardian would still pass the ACL check.
@@ -361,7 +365,7 @@ export async function verifyTrustedContact(
         ? (normalizePhoneNumber(destination) ?? destination)
         : destination;
 
-  const recentSendCount = countRecentSendsToDestination(
+  const recentSendCount = await countRecentSendsToDestination(
     verificationChannel,
     effectiveDestination,
     DESTINATION_RATE_WINDOW_MS,
@@ -378,7 +382,7 @@ export async function verifyTrustedContact(
   // --- Telegram verification ---
   if (verificationChannel === "telegram") {
     if (channel.externalChatId) {
-      const sessionResult = createOutboundSession({
+      const sessionResult = await createOutboundSession({
         channel: verificationChannel,
         expectedChatId: channel.externalChatId,
         expectedExternalUserId:
@@ -400,7 +404,7 @@ export async function verifyTrustedContact(
 
       const now = Date.now();
       const sendCount = 1;
-      updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+      await updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
       deliverVerificationTelegram(
         channel.externalChatId,
         telegramBody,
@@ -434,7 +438,7 @@ export async function verifyTrustedContact(
       .update(bootstrapToken)
       .digest("hex");
 
-    const sessionResult = createOutboundSession({
+    const sessionResult = await createOutboundSession({
       channel: verificationChannel,
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: effectiveDestination,
@@ -459,7 +463,7 @@ export async function verifyTrustedContact(
   if (verificationChannel === "slack") {
     const slackUserId = channel.address;
 
-    const sessionResult = createOutboundSession({
+    const sessionResult = await createOutboundSession({
       channel: verificationChannel,
       expectedExternalUserId:
         channel.address !== channel.externalChatId
@@ -481,7 +485,7 @@ export async function verifyTrustedContact(
 
     const now = Date.now();
     const sendCount = 1;
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+    await updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
     deliverVerificationSlack(slackUserId, slackBody, assistantId);
 
     return {
@@ -503,7 +507,7 @@ export async function verifyTrustedContact(
       };
     }
 
-    const sessionResult = createOutboundSession({
+    const sessionResult = await createOutboundSession({
       channel: verificationChannel,
       expectedPhoneE164: normalizedPhone,
       expectedExternalUserId: normalizedPhone,
@@ -514,7 +518,7 @@ export async function verifyTrustedContact(
 
     const now = Date.now();
     const sendCount = 1;
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+    await updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
 
     // Fire-and-forget: initiate Twilio verification call
     (async () => {
@@ -632,8 +636,8 @@ export async function handleChannelVerificationSession(
         ...result,
       });
     } else if (msg.action === "cancel_session") {
-      cancelOutbound({ channel });
-      revokePendingSessions(channel);
+      await cancelOutbound({ channel });
+      await revokePendingSessions(channel);
       broadcastMessage({
         type: "channel_verification_session_response",
         success: true,
@@ -646,7 +650,7 @@ export async function handleChannelVerificationSession(
         ...result,
       });
     } else if (msg.action === "resend_session") {
-      const result = resendOutbound({
+      const result = await resendOutbound({
         channel,
         originConversationId: msg.originConversationId,
       });

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,12 +10,12 @@
 import { isAbsolute, resolve, sep } from "node:path";
 
 import { addAppConversationId } from "../apps/app-store.js";
+import { findActiveSession } from "../channels/gateway-verification-sessions.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { invalidateEdgeIndex } from "../plugins/defaults/memory/v2/edge-index.js";
 import { invalidatePageIndex } from "../plugins/defaults/memory/v2/page-index.js";
 import { getConceptsDir } from "../plugins/defaults/memory/v2/page-store.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
-import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
@@ -41,7 +41,7 @@ export type PostExecutionHook = (
   input: Record<string, unknown>,
   result: ToolExecutionResult,
   sideEffectCtx: SideEffectContext,
-) => void;
+) => void | Promise<void>;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -208,7 +208,7 @@ registerHook("voice_config_update", (_name, input) => {
 // completes.  The CLI subprocess is sandboxed and cannot reach the
 // gateway, so it includes a `_pendingSlackDm` field in its JSON output.
 // This hook runs in the unsandboxed daemon process and delivers the DM.
-registerHook("bash", (_name, input, result) => {
+registerHook("bash", async (_name, input, result) => {
   const command = (input.command ?? "") as string;
   if (!command.includes("channel-verification-sessions")) return;
   if (!result.content.includes("_pendingSlackDm")) return;
@@ -218,13 +218,25 @@ registerHook("bash", (_name, input, result) => {
 
   // Returns "delivered" when DM was sent, "rejected" when _pendingSlackDm
   // was found but failed validation, or null when the field was absent.
-  const dispatch = (parsed: Parsed): "delivered" | "rejected" | null => {
+  const dispatch = async (
+    parsed: Parsed,
+  ): Promise<"delivered" | "rejected" | null> => {
     if (parsed._pendingSlackDm) {
       const { userId, text, assistantId } = parsed._pendingSlackDm;
 
       // Validate that an active Slack verification session exists and
       // that the destination matches the userId in the parsed payload.
-      const session = findActiveSession("slack");
+      // Fail closed: an unverifiable DM (gateway unreachable) is not sent.
+      let session;
+      try {
+        session = await findActiveSession("slack");
+      } catch (err) {
+        log.warn(
+          { err, userId, assistantId },
+          "Bash hook: gateway session lookup failed — ignoring _pendingSlackDm",
+        );
+        return "rejected";
+      }
       if (!session) {
         log.warn(
           { userId, assistantId },
@@ -247,20 +259,26 @@ registerHook("bash", (_name, input, result) => {
   };
 
   // Try full content first (handles pretty-printed single-object JSON)
+  let singleObject: Parsed | undefined;
   try {
-    if (dispatch(JSON.parse(result.content.trim()) as Parsed) !== null) return;
+    singleObject = JSON.parse(result.content.trim()) as Parsed;
   } catch {
     // Not a single JSON object — fall back to line-by-line for
     // multi-object output (e.g. cancel + create chained with &&).
   }
+  if (singleObject !== undefined) {
+    if ((await dispatch(singleObject)) !== null) return;
+  }
   for (const line of result.content.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("{")) continue;
+    let parsed: Parsed;
     try {
-      if (dispatch(JSON.parse(trimmed) as Parsed) === "delivered") return;
+      parsed = JSON.parse(trimmed) as Parsed;
     } catch {
       continue;
     }
+    if ((await dispatch(parsed)) === "delivered") return;
   }
 });
 
@@ -299,18 +317,25 @@ registerHook("file_edit", (_name, input) =>
  * Run all applicable post-execution side effects for a completed tool call.
  * Handles both registry-based hooks and the DoorDash step tracker (which
  * uses its own name-matching logic).
+ *
+ * Fire-and-forget for production callers; the returned promise lets tests
+ * await async hooks. Hook failures are logged, never propagated.
  */
-export function runPostExecutionSideEffects(
+export async function runPostExecutionSideEffects(
   name: string,
   input: Record<string, unknown>,
   result: ToolExecutionResult,
   sideEffectCtx: SideEffectContext,
-): void {
+): Promise<void> {
   // Registry-based hooks only fire on success
   if (!result.isError) {
     const hook = postExecutionHooks.get(name);
     if (hook) {
-      hook(name, input, result, sideEffectCtx);
+      try {
+        await hook(name, input, result, sideEffectCtx);
+      } catch (err) {
+        log.error({ err, toolName: name }, "Post-execution hook failed");
+      }
     }
   }
 

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -2,10 +2,10 @@
  * Tests for the verification-revoke route relay.
  *
  * The revoke route downgrades the channel's ACL status through the gateway
- * (source of truth) via `ipcCallPersistent("mark_channel_revoked", ...)` while
- * keeping session teardown (`cancelOutbound`, `revokePendingSessions`)
- * assistant-side. The gateway enforces the guardian guard; a rejected guardian
- * downgrade surfaces here as a relayed IpcCallError.
+ * (source of truth) via `ipcCallPersistent("mark_channel_revoked", ...)`;
+ * session teardown (`cancelOutbound`, `revokePendingSessions`) relays through
+ * the gateway session client. The gateway enforces the guardian guard; a
+ * rejected guardian downgrade surfaces here as a relayed IpcCallError.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -43,8 +43,8 @@ mock.module("../../../ipc/gateway-client.js", () => ({
   ipcCallPersistent: ipcCallPersistentMock,
 }));
 
-// Session teardown — assert these still run locally on every revoke.
-const cancelOutboundMock = mock((_args: { channel: string }) => {});
+// Session teardown — assert these still run on every revoke.
+const cancelOutboundMock = mock(async (_args: { channel: string }) => {});
 const actualOutboundActions =
   await import("../../verification-outbound-actions.js");
 mock.module("../../verification-outbound-actions.js", () => ({
@@ -52,7 +52,14 @@ mock.module("../../verification-outbound-actions.js", () => ({
   cancelOutbound: cancelOutboundMock,
 }));
 
-const revokePendingSessionsMock = mock((_channel: string) => {});
+const revokePendingSessionsMock = mock(async (_channel: string) => {});
+const actualGatewaySessions =
+  await import("../../../channels/gateway-verification-sessions.js");
+mock.module("../../../channels/gateway-verification-sessions.js", () => ({
+  ...actualGatewaySessions,
+  revokePendingSessions: revokePendingSessionsMock,
+}));
+
 let guardianBinding: {
   guardianExternalUserId: string;
   guardianDeliveryChatId?: string;
@@ -61,7 +68,6 @@ const actualVerificationService =
   await import("../../channel-verification-service.js");
 mock.module("../../channel-verification-service.js", () => ({
   ...actualVerificationService,
-  revokePendingSessions: revokePendingSessionsMock,
   getGuardianBinding: mock(() => guardianBinding),
 }));
 

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -7,8 +7,12 @@
  * POST   /v1/channel-verification-sessions/revoke  — cancel all sessions and revoke binding
  * GET    /v1/channel-verification-sessions/status   — check guardian binding status
  *
- * Source-of-truth split:
- * - Verification SESSION state (pending sessions, codes, resend, rate-limit) is assistant-owned.
+ * Source of truth:
+ * - Verification SESSION state (pending sessions, codes, resend counters) is
+ *   gateway-owned; the daemon relays lifecycle ops over the
+ *   `verification_sessions_*` IPC client and fails loudly when the gateway is
+ *   unreachable. The in-memory initiation throttle (`verificationRateLimiter`)
+ *   stays daemon-side.
  * - The channel-verified OUTCOME (status / verifiedAt / verifiedVia) is gateway-owned, written
  *   in-process by the HTTP guardian-attest handler (`ContactStore.markChannelVerified`) and by the
  *   inbound code-match path (`gateway/src/verification/text-verification.ts`).
@@ -18,6 +22,7 @@
 
 import { z } from "zod";
 
+import { revokePendingSessions } from "../../channels/gateway-verification-sessions.js";
 import type { ChannelId } from "../../channels/types.js";
 import {
   createInboundChallenge,
@@ -28,7 +33,6 @@ import {
 import { normalizePhoneNumber } from "../../util/phone.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { revokePendingSessions } from "../channel-verification-service.js";
 import {
   cancelOutbound,
   deliverVerificationEmail,
@@ -215,7 +219,7 @@ export async function handleResendVerificationSession({
     throw new BadRequestError('The "channel" field is required.');
   }
 
-  const result = resendOutbound({ channel, originConversationId });
+  const result = await resendOutbound({ channel, originConversationId });
 
   // Dispatch delivery from the daemon process (not sandboxed).
   if (result._pendingSlackDm) {
@@ -257,8 +261,8 @@ export async function handleCancelVerificationSession({
     throw new BadRequestError('The "channel" field is required.');
   }
 
-  cancelOutbound({ channel });
-  revokePendingSessions(channel);
+  await cancelOutbound({ channel });
+  await revokePendingSessions(channel);
 
   return { success: true, channel };
 }

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -1,15 +1,26 @@
 /**
  * Shared outbound verification action logic.
  *
- * These pure functions encapsulate the business logic for starting, resending,
+ * These functions encapsulate the business logic for starting, resending,
  * and cancelling outbound verification flows (Telegram, voice, Slack, email).
  * They return transport-agnostic result objects and are consumed by both the
  * message handler (config-channels.ts) and the HTTP route layer (channel-verification-routes.ts).
+ *
+ * Session state is gateway-owned: lifecycle calls go through the gateway
+ * session client and fail loudly when the gateway is unreachable (no local
+ * fallback writes). Message composition and delivery stay daemon-side.
  */
 
 import { createHash, randomBytes } from "node:crypto";
 
 import { startVerificationCall } from "../calls/call-domain.js";
+import {
+  countRecentSendsToDestination,
+  createOutboundSession,
+  findActiveSession,
+  updateSessionDelivery,
+  updateSessionStatus,
+} from "../channels/gateway-verification-sessions.js";
 import type { ChannelId } from "../channels/types.js";
 import { sendSlackReply } from "../messaging/providers/slack/send.js";
 import { sendTelegramReply } from "../messaging/providers/telegram-bot/send.js";
@@ -17,14 +28,7 @@ import { getTelegramBotUsername } from "../telegram/bot-username.js";
 import { getLogger } from "../util/logger.js";
 import { normalizePhoneNumber } from "../util/phone.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
-import {
-  countRecentSendsToDestination,
-  createOutboundSession,
-  findActiveSession,
-  isGuardianBoundForChannel,
-  updateSessionDelivery,
-  updateSessionStatus,
-} from "./channel-verification-service.js";
+import { isGuardianBoundForChannel } from "./channel-verification-service.js";
 import {
   composeVerificationEmail,
   composeVerificationSlack,
@@ -287,7 +291,7 @@ async function startOutboundTelegram(
 
   const normalizedDestination = normalizeTelegramDestination(destination);
 
-  const recentSendCount = countRecentSendsToDestination(
+  const recentSendCount = await countRecentSendsToDestination(
     channel,
     normalizedDestination,
     DESTINATION_RATE_WINDOW_MS,
@@ -314,7 +318,7 @@ async function startOutboundTelegram(
       };
     }
 
-    const sessionResult = createOutboundSession({
+    const sessionResult = await createOutboundSession({
       channel,
       expectedChatId: destination,
       identityBindingStatus: "bound",
@@ -334,7 +338,7 @@ async function startOutboundTelegram(
     const nextResendAt = now + RESEND_COOLDOWN_MS;
     const sendCount = 1;
 
-    updateSessionDelivery(
+    await updateSessionDelivery(
       sessionResult.sessionId,
       now,
       sendCount,
@@ -374,7 +378,7 @@ async function startOutboundTelegram(
     .update(bootstrapToken)
     .digest("hex");
 
-  const sessionResult = createOutboundSession({
+  const sessionResult = await createOutboundSession({
     channel,
     identityBindingStatus: "pending_bootstrap",
     destinationAddress: normalizedDestination,
@@ -433,7 +437,7 @@ async function startOutboundVoice(
     };
   }
 
-  const recentSendCount = countRecentSendsToDestination(
+  const recentSendCount = await countRecentSendsToDestination(
     channel,
     destination,
     DESTINATION_RATE_WINDOW_MS,
@@ -448,7 +452,7 @@ async function startOutboundVoice(
     };
   }
 
-  const sessionResult = createOutboundSession({
+  const sessionResult = await createOutboundSession({
     channel,
     expectedPhoneE164: destination,
     expectedExternalUserId: destination,
@@ -461,7 +465,12 @@ async function startOutboundVoice(
   const nextResendAt = now + RESEND_COOLDOWN_MS;
   const sendCount = 1;
 
-  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+  await updateSessionDelivery(
+    sessionResult.sessionId,
+    now,
+    sendCount,
+    nextResendAt,
+  );
   initiateGuardianVoiceCall(
     destination,
     sessionResult.sessionId,
@@ -618,7 +627,7 @@ async function startOutboundSlack(
     };
   }
 
-  const recentSendCount = countRecentSendsToDestination(
+  const recentSendCount = await countRecentSendsToDestination(
     channel,
     destination,
     DESTINATION_RATE_WINDOW_MS,
@@ -633,7 +642,7 @@ async function startOutboundSlack(
     };
   }
 
-  const sessionResult = createOutboundSession({
+  const sessionResult = await createOutboundSession({
     channel,
     expectedExternalUserId: destination,
     expectedChatId: destination,
@@ -654,7 +663,12 @@ async function startOutboundSlack(
   const nextResendAt = now + RESEND_COOLDOWN_MS;
   const sendCount = 1;
 
-  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+  await updateSessionDelivery(
+    sessionResult.sessionId,
+    now,
+    sendCount,
+    nextResendAt,
+  );
 
   return {
     success: true,
@@ -699,7 +713,7 @@ async function startOutboundEmail(
     };
   }
 
-  const recentSendCount = countRecentSendsToDestination(
+  const recentSendCount = await countRecentSendsToDestination(
     channel,
     normalizedEmail,
     DESTINATION_RATE_WINDOW_MS,
@@ -714,7 +728,7 @@ async function startOutboundEmail(
     };
   }
 
-  const sessionResult = createOutboundSession({
+  const sessionResult = await createOutboundSession({
     channel,
     expectedExternalUserId: normalizedEmail,
     expectedChatId: normalizedEmail,
@@ -735,7 +749,12 @@ async function startOutboundEmail(
   const nextResendAt = now + RESEND_COOLDOWN_MS;
   const sendCount = 1;
 
-  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+  await updateSessionDelivery(
+    sessionResult.sessionId,
+    now,
+    sendCount,
+    nextResendAt,
+  );
 
   return {
     success: true,
@@ -759,14 +778,14 @@ async function startOutboundEmail(
 // Resend outbound
 // ---------------------------------------------------------------------------
 
-export function resendOutbound(
+export async function resendOutbound(
   params: ResendOutboundParams,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
-  const session = findActiveSession(channel);
+  const session = await findActiveSession(channel);
   if (!session) {
     return {
       success: false,
@@ -810,7 +829,7 @@ export function resendOutbound(
     session.expectedPhoneE164 ??
     session.expectedChatId;
   if (resendDestination) {
-    const recentDestSends = countRecentSendsToDestination(
+    const recentDestSends = await countRecentSendsToDestination(
       channel,
       resendDestination,
       DESTINATION_RATE_WINDOW_MS,
@@ -840,7 +859,7 @@ export function resendOutbound(
   }
 
   if (channel === "telegram") {
-    const newSession = createOutboundSession({
+    const newSession = await createOutboundSession({
       channel,
       expectedChatId: destination,
       identityBindingStatus: "bound",
@@ -860,7 +879,7 @@ export function resendOutbound(
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(
+    await updateSessionDelivery(
       newSession.sessionId,
       now,
       newSendCount,
@@ -878,7 +897,7 @@ export function resendOutbound(
       originConversationId,
     };
   } else if (channel === "phone") {
-    const newSession = createOutboundSession({
+    const newSession = await createOutboundSession({
       channel,
       expectedPhoneE164: destination,
       expectedExternalUserId: destination,
@@ -891,7 +910,7 @@ export function resendOutbound(
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(
+    await updateSessionDelivery(
       newSession.sessionId,
       now,
       newSendCount,
@@ -914,7 +933,7 @@ export function resendOutbound(
       originConversationId,
     };
   } else if (channel === "slack") {
-    const newSession = createOutboundSession({
+    const newSession = await createOutboundSession({
       channel,
       expectedExternalUserId: destination,
       expectedChatId: destination,
@@ -935,7 +954,7 @@ export function resendOutbound(
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(
+    await updateSessionDelivery(
       newSession.sessionId,
       now,
       newSendCount,
@@ -953,7 +972,7 @@ export function resendOutbound(
       _pendingSlackDm: { userId: destination, text: slackBody, assistantId },
     };
   } else if (channel === "email") {
-    const newSession = createOutboundSession({
+    const newSession = await createOutboundSession({
       channel,
       expectedExternalUserId: destination,
       expectedChatId: destination,
@@ -974,7 +993,7 @@ export function resendOutbound(
     const newSendCount = currentSendCount + 1;
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
-    updateSessionDelivery(
+    await updateSessionDelivery(
       newSession.sessionId,
       now,
       newSendCount,
@@ -1010,12 +1029,12 @@ export function resendOutbound(
 // Cancel outbound
 // ---------------------------------------------------------------------------
 
-export function cancelOutbound(
+export async function cancelOutbound(
   params: CancelOutboundParams,
-): OutboundActionResult {
+): Promise<OutboundActionResult> {
   const channel = params.channel;
 
-  const session = findActiveSession(channel);
+  const session = await findActiveSession(channel);
   if (!session) {
     return {
       success: false,
@@ -1025,7 +1044,7 @@ export function cancelOutbound(
     };
   }
 
-  updateSessionStatus(session.id, "revoked");
+  await updateSessionStatus(session.id, "revoked");
 
   return {
     success: true,


### PR DESCRIPTION
## Summary
- Flips the control-plane cluster (config-channels, verification-outbound-actions, channel-verification-routes, guardian-request-resolvers, tool-side-effects) to the gateway-backed session client
- In-memory initiation rate limiter and guardian-binding reads unchanged; message composition stays daemon-side
- Gateway outage now fails these flows loudly (no local writes)

Part of plan: verif-sessions-gateway-native.md (PR 7 of 12)