### PR TITLE
refactor(assistant): read default-plugin names from the filesystem in conversation-tool-setup

### DIFF
--- a/assistant/src/__tests__/default-plugin-names-guard.test.ts
+++ b/assistant/src/__tests__/default-plugin-names-guard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAllDefaultPlugins } from "../plugins/defaults/index.js";
+import { getAllDefaultPluginNames } from "../plugins/defaults/main.js";
+
+/**
+ * Guard: the filesystem-backed default-plugin registry (`defaults/main.ts`)
+ * and the import-backed barrel (`defaults/index.ts`) must agree on the
+ * plugin set. `main.ts` is the barrel's eventual replacement; while both
+ * exist, a plugin added to one but not the other would silently diverge the
+ * consumers (e.g. per-chat plugin scoping reads names from `main.ts`, while
+ * bootstrap registers plugins from the barrel).
+ */
+describe("default plugin names", () => {
+  test("the filesystem registry matches the barrel's manifests exactly", () => {
+    const fromFs = [...getAllDefaultPluginNames()].sort();
+    const fromBarrel = getAllDefaultPlugins()
+      .map((p) => p.manifest.name)
+      .sort();
+    expect(fromFs).toEqual(fromBarrel);
+  });
+
+  test("every name uses the default- prefix convention", () => {
+    for (const name of getAllDefaultPluginNames()) {
+      expect(name).toMatch(/^default-[a-z0-9-]+$/);
+    }
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -17,7 +17,7 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { getBindingByConversation } from "../persistence/external-conversation-store.js";
-import { getAllDefaultPlugins } from "../plugins/defaults/index.js";
+import { getAllDefaultPluginNames } from "../plugins/defaults/main.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -158,8 +158,7 @@ export function getEffectiveEnabledPluginSet(conv: {
   const effective = new Set(conv.enabledPlugins);
   // Rules 2 + 3: add a default the conversation did not already decide, unless
   // it is disabled at the workspace level.
-  for (const plugin of getAllDefaultPlugins()) {
-    const name = plugin.manifest.name;
+  for (const name of getAllDefaultPluginNames()) {
     if (!effective.has(name) && !isPluginDisabled(name)) {
       effective.add(name);
     }

--- a/assistant/src/plugins/defaults/main.ts
+++ b/assistant/src/plugins/defaults/main.ts
@@ -1,0 +1,52 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Filesystem-backed access to the first-party default plugins. This module
+ * will eventually replace `defaults/index.ts`.
+ *
+ * The barrel (`defaults/index.ts`) derives everything from static imports of
+ * every plugin's hook and injector modules, so any consumer that only needs
+ * plugin *identity* still ends up downstream of the entire plugin
+ * implementation graph. This module answers identity questions from the
+ * source tree instead: each immediate subdirectory of `plugins/defaults/`
+ * that carries a `package.json` is one plugin, named by that manifest — the
+ * same `package.json` the barrel imports for its `manifest.name`.
+ *
+ * Relying on the directory layout is safe because the assistant ships its
+ * source hierarchy as-is (`bun --compile` is not supported), so the tree this
+ * module reads in production is the tree the plugins are loaded from.
+ */
+
+const DEFAULTS_DIR = import.meta.dir;
+
+let cachedNames: readonly string[] | null = null;
+
+/**
+ * Names of every first-party default plugin (their `package.json` names,
+ * e.g. `default-memory`), read from the `plugins/defaults/` directory tree.
+ * Read once and memoized: the plugin set is fixed for the lifetime of the
+ * process — the source tree does not change under a running assistant.
+ */
+export function getAllDefaultPluginNames(): readonly string[] {
+  if (cachedNames === null) {
+    const names: string[] = [];
+    for (const entry of readdirSync(DEFAULTS_DIR, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      let manifest: { name?: unknown };
+      try {
+        manifest = JSON.parse(
+          readFileSync(join(DEFAULTS_DIR, entry.name, "package.json"), "utf-8"),
+        ) as { name?: unknown };
+      } catch {
+        // A subdirectory without a readable package.json is not a plugin.
+        continue;
+      }
+      if (typeof manifest.name === "string" && manifest.name.length > 0) {
+        names.push(manifest.name);
+      }
+    }
+    cachedNames = names.sort();
+  }
+  return cachedNames;
+}


### PR DESCRIPTION
## Prompt / plan

`conversation-tool-setup.ts` imported the defaults barrel (`defaults/index.ts`) only to enumerate default-plugin names in `getEffectiveEnabledPluginSet` — putting the entire conversation graph downstream of every plugin's implementation modules just to learn eighteen strings.

- **New `plugins/defaults/main.ts`** — the eventual replacement for `defaults/index.ts`. It answers plugin-identity questions from the source tree: each immediate subdirectory of `plugins/defaults/` carrying a `package.json` is one plugin, named by that manifest (the same `package.json` the barrel imports for `manifest.name`). Relying on the directory layout is safe because the assistant ships its source hierarchy as-is — `bun --compile` is no longer supported. Names are read once and memoized; the plugin set is fixed for the life of the process.
- **`getEffectiveEnabledPluginSet` switches to `getAllDefaultPluginNames()`**, severing the conversation graph's only edge into the barrel.
- **Guard test** pins the filesystem registry against the barrel's manifests (exact set equality + the `default-` prefix convention), so the two views cannot drift while both exist.

**Cycle-graph payoff** (SCC pass over the runtime import graph): the knot shrinks from **100 modules to 91**. The barrel drops out of the cycle set, taking with it the memory job machinery behind its init hook (`hooks/init`, `job-handler-registration`, `job-handlers`, `filing-jobs`, `v2/consolidation-job`), `runtime/background-job-runner` (the four modules #37131 added to the knot leave again), and the conversation-analyze services.

## Test plan

- New guard: `default-plugin-names-guard.test.ts` (2 tests — FS ↔ barrel set equality, name convention).
- Scope consumers green in isolation: conversation-tool-setup (8), plugin-effective-enabled-set (5), conversation-routes-enabled-plugins (5), subagent-tool-gate-mode (16), plugin-bootstrap (12), plugin-disabled-state (9).
- Verified all 18 plugin directories resolve a `package.json` name matching the barrel's manifests.
- `tsc` clean, eslint/prettier clean (pre-push hook).

## CLI verb checklist

No new routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_