### PR TITLE
feat(monitoring): capture top slab caches in high-mem snapshots (3/7)

### DIFF
--- a/assistant/src/monitoring/__tests__/slabinfo.test.ts
+++ b/assistant/src/monitoring/__tests__/slabinfo.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseSlabinfo } from "../slabinfo.js";
+
+const SLABINFO = `slabinfo - version: 2.1
+# name            <active_objs> <num_objs> <objsize> <objperslab> <pagesperslab> : tunables <limit> <batchcount> <sharedfactor> : slabdata <active_slabs> <num_slabs> <sharedavail>
+fuse_inode        820000 825000    832   39    8 : tunables    0    0    0 : slabdata  21154  21154      0
+dentry            780000 782000    192   21    1 : tunables    0    0    0 : slabdata  37238  37238      0
+ext4_groupinfo_4k   2054   2054    152   26    1 : tunables    0    0    0 : slabdata     79     79      0
+nf_conntrack           0      0    256   16    1 : tunables    0    0    0 : slabdata      0      0      0
+`;
+
+describe("parseSlabinfo", () => {
+  test("parses caches and sorts by held memory, largest first", () => {
+    const caches = parseSlabinfo(SLABINFO);
+
+    expect(caches.map((c) => c.name)).toEqual([
+      "fuse_inode",
+      "dentry",
+      "ext4_groupinfo_4k",
+      "nf_conntrack",
+    ]);
+    expect(caches[0]).toEqual({
+      name: "fuse_inode",
+      activeObjs: 820000,
+      numObjs: 825000,
+      objSizeBytes: 832,
+      totalBytes: 825000 * 832,
+    });
+    expect(caches[1].totalBytes).toBe(782000 * 192);
+  });
+
+  test("skips headers and malformed lines", () => {
+    expect(parseSlabinfo("")).toEqual([]);
+    expect(
+      parseSlabinfo("slabinfo - version: 2.1\n# name legend\nshort line\n"),
+    ).toEqual([]);
+    expect(parseSlabinfo("bad notanumber 5 10 1 : tunables 0 0 0\n")).toEqual(
+      [],
+    );
+  });
+});

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -40,6 +40,7 @@ import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { buildProcessTree, listProcesses } from "../util/process-tree.js";
 import { SampleRingBuffer } from "./sample-ring-buffer.js";
+import { topSlabCaches } from "./slabinfo.js";
 
 const log = getLogger("resource-sampler");
 
@@ -208,8 +209,9 @@ function topProcessesByRss(limit: number): ProcessRss[] {
 
 /**
  * Capture a high-memory snapshot to the snapshots directory: the triggering
- * sample, the cgroup memory.events counters, the top processes by RSS, and the
- * full process tree of the container. Prunes to {@link MAX_SNAPSHOTS} newest.
+ * sample, the cgroup memory.events counters, the top processes by RSS, the top
+ * kernel slab caches, and the full process tree of the container. Prunes to
+ * {@link MAX_SNAPSHOTS} newest.
  */
 export async function writeHighMemSnapshot(
   dataDir: string,
@@ -233,6 +235,9 @@ export async function writeHighMemSnapshot(
     ts: sample.ts,
     sample,
     topProcessesByRss: topProcessesByRss(15),
+    // Slab memory belongs to no process; without this, cgroup usage that
+    // exceeds the RSS sum has no visible owner.
+    topSlabCaches: topSlabCaches(10),
     processTree: tree,
   };
 

--- a/assistant/src/monitoring/slabinfo.ts
+++ b/assistant/src/monitoring/slabinfo.ts
@@ -1,0 +1,73 @@
+/**
+ * Kernel slab-cache accounting from `/proc/slabinfo`, for high-memory
+ * snapshots. Slab memory (dentries, inodes, fuse_inode, …) is charged to the
+ * cgroup but belongs to no process, so per-process RSS accounting can never
+ * explain it — hundreds of MB of inode/dentry cache driven by workspace file
+ * count are invisible without this view.
+ *
+ * `/proc/slabinfo` is root-only (mode 0400); reads are best-effort and return
+ * null when the file is unreadable (unprivileged process, macOS).
+ */
+
+import { readFileSync } from "node:fs";
+
+export interface SlabCache {
+  name: string;
+  activeObjs: number;
+  numObjs: number;
+  objSizeBytes: number;
+  /** numObjs × objSizeBytes — the memory held by this cache's slabs. */
+  totalBytes: number;
+}
+
+/**
+ * Parse `/proc/slabinfo` (version 2.x) content into per-cache totals, largest
+ * first. Header and malformed lines are skipped.
+ */
+export function parseSlabinfo(raw: string): SlabCache[] {
+  const caches: SlabCache[] = [];
+  for (const line of raw.split("\n")) {
+    // Header lines: "slabinfo - version: 2.1" and the "# name ..." legend.
+    if (!line || line.startsWith("#") || line.startsWith("slabinfo")) {
+      continue;
+    }
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 4) {
+      continue;
+    }
+    const [name, activeRaw, numRaw, sizeRaw] = fields;
+    const activeObjs = parseInt(activeRaw, 10);
+    const numObjs = parseInt(numRaw, 10);
+    const objSizeBytes = parseInt(sizeRaw, 10);
+    if (
+      !Number.isFinite(activeObjs) ||
+      !Number.isFinite(numObjs) ||
+      !Number.isFinite(objSizeBytes)
+    ) {
+      continue;
+    }
+    caches.push({
+      name,
+      activeObjs,
+      numObjs,
+      objSizeBytes,
+      totalBytes: numObjs * objSizeBytes,
+    });
+  }
+  caches.sort((a, b) => b.totalBytes - a.totalBytes);
+  return caches;
+}
+
+/**
+ * The top `limit` slab caches by held memory, largest first. Null when
+ * `/proc/slabinfo` is unavailable or unreadable.
+ */
+export function topSlabCaches(limit: number): SlabCache[] | null {
+  let raw: string;
+  try {
+    raw = readFileSync("/proc/slabinfo", "utf-8");
+  } catch {
+    return null;
+  }
+  return parseSlabinfo(raw).slice(0, limit);
+}


### PR DESCRIPTION
## Prompt / plan

3/7 of the resource-monitor forensics series (stacked on #37107). During the incident, 656 MB of `fuse_inode` + 143 MB of `dentry` — ~17% of the container limit, driven by workspace file count — were completely invisible: slab memory is charged to the cgroup but belongs to no process, so per-process RSS accounting can never explain it.

- New `assistant/src/monitoring/slabinfo.ts`: parses `/proc/slabinfo` (v2.x format, verified against a live file) into per-cache `{name, activeObjs, numObjs, objSizeBytes, totalBytes}` sorted by held memory (`numObjs × objsize`).
- `writeHighMemSnapshot` now records the top 10 caches under `topSlabCaches`. Snapshot-only (not the 250ms sample path): slabs move slowly and the read is comparatively heavy.
- Best-effort: `/proc/slabinfo` is root-only (mode 0400) — the snapshot records `null` when unreadable (unprivileged process, macOS) rather than failing.

No route/OpenAPI changes — snapshots are on-disk forensics artifacts only.

## Test plan

- Parser tests with a real-format fixture: parsing, largest-first sorting, header/malformed-line skipping (`src/monitoring/__tests__/slabinfo.test.ts`).
- `bun test` on monitoring suites, `bun run typecheck:fast`, eslint clean on new files.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm)_