### PR TITLE
refactor(tts): close the TtsProviderId union and drop VALID_TTS_PROVIDERS

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3111,7 +3111,8 @@ describe("call-controller", () => {
 
     test("returns fallback when the configured provider is not in the catalog", async () => {
       const cfg = loadConfig();
-      cfg.services.tts.provider = "not-a-real-provider";
+      (cfg.services.tts as { provider: string }).provider =
+        "not-a-real-provider";
 
       const result = await resolveCallTtsProvider();
       expect(result.provider).toBeNull();

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -24,7 +24,9 @@ function ensureTestDir(): void {
     join(WORKSPACE_DIR, "data", "logs"),
   ];
   for (const dir of dirs) {
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
   }
 }
 
@@ -56,14 +58,12 @@ import {
   DEFAULT_ELEVENLABS_VOICE_ID,
 } from "../config/schema.js";
 import { SttServiceSchema } from "../config/schemas/stt.js";
-import {
-  TtsServiceSchema,
-  VALID_TTS_PROVIDERS as VALID_TTS_SERVICE_PROVIDERS,
-} from "../config/schemas/tts.js";
+import { TtsServiceSchema } from "../config/schemas/tts.js";
 import type { AssistantConfig } from "../config/types.js";
 import { listCatalogProviderIds } from "../tts/provider-catalog.js";
 import { buildElevenLabsVoiceSpec } from "../tts/providers/elevenlabs-provider.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import { TTS_PROVIDER_IDS } from "../tts/types.js";
 import { setStorePathForTesting } from "./encrypted-store-test-helpers.js";
 
 // ---------------------------------------------------------------------------
@@ -1824,7 +1824,7 @@ describe("resolveTtsConfig", () => {
     ) as AssistantConfig;
     (config.services.tts as { provider: string }).provider = "aws-polly";
     const resolved = resolveTtsConfig(config);
-    expect(resolved.provider).toBe("aws-polly");
+    expect(resolved.provider as string).toBe("aws-polly");
     expect(resolved.providerConfig).toEqual({});
   });
 
@@ -1845,9 +1845,9 @@ describe("resolveTtsConfig", () => {
 // ---------------------------------------------------------------------------
 
 describe("TTS provider catalog integration", () => {
-  test("VALID_TTS_SERVICE_PROVIDERS matches catalog provider IDs", () => {
+  test("TTS_PROVIDER_IDS matches catalog provider IDs", () => {
     const catalogIds = listCatalogProviderIds();
-    expect([...VALID_TTS_SERVICE_PROVIDERS]).toEqual(catalogIds);
+    expect([...TTS_PROVIDER_IDS]).toEqual(catalogIds);
   });
 
   test("schema accepts all catalog provider IDs as services.tts.provider", () => {

--- a/assistant/src/__tests__/guardian-wait-controller.test.ts
+++ b/assistant/src/__tests__/guardian-wait-controller.test.ts
@@ -19,6 +19,7 @@ import {
   expect,
   jest,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -332,23 +333,31 @@ describe("GuardianWaitController", () => {
       seedRequest("pending");
       // Stamp the wait start 10s in the past so elapsed exceeds the 300ms
       // initial window and the steady interval range [150, 200) applies.
-      nowValue = Date.now() - 10_000;
-      const { controller, spoken } = createController();
-      controller.start(START_PARAMS);
+      // Pin the jitter to the midpoint (175ms): with live randomness, two
+      // consecutive near-minimum intervals can fit a second heartbeat into
+      // the 210ms window below and flake the exact-count assertions.
+      const randomSpy = spyOn(Math, "random").mockReturnValue(0.5);
+      try {
+        nowValue = Date.now() - 10_000;
+        const { controller, spoken } = createController();
+        controller.start(START_PARAMS);
 
-      jest.advanceTimersByTime(140);
-      expect(spoken).toHaveLength(1);
+        jest.advanceTimersByTime(140);
+        expect(spoken).toHaveLength(1);
 
-      jest.advanceTimersByTime(120);
-      expect(spoken).toHaveLength(2);
+        jest.advanceTimersByTime(120);
+        expect(spoken).toHaveLength(2);
 
-      // The next heartbeat is rescheduled and uses the next message in the
-      // rotation.
-      jest.advanceTimersByTime(210);
-      expect(spoken).toHaveLength(3);
-      expect(spoken[2]).not.toBe(spoken[1]);
+        // The next heartbeat is rescheduled and uses the next message in the
+        // rotation.
+        jest.advanceTimersByTime(210);
+        expect(spoken).toHaveLength(3);
+        expect(spoken[2]).not.toBe(spoken[1]);
 
-      controller.dispose();
+        controller.dispose();
+      } finally {
+        randomSpy.mockRestore();
+      }
     });
 
     test("a caller reply resets the heartbeat timer", () => {

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -244,7 +244,7 @@ async function synthesizeAndPlay(
 }
 
 /** Look up a registered provider, returning null instead of throwing. */
-function lookupRegisteredProvider(id: TtsProviderId): TtsProvider | null {
+function lookupRegisteredProvider(id: string): TtsProvider | null {
   try {
     return getTtsProvider(id);
   } catch {

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -187,7 +187,7 @@ export async function resolveCallTtsProvider(
  * no provider qualifies.
  */
 export async function findPlayableTelephonyTtsFallback(
-  excludeProviderId?: TtsProviderId,
+  excludeProviderId?: string,
 ): Promise<TtsProviderId | null> {
   const candidates = [
     ...new Set<TtsProviderId>(["elevenlabs", ...listCatalogProviderIds()]),

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -28,7 +28,6 @@ import {
 import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
-import type { TtsProviderId } from "../tts/types.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -48,12 +47,12 @@ export type TelephonyTtsCapability =
   | {
       /** The provider produces playable audio and credentials resolve. */
       status: "playable";
-      providerId: TtsProviderId;
+      providerId: string;
     }
   | {
       /** The provider cannot play over media-stream transports. */
       status: "not-playable";
-      providerId: TtsProviderId;
+      providerId: string;
       reason: TelephonyTtsNotPlayableReason;
     };
 
@@ -85,7 +84,7 @@ export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapab
  * the call TTS resolver's fallback scan (candidate providers).
  */
 export async function evaluateTelephonyTtsPlayability(
-  providerId: TtsProviderId,
+  providerId: string,
 ): Promise<TelephonyTtsCapability> {
   let entry: TtsProviderCatalogEntry;
   try {
@@ -176,7 +175,11 @@ async function secretResolves(credentialStoreKey: string): Promise<boolean> {
   if (parts.length === 1) {
     return Boolean(await getProviderKeyAsync(credentialStoreKey));
   }
-  if (parts.length === 3 && parts[0] === "credential" && parts[2] === "api_key") {
+  if (
+    parts.length === 3 &&
+    parts[0] === "credential" &&
+    parts[2] === "api_key"
+  ) {
     return Boolean(await getProviderKeyAsync(parts[1]));
   }
   return Boolean(await getSecureKeyAsync(credentialStoreKey));

--- a/assistant/src/calls/tts-call-strategy.ts
+++ b/assistant/src/calls/tts-call-strategy.ts
@@ -50,7 +50,7 @@ export type {
  *   `native-twilio` provider (synthesized-play providers have no spec).
  */
 export function getNativeTwilioVoiceSpec(
-  providerId: TtsProviderId,
+  providerId: string,
 ): NativeTwilioVoiceSpec {
   const definition = getProviderDefinition(providerId);
   if (definition.callMode !== "native-twilio") {

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -108,7 +108,7 @@ function validateSetting(
       return { ok: true, coerced: trimmed };
     }
     case "tts_provider": {
-      const catalogIds = listCatalogProviderIds();
+      const catalogIds: readonly string[] = listCatalogProviderIds();
       if (typeof value !== "string" || !catalogIds.includes(value.trim())) {
         return {
           ok: false,

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -7,17 +7,6 @@ import {
 } from "./elevenlabs.js";
 
 /**
- * Valid TTS provider identifiers derived from the canonical provider ID list.
- *
- * Adding a new TTS provider starts in `tts/types.ts` (`TTS_PROVIDER_IDS`) —
- * the IDs flow here automatically. Sourced from that dependency-free leaf
- * rather than the provider catalog so the config schema never pulls in the
- * provider adapters (whose modules import the config loader — a cycle).
- */
-export const VALID_TTS_PROVIDERS: readonly [string, ...string[]] =
-  TTS_PROVIDER_IDS as unknown as [string, ...string[]];
-
-/**
  * Per-provider config schemas nested under `services.tts.providers.<id>`.
  *
  * Each provider's schema is the full provider-specific config (voice ID,
@@ -244,7 +233,7 @@ export type TtsProviders = z.infer<typeof TtsProvidersSchema>;
 // immediately rather than at runtime when a user selects the provider.
 // ---------------------------------------------------------------------------
 const schemaKeys = new Set(Object.keys(TtsProvidersSchema.shape));
-for (const id of VALID_TTS_PROVIDERS) {
+for (const id of TTS_PROVIDER_IDS) {
   if (!schemaKeys.has(id)) {
     throw new Error(
       `TTS provider "${id}" exists in the catalog but has no schema entry ` +
@@ -252,7 +241,7 @@ for (const id of VALID_TTS_PROVIDERS) {
     );
   }
 }
-const catalogKeys = new Set<string>(VALID_TTS_PROVIDERS);
+const catalogKeys = new Set<string>(TTS_PROVIDER_IDS);
 for (const id of schemaKeys) {
   if (!catalogKeys.has(id)) {
     throw new Error(
@@ -281,8 +270,8 @@ export const TtsServiceSchema = z
         'TTS service mode — only "your-own" is supported (managed TTS is not available)',
       ),
     provider: z
-      .enum(VALID_TTS_PROVIDERS, {
-        error: `services.tts.provider must be one of: ${VALID_TTS_PROVIDERS.join(", ")}`,
+      .enum(TTS_PROVIDER_IDS, {
+        error: `services.tts.provider must be one of: ${TTS_PROVIDER_IDS.join(", ")}`,
       })
       .default("elevenlabs")
       .describe("Active TTS provider used for speech synthesis"),

--- a/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
@@ -62,7 +62,7 @@ function loadClientArtifact(): ClientCatalog {
 // ---------------------------------------------------------------------------
 
 describe("TTS provider catalog / client artifact consistency", () => {
-  const assistantIds = listCatalogProviderIds();
+  const assistantIds: readonly string[] = listCatalogProviderIds();
   const clientCatalog = loadClientArtifact();
   const clientIds = clientCatalog.providers.map((p) => p.id);
 
@@ -163,9 +163,10 @@ describe("TTS provider catalog / client artifact consistency", () => {
       }
     }
     if (violations.length > 0) {
-      expect(violations, "Subtitle mismatch:\n" + violations.join("\n")).toEqual(
-        [],
-      );
+      expect(
+        violations,
+        "Subtitle mismatch:\n" + violations.join("\n"),
+      ).toEqual([]);
     }
   });
 
@@ -203,7 +204,9 @@ describe("TTS provider catalog / client artifact consistency", () => {
         const ag = assistantEntry.credentialsGuide;
         if (cg && ag) {
           if (cg.url !== ag.url) {
-            violations.push(`"${clientEntry.id}": credentialsGuide.url mismatch`);
+            violations.push(
+              `"${clientEntry.id}": credentialsGuide.url mismatch`,
+            );
           }
           if (cg.description !== ag.description) {
             violations.push(

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -9,7 +9,7 @@
  * query via {@link getCatalogProvider}, {@link listCatalogProviders}, or
  * {@link listCatalogProviderIds}.
  *
- * The `satisfies Record<CatalogTtsProviderId, TtsProviderDefinition>` check
+ * The `satisfies Record<TtsProviderId, TtsProviderDefinition>` check
  * makes the catalog exhaustive at compile time: adding an ID to
  * `TTS_PROVIDER_IDS` (`types.ts`) without a definition here — or a definition
  * without wiring — is a type error, not a boot-time failure. Likewise the
@@ -28,11 +28,7 @@ import { deepgramTtsProviderDefinition } from "./providers/deepgram-provider.js"
 import { elevenLabsTtsProviderDefinition } from "./providers/elevenlabs-provider.js";
 import { fishAudioTtsProviderDefinition } from "./providers/fish-audio-provider.js";
 import { xaiTtsProviderDefinition } from "./providers/xai-provider.js";
-import type {
-  CatalogTtsProviderId,
-  TtsProvider,
-  TtsProviderId,
-} from "./types.js";
+import type { TtsProvider, TtsProviderId } from "./types.js";
 
 export type {
   TtsMediaStreamOutputFormat,
@@ -54,7 +50,7 @@ const DEFINITIONS = {
   "fish-audio": fishAudioTtsProviderDefinition,
   deepgram: deepgramTtsProviderDefinition,
   xai: xaiTtsProviderDefinition,
-} as const satisfies Record<CatalogTtsProviderId, TtsProviderDefinition>;
+} as const satisfies Record<TtsProviderId, TtsProviderDefinition>;
 
 /**
  * Definitions in display order (e.g. settings dropdowns).
@@ -103,7 +99,7 @@ export function listCatalogProvidersForDisplay() {
  *
  * @throws if the ID is not in the catalog.
  */
-export function getCatalogProvider(id: TtsProviderId): TtsProviderCatalogEntry {
+export function getCatalogProvider(id: string): TtsProviderCatalogEntry {
   return getProviderDefinition(id);
 }
 
@@ -112,9 +108,7 @@ export function getCatalogProvider(id: TtsProviderId): TtsProviderCatalogEntry {
  *
  * @throws if the ID is not in the catalog.
  */
-export function getProviderDefinition(
-  id: TtsProviderId,
-): TtsProviderDefinition {
+export function getProviderDefinition(id: string): TtsProviderDefinition {
   const definition = (
     DEFINITIONS as Record<string, TtsProviderDefinition | undefined>
   )[id];
@@ -137,14 +131,14 @@ export function getProviderDefinition(
  * can substitute stub providers (no real HTTP) or inject providers with
  * non-catalog IDs.
  */
-const testOverrides = new Map<TtsProviderId, TtsProvider>();
+const testOverrides = new Map<string, TtsProvider>();
 
 /**
  * Resolve the runtime synthesis adapter for a provider ID.
  *
  * @throws if the ID is not in the catalog (and no test override exists).
  */
-export function getTtsProvider(id: TtsProviderId): TtsProvider {
+export function getTtsProvider(id: string): TtsProvider {
   const override = testOverrides.get(id);
   if (override) {
     return override;

--- a/assistant/src/tts/provider-definition.ts
+++ b/assistant/src/tts/provider-definition.ts
@@ -9,7 +9,7 @@
  *
  * Each provider module (`providers/<id>-provider.ts`) exports one
  * definition; `provider-catalog.ts` assembles them into the canonical
- * catalog, statically checked to cover every {@link CatalogTtsProviderId}.
+ * catalog, statically checked to cover every {@link TtsProviderId}.
  * There is no runtime registration step — a provider that exists in the
  * catalog is fully wired by construction.
  *
@@ -18,11 +18,7 @@
  * the catalog that aggregates them.
  */
 
-import type {
-  CatalogTtsProviderId,
-  TtsCallMode,
-  TtsProvider,
-} from "./types.js";
+import type { TtsCallMode, TtsProvider, TtsProviderId } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Catalog metadata
@@ -140,7 +136,7 @@ export interface NativeTwilioVoiceSpec {
  */
 export interface TtsProviderCatalogEntry {
   /** Unique provider identifier. */
-  readonly id: CatalogTtsProviderId;
+  readonly id: TtsProviderId;
 
   /** Human-readable name for display in settings UI and logs. */
   readonly displayName: string;

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -31,20 +31,13 @@ export const TTS_PROVIDER_IDS = [
 ] as const;
 
 /**
- * A built-in provider ID — the closed union used where exhaustiveness is
- * enforced (the provider catalog).
+ * Unique identifier for a TTS provider — the closed union derived from
+ * {@link TTS_PROVIDER_IDS}. Values correspond to the provider names used in
+ * config schemas (e.g. `"elevenlabs"`, `"fish-audio"`). Lookup functions that
+ * accept runtime-sourced IDs (config values, test stubs) take `string` and
+ * validate at runtime instead of widening this union.
  */
-export type CatalogTtsProviderId = (typeof TTS_PROVIDER_IDS)[number];
-
-/**
- * Unique identifier for a TTS provider.
- *
- * Values correspond to the provider names already used in config schemas
- * (e.g. `"elevenlabs"`, `"fish-audio"`). The union stays open (`string & {}`)
- * so tests and future dynamic sources can carry arbitrary IDs while built-in
- * IDs keep autocomplete.
- */
-export type TtsProviderId = CatalogTtsProviderId | (string & {});
+export type TtsProviderId = (typeof TTS_PROVIDER_IDS)[number];
 
 // ---------------------------------------------------------------------------
 // Call-mode discriminator
@@ -186,8 +179,12 @@ export interface TtsProviderCapabilities {
  * `synthesizeStream`.
  */
 export interface TtsProvider {
-  /** Unique provider identifier used for registry lookup. */
-  readonly id: TtsProviderId;
+  /**
+   * Unique provider identifier used for adapter lookup. Plain `string`
+   * rather than {@link TtsProviderId} so tests can install stub adapters
+   * under arbitrary IDs; catalog adapters carry their catalog ID.
+   */
+  readonly id: string;
 
   /** Static capability advertisement. */
   readonly capabilities: TtsProviderCapabilities;


### PR DESCRIPTION
## Why

Follow-up to the two review comments on #37072:
- `VALID_TTS_PROVIDERS` was a redundant re-cast of `TTS_PROVIDER_IDS` — use the const directly.
- The `(string & {})` arm on `TtsProviderId` was redundant — the provider set is closed.

## What

**`TtsProviderId` is now the closed union** derived from `TTS_PROVIDER_IDS`; `CatalogTtsProviderId` (which became identical) is folded into it. The open-string escape hatch moves to where it actually belongs: lookup functions that accept runtime-sourced IDs and validate by throwing (`getCatalogProvider`, `getProviderDefinition`, `getTtsProvider`, `getNativeTwilioVoiceSpec`, `evaluateTelephonyTtsPlayability`, and `findPlayableTelephonyTtsFallback`'s exclude param) take plain `string`, and `TtsProvider.id` is `string` so tests can stub adapters under arbitrary IDs. `TelephonyTtsCapability.providerId` follows, since it can echo an unknown configured ID back to the caller.

**`config/schemas/tts.ts` uses `TTS_PROVIDER_IDS` directly** in `z.enum` and the schema⟷catalog consistency loops. A bonus from dropping the `[string, ...string[]]` re-cast: `services.tts.provider` is now typed as the literal provider union instead of `string`, which is what lets the closed `TtsProviderId` typecheck through `resolveTtsConfig` without casts.

## Tests

`src/tts/` (107), `voice-quality` + `telephony-tts-guard` + `config-schema` + `live-voice-tts` (325 combined), `call-controller` + `calls/` (230) — all pass. tsc / eslint / prettier clean. Two tests that deliberately force non-catalog provider IDs through config now do so via an explicit narrow cast at the mutation site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NtK9smrBuYfXaQ9a9G8z)_