### PR TITLE
chore(skills): regenerate catalog.json

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -643,7 +643,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-03T18:56:33.000Z"
+      "updatedAt": "2026-07-03T20:12:42.000Z"
     },
     {
       "id": "public-ingress",


### PR DESCRIPTION
These timestamps constantly get out of sync

1. When a dev edits a skill on a feature branch and commits some changes, the catalog generation script takes the timestamp of that commit.
2. Squash merging that branch onto main produces a new commit with a more recent timestamp that later CI checks will complain about.
