### PR TITLE
refactor(hooks): input/full context split, pipeline-built logger, safe hook_event serialization

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -566,4 +566,32 @@ describe("broadcastMessage — replay ring", () => {
       "assistant_text_delta",
     ]);
   });
+
+  test("an unserializable payload does not throw and is not buffered", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    // The emit path must survive a payload JSON cannot represent — the event
+    // is left unstamped (no seq gap) and skipped by the replay ring, while
+    // later events buffer normally.
+    expect(() =>
+      broadcastMessage({
+        type: "hook_event",
+        conversationId: "sess_1",
+        hookName: "user-prompt-submit",
+        owner: { kind: "plugin", id: "default-memory" },
+        detail: circular,
+      }),
+    ).not.toThrow();
+    broadcastMessage({
+      type: "assistant_text_delta",
+      conversationId: "sess_1",
+      text: "hi",
+    });
+
+    const replayed = getReplayWindow(0, undefined, "sess_1");
+    expect(replayed?.map((e) => e.message.type)).toEqual([
+      "assistant_text_delta",
+    ]);
+  });
 });

--- a/assistant/src/__tests__/hook-broadcast.test.ts
+++ b/assistant/src/__tests__/hook-broadcast.test.ts
@@ -144,6 +144,28 @@ describe("user-prompt-submit broadcast capability", () => {
     expect(events[0]!.owner).toEqual({ kind: "plugin", id: "owner-a" });
   });
 
