### PR TITLE
fix(web): restore navigation-handlers clobbered by v0.10.5 release merge

### DIFF
--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
@@ -68,39 +68,21 @@ export function handleNavigateSettings(
   ctx.router.push(route);
 }
 
-export function handleOpenPanel(
+/**
+ * Report whether this client actually opened the requested panel. The daemon
+ * holds the emitting `ui_show` tool call open until a client acks (or its
+ * timeout elapses), so a missed or failed open surfaces as a tool error
+ * instead of the model announcing a panel the user cannot see. Daemons that
+ * emit `open_panel` without a `surfaceId` expect no acknowledgment.
+ */
+function reportOpenPanelOutcome(
   event: OpenPanelEvent,
   ctx: StreamHandlerContext,
+  outcome: "ack" | "nack",
+  reason?: string,
 ): void {
-  if (event.panelType === "channel_setup") {
-    const rawChannel =
-      typeof event.data?.channel === "string" ? event.data.channel : undefined;
-    const channel =
-      rawChannel && isSetupChannelId(rawChannel) ? rawChannel : "slack";
-    // The event's conversationId belongs to the assistant whose stream
-    // delivered it — pair the payload with that assistant, not whatever is
-    // active at arrival time, so a close-notify posted later can't mix
-    // assistant A's conversation with assistant B's message endpoint (a
-    // mid-switch race would otherwise 404 or mint a phantom conversation).
-    const streamAssistantId = ctx.assistantId;
-    if (!streamAssistantId) {
-      return;
-    }
-    const { assistants } = useResolvedAssistantsStore.getState();
-    // The identity store carries the assistant's self-chosen name from
-    // IDENTITY.md; the platform record name can be a placeholder
-    // (e.g. "New Assistant"), so it is only a fallback.
-    const identityName = useAssistantIdentityStore.getState().name;
-    const assistantName =
-      identityName?.trim() ||
-      assistants.find((a) => a.id === streamAssistantId)?.name ||
-      "Assistant";
-    useViewerStore.getState().openChannelSetup({
-      channel,
-      assistantId: streamAssistantId,
-      assistantName,
-      conversationId: event.conversationId,
-    });
+  if (!event.surfaceId) {
+    return;
   }
   const assistantId = ctx.streamContext?.assistantId;
   if (!assistantId) {


### PR DESCRIPTION
## Summary
- The v0.10.5 release squash (#37070, commit 91fa0538c1) re-applied a stale hunk of `handleOpenPanel` over the version main already had from #37000, deleting the `reportOpenPanelOutcome` helper it references and duplicating the exported function.
- `ci-main-web` never ran on the release commit, so main's web typecheck is silently broken — every open web PR now fails Type Check/Build/Test on the merge ref.
- This restores `clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts` to the last-green main version (59e4d53209). Verified `bunx tsc --noEmit` passes in clients/web with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->