### PR TITLE
fix(memory): populate the tool registry in the standalone memory jobs worker

### DIFF
--- a/assistant/src/__tests__/memory-worker-tool-registry-guard.test.ts
+++ b/assistant/src/__tests__/memory-worker-tool-registry-guard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Guard test: memory-worker tool registry bootstrap
+ *
+ * The standalone memory jobs worker (`src/jobs/worker.ts`) hosts real agent
+ * conversations — retrospective and consolidation passes, plus any subagents
+ * they spawn — and those conversations resolve their tool surface from that
+ * process's registry. The daemon and the schedule worker populate the
+ * registry at startup via `initializeTools()`; the memory worker must do the
+ * same or every tool a pass is granted (including `remember`, the point of a
+ * retrospective) errors as "Unknown tool".
+ *
+ * Two layers:
+ * 1. A source guard that the worker entrypoint calls `initializeTools()`.
+ * 2. A behavioral check that `initializeTools()` actually yields the tools
+ *    background passes depend on, so a manifest reshuffle that moves one of
+ *    them behind daemon-only bootstrap (e.g. plugin `init()`) fails here
+ *    instead of silently re-crippling worker-hosted conversations.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import {
+  __resetRegistryForTesting,
+  getTool,
+  initializeTools,
+} from "../tools/registry.js";
+
+afterAll(() => {
+  __resetRegistryForTesting();
+});
+
+describe("memory worker tool registry", () => {
+  test("worker entrypoint populates the tool registry at startup", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "..", "jobs", "worker.ts"),
+      "utf8",
+    );
+    expect(source).toContain("await initializeTools()");
+  });
+
+  test("initializeTools registers the tools background passes rely on", async () => {
+    await initializeTools();
+
+    // Granted by the retrospective wake allowlist (skill-authoring tools in
+    // that allowlist are skill-projected per turn, not registry-backed, so
+    // they are not asserted here).
+    for (const name of ["remember", "recall", "skill_load"]) {
+      expect(getTool(name), `expected registry tool "${name}"`).toBeDefined();
+    }
+
+    // Relied on by consolidation passes and fork-spawned subagents, whose
+    // inherited transcripts assume the parent conversation's core surface.
+    for (const name of ["bash", "file_read", "file_list", "skill_execute"]) {
+      expect(getTool(name), `expected registry tool "${name}"`).toBeDefined();
+    }
+  });
+});

--- a/assistant/src/jobs/worker.ts
+++ b/assistant/src/jobs/worker.ts
@@ -16,6 +16,7 @@ import { getConfig } from "../config/loader.js";
 import { startInProcessMemoryJobsWorker } from "../persistence/jobs-worker.js";
 import { registerDefaultPluginPersistenceHooks } from "../plugins/defaults/index.js";
 import { registerMemoryPluginJobHandlers } from "../plugins/defaults/memory/job-handler-registration.js";
+import { initializeTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryWorkerPidPath } from "../util/platform.js";
 
@@ -24,7 +25,9 @@ const log = getLogger("memory-worker-process");
 function cleanupPidFile(): void {
   const pidPath = getMemoryWorkerPidPath();
   try {
-    if (existsSync(pidPath)) unlinkSync(pidPath);
+    if (existsSync(pidPath)) {
+      unlinkSync(pidPath);
+    }
   } catch {
     // best-effort
   }
@@ -50,6 +53,24 @@ async function main(): Promise<void> {
   // silently drop carried memory state).
   registerMemoryPluginJobHandlers();
   registerDefaultPluginPersistenceHooks();
+
+  // Populate the tool registry (core built-ins + workspace tools), exactly as
+  // the daemon and the schedule worker do at startup. Jobs in this process
+  // wake real agent conversations (retrospective and consolidation passes,
+  // and any subagents they spawn), and those conversations resolve their tool
+  // surface from this process's registry — without it, every tool such a pass
+  // is granted (including `remember`, the point of a retrospective) errors as
+  // "Unknown tool". Best-effort: a registry failure must not take the worker
+  // down; passes degrade to a reduced tool surface instead.
+  try {
+    await initializeTools();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to initialize tools in memory worker; continuing degraded",
+    );
+  }
+
   const worker = startInProcessMemoryJobsWorker();
 
   // Keep-alive: the worker's setTimeout timers are unref'd, so without


### PR DESCRIPTION
## Problem

The standalone memory jobs worker (`assistant memory worker start`) hosts real agent conversations — retrospective passes, consolidation passes, and any subagents they spawn — but never populates the tool registry. Conversations hosted there resolve their tool surface from a registry containing only import-side-effect registrations (empirically: exactly `skill_execute`, plus the preactivated subagent skill's projected tools).

Result: every registry-backed tool a pass is granted errors as `Unknown tool: X. Available tools: skill_execute, subagent_abort, subagent_message, subagent_read, subagent_spawn, subagent_status` — **including `remember`, the entire point of a retrospective**. Consolidation passes prompted to tend wiki files have no file tools; fork-task subagents inherit transcripts full of `bash`/`file_read` usage they cannot perform.

Production telemetry (48h post-v0.10.5): 263 errors with this signature across retrospective / consolidation / fork-task conversations — **38% of all tool errors fleet-wide** — i.e. memory upkeep silently failing at its job.

## Fix

Boot the registry in the worker entrypoint exactly as the daemon and the schedule worker (`src/schedule/worker.ts`) already do: best-effort `await initializeTools()` before the worker loop starts, degrading with a warning instead of blocking startup (daemon startup philosophy).

No plugin-bootstrap call is needed for this: `remember`/`recall` are registered by `initializeTools()` via the core tool manifest, and the skill-authoring tools on the retrospective allowlist are skill-projected per turn, not registry-backed.

## Verification

Booted the entrypoint against a scratch workspace before/after:
- **before**: 1 `Tool registered` line (`skill_execute`), no `Tools initialized`
- **after**: 24 `Tool registered` lines + `Tools initialized`

(Both runs then stop at `no such table: memory_jobs` — scratch workspace has no daemon-migrated DB; not reachable in real deployments.)

Guard test pins (1) the entrypoint's `initializeTools()` call and (2) that `initializeTools()` registers the tools background passes rely on, so a manifest reshuffle that moves one behind daemon-only bootstrap fails the test instead of silently re-crippling worker-hosted conversations.

## Known follow-ups (out of scope)

- **User-plugin tools** are still absent in worker-hosted conversations (worker deliberately runs no plugin bootstrap). Default-plugin tools all ride the core manifest today, so nothing user-visible regresses, but marketplace plugins contributing tools would.
- **Runtime injector parity** in worker-hosted turns (`registerDefaultPluginInjectors` is also daemon-only) is a separate open question — not needed to fix the error class here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)