### PR TITLE
Add Active Web Doctor Session Resume

### DIFF
--- a/clients/web/src/domains/settings/components/panels/doctor-event-schema.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-event-schema.ts
@@ -8,34 +8,62 @@
 
 import { z } from "zod";
 
+const DoctorSourceEventFields = {
+  source_event_id: z.string().nullable().optional(),
+};
+
 export const DoctorEventSchema = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("message"), content: z.string() }),
-  z.object({ type: z.literal("message_delta"), content: z.string() }),
   z.object({
+    ...DoctorSourceEventFields,
+    type: z.literal("message"),
+    content: z.string(),
+  }),
+  z.object({
+    ...DoctorSourceEventFields,
+    type: z.literal("message_delta"),
+    content: z.string(),
+  }),
+  z.object({
+    ...DoctorSourceEventFields,
     type: z.literal("tool_call"),
     toolName: z.string(),
     input: z.record(z.string(), z.unknown()),
     id: z.string(),
   }),
   z.object({
+    ...DoctorSourceEventFields,
     type: z.literal("tool_result"),
     toolCallId: z.string(),
     content: z.string(),
     isError: z.boolean(),
   }),
   z.object({
+    ...DoctorSourceEventFields,
     type: z.literal("approval_required"),
     toolName: z.string(),
     input: z.record(z.string(), z.unknown()),
     id: z.string(),
     description: z.string(),
   }),
-  z.object({ type: z.literal("backup_prompt"), toolName: z.string() }),
   z.object({
-    type: z.literal("status"),
-    status: z.union([z.literal("active"), z.literal("completed"), z.literal("error")]),
+    ...DoctorSourceEventFields,
+    type: z.literal("backup_prompt"),
+    toolName: z.string(),
   }),
-  z.object({ type: z.literal("error"), message: z.string() }),
+  z.object({
+    ...DoctorSourceEventFields,
+    type: z.literal("status"),
+    status: z.union([
+      z.literal("active"),
+      z.literal("completed"),
+      z.literal("error"),
+    ]),
+  }),
+  z.object({
+    ...DoctorSourceEventFields,
+    type: z.literal("error"),
+    message: z.string(),
+  }),
 ]);
 
 export type DoctorEvent = z.infer<typeof DoctorEventSchema>;

--- a/clients/web/src/domains/settings/components/panels/doctor-history.test.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-history.test.ts
@@ -5,8 +5,11 @@ import type { DoctorMessage } from "@/generated/api/types.gen";
 import {
   hasPendingApproval,
   hasPendingBackup,
+  isReplayableDoctorSourceEventId,
+  latestReplayableDoctorSourceEventId,
   mapPersistedMessagesToEntries,
   mapPersistedStatusToPanelStatus,
+  replayableDoctorSourceEventIds,
   selectLatestHistorySession,
   serializeSessionToText,
 } from "@/domains/settings/components/panels/doctor-history";
@@ -67,7 +70,9 @@ describe("mapPersistedMessagesToEntries", () => {
     expect(entries).toHaveLength(1);
     const entry = entries[0]!;
     expect(entry.kind).toBe("tool_call");
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("run_diagnostics");
     expect(entry.meta.input).toEqual({ flag: true });
     expect(entry.meta.toolCallId).toBe("tc-1");
@@ -79,7 +84,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "tool_call", content: "fallback_name", metadata: {} }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("fallback_name");
     expect(entry.content).toBe("fallback_name");
   });
@@ -89,7 +96,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ id: "msg-tc", kind: "tool_call", content: "tool", metadata: { toolName: "tool" } }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolCallId).toBe("msg-tc");
   });
 
@@ -110,7 +119,9 @@ describe("mapPersistedMessagesToEntries", () => {
     ]);
     expect(entries).toHaveLength(1);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.result).toBe("result data");
     expect(entry.meta.isError).toBe(false);
     expect(entry.meta.status).toBe("completed");
@@ -132,7 +143,9 @@ describe("mapPersistedMessagesToEntries", () => {
       }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.isError).toBe(true);
     expect(entry.meta.status).toBe("error");
   });
@@ -163,7 +176,9 @@ describe("mapPersistedMessagesToEntries", () => {
     ]);
     expect(entries).toHaveLength(1);
     const entry = entries[0]!;
-    if (entry.kind !== "approval") throw new Error("unreachable");
+    if (entry.kind !== "approval") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("exec_command");
     expect(entry.meta.toolCallId).toBe("ap-1");
     expect(entry.meta.description).toBe("Run ls in /tmp");
@@ -174,7 +189,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "approval", content: "exec", metadata: { toolName: "exec" } }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "approval") throw new Error("unreachable");
+    if (entry.kind !== "approval") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.description).toBe("");
   });
 
@@ -225,7 +242,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "tool_call", content: "tool", metadata: "not an object" }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("tool");
     expect(entry.meta.input).toEqual({});
   });
@@ -235,7 +254,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "tool_call", content: "tool", metadata: null }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("tool");
   });
 
@@ -244,7 +265,9 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "tool_call", content: "tool", metadata: [1, 2, 3] }),
     ]);
     const entry = entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("tool");
     expect(entry.meta.input).toEqual({});
   });
