### PR TITLE
fix(onboarding): stop iOS auto-zoom on onboarding inputs (LUM-2597)

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -31,6 +31,8 @@ import { Plus, Search } from "lucide-react";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { cn } from "@vellumai/design-library/utils/cn";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 /** Field shell shared by both fields — label + token-matched container. */
 const FIELD_BOX = cn(
   "flex w-full items-center gap-1.5 rounded-md border bg-[var(--field-bg)] px-3",
@@ -41,6 +43,8 @@ const FIELD_BOX = cn(
 const BARE_INPUT = cn(
   "min-w-0 flex-1 bg-transparent text-body-medium-lighter text-[var(--content-default)]",
   "placeholder:text-[var(--content-tertiary)] outline-none",
+  // iOS auto-zoom guard — render at 16px on touch phones. See LUM-2597.
+  MOBILE_INPUT_NO_ZOOM,
 );
 
 function normalize(value: string): string {

--- a/clients/web/src/domains/onboarding/onboarding-step-layout.ts
+++ b/clients/web/src/domains/onboarding/onboarding-step-layout.ts
@@ -8,3 +8,13 @@
  */
 export const ONBOARDING_STEP_CONTENT =
   "absolute left-1/2 top-[30%] z-10 flex w-full -translate-x-1/2 flex-col items-center gap-8 px-6 text-center";
+
+/**
+ * iOS Safari / WKWebView auto-zooms the viewport when a focused form control
+ * renders below 16px. The onboarding text inputs inherit the design-library
+ * 14px body size (`text-body-medium-lighter`), so append this to bump them to
+ * 16px on touch phones only — desktop and Electron keep the 14px design size
+ * via the `touch-mobile` guard (`width < 48rem` and `pointer: coarse`).
+ * See LUM-2597.
+ */
+export const MOBILE_INPUT_NO_ZOOM = "touch-mobile:text-[16px]";

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -19,6 +19,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 export function ApiKeyScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -188,6 +190,7 @@ export function ApiKeyScreen() {
                 placeholder={entry.apiKeyPlaceholder ?? "Enter your API key"}
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
+                className={MOBILE_INPUT_NO_ZOOM}
                 fullWidth
               />
               {entry.docsUrl && (

--- a/clients/web/src/domains/onboarding/screens/name-exchange-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/name-exchange-screen.tsx
@@ -9,6 +9,8 @@ import {
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 interface NameExchangeScreenProps {
   userName: string;
   assistantName: string;
@@ -77,6 +79,7 @@ export function NameExchangeScreen({
             placeholder="Your name"
             value={userName}
             onChange={(e) => onUserNameChange(e.target.value)}
+            className={MOBILE_INPUT_NO_ZOOM}
             fullWidth
           />
 
@@ -86,6 +89,7 @@ export function NameExchangeScreen({
               placeholder="Assistant name"
               value={assistantName}
               onChange={(e) => onAssistantNameChange(e.target.value)}
+              className={MOBILE_INPUT_NO_ZOOM}
               fullWidth
             />
 

--- a/clients/web/src/domains/onboarding/screens/name-step-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/name-step-screen.tsx
@@ -5,6 +5,8 @@ import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicato
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 interface NameStepScreenProps {
   userName: string;
   assistantName: string;
@@ -85,6 +87,7 @@ export function NameStepScreen({
               placeholder="Your name"
               value={userName}
               onChange={(e) => onUserNameChange(e.target.value)}
+              className={MOBILE_INPUT_NO_ZOOM}
               fullWidth
             />
 
@@ -94,6 +97,7 @@ export function NameStepScreen({
                 placeholder="Assistant name"
                 value={assistantName}
                 onChange={(e) => onAssistantNameChange(e.target.value)}
+                className={MOBILE_INPUT_NO_ZOOM}
                 fullWidth
               />
 

--- a/clients/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
@@ -11,6 +11,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 interface PriorAssistantSelectionScreenProps {
   selectedAssistants: Set<string>;
   onChange: (next: Set<string>) => void;
@@ -169,6 +171,7 @@ export function PriorAssistantSelectionScreen({
                 value={otherText}
                 onChange={(e) => setOtherText(e.target.value)}
                 helperText="Separate multiple assistants with commas"
+                className={MOBILE_INPUT_NO_ZOOM}
                 fullWidth
               />
               {otherEntries.length > 0 ? (

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -18,6 +18,8 @@ import { HOBBY_SUGGESTIONS } from "@/domains/onboarding/onboarding-suggestions";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 export interface ResearchOnboardingValues {
   firstName: string;
   lastName: string;
@@ -109,6 +111,7 @@ export function ResearchOnboardingScreen({
               placeholder="Your name"
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
+              className={MOBILE_INPUT_NO_ZOOM}
               autoFocus
               required
               fullWidth
@@ -121,6 +124,7 @@ export function ResearchOnboardingScreen({
               placeholder="Your last name (optional)"
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
+              className={MOBILE_INPUT_NO_ZOOM}
               fullWidth
             />
           </div>
@@ -131,6 +135,7 @@ export function ResearchOnboardingScreen({
               placeholder="What do you do for work?"
               value={role}
               onChange={(e) => setRole(e.target.value)}
+              className={MOBILE_INPUT_NO_ZOOM}
               required
               fullWidth
             />

--- a/clients/web/src/domains/onboarding/screens/tool-selection-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/tool-selection-screen.tsx
@@ -11,6 +11,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Input } from "@vellumai/design-library/components/input";
 
+import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+
 interface ToolSelectionScreenProps {
   selectedTools: Set<string>;
   onChange: (next: Set<string>) => void;
@@ -175,6 +177,7 @@ export function ToolSelectionScreen({
                 value={otherText}
                 onChange={(e) => setOtherText(e.target.value)}
                 helperText="Separate multiple tools with commas"
+                className={MOBILE_INPUT_NO_ZOOM}
                 fullWidth
               />
               {otherEntries.length > 0 ? (


### PR DESCRIPTION
## Problem

[LUM-2597](https://linear.app/vellum/issue/LUM-2597/ios-input-auto-zoom-design-library-input-renders-text-below-16px) — iOS Safari / WKWebView auto-zooms the viewport whenever a focused `<input>`/`<textarea>` renders **below 16px**. The onboarding text fields inherit the design-library body size `text-body-medium-lighter` (**14px**), so focusing any of them on a phone triggers an unwanted zoom and janky layout shift.

## Fix (mobile-only)

Add a documented shared constant in `onboarding-step-layout.ts`:

```ts
export const MOBILE_INPUT_NO_ZOOM = "touch-mobile:text-[16px]";
```

and apply it to the onboarding inputs. It bumps them to 16px **only** on touch phones via the codebase's existing `touch-mobile` variant (`@media (width < 48rem) and (pointer: coarse)`). Desktop and Electron keep the 14px design size — zero visual change off mobile.

Deliberately **not** touching the viewport meta / `maximum-scale` — `clients/web/docs/CAPACITOR.md` forbids disabling user scaling (it's an accessibility regression); the correct fix is the font-size floor.

### Scope
- **Fixed** (were 14px): `name-step`, `name-exchange`, `research-onboarding` (name / last name / role), `prior-assistant-selection`, `tool-selection`, `api-key` screens, and the hobbies `TagAutocompleteInput` (`BARE_INPUT`).
- **Unchanged** (already ≥16px): `persona-step` (`text-[16px]`), `give-me-a-face` (`text-lg` / 18px).
- Shared design-library `Input` primitive left untouched — fix is scoped to onboarding per the request.

## Verification
- `bunx tsc --noEmit` ✓
- `bun run lint` ✓ (0 errors)
- `bun run build` ✓ — confirmed the compiled CSS emits `.touch-mobile\:text-\[16px\]{font-size:16px}` **inside** `@media ((width<48rem)) and (pointer:coarse)`.

Recommend a visual QA pass in a mobile viewport (or the iOS shell) to confirm no zoom on focus across the onboarding steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)