### PR TITLE
feat(web): show author emoji on the plugin detail pages

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -35,6 +35,9 @@ function makePlugin(
     readme: "# Readme heading",
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
     ...overrides,
   };
 }
@@ -256,6 +259,21 @@ describe("PluginDetailMobile", () => {
     );
 
     expect(document.body.textContent).toContain(PACKAGE);
+    expect(document.body.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the author emoji when the plugin declares one, overriding the origin glyph", () => {
+    hookState.plugin = makePlugin({
+      icon: "\u{1F3A8}", // 🎨
+      source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+    });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(document.body.textContent).toContain("\u{1F3A8}");
+    expect(document.body.textContent).not.toContain(PACKAGE);
     expect(document.body.textContent).not.toContain(PUZZLE);
   });
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -135,7 +135,11 @@ export function PluginDetailMobile({
             {resolvedExternal === undefined ? (
               <span aria-hidden className="h-8 w-8 shrink-0" />
             ) : (
-              <PluginIcon external={resolvedExternal} size="md" />
+              <PluginIcon
+                external={resolvedExternal}
+                icon={plugin?.icon ?? undefined}
+                size="md"
+              />
             )}
             <h2
               className="min-w-0 truncate text-title-medium"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -32,6 +32,9 @@ const githubPlugin: PluginsByNameGetResponse = {
   readme: "# Level Up",
   ref: "main",
   artifact: null,
+  icon: null,
+  hasIcon: false,
+  iconVersion: null,
 };
 
 describe("PluginDetailMetadata", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -175,6 +175,9 @@ describe("PluginDetail", () => {
         readme: "# Caveman\n\nMakes the agent speak in grunts.",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );
@@ -207,6 +210,9 @@ describe("PluginDetail", () => {
         readme: null,
         ref: "main",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("simple-memory", true),
     );
@@ -235,6 +241,9 @@ describe("PluginDetail", () => {
         readme: "# Level Up",
         ref: "main",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       updateAvailableInspect("level-up"),
     );
@@ -266,6 +275,9 @@ describe("PluginDetail", () => {
         readme: "# Dynamic Notch",
         ref: "v1.0.0",
         artifact: { url, sha256: "a".repeat(64), label: "Download for macOS" },
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("dynamic-notch", true),
     );
@@ -306,11 +318,41 @@ describe("PluginDetail", () => {
         readme: "# Caveman",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );
 
     expect(container.textContent).toContain(PACKAGE);
+    expect(container.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the author emoji when the plugin declares one, overriding the origin glyph", () => {
+    const AUTHOR_EMOJI = "\u{1F3A8}"; // 🎨
+    const { container } = renderDetail(
+      "caveman",
+      {
+        name: "caveman",
+        installed: false,
+        description: "Talk like a caveman.",
+        homepage: null,
+        license: null,
+        version: "1.8.2",
+        source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
+        readme: "# Caveman",
+        ref: "v1.8.2",
+        artifact: null,
+        icon: AUTHOR_EMOJI,
+        hasIcon: false,
+        iconVersion: null,
+      },
+      upToDateInspect("caveman", false),
+    );
+
+    expect(container.textContent).toContain(AUTHOR_EMOJI);
+    expect(container.textContent).not.toContain(PACKAGE);
     expect(container.textContent).not.toContain(PUZZLE);
   });
 
@@ -328,6 +370,9 @@ describe("PluginDetail", () => {
         readme: "# Caveman",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -186,7 +186,11 @@ function Header({
         {resolvedExternal === undefined ? (
           <span aria-hidden className="h-8 w-8 shrink-0" />
         ) : (
-          <PluginIcon external={resolvedExternal} size="md" />
+          <PluginIcon
+            external={resolvedExternal}
+            icon={plugin?.icon ?? undefined}
+            size="md"
+          />
         )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -178,6 +178,9 @@ function pluginDetail(name: string): PluginsByNameGetResponse {
     readme: null,
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
   };
 }
 

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
@@ -95,6 +95,9 @@ function installedDetail(name: string): PluginsByNameGetResponse {
     readme: "# Level Up",
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Pass the plugin `icon` (author emoji) to `PluginIcon` on the desktop + mobile plugin detail pages, with the 📦/🧩 fallback.
- Reconcile the plugin-detail test fixtures with the now-required `icon`/`hasIcon`/`iconVersion` detail fields (added by daemon-only PRs #37067/#37069, which didn't touch web) so the regenerated `PluginsByNameGetResponse` type-checks, and assert the author-emoji passthrough on both detail pages.

Part of plan: plugin-custom-icons.md (PR 6 of 12)