@@ -270,7 +293,9 @@ describe("mapPersistedMessagesToEntries", () => {
     expect(entries).toHaveLength(4);
     expect(entries.map((e) => e.kind)).toEqual(["user", "assistant", "tool_call", "status"]);
     const toolEntry = entries[2]!;
-    if (toolEntry.kind !== "tool_call") throw new Error("unreachable");
+    if (toolEntry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(toolEntry.meta.status).toBe("completed");
   });
 
@@ -292,6 +317,51 @@ describe("mapPersistedStatusToPanelStatus", () => {
   });
   test("maps error", () => {
     expect(mapPersistedStatusToPanelStatus("error")).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replayable Doctor source event IDs
+// ---------------------------------------------------------------------------
+
+describe("Doctor source event ID helpers", () => {
+  test("accepts Redis stream IDs and rejects legacy or malformed values", () => {
+    expect(isReplayableDoctorSourceEventId("123-0")).toBe(true);
+    expect(isReplayableDoctorSourceEventId("123")).toBe(false);
+    expect(isReplayableDoctorSourceEventId("evt-123")).toBe(false);
+    expect(isReplayableDoctorSourceEventId(null)).toBe(false);
+    expect(isReplayableDoctorSourceEventId(undefined)).toBe(false);
+  });
+
+  test("extracts replayable IDs in persisted message order", () => {
+    const messages = [
+      { source_event_id: null },
+      { source_event_id: "1-0" },
+      { source_event_id: "legacy-event" },
+      { source_event_id: "2-0" },
+    ];
+
+    expect(replayableDoctorSourceEventIds(messages)).toEqual(["1-0", "2-0"]);
+  });
+
+  test("returns the latest replayable ID from persisted history", () => {
+    const messages = [
+      { source_event_id: "1-0" },
+      { source_event_id: undefined },
+      { source_event_id: "2-0" },
+      { source_event_id: "legacy-event" },
+    ];
+
+    expect(latestReplayableDoctorSourceEventId(messages)).toBe("2-0");
+  });
+
+  test("returns null when persisted history has no replayable IDs", () => {
+    expect(
+      latestReplayableDoctorSourceEventId([
+        { source_event_id: null },
+        { source_event_id: "legacy-event" },
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/components/panels/doctor-history.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-history.ts
@@ -42,6 +42,10 @@ export type ChatEntry =
   | (ChatEntryBase & { kind: "error" })
   | (ChatEntryBase & { kind: "status" });
 
+export type DoctorMessageWithSourceEventId = DoctorMessage & {
+  source_event_id?: string | null;
+};
+
 /** Distributive omit that preserves the discriminated union structure. */
 export type NewChatEntry =
   | { kind: "user"; content: string }
@@ -61,6 +65,36 @@ function metaRecord(metadata: unknown): Record<string, unknown> {
     return metadata as Record<string, unknown>;
   }
   return {};
+}
+
+const REPLAYABLE_DOCTOR_SOURCE_EVENT_ID = /^\d+-\d+$/;
+
+export function isReplayableDoctorSourceEventId(
+  value: string | null | undefined,
+): value is string {
+  return (
+    typeof value === "string" && REPLAYABLE_DOCTOR_SOURCE_EVENT_ID.test(value)
+  );
+}
+
+export function replayableDoctorSourceEventIds(
+  messages: readonly Pick<DoctorMessageWithSourceEventId, "source_event_id">[],
+): string[] {
+  return messages
+    .map((message) => message.source_event_id)
+    .filter(isReplayableDoctorSourceEventId);
+}
+
+export function latestReplayableDoctorSourceEventId(
+  messages: readonly Pick<DoctorMessageWithSourceEventId, "source_event_id">[],
+): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const sourceEventId = messages[index]?.source_event_id;
+    if (isReplayableDoctorSourceEventId(sourceEventId)) {
+      return sourceEventId;
+    }
+  }
+  return null;
 }
 
 export function mapPersistedMessagesToEntries(
@@ -116,9 +150,13 @@ export function mapPersistedMessagesToEntries(
             e.kind === "tool_call" &&
             e.meta.toolCallId === toolCallId,
         );
-        if (idx === -1) break;
+        if (idx === -1) {
+          break;
+        }
         const existing = entries[idx]!;
-        if (existing.kind !== "tool_call") break;
+        if (existing.kind !== "tool_call") {
+          break;
+        }
         entries[idx] = {
           ...existing,
           meta: {
@@ -199,8 +237,12 @@ export function mapPersistedStatusToPanelStatus(
 export function hasPendingApproval(entries: ChatEntry[]): boolean {
   for (let i = entries.length - 1; i >= 0; i -= 1) {
     const entry = entries[i];
-    if (!entry) continue;
-    if (entry.kind === "status") continue;
+    if (!entry) {
+      continue;
+    }
+    if (entry.kind === "status") {
+      continue;
+    }
     return entry.kind === "approval";
   }
   return false;
@@ -209,8 +251,12 @@ export function hasPendingApproval(entries: ChatEntry[]): boolean {
 export function hasPendingBackup(entries: ChatEntry[]): boolean {
   for (let i = entries.length - 1; i >= 0; i -= 1) {
     const entry = entries[i];
-    if (!entry) continue;
-    if (entry.kind === "status") continue;
+    if (!entry) {
+      continue;
+    }
+    if (entry.kind === "status") {
+      continue;
+    }
     return entry.kind === "backup_prompt";
   }
   return false;

--- a/clients/web/src/domains/settings/components/panels/doctor-panel-store.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel-store.ts
@@ -47,6 +47,12 @@ export interface DoctorPanelState {
 
   /** Tracks which assistant owns the current store state. */
   lastAssistantId: string | null;
+
+  /** Latest Redis stream event ID that can be used to resume the Doctor stream. */
+  latestReplayableSourceEventId: string | null;
+
+  /** Redis stream event IDs already folded into the active Doctor transcript. */
+  processedSourceEventIds: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +83,9 @@ export interface DoctorPanelActions {
 
   setStreamingEntryId: (id: string | null) => void;
   setEntries: (entries: ChatEntry[]) => void;
+  resetReplayState: () => void;
+  seedReplayState: (sourceEventIds: string[], latestSourceEventId: string | null) => void;
+  recordReplayableSourceEventId: (sourceEventId: string) => boolean;
 }
 
 export type DoctorPanelStore = DoctorPanelState & DoctorPanelActions;
@@ -118,6 +127,8 @@ const useDoctorPanelStoreBase = create<DoctorPanelStore>()((set, get) => ({
   streamingEntryId: null,
   entryCounter: 0,
   lastAssistantId: null,
+  latestReplayableSourceEventId: null,
+  processedSourceEventIds: new Set(),
 
   // Actions
   nextId: () => {
@@ -145,6 +156,8 @@ const useDoctorPanelStoreBase = create<DoctorPanelStore>()((set, get) => ({
       pendingBackup: false,
       thinking: false,
       streamingEntryId: null,
+      latestReplayableSourceEventId: null,
+      processedSourceEventIds: new Set(),
     });
   },
 
@@ -160,6 +173,8 @@ const useDoctorPanelStoreBase = create<DoctorPanelStore>()((set, get) => ({
       historyDismissed: false,
       streamingEntryId: null,
       entryCounter: 0,
+      latestReplayableSourceEventId: null,
+      processedSourceEventIds: new Set(),
     });
   },
 
@@ -175,6 +190,8 @@ const useDoctorPanelStoreBase = create<DoctorPanelStore>()((set, get) => ({
       historyDismissed: true,
       streamingEntryId: null,
       entryCounter: 0,
+      latestReplayableSourceEventId: null,
+      processedSourceEventIds: new Set(),
     });
   },
 
@@ -187,6 +204,31 @@ const useDoctorPanelStoreBase = create<DoctorPanelStore>()((set, get) => ({
   setHistoryDismissed: (v) => set({ historyDismissed: v }),
   setStreamingEntryId: (id) => set({ streamingEntryId: id }),
   setEntries: (entries) => set({ entries }),
+  resetReplayState: () => {
+    set({
+      latestReplayableSourceEventId: null,
+      processedSourceEventIds: new Set(),
+    });
+  },
+  seedReplayState: (sourceEventIds, latestSourceEventId) => {
+    set({
+      latestReplayableSourceEventId: latestSourceEventId,
+      processedSourceEventIds: new Set(sourceEventIds),
+    });
+  },
+  recordReplayableSourceEventId: (sourceEventId) => {
+    const processedSourceEventIds = get().processedSourceEventIds;
+    if (processedSourceEventIds.has(sourceEventId)) {
+      return false;
+    }
+    set({
+      latestReplayableSourceEventId: sourceEventId,
+      processedSourceEventIds: new Set(processedSourceEventIds).add(
+        sourceEventId,
+      ),
+    });
+    return true;
+  },
 }));
 
 export const useDoctorPanelStore = createSelectors(useDoctorPanelStoreBase);

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -20,10 +20,13 @@ import {
   type ChatEntry,
   hasPendingApproval,
   hasPendingBackup,
+  latestReplayableDoctorSourceEventId,
   mapPersistedMessagesToEntries,
   mapPersistedStatusToPanelStatus,
+  replayableDoctorSourceEventIds,
   selectLatestHistorySession,
   serializeSessionToText,
+  type DoctorMessageWithSourceEventId,
 } from "@/domains/settings/components/panels/doctor-history";
 import { useDoctorPanelStore } from "@/domains/settings/components/panels/doctor-panel-store";
 import {
@@ -178,21 +181,46 @@ export function DoctorPanel() {
   // This is NOT "copying server state to client state" — it's seeding the store
   // with the initial entries before SSE takes over appending new ones.
   useEffect(() => {
-    if (historyDismissed) return;
-    if (sessionId !== null) return;
-    if (storeEntries.length > 0) return;
-    if (!historyDetail || !latestHistorySessionId) return;
-    if (historyStatus !== "active") return;
+    if (historyDismissed) {
+      return;
+    }
+    if (sessionId !== null) {
+      return;
+    }
+    if (storeEntries.length > 0) {
+      return;
+    }
+    if (!historyDetail || !latestHistorySessionId) {
+      return;
+    }
+    if (historyStatus !== "active") {
+      return;
+    }
 
     const store = useDoctorPanelStore.getState();
-    const resumedEntries = mapPersistedMessagesToEntries(historyDetail.messages ?? []);
+    const messages = (historyDetail.messages ??
+      []) as DoctorMessageWithSourceEventId[];
+    const resumedEntries = mapPersistedMessagesToEntries(messages);
     store.setEntries(resumedEntries);
     store.setPendingApproval(hasPendingApproval(resumedEntries));
     store.setPendingBackup(hasPendingBackup(resumedEntries));
+    store.seedReplayState(
+      replayableDoctorSourceEventIds(messages),
+      latestReplayableDoctorSourceEventId(messages),
+    );
     store.setSessionId(latestHistorySessionId);
     store.setSessionStatus("active");
     connectSSE(assistantId, latestHistorySessionId);
-  }, [historyDismissed, sessionId, storeEntries.length, historyDetail, historyStatus, latestHistorySessionId, assistantId, connectSSE]);
+  }, [
+    historyDismissed,
+    sessionId,
+    storeEntries.length,
+    historyDetail,
+    historyStatus,
+    latestHistorySessionId,
+    assistantId,
+    connectSSE,
+  ]);
 
   // Capture query errors for observability
   useEffect(() => {
@@ -233,6 +261,7 @@ export function DoctorPanel() {
     },
     onSuccess(data) {
       const store = useDoctorPanelStore.getState();
+      store.resetReplayState();
       store.setSessionId(data.session_id);
       store.setSessionStatus("active");
       store.setEntries([
@@ -286,7 +315,9 @@ export function DoctorPanel() {
 
   const handleSend = (content: string) => {
     const text = content.trim();
-    if (!text || !sessionId) return;
+    if (!text || !sessionId) {
+      return;
+    }
     // Re-pin to the latest so the outgoing message and the streamed
     // response are in view, even if the user had scrolled up to read
     // earlier content before sending.
@@ -336,12 +367,9 @@ export function DoctorPanel() {
   const { scrollContainerRef, showScrollToLatest, scrollToLatest } =
     useDoctorAutoScroll(entries);
 
-  // Recover from stale state on same-assistant remount.
-  // The module-level store survives unmount, but useDoctorSSE's AbortController
-  // does not — it's a React ref that dies with the hook instance. If the store
-  // still shows an active session, the SSE stream is gone with no way to resume
-  // it from the old controller. Full-reset so the history queries can re-discover
-  // and reconnect to the still-active server session.
+  // Recover the stream on same-assistant remount. The module-level store
+  // preserves the active session and replay cursor, while useDoctorSSE's
+  // AbortController is owned by the mounted hook instance.
   useEffect(() => {
     const store = useDoctorPanelStore.getState();
     if (
@@ -349,7 +377,7 @@ export function DoctorPanel() {
       store.sessionStatus === "active" &&
       store.sessionId
     ) {
-      store.reset();
+      connectSSE(assistantId, store.sessionId);
     }
     // Clear historyDismissed on remount so history queries re-discover new
     // sessions that may have completed while the panel was unmounted.
@@ -362,7 +390,9 @@ export function DoctorPanel() {
   // Reset all doctor state when active assistant changes.
   useEffect(() => {
     const store = useDoctorPanelStore.getState();
-    if (store.lastAssistantId === assistantId) return;
+    if (store.lastAssistantId === assistantId) {
+      return;
+    }
     const oldAssistantId = store.lastAssistantId;
     const oldSessionId = store.sessionId;
 
@@ -601,9 +631,15 @@ export function DoctorPanel() {
                   e.target.style.height = `${Math.min(e.target.scrollHeight, 160)}px`;
                 }}
                 onKeyDown={(e) => {
-                  if (e.key !== "Enter" || e.shiftKey) return;
-                  if (e.nativeEvent.isComposing || e.keyCode === 229) return;
-                  if (isPointerCoarse()) return;
+                  if (e.key !== "Enter" || e.shiftKey) {
+                    return;
+                  }
+                  if (e.nativeEvent.isComposing || e.keyCode === 229) {
+                    return;
+                  }
+                  if (isPointerCoarse()) {
+                    return;
+                  }
                   e.preventDefault();
                   if (inputValue.trim() && !sending) {
                     handleSend(inputValue);

--- a/clients/web/src/domains/settings/components/panels/doctor-sse-reconnect.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-sse-reconnect.ts
@@ -1,0 +1,5 @@
+export function shouldResetDoctorSseReconnectBudget(
+  receivedDataFrame: boolean,
+): boolean {
+  return receivedDataFrame;
+}

--- a/clients/web/src/domains/settings/components/panels/use-doctor-sse.test.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-sse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { ChatEntry } from "@/domains/settings/components/panels/doctor-history";
 import {
@@ -12,13 +12,20 @@ import {
   handleToolResult,
 } from "@/domains/settings/components/panels/doctor-event-handlers";
 import { parseDoctorEvent } from "@/domains/settings/components/panels/doctor-event-schema";
-import type { DoctorPanelContext } from "@/domains/settings/components/panels/doctor-panel-store";
+import {
+  type DoctorPanelContext,
+  useDoctorPanelStore,
+} from "@/domains/settings/components/panels/doctor-panel-store";
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
 let idCounter = 0;
+
+beforeEach(() => {
+  useDoctorPanelStore.getState().resetReplayState();
+});
 
 function createMockContext(initialEntries: ChatEntry[] = []): DoctorPanelContext & {
   entries: ChatEntry[];
@@ -65,6 +72,30 @@ describe("parseDoctorEvent", () => {
   test("parses message_delta event", () => {
     const event = parseDoctorEvent(JSON.stringify({ type: "message_delta", content: "hi" }));
     expect(event).toEqual({ type: "message_delta", content: "hi" });
+  });
+
+  test("preserves optional source_event_id on replayable events", () => {
+    const event = parseDoctorEvent(
+      JSON.stringify({
+        type: "message_delta",
+        content: "hi",
+        source_event_id: "123-0",
+      }),
+    );
+
+    expect(event).toEqual({
+      type: "message_delta",
+      content: "hi",
+      source_event_id: "123-0",
+    });
+  });
+
+  test("allows legacy events without source_event_id", () => {
+    const event = parseDoctorEvent(
+      JSON.stringify({ type: "status", status: "active" }),
+    );
+
+    expect(event).toEqual({ type: "status", status: "active" });
   });
 
   test("parses message event", () => {
@@ -172,9 +203,40 @@ describe("parseDoctorEvent", () => {
     );
     expect(event).not.toBeNull();
     expect(event!.type).toBe("message_delta");
-    if (event!.type !== "message_delta") throw new Error("unreachable");
+    if (event!.type !== "message_delta") {
+      throw new Error("unreachable");
+    }
     expect(event!.content).toBe("hi");
     expect("extra" in event!).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Doctor replay state
+// ---------------------------------------------------------------------------
+
+describe("Doctor replay state", () => {
+  test("seeds latest cursor and processed IDs from persisted history", () => {
+    const store = useDoctorPanelStore.getState();
+
+    store.seedReplayState(["1-0", "2-0"], "2-0");
+
+    const state = useDoctorPanelStore.getState();
+    expect(state.latestReplayableSourceEventId).toBe("2-0");
+    expect([...state.processedSourceEventIds]).toEqual(["1-0", "2-0"]);
+  });
+
+  test("drops duplicate replay IDs before they can be applied twice", () => {
+    const store = useDoctorPanelStore.getState();
+
+    store.seedReplayState(["1-0"], "1-0");
+
+    expect(store.recordReplayableSourceEventId("1-0")).toBe(false);
+    expect(store.recordReplayableSourceEventId("2-0")).toBe(true);
+    expect(store.recordReplayableSourceEventId("2-0")).toBe(false);
+    expect(useDoctorPanelStore.getState().latestReplayableSourceEventId).toBe(
+      "2-0",
+    );
   });
 });
 
@@ -249,7 +311,9 @@ describe("handleToolCall", () => {
     expect(ctx.entries).toHaveLength(1);
     const entry = ctx.entries[0]!;
     expect(entry.kind).toBe("tool_call");
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("run_diag");
     expect(entry.meta.input).toEqual({ flag: true });
     expect(entry.meta.toolCallId).toBe("tc-1");
@@ -279,7 +343,9 @@ describe("handleToolResult", () => {
 
     expect(ctx.entries).toHaveLength(1);
     const entry = ctx.entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.result).toBe("all good");
     expect(entry.meta.isError).toBe(false);
     expect(entry.meta.status).toBe("completed");
@@ -299,7 +365,9 @@ describe("handleToolResult", () => {
     handleToolResult(ctx, { toolCallId: "tc-1", content: "failed", isError: true });
 
     const entry = ctx.entries[0]!;
-    if (entry.kind !== "tool_call") throw new Error("unreachable");
+    if (entry.kind !== "tool_call") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.status).toBe("error");
     expect(entry.meta.isError).toBe(true);
   });
@@ -334,7 +402,9 @@ describe("handleApprovalRequired", () => {
     expect(ctx.entries).toHaveLength(1);
     const entry = ctx.entries[0]!;
     expect(entry.kind).toBe("approval");
-    if (entry.kind !== "approval") throw new Error("unreachable");
+    if (entry.kind !== "approval") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("exec_cmd");
     expect(entry.meta.toolCallId).toBe("ap-1");
     expect(entry.meta.description).toBe("Run ls");
@@ -356,7 +426,9 @@ describe("handleBackupPrompt", () => {
     expect(ctx.entries).toHaveLength(1);
     const entry = ctx.entries[0]!;
     expect(entry.kind).toBe("backup_prompt");
-    if (entry.kind !== "backup_prompt") throw new Error("unreachable");
+    if (entry.kind !== "backup_prompt") {
+      throw new Error("unreachable");
+    }
     expect(entry.meta.toolName).toBe("dangerous_tool");
     expect(ctx.calls.setThinking).toEqual([false]);
     expect(ctx.calls.setPendingBackup).toEqual([true]);

--- a/clients/web/src/domains/settings/components/panels/use-doctor-sse.test.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-sse.test.ts
@@ -16,6 +16,7 @@ import {
   type DoctorPanelContext,
   useDoctorPanelStore,
 } from "@/domains/settings/components/panels/doctor-panel-store";
+import { shouldResetDoctorSseReconnectBudget } from "@/domains/settings/components/panels/doctor-sse-reconnect";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -237,6 +238,20 @@ describe("Doctor replay state", () => {
     expect(useDoctorPanelStore.getState().latestReplayableSourceEventId).toBe(
       "2-0",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Doctor SSE reconnect budget
+// ---------------------------------------------------------------------------
+
+describe("Doctor SSE reconnect budget", () => {
+  test("keeps retry budget for heartbeat-only attempts", () => {
+    expect(shouldResetDoctorSseReconnectBudget(false)).toBe(false);
+  });
+
+  test("resets retry budget after data frames", () => {
+    expect(shouldResetDoctorSseReconnectBudget(true)).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
@@ -12,6 +12,16 @@ import { useCallback, useRef } from "react";
 import type { DoctorPanelContext } from "@/domains/settings/components/panels/doctor-panel-store";
 import { useDoctorPanelStore } from "@/domains/settings/components/panels/doctor-panel-store";
 import {
+  hasPendingApproval,
+  hasPendingBackup,
+  isReplayableDoctorSourceEventId,
+  latestReplayableDoctorSourceEventId,
+  mapPersistedMessagesToEntries,
+  mapPersistedStatusToPanelStatus,
+  replayableDoctorSourceEventIds,
+  type DoctorMessageWithSourceEventId,
+} from "@/domains/settings/components/panels/doctor-history";
+import {
   type DoctorEvent,
   parseDoctorEvent,
 } from "@/domains/settings/components/panels/doctor-event-schema";
@@ -25,8 +35,12 @@ import {
   handleToolCall,
   handleToolResult,
 } from "@/domains/settings/components/panels/doctor-event-handlers";
-import { assistantsDoctorSessionsEventsRetrieve } from "@/generated/api";
+import {
+  assistantsDoctorHistoryRetrieve,
+  assistantsDoctorSessionsEventsRetrieve,
+} from "@/generated/api";
 import { captureError } from "@/lib/sentry/capture-error";
+import { createStreamWatchdog } from "@/lib/streaming/stream-watchdog";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import { toError } from "@/utils/to-error";
 
@@ -35,12 +49,113 @@ import { toError } from "@/utils/to-error";
 // ---------------------------------------------------------------------------
 
 const SESSION_EXPIRED_STATUSES = new Set([404, 410]);
+const DOCTOR_REPLAY_GAP_CODE = "replay_gap";
+const MAX_DOCTOR_SSE_RECONNECT_ATTEMPTS = 5;
+const DOCTOR_SSE_RECONNECT_BASE_MS = 500;
+const DOCTOR_SSE_RECONNECT_MAX_MS = 5_000;
+const DOCTOR_SSE_IDLE_TIMEOUT_MS = 45_000;
+
+function doctorReconnectDelayMs(attempt: number): number {
+  const exponential = DOCTOR_SSE_RECONNECT_BASE_MS * 2 ** attempt;
+  const jitter = Math.floor(Math.random() * 250);
+  return Math.min(exponential, DOCTOR_SSE_RECONNECT_MAX_MS) + jitter;
+}
+
+function waitForDoctorReconnect(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const timeout = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+async function readDoctorReplayGap(response: Response): Promise<boolean> {
+  if (response.status !== 409) {
+    return false;
+  }
+
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as { code?: unknown } | null;
+
+  return body?.code === DOCTOR_REPLAY_GAP_CODE;
+}
+
+function getSseEventId(event: unknown): string | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return null;
+  }
+
+  const id = (event as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+function seedDoctorPanelFromPersistedMessages(
+  status: Parameters<typeof mapPersistedStatusToPanelStatus>[0],
+  messages: DoctorMessageWithSourceEventId[],
+): ReturnType<typeof mapPersistedStatusToPanelStatus> {
+  const entries = mapPersistedMessagesToEntries(messages);
+  const panelStatus = mapPersistedStatusToPanelStatus(status);
+  const store = useDoctorPanelStore.getState();
+
+  store.setEntries(entries);
+  store.setSessionStatus(panelStatus);
+  store.setPendingApproval(
+    panelStatus === "active" && hasPendingApproval(entries),
+  );
+  store.setPendingBackup(panelStatus === "active" && hasPendingBackup(entries));
+  store.seedReplayState(
+    replayableDoctorSourceEventIds(messages),
+    latestReplayableDoctorSourceEventId(messages),
+  );
+
+  return panelStatus;
+}
+
+async function refreshPersistedDoctorSession(
+  assistantId: string,
+  sessionId: string,
+): Promise<"active" | "terminal" | null> {
+  const result = await assistantsDoctorHistoryRetrieve({
+    path: { assistant_id: assistantId, doctor_session_id: sessionId },
+    throwOnError: false,
+  });
+
+  if (!result.response?.ok || !result.data) {
+    return null;
+  }
+
+  const panelStatus = seedDoctorPanelFromPersistedMessages(
+    result.data.status,
+    (result.data.messages ?? []) as DoctorMessageWithSourceEventId[],
+  );
+
+  if (panelStatus === "active") {
+    useDoctorPanelStore.getState().setSessionId(sessionId);
+    return "active";
+  }
+
+  return "terminal";
+}
 
 export function useDoctorSSE() {
   const controllerRef = useRef<AbortController | null>(null);
 
   const connectSSE = useCallback(
     (assistantId: string, sessionId: string) => {
+      controllerRef.current?.abort();
       const controller = new AbortController();
       controllerRef.current = controller;
 
@@ -49,30 +164,52 @@ export function useDoctorSSE() {
       const isCurrentStream = () => controllerRef.current === controller;
 
       const ctx: DoctorPanelContext = {
-        updateEntries: (updater) => useDoctorPanelStore.getState().updateEntries(updater),
+        updateEntries: (updater) =>
+          useDoctorPanelStore.getState().updateEntries(updater),
         setThinking: (v) => useDoctorPanelStore.getState().setThinking(v),
-        setPendingApproval: (v) => useDoctorPanelStore.getState().setPendingApproval(v),
-        setPendingBackup: (v) => useDoctorPanelStore.getState().setPendingBackup(v),
-        setSessionStatus: (s) => useDoctorPanelStore.getState().setSessionStatus(s),
-        appendEntry: (entry) => useDoctorPanelStore.getState().appendEntry(entry),
+        setPendingApproval: (v) =>
+          useDoctorPanelStore.getState().setPendingApproval(v),
+        setPendingBackup: (v) =>
+          useDoctorPanelStore.getState().setPendingBackup(v),
+        setSessionStatus: (s) =>
+          useDoctorPanelStore.getState().setSessionStatus(s),
+        appendEntry: (entry) =>
+          useDoctorPanelStore.getState().appendEntry(entry),
         nextId: () => useDoctorPanelStore.getState().nextId(),
-        getStreamingEntryId: () => useDoctorPanelStore.getState().streamingEntryId,
-        setStreamingEntryId: (id) => useDoctorPanelStore.getState().setStreamingEntryId(id),
+        getStreamingEntryId: () =>
+          useDoctorPanelStore.getState().streamingEntryId,
+        setStreamingEntryId: (id) =>
+          useDoctorPanelStore.getState().setStreamingEntryId(id),
       };
 
       const failStream = (content: string) => {
-        if (!isCurrentStream()) return;
+        if (!isCurrentStream()) {
+          return;
+        }
         controllerRef.current = null;
         const s = useDoctorPanelStore.getState();
         s.setThinking(false);
         s.setPendingApproval(false);
+        s.setPendingBackup(false);
         s.setStreamingEntryId(null);
         s.setSessionStatus("error");
         s.appendEntry({ kind: "error", content });
       };
 
       function dispatchEvent(event: DoctorEvent): void {
-        if (!isCurrentStream()) return;
+        if (!isCurrentStream()) {
+          return;
+        }
+
+        const sourceEventId = event.source_event_id;
+        if (isReplayableDoctorSourceEventId(sourceEventId)) {
+          const shouldApply = useDoctorPanelStore
+            .getState()
+            .recordReplayableSourceEventId(sourceEventId);
+          if (!shouldApply) {
+            return;
+          }
+        }
 
         switch (event.type) {
           case "message_delta":
@@ -105,45 +242,163 @@ export function useDoctorSSE() {
       }
 
       (async () => {
-        let streamError: Error | null = null;
-        let sessionExpired = false;
-        let failedStatus: number | null = null;
-        try {
-          const { stream } = await assistantsDoctorSessionsEventsRetrieve({
-            path: { assistant_id: assistantId, session_id: sessionId },
-            headers: {
-              Accept: "text/event-stream, application/json",
-              ...getClientRegistrationHeaders(),
-            },
-            signal: controller.signal,
-            sseMaxRetryAttempts: 0,
-            fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
-              const response = await globalThis.fetch(input, init);
-              if (!response.ok) {
-                failedStatus = response.status;
-                if (SESSION_EXPIRED_STATUSES.has(response.status)) {
-                  sessionExpired = true;
-                }
-              }
-              return response;
-            }) as typeof globalThis.fetch,
-            onSseError: (error) => {
-              if (sessionExpired) return;
-              streamError = toError(error, "Doctor stream disconnected");
-            },
+        let reconnectAttempt = 0;
+        let replayGapRefreshes = 0;
+
+        while (!controller.signal.aborted && isCurrentStream()) {
+          const attemptController = new AbortController();
+          const abortAttempt = () => {
+            attemptController.abort();
+          };
+          controller.signal.addEventListener("abort", abortAttempt, {
+            once: true,
           });
 
-          if (!isCurrentStream()) return;
+          const watchdog = createStreamWatchdog({
+            idleTimeoutMs: DOCTOR_SSE_IDLE_TIMEOUT_MS,
+            assistantId,
+          });
+          watchdog.resetCounters();
 
-          for await (const payload of stream) {
-            if (!isCurrentStream()) return;
-            const event = parseDoctorEvent(payload);
-            if (event) {
-              dispatchEvent(event);
+          let streamError: Error | null = null;
+          let sessionExpired = false;
+          let replayGap = false;
+          let failedStatus: number | null = null;
+          let receivedTraffic = false;
+          let pendingSseEventId: string | null = null;
+
+          try {
+            const latestReplayableSourceEventId =
+              useDoctorPanelStore.getState().latestReplayableSourceEventId;
+
+            const headers: Record<string, string> = {
+              Accept: "text/event-stream, application/json",
+              ...getClientRegistrationHeaders(),
+            };
+            if (latestReplayableSourceEventId) {
+              headers["Last-Event-ID"] = latestReplayableSourceEventId;
             }
+
+            const { stream } = await assistantsDoctorSessionsEventsRetrieve({
+              path: { assistant_id: assistantId, session_id: sessionId },
+              headers,
+              signal: attemptController.signal,
+              sseMaxRetryAttempts: 0,
+              fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+                const response = await globalThis.fetch(input, init);
+                if (!response.ok) {
+                  failedStatus = response.status;
+                  if (SESSION_EXPIRED_STATUSES.has(response.status)) {
+                    sessionExpired = true;
+                  }
+                  if (await readDoctorReplayGap(response)) {
+                    replayGap = true;
+                  }
+                }
+                return response;
+              }) as typeof globalThis.fetch,
+              onSseEvent: (event) => {
+                receivedTraffic = true;
+                const isData =
+                  typeof (event as { data?: unknown }).data !== "undefined";
+                if (isData) {
+                  pendingSseEventId = getSseEventId(event);
+                }
+                watchdog.recordTraffic(isData);
+                if (!controller.signal.aborted && isCurrentStream()) {
+                  watchdog.arm(attemptController, reconnectAttempt);
+                }
+              },
+              onSseError: (error) => {
+                if (sessionExpired || replayGap) {
+                  return;
+                }
+                streamError = toError(error, "Doctor stream disconnected");
+              },
+            });
+
+            if (!isCurrentStream()) {
+              return;
+            }
+
+            watchdog.arm(attemptController, reconnectAttempt);
+
+            for await (const payload of stream) {
+              if (!isCurrentStream()) {
+                return;
+              }
+
+              receivedTraffic = true;
+              reconnectAttempt = 0;
+              watchdog.arm(attemptController, reconnectAttempt);
+
+              const sseEventId = pendingSseEventId;
+              pendingSseEventId = null;
+              const event = parseDoctorEvent(payload);
+              if (event) {
+                const eventWithSource =
+                  event.source_event_id || !sseEventId
+                    ? event
+                    : { ...event, source_event_id: sseEventId };
+                dispatchEvent(eventWithSource);
+              }
+            }
+          } catch (err) {
+            if (controller.signal.aborted) {
+              return;
+            }
+            const abortCause = watchdog.consumeLastAbortCause();
+            streamError =
+              abortCause === "watchdog"
+                ? toError(err, "Doctor stream stalled")
+                : toError(err, "Doctor stream connection failed");
+          } finally {
+            watchdog.clear();
+            controller.signal.removeEventListener("abort", abortAttempt);
           }
 
-          if (!isCurrentStream()) return;
+          if (!isCurrentStream()) {
+            return;
+          }
+
+          if (streamEndedTerminally) {
+            return;
+          }
+
+          if (replayGap) {
+            if (replayGapRefreshes >= 1) {
+              failStream(
+                "Doctor event history changed while reconnecting. Start a new session to continue.",
+              );
+              return;
+            }
+
+            replayGapRefreshes += 1;
+            let refreshed: "active" | "terminal" | null = null;
+            try {
+              refreshed = await refreshPersistedDoctorSession(
+                assistantId,
+                sessionId,
+              );
+            } catch (err) {
+              captureError(err, { context: "doctor_replay_gap_refresh" });
+            }
+            if (!isCurrentStream()) {
+              return;
+            }
+            if (refreshed === "active") {
+              continue;
+            }
+            if (refreshed === "terminal") {
+              streamEndedTerminally = true;
+              return;
+            }
+
+            failStream(
+              "Doctor event history changed while reconnecting. Start a new session to continue.",
+            );
+            return;
+          }
 
           if (sessionExpired) {
             streamEndedTerminally = true;
@@ -152,6 +407,7 @@ export function useDoctorSSE() {
             s.setStreamingEntryId(null);
             s.setSessionStatus("completed");
             s.setPendingApproval(false);
+            s.setPendingBackup(false);
             s.appendEntry({
               kind: "status",
               content:
@@ -160,7 +416,17 @@ export function useDoctorSSE() {
             return;
           }
 
-          if (streamError) {
+          if (!streamError) {
+            streamError = new Error(
+              "Doctor event stream ended before the session completed.",
+            );
+          }
+
+          if (receivedTraffic) {
+            reconnectAttempt = 0;
+          }
+
+          if (reconnectAttempt >= MAX_DOCTOR_SSE_RECONNECT_ATTEMPTS) {
             captureError(streamError, { context: "doctor_sse_stream" });
             failStream(
               failedStatus
@@ -170,17 +436,11 @@ export function useDoctorSSE() {
             return;
           }
 
-          if (!streamEndedTerminally) {
-            failStream(
-              "Doctor event stream ended before the session completed. Start a new session to continue.",
-            );
-          }
-        } catch (err) {
-          if (controller.signal.aborted) return;
-          captureError(err, { context: "doctor_sse_stream" });
-          failStream(
-            "Event stream disconnected. Start a new session to continue.",
+          await waitForDoctorReconnect(
+            doctorReconnectDelayMs(reconnectAttempt),
+            controller.signal,
           );
+          reconnectAttempt += 1;
         }
       })();
     },

--- a/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
@@ -35,6 +35,7 @@ import {
   handleToolCall,
   handleToolResult,
 } from "@/domains/settings/components/panels/doctor-event-handlers";
+import { shouldResetDoctorSseReconnectBudget } from "@/domains/settings/components/panels/doctor-sse-reconnect";
 import {
   assistantsDoctorHistoryRetrieve,
   assistantsDoctorSessionsEventsRetrieve,
@@ -264,7 +265,7 @@ export function useDoctorSSE() {
           let sessionExpired = false;
           let replayGap = false;
           let failedStatus: number | null = null;
-          let receivedTraffic = false;
+          let receivedDataFrame = false;
           let pendingSseEventId: string | null = null;
 
           try {
@@ -298,10 +299,10 @@ export function useDoctorSSE() {
                 return response;
               }) as typeof globalThis.fetch,
               onSseEvent: (event) => {
-                receivedTraffic = true;
                 const isData =
                   typeof (event as { data?: unknown }).data !== "undefined";
                 if (isData) {
+                  receivedDataFrame = true;
                   pendingSseEventId = getSseEventId(event);
                 }
                 watchdog.recordTraffic(isData);
@@ -328,7 +329,7 @@ export function useDoctorSSE() {
                 return;
               }
 
-              receivedTraffic = true;
+              receivedDataFrame = true;
               reconnectAttempt = 0;
               watchdog.arm(attemptController, reconnectAttempt);
 
@@ -422,7 +423,7 @@ export function useDoctorSSE() {
             );
           }
 
-          if (receivedTraffic) {
+          if (shouldResetDoctorSseReconnectBudget(receivedDataFrame)) {
             reconnectAttempt = 0;
           }
 


### PR DESCRIPTION
## Summary

- Track replayable Doctor `source_event_id` values in the active web Doctor store and seed them from persisted history.
- Send `Last-Event-ID` when reconnecting, dedupe replayed Redis-style event IDs, and recover one `replay_gap` by reloading persisted history before retrying.
- Add bounded jittered reconnects plus the shared idle watchdog while preserving legacy streams that do not include source IDs.

## Plan context

This is the companion active-web slice for the platform Durable Doctor Sessions plan. It should be merged before the platform single-writer cutover PR.

## Validation

- `bun test src/domains/settings/components/panels/doctor-history.test.ts src/domains/settings/components/panels/use-doctor-sse.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint src/domains/settings/components/panels/doctor-event-schema.ts src/domains/settings/components/panels/doctor-history.ts src/domains/settings/components/panels/doctor-panel-store.ts src/domains/settings/components/panels/doctor-panel.tsx src/domains/settings/components/panels/use-doctor-sse.ts src/domains/settings/components/panels/doctor-history.test.ts src/domains/settings/components/panels/use-doctor-sse.test.ts`
- `bun run lint` (passes; repo still emits unrelated pre-existing warnings outside this slice)
