### PR TITLE
chore(deps): bump Playwright to 1.61.1 for Ubuntu 26.04 support

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -36,7 +36,7 @@
         "openai": "6.29.0",
         "pino": "9.14.0",
         "pino-pretty": "13.1.3",
-        "playwright": "1.58.2",
+        "playwright": "1.61.1",
         "quickjs-emscripten": "0.32.0",
         "re2js": "2.8.3",
         "remark-gfm": "4.0.1",
@@ -1123,9 +1123,9 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -65,7 +65,7 @@
     "openai": "6.29.0",
     "pino": "9.14.0",
     "pino-pretty": "13.1.3",
-    "playwright": "1.58.2",
+    "playwright": "1.61.1",
     "quickjs-emscripten": "0.32.0",
     "re2js": "2.8.3",
     "remark-gfm": "4.0.1",

--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@vellumai/design-library",
       "devDependencies": {
-        "@playwright/browser-chromium": "1.60.0",
+        "@playwright/browser-chromium": "1.61.1",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-checkbox": "1.3.3",
         "@radix-ui/react-context-menu": "2.2.16",
@@ -35,7 +35,7 @@
         "clsx": "2.1.1",
         "katex": "0.16.47",
         "lucide-react": "1.16.0",
-        "playwright": "1.60.0",
+        "playwright": "1.61.1",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-markdown": "10.1.0",
@@ -289,7 +289,7 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw=="],
 
-    "@playwright/browser-chromium": ["@playwright/browser-chromium@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" } }, "sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA=="],
+    "@playwright/browser-chromium": ["@playwright/browser-chromium@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" } }, "sha512-t3/zE0i9gik5R/NpRs7G2Xo/6NPeABW6ReplGdtkeWeAkaV764CgFgoKjJo21D2xgjnvDvRYubqBUu4xl0VCqA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -921,9 +921,9 @@
 
     "picoquery": ["picoquery@2.5.0", "", {}, "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g=="],
 
-    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -55,7 +55,7 @@
     "unified": ">=11.0.0"
   },
   "devDependencies": {
-    "@playwright/browser-chromium": "1.60.0",
+    "@playwright/browser-chromium": "1.61.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-checkbox": "1.3.3",
     "@radix-ui/react-context-menu": "2.2.16",
@@ -85,7 +85,7 @@
     "clsx": "2.1.1",
     "katex": "0.16.47",
     "lucide-react": "1.16.0",
-    "playwright": "1.60.0",
+    "playwright": "1.61.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "10.1.0",


### PR DESCRIPTION
## Summary

Playwright added Ubuntu 26.04 host support in **1.61**. On 26.04 the previous pins failed the Chromium browser download during `bun install` with:

```
ERROR: Playwright does not support chromium on ubuntu26.04-x64
```

This bumps Playwright to **1.61.1** across the workspace.

## Changes

- `assistant`: `playwright` 1.58.2 → 1.61.1
- `packages/design-library`: `playwright` 1.60.0 → 1.61.1, `@playwright/browser-chromium` 1.60.0 → 1.61.1
- Regenerated `bun.lock` in both packages

## Verification

On Ubuntu 26.04 (x64), after `playwright install-deps chromium`:

- `bun install` completes with no host-platform error
- Chromium 1228 downloads and reports `Google Chrome for Testing 149.0.7827.55`
- End-to-end Playwright launch (chromium.launch → newPage → setContent → close) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)