### PR TITLE
feat(tools): alias commonly hallucinated tool names and suggest near-misses

### DIFF
--- a/assistant/src/__tests__/tool-name-aliases.test.ts
+++ b/assistant/src/__tests__/tool-name-aliases.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for hallucinated-tool-name handling:
+ *
+ * - `resolveToolInvocationAlias` — rewrites commonly invented names
+ *   (`read_file`, `shell`, `list_files`, …) to the canonical tool, only when
+ *   the canonical tool is active and the requested name is not, translating
+ *   the arg-key convention each alias is typically called with.
+ * - `suggestToolName` — conservative `Did you mean "…"?` candidate for the
+ *   Unknown-tool error: token permutations and tiny typos only, never a
+ *   semantically different tool.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveToolInvocationAlias,
+  suggestToolName,
+} from "../tools/tool-name-aliases.js";
+
+const ACTIVE = new Set([
+  "bash",
+  "file_read",
+  "file_list",
+  "web_search",
+  "app_create",
+]);
+
+describe("resolveToolInvocationAlias", () => {
+  test.each([
+    ["read_file", "file_read"],
+    ["read", "file_read"],
+    ["cat", "file_read"],
+    ["fs_read", "file_read"],
+    ["workspace_read", "file_read"],
+    ["list_files", "file_list"],
+    ["list_directory", "file_list"],
+    ["shell", "bash"],
+    ["exec", "bash"],
+  ])(
+    "rewrites %s to %s when the canonical tool is active",
+    (alias, canonical) => {
+      const resolved = resolveToolInvocationAlias(alias, {}, ACTIVE);
+      expect(resolved.name).toBe(canonical);
+    },
+  );
+
+  test("translates the alias arg-key convention to the canonical schema", () => {
+    expect(
+      resolveToolInvocationAlias("read_file", { file_path: "/tmp/x" }, ACTIVE)
+        .input,
+    ).toEqual({ path: "/tmp/x" });
+    expect(
+      resolveToolInvocationAlias("list_files", { directory: "/tmp" }, ACTIVE)
+        .input,
+    ).toEqual({ path: "/tmp" });
+    expect(
+      resolveToolInvocationAlias("shell", { cmd: "ls" }, ACTIVE).input,
+    ).toEqual({ command: "ls" });
+  });
+
+  test("keeps input keys that already match the canonical schema", () => {
+    expect(
+      resolveToolInvocationAlias(
+        "read_file",
+        { path: "/tmp/x", limit: 5 },
+        ACTIVE,
+      ).input,
+    ).toEqual({ path: "/tmp/x", limit: 5 });
+  });
+
+  test("does not rewrite when the requested name is itself active", () => {
+    const active = new Set(["read", "file_read"]);
+    const resolved = resolveToolInvocationAlias("read", { path: "x" }, active);
+    expect(resolved.name).toBe("read");
+  });
+
+  test("does not rewrite when the canonical tool is not active", () => {
+    const resolved = resolveToolInvocationAlias(
+      "read_file",
+      { path: "x" },
+      new Set(["web_search"]),
+    );
+    expect(resolved.name).toBe("read_file");
+  });
+});
+
+describe("suggestToolName", () => {
+  test("suggests the token permutation of a real tool", () => {
+    // Reachable when the alias table cannot rewrite (canonical inactive) or
+    // for permutations the table does not carry.
+    expect(suggestToolName("search_web", ACTIVE)).toBe("web_search");
+  });
+
+  test("suggests for a small typo", () => {
+    expect(suggestToolName("bassh", ACTIVE)).toBe("bash");
+    expect(suggestToolName("file_reed", ACTIVE)).toBe("file_read");
+  });
+
+  test("never suggests a semantically different tool", () => {
+    // task_create is 3 edits from app_create — close enough to fool a loose
+    // threshold, far enough that the suggestion would misdirect.
+    expect(suggestToolName("task_create", ACTIVE)).toBeUndefined();
+    expect(suggestToolName("glob", ACTIVE)).toBeUndefined();
+    expect(suggestToolName("notifications_send", ACTIVE)).toBeUndefined();
+  });
+
+  test("is deterministic on ties", () => {
+    expect(suggestToolName("bath", ["bash", "bat"])).toBe("bash");
+    expect(suggestToolName("bath", ["bat", "bash"])).toBe("bash");
+  });
+});

