### PR TITLE
fix(design-library): toast dismiss button no-ops when no explicit id is set

### DIFF
--- a/packages/design-library/src/components/toast.test.tsx
+++ b/packages/design-library/src/components/toast.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for the toast wrapper around sonner.
+ *
+ * No DOM environment — sonner's imperative state (`ToastState`) works without
+ * one, so we verify the id contract directly against `sonnerToast.getHistory()`.
+ *
+ * Regression guard: sonner spreads caller options over its generated id
+ * (`{ jsx: jsx(id), id, ...data }`), so passing an explicit `id: undefined`
+ * key detaches the stored toast's id from the id given to the jsx callback
+ * and returned to the caller — dismissing (the X button) then no-ops.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { toast as sonnerToast } from "sonner";
+
+import { toast } from "./toast";
+
+// sonner's dismiss() notifies subscribers via requestAnimationFrame, which
+// this DOM-less environment doesn't provide.
+globalThis.requestAnimationFrame ??= (cb: FrameRequestCallback) =>
+  setTimeout(() => cb(performance.now()), 0) as unknown as number;
+
+function storedToast(id: string | number) {
+  return sonnerToast.getHistory().find((t) => t.id === id);
+}
+
+describe("toast id contract", () => {
+  test("variant toast without an explicit id stores the toast under the returned id", () => {
+    const id = toast.success("Update complete — assistant is healthy.");
+    expect(storedToast(id)).toBeDefined();
+  });
+
+  test("variant toast with an explicit id keeps that id", () => {
+    const id = toast.info("hello", { id: "my-toast" });
+    expect(id).toBe("my-toast");
+    expect(storedToast("my-toast")).toBeDefined();
+  });
+
+  test("custom toast without an explicit id stores the toast under the id given to the render callback", () => {
+    let renderedWithId: string | number | undefined;
+    const id = toast.custom((toastId) => {
+      renderedWithId = toastId;
+      return <div />;
+    });
+    expect(renderedWithId).toBe(id);
+    expect(storedToast(id)).toBeDefined();
+  });
+
+  test("dismissing by the returned id marks the toast dismissed", () => {
+    const id = toast.warning("something");
+    expect(sonnerToast.getToasts().some((t) => t.id === id)).toBe(true);
+    toast.dismiss(id);
+    expect(sonnerToast.getToasts().some((t) => t.id === id)).toBe(false);
+  });
+});

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -128,17 +128,14 @@ function ToastContent({
   );
 }
 
-// Sonner builds the toast object as `{ jsx: jsx(id), id, ...data }`, so an
-// explicit `id: undefined` key in `data` overwrites the id it just generated
-// and passed to the jsx render callback — sonner then mints a *different* id
-// for the stored toast, and dismissing by the callback's id (the close
-// button, or the id returned to the caller) targets a toast that doesn't
-// exist. Strip undefined keys before handing options to sonner.
-function definedOptions<T extends object>(options: T | undefined): Partial<T> {
-  if (!options) return {};
-  return Object.fromEntries(
-    Object.entries(options).filter(([, value]) => value !== undefined),
-  ) as Partial<T>;
+// Sonner builds the toast object as `{ jsx: jsx(id), id, ...data }`, so
+// forwarding `id: undefined` overwrites the id it generated and handed to
+// the jsx render callback — the stored toast ends up under a different id
+// and dismissing by the callback's id (the close button) no-ops. Always
+// hand sonner a concrete id of our own instead.
+let toastIdCounter = 0;
+function nextToastId(): string {
+  return `toast-${++toastIdCounter}`;
 }
 
 function showToast(
@@ -146,8 +143,9 @@ function showToast(
   variant: ToastVariant = "default",
   options?: ToastOptions,
 ) {
+  const id = options?.id ?? nextToastId();
   return sonnerToast.custom(
-    (id) => (
+    () => (
       <ToastContent
         message={message}
         variant={variant}
@@ -155,7 +153,7 @@ function showToast(
         onDismiss={() => sonnerToast.dismiss(id)}
       />
     ),
-    definedOptions({ duration: options?.duration, id: options?.id }),
+    { duration: options?.duration, id },
   );
 }
 
@@ -180,7 +178,11 @@ const toast = Object.assign(
     custom: (
       render: (id: number | string) => ReactElement,
       options?: CustomToastOptions,
-    ) => sonnerToast.custom(render, definedOptions(options)),
+    ) =>
+      sonnerToast.custom(render, {
+        ...options,
+        id: options?.id ?? nextToastId(),
+      }),
     dismiss: (id?: string | number) => sonnerToast.dismiss(id),
   },
 );

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -128,6 +128,19 @@ function ToastContent({
   );
 }
 
+// Sonner builds the toast object as `{ jsx: jsx(id), id, ...data }`, so an
+// explicit `id: undefined` key in `data` overwrites the id it just generated
+// and passed to the jsx render callback — sonner then mints a *different* id
+// for the stored toast, and dismissing by the callback's id (the close
+// button, or the id returned to the caller) targets a toast that doesn't
+// exist. Strip undefined keys before handing options to sonner.
+function definedOptions<T extends object>(options: T | undefined): Partial<T> {
+  if (!options) return {};
+  return Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
+}
+
 function showToast(
   message: string,
   variant: ToastVariant = "default",
@@ -142,7 +155,7 @@ function showToast(
         onDismiss={() => sonnerToast.dismiss(id)}
       />
     ),
-    { duration: options?.duration, id: options?.id },
+    definedOptions({ duration: options?.duration, id: options?.id }),
   );
 }
 
@@ -167,7 +180,7 @@ const toast = Object.assign(
     custom: (
       render: (id: number | string) => ReactElement,
       options?: CustomToastOptions,
-    ) => sonnerToast.custom(render, options),
+    ) => sonnerToast.custom(render, definedOptions(options)),
     dismiss: (id?: string | number) => sonnerToast.dismiss(id),
   },
 );


### PR DESCRIPTION
## Prompt / plan

Bug report: clicking the X dismiss button on toasts (e.g. "Upgraded to version 0.10.5-dev…", "Update complete — assistant is healthy.") does nothing.

Root cause: sonner builds its toast object as `{ jsx: jsx(id), id, ...data }`. Our `showToast` wrapper always forwarded `{ duration: options?.duration, id: options?.id }`, so when the caller set no id, the explicit `id: undefined` key in that object overwrote the id sonner had just generated and handed to the jsx render callback. sonner's `create()` then minted a *different* id for the stored toast, so the close button's `sonnerToast.dismiss(id)` targeted an id that didn't exist — a silent no-op. Toasts created with an explicit id (like the Electron app-update toast) were unaffected, which is why only auto-id toasts were broken.

Fix: always hand sonner a concrete id — the caller's id when given, otherwise a locally generated default — in both the variant helpers (`toast.success/error/info/warning`) and the `toast.custom` passthrough. Only the `id` key is merge-order-sensitive in sonner; `duration` is safely defaulted at read time.

## Test plan

- Reproduced the bug in the design-library Storybook with Playwright (real Chromium): clicking the Close button left the toast in place; after the fix the same script removes it.
- Traced the id mismatch by instrumenting sonner: the dismiss closure captured id 1 while the stored toast had id 2.
- New DOM-less regression tests in `toast.test.tsx` pin the id contract against `sonnerToast.getHistory()`/`getToasts()`; they fail on the pre-fix code (2/4) and pass with the fix.
- `cd packages/design-library && bun test` — 156 pass / 0 fail; `bun run typecheck` clean.

## CLI verb checklist

N/A — no new IPC routes; design-library component fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fUszSqHC1RwpKnLmBiMJy