### PR TITLE
feat(monitoring): tag samples with processing conversations + baseline snapshots (7/7)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19830,6 +19830,36 @@ paths:
                                   - freeMb
                                 additionalProperties: false
                               - type: "null"
+                          activeConversations:
+                            anyOf:
+                              - type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    conversationId:
+                                      type: string
+                                    title:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                    originChannel:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                    originInterface:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                    processingStartedAt:
+                                      type: number
+                                  required:
+                                    - conversationId
+                                    - title
+                                    - originChannel
+                                    - originInterface
+                                    - processingStartedAt
+                                  additionalProperties: false
+                              - type: "null"
                         required:
                           - ts
                           - memory
@@ -19839,6 +19869,7 @@ paths:
                           - events
                           - deltas
                           - disk
+                          - activeConversations
                         additionalProperties: false
                       - type: "null"
                 required:

--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -76,6 +76,13 @@ interface LatestSample {
     totalMb: number;
     freeMb: number;
   } | null;
+  activeConversations: Array<{
+    conversationId: string;
+    title: string | null;
+    originChannel: string | null;
+    originInterface: string | null;
+    processingStartedAt: number;
+  }> | null;
 }
 
 interface StartResponse {
@@ -261,6 +268,15 @@ Examples:
             log.info(
               `  Disk (${sample.disk.path}): ${sample.disk.usedMb} / ${sample.disk.totalMb} MiB used`,
             );
+          }
+          if (sample.activeConversations?.length) {
+            const items = sample.activeConversations
+              .map(
+                (c) =>
+                  `${c.conversationId}${c.title ? ` "${c.title}"` : ""}${c.originChannel ? ` via ${c.originChannel}` : ""}`,
+              )
+              .join(", ");
+            log.info(`  Processing: ${items}`);
           }
         });
     },

--- a/assistant/src/config/schemas/monitoring.ts
+++ b/assistant/src/config/schemas/monitoring.ts
@@ -55,6 +55,16 @@ export const MonitoringConfigSchema = z
       .describe(
         "Minimum interval between high-memory snapshots, in milliseconds, so a sustained spike does not write a snapshot on every sample.",
       ),
+    baselineSnapshotIntervalMs: z
+      .number({
+        error: "monitoring.baselineSnapshotIntervalMs must be a number",
+      })
+      .int("monitoring.baselineSnapshotIntervalMs must be an integer")
+      .min(60_000, "monitoring.baselineSnapshotIntervalMs must be >= 60000ms")
+      .default(600_000)
+      .describe(
+        "Interval between periodic baseline snapshots, in milliseconds (default 10 minutes). Baselines capture the same forensics as high-memory snapshots but on a steady cadence, so a spike can be diffed against a healthy reference instead of only against other over-threshold captures. Retained separately from high-memory snapshots.",
+      ),
   })
   .describe("Resource monitor process configuration");
 

--- a/assistant/src/monitoring/__tests__/active-conversations.test.ts
+++ b/assistant/src/monitoring/__tests__/active-conversations.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the monitor-side read of in-flight conversations. A minimal
+ * conversations table (the columns the query touches) is created in the
+ * per-test workspace database via a separate writer connection; the module
+ * under test reads it through its own read-only connection.
+ */
+
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDbPath } from "../../util/platform.js";
+import { readActiveConversations } from "../active-conversations.js";
+
+function openWriter(): Database {
+  mkdirSync(dirname(getDbPath()), { recursive: true });
+  const db = new Database(getDbPath());
+  db.run(
+    `CREATE TABLE IF NOT EXISTS conversations (
+       id TEXT PRIMARY KEY,
+       title TEXT,
+       origin_channel TEXT,
+       origin_interface TEXT,
+       processing_started_at INTEGER
+     )`,
+  );
+  return db;
+}
+
+beforeEach(() => {
+  const db = openWriter();
+  db.run("DELETE FROM conversations");
+  db.close();
+});
+
+describe("readActiveConversations", () => {
+  test("returns processing conversations, longest-running first", () => {
+    const db = openWriter();
+    db.run(
+      "INSERT INTO conversations (id, title, origin_channel, origin_interface, processing_started_at) VALUES (?, ?, ?, ?, ?)",
+      ["conv-new", "Newer turn", "slack", "web", 2_000],
+    );
+    db.run(
+      "INSERT INTO conversations (id, title, origin_channel, origin_interface, processing_started_at) VALUES (?, ?, ?, ?, ?)",
+      ["conv-old", "Memory consolidation", null, null, 1_000],
+    );
+    db.run(
+      "INSERT INTO conversations (id, title, origin_channel, origin_interface, processing_started_at) VALUES (?, ?, ?, ?, ?)",
+      ["conv-idle", "Finished turn", null, null, null],
+    );
+    db.close();
+
+    expect(readActiveConversations()).toEqual([
+      {
+        conversationId: "conv-old",
+        title: "Memory consolidation",
+        originChannel: null,
+        originInterface: null,
+        processingStartedAt: 1_000,
+      },
+      {
+        conversationId: "conv-new",
+        title: "Newer turn",
+        originChannel: "slack",
+        originInterface: "web",
+        processingStartedAt: 2_000,
+      },
+    ]);
+  });
+
+  test("truncates long titles", () => {
+    const db = openWriter();
+    db.run(
+      "INSERT INTO conversations (id, title, processing_started_at) VALUES (?, ?, ?)",
+      ["conv-long", "x".repeat(500), 1_000],
+    );
+    db.close();
+
+    const active = readActiveConversations();
+    expect(active![0].title).toHaveLength(80);
+  });
+
+  test("returns null when nothing is processing", () => {
+    expect(readActiveConversations()).toBeNull();
+  });
+});

