### PR TITLE
refactor(assistant): hoist the runner's processMessage import

### DIFF
--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -19,6 +19,7 @@
  */
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import { processMessage } from "../daemon/process-message.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import {
   commitDeferredConversation,
@@ -287,15 +288,6 @@ export async function runBackgroundJob(
       );
     }
 
-    // Loaded at call time: `processMessage` is the daemon's turn entrypoint
-    // and statically pulls the conversation stack (conversation-store →
-    // Conversation → conversation-tool-setup → the defaults barrel). Memory's
-    // job modules import this runner at module scope, so a static import here
-    // would put them on a cycle with the defaults barrel and its plugin
-    // definitions would hit their bindings mid-initialization (TDZ). By the
-    // time a job runs, the module graph has settled (and in the daemon the
-    // module is already loaded via the routes layer).
-    const { processMessage } = await import("../daemon/process-message.js");
     const work = processMessage(conversation.id, opts.prompt, {
       trustContext: opts.trustContext,
       callSite: opts.callSite,


### PR DESCRIPTION
## Prompt / plan

`runtime/background-job-runner.ts` loaded `processMessage` with a call-time `await import(...)` to stay off the import cycle through memory's job modules — `filing-jobs.ts` and `v2/consolidation-job.ts` import `runBackgroundJob` at module scope, and `processMessage`'s static graph reaches them through the defaults barrel. This PR hoists it to a plain static import and changes nothing else (+1/−9, one file).

**Why the cycle is safe to make real.** An ESM cycle only breaks when a module *body* reads a binding from a mid-initialization module (TDZ). The only eval-time binding reads on this cycle are the defaults barrel's plugin consts reading their hook/injector bindings — and a crash requires one of those modules to be evaluated *ahead of* the barrel from some entry point. Verified mechanically over the runtime import graph: **every module the barrel's consts read at eval time is imported by the barrel alone**, so no evaluation order can reach one mid-init. The memory job modules use `runBackgroundJob` only inside their handlers, and the runner uses `processMessage` only inside `runBackgroundJob` — no eval-time reads across the back-edges.

Also verified empirically: evaluating the graph from each entry direction in fresh processes — `filing-jobs`, `consolidation-job`, the runner itself, the defaults barrel, `processMessage`, and the standalone memory worker's exact import sequence — all initialize cleanly.

**Cost, stated honestly:** four modules (`background-job-runner`, `filing-jobs`, `v2/consolidation-job`, `job-handlers`) join the repo's one pre-existing large SCC. The barrel-only invariant above is what keeps that SCC benign; it's the same invariant the earlier barrel-cycle fixes established.

(An earlier revision of this branch severed the cycle with a registered runner slot instead — dropped in favor of this minimal version: the slot was dependency-injection ceremony guarding against a cycle that is provably and empirically benign.)

## Test plan

- The runner's own suite (17) passes with the static import — its `process-message` mock precedes the runner import.
- `filing-jobs` (4) and `consolidation-job` (30) suites pass unchanged.
- Runner consumers green: heartbeat-service (78), task-scheduler (18), watcher engine (6); plugin-bootstrap (12).
- Import guards green (no baseline changes — both memory→runner imports remain as before).
- Entry-order evaluation checks (above) all pass; `tsc`/lint/prettier clean via the pre-push hook.

## CLI verb checklist

No new routes.