### PR TITLE
fix(web): never show 'Show more' and 'Show less' together in sidebar sections

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -464,6 +464,10 @@ export function useStreamEventHandler(
         // handler ignores them.
         case "trace_event":
           break;
+        // Transient, best-effort progress signals from lifecycle hooks
+        // (e.g. user-prompt-submit). No web UI renders them yet.
+        case "hook_event":
+          break;
         case "unknown":
           break;
         default: {

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -69,8 +69,10 @@ describe("useSidebarState pagination", () => {
     expect(result.current.recents.items).toHaveLength(
       SIDEBAR_CONVERSATION_LIMIT * 2,
     );
+    // Mid-expansion offers only "Show more" — "Show less" waits until the
+    // section is fully revealed so the two never render stacked together.
     expect(result.current.recents.showMore).toBe(true);
-    expect(result.current.recents.showLess).toBe(true);
+    expect(result.current.recents.showLess).toBe(false);
 
     act(() => result.current.recents.onShowMore());
 
@@ -117,7 +119,7 @@ describe("useSidebarState pagination", () => {
 
     expect(slackSection().items).toHaveLength(SIDEBAR_CONVERSATION_LIMIT * 2);
     expect(slackSection().showMore).toBe(true);
-    expect(slackSection().showLess).toBe(true);
+    expect(slackSection().showLess).toBe(false);
   });
 
   test("exposes one paginated section per origin channel", () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -43,6 +43,11 @@ export interface PaginatedSection {
   all: Conversation[];
   items: Conversation[];
   totalCount: number;
+  /**
+   * At most one of `showMore` / `showLess` is true: "Show more" while
+   * items remain hidden, "Show less" only once the section is fully
+   * revealed past the default limit.
+   */
   showMore: boolean;
   showLess: boolean;
   onShowMore: () => void;
@@ -71,12 +76,16 @@ function buildPaginatedSection(
   // Force enough rows visible to reveal a conversation that needs attention.
   const effectiveVisibleCount =
     attentionIndex >= visibleCount ? attentionIndex + 1 : visibleCount;
+  const showMore = effectiveVisibleCount < all.length;
   return {
     all,
     items: all.slice(0, effectiveVisibleCount),
     totalCount: all.length,
-    showMore: effectiveVisibleCount < all.length,
+    showMore,
+    // Never alongside showMore — two stacked, contradictory affordances.
+    // Collapse is offered only once the section is fully revealed.
     showLess:
+      !showMore &&
       visibleCount > SIDEBAR_CONVERSATION_LIMIT &&
       all.length > SIDEBAR_CONVERSATION_LIMIT,
     onShowMore: () =>


### PR DESCRIPTION
## Prompt / plan

User report (with screenshot): a sidebar conversation section rendered both a "Show more" row and a "Show less" row stacked directly under each other — two contradictory affordances at once.

Root cause: in `buildPaginatedSection()` (`clients/web/src/domains/chat/use-sidebar-state.ts`), `showMore` and `showLess` were computed independently. In the mid-paginated state — one "Show more" click on a section with more than 2×`SIDEBAR_CONVERSATION_LIMIT` items — both flags were true, and `ConversationRowList` renders each flag as its own `SideMenu.Item`, so both rows appeared. This behavior was even codified in the hook's tests.

Fix: make the two affordances mutually exclusive at the data layer — `showLess` is now `!showMore && …`, so a section offers "Show more" while items remain hidden and "Show less" only once it is fully revealed past the default limit. This applies uniformly to Recents and every per-channel section (they share `buildPaginatedSection`). Attention-forced reveals keep their existing behavior: when an attention item forces everything visible without the user having clicked, neither control shows, same as before.

Also carries an unrelated CI unblock: `c6f49ca` (#37022) added the `hook_event` SSE event to the daemon API without updating the web client's exhaustive stream-event switch, so any web PR that regenerates the API clients failed Type Check on the merge ref. Added an explicit no-op `case "hook_event"` (transient hook progress signal, no web renderer yet).

## Test plan

- Updated `use-sidebar-state.test.tsx` mid-expansion expectations to the new mutually-exclusive semantics; full expand → collapse round-trip still covered.
- `bun test` on `use-sidebar-state.test.tsx`, `assistant-side-menu.test.tsx`, `subagent-detail-panel.test.tsx`: 38 pass, 0 fail.
- `bun run typecheck` (regenerates API clients like CI, then `tsc --noEmit`) against the branch merged with latest main: clean. Reproduced the `hook_event` TS2322 failure before the fix.
- `eslint` on changed files: no new warnings (10 pre-existing `curly` warnings unchanged, verified against a stash of the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrwqegYdNCpEhbTSow2Qin