### PR TITLE
refactor(assistant): drop the persistence-hooks registration from the test-reset helper

### DIFF
--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -65,7 +65,6 @@ import memoryPostCompact from "./memory/hooks/post-compact.js";
 import memoryUserPromptSubmit from "./memory/hooks/user-prompt-submit.js";
 import { memoryInjectors } from "./memory/injectors.js";
 import memoryPkg from "./memory/package.json" with { type: "json" };
-import { registerDefaultPluginPersistenceHooks } from "./memory/persistence-hooks-registration.js";
 import {
   memoryV3Injector,
   memoryV3SpotlightInjector,
@@ -477,7 +476,10 @@ export function registerDefaultPluginInjectors(): void {
  * so integration tests that exercise the full agent loop have a
  * production-parity plugin stack. Use this in `beforeEach` of tests that
  * dispatch through pipelines with a terminal that assumes the default
- * plugin handles every op (e.g. compaction).
+ * plugin handles every op (e.g. compaction). Deliberately does NOT touch
+ * the memory plugin's persistence-lifecycle seam — that is a memory-plugin
+ * concept (`memory/persistence-hooks-registration.ts`), and tests that
+ * exercise persistence side effects register it themselves.
  *
  * Tests that specifically need an empty hook registry (pipeline-unit tests)
  * should continue to call {@link resetHookRegistryForTests} directly.
@@ -495,5 +497,4 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   registerDefaultPlugins();
   clearInjectorRegistry();
   registerDefaultPluginInjectors();
-  registerDefaultPluginPersistenceHooks();
 }


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37117: the barrel's last remaining import of `memory/persistence-hooks-registration` existed only because `resetPluginRegistryAndRegisterDefaults` — a test-only helper — wired the memory plugin's persistence-lifecycle seam. That's test-only code slipping into implementation: no production path goes through the helper (the daemon bootstrap and the standalone memory jobs worker both call `registerDefaultPluginPersistenceHooks` directly), and the seam is a memory-plugin concept the defaults barrel shouldn't reach into.

This removes the call and the import from the barrel. Tests that exercise persistence side effects register the seam themselves (all such tests already do, since #37117).

## Test plan

- All eight test files that call `resetPluginRegistryAndRegisterDefaults` pass unchanged in per-file isolation (agent-loop 58, conversation-agent-loop 67, agent-loop-output-hooks 19, workspace-injection 11, tool-result-spool 10, inference-profile 8, overflow 6, provider-retry-repair 2) — none depended on the seam being wired; the seam's no-op default is the correct "memory not present" behaviour for them.
- Import guards, job-handler registration guard, and plugin-bootstrap suite green (23 tests).
- `tsc` clean, eslint/prettier clean.

## CLI verb checklist

No new routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_