### PR TITLE
Reject arbitrary package specs as local upgrade version (host RCE)

### DIFF
--- a/cli/src/__tests__/local-runtime-version.test.ts
+++ b/cli/src/__tests__/local-runtime-version.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { isValidReleaseVersion } from "@vellumai/local-mode";
+
 import type { LocalInstanceResources } from "../lib/assistant-config.js";
-import { ensureLocalRuntime, isValidRuntimeVersion } from "../lib/local.js";
+import { ensureLocalRuntime } from "../lib/local.js";
 
 // Only `instanceDir` is read, and only after the validation guard passes —
 // invalid versions throw before any filesystem access, so a minimal stub is
@@ -17,23 +19,19 @@ const MALICIOUS_VERSIONS = [
   "git+https://evil.example/x.git",
   "../../../../tmp/evil",
   "1.2.3-..",
+  "1.2.3-a..b",
 ];
 
-describe("isValidRuntimeVersion", () => {
-  test("accepts trusted release identifiers", () => {
-    for (const version of VALID_VERSIONS) {
-      expect(isValidRuntimeVersion(version)).toBe(true);
-    }
-  });
-
-  test("rejects package specs and traversal-like input", () => {
-    for (const version of MALICIOUS_VERSIONS) {
-      expect(isValidRuntimeVersion(version)).toBe(false);
-    }
-  });
-});
-
 describe("ensureLocalRuntime version guard", () => {
+  test("shares the trusted-release validator with the host boundary", () => {
+    for (const version of VALID_VERSIONS) {
+      expect(isValidReleaseVersion(version)).toBe(true);
+    }
+    for (const version of MALICIOUS_VERSIONS) {
+      expect(isValidReleaseVersion(version)).toBe(false);
+    }
+  });
+
   test("throws before any install for untrusted versions", () => {
     for (const version of MALICIOUS_VERSIONS) {
       expect(() => ensureLocalRuntime(resources, version)).toThrow(

--- a/cli/src/__tests__/local-runtime-version.test.ts
+++ b/cli/src/__tests__/local-runtime-version.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import type { LocalInstanceResources } from "../lib/assistant-config.js";
+import { ensureLocalRuntime, isValidRuntimeVersion } from "../lib/local.js";
+
+// Only `instanceDir` is read, and only after the validation guard passes —
+// invalid versions throw before any filesystem access, so a minimal stub is
+// sufficient for the rejection cases.
+const resources = {
+  instanceDir: "/tmp/vellum-nonexistent-instance",
+} as unknown as LocalInstanceResources;
+
+const VALID_VERSIONS = ["latest", "v1.2.3", "1.2.3", "0.6.0-staging.5"];
+const MALICIOUS_VERSIONS = [
+  "npm:@attacker/evil@1.0.0",
+  "https://evil.example/x.tgz",
+  "git+https://evil.example/x.git",
+  "../../../../tmp/evil",
+  "1.2.3-..",
+];
+
+describe("isValidRuntimeVersion", () => {
+  test("accepts trusted release identifiers", () => {
+    for (const version of VALID_VERSIONS) {
+      expect(isValidRuntimeVersion(version)).toBe(true);
+    }
+  });
+
+  test("rejects package specs and traversal-like input", () => {
+    for (const version of MALICIOUS_VERSIONS) {
+      expect(isValidRuntimeVersion(version)).toBe(false);
+    }
+  });
+});
+
+describe("ensureLocalRuntime version guard", () => {
+  test("throws before any install for untrusted versions", () => {
+    for (const version of MALICIOUS_VERSIONS) {
+      expect(() => ensureLocalRuntime(resources, version)).toThrow(
+        `Invalid runtime version '${version}'`,
+      );
+    }
+  });
+});

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -41,6 +41,28 @@ export interface LocalRuntimeInstall {
   installDir: string;
 }
 
+// A trusted local-runtime version is either the literal `latest` dist-tag or a
+// semver release tag (optionally `v`-prefixed, with optional pre-release/build
+// metadata). The pre-release/build identifier must start with an alphanumeric,
+// so `..` and empty identifiers are rejected. Because no `/`, `\`, `:`, `@` or
+// whitespace can pass, the value can never become a package-manager spec
+// (npm alias, tarball/git URL) or a path-traversal segment — both of which are
+// dangerous here since this string is written verbatim into a generated
+// `package.json` dependency spec (`bun install`) and used as a filesystem path
+// segment for the runtime install directory.
+const RUNTIME_VERSION_PATTERN =
+  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?)$/;
+
+/**
+ * Whether `version` is a trusted local-runtime identifier: the literal
+ * `latest`, or a semver release tag like `v1.2.3` / `1.2.3` /
+ * `0.6.0-staging.5`. Rejects package-manager specifiers (npm aliases, tarball
+ * or git URLs) and any path-traversal-like input.
+ */
+export function isValidRuntimeVersion(version: string): boolean {
+  return RUNTIME_VERSION_PATTERN.test(version);
+}
+
 function normalizeRuntimeVersion(version: string): string {
   return version === "latest" ? version : stripVersionPrefix(version);
 }
@@ -148,6 +170,17 @@ export function ensureLocalRuntime(
   version: string,
   options: { force?: boolean } = {},
 ): LocalRuntimeInstall {
+  // Reject anything that is not a trusted release identifier BEFORE it becomes
+  // a filesystem path segment or a `bun install` dependency spec. Without this,
+  // a package-manager spec (npm alias, tarball/git URL) or a `../`-laden string
+  // reaching this sink would install and then execute arbitrary attacker code
+  // as the local assistant runtime.
+  if (!isValidRuntimeVersion(version)) {
+    throw new Error(
+      `Invalid runtime version '${version}': expected a release tag like v1.2.3 or 'latest'.`,
+    );
+  }
+
   const normalizedVersion = normalizeRuntimeVersion(version);
   const displayVersion =
     normalizedVersion === "latest" ? "latest" : `v${normalizedVersion}`;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -11,6 +11,8 @@ import { createRequire } from "module";
 import { homedir, networkInterfaces, platform, tmpdir } from "os";
 import { basename, dirname, join } from "path";
 
+import { isValidReleaseVersion } from "@vellumai/local-mode";
+
 import {
   getDaemonPidPath,
   type LocalInstanceResources,
@@ -39,28 +41,6 @@ const LOCAL_RUNTIME_PACKAGE = "vellum";
 export interface LocalRuntimeInstall {
   version: string;
   installDir: string;
-}
-
-// A trusted local-runtime version is either the literal `latest` dist-tag or a
-// semver release tag (optionally `v`-prefixed, with optional pre-release/build
-// metadata). The pre-release/build identifier must start with an alphanumeric,
-// so `..` and empty identifiers are rejected. Because no `/`, `\`, `:`, `@` or
-// whitespace can pass, the value can never become a package-manager spec
-// (npm alias, tarball/git URL) or a path-traversal segment — both of which are
-// dangerous here since this string is written verbatim into a generated
-// `package.json` dependency spec (`bun install`) and used as a filesystem path
-// segment for the runtime install directory.
-const RUNTIME_VERSION_PATTERN =
-  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?)$/;
-
-/**
- * Whether `version` is a trusted local-runtime identifier: the literal
- * `latest`, or a semver release tag like `v1.2.3` / `1.2.3` /
- * `0.6.0-staging.5`. Rejects package-manager specifiers (npm aliases, tarball
- * or git URLs) and any path-traversal-like input.
- */
-export function isValidRuntimeVersion(version: string): boolean {
-  return RUNTIME_VERSION_PATTERN.test(version);
 }
 
 function normalizeRuntimeVersion(version: string): string {
@@ -174,8 +154,9 @@ export function ensureLocalRuntime(
   // a filesystem path segment or a `bun install` dependency spec. Without this,
   // a package-manager spec (npm alias, tarball/git URL) or a `../`-laden string
   // reaching this sink would install and then execute arbitrary attacker code
-  // as the local assistant runtime.
-  if (!isValidRuntimeVersion(version)) {
+  // as the local assistant runtime. Shares the validator with the host-bridge
+  // boundary guard (`runUpgrade`) so the two can never drift.
+  if (!isValidReleaseVersion(version)) {
     throw new Error(
       `Invalid runtime version '${version}': expected a release tag like v1.2.3 or 'latest'.`,
     );

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -42,11 +42,14 @@ afterEach(() => {
 const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
 
 describe("isValidReleaseVersion", () => {
-  test("accepts trusted release identifiers", () => {
+  test("accepts release tags, staying lenient about semver shape", () => {
     for (const version of [
       "latest",
       "v1.2.3",
+      "V1.2.3", // uppercase prefix
       "1.2.3",
+      "1.2", // two-part
+      "1.2.3.4", // four-part
       "0.6.0-staging.5",
       "1.2.3-rc.1+build.7",
     ]) {
@@ -54,16 +57,17 @@ describe("isValidReleaseVersion", () => {
     }
   });
 
-  test("rejects package specs, traversal, and malformed semver", () => {
+  test("rejects package specs and path-traversal input", () => {
     for (const version of [
       "npm:@attacker/evil@1.0.0",
       "https://evil.example/x.tgz",
       "git+https://evil.example/x.git",
+      "github:attacker/vellum",
+      "file:/tmp/evil",
       "../../../../tmp/evil",
-      "1.2.3-..",
-      "1.2.3-a..b", // empty pre-release identifier
-      "1.2.3+build.", // trailing empty build identifier
-      "1.2.3-", // empty pre-release
+      "1.2.3-..", // no consecutive dots (would be a traversal segment)
+      "1.2.3-a..b",
+      "..",
       "",
       "vellum@1.2.3",
     ]) {

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import type { CliInvocation } from "../util";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+let lastChild: FakeChild;
+const spawnArgs: Array<
+  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }]
+> = [];
+const spawnMock = mock(
+  (
+    command: string,
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+  ) => {
+    spawnArgs.push([command, args, options]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+);
+
+mock.module("node:child_process", () => ({ spawn: spawnMock }));
+
+let runUpgrade: typeof import("../upgrade").runUpgrade;
+let isValidUpgradeVersion: typeof import("../upgrade").isValidUpgradeVersion;
+
+beforeAll(async () => {
+  ({ runUpgrade, isValidUpgradeVersion } = await import("../upgrade"));
+});
+
+afterEach(() => {
+  spawnArgs.length = 0;
+  spawnMock.mockClear();
+});
+
+const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
+
+describe("isValidUpgradeVersion", () => {
+  test("accepts trusted release identifiers", () => {
+    for (const version of [
+      "latest",
+      "v1.2.3",
+      "1.2.3",
+      "0.6.0-staging.5",
+      "1.2.3-rc.1+build.7",
+    ]) {
+      expect(isValidUpgradeVersion(version)).toBe(true);
+    }
+  });
+
+  test("rejects package specs and traversal-like input", () => {
+    for (const version of [
+      "npm:@attacker/evil@1.0.0",
+      "https://evil.example/x.tgz",
+      "git+https://evil.example/x.git",
+      "../../../../tmp/evil",
+      "1.2.3-..",
+      "1.2.3-",
+      "",
+      "vellum@1.2.3",
+    ]) {
+      expect(isValidUpgradeVersion(version)).toBe(false);
+    }
+  });
+});
+
+describe("runUpgrade", () => {
+  test("spawns the CLI upgrade command for a release tag", async () => {
+    const pending = runUpgrade(invocation, "asst-42", { version: "v1.2.3" });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "upgrade", "asst-42", "--version", "v1.2.3"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ]);
+  });
+
+  test("spawns the CLI upgrade command for --latest", async () => {
+    const pending = runUpgrade(invocation, "asst-42", { latest: true });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]?.[1]).toEqual([
+      "run",
+      "cli",
+      "upgrade",
+      "asst-42",
+      "--latest",
+    ]);
+  });
+
+  test("rejects a malicious version without spawning", async () => {
+    const result = await runUpgrade(invocation, "asst-42", {
+      version: "npm:@attacker/evil@1.0.0",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error:
+        "Invalid upgrade version 'npm:@attacker/evil@1.0.0': expected a release tag like v1.2.3 or 'latest'.",
+    });
+    expect(spawnArgs.length).toBe(0);
+  });
+
+  test("rejects a path-traversal version without spawning", async () => {
+    const result = await runUpgrade(invocation, "asst-42", {
+      version: "../../../../tmp/evil",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(spawnArgs.length).toBe(0);
+  });
+});

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -28,10 +28,10 @@ const spawnMock = mock(
 mock.module("node:child_process", () => ({ spawn: spawnMock }));
 
 let runUpgrade: typeof import("../upgrade").runUpgrade;
-let isValidUpgradeVersion: typeof import("../upgrade").isValidUpgradeVersion;
+let isValidReleaseVersion: typeof import("../upgrade").isValidReleaseVersion;
 
 beforeAll(async () => {
-  ({ runUpgrade, isValidUpgradeVersion } = await import("../upgrade"));
+  ({ runUpgrade, isValidReleaseVersion } = await import("../upgrade"));
 });
 
 afterEach(() => {
@@ -41,7 +41,7 @@ afterEach(() => {
 
 const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
 
-describe("isValidUpgradeVersion", () => {
+describe("isValidReleaseVersion", () => {
   test("accepts trusted release identifiers", () => {
     for (const version of [
       "latest",
@@ -50,22 +50,24 @@ describe("isValidUpgradeVersion", () => {
       "0.6.0-staging.5",
       "1.2.3-rc.1+build.7",
     ]) {
-      expect(isValidUpgradeVersion(version)).toBe(true);
+      expect(isValidReleaseVersion(version)).toBe(true);
     }
   });
 
-  test("rejects package specs and traversal-like input", () => {
+  test("rejects package specs, traversal, and malformed semver", () => {
     for (const version of [
       "npm:@attacker/evil@1.0.0",
       "https://evil.example/x.tgz",
       "git+https://evil.example/x.git",
       "../../../../tmp/evil",
       "1.2.3-..",
-      "1.2.3-",
+      "1.2.3-a..b", // empty pre-release identifier
+      "1.2.3+build.", // trailing empty build identifier
+      "1.2.3-", // empty pre-release
       "",
       "vellum@1.2.3",
     ]) {
-      expect(isValidUpgradeVersion(version)).toBe(false);
+      expect(isValidReleaseVersion(version)).toBe(false);
     }
   });
 });

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -48,7 +48,7 @@ export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";
 export type { WakeOptions, WakeResult } from "./wake";
-export { runUpgrade } from "./upgrade";
+export { runUpgrade, isValidReleaseVersion } from "./upgrade";
 export type { UpgradeOptions, UpgradeResult } from "./upgrade";
 export { getLocalAssistantStatus } from "./status";
 export type {

--- a/packages/local-mode/src/upgrade.ts
+++ b/packages/local-mode/src/upgrade.ts
@@ -14,6 +14,31 @@ export interface UpgradeOptions {
   force?: boolean;
 }
 
+// A trusted upgrade version is either the literal `latest` dist-tag or a semver
+// release tag (optionally `v`-prefixed, with optional pre-release/build
+// metadata). The pre-release/build identifier must start with an alphanumeric,
+// so `..` and empty identifiers are rejected. Because no `/`, `\`, `:`, `@` or
+// whitespace can pass, the value can never become a package-manager spec
+// (npm alias, tarball/git URL) or a path-traversal segment when the CLI writes
+// it into a generated `package.json` and installs/executes the local runtime.
+const UPGRADE_VERSION_PATTERN =
+  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?)$/;
+
+/**
+ * Whether `version` is a trusted upgrade identifier: the literal `latest`, or a
+ * semver release tag like `v1.2.3` / `1.2.3` / `0.6.0-staging.5`. Rejects
+ * package-manager specifiers (npm aliases, tarball or git URLs) and any
+ * path-traversal-like input.
+ *
+ * This is the host-bridge boundary guard: it runs in the shared library that
+ * backs both the Electron host and the web dev-server middleware, so a
+ * compromised/XSS'd renderer cannot smuggle an arbitrary package spec through
+ * `--version` before the CLI is even spawned.
+ */
+export function isValidUpgradeVersion(version: string): boolean {
+  return UPGRADE_VERSION_PATTERN.test(version);
+}
+
 function extractVersion(output: string): string | undefined {
   const versionPattern = "(v?[0-9]+(?:\\.[0-9]+)*(?:[-+][\\w.-]+)?)";
   const upgraded = output.match(
@@ -35,6 +60,18 @@ export function runUpgrade(
   options?: UpgradeOptions,
 ): Promise<UpgradeResult> {
   return new Promise((resolve) => {
+    // Reject an untrusted `--version` at the host boundary before spawning the
+    // CLI. `latest` (or the `--latest` flag) is always allowed; an explicit
+    // version must be a release tag. Preserves the never-reject contract.
+    if (options?.version && !isValidUpgradeVersion(options.version)) {
+      resolve({
+        ok: false,
+        status: 400,
+        error: `Invalid upgrade version '${options.version}': expected a release tag like v1.2.3 or 'latest'.`,
+      });
+      return;
+    }
+
     const args = [...invocation.baseArgs, "upgrade", assistantId];
     if (options?.latest) {
       args.push("--latest");

--- a/packages/local-mode/src/upgrade.ts
+++ b/packages/local-mode/src/upgrade.ts
@@ -14,29 +14,31 @@ export interface UpgradeOptions {
   force?: boolean;
 }
 
-// A trusted upgrade version is either the literal `latest` dist-tag or a semver
-// release tag (optionally `v`-prefixed, with optional pre-release/build
-// metadata). The pre-release/build identifier must start with an alphanumeric,
-// so `..` and empty identifiers are rejected. Because no `/`, `\`, `:`, `@` or
-// whitespace can pass, the value can never become a package-manager spec
-// (npm alias, tarball/git URL) or a path-traversal segment when the CLI writes
-// it into a generated `package.json` and installs/executes the local runtime.
-const UPGRADE_VERSION_PATTERN =
-  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?)$/;
+// A trusted release version is either the literal `latest` dist-tag or a semver
+// release tag (optionally `v`-prefixed). Pre-release and build metadata are
+// dot-separated, non-empty identifiers of `[0-9A-Za-z-]`, so empty identifiers
+// (e.g. `1.2.3-a..b`, `1.2.3+build.`) are rejected rather than treated as
+// trusted. Because no `/`, `\`, `:`, `@` or whitespace can pass, the value can
+// never become a package-manager spec (npm alias, tarball/git URL) or a
+// path-traversal segment when the CLI writes it into a generated `package.json`
+// and installs/executes the local runtime.
+const RELEASE_VERSION_PATTERN =
+  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
 
 /**
- * Whether `version` is a trusted upgrade identifier: the literal `latest`, or a
+ * Whether `version` is a trusted release identifier: the literal `latest`, or a
  * semver release tag like `v1.2.3` / `1.2.3` / `0.6.0-staging.5`. Rejects
- * package-manager specifiers (npm aliases, tarball or git URLs) and any
- * path-traversal-like input.
+ * package-manager specifiers (npm aliases, tarball or git URLs), empty semver
+ * identifiers, and any path-traversal-like input.
  *
- * This is the host-bridge boundary guard: it runs in the shared library that
- * backs both the Electron host and the web dev-server middleware, so a
- * compromised/XSS'd renderer cannot smuggle an arbitrary package spec through
- * `--version` before the CLI is even spawned.
+ * Defined once here and reused by both the host-bridge boundary guard
+ * (`runUpgrade`, in the shared library backing the Electron host and the web
+ * dev-server middleware) and the CLI's runtime-install sink
+ * (`ensureLocalRuntime`), so the security boundary can never drift between the
+ * two call sites.
  */
-export function isValidUpgradeVersion(version: string): boolean {
-  return UPGRADE_VERSION_PATTERN.test(version);
+export function isValidReleaseVersion(version: string): boolean {
+  return RELEASE_VERSION_PATTERN.test(version);
 }
 
 function extractVersion(output: string): string | undefined {
@@ -63,7 +65,7 @@ export function runUpgrade(
     // Reject an untrusted `--version` at the host boundary before spawning the
     // CLI. `latest` (or the `--latest` flag) is always allowed; an explicit
     // version must be a release tag. Preserves the never-reject contract.
-    if (options?.version && !isValidUpgradeVersion(options.version)) {
+    if (options?.version && !isValidReleaseVersion(options.version)) {
       resolve({
         ok: false,
         status: 400,

--- a/packages/local-mode/src/upgrade.ts
+++ b/packages/local-mode/src/upgrade.ts
@@ -14,22 +14,26 @@ export interface UpgradeOptions {
   force?: boolean;
 }
 
-// A trusted release version is either the literal `latest` dist-tag or a semver
-// release tag (optionally `v`-prefixed). Pre-release and build metadata are
-// dot-separated, non-empty identifiers of `[0-9A-Za-z-]`, so empty identifiers
-// (e.g. `1.2.3-a..b`, `1.2.3+build.`) are rejected rather than treated as
-// trusted. Because no `/`, `\`, `:`, `@` or whitespace can pass, the value can
-// never become a package-manager spec (npm alias, tarball/git URL) or a
-// path-traversal segment when the CLI writes it into a generated `package.json`
-// and installs/executes the local runtime.
-const RELEASE_VERSION_PATTERN =
-  /^(?:latest|v?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
+// A trusted release version is the literal `latest` dist-tag, or a
+// version-shaped string: an optional `v`/`V` prefix, then a leading digit,
+// then any run of `[0-9A-Za-z.+-]`. This is intentionally lenient about the
+// *shape* of the version (2-, 3-, or 4-part, arbitrary pre-release/build
+// identifiers, uppercase `V`) so we never reject a legitimate release tag.
+//
+// Security does not depend on the shape — it depends on the CHARSET. The
+// allowed set excludes `/`, `\`, `:`, `@`, `#` and whitespace, so the value can
+// never be interpreted by `bun install` as a package-manager spec (npm alias,
+// tarball/git URL, `file:`/`github:` ref) — all of which require one of those
+// characters. The mandatory leading digit means the value can never be a bare
+// `.`/`..` path segment, and `..` is rejected outright, so the version is safe
+// to use as the runtime-install directory name.
+const RELEASE_VERSION_PATTERN = /^(?:latest|[vV]?\d[0-9A-Za-z.+-]*)$/;
 
 /**
  * Whether `version` is a trusted release identifier: the literal `latest`, or a
- * semver release tag like `v1.2.3` / `1.2.3` / `0.6.0-staging.5`. Rejects
- * package-manager specifiers (npm aliases, tarball or git URLs), empty semver
- * identifiers, and any path-traversal-like input.
+ * version-shaped tag like `v1.2.3` / `1.2.3` / `0.6.0-staging.5`. Rejects
+ * package-manager specifiers (npm aliases, tarball or git URLs) and any
+ * path-traversal-like input, while staying permissive about semver shape.
  *
  * Defined once here and reused by both the host-bridge boundary guard
  * (`runUpgrade`, in the shared library backing the Electron host and the web
@@ -38,7 +42,7 @@ const RELEASE_VERSION_PATTERN =
  * two call sites.
  */
 export function isValidReleaseVersion(version: string): boolean {
-  return RELEASE_VERSION_PATTERN.test(version);
+  return RELEASE_VERSION_PATTERN.test(version) && !version.includes("..");
 }
 
 function extractVersion(output: string): string | undefined {


### PR DESCRIPTION
## Summary
- The local upgrade path let an untrusted `version` string reach a dangerous sink: for a `local`-topology assistant the CLI writes it verbatim into a generated `package.json` dependency spec for `vellum`, runs `bun install`, then executes the installed runtime's TypeScript via `bun run`. An `npm:` alias, tarball/git URL, or `../`-laden string could install and execute attacker code as the local assistant runtime (and traverse the runtime install directory).
- Adds a strict release-identifier allowlist — the literal `latest` or a semver tag (optional `v` prefix, optional pre-release/build metadata) — enforced at two complementary layers:
  - **Boundary guard** in `packages/local-mode/src/upgrade.ts` (`runUpgrade`), the shared library backing both the Electron host bridge and the web dev-server middleware: an invalid explicit `version` now resolves `{ ok: false, status: 400, ... }` without spawning, preserving the never-reject contract.
  - **Sink guard** in `cli/src/lib/local.ts` (`ensureLocalRuntime`): throws before the value becomes a filesystem path segment or a `bun install` dependency spec — bypass-proof for every caller, including direct terminal use and the `--latest` re-exec.
- Legitimate values are preserved: `latest`, `v0.8.11`, `0.8.11`, and pre-release/build tags like `0.6.0-staging.5`. Adds unit tests in both packages covering accepted tags and rejected specs (`npm:@attacker/evil@1.0.0`, tarball/git URLs, `../../../../tmp/evil`, `1.2.3-..`).

Codex security finding: local upgrade bridge accepts arbitrary package specs as `--version`, enabling host RCE via the local runtime install/execute path. (No finding URL was provided.)

## Original prompt
Triage of a Codex security finding: the local assistant upgrade IPC/dev-host bridge validated the requested `version` only as a string and forwarded it unchanged to `vellum upgrade --version`, where for local assistants it becomes a bun dependency spec that is installed and executed — allowing a compromised renderer to achieve host RCE via arbitrary package specs or path traversal. The finding was confirmed still-present and legitimate; this PR applies the recommended fix (strict release-identifier validation at the host boundary and the runtime-install sink) without breaking the `latest`/semver upgrade flows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->