### PR TITLE
feat(monitoring): record memory.stat breakdown in every sample (1/7)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19585,6 +19585,48 @@ paths:
                                   - ratio
                                 additionalProperties: false
                               - type: "null"
+                          memoryStat:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  anonBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  fileBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  kernelBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  slabReclaimableBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  slabUnreclaimableBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  unevictableBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  reclaimableBytes:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                required:
+                                  - anonBytes
+                                  - fileBytes
+                                  - kernelBytes
+                                  - slabReclaimableBytes
+                                  - slabUnreclaimableBytes
+                                  - unevictableBytes
+                                  - reclaimableBytes
+                                additionalProperties: false
+                              - type: "null"
                           events:
                             anyOf:
                               - type: object
@@ -19629,6 +19671,7 @@ paths:
                         required:
                           - ts
                           - memory
+                          - memoryStat
                           - events
                           - disk
                         additionalProperties: false

--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -33,6 +33,15 @@ interface LatestSample {
     peakBytes: number | null;
     ratio: number | null;
   } | null;
+  memoryStat: {
+    anonBytes: number | null;
+    fileBytes: number | null;
+    kernelBytes: number | null;
+    slabReclaimableBytes: number | null;
+    slabUnreclaimableBytes: number | null;
+    unevictableBytes: number | null;
+    reclaimableBytes: number | null;
+  } | null;
   disk: {
     path: string;
     usedMb: number;
@@ -178,6 +187,17 @@ Examples:
             const peak = peakBytes != null ? formatMib(peakBytes) : "unknown";
             log.info(
               `  Memory: ${formatMib(currentBytes)} / ${limit}${pct}, peak ${peak}`,
+            );
+          }
+          if (sample.memoryStat) {
+            const stat = sample.memoryStat;
+            const fmt = (bytes: number | null) =>
+              bytes != null ? formatMib(bytes) : "unknown";
+            log.info(
+              `  Breakdown: anon ${fmt(stat.anonBytes)}, file ${fmt(stat.fileBytes)}, kernel ${fmt(stat.kernelBytes)}, slab ${fmt(stat.slabReclaimableBytes)} reclaimable + ${fmt(stat.slabUnreclaimableBytes)} unreclaimable`,
+            );
+            log.info(
+              `  Split: unevictable ${fmt(stat.unevictableBytes)}, reclaimable ${fmt(stat.reclaimableBytes)}`,
             );
           }
           if (sample.disk) {

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -25,9 +25,11 @@ import { join } from "node:path";
 import type { MonitoringConfig } from "../config/schemas/monitoring.js";
 import {
   type ContainerMemoryEvents,
+  type ContainerMemoryStat,
   getContainerMemoryEvents,
   getContainerMemoryLimitBytes,
   getContainerMemoryPeakBytes,
+  getContainerMemoryStat,
   getContainerMemoryUsageBytes,
 } from "../util/cgroup-memory.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
@@ -63,6 +65,12 @@ export interface ResourceSampleDisk {
 export interface ResourceSample {
   ts: number;
   memory: ResourceSampleMemory | null;
+  /**
+   * memory.stat breakdown (anon / file / kernel / slab, plus the derived
+   * unevictable vs reclaimable split). `memory.currentBytes` alone cannot say
+   * whether the cgroup is filling with process heap or with droppable cache.
+   */
+  memoryStat: ContainerMemoryStat | null;
   events: ContainerMemoryEvents | null;
   disk: ResourceSampleDisk | null;
 }
@@ -86,6 +94,7 @@ export function takeSample(now: number): ResourceSample {
   return {
     ts: now,
     memory,
+    memoryStat: getContainerMemoryStat(),
     events: getContainerMemoryEvents(),
     disk: disk
       ? {
@@ -178,6 +187,8 @@ export async function writeHighMemSnapshot(
       currentBytes: sample.memory?.currentBytes,
       limitBytes: sample.memory?.limitBytes,
       ratio: sample.memory?.ratio,
+      unevictableBytes: sample.memoryStat?.unevictableBytes,
+      reclaimableBytes: sample.memoryStat?.reclaimableBytes,
       file: filename,
     },
     "Captured high-memory snapshot",

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -136,7 +136,10 @@ describe("monitoring_stop", () => {
     const res = await handler("monitoring_stop")();
 
     expect(enabledCalls).toEqual([false]);
-    expect(res).toEqual({ monitoringWasRunning: false, monitoringEnabled: false });
+    expect(res).toEqual({
+      monitoringWasRunning: false,
+      monitoringEnabled: false,
+    });
   });
 });
 
@@ -166,6 +169,15 @@ describe("monitoring_status", () => {
         limitBytes: 8 * 1024 * 1024 * 1024,
         peakBytes: 7 * 1024 * 1024 * 1024,
         ratio: 0.75,
+      },
+      memoryStat: {
+        anonBytes: 4 * 1024 * 1024 * 1024,
+        fileBytes: 1024 * 1024 * 1024,
+        kernelBytes: 512 * 1024 * 1024,
+        slabReclaimableBytes: 400 * 1024 * 1024,
+        slabUnreclaimableBytes: 100 * 1024 * 1024,
+        unevictableBytes: 4 * 1024 * 1024 * 1024 + 100 * 1024 * 1024,
+        reclaimableBytes: 1024 * 1024 * 1024 + 400 * 1024 * 1024,
       },
       events: { low: 0, high: 0, max: 2, oom: 0, oomKill: 0 },
       disk: { path: "/workspace", usedMb: 100, totalMb: 1000, freeMb: 900 },

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -70,9 +70,20 @@ const sampleEventsSchema = z.object({
   oomKill: z.number(),
 });
 
+const sampleMemoryStatSchema = z.object({
+  anonBytes: z.number().nullable(),
+  fileBytes: z.number().nullable(),
+  kernelBytes: z.number().nullable(),
+  slabReclaimableBytes: z.number().nullable(),
+  slabUnreclaimableBytes: z.number().nullable(),
+  unevictableBytes: z.number().nullable(),
+  reclaimableBytes: z.number().nullable(),
+});
+
 const latestSampleSchema = z.object({
   ts: z.number(),
   memory: sampleMemorySchema.nullable(),
+  memoryStat: sampleMemoryStatSchema.nullable(),
   events: sampleEventsSchema.nullable(),
   disk: sampleDiskSchema.nullable(),
 });

--- a/assistant/src/util/__tests__/cgroup-memory.test.ts
+++ b/assistant/src/util/__tests__/cgroup-memory.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the pure cgroup v2 memory.stat parser. The file-reading wrappers in
+ * cgroup-memory.ts read fixed /sys/fs/cgroup paths, so only the parsing layer
+ * is exercised here.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseMemoryStat } from "../cgroup-memory.js";
+
+const FULL_MEMORY_STAT = `anon 2147483648
+file 1610612736
+kernel 943718400
+kernel_stack 5242880
+pagetables 31457280
+percpu 1048576
+sock 4096
+vmalloc 0
+shmem 8192
+zswap 0
+zswapped 0
+file_mapped 209715200
+file_dirty 135168
+file_writeback 0
+slab_reclaimable 838860800
+slab_unreclaimable 104857600
+slab 943718400
+workingset_refault_anon 0
+workingset_refault_file 123456
+pgscan_direct 7000000
+pgsteal_direct 6500000
+`;
+
+describe("parseMemoryStat", () => {
+  test("extracts the recorded fields and derives the split", () => {
+    const stat = parseMemoryStat(FULL_MEMORY_STAT);
+
+    expect(stat).toEqual({
+      anonBytes: 2147483648,
+      fileBytes: 1610612736,
+      kernelBytes: 943718400,
+      slabReclaimableBytes: 838860800,
+      slabUnreclaimableBytes: 104857600,
+      // anon + slab_unreclaimable
+      unevictableBytes: 2147483648 + 104857600,
+      // file + slab_reclaimable
+      reclaimableBytes: 1610612736 + 838860800,
+    });
+  });
+
+  test("reports null for fields the kernel does not expose", () => {
+    // Older kernels lack the aggregate `kernel` counter.
+    const stat = parseMemoryStat(
+      "anon 100\nfile 200\nslab_reclaimable 30\nslab_unreclaimable 40\n",
+    );
+
+    expect(stat.kernelBytes).toBeNull();
+    expect(stat.unevictableBytes).toBe(140);
+    expect(stat.reclaimableBytes).toBe(230);
+  });
+
+  test("derived split is null when a component is missing", () => {
+    const stat = parseMemoryStat("anon 100\nfile 200\n");
+
+    expect(stat.anonBytes).toBe(100);
+    expect(stat.fileBytes).toBe(200);
+    expect(stat.unevictableBytes).toBeNull();
+    expect(stat.reclaimableBytes).toBeNull();
+  });
+
+  test("tolerates malformed lines and empty input", () => {
+    expect(parseMemoryStat("")).toEqual({
+      anonBytes: null,
+      fileBytes: null,
+      kernelBytes: null,
+      slabReclaimableBytes: null,
+      slabUnreclaimableBytes: null,
+      unevictableBytes: null,
+      reclaimableBytes: null,
+    });
+
+    const stat = parseMemoryStat("anon notanumber\nfile 200\ngarbage\n");
+    expect(stat.anonBytes).toBeNull();
+    expect(stat.fileBytes).toBe(200);
+  });
+});

--- a/assistant/src/util/cgroup-memory.ts
+++ b/assistant/src/util/cgroup-memory.ts
@@ -101,6 +101,88 @@ export function getContainerMemoryPeakBytes(): number | null {
 }
 
 /**
+ * Breakdown of the cgroup's memory charge from the cgroup v2 `memory.stat`
+ * file. `memory.current` alone hides *what kind* of memory fills the cgroup —
+ * anonymous process heap, page cache, and kernel allocations are all charged to
+ * the same total but respond to completely different remedies.
+ *
+ * The derived split is the headline number:
+ *
+ * - `unevictableBytes` (anon + slab_unreclaimable): memory reclaim cannot
+ *   evict. It only shrinks when processes free it or die — growth here is real
+ *   pressure heading toward an OOM kill.
+ * - `reclaimableBytes` (file + slab_reclaimable): the kernel can drop this
+ *   under pressure. A large value is not by itself a problem, but reclaiming it
+ *   synchronously is what stalls allocations.
+ *
+ * Individual fields are null when the kernel doesn't expose them (e.g. the
+ * aggregate `kernel` counter only exists on newer kernels). The whole read
+ * returns null on cgroups v1 or when the file is unreadable.
+ */
+export interface ContainerMemoryStat {
+  /** Anonymous memory (process heaps/stacks) charged to the cgroup. */
+  anonBytes: number | null;
+  /** Page cache (file-backed pages) charged to the cgroup. */
+  fileBytes: number | null;
+  /** Total kernel memory charged to the cgroup (includes slab). */
+  kernelBytes: number | null;
+  /** Slab memory the kernel can reclaim under pressure (dentries, inodes). */
+  slabReclaimableBytes: number | null;
+  /** Slab memory pinned until explicitly freed. */
+  slabUnreclaimableBytes: number | null;
+  /** anon + slab_unreclaimable — reclaim cannot evict this. */
+  unevictableBytes: number | null;
+  /** file + slab_reclaimable — the kernel can drop this under pressure. */
+  reclaimableBytes: number | null;
+}
+
+/** Parse cgroup v2 `memory.stat` content into the recorded breakdown. */
+export function parseMemoryStat(raw: string): ContainerMemoryStat {
+  const counts: Record<string, number> = {};
+  for (const line of raw.split("\n")) {
+    const [key, value] = line.trim().split(/\s+/);
+    if (!key) {
+      continue;
+    }
+    const parsed = parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      counts[key] = parsed;
+    }
+  }
+
+  const anonBytes = counts.anon ?? null;
+  const fileBytes = counts.file ?? null;
+  const slabReclaimableBytes = counts.slab_reclaimable ?? null;
+  const slabUnreclaimableBytes = counts.slab_unreclaimable ?? null;
+
+  return {
+    anonBytes,
+    fileBytes,
+    kernelBytes: counts.kernel ?? null,
+    slabReclaimableBytes,
+    slabUnreclaimableBytes,
+    unevictableBytes:
+      anonBytes != null && slabUnreclaimableBytes != null
+        ? anonBytes + slabUnreclaimableBytes
+        : null,
+    reclaimableBytes:
+      fileBytes != null && slabReclaimableBytes != null
+        ? fileBytes + slabReclaimableBytes
+        : null,
+  };
+}
+
+export function getContainerMemoryStat(): ContainerMemoryStat | null {
+  let raw: string;
+  try {
+    raw = readFileSync("/sys/fs/cgroup/memory.stat", "utf-8");
+  } catch {
+    return null;
+  }
+  return parseMemoryStat(raw);
+}
+
+/**
  * Pressure counters from the cgroup v2 `memory.events` file. Each field counts
  * how many times the cgroup crossed the corresponding boundary since boot; a
  * rising `max` (usage hit the hard limit and allocation was throttled) or


### PR DESCRIPTION
## Prompt / plan

First of a 7-PR series applying the resource-monitor recommendations from a memory-pressure retrospective. This one: record the cgroup v2 `memory.stat` breakdown, not just `currentBytes`/`ratio` — during the incident, kernel+cache pressure was initially mistaken for JS GC because ~50% of the cgroup charge was invisible.

- New `parseMemoryStat()` / `getContainerMemoryStat()` in `assistant/src/util/cgroup-memory.ts` reading `anon`, `file`, `kernel`, `slab_reclaimable`, `slab_unreclaimable` from `/sys/fs/cgroup/memory.stat`, plus the derived split:
  - **unevictable** (`anon + slab_unreclaimable`) — reclaim can't evict it; growth here is real pressure heading toward an OOM kill.
  - **reclaimable** (`file + slab_reclaimable`) — the kernel can drop it; a large value is not itself a problem.
- Every resource sample (default 250ms cadence) now carries `memoryStat`, so high-memory snapshots and the persisted ring buffer include the breakdown. The snapshot log line reports the unevictable/reclaimable split.
- `monitoring_status` route schema, CLI `assistant monitoring status` output, and `openapi.yaml` (regenerated) updated accordingly. Fields are nullable: cgroup v1 / macOS return null wholesale, and the aggregate `kernel` counter only exists on newer kernels.

## Test plan

- New unit tests for the parser: full fixture, missing `kernel` key, missing split components, malformed/empty input (`src/util/__tests__/cgroup-memory.test.ts`).
- Extended `monitoring-routes.test.ts` sample fixture with the new field.
- `bun test` on monitoring/util/route suites (28 pass), `bun run typecheck:fast`, eslint on touched files, `bun run generate:openapi`.

## CLI verb checklist

No new routes — the existing `monitoring_status` response gained a field, surfaced by the existing `assistant monitoring status` verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm)_