### PR TITLE
Plugin Custom Icons (emoji + bundled PNG)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21660,6 +21660,35 @@ paths:
           description: No plugin directory exists with the given name.
         "409":
           description: The plugin is already enabled.
+  /v1/plugins/{name}/icon:
+    get:
+      operationId: plugins_by_name_icon_get
+      summary: Serve a plugin's bundled icon
+      description:
+        Serve the installed plugin's validated author-bundled `icon.png` as `image/png`. The PNG is re-validated on
+        read (magic bytes + IHDR dimensions + size) and served with an immutable `Cache-Control` plus a content-hash
+        `ETag` — the `iconVersion` reported by `GET /v1/plugins` and `GET /v1/plugins/:name` — so clients cache
+        aggressively and only refetch when the hash changes. A plugin with no valid bundled icon returns 404; a
+        malformed name returns 400. Pair with the `hasIcon` / `iconVersion` fields on the list and detail responses to
+        decide whether to fetch.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: No installed plugin with the given name has an icon.
   /v1/plugins/{name}/inspect:
     get:
       operationId: plugins_by_name_inspect_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21266,6 +21266,9 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        icon:
+                          description: Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.
+                          type: string
                       required:
                         - id
                         - name

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21269,6 +21269,16 @@ paths:
                         icon:
                           description: Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.
                           type: string
+                        hasIcon:
+                          description:
+                            Whether the plugin ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated).
+                            Drives whether a client fetches the bundled icon.
+                          type: boolean
+                        iconVersion:
+                          description:
+                            Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for
+                            the bundled-icon endpoint.
+                          type: string
                       required:
                         - id
                         - name
@@ -21442,6 +21452,18 @@ paths:
                       - type: string
                       - type: "null"
                     description: Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.
+                  hasIcon:
+                    type: boolean
+                    description:
+                      Whether the locally installed copy ships a valid author-bundled `icon.png` (PNG magic + dimensions + size
+                      validated). Always false when the plugin is not installed.
+                  iconVersion:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description:
+                      Content hash of the validated `icon.png`; null when `hasIcon` is false. Use it as a cache-buster for the
+                      bundled-icon endpoint.
                 required:
                   - name
                   - installed
@@ -21454,6 +21476,8 @@ paths:
                   - ref
                   - artifact
                   - icon
+                  - hasIcon
+                  - iconVersion
                 additionalProperties: false
         "400":
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21437,6 +21437,11 @@ paths:
                     description:
                       Prebuilt client artifact from `package.json` `vellum.artifact`, or null when the plugin ships none or its
                       descriptor is incomplete (e.g. a placeholder sha256).
+                  icon:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.
                 required:
                   - name
                   - installed
@@ -21448,6 +21453,7 @@ paths:
                   - readme
                   - ref
                   - artifact
+                  - icon
                 additionalProperties: false
         "400":
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).

--- a/assistant/src/cli/lib/__tests__/list-installed-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/list-installed-plugins.test.ts
@@ -78,6 +78,42 @@ describe("listInstalledPlugins", () => {
     expect(result.every((p) => p.issues.length === 0)).toBe(true);
   });
 
+  test("surfaces a valid vellum.icon emoji on packageJson", () => {
+    mkdirSync(join(pluginsDir, "iconed"));
+    writeFileSync(
+      join(pluginsDir, "iconed", "package.json"),
+      JSON.stringify({
+        name: "iconed",
+        version: "1.0.0",
+        vellum: { icon: "🚀" },
+      }),
+    );
+
+    const result = listInstalledPlugins({ workspacePluginsDir: pluginsDir });
+    expect(result[0]!.packageJson?.icon).toBe("🚀");
+  });
+
+  test.each([
+    ["missing vellum block", { name: "p", version: "1.0.0" }],
+    ["non-string icon", { name: "p", version: "1.0.0", vellum: { icon: 42 } }],
+    ["empty icon", { name: "p", version: "1.0.0", vellum: { icon: "" } }],
+    [
+      "over-long icon",
+      { name: "p", version: "1.0.0", vellum: { icon: "x".repeat(17) } },
+    ],
+  ])("leaves icon undefined for %s", (_label, pkg) => {
+    mkdirSync(join(pluginsDir, "no-icon"));
+    writeFileSync(
+      join(pluginsDir, "no-icon", "package.json"),
+      JSON.stringify(pkg),
+    );
+
+    const result = listInstalledPlugins({ workspacePluginsDir: pluginsDir });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.packageJson?.icon).toBeUndefined();
+    expect(result[0]!.issues).toEqual([]);
+  });
+
   test("reports missing package.json as an issue rather than failing", () => {
     mkdirSync(join(pluginsDir, "barebones"));
 

--- a/assistant/src/cli/lib/__tests__/plugin-artifact.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-artifact.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parsePluginArtifact } from "../plugin-artifact.js";
+import { parsePluginArtifact, parsePluginIcon } from "../plugin-artifact.js";
 
 const VALID_SHA = "a".repeat(64);
 
@@ -179,5 +179,58 @@ describe("parsePluginArtifact", () => {
     // WHEN we parse a non-object package.json value
     // THEN nothing is surfaced
     expect(parsePluginArtifact(value)).toBeNull();
+  });
+});
+
+describe("parsePluginIcon", () => {
+  test("returns the emoji when vellum.icon is a short glyph", () => {
+    expect(parsePluginIcon({ vellum: { icon: "🚀" } })).toBe("🚀");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(parsePluginIcon({ vellum: { icon: "  🎯 " } })).toBe("🎯");
+  });
+
+  test("accepts a multi-code-point glyph within the bound", () => {
+    // A ZWJ family emoji is several code points but well under the cap.
+    const family = "👩‍👩‍👧‍👦";
+    expect(parsePluginIcon({ vellum: { icon: family } })).toBe(family);
+  });
+
+  test("accepts a value at exactly the 16-code-point bound", () => {
+    const sixteen = "a".repeat(16);
+    expect(parsePluginIcon({ vellum: { icon: sixteen } })).toBe(sixteen);
+  });
+
+  test.each([
+    ["no vellum block", { name: "x" }],
+    ["no icon field", { vellum: {} }],
+    ["icon is empty", { vellum: { icon: "" } }],
+    ["icon is whitespace-only", { vellum: { icon: "   " } }],
+    [
+      "icon is too long (>16 code points)",
+      { vellum: { icon: "x".repeat(17) } },
+    ],
+    ["icon is a number", { vellum: { icon: 42 } }],
+    ["icon is an object", { vellum: { icon: {} } }],
+    ["vellum is an array", { vellum: [] }],
+  ])("returns undefined for %s", (_label, pkg) => {
+    expect(parsePluginIcon(pkg)).toBeUndefined();
+  });
+
+  test.each([
+    ["null", null],
+    ["a string", "not-a-package"],
+    ["an array", []],
+    ["a number", 42],
+  ])("returns undefined when package.json is %s", (_label, value) => {
+    expect(parsePluginIcon(value)).toBeUndefined();
+  });
+
+  test("does not count a >16-code-point emoji sequence as valid", () => {
+    // 17 rocket emoji: 17 code points, over the cap.
+    expect(
+      parsePluginIcon({ vellum: { icon: "🚀".repeat(17) } }),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -305,6 +305,36 @@ describe("getPluginDetails", () => {
     expect(details.version).toBe("2.0.0");
     expect(details.license).toBe("Apache-2.0");
     expect(details.description).toBe("manifest description");
+    // AND a package.json without vellum.icon surfaces icon as null
+    expect(details.icon).toBeNull();
+  });
+
+  test("surfaces the installed copy's vellum.icon", async () => {
+    // GIVEN an installed copy whose package.json declares vellum.icon
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0", vellum: { icon: "🦴" } }),
+    );
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+      listings: {},
+      raw: {},
+    });
+
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN the author emoji is surfaced from the installed package.json
+    expect(details.installed).toBe(true);
+    expect(details.icon).toBe("🦴");
   });
 
   test("throws PluginDetailsNotFoundError when nothing claims the name", async () => {

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -10,6 +10,7 @@
  *   - raw file downloads (a listing entry's `download_url`).
  */
 
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -92,6 +93,25 @@ function splitOnce(s: string, sep: string): [string, string] {
   const i = s.indexOf(sep);
   if (i === -1) return [s, ""];
   return [s.slice(0, i), s.slice(i + sep.length)];
+}
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/** Build a minimal, well-formed PNG with a valid signature and IHDR dimensions. */
+function makePng(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function sha16(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex").slice(0, 16);
 }
 
 let workspace: string;
@@ -335,6 +355,92 @@ describe("getPluginDetails", () => {
     // THEN the author emoji is surfaced from the installed package.json
     expect(details.installed).toBe(true);
     expect(details.icon).toBe("🦴");
+  });
+
+  test("surfaces hasIcon + iconVersion from the installed copy's icon.png", async () => {
+    // GIVEN an installed copy that ships a valid bundled icon.png
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0" }),
+    );
+    const png = makePng(64, 64);
+    writeFileSync(join(target, "icon.png"), png);
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+    });
+
+    // WHEN we resolve the detail view
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN the validated icon presence + content-hash version are surfaced
+    expect(details.installed).toBe(true);
+    expect(details.hasIcon).toBe(true);
+    expect(details.iconVersion).toBe(sha16(png));
+  });
+
+  test("reports hasIcon false + null iconVersion when no bundled icon.png", async () => {
+    // GIVEN an installed copy with no icon.png
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0" }),
+    );
+
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [{ name: "caveman", description: "d" }],
+      },
+    });
+
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN no icon is surfaced (fail-closed) — a client offers no bundled image
+    expect(details.hasIcon).toBe(false);
+    expect(details.iconVersion).toBeNull();
+  });
+
+  test("reports hasIcon false + null iconVersion for an uninstalled plugin", async () => {
+    // GIVEN a marketplace-only plugin with no installed copy
+    const fetch = makeFetch({
+      marketplace: {
+        name: "vellum",
+        plugins: [
+          {
+            name: "simple-memory",
+            source: {
+              source: "github",
+              repo: "example-org/simple-memory",
+              ref: "9999999999999999999999999999999999999999",
+            },
+          },
+        ],
+      },
+      listings: { "example-org/simple-memory": [] },
+    });
+
+    const details = await getPluginDetails(
+      { name: "simple-memory" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN a not-installed plugin has no bundled icon to validate
+    expect(details.installed).toBe(false);
+    expect(details.hasIcon).toBe(false);
+    expect(details.iconVersion).toBeNull();
   });
 
   test("throws PluginDetailsNotFoundError when nothing claims the name", async () => {

--- a/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for {@link readValidatedPluginIcon} — the fail-closed `icon.png`
+ * validator. An icon is surfaced only when the file is a PNG (correct magic
+ * bytes) whose IHDR dimensions are within 128×128 and whose size is within
+ * 32 KB. Every other shape — missing, wrong magic, oversized dims/bytes,
+ * unreadable — is "no icon" (`{ hasIcon: false }`) and never throws.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { readValidatedPluginIcon } from "../plugin-icon-file.js";
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * Build a minimal PNG buffer with a valid signature and IHDR width/height.
+ * `padBytes` appends filler after the header so callers can produce an
+ * oversized-but-otherwise-valid file for the size-cap case.
+ */
+function makePng(width: number, height: number, padBytes = 0): Buffer {
+  const buf = Buffer.alloc(24 + Math.max(0, padBytes));
+  PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function sha16(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex").slice(0, 16);
+}
+
+let pluginDir: string;
+
+beforeEach(() => {
+  pluginDir = mkdtempSync(join(tmpdir(), "plugin-icon-"));
+});
+
+afterEach(() => {
+  rmSync(pluginDir, { recursive: true, force: true });
+});
+
+function writeIcon(bytes: Buffer): void {
+  writeFileSync(join(pluginDir, "icon.png"), bytes);
+}
+
+describe("readValidatedPluginIcon", () => {
+  test("accepts a valid <=128x128 <=32KB PNG with a content-hash version", () => {
+    // GIVEN a small, well-formed PNG at the fixed path
+    const bytes = makePng(64, 64);
+    writeIcon(bytes);
+
+    // WHEN we validate it
+    const result = readValidatedPluginIcon(pluginDir);
+
+    // THEN it is surfaced with a stable content-hash version and its path
+    expect(result.hasIcon).toBe(true);
+    expect(result.iconVersion).toBe(sha16(bytes));
+    expect(result.path).toBe(join(pluginDir, "icon.png"));
+  });
+
+  test("accepts exactly 128x128 (the dimension boundary)", () => {
+    writeIcon(makePng(128, 128));
+    expect(readValidatedPluginIcon(pluginDir).hasIcon).toBe(true);
+  });
+
+  test("returns a stable iconVersion across repeated reads of the same bytes", () => {
+    writeIcon(makePng(32, 48));
+    const first = readValidatedPluginIcon(pluginDir);
+    const second = readValidatedPluginIcon(pluginDir);
+    expect(first.iconVersion).toBe(second.iconVersion);
+  });
+
+  test("iconVersion changes when the bytes change", () => {
+    writeIcon(makePng(32, 32));
+    const before = readValidatedPluginIcon(pluginDir).iconVersion;
+    writeIcon(makePng(48, 48));
+    const after = readValidatedPluginIcon(pluginDir).iconVersion;
+    expect(before).not.toBe(after);
+  });
+
+  test("rejects a non-PNG file with wrong magic bytes (renamed JPEG/text)", () => {
+    // GIVEN a file with JPEG magic bytes renamed to icon.png
+    const jpeg = Buffer.alloc(24);
+    jpeg.writeUInt16BE(0xffd8, 0); // JPEG SOI marker
+    writeIcon(jpeg);
+
+    // THEN it is rejected without throwing
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects plain text renamed to icon.png", () => {
+    writeIcon(Buffer.from("<svg>not a png at all, just some text</svg>"));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects oversized dimensions (129x129)", () => {
+    writeIcon(makePng(129, 129));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects zero-dimension IHDR", () => {
+    writeIcon(makePng(0, 0));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a PNG larger than 32KB", () => {
+    // GIVEN a valid-header PNG padded past the 32 KB cap
+    writeIcon(makePng(64, 64, 33 * 1024));
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a truncated file too short to hold an IHDR", () => {
+    writeIcon(PNG_SIGNATURE); // 8 bytes — signature only, no IHDR
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a signature-prefixed file whose first chunk is not IHDR", () => {
+    // Valid signature + in-range integers at offsets 16/20, but the first
+    // chunk type is IDAT — must not be treated as dimensions.
+    const buf = makePng(64, 64);
+    buf.write("IDAT", 12, "ascii");
+    writeIcon(buf);
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("returns hasIcon:false when no icon.png exists", () => {
+    expect(readValidatedPluginIcon(pluginDir)).toEqual({ hasIcon: false });
+  });
+
+  test("returns hasIcon:false for a non-existent plugin directory", () => {
+    const missing = join(pluginDir, "does-not-exist");
+    expect(readValidatedPluginIcon(missing)).toEqual({ hasIcon: false });
+  });
+});

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -16,6 +16,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { parsePluginIcon } from "./plugin-artifact.js";
 
 /**
  * Directory containing first-party default plugin packages. Each subdirectory
@@ -38,6 +39,8 @@ export interface PluginPackageMetadata {
   readonly version?: string;
   readonly description?: string;
   readonly peerDependencies?: Record<string, string>;
+  /** Author-supplied short glyph (emoji) from `vellum.icon`, when present. */
+  readonly icon?: string;
 }
 
 /** One installed plugin entry. */
@@ -160,6 +163,7 @@ function readPluginEntry(
   }
 
   const meta = parsed as Record<string, unknown>;
+  const icon = parsePluginIcon(meta);
   const packageJson: PluginPackageMetadata = {
     name: typeof meta.name === "string" ? meta.name : undefined,
     version: typeof meta.version === "string" ? meta.version : undefined,
@@ -171,6 +175,7 @@ function readPluginEntry(
       !Array.isArray(meta.peerDependencies)
         ? (meta.peerDependencies as Record<string, string>)
         : undefined,
+    ...(icon ? { icon } : {}),
   };
 
   return { name, target, packageJson, issues };
@@ -206,9 +211,7 @@ export function listAllPlugins(
   // ── User plugins ───────────────────────────────────────────────────────
   // Filter out default-plugin stub directories (created by `plugins disable
   // default-<name>`) so they don't show up as duplicate user entries.
-  const defaultNames = new Set(
-    readDefaultPluginManifests().map((m) => m.name),
-  );
+  const defaultNames = new Set(readDefaultPluginManifests().map((m) => m.name));
   const userPlugins: AllPluginInfo[] = listInstalledPlugins(opts)
     .filter((entry) => !defaultNames.has(entry.name))
     .map((entry) => ({
@@ -255,7 +258,12 @@ export function listAllPlugins(
   );
   // enabledDefault and disabledDefault keep repo array order (no sort).
 
-  return [...enabledUser, ...disabledUser, ...enabledDefault, ...disabledDefault];
+  return [
+    ...enabledUser,
+    ...disabledUser,
+    ...enabledDefault,
+    ...disabledDefault,
+  ];
 }
 
 interface DefaultPluginManifest {
@@ -309,7 +317,10 @@ function getPluginInstallDate(plugin: AllPluginInfo): number {
   const metaPath = join(plugin.target, "install-meta.json");
   try {
     if (existsSync(metaPath)) {
-      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>;
+      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
       if (typeof raw.installedAt === "string") {
         const ms = Date.parse(raw.installedAt);
         if (Number.isFinite(ms)) return ms;

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -254,8 +254,6 @@ export function listAllPlugins(
     (manifest) => {
       const target = join(pluginsDir, manifest.name);
       const disabled = existsSync(join(target, ".disabled"));
-      // A default plugin's files (including icon.png) live in the source tree,
-      // not the workspace stub dir that only holds the `.disabled` sentinel.
       return {
         name: manifest.name,
         target,
@@ -266,7 +264,12 @@ export function listAllPlugins(
         issues: [],
         source: "default" as const,
         disabled,
-        ...pluginIconFields(join(DEFAULT_PLUGINS_DIR, manifest.name)),
+        // Read icon fields from the workspace copy — the same source the plugin
+        // detail + icon-serving routes use — so every surface agrees: a default
+        // plugin reports no bundled icon (its workspace dir is a `.disabled`
+        // stub), keeping list/detail/serve consistent rather than advertising a
+        // source-tree icon the HTTP routes can't serve.
+        ...pluginIconFields(target),
       };
     },
   );

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -17,6 +17,7 @@ import { dirname, join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { parsePluginIcon } from "./plugin-artifact.js";
+import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 
 /**
  * Directory containing first-party default plugin packages. Each subdirectory
@@ -56,6 +57,10 @@ export interface InstalledPluginInfo {
    * JSON, unexpected type, etc.). Empty when the entry parses cleanly.
    */
   readonly issues: readonly string[];
+  /** Whether a valid author-bundled `icon.png` was found in the plugin dir. */
+  readonly hasIcon: boolean;
+  /** Content-hash version of the validated `icon.png`, when {@link hasIcon}. */
+  readonly iconVersion?: string;
 }
 
 /** Where the plugin comes from. */
@@ -132,9 +137,13 @@ function readPluginEntry(
   const pkgJsonPath = join(target, "package.json");
   const issues: string[] = [];
 
+  // Icon validation is independent of package.json parsing, so resolve it
+  // once and attach to every return below (including error paths).
+  const iconFields = pluginIconFields(target);
+
   if (!existsSync(pkgJsonPath)) {
     issues.push("missing package.json");
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   let raw: string;
@@ -144,7 +153,7 @@ function readPluginEntry(
     issues.push(
       `package.json unreadable: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   let parsed: unknown;
@@ -154,12 +163,12 @@ function readPluginEntry(
     issues.push(
       `package.json invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     issues.push("package.json is not an object");
-    return { name, target, packageJson: null, issues };
+    return { name, target, packageJson: null, issues, ...iconFields };
   }
 
   const meta = parsed as Record<string, unknown>;
@@ -178,7 +187,21 @@ function readPluginEntry(
     ...(icon ? { icon } : {}),
   };
 
-  return { name, target, packageJson, issues };
+  return { name, target, packageJson, issues, ...iconFields };
+}
+
+/**
+ * Validate `<dir>/icon.png` and shape the result into the two fields surfaced
+ * on {@link InstalledPluginInfo}. `iconVersion` is omitted when no valid icon
+ * is present.
+ */
+function pluginIconFields(
+  dir: string,
+): Pick<InstalledPluginInfo, "hasIcon" | "iconVersion"> {
+  const icon = readValidatedPluginIcon(dir);
+  return icon.hasIcon
+    ? { hasIcon: true, iconVersion: icon.iconVersion }
+    : { hasIcon: false };
 }
 
 /**
@@ -231,6 +254,8 @@ export function listAllPlugins(
     (manifest) => {
       const target = join(pluginsDir, manifest.name);
       const disabled = existsSync(join(target, ".disabled"));
+      // A default plugin's files (including icon.png) live in the source tree,
+      // not the workspace stub dir that only holds the `.disabled` sentinel.
       return {
         name: manifest.name,
         target,
@@ -241,6 +266,7 @@ export function listAllPlugins(
         issues: [],
         source: "default" as const,
         disabled,
+        ...pluginIconFields(join(DEFAULT_PLUGINS_DIR, manifest.name)),
       };
     },
   );

--- a/assistant/src/cli/lib/plugin-artifact.ts
+++ b/assistant/src/cli/lib/plugin-artifact.ts
@@ -101,3 +101,33 @@ export function parsePluginArtifact(
     ...(label ? { label } : {}),
   };
 }
+
+/** Upper bound on `vellum.icon`, in Unicode code points. */
+const MAX_ICON_CODE_POINTS = 16;
+
+/**
+ * Read `vellum.icon` from an already-parsed `package.json` value and return
+ * it only when it is a short, non-empty glyph (an emoji or similar). The
+ * value is trimmed and bounded to {@link MAX_ICON_CODE_POINTS} code points so
+ * it can never carry markup or a URL. Any other shape — missing block, wrong
+ * type, empty, or too long — yields `undefined` rather than throwing.
+ */
+export function parsePluginIcon(packageJson: unknown): string | undefined {
+  if (
+    typeof packageJson !== "object" ||
+    packageJson === null ||
+    Array.isArray(packageJson)
+  ) {
+    return undefined;
+  }
+  const vellum = (packageJson as Record<string, unknown>).vellum;
+  if (typeof vellum !== "object" || vellum === null || Array.isArray(vellum)) {
+    return undefined;
+  }
+  const icon = (vellum as Record<string, unknown>).icon;
+  if (typeof icon !== "string") return undefined;
+  const trimmed = icon.trim();
+  const codePoints = [...trimmed].length;
+  if (codePoints < 1 || codePoints > MAX_ICON_CODE_POINTS) return undefined;
+  return trimmed;
+}

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -33,7 +33,11 @@ import {
   type FetchLike,
   sanitizePluginName,
 } from "./install-from-github.js";
-import { parsePluginArtifact, type PluginArtifact } from "./plugin-artifact.js";
+import {
+  parsePluginArtifact,
+  parsePluginIcon,
+  type PluginArtifact,
+} from "./plugin-artifact.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
@@ -58,6 +62,7 @@ interface PluginManifestFields {
   readonly homepage: string | null;
   readonly license: string | null;
   readonly artifact: PluginArtifact | null;
+  readonly icon: string | null;
 }
 
 /** Options that control which plugin to resolve and at what ref. */
@@ -106,6 +111,11 @@ export interface PluginDetails {
    * descriptor is incomplete (e.g. a placeholder `sha256`).
    */
   readonly artifact: PluginArtifact | null;
+  /**
+   * Author-declared emoji icon from the plugin's `package.json` `vellum.icon`,
+   * resolved from the installed copy first then the repo; `null` when none.
+   */
+  readonly icon: string | null;
 }
 
 /** No installed copy and no catalog/source entry claims the name. */
@@ -185,6 +195,7 @@ export async function getPluginDetails(
     readme,
     ref,
     artifact: local.manifest.artifact ?? remote.manifest.artifact,
+    icon: local.manifest.icon ?? remote.manifest.icon,
   };
 }
 
@@ -358,6 +369,7 @@ function emptyManifest(): PluginManifestFields {
     homepage: null,
     license: null,
     artifact: null,
+    icon: null,
   };
 }
 
@@ -382,6 +394,7 @@ function parseManifest(raw: string): PluginManifestFields {
     homepage: typeof meta.homepage === "string" ? meta.homepage : null,
     license: normalizeLicense(meta.license),
     artifact: parsePluginArtifact(parsed),
+    icon: parsePluginIcon(parsed) ?? null,
   };
 }
 

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -38,6 +38,7 @@ import {
   parsePluginIcon,
   type PluginArtifact,
 } from "./plugin-artifact.js";
+import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
@@ -116,6 +117,17 @@ export interface PluginDetails {
    * resolved from the installed copy first then the repo; `null` when none.
    */
   readonly icon: string | null;
+  /**
+   * Whether the locally installed copy ships a valid author-bundled `icon.png`
+   * (validated for PNG magic, dimensions, and size). `false` when the plugin is
+   * not installed or ships no valid icon.
+   */
+  readonly hasIcon: boolean;
+  /**
+   * Content hash of the validated `icon.png`; `null` when {@link hasIcon} is
+   * false. A cache-buster for the bundled-icon endpoint.
+   */
+  readonly iconVersion: string | null;
 }
 
 /** No installed copy and no catalog/source entry claims the name. */
@@ -148,6 +160,9 @@ export async function getPluginDetails(
 
   const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
   const local = readLocalPlugin(pluginsDir, name);
+  // Validate the installed copy's bundled icon.png (fail-closed: a missing or
+  // invalid icon — including a not-installed plugin — resolves to no icon).
+  const localIcon = readValidatedPluginIcon(join(pluginsDir, name));
 
   const marketplaceEntry = await findMarketplaceEntry(name, ref, fetchFn);
 
@@ -196,6 +211,8 @@ export async function getPluginDetails(
     ref,
     artifact: local.manifest.artifact ?? remote.manifest.artifact,
     icon: local.manifest.icon ?? remote.manifest.icon,
+    hasIcon: localIcon.hasIcon,
+    iconVersion: localIcon.iconVersion ?? null,
   };
 }
 

--- a/assistant/src/cli/lib/plugin-icon-file.ts
+++ b/assistant/src/cli/lib/plugin-icon-file.ts
@@ -1,0 +1,101 @@
+/**
+ * Validate a plugin's optional author-bundled `icon.png`.
+ *
+ * A plugin may ship a raster icon at a fixed path — `icon.png` in the plugin
+ * root. The filename is fixed (no author-controlled path) so there is no
+ * traversal surface. Validation is fail-closed: any problem — missing file,
+ * wrong magic bytes, oversized bytes, oversized dimensions, unreadable —
+ * resolves to `{ hasIcon: false }` and never throws, so callers can surface
+ * "no icon" uniformly without per-source error handling.
+ *
+ * PNG-only by design: a single well-known container keeps the parser tiny
+ * (magic signature + IHDR) and adds no dependency.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Fixed icon filename in the plugin root — no author path, no traversal. */
+const ICON_FILENAME = "icon.png";
+/** Byte cap: reject anything larger (also bounds what we read into memory). */
+const MAX_ICON_BYTES = 32 * 1024;
+/** Dimension cap (px) enforced against the IHDR width/height. */
+const MAX_ICON_DIMENSION = 128;
+/** PNG signature: the first 8 bytes of every PNG file. */
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+/** The first chunk of a valid PNG is always IHDR with a 13-byte payload. */
+const PNG_IHDR_LENGTH = 13;
+const PNG_IHDR_TYPE = Buffer.from("IHDR", "ascii");
+/** Smallest prefix we need: 8-byte magic + 8-byte chunk header + IHDR w/h. */
+const MIN_HEADER_BYTES = 24;
+
+/** Result of validating a plugin's `icon.png`. */
+export interface ValidatedPluginIcon {
+  /** Whether a valid icon was found. `false` for every failure mode. */
+  readonly hasIcon: boolean;
+  /** First 16 hex chars of sha256(bytes) — a stable content version. */
+  readonly iconVersion?: string;
+  /** Absolute path to the validated `icon.png`. */
+  readonly path?: string;
+}
+
+/**
+ * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
+ * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
+ * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
+ * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ */
+export function readValidatedPluginIcon(
+  pluginDir: string,
+): ValidatedPluginIcon {
+  const iconPath = join(pluginDir, ICON_FILENAME);
+
+  let bytes: Buffer;
+  try {
+    const stat = statSync(iconPath);
+    // Size-gate before reading so an oversized file never enters memory.
+    // A missing file throws here and is caught as "no icon".
+    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
+      return { hasIcon: false };
+    }
+    bytes = readFileSync(iconPath);
+  } catch {
+    return { hasIcon: false };
+  }
+
+  if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
+    return { hasIcon: false };
+  }
+  if (!bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return { hasIcon: false };
+  }
+
+  // The first chunk must be IHDR (length 13, type "IHDR") before its bytes
+  // can be read as dimensions — otherwise a non-PNG with the signature and
+  // small integers at offsets 16/20 would be accepted.
+  if (
+    bytes.readUInt32BE(8) !== PNG_IHDR_LENGTH ||
+    !bytes.subarray(12, 16).equals(PNG_IHDR_TYPE)
+  ) {
+    return { hasIcon: false };
+  }
+
+  // IHDR width/height: big-endian uint32 at byte offsets 16 and 20.
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_ICON_DIMENSION ||
+    height > MAX_ICON_DIMENSION
+  ) {
+    return { hasIcon: false };
+  }
+
+  const iconVersion = createHash("sha256")
+    .update(bytes)
+    .digest("hex")
+    .slice(0, 16);
+  return { hasIcon: true, iconVersion, path: iconPath };
+}

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -381,6 +381,10 @@ function pluginEntry(
     target: overrides.target ?? `/tmp/plugins/${overrides.name}`,
     packageJson: overrides.packageJson ?? null,
     issues: overrides.issues ?? [],
+    hasIcon: overrides.hasIcon ?? false,
+    ...(overrides.iconVersion !== undefined
+      ? { iconVersion: overrides.iconVersion }
+      : {}),
   };
 }
 
@@ -433,6 +437,8 @@ describe("GET /v1/plugins", () => {
       version: "1.2.3",
       path: "/workspace/plugins/alpha",
       category: null,
+      // No bundled `icon.png` on this fixture → hasIcon is false, iconVersion absent.
+      hasIcon: false,
     });
     // `issues` is omitted (not just undefined) when the entry is clean.
     expect("issues" in result.plugins[0]!).toBe(false);
@@ -528,6 +534,28 @@ describe("GET /v1/plugins", () => {
     expect(byId.get("with-icon")?.icon).toBe("🎨");
     // Absent icon is omitted from the wire object, not set to undefined/null.
     expect("icon" in byId.get("no-icon")!).toBe(false);
+  });
+
+  test("serializes hasIcon + iconVersion from the validated bundled icon.png", async () => {
+    installedFixture = [
+      pluginEntry({
+        name: "bundled",
+        packageJson: { name: "bundled", version: "1.0.0" },
+        hasIcon: true,
+        iconVersion: "deadbeefdeadbeef",
+      }),
+      pluginEntry({
+        name: "plain",
+        packageJson: { name: "plain", version: "1.0.0" },
+      }),
+    ];
+
+    const byId = new Map((await invoke()).plugins.map((p) => [p.id, p]));
+    expect(byId.get("bundled")?.hasIcon).toBe(true);
+    expect(byId.get("bundled")?.iconVersion).toBe("deadbeefdeadbeef");
+    // No valid icon → hasIcon false and iconVersion omitted (not null).
+    expect(byId.get("plain")?.hasIcon).toBe(false);
+    expect("iconVersion" in byId.get("plain")!).toBe(false);
   });
 
   test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {
@@ -1243,6 +1271,9 @@ function pluginDetails(overrides: Partial<PluginDetails> = {}): PluginDetails {
     readme: overrides.readme ?? null,
     ref: overrides.ref ?? "main",
     artifact: overrides.artifact ?? null,
+    icon: overrides.icon ?? null,
+    hasIcon: overrides.hasIcon ?? false,
+    iconVersion: overrides.iconVersion ?? null,
   };
 }
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -3,7 +3,7 @@
  *
  * GET /v1/plugins (list):
  *   - Projection from `InstalledPluginInfo` → response shape (id, name,
- *     description, version, path; issues omitted when empty)
+ *     description, version, path; issues + icon omitted when absent)
  *   - `?q=` substring filter (case-insensitive across id/name/description)
  *   - Trimming + empty-string fallthrough on `?q=`
  *   - Empty install dir → `{ plugins: [], categoryCounts: {}, totalCount: 0 }`
@@ -510,6 +510,24 @@ describe("GET /v1/plugins", () => {
 
     const [entry] = (await invoke()).plugins;
     expect(entry?.issues).toEqual(["missing package.json"]);
+  });
+
+  test("serializes `icon` from vellum.icon, omitting it when absent", async () => {
+    installedFixture = [
+      pluginEntry({
+        name: "with-icon",
+        packageJson: { name: "with-icon", version: "1.0.0", icon: "🎨" },
+      }),
+      pluginEntry({
+        name: "no-icon",
+        packageJson: { name: "no-icon", version: "1.0.0" },
+      }),
+    ];
+
+    const byId = new Map((await invoke()).plugins.map((p) => [p.id, p]));
+    expect(byId.get("with-icon")?.icon).toBe("🎨");
+    // Absent icon is omitted from the wire object, not set to undefined/null.
+    expect("icon" in byId.get("no-icon")!).toBe(false);
   });
 
   test("reports enabled: false for a plugin with a `.disabled` sentinel, true otherwise", async () => {

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -2465,7 +2465,7 @@ describe("GET /v1/plugins/:name/icon", () => {
 
     // Exact bytes flow through unmodified as an image/png body.
     expect(result).toBeInstanceOf(RouteResponse);
-    expect(Buffer.from(result.body as Uint8Array)).toEqual(bytes);
+    expect(Buffer.from(result.body as Uint8Array).equals(bytes)).toBe(true);
     expect(result.headers["Content-Type"]).toBe("image/png");
     expect(result.headers["Content-Length"]).toBe(String(bytes.length));
     // Private immutable cache + nosniff: an authenticated per-workspace

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -50,7 +50,9 @@
  * here we mock them to isolate the route's wiring logic.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   type DiffPluginDeps,
@@ -71,6 +73,7 @@ import {
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  sanitizePluginName,
 } from "../../../cli/lib/install-from-github.js";
 import type { InstalledPluginInfo } from "../../../cli/lib/list-installed-plugins.js";
 import {
@@ -174,6 +177,10 @@ mock.module("../../../cli/lib/install-from-github.js", () => ({
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  // The icon route calls the real name guard directly (it builds a filesystem
+  // path from `:name` rather than delegating to a lib that sanitizes), so pass
+  // the real `sanitizePluginName` through — a traversal name must still 400.
+  sanitizePluginName,
   installPlugin: installSpy,
 }));
 
@@ -316,6 +323,7 @@ mock.module("../../../skills/categories-cache.js", () => ({
   getLocalCategorySlugs: () => SKILLS_CATEGORY_SLUGS,
 }));
 
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import {
   BadRequestError,
   ConflictError,
@@ -329,6 +337,7 @@ import {
   ROUTES as PLUGINS_ROUTES,
 } from "../plugins-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+import { RouteResponse } from "../types.js";
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
   const route = PLUGINS_ROUTES.find((r) => r.operationId === operationId);
@@ -347,6 +356,7 @@ const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
 const enableHandler = findHandler("plugins_enable");
 const disableHandler = findHandler("plugins_disable");
+const iconHandler = findHandler("plugins_icon");
 
 async function invoke(args: RouteHandlerArgs = {}): Promise<{
   plugins: Array<Record<string, unknown>>;
@@ -2399,6 +2409,88 @@ describe("POST /v1/plugins/:name/disable", () => {
     });
 
     expect(() => invokeDisable({ pathParams: { name: "../escape" } })).toThrow(
+      BadRequestError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/plugins/:name/icon
+// ---------------------------------------------------------------------------
+
+const ICON_PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/** Minimal valid PNG: signature + IHDR width/height, within the 128×128 cap. */
+function makeIconPng(width = 64, height = 64): Buffer {
+  const buf = Buffer.alloc(24);
+  ICON_PNG_SIGNATURE.copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write("IHDR", 12, "ascii"); // IHDR chunk type
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+/**
+ * Create `<workspacePlugins>/<name>/`, optionally writing `icon.png` into it.
+ * Returns the plugin directory so the caller can clean it up. Uses the real
+ * `getWorkspacePluginsDir()` (rooted at the per-test temp workspace), so the
+ * route's real `readValidatedPluginIcon` + `readFileSync` path is exercised.
+ */
+function makePluginDir(name: string, icon?: Buffer): string {
+  const dir = join(getWorkspacePluginsDir(), name);
+  mkdirSync(dir, { recursive: true });
+  if (icon) writeFileSync(join(dir, "icon.png"), icon);
+  return dir;
+}
+
+describe("GET /v1/plugins/:name/icon", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("serves the validated icon.png as image/png with caching headers", () => {
+    const bytes = makeIconPng(64, 64);
+    created.push(makePluginDir("with-icon", bytes));
+
+    const result = iconHandler({
+      pathParams: { name: "with-icon" },
+    }) as RouteResponse;
+
+    // Exact bytes flow through unmodified as an image/png body.
+    expect(result).toBeInstanceOf(RouteResponse);
+    expect(Buffer.from(result.body as Uint8Array)).toEqual(bytes);
+    expect(result.headers["Content-Type"]).toBe("image/png");
+    expect(result.headers["Content-Length"]).toBe(String(bytes.length));
+    // Private immutable cache + nosniff: an authenticated per-workspace
+    // resource, content-addressed by the ETag; no shared cache may reuse it.
+    expect(result.headers["Cache-Control"]).toBe(
+      "private, max-age=31536000, immutable",
+    );
+    expect(result.headers["X-Content-Type-Options"]).toBe("nosniff");
+    // ETag is the quoted content-hash iconVersion (16 hex chars).
+    expect(result.headers.ETag).toMatch(/^"[0-9a-f]{16}"$/);
+  });
+
+  test("404 (NotFoundError) when the installed plugin ships no valid icon", () => {
+    // Directory exists but carries no icon.png → validator returns hasIcon:false.
+    created.push(makePluginDir("no-icon"));
+
+    expect(() => iconHandler({ pathParams: { name: "no-icon" } })).toThrow(
+      NotFoundError,
+    );
+  });
+
+  test("400 (BadRequestError) on a traversal / malformed name", () => {
+    // The name guard rejects `../escape` before it can become a filesystem
+    // path, so no icon is ever read for an out-of-tree name.
+    expect(() => iconHandler({ pathParams: { name: "../escape" } })).toThrow(
       BadRequestError,
     );
   });

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -138,6 +138,12 @@ const pluginInfoSchema = z.object({
     .describe(
       "Marketplace category slug (Skills taxonomy); null when origin/category is unknown, e.g. non-marketplace installs.",
     ),
+  icon: z
+    .string()
+    .optional()
+    .describe(
+      "Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.",
+    ),
 });
 
 const pluginsListResponseSchema = z.object({
@@ -658,6 +664,7 @@ interface PluginView {
   path: string;
   issues?: string[];
   category?: string | null;
+  icon?: string;
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -675,6 +682,9 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   };
   if (entry.issues.length > 0) {
     view.issues = [...entry.issues];
+  }
+  if (entry.packageJson?.icon !== undefined) {
+    view.icon = entry.packageJson.icon;
   }
   return view;
 }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -23,6 +23,9 @@
  * `get_route_schema` so the gateway's IPC proxy stays in sync.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { z } from "zod";
 
 import {
@@ -40,6 +43,7 @@ import {
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  sanitizePluginName,
 } from "../../cli/lib/install-from-github.js";
 import {
   type InstalledPluginInfo,
@@ -50,6 +54,7 @@ import {
   getPluginDetails,
   PluginDetailsNotFoundError,
 } from "../../cli/lib/plugin-details.js";
+import { readValidatedPluginIcon } from "../../cli/lib/plugin-icon-file.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
   listPinHistory,
@@ -82,6 +87,7 @@ import {
 } from "../../cli/lib/upgrade-plugin.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   getOriginClientId,
@@ -96,6 +102,7 @@ import {
   ServiceUnavailableError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import { RouteResponse } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -1363,6 +1370,50 @@ function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// Handler — icon (bundled icon.png)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serve an installed plugin's validated author-bundled `icon.png` as
+ * `image/png`. Side-effect-free: the on-disk icon is re-validated on read and
+ * never mutated. `sanitizePluginName` rejects a traversal name (`../escape`)
+ * with a 400 before it becomes a filesystem path. The content-hash
+ * `iconVersion` is the `ETag` and the bytes are immutable-cacheable, so a byte
+ * change yields a new hash — clients refetch off the `hasIcon` / `iconVersion`
+ * fields on the list / detail responses.
+ */
+function handleGetPluginIcon({
+  pathParams = {},
+}: RouteHandlerArgs): RouteResponse {
+  let name: string;
+  try {
+    name = sanitizePluginName(pathParams.name ?? "");
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+
+  const v = readValidatedPluginIcon(join(getWorkspacePluginsDir(), name));
+  if (!v.hasIcon || !v.path) {
+    throw new NotFoundError("Plugin icon not found");
+  }
+
+  const bytes = readFileSync(v.path);
+  return new RouteResponse(new Uint8Array(bytes), {
+    "Content-Type": "image/png",
+    "Content-Length": String(bytes.length),
+    // `private`: the icon is an authenticated, workspace-specific resource, so
+    // no shared/proxy cache may reuse it across requests. The content-hash
+    // ETag + immutable still let the browser cache aggressively.
+    "Cache-Control": "private, max-age=31536000, immutable",
+    ETag: `"${v.iconVersion}"`,
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -1495,6 +1546,36 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleGetPluginDetails,
+  },
+  {
+    operationId: "plugins_icon",
+    endpoint: "plugins/:name/icon",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Serve a plugin's bundled icon",
+    description:
+      "Serve the installed plugin's validated author-bundled `icon.png` as `image/png`. The PNG is re-validated on read (magic bytes + IHDR dimensions + size) and served with an immutable `Cache-Control` plus a content-hash `ETag` — the `iconVersion` reported by `GET /v1/plugins` and `GET /v1/plugins/:name` — so clients cache aggressively and only refetch when the hash changes. A plugin with no valid bundled icon returns 404; a malformed name returns 400. Pair with the `hasIcon` / `iconVersion` fields on the list and detail responses to decide whether to fetch.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description: "Install name (kebab-case).",
+      },
+    ],
+    responseBody: {
+      contentType: "image/png",
+      schema: { type: "string", format: "binary" },
+    },
+    additionalResponses: {
+      "404": {
+        description: "No installed plugin with the given name has an icon.",
+      },
+    },
+    handler: handleGetPluginIcon,
   },
   {
     operationId: "plugins_uninstall",

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -144,6 +144,18 @@ const pluginInfoSchema = z.object({
     .describe(
       "Author-declared emoji icon from the plugin's package.json vellum.icon; absent when none.",
     ),
+  hasIcon: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the plugin ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated). Drives whether a client fetches the bundled icon.",
+    ),
+  iconVersion: z
+    .string()
+    .optional()
+    .describe(
+      "Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for the bundled-icon endpoint.",
+    ),
 });
 
 const pluginsListResponseSchema = z.object({
@@ -285,6 +297,17 @@ const pluginDetailsResponseSchema = z.object({
     .nullable()
     .describe(
       "Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.",
+    ),
+  hasIcon: z
+    .boolean()
+    .describe(
+      "Whether the locally installed copy ships a valid author-bundled `icon.png` (PNG magic + dimensions + size validated). Always false when the plugin is not installed.",
+    ),
+  iconVersion: z
+    .string()
+    .nullable()
+    .describe(
+      "Content hash of the validated `icon.png`; null when `hasIcon` is false. Use it as a cache-buster for the bundled-icon endpoint.",
     ),
 });
 
@@ -671,6 +694,8 @@ interface PluginView {
   issues?: string[];
   category?: string | null;
   icon?: string;
+  hasIcon: boolean;
+  iconVersion?: string;
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -685,12 +710,16 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
     description: entry.packageJson?.description ?? null,
     version: entry.packageJson?.version ?? null,
     path: entry.target,
+    hasIcon: entry.hasIcon,
   };
   if (entry.issues.length > 0) {
     view.issues = [...entry.issues];
   }
   if (entry.packageJson?.icon !== undefined) {
     view.icon = entry.packageJson.icon;
+  }
+  if (entry.iconVersion !== undefined) {
+    view.iconVersion = entry.iconVersion;
   }
   return view;
 }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -280,6 +280,12 @@ const pluginDetailsResponseSchema = z.object({
     .describe(
       "Prebuilt client artifact from `package.json` `vellum.artifact`, or null when the plugin ships none or its descriptor is incomplete (e.g. a placeholder sha256).",
     ),
+  icon: z
+    .string()
+    .nullable()
+    .describe(
+      "Author-declared emoji icon from the plugin's `package.json` `vellum.icon`, or null when none.",
+    ),
 });
 
 const pluginInstallRequestSchema = z.object({

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -72,7 +72,8 @@ export type RouteResponseContentType =
   | "application/octet-stream"
   | "application/gzip"
   | "application/pdf"
-  | "application/zip";
+  | "application/zip"
+  | "image/png";
 
 /**
  * A route's success response body. Either:

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -14,9 +14,11 @@
  * Mounted via `@testing-library/react` (happy-dom — see `clients/web/test-setup.ts`).
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
 
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen.js";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift.js";
@@ -98,9 +100,29 @@ mock.module("@/domains/intelligence/plugins/use-plugin-toggle", () => ({
   usePluginToggle: () => ({ toggle: () => {}, togglingName: null }),
 }));
 
-const { PluginDetailMobile } = await import(
-  "@/domains/intelligence/components/plugins/plugin-detail-mobile.js"
-);
+const { PluginDetailMobile } =
+  await import("@/domains/intelligence/components/plugins/plugin-detail-mobile.js");
+
+// The mobile detail renders the real `usePluginIconSrc`, whose `useQuery` needs
+// a client. These fixtures all ship `hasIcon: false`, so the icon query stays
+// disabled (no fetch) — the provider just satisfies the hook.
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderMobile(ui: ReactElement) {
+  return render(ui, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+});
 
 afterEach(() => {
   cleanup();
@@ -133,8 +155,12 @@ describe("PluginDetailMobile", () => {
   test("back button calls onBack", () => {
     const onBack = mock(() => {});
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={onBack} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={onBack}
+      />,
     );
 
     fireEvent.click(getButton("Back to plugins"));
@@ -148,8 +174,12 @@ describe("PluginDetailMobile", () => {
       description: "A long description that should not be clamped.",
     });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="My Plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="My Plugin"
+        onBack={() => {}}
+      />,
     );
 
     // Title appears both in the action bar and the header block.
@@ -162,8 +192,12 @@ describe("PluginDetailMobile", () => {
   test("renders the README markdown", () => {
     hookState.plugin = makePlugin({ readme: "# Readme heading" });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(screen.getByText("Readme heading")).toBeTruthy();
@@ -172,8 +206,12 @@ describe("PluginDetailMobile", () => {
   test("uninstalled plugin: install action appears", () => {
     hookState.plugin = makePlugin({ installed: false });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(getActionButton("Install")).toBeTruthy();
@@ -184,8 +222,12 @@ describe("PluginDetailMobile", () => {
   test("installed plugin: remove action appears", () => {
     hookState.plugin = makePlugin({ installed: true });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(getActionButton("Remove")).toBeTruthy();
@@ -194,7 +236,7 @@ describe("PluginDetailMobile", () => {
   test("installed plugin: auto-include toggle appears when enabled is provided", () => {
     hookState.plugin = makePlugin({ installed: true });
 
-    render(
+    renderMobile(
       <PluginDetailMobile
         assistantId="asst-1"
         name="test-plugin"
@@ -211,8 +253,12 @@ describe("PluginDetailMobile", () => {
   test("installed plugin: no toggle when enabled is undefined", () => {
     hookState.plugin = makePlugin({ installed: true });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(screen.queryByRole("switch")).toBeNull();
@@ -224,8 +270,12 @@ describe("PluginDetailMobile", () => {
     hookState.plugin = null;
     hookState.isLoading = true;
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(document.body.textContent).not.toContain(PUZZLE);
@@ -236,7 +286,7 @@ describe("PluginDetailMobile", () => {
     hookState.plugin = null;
     hookState.isLoading = true;
 
-    render(
+    renderMobile(
       <PluginDetailMobile
         assistantId="asst-1"
         name="test-plugin"
@@ -254,8 +304,12 @@ describe("PluginDetailMobile", () => {
       source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
     });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(document.body.textContent).toContain(PACKAGE);
@@ -268,8 +322,12 @@ describe("PluginDetailMobile", () => {
       source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
     });
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(document.body.textContent).toContain("\u{1F3A8}");
@@ -283,8 +341,12 @@ describe("PluginDetailMobile", () => {
     hookState.plugin = null;
     hookState.isLoading = true;
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(screen.queryByText("Local")).toBeNull();
@@ -298,8 +360,12 @@ describe("PluginDetailMobile", () => {
     hookState.plugin = makePlugin({ installed: true });
     hookState.drift = UPDATE_DRIFT;
 
-    render(
-      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    renderMobile(
+      <PluginDetailMobile
+        assistantId="asst-1"
+        name="test-plugin"
+        onBack={() => {}}
+      />,
     );
 
     expect(getActionButton("Upgrade")).toBeTruthy();

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.test.tsx
@@ -35,6 +35,9 @@ function makePlugin(
     readme: "# Readme heading",
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
     ...overrides,
   };
 }
@@ -256,6 +259,21 @@ describe("PluginDetailMobile", () => {
     );
 
     expect(document.body.textContent).toContain(PACKAGE);
+    expect(document.body.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the author emoji when the plugin declares one, overriding the origin glyph", () => {
+    hookState.plugin = makePlugin({
+      icon: "\u{1F3A8}", // 🎨
+      source: { kind: "github", repo: "vellum-ai/level-up", ref: "main" },
+    });
+
+    render(
+      <PluginDetailMobile assistantId="asst-1" name="test-plugin" onBack={() => {}} />,
+    );
+
+    expect(document.body.textContent).toContain("\u{1F3A8}");
+    expect(document.body.textContent).not.toContain(PACKAGE);
     expect(document.body.textContent).not.toContain(PUZZLE);
   });
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -135,7 +135,11 @@ export function PluginDetailMobile({
             {resolvedExternal === undefined ? (
               <span aria-hidden className="h-8 w-8 shrink-0" />
             ) : (
-              <PluginIcon external={resolvedExternal} size="md" />
+              <PluginIcon
+                external={resolvedExternal}
+                icon={plugin?.icon ?? undefined}
+                size="md"
+              />
             )}
             <h2
               className="min-w-0 truncate text-title-medium"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -14,6 +14,7 @@ import {
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon-src";
 import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import { Button, Card } from "@vellumai/design-library";
 
@@ -91,6 +92,13 @@ export function PluginDetailMobile({
   const updateAvailable = drift?.status === "update-available";
   const title = plugin?.name ?? name;
 
+  const iconSrc = usePluginIconSrc(
+    assistantId,
+    name,
+    plugin?.hasIcon,
+    plugin?.iconVersion,
+  );
+
   const overlay = (
     <div
       className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-[var(--surface-overlay)]"
@@ -138,6 +146,7 @@ export function PluginDetailMobile({
               <PluginIcon
                 external={resolvedExternal}
                 icon={plugin?.icon ?? undefined}
+                iconSrc={iconSrc}
                 size="md"
               />
             )}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.test.tsx
@@ -32,6 +32,9 @@ const githubPlugin: PluginsByNameGetResponse = {
   readme: "# Level Up",
   ref: "main",
   artifact: null,
+  icon: null,
+  hasIcon: false,
+  iconVersion: null,
 };
 
 describe("PluginDetailMetadata", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -12,9 +12,9 @@
  * exercised.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import {
   pluginsByNameGetQueryKey,
@@ -29,6 +29,8 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-detail";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-plugin-icons";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 const ASSISTANT_ID = "asst-1";
 const LOCAL_COMMIT = "60a392b0000000000000000000000000000000aa";
@@ -39,9 +41,18 @@ const PUZZLE = "\u{1F9E9}"; // 🧩 — local glyph
 
 const realFetch = globalThis.fetch;
 
+beforeEach(() => {
+  // happy-dom doesn't implement object URLs; the icon hook turns the fetched
+  // blob into one.
+  globalThis.URL.createObjectURL = () => "blob:detail-icon";
+  globalThis.URL.revokeObjectURL = () => undefined;
+});
+
 afterEach(() => {
   cleanup();
   globalThis.fetch = realFetch;
+  // Reset the version gate PluginDetail reads for the bundled icon.
+  useAssistantIdentityStore.setState({ version: null });
 });
 
 /**
@@ -130,6 +141,7 @@ function renderDetail(
   name: string,
   detail: PluginsByNameGetResponse,
   inspect: PluginsByNameInspectGetResponse,
+  opts: { seedIconBlob?: Blob } = {},
 ) {
   const client = new QueryClient({
     // Infinite stale time keeps the seeded queries from refetching on mount
@@ -151,6 +163,14 @@ function renderDetail(
     } as Options<PluginsByNameInspectGetData>),
     inspect,
   );
+  if (opts.seedIconBlob) {
+    // Mirror `usePluginIconSrc`'s query key so the icon fetch resolves from
+    // cache (staleTime infinity) without a network call.
+    client.setQueryData(
+      ["pluginIcon", ASSISTANT_ID, name, detail.iconVersion],
+      opts.seedIconBlob,
+    );
+  }
   const onBack = mock(() => {});
   const result = render(
     <QueryClientProvider client={client}>
@@ -354,6 +374,71 @@ describe("PluginDetail", () => {
     expect(container.textContent).toContain(AUTHOR_EMOJI);
     expect(container.textContent).not.toContain(PACKAGE);
     expect(container.textContent).not.toContain(PUZZLE);
+  });
+
+  test("supporting daemon + hasIcon renders the bundled-icon <img> from the fetched blob", async () => {
+    useAssistantIdentityStore.setState({ version: MIN_VERSION });
+
+    const { container } = renderDetail(
+      "simple-memory",
+      {
+        name: "simple-memory",
+        installed: true,
+        description: null,
+        homepage: null,
+        license: null,
+        version: "0.1.0",
+        source: null,
+        readme: null,
+        ref: "main",
+        artifact: null,
+        icon: null,
+        hasIcon: true,
+        iconVersion: "v9",
+      },
+      upToDateInspect("simple-memory", true),
+      { seedIconBlob: new Blob(["icon"]) },
+    );
+
+    // The image renders once the fetched blob's object URL is created.
+    const img = await waitFor(() => {
+      const el = container.querySelector("img");
+      if (!el) {
+        throw new Error("icon <img> not rendered yet");
+      }
+      return el;
+    });
+    expect(img.getAttribute("src")).toBe("blob:detail-icon");
+    // With the image showing, neither origin glyph is rendered.
+    expect(container.textContent).not.toContain(PUZZLE);
+    expect(container.textContent).not.toContain(PACKAGE);
+  });
+
+  test("gate off (older daemon) renders no <img> even with hasIcon", () => {
+    // Version stays null (default) — the daemon doesn't serve the icon endpoint.
+    const { container } = renderDetail(
+      "simple-memory",
+      {
+        name: "simple-memory",
+        installed: true,
+        description: null,
+        homepage: null,
+        license: null,
+        version: "0.1.0",
+        source: null,
+        readme: null,
+        ref: "main",
+        artifact: null,
+        icon: null,
+        hasIcon: true,
+        iconVersion: "v9",
+      },
+      upToDateInspect("simple-memory", true),
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    // Falls back to the local origin glyph.
+    expect(container.textContent).toContain(PUZZLE);
   });
 
   test("invokes onBack when the back button is clicked", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.test.tsx
@@ -175,6 +175,9 @@ describe("PluginDetail", () => {
         readme: "# Caveman\n\nMakes the agent speak in grunts.",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );
@@ -207,6 +210,9 @@ describe("PluginDetail", () => {
         readme: null,
         ref: "main",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("simple-memory", true),
     );
@@ -235,6 +241,9 @@ describe("PluginDetail", () => {
         readme: "# Level Up",
         ref: "main",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       updateAvailableInspect("level-up"),
     );
@@ -266,6 +275,9 @@ describe("PluginDetail", () => {
         readme: "# Dynamic Notch",
         ref: "v1.0.0",
         artifact: { url, sha256: "a".repeat(64), label: "Download for macOS" },
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("dynamic-notch", true),
     );
@@ -306,11 +318,41 @@ describe("PluginDetail", () => {
         readme: "# Caveman",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );
 
     expect(container.textContent).toContain(PACKAGE);
+    expect(container.textContent).not.toContain(PUZZLE);
+  });
+
+  test("renders the author emoji when the plugin declares one, overriding the origin glyph", () => {
+    const AUTHOR_EMOJI = "\u{1F3A8}"; // 🎨
+    const { container } = renderDetail(
+      "caveman",
+      {
+        name: "caveman",
+        installed: false,
+        description: "Talk like a caveman.",
+        homepage: null,
+        license: null,
+        version: "1.8.2",
+        source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
+        readme: "# Caveman",
+        ref: "v1.8.2",
+        artifact: null,
+        icon: AUTHOR_EMOJI,
+        hasIcon: false,
+        iconVersion: null,
+      },
+      upToDateInspect("caveman", false),
+    );
+
+    expect(container.textContent).toContain(AUTHOR_EMOJI);
+    expect(container.textContent).not.toContain(PACKAGE);
     expect(container.textContent).not.toContain(PUZZLE);
   });
 
@@ -328,6 +370,9 @@ describe("PluginDetail", () => {
         readme: "# Caveman",
         ref: "v1.8.2",
         artifact: null,
+        icon: null,
+        hasIcon: false,
+        iconVersion: null,
       },
       upToDateInspect("caveman", false),
     );

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -3,15 +3,16 @@ import { ArrowLeft } from "lucide-react";
 import { FileMarkdown } from "@/components/file-markdown";
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import {
-    PluginDetailActionError,
-    PluginDetailActions,
-    PluginDetailError,
-    PluginDetailLoading,
-    PluginDetailMetadata,
+  PluginDetailActionError,
+  PluginDetailActions,
+  PluginDetailError,
+  PluginDetailLoading,
+  PluginDetailMetadata,
 } from "@/domains/intelligence/components/plugins/plugin-detail-shared";
 import { PluginOriginBadge } from "@/domains/intelligence/components/plugins/plugin-origin-badge";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
+import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon-src";
 import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
@@ -72,6 +73,13 @@ export function PluginDetail({
 
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
+  const iconSrc = usePluginIconSrc(
+    assistantId,
+    name,
+    plugin?.hasIcon,
+    plugin?.iconVersion,
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="mb-4 flex items-start gap-3">
@@ -86,6 +94,7 @@ export function PluginDetail({
           name={name}
           plugin={plugin}
           externalHint={externalHint}
+          iconSrc={iconSrc}
           drift={drift}
           onInstall={install}
           onRemove={remove}
@@ -142,6 +151,8 @@ interface HeaderProps {
   name: string;
   plugin: PluginsByNameGetResponse | null;
   externalHint?: boolean;
+  /** Bundled-icon object URL, gated + fetched by the parent; `undefined` → emoji/glyph. */
+  iconSrc?: string;
   drift: PluginDrift | undefined;
   onInstall: () => void;
   onRemove: () => void;
@@ -159,6 +170,7 @@ function Header({
   name,
   plugin,
   externalHint,
+  iconSrc,
   drift,
   onInstall,
   onRemove,
@@ -189,6 +201,7 @@ function Header({
           <PluginIcon
             external={resolvedExternal}
             icon={plugin?.icon ?? undefined}
+            iconSrc={iconSrc}
             size="md"
           />
         )}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -186,7 +186,11 @@ function Header({
         {resolvedExternal === undefined ? (
           <span aria-hidden className="h-8 w-8 shrink-0" />
         ) : (
-          <PluginIcon external={resolvedExternal} size="md" />
+          <PluginIcon
+            external={resolvedExternal}
+            icon={plugin?.icon ?? undefined}
+            size="md"
+          />
         )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,14 +1,16 @@
 /**
- * Tests for `PluginIcon`: the author `icon` emoji, glyph defaulting by
- * `external`, and the `sm` / `md` container sizing that matches `SkillIcon`.
+ * Tests for `PluginIcon`: the bundled `iconSrc` image (and its `onError`
+ * fallback), the author `icon` emoji, glyph defaulting by `external`, and the
+ * `sm` / `md` container sizing that matches `SkillIcon`.
  *
  * Mounted via `@testing-library/react` (happy-dom — see
- * `clients/web/test-setup.ts`).
+ * `clients/web/test-setup.ts`); fires a real `error` event on the `<img>` to
+ * exercise the `useState`-driven fallback.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon.js";
 
@@ -20,6 +22,51 @@ const PACKAGE = "\u{1F4E6}"; // 📦
 const PUZZLE = "\u{1F9E9}"; // 🧩
 
 describe("PluginIcon", () => {
+  test("renders a lazy, decorative <img> when iconSrc is provided", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" icon="🚀" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/x.png");
+    expect(img!.getAttribute("loading")).toBe("lazy");
+    expect(img!.getAttribute("alt")).toBe("");
+    expect(img!.getAttribute("aria-hidden")).toBe("true");
+    // The image wins over the emoji, so no glyph text renders alongside it.
+    expect(container.textContent).toBe("");
+  });
+
+  test("falls back to the icon emoji when the image errors", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" icon="🚀" />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe("🚀");
+  });
+
+  test("retries the image when iconSrc changes after a failure", () => {
+    const { container, rerender } = render(
+      <PluginIcon iconSrc="/a.png" icon="🚀" />,
+    );
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    rerender(<PluginIcon iconSrc="/b.png" icon="🚀" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/b.png");
+  });
+
+  test("falls back to 📦 when the image errors, no icon, external", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" external />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(PACKAGE);
+  });
+
+  test("falls back to 🧩 when the image errors, no icon, not external", () => {
+    const { container } = render(<PluginIcon iconSrc="/x.png" />);
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(PUZZLE);
+  });
+
   test("renders the provided icon emoji", () => {
     const { container } = render(<PluginIcon icon="🚀" />);
     expect(container.textContent).toBe("🚀");

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Tests for `PluginIcon`: glyph defaulting by `external` and the `sm` / `md`
- * container sizing that matches `SkillIcon`.
+ * Tests for `PluginIcon`: the author `icon` emoji, glyph defaulting by
+ * `external`, and the `sm` / `md` container sizing that matches `SkillIcon`.
  *
  * Mounted via `@testing-library/react` (happy-dom — see
  * `clients/web/test-setup.ts`).
@@ -20,6 +20,11 @@ const PACKAGE = "\u{1F4E6}"; // 📦
 const PUZZLE = "\u{1F9E9}"; // 🧩
 
 describe("PluginIcon", () => {
+  test("renders the provided icon emoji", () => {
+    const { container } = render(<PluginIcon icon="🚀" />);
+    expect(container.textContent).toBe("🚀");
+  });
+
   test("defaults to 📦 when external", () => {
     const { container } = render(<PluginIcon external />);
     expect(container.textContent).toBe(PACKAGE);

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from "react";
+
 import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
   icon?: string;
+  iconSrc?: string;
   size?: "sm" | "md";
   className?: string;
 }
@@ -13,19 +16,29 @@ const SIZE_CLASS = {
 } as const;
 
 /**
- * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
- * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
- * icon-image endpoint, so there is no remote-image branch. Renders the
- * author-provided `icon` emoji when present, otherwise the origin glyph:
- * 📦 for catalog (external), 🧩 otherwise.
+ * Icon for a plugin, mirroring `SkillIcon`'s container dimensions for
+ * Plugins-tab / Skills-tab parity. A dumb renderer: the caller decides
+ * `iconSrc` (only when a gate passes and the plugin ships an icon). Render
+ * precedence — a bundled `iconSrc` image, then the author-provided `icon`
+ * emoji, then the origin glyph (📦 for catalog/external, 🧩 otherwise). A
+ * failed image load falls through to the emoji/glyph chain.
  */
 export function PluginIcon({
   external = false,
   icon,
+  iconSrc,
   size = "sm",
   className,
 }: PluginIconProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  // Retry the image when the source changes (e.g. a new icon URL or a
+  // cache-busting version) so a past failure doesn't pin a reused instance
+  // to the fallback.
+  useEffect(() => {
+    setImageFailed(false);
+  }, [iconSrc]);
   const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
+  const showImage = Boolean(iconSrc) && !imageFailed;
 
   return (
     <span
@@ -35,7 +48,18 @@ export function PluginIcon({
         className,
       )}
     >
-      {glyph}
+      {showImage ? (
+        <img
+          src={iconSrc}
+          alt=""
+          aria-hidden
+          loading="lazy"
+          className="h-full w-full object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        glyph
+      )}
     </span>
   );
 }

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
+  icon?: string;
   size?: "sm" | "md";
   className?: string;
 }
@@ -14,16 +15,17 @@ const SIZE_CLASS = {
 /**
  * Emoji-only icon for a plugin, mirroring `SkillIcon`'s container
  * dimensions for Plugins-tab / Skills-tab parity. Plugins have no
- * icon-image endpoint, so there is no remote-image branch. The glyph
- * follows the existing Plugins convention: 📦 for catalog (external),
- * 🧩 otherwise.
+ * icon-image endpoint, so there is no remote-image branch. Renders the
+ * author-provided `icon` emoji when present, otherwise the origin glyph:
+ * 📦 for catalog (external), 🧩 otherwise.
  */
 export function PluginIcon({
   external = false,
+  icon,
   size = "sm",
   className,
 }: PluginIconProps) {
-  const glyph = external ? "\u{1F4E6}" : "\u{1F9E9}";
+  const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
 
   return (
     <span

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -12,20 +12,57 @@
  * The Upgrade affordance is gated on `update-available` drift, so it only
  * appears when that signal is passed in.
  *
+ * The bundled icon is fetched through the authenticated daemon client (see
+ * `usePluginIconSrc`), so the rows are wrapped in a `QueryClientProvider` and
+ * the icon test seeds the fetched blob into the cache; object URLs are stubbed
+ * (happy-dom has none).
+ *
  * Mounted via `@testing-library/react` (happy-dom — see
  * `clients/web/test-setup.ts`).
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
-
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
 
 import { PluginListRow } from "@/domains/intelligence/components/plugins/plugin-list-row.js";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types.js";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift.js";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-plugin-icons.js";
+
+const ASSISTANT_ID = "asst-1";
+
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+// Wrap every row so `usePluginIconSrc`'s `useQuery` has a client. The wrapper
+// is re-applied on `rerender`, so the same client is reused across re-renders.
+function renderRow(ui: ReactElement) {
+  return render(ui, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  // happy-dom doesn't implement object URLs.
+  globalThis.URL.createObjectURL = () => "blob:row-icon";
+  globalThis.URL.revokeObjectURL = () => undefined;
+});
 
 afterEach(() => {
   cleanup();
+  // Reset the version gate that PluginListRow reads for the bundled icon.
+  useAssistantIdentityStore.setState({ version: null });
 });
 
 function makeItem(overrides: Partial<PluginListItem> = {}): PluginListItem {
@@ -61,8 +98,12 @@ describe("PluginListRow", () => {
   test("clicking the row fires onSelect", () => {
     const onSelect = mock(() => {});
 
-    const { getByText } = render(
-      <PluginListRow item={makeItem()} onSelect={onSelect} />,
+    const { getByText } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem()}
+        onSelect={onSelect}
+      />,
     );
 
     fireEvent.click(getByText("Test Plugin"));
@@ -74,8 +115,9 @@ describe("PluginListRow", () => {
     const onSelect = mock(() => {});
     const onRemove = mock(() => {});
 
-    render(
+    renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         onSelect={onSelect}
         onRemove={onRemove}
@@ -92,8 +134,9 @@ describe("PluginListRow", () => {
     const onSelect = mock(() => {});
     const onInstall = mock(() => {});
 
-    render(
+    renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "available" })}
         onSelect={onSelect}
         onInstall={onInstall}
@@ -110,8 +153,9 @@ describe("PluginListRow", () => {
     const onSelect = mock(() => {});
     const onRemove = mock(() => {});
 
-    render(
+    renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         onSelect={onSelect}
         onRemove={onRemove}
@@ -129,8 +173,9 @@ describe("PluginListRow", () => {
     const onSelect = mock(() => {});
     const onUpgrade = mock(() => {});
 
-    render(
+    renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         drift={makeDrift("update-available")}
         onSelect={onSelect}
@@ -145,8 +190,9 @@ describe("PluginListRow", () => {
   });
 
   test("Remove is disabled while an upgrade is in flight (no concurrent delete)", () => {
-    render(
+    renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         drift={makeDrift("update-available")}
         onSelect={() => {}}
@@ -162,8 +208,9 @@ describe("PluginListRow", () => {
   test("does not render an origin badge (origin is unknowable from the list)", () => {
     const onSelect = mock(() => {});
 
-    const { container } = render(
+    const { container } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed", external: false })}
         onSelect={onSelect}
       />,
@@ -182,8 +229,9 @@ describe("PluginListRow", () => {
     const onUpgrade = mock(() => {});
 
     // Up-to-date installed plugin shows Remove, not Upgrade.
-    const { rerender } = render(
+    const { rerender } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         drift={makeDrift("up-to-date")}
         onSelect={onSelect}
@@ -201,6 +249,7 @@ describe("PluginListRow", () => {
     // Same plugin with drift now exposes Upgrade (Remove stays put).
     rerender(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         drift={makeDrift("update-available")}
         onSelect={onSelect}
@@ -214,8 +263,9 @@ describe("PluginListRow", () => {
   });
 
   test("Enabled installed row shows an Enabled tag beside Remove (no toggle)", () => {
-    const { getByText } = render(
+    const { getByText } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed", enabled: true })}
         onSelect={mock(() => {})}
         onRemove={mock(() => {})}
@@ -231,8 +281,9 @@ describe("PluginListRow", () => {
   });
 
   test("Disabled row is dimmed and shows a Disabled tag", () => {
-    const { getByText } = render(
+    const { getByText } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed", enabled: false })}
         onSelect={mock(() => {})}
       />,
@@ -244,8 +295,9 @@ describe("PluginListRow", () => {
   });
 
   test("drift renders the Update chip (Remove stays), even when Disabled", () => {
-    const { getByText } = render(
+    const { getByText } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed", enabled: false })}
         drift={makeDrift("update-available")}
         onSelect={mock(() => {})}
@@ -266,8 +318,9 @@ describe("PluginListRow", () => {
   });
 
   test("available row shows only Install (no tag, no Remove)", () => {
-    const { queryByText } = render(
+    const { queryByText } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "available" })}
         onSelect={mock(() => {})}
         onInstall={mock(() => {})}
@@ -284,9 +337,77 @@ describe("PluginListRow", () => {
     ).toBeNull();
   });
 
-  test("installed row without `enabled` (older daemon) renders no tag", () => {
-    const { queryByText } = render(
+  test("supporting daemon + hasIcon renders the bundled-icon <img> from the fetched blob", async () => {
+    useAssistantIdentityStore.setState({ version: MIN_VERSION });
+    // Seed the icon fetch so the hook resolves it to an object URL without a
+    // network call (key mirrors `usePluginIconSrc`'s query key).
+    queryClient.setQueryData(
+      ["pluginIcon", ASSISTANT_ID, "cool plugin", "abc123"],
+      new Blob(["icon"]),
+    );
+
+    const { container } = renderRow(
       <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({
+          name: "cool plugin",
+          status: "installed",
+          hasIcon: true,
+          iconVersion: "abc123",
+        })}
+        onSelect={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    // The image renders once the fetched blob's object URL is created.
+    const img = await waitFor(() => {
+      const el = container.querySelector("img");
+      if (!el) {
+        throw new Error("icon <img> not rendered yet");
+      }
+      return el;
+    });
+    expect(img.getAttribute("src")).toBe("blob:row-icon");
+  });
+
+  test("gate off (older daemon) renders no <img> even with hasIcon", () => {
+    // Version stays null (default) — the daemon doesn't serve the icon endpoint.
+    const { container } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({
+          status: "installed",
+          hasIcon: true,
+          iconVersion: "abc123",
+        })}
+        onSelect={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  test("supporting daemon but no hasIcon renders no <img>", () => {
+    useAssistantIdentityStore.setState({ version: MIN_VERSION });
+
+    const { container } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({ status: "installed", hasIcon: false })}
+        onSelect={mock(() => {})}
+        onRemove={mock(() => {})}
+      />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  test("installed row without `enabled` (older daemon) renders no tag", () => {
+    const { queryByText } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
         item={makeItem({ status: "installed" })}
         onSelect={mock(() => {})}
         onRemove={mock(() => {})}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -66,6 +66,7 @@ export function PluginListRow({
         <PluginIcon
           size="sm"
           external={item.external}
+          icon={item.icon}
           className={dimmed ? "opacity-50" : undefined}
         />
         <div className="min-w-0 flex-1">

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -4,10 +4,13 @@ import type { KeyboardEvent } from "react";
 import { PluginIcon } from "@/domains/intelligence/components/plugins/plugin-icon";
 import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/update-available-badge";
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
+import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon-src";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import { Button, Card, Tag } from "@vellumai/design-library";
 
 interface PluginListRowProps {
+  /** Owning assistant — used to fetch the bundled icon through the daemon client. */
+  assistantId: string;
   item: PluginListItem;
   /** Inspect result for the installed copy; owned by the tab, passed in so
    *  the row stays presentational. Gates the upgrade affordance. */
@@ -27,6 +30,7 @@ interface PluginListRowProps {
  * `stopPropagation`s so it never also selects the row.
  */
 export function PluginListRow({
+  assistantId,
   item,
   drift,
   onSelect,
@@ -43,6 +47,13 @@ export function PluginListRow({
   // it happens on the detail page (the row is not interactive).
   const showEnablement = item.enabled !== undefined;
   const dimmed = item.enabled === false;
+
+  const iconSrc = usePluginIconSrc(
+    assistantId,
+    item.name,
+    item.hasIcon,
+    item.iconVersion,
+  );
 
   const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     // Ignore key events bubbling up from a focused inline action button —
@@ -67,6 +78,7 @@ export function PluginListRow({
           size="sm"
           external={item.external}
           icon={item.icon}
+          iconSrc={iconSrc}
           className={dimmed ? "opacity-50" : undefined}
         />
         <div className="min-w-0 flex-1">
@@ -110,7 +122,9 @@ export function PluginListRow({
           {item.issues && item.issues.length > 0 ? (
             <p
               className="mt-1 truncate text-body-small-default"
-              style={{ color: "var(--content-warning, var(--content-tertiary))" }}
+              style={{
+                color: "var(--content-warning, var(--content-tertiary))",
+              }}
               title={item.issues.join("; ")}
             >
               {item.issues[0]}

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -178,6 +178,9 @@ function pluginDetail(name: string): PluginsByNameGetResponse {
     readme: null,
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
   };
 }
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -345,6 +345,7 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
                 />
               ) : (
                 <PluginListRow
+                  assistantId={assistantId}
                   item={item}
                   onSelect={() => handleSelect(item)}
                   onInstall={() => handleInstall(item)}
@@ -537,6 +538,7 @@ function InstalledPluginRow({
 
   return (
     <PluginListRow
+      assistantId={assistantId}
       item={item}
       drift={drift}
       onSelect={onSelect}

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -49,6 +49,17 @@ export interface PluginListItem {
    * when the plugin declares no icon; the row falls back to 📦/🧩.
    */
   icon?: string;
+  /**
+   * Whether the installed copy ships a valid author-bundled `icon.png`.
+   * Installed rows only. `undefined` on the catalog and on daemons that
+   * predate the icon endpoint; the icon `<img>` renders only when this is true.
+   */
+  hasIcon?: boolean;
+  /**
+   * Content hash of the bundled `icon.png`, used as the icon endpoint's
+   * cache-buster. Present only when `hasIcon` is true.
+   */
+  iconVersion?: string;
 }
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
@@ -75,6 +86,8 @@ interface InstalledPluginSource {
   issues?: string[];
   enabled?: boolean;
   icon?: string;
+  hasIcon?: boolean;
+  iconVersion?: string;
 }
 
 interface CatalogPluginSource {

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -43,6 +43,12 @@ export interface PluginListItem {
    * predate the enable/disable surface (version-skew safeguard).
    */
   enabled?: boolean;
+  /**
+   * Author-declared emoji (`package.json` `vellum.icon`), shown in the row
+   * icon. Installed rows only — the catalog endpoint carries none. `undefined`
+   * when the plugin declares no icon; the row falls back to 📦/🧩.
+   */
+  icon?: string;
 }
 
 /** Generated element type for an installed plugin (`pluginsGet`). */
@@ -68,6 +74,7 @@ interface InstalledPluginSource {
   path?: string;
   issues?: string[];
   enabled?: boolean;
+  icon?: string;
 }
 
 interface CatalogPluginSource {

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.test.ts
@@ -95,6 +95,9 @@ function installedDetail(name: string): PluginsByNameGetResponse {
     readme: "# Level Up",
     ref: "main",
     artifact: null,
+    icon: null,
+    hasIcon: false,
+    iconVersion: null,
   };
 }
 

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for `usePluginIconSrc`. The hook fetches the bundled icon through the
+ * authenticated daemon client (so the request interceptor + auth run, unlike a
+ * bare `<img src>`) and returns it as an object URL, or `undefined` when the
+ * version gate is off or the plugin ships no icon (in which case it never
+ * fetches).
+ *
+ * The generated SDK and the object-URL helpers are mocked; the version gate is
+ * driven the real way, by seeding the assistant identity store (the SDK mock
+ * spreads the real module so no export is dropped for other suites in the run).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-plugin-icons";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+const ASSISTANT_ID = "asst-1";
+const NAME = "simple-memory";
+const VERSION = "abc123";
+
+type IconResult = { data: Blob | null; error: { message: string } | null };
+
+// Per-test holder the SDK mock reads.
+let iconResult: IconResult;
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+const pluginsByNameIconGetSpy = mock(
+  async (_options: unknown): Promise<IconResult> => iconResult,
+);
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsByNameIconGet: pluginsByNameIconGetSpy,
+}));
+
+// happy-dom doesn't implement object URLs.
+const createObjectURL = mock(
+  (_obj: Blob | MediaSource): string => "blob:icon-mock",
+);
+const revokeObjectURL = mock((_url: string): void => undefined);
+globalThis.URL.createObjectURL = createObjectURL;
+globalThis.URL.revokeObjectURL = revokeObjectURL;
+
+const { usePluginIconSrc } =
+  await import("@/domains/intelligence/plugins/use-plugin-icon-src");
+
+function renderIconSrc(
+  hasIcon: boolean | undefined,
+  iconVersion: string | null | undefined,
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+  return renderHook(
+    () => usePluginIconSrc(ASSISTANT_ID, NAME, hasIcon, iconVersion),
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  // Gate open by default; individual cases override.
+  useAssistantIdentityStore.setState({ version: MIN_VERSION });
+  iconResult = { data: new Blob(["icon"]), error: null };
+  pluginsByNameIconGetSpy.mockClear();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.setState({ version: null });
+});
+
+describe("usePluginIconSrc", () => {
+  test("fetches through the daemon client and returns an object URL when gated + hasIcon", async () => {
+    const { result } = renderIconSrc(true, VERSION);
+
+    await waitFor(() => expect(result.current).toBe("blob:icon-mock"));
+
+    expect(pluginsByNameIconGetSpy).toHaveBeenCalledTimes(1);
+    expect(pluginsByNameIconGetSpy.mock.calls[0]![0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: NAME },
+      parseAs: "blob",
+    });
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns undefined and never fetches when the version gate is off", async () => {
+    // Older daemon: no icon endpoint.
+    useAssistantIdentityStore.setState({ version: null });
+
+    const { result } = renderIconSrc(true, VERSION);
+
+    // Give any (unexpected) query a chance to fire before asserting no fetch.
+    await Promise.resolve();
+    expect(result.current).toBeUndefined();
+    expect(pluginsByNameIconGetSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns undefined and never fetches when the plugin ships no icon", async () => {
+    const { result } = renderIconSrc(false, undefined);
+
+    await Promise.resolve();
+    expect(result.current).toBeUndefined();
+    expect(pluginsByNameIconGetSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns undefined and never fetches when iconVersion is missing", async () => {
+    const { result } = renderIconSrc(true, null);
+
+    await Promise.resolve();
+    expect(result.current).toBeUndefined();
+    expect(pluginsByNameIconGetSpy).not.toHaveBeenCalled();
+  });
+
+  test("stays undefined when the fetch fails (falls through to the glyph)", async () => {
+    iconResult = { data: null, error: { message: "boom" } };
+
+    const { result } = renderIconSrc(true, VERSION);
+
+    await waitFor(() =>
+      expect(pluginsByNameIconGetSpy).toHaveBeenCalledTimes(1),
+    );
+    expect(result.current).toBeUndefined();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  test("revokes the object URL on unmount", async () => {
+    const { result, unmount } = renderIconSrc(true, VERSION);
+
+    await waitFor(() => expect(result.current).toBe("blob:icon-mock"));
+
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:icon-mock");
+  });
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.ts
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import { pluginsByNameIconGet } from "@/generated/daemon/sdk.gen";
+import { useSupportsPluginIcons } from "@/lib/backwards-compat/use-supports-plugin-icons";
+
+/**
+ * Object URL for a plugin's bundled icon, or `undefined` when the daemon
+ * doesn't serve icons (version gate) or the plugin ships none. Callers pass the
+ * result to `<PluginIcon iconSrc>`, which falls back to the emoji/glyph.
+ *
+ * The icon is fetched through the authenticated daemon client so the request
+ * interceptor rewrites it to the self-hosted gateway and attaches the
+ * bearer/ngrok auth in local / remote-gateway modes. A bare `<img src>` would
+ * bypass that interceptor and only load in same-origin platform deployments.
+ * The bytes are held as an object URL and revoked on change/unmount, mirroring
+ * `attachment-preview-modal`.
+ */
+export function usePluginIconSrc(
+  assistantId: string,
+  name: string,
+  hasIcon: boolean | undefined,
+  // `null` accommodates the detail response, where `iconVersion` is nulled out
+  // when `hasIcon` is false; the list row's field is `string | undefined`.
+  iconVersion: string | null | undefined,
+): string | undefined {
+  const supportsIcons = useSupportsPluginIcons();
+  // `iconVersion` keys the query, so a byte change (new content hash) refetches
+  // and bypasses the endpoint's immutable cache.
+  const enabled = Boolean(supportsIcons && hasIcon && iconVersion);
+
+  const { data: blob } = useQuery({
+    queryKey: ["pluginIcon", assistantId, name, iconVersion],
+    queryFn: async () => {
+      const { data, error } = await pluginsByNameIconGet({
+        path: { assistant_id: assistantId, name },
+        parseAs: "blob",
+        throwOnError: false,
+      });
+      if (error || !(data instanceof Blob)) {
+        throw new Error("Failed to load plugin icon");
+      }
+      return data;
+    },
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  // Hold the fetched blob as an object URL for the `<img>`, and revoke it when
+  // the blob changes or the consumer unmounts.
+  const [objectUrl, setObjectUrl] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(undefined);
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setObjectUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [blob]);
+
+  return objectUrl;
+}

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-icon-src.ts
@@ -14,7 +14,9 @@ import { useSupportsPluginIcons } from "@/lib/backwards-compat/use-supports-plug
  * bearer/ngrok auth in local / remote-gateway modes. A bare `<img src>` would
  * bypass that interceptor and only load in same-origin platform deployments.
  * The bytes are held as an object URL and revoked on change/unmount, mirroring
- * `attachment-preview-modal`.
+ * `attachment-preview-modal`. Because the rendered `<img src>` is a `blob:` URL,
+ * any Content-Security-Policy on the platform gateway (in vellum-assistant-platform)
+ * must permit `img-src blob:`, or the icon silently falls back to the emoji/glyph.
  */
 export function usePluginIconSrc(
   assistantId: string,

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -87,6 +87,17 @@ describe("mergePlugins", () => {
     expect(row.description).toBeUndefined();
     expect(row.version).toBeUndefined();
   });
+
+  test("carries an installed plugin's author icon onto the row", () => {
+    const [installedRow, catalogRow] = mergePlugins(
+      [installed({ name: "alpha", icon: "🚀" })],
+      [catalog({ name: "beta" })],
+    );
+
+    expect(installedRow.icon).toBe("🚀");
+    // Catalog rows carry no icon (the search endpoint has none).
+    expect(catalogRow.icon).toBeUndefined();
+  });
 });
 
 describe("matchesQuery", () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -98,6 +98,19 @@ describe("mergePlugins", () => {
     // Catalog rows carry no icon (the search endpoint has none).
     expect(catalogRow.icon).toBeUndefined();
   });
+
+  test("carries hasIcon/iconVersion onto installed rows (not the catalog)", () => {
+    const [installedRow, catalogRow] = mergePlugins(
+      [installed({ name: "alpha", hasIcon: true, iconVersion: "abc123" })],
+      [catalog({ name: "beta" })],
+    );
+
+    expect(installedRow.hasIcon).toBe(true);
+    expect(installedRow.iconVersion).toBe("abc123");
+    // Catalog rows have no bundled icon (the search endpoint carries none).
+    expect(catalogRow.hasIcon).toBeUndefined();
+    expect(catalogRow.iconVersion).toBeUndefined();
+  });
 });
 
 describe("matchesQuery", () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -30,6 +30,9 @@ export function mergePlugins(
     // Installed rows carry enablement; older daemons omit it (undefined).
     enabled: p.enabled,
     icon: p.icon,
+    // Bundled-icon signals; absent on the catalog and on pre-icon daemons.
+    hasIcon: p.hasIcon,
+    iconVersion: p.iconVersion,
   }));
 
   const installedNames = new Set(installedItems.map((i) => i.name));

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -29,6 +29,7 @@ export function mergePlugins(
     issues: p.issues,
     // Installed rows carry enablement; older daemons omit it (undefined).
     enabled: p.enabled,
+    icon: p.icon,
   }));
 
   const installedNames = new Set(installedItems.map((i) => i.name));

--- a/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useSupportsPluginIcons } from "@/lib/backwards-compat/use-supports-plugin-icons";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+function check(version: string | null): boolean {
+  setVersion(version);
+  const { result } = renderHook(() => useSupportsPluginIcons());
+  return result.current;
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("useSupportsPluginIcons", () => {
+  test("returns false when the version is unknown", () => {
+    expect(check(null)).toBe(false);
+    expect(check("")).toBe(false);
+  });
+
+  test("returns true at exactly MIN_VERSION (0.10.5)", () => {
+    expect(check("0.10.5")).toBe(true);
+  });
+
+  test("returns true for dev builds ahead of MIN_VERSION", () => {
+    expect(check("0.10.5-dev.202606211252.5cf8576")).toBe(true);
+  });
+
+  test("returns true for versions above MIN_VERSION", () => {
+    expect(check("0.10.6")).toBe(true);
+    expect(check("0.11.0")).toBe(true);
+    expect(check("1.0.0")).toBe(true);
+  });
+
+  test("returns false for versions below MIN_VERSION", () => {
+    expect(check("0.10.4")).toBe(false);
+    expect(check("0.9.0")).toBe(false);
+  });
+
+  test("returns false for unparseable versions", () => {
+    expect(check("not-a-version")).toBe(false);
+    expect(check("0.10")).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-plugin-icons.ts
@@ -1,0 +1,31 @@
+/**
+ * Backwards-compat gate: plugin custom icons.
+ *
+ * Plugins can carry a custom icon served by the daemon's plugin-icon
+ * endpoint. The web app renders that icon via an `<img>` pointed at the
+ * endpoint, so it must only do so when the active assistant is known to
+ * serve it — an older daemon 404s the request and the image breaks.
+ *
+ * The web app always serves the latest bundle, but the assistant can be
+ * any locally-installed version. Emoji/text icons degrade naturally via
+ * the optional field, so this gate only guards the `<img>` path.
+ *
+ * MIN_VERSION is the minimum assistant version that serves the
+ * plugin-icon endpoint.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.5";
+
+/**
+ * Returns `true` when the active assistant serves the plugin-icon
+ * endpoint. Subscribes to the identity store so consumers re-render when
+ * the assistant version crosses `MIN_VERSION`.
+ *
+ * Returns `false` while the identity store has no version yet, when the
+ * version is unparseable, or when it falls below `MIN_VERSION` — callers
+ * fall back to the non-`<img>` icon on the `false` branch.
+ */
+export function useSupportsPluginIcons(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary
Lets plugin authors give their plugin a custom icon, in two additive, version-gated tiers:
- **Emoji** — declare `"vellum": { "icon": "🚀" }` in the plugin's `package.json`; surfaced on the plugin list + detail responses and rendered on the Plugins tab (list rows + detail) with the existing 📦/🧩 fallback.
- **Bundled PNG** — ship a fixed `icon.png`; validated fail-closed on the daemon (PNG magic + IHDR chunk + ≤128×128 + ≤32KB, no new dependency), served from `GET /v1/plugins/:name/icon` (`image/png`, `nosniff`, `private` immutable cache, content-hash `ETag`), and rendered on the web via the **authenticated** daemon client (blob → object URL, so it works in local/remote-gateway modes too).

Precedence everywhere: **bundled image → author emoji → 📦/🧩**. Security posture: PNG-only (no SVG → no XSS), fixed filename (no traversal), bundled-only (no URLs → no SSRF).

## Self-review result
PASS after remediation. Four fresh-eyes passes (external-feedback, plan-faithfulness, integration, slop) ran on the full diff. All 6 codex review comments across the milestone PRs were addressed. Two self-review findings fixed in `fc606e8ffb`: (1) default-plugin icon fields now read the workspace copy so list/detail/serve agree; (2) documented the `img-src blob:` CSP requirement. Intentionally deferred: the optional `pngjs` re-encode (plan PR 13) and in-chat-pill threading (plan "Deferred").

## Milestone PRs merged into this branch
- #37036 read `vellum.icon` · #37040 list `icon` · #37067 detail `icon`
- #37043 validate `icon.png` · #37069 `hasIcon`/`iconVersion` · #37073 icon serve route
- #37035 version gate · #37034 PluginIcon emoji · #37039 PluginIcon `<img>`
- #37068 web list wiring · #37075 web detail wiring · #37079 authenticated blob fetch

## ⚠️ Before release
The feature is **version-gated at MIN_VERSION 0.10.5** and the monorepo is currently 0.10.4, so the `<img>` path stays dark (emoji still works) until the version bumps to 0.10.5 — release-correct (hidden on daemons without the icon route). Also verify the platform-gateway CSP allows `img-src blob:`.

Part of plan: plugin-custom-icons.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)