### PR TITLE
feat(gateway-client): trust verdict carries hasInterceptableVerificationSession; daemon deny branches use the stamp

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4136,6 +4136,8 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        hasInterceptableVerificationSession:
+                          type: boolean
                       required:
                         - trustClass
                         - canonicalSenderId

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -69,6 +69,9 @@ mock.module("../../access-request-helper.js", () => ({
 // presses; the throw toggle simulates an unreachable gateway (transport
 // errors surface as thrown errors from the client).
 const createOutboundSessionCalls: unknown[] = [];
+// Verification-read IPC calls (getPendingSession/findActiveSession) — the
+// verdict's session-presence stamp must skip these when present-and-false.
+const sessionReadCalls: string[] = [];
 let gatewaySessionsUnreachable = false;
 let pendingSessionForTest: Record<string, unknown> | null = null;
 let activeSessionForTest: Record<string, unknown> | null = null;
@@ -102,10 +105,12 @@ mock.module("../../../channels/gateway-verification-sessions.js", () => ({
     };
   },
   findActiveSession: async () => {
+    sessionReadCalls.push("findActiveSession");
     throwIfUnreachable();
     return activeSessionForTest;
   },
   getPendingSession: async () => {
+    sessionReadCalls.push("getPendingSession");
     throwIfUnreachable();
     return pendingSessionForTest;
   },
@@ -163,6 +168,7 @@ beforeEach(() => {
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
   createOutboundSessionCalls.length = 0;
+  sessionReadCalls.length = 0;
   accessRequestDeniedForTest = false;
   approvalHandshakeForTest = false;
   guardianDeliveryList = [];
@@ -958,5 +964,152 @@ describe("enforceIngressAcl — gateway-unreachable deny branches degrade to a p
 
     expect(result.earlyResponse!.reason).toBe("not_a_member");
     expect(createOutboundSessionCalls.length).toBe(0);
+  });
+});
+
+describe("enforceIngressAcl — verdict session-presence stamp elides the verification-read IPC pair", () => {
+  function strangerVerdict(
+    stamp: boolean | undefined,
+    senderId = "U123STRANGER",
+  ): TrustVerdict {
+    return {
+      trustClass: "unknown",
+      canonicalSenderId: senderId,
+      ...(stamp !== undefined && {
+        hasInterceptableVerificationSession: stamp,
+      }),
+    };
+  }
+
+  test("stamp false (Slack stranger): challenge minted with ZERO verification-read IPC calls", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict(strangerVerdict(false)),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(sessionReadCalls.length).toBe(0);
+  });
+
+  test("stamp false (email stranger): challenge minted with ZERO verification-read IPC calls", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "email",
+        canonicalSenderId: "stranger@example.com",
+        rawSenderId: "stranger@example.com",
+        sourceMetadata: withVerdict(
+          strangerVerdict(false, "stranger@example.com"),
+        ),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(sessionReadCalls.length).toBe(0);
+  });
+
+  test("stamp false (Slack inactive member): re-verify challenge minted with ZERO verification-read IPC calls", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123MEMBER",
+        rawSenderId: "U123MEMBER",
+        sourceMetadata: withVerdict(
+          memberVerdict({
+            status: "unverified",
+            canonicalSenderId: "U123MEMBER",
+            address: "U123MEMBER",
+            type: "slack",
+            hasInterceptableVerificationSession: false,
+          }),
+        ),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(sessionReadCalls.length).toBe(0);
+  });
+
+  test("stamp true: falls back to the IPC reads — same-sender session still dedups", async () => {
+    // The stamp is channel-scoped; only `false` is authoritative. A `true`
+    // stamp must preserve the sender-scoped dedup via the reads.
+    activeSessionForTest = {
+      id: "existing-session",
+      channel: "slack",
+      status: "awaiting_response",
+      expectedExternalUserId: "U123STRANGER",
+    };
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict(strangerVerdict(true)),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(sessionReadCalls.length).toBe(2);
+  });
+
+  test("stamp true: a DIFFERENT sender's session does not suppress the challenge", async () => {
+    activeSessionForTest = {
+      id: "existing-session",
+      channel: "slack",
+      status: "awaiting_response",
+      expectedExternalUserId: "U_SOMEONE_ELSE",
+    };
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict(strangerVerdict(true)),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(sessionReadCalls.length).toBe(2);
+  });
+
+  test("absent stamp (legacy/voice-relay verdict): falls back to the IPC reads", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict(strangerVerdict(undefined)),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(sessionReadCalls.length).toBe(2);
+  });
+
+  test("stamp false with the gateway unreachable at mint time degrades to a plain deny", async () => {
+    gatewaySessionsUnreachable = true;
+
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict(strangerVerdict(false)),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    expect(sessionReadCalls.length).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -424,6 +424,8 @@ export async function enforceIngressAcl(
           const slackVerifyResult = await initiateVerificationChallenge({
             sourceChannel,
             senderUserId: (canonicalSenderId ?? rawSenderId)!,
+            hasInterceptableVerificationSession:
+              verdict.hasInterceptableVerificationSession,
           });
 
           if (slackVerifyResult.initiated) {
@@ -506,6 +508,8 @@ export async function enforceIngressAcl(
           const emailVerifyResult = await initiateVerificationChallenge({
             sourceChannel,
             senderUserId: (canonicalSenderId ?? rawSenderId)!,
+            hasInterceptableVerificationSession:
+              verdict.hasInterceptableVerificationSession,
           });
 
           if (emailVerifyResult.initiated) {
@@ -731,6 +735,8 @@ export async function enforceIngressAcl(
             const slackVerifyResult = await initiateVerificationChallenge({
               sourceChannel,
               senderUserId: (canonicalSenderId ?? rawSenderId)!,
+              hasInterceptableVerificationSession:
+                verdict.hasInterceptableVerificationSession,
             });
 
             if (slackVerifyResult.initiated) {
@@ -956,48 +962,60 @@ interface VerificationChallengeResult {
 async function initiateVerificationChallenge(params: {
   sourceChannel: ChannelId;
   senderUserId: string;
+  /** Channel-scoped session-presence stamp from the trust verdict. */
+  hasInterceptableVerificationSession?: boolean;
 }): Promise<VerificationChallengeResult> {
-  const { sourceChannel, senderUserId } = params;
+  const { sourceChannel, senderUserId, hasInterceptableVerificationSession } =
+    params;
 
   // Skip if there is already a pending challenge or active session for
   // this sender to avoid flooding them with duplicate codes. We scope by
   // sender identity (expectedExternalUserId) so that a pending session for
   // user A does not suppress challenges for user B.
   //
-  // Inbound messages arrive through the gateway, so an unreachable gateway
-  // here is a narrow race, not a steady state: treat it as "no active
-  // session but do not create" (creating would fail anyway) and fall
-  // through to the normal deny.
-  let existingChallenge: VerificationSessionWire | null;
-  let existingSession: VerificationSessionWire | null;
-  try {
-    [existingChallenge, existingSession] = await Promise.all([
-      getPendingSession(sourceChannel),
-      findActiveSession(sourceChannel),
-    ]);
-  } catch (err) {
-    log.warn(
-      { err, sourceChannel, senderUserId },
-      "Verification challenge: session reads failed (gateway unreachable), skipping challenge",
-    );
-    return { initiated: false };
-  }
-  const senderHasPending =
-    (existingChallenge &&
-      existingChallenge.expectedExternalUserId === senderUserId) ||
-    (existingSession &&
-      existingSession.expectedExternalUserId === senderUserId);
-  if (senderHasPending) {
-    log.debug(
-      {
-        sourceChannel,
-        senderUserId,
-        hasChallenge: !!existingChallenge,
-        hasSession: !!existingSession,
-      },
-      "Verification challenge: skipping — existing challenge/session for this sender",
-    );
-    return { initiated: false };
+  // The verdict stamp is only trusted as a fast-path NEGATIVE: `false` means
+  // the gateway saw no interceptable session for this CHANNEL at verdict
+  // time, so the sender-scoped checks below cannot match — skip both IPC
+  // reads and mint (the conditional mint's atomic claim stays the second
+  // line of defense against races). A `true` or absent stamp (voice-relay /
+  // legacy verdicts) is channel-scoped, not sender-scoped, so it falls back
+  // to the reads to preserve the exact dedup semantics.
+  if (hasInterceptableVerificationSession !== false) {
+    // Inbound messages arrive through the gateway, so an unreachable gateway
+    // here is a narrow race, not a steady state: treat it as "no active
+    // session but do not create" (creating would fail anyway) and fall
+    // through to the normal deny.
+    let existingChallenge: VerificationSessionWire | null;
+    let existingSession: VerificationSessionWire | null;
+    try {
+      [existingChallenge, existingSession] = await Promise.all([
+        getPendingSession(sourceChannel),
+        findActiveSession(sourceChannel),
+      ]);
+    } catch (err) {
+      log.warn(
+        { err, sourceChannel, senderUserId },
+        "Verification challenge: session reads failed (gateway unreachable), skipping challenge",
+      );
+      return { initiated: false };
+    }
+    const senderHasPending =
+      (existingChallenge &&
+        existingChallenge.expectedExternalUserId === senderUserId) ||
+      (existingSession &&
+        existingSession.expectedExternalUserId === senderUserId);
+    if (senderHasPending) {
+      log.debug(
+        {
+          sourceChannel,
+          senderUserId,
+          hasChallenge: !!existingChallenge,
+          hasSession: !!existingSession,
+        },
+        "Verification challenge: skipping — existing challenge/session for this sender",
+      );
+      return { initiated: false };
+    }
   }
 
   try {

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -228,6 +228,30 @@ export function findPendingSessionForChannel(
   return row ? rowToSession(row) : null;
 }
 
+/**
+ * Channel-scoped existence check: any interceptable, non-expired session for
+ * the channel (union of `findPendingSessionForChannel` + `findActiveSession`
+ * statuses). Powers the trust verdict's session-presence stamp.
+ */
+export function hasInterceptableSessionForChannel(channel: string): boolean {
+  const db = getGatewayDb();
+
+  const row = db
+    .select({ id: channelVerificationSessions.id })
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, INTERCEPTABLE_STATUSES),
+        gt(channelVerificationSessions.expiresAt, Date.now()),
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return row !== undefined;
+}
+
 export type ConsumeSessionResult =
   | { consumed: true; consumedAt: number }
   | { consumed: false };

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -11,8 +11,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 await import("../../__tests__/test-preload.js");
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../../db/connection.js");
-const { contacts: gwContacts, contactChannels: gwContactChannels } =
-  await import("../../db/schema.js");
+const {
+  contacts: gwContacts,
+  contactChannels: gwContactChannels,
+  channelVerificationSessions: gwVerificationSessions,
+} = await import("../../db/schema.js");
 const { resolveTrustVerdict } = await import("../trust-verdict-resolver.js");
 
 const CHANNEL = "telegram";
@@ -70,6 +73,27 @@ function insertChannel(args: {
     .run();
 }
 
+function insertSession(args: {
+  id: string;
+  channel?: string;
+  status?: string;
+  expiresAt?: number;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(gwVerificationSessions)
+    .values({
+      id: args.id,
+      channel: args.channel ?? CHANNEL,
+      challengeHash: `hash-${args.id}`,
+      expiresAt: args.expiresAt ?? now + 600_000,
+      status: args.status ?? "pending",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
 beforeEach(async () => {
   resetGatewayDb();
   await initGatewayDb();
@@ -77,6 +101,7 @@ beforeEach(async () => {
   // prior test left behind (channels first — FK cascade from contacts).
   getGatewayDb().delete(gwContactChannels).run();
   getGatewayDb().delete(gwContacts).run();
+  getGatewayDb().delete(gwVerificationSessions).run();
 });
 
 afterEach(() => {
@@ -532,5 +557,85 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.status).toBe("revoked");
     // No active guardian binding exists, so guardian label fields are absent.
     expect(verdict.guardianExternalUserId).toBeUndefined();
+  });
+});
+
+describe("resolveTrustVerdict — hasInterceptableVerificationSession stamp", () => {
+  test("no sessions → stamped false", async () => {
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.hasInterceptableVerificationSession).toBe(false);
+  });
+
+  test.each(["pending", "pending_bootstrap", "awaiting_response"])(
+    "non-expired %s session → stamped true",
+    async (status) => {
+      insertSession({ id: `s-${status}`, status });
+
+      const verdict = await resolveTrustVerdict({
+        channelType: CHANNEL,
+        actorExternalId: "U_STRANGER",
+      });
+
+      expect(verdict.hasInterceptableVerificationSession).toBe(true);
+    },
+  );
+
+  test.each(["consumed", "verified", "expired", "revoked", "locked"])(
+    "non-interceptable %s session → stamped false",
+    async (status) => {
+      insertSession({ id: `s-${status}`, status });
+
+      const verdict = await resolveTrustVerdict({
+        channelType: CHANNEL,
+        actorExternalId: "U_STRANGER",
+      });
+
+      expect(verdict.hasInterceptableVerificationSession).toBe(false);
+    },
+  );
+
+  test("expired pending session → stamped false", async () => {
+    insertSession({ id: "s-expired", expiresAt: Date.now() - 1_000 });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.hasInterceptableVerificationSession).toBe(false);
+  });
+
+  test("session on a different channel → stamped false (channel-scoped)", async () => {
+    insertSession({ id: "s-other", channel: "slack" });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.hasInterceptableVerificationSession).toBe(false);
+  });
+
+  test("stamp rides on member verdicts too", async () => {
+    insertContact({ id: "c-member", displayName: "Member" });
+    insertChannel({
+      id: "ch-member",
+      contactId: "c-member",
+      address: "U_MEMBER",
+      status: "active",
+    });
+    insertSession({ id: "s-pending" });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.hasInterceptableVerificationSession).toBe(true);
   });
 });

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -1,10 +1,11 @@
 /**
  * Gateway-side per-actor trust verdict resolver.
  *
- * Reads ONLY the gateway ACL DB to produce a {@link TrustVerdict} for an
- * inbound actor. Mirrors the daemon's classification precedence
- * (`actor-trust-resolver.ts`) and resolves channels by `(type,address)`
- * COLLATE NOCASE. Read-only — no writes, no assistant DB, no IPC.
+ * Reads ONLY the gateway DB (ACL tables + verification session presence) to
+ * produce a {@link TrustVerdict} for an inbound actor. Mirrors the daemon's
+ * classification precedence (`actor-trust-resolver.ts`) and resolves channels
+ * by `(type,address)` COLLATE NOCASE. Read-only — no writes, no assistant DB,
+ * no IPC.
  *
  * Blocked/revoked member channels classify as `unknown` (mirroring the
  * daemon), while their raw `status`/`policy` are surfaced verbatim so the
@@ -19,6 +20,7 @@ import {
   contacts as gwContacts,
   contactChannels as gwContactChannels,
 } from "../db/schema.js";
+import { hasInterceptableSessionForChannel } from "../db/session-store.js";
 import { canonicalSenderIdFor } from "../verification/identity.js";
 
 export interface ResolveTrustVerdictInput {
@@ -202,6 +204,17 @@ export async function resolveTrustVerdict(
   }
 
   const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  // Session-presence stamp (channel-scoped): lets the daemon's deny branches
+  // skip their verification-read IPC pair when no session exists. Best-effort
+  // — an omitted stamp just falls back to those reads, so a store failure
+  // must not convert an otherwise-good verdict into a resolver failure.
+  try {
+    verdict.hasInterceptableVerificationSession =
+      hasInterceptableSessionForChannel(input.channelType);
+  } catch {
+    // Stamp omitted; consumer falls back to IPC reads.
+  }
 
   if (guardianRow) {
     verdict.guardianExternalUserId = guardianRow.address;

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -83,6 +83,14 @@ export const TrustVerdictSchema = z.object({
   // Present only when a member channel resolves; absent for unknown senders.
   interactionCount: z.number().optional(),
   lastInteraction: z.number().nullable().optional(),
+
+  // CHANNEL-scoped session-presence stamp: true ⇒ an interceptable
+  // (pending | pending_bootstrap | awaiting_response), non-expired
+  // verification session existed for this channel at resolution time.
+  // Not sender-scoped, so consumers may treat only `false` as authoritative
+  // (safe to skip session reads before minting a challenge); on true/absent
+  // they fall back to session reads for sender-scoped dedup.
+  hasInterceptableVerificationSession: z.boolean().optional(),
 });
 
 export type TrustVerdict = z.infer<typeof TrustVerdictSchema>;


### PR DESCRIPTION
## Summary
- TrustVerdictSchema gains optional hasInterceptableVerificationSession, stamped by resolveTrustVerdict from the gateway session store
- acl-enforcement uses the stamp for the challenge-outstanding existence check (IPC reads remain as fallback)
- Additive contract change; denied inbound with a fresh stamp-false verdict makes zero verification-read IPC calls

Part of plan: verif-sessions-gateway-native.md (PR 11 of 12)