### PR TITLE
[codex] Match universal blockquote quote UI

### DIFF
--- a/clients/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -83,7 +83,6 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
   content,
   className,
   hardLineBreaks,
-  blockquoteVariant,
   onVellumLinkClick,
 }: ChatMarkdownMessageProps) {
   const linkComponent = useCallback(
@@ -119,7 +118,6 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
       content={content}
       className={className}
       hardLineBreaks={hardLineBreaks}
-      blockquoteVariant={blockquoteVariant}
       linkComponent={linkComponent}
       urlTransform={vellumUrlTransform}
     />

--- a/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
@@ -15,8 +15,6 @@ import {
   useRef,
   useState,
 } from "react";
-
-import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import {
   Button,
   Card,
@@ -24,6 +22,13 @@ import {
   Textarea,
   Typography,
 } from "@vellumai/design-library";
+import {
+  quoteBlockquoteAccentClassName,
+  quoteBlockquoteClassName,
+  quoteBlockquoteContentClassName,
+} from "@vellumai/design-library/components/markdown-message";
+
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 interface QuoteReplyBubbleProps {
   onAddToChat?: () => void;
@@ -136,9 +141,15 @@ export function QuoteReplyBubble({ onAddToChat }: QuoteReplyBubbleProps) {
             <Typography
               as="div"
               variant="body-small-default"
-              className="rounded-md border-l-2 border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-[var(--content-secondary)] [&_p]:mb-0"
+              className={`${quoteBlockquoteClassName} mb-0`}
             >
-              {truncatedQuote}
+              <span
+                aria-hidden="true"
+                className={quoteBlockquoteAccentClassName}
+              />
+              <span className={quoteBlockquoteContentClassName}>
+                {truncatedQuote}
+              </span>
             </Typography>
 
             <Textarea

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -261,6 +261,14 @@ describe("QuoteReplyBubble", () => {
     });
     expect(document.body.querySelector('[data-slot="card"]')).toBeTruthy();
     expect(document.body.querySelector('[data-slot="textarea"]')).toBeTruthy();
+    const quoteBlock = screen.getByText(
+      "here's the anthropic competitive research brief from last night",
+    );
+    expect(quoteBlock.className).toContain("flex-1");
+    expect(quoteBlock.parentElement?.className).toContain("mx-0");
+    expect(quoteBlock.parentElement?.className).toContain("gap-3");
+    expect(quoteBlock.previousElementSibling?.className).toContain("h-5");
+    expect(quoteBlock.previousElementSibling?.className).toContain("w-0.5");
     expect(
       screen.getByRole("button", { name: "Close reply" }).getAttribute("data-slot"),
     ).toBe("button");
@@ -321,6 +329,10 @@ describe("StagedQuotesStrip", () => {
     render(<StagedQuotesStrip />);
 
     expect(document.body.querySelector('[data-slot="card"]')).toBeTruthy();
+    const quoteText = screen.getByText("competitive research");
+    expect(quoteText.className).toContain("flex-1");
+    expect(quoteText.parentElement?.className).toContain("gap-3");
+    expect(quoteText.previousElementSibling?.className).toContain("h-5");
     expect(
       screen.getByRole("button", { name: "Remove quote" }).getAttribute("data-slot"),
     ).toBe("button");

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -8,12 +8,21 @@
  */
 
 import { MessageSquareQuote, X } from "lucide-react";
+import {
+  Button,
+  Card,
+  Typography,
+} from "@vellumai/design-library";
+import {
+  quoteBlockquoteAccentClassName,
+  quoteBlockquoteClassName,
+  quoteBlockquoteContentClassName,
+} from "@vellumai/design-library/components/markdown-message";
 
 import {
   type StagedQuote,
   useQuoteReplyStore,
 } from "@/domains/chat/quote-reply-store";
-import { Button, Card, Typography } from "@vellumai/design-library";
 
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) {
@@ -37,9 +46,15 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
           <Typography
             as="div"
             variant="body-small-default"
-            className="text-[var(--content-tertiary)]"
+            className={`${quoteBlockquoteClassName} mb-0`}
           >
-            &ldquo;{truncate(quote.quotedText, 80)}&rdquo;
+            <span
+              aria-hidden="true"
+              className={quoteBlockquoteAccentClassName}
+            />
+            <span className={quoteBlockquoteContentClassName}>
+              {truncate(quote.quotedText, 80)}
+            </span>
           </Typography>
           <Typography
             as="div"

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -318,7 +318,6 @@ export function TranscriptMessageBody({
                 <ChatMarkdownMessage
                   content={seg.content}
                   hardLineBreaks
-                  blockquoteVariant={isUser ? "quotePreview" : "default"}
                   onVellumLinkClick={handleVellumLinkClick}
                 />
               </div>
@@ -332,7 +331,6 @@ export function TranscriptMessageBody({
         <ChatMarkdownMessage
           content={text}
           hardLineBreaks
-          blockquoteVariant={isUser ? "quotePreview" : "default"}
           onVellumLinkClick={handleVellumLinkClick}
         />
       </div>

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -35,30 +35,26 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("text-body-medium-default");
   });
 
-  test("blockquotes render with default markdown quote styling", () => {
+  test("blockquotes render as universal inset quote blocks", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {
         content: "> This is quoted.\n\nReply text.",
-      }),
-    );
-
-    expect(html).toContain("italic");
-    expect(html).toContain("text-stone-600");
-    expect(html).not.toContain("rounded-md");
-    expect(html).not.toContain("bg-[var(--surface-sunken)]");
-  });
-
-  test("quotePreview blockquotes render as compact quote previews", () => {
-    const html = renderToStaticMarkup(
-      createElement(MarkdownMessage, {
-        content: "> This is quoted.\n\nReply text.",
-        blockquoteVariant: "quotePreview",
       }),
     );
 
     expect(html).toContain("rounded-md");
     expect(html).toContain("bg-[var(--surface-sunken)]");
-    expect(html).not.toContain(" italic ");
+    expect(html).toContain("mx-0");
+    expect(html).toContain("flex");
+    expect(html).toContain("gap-3");
+    expect(html).toContain("h-5");
+    expect(html).toContain("w-0.5");
+    expect(html).toContain("rounded-full");
+    expect(html).toContain("min-w-0");
+    expect(html).toContain("flex-1");
+    expect(html).toContain("text-[var(--content-secondary)]");
+    expect(html).not.toContain("text-stone-600");
+    expect(html).not.toContain("italic");
   });
 
   test("ordered list beginning at a non-1 number preserves its start", () => {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -23,7 +23,13 @@ import "katex/dist/katex.min.css";
 import { cn } from "../utils/cn";
 
 const MAX_CODE_BLOCK_HEIGHT = 400;
-type BlockquoteVariant = "default" | "quotePreview";
+
+export const quoteBlockquoteClassName = cn(
+  "mx-0 mt-0 mb-3 flex w-full items-center gap-3 rounded-md bg-[var(--surface-sunken)] px-3 py-2.5 text-body-small-default text-[var(--content-secondary)] last:mb-0",
+);
+export const quoteBlockquoteAccentClassName =
+  "h-5 w-0.5 shrink-0 rounded-full bg-[var(--content-tertiary)]";
+export const quoteBlockquoteContentClassName = "min-w-0 flex-1 [&_p]:mb-0";
 
 function CopyButton({ visible, onClick, copied }: {
   visible: boolean;
@@ -244,7 +250,6 @@ function renderUprightEmoji(children: ReactNode): ReactNode {
 
 function buildMarkdownComponents(
   LinkComponent: MarkdownLinkComponent,
-  blockquoteVariant: BlockquoteVariant,
 ): Components {
   return {
     // mb-6 (24px) equals one --text-chat-line-height, so a `\n\n` paragraph
@@ -326,15 +331,9 @@ function buildMarkdownComponents(
     // emphasis render upright instead of skewed (see splitEmojiRuns).
     em: ({ children }) => <em>{renderUprightEmoji(children)}</em>,
     blockquote: ({ children }) => (
-      <blockquote
-        className={cn(
-          "mb-3 border-l-2 last:mb-0",
-          blockquoteVariant === "quotePreview"
-            ? "rounded-md border-[var(--content-tertiary)] bg-[var(--surface-sunken)] px-3 py-1.5 text-body-small-default text-[var(--content-secondary)] [&_p]:mb-0"
-            : "border-stone-300 pl-3 italic text-stone-600 dark:border-moss-500 dark:text-stone-400",
-        )}
-      >
-        {children}
+      <blockquote className={quoteBlockquoteClassName}>
+        <span aria-hidden="true" className={quoteBlockquoteAccentClassName} />
+        <div className={quoteBlockquoteContentClassName}>{children}</div>
       </blockquote>
     ),
     table: ({ children }) => (
@@ -566,11 +565,6 @@ export interface MarkdownMessageProps {
   /** When true, single newlines render as hard line breaks. */
   hardLineBreaks?: boolean;
   /**
-   * Controls blockquote chrome. The default preserves ordinary markdown
-   * quote styling; quotePreview is for compact quoted-message previews.
-   */
-  blockquoteVariant?: BlockquoteVariant;
-  /**
    * Custom link component for rendering `<a>` elements inside markdown.
    * Receives `href` and `children` props. Defaults to a plain
    * `<a target="_blank" rel="noopener noreferrer">`.
@@ -594,7 +588,6 @@ export function MarkdownMessage({
   content,
   className,
   hardLineBreaks,
-  blockquoteVariant = "default",
   linkComponent,
   urlTransform,
 }: MarkdownMessageProps) {
@@ -603,10 +596,7 @@ export function MarkdownMessage({
     return hardLineBreaks ? hardBreakNewlines(escaped) : escaped;
   }, [content, hardLineBreaks]);
   const Link = linkComponent ?? DefaultLink;
-  const components = useMemo(
-    () => buildMarkdownComponents(Link, blockquoteVariant),
-    [Link, blockquoteVariant],
-  );
+  const components = useMemo(() => buildMarkdownComponents(Link), [Link]);
   return (
     <div data-slot="markdown-message" className={cn("text-chat text-[var(--content-default)]", className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath, remarkPreserveOrderedListNumbers]} rehypePlugins={[rehypeKatex]} components={components} urlTransform={urlTransform}>

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -172,6 +172,9 @@ export {
 } from "./components/panel-item/marquee-text";
 export {
   MarkdownMessage,
+  quoteBlockquoteAccentClassName,
+  quoteBlockquoteClassName,
+  quoteBlockquoteContentClassName,
   type MarkdownMessageProps,
   type MarkdownLinkComponent,
 } from "./components/markdown-message";


### PR DESCRIPTION
## Summary
- Render Markdown blockquotes with the shared inset quote block chrome from the provided screenshot
- Reuse that same quote styling in the quote/reply modal preview and staged quote strip
- Remove the old sent-message-only blockquote variant plumbing

## Original prompt
The earlier quote/reply UI PR had merged, but the quote block still looked like a compact pill in some places. The follow-up asks for blockquotes universally to match the screenshot: a dark rounded inset quote block with a vertical accent line and text beside it.

## Test plan
- cd clients/web && bun test src/domains/chat/components/quote-reply-components.test.tsx src/domains/chat/components/chat-markdown-message.test.tsx
- cd packages/design-library && bun test src/components/markdown-message.test.tsx
- cd clients/web && bun run typecheck
- cd clients/web && bun run lint -- src/domains/chat/components/chat-markdown-message.tsx src/domains/chat/components/quote-reply-bubble.tsx src/domains/chat/components/staged-quotes-strip.tsx src/domains/chat/components/quote-reply-components.test.tsx src/domains/chat/transcript/transcript-message-body.tsx
- design-library temp-copy typecheck: bun run typecheck
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->