### PR TITLE
feat(monitoring): record reclaim/thrash counters with deltas (2/7)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19627,6 +19627,28 @@ paths:
                                   - reclaimableBytes
                                 additionalProperties: false
                               - type: "null"
+                          reclaim:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  pgscanDirect:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  pgstealDirect:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                  workingsetRefaultFile:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                required:
+                                  - pgscanDirect
+                                  - pgstealDirect
+                                  - workingsetRefaultFile
+                                additionalProperties: false
+                              - type: "null"
                           events:
                             anyOf:
                               - type: object
@@ -19647,6 +19669,69 @@ paths:
                                   - max
                                   - oom
                                   - oomKill
+                                additionalProperties: false
+                              - type: "null"
+                          deltas:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  events:
+                                    anyOf:
+                                      - type: object
+                                        properties:
+                                          low:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          high:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          max:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          oom:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          oomKill:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                        required:
+                                          - low
+                                          - high
+                                          - max
+                                          - oom
+                                          - oomKill
+                                        additionalProperties: false
+                                      - type: "null"
+                                  reclaim:
+                                    anyOf:
+                                      - type: object
+                                        properties:
+                                          pgscanDirect:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          pgstealDirect:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                          workingsetRefaultFile:
+                                            anyOf:
+                                              - type: number
+                                              - type: "null"
+                                        required:
+                                          - pgscanDirect
+                                          - pgstealDirect
+                                          - workingsetRefaultFile
+                                        additionalProperties: false
+                                      - type: "null"
+                                required:
+                                  - events
+                                  - reclaim
                                 additionalProperties: false
                               - type: "null"
                           disk:
@@ -19672,7 +19757,9 @@ paths:
                           - ts
                           - memory
                           - memoryStat
+                          - reclaim
                           - events
+                          - deltas
                           - disk
                         additionalProperties: false
                       - type: "null"

