### PR TITLE
refactor(assistant): drop the worker-only members from the persistence-lifecycle seam

### DIFF
--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -356,13 +356,6 @@ describe("delete paths route through the persistence-hook seam", () => {
       deletedBatches.push(ids);
     },
     async onAllConversationsCleared() {},
-    onWorkerStartup() {},
-    countMemoryBufferLines() {
-      return 0;
-    },
-    hasPkbBufferContent() {
-      return false;
-    },
   };
 
   beforeEach(() => {

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -17,8 +17,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { getHooksFor } from "../hooks/registry.js";
 import { RiskLevel } from "../permissions/types.js";
-import { guardPersistenceHooksByDisabledState } from "../plugins/defaults/memory/persistence-hooks-registration.js";
-import type { MessagePersistedEvent } from "../plugins/defaults/memory/persistence-lifecycle-seam.js";
 import {
   clearInjectorRegistry,
   getRegisteredInjectors,
@@ -257,110 +255,5 @@ describe("per-surface disabled-state filtering", () => {
 
     hooks = await getHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(0);
-  });
-
-  test("persistence hooks no-op while the memory plugin is disabled", async () => {
-    let calls = 0;
-    const bufferLines = 25;
-    const guarded = guardPersistenceHooksByDisabledState("default-memory", {
-      onMessagePersisted() {
-        calls++;
-      },
-      onConversationForked() {},
-      onConversationWiped() {
-        return 0;
-      },
-      onConversationDeleted() {},
-      onMessagesDeleted() {},
-      async onAllConversationsCleared() {},
-      onWorkerStartup() {},
-      countMemoryBufferLines() {
-        return bufferLines;
-      },
-      hasPkbBufferContent() {
-        return true;
-      },
-    });
-    const event: MessagePersistedEvent = {
-      messageId: "msg-1",
-      conversationId: "conv-1",
-      role: "user",
-      content: "[]",
-      createdAt: 0,
-    };
-
-    // Enabled: the wrapped handler runs.
-    await guarded.onMessagePersisted(event);
-    expect(calls).toBe(1);
-    // The gated queries return the real buffer state while enabled.
-    expect(guarded.countMemoryBufferLines()).toBe(25);
-    expect(guarded.hasPkbBufferContent()).toBe(true);
-
-    // Disable via sentinel — checked at call time, no restart needed.
-    await createSentinel("default-memory");
-    await guarded.onMessagePersisted(event);
-    expect(calls).toBe(1);
-    // Gated: reports empty buffers while disabled, so scheduled consolidation
-    // and filing stay inert.
-    expect(guarded.countMemoryBufferLines()).toBe(0);
-    expect(guarded.hasPkbBufferContent()).toBe(false);
-
-    // Re-enable.
-    await removeSentinel("default-memory");
-    await guarded.onMessagePersisted(event);
-    expect(calls).toBe(2);
-    expect(guarded.countMemoryBufferLines()).toBe(25);
-    expect(guarded.hasPkbBufferContent()).toBe(true);
-  });
-
-  test("cleanup persistence hooks run even while the memory plugin is disabled", async () => {
-    let wiped = 0;
-    let swept = 0;
-    const deleted: string[][] = [];
-    const convDeleted: string[] = [];
-    let cleared = 0;
-    const guarded = guardPersistenceHooksByDisabledState("default-memory", {
-      onMessagePersisted() {},
-      onConversationForked() {},
-      onConversationWiped() {
-        wiped++;
-        return 7;
-      },
-      onConversationDeleted(id) {
-        convDeleted.push(id);
-      },
-      onMessagesDeleted(ids) {
-        deleted.push(ids);
-      },
-      async onAllConversationsCleared() {
-        cleared++;
-      },
-      onWorkerStartup() {
-        swept++;
-      },
-      countMemoryBufferLines() {
-        return 0;
-      },
-      hasPkbBufferContent() {
-        return false;
-      },
-    });
-
-    await createSentinel("default-memory");
-
-    // Cleanup hooks are NOT gated: they must still run (and return real values)
-    // while disabled, or state created while enabled would be orphaned.
-    expect(guarded.onConversationWiped("conv-1")).toBe(7);
-    guarded.onConversationDeleted("conv-9");
-    guarded.onMessagesDeleted(["msg-1", "msg-2"]);
-    await guarded.onAllConversationsCleared();
-    guarded.onWorkerStartup();
-    expect(wiped).toBe(1);
-    expect(convDeleted).toEqual(["conv-9"]);
-    expect(deleted).toEqual([["msg-1", "msg-2"]]);
-    expect(cleared).toBe(1);
-    expect(swept).toBe(1);
-
-    await removeSentinel("default-memory");
   });
 });

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -218,7 +218,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../util/sqlite-retry.js",
     "../../../util/strip-comment-lines.js",
     "../../../util/worker-memory.js",
-    "../../disabled-state.js",
     "../../types.js",
     "../injection-presence.js",
     "../injector-order.js",

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-pkb-schedule.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-pkb-schedule.test.ts
@@ -71,15 +71,6 @@ const { enqueueMemoryJob } =
   await import("../../../../persistence/jobs-store.js");
 const { GRAPH_MAINTENANCE_CHECKPOINTS, maybeEnqueueGraphMaintenanceJobs } =
   await import("../jobs-worker.js");
-const { registerMemoryPersistenceHooks } =
-  await import("../persistence-lifecycle-seam.js");
-const { memoryPersistenceHooks } = await import("../persistence-hooks.js");
-
-// The scheduler reads the PKB buffer state through the persistence seam;
-// register the real memory implementation so `hasPkbBufferContent` reflects
-// the buffer files these tests write.
-registerMemoryPersistenceHooks(memoryPersistenceHooks);
-
 const FILING_KEY = GRAPH_MAINTENANCE_CHECKPOINTS.pkbFiling;
 const COMPACTION_KEY = GRAPH_MAINTENANCE_CHECKPOINTS.pkbCompaction;
 

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -57,7 +57,6 @@ afterAll(() => {
     process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
   }
   rmSync(tmpWorkspace, { recursive: true, force: true });
-  resetMemoryPersistenceHooksForTests();
 });
 
 const { getMemoryDb } =
@@ -70,15 +69,6 @@ const { applyNestedDefaults } = await import("../../../../config/loader.js");
 const { getMemoryCheckpoint, setMemoryCheckpoint, deleteMemoryCheckpoint } =
   await import("../../../../persistence/checkpoints.js");
 const { maybeEnqueueGraphMaintenanceJobs } = await import("../jobs-worker.js");
-const { registerMemoryPersistenceHooks, resetMemoryPersistenceHooksForTests } =
-  await import("../persistence-lifecycle-seam.js");
-const { memoryPersistenceHooks } = await import("../persistence-hooks.js");
-
-// The scheduler reads the memory buffer's line count through the persistence
-// seam; register the real memory implementation so `countMemoryBufferLines`
-// reflects the buffer files these tests write.
-registerMemoryPersistenceHooks(memoryPersistenceHooks);
-
 const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
 
 function buildConfig(overrides: {

--- a/assistant/src/plugins/defaults/memory/__tests__/persistence-lifecycle-seam.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/persistence-lifecycle-seam.test.ts
@@ -26,13 +26,6 @@ const baseHooks: MemoryPersistenceHooks = {
   onConversationDeleted() {},
   onMessagesDeleted() {},
   async onAllConversationsCleared() {},
-  onWorkerStartup() {},
-  countMemoryBufferLines() {
-    return 0;
-  },
-  hasPkbBufferContent() {
-    return false;
-  },
 };
 
 describe("memory persistence-lifecycle seam", () => {
@@ -41,18 +34,6 @@ describe("memory persistence-lifecycle seam", () => {
   test("defaults to a no-op when no implementation is registered", async () => {
     // Resolves without throwing — the "memory not present" path.
     await getMemoryPersistenceHooks().onMessagePersisted(event);
-  });
-
-  test("countMemoryBufferLines defaults to 0 when memory is not present", () => {
-    expect(getMemoryPersistenceHooks().countMemoryBufferLines()).toBe(0);
-  });
-
-  test("countMemoryBufferLines returns the registered implementation's count", () => {
-    registerMemoryPersistenceHooks({
-      ...baseHooks,
-      countMemoryBufferLines: () => 42,
-    });
-    expect(getMemoryPersistenceHooks().countMemoryBufferLines()).toBe(42);
   });
 
   test("getMemoryPersistenceHooks returns the registered implementation", async () => {

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { getConfig } from "../../../config/loader.js";
 import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
@@ -49,7 +51,10 @@ import {
 } from "../../../persistence/jobs-store.js";
 import { spawnMemoryWorkerProcess } from "../../../persistence/worker-control.js";
 import { getLogger } from "../../../util/logger.js";
-import { getMemoryPersistenceHooks } from "./persistence-lifecycle-seam.js";
+import { getWorkspaceDir } from "../../../util/platform.js";
+import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
+import { hasPkbBufferContent } from "./pkb-schedule.js";
+import { countBufferLines } from "./v2/consolidation-job.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -240,7 +245,7 @@ export function startInProcessMemoryJobsWorker(
   // left behind by daemon crashes mid-job. Best-effort — never block worker
   // startup on cleanup failures.
   try {
-    getMemoryPersistenceHooks().onWorkerStartup();
+    sweepOrphanMemoryRetrospectiveConversations();
   } catch (err) {
     log.warn(
       { err },
@@ -773,6 +778,11 @@ function isWithinPkbActiveHours(
   return hour >= start || hour < end;
 }
 
+/** Line count of the memory buffer, the scheduler's consolidation gate. */
+function memoryBufferLineCount(): number {
+  return countBufferLines(join(getWorkspaceDir(), "memory", "buffer.md"));
+}
+
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
@@ -846,10 +856,7 @@ export function maybeEnqueueGraphMaintenanceJobs(
       // The checkpoint advances so the next check fires after the regular
       // interval. Manual "Run now" is unaffected (routes layer, not schedule).
       if (jobType === consolidateEntry.jobType) {
-        if (
-          getMemoryPersistenceHooks().countMemoryBufferLines() <
-          MIN_BUFFER_LINES_FOR_CONSOLIDATION
-        ) {
+        if (memoryBufferLineCount() < MIN_BUFFER_LINES_FOR_CONSOLIDATION) {
           log.debug(
             "Scheduled consolidation skipped: buffer under minimum line threshold",
           );
@@ -884,7 +891,7 @@ export function maybeEnqueueGraphMaintenanceJobs(
     maxLines !== null &&
     !hasActiveJobOfType(consolidateEntry.jobType)
   ) {
-    if (getMemoryPersistenceHooks().countMemoryBufferLines() >= maxLines) {
+    if (memoryBufferLineCount() >= maxLines) {
       enqueueMemoryJob(
         consolidateEntry.jobType,
         AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD,
@@ -926,7 +933,7 @@ export function maybeEnqueueGraphMaintenanceJobs(
         intervalMs: filingConfig.intervalMs,
         jobType: "pkb_filing",
         enabled: filingConfig.enabled,
-        hasWork: () => getMemoryPersistenceHooks().hasPkbBufferContent(),
+        hasWork: () => hasPkbBufferContent(),
       },
       {
         key: GRAPH_MAINTENANCE_CHECKPOINTS.pkbCompaction,

--- a/assistant/src/plugins/defaults/memory/persistence-hooks-registration.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks-registration.ts
@@ -1,16 +1,10 @@
-import { isPluginDisabled } from "../../disabled-state.js";
-import memoryPkg from "./package.json" with { type: "json" };
 import { memoryPersistenceHooks } from "./persistence-hooks.js";
-import {
-  type MemoryPersistenceHooks,
-  registerMemoryPersistenceHooks,
-} from "./persistence-lifecycle-seam.js";
+import { registerMemoryPersistenceHooks } from "./persistence-lifecycle-seam.js";
 
 /**
  * Registration entry point for the memory plugin's persistence-lifecycle seam
  * (`persistence-lifecycle-seam.ts`): wires the plugin's handler implementation
- * (`persistence-hooks.ts`) into the seam's slot, wrapped in the disabled-state
- * guard.
+ * (`persistence-hooks.ts`) into the seam's slot.
  *
  * Kept separate from the seam module on purpose: this module transitively
  * imports persistence (through the handler implementation) while persistence
@@ -18,78 +12,12 @@ import {
  */
 
 /**
- * Wrap the plugin's persistence hooks so its ACTIVE side-effect hooks no-op while
- * the plugin is disabled (`assistant plugins disable <name>`), mirroring the
- * read-time disabled-state filtering the injector/hook/job-handler/tool surfaces
- * apply. The sentinel is checked per call, so enable/disable takes effect on the
- * next write without a daemon restart. CLEANUP hooks (`onConversationWiped`,
- * `onConversationDeleted`, `onMessagesDeleted`, `onAllConversationsCleared`,
- * `onWorkerStartup`) are intentionally NOT gated — they must run even when the
- * plugin is disabled so state created while it was enabled is not orphaned.
- */
-export function guardPersistenceHooksByDisabledState(
-  pluginName: string,
-  hooks: MemoryPersistenceHooks,
-): MemoryPersistenceHooks {
-  return {
-    onMessagePersisted(event) {
-      if (isPluginDisabled(pluginName)) return;
-      return hooks.onMessagePersisted(event);
-    },
-    onConversationForked(event) {
-      if (isPluginDisabled(pluginName)) return;
-      return hooks.onConversationForked(event);
-    },
-    // Gated like the active side effects above: a disabled plugin reports an
-    // empty buffer, so the maintenance scheduler treats it as "no buffered
-    // work" and skips consolidation — matching how disabled injectors/hooks go
-    // inert.
-    countMemoryBufferLines() {
-      if (isPluginDisabled(pluginName)) return 0;
-      return hooks.countMemoryBufferLines();
-    },
-    // Gated the same way: a disabled plugin reports an empty PKB buffer, so
-    // the maintenance scheduler skips scheduled filing.
-    hasPkbBufferContent() {
-      if (isPluginDisabled(pluginName)) return false;
-      return hooks.hasPkbBufferContent();
-    },
-    // Cleanup hooks are NOT gated on disabled-state: they must run even while
-    // the plugin is disabled, or jobs/conversations created while it was
-    // enabled would be orphaned.
-    onConversationWiped(conversationId) {
-      return hooks.onConversationWiped(conversationId);
-    },
-    onConversationDeleted(conversationId) {
-      return hooks.onConversationDeleted(conversationId);
-    },
-    onMessagesDeleted(messageIds) {
-      return hooks.onMessagesDeleted(messageIds);
-    },
-    onAllConversationsCleared() {
-      return hooks.onAllConversationsCleared();
-    },
-    onWorkerStartup() {
-      return hooks.onWorkerStartup();
-    },
-  };
-}
-
-/**
  * Install the memory feature's persistence-lifecycle handlers into the seam.
  * `bootstrapPlugins` calls this before the per-plugin init loop so the seam is
  * wired up front (the standalone memory jobs worker, which has no plugin
- * bootstrap, calls it directly); the handlers are guarded by
- * {@link guardPersistenceHooksByDisabledState} so a disabled memory plugin
- * drives no persistence side effects and re-enabling it takes effect on the
- * next write. The seam holds a single handler set, so this replaces any prior
- * registration.
+ * bootstrap, calls it directly). The seam holds a single handler set, so this
+ * replaces any prior registration.
  */
 export function registerDefaultPluginPersistenceHooks(): void {
-  registerMemoryPersistenceHooks(
-    guardPersistenceHooksByDisabledState(
-      memoryPkg.name,
-      memoryPersistenceHooks,
-    ),
-  );
+  registerMemoryPersistenceHooks(memoryPersistenceHooks);
 }

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,29 +1,23 @@
-import { join } from "node:path";
-
 import { getConfig } from "../../../config/loader.js";
 import {
   clearMessagesLexicalIndex,
   enqueueDeleteMessageLexical,
   enqueuePurgeConversationLexical,
 } from "../../../persistence/job-handlers/message-lexical.js";
-import { getWorkspaceDir } from "../../../util/platform.js";
 import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
-import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
 import type {
   ConversationForkedEvent,
   MemoryPersistenceHooks,
   MessagePersistedEvent,
 } from "./persistence-lifecycle-seam.js";
-import { hasPkbBufferContent as pkbBufferHasContent } from "./pkb-schedule.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 import {
   forkActivationState,
   seedForkActivationState,
 } from "./v2/activation-store.js";
-import { countBufferLines } from "./v2/consolidation-job.js";
 import {
   extractInjectedConceptSlugs,
   readInjectedBlock,
@@ -153,17 +147,5 @@ export const memoryPersistenceHooks: MemoryPersistenceHooks = {
     // after clear-all could upsert into the not-yet-dropped collection and then
     // be erased when the drop lands.
     await clearMessagesLexicalIndex(getConfig());
-  },
-
-  onWorkerStartup(): void {
-    sweepOrphanMemoryRetrospectiveConversations();
-  },
-
-  countMemoryBufferLines(): number {
-    return countBufferLines(join(getWorkspaceDir(), "memory", "buffer.md"));
-  },
-
-  hasPkbBufferContent(): boolean {
-    return pkbBufferHasContent();
   },
 };

--- a/assistant/src/plugins/defaults/memory/persistence-lifecycle-seam.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-lifecycle-seam.ts
@@ -134,31 +134,6 @@ export interface MemoryPersistenceHooks {
    * collection that is about to be dropped).
    */
   onAllConversationsCleared(): Promise<void>;
-
-  /**
-   * The background-job worker is starting. The memory feature sweeps orphan
-   * retrospective conversations left by a crash mid-job. Best-effort; the caller
-   * wraps it in try/catch. Cleanup — runs even while the plugin is disabled.
-   */
-  onWorkerStartup(): void;
-
-  /**
-   * Current line count of the memory buffer (`memory/buffer.md`). The
-   * maintenance scheduler reads it to gate scheduled consolidation — skip a
-   * scheduled run below a floor, force one above a ceiling. Returns 0 when
-   * memory is not present, which the scheduler reads as "no buffered work" and
-   * therefore no consolidation.
-   */
-  countMemoryBufferLines(): number;
-
-  /**
-   * Whether the PKB buffer (`pkb/buffer.md`) has any filable content. The
-   * maintenance scheduler reads it to gate the scheduled `pkb_filing` job —
-   * an empty buffer means no work, so no LLM run. Returns false when memory
-   * is not present, which the scheduler reads as "no buffered work" and
-   * therefore no filing.
-   */
-  hasPkbBufferContent(): boolean;
 }
 
 const NOOP: MemoryPersistenceHooks = {
@@ -170,13 +145,6 @@ const NOOP: MemoryPersistenceHooks = {
   onConversationDeleted() {},
   onMessagesDeleted() {},
   async onAllConversationsCleared() {},
-  onWorkerStartup() {},
-  countMemoryBufferLines() {
-    return 0;
-  },
-  hasPkbBufferContent() {
-    return false;
-  },
 };
 
 let current: MemoryPersistenceHooks = NOOP;


### PR DESCRIPTION
## Prompt / plan

The "free win" slice of the seam→hooks migration: with the jobs worker now living inside the memory plugin (#37134), three of the seam's nine members were plugin-internal calls dressed up as a cross-layer contract — `onWorkerStartup`, `countMemoryBufferLines`, and `hasPkbBufferContent` were only ever invoked by the worker. They don't need the seam or the future hooks system; they need a plain sibling import.

- **`jobs-worker.ts`** now calls the implementations directly: the startup sweep via `sweepOrphanMemoryRetrospectiveConversations()`, the consolidation gate via a plain buffer-line read, and the filing gate via `hasPkbBufferContent()`.
- **No disabled-state self-checks come along** (review feedback): the harness owns disabled state — a plugin disabled at boot never starts the worker, and a runtime disable fires the plugin's `shutdown` hook, which stops it. For the same reason `guardPersistenceHooksByDisabledState` is **deleted outright**: registration installs `memoryPersistenceHooks` directly, and the memory plugin no longer imports `disabled-state.js` at all — the import baseline ratchets down.
- **The seam shrinks to the six `conversation-crud` lifecycle events** (persist, fork, wipe, delete, messages-deleted, clear-all) — precisely the surface the remaining hooks-system migration has to absorb.
- **The schedule tests no longer register the seam at all** — the scheduler reads the workspace directly, so the `registerMemoryPersistenceHooks(memoryPersistenceHooks)` scaffolding in `jobs-worker-pkb-schedule` and `jobs-worker-v2-schedule` is gone.

One deliberate nuance: the worker-startup sweep previously no-opped when the seam wasn't registered (memory absent); it now always runs at worker startup — correct, since the worker *is* the memory plugin, and the call was already best-effort/try-catch-wrapped.

Import-cycle set verified byte-identical to main (SCC pass).

## Test plan

- v2-schedule (21) and pkb-schedule (8) pass *without* seam registration — proving the direct reads.
- Seam suite reflects the smaller contract (7); disabled-state suite drops the deleted guard's tests (7); lexical dual-write (18), clear-all (3), conversation-wipe (4), filing-jobs (4), jobs-worker-memory-disabled (2), lanes (1), backoff (3), disk-pressure (2), job-handler-registration guard (3), plugin-bootstrap (12), both import guards (8, memory baseline drops `disabled-state.js`).
- `tsc` clean, eslint/prettier clean (pre-commit + pre-push hooks).

## CLI verb checklist

No new routes.