### PR TITLE
feat: pair recovery reconciles with a server event tail (GET /events/tail)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11518,6 +11518,16 @@ paths:
           description:
             Return buffered events with seq strictly greater than this value — typically the seq watermark of a
             just-fetched /messages snapshot. Must be a non-negative integer.
+        - name: toSeq
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            Optional inclusive upper bound on returned seqs. A caller that already knows where its live delivery
+            resumed (e.g. the first live event after a gap) can trim the response to exactly the hole. Purely a
+            bandwidth trim — client folds are seq-idempotent, so overlap with live delivery is harmless without it. Must
+            be an integer >= fromSeq.
       responses:
         "200":
           description: Successful response

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11490,6 +11490,66 @@ paths:
       responses:
         "204":
           description: Successful response
+  /v1/events/tail:
+    get:
+      operationId: events_tail_get
+      summary: Fetch a conversation's buffered event tail
+      description:
+        Return the ring-buffered assistant events for one conversation with seq greater than fromSeq — the
+        request/response twin of reconnecting the SSE stream with lastSeenSeq. A client recovering from a delivery gap
+        fetches the /messages snapshot (anchored at its seq watermark) and then this tail from that anchor, folding the
+        returned envelopes through the same apply path as live events; snapshot plus tail is deterministically complete.
+        complete=false means the ring no longer reaches back to fromSeq and the snapshot alone must serve as the
+        recovery.
+      tags:
+        - events
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Assistant-minted internal conversation id whose events to return. Required.
+        - name: fromSeq
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            Return buffered events with seq strictly greater than this value — typically the seq watermark of a
+            just-fetched /messages snapshot. Must be a non-negative integer.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items: {}
+                    description:
+                      Buffered assistant event envelopes ({id, conversationId, emittedAt, seq, message}) with seq > fromSeq,
+                      ascending, filtered to the conversation and to the caller's delivery set (client identity
+                      headers). Same wire shape as the /events SSE data frames.
+                  complete:
+                    type: boolean
+                    description:
+                      True when the ring still covered fromSeq, so the returned events are the contiguous tail. False when
+                      eviction broke contiguity — events is empty and the caller must recover from the snapshot alone.
+                  frontier:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                    description:
+                      Seq of the last returned event (or fromSeq when the tail is empty but contiguous). Null when complete is
+                      false.
+                required:
+                  - events
+                  - complete
+                  - frontier
+                additionalProperties: false
   /v1/export:
     post:
       operationId: export_post