--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -25,6 +25,12 @@ import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 
+interface ReclaimCounters {
+  pgscanDirect: number | null;
+  pgstealDirect: number | null;
+  workingsetRefaultFile: number | null;
+}
+
 interface LatestSample {
   ts: number;
   memory: {
@@ -41,6 +47,17 @@ interface LatestSample {
     slabUnreclaimableBytes: number | null;
     unevictableBytes: number | null;
     reclaimableBytes: number | null;
+  } | null;
+  reclaim: ReclaimCounters | null;
+  deltas: {
+    events: {
+      low: number | null;
+      high: number | null;
+      max: number | null;
+      oom: number | null;
+      oomKill: number | null;
+    } | null;
+    reclaim: ReclaimCounters | null;
   } | null;
   disk: {
     path: string;
@@ -198,6 +215,18 @@ Examples:
             );
             log.info(
               `  Split: unevictable ${fmt(stat.unevictableBytes)}, reclaimable ${fmt(stat.reclaimableBytes)}`,
+            );
+          }
+          if (sample.reclaim) {
+            const counter = (total: number | null, delta?: number | null) => {
+              if (total == null) {
+                return "unknown";
+              }
+              return delta != null ? `${total} (+${delta})` : `${total}`;
+            };
+            const d = sample.deltas?.reclaim;
+            log.info(
+              `  Reclaim: pgscan_direct ${counter(sample.reclaim.pgscanDirect, d?.pgscanDirect)}, pgsteal_direct ${counter(sample.reclaim.pgstealDirect, d?.pgstealDirect)}, workingset_refault_file ${counter(sample.reclaim.workingsetRefaultFile, d?.workingsetRefaultFile)}`,
             );
           }
           if (sample.disk) {

--- a/assistant/src/monitoring/__tests__/resource-sampler.test.ts
+++ b/assistant/src/monitoring/__tests__/resource-sampler.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the sampler's pure delta computation. The sampling functions
+ * themselves read fixed /sys and /proc paths, so only the diff layer is
+ * exercised here.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeSampleDeltas,
+  type ResourceSample,
+} from "../resource-sampler.js";
+
+function makeSample(overrides: Partial<ResourceSample>): ResourceSample {
+  return {
+    ts: 0,
+    memory: null,
+    memoryStat: null,
+    reclaim: null,
+    events: null,
+    deltas: null,
+    disk: null,
+    ...overrides,
+  };
+}
+
+describe("computeSampleDeltas", () => {
+  test("diffs events and reclaim counters per key", () => {
+    const prev = makeSample({
+      ts: 1000,
+      events: { low: 0, high: 5, max: 100, oom: 0, oomKill: 0 },
+      reclaim: {
+        pgscanDirect: 1_000_000,
+        pgstealDirect: 900_000,
+        workingsetRefaultFile: 500,
+      },
+    });
+    const current = makeSample({
+      ts: 1250,
+      events: { low: 0, high: 7, max: 150, oom: 1, oomKill: 0 },
+      reclaim: {
+        pgscanDirect: 1_400_000,
+        pgstealDirect: 1_200_000,
+        workingsetRefaultFile: 800,
+      },
+    });
+
+    expect(computeSampleDeltas(prev, current)).toEqual({
+      events: { low: 0, high: 2, max: 50, oom: 1, oomKill: 0 },
+      reclaim: {
+        pgscanDirect: 400_000,
+        pgstealDirect: 300_000,
+        workingsetRefaultFile: 300,
+      },
+    });
+  });
+
+  test("is null-wise when a side or a counter is unavailable", () => {
+    const prev = makeSample({
+      reclaim: {
+        pgscanDirect: 100,
+        pgstealDirect: null,
+        workingsetRefaultFile: 10,
+      },
+    });
+    const current = makeSample({
+      events: { low: 0, high: 0, max: 0, oom: 0, oomKill: 0 },
+      reclaim: {
+        pgscanDirect: 150,
+        pgstealDirect: 90,
+        workingsetRefaultFile: 10,
+      },
+    });
+
+    const deltas = computeSampleDeltas(prev, current);
+    // prev.events is null, so no event deltas.
+    expect(deltas.events).toBeNull();
+    expect(deltas.reclaim).toEqual({
+      pgscanDirect: 50,
+      pgstealDirect: null,
+      workingsetRefaultFile: 0,
+    });
+  });
+});

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -26,11 +26,14 @@ import type { MonitoringConfig } from "../config/schemas/monitoring.js";
 import {
   type ContainerMemoryEvents,
   type ContainerMemoryStat,
+  type ContainerReclaimCounters,
   getContainerMemoryEvents,
   getContainerMemoryLimitBytes,
   getContainerMemoryPeakBytes,
-  getContainerMemoryStat,
   getContainerMemoryUsageBytes,
+  parseMemoryStat,
+  parseReclaimCounters,
+  readMemoryStatRaw,
 } from "../util/cgroup-memory.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
@@ -62,6 +65,17 @@ export interface ResourceSampleDisk {
   freeMb: number;
 }
 
+/**
+ * Counter increases since the previous sample. The cumulative since-boot
+ * counters answer "has this ever happened"; the deltas are what turn a stall
+ * into a timeline — a burst of `reclaim.pgscanDirect` across a few samples *is*
+ * the synchronous-reclaim stall, invisible in the cumulative totals.
+ */
+export interface ResourceSampleDeltas {
+  events: ContainerMemoryEvents | null;
+  reclaim: ContainerReclaimCounters | null;
+}
+
 export interface ResourceSample {
   ts: number;
   memory: ResourceSampleMemory | null;
@@ -71,12 +85,49 @@ export interface ResourceSample {
    * whether the cgroup is filling with process heap or with droppable cache.
    */
   memoryStat: ContainerMemoryStat | null;
+  /** Cumulative reclaim/thrash counters from memory.stat (since boot). */
+  reclaim: ContainerReclaimCounters | null;
   events: ContainerMemoryEvents | null;
+  /** Since the previous sample; null on the monitor's first sample. */
+  deltas: ResourceSampleDeltas | null;
   disk: ResourceSampleDisk | null;
 }
 
-/** Take a single point-in-time sample of memory + disk. */
-export function takeSample(now: number): ResourceSample {
+function diffCounters<T extends Record<keyof T & string, number | null>>(
+  prev: T | null,
+  current: T | null,
+): T | null {
+  if (prev == null || current == null) {
+    return null;
+  }
+  const out: Record<string, number | null> = {};
+  for (const key of Object.keys(current) as Array<keyof T & string>) {
+    const before = prev[key];
+    const after = current[key];
+    out[key] = before != null && after != null ? after - before : null;
+  }
+  return out as T;
+}
+
+/** Per-counter increases from `prev` to `current`. */
+export function computeSampleDeltas(
+  prev: ResourceSample,
+  current: ResourceSample,
+): ResourceSampleDeltas {
+  return {
+    events: diffCounters(prev.events, current.events),
+    reclaim: diffCounters(prev.reclaim, current.reclaim),
+  };
+}
+
+/**
+ * Take a single point-in-time sample of memory + disk. When `prev` is given,
+ * the sample carries counter deltas relative to it.
+ */
+export function takeSample(
+  now: number,
+  prev: ResourceSample | null = null,
+): ResourceSample {
   const currentBytes = getContainerMemoryUsageBytes();
   const limitBytes = getContainerMemoryLimitBytes();
   const memory: ResourceSampleMemory | null =
@@ -91,11 +142,16 @@ export function takeSample(now: number): ResourceSample {
 
   const disk = getDiskUsageInfo();
 
-  return {
+  // One read feeds both parsers so the breakdown and counters are coherent.
+  const statRaw = readMemoryStatRaw();
+
+  const sample: ResourceSample = {
     ts: now,
     memory,
-    memoryStat: getContainerMemoryStat(),
+    memoryStat: statRaw != null ? parseMemoryStat(statRaw) : null,
+    reclaim: statRaw != null ? parseReclaimCounters(statRaw) : null,
     events: getContainerMemoryEvents(),
+    deltas: null,
     disk: disk
       ? {
           path: disk.path,
@@ -105,6 +161,10 @@ export function takeSample(now: number): ResourceSample {
         }
       : null,
   };
+  if (prev != null) {
+    sample.deltas = computeSampleDeltas(prev, sample);
+  }
+  return sample;
 }
 
 interface ProcessRss {
@@ -189,6 +249,8 @@ export async function writeHighMemSnapshot(
       ratio: sample.memory?.ratio,
       unevictableBytes: sample.memoryStat?.unevictableBytes,
       reclaimableBytes: sample.memoryStat?.reclaimableBytes,
+      pgscanDirectDelta: sample.deltas?.reclaim?.pgscanDirect,
+      workingsetRefaultFileDelta: sample.deltas?.reclaim?.workingsetRefaultFile,
       file: filename,
     },
     "Captured high-memory snapshot",
@@ -236,12 +298,14 @@ export function startResourceSampler(
   );
 
   let lastSnapshotAt = 0;
+  let prevSample: ResourceSample | null = null;
 
   const tick = () => {
     const now = clock();
     let sample: ResourceSample;
     try {
-      sample = takeSample(now);
+      sample = takeSample(now, prevSample);
+      prevSample = sample;
       buffer.append(sample);
     } catch (err) {
       log.warn({ err }, "Resource sample failed");

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -179,7 +179,20 @@ describe("monitoring_status", () => {
         unevictableBytes: 4 * 1024 * 1024 * 1024 + 100 * 1024 * 1024,
         reclaimableBytes: 1024 * 1024 * 1024 + 400 * 1024 * 1024,
       },
+      reclaim: {
+        pgscanDirect: 7_000_000,
+        pgstealDirect: 6_500_000,
+        workingsetRefaultFile: 123_456,
+      },
       events: { low: 0, high: 0, max: 2, oom: 0, oomKill: 0 },
+      deltas: {
+        events: { low: 0, high: 0, max: 1, oom: 0, oomKill: 0 },
+        reclaim: {
+          pgscanDirect: 40_000,
+          pgstealDirect: 35_000,
+          workingsetRefaultFile: 300,
+        },
+      },
       disk: { path: "/workspace", usedMb: 100, totalMb: 1000, freeMb: 900 },
     };
 

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -80,11 +80,32 @@ const sampleMemoryStatSchema = z.object({
   reclaimableBytes: z.number().nullable(),
 });
 
+const sampleReclaimSchema = z.object({
+  pgscanDirect: z.number().nullable(),
+  pgstealDirect: z.number().nullable(),
+  workingsetRefaultFile: z.number().nullable(),
+});
+
+const sampleEventDeltasSchema = z.object({
+  low: z.number().nullable(),
+  high: z.number().nullable(),
+  max: z.number().nullable(),
+  oom: z.number().nullable(),
+  oomKill: z.number().nullable(),
+});
+
+const sampleDeltasSchema = z.object({
+  events: sampleEventDeltasSchema.nullable(),
+  reclaim: sampleReclaimSchema.nullable(),
+});
+
 const latestSampleSchema = z.object({
   ts: z.number(),
   memory: sampleMemorySchema.nullable(),
   memoryStat: sampleMemoryStatSchema.nullable(),
+  reclaim: sampleReclaimSchema.nullable(),
   events: sampleEventsSchema.nullable(),
+  deltas: sampleDeltasSchema.nullable(),
   disk: sampleDiskSchema.nullable(),
 });
 

--- a/assistant/src/util/__tests__/cgroup-memory.test.ts
+++ b/assistant/src/util/__tests__/cgroup-memory.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseMemoryStat } from "../cgroup-memory.js";
+import { parseMemoryStat, parseReclaimCounters } from "../cgroup-memory.js";
 
 const FULL_MEMORY_STAT = `anon 2147483648
 file 1610612736
@@ -82,5 +82,23 @@ describe("parseMemoryStat", () => {
     const stat = parseMemoryStat("anon notanumber\nfile 200\ngarbage\n");
     expect(stat.anonBytes).toBeNull();
     expect(stat.fileBytes).toBe(200);
+  });
+});
+
+describe("parseReclaimCounters", () => {
+  test("extracts the reclaim/thrash counters", () => {
+    expect(parseReclaimCounters(FULL_MEMORY_STAT)).toEqual({
+      pgscanDirect: 7000000,
+      pgstealDirect: 6500000,
+      workingsetRefaultFile: 123456,
+    });
+  });
+
+  test("reports null for counters the kernel does not expose", () => {
+    expect(parseReclaimCounters("anon 100\npgscan_direct 5\n")).toEqual({
+      pgscanDirect: 5,
+      pgstealDirect: null,
+      workingsetRefaultFile: null,
+    });
   });
 });

--- a/assistant/src/util/cgroup-memory.ts
+++ b/assistant/src/util/cgroup-memory.ts
@@ -136,8 +136,8 @@ export interface ContainerMemoryStat {
   reclaimableBytes: number | null;
 }
 
-/** Parse cgroup v2 `memory.stat` content into the recorded breakdown. */
-export function parseMemoryStat(raw: string): ContainerMemoryStat {
+/** Parse `<key> <count>` lines (the memory.stat / memory.events format). */
+function parseKeyedCounts(raw: string): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const line of raw.split("\n")) {
     const [key, value] = line.trim().split(/\s+/);
@@ -149,6 +149,12 @@ export function parseMemoryStat(raw: string): ContainerMemoryStat {
       counts[key] = parsed;
     }
   }
+  return counts;
+}
+
+/** Parse cgroup v2 `memory.stat` content into the recorded breakdown. */
+export function parseMemoryStat(raw: string): ContainerMemoryStat {
+  const counts = parseKeyedCounts(raw);
 
   const anonBytes = counts.anon ?? null;
   const fileBytes = counts.file ?? null;
@@ -172,14 +178,53 @@ export function parseMemoryStat(raw: string): ContainerMemoryStat {
   };
 }
 
-export function getContainerMemoryStat(): ContainerMemoryStat | null {
-  let raw: string;
+/**
+ * Reclaim / thrash counters from cgroup v2 `memory.stat`. All are cumulative
+ * since boot and monotonic:
+ *
+ * - `pgscanDirect` / `pgstealDirect`: pages scanned / reclaimed *synchronously*
+ *   by an allocating process because the cgroup was at its limit. Sustained
+ *   growth means allocations are stalling inside the kernel — what looks like a
+ *   multi-second GC pause from userspace is usually this.
+ * - `workingsetRefaultFile`: previously-evicted file pages faulted back in.
+ *   Growth means reclaim is evicting pages that are still needed (cache
+ *   thrash), so the page cache is undersized for the working set.
+ *
+ * Fields are null when the kernel doesn't expose them; the whole read is null
+ * on cgroups v1 or when the file is unreadable.
+ */
+export interface ContainerReclaimCounters {
+  pgscanDirect: number | null;
+  pgstealDirect: number | null;
+  workingsetRefaultFile: number | null;
+}
+
+/** Parse cgroup v2 `memory.stat` content into the reclaim/thrash counters. */
+export function parseReclaimCounters(raw: string): ContainerReclaimCounters {
+  const counts = parseKeyedCounts(raw);
+  return {
+    pgscanDirect: counts.pgscan_direct ?? null,
+    pgstealDirect: counts.pgsteal_direct ?? null,
+    workingsetRefaultFile: counts.workingset_refault_file ?? null,
+  };
+}
+
+/**
+ * Raw cgroup v2 `memory.stat` content, or null on cgroups v1 / unreadable.
+ * Callers that need both the byte breakdown and the reclaim counters read once
+ * and feed the same content to both parsers, so the two views are coherent.
+ */
+export function readMemoryStatRaw(): string | null {
   try {
-    raw = readFileSync("/sys/fs/cgroup/memory.stat", "utf-8");
+    return readFileSync("/sys/fs/cgroup/memory.stat", "utf-8");
   } catch {
     return null;
   }
-  return parseMemoryStat(raw);
+}
+
+export function getContainerMemoryStat(): ContainerMemoryStat | null {
+  const raw = readMemoryStatRaw();
+  return raw != null ? parseMemoryStat(raw) : null;
 }
 
 /**
@@ -206,13 +251,7 @@ export function getContainerMemoryEvents(): ContainerMemoryEvents | null {
     return null;
   }
 
-  const counts: Record<string, number> = {};
-  for (const line of raw.split("\n")) {
-    const [key, value] = line.trim().split(/\s+/);
-    if (!key) continue;
-    const parsed = parseInt(value, 10);
-    if (Number.isFinite(parsed)) counts[key] = parsed;
-  }
+  const counts = parseKeyedCounts(raw);
 
   return {
     low: counts.low ?? 0,


### PR DESCRIPTION
## Prompt / plan

2/7 of the resource-monitor forensics series (stacked on #37106). During the incident, ~525k `memory.events max` events and ~70M direct-reclaim pages scanned were what the apparent "21s GC pauses" actually were — synchronous kernel reclaim — and nothing surfaced them.

- `parseReclaimCounters()` in `cgroup-memory.ts` reads `pgscan_direct`, `pgsteal_direct`, `workingset_refault_file` from cgroup v2 `memory.stat`. Doc comments explain the diagnostic meaning (direct reclaim = allocations stalling in the kernel; refaults = cache thrash).
- Every sample now records these cumulative counters **plus per-sample deltas** for both the reclaim counters and the existing `memory.events` counters (`sample.deltas`, null on the monitor's first sample). Cumulative totals say "has this ever happened"; deltas across 250ms samples turn a stall into a timeline.
- The sampler reads `memory.stat` once per tick and feeds both parsers (byte breakdown from 1/7 + counters) so the two views are coherent; the duplicated key/value line parsing is extracted into a shared `parseKeyedCounts`.
- High-memory snapshot log line includes the reclaim deltas; `assistant monitoring status` prints `pgscan_direct N (+d)`-style counters; route schema + `openapi.yaml` regenerated.

## Test plan

- Parser tests for `parseReclaimCounters` (full fixture, missing counters).
- New `resource-sampler.test.ts` covering `computeSampleDeltas` (per-key diffs, null-wise behavior when a side or counter is unavailable).
- Routes fixture extended; `bun test` on the four monitoring suites (25 pass), `bun run typecheck:fast`, eslint, `bun run generate:openapi`.

## CLI verb checklist

No new routes — existing `monitoring_status` response gained fields, surfaced by the existing `assistant monitoring status` verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm)_