### PR TITLE
fix: stop stale /messages reseeds erasing a just-sent message (web guard + truthful daemon seq anchor)

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
+import { stampAndBuffer } from "../runtime/assistant-stream-state.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — must precede the Conversation import so Bun applies them at load time.
@@ -116,6 +117,9 @@ const capturedAddMessages: Array<{
   metadata?: Record<string, unknown>;
 }> = [];
 
+/** Snapshot↔stream anchor advances recorded via `recordConversationPersistedSeq`. */
+const capturedPersistedSeqs: Array<{ id: string; seq: number }> = [];
+
 /**
  * Content substrings that should cause `addMessage` to throw — used to
  * simulate a mid-batch persist failure (e.g. a DB error on a specific
@@ -200,6 +204,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getLastUserTimestampBefore: () => 0,
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
   updateMessageContent: mock(() => {}),
+  recordConversationPersistedSeq: (id: string, seq: number) => {
+    capturedPersistedSeqs.push({ id, seq });
+  },
 }));
 
 mock.module("../persistence/conversation-queries.js", () => ({
@@ -2971,6 +2978,107 @@ describe("MessageQueue byte budget", () => {
     expect(
       q.push(makeItem("y".repeat(100), "r2", [{ data: "b".repeat(100) }])),
     ).toBe(false);
+  });
+});
+
+describe("persisted-seq anchor advance on user_message_echo", () => {
+  beforeEach(() => {
+    pendingRuns = [];
+    capturedAddMessages.length = 0;
+    capturedPersistedSeqs.length = 0;
+  });
+
+  test("drained message advances the anchor to its echo's stamped seq", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const eventsQueued: ServerMessage[] = [];
+    // Mirror `broadcastMessage`'s inline stamp so `getCurrentSeq()` read
+    // right after the emit is this echo's seq, as in production.
+    const stampingOnEvent = (sink: ServerMessage[]) => (e: ServerMessage) => {
+      stampAndBuffer(e as unknown as Parameters<typeof stampAndBuffer>[0]);
+      sink.push(e);
+    };
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: stampingOnEvent(events1),
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({
+      content: "ordinary message",
+      onEvent: stampingOnEvent(eventsQueued),
+      requestId: "req-queued",
+    });
+
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    const echo = eventsQueued.find((e) => e.type === "user_message_echo") as
+      | (ServerMessage & { seq?: number })
+      | undefined;
+    const echoSeq = echo?.seq;
+    if (typeof echoSeq !== "number") {
+      throw new Error("user_message_echo was not stamped with a seq");
+    }
+    // The snapshot↔stream anchor now covers the echo: a `/messages` fetch
+    // served after this point carries the row AND an anchor at (not below)
+    // the echo's seq, so clients comparing the anchor against their fold
+    // watermark no longer classify the fetch as stale.
+    expect(capturedPersistedSeqs).toContainEqual({
+      id: "conv-1",
+      seq: echoSeq,
+    });
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  test("echo-suppressed drained rows do not advance the anchor", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const eventsNotif: ServerMessage[] = [];
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: (e) => events1.push(e),
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+    const advancesAfterFirstDrain = capturedPersistedSeqs.length;
+
+    conversation.enqueueMessage({
+      content: '[Subagent "research" completed]',
+      onEvent: (e) => eventsNotif.push(e),
+      requestId: "req-notif",
+      metadata: {
+        subagentNotification: {
+          subagentId: "sub-1",
+          label: "research",
+          status: "completed",
+        },
+      },
+    });
+
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // No echo event exists for the suppressed row, so there is no seq the
+    // anchor could truthfully advance to — it must stay where it was.
+    expect(eventsNotif.some((e) => e.type === "user_message_echo")).toBe(false);
+    expect(capturedPersistedSeqs.length).toBe(advancesAfterFirstDrain);
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
   });
 });
 

--- a/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
+++ b/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
@@ -125,6 +125,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
     plugins: string[] | null,
   ) => setConversationEnabledPluginsMock(conversationId, plugins),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../persistence/conversation-disk-view.js", () => ({

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -86,6 +86,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
     options?: { metadata?: Record<string, unknown> },
   ) => addMessageMock(conversationId, role, content, options),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({

--- a/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
+++ b/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
@@ -115,6 +115,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   setConversationInferenceProfile: () => {},
   setConversationEnabledPlugins: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../persistence/conversation-disk-view.js", () => ({

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -147,6 +147,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../persistence/conversation-disk-view.js", () => ({

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -118,6 +118,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
     options?: { metadata?: Record<string, unknown> },
   ) => addMessageMock(conversationId, role, content, options),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -109,6 +109,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -25,10 +25,12 @@ import {
   addMessage,
   isHiddenMessageMetadata,
   provenanceFromTrustContext,
+  recordConversationPersistedSeq,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../persistence/conversation-crud.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
+import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import {
   type GuardianPendingScope,
   routeGuardianReply,
@@ -147,7 +149,9 @@ function resolveQueuedTurnContext(
   },
   fallback: TurnChannelContext | null,
 ): TurnChannelContext | null {
-  if (queued.turnChannelContext) return queued.turnChannelContext;
+  if (queued.turnChannelContext) {
+    return queued.turnChannelContext;
+  }
   const metadata = queued.metadata;
   if (metadata) {
     const userMessageChannel = parseChannelId(metadata.userMessageChannel);
@@ -168,7 +172,9 @@ function resolveQueuedTurnInterfaceContext(
   },
   fallback: TurnInterfaceContext | null,
 ): TurnInterfaceContext | null {
-  if (queued.turnInterfaceContext) return queued.turnInterfaceContext;
+  if (queued.turnInterfaceContext) {
+    return queued.turnInterfaceContext;
+  }
   const metadata = queued.metadata;
   if (metadata) {
     const userMessageInterface = parseInterfaceId(
@@ -215,7 +221,9 @@ async function buildPassthroughBatch(
   conversation: Conversation,
 ): Promise<QueuedMessage[]> {
   const head = conversation.queue.peek(0);
-  if (head === undefined) return [];
+  if (head === undefined) {
+    return [];
+  }
 
   const headInterface = resolveQueuedTurnInterfaceContext(
     head,
@@ -224,7 +232,9 @@ async function buildPassthroughBatch(
   // Pure classifier — no side effects. `resolveSlash` may run side effects
   // (e.g. /compact); if we called it here the real drain would invoke those
   // again.
-  if (classifySlash(head.content) !== "passthrough") return [];
+  if (classifySlash(head.content) !== "passthrough") {
+    return [];
+  }
   if (resolveVerificationSessionIntent(head.content).kind === "direct_setup") {
     // Verification intents stay on the single-message path so their per-turn
     // skill preactivation isn't leaked into batched tail messages.
@@ -244,7 +254,9 @@ async function buildPassthroughBatch(
   let i = 1;
   for (;;) {
     const candidate = conversation.queue.peek(i);
-    if (candidate === undefined) break;
+    if (candidate === undefined) {
+      break;
+    }
     const candIf = resolveQueuedTurnInterfaceContext(
       candidate,
       conversation.getTurnInterfaceContext(),
@@ -252,20 +264,28 @@ async function buildPassthroughBatch(
     // Treat an undefined interface as distinct from a defined one so we don't
     // silently batch cross-interface messages whose env/transport would
     // otherwise diverge.
-    if (candIf?.userMessageInterface !== headInterface?.userMessageInterface)
+    if (candIf?.userMessageInterface !== headInterface?.userMessageInterface) {
       break;
+    }
     // The batched turn applies only the head's `clientOs`, so messages from a
     // different OS surface must not coalesce. The web, iOS, and macOS apps all
     // report `interfaceId: "web"`, so the interface check above no longer
     // separates them — split on the reported OS explicitly.
-    if (candidate.transport?.clientOs !== head.transport?.clientOs) break;
-    if (candidate.sourceActorPrincipalId !== head.sourceActorPrincipalId) break;
-    if (classifySlash(candidate.content) !== "passthrough") break;
+    if (candidate.transport?.clientOs !== head.transport?.clientOs) {
+      break;
+    }
+    if (candidate.sourceActorPrincipalId !== head.sourceActorPrincipalId) {
+      break;
+    }
+    if (classifySlash(candidate.content) !== "passthrough") {
+      break;
+    }
     if (
       resolveVerificationSessionIntent(candidate.content).kind ===
       "direct_setup"
-    )
+    ) {
       break;
+    }
     // Stop at the first surface-action tail; it will drain via the single-
     // message path so its per-message surface context is preserved.
     if (
@@ -292,11 +312,15 @@ async function buildPassthroughBatch(
  * unmatched `tool_use` blocks.
  */
 function repairPendingToolUseBlocks(conversation: Conversation): void {
-  if (!conversation.pendingSteerRepair) return;
+  if (!conversation.pendingSteerRepair) {
+    return;
+  }
   conversation.pendingSteerRepair = false;
 
   const messages = conversation.messages;
-  if (messages.length === 0) return;
+  if (messages.length === 0) {
+    return;
+  }
 
   // Walk backwards from the tail to find the last assistant message with
   // tool_use blocks. Collect resolved IDs from any user messages between
@@ -326,7 +350,9 @@ function repairPendingToolUseBlocks(conversation: Conversation): void {
     }
   }
 
