### PR TITLE
perf(memory): store Qdrant sparse indexes on disk instead of RAM

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -33,6 +33,7 @@ interface MockCallLog {
   getCollection: number;
   deleteCollection: number;
   createCollection: number;
+  updateCollection: number;
   createPayloadIndex: number;
   retrieve: number;
   upsert: number;
@@ -41,16 +42,24 @@ interface MockCallLog {
 let mockCollectionExists: boolean;
 let mockCollectionSize: number;
 let mockUseNamedVectors: boolean;
+// Sparse-vector config reported by getCollection, or null to omit
+// `sparse_vectors` from the probe entirely.
+let mockSparseVectors: Record<string, unknown> | null;
 let mockSentinelPayload: Record<string, unknown> | null;
 let mockCreateCollectionThrows: Error | null;
+let mockUpdateCollectionThrows: Error | null;
+let updateCollectionParams: unknown;
 let callLog: MockCallLog;
 
 function resetMockState() {
   mockCollectionExists = false;
   mockCollectionSize = 384;
   mockUseNamedVectors = false;
+  mockSparseVectors = null;
   mockSentinelPayload = null;
   mockCreateCollectionThrows = null;
+  mockUpdateCollectionThrows = null;
+  updateCollectionParams = null;
   // Drop any sentinel a prior test left behind so the no-drift default path
   // doesn't accidentally report `migrated: true`.
   if (existsSync(REBUILD_SENTINEL_PATH)) {
@@ -61,6 +70,7 @@ function resetMockState() {
     getCollection: 0,
     deleteCollection: 0,
     createCollection: 0,
+    updateCollection: 0,
     createPayloadIndex: 0,
     retrieve: 0,
     upsert: 0,
@@ -82,6 +92,7 @@ mock.module("@qdrant/js-client-rest", () => ({
             vectors: mockUseNamedVectors
               ? { dense: { size: mockCollectionSize } }
               : { size: mockCollectionSize },
+            ...(mockSparseVectors ? { sparse_vectors: mockSparseVectors } : {}),
           },
         },
       };
@@ -98,6 +109,14 @@ mock.module("@qdrant/js-client-rest", () => ({
         throw mockCreateCollectionThrows;
       }
       mockCollectionExists = true;
+    }
+
+    async updateCollection(_name: string, params: unknown) {
+      callLog.updateCollection++;
+      updateCollectionParams = params;
+      if (mockUpdateCollectionThrows) {
+        throw mockUpdateCollectionThrows;
+      }
     }
 
     async createPayloadIndex(_name: string, _config: unknown) {
@@ -410,5 +429,90 @@ describe("Qdrant v1 rebuild sentinel (durable migration signal)", () => {
     expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
     await clearRebuildSentinel();
     expect(existsSync(REBUILD_SENTINEL_PATH)).toBe(false);
+  });
+});
+
+describe("sparse index placement reconcile", () => {
+  const makeClient = (onDisk: boolean) =>
+    new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768,
+      onDisk,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2",
+    });
+
+  function compatibleCollection() {
+    mockCollectionExists = true;
+    mockUseNamedVectors = true;
+    mockCollectionSize = 768;
+    mockSentinelPayload = {
+      _meta: true,
+      embedding_model: "gemini:gemini-embedding-2",
+    };
+  }
+
+  test("moves an in-RAM sparse index to disk on a compatible collection", async () => {
+    compatibleCollection();
+    // Collection created before sparse indexes carried an explicit placement.
+    mockSparseVectors = { sparse: {} };
+
+    const result = await makeClient(true).ensureCollection();
+
+    // In-place update only — no destructive recreate, no rebuild owed.
+    expect(callLog.updateCollection).toBe(1);
+    expect(updateCollectionParams).toEqual({
+      sparse_vectors: { sparse: { index: { on_disk: true } } },
+    });
+    expect(callLog.deleteCollection).toBe(0);
+    expect(callLog.createCollection).toBe(0);
+    expect(result.migrated).toBe(false);
+  });
+
+  test("leaves an already on-disk sparse index alone", async () => {
+    compatibleCollection();
+    mockSparseVectors = { sparse: { index: { on_disk: true } } };
+
+    await makeClient(true).ensureCollection();
+
+    expect(callLog.updateCollection).toBe(0);
+  });
+
+  test("moves an on-disk sparse index back to RAM when onDisk is false", async () => {
+    compatibleCollection();
+    mockSparseVectors = { sparse: { index: { on_disk: true } } };
+
+    await makeClient(false).ensureCollection();
+
+    expect(callLog.updateCollection).toBe(1);
+    expect(updateCollectionParams).toEqual({
+      sparse_vectors: { sparse: { index: { on_disk: false } } },
+    });
+  });
+
+  test("skips the update when the probe reports no sparse vectors", async () => {
+    compatibleCollection();
+    mockSparseVectors = null;
+
+    await makeClient(true).ensureCollection();
+
+    expect(callLog.updateCollection).toBe(0);
+  });
+
+  test("a failed placement update does not block collection readiness", async () => {
+    compatibleCollection();
+    mockSparseVectors = { sparse: {} };
+    mockUpdateCollectionThrows = new Error("optimizer busy");
+
+    const client = makeClient(true);
+    const result = await client.ensureCollection();
+
+    expect(callLog.updateCollection).toBe(1);
+    expect(result.migrated).toBe(false);
+
+    // Readiness latched — a follow-up ensure is a pure cache hit.
+    await client.ensureCollection();
+    expect(callLog.collectionExists).toBe(1);
   });
 });

--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -36,6 +36,9 @@ let queryCalls: QueryCall[];
 let deleteCalls: DeleteCall[];
 let deleteCollectionCalls: string[];
 let payloadIndexCalls: Array<Record<string, unknown>>;
+// Sparse-vector config reported by getCollection for an existing collection.
+let mockSparseVectors: Record<string, unknown> | null;
+let updateCollectionCalls: Array<{ name: string; params: unknown }>;
 let mockQueryPoints: Array<{
   id: string | number;
   score: number;
@@ -50,6 +53,8 @@ function resetMockState() {
   deleteCalls = [];
   deleteCollectionCalls = [];
   payloadIndexCalls = [];
+  mockSparseVectors = { sparse: { index: { on_disk: true } } };
+  updateCollectionCalls = [];
   mockQueryPoints = [];
 }
 
@@ -62,6 +67,20 @@ mock.module("@qdrant/js-client-rest", () => ({
     async createCollection(name: string, config: Record<string, unknown>) {
       createCollectionCalls.push({ name, config });
       mockCollectionExists = true;
+    }
+
+    async getCollection(_name: string) {
+      return {
+        config: {
+          params: {
+            ...(mockSparseVectors ? { sparse_vectors: mockSparseVectors } : {}),
+          },
+        },
+      };
+    }
+
+    async updateCollection(name: string, params: unknown) {
+      updateCollectionCalls.push({ name, params });
     }
 
     async createPayloadIndex(_name: string, config: Record<string, unknown>) {
@@ -119,11 +138,13 @@ describe("MessagesLexicalIndex", () => {
     expect(createCollectionCalls.length).toBe(1);
     const config = createCollectionCalls[0].config;
 
-    // Sparse vector named "sparse" must be present.
+    // Sparse vector named "sparse" must be present, with its inverted index
+    // on disk instead of Qdrant's in-RAM default — this index grows with
+    // every message ever written.
     expect(config.sparse_vectors).toBeDefined();
-    expect(
-      (config.sparse_vectors as Record<string, unknown>).sparse,
-    ).toBeDefined();
+    expect((config.sparse_vectors as Record<string, unknown>).sparse).toEqual({
+      index: { on_disk: true },
+    });
 
     // No dense `vectors` config at all.
     expect(config.vectors).toBeUndefined();
@@ -141,6 +162,35 @@ describe("MessagesLexicalIndex", () => {
     );
     expect(convIdx?.field_schema).toBe("keyword");
     expect(createdIdx?.field_schema).toBe("integer");
+  });
+
+  test("moves an in-RAM sparse index to disk on an existing collection", async () => {
+    mockCollectionExists = true;
+    // Collection created before the sparse index carried an explicit placement.
+    mockSparseVectors = { sparse: {} };
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    // In-place update only — the collection is never dropped or recreated.
+    expect(createCollectionCalls).toEqual([]);
+    expect(deleteCollectionCalls).toEqual([]);
+    expect(updateCollectionCalls).toEqual([
+      {
+        name: "messages_lexical",
+        params: { sparse_vectors: { sparse: { index: { on_disk: true } } } },
+      },
+    ]);
+  });
+
+  test("leaves an already on-disk sparse index alone", async () => {
+    mockCollectionExists = true;
+    mockSparseVectors = { sparse: { index: { on_disk: true } } };
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    expect(updateCollectionCalls).toEqual([]);
   });
 
   test("upsertMessage writes a deterministic point id and a sparse-only vector with the right payload", async () => {

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -87,6 +87,7 @@ export class MessagesLexicalIndex {
     try {
       const exists = await this.client.collectionExists(this.collection);
       if (exists.exists) {
+        await this.reconcileSparseIndexOnDisk();
         if (await this.ensurePayloadIndexesSafe()) {
           this.collectionReady = true;
         }
@@ -106,7 +107,11 @@ export class MessagesLexicalIndex {
         // Sparse-only: no dense `vectors` config. The lexical index is a
         // BM25-style replacement for FTS5 and never holds a dense vector.
         sparse_vectors: {
-          sparse: {}, // Qdrant auto-infers sparse vector params
+          // The sparse inverted index lives in RAM unless placed on disk
+          // explicitly. This index covers every message ever written, so its
+          // RAM footprint grows without bound — keep it on disk alongside the
+          // payloads.
+          sparse: { index: { on_disk: this.onDisk } },
         },
         on_disk_payload: this.onDisk,
       });
@@ -339,6 +344,50 @@ export class MessagesLexicalIndex {
         "Failed to clear messages lexical index collection",
       );
       return false;
+    }
+  }
+
+  /**
+   * Align an existing collection's sparse-index placement with the configured
+   * `onDisk` flag. Qdrant keeps the sparse inverted index in RAM unless the
+   * collection explicitly opts into on-disk, and collections keep whatever
+   * they were created with — for this index that means RAM usage growing with
+   * every message ever written. `updateCollection` moves the index in place
+   * (the optimizer rewrites segments in the background) with no re-encode.
+   *
+   * Best-effort: a failed probe or update logs and leaves the collection
+   * serving from its current index — search keeps working either way.
+   */
+  private async reconcileSparseIndexOnDisk(): Promise<void> {
+    try {
+      const info = await this.client.getCollection(this.collection);
+      const sparseParams = (
+        info.config?.params as
+          | {
+              sparse_vectors?: Record<
+                string,
+                { index?: { on_disk?: boolean | null } | null } | undefined
+              >;
+            }
+          | undefined
+      )?.sparse_vectors;
+      if (!sparseParams || !("sparse" in sparseParams)) return;
+
+      const current = sparseParams.sparse?.index?.on_disk ?? false;
+      if (current === this.onDisk) return;
+
+      await this.client.updateCollection(this.collection, {
+        sparse_vectors: { sparse: { index: { on_disk: this.onDisk } } },
+      });
+      log.info(
+        { collection: this.collection, onDisk: this.onDisk },
+        "Moved sparse index placement on existing Qdrant collection",
+      );
+    } catch (err) {
+      log.warn(
+        { err, collection: this.collection, onDisk: this.onDisk },
+        "Failed to update sparse index placement — continuing with current index",
+      );
     }
   }
 

--- a/assistant/src/persistence/embeddings/qdrant-client.ts
+++ b/assistant/src/persistence/embeddings/qdrant-client.ts
@@ -271,6 +271,7 @@ export class VellumQdrantClient {
             migrated = true;
             // Fall through to collection creation below
           } else {
+            await this.reconcileSparseIndexOnDisk(info);
             if (await this.ensurePayloadIndexesSafe()) {
               this.collectionReady = true;
             }
@@ -313,7 +314,10 @@ export class VellumQdrantClient {
           },
         },
         sparse_vectors: {
-          sparse: {}, // Qdrant auto-infers sparse vector params
+          // The sparse inverted index lives in RAM unless placed on disk
+          // explicitly; it grows with every indexed point, so it follows the
+          // same on-disk setting as the dense vectors and payloads.
+          sparse: { index: { on_disk: this.onDisk } },
         },
         hnsw_config: {
           on_disk: this.onDisk,
@@ -376,6 +380,53 @@ export class VellumQdrantClient {
   private async deleteCollectionForRebuild(): Promise<void> {
     await writeRebuildSentinel();
     await this.client.deleteCollection(this.collection);
+  }
+
+  /**
+   * Align an existing collection's sparse-index placement with the configured
+   * `onDisk` flag. Qdrant keeps the sparse inverted index in RAM unless the
+   * collection explicitly opts into on-disk, and collections keep whatever
+   * they were created with — so long-lived installs hold the whole index in
+   * RAM even when `onDisk` is set. `updateCollection` moves it in place (the
+   * optimizer rewrites segments in the background) without a reembed.
+   *
+   * Best-effort: a failed update logs and leaves the collection serving from
+   * its current index — search keeps working either way.
+   */
+  private async reconcileSparseIndexOnDisk(
+    info: Awaited<ReturnType<QdrantRestClient["getCollection"]>>,
+  ): Promise<void> {
+    const sparseParams = (
+      info.config?.params as
+        | {
+            sparse_vectors?: Record<
+              string,
+              { index?: { on_disk?: boolean | null } | null } | undefined
+            >;
+          }
+        | undefined
+    )?.sparse_vectors;
+    // No sparse config in the probe — nothing to move. (A collection without
+    // the `sparse` named vector cannot accept an index update for it.)
+    if (!sparseParams || !("sparse" in sparseParams)) return;
+
+    const current = sparseParams.sparse?.index?.on_disk ?? false;
+    if (current === this.onDisk) return;
+
+    try {
+      await this.client.updateCollection(this.collection, {
+        sparse_vectors: { sparse: { index: { on_disk: this.onDisk } } },
+      });
+      log.info(
+        { collection: this.collection, onDisk: this.onDisk },
+        "Moved sparse index placement on existing Qdrant collection",
+      );
+    } catch (err) {
+      log.warn(
+        { err, collection: this.collection, onDisk: this.onDisk },
+        "Failed to update sparse index placement — continuing with current index",
+      );
+    }
   }
 
   async upsert(

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/qdrant.test.ts
@@ -72,8 +72,8 @@ const FULL_SCHEMA_INFO: MockCollectionInfo = {
         summary_dense: { size: 384 },
       },
       sparse_vectors: {
-        sparse: {},
-        summary_sparse: {},
+        sparse: { index: { on_disk: true } },
+        summary_sparse: { index: { on_disk: true } },
       },
     },
   },
@@ -107,6 +107,10 @@ const state = {
     }>,
   },
   createCollectionThrows: null as Error | null,
+  // Tracks `client.updateCollection(name, params)` calls — the in-place
+  // sparse-index placement reconcile issues these on the compatible path.
+  updateCollectionCalls: [] as Array<{ name: string; params: unknown }>,
+  updateCollectionThrows: null as Error | null,
   // Schema returned by `client.getCollection`. Tests that exercise the
   // drift path point this at a partial schema; the default mirrors a fully
   // migrated collection so the no-drift path is the silent default.
@@ -148,6 +152,11 @@ class MockQdrantClient {
   async deleteCollection(name: string) {
     state.deleteCollectionCalls.push(name);
     state.collectionExistsBeforeCreate = false;
+    return {};
+  }
+  async updateCollection(name: string, params: unknown) {
+    state.updateCollectionCalls.push({ name, params });
+    if (state.updateCollectionThrows) throw state.updateCollectionThrows;
     return {};
   }
   async count(_name: string, _opts: { exact: boolean }) {
@@ -228,6 +237,8 @@ function resetState(): void {
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   state.createCollectionThrows = null;
+  state.updateCollectionCalls.length = 0;
+  state.updateCollectionThrows = null;
   state.getCollectionInfo = FULL_SCHEMA_INFO;
   state.getCollectionThrows = null;
   state.getCollectionCalls = 0;
@@ -277,8 +288,14 @@ describe("memory v2 qdrant — collection lifecycle", () => {
       distance: "Cosine",
       on_disk: true,
     });
-    expect(params.sparse_vectors.sparse).toEqual({});
-    expect(params.sparse_vectors.summary_sparse).toEqual({});
+    // Sparse inverted indexes follow the collection's on-disk setting instead
+    // of Qdrant's in-RAM default.
+    expect(params.sparse_vectors.sparse).toEqual({
+      index: { on_disk: true },
+    });
+    expect(params.sparse_vectors.summary_sparse).toEqual({
+      index: { on_disk: true },
+    });
     expect(params.hnsw_config).toEqual({
       on_disk: true,
       m: 16,
@@ -312,6 +329,100 @@ describe("memory v2 qdrant — collection lifecycle", () => {
       { field_name: "slug", field_schema: "keyword" },
       { field_name: "kind", field_schema: "keyword" },
     ]);
+    expect(state.collectionExistsCalls).toBe(1);
+    // The sparse indexes already sit on disk — no placement update issued.
+    expect(state.updateCollectionCalls).toEqual([]);
+  });
+
+  test("moves in-RAM sparse indexes to disk on an existing compatible collection", async () => {
+    // Collection created before sparse indexes carried an explicit placement:
+    // full named-vector schema, but both sparse channels default to RAM.
+    state.collectionExistsBeforeCreate = true;
+    state.getCollectionInfo = {
+      config: {
+        params: {
+          vectors: {
+            dense: { size: 384 },
+            summary_dense: { size: 384 },
+          },
+          sparse_vectors: { sparse: {}, summary_sparse: {} },
+        },
+      },
+    };
+
+    const result = await ensureConceptPageCollection();
+
+    // In-place update only — no destructive recreate, no reembed owed.
+    expect(result).toEqual({ migrated: false });
+    expect(state.deleteCollectionCalls).toEqual([]);
+    expect(state.createCollectionCalls).toBe(0);
+    expect(state.updateCollectionCalls).toEqual([
+      {
+        name: MEMORY_V2_COLLECTION,
+        params: {
+          sparse_vectors: {
+            sparse: { index: { on_disk: true } },
+            summary_sparse: { index: { on_disk: true } },
+          },
+        },
+      },
+    ]);
+  });
+
+  test("only updates the sparse channels that drift", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.getCollectionInfo = {
+      config: {
+        params: {
+          vectors: {
+            dense: { size: 384 },
+            summary_dense: { size: 384 },
+          },
+          sparse_vectors: {
+            sparse: { index: { on_disk: true } },
+            summary_sparse: {},
+          },
+        },
+      },
+    };
+
+    await ensureConceptPageCollection();
+
+    expect(state.updateCollectionCalls).toEqual([
+      {
+        name: MEMORY_V2_COLLECTION,
+        params: {
+          sparse_vectors: { summary_sparse: { index: { on_disk: true } } },
+        },
+      },
+    ]);
+  });
+
+  test("a failed sparse-placement update does not block collection readiness", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.getCollectionInfo = {
+      config: {
+        params: {
+          vectors: {
+            dense: { size: 384 },
+            summary_dense: { size: 384 },
+          },
+          sparse_vectors: { sparse: {}, summary_sparse: {} },
+        },
+      },
+    };
+    state.updateCollectionThrows = new Error("optimizer busy");
+
+    const result = await ensureConceptPageCollection();
+
+    // Best-effort: readiness latches and the collection keeps serving from
+    // its current in-RAM indexes.
+    expect(result).toEqual({ migrated: false });
+    expect(state.updateCollectionCalls.length).toBe(1);
+
+    // Readiness latched — a follow-up ensure is a pure cache hit.
+    const again = await ensureConceptPageCollection();
+    expect(again).toEqual({ migrated: false });
     expect(state.collectionExistsCalls).toBe(1);
   });
 

--- a/assistant/src/plugins/defaults/memory/v2/qdrant.ts
+++ b/assistant/src/plugins/defaults/memory/v2/qdrant.ts
@@ -203,6 +203,7 @@ async function ensureConceptPageCollectionOnce(): Promise<{
         // Long-lived installs may predate the `kind` payload index; ensure
         // every required index exists before declaring the collection ready.
         await ensurePayloadIndexes();
+        await reconcileSparseIndexOnDisk(info, onDisk);
         _collectionReady = true;
         return { migrated: false };
       }
@@ -274,8 +275,10 @@ async function ensureConceptPageCollectionOnce(): Promise<{
         },
       },
       sparse_vectors: {
-        sparse: {}, // Qdrant auto-infers sparse vector params
-        summary_sparse: {}, // BM25 sparse vector for the summary
+        // Sparse inverted indexes live in RAM unless placed on disk
+        // explicitly; both channels follow the collection's on-disk setting.
+        sparse: { index: { on_disk: onDisk } },
+        summary_sparse: { index: { on_disk: onDisk } }, // BM25 sparse vector for the summary
       },
       hnsw_config: {
         on_disk: onDisk,
@@ -343,6 +346,60 @@ async function ensurePayloadIndexes(): Promise<void> {
       }
     }),
   );
+}
+
+/**
+ * Align an existing collection's sparse-index placement with the configured
+ * `onDisk` flag, covering both sparse channels. Qdrant keeps sparse inverted
+ * indexes in RAM unless the collection explicitly opts into on-disk, and
+ * collections keep whatever they were created with — `updateCollection` moves
+ * them in place (the optimizer rewrites segments in the background) without a
+ * reembed.
+ *
+ * Best-effort: a failed update logs and leaves the collection serving from
+ * its current indexes — search keeps working either way.
+ */
+async function reconcileSparseIndexOnDisk(
+  info: Awaited<ReturnType<QdrantRestClient["getCollection"]>>,
+  onDisk: boolean,
+): Promise<void> {
+  const sparseParams = (
+    info.config?.params as
+      | {
+          sparse_vectors?: Record<
+            string,
+            { index?: { on_disk?: boolean | null } | null } | undefined
+          >;
+        }
+      | undefined
+  )?.sparse_vectors;
+  if (!sparseParams) return;
+
+  // Only touch channels that exist in the collection and whose placement
+  // drifts from the target — an update naming an absent sparse vector fails.
+  const drifted = REQUIRED_SPARSE_VECTORS.filter(
+    (name) =>
+      name in sparseParams &&
+      (sparseParams[name]?.index?.on_disk ?? false) !== onDisk,
+  );
+  if (drifted.length === 0) return;
+
+  try {
+    await getClient().updateCollection(MEMORY_V2_COLLECTION, {
+      sparse_vectors: Object.fromEntries(
+        drifted.map((name) => [name, { index: { on_disk: onDisk } }]),
+      ),
+    });
+    log.info(
+      { collection: MEMORY_V2_COLLECTION, sparseVectors: drifted, onDisk },
+      "Moved sparse index placement on existing Qdrant collection",
+    );
+  } catch (err) {
+    log.warn(
+      { err, collection: MEMORY_V2_COLLECTION, sparseVectors: drifted, onDisk },
+      "Failed to update sparse index placement — continuing with current indexes",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Investigation into Qdrant sidecars idling at ~580 MB RSS on some assistants. Qdrant keeps sparse inverted indexes **fully in RAM** unless a collection explicitly opts into on-disk placement, and none of our collections did. Three collections carry sparse vectors:

- `messages_lexical` — a sparse index over **every message ever written** (the FTS5 replacement), so its RAM footprint grows without bound. Best explanation for why only chatty assistants hit 580 MB.
- `memory` (v1) — one sparse channel.
- `memory_v2_concept_pages` — two sparse channels (`sparse`, `summary_sparse`).

This PR is the first (lowest-risk, config-only) knob from that investigation: place the sparse indexes on disk, keyed to the existing `memory.qdrant.onDisk` flag (default `true`), matching how dense vectors, HNSW, and payloads are already placed.

Two parts:

1. **Creation sites** set `sparse_vectors.<name>.index.on_disk` in the three collection configs.
2. **In-place migration for deployed assistants**: the ensure paths probe the current placement and issue an `updateCollection` when it drifts, so existing collections shed the RAM without a destructive recreate or reembed. Best-effort per the daemon's never-block-startup policy — a failed update logs a warning and the collection keeps serving from its current index.

The v3 section collection is dense-only and unaffected.

**Tradeoff:** sparse (lexical/hybrid) queries read the index through the page cache instead of guaranteed RAM, so cold queries can hit disk. For single-user assistant QPS this should be unnoticeable, but worth watching on a canary — note we pin Qdrant 1.13.2, which has a known sparse-index crash that `skipSparse` exists to dodge (`v2/qdrant.ts` comment), so a canary before fleet-wide rollout is doubly advised.

## Test plan

- New unit coverage in all three modules: creation config carries `index.on_disk`; an existing compatible collection with an in-RAM sparse index gets exactly one `updateCollection` with the expected params (no delete/recreate, no reembed signaled); already-on-disk indexes are left alone; per-channel drift updates only the drifted channel (v2); a failed update still latches collection readiness.
- Ran the full affected suites individually: `qdrant-collection-migration` (17), `messages-lexical-index` (14), v2 `qdrant` (33), v2 `activation`/`backfill-jobs`/`injection`/`sim`, `embedding-reconcile`, `lifecycle-embedding-reconcile`, v3 `section-dense-store`, graph v2 routing — all pass.
- Pre-commit hooks: Prettier, ESLint (no new errors; the 7 new warnings are the `curly` style warning already prevalent in these files), and full `assistant/` typecheck all green.
- Not verified against a live Qdrant 1.13.2 binary (sandbox cannot fetch it); the in-place update relies on the documented `PATCH /collections` `sparse_vectors` diff, present in the REST schema of the pinned client.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKfYx8hk7KUaaWbHq6wzXs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKfYx8hk7KUaaWbHq6wzXs)_