### PR TITLE
fix(tools): name the real gate in inactive-tool errors

### DIFF
--- a/assistant/src/__tests__/inactive-tool-error-messages.test.ts
+++ b/assistant/src/__tests__/inactive-tool-error-messages.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `buildInactiveToolMessage` — the error composed when a registered
+ * tool is excluded from the current turn's active tool set.
+ *
+ * The message must name the gate that actually excluded the tool. The
+ * telemetry failure mode this pins down: core tools gated by a subagent
+ * allowlist or by client-context filtering were told to "load the skill that
+ * provides this tool", which no skill does — models retried `skill_load` in a
+ * loop instead of re-planning with the tools that exist.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildInactiveToolMessage } from "../tools/tool-approval-handler.js";
+
+const ACTIVE = new Set(["bash", "file_read", "web_search"]);
+
+describe("buildInactiveToolMessage", () => {
+  test("subagent allowlist gate names the allowlist", () => {
+    const msg = buildInactiveToolMessage({
+      name: "skill_load",
+      owner: undefined,
+      subagentAllowedTools: new Set(["web_search", "file_read"]),
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toBe(
+      'Tool "skill_load" is not available to this subagent. This subagent may only use: file_read, web_search.',
+    );
+  });
+
+  test("subagent allowlist outranks the skill-owner hint", () => {
+    const msg = buildInactiveToolMessage({
+      name: "pdf_extract",
+      owner: { kind: "skill", id: "pdf-tools" },
+      subagentAllowedTools: new Set(["web_search"]),
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    // Loading a skill cannot widen a subagent allowlist, so the skill hint
+    // would send the model in a loop.
+    expect(msg).toContain("not available to this subagent");
+    expect(msg).not.toContain("Load the");
+  });
+
+  test("skill-owned tool keeps the named load hint", () => {
+    const msg = buildInactiveToolMessage({
+      name: "pdf_extract",
+      owner: { kind: "skill", id: "pdf-tools" },
+      subagentAllowedTools: undefined,
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toBe(
+      'Tool "pdf_extract" is not currently active. Load the "pdf-tools" skill that provides this tool first.',
+    );
+  });
+
+  test("plugin-owned tool names the plugin, not a skill", () => {
+    const msg = buildInactiveToolMessage({
+      name: "acme_sync",
+      owner: { kind: "plugin", id: "acme-plugin" },
+      subagentAllowedTools: undefined,
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toBe(
+      'Tool "acme_sync" belongs to the "acme-plugin" plugin, which is not enabled for this conversation.',
+    );
+  });
+
+  test("remember while memory is disabled says so", () => {
+    const msg = buildInactiveToolMessage({
+      name: "remember",
+      owner: undefined,
+      subagentAllowedTools: undefined,
+      memoryEnabled: false,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toBe(
+      'Tool "remember" is unavailable because memory is disabled for this assistant.',
+    );
+  });
+
+  test("owner-less context gating lists the active tools instead of a skill hint", () => {
+    const msg = buildInactiveToolMessage({
+      name: "app_open",
+      owner: undefined,
+      subagentAllowedTools: undefined,
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toBe(
+      'Tool "app_open" is not available in this context. Available tools: bash, file_read, web_search',
+    );
+    expect(msg).not.toContain("Load the skill");
+  });
+
+  test("remember with memory enabled falls through to the context message", () => {
+    const msg = buildInactiveToolMessage({
+      name: "remember",
+      owner: undefined,
+      subagentAllowedTools: undefined,
+      memoryEnabled: true,
+      activeToolNames: ACTIVE,
+    });
+    expect(msg).toContain("not available in this context");
+  });
+});

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -303,10 +303,10 @@ describe("ToolExecutor allowedToolNames gating", () => {
       makeContext({ allowedToolNames: allowed }),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("not currently active");
+    expect(result.content).toContain("not available in this context");
   });
 
-  test("error message includes the blocked tool name", async () => {
+  test("error message includes the blocked tool name and the active set", async () => {
     const executor = new ToolExecutor(makePrompter());
     const allowed = new Set(["bash"]);
     const result = await executor.execute(
@@ -316,7 +316,7 @@ describe("ToolExecutor allowedToolNames gating", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toBe(
-      'Tool "file_edit" is not currently active. Load the skill that provides this tool first.',
+      'Tool "file_edit" is not available in this context. Available tools: bash',
     );
   });
 
@@ -330,7 +330,7 @@ describe("ToolExecutor allowedToolNames gating", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("file_read");
-    expect(result.content).toContain("not currently active");
+    expect(result.content).toContain("No tools are active this turn");
   });
 
   test("unknown tool suggestion list is scoped to allowedToolNames", async () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -301,6 +301,7 @@ export function createToolExecutor(
       onOutput,
       signal: ctx.abortController?.signal,
       allowedToolNames: ctx.allowedToolNames,
+      subagentAllowedTools: ctx.subagentAllowedTools,
       forcePromptSideEffects: ctx.forcePromptSideEffects,
       diskPressureCleanupModeActive: ctx.diskPressureCleanupModeActive,
       toolUseId,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,6 +1,7 @@
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import { isToolAllowedInChannel } from "../channels/permission-profiles.js";
 import type { ChannelId } from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
 import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
@@ -24,6 +25,7 @@ import { summarizeToolInput } from "./tool-input-summary.js";
 import {
   type ExecutionTarget,
   isDiskPressureCleanupToolName,
+  type OwnerInfo,
   type Tool,
   type ToolContext,
   type ToolExecutionResult,
@@ -54,6 +56,50 @@ function buildToolGrantQuestionText(
   const inputSummary = redactSecrets(summarizeToolInput(toolName, input));
   const summaryPart = inputSummary ? ` — ${inputSummary}` : "";
   return `Approve tool: ${toolName}${summaryPart}${requesterNote}`;
+}
+
+/**
+ * Compose the error message for a registered tool that is not part of the
+ * current turn's active tool set, naming the gate that actually excluded it.
+ * Ordered most-specific first:
+ *
+ * 1. Subagent allowlist — loading a skill cannot widen a subagent's
+ *    allowlist, so this outranks the skill hint.
+ * 2. Skill-owned tool whose skill is not loaded — the one case where
+ *    "load the skill" is the correct instruction.
+ * 3. Plugin-owned tool filtered by plugin enablement.
+ * 4. `remember` while memory is disabled.
+ * 5. Context gating (no connected client, channel capabilities, …) — no
+ *    load hint; list the active tools so the model can re-plan with what
+ *    actually exists this turn.
+ */
+export function buildInactiveToolMessage(args: {
+  name: string;
+  owner: OwnerInfo | undefined;
+  subagentAllowedTools: ReadonlySet<string> | undefined;
+  memoryEnabled: boolean;
+  activeToolNames: ReadonlySet<string>;
+}): string {
+  const { name, owner, subagentAllowedTools, memoryEnabled, activeToolNames } =
+    args;
+  if (subagentAllowedTools && !subagentAllowedTools.has(name)) {
+    const allowed = [...subagentAllowedTools].sort().join(", ");
+    return `Tool "${name}" is not available to this subagent. This subagent may only use: ${allowed}.`;
+  }
+  if (owner?.kind === "skill") {
+    return `Tool "${name}" is not currently active. Load the "${owner.id}" skill that provides this tool first.`;
+  }
+  if (owner?.kind === "plugin") {
+    return `Tool "${name}" belongs to the "${owner.id}" plugin, which is not enabled for this conversation.`;
+  }
+  if (name === "remember" && !memoryEnabled) {
+    return `Tool "remember" is unavailable because memory is disabled for this assistant.`;
+  }
+  if (activeToolNames.size === 0) {
+    return `Tool "${name}" is not available in this context. No tools are active this turn.`;
+  }
+  const available = [...activeToolNames].sort().join(", ");
+  return `Tool "${name}" is not available in this context. Available tools: ${available}`;
 }
 
 /** Default polling interval for inline grant wait (ms). */
@@ -483,12 +529,19 @@ export class ToolApprovalHandler {
 
     // Gate tools not active for the current turn
     if (context.allowedToolNames && !context.allowedToolNames.has(name)) {
-      const owner = getToolOwner(name);
-      const ownerSkillId = owner?.kind === "skill" ? owner.id : undefined;
-      const loadHint = ownerSkillId
-        ? `Load the "${ownerSkillId}" skill that provides this tool first.`
-        : `Load the skill that provides this tool first.`;
-      const msg = `Tool "${name}" is not currently active. ${loadHint}`;
+      let memoryEnabled = true;
+      try {
+        memoryEnabled = getConfig().memory?.enabled !== false;
+      } catch {
+        // Config unavailable — leave the memory hint out rather than guess.
+      }
+      const msg = buildInactiveToolMessage({
+        name,
+        owner: getToolOwner(name),
+        subagentAllowedTools: context.subagentAllowedTools,
+        memoryEnabled,
+        activeToolNames: context.allowedToolNames,
+      });
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({
         type: "error",

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -312,6 +312,13 @@ export interface ToolContext {
    */
   allowedToolNames?: Set<string>;
   /**
+   * When the conversation runs as a subagent, the parent-imposed tool
+   * allowlist (see `SubagentRoleConfig.allowedTools`). Carried so
+   * availability errors can name the allowlist as the gate instead of
+   * suggesting a skill load that cannot widen it.
+   */
+  subagentAllowedTools?: ReadonlySet<string>;
+  /**
    * True when this turn is restricted to storage cleanup-safe tools.
    * @legacy
    */


### PR DESCRIPTION
## Problem

When a registered tool is excluded from the turn's active set, the error is always:

> Tool "X" is not currently active. Load the skill that provides this tool first.

That instruction is only correct when an unloaded skill owns the tool. Production telemetry (48h post-v0.10.5): 235 errors in this class, dominated by **core tools no skill provides** — `skill_load` itself (59, gated by subagent wire allowlists), `app_open` (41, no connected client), `web_search` (27). Models follow the bogus hint and retry `skill_load` in a loop instead of re-planning with the tools that exist.

## Fix

New `buildInactiveToolMessage` (exported, unit-tested) names the gate that actually excluded the tool, most-specific first:

1. **Subagent allowlist** (wire mode) — "This subagent may only use: …" — outranks the skill hint because loading a skill cannot widen the allowlist. Plumbed via a new optional `ToolContext.subagentAllowedTools` populated in `createToolExecutor`.
2. **Skill-owned** — unchanged named hint: `Load the "<skill>" skill that provides this tool first.`
3. **Plugin-owned** — names the plugin enablement gate (mirrors the `skill_execute` scope-guard copy).
4. **`remember` with memory disabled** — says memory is disabled.
5. **Context gating fallback** — "not available in this context" + the turn's active tool list (same self-correction affordance the Unknown-tool path already provides), or "No tools are active this turn." when the set is empty.

Gate **decisions** are unchanged — same calls blocked, same lifecycle events; only the error copy differs. Execution-gate-mode subagent rejections keep their existing earlier message.

## Tests

- `inactive-tool-error-messages.test.ts`: all five branches + priority (subagent gate over skill hint) + `remember`-with-memory-enabled falls through.
- `tool-executor.test.ts`: assertions updated to the new copy; the unknown-tool-before-gate regression test and the named-skill-hint test pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)