-  if (pendingToolUseIds.length === 0) return;
+  if (pendingToolUseIds.length === 0) {
+    return;
+  }
 
   log.info(
     {
@@ -375,7 +401,9 @@ export async function drainQueue(
 
   if (steered) {
     const next = conversation.queue.shift();
-    if (!next) return;
+    if (!next) {
+      return;
+    }
     return drainSingleMessage(conversation, next, reason);
   }
 
@@ -385,7 +413,9 @@ export async function drainQueue(
     // an item the builder rejected, pop it and hand it to the single-message
     // path — which owns slash / compact / verification-intent behavior.
     const next = conversation.queue.shift();
-    if (!next) return;
+    if (!next) {
+      return;
+    }
     return drainSingleMessage(conversation, next, reason);
   }
   if (batch.length === 1) {
@@ -898,6 +928,18 @@ async function drainSingleMessage(
       requestId: next.requestId,
       clientMessageId: next.clientMessageId,
     });
+    // The row this echo announces is already durably persisted, so advance
+    // the snapshot↔stream anchor to the echo's seq (stamped inline by the
+    // publish path). Without this, `/messages` returns the row while still
+    // advertising the previous flush's anchor — under-claiming, which breaks
+    // the contract that the rows reflect all of this conversation's events
+    // through the advertised seq. Safe to claim here: the previous turn's
+    // content flushed at turn end and this turn's loop hasn't started, so no
+    // streamed-but-unflushed content exists for this conversation.
+    recordConversationPersistedSeq(
+      conversation.conversationId,
+      getCurrentSeq(),
+    );
   }
   publishConversationMessagesChanged(conversation.conversationId);
 
@@ -913,7 +955,9 @@ async function drainSingleMessage(
   if (conversation.assistantId && !isHiddenMessageMetadata(next.metadata)) {
     extractPreferences(resolvedContent)
       .then((result) => {
-        if (!result.detected) return;
+        if (!result.detected) {
+          return;
+        }
         for (const pref of result.preferences) {
           createPreference({
             preferenceText: pref.preferenceText,
@@ -947,12 +991,15 @@ async function drainSingleMessage(
     titleText?: string;
     isHiddenPrompt?: boolean;
   } = { isUserMessage: true };
-  if (next.isInteractive !== undefined)
+  if (next.isInteractive !== undefined) {
     drainLoopOptions.isInteractive = next.isInteractive;
-  if (agentLoopContent !== resolvedContent)
+  }
+  if (agentLoopContent !== resolvedContent) {
     drainLoopOptions.titleText = resolvedContent;
-  if (isHiddenMessageMetadata(next.metadata))
+  }
+  if (isHiddenMessageMetadata(next.metadata)) {
     drainLoopOptions.isHiddenPrompt = true;
+  }
 
   conversation
     .runAgentLoop(agentLoopContent, userMessageId, {
@@ -1258,6 +1305,13 @@ async function drainBatch(
         requestId: qm.requestId,
         clientMessageId: qm.clientMessageId,
       });
+      // Advance the snapshot↔stream anchor to this echo's seq — the batched
+      // row persisted just above and the agent loop for the batch has not
+      // started. See the identical advance in `drainSingleMessage`.
+      recordConversationPersistedSeq(
+        conversation.conversationId,
+        getCurrentSeq(),
+      );
     }
     publishConversationMessagesChanged(conversation.conversationId);
 
@@ -1275,7 +1329,9 @@ async function drainBatch(
     if (conversation.assistantId && !isHiddenMessageMetadata(qm.metadata)) {
       extractPreferences(qmContent)
         .then((result) => {
-          if (!result.detected) return;
+          if (!result.detected) {
+            return;
+          }
           for (const pref of result.preferences) {
             createPreference({
               preferenceText: pref.preferenceText,
@@ -1352,7 +1408,9 @@ async function drainBatch(
     new Set(successfulBatch.map((qm) => qm.onEvent)),
   );
   const fanOutOnEvent = (msg: ServerMessage) => {
-    for (const onEvent of successfulEventSinks) onEvent(msg);
+    for (const onEvent of successfulEventSinks) {
+      onEvent(msg);
+    }
   };
 
   const drainLoopOptions: {
@@ -1367,16 +1425,18 @@ async function drainBatch(
     successfulBatch.length > 0
       ? successfulBatch[successfulBatch.length - 1]
       : undefined;
-  if (lastSuccessfulBatchEntry?.isInteractive !== undefined)
+  if (lastSuccessfulBatchEntry?.isInteractive !== undefined) {
     drainLoopOptions.isInteractive = lastSuccessfulBatchEntry.isInteractive;
+  }
   // A batch counts as a hidden turn only when every message in it is a
   // hidden machine signal — one genuine user prompt justifies the
   // prompt-as-user-speech consumers (title generation).
   if (
     successfulBatch.length > 0 &&
     successfulBatch.every((qm) => isHiddenMessageMetadata(qm.metadata))
-  )
+  ) {
     drainLoopOptions.isHiddenPrompt = true;
+  }
 
   // Fire-and-forget: runAgentLoop's finally block recursively calls drainQueue
   // when this run completes. Mirrors drainSingleMessage.
@@ -1896,7 +1956,9 @@ export async function processMessage(
   if (conversation.assistantId) {
     extractPreferences(resolvedContent)
       .then((result) => {
-        if (!result.detected) return;
+        if (!result.detected) {
+          return;
+        }
         for (const pref of result.preferences) {
           createPreference({
             preferenceText: pref.preferenceText,
@@ -1928,12 +1990,18 @@ export async function processMessage(
     callSite?: LLMCallSite;
     overrideProfile?: string;
   } = { isUserMessage: true };
-  if (isInteractive !== undefined) loopOptions.isInteractive = isInteractive;
-  if (agentLoopContent !== resolvedContent)
+  if (isInteractive !== undefined) {
+    loopOptions.isInteractive = isInteractive;
+  }
+  if (agentLoopContent !== resolvedContent) {
     loopOptions.titleText = resolvedContent;
-  if (callSite !== undefined) loopOptions.callSite = callSite;
-  if (overrideProfile !== undefined)
+  }
+  if (callSite !== undefined) {
+    loopOptions.callSite = callSite;
+  }
+  if (overrideProfile !== undefined) {
     loopOptions.overrideProfile = overrideProfile;
+  }
 
   await conversation.runAgentLoop(agentLoopContent, userMessageId, {
     ...loopOptions,

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -37,9 +37,14 @@
  * `/messages` snapshot returns it so a client can align the snapshot with the
  * stream: "these rows reflect all of this conversation's events through
  * `seq = S`." It is written at each persistence flush (assistant rows persist
- * incrementally, debounced, so the snapshot can lag the live counter) -- never
- * the live counter itself, which would over-claim events that have streamed
- * but not yet been written. Because it lives in the database it survives a
+ * incrementally, debounced, so the snapshot can lag the live counter) and at
+ * each user-row echo (the row persists before the echo is emitted, so the
+ * echo's seq is covered the moment it exists) -- never the live counter while
+ * a turn is streaming, which would over-claim events that have streamed but
+ * not yet been written. Under-claiming is equally a contract violation: a
+ * snapshot carrying a row whose event is above the advertised seq defeats
+ * clients that compare the anchor against their fold watermark to detect
+ * stale in-flight fetches. Because it lives in the database it survives a
  * restart; and because the counter resumes above the persisted reservation, a
  * value written by a previous process could only ever be lower than any seq
  * the new process assigns -- never ambiguous against it.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -109,6 +109,7 @@ import {
   isHiddenMessageMetadata,
   type MessageRow,
   provenanceFromTrustContext,
+  recordConversationPersistedSeq,
   setConversationInferenceProfile,
 } from "../../persistence/conversation-crud.js";
 import {
@@ -134,6 +135,7 @@ import {
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
+import { getCurrentSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   type GuardianPendingScope,
@@ -602,6 +604,11 @@ async function tryConsumeCanonicalGuardianReply(params: {
         conversationId: conversationId,
       });
       emitCannedMessageComplete(onEvent, conversationId, persistedAssistant.id);
+      // Both rows persisted above and no run is active (no unflushed stream
+      // content), so advance the snapshot↔stream anchor past the events just
+      // emitted. Otherwise `/messages` returns these rows while advertising
+      // the previous anchor, under-claiming what the snapshot reflects.
+      recordConversationPersistedSeq(conversationId, getCurrentSeq());
     }
     publishConversationMessagesChanged(conversationId, originClientId);
   } catch (err) {
@@ -1883,6 +1890,10 @@ export async function handleSendMessage(
           conversationId,
           persistedAssistant.id,
         );
+        // Rows persisted before this deferred burst; advance the
+        // snapshot↔stream anchor past the events just emitted so `/messages`
+        // never returns these rows behind a stale anchor.
+        recordConversationPersistedSeq(conversationId, getCurrentSeq());
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.setProcessing(false);
         silentlyWithLog(
@@ -2199,6 +2210,8 @@ export async function handleSendMessage(
           conversationId,
           persistedAssistant.id,
         );
+        // Same anchor advance as the canned-greeting path above.
+        recordConversationPersistedSeq(conversationId, getCurrentSeq());
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.setProcessing(false);
         silentlyWithLog(conversation.drainQueue(), "slash-command queue drain");
@@ -2294,6 +2307,8 @@ export async function handleSendMessage(
           conversationId,
           persistedAssistant.id,
         );
+        // Same anchor advance as the canned-greeting path above.
+        recordConversationPersistedSeq(conversationId, getCurrentSeq());
         publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
         if (assistantMessagePersisted) {
@@ -2389,6 +2404,8 @@ export async function handleSendMessage(
           conversationId,
           persistedAssistant.id,
         );
+        // Same anchor advance as the canned-greeting path above.
+        recordConversationPersistedSeq(conversationId, getCurrentSeq());
         publishConversationMessagesChanged(conversationId, originClientId);
       } catch (err) {
         if (assistantMessagePersisted) {
@@ -2455,6 +2472,15 @@ export async function handleSendMessage(
       requestId,
       clientMessageId,
     });
+    // The row this echo announces was durably persisted above, so advance
+    // the snapshot↔stream anchor to the echo's seq (stamped inline by
+    // `broadcastMessage`). Without this, `/messages` returns the row while
+    // still advertising the previous flush's anchor — under-claiming, which
+    // breaks the contract that the snapshot reflects all of this
+    // conversation's events through the advertised seq. Safe to claim here:
+    // the agent loop for this turn hasn't started, so no streamed-but-
+    // unflushed content exists for this conversation.
+    recordConversationPersistedSeq(mapping.conversationId, getCurrentSeq());
   }
   publishConversationMessagesChanged(mapping.conversationId, originClientId);
 

--- a/clients/web/docs/CONVERSATION_SSE.md
+++ b/clients/web/docs/CONVERSATION_SSE.md
@@ -88,7 +88,11 @@ later can't be ring-replayed. The recovery path is a refetch:
   partial-persist debounce) is **dropped** when the live view has already
   folded seq-stamped events: with no cursor to replay from, taking it
   wholesale would wipe the streamed turn (the mid-turn "vanishing prefix"
-  flicker) until the turn-end reseed restored it.
+  flicker) until the turn-end reseed restored it. A **stale-anchored** fetch
+  (`seq` strictly below the live view's) whose gap the ring can't bridge is
+  dropped for the same reason: it was in flight before newer events folded
+  in, and taking it wholesale would regress the view — e.g. erase a just-sent
+  user row whose echo already retired the optimistic copy (the send flicker).
 - The reseed also **prunes** any optimistic send the snapshot now represents
   (`pruneConfirmedOptimisticSends`), keyed by the same identity
   `selectTranscriptMessages` overlays on. Without this, a send whose echo/dequeue

--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -82,6 +82,55 @@ describe("chat-session-store — snapshot + optimistic", () => {
     expect(store().snapshot).toBe(snap); // wholesale, no partial replay
   });
 
+  test("seedSnapshot drops a stale-anchored fetch the ring can't bridge (send flicker)", () => {
+    // The logged incident: the live view seeded at seq 100, then folded the
+    // send's user_message_echo (seq 500 — other conversations' events advanced
+    // the global counter in between, so the ring can't bridge from 100). The
+    // echo handler already retired the optimistic copy, so a pre-send fetch
+    // committing now (anchor still 100, no user row) must be dropped — taking
+    // it wholesale would erase the just-sent message from the screen.
+    const id = registerSseClient(new AbortController().signal);
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "earlier")], 100));
+    const echo = envelope(500, CONV, {
+      type: "user_message_echo",
+      text: "hi",
+      messageId: "msg-user-1",
+      clientMessageId: "nonce-1",
+    } as AssistantEvent);
+    pushSseEvent(id, echo);
+    store().applyEnvelopeToSnapshot(echo);
+    expect(store().snapshot?.messages.some((m) => m.id === "msg-user-1")).toBe(true);
+
+    const before = store().snapshot;
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "earlier")], 100));
+
+    expect(store().snapshot).toBe(before);
+    expect(store().snapshot?.messages.some((m) => m.id === "msg-user-1")).toBe(true);
+  });
+
+  test("seedSnapshot accepts a caught-up anchor after dropping a stale one", () => {
+    const id = registerSseClient(new AbortController().signal);
+    store().seedSnapshot(CONV, snapshot([textRow("a1", "earlier")], 100));
+    const echo = envelope(500, CONV, {
+      type: "user_message_echo",
+      text: "hi",
+      messageId: "msg-user-1",
+      clientMessageId: "nonce-1",
+    } as AssistantEvent);
+    pushSseEvent(id, echo);
+    store().applyEnvelopeToSnapshot(echo);
+
+    // The authoritative reconcile refetch lands with the persisted user row
+    // and an anchor at (or past) the live watermark — reseeds normally.
+    const fresh = snapshot(
+      [textRow("a1", "earlier"), { ...textRow("msg-user-1", "hi"), role: "user" }],
+      500,
+    );
+    store().seedSnapshot(CONV, fresh);
+    expect(store().snapshot?.messages.some((m) => m.id === "msg-user-1")).toBe(true);
+    expect(store().snapshot?.seq).toBe(500);
+  });
+
   test("applyEnvelopeToSnapshot folds a live event once seeded; idempotent by seq", () => {
     store().seedSnapshot(CONV, snapshot([textRow("a1", "persisted")], 5));
     store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", " live"));

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -130,9 +130,10 @@ export interface ChatSessionActions {
   /** Seed (or resync) the snapshot from a freshly fetched server snapshot,
    *  replaying the buffered event tail with `seq > snapshot.seq` onto it so
    *  events that raced the fetch aren't lost. A gap (evicted tail) falls back
-   *  to the fetched snapshot alone — except when the fetch is anchor-less
-   *  (`seq` null) while the live view has already folded seq-stamped events;
-   *  such a fetch is provably behind the stream and is dropped instead. */
+   *  to the fetched snapshot alone — except when the fetch is provably behind
+   *  the live view and the gap makes it unbridgeable: an anchor-less fetch
+   *  (`seq` null) while the live view has folded seq-stamped events, or a
+   *  stale-anchored fetch (`seq` below the live view's). Either is dropped. */
   seedSnapshot: (conversationId: string, snapshot: PaginatedHistoryResult) => void;
   /** Fold one live stream event into the snapshot (no-op until seeded; the
    *  seed's replay covers anything that arrived first). Idempotent by `seq`. */
@@ -342,6 +343,32 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
       return;
     }
     const tail = getSseEnvelopesSince(conversationId, snapshot.seq ?? null);
+    // Stale-anchored regression guard, the anchored twin of the guard above.
+    // A `/messages` fetch that was already in flight when the live view folded
+    // newer stream content commits with an older watermark — e.g. a refetch
+    // started just before a send whose `user_message_echo` has since folded in.
+    // When the ring can't bridge from the fetch's anchor (`tail === null`,
+    // typically because other conversations' events pushed the global seq past
+    // it while this tab was backgrounded), taking the fetch wholesale would
+    // regress the snapshot to its pre-send state — and since the echo already
+    // retired the optimistic copy, the user's just-sent message vanishes until
+    // the next authoritative reconcile restores it (the send flicker). The
+    // live view is anchored strictly ahead of the fetch, so keep it and drop
+    // the fetch; a later fetch with a caught-up anchor reseeds normally.
+    if (
+      tail === null &&
+      current !== null &&
+      typeof current.seq === "number" &&
+      typeof snapshot.seq === "number" &&
+      snapshot.seq < current.seq
+    ) {
+      recordDiagnostic("history_seed_skipped_stale_anchor", {
+        conversationId,
+        liveSeq: current.seq,
+        fetchedSeq: snapshot.seq,
+      });
+      return;
+    }
     const resolved = resolveSnapshot(snapshot, tail);
     set((s) => ({
       snapshot: resolved,


### PR DESCRIPTION
## Prompt / plan

User report (with a diagnostics bundle attached): *"I sent the message, then my message disappeared from screen, then my message reappeared on screen resuming the standard loading state."*

The bundle pinned the race down to the second (conversation `45defe4d`, 2026-07-03 15:09:22–24):

1. `15:09:22.5` — the reconciliation loop invalidated history, starting a `/messages` refetch chain (server latest page: 7 messages, `seq 1966984` — pre-send).
2. `15:09:22.9` — the user hit send; the optimistic row rendered and the loop was cancelled, but the refetch chain stayed in flight.
3. `15:09:23.256` — the `user_message_echo` (`seq 1971153`) arrived: the fold materialized the user row in the live snapshot and the echo handler retired the optimistic copy. (Other conversations had advanced the global seq by ~400 in between — `sse_seq_gap_detected` fired at the same instant.)
4. `15:09:23.309` — the **stale pre-send fetch committed** (`history_tq_data_apply`, `seq 1966984`, no user row). `getSseEnvelopesSince` couldn't bridge from that anchor, so `seedSnapshot` took the fetch wholesale — regressing the snapshot to its pre-send state. With the optimistic copy already retired, the message vanished from **both** render sources.
5. `15:09:23.5–24.5` — the seq-gap authoritative reconcile refetched and restored the row. Net: the message was gone for ~1.2s — the reported flicker.

### The fix, in two halves

**Web (`seedSnapshot` guard):** drop a committed `/messages` fetch whose `seq` anchor is strictly behind the live view's watermark when the SSE ring can't bridge the gap — the anchored twin of the existing anchor-less guard. A later fetch with a caught-up anchor reseeds normally.

**Assistant (truthful anchor — addresses Codex's P1):** the guard is only sound if the advertised anchor accurately reflects the response's content. The daemon under-claimed: `conversations.seq` only advanced at assistant-turn persistence flushes, so a just-persisted user row appeared in `/messages` while the anchor still pointed at the previous flush — indistinguishable, client-side, from a genuinely stale fetch. Codex correctly flagged that this could make the guard drop a gap-heal snapshot that carries missed rows behind a lagging anchor. Rather than adding client-side heuristics, this PR fixes the invariant at the source: every path that emits events for an already-persisted row now advances the anchor to the just-stamped seq (direct HTTP send, queue-drain echoes single/batched, canned greeting, unknown slash, `/compact`, `/clean`, inline approval replies). All these sites run while no turn is streaming, so the anchor never over-claims unflushed content. With a truthful anchor, "anchor < live watermark + unbridgeable" is *proof* of staleness, and the heal fetch (issued after the gap event, so its anchor covers it) always passes the guard.

Known residual: an **old daemon + new web client** still under-claims, so Codex's heal-drop edge can exist across that version skew until the daemon updates; matched versions are fully correct.

## Test plan

- **Live daemon (backend half):** booted the assistant from this branch, attached SSE, `POST /v1/messages`. The echo streamed with `seq 1025` and the immediately following `GET /v1/messages` advertised `seq 1025` with the row present (pre-fix: row present, anchor stale at the previous flush).
- **Runtime repro in Chromium (web half):** Playwright against the Vite dev server mounting the real `useTranscriptMessages` → chat-session store → rolling-snapshot reducer → SSE ring pipeline, replaying the logged sequence: without the guard the sent row is erased at the stale reseed; with it, it survives. Probes: authoritative recovery reseed applies with no duplicate row; equal-anchor reseed before the echo keeps the optimistic row visible.
- New unit tests: web store (stale-anchored fetch with unbridgeable gap dropped; caught-up anchor reseeds) and assistant queue (anchor advances to the echo's stamped seq; echo-suppressed rows don't advance it).
- Suites: web store/transcript/reconciliation suites (111 tests) and assistant conversation-queue/routes/slash/stream-state suites (152 tests) pass; `tsc` clean in both packages; eslint 0 errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdqRyAQsbCxbmCjzZt6CYS