### PR TITLE
refactor(gateway): session-helpers + voice verification read the gateway DB; drop assistant rate-limit dual-writes

### DIFF
--- a/gateway/src/__tests__/db-proxy-allowlist.test.ts
+++ b/gateway/src/__tests__/db-proxy-allowlist.test.ts
@@ -5,17 +5,16 @@ import { join, sep } from "node:path";
 /**
  * db_proxy surface guard: the assistant-DB proxy (`assistant-db-proxy.ts` +
  * the daemon-side `db-proxy` route) is a temporary raw-SQL bridge, slated for
- * removal with the verification-session source-of-truth move. This source scan
+ * removal once its last callers get typed ops. This source scan
  * fails if any gateway file OUTSIDE the allowlist imports the proxy or names
  * either raw-SQL bridge method (`db_proxy` / `db_proxy_transaction`), so the
  * surface can only shrink, never grow.
  *
- * The proxy currently serves three groups (the allowlist below):
- *   1. Verification-session + rate-limit state — dies with the session-SoT move.
- *   2. The contact-merge identity-mirror cluster (`contact-store.ts`) — a
+ * The proxy currently serves two groups (the allowlist below):
+ *   1. The contact-merge identity-mirror cluster (`contact-store.ts`) — a
  *      notes-only survivor UPDATE and a resolved-slug dual-write INSERT that no
  *      existing typed mirror op expresses; pending a merge-shaped op.
- *   3. Data migrations — one-time backfills that legitimately touch the
+ *   2. Data migrations — one-time backfills that legitimately touch the
  *      assistant DB broadly.
  */
 
@@ -25,10 +24,6 @@ const ALLOWLIST = new Set<string>([
   // The proxy definition itself (calls ipcCallAssistant("db_proxy")).
   "db/assistant-db-proxy.ts",
 
-  // Verification-session + rate-limit group. Retired with the session-SoT move.
-  "verification/session-helpers.ts",
-  "verification/rate-limit-helpers.ts",
-  "voice/verification.ts",
   // Residual raw-SQL (type,address) lookup in the verification intercept flow;
   // identity/info reads and mirror writes are already typed IPC.
   "verification/contact-helpers.ts",

--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -31,8 +31,7 @@ import "./test-preload.js";
 // ---------------------------------------------------------------------------
 
 // db_proxy — backed by an in-process sqlite DB with the mirror tables the
-// consume path touches (rate-limit dual-writes, trusted-contact mirror
-// lookup).
+// consume path touches (trusted-contact mirror lookup).
 let testAssistantDb: Database | null = null;
 
 mock.module("../db/assistant-db-proxy.js", () => ({
@@ -141,17 +140,6 @@ function seedAssistantMirrorTables(db: Database): void {
       verified_via TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER
-    );
-    CREATE TABLE channel_guardian_rate_limits (
-      id TEXT PRIMARY KEY,
-      channel TEXT NOT NULL,
-      actor_external_user_id TEXT NOT NULL,
-      actor_chat_id TEXT NOT NULL,
-      attempt_timestamps_json TEXT NOT NULL DEFAULT '[]',
-      locked_until INTEGER,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      UNIQUE (channel, actor_external_user_id, actor_chat_id)
     );
   `);
 }

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -11,10 +11,12 @@ import {
   createInboundSession,
   createOutboundSession,
   findActiveSession,
+  findLatestSessionByStatuses,
   findPendingSessionByHash,
   findPendingSessionForChannel,
   findSessionByBootstrapTokenHash,
   findSessionByIdentity,
+  hasInterceptableSession,
   revokePendingSessions,
   updateSessionDelivery,
   updateSessionStatus,
@@ -297,6 +299,58 @@ describe("findActiveSession", () => {
   test("ignores expired sessions", () => {
     insertRaw({ id: "stale", status: "awaiting_response", expiresAt: PAST() });
     expect(findActiveSession("telegram")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findLatestSessionByStatuses
+// ---------------------------------------------------------------------------
+
+describe("findLatestSessionByStatuses", () => {
+  test("matches only the given statuses, newest first", () => {
+    const now = Date.now();
+    insertRaw({ id: "await", status: "awaiting_response", createdAt: now });
+    expect(
+      findLatestSessionByStatuses("telegram", ["pending", "pending_bootstrap"]),
+    ).toBeNull();
+
+    insertRaw({ id: "old", status: "pending", createdAt: now - 500 });
+    insertRaw({ id: "new", status: "pending_bootstrap", createdAt: now });
+    expect(
+      findLatestSessionByStatuses("telegram", ["pending", "pending_bootstrap"])
+        ?.id,
+    ).toBe("new");
+  });
+
+  test("ignores expired sessions and other channels", () => {
+    insertRaw({ id: "stale", status: "pending", expiresAt: PAST() });
+    insertRaw({ id: "other", status: "pending", channel: "slack" });
+    expect(findLatestSessionByStatuses("telegram", ["pending"])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasInterceptableSession
+// ---------------------------------------------------------------------------
+
+describe("hasInterceptableSession", () => {
+  test("true for any non-expired interceptable status", () => {
+    for (const status of [
+      "pending",
+      "pending_bootstrap",
+      "awaiting_response",
+    ] as SessionStatus[]) {
+      getGatewayDb().delete(channelVerificationSessions).run();
+      insertRaw({ id: `s-${status}`, status });
+      expect(hasInterceptableSession("telegram")).toBe(true);
+    }
+  });
+
+  test("false for consumed, expired, or other-channel sessions", () => {
+    insertRaw({ id: "spent", status: "consumed" });
+    insertRaw({ id: "stale", status: "pending", expiresAt: PAST() });
+    insertRaw({ id: "other", status: "pending", channel: "slack" });
+    expect(hasInterceptableSession("telegram")).toBe(false);
   });
 });
 

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -228,6 +228,52 @@ export function findPendingSessionForChannel(
   return row ? rowToSession(row) : null;
 }
 
+/**
+ * Latest non-expired session for a channel in one of the given statuses.
+ */
+export function findLatestSessionByStatuses(
+  channel: string,
+  statuses: SessionStatus[],
+): VerificationSession | null {
+  const db = getGatewayDb();
+
+  const row = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, statuses),
+        gt(channelVerificationSessions.expiresAt, Date.now()),
+      ),
+    )
+    .orderBy(desc(channelVerificationSessions.createdAt))
+    .get();
+
+  return row ? rowToSession(row) : null;
+}
+
+/**
+ * True if the channel has any non-expired interceptable session
+ * (pending, pending_bootstrap, or awaiting_response).
+ */
+export function hasInterceptableSession(channel: string): boolean {
+  const db = getGatewayDb();
+  const row = db
+    .select({ id: channelVerificationSessions.id })
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, INTERCEPTABLE_STATUSES),
+        gt(channelVerificationSessions.expiresAt, Date.now()),
+      ),
+    )
+    .get();
+
+  return row !== undefined;
+}
+
 export type ConsumeSessionResult =
   | { consumed: true; consumedAt: number }
   | { consumed: false };
@@ -351,26 +397,10 @@ export function getSessionById(id: string): VerificationSession | null {
  * for a given channel.
  */
 export function findActiveSession(channel: string): VerificationSession | null {
-  const db = getGatewayDb();
-  const now = Date.now();
-
-  const row = db
-    .select()
-    .from(channelVerificationSessions)
-    .where(
-      and(
-        eq(channelVerificationSessions.channel, channel),
-        inArray(channelVerificationSessions.status, [
-          "pending_bootstrap",
-          "awaiting_response",
-        ]),
-        gt(channelVerificationSessions.expiresAt, now),
-      ),
-    )
-    .orderBy(desc(channelVerificationSessions.createdAt))
-    .get();
-
-  return row ? rowToSession(row) : null;
+  return findLatestSessionByStatuses(channel, [
+    "pending_bootstrap",
+    "awaiting_response",
+  ]);
 }
 
 /**

--- a/gateway/src/verification/rate-limit-helpers.ts
+++ b/gateway/src/verification/rate-limit-helpers.ts
@@ -1,18 +1,14 @@
 /**
  * Rate limiting helpers for gateway-owned verification.
  *
- * Gateway DB is the primary store; assistant DB gets best-effort dual-writes.
- * Uses atomic upserts (ON CONFLICT) to handle concurrent webhook deliveries.
+ * Gateway DB only. Uses atomic upserts (ON CONFLICT) to handle concurrent
+ * webhook deliveries.
  */
 
 import { and, eq, sql } from "drizzle-orm";
 
-import { assistantDbRun } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
 import { channelGuardianRateLimits as gwRateLimits } from "../db/schema.js";
-import { getLogger } from "../logger.js";
-
-const log = getLogger("verification-rate-limits");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -30,10 +26,6 @@ interface RateLimitRecord {
   attemptTimestampsJson: string;
   lockedUntil: number | null;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Read
@@ -134,37 +126,6 @@ export async function recordInvalidAttempt(
       END,
       updated_at = ${now}
   `);
-
-  // Read back for assistant DB dual-write
-  const updated = getRateLimit(channel, actorExternalUserId, actorChatId);
-  const timestampsJson = updated?.attemptTimestampsJson ?? singleTimestampJson;
-  const lockedUntil = updated?.lockedUntil ?? null;
-
-  // Assistant DB dual-write
-  try {
-    await assistantDbRun(
-      `INSERT INTO channel_guardian_rate_limits
-         (id, channel, actor_external_user_id, actor_chat_id,
-          attempt_timestamps_json, locked_until, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT (channel, actor_external_user_id, actor_chat_id) DO UPDATE SET
-         attempt_timestamps_json = excluded.attempt_timestamps_json,
-         locked_until = excluded.locked_until,
-         updated_at = excluded.updated_at`,
-      [
-        crypto.randomUUID(),
-        channel,
-        actorExternalUserId,
-        actorChatId,
-        timestampsJson,
-        lockedUntil,
-        now,
-        now,
-      ],
-    );
-  } catch (err) {
-    log.warn({ err }, "Assistant DB rate limit dual-write failed (best-effort)");
-  }
 }
 
 export async function resetRateLimit(
@@ -189,17 +150,4 @@ export async function resetRateLimit(
       ),
     )
     .run();
-
-  try {
-    await assistantDbRun(
-      `UPDATE channel_guardian_rate_limits
-       SET attempt_timestamps_json = '[]', locked_until = NULL, updated_at = ?
-       WHERE channel = ?
-         AND actor_external_user_id = ?
-         AND actor_chat_id = ?`,
-      [now, channel, actorExternalUserId, actorChatId],
-    );
-  } catch (err) {
-    log.warn({ err }, "Assistant DB rate limit reset dual-write failed (best-effort)");
-  }
 }

--- a/gateway/src/verification/session-helpers.ts
+++ b/gateway/src/verification/session-helpers.ts
@@ -1,14 +1,16 @@
 /**
  * Verification session helpers for gateway-owned verification.
  *
- * Session lookup, consumption, and status checks — all via raw SQL
- * through the assistant DB IPC proxy. The assistant DB owns session state.
+ * Thin delegates over the gateway-native session store — the gateway DB
+ * owns session state. The async signatures are preserved from the db_proxy
+ * era so callers are unaffected.
  */
 
 import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../db/assistant-db-proxy.js";
+  consumeSession as storeConsumeSession,
+  findPendingSessionByHash,
+  hasInterceptableSession,
+} from "../db/session-store.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("verification-sessions");
@@ -32,28 +34,6 @@ export interface VerificationSession {
 }
 
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const SESSION_COLUMNS = `
-  id, challenge_hash AS challengeHash, expires_at AS expiresAt,
-  status, verification_purpose AS verificationPurpose,
-  expected_external_user_id AS expectedExternalUserId,
-  expected_chat_id AS expectedChatId,
-  expected_phone_e164 AS expectedPhoneE164,
-  identity_binding_status AS identityBindingStatus,
-  code_digits AS codeDigits, max_attempts AS maxAttempts
-`;
-
-/**
- * All session statuses that represent an interceptable verification session.
- *
- * Includes 'awaiting_response' — outbound text verification sessions are
- * created with this status (see assistant createOutboundSession).
- */
-const INTERCEPTABLE_STATUSES = `('pending', 'pending_bootstrap', 'awaiting_response')`;
-
-// ---------------------------------------------------------------------------
 // Session lookup
 // ---------------------------------------------------------------------------
 
@@ -64,16 +44,7 @@ const INTERCEPTABLE_STATUSES = `('pending', 'pending_bootstrap', 'awaiting_respo
 export async function hasPendingOrActiveSession(
   channel: string,
 ): Promise<boolean> {
-  const now = Date.now();
-  const rows = await assistantDbQuery<{ id: string }>(
-    `SELECT id FROM channel_verification_sessions
-     WHERE channel = ?
-       AND status IN ${INTERCEPTABLE_STATUSES}
-       AND expires_at > ?
-     LIMIT 1`,
-    [channel, now],
-  );
-  return rows.length > 0;
+  return hasInterceptableSession(channel);
 }
 
 /**
@@ -83,18 +54,7 @@ export async function findSessionByHash(
   channel: string,
   challengeHash: string,
 ): Promise<VerificationSession | null> {
-  const now = Date.now();
-  const rows = await assistantDbQuery<VerificationSession>(
-    `SELECT ${SESSION_COLUMNS}
-     FROM channel_verification_sessions
-     WHERE channel = ?
-       AND challenge_hash = ?
-       AND status IN ${INTERCEPTABLE_STATUSES}
-       AND expires_at > ?
-     LIMIT 1`,
-    [channel, challengeHash, now],
-  );
-  return rows[0] ?? null;
+  return findPendingSessionByHash(channel, challengeHash);
 }
 
 // ---------------------------------------------------------------------------
@@ -102,11 +62,8 @@ export async function findSessionByHash(
 // ---------------------------------------------------------------------------
 
 /**
- * Mark a verification session as consumed in the assistant DB, which owns
- * session state.
- *
- * The UPDATE includes a status predicate so only the first concurrent
- * consumer wins — subsequent attempts see zero changes and return false,
+ * Mark a verification session as consumed. The store's status guard ensures
+ * only the first concurrent consumer wins — subsequent attempts return false,
  * preserving one-time-code semantics under race conditions.
  */
 export async function consumeSession(
@@ -114,21 +71,13 @@ export async function consumeSession(
   actorExternalUserId: string,
   actorChatId: string,
 ): Promise<boolean> {
-  const now = Date.now();
-
-  // Status guard ensures atomicity under concurrent consumers.
-  const result = await assistantDbRun(
-    `UPDATE channel_verification_sessions
-     SET status = 'consumed',
-         consumed_by_external_user_id = ?,
-         consumed_by_chat_id = ?,
-         updated_at = ?
-     WHERE id = ?
-       AND status IN ${INTERCEPTABLE_STATUSES}`,
-    [actorExternalUserId, actorChatId, now, sessionId],
+  const result = storeConsumeSession(
+    sessionId,
+    actorExternalUserId,
+    actorChatId,
   );
 
-  if (result.changes === 0) {
+  if (!result.consumed) {
     log.warn(
       { sessionId },
       "Session consume returned 0 changes — already consumed or status changed",

--- a/gateway/src/verification/text-verification.ts
+++ b/gateway/src/verification/text-verification.ts
@@ -9,7 +9,7 @@
  *   2. Check rate limits
  *   3. Hash + find matching session
  *   4. Verify identity binding (outbound sessions)
- *   5. Consume session (dual-write, atomic status guard)
+ *   5. Consume session (atomic status guard)
  *   6. Apply side effects (guardian binding OR trusted contact upsert)
  *   7. Deliver deterministic reply
  *

--- a/gateway/src/voice/verification.test.ts
+++ b/gateway/src/voice/verification.test.ts
@@ -1,43 +1,16 @@
-import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Database } from "bun:sqlite";
 
 import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+import { createInboundSession, getSessionById } from "../db/session-store.js";
+import {
+  findPendingPhoneSession,
+  validateVerificationCode,
+} from "./verification.js";
 
-// ---------------------------------------------------------------------------
-// Assistant DB proxy mock — backed by an in-process bun:sqlite test DB
-// ---------------------------------------------------------------------------
-
-let testAssistantDb: Database | null = null;
-
-mock.module("../db/assistant-db-proxy.js", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async assistantDbQuery(sql: string, bind?: any[]) {
-    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
-    const stmt = testAssistantDb.prepare(sql);
-    return bind ? stmt.all(...bind) : stmt.all();
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async assistantDbRun(sql: string, bind?: any[]) {
-    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
-    const stmt = testAssistantDb.prepare(sql);
-    const result = bind ? stmt.run(...bind) : stmt.run();
-    return {
-      changes: result.changes,
-      lastInsertRowid: Number(result.lastInsertRowid),
-    };
-  },
-  async assistantDbExec(sql: string) {
-    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
-    testAssistantDb.exec(sql);
-  },
-}));
-
-const { validateVerificationCode } = await import("./verification.js");
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PendingSession = Parameters<typeof validateVerificationCode>[0];
 
 // ---------------------------------------------------------------------------
@@ -55,47 +28,6 @@ async function setupTestDirs(): Promise<void> {
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
 
-  const dbDir = join(testRoot, "data", "db");
-  mkdirSync(dbDir, { recursive: true });
-
-  const db = new Database(join(dbDir, "assistant.db"));
-  db.exec("PRAGMA journal_mode=WAL");
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS channel_verification_sessions (
-      id TEXT PRIMARY KEY,
-      channel TEXT NOT NULL,
-      challenge_hash TEXT NOT NULL,
-      expires_at INTEGER NOT NULL,
-      status TEXT NOT NULL,
-      verification_purpose TEXT NOT NULL DEFAULT 'guardian',
-      expected_external_user_id TEXT,
-      expected_chat_id TEXT,
-      expected_phone_e164 TEXT,
-      identity_binding_status TEXT,
-      code_digits INTEGER NOT NULL DEFAULT 6,
-      max_attempts INTEGER NOT NULL DEFAULT 3,
-      consumed_by_external_user_id TEXT,
-      consumed_by_chat_id TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS channel_guardian_rate_limits (
-      id TEXT PRIMARY KEY,
-      channel TEXT NOT NULL,
-      actor_external_user_id TEXT NOT NULL,
-      actor_chat_id TEXT NOT NULL,
-      attempt_timestamps_json TEXT NOT NULL,
-      locked_until INTEGER,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      UNIQUE (channel, actor_external_user_id, actor_chat_id)
-    )
-  `);
-
-  testAssistantDb = db;
-
   process.env.VELLUM_WORKSPACE_DIR = testRoot;
   process.env.GATEWAY_SECURITY_DIR = securityDir;
 
@@ -103,39 +35,30 @@ async function setupTestDirs(): Promise<void> {
 }
 
 function seedPendingSession(id: string, code: string): PendingSession {
-  const now = Date.now();
-  const expiresAt = now + 5 * 60 * 1000;
-  const challengeHash = hashSecret(code);
-
-  testAssistantDb!
-    .prepare(
-      `INSERT INTO channel_verification_sessions
-        (id, channel, challenge_hash, expires_at, status,
-         verification_purpose, code_digits, max_attempts, created_at, updated_at)
-       VALUES (?, 'phone', ?, ?, 'pending', 'guardian', 6, 3, ?, ?)`,
-    )
-    .run(id, challengeHash, expiresAt, now, now);
+  const session = createInboundSession({
+    id,
+    channel: "phone",
+    challengeHash: hashSecret(code),
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  });
 
   return {
-    id,
-    challengeHash,
-    expiresAt,
-    status: "pending",
-    verificationPurpose: "guardian",
+    id: session.id,
+    challengeHash: session.challengeHash,
+    expiresAt: session.expiresAt,
+    status: session.status,
+    verificationPurpose: session.verificationPurpose,
     expectedExternalUserId: null,
     expectedChatId: null,
     expectedPhoneE164: null,
     identityBindingStatus: null,
-    codeDigits: 6,
-    maxAttempts: 3,
+    codeDigits: session.codeDigits,
+    maxAttempts: session.maxAttempts,
   };
 }
 
 function sessionStatus(id: string): string | undefined {
-  const row = testAssistantDb!
-    .prepare(`SELECT status FROM channel_verification_sessions WHERE id = ?`)
-    .get(id) as { status: string } | undefined;
-  return row?.status;
+  return getSessionById(id)?.status;
 }
 
 beforeEach(async () => {
@@ -144,19 +67,30 @@ beforeEach(async () => {
 
 afterEach(() => {
   resetGatewayDb();
-  if (testAssistantDb) {
-    try {
-      testAssistantDb.close();
-    } catch {
-      /* best effort */
-    }
-    testAssistantDb = null;
-  }
   try {
     rmSync(testRoot, { recursive: true, force: true });
   } catch {
     /* best effort */
   }
+});
+
+// ---------------------------------------------------------------------------
+// findPendingPhoneSession — gateway DB read
+// ---------------------------------------------------------------------------
+
+describe("findPendingPhoneSession", () => {
+  test("returns a gateway-seeded pending phone session", async () => {
+    seedPendingSession("sess-lookup", "123456");
+
+    const found = await findPendingPhoneSession();
+    expect(found?.id).toBe("sess-lookup");
+    expect(found?.status).toBe("pending");
+    expect(found?.codeDigits).toBe(6);
+  });
+
+  test("returns null when no pending session exists", async () => {
+    expect(await findPendingPhoneSession()).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/voice/verification.ts
+++ b/gateway/src/voice/verification.ts
@@ -13,22 +13,18 @@
  *   4. Gateway validates code, creates guardian binding, returns TwiML
  *      that forwards to the assistant for ConversationRelay setup
  *
- * Verification sessions are read from the assistant DB (via IPC proxy)
- * because the session creation still happens on the assistant side (the
- * guardian initiates verification through chat channels).
+ * Verification sessions and rate limits live in the gateway DB.
  */
 
 import { createHash } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
-
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../db/assistant-db-proxy.js";
-import { getGatewayDb } from "../db/connection.js";
-import { channelGuardianRateLimits as gwRateLimits } from "../db/schema.js";
+import { findLatestSessionByStatuses } from "../db/session-store.js";
 import { getLogger } from "../logger.js";
+import {
+  getRateLimit,
+  recordInvalidAttempt,
+  resetRateLimit,
+} from "../verification/rate-limit-helpers.js";
 import { consumeSession } from "../verification/session-helpers.js";
 
 const log = getLogger("voice-verification");
@@ -38,9 +34,6 @@ const log = getLogger("voice-verification");
 // ---------------------------------------------------------------------------
 
 const MAX_ATTEMPTS = 3;
-const RATE_LIMIT_MAX_ATTEMPTS = 5;
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
-const RATE_LIMIT_LOCKOUT_MS = 30 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,11 +51,6 @@ interface PendingSession {
   identityBindingStatus: string | null;
   codeDigits: number;
   maxAttempts: number;
-}
-
-interface RateLimitRecord {
-  attemptTimestampsJson: string;
-  lockedUntil: number | null;
 }
 
 export interface VoiceVerificationResult {
@@ -94,167 +82,14 @@ function hashSecret(secret: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Check if there is a pending phone verification session.
- * Reads from the assistant's channel_verification_sessions table.
+ * Check if there is a pending phone verification session in the gateway DB.
  *
  * Narrower status set than the shared INTERCEPTABLE_STATUSES: phone
  * sessions never use 'awaiting_response' (that status is created only by
  * outbound text verification), so it is deliberately excluded here.
  */
 export async function findPendingPhoneSession(): Promise<PendingSession | null> {
-  const now = Date.now();
-  const rows = await assistantDbQuery<PendingSession>(
-    `SELECT id, challenge_hash AS challengeHash, expires_at AS expiresAt,
-            status, verification_purpose AS verificationPurpose,
-            expected_external_user_id AS expectedExternalUserId,
-            expected_chat_id AS expectedChatId,
-            expected_phone_e164 AS expectedPhoneE164,
-            identity_binding_status AS identityBindingStatus,
-            code_digits AS codeDigits, max_attempts AS maxAttempts
-     FROM channel_verification_sessions
-     WHERE channel = 'phone'
-       AND status IN ('pending', 'pending_bootstrap')
-       AND expires_at > ?
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    [now],
-  );
-
-  return rows[0] ?? null;
-}
-
-// ---------------------------------------------------------------------------
-// Rate limiting (gateway DB primary, assistant DB dual-write)
-// ---------------------------------------------------------------------------
-
-function parseTimestamps(json: string): number[] {
-  try {
-    const arr = JSON.parse(json);
-    return Array.isArray(arr) ? arr : [];
-  } catch {
-    return [];
-  }
-}
-
-function getRateLimit(
-  fromNumber: string,
-): RateLimitRecord | null {
-  const gwDb = getGatewayDb();
-  const row = gwDb
-    .select()
-    .from(gwRateLimits)
-    .where(
-      and(
-        eq(gwRateLimits.channel, "phone"),
-        eq(gwRateLimits.actorExternalUserId, fromNumber),
-        eq(gwRateLimits.actorChatId, fromNumber),
-      ),
-    )
-    .get();
-
-  return row
-    ? { attemptTimestampsJson: row.attemptTimestampsJson, lockedUntil: row.lockedUntil }
-    : null;
-}
-
-async function recordInvalidAttempt(fromNumber: string): Promise<void> {
-  const now = Date.now();
-  const cutoff = now - RATE_LIMIT_WINDOW_MS;
-
-  const existing = getRateLimit(fromNumber);
-  const recentTimestamps = existing
-    ? parseTimestamps(existing.attemptTimestampsJson).filter((ts) => ts > cutoff)
-    : [];
-  recentTimestamps.push(now);
-
-  const timestampsJson = JSON.stringify(recentTimestamps);
-  const newLockedUntil =
-    recentTimestamps.length >= RATE_LIMIT_MAX_ATTEMPTS
-      ? now + RATE_LIMIT_LOCKOUT_MS
-      : existing?.lockedUntil ?? null;
-
-  // Gateway DB — atomic upsert
-  const gwDb = getGatewayDb();
-  gwDb.insert(gwRateLimits)
-    .values({
-      id: crypto.randomUUID(),
-      channel: "phone",
-      actorExternalUserId: fromNumber,
-      actorChatId: fromNumber,
-      attemptTimestampsJson: timestampsJson,
-      lockedUntil: newLockedUntil,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [gwRateLimits.channel, gwRateLimits.actorExternalUserId, gwRateLimits.actorChatId],
-      set: {
-        attemptTimestampsJson: timestampsJson,
-        lockedUntil: newLockedUntil,
-        updatedAt: now,
-      },
-    })
-    .run();
-
-  // Assistant DB dual-write — atomic upsert via ON CONFLICT
-  try {
-    await assistantDbRun(
-      `INSERT INTO channel_guardian_rate_limits
-         (id, channel, actor_external_user_id, actor_chat_id,
-          attempt_timestamps_json, locked_until, created_at, updated_at)
-       VALUES (?, 'phone', ?, ?, ?, ?, ?, ?)
-       ON CONFLICT (channel, actor_external_user_id, actor_chat_id) DO UPDATE SET
-         attempt_timestamps_json = excluded.attempt_timestamps_json,
-         locked_until = excluded.locked_until,
-         updated_at = excluded.updated_at`,
-      [
-        crypto.randomUUID(),
-        fromNumber,
-        fromNumber,
-        timestampsJson,
-        newLockedUntil,
-        now,
-        now,
-      ],
-    );
-  } catch (err) {
-    log.warn({ err }, "Assistant DB rate limit dual-write failed (best-effort)");
-  }
-}
-
-async function resetRateLimit(fromNumber: string): Promise<void> {
-  const now = Date.now();
-
-  // Gateway DB
-  const gwDb = getGatewayDb();
-  gwDb.update(gwRateLimits)
-    .set({
-      attemptTimestampsJson: "[]",
-      lockedUntil: null,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(gwRateLimits.channel, "phone"),
-        eq(gwRateLimits.actorExternalUserId, fromNumber),
-        eq(gwRateLimits.actorChatId, fromNumber),
-      ),
-    )
-    .run();
-
-  // Assistant DB dual-write
-  try {
-    await assistantDbRun(
-      `UPDATE channel_guardian_rate_limits
-       SET attempt_timestamps_json = '[]', locked_until = NULL, updated_at = ?
-       WHERE channel = 'phone'
-         AND actor_external_user_id = ?
-         AND actor_chat_id = ?`,
-      [now, fromNumber, fromNumber],
-    );
-  } catch (err) {
-    log.warn({ err }, "Assistant DB rate limit reset dual-write failed (best-effort)");
-  }
+  return findLatestSessionByStatuses("phone", ["pending", "pending_bootstrap"]);
 }
 
 // ---------------------------------------------------------------------------
@@ -277,7 +112,7 @@ export async function validateVerificationCode(
   attempt: number,
 ): Promise<CodeValidationResult> {
   // Rate limit check
-  const rateLimit = await getRateLimit(fromNumber);
+  const rateLimit = getRateLimit("phone", fromNumber, fromNumber);
   if (rateLimit?.lockedUntil && Date.now() < rateLimit.lockedUntil) {
     return {
       success: false,
@@ -300,7 +135,7 @@ export async function validateVerificationCode(
   // Hash the entered code and compare
   const enteredHash = hashSecret(enteredCode);
   if (enteredHash !== session.challengeHash) {
-    await recordInvalidAttempt(fromNumber);
+    await recordInvalidAttempt("phone", fromNumber, fromNumber);
 
     if (attempt + 1 >= MAX_ATTEMPTS) {
       return {
@@ -358,7 +193,7 @@ export async function validateVerificationCode(
     }
 
     if (!identityMatch) {
-      await recordInvalidAttempt(fromNumber);
+      await recordInvalidAttempt("phone", fromNumber, fromNumber);
       if (attempt + 1 >= MAX_ATTEMPTS) {
         return {
           success: false,
@@ -390,7 +225,7 @@ export async function validateVerificationCode(
       exhausted: true,
     };
   }
-  await resetRateLimit(fromNumber);
+  await resetRateLimit("phone", fromNumber, fromNumber);
 
   const verificationType: "guardian" | "trusted_contact" =
     session.verificationPurpose === "trusted_contact"


### PR DESCRIPTION
## Summary
- session-helpers and voice/verification now read/consume via the gateway session store — zero db_proxy on the verification surface
- Assistant rate-limit dual-writes deleted; gateway is the only writer
- db-proxy allowlist shrunk to the contact-merge cluster + data migrations

Part of plan: verif-sessions-gateway-native.md (PR 10 of 12)