--- a/assistant/src/tools/filesystem/fuzzy-match.ts
+++ b/assistant/src/tools/filesystem/fuzzy-match.ts
@@ -14,7 +14,7 @@ interface IndexedLine {
   end: number;
 }
 
-function levenshtein(a: string, b: string): number {
+export function levenshtein(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
   const dp: number[][] = Array.from({ length: m + 1 }, () =>

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -22,6 +22,7 @@ import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool, getToolOwner } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
 import { summarizeToolInput } from "./tool-input-summary.js";
+import { suggestToolName } from "./tool-name-aliases.js";
 import {
   type ExecutionTarget,
   isDiskPressureCleanupToolName,
@@ -502,12 +503,13 @@ export class ToolApprovalHandler {
       // from their `execute()` when no resolver is connected, rather than
       // being filtered out here — listing them surfaces a clearer path
       // than hiding their names entirely.
-      const available = getAllTools()
+      const availableNames = getAllTools()
         .map((t) => t.name)
         .filter((n) => !allowedToolNames || allowedToolNames.has(n))
-        .sort()
-        .join(", ");
-      const msg = `Unknown tool: ${name}. Available tools: ${available}`;
+        .sort();
+      const suggestion = suggestToolName(name, availableNames);
+      const didYouMean = suggestion ? ` Did you mean "${suggestion}"?` : "";
+      const msg = `Unknown tool: ${name}.${didYouMean} Available tools: ${availableNames.join(", ")}`;
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({
         type: "error",

--- a/assistant/src/tools/tool-name-aliases.ts
+++ b/assistant/src/tools/tool-name-aliases.ts
@@ -1,7 +1,34 @@
+import { levenshtein } from "./filesystem/fuzzy-match.js";
+
 type ToolInputNormalizer = (
   input: Record<string, unknown>,
 ) => Record<string, unknown>;
 
+/**
+ * Return a normalizer that renames input key `from` to `to`, translating the
+ * arg-key convention an alias is typically called with. A no-op when `from`
+ * is absent or `to` is already present, so inputs that already match the
+ * canonical schema pass through untouched.
+ */
+function renameInputKey(from: string, to: string): ToolInputNormalizer {
+  return (input) => {
+    if (!(from in input) || to in input) {
+      return input;
+    }
+    const { [from]: value, ...rest } = input;
+    return { ...rest, [to]: value };
+  };
+}
+
+/**
+ * Tool names models commonly invent, mapped to the canonical tool. An alias
+ * is only rewritten when the canonical tool is active for the turn and the
+ * requested name is not (see {@link resolveToolInvocationAlias}), so a live
+ * tool that happens to carry an aliased name always wins. Keep entries to
+ * unambiguous 1:1 semantics — a name whose intent could map to several tools
+ * belongs in {@link suggestToolName} territory instead, where the model
+ * re-decides with the real list.
+ */
 const TOOL_NAME_ALIASES = new Map<
   string,
   { canonicalName: string; normalizeInput?: ToolInputNormalizer }
@@ -14,16 +41,128 @@ const TOOL_NAME_ALIASES = new Map<
       normalizeInput: normalizeLegacyComputerUsePressKeyInput,
     },
   ],
+  // Filesystem reads — Claude-Code-style and unix-style names.
+  [
+    "read_file",
+    {
+      canonicalName: "file_read",
+      normalizeInput: renameInputKey("file_path", "path"),
+    },
+  ],
+  [
+    "read",
+    {
+      canonicalName: "file_read",
+      normalizeInput: renameInputKey("file_path", "path"),
+    },
+  ],
+  [
+    "cat",
+    {
+      canonicalName: "file_read",
+      normalizeInput: renameInputKey("file_path", "path"),
+    },
+  ],
+  [
+    "fs_read",
+    {
+      canonicalName: "file_read",
+      normalizeInput: renameInputKey("file_path", "path"),
+    },
+  ],
+  [
+    "workspace_read",
+    {
+      canonicalName: "file_read",
+      normalizeInput: renameInputKey("file_path", "path"),
+    },
+  ],
+  // Directory listings.
+  [
+    "list_files",
+    {
+      canonicalName: "file_list",
+      normalizeInput: renameInputKey("directory", "path"),
+    },
+  ],
+  [
+    "list_directory",
+    {
+      canonicalName: "file_list",
+      normalizeInput: renameInputKey("directory", "path"),
+    },
+  ],
+  // Shell execution.
+  [
+    "shell",
+    {
+      canonicalName: "bash",
+      normalizeInput: renameInputKey("cmd", "command"),
+    },
+  ],
+  [
+    "exec",
+    {
+      canonicalName: "bash",
+      normalizeInput: renameInputKey("cmd", "command"),
+    },
+  ],
 ]);
+
+/**
+ * Suggest the closest known tool name for an unknown one, for a
+ * `Did you mean "…"?` hint. Two conservative signals:
+ *
+ * - underscore-token permutations (`file_read` for `read_file`), which pure
+ *   edit distance misses, and
+ * - edit distance ≤ 2, catching typos without misdirecting semantically
+ *   different names (`task_create` must NOT suggest `app_create`).
+ *
+ * Ties resolve to the smallest distance, then lexicographically, so the
+ * suggestion is deterministic. Returns `undefined` when nothing is close.
+ */
+export function suggestToolName(
+  name: string,
+  candidates: Iterable<string>,
+): string | undefined {
+  const tokenKey = (value: string): string =>
+    value.toLowerCase().split(/[_-]/).filter(Boolean).sort().join("_");
+  const nameKey = tokenKey(name);
+
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const candidate of candidates) {
+    if (candidate === name) {
+      continue;
+    }
+    const distance =
+      tokenKey(candidate) === nameKey ? 0 : levenshtein(name, candidate);
+    if (distance > 2) {
+      continue;
+    }
+    if (
+      distance < bestDistance ||
+      (distance === bestDistance && best !== undefined && candidate < best)
+    ) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
 
 export function resolveToolInvocationAlias(
   name: string,
   input: Record<string, unknown>,
   allowedToolNames?: ReadonlySet<string>,
 ): { name: string; input: Record<string, unknown> } {
-  if (allowedToolNames?.has(name)) return { name, input };
+  if (allowedToolNames?.has(name)) {
+    return { name, input };
+  }
   const alias = TOOL_NAME_ALIASES.get(name);
-  if (!alias) return { name, input };
+  if (!alias) {
+    return { name, input };
+  }
   if (allowedToolNames && !allowedToolNames.has(alias.canonicalName)) {
     return { name, input };
   }


### PR DESCRIPTION
## Problem

Models invent tool names and burn turns on `Unknown tool` round-trips. 48h telemetry (post-v0.10.5): 177 unknown-name errors in main-agent contexts — `read_file`, `list_files`, `list_directory`, `read`, `shell`, `cat`, `exec`, `glob`, `fs_read`, `workspace_read`, `notifications_send`, `task_create`, …

## Fix — two conservative layers

**1. Alias table extensions** (`resolveToolInvocationAlias` — already runs on both the executor and conversation callback paths, and only rewrites when the canonical tool is active for the turn AND the requested name is not, so a real tool carrying an aliased name always wins):

| invented | canonical | input normalization |
|---|---|---|
| `read_file`, `read`, `cat`, `fs_read`, `workspace_read` | `file_read` | `file_path` → `path` |
| `list_files`, `list_directory` | `file_list` | `directory` → `path` |
| `shell`, `exec` | `bash` | `cmd` → `command` |

Key renames are no-ops when the canonical key is already present.

**2. `Did you mean "…"?`** appended to the Unknown-tool error, computed over the turn's active tools by underscore-token permutation (`search_web` → `web_search`) or edit distance ≤ 2 (`bassh` → `bash`). The cap is deliberately tight: `task_create` (3 edits from `app_create`) suggests nothing rather than misdirecting. Reuses the existing `levenshtein` from `filesystem/fuzzy-match.ts` (now exported).

Ambiguous-intent names (`glob`, `task_create`, `notifications_send`) are deliberately NOT aliased — the model re-decides from the real list.

## Tests

`tool-name-aliases.test.ts`: every alias + arg-key translation + both no-rewrite guards; suggestion positives (permutation, typo), negatives (semantically different names), and tie determinism. Existing `tool-executor.test.ts` unknown-tool exact-string assertions pass unchanged (no suggestion fires for `unknown_tool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)