+  test("sanitizes unserializable detail instead of throwing into the hook", async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    let ranPastBroadcast = false;
+    registerPlugin(
+      buildPlugin("owner-a", (ctx) => {
+        ctx.broadcast(circular);
+        ranPastBroadcast = true;
+        return Promise.resolve();
+      }),
+    );
+
+    await runHook("user-prompt-submit", baseCtx());
+
+    // The broadcast never throws into the hook; the payload is replaced with
+    // a marker so the emitted event stays JSON-serializable.
+    expect(ranPastBroadcast).toBe(true);
+    const events = emittedHookEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.detail).toEqual({ unserializableDetail: true });
+  });
+
   test("a hook that never broadcasts emits nothing", async () => {
     registerPlugin(buildPlugin("owner-quiet", () => Promise.resolve()));
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -15,20 +15,20 @@ import { spoolAndStubOversizedToolResults } from "../context/tool-result-spool.j
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { parseActualTokensFromError } from "../daemon/parse-actual-tokens-from-error.js";
 import type { TrustContext } from "../daemon/trust-context.js";
+import type {
+  AgentLoopExitReason,
+  PostCompactInputContext,
+  PostModelCallDecision,
+  PostModelCallInputContext,
+  PostToolUseInputContext,
+  PreModelCallInputContext,
+  StopInputContext,
+} from "../hooks/types.js";
 import {
   timeSyncSection,
   traceAsyncSection,
 } from "../persistence/slow-sync-log.js";
 import { HOOKS } from "../plugin-api/constants.js";
-import type {
-  AgentLoopExitReason,
-  PostCompactContext,
-  PostModelCallContext,
-  PostModelCallDecision,
-  PostToolUseContext,
-  PreModelCallContext,
-  StopContext,
-} from "../plugin-api/types.js";
 import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import { runHook } from "../plugins/pipeline.js";
@@ -157,7 +157,9 @@ function buildNativeWebSearchProbeOptions(
   forceOverrideProfile: boolean,
   conversationId: string | undefined,
 ): SendMessageOptions | undefined {
-  if (!callSite) return undefined;
+  if (!callSite) {
+    return undefined;
+  }
   return {
     config: {
       callSite,
@@ -505,7 +507,9 @@ const MAX_POST_MODEL_CALL_CONTINUES = 5;
 function assistantTextOf(content: ReadonlyArray<ContentBlock>): string {
   let text = "";
   for (const block of content) {
-    if (block.type === "text") text += block.text;
+    if (block.type === "text") {
+      text += block.text;
+    }
   }
   return text;
 }
@@ -1000,14 +1004,13 @@ export class AgentLoop {
       overflowSignal != null || compactResult.compacted
         ? compactResult.messages
         : history;
-    const postCompactCtx: Omit<PostCompactContext, "broadcast"> = {
+    const postCompactCtx: PostCompactInputContext = {
       history: base,
       requestId,
       conversationId: this.conversationId,
       isNonInteractive,
       modelProfileKey,
       injectionMode: compactResult.injectionMode,
-      logger: log.child({ requestId }),
     };
     // The hook chain writes the re-injected history back onto the context;
     // read it from there once the chain settles.
@@ -1158,14 +1161,15 @@ export class AgentLoop {
       reason: AgentLoopExitReason,
       { emitExit, error }: { emitExit: boolean; error?: Error },
     ): Promise<void> => {
-      if (turnStopped) return;
+      if (turnStopped) {
+        return;
+      }
       turnStopped = true;
-      const stopCtx: Omit<StopContext, "broadcast"> = {
+      const stopCtx: StopInputContext = {
         conversationId: this.conversationId,
         messages: [...history],
         error,
         exitReason: reason,
-        logger: rlog,
       };
       try {
         await runHook(HOOKS.STOP, stopCtx);
@@ -1577,7 +1581,9 @@ export class AgentLoop {
             if (event.type === "text_delta") {
               // Held when the turn's output is deferred — the final text is
               // emitted once, after the `post-model-call` hook runs.
-              if (deferAssistantOutput) return;
+              if (deferAssistantOutput) {
+                return;
+              }
               // Apply sensitive-output placeholder substitution (chunk-safe)
               if (substitutionMap.size > 0) {
                 const combined = streamingPending + event.text;
@@ -1591,7 +1597,9 @@ export class AgentLoop {
                   onEvent({ type: "text_delta", text: emit });
                 }
               } else {
-                if (event.text.length > 0) streamedVisibleText = true;
+                if (event.text.length > 0) {
+                  streamedVisibleText = true;
+                }
                 onEvent({ type: "text_delta", text: event.text });
               }
             } else if (event.type === "thinking_delta") {
@@ -1640,13 +1648,12 @@ export class AgentLoop {
         // call site / conversation. Fail-open: a throwing hook leaves the
         // request unchanged and streaming live.
         try {
-          const preModelCtx: Omit<PreModelCallContext, "broadcast"> = {
+          const preModelCtx: PreModelCallInputContext = {
             conversationId: this.conversationId,
             callSite: callSite ?? null,
             systemPrompt: providerOptions.systemPrompt ?? null,
             modelProfile: effectiveOverrideProfile ?? null,
             deferAssistantOutput: false,
-            logger: rlog,
           };
           const finalPreModelCtx = await traceAsyncSection(
             "agent-loop:pre-model-call-hook",
@@ -1807,14 +1814,13 @@ export class AgentLoop {
           messages: Message[];
         }> => {
           try {
-            const ctx: Omit<PostModelCallContext, "broadcast"> = {
+            const ctx: PostModelCallInputContext = {
               conversationId: this.conversationId,
               callSite: callSite ?? null,
               content: structuredClone(message.content),
               messages: [...history],
               stopReason: response.stopReason,
               decision: "stop",
-              logger: rlog,
             };
             const result = await traceAsyncSection(
               "agent-loop:post-model-call-hook",
@@ -1842,7 +1848,9 @@ export class AgentLoop {
         // would have shown. A no-op when text already streamed live — that
         // stream stands. Call only for a turn being kept.
         const emitFinalAssistantText = (content: ContentBlock[]): void => {
-          if (streamedVisibleText) return;
+          if (streamedVisibleText) {
+            return;
+          }
           const finalText = applySubstitutions(
             assistantTextOf(content),
             substitutionMap,
@@ -2246,7 +2254,7 @@ export class AgentLoop {
             resultBlocks.push(block);
             continue;
           }
-          const postToolUseCtx: Omit<PostToolUseContext, "broadcast"> = {
+          const postToolUseCtx: PostToolUseInputContext = {
             conversationId: this.conversationId,
             toolResponse: block as ToolResultContent,
             messages: history,
@@ -2255,7 +2263,6 @@ export class AgentLoop {
             maxInputTokens: contextWindowTokens,
             callSite: callSite ?? null,
             supportsDynamicUi,
-            logger: rlog,
           };
           const finalCtx = await runHook(HOOKS.POST_TOOL_USE, postToolUseCtx);
           resultBlocks.push(finalCtx.toolResponse);
@@ -2452,7 +2459,7 @@ export class AgentLoop {
         // hooks) is not a provider stop, so it falls straight through to the
         // error path below.
         if (error === providerCallError) {
-          const errorOutcomeCtx: Omit<PostModelCallContext, "broadcast"> = {
+          const errorOutcomeCtx: PostModelCallInputContext = {
             conversationId: this.conversationId,
             callSite: callSite ?? null,
             content: [],
@@ -2460,10 +2467,8 @@ export class AgentLoop {
             stopReason: null,
             error: err,
             decision: "stop",
-            logger: rlog,
           };
-          let errorOutcome: Omit<PostModelCallContext, "broadcast"> =
-            errorOutcomeCtx;
+          let errorOutcome: PostModelCallInputContext = errorOutcomeCtx;
           try {
             errorOutcome = await runHook(
               HOOKS.POST_MODEL_CALL,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -35,6 +35,7 @@ import {
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { writeRelationshipState } from "../home/relationship-state-writer.js";
+import type { UserPromptSubmitInputContext } from "../hooks/types.js";
 import {
   clearSentryConversationContext,
   setSentryConversationContext,
@@ -58,7 +59,6 @@ import {
   recordSyntheticAgentErrorMessageLog,
 } from "../persistence/llm-request-log-store.js";
 import { HOOKS } from "../plugin-api/constants.js";
-import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import { runHook } from "../plugins/pipeline.js";
@@ -234,8 +234,9 @@ async function withAbortWatchdog<T>(
         );
       }, timeoutMs);
     };
-    if (signal.aborted) arm();
-    else {
+    if (signal.aborted) {
+      arm();
+    } else {
       onAbort = arm;
       signal.addEventListener("abort", onAbort, { once: true });
     }
@@ -243,8 +244,12 @@ async function withAbortWatchdog<T>(
   try {
     return await Promise.race([work, watchdog]);
   } finally {
-    if (timer) clearTimeout(timer);
-    if (onAbort) signal.removeEventListener("abort", onAbort);
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
     void work.catch(() => {});
   }
 }
@@ -488,10 +493,13 @@ export async function runAgentLoopImpl(
   // fall back to the conversation's persisted origin channel.
   const capturedTurnChannelContext: TurnChannelContext = (() => {
     const live = ctx.getTurnChannelContext();
-    if (live) return live;
+    if (live) {
+      return live;
+    }
     const origin = getConversationOriginChannel(ctx.conversationId);
-    if (origin)
+    if (origin) {
       return { userMessageChannel: origin, assistantMessageChannel: origin };
+    }
     return {
       userMessageChannel: "vellum" as ChannelId,
       assistantMessageChannel: "vellum" as ChannelId,
@@ -504,13 +512,16 @@ export async function runAgentLoopImpl(
   // deriving from channel.
   const capturedTurnInterfaceContext: TurnInterfaceContext = (() => {
     const live = ctx.getTurnInterfaceContext();
-    if (live) return live;
+    if (live) {
+      return live;
+    }
     const origin = getConversationOriginInterface(ctx.conversationId);
-    if (origin)
+    if (origin) {
       return {
         userMessageInterface: origin,
         assistantMessageInterface: origin,
       };
+    }
     return {
       userMessageInterface: "web" as InterfaceId,
       assistantMessageInterface: "web" as InterfaceId,
@@ -643,7 +654,9 @@ export async function runAgentLoopImpl(
     // Placed inside try so the finally block still runs if onEvent throws.
     if (options?.isUserMessage && !ctx.surfaceActionRequestIds.has(reqId)) {
       for (const [surfaceId, entry] of ctx.pendingSurfaceActions) {
-        if (entry.surfaceType === "dynamic_page") continue;
+        if (entry.surfaceType === "dynamic_page") {
+          continue;
+        }
         onEvent({
           type: "ui_surface_complete",
           conversationId: ctx.conversationId,
@@ -659,7 +672,9 @@ export async function runAgentLoopImpl(
     const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
     const loadCurrentSlackChronologicalContext =
       (): SlackChronologicalContext | null => {
-        if (!isSlackConversation) return null;
+        if (!isSlackConversation) {
+          return null;
+        }
         return loadSlackChronologicalContext(
           ctx.conversationId,
           ctx.channelCapabilities!,
@@ -678,10 +693,16 @@ export async function runAgentLoopImpl(
       messages: Message[],
       compactedMessages: number,
     ): SlackChronologicalContext | null => {
-      if (!isSlackConversation || compactedMessages <= 0) return null;
+      if (!isSlackConversation || compactedMessages <= 0) {
+        return null;
+      }
       const context = slackChronologicalContext;
-      if (!context) return null;
-      if (messages !== context.messages) return null;
+      if (!context) {
+        return null;
+      }
+      if (messages !== context.messages) {
+        return null;
+      }
       const end = context.compactableStartIndex + compactedMessages;
       if (
         end <= context.compactableStartIndex ||
@@ -904,7 +925,7 @@ export async function runAgentLoopImpl(
     // the chain settles on, in plugin registration order. The loop then reports
     // its own appended output via `AgentLoopRunResult.newMessages`, which
     // persistence consumes.
-    const userPromptCtx: Omit<UserPromptSubmitContext, "broadcast"> = {
+    const userPromptCtx: UserPromptSubmitInputContext = {
       conversationId: ctx.conversationId,
       userMessageId,
       requestId: reqId,
@@ -912,7 +933,6 @@ export async function runAgentLoopImpl(
       isHiddenPrompt: options?.isHiddenPrompt === true,
       originalMessages: ctx.messages,
       latestMessages: ctx.messages,
-      logger: rlog,
       modelProfileKey,
       isNonInteractive,
     };
@@ -1203,7 +1223,9 @@ export async function runAgentLoopImpl(
 
     // Reconstruct history
     const newMessages = lastRunNewMessages.map((msg) => {
-      if (msg.role !== "assistant") return msg;
+      if (msg.role !== "assistant") {
+        return msg;
+      }
       const { cleanedContent } = cleanAssistantContent(msg.content);
       const cleanedBlocks = cleanedContent as ContentBlock[];
       return { ...msg, content: cleanedBlocks };
@@ -1800,7 +1822,9 @@ export async function applyCompactionResult(
 }
 
 function collapseRawResponses(rawResponses?: unknown[]): unknown | undefined {
-  if (!rawResponses || rawResponses.length === 0) return undefined;
+  if (!rawResponses || rawResponses.length === 0) {
+    return undefined;
+  }
   return rawResponses.length === 1 ? rawResponses[0] : rawResponses;
 }
 

--- a/assistant/src/hooks/hook-broadcast.ts
+++ b/assistant/src/hooks/hook-broadcast.ts
@@ -7,12 +7,21 @@
  *
  * `hook_event` travels the standard SSE stream (including reconnect replay)
  * like every other event; clients render it as transient progress.
+ *
+ * The closure never throws: `detail` is hook-supplied and untrusted, so a
+ * payload JSON cannot represent (circular reference, BigInt, throwing toJSON)
+ * is replaced with a marker instead of propagating a serialization error into
+ * the hook chain, and any emit failure is logged and swallowed — `broadcast`
+ * is best-effort by contract.
  */
 
 import type { HookEventOwner } from "../api/events/hook-event.js";
 import type { HookName } from "../plugin-api/constants.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
 import type { HookBroadcast } from "./types.js";
+
+const log = getLogger("hook-broadcast");
 
 export function makeHookBroadcast(meta: {
   conversationId?: string;
@@ -20,15 +29,32 @@ export function makeHookBroadcast(meta: {
   owner: HookEventOwner;
 }): HookBroadcast {
   return (detail) => {
-    broadcastMessage(
-      {
-        type: "hook_event",
-        conversationId: meta.conversationId,
-        hookName: meta.hookName,
-        owner: meta.owner,
-        detail,
-      },
-      meta.conversationId,
-    );
+    let safeDetail = detail;
+    try {
+      JSON.stringify(detail);
+    } catch (err) {
+      log.warn(
+        { err, hookName: meta.hookName, owner: meta.owner },
+        "hook_event detail is not JSON-serializable — emitting a marker payload instead",
+      );
+      safeDetail = { unserializableDetail: true };
+    }
+    try {
+      broadcastMessage(
+        {
+          type: "hook_event",
+          conversationId: meta.conversationId,
+          hookName: meta.hookName,
+          owner: meta.owner,
+          detail: safeDetail,
+        },
+        meta.conversationId,
+      );
+    } catch (err) {
+      log.warn(
+        { err, hookName: meta.hookName, owner: meta.owner },
+        "hook_event broadcast failed (non-fatal)",
+      );
+    }
   };
 }

--- a/assistant/src/hooks/hook-logger.ts
+++ b/assistant/src/hooks/hook-logger.ts
@@ -1,0 +1,28 @@
+/**
+ * Builds the `logger` capability the pipeline stamps onto every hook context.
+ * Constructed per hook alongside `broadcast`, so each hook's log lines carry
+ * its own attribution — the hook name, the owning plugin (or workspace), and
+ * the conversation / request identity when the dispatching context has them —
+ * without the hook tagging anything itself.
+ */
+
+import type { HookEventOwner } from "../api/events/hook-event.js";
+import type { HookName } from "../plugin-api/constants.js";
+import { getLogger } from "../util/logger.js";
+import type { PluginLogger } from "./types.js";
+
+const log = getLogger("hooks");
+
+export function makeHookLogger(meta: {
+  hookName: HookName;
+  owner: HookEventOwner;
+  conversationId?: string;
+  requestId?: string;
+}): PluginLogger {
+  return log.child({
+    hook: meta.hookName,
+    plugin: meta.owner.id,
+    ...(meta.conversationId != null && { conversationId: meta.conversationId }),
+    ...(meta.requestId != null && { requestId: meta.requestId }),
+  });
+}

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -3,10 +3,18 @@
  * threads through `runHook` chains, plus the base capabilities every chain
  * context shares.
  *
- * These types are public plugin-API surface: `plugin-api/types.ts` re-exports
- * them, and plugin authors import them from `@vellumai/plugin-api`. Adding
- * fields is non-breaking; renaming / removing is breaking and gated on a
- * major bump.
+ * Each chain hook has two shapes:
+ *
+ * - `XInputContext` — the fields the dispatching call site constructs and
+ *   passes to `runHook`. Internal to the daemon.
+ * - `XContext extends XInputContext, BaseHookContext` — what a hook body
+ *   receives: the input fields plus the pipeline-stamped capabilities
+ *   (`logger`, `broadcast`).
+ *
+ * The full contexts (and {@link BaseHookContext}) are public plugin-API
+ * surface: `plugin-api/types.ts` re-exports them, and plugin authors import
+ * them from `@vellumai/plugin-api`. Adding fields is non-breaking; renaming /
+ * removing is breaking and gated on a major bump.
  */
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -58,16 +66,16 @@ export type HookBroadcast = (detail: Record<string, unknown>) => void;
  * `post-compact`, `post-tool-use`, `stop`, `pre-model-call`,
  * `post-model-call`).
  *
- * `logger` is supplied by the dispatching call site. `broadcast` is stamped
- * onto each hook's draft by the pipeline (`runHook`) before the hook runs,
- * bound to that hook's owner — call sites construct
- * `Omit<XContext, "broadcast">` and never supply it themselves.
+ * Both are stamped onto each hook's draft by the pipeline (`runHook`) before
+ * the hook runs, bound to that hook's identity — dispatching call sites
+ * construct the `XInputContext` shapes and never supply these.
  */
 export interface BaseHookContext {
   /**
-   * Logger scoped to the current turn. The same instance is shared by
-   * every hook in the chain, so plugins should tag their structured log
-   * fields (e.g. `{ plugin: "<name>" }`) for attribution.
+   * Logger bound to the emitting hook — pre-tagged with the hook name and
+   * owning plugin (plus `conversationId` / `requestId` when the dispatching
+   * context carries them), so hook log lines are attributed without manual
+   * tagging.
    */
   readonly logger: PluginLogger;
   /**
@@ -101,7 +109,7 @@ export interface BaseHookContext {
  * hook sees the previous plugin's mutations (whether by reassignment or
  * in-place mutation).
  */
-export interface UserPromptSubmitContext extends BaseHookContext {
+export interface UserPromptSubmitInputContext {
   /** Conversation ID the user prompt was submitted on. */
   readonly conversationId: string;
   /**
@@ -177,6 +185,14 @@ export interface UserPromptSubmitContext extends BaseHookContext {
   latestMessages: Message[];
 }
 
+/**
+ * The full `user-prompt-submit` context a hook receives — the dispatching
+ * call site's {@link UserPromptSubmitInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface UserPromptSubmitContext
+  extends UserPromptSubmitInputContext, BaseHookContext {}
+
 // ─── Post-compact hook context ───────────────────────────────────────────────
 
 /**
@@ -198,7 +214,7 @@ export interface UserPromptSubmitContext extends BaseHookContext {
  * the context and resumes the turn from it. Multiple plugins' hooks chain in
  * registration order, each seeing the previous plugin's edits.
  */
-export interface PostCompactContext extends BaseHookContext {
+export interface PostCompactInputContext {
   /**
    * The compacted message history to re-inject onto. Hooks mutate this in
    * place (or return a new context with a replacement) to re-apply context
@@ -237,6 +253,14 @@ export interface PostCompactContext extends BaseHookContext {
   readonly injectionMode?: "full" | "minimal";
 }
 
+/**
+ * The full `post-compact` context a hook receives — the dispatching call
+ * site's {@link PostCompactInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface PostCompactContext
+  extends PostCompactInputContext, BaseHookContext {}
+
 // ─── Post-tool-use hook context ──────────────────────────────────────────────
 
 /**
@@ -259,7 +283,7 @@ export interface PostCompactContext extends BaseHookContext {
  * can swap in a smarter strategy (e.g. a summarizer) or observe results for
  * side effects.
  */
-export interface PostToolUseContext extends BaseHookContext {
+export interface PostToolUseInputContext {
   /** Conversation ID the tool ran on. */
   readonly conversationId: string;
   /**
@@ -320,6 +344,14 @@ export interface PostToolUseContext extends BaseHookContext {
    */
   readonly maxInputTokens: number;
 }
+
+/**
+ * The full `post-tool-use` context a hook receives — the dispatching call
+ * site's {@link PostToolUseInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface PostToolUseContext
+  extends PostToolUseInputContext, BaseHookContext {}
 
 // ─── Stop hook context ───────────────────────────────────────────────────────
 
@@ -384,7 +416,7 @@ export type AgentLoopExitReason =
  *
  * Multiple plugins' hooks chain in registration order over the same context.
  */
-export interface StopContext extends BaseHookContext {
+export interface StopInputContext {
   /** Conversation ID the run belongs to. */
   readonly conversationId: string;
   /**
@@ -409,6 +441,13 @@ export interface StopContext extends BaseHookContext {
   readonly exitReason: AgentLoopExitReason;
 }
 
+/**
+ * The full `stop` context a hook receives — the dispatching call site's
+ * {@link StopInputContext} plus the pipeline-stamped {@link BaseHookContext}
+ * capabilities.
+ */
+export interface StopContext extends StopInputContext, BaseHookContext {}
+
 // ─── Pre-model-call hook context ─────────────────────────────────────────────
 
 /**
@@ -424,7 +463,7 @@ export interface StopContext extends BaseHookContext {
  * Mutate the context in place or return a new one; throwing is contained by the
  * loop (the call proceeds with the original request).
  */
-export interface PreModelCallContext extends BaseHookContext {
+export interface PreModelCallInputContext {
   /** Conversation ID the call belongs to. */
   readonly conversationId: string;
   /**
@@ -464,6 +503,14 @@ export interface PreModelCallContext extends BaseHookContext {
    */
   deferAssistantOutput: boolean;
 }
+
+/**
+ * The full `pre-model-call` context a hook receives — the dispatching call
+ * site's {@link PreModelCallInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface PreModelCallContext
+  extends PreModelCallInputContext, BaseHookContext {}
 
 // ─── Post-model-call hook context ────────────────────────────────────────────
 
@@ -512,7 +559,7 @@ export type PostModelCallDecision = "continue" | "stop";
  * the outcome is treated as `"stop"`). Multiple plugins' hooks chain in
  * registration order — each sees the previous hook's `decision` and mutations.
  */
-export interface PostModelCallContext extends BaseHookContext {
+export interface PostModelCallInputContext {
   /** Conversation ID the message belongs to. */
   readonly conversationId: string;
   /** The call site this message serves — `"mainAgent"` for the user-facing reply; `null` when untagged. */
@@ -556,3 +603,11 @@ export interface PostModelCallContext extends BaseHookContext {
    */
   decision: PostModelCallDecision;
 }
+
+/**
+ * The full `post-model-call` context a hook receives — the dispatching call
+ * site's {@link PostModelCallInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface PostModelCallContext
+  extends PostModelCallInputContext, BaseHookContext {}

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -17,8 +17,9 @@
  */
 
 import { makeHookBroadcast } from "../hooks/hook-broadcast.js";
+import { makeHookLogger } from "../hooks/hook-logger.js";
 import { getHookEntriesFor } from "../hooks/registry.js";
-import type { HookBroadcast } from "../hooks/types.js";
+import type { BaseHookContext } from "../hooks/types.js";
 import type { HookName } from "../plugin-api/constants.js";
 import { getLogger } from "../util/logger.js";
 import type { HookEntry } from "./types.js";
@@ -49,11 +50,17 @@ function isPlainObject(value: object): boolean {
 }
 
 function cloneHookValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
-  if (value === null || typeof value !== "object") return value;
-  if (value instanceof Error || isPluginLogger(value)) return value;
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (value instanceof Error || isPluginLogger(value)) {
+    return value;
+  }
 
   const existing = seen.get(value);
-  if (existing !== undefined) return existing as T;
+  if (existing !== undefined) {
+    return existing as T;
+  }
 
   if (Array.isArray(value)) {
     const copy: unknown[] = [];
@@ -86,7 +93,9 @@ function cloneHookValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
     return copy as T;
   }
 
-  if (!isPlainObject(value)) return value;
+  if (!isPlainObject(value)) {
+    return value;
+  }
 
   const copy: Record<PropertyKey, unknown> = {};
   seen.set(value, copy);
@@ -116,26 +125,30 @@ function cloneHookValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
  * every globally-enabled plugin's hook runs.
  *
  * Before each hook runs, the pipeline stamps the {@link BaseHookContext}
- * `broadcast` capability onto its (freshly-cloned) draft, bound to the hook's
- * owner and — when the context carries one — its `conversationId`. A hook
- * calls `ctx.broadcast(detail)` to emit a `hook_event` attributed to itself;
- * it cannot pick the event type, conversation, or owner. Because the pipeline
- * supplies it, call sites construct their context as
- * `Omit<XContext, "broadcast">` and never provide the field themselves.
+ * capabilities onto its (freshly-cloned) draft, both bound to that hook's
+ * identity: `broadcast` emits a `hook_event` attributed to the hook's owner
+ * (and the context's `conversationId`, when present), and `logger` is a child
+ * pre-tagged with the hook name, owner, and conversation / request identity.
+ * Because the pipeline supplies them, call sites construct the per-hook
+ * `XInputContext` shapes and never provide these fields themselves.
  *
  * @param name        The hook identifier — pick one from {@link HOOKS}.
- * @param initialCtx  Context the first hook receives.
+ * @param initialCtx  Input context the first hook receives (the hook sees it
+ *                    with the {@link BaseHookContext} capabilities added).
  * @returns The final context after the chain settles. Same reference as
  *          `initialCtx` when no plugin registers `name`.
  */
-export async function runHook<TCtx>(
+export async function runHook<TInput extends object>(
   name: HookName,
-  initialCtx: TCtx,
-): Promise<TCtx> {
-  const conversationId = extractConversationId(initialCtx);
-  let entries: HookEntry<TCtx>[];
+  initialCtx: TInput,
+): Promise<TInput> {
+  const conversationId = extractStringField(initialCtx, "conversationId");
+  const requestId = extractStringField(initialCtx, "requestId");
+  let entries: HookEntry<TInput & BaseHookContext>[];
   try {
-    entries = await getHookEntriesFor<TCtx>(name, { conversationId });
+    entries = await getHookEntriesFor<TInput & BaseHookContext>(name, {
+      conversationId,
+    });
   } catch (err) {
     log.error(
       { err, hookName: name },
@@ -144,17 +157,18 @@ export async function runHook<TCtx>(
     return initialCtx;
   }
 
-  let active = initialCtx;
+  let active: TInput = initialCtx;
   for (const { fn, owner } of entries) {
-    const draft = cloneHookValue(active);
-    // Stamp a per-hook broadcast bound to this hook's owner and the
-    // conversation resolved above (most hooks run inside one; hooks without a
-    // `conversationId` emit an unscoped `hook_event`).
-    (draft as { broadcast?: HookBroadcast }).broadcast = makeHookBroadcast({
-      conversationId,
-      hookName: name,
-      owner,
-    });
+    const draft = {
+      ...cloneHookValue(active),
+      logger: makeHookLogger({
+        hookName: name,
+        owner,
+        conversationId,
+        requestId,
+      }),
+      broadcast: makeHookBroadcast({ conversationId, hookName: name, owner }),
+    };
     try {
       const result = await fn(draft);
       if (result !== undefined) {
@@ -172,9 +186,8 @@ export async function runHook<TCtx>(
   return active;
 }
 
-/** The `conversationId` off a hook context, when it carries one as a string. */
-function extractConversationId(ctx: unknown): string | undefined {
-  const conversationId = (ctx as { conversationId?: unknown } | null)
-    ?.conversationId;
-  return typeof conversationId === "string" ? conversationId : undefined;
+/** A string-valued field off a hook context, when it carries one. */
+function extractStringField(ctx: unknown, field: string): string | undefined {
+  const value = (ctx as Record<string, unknown> | null)?.[field];
+  return typeof value === "string" ? value : undefined;
 }

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -52,8 +52,11 @@ import {
   SSE_REPLAY_RING_AGE_LIMIT_MS,
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "../api/constants/sse-replay.js";
+import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import type { AssistantEvent } from "./assistant-event.js";
+
+const log = getLogger("assistant-stream-state");
 
 // ── Tunables ─────────────────────────────────────────────────────────
 
@@ -161,16 +164,37 @@ export function stampAndBuffer(
   event: AssistantEvent,
   options?: { targeting?: EventTargeting },
 ): void {
-  if (event.conversationId == null) return;
-
-  reserveSeqCapacity();
-  event.seq = state.nextSeq++;
-  if (state.firstStampedSeq === 0) state.firstStampedSeq = event.seq;
+  if (event.conversationId == null) {
+    return;
+  }
 
   // Approximate size by serialized JSON length. This is the same
   // bytes-on-wire we'll send, so it tracks ring memory pressure
-  // closely without a separate measurement pass.
-  const sizeBytes = JSON.stringify(event).length;
+  // closely without a separate measurement pass. Serialized before `seq`
+  // is stamped, so the count misses that one small field — negligible
+  // against the ring budget. An event whose payload cannot serialize
+  // (circular reference, BigInt, throwing toJSON — e.g. a plugin-supplied
+  // `hook_event` detail) is left unstamped and not buffered: it could
+  // never be written to the SSE wire, so buffering it would poison
+  // reconnect replay, and skipping the stamp entirely (like an unscoped
+  // event) keeps the seq stream gap-free. Live delivery to in-process
+  // subscribers still proceeds.
+  let sizeBytes: number;
+  try {
+    sizeBytes = JSON.stringify(event).length;
+  } catch (err) {
+    log.error(
+      { err, eventType: event.message.type },
+      "event payload failed to serialize — not stamping or buffering for replay",
+    );
+    return;
+  }
+
+  reserveSeqCapacity();
+  event.seq = state.nextSeq++;
+  if (state.firstStampedSeq === 0) {
+    state.firstStampedSeq = event.seq;
+  }
   const entry: RingEntry = {
     seq: event.seq,
     event,
@@ -212,7 +236,9 @@ export function getReplayWindow(
 ): readonly AssistantEvent[] | null {
   evict();
 
-  if (state.ring.length === 0) return [];
+  if (state.ring.length === 0) {
+    return [];
+  }
 
   // A cursor from before this process started can skip over the
   // reservation gap: seqs below `firstStampedSeq` were never assigned
@@ -223,7 +249,9 @@ export function getReplayWindow(
   const oldest = state.ring[0]?.seq ?? Infinity;
   const coversRestartGap =
     lastSeenSeq < state.firstStampedSeq && oldest === state.firstStampedSeq;
-  if (lastSeenSeq < oldest - 1 && !coversRestartGap) return null;
+  if (lastSeenSeq < oldest - 1 && !coversRestartGap) {
+    return null;
+  }
 
   return state.ring
     .filter(
@@ -324,7 +352,9 @@ function seqReservationPath(): string {
  * have emitted.
  */
 function loadSeqReservation(): void {
-  if (state.seqReservationLoaded) return;
+  if (state.seqReservationLoaded) {
+    return;
+  }
   state.seqReservationLoaded = true;
   state.reservedSeqCeiling = readReservedCeiling();
   if (state.reservedSeqCeiling >= state.nextSeq) {
@@ -335,7 +365,9 @@ function loadSeqReservation(): void {
 function reserveSeqCapacity(): void {
   loadSeqReservation();
 
-  if (state.nextSeq <= state.reservedSeqCeiling) return;
+  if (state.nextSeq <= state.reservedSeqCeiling) {
+    return;
+  }
 
   const ceiling = state.nextSeq + SEQ_RESERVATION_BLOCK - 1;
   try {
@@ -386,7 +418,9 @@ function matchesSubscriber(
   subscriber: ReplaySubscriber,
 ): boolean {
   const t = entry.targeting;
-  if (!t) return true;
+  if (!t) {
+    return true;
+  }
 
   // Self-echo suppression: the originating client never receives the
   // event back.
@@ -444,13 +478,17 @@ function evict(): void {
   const now = Date.now();
   while (state.ring.length > 0) {
     const head = state.ring[0];
-    if (head == null) break;
+    if (head == null) {
+      break;
+    }
 
     const overCount = state.ring.length > RING_COUNT_LIMIT;
     const overSize = state.totalSizeBytes > RING_SIZE_LIMIT_BYTES;
     const overAge = now - head.emittedAt > RING_AGE_LIMIT_MS;
 
-    if (!overCount && !overSize && !overAge) break;
+    if (!overCount && !overSize && !overAge) {
+      break;
+    }
 
     state.ring.shift();
     state.totalSizeBytes -= head.sizeBytes;


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37094, addressing its review comments:

**1. Input/full context split ([r3521265881](https://github.com/vellum-ai/vellum-assistant/pull/37094#discussion_r3521265881)).** Each chain hook now has two shapes in `assistant/src/hooks/types.ts`: `XInputContext` — the fields the dispatching call site constructs — and `XContext extends XInputContext, BaseHookContext` — what a hook body receives. Call sites construct plain `XInputContext` literals; the `Omit<XContext, "broadcast">` pattern is gone. The full contexts stay the `@vellumai/plugin-api` surface (re-exported unchanged); the input contexts are daemon-internal.

**2. Logger constructed alongside broadcast ([r3521269056](https://github.com/vellum-ai/vellum-assistant/pull/37094#discussion_r3521269056)).** `runHook` now stamps *both* `BaseHookContext` capabilities per hook: `broadcast`, and a `logger` built next to it via `makeHookLogger` (`hooks/hook-logger.ts`) — pre-tagged with the hook name, owner, and the context's `conversationId` / `requestId` when present. Call sites stop supplying a logger, and hook log lines are attributed without hooks tagging `{ plugin }` themselves.

**3. No casts in the stamp ([r3521273549](https://github.com/vellum-ai/vellum-assistant/pull/37094#discussion_r3521273549)).** The draft is built by spreading the clone together with the injected capabilities (`{ ...cloneHookValue(active), logger, broadcast }`), so `runHook` needs no `as` assertions — the spread's type is `TInput & { logger; broadcast }`, assignable to `TInput & BaseHookContext`.

**4. Safe stringify ([r3521072148](https://github.com/vellum-ai/vellum-assistant/pull/37094#discussion_r3521072148) / [r3521275419](https://github.com/vellum-ai/vellum-assistant/pull/37094#discussion_r3521275419)).** Two layers:
   - `makeHookBroadcast` never throws into the hook chain: hook-supplied `detail` that JSON cannot represent (circular reference, BigInt, throwing `toJSON`) is replaced with an `{ unserializableDetail: true }` marker and logged; any emit failure is logged and swallowed — `broadcast` is best-effort by contract.
   - `stampAndBuffer` serializes **before** stamping `seq`, and on failure leaves the event unstamped and unbuffered (identical degradation to an unscoped event — no seq gap, no unserializable entry poisoning reconnect replay, live in-process delivery unaffected). The size estimate now excludes the not-yet-stamped `seq` field, which is negligible against the ring budget.

Also picks up auto-fixed `curly` braces in the touched files, per the repo lint rule.

## Test plan

- New: `hook-broadcast.test.ts` case — a hook broadcasting a circular `detail` doesn't throw, execution continues past the broadcast, and the emitted event carries the marker payload. `assistant-event-hub.test.ts` case — an unserializable payload through `broadcastMessage` doesn't throw, isn't buffered, and later events stamp/replay normally.
- Full `assistant` typecheck: 0 errors. Lint 0 errors, prettier clean (pre-commit hook verified).
- Ran the affected test files individually (per-file isolation matching `scripts/test.sh`): `hook-broadcast`, `plugin-pipeline`, `assistant-event-hub`, `assistant-stream-state`, `memory-retrieval-hook`, `conversation-runtime-assembly`, `history-repair-hook`, `title-generate-hook`, `empty-response-hook`, `exploration-drift-hook`, `image-recovery-hook`, `max-tokens-continue-hook`, `surface-completion-nudge-hook`, `task-progress-nudge-hook`, `tool-error-hook`, `tool-result-truncate-hook`, `plugin-effective-enabled-set`, `plugin-disabled-state`, `mtime-cache`, `user-plugin-loader`, `plugin-bootstrap` — all green.

No new routes under `assistant/src/runtime/routes/`, so the CLI verb checklist does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ExXxDvG5CVDyvTs96GRCB

---
_Generated by [Claude Code](https://claude.ai/code/session_019ExXxDvG5CVDyvTs96GRCB)_