### PR TITLE
feat(providers): Vellum-managed model routing codec (PR1)

### DIFF
--- a/assistant/src/providers/vellum-model-routing.test.ts
+++ b/assistant/src/providers/vellum-model-routing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatVellumModel,
+  MANAGED_ROUTABLE_PROVIDERS,
+  parseVellumModel,
+} from "./vellum-model-routing.js";
+
+describe("vellum-model-routing", () => {
+  test("round-trips a slashy native Fireworks id losslessly", () => {
+    const native = "accounts/fireworks/models/minimax-m3";
+    const encoded = formatVellumModel("fireworks", native);
+    expect(encoded).toBe("fireworks/accounts/fireworks/models/minimax-m3");
+    expect(parseVellumModel(encoded)).toEqual({
+      provider: "fireworks",
+      model: native,
+    });
+  });
+
+  test("round-trips a bare Anthropic id", () => {
+    const encoded = formatVellumModel("anthropic", "claude-fable-5");
+    expect(parseVellumModel(encoded)).toEqual({
+      provider: "anthropic",
+      model: "claude-fable-5",
+    });
+  });
+
+  test("format rejects a non-managed provider", () => {
+    expect(() => formatVellumModel("openrouter", "x")).toThrow();
+    expect(() => formatVellumModel("fireworks", "")).toThrow();
+  });
+
+  test("parse returns null for non-routed strings", () => {
+    expect(parseVellumModel("claude-opus-4-8")).toBeNull(); // no slash
+    expect(parseVellumModel("openrouter/whatever")).toBeNull(); // not managed
+    expect(parseVellumModel("minimax/minimax-m3")).toBeNull(); // not managed
+    expect(parseVellumModel("fireworks/")).toBeNull(); // empty model
+    expect(parseVellumModel("/foo")).toBeNull(); // empty provider
+  });
+
+  test("managed set matches the platform proxy table", () => {
+    // Guards against drift if PLATFORM_PROVIDER_META changes.
+    expect([...MANAGED_ROUTABLE_PROVIDERS].sort()).toEqual([
+      "anthropic",
+      "fireworks",
+      "gemini",
+      "openai",
+      "together",
+    ]);
+  });
+});

--- a/assistant/src/providers/vellum-model-routing.ts
+++ b/assistant/src/providers/vellum-model-routing.ts
@@ -1,0 +1,84 @@
+/**
+ * Codec for Vellum-managed model routing strings.
+ *
+ * A single `vellum` provider connection is provider-agnostic: unlike the
+ * per-provider `*-managed` connections it does not carry the upstream provider
+ * on its DB row. The upstream provider therefore has to travel *with* the
+ * model. Where a routing site has the provider as a sibling field it uses that
+ * directly; where only a single model string is available (telemetry headers
+ * like `X-Vellum-Resolved-Model`, persisted model overrides, display), the
+ * provider is encoded as a `<provider>/<model>` prefix, e.g.
+ * `fireworks/accounts/fireworks/models/minimax-m3`.
+ *
+ * This module is the single source of truth for that encoding. It is a pure
+ * codec — no I/O, no wiring — so it can be adopted incrementally.
+ */
+
+import { PLATFORM_PROVIDER_META } from "./platform-proxy/constants.js";
+
+/**
+ * Provider ids that can front a Vellum-managed (platform-proxied) route.
+ * Only these are valid prefixes for a routing string; everything else
+ * (openrouter, ollama, openai-compatible, or a raw native model id) is not a
+ * Vellum-routed string and `parseVellumModel` returns null for it.
+ */
+export const MANAGED_ROUTABLE_PROVIDERS: ReadonlySet<string> = new Set(
+  Object.values(PLATFORM_PROVIDER_META)
+    .filter((m) => m.managed)
+    .map((m) => m.name),
+);
+
+export interface VellumModelRoute {
+  /** Upstream provider id, e.g. "fireworks". Always a managed-routable id. */
+  provider: string;
+  /** Native upstream model id, slashes intact, e.g. "accounts/fireworks/models/minimax-m3". */
+  model: string;
+}
+
+/**
+ * Encode a provider + native model id into a Vellum routing string.
+ * Throws on a non-routable provider — that is a caller bug, not user input.
+ */
+export function formatVellumModel(provider: string, model: string): string {
+  if (!MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+    throw new Error(
+      `formatVellumModel: "${provider}" is not a Vellum-managed provider ` +
+        `(expected one of ${[...MANAGED_ROUTABLE_PROVIDERS].join(", ")})`,
+    );
+  }
+  if (!model) {
+    throw new Error("formatVellumModel: model must be non-empty");
+  }
+  return `${provider}/${model}`;
+}
+
+/**
+ * Decode a Vellum routing string back into provider + native model id.
+ *
+ * Splits on the FIRST slash only so native ids that themselves contain
+ * slashes (Fireworks `accounts/fireworks/models/...`) round-trip losslessly.
+ * Returns null when the string is not a Vellum-routed model — no slash, empty
+ * model, or a prefix that is not a managed-routable provider.
+ *
+ * Note: `anthropic/…` is also OpenRouter's native id shape, so this codec
+ * must only be applied in a Vellum-connection context. OpenRouter is
+ * `managed:false` and never routes through a vellum connection, so the
+ * collision is unreachable in practice; the guard here is belt-and-suspenders.
+ */
+export function parseVellumModel(
+  routingString: string,
+): VellumModelRoute | null {
+  const slash = routingString.indexOf("/");
+  if (slash <= 0) {
+    return null;
+  }
+  const provider = routingString.slice(0, slash);
+  const model = routingString.slice(slash + 1);
+  if (!model) {
+    return null;
+  }
+  if (!MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+    return null;
+  }
+  return { provider, model };
+}


### PR DESCRIPTION
## What

PR1 of the "consolidate Vellum-managed providers into a single `vellum` provider" effort. Adds a pure, **dormant** codec for `<provider>/<model>` Vellum routing strings. Nothing is wired yet — this is the foundation later PRs build on.

- `assistant/src/providers/vellum-model-routing.ts` — `formatVellumModel` / `parseVellumModel` + `MANAGED_ROUTABLE_PROVIDERS` (derived from `PLATFORM_PROVIDER_META`, so it can't drift from the proxy table).
- `assistant/src/providers/vellum-model-routing.test.ts` — round-trip + edge-case coverage.

## Why

A single provider-agnostic `vellum` connection can't carry the upstream provider on its DB row (today `connection.provider` drives both the proxy path and the adapter class). The provider therefore has to travel *with* the model. Where a routing site has the provider as a sibling field it uses that directly; where only a single model string is available (telemetry `X-Vellum-Resolved-Model`, persisted overrides, display) the provider is encoded as a prefix. This module is the single source of truth for that encoding.

## Design notes

- **Splits on the first slash** so native slashy ids (Fireworks `accounts/fireworks/models/minimax-m3`) round-trip losslessly.
- **`parse` returns `null`** for non-Vellum-routed strings (no slash / non-managed prefix), so it's safe to call speculatively.
- The `fireworks/minimax-m3` example in the spec is illustrative — routing uses the lossless native id, so the real string is `fireworks/accounts/fireworks/models/minimax-m3`. A short display/alias form (native → `minimax-m3`) is deliberately **not** included (YAGNI until a UI surface needs it).

## Risk

Additive and unreferenced — zero behavior change. First consumer lands in PR2 (relax the `provider_mismatch` guard + thread the resolved provider through `resolveAuth` / `createAdapterFromConnection`).

## Test

`cd assistant && bun test src/providers/vellum-model-routing.test.ts` → 5 pass. Format / lint / typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)