--- a/assistant/src/monitoring/__tests__/resource-sampler.test.ts
+++ b/assistant/src/monitoring/__tests__/resource-sampler.test.ts
@@ -21,6 +21,7 @@ function makeSample(overrides: Partial<ResourceSample>): ResourceSample {
     events: null,
     deltas: null,
     disk: null,
+    activeConversations: null,
     ...overrides,
   };
 }

--- a/assistant/src/monitoring/__tests__/stall-capture.test.ts
+++ b/assistant/src/monitoring/__tests__/stall-capture.test.ts
@@ -28,6 +28,7 @@ function makeSample(ts: number): ResourceSample {
     events: null,
     deltas: null,
     disk: null,
+    activeConversations: null,
   };
 }
 

--- a/assistant/src/monitoring/active-conversations.ts
+++ b/assistant/src/monitoring/active-conversations.ts
@@ -1,0 +1,97 @@
+/**
+ * In-flight conversation turns, read from the daemon's SQLite database.
+ *
+ * The daemon persists `conversations.processing_started_at` at every turn
+ * boundary (see `Conversation.setProcessing`) precisely so out-of-process
+ * callers can detect mid-turn state by reading the row directly. The monitor
+ * folds that into each sample, so a memory spike in the ring buffer names the
+ * conversation that was running — the live flag is nulled when the turn ends,
+ * so only a sampling-time capture preserves the correlation for post-mortems.
+ *
+ * The read is a read-only connection (WAL allows concurrent readers, and the
+ * daemon being frozen mid-turn does not block it). Best-effort: any failure —
+ * database or table not created yet, lock contention — yields null.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getDbPath } from "../util/platform.js";
+
+/** Cap on entries recorded per sample so a pathological burst stays bounded. */
+const MAX_ENTRIES = 20;
+/** Cap on recorded title length; titles can carry long user content. */
+const MAX_TITLE_CHARS = 80;
+
+export interface ActiveConversation {
+  conversationId: string;
+  /** Truncated conversation title — names background jobs at a glance. */
+  title: string | null;
+  originChannel: string | null;
+  originInterface: string | null;
+  processingStartedAt: number;
+}
+
+let db: Database | null = null;
+
+function getDb(): Database | null {
+  if (db != null) {
+    return db;
+  }
+  try {
+    db = new Database(getDbPath(), { readonly: true });
+  } catch {
+    // Database not created yet — retried on the next read.
+    db = null;
+  }
+  return db;
+}
+
+/**
+ * Conversations currently mid-turn, longest-running first. Null when the
+ * database is unavailable or nothing is processing.
+ */
+export function readActiveConversations(): ActiveConversation[] | null {
+  const handle = getDb();
+  if (handle == null) {
+    return null;
+  }
+  try {
+    const rows = handle
+      .query(
+        `SELECT id, title, origin_channel AS originChannel,
+                origin_interface AS originInterface,
+                processing_started_at AS processingStartedAt
+         FROM conversations
+         WHERE processing_started_at IS NOT NULL
+         ORDER BY processing_started_at ASC
+         LIMIT ?`,
+      )
+      .all(MAX_ENTRIES) as Array<{
+      id: string;
+      title: string | null;
+      originChannel: string | null;
+      originInterface: string | null;
+      processingStartedAt: number;
+    }>;
+    if (rows.length === 0) {
+      return null;
+    }
+    return rows.map((row) => ({
+      conversationId: row.id,
+      title: row.title != null ? row.title.slice(0, MAX_TITLE_CHARS) : null,
+      originChannel: row.originChannel,
+      originInterface: row.originInterface,
+      processingStartedAt: row.processingStartedAt,
+    }));
+  } catch {
+    // Schema not migrated yet, or the handle went stale — drop it and retry
+    // with a fresh connection on the next read.
+    try {
+      handle.close();
+    } catch {
+      // best-effort
+    }
+    db = null;
+    return null;
+  }
+}

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -41,6 +41,10 @@ import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { buildProcessTree, listProcesses } from "../util/process-tree.js";
+import {
+  type ActiveConversation,
+  readActiveConversations,
+} from "./active-conversations.js";
 import { getTrackedDataFiles, readFileResidency } from "./page-cache.js";
 import { topProcessesByMemory } from "./process-memory.js";
 import { prunePrefixedJsonFiles } from "./prune-snapshots.js";
@@ -54,6 +58,17 @@ const SAMPLES_FILE = "samples.jsonl";
 const SNAPSHOTS_DIR = "snapshots";
 /** Cap on retained high-memory snapshots so forensics can't fill the volume. */
 const MAX_SNAPSHOTS = 20;
+/** Cap on retained baseline snapshots (4h of history at the 10min default). */
+const MAX_BASELINE_SNAPSHOTS = 24;
+
+/** Snapshot kinds: filename prefix + retention are per-kind so periodic
+ * baselines can never evict high-memory forensics. */
+const SNAPSHOT_KINDS = {
+  "high-mem": { prefix: "snapshot-", max: MAX_SNAPSHOTS },
+  baseline: { prefix: "baseline-", max: MAX_BASELINE_SNAPSHOTS },
+} as const;
+
+type SnapshotKind = keyof typeof SNAPSHOT_KINDS;
 
 export interface ResourceSampleMemory {
   currentBytes: number;
@@ -103,6 +118,14 @@ export interface ResourceSample {
   /** Since the previous sample; null on the monitor's first sample. */
   deltas: ResourceSampleDeltas | null;
   disk: ResourceSampleDisk | null;
+  /**
+   * Conversations mid-turn per the daemon's persisted
+   * `conversations.processing_started_at` flag, so a spike in the timeline
+   * names what was running. The live flag is nulled when a turn ends, so only
+   * this sampling-time capture preserves the correlation for post-mortems.
+   * Null when nothing is processing or the database is unavailable.
+   */
+  activeConversations: ActiveConversation[] | null;
 }
 
 /** Per-counter increases from `prev` to `current`. */
@@ -158,6 +181,7 @@ export function takeSample(
           freeMb: disk.freeMb,
         }
       : null,
+    activeConversations: readActiveConversations(),
   };
   if (prev != null) {
     sample.deltas = computeSampleDeltas(prev, sample);
@@ -166,14 +190,19 @@ export function takeSample(
 }
 
 /**
- * Capture a high-memory snapshot to the snapshots directory: the triggering
- * sample, page-cache residency of the large data files, the top processes by
- * PSS, the top kernel slab caches, and the full process tree of the container.
- * Prunes to {@link MAX_SNAPSHOTS} newest.
+ * Capture a full snapshot to the snapshots directory: the triggering sample,
+ * page-cache residency of the large data files, the top processes by PSS, the
+ * top kernel slab caches, and the full process tree of the container.
+ *
+ * `high-mem` snapshots fire when memory crosses the configured threshold;
+ * `baseline` snapshots fire on a slow periodic timer so there is always a
+ * healthy capture to diff a spike against — threshold-only snapshots record
+ * the system once already over the cliff. Each kind prunes independently.
  */
-export async function writeHighMemSnapshot(
+export async function writeSnapshot(
   dataDir: string,
   sample: ResourceSample,
+  kind: SnapshotKind,
 ): Promise<void> {
   const snapshotsDir = join(dataDir, SNAPSHOTS_DIR);
   // The ring buffer only creates the data dir for samples.jsonl; the nested
@@ -200,6 +229,7 @@ export async function writeHighMemSnapshot(
 
   const snapshot = {
     ts: sample.ts,
+    kind,
     sample,
     fileResidency,
     // PSS-ranked with per-process anon/file split; PSS sums reconcile against
@@ -211,25 +241,28 @@ export async function writeHighMemSnapshot(
     processTree: tree,
   };
 
-  const filename = `snapshot-${sample.ts}.json`;
+  const { prefix, max } = SNAPSHOT_KINDS[kind];
+  const filename = `${prefix}${sample.ts}.json`;
   writeFileSync(
     join(snapshotsDir, filename),
     JSON.stringify(snapshot, null, 2),
   );
-  prunePrefixedJsonFiles(snapshotsDir, "snapshot-", MAX_SNAPSHOTS);
-  log.warn(
-    {
-      currentBytes: sample.memory?.currentBytes,
-      limitBytes: sample.memory?.limitBytes,
-      ratio: sample.memory?.ratio,
-      unevictableBytes: sample.memoryStat?.unevictableBytes,
-      reclaimableBytes: sample.memoryStat?.reclaimableBytes,
-      pgscanDirectDelta: sample.deltas?.reclaim?.pgscanDirect,
-      workingsetRefaultFileDelta: sample.deltas?.reclaim?.workingsetRefaultFile,
-      file: filename,
-    },
-    "Captured high-memory snapshot",
-  );
+  prunePrefixedJsonFiles(snapshotsDir, prefix, max);
+  const fields = {
+    currentBytes: sample.memory?.currentBytes,
+    limitBytes: sample.memory?.limitBytes,
+    ratio: sample.memory?.ratio,
+    unevictableBytes: sample.memoryStat?.unevictableBytes,
+    reclaimableBytes: sample.memoryStat?.reclaimableBytes,
+    pgscanDirectDelta: sample.deltas?.reclaim?.pgscanDirect,
+    workingsetRefaultFileDelta: sample.deltas?.reclaim?.workingsetRefaultFile,
+    file: filename,
+  };
+  if (kind === "high-mem") {
+    log.warn(fields, "Captured high-memory snapshot");
+  } else {
+    log.debug(fields, "Captured baseline snapshot");
+  }
 }
 
 export interface ResourceSamplerHandle {
@@ -252,6 +285,9 @@ export function startResourceSampler(
   );
 
   let lastSnapshotAt = 0;
+  // 0 so the first tick writes a boot baseline — a reference point exists even
+  // if the container spikes before the first interval elapses.
+  let lastBaselineAt = 0;
   let prevSample: ResourceSample | null = null;
   // Watches the daemon's event-loop heartbeat; captures the daemon main
   // thread's kernel state mid-stall when the heartbeat goes stale.
@@ -282,8 +318,13 @@ export function startResourceSampler(
       now - lastSnapshotAt >= config.snapshotCooldownMs
     ) {
       lastSnapshotAt = now;
-      void writeHighMemSnapshot(dataDir, sample).catch((err) =>
+      void writeSnapshot(dataDir, sample, "high-mem").catch((err) =>
         log.warn({ err }, "Failed to write high-memory snapshot"),
+      );
+    } else if (now - lastBaselineAt >= config.baselineSnapshotIntervalMs) {
+      lastBaselineAt = now;
+      void writeSnapshot(dataDir, sample, "baseline").catch((err) =>
+        log.warn({ err }, "Failed to write baseline snapshot"),
       );
     }
   };

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -210,6 +210,15 @@ describe("monitoring_status", () => {
         },
       },
       disk: { path: "/workspace", usedMb: 100, totalMb: 1000, freeMb: 900 },
+      activeConversations: [
+        {
+          conversationId: "conv-xyz",
+          title: "Memory consolidation",
+          originChannel: null,
+          originInterface: null,
+          processingStartedAt: 900,
+        },
+      ],
     };
 
     const res = await handler("monitoring_status")();
@@ -217,6 +226,42 @@ describe("monitoring_status", () => {
     expect(res).toMatchObject({
       monitoringEnabled: true,
       latestSample: { ts: 1000, memory: { ratio: 0.75 } },
+    });
+  });
+
+  test("normalizes a legacy sample that predates newer fields", async () => {
+    monitoringProbe = { status: "running", pid: 321 };
+    configEnabled = true;
+    // A record persisted by an older monitor: only the original fields.
+    latestSample = {
+      ts: 500,
+      memory: {
+        currentBytes: 1024,
+        limitBytes: 2048,
+        peakBytes: null,
+        ratio: 0.5,
+      },
+      events: null,
+      disk: null,
+    } as ResourceSample;
+
+    const res = await handler("monitoring_status")();
+
+    expect(res.latestSample).toEqual({
+      ts: 500,
+      memory: {
+        currentBytes: 1024,
+        limitBytes: 2048,
+        peakBytes: null,
+        ratio: 0.5,
+      },
+      memoryStat: null,
+      reclaim: null,
+      cpu: null,
+      events: null,
+      deltas: null,
+      disk: null,
+      activeConversations: null,
     });
   });
 

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -109,6 +109,14 @@ const sampleDeltasSchema = z.object({
   cpu: sampleCpuSchema.nullable(),
 });
 
+const activeConversationSchema = z.object({
+  conversationId: z.string(),
+  title: z.string().nullable(),
+  originChannel: z.string().nullable(),
+  originInterface: z.string().nullable(),
+  processingStartedAt: z.number(),
+});
+
 const latestSampleSchema = z.object({
   ts: z.number(),
   memory: sampleMemorySchema.nullable(),
@@ -118,6 +126,7 @@ const latestSampleSchema = z.object({
   events: sampleEventsSchema.nullable(),
   deltas: sampleDeltasSchema.nullable(),
   disk: sampleDiskSchema.nullable(),
+  activeConversations: z.array(activeConversationSchema).nullable(),
 });
 
 const startResponseSchema = z.object({
@@ -206,7 +215,20 @@ function readLatestSample(): ResourceSample | null {
       join(getMonitoringDataDir(), "samples.jsonl"),
       config.monitoring.ringBufferSize,
     );
-    return buffer.readLast();
+    const sample = buffer.readLast();
+    if (sample == null) {
+      return null;
+    }
+    // Samples persisted by an older monitor may predate some fields; fill
+    // them with null so the response always matches the documented shape.
+    return {
+      ...sample,
+      memoryStat: sample.memoryStat ?? null,
+      reclaim: sample.reclaim ?? null,
+      cpu: sample.cpu ?? null,
+      deltas: sample.deltas ?? null,
+      activeConversations: sample.activeConversations ?? null,
+    };
   } catch (err) {
     log.warn({ err }, "Failed to read latest resource sample");
     return null;


### PR DESCRIPTION
## Prompt / plan

7/7, final PR of the resource-monitor forensics series. During the incident, snapshots existed only from after the memory cliff, and correlating the spike to the in-flight memory job relied on log proximity. Two additions:

**Active-conversation tagging** (`assistant/src/monitoring/active-conversations.ts`)
- The daemon already persists `conversations.processing_started_at` at every turn boundary (`Conversation.setProcessing`) as the cross-process source of truth for mid-turn state — so the monitor reads it directly through its own **read-only SQLite connection** each 250ms sample, recording in-flight conversations (id, truncated title, origin channel/interface, started-at) as `sample.activeConversations`. **No daemon-side changes at all** — this PR no longer touches `src/daemon/`. (Reworked per review: an earlier revision wrote a separate activity-beacon file from the agent loop, duplicating the existing persisted flag.)
- The live flag is nulled when a turn ends, so only a sampling-time capture preserves the spike↔conversation correlation for post-mortems. WAL allows the read while the daemon is frozen mid-turn; a missing database/schema yields null and is retried next sample.

**Periodic baseline snapshots**
- The full forensics capture (process tree, PSS ranking, slab caches, file residency) also fires on a slow timer: `monitoring.baselineSnapshotIntervalMs` (default 10 min, first at monitor start). `baseline-*.json` files retain independently (24) from high-mem `snapshot-*.json` captures (20), so baselines can never evict incident forensics. Baselines log at debug; high-mem still warns.

Also addresses the review finding: `monitoring_status` normalizes legacy persisted samples (all series-added fields default to null) so old ring-buffer records can't violate the response contract, even when the monitor is stopped.

## Test plan

- New `active-conversations.test.ts`: reads a minimal conversations table via the module's read-only connection — processing rows returned longest-running first, idle rows excluded, long titles truncated, empty set → null.
- Legacy-sample normalization regression test in `monitoring-routes.test.ts`.
- `bun test src/monitoring/__tests__/` + routes (53 pass) and the full `conversation-agent-loop.test.ts` suite (67 pass, unchanged code); `bun run typecheck:fast`, eslint, `bun run generate:openapi`.

## CLI verb checklist

No new routes — `monitoring_status` gained the `activeConversations` field, surfaced by the existing `assistant monitoring status` verb (`Processing: <id> "<title>" via <channel>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPRH41o3p3raVmfQEeLEUm