### PR TITLE
feat(assistant): run background workers with --smol and a container-sized RAM hint

### DIFF
--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -4,6 +4,7 @@ import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js
 import type { SkillProjectionContext } from "../daemon/conversation-tool-setup.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { DiskUsageInfo } from "../util/disk-usage.js";
+import * as realDiskUsage from "../util/disk-usage.js";
 
 let diskSample: DiskUsageInfo | null = null;
 
@@ -76,7 +77,12 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   },
 }));
 
+// Spread the real module and override only what we need: `mock.module` is
+// global across the test process, so a partial mock missing exports that
+// other modules in this graph import (e.g. cgroup-memory's
+// `parseK8sMemoryBytes`) would break them.
 mock.module("../util/disk-usage.js", () => ({
+  ...realDiskUsage,
   getDiskUsageInfo: () => diskSample,
 }));
 

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -213,6 +213,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../util/promise-guard.js",
     "../../../util/sqlite-retry.js",
     "../../../util/strip-comment-lines.js",
+    "../../../util/worker-memory.js",
     "../../types.js",
     "../injection-presence.js",
     "../injector-order.js",

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -14,6 +14,7 @@ import {
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
+import { workerMemoryEnv } from "../../util/worker-memory.js";
 import { EmbeddingRuntimeManager } from "./embedding-runtime-manager.js";
 import {
   type EmbeddingBackend,
@@ -234,6 +235,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
 
     const proc = Bun.spawn({
       cmd: [bunPath, "--smol", workerPath, this.model, modelCacheDir],
+      env: workerMemoryEnv(),
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",

--- a/assistant/src/plugins/defaults/memory/rerank-local.ts
+++ b/assistant/src/plugins/defaults/memory/rerank-local.ts
@@ -6,6 +6,7 @@ import { EmbeddingRuntimeManager } from "../../../persistence/embeddings/embeddi
 import { getLogger } from "../../../util/logger.js";
 import { getEmbeddingModelsDir } from "../../../util/platform.js";
 import { PromiseGuard } from "../../../util/promise-guard.js";
+import { workerMemoryEnv } from "../../../util/worker-memory.js";
 
 const log = getLogger("memory-rerank-local");
 
@@ -156,6 +157,7 @@ export class LocalRerankBackend {
         modelCacheDir,
         this.dtype,
       ],
+      env: workerMemoryEnv(),
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",

--- a/assistant/src/util/__tests__/worker-memory.test.ts
+++ b/assistant/src/util/__tests__/worker-memory.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeWorkerForceRamSizeBytes,
+  WORKER_FORCE_RAM_MAX_BYTES,
+  WORKER_FORCE_RAM_MIN_BYTES,
+  workerMemoryEnv,
+} from "../worker-memory.js";
+
+const GIB = 1024 * 1024 * 1024;
+
+describe("computeWorkerForceRamSizeBytes", () => {
+  test("targets a quarter of the container limit", () => {
+    // 5 GiB (medium machine) → 1.25 GiB, inside both clamps.
+    expect(computeWorkerForceRamSizeBytes(5 * GIB)).toBe(1.25 * GIB);
+  });
+
+  test("clamps small containers up to the minimum", () => {
+    // 1 GiB → 256 MiB raw, clamped up.
+    expect(computeWorkerForceRamSizeBytes(1 * GIB)).toBe(
+      WORKER_FORCE_RAM_MIN_BYTES,
+    );
+  });
+
+  test("clamps large containers down to the maximum", () => {
+    // 16 GiB (extra_large machine) → 4 GiB raw, clamped down.
+    expect(computeWorkerForceRamSizeBytes(16 * GIB)).toBe(
+      WORKER_FORCE_RAM_MAX_BYTES,
+    );
+  });
+
+  test("falls back to host total memory when no container limit applies", () => {
+    const result = computeWorkerForceRamSizeBytes(null);
+    expect(result).toBeGreaterThanOrEqual(WORKER_FORCE_RAM_MIN_BYTES);
+    expect(result).toBeLessThanOrEqual(WORKER_FORCE_RAM_MAX_BYTES);
+  });
+});
+
+describe("workerMemoryEnv", () => {
+  test("adds BUN_JSC_forceRAMSize on top of the parent environment", () => {
+    const env = workerMemoryEnv({ PATH: "/usr/bin" }, 5 * GIB);
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.BUN_JSC_forceRAMSize).toBe(String(1.25 * GIB));
+  });
+
+  test("keeps an operator-provided BUN_JSC_forceRAMSize", () => {
+    const env = workerMemoryEnv({ BUN_JSC_forceRAMSize: "12345" }, 5 * GIB);
+    expect(env.BUN_JSC_forceRAMSize).toBe("12345");
+  });
+});

--- a/assistant/src/util/__tests__/worker-memory.test.ts
+++ b/assistant/src/util/__tests__/worker-memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   computeWorkerForceRamSizeBytes,
@@ -37,14 +37,28 @@ describe("computeWorkerForceRamSizeBytes", () => {
 });
 
 describe("workerMemoryEnv", () => {
-  test("adds BUN_JSC_forceRAMSize on top of the parent environment", () => {
-    const env = workerMemoryEnv({ PATH: "/usr/bin" }, 5 * GIB);
-    expect(env.PATH).toBe("/usr/bin");
-    expect(env.BUN_JSC_forceRAMSize).toBe(String(1.25 * GIB));
+  const savedForceRamSize = process.env.BUN_JSC_forceRAMSize;
+
+  afterEach(() => {
+    if (savedForceRamSize === undefined) {
+      delete process.env.BUN_JSC_forceRAMSize;
+    } else {
+      process.env.BUN_JSC_forceRAMSize = savedForceRamSize;
+    }
+  });
+
+  test("adds a clamped BUN_JSC_forceRAMSize on top of the parent environment", () => {
+    delete process.env.BUN_JSC_forceRAMSize;
+    const env = workerMemoryEnv();
+    expect(env.PATH).toBe(process.env.PATH);
+    const hint = Number(env.BUN_JSC_forceRAMSize);
+    expect(hint).toBeGreaterThanOrEqual(WORKER_FORCE_RAM_MIN_BYTES);
+    expect(hint).toBeLessThanOrEqual(WORKER_FORCE_RAM_MAX_BYTES);
   });
 
   test("keeps an operator-provided BUN_JSC_forceRAMSize", () => {
-    const env = workerMemoryEnv({ BUN_JSC_forceRAMSize: "12345" }, 5 * GIB);
+    process.env.BUN_JSC_forceRAMSize = "12345";
+    const env = workerMemoryEnv();
     expect(env.BUN_JSC_forceRAMSize).toBe("12345");
   });
 });

--- a/assistant/src/util/worker-memory.ts
+++ b/assistant/src/util/worker-memory.ts
@@ -1,0 +1,80 @@
+/**
+ * Bun memory tuning for background worker subprocesses (memory jobs worker,
+ * schedule worker, resource monitor, embed/rerank workers).
+ *
+ * JavaScriptCore calibrates its heap-growth heuristics from perceived machine
+ * RAM. Under gVisor the cgroup limit files report the host node's memory
+ * rather than the container's (the same discrepancy that motivates
+ * VELLUM_MEMORY_LIMIT — see cgroup-memory.ts), so an unhinted worker grows its
+ * heap as if it owned the whole node. `BUN_JSC_forceRAMSize` pins the
+ * heuristic to a fraction of the actual container limit instead.
+ *
+ * The hint is a soft target, not a hard cap: a job that needs more memory
+ * still gets it, at the cost of heavier GC pressure near the target. Workers
+ * are latency-insensitive background processes, so the GC-throughput trade is
+ * acceptable — the same reasoning behind spawning them with `--smol`.
+ */
+
+import { totalmem } from "node:os";
+
+import { getContainerMemoryLimitBytes } from "./cgroup-memory.js";
+
+const MIB = 1024 * 1024;
+
+/**
+ * Fraction of the container memory limit a single worker's heap heuristic
+ * targets. The container budget is shared with the daemon (the largest
+ * resident), the gateway, and transient tool subprocesses, so one background
+ * worker gets a quarter.
+ */
+const WORKER_RAM_FRACTION = 0.25;
+
+/**
+ * Lower clamp: the memory jobs worker runs full background agent
+ * conversations in-process, so a target below this forces constant GC without
+ * fitting the workload anyway.
+ */
+export const WORKER_FORCE_RAM_MIN_BYTES = 512 * MIB;
+
+/**
+ * Upper clamp: past this, a bigger heap target only delays collection of
+ * garbage the worker will never reuse, regardless of how large the machine is.
+ */
+export const WORKER_FORCE_RAM_MAX_BYTES = 2048 * MIB;
+
+/**
+ * RAM-size hint for a background worker, derived from the container memory
+ * limit (host total memory when no container limit applies, e.g. local dev),
+ * clamped to [{@link WORKER_FORCE_RAM_MIN_BYTES}, {@link WORKER_FORCE_RAM_MAX_BYTES}].
+ */
+export function computeWorkerForceRamSizeBytes(
+  limitBytes: number | null = getContainerMemoryLimitBytes(),
+): number {
+  const base = limitBytes ?? totalmem();
+  const target = Math.floor(base * WORKER_RAM_FRACTION);
+  return Math.min(
+    WORKER_FORCE_RAM_MAX_BYTES,
+    Math.max(WORKER_FORCE_RAM_MIN_BYTES, target),
+  );
+}
+
+/**
+ * Environment for spawning a background worker `bun` process: the parent
+ * environment plus `BUN_JSC_forceRAMSize`. An operator-provided
+ * `BUN_JSC_forceRAMSize` in the parent environment wins over the computed
+ * value.
+ *
+ * Bun.spawn replaces (rather than merges) the child environment when `env` is
+ * passed, so this spreads the full parent environment.
+ */
+export function workerMemoryEnv(
+  parentEnv: Record<string, string | undefined> = process.env,
+  limitBytes: number | null = getContainerMemoryLimitBytes(),
+): Record<string, string | undefined> {
+  return {
+    ...parentEnv,
+    BUN_JSC_forceRAMSize:
+      parentEnv.BUN_JSC_forceRAMSize ??
+      String(computeWorkerForceRamSizeBytes(limitBytes)),
+  };
+}

--- a/assistant/src/util/worker-memory.ts
+++ b/assistant/src/util/worker-memory.ts
@@ -48,7 +48,7 @@ export const WORKER_FORCE_RAM_MAX_BYTES = 2048 * MIB;
  * clamped to [{@link WORKER_FORCE_RAM_MIN_BYTES}, {@link WORKER_FORCE_RAM_MAX_BYTES}].
  */
 export function computeWorkerForceRamSizeBytes(
-  limitBytes: number | null = getContainerMemoryLimitBytes(),
+  limitBytes: number | null,
 ): number {
   const base = limitBytes ?? totalmem();
   const target = Math.floor(base * WORKER_RAM_FRACTION);
@@ -67,14 +67,11 @@ export function computeWorkerForceRamSizeBytes(
  * Bun.spawn replaces (rather than merges) the child environment when `env` is
  * passed, so this spreads the full parent environment.
  */
-export function workerMemoryEnv(
-  parentEnv: Record<string, string | undefined> = process.env,
-  limitBytes: number | null = getContainerMemoryLimitBytes(),
-): Record<string, string | undefined> {
+export function workerMemoryEnv(): Record<string, string | undefined> {
   return {
-    ...parentEnv,
+    ...process.env,
     BUN_JSC_forceRAMSize:
-      parentEnv.BUN_JSC_forceRAMSize ??
-      String(computeWorkerForceRamSizeBytes(limitBytes)),
+      process.env.BUN_JSC_forceRAMSize ??
+      String(computeWorkerForceRamSizeBytes(getContainerMemoryLimitBytes())),
   };
 }

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -19,6 +19,7 @@ import {
 import { dirname } from "node:path";
 
 import { getCurrentLogFilePath } from "./logger.js";
+import { workerMemoryEnv } from "./worker-memory.js";
 
 export interface WorkerProcessStatus {
   status: "running" | "not_running";
@@ -206,8 +207,11 @@ export async function spawnWorkerProcess(args: {
     // output is at least visible to the spawning process.
   }
 
+  // Workers are latency-insensitive, so run them in bun's small-heap mode
+  // with a RAM-size hint sized to the container — see worker-memory.ts.
   const child = Bun.spawn({
-    cmd: ["bun", "run", args.entry.pathname],
+    cmd: ["bun", "--smol", "run", args.entry.pathname],
+    env: workerMemoryEnv(),
     stdio: ["ignore", "ignore", stderrFd],
     detached,
   });


### PR DESCRIPTION
<!-- PR title format: type(scope): description -->

## Prompt / plan

The memory jobs worker was observed at 968 MB RSS on an assistant — roughly a third of a small (3 GiB) machine's budget. Investigation found two gaps:

1. **The worker is the only long-lived bun subprocess spawned without `--smol`.** The daemon (`docker-entrypoint.sh`), gateway (`Dockerfile`), embed worker, and rerank worker all run in bun's small-heap mode; the shared `spawnWorkerProcess()` helper (memory jobs worker, schedule worker, resource monitor) spawned plain `bun run`.
2. **JSC's GC calibrates against the wrong RAM size.** JavaScriptCore sizes its heap-growth heuristics from perceived machine memory, and under gVisor the cgroup files report the host node's memory rather than the container limit — the same discrepancy that motivates `VELLUM_MEMORY_LIMIT` (see `cgroup-memory.ts`). An unhinted worker therefore lets its heap balloon as if it owned the whole node before GC bothers collecting.

This PR makes all background worker subprocesses spawn with both mitigations by default:

- New `assistant/src/util/worker-memory.ts` computes a `BUN_JSC_forceRAMSize` hint: a quarter of the container memory limit (host total memory in local dev), clamped to 512 MiB – 2 GiB. An operator-provided `BUN_JSC_forceRAMSize` in the parent environment wins.
- `spawnWorkerProcess()` (memory jobs worker, schedule worker, resource monitor) now spawns `bun --smol run` with that env.
- The embed and rerank workers (already `--smol`) now also get the RAM-size hint.

The hint is a **soft target**, not a hard cap: a job that genuinely needs more memory still gets it, at the cost of heavier GC pressure near the target. Workers are latency-insensitive background processes, so the GC-throughput trade is acceptable. The clamp floor exists because the memory jobs worker runs full background agent conversations in-process (v2 consolidation, retrospectives) and needs real transient headroom.

## Test plan

- New unit tests for the fraction/clamp math and env merging/override behavior (`src/util/__tests__/worker-memory.test.ts`).
- Existing spawner tests pass: `src/persistence/__tests__/worker-control.test.ts`, `src/schedule/__tests__/worker-control.test.ts`, `src/monitoring/__tests__/control.test.ts`.
- End-to-end: drove the real `spawnWorkerProcess()` against a scratch entry script — the child came up with `--smol` in `execArgv`, `BUN_JSC_forceRAMSize` set (clamped to 2 GiB on an unlimited host), and the parent environment inherited.
- Verified bun validates `BUN_JSC_forceRAMSize` at startup (an invalid value is a hard startup error), confirming the option is parsed and applied rather than silently ignored.
- `bunx tsc --noEmit` clean; eslint clean on changed lines (remaining `curly` warnings are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X35wPHS4hL3CajZz3Jk79p

---
_Generated by [Claude Code](https://claude.ai/code/session_01X35wPHS4hL3CajZz3Jk79p)_