--- a/assistant/src/__tests__/events-tail-route.test.ts
+++ b/assistant/src/__tests__/events-tail-route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for `GET /v1/events/tail` — the replay-by-request companion to the
+ * SSE `lastSeenSeq` resume.
+ *
+ * Pins:
+ *  1. The tail is the conversation-filtered ring window with
+ *     `seq > fromSeq`, ascending, with `frontier` at the last returned seq.
+ *  2. `complete: false` when the ring no longer reaches back to `fromSeq`
+ *     (eviction) — the caller must recover from the snapshot alone.
+ *  3. Targeting filters are re-applied from the caller's client identity
+ *     headers, mirroring the SSE replay path.
+ *  4. Input validation rejects missing/invalid params.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  _resetStreamStateForTesting,
+  stampAndBuffer,
+} from "../runtime/assistant-stream-state.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+import { ROUTES } from "../runtime/routes/events-routes.js";
+
+const CONV = "conv-a";
+const OTHER = "conv-b";
+
+const tailRoute = ROUTES.find((r) => r.operationId === "events_tail_get");
+if (!tailRoute) {
+  throw new Error("events_tail_get route not registered");
+}
+
+interface TailResponse {
+  events: AssistantEvent[];
+  complete: boolean;
+  frontier: number | null;
+}
+
+function callTail(
+  query: Record<string, string>,
+  headers?: Record<string, string>,
+): TailResponse {
+  return tailRoute!.handler({
+    queryParams: query,
+    headers,
+  }) as TailResponse;
+}
+
+function mkEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+  const conversationId =
+    "conversationId" in overrides ? overrides.conversationId : CONV;
+  return {
+    id: `uuid-${Math.random().toString(36).slice(2, 10)}`,
+    conversationId,
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: "assistant_text_delta",
+      conversationId,
+      text: "x",
+    },
+    ...overrides,
+  } as AssistantEvent;
+}
+
+describe("GET events/tail", () => {
+  beforeEach(() => {
+    _resetStreamStateForTesting();
+  });
+
+  test("returns the conversation's tail above fromSeq with the frontier", () => {
+    // GIVEN interleaved events across two conversations (seq 1..6)
+    for (let i = 0; i < 3; i++) {
+      stampAndBuffer(mkEvent()); // CONV: seq 1, 3, 5
+      stampAndBuffer(mkEvent({ conversationId: OTHER })); // OTHER: 2, 4, 6
+    }
+
+    // WHEN fetching CONV's tail above seq 1 (a snapshot anchored at 1)
+    const body = callTail({ conversationId: CONV, fromSeq: "1" });
+
+    // THEN only CONV's newer events come back, ascending, with the frontier
+    expect(body.complete).toBe(true);
+    expect(body.events.map((e) => e.seq)).toEqual([3, 5]);
+    expect(body.events.every((e) => e.conversationId === CONV)).toBe(true);
+    expect(body.frontier).toBe(5);
+  });
+
+  test("an up-to-date anchor yields an empty but complete tail", () => {
+    // GIVEN three buffered events (seq 1..3)
+    for (let i = 0; i < 3; i++) {
+      stampAndBuffer(mkEvent());
+    }
+
+    // WHEN fetching from the live frontier
+    const body = callTail({ conversationId: CONV, fromSeq: "3" });
+
+    // THEN nothing is missing and the frontier is the anchor itself
+    expect(body.complete).toBe(true);
+    expect(body.events).toEqual([]);
+    expect(body.frontier).toBe(3);
+  });
+
+  test("reports complete=false when the ring no longer covers fromSeq", () => {
+    // GIVEN a ring whose oldest retained entry is well past the anchor:
+    // overflow the 200-event count bound so seq 1 is evicted
+    for (let i = 0; i < 210; i++) {
+      stampAndBuffer(mkEvent());
+    }
+
+    // WHEN fetching from a pre-eviction anchor
+    const body = callTail({ conversationId: CONV, fromSeq: "1" });
+
+    // THEN no contiguous tail can be served
+    expect(body.complete).toBe(false);
+    expect(body.events).toEqual([]);
+    expect(body.frontier).toBeNull();
+  });
+
+  test("re-applies targeting filters from the caller's client identity", () => {
+    // GIVEN an event excluded from a specific client (self-echo suppression)
+    stampAndBuffer(mkEvent()); // seq 1 — untargeted
+    stampAndBuffer(mkEvent(), { targeting: { excludeClientId: "client-1" } }); // seq 2
+
+    // WHEN the excluded client fetches the tail
+    const excluded = callTail(
+      { conversationId: CONV, fromSeq: "0" },
+      { "x-vellum-client-id": "client-1", "x-vellum-interface-id": "web" },
+    );
+    // AND a different client fetches the same tail
+    const other = callTail(
+      { conversationId: CONV, fromSeq: "0" },
+      { "x-vellum-client-id": "client-2", "x-vellum-interface-id": "web" },
+    );
+
+    // THEN the targeted event is withheld only from its excluded client
+    expect(excluded.events.map((e) => e.seq)).toEqual([1]);
+    expect(other.events.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  test("rejects missing or invalid params", () => {
+    expect(() => callTail({ fromSeq: "1" })).toThrow(BadRequestError);
+    expect(() => callTail({ conversationId: CONV })).toThrow(BadRequestError);
+    expect(() =>
+      callTail({ conversationId: CONV, fromSeq: "not-a-number" }),
+    ).toThrow(BadRequestError);
+    expect(() => callTail({ conversationId: CONV, fromSeq: "-1" })).toThrow(
+      BadRequestError,
+    );
+    expect(() => callTail({ conversationId: CONV, fromSeq: "1.5" })).toThrow(
+      BadRequestError,
+    );
+  });
+});

--- a/assistant/src/__tests__/events-tail-route.test.ts
+++ b/assistant/src/__tests__/events-tail-route.test.ts
@@ -142,6 +142,21 @@ describe("GET events/tail", () => {
     expect(other.events.map((e) => e.seq)).toEqual([1, 2]);
   });
 
+  test("toSeq bounds the window inclusively and moves the frontier", () => {
+    // GIVEN five buffered events for the conversation (seq 1..5)
+    for (let i = 0; i < 5; i++) {
+      stampAndBuffer(mkEvent());
+    }
+
+    // WHEN fetching (1, 3] — the caller already has 4+ from live delivery
+    const body = callTail({ conversationId: CONV, fromSeq: "1", toSeq: "3" });
+
+    // THEN only the hole comes back, with the frontier at the bound
+    expect(body.complete).toBe(true);
+    expect(body.events.map((e) => e.seq)).toEqual([2, 3]);
+    expect(body.frontier).toBe(3);
+  });
+
   test("rejects missing or invalid params", () => {
     expect(() => callTail({ fromSeq: "1" })).toThrow(BadRequestError);
     expect(() => callTail({ conversationId: CONV })).toThrow(BadRequestError);
@@ -154,5 +169,11 @@ describe("GET events/tail", () => {
     expect(() => callTail({ conversationId: CONV, fromSeq: "1.5" })).toThrow(
       BadRequestError,
     );
+    expect(() =>
+      callTail({ conversationId: CONV, fromSeq: "5", toSeq: "3" }),
+    ).toThrow(BadRequestError);
+    expect(() =>
+      callTail({ conversationId: CONV, fromSeq: "1", toSeq: "x" }),
+    ).toThrow(BadRequestError);
   });
 });

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -591,6 +591,22 @@ function handleEventsTail({
   if (!Number.isInteger(fromSeq) || fromSeq < 0) {
     throw new BadRequestError("fromSeq must be a non-negative integer");
   }
+  // Optional upper bound: a caller that already knows where its live
+  // delivery resumed (e.g. the seq-gap heal's first live event) can trim
+  // the response to exactly the hole. Purely a bandwidth trim — the
+  // client fold is seq-idempotent, so an unbounded overlap with live
+  // delivery is harmless.
+  const rawToSeq = queryParams?.toSeq;
+  let toSeq: number | null = null;
+  if (rawToSeq != null && rawToSeq.trim() !== "") {
+    const parsed = Number(rawToSeq);
+    if (!Number.isInteger(parsed) || parsed < fromSeq) {
+      throw new BadRequestError(
+        "toSeq must be an integer greater than or equal to fromSeq",
+      );
+    }
+    toSeq = parsed;
+  }
 
   // Same client-identity resolution as the SSE subscribe handler, so the
   // replay filter matches what a live subscription would have delivered.
@@ -615,10 +631,14 @@ function handleEventsTail({
   if (window === null) {
     return { events: [], complete: false, frontier: null };
   }
+  const bounded =
+    toSeq === null
+      ? window
+      : window.filter((e) => typeof e.seq === "number" && e.seq <= toSeq);
   const lastSeq =
-    window.length > 0 ? window[window.length - 1]?.seq : undefined;
+    bounded.length > 0 ? bounded[bounded.length - 1]?.seq : undefined;
   return {
-    events: window,
+    events: bounded,
     complete: true,
     frontier: typeof lastSeq === "number" ? lastSeq : fromSeq,
   };
@@ -712,6 +732,11 @@ export const ROUTES: RouteDefinition[] = [
         name: "fromSeq",
         description:
           "Return buffered events with seq strictly greater than this value — typically the seq watermark of a just-fetched /messages snapshot. Must be a non-negative integer.",
+      },
+      {
+        name: "toSeq",
+        description:
+          "Optional inclusive upper bound on returned seqs. A caller that already knows where its live delivery resumed (e.g. the first live event after a gap) can trim the response to exactly the hole. Purely a bandwidth trim — client folds are seq-idempotent, so overlap with live delivery is harmless without it. Must be an integer >= fromSeq.",
       },
     ],
     responseBody: z.object({

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -53,6 +53,14 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
 
+const ALL_CAPABILITIES: HostProxyCapability[] = [
+  "host_bash",
+  "host_file",
+  "host_cu",
+  "host_app_control",
+  "host_browser",
+];
+
 /**
  * Resolution of the event-loop delay histogram, per
  * https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions.
@@ -330,14 +338,6 @@ export function handleSubscribeAssistantEvents(
     options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
   const shedReporter = options?.shedReporter ?? defaultSseShedReporter;
 
-  const ALL_CAPABILITIES: HostProxyCapability[] = [
-    "host_bash",
-    "host_file",
-    "host_cu",
-    "host_app_control",
-    "host_browser",
-  ];
-
   // Resolve the scope. `conversationId` (when supplied) is the
   // assistant-minted internal id — looked up directly; 404 if absent.
   // Otherwise fall through to `conversationKey`, which is treated as an
@@ -557,6 +557,73 @@ export function handleSubscribeAssistantEvents(
   return stream;
 }
 
+/**
+ * Replay-by-request companion to the SSE `lastSeenSeq` resume: return the
+ * ring-buffered event tail for one conversation with `seq > fromSeq`.
+ *
+ * A client recovering from a delivery gap fetches the `/messages` snapshot
+ * (anchored at the seq of the last durably persisted event) and then this
+ * tail from that anchor, folding the returned envelopes through the same
+ * apply path as live SSE events. Snapshot-at-anchor plus tail-from-anchor
+ * is deterministically complete, without bouncing the live connection —
+ * the request/response twin of reconnecting with `lastSeenSeq`.
+ *
+ * `complete: false` means the ring no longer reaches back to `fromSeq`
+ * (eviction) and no contiguous tail can be served — the caller must treat
+ * the snapshot alone as the recovery, exactly as an out-of-ring reconnect
+ * does. Targeting filters are re-applied from the caller's client identity
+ * headers, mirroring the SSE replay path, so targeted events do not leak
+ * outside their delivery set.
+ */
+function handleEventsTail({
+  queryParams,
+  headers,
+}: RouteHandlerArgs): Record<string, unknown> {
+  const conversationId = queryParams?.conversationId?.trim();
+  if (!conversationId) {
+    throw new BadRequestError("conversationId query parameter is required");
+  }
+  const rawFromSeq = queryParams?.fromSeq;
+  if (rawFromSeq == null || rawFromSeq.trim() === "") {
+    throw new BadRequestError("fromSeq query parameter is required");
+  }
+  const fromSeq = Number(rawFromSeq);
+  if (!Number.isInteger(fromSeq) || fromSeq < 0) {
+    throw new BadRequestError("fromSeq must be a non-negative integer");
+  }
+
+  // Same client-identity resolution as the SSE subscribe handler, so the
+  // replay filter matches what a live subscription would have delivered.
+  const rawClientId = headers?.["x-vellum-client-id"];
+  const clientId = rawClientId?.trim() || null;
+  const interfaceId = clientId
+    ? parseInterfaceId(headers?.["x-vellum-interface-id"]?.trim())
+    : null;
+  const subscriber: ReplaySubscriber | undefined =
+    clientId && interfaceId
+      ? {
+          type: "client",
+          clientId,
+          interfaceId,
+          capabilities: ALL_CAPABILITIES.filter((cap) =>
+            supportsHostProxy(interfaceId, cap),
+          ),
+        }
+      : undefined;
+
+  const window = getReplayWindow(fromSeq, subscriber, conversationId);
+  if (window === null) {
+    return { events: [], complete: false, frontier: null };
+  }
+  const lastSeq =
+    window.length > 0 ? window[window.length - 1]?.seq : undefined;
+  return {
+    events: window,
+    complete: true,
+    frontier: typeof lastSeq === "number" ? lastSeq : fromSeq,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -622,5 +689,49 @@ export const ROUTES: RouteDefinition[] = [
       Connection: "keep-alive",
     },
     handler: (args) => handleSubscribeAssistantEvents(args),
+  },
+  {
+    operationId: "events_tail_get",
+    endpoint: "events/tail",
+    method: "GET",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Fetch a conversation's buffered event tail",
+    description:
+      "Return the ring-buffered assistant events for one conversation with seq greater than fromSeq — the request/response twin of reconnecting the SSE stream with lastSeenSeq. A client recovering from a delivery gap fetches the /messages snapshot (anchored at its seq watermark) and then this tail from that anchor, folding the returned envelopes through the same apply path as live events; snapshot plus tail is deterministically complete. complete=false means the ring no longer reaches back to fromSeq and the snapshot alone must serve as the recovery.",
+    tags: ["events"],
+    queryParams: [
+      {
+        name: "conversationId",
+        description:
+          "Assistant-minted internal conversation id whose events to return. Required.",
+      },
+      {
+        name: "fromSeq",
+        description:
+          "Return buffered events with seq strictly greater than this value — typically the seq watermark of a just-fetched /messages snapshot. Must be a non-negative integer.",
+      },
+    ],
+    responseBody: z.object({
+      events: z
+        .array(z.unknown())
+        .describe(
+          "Buffered assistant event envelopes ({id, conversationId, emittedAt, seq, message}) with seq > fromSeq, ascending, filtered to the conversation and to the caller's delivery set (client identity headers). Same wire shape as the /events SSE data frames.",
+        ),
+      complete: z
+        .boolean()
+        .describe(
+          "True when the ring still covered fromSeq, so the returned events are the contiguous tail. False when eviction broke contiguity — events is empty and the caller must recover from the snapshot alone.",
+        ),
+      frontier: z
+        .number()
+        .nullable()
+        .describe(
+          "Seq of the last returned event (or fromSeq when the tail is empty but contiguous). Null when complete is false.",
+        ),
+    }),
+    handler: (args) => handleEventsTail(args),
   },
 ];

--- a/clients/web/src/domains/chat/api/events-tail.ts
+++ b/clients/web/src/domains/chat/api/events-tail.ts
@@ -1,0 +1,80 @@
+/**
+ * Server-side event-tail catch-up for recovery reconciles.
+ *
+ * A `/messages` snapshot is anchored at the `seq` of the last event whose
+ * content the daemon has durably persisted — which, mid-turn, can honestly
+ * lag the live stream by up to the daemon's partial-persist debounce. On a
+ * healthy connection that window arrives as ordinary SSE deltas; after a
+ * delivery gap (out-of-ring reconnect, backgrounded tab) those events were
+ * never delivered and the snapshot alone leaves a hole until the next
+ * flush-driven refetch.
+ *
+ * `GET /events/tail` closes the hole the canonical way — snapshot at
+ * anchor, then the event log from that anchor: it returns the daemon's
+ * ring-buffered envelopes for the conversation with `seq > fromSeq`, which
+ * are ingested into the client event ring so the reseed replay
+ * (`getSseEnvelopesSince` → `resolveSnapshot`) folds them exactly like
+ * live events. Everything is best-effort: failures and incomplete
+ * (ring-evicted) tails degrade to today's snapshot-only recovery.
+ */
+
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+
+import { eventsTailGet } from "@/generated/daemon/sdk.gen";
+import { supportsEventsTail } from "@/lib/backwards-compat/events-tail";
+import { recordDiagnostic } from "@/lib/diagnostics";
+import { ingestReplayedEnvelopes } from "@/lib/streaming/stream-debug";
+
+/**
+ * Fetch the buffered event tail above `fromSeq` and ingest it into the
+ * client event ring, so an immediately following history reseed folds the
+ * events the live connection never delivered.
+ *
+ * No-ops when the snapshot carried no anchor or the assistant predates
+ * the endpoint. Never throws — the tail is an upgrade to the reconcile,
+ * not a prerequisite.
+ */
+export async function ingestServerEventsTail(
+  assistantId: string,
+  conversationId: string,
+  fromSeq: number | null,
+): Promise<void> {
+  if (fromSeq == null) return;
+  if (!supportsEventsTail()) return;
+  try {
+    const { data, response } = await eventsTailGet({
+      path: { assistant_id: assistantId },
+      query: { conversationId, fromSeq: String(fromSeq) },
+      throwOnError: false,
+    });
+    if (!response?.ok || !data) {
+      recordDiagnostic("events_tail_fetch_failed", {
+        conversationId,
+        fromSeq,
+        status: response?.status,
+      });
+      return;
+    }
+    if (!data.complete) {
+      // The daemon's ring no longer reaches back to the anchor — the
+      // snapshot alone is the recovery, as with an out-of-ring reconnect.
+      recordDiagnostic("events_tail_incomplete", { conversationId, fromSeq });
+      return;
+    }
+    if (data.events.length > 0) {
+      ingestReplayedEnvelopes(data.events as AssistantEventEnvelope[]);
+    }
+    recordDiagnostic("events_tail_ingested", {
+      conversationId,
+      fromSeq,
+      count: data.events.length,
+      frontier: data.frontier,
+    });
+  } catch (err) {
+    recordDiagnostic("events_tail_fetch_failed", {
+      conversationId,
+      fromSeq,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -40,9 +40,17 @@ mock.module("@/domains/chat/utils/map-runtime-message", () => ({
 // Server fetch is driven per-test — spied (not module-mocked) so the rest of
 // the messages module's exports stay real for other importers in the graph.
 import * as messagesApi from "@/domains/chat/api/messages";
+import * as eventsTailApi from "@/domains/chat/api/events-tail";
 let fetchResult: unknown = undefined;
+/** Ordered trace of the reconcile's async steps, for ordering assertions. */
+const reconcileTrace: Array<{ step: string; args?: unknown[] }> = [];
 spyOn(messagesApi, "fetchConversationMessages").mockImplementation(
   async () => fetchResult as never,
+);
+spyOn(eventsTailApi, "ingestServerEventsTail").mockImplementation(
+  async (...args: unknown[]) => {
+    reconcileTrace.push({ step: "ingest-tail", args });
+  },
 );
 
 const { useMessageReconciliation } = await import(
@@ -99,6 +107,7 @@ function renderReconciliation() {
 }
 
 beforeEach(() => {
+  reconcileTrace.length = 0;
   __resetLocalSeqForTesting();
   useStreamStore.getState().setStreamContext({
     assistantId: ASSISTANT_ID,
@@ -159,4 +168,30 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
+});
+
+describe("useMessageReconciliation — server event-tail catch-up", () => {
+  test("pairs the snapshot with the tail from its anchor before reseeding", async () => {
+    // GIVEN a reconcile that will reseed (server cleared processing)
+    seedSnapshotProcessing(true);
+    seedServerFetch(false);
+    const { result, invalidateSpy } = renderReconciliation();
+    invalidateSpy.mockImplementation(async () => {
+      reconcileTrace.push({ step: "invalidate" });
+    });
+
+    // WHEN the active conversation reconciles
+    await result.current.reconcileActiveConversation();
+
+    // THEN the tail was fetched from the snapshot's anchor ...
+    const ingest = reconcileTrace.find((t) => t.step === "ingest-tail");
+    expect(ingest?.args).toEqual([ASSISTANT_ID, CONV_ID, 11]);
+    // ... and ingested BEFORE the history invalidation, so the reseed
+    // replay reads a primed event ring.
+    expect(reconcileTrace.map((t) => t.step)).toEqual([
+      "ingest-tail",
+      "invalidate",
+    ]);
+  });
+
 });

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -19,6 +19,7 @@ import {
   serverSnapshotHasNewContent,
 } from "@/domains/chat/utils/reconcile-detection";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
+import { ingestServerEventsTail } from "@/domains/chat/api/events-tail";
 import {
   fetchConversationMessages,
   RECONCILE_LATEST_PAGE_LIMIT,
@@ -336,11 +337,23 @@ export function useMessageReconciliation({
         fetchConversationMessages(ctx.assistantId, ctx.conversationId, {
           latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT,
         })
-          .then((snapshot) => {
+          .then(async (snapshot) => {
             if (epoch !== useStreamStore.getState().streamEpoch) return;
             const serverMessages = snapshot?.messages ?? [];
             const serverSeq = snapshot?.seq ?? null;
             const serverProcessing = snapshot?.processing;
+            // Pair the snapshot with the daemon's buffered event tail above
+            // its anchor BEFORE reconciling: the reconcile invalidates
+            // history, and the reseed replay reads the client event ring —
+            // priming it first lets the reseed fold events the live
+            // connection never delivered (snapshot at anchor + log from
+            // anchor), instead of trusting the snapshot alone.
+            await ingestServerEventsTail(
+              ctx.assistantId,
+              ctx.conversationId,
+              serverSeq,
+            );
+            if (epoch !== useStreamStore.getState().streamEpoch) return;
             recordDiagnostic("reconciliation_fetch", {
               assistantId: ctx.assistantId,
               conversationId: ctx.conversationId,
@@ -443,6 +456,15 @@ export function useMessageReconciliation({
         if (useConversationStore.getState().activeConversationId !== ctx.conversationId) return empty;
         // If the epoch changed during the fetch (e.g. page went hidden
         // and back), this reconciliation is stale — bail out.
+        if (useStreamStore.getState().streamEpoch !== snapshotEpoch) return empty;
+        // Pair the snapshot with the daemon's buffered event tail above its
+        // anchor BEFORE reconciling — see the loop tick for the rationale.
+        await ingestServerEventsTail(
+          ctx.assistantId,
+          ctx.conversationId,
+          serverSeq,
+        );
+        if (useConversationStore.getState().activeConversationId !== ctx.conversationId) return empty;
         if (useStreamStore.getState().streamEpoch !== snapshotEpoch) return empty;
         recordDiagnostic("reconciliation_active_fetch", {
           assistantId: ctx.assistantId,

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -20,6 +20,7 @@ import {
 } from "@/domains/chat/utils/reconcile-detection";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { ingestServerEventsTail } from "@/domains/chat/api/events-tail";
+import { supportsEventsTail } from "@/lib/backwards-compat/events-tail";
 import {
   fetchConversationMessages,
   RECONCILE_LATEST_PAGE_LIMIT,
@@ -370,6 +371,24 @@ export function useMessageReconciliation({
               serverSeq,
               serverProcessing,
             );
+
+            // On daemons that serve `/events/tail`, the reconcile above
+            // paired the snapshot with the event tail from its anchor —
+            // one pass is complete by construction, so there is nothing
+            // to poll for. The multi-tick poll-until-stable below exists
+            // only to wait out the partial-persist debounce on older
+            // daemons, and is deleted with them once the assistant
+            // version floor passes the tail endpoint.
+            if (supportsEventsTail()) {
+              recordDiagnostic("reconciliation_loop_finish", {
+                epoch,
+                reason: "single_pass_complete",
+                stableCount,
+                elapsedMs: Date.now() - startTime,
+              });
+              return;
+            }
+
             if (changed) {
               stableCount = 0;
             } else {

--- a/clients/web/src/lib/backwards-compat/events-tail.ts
+++ b/clients/web/src/lib/backwards-compat/events-tail.ts
@@ -1,0 +1,25 @@
+/**
+ * Backwards-compat gate: server-side event-tail catch-up.
+ *
+ * Vellum Assistant 0.10.7 adds `GET /events/tail` — the request/response
+ * twin of reconnecting the SSE stream with `lastSeenSeq`. It returns the
+ * daemon's ring-buffered events for one conversation above a seq anchor,
+ * so a recovery reconcile can pair a `/messages` snapshot with the exact
+ * events the live connection never delivered, instead of relying on the
+ * snapshot alone (which can honestly lag the stream by up to the daemon's
+ * partial-persist debounce).
+ *
+ * Older daemons don't serve the route; callers skip the tail fetch and
+ * keep the snapshot-only recovery behavior.
+ *
+ * Once 0.10.7 is the minimum supported assistant version, delete this
+ * module and call the endpoint unconditionally.
+ */
+import { assistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.7";
+
+/** Whether the active assistant serves `GET /events/tail`. */
+export function supportsEventsTail(): boolean {
+  return assistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/streaming/stream-debug.test.ts
+++ b/clients/web/src/lib/streaming/stream-debug.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test, beforeEach } from "bun:test";
 
 import {
   endSseClient,
+  EVENTS_TAIL_CLIENT_ID,
+  ingestReplayedEnvelopes,
   getSseClients,
   getSseEnvelopesSince,
   getSseEvents,
@@ -372,5 +374,62 @@ describe("recordSseTraffic", () => {
     // WHEN traffic is recorded against it
     // THEN it does not throw and records nothing
     expect(() => recordSseTraffic("sse-nonexistent", true)).not.toThrow();
+  });
+});
+
+describe("ingestReplayedEnvelopes", () => {
+  test("bridges an eviction gap so the reseed replay can serve the tail", () => {
+    // GIVEN a live buffer whose oldest retained seq (50) is past the
+    // snapshot anchor (3) — a delivery gap: getSseEnvelopesSince signals
+    // "no safe replay"
+    const ctrl = new AbortController();
+    const id = registerSseClient(ctrl.signal);
+    pushSseEvent(id, makeEnvelope(makeTextDeltaEvent("a50"), { seq: 50, conversationId: "A" }));
+    pushSseEvent(id, makeEnvelope(makeTextDeltaEvent("a60"), { seq: 60, conversationId: "A" }));
+    expect(getSseEnvelopesSince("A", 3)).toBeNull();
+
+    // WHEN the server-fetched tail above the anchor is ingested
+    ingestReplayedEnvelopes([
+      makeEnvelope(makeTextDeltaEvent("a4"), { seq: 4, conversationId: "A" }),
+      makeEnvelope(makeTextDeltaEvent("a20"), { seq: 20, conversationId: "A" }),
+    ]);
+
+    // THEN the replay bridges from the anchor through the live events
+    const tail = getSseEnvelopesSince("A", 3);
+    expect(tail?.map((e) => e.seq)).toEqual([4, 20, 50, 60]);
+    expect(tail?.[0]?.message as AssistantEvent).toEqual(makeTextDeltaEvent("a4"));
+  });
+
+  test("skips envelopes whose seq the ring already retains", () => {
+    // GIVEN a live buffer holding seq 5
+    const ctrl = new AbortController();
+    const id = registerSseClient(ctrl.signal);
+    pushSseEvent(id, makeEnvelope(makeTextDeltaEvent("live-5"), { seq: 5, conversationId: "A" }));
+
+    // WHEN a tail overlapping that seq is ingested
+    ingestReplayedEnvelopes([
+      makeEnvelope(makeTextDeltaEvent("tail-5"), { seq: 5, conversationId: "A" }),
+      makeEnvelope(makeTextDeltaEvent("tail-6"), { seq: 6, conversationId: "A" }),
+    ]);
+
+    // THEN the overlap is deduplicated and the live copy kept
+    const tail = getSseEnvelopesSince("A", 4);
+    expect(tail?.map((e) => e.seq)).toEqual([5, 6]);
+    expect(tail?.[0]?.message as AssistantEvent).toEqual(
+      makeTextDeltaEvent("live-5"),
+    );
+  });
+
+  test("ingested entries carry the events-tail sentinel client id", () => {
+    ingestReplayedEnvelopes([
+      makeEnvelope(makeTextDeltaEvent("t1"), { seq: 1, conversationId: "A" }),
+    ]);
+    const [entry] = getSseEvents(1);
+    expect(entry.clientId).toBe(EVENTS_TAIL_CLIENT_ID);
+  });
+
+  test("empty input is a no-op", () => {
+    expect(() => ingestReplayedEnvelopes([])).not.toThrow();
+    expect(getSseEvents().length).toBe(0);
   });
 });

--- a/clients/web/src/lib/streaming/stream-debug.ts
+++ b/clients/web/src/lib/streaming/stream-debug.ts
@@ -200,6 +200,47 @@ export function pushSseEvent(
 }
 
 /**
+ * Sentinel `clientId` stamped on entries ingested from the daemon's
+ * `/events/tail` endpoint rather than received on a live SSE connection.
+ */
+export const EVENTS_TAIL_CLIENT_ID = "events-tail";
+
+/**
+ * Ingest server-replayed envelopes (a `/events/tail` response) into the
+ * ring, so the resync replay ({@link getSseEnvelopesSince}) can bridge a
+ * snapshot anchor whose following events were never delivered on the live
+ * connection (a delivery gap the daemon's ring still covers). Entries the
+ * ring already holds (by `seq`) are skipped; the downstream fold is
+ * seq-idempotent regardless, this just keeps the ring free of duplicates.
+ *
+ * Entries are appended without re-sorting: {@link getSseEnvelopesSince}
+ * sorts its result and scans the whole ring for its contiguity check, so
+ * buffer order is not load-bearing.
+ */
+export function ingestReplayedEnvelopes(
+  envelopes: AssistantEventEnvelope[],
+): void {
+  if (envelopes.length === 0) return;
+  const retained = new Set<number>();
+  for (const e of events) {
+    if (typeof e.seq === "number") retained.add(e.seq);
+  }
+  for (const envelope of envelopes) {
+    if (typeof envelope.seq === "number" && retained.has(envelope.seq)) {
+      continue;
+    }
+    events.push({
+      clientId: EVENTS_TAIL_CLIENT_ID,
+      receivedAt: new Date().toISOString(),
+      ...envelope,
+    });
+  }
+  while (events.length > MAX_EVENTS) {
+    events.shift();
+  }
+}
+
+/**
  * Return a snapshot of all stream clients — live and recently-ended —
  * in registration order. Ended connections retain their final
  * `dataFrames`/`keepalives` counters and an `endReason`, so a reconnect


### PR DESCRIPTION
## Prompt / plan

**Respin — this PR previously carried a flush-on-GET stopgap; that is fully reverted.** Direction settled in discussion: no stopgaps, only the proper fix, which is the canonical snapshot-then-log recovery every reference system uses (Debezium's consistent-snapshot→LSN handoff, Linear's `lastSyncId` + delta endpoint, SSE `Last-Event-ID` — and the ordering `cold-anchor.ts` in this codebase already applies at cold start).

**The gap:** a `/messages` snapshot is anchored at the seq of the last durably persisted event, which mid-turn honestly lags the live stream by up to the daemon's 1s partial-persist debounce. On a healthy connection that window arrives as ordinary SSE deltas. After a delivery gap (out-of-ring reconnect, backgrounded tab) those events were never delivered — so a recovery reconcile that trusts the snapshot alone leaves a transcript hole, which is why the web client's reconciliation loop polls until two consecutive identical snapshots.

**The fix, three pieces:**

- **Daemon — `GET /events/tail?conversationId&fromSeq[&toSeq]`:** returns the ring-buffered envelopes for one conversation with `seq > fromSeq` (optionally bounded by `toSeq`, for callers that already know where live delivery resumed) — the request/response twin of reconnecting the SSE stream with `lastSeenSeq`. It reuses `getReplayWindow`'s contiguity and targeting-filter rules verbatim (client-identity headers re-apply self-echo/capability filters, same as SSE replay). `complete: false` signals ring eviction; the caller then recovers from the snapshot alone, exactly as an out-of-ring reconnect behaves today. Read-only — no GET-idempotency exception needed. This does **not** replace `lastSeenSeq` on `GET /events`: the SSE resume remains the fast path (global cursor, all conversations, atomic replay→live handoff on one channel); the tail is the recovery path for when that cursor falls outside the ring.
- **Web — every recovery reconcile pairs its snapshot with the tail:** all recovery triggers funnel through `reconcileActiveConversation` (reopen one-shots in `reconcile-on-reopen`, the seq-gap heal and daemon-restart reset in `sse-event-consumer`, the `sync_changed`-tag reconcile in `use-message-lifecycle`) or the loop tick — both fetch sites now ingest the tail envelopes into the client event ring **before** invalidating history. The reseed replay (`getSseEnvelopesSince` → `resolveSnapshot`) folds them exactly like live events — no new fold path, no snapshot-API shape change — and the stale-anchor seed guard stops firing because the ring can now bridge. Overlap with concurrent live delivery is safe by construction (seq-dedup on ingest + the fold's seq idempotency, the same invariant cold-anchor's snapshot/replay overlap relies on). Gated on assistant ≥ 0.10.7 via the backwards-compat registry; all tail failures degrade to snapshot-only recovery.
- **Web — the reconciliation loop collapses to a single pass on tail-capable daemons:** with one pass complete by construction, the loop's poll-until-stable cadence has nothing left to wait for. On assistants that serve the tail, `startReconciliationLoop` finishes after its first reconcile (`single_pass_complete`); the multi-tick polling survives **only** for pre-0.10.7 daemons and is deleted with them — along with `RECONCILE_STABLE_COUNT`, the 60s cap, and the stable-count heuristics — once the version floor passes the endpoint.

This is the loop's retirement path: on current daemons the loop is already reduced to one delayed complete reconcile; the version-floor follow-up deletes the machinery outright.

## Test plan

- **Live daemon (end-to-end):** hatched a local instance from this branch driving a slow-streaming stub provider (50 deltas × 250ms). Mid-turn: the `/messages` snapshot anchored at seq 86 ended at "word12"; `GET /events/tail?fromSeq=86` returned exactly seqs 87–89 ("word13 word14 word15") — conversation-scoped, ascending, all above the anchor — and snapshot+tail was verified as a prefix of the finished turn's authoritative row. Frontier-anchored fetches return empty-but-complete; invalid/missing params 400.
- **New unit tests:** `events-tail-route.test.ts` (conversation-filtered window + frontier, empty-complete at the live frontier, `complete: false` on ring eviction, `toSeq` bounding, targeting filters re-applied per client identity, param validation). Web: `stream-debug.test.ts` gains an `ingestReplayedEnvelopes` suite (an ingested tail bridges an eviction gap so `getSseEnvelopesSince` serves the full replay; seq-dedup keeps the live copy); `use-message-reconciliation.test.tsx` pins that the reconcile fetches the tail from the snapshot's anchor and ingests it **before** history invalidation. The single-pass loop collapse follows the file's existing convention of not driving the 5s tick timer in tests; it is exercised by the shared tick body those tests cover.
- **Suites:** all events-route suites (SSE hardening/shed/registration/dev-bypass), `assistant-stream-state`, and the web reconciliation suites (`use-message-reconciliation`, `reconcile-on-reopen`, `sse-event-consumer`, `use-event-stream-resume-reconcile`, `use-send-message-hidden-poll`, `stream-debug`) pass in isolation; `tsc` clean in both packages; eslint 0 errors on changed files; `openapi.yaml` regenerated from the ROUTES definition (web SDK is generated at build time from it).

## CLI verb checklist

- New route `events_tail_get` needs no `assistant` CLI verb: it is an internal client-resync primitive consumed by the web app's reconcile path (composed with `/messages`), not a user-facing operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3mtoFx6KM41xRNCa7fz1R