### PR TITLE
feat(monitoring): rank snapshot processes by PSS with anon/file split (4/7)

### DIFF
--- a/assistant/src/monitoring/__tests__/process-memory.test.ts
+++ b/assistant/src/monitoring/__tests__/process-memory.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { effectiveSizeBytes, parseSmapsRollup } from "../process-memory.js";
+
+const SMAPS_ROLLUP = `555c98516000-7ffe248ca000 ---p 00000000 00:00 0                          [rollup]
+Rss:              524288 kB
+Pss:              262144 kB
+Pss_Dirty:        131072 kB
+Pss_Anon:         196608 kB
+Pss_File:          61440 kB
+Pss_Shmem:          4096 kB
+Shared_Clean:     262144 kB
+Private_Dirty:    131072 kB
+Anonymous:        196608 kB
+Swap:                  0 kB
+`;
+
+describe("parseSmapsRollup", () => {
+  test("extracts PSS, RSS, and the anon/file/shmem split in bytes", () => {
+    expect(parseSmapsRollup(SMAPS_ROLLUP)).toEqual({
+      rssBytes: 524288 * 1024,
+      pssBytes: 262144 * 1024,
+      pssAnonBytes: 196608 * 1024,
+      pssFileBytes: 61440 * 1024,
+      pssShmemBytes: 4096 * 1024,
+    });
+  });
+
+  test("reports null for fields the kernel does not expose", () => {
+    // Pre-5.4 kernels lack the Pss_Anon/Pss_File/Pss_Shmem split.
+    const mem = parseSmapsRollup("Rss:  100 kB\nPss:  60 kB\n");
+    expect(mem).toEqual({
+      rssBytes: 100 * 1024,
+      pssBytes: 60 * 1024,
+      pssAnonBytes: null,
+      pssFileBytes: null,
+      pssShmemBytes: null,
+    });
+  });
+
+  test("tolerates the header line and empty input", () => {
+    expect(parseSmapsRollup("").rssBytes).toBeNull();
+    expect(
+      parseSmapsRollup("00400000-7fff0000 ---p 00000000 00:00 0 [rollup]\n")
+        .pssBytes,
+    ).toBeNull();
+  });
+});
+
+describe("effectiveSizeBytes", () => {
+  test("prefers PSS, falls back to RSS, then zero", () => {
+    const base = {
+      pssAnonBytes: null,
+      pssFileBytes: null,
+      pssShmemBytes: null,
+    };
+    expect(effectiveSizeBytes({ ...base, rssBytes: 100, pssBytes: 60 })).toBe(
+      60,
+    );
+    expect(effectiveSizeBytes({ ...base, rssBytes: 100, pssBytes: null })).toBe(
+      100,
+    );
+    expect(
+      effectiveSizeBytes({ ...base, rssBytes: null, pssBytes: null }),
+    ).toBe(0);
+  });
+});

--- a/assistant/src/monitoring/process-memory.ts
+++ b/assistant/src/monitoring/process-memory.ts
@@ -1,0 +1,115 @@
+/**
+ * Per-process memory accounting for high-memory snapshots, read from
+ * `/proc/<pid>/smaps_rollup` with a `/proc/<pid>/statm` RSS fallback.
+ *
+ * PSS (proportional set size) divides each shared page's cost across the
+ * processes mapping it, so summing PSS over all processes reconciles against
+ * the cgroup total — summing RSS double-counts every page the runtime
+ * processes share and cannot be added up. The per-process anon vs file split
+ * separates heap owned by that process from page cache mapped into it.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+
+/** Linux page size assumed when converting `/proc/<pid>/statm` pages to bytes. */
+const PAGE_SIZE_BYTES = 4096;
+
+export interface SmapsRollup {
+  rssBytes: number | null;
+  pssBytes: number | null;
+  pssAnonBytes: number | null;
+  pssFileBytes: number | null;
+  pssShmemBytes: number | null;
+}
+
+export interface ProcessMemory extends SmapsRollup {
+  pid: number;
+  command: string;
+}
+
+/**
+ * Parse `/proc/<pid>/smaps_rollup` content (`Key:  <n> kB` lines). Fields the
+ * kernel doesn't expose (the Pss_* split needs Linux ≥ 5.4) are null.
+ */
+export function parseSmapsRollup(raw: string): SmapsRollup {
+  const kb: Record<string, number> = {};
+  for (const line of raw.split("\n")) {
+    const match = /^(\w+):\s+(\d+)\s+kB/.exec(line.trim());
+    if (match) {
+      kb[match[1]] = parseInt(match[2], 10);
+    }
+  }
+  const bytes = (key: string) => (kb[key] != null ? kb[key] * 1024 : null);
+  return {
+    rssBytes: bytes("Rss"),
+    pssBytes: bytes("Pss"),
+    pssAnonBytes: bytes("Pss_Anon"),
+    pssFileBytes: bytes("Pss_File"),
+    pssShmemBytes: bytes("Pss_Shmem"),
+  };
+}
+
+/** PSS when available, else RSS — the sort key for the top-process list. */
+export function effectiveSizeBytes(mem: SmapsRollup): number {
+  return mem.pssBytes ?? mem.rssBytes ?? 0;
+}
+
+function readProcessMemory(pid: number): SmapsRollup | null {
+  try {
+    return parseSmapsRollup(readFileSync(`/proc/${pid}/smaps_rollup`, "utf-8"));
+  } catch {
+    // smaps_rollup needs ptrace read access; fall back to statm RSS.
+  }
+  try {
+    const statm = readFileSync(`/proc/${pid}/statm`, "utf-8").trim();
+    const residentPages = parseInt(statm.split(/\s+/)[1], 10);
+    if (!Number.isFinite(residentPages)) {
+      return null;
+    }
+    return {
+      rssBytes: residentPages * PAGE_SIZE_BYTES,
+      pssBytes: null,
+      pssAnonBytes: null,
+      pssFileBytes: null,
+      pssShmemBytes: null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort snapshot of the top `limit` processes by PSS (RSS when PSS is
+ * unavailable), largest first. Empty when `/proc` is unavailable (e.g. macOS)
+ * — the high-memory snapshot's process *tree* still captures what was running
+ * in that case.
+ */
+export function topProcessesByMemory(limit: number): ProcessMemory[] {
+  let pids: string[];
+  try {
+    pids = readdirSync("/proc").filter((e) => /^\d+$/.test(e));
+  } catch {
+    return [];
+  }
+
+  const rows: ProcessMemory[] = [];
+  for (const entry of pids) {
+    const pid = Number(entry);
+    const mem = readProcessMemory(pid);
+    if (mem == null) {
+      continue;
+    }
+    let command: string;
+    try {
+      const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      command = raw.split("\0").filter(Boolean).join(" ") || `pid ${pid}`;
+    } catch {
+      // Process exited between readdir and read — skip.
+      continue;
+    }
+    rows.push({ pid, command, ...mem });
+  }
+
+  rows.sort((a, b) => effectiveSizeBytes(b) - effectiveSizeBytes(a));
+  return rows.slice(0, limit);
+}

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -5,21 +5,15 @@
  * accounting and workspace-disk usage and appends a compact sample to an
  * on-disk ring buffer. When memory crosses a configurable fraction of the
  * container limit it also captures a one-off "high-memory" snapshot — cgroup
- * stats plus the live process tree with per-process RSS — so a spike leaves
- * behind a record of *what was running* when it happened.
+ * stats plus the live process tree with per-process memory accounting — so a
+ * spike leaves behind a record of *what was running* when it happened.
  *
  * Everything here runs in the resource monitor's own OS process, off the
  * assistant's main event loop, so it keeps sampling even while that loop is
  * frozen mid-allocation and the samples survive an OOM SIGKILL.
  */
 
-import {
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { MonitoringConfig } from "../config/schemas/monitoring.js";
@@ -39,6 +33,7 @@ import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { buildProcessTree, listProcesses } from "../util/process-tree.js";
+import { topProcessesByMemory } from "./process-memory.js";
 import { SampleRingBuffer } from "./sample-ring-buffer.js";
 import { topSlabCaches } from "./slabinfo.js";
 
@@ -48,8 +43,6 @@ const SAMPLES_FILE = "samples.jsonl";
 const SNAPSHOTS_DIR = "snapshots";
 /** Cap on retained high-memory snapshots so forensics can't fill the volume. */
 const MAX_SNAPSHOTS = 20;
-/** Linux page size assumed when converting `/proc/<pid>/statm` pages to bytes. */
-const PAGE_SIZE_BYTES = 4096;
 
 export interface ResourceSampleMemory {
   currentBytes: number;
@@ -168,45 +161,6 @@ export function takeSample(
   return sample;
 }
 
-interface ProcessRss {
-  pid: number;
-  command: string;
-  rssBytes: number;
-}
-
-/**
- * Best-effort per-process RSS read from `/proc/<pid>/statm` (resident pages,
- * field 2). Returns the top `limit` processes by RSS, largest first. Empty when
- * `/proc` is unavailable (e.g. macOS) — the snapshot's process *tree* still
- * captures what was running in that case.
- */
-function topProcessesByRss(limit: number): ProcessRss[] {
-  let pids: string[];
-  try {
-    pids = readdirSync("/proc").filter((e) => /^\d+$/.test(e));
-  } catch {
-    return [];
-  }
-
-  const rows: ProcessRss[] = [];
-  for (const entry of pids) {
-    const pid = Number(entry);
-    try {
-      const statm = readFileSync(`/proc/${pid}/statm`, "utf-8").trim();
-      const residentPages = parseInt(statm.split(/\s+/)[1], 10);
-      if (!Number.isFinite(residentPages)) continue;
-      const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
-      const command = raw.split("\0").filter(Boolean).join(" ") || `pid ${pid}`;
-      rows.push({ pid, command, rssBytes: residentPages * PAGE_SIZE_BYTES });
-    } catch {
-      // Process exited between readdir and read — skip.
-    }
-  }
-
-  rows.sort((a, b) => b.rssBytes - a.rssBytes);
-  return rows.slice(0, limit);
-}
-
 /**
  * Capture a high-memory snapshot to the snapshots directory: the triggering
  * sample, the cgroup memory.events counters, the top processes by RSS, the top
@@ -234,9 +188,11 @@ export async function writeHighMemSnapshot(
   const snapshot = {
     ts: sample.ts,
     sample,
-    topProcessesByRss: topProcessesByRss(15),
+    // PSS-ranked with per-process anon/file split; PSS sums reconcile against
+    // the cgroup total where an RSS sum double-counts shared pages.
+    topProcesses: topProcessesByMemory(15),
     // Slab memory belongs to no process; without this, cgroup usage that
-    // exceeds the RSS sum has no visible owner.
+    // exceeds the per-process sum has no visible owner.
     topSlabCaches: topSlabCaches(10),
     processTree: tree,
   };


### PR DESCRIPTION
## Prompt / plan

4/7 of the resource-monitor forensics series (stacked on #37108). The snapshot's top-processes list was ranked by RSS from `/proc/<pid>/statm`, which double-counts shared pages across the runtime's processes — the list couldn't be summed or reconciled against the cgroup total.

- New `assistant/src/monitoring/process-memory.ts`: reads `/proc/<pid>/smaps_rollup` per process (format verified against a live file) and records both **PSS and RSS** plus the per-process **`Pss_Anon` / `Pss_File` / `Pss_Shmem` split**, so heap owned by a process is distinguishable from page cache mapped into it.
- Snapshot's `topProcessesByRss` becomes `topProcesses`, ranked by PSS with RSS fallback (`effectiveSizeBytes`). The old statm-RSS read remains the per-process fallback when `smaps_rollup` is unreadable (no ptrace access), and the `Pss_*` fields are null on pre-5.4 kernels.
- The RSS-only capture is removed from `resource-sampler.ts` (moved, not duplicated).

Snapshot-only change; no route/OpenAPI surface.

## Test plan

- Parser tests: full rollup fixture (bytes conversion), missing `Pss_*` split, header-only/empty input; `effectiveSizeBytes` PSS→RSS→0 fallback order.
- `bun test src/monitoring/__tests__/` (24 pass), `bun run typecheck:fast`, eslint clean on touched code.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm)_