### PR TITLE
feat(monitoring): attribute page cache to data files in snapshots (5/7)

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -109,6 +109,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     sudo \
     util-linux \
+    util-linux-extra \
     unzip \
     uuid-runtime \
     vim \

--- a/assistant/src/monitoring/__tests__/page-cache.test.ts
+++ b/assistant/src/monitoring/__tests__/page-cache.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { getDataDir, getDbPath } from "../../util/platform.js";
+import { getTrackedDataFiles, parseFincoreJson } from "../page-cache.js";
+
+describe("parseFincoreJson", () => {
+  test("parses numeric and string-numeric fincore output", () => {
+    const stdout = JSON.stringify({
+      fincore: [
+        {
+          res: 1363148800,
+          pages: 332800,
+          size: 2147483648,
+          file: "/workspace/data/db/assistant.db",
+        },
+        {
+          res: "4096",
+          pages: "1",
+          size: "8192",
+          file: "/workspace/data/db/assistant.db-wal",
+        },
+      ],
+    });
+
+    expect(parseFincoreJson(stdout)).toEqual([
+      {
+        path: "/workspace/data/db/assistant.db",
+        sizeBytes: 2147483648,
+        residentBytes: 1363148800,
+        residentRatio: 1363148800 / 2147483648,
+      },
+      {
+        path: "/workspace/data/db/assistant.db-wal",
+        sizeBytes: 8192,
+        residentBytes: 4096,
+        residentRatio: 0.5,
+      },
+    ]);
+  });
+
+  test("empty file yields a null ratio", () => {
+    const rows = parseFincoreJson(
+      JSON.stringify({ fincore: [{ res: 0, size: 0, file: "/tmp/empty" }] }),
+    );
+    expect(rows[0].residentRatio).toBeNull();
+  });
+
+  test("tolerates malformed output", () => {
+    expect(parseFincoreJson("")).toEqual([]);
+    expect(parseFincoreJson("not json")).toEqual([]);
+    expect(parseFincoreJson(JSON.stringify({ fincore: "nope" }))).toEqual([]);
+    expect(
+      parseFincoreJson(JSON.stringify({ fincore: [{ file: 42, res: "x" }] })),
+    ).toEqual([]);
+  });
+});
+
+describe("getTrackedDataFiles", () => {
+  test("returns existing db sidecars and the largest qdrant files", () => {
+    const dbPath = getDbPath();
+    mkdirSync(join(getDataDir(), "db"), { recursive: true });
+    writeFileSync(dbPath, "x".repeat(64));
+    writeFileSync(`${dbPath}-wal`, "x".repeat(32));
+    // No -shm file — it must not be reported.
+
+    const segments = join(getDataDir(), "qdrant", "collections", "c1");
+    mkdirSync(segments, { recursive: true });
+    writeFileSync(join(segments, "big.seg"), "x".repeat(100));
+    writeFileSync(join(segments, "small.seg"), "x".repeat(10));
+
+    const tracked = getTrackedDataFiles(1);
+
+    expect(tracked).toEqual([
+      dbPath,
+      `${dbPath}-wal`,
+      join(segments, "big.seg"),
+    ]);
+  });
+});

--- a/assistant/src/monitoring/page-cache.ts
+++ b/assistant/src/monitoring/page-cache.ts
@@ -1,0 +1,152 @@
+/**
+ * Page-cache residency attribution for the assistant's large data files, for
+ * high-memory snapshots. The memory.stat `file` number says how much page
+ * cache the cgroup holds; this says *which files* it is — e.g. "1.3 GB of the
+ * cache is assistant.db" — via `fincore(1)` (util-linux), which reports the
+ * cached page count per file without touching the file's contents.
+ *
+ * Reads are best-effort: when the fincore binary is missing or fails, the
+ * snapshot records null rather than failing.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { getDataDir, getDbPath } from "../util/platform.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Cap on directory entries visited when hunting for large qdrant files. */
+const MAX_WALK_ENTRIES = 20_000;
+
+export interface FileResidency {
+  path: string;
+  sizeBytes: number;
+  /** Bytes of this file currently resident in the page cache. */
+  residentBytes: number;
+  /** residentBytes / sizeBytes, or null for an empty file. */
+  residentRatio: number | null;
+}
+
+/**
+ * Parse `fincore --bytes --json` output. util-linux emits
+ * `{"fincore": [{"res": ..., "pages": ..., "size": ..., "file": ...}]}`;
+ * numeric columns are strings on older versions, so values go through
+ * Number().
+ */
+export function parseFincoreJson(stdout: string): FileResidency[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  const rows = (parsed as { fincore?: unknown[] })?.fincore;
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  const out: FileResidency[] = [];
+  for (const row of rows) {
+    const { res, size, file } = row as {
+      res?: unknown;
+      size?: unknown;
+      file?: unknown;
+    };
+    const residentBytes = Number(res);
+    const sizeBytes = Number(size);
+    if (
+      typeof file !== "string" ||
+      !Number.isFinite(residentBytes) ||
+      !Number.isFinite(sizeBytes)
+    ) {
+      continue;
+    }
+    out.push({
+      path: file,
+      sizeBytes,
+      residentBytes,
+      residentRatio: sizeBytes > 0 ? residentBytes / sizeBytes : null,
+    });
+  }
+  return out;
+}
+
+/** The largest `limit` regular files under `root`, bounded-walk, largest first. */
+function largestFilesUnder(
+  root: string,
+  limit: number,
+): Array<{ path: string; sizeBytes: number }> {
+  const found: Array<{ path: string; sizeBytes: number }> = [];
+  const queue = [root];
+  let visited = 0;
+  while (queue.length > 0 && visited < MAX_WALK_ENTRIES) {
+    const dir = queue.shift()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (++visited > MAX_WALK_ENTRIES) {
+        break;
+      }
+      const path = join(dir, entry);
+      try {
+        const stat = statSync(path);
+        if (stat.isDirectory()) {
+          queue.push(path);
+        } else if (stat.isFile()) {
+          found.push({ path, sizeBytes: stat.size });
+        }
+      } catch {
+        // Removed mid-walk — skip.
+      }
+    }
+  }
+  found.sort((a, b) => b.sizeBytes - a.sizeBytes);
+  return found.slice(0, limit);
+}
+
+/**
+ * The data files worth attributing cache to: the SQLite database (plus its
+ * WAL/shm sidecars) and the largest files under the qdrant storage directory.
+ * Only files that currently exist are returned.
+ */
+export function getTrackedDataFiles(qdrantLimit = 10): string[] {
+  const dbPath = getDbPath();
+  const candidates = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`].filter((p) =>
+    existsSync(p),
+  );
+  const qdrantFiles = largestFilesUnder(
+    join(getDataDir(), "qdrant"),
+    qdrantLimit,
+  );
+  return [...candidates, ...qdrantFiles.map((f) => f.path)];
+}
+
+/**
+ * Page-cache residency for `paths` via fincore. Null when fincore is
+ * unavailable or fails (the binary ships in util-linux-extra); an empty input
+ * yields an empty result.
+ */
+export async function readFileResidency(
+  paths: string[],
+): Promise<FileResidency[] | null> {
+  if (paths.length === 0) {
+    return [];
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      "fincore",
+      ["--bytes", "--json", ...paths],
+      { timeout: 10_000, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return parseFincoreJson(stdout);
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -33,6 +33,7 @@ import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { buildProcessTree, listProcesses } from "../util/process-tree.js";
+import { getTrackedDataFiles, readFileResidency } from "./page-cache.js";
 import { topProcessesByMemory } from "./process-memory.js";
 import { SampleRingBuffer } from "./sample-ring-buffer.js";
 import { topSlabCaches } from "./slabinfo.js";
@@ -163,9 +164,9 @@ export function takeSample(
 
 /**
  * Capture a high-memory snapshot to the snapshots directory: the triggering
- * sample, the cgroup memory.events counters, the top processes by RSS, the top
- * kernel slab caches, and the full process tree of the container. Prunes to
- * {@link MAX_SNAPSHOTS} newest.
+ * sample, page-cache residency of the large data files, the top processes by
+ * PSS, the top kernel slab caches, and the full process tree of the container.
+ * Prunes to {@link MAX_SNAPSHOTS} newest.
  */
 export async function writeHighMemSnapshot(
   dataDir: string,
@@ -185,9 +186,19 @@ export async function writeHighMemSnapshot(
     log.warn({ err }, "Failed to enumerate process tree for snapshot");
   }
 
+  // Attributes the memory.stat `file` charge to specific files (SQLite DB +
+  // WAL, largest qdrant segments); null when fincore is unavailable.
+  let fileResidency: Awaited<ReturnType<typeof readFileResidency>> = null;
+  try {
+    fileResidency = await readFileResidency(getTrackedDataFiles());
+  } catch (err) {
+    log.warn({ err }, "Failed to read page-cache residency for snapshot");
+  }
+
   const snapshot = {
     ts: sample.ts,
     sample,
+    fileResidency,
     // PSS-ranked with per-process anon/file split; PSS sums reconcile against
     // the cgroup total where an RSS sum double-counts shared pages.
     topProcesses: topProcessesByMemory(15),


### PR DESCRIPTION
## Prompt / plan

5/7 of the resource-monitor forensics series (stacked on #37109). The retrospective's "1.3 GB of the cache is assistant.db" conclusion took a multi-step manual deduction; this makes it one line in every high-memory snapshot.

- New `assistant/src/monitoring/page-cache.ts`:
  - `getTrackedDataFiles()` — the SQLite DB (`assistant.db` + `-wal`/`-shm` sidecars when present) and the largest files under `data/qdrant/` (bounded directory walk, top 10 by size).
  - `readFileResidency()` — runs `fincore --bytes --json` over those paths and records `{path, sizeBytes, residentBytes, residentRatio}` per file. Parser handles older util-linux versions that emit numeric columns as JSON strings.
- High-memory snapshots now include `fileResidency`; null when fincore is unavailable (best-effort, 10s timeout).
- **Dockerfile**: adds `util-linux-extra` to the assistant runtime image — Debian trixie ships `fincore` there, not in `util-linux` (which was already installed), which is why the binary was missing during the incident. apt packages are intentionally unpinned per repo convention. Gateway/CES images don't run the monitor, so they're untouched.

Snapshot-only change; no route/OpenAPI surface.

## Test plan

- Parser tests: numeric + string-numeric fincore JSON, empty-file null ratio, malformed output.
- `getTrackedDataFiles` test against the per-test workspace: existing sidecars only, largest-qdrant-file selection with a limit.
- `bun test src/monitoring/__tests__/`, `bun run typecheck:fast`, eslint.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm)_