### PR TITLE
feat(assistant): redeploy a plugin in place when any of its source files change

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -661,3 +661,167 @@ describe("plugin runtime activation", () => {
     expect(getToolOwner("disable-tool")).toBeUndefined();
   });
 });
+
+// ─── Live reload via source fingerprint ──────────────────────────────────────
+
+/** Write a helper module at `relPath` (e.g. `lib/helper.ts`) inside a plugin. */
+function writeLibFile(dir: string, relPath: string, body: string): string {
+  const path = join(dir, relPath);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, body);
+  return path;
+}
+
+/** Dispatch `hookName` for the discovered plugins and return the first hook's result. */
+async function dispatchFirst(hookName: string): Promise<unknown> {
+  const hooks = await getUserHooksFor(hookName);
+  expect(hooks).toHaveLength(1);
+  return (hooks[0] as unknown as () => unknown)();
+}
+
+describe("plugin live reload (source fingerprint)", () => {
+  test("editing a helper imported by a hook redeploys the plugin", async () => {
+    const dir = freshPluginDir("helper-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "helper-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = "v1";`,
+    );
+    writeHook(
+      dir,
+      "helper-reload",
+      `import { value } from "../lib/helper.ts";\nexport default () => value;`,
+    );
+
+    await populateCacheAtBoot();
+    expect(await dispatchFirst("helper-reload")).toBe("v1");
+
+    // Only the helper changes — the hook file's own mtime never moves, so
+    // any per-entry-file scheme would keep serving v1 here.
+    writeFileSync(helperPath, `export const value = "v2";`);
+    touchFile(helperPath, 2);
+    expect(await dispatchFirst("helper-reload")).toBe("v2");
+
+    // A reloaded plugin must itself be reloadable.
+    writeFileSync(helperPath, `export const value = "v3";`);
+    touchFile(helperPath, 4);
+    expect(await dispatchFirst("helper-reload")).toBe("v3");
+  });
+
+  test("editing a transitive helper (hook → a → b) redeploys consistently", async () => {
+    const dir = freshPluginDir("transitive-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "transitive-plugin" });
+    const bPath = writeLibFile(
+      dir,
+      join("lib", "b.ts"),
+      `export const leaf = "b1";`,
+    );
+    writeLibFile(
+      dir,
+      join("lib", "a.ts"),
+      `import { leaf } from "./b.ts";\nexport const mid = "a:" + leaf;`,
+    );
+    writeHook(
+      dir,
+      "transitive-reload",
+      `import { mid } from "../lib/a.ts";\nexport default () => mid;`,
+    );
+
+    await populateCacheAtBoot();
+    expect(await dispatchFirst("transitive-reload")).toBe("a:b1");
+
+    // The intermediate module `a` is untouched. Whole-plugin eviction is
+    // what keeps it from pairing a re-imported hook with its stale cached
+    // binding to the old `b`.
+    writeFileSync(bPath, `export const leaf = "b2";`);
+    touchFile(bPath, 2);
+    expect(await dispatchFirst("transitive-reload")).toBe("a:b2");
+  });
+
+  test("a reload runs the old shutdown (reason: reload) and the new init", async () => {
+    const dir = freshPluginDir("lifecycle-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "lifecycle-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = 1;`,
+    );
+    const initMarker = join(ROOT, "reload-init.log");
+    const shutdownMarker = join(ROOT, "reload-shutdown.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+    writeHook(
+      dir,
+      "shutdown",
+      `import { appendFileSync } from "node:fs";\nexport default (ctx: { reason: string }) => { appendFileSync(${JSON.stringify(shutdownMarker)}, ctx.reason + "\\n"); };`,
+    );
+
+    await populateCacheAtBoot();
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+    expect(existsSync(shutdownMarker)).toBe(false);
+
+    writeFileSync(helperPath, `export const value = 2;`);
+    touchFile(helperPath, 2);
+    await triggerScan();
+
+    // The edit is a redeploy: old version torn down with reason "reload",
+    // new version brought up through the same init path as boot.
+    expect(readFileSync(shutdownMarker, "utf8").trim().split("\n")).toEqual([
+      "reload",
+    ]);
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
+  });
+
+  test("scans without source changes do not redeploy", async () => {
+    const dir = freshPluginDir("stable-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "stable-plugin" });
+    writeLibFile(dir, join("lib", "helper.ts"), `export const value = 1;`);
+    writeHook(
+      dir,
+      "stable-reload",
+      `import { value } from "../lib/helper.ts";\nexport default () => value;`,
+    );
+    const initMarker = join(ROOT, "stable-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    await populateCacheAtBoot();
+    await triggerScan();
+    await triggerScan();
+
+    // A false-positive fingerprint change would re-run init on every scan —
+    // a redeploy storm on the per-turn dispatch path.
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  test("editing a tool file re-registers the new definition in the tool registry", async () => {
+    const dir = freshPluginDir("tool-reload-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "tool-reload-plugin" });
+    const toolPath = join(dir, "tools", "reloading-tool.ts");
+    writeTool(
+      dir,
+      "reloading-tool",
+      `export default { name: "reloading-tool", description: "one", parameters: { type: "object", properties: {} } };`,
+    );
+
+    await populateCacheAtBoot();
+    expect(
+      getAllToolDefinitions().find((t) => t.name === "reloading-tool")
+        ?.description,
+    ).toBe("one");
+
+    writeFileSync(
+      toolPath,
+      `export default { name: "reloading-tool", description: "two", parameters: { type: "object", properties: {} } };`,
+    );
+    touchFile(toolPath, 2);
+    await triggerScan();
+
+    // The global registry — not just the tool cache — must serve the new
+    // definition: reload unregisters the old tool and re-registers the
+    // freshly imported one.
+    expect(
+      getAllToolDefinitions().find((t) => t.name === "reloading-tool")
+        ?.description,
+    ).toBe("two");
+  });
+});

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -33,6 +33,7 @@ import {
   getUserHooksFor,
   populateCacheAtBoot,
   resetPluginCacheForTests,
+  setSourceScanIntervalMs,
 } from "../plugins/mtime-cache.js";
 import {
   getAllToolDefinitions,
@@ -791,6 +792,36 @@ describe("plugin live reload (source fingerprint)", () => {
     // A false-positive fingerprint change would re-run init on every scan —
     // a redeploy storm on the per-turn dispatch path.
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  test("fingerprint passes are rate-limited by the scan interval", async () => {
+    const dir = freshPluginDir("gated-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "gated-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = "g1";`,
+    );
+    writeHook(
+      dir,
+      "gated-reload",
+      `import { value } from "../lib/helper.ts";\nexport default () => value;`,
+    );
+
+    await populateCacheAtBoot();
+    expect(await dispatchFirst("gated-reload")).toBe("g1");
+
+    // Inside the interval the scan skips the walk entirely — the dispatch
+    // path pays nothing for the fingerprint and the edit is not seen yet.
+    setSourceScanIntervalMs(60_000);
+    writeFileSync(helperPath, `export const value = "g2";`);
+    touchFile(helperPath, 2);
+    expect(await dispatchFirst("gated-reload")).toBe("g1");
+
+    // Once the interval admits a pass, the same edit lands on the next
+    // dispatch — nothing was lost by skipping, only deferred.
+    setSourceScanIntervalMs(0);
+    expect(await dispatchFirst("gated-reload")).toBe("g2");
   });
 
   test("editing a tool file re-registers the new definition in the tool registry", async () => {

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -161,9 +161,12 @@ async function resolveCachedHook<TCtx>(
  * Added, removed, and edited hook files are all picked up live: discovery is
  * by directory listing, and a changed source mtime evicts the module from
  * the runtime registry before re-import, so the edited hook takes effect on
- * the next dispatch without a daemon restart. Eviction is per-file — an edit
- * to a helper module a hook imports is not detected (the hook file's own
- * mtime is what's watched) and still needs a restart.
+ * the next dispatch without a daemon restart. For plugin hooks, helper
+ * modules are covered too: the plugin scan in `../plugins/mtime-cache.ts`
+ * fingerprints every source file under the plugin directory and redeploys
+ * the plugin when any of them change. Standalone workspace hooks are single
+ * files by design (every file in the directory is treated as a hook), so
+ * only the hook file itself is watched there.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null, a
  * plugin whose name is not in the set is skipped (its hooks do not run for this

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -132,8 +132,11 @@ export interface ModelProfileInfo {
  * - `uninstall` — the plugin's directory was removed at runtime.
  * - `disable` — the plugin was disabled at runtime (e.g. a `.disabled`
  *   sentinel was added, or a feature flag turned it off).
+ * - `reload` — a source file inside the plugin directory changed and the
+ *   plugin is being redeployed in place; the old version's `shutdown` runs
+ *   before the new version is imported and its `init` fires.
  */
-export type ShutdownReason = "shutdown" | "uninstall" | "disable";
+export type ShutdownReason = "shutdown" | "uninstall" | "disable" | "reload";
 
 /**
  * Context passed to the `shutdown` hook. Kept intentionally narrower than

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -14,8 +14,9 @@
  * - Any source change inside a plugin directory (hook, tool, or a helper
  *   module either imports) redeploys the plugin in place: shutdown → module
  *   eviction → re-import → init. Detection is a per-directory source
- *   fingerprint (see `./source-fingerprint.ts`), so edits land on the next
- *   scan without a daemon restart.
+ *   fingerprint (see `./source-fingerprint.ts`), rate-limited to one pass
+ *   per {@link setSourceScanIntervalMs interval}, so edits land within the
+ *   interval of the next scan without a daemon restart.
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry and cache-bust them using mtime on reads.
  *
@@ -190,6 +191,33 @@ const disabledPluginDirs = new Set<string>();
  */
 const sourceSnapshots = new Map<string, SourceSnapshot>();
 
+/**
+ * Minimum interval between fingerprint passes, in milliseconds. The
+ * fingerprint walk stats every source file in every plugin directory
+ * (~3.6µs/file measured warm — ~3.6ms for 10 plugins × 100 files), and the
+ * scan runs on every hook dispatch, which is many times per turn. Source
+ * edits happen at human speed, so scans inside the interval skip the walk;
+ * an edit is still picked up within the interval by whichever dispatch runs
+ * next. Per-entry-file mtime checks (hook files themselves) are not gated —
+ * single-file edits stay instant. 0 fingerprints on every scan.
+ */
+let sourceScanIntervalMs = 1_000;
+
+/**
+ * Monotonic time of the last fingerprint pass. Starts at `-Infinity` so the
+ * first scan after boot (or test reset) always takes a baseline snapshot.
+ */
+let lastFingerprintPassAt = -Infinity;
+
+/**
+ * Override the fingerprint-pass interval. Called by `populateCacheAtBoot`
+ * when configured, and by tests (0 makes every scan fingerprint, so
+ * edit → scan → reload is deterministic).
+ */
+export function setSourceScanIntervalMs(ms: number): void {
+  sourceScanIntervalMs = ms;
+}
+
 // ─── Hook reads ──────────────────────────────────────────────────────────────
 
 /**
@@ -324,10 +352,13 @@ export function getCachedUserTools(): Tool[] {
  * Scan the plugins directory, update the discovered set, and reconcile
  * tools for each plugin. Also evicts cache entries for deleted plugins.
  *
- * This is the "pull" — called on every hook read and at boot. The cost
- * is one `readdirSync` + N `statSync` calls where N = total surface files
- * across all plugins. For a typical workspace with 2-3 plugins, that's
- * ~10-15 stats — sub-millisecond.
+ * This is the "pull" — called on every hook read and at boot. The
+ * every-scan cost is one `readdirSync` + a stat per surface file across all
+ * plugins (~10-15 stats for a typical 2-3 plugin workspace —
+ * sub-millisecond). The fingerprint walk over every plugin source file is
+ * the expensive part, so it runs at most once per
+ * {@link setSourceScanIntervalMs interval}; discovery, disable/uninstall
+ * handling, and per-file tool reconciliation stay live on every scan.
  */
 async function scanPlugins(): Promise<void> {
   const pluginsDir = getWorkspacePluginsDir();
@@ -344,6 +375,15 @@ async function scanPlugins(): Promise<void> {
   } catch {
     log.warn({ pluginsDir }, "scanPlugins: failed to read plugins directory");
     return;
+  }
+
+  // Gate the fingerprint walk to one pass per interval. Claimed up front so
+  // concurrent scans (hook dispatches overlap) don't both pay for the walk.
+  const now = performance.now();
+  const fingerprintThisScan =
+    now - lastFingerprintPassAt >= sourceScanIntervalMs;
+  if (fingerprintThisScan) {
+    lastFingerprintPassAt = now;
   }
 
   const currentDirs = new Map<string, string>();
@@ -396,38 +436,40 @@ async function scanPlugins(): Promise<void> {
     }
 
     // Live reload: a fingerprint change means some source file inside the
-    // plugin directory changed since the last scan — including helper
-    // modules that hooks/tools import, which no per-entry-file mtime check
-    // can see. Redeploy the plugin in place: shut the old version down,
-    // sweep every source path (old and new — deleted files may still be
-    // cached) out of the module registry so nothing re-binds to a stale
+    // plugin directory changed since the last fingerprint pass — including
+    // helper modules that hooks/tools import, which no per-entry-file mtime
+    // check can see. Redeploy the plugin in place: shut the old version
+    // down, sweep every source path (old and new — deleted files may still
+    // be cached) out of the module registry so nothing re-binds to a stale
     // module, and drop its cache entries. The activation pass at the end of
     // this scan brings the new version up (pre-import, tool registration,
     // `init`). The whole directory is the reload unit on purpose: partial
     // eviction would let a re-imported hook pair with a stale intermediate
     // helper, silently mixing versions.
-    const snapshot = snapshotPluginSource(pluginDir);
-    const previous = sourceSnapshots.get(pluginDir);
-    sourceSnapshots.set(pluginDir, snapshot);
-    if (
-      previous !== undefined &&
-      previous.fingerprint !== snapshot.fingerprint &&
-      activatedNames.has(pluginName)
-    ) {
-      log.info(
-        { plugin: pluginName, pluginDir },
-        "plugin source changed — reloading",
-      );
-      // Shutdown reads the old version's hook from the cache, so it must run
-      // before the hook cache is cleared.
-      await deactivatePlugin(pluginName, "reload");
-      evictHooksForOwner(pluginName);
-      evictToolCacheEntries(pluginName);
-      for (const path of new Set([
-        ...previous.evictionPaths,
-        ...snapshot.evictionPaths,
-      ])) {
-        evictModule(path);
+    if (fingerprintThisScan) {
+      const snapshot = snapshotPluginSource(pluginDir);
+      const previous = sourceSnapshots.get(pluginDir);
+      sourceSnapshots.set(pluginDir, snapshot);
+      if (
+        previous !== undefined &&
+        previous.fingerprint !== snapshot.fingerprint &&
+        activatedNames.has(pluginName)
+      ) {
+        log.info(
+          { plugin: pluginName, pluginDir },
+          "plugin source changed — reloading",
+        );
+        // Shutdown reads the old version's hook from the cache, so it must
+        // run before the hook cache is cleared.
+        await deactivatePlugin(pluginName, "reload");
+        evictHooksForOwner(pluginName);
+        evictToolCacheEntries(pluginName);
+        for (const path of new Set([
+          ...previous.evictionPaths,
+          ...snapshot.evictionPaths,
+        ])) {
+          evictModule(path);
+        }
       }
     }
 
@@ -665,10 +707,13 @@ async function deactivatePlugin(
  * files appear or disappear at runtime are picked up without a restart.
  */
 export async function populateCacheAtBoot(
-  opts: { importTimeoutMs?: number } = {},
+  opts: { importTimeoutMs?: number; sourceScanIntervalMs?: number } = {},
 ): Promise<void> {
   if (opts.importTimeoutMs !== undefined) {
     setSurfaceImportTimeout(opts.importTimeoutMs);
+  }
+  if (opts.sourceScanIntervalMs !== undefined) {
+    setSourceScanIntervalMs(opts.sourceScanIntervalMs);
   }
 
   // Scans + activates every discovered plugin (tools registered + `init` run).
@@ -709,6 +754,10 @@ export function resetPluginCacheForTests(): void {
   activatedNames.clear();
   disabledPluginDirs.clear();
   sourceSnapshots.clear();
+  // Fingerprint on every scan so edit → scan → reload is deterministic in
+  // tests; a test that exercises the gate itself sets its own interval.
+  sourceScanIntervalMs = 0;
+  lastFingerprintPassAt = -Infinity;
 }
 
 /**

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -9,9 +9,13 @@
  * plugins directory, registers tools, and drives hook pre-import / init /
  * shutdown by handing the discovered directories to the hook loader.
  *
- * - A changed tool file triggers a re-import of just that tool, not a full
- *   plugin rebuild. Added and removed surface files are picked up live, since
- *   discovery is by directory listing.
+ * - Added and removed surface files are picked up live, since discovery is
+ *   by directory listing.
+ * - Any source change inside a plugin directory (hook, tool, or a helper
+ *   module either imports) redeploys the plugin in place: shutdown → module
+ *   eviction → re-import → init. Detection is a per-directory source
+ *   fingerprint (see `./source-fingerprint.ts`), so edits land on the next
+ *   scan without a daemon restart.
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry and cache-bust them using mtime on reads.
  *
@@ -49,8 +53,11 @@ import {
   listSurfaceDir,
   parsePluginManifest,
 } from "./external-plugin-loader.js";
+import type { SourceSnapshot } from "./source-fingerprint.js";
+import { snapshotPluginSource } from "./source-fingerprint.js";
 import {
   clearSurfaceImportInflight,
+  evictModule,
   getMtime,
   importWithTimeout,
   setSurfaceImportTimeout,
@@ -93,7 +100,9 @@ const INSTALL_META_FILENAME = "install-meta.json";
  */
 function getInstallDate(pluginDir: string): number {
   const cached = installDateCache.get(pluginDir);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    return cached;
+  }
 
   // Try install-meta.json first.
   const metaPath = join(pluginDir, INSTALL_META_FILENAME);
@@ -170,6 +179,16 @@ const discoveredPluginDirs = new Map<string, string>();
  * transitions back to active or is evicted entirely.
  */
 const disabledPluginDirs = new Set<string>();
+
+/**
+ * Last observed source snapshot per plugin directory. A fingerprint change
+ * between scans means some source file inside the directory was edited,
+ * added, removed, or renamed — including helper modules that hooks/tools
+ * import — and triggers an in-place redeploy of the plugin. The snapshot's
+ * eviction list is what gets swept from the module registry so the redeploy
+ * re-evaluates a mutually consistent set of modules.
+ */
+const sourceSnapshots = new Map<string, SourceSnapshot>();
 
 // ─── Hook reads ──────────────────────────────────────────────────────────────
 
@@ -282,7 +301,9 @@ async function reconcilePluginTools(
   // Evict cached tools whose files no longer exist on disk.
   for (const key of toolCache.keys()) {
     const [cachedPluginName, cachedToolName] = key.split("/");
-    if (cachedPluginName !== pluginName) continue;
+    if (cachedPluginName !== pluginName) {
+      continue;
+    }
     if (!onDiskNames.has(cachedToolName)) {
       toolCache.delete(key);
     }
@@ -330,11 +351,15 @@ async function scanPlugins(): Promise<void> {
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
     try {
-      if (!statSync(pluginDir).isDirectory()) continue;
+      if (!statSync(pluginDir).isDirectory()) {
+        continue;
+      }
     } catch {
       continue;
     }
-    if (!existsSync(join(pluginDir, "package.json"))) continue;
+    if (!existsSync(join(pluginDir, "package.json"))) {
+      continue;
+    }
 
     // Check for the .disabled sentinel. A plugin is disabled when a file
     // named `.disabled` exists inside its plugin directory. Disabled
@@ -358,7 +383,9 @@ async function scanPlugins(): Promise<void> {
     }
 
     const manifest = await parsePluginManifest(pluginDir);
-    if (manifest === undefined) continue;
+    if (manifest === undefined) {
+      continue;
+    }
     const { name: pluginName } = manifest;
 
     currentDirs.set(pluginDir, pluginName);
@@ -366,6 +393,42 @@ async function scanPlugins(): Promise<void> {
 
     if (!discoveredPluginDirs.has(pluginDir)) {
       log.info({ plugin: pluginName, pluginDir }, "plugin discovered");
+    }
+
+    // Live reload: a fingerprint change means some source file inside the
+    // plugin directory changed since the last scan — including helper
+    // modules that hooks/tools import, which no per-entry-file mtime check
+    // can see. Redeploy the plugin in place: shut the old version down,
+    // sweep every source path (old and new — deleted files may still be
+    // cached) out of the module registry so nothing re-binds to a stale
+    // module, and drop its cache entries. The activation pass at the end of
+    // this scan brings the new version up (pre-import, tool registration,
+    // `init`). The whole directory is the reload unit on purpose: partial
+    // eviction would let a re-imported hook pair with a stale intermediate
+    // helper, silently mixing versions.
+    const snapshot = snapshotPluginSource(pluginDir);
+    const previous = sourceSnapshots.get(pluginDir);
+    sourceSnapshots.set(pluginDir, snapshot);
+    if (
+      previous !== undefined &&
+      previous.fingerprint !== snapshot.fingerprint &&
+      activatedNames.has(pluginName)
+    ) {
+      log.info(
+        { plugin: pluginName, pluginDir },
+        "plugin source changed — reloading",
+      );
+      // Shutdown reads the old version's hook from the cache, so it must run
+      // before the hook cache is cleared.
+      await deactivatePlugin(pluginName, "reload");
+      evictHooksForOwner(pluginName);
+      evictToolCacheEntries(pluginName);
+      for (const path of new Set([
+        ...previous.evictionPaths,
+        ...snapshot.evictionPaths,
+      ])) {
+        evictModule(path);
+      }
     }
 
     // Reconcile this plugin's tools (re-imports changed files).
@@ -413,12 +476,12 @@ async function evictPlugin(
   evictHooksForOwner(pluginName);
 
   // Evict tools.
-  const toolPrefix = `${pluginName}/`;
-  for (const key of toolCache.keys()) {
-    if (key.startsWith(toolPrefix)) {
-      toolCache.delete(key);
-    }
-  }
+  evictToolCacheEntries(pluginName);
+
+  // Sweep the plugin's source modules out of the module registry, so a
+  // reinstall at the same path re-evaluates fresh files instead of serving
+  // the removed install's cached modules.
+  evictSnapshotModules(pluginDir);
 
   log.info(
     { plugin: pluginName, pluginDir },
@@ -426,6 +489,32 @@ async function evictPlugin(
   );
   discoveredPluginDirs.delete(pluginDir);
   installDateCache.delete(pluginDir);
+}
+
+/** Drop every `toolCache` entry owned by `pluginName`. */
+function evictToolCacheEntries(pluginName: string): void {
+  const toolPrefix = `${pluginName}/`;
+  for (const key of toolCache.keys()) {
+    if (key.startsWith(toolPrefix)) {
+      toolCache.delete(key);
+    }
+  }
+}
+
+/**
+ * Evict the module-registry entries recorded in `pluginDir`'s last source
+ * snapshot and forget the snapshot. No-op for a directory that was never
+ * snapshotted.
+ */
+function evictSnapshotModules(pluginDir: string): void {
+  const snapshot = sourceSnapshots.get(pluginDir);
+  if (snapshot === undefined) {
+    return;
+  }
+  for (const path of snapshot.evictionPaths) {
+    evictModule(path);
+  }
+  sourceSnapshots.delete(pluginDir);
 }
 
 /**
@@ -440,6 +529,9 @@ async function evictAll(): Promise<void> {
   discoveredPluginDirs.clear();
   installDateCache.clear();
   disabledPluginDirs.clear();
+  for (const pluginDir of [...sourceSnapshots.keys()]) {
+    evictSnapshotModules(pluginDir);
+  }
 }
 
 // ─── Activation lifecycle ────────────────────────────────────────────────────
@@ -477,7 +569,9 @@ async function activatePlugin(
   pluginDir: string,
   pluginName: string,
 ): Promise<void> {
-  if (activatedNames.has(pluginName)) return;
+  if (activatedNames.has(pluginName)) {
+    return;
+  }
   // Reserve synchronously, before any await, so a re-entrant or concurrent
   // scan observes this plugin as already handled.
   activatedNames.add(pluginName);
@@ -523,10 +617,14 @@ async function deactivatePlugin(
   pluginName: string,
   reason: ShutdownReason,
 ): Promise<void> {
-  if (!activatedNames.has(pluginName)) return;
+  if (!activatedNames.has(pluginName)) {
+    return;
+  }
   activatedNames.delete(pluginName);
   const idx = activatedPlugins.findIndex((p) => p.name === pluginName);
-  if (idx >= 0) activatedPlugins.splice(idx, 1);
+  if (idx >= 0) {
+    activatedPlugins.splice(idx, 1);
+  }
 
   // Unregister tools before running shutdown so the model-visible surface is
   // clean before teardown.
@@ -610,6 +708,7 @@ export function resetPluginCacheForTests(): void {
   activatedPlugins.length = 0;
   activatedNames.clear();
   disabledPluginDirs.clear();
+  sourceSnapshots.clear();
 }
 
 /**

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-plugin source snapshots — the change detector behind plugin live
+ * reload.
+ *
+ * A hook or tool file may import helper modules from anywhere inside its
+ * plugin directory, and the runtime module registry caches every one of
+ * them independently. Watching only the entry file's mtime therefore misses
+ * helper edits, and evicting only the entry file would re-bind it to stale
+ * cached helpers (or worse, to a stale intermediate module in a
+ * `hook → a → b` chain). Instead of tracking the real import graph, the
+ * plugin scan treats the whole plugin directory as the reload unit: one walk
+ * produces both a **fingerprint** (did any source file change?) and the
+ * **eviction list** (every path that must leave the module registry so the
+ * next imports re-evaluate a mutually consistent set). Evicting a path that
+ * was never imported is a harmless no-op, so the walk doesn't need to know
+ * what the plugin actually imported.
+ *
+ * Exclusions: dot-entries anywhere (`.disabled`, `.git`, …), `node_modules`
+ * anywhere (vendored deps change only through install flows, which recycle
+ * the plugin directory), and — at the plugin root only — the `data/` runtime
+ * directory and the `config.json` / `install-meta.json` sidecars, none of
+ * which are importable source. Imports that reach *outside* the plugin
+ * directory are out of scope by design: shared deps keep their module
+ * identity across reloads, and cross-plugin imports are unsupported.
+ */
+
+import { readdirSync, realpathSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Directory names skipped at any depth. */
+const EXCLUDED_DIRS_ANYWHERE = new Set(["node_modules"]);
+
+/** Directory names skipped only directly under the plugin root. */
+const EXCLUDED_ROOT_DIRS = new Set(["data"]);
+
+/** File names skipped only directly under the plugin root. */
+const EXCLUDED_ROOT_FILES = new Set(["config.json", "install-meta.json"]);
+
+/**
+ * The result of one source walk over a plugin directory.
+ */
+export interface SourceSnapshot {
+  /**
+   * Opaque version stamp for the plugin's source: the sorted
+   * `(path, mtimeMs)` pairs of every included file. Two snapshots compare
+   * equal iff no source file was edited, added, removed, or renamed —
+   * unlike a max-mtime scheme, which misses swaps that don't advance the
+   * clock.
+   */
+  readonly fingerprint: string;
+  /**
+   * Absolute paths to evict from the module registry when the fingerprint
+   * changes. Contains the realpath form of every included file, plus the
+   * symlink-rooted alias of each when the plugin directory is reached
+   * through a symlink — the registry may key a module under either form
+   * depending on the path the importer used.
+   */
+  readonly evictionPaths: readonly string[];
+}
+
+/**
+ * Walk `pluginDir` and snapshot its source files. Best-effort on a directory
+ * that's being mutated mid-walk: unreadable entries are skipped, and a
+ * missing directory yields an empty snapshot (the plugin-deletion path in
+ * the scan handles that case before fingerprints are compared).
+ */
+export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
+  let realRoot = pluginDir;
+  try {
+    realRoot = realpathSync(pluginDir);
+  } catch {
+    // Unresolvable (deleted mid-scan) — walk the given path; it will yield
+    // an empty file list.
+  }
+
+  const files: Array<{ path: string; mtimeMs: number }> = [];
+  walk(realRoot, realRoot, files);
+
+  // readdir order is platform-dependent; sort for a stable fingerprint.
+  files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const fingerprint = files
+    .map((f) => `${f.path}\u0000${f.mtimeMs}`)
+    .join("\n");
+
+  const evictionPaths = files.map((f) => f.path);
+  if (realRoot !== pluginDir) {
+    for (const f of files) {
+      evictionPaths.push(pluginDir + f.path.slice(realRoot.length));
+    }
+  }
+
+  return { fingerprint, evictionPaths };
+}
+
+function walk(
+  dir: string,
+  root: string,
+  out: Array<{ path: string; mtimeMs: number }>,
+): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith(".")) {
+      continue;
+    }
+
+    const path = join(dir, name);
+    let isDir = entry.isDirectory();
+    let isFile = entry.isFile();
+    if (entry.isSymbolicLink()) {
+      try {
+        const st = statSync(path);
+        isDir = st.isDirectory();
+        isFile = st.isFile();
+      } catch {
+        continue; // dangling symlink
+      }
+    }
+
+    if (isDir) {
+      if (EXCLUDED_DIRS_ANYWHERE.has(name)) {
+        continue;
+      }
+      if (dir === root && EXCLUDED_ROOT_DIRS.has(name)) {
+        continue;
+      }
+      walk(path, root, out);
+    } else if (isFile) {
+      if (dir === root && EXCLUDED_ROOT_FILES.has(name)) {
+        continue;
+      }
+      try {
+        out.push({ path, mtimeMs: statSync(path).mtimeMs });
+      } catch {
+        // Deleted between readdir and stat — the next scan sees the removal.
+      }
+    }
+  }
+}

--- a/assistant/src/plugins/surface-import.ts
+++ b/assistant/src/plugins/surface-import.ts
@@ -64,7 +64,9 @@ export function getMtime(filePath: string): number {
  * (mtime moved, or the file was deleted and recreated) — evicting on every
  * read would defeat the module cache entirely. Eviction is per-file: modules
  * the evicted file imports stay cached, so an edit to a hook's helper module
- * takes effect only if the helper is evicted as well.
+ * takes effect only if the helper is evicted as well. The plugin scan sweeps
+ * every path under a changed plugin directory for exactly that reason (see
+ * `./source-fingerprint.ts`).
  */
 export function evictModule(filePath: string): void {
   delete require.cache[filePath];


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37135, which made an edited hook *file* reload but left helpers uncovered: a hook may import helper modules from anywhere inside its plugin directory, the module registry caches each file independently, and watching only the entry file's mtime can't see a helper edit. Evicting just the entry file wouldn't be enough either — it would re-bind to stale cached helpers, or pair a fresh hook with a stale intermediate module in a `hook → a → b` chain.

Strategy: **the plugin directory is the reload unit.**

- **`plugins/source-fingerprint.ts`** (new): one walk over the plugin dir (excluding `node_modules`, `data/`, dotfiles, and the `config.json`/`install-meta.json` sidecars) yields a **fingerprint** — sorted `(path, mtimeMs)` pairs, so edits, adds, deletes, and renames all register, unlike max-mtime — and doubles as the **eviction list**. Evicting a never-imported path is a no-op, so no module-registry enumeration or import-graph tracking is needed. The walk realpaths the plugin root and evicts both canonical and symlink-rooted path forms.
- **`plugins/mtime-cache.ts`**: on scan, a fingerprint change redeploys the plugin through the existing activation lifecycle — `deactivatePlugin` (old version's `shutdown` runs, tools unregister), sweep old+new source paths from the module registry, and the scan's activation pass brings the new version up (fresh pre-import, tool re-registration, `init`). Whole-directory eviction is deliberate: partial eviction silently mixes module versions. Uninstall now also sweeps the removed install's modules so a reinstall at the same path starts fresh.
- **Interval gate**: `scanPlugins` runs on every hook dispatch (many times per turn), while source edits happen at human speed. The fingerprint pass is rate-limited to one per interval (default 1s; configurable via `populateCacheAtBoot`; 0 disables — tests use that for determinism). Discovery, disable/uninstall handling, and per-file tool reconciliation stay live on every scan, and the ungated per-entry-file mtime check keeps single-file hook edits instant; only helper-edit detection defers, by at most the interval. Measured at 10 plugins × 100 source files (ext4, warm): ungated the walk costs ~3.6 ms of synchronous stat work per dispatch (~110 ms cumulative across a 10-iteration turn); gated, dispatch cost is ~1.0 ms, all of it pre-existing discovery overhead.
- **`plugin-api/types.ts`**: new `ShutdownReason` variant `"reload"` so plugins can distinguish an in-place redeploy from uninstall/disable/process exit.
- **Bonus fix**: this closes the tool staleness hole flagged in #37135 — an edited tool file previously re-imported into the cache but served the stale module, and the global tool registry kept the old registration. The redeploy re-registers the freshly imported definition. (This also clears the path for deleting the tool registry in favor of per-dispatch filesystem resolution: invalidation is now owned by the fingerprint, loading by the runtime's module cache.)
- **Still out of scope by design**: imports reaching *outside* the plugin dir stay cached (module identity for shared deps is a feature); standalone workspace hooks remain single-file surfaces (every file in that directory is treated as a hook, so helpers aren't a supported layout there).

## Test plan

- New `mtime-cache.test.ts` suite "plugin live reload (source fingerprint)": direct helper edit reloads (repeatably), transitive `hook → a → b` edit reloads consistently, a reload runs the old `shutdown` with reason `"reload"` plus the new `init`, no-change scans don't redeploy (guards against redeploy storms on the per-turn dispatch path), the fingerprint pass is rate-limited by the scan interval (an edit inside the window is deferred, not lost), and an edited tool serves its new definition from the **global registry**, not just the cache.
- Mutation-checked both mechanisms independently: disabling fingerprint comparison fails 4 tests; disabling only the module-eviction sweep fails 3.
- Benchmarked at 10 plugins × 100 files: fingerprint pass 3.6 ms warm mean (13.5 ms cold); end-to-end dispatch 5.8 ms ungated → 1.0 ms gated.
- All existing machinery suites green run per-file as CI does (`hook-live-reload`, `mtime-cache`, `plugin-bootstrap`, `plugin-config-data-migration`, `plugin-disabled-state`, `plugin-effective-enabled-set`, `user-plugin-loader`).
- eslint, prettier, and `tsc --noEmit` clean via pre-commit and pre-push hooks.

## CLI verb checklist

No new routes — daemon-internal loader/scan change plus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP