### PR TITLE
feat(platform): add 'assistant platform credits' command for remaining balance

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21295,6 +21295,44 @@ paths:
                   showPlatformLogin:
                     type: boolean
                 additionalProperties: false
+  /v1/platform/credits:
+    get:
+      operationId: platform_credits_get
+      summary: Get the organization's remaining credit balance
+      description:
+        Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform
+        billing summary.
+      tags:
+        - platform
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  remaining:
+                    type: number
+                  settled:
+                    type: number
+                  pending:
+                    type: number
+                  unit:
+                    type: string
+                    const: USD
+                  stale:
+                    type: boolean
+                  as_of:
+                    type: string
+                required:
+                  - remaining
+                  - settled
+                  - pending
+                  - unit
+                  - stale
+                  - as_of
+                additionalProperties: false
   /v1/platform/disconnect:
     post:
       operationId: platform_disconnect_post

--- a/assistant/src/cli/commands/platform/__tests__/credits.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/credits.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockCalls: Array<[string, Record<string, unknown>]> = [];
+let mockResponse: unknown = {
+  ok: true,
+  result: {
+    remaining: 42.17,
+    settled: 50,
+    pending: 7.83,
+    unit: "USD",
+    stale: false,
+    as_of: "2026-07-06T00:00:00.000Z",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
+    mockCalls.push([method, params]);
+    return mockResponse;
+  },
+  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
+    throw new Error("exitFromIpcResult called");
+  },
+}));
+
+const { registerPlatformCommand } = await import("../index.js");
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPlatformCommand(program);
+  return program;
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  return fn()
+    .then(() => chunks)
+    .finally(() => {
+      process.stdout.write = origWrite;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant platform credits", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = {
+      ok: true,
+      result: {
+        remaining: 42.17,
+        settled: 50,
+        pending: 7.83,
+        unit: "USD",
+        stale: false,
+        as_of: "2026-07-06T00:00:00.000Z",
+      },
+    };
+    process.exitCode = 0;
+  });
+
+  test("calls platform_credits and emits balance JSON with --json", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync([
+        "node",
+        "assistant",
+        "platform",
+        "credits",
+        "--json",
+      ]);
+    });
+
+    expect(mockCalls[0][0]).toBe("platform_credits");
+
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.remaining).toBe(42.17);
+    expect(parsed.settled).toBe(50);
+    expect(parsed.pending).toBe(7.83);
+    expect(parsed.unit).toBe("USD");
+    expect(parsed.stale).toBe(false);
+  });
+
+  test("plain text mode does not emit JSON to stdout", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync(["node", "assistant", "platform", "credits"]);
+    });
+
+    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    expect(() => JSON.parse(out.join("").trim())).toThrow();
+  });
+});

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -25,6 +25,15 @@ interface PlatformStatusResult {
   velayTunnel: { connected: boolean; publicUrl: string | null } | null;
 }
 
+interface PlatformCreditsResult {
+  remaining: number;
+  settled: number;
+  pending: number;
+  unit: "USD";
+  stale: boolean;
+  as_of: string;
+}
+
 export function registerPlatformCommand(program: Command): void {
   registerCommand(program, {
     name: "platform",
@@ -47,6 +56,7 @@ assistants.
 
 Examples:
   $ assistant platform status --json
+  $ assistant platform credits --json
   $ assistant platform connect
   $ assistant platform disconnect
   $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json`,
@@ -95,7 +105,11 @@ Examples:
             "platform_status",
             {},
           );
-          if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
 
           const result = r.result!;
 
@@ -114,7 +128,9 @@ Examples:
             log.info(
               `Callback registration available: ${result.available ? "yes" : "no"}`,
             );
-            log.info(`Organization ID: ${result.organizationId || "(not set)"}`);
+            log.info(
+              `Organization ID: ${result.organizationId || "(not set)"}`,
+            );
             log.info(`User ID: ${result.userId || "(not set)"}`);
             if (result.velayTunnel !== null) {
               const tunnelState = result.velayTunnel.connected
@@ -124,6 +140,64 @@ Examples:
             } else {
               log.info(`Velay tunnel: (gateway not running)`);
             }
+          }
+        });
+
+      // -----------------------------------------------------------------------
+      // credits
+      // -----------------------------------------------------------------------
+
+      platform
+        .command("credits")
+        .description("Show the organization's remaining credit balance")
+        .addHelpText(
+          "after",
+          `
+Fetches the org's credit balance from the platform billing summary.
+
+Fields:
+  remaining   Effective balance (settled minus pending charges) in USD
+  settled     On-ledger balance in USD
+  pending     Estimated pending compute charges not yet settled, in USD
+  unit        Balance currency (USD)
+  stale       True when pending-charge data may be stale or unavailable
+  as_of       When this balance was read (response receipt time)
+
+Combine with 'assistant usage daily' to compute runway (remaining divided
+by rolling daily average) and warn before credits run out.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform credits
+  $ assistant platform credits --json`,
+        )
+        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+          const r = await cliIpcCall<PlatformCreditsResult>(
+            "platform_credits",
+            {},
+          );
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+
+          const result = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, result);
+          } else {
+            const staleNote = result.stale
+              ? " (pending data may be stale)"
+              : "";
+            log.info(
+              `Remaining: $${result.remaining.toFixed(2)} ${result.unit} (as of ${result.as_of})${staleNote}`,
+            );
+            log.info(
+              `Settled:   $${result.settled.toFixed(2)}   Pending: $${result.pending.toFixed(2)}`,
+            );
           }
         });
 
@@ -209,7 +283,11 @@ Examples:
           }>("platform_callback_routes_register", {
             body: { path: opts.path, type: opts.type },
           });
-          if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
 
           writeOutput(cmd, { ok: true, ...r.result });
 
@@ -248,7 +326,11 @@ Examples:
               callback_url: string;
             }>;
           }>("platform_callback_routes_list", {});
-          if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
 
           const routes = r.result!.routes;
 

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Platform route handlers for the shared HTTP/IPC route table.
  *
- * Serves five operations:
+ * Serves six operations:
  *   - platform_status (GET platform/status): aggregates platform context,
  *     credentials, assistant ID, webhook secret, and Velay tunnel status.
  *   - platform_connect (POST platform/connect): checks existing credentials
@@ -403,7 +403,7 @@ async function handlePlatformCredits(
     settled_balance_usd: string;
     pending_compute_usd: string;
     effective_balance_usd: string;
-    stale: boolean;
+    is_degraded: boolean;
   };
 
   return {
@@ -411,9 +411,9 @@ async function handlePlatformCredits(
     settled: Number(summary.settled_balance_usd),
     pending: Number(summary.pending_compute_usd),
     unit: "USD",
-    stale: summary.stale,
-    // ponytail: as_of is response receipt time; add a server as_of field if the
-    // billing summary endpoint ever returns one.
+    stale: summary.is_degraded,
+    // as_of is response receipt time; add a server as_of field if the billing
+    // summary endpoint ever returns one.
     as_of: new Date().toISOString(),
   };
 }

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -12,6 +12,8 @@
  *     registers a callback route with the platform gateway.
  *   - platform_callback_routes_list (GET platform/callback-routes): lists
  *     registered callback routes for this assistant.
+ *   - platform_credits (GET platform/credits): fetches the org's remaining
+ *     credit balance from the platform billing summary.
  */
 
 import { z } from "zod";
@@ -117,6 +119,16 @@ const CallbackRoutesListResponseSchema = z.object({
 type CallbackRoutesListResponse = z.infer<
   typeof CallbackRoutesListResponseSchema
 >;
+
+const PlatformCreditsResponseSchema = z.object({
+  remaining: z.number(),
+  settled: z.number(),
+  pending: z.number(),
+  unit: z.literal("USD"),
+  stale: z.boolean(),
+  as_of: z.string(),
+});
+type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -352,6 +364,60 @@ async function handleCallbackRoutesList(
   return { routes };
 }
 
+async function handlePlatformCredits(
+  _args: RouteHandlerArgs,
+): Promise<PlatformCreditsResponse> {
+  const context = await resolvePlatformCallbackRegistrationContext();
+
+  if (!context.platformBaseUrl || !context.authHeader) {
+    throw new UnprocessableEntityError(
+      "Platform credentials not available — run 'assistant platform connect' or set VELLUM_PLATFORM_URL",
+    );
+  }
+
+  const url = `${context.platformBaseUrl}/v1/organizations/billing/summary/`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: context.authHeader,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    throw new InternalError(
+      `Failed to fetch credit balance: ${(err as Error).message}`,
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new InternalError(
+      `Failed to fetch credit balance (HTTP ${response.status}): ${detail}`,
+    );
+  }
+
+  const summary = (await response.json()) as {
+    settled_balance_usd: string;
+    pending_compute_usd: string;
+    effective_balance_usd: string;
+    stale: boolean;
+  };
+
+  return {
+    remaining: Number(summary.effective_balance_usd),
+    settled: Number(summary.settled_balance_usd),
+    pending: Number(summary.pending_compute_usd),
+    unit: "USD",
+    stale: summary.stale,
+    // ponytail: as_of is response receipt time; add a server as_of field if the
+    // billing summary endpoint ever returns one.
+    as_of: new Date().toISOString(),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -432,5 +498,20 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["platform"],
     handler: handleCallbackRoutesList,
     responseBody: CallbackRoutesListResponseSchema,
+  },
+  {
+    operationId: "platform_credits",
+    endpoint: "platform/credits",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get the organization's remaining credit balance",
+    description:
+      "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform billing summary.",
+    tags: ["platform"],
+    handler: handlePlatformCredits,
+    responseBody: PlatformCreditsResponseSchema,
   },
 ];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -204,6 +204,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "platform",
   "platform connect",
   "platform status",
+  "platform credits",
   "platform disconnect",
   "platform callback-routes",
   "platform callback-routes register",


### PR DESCRIPTION
## Summary
- Add a `platform_credits` shared route (GET `platform/credits`) that passes through the platform's `/v1/organizations/billing/summary/` endpoint and returns `remaining` (effective), `settled`, `pending` (all USD), `stale`, and `as_of`.
- Add an `assistant platform credits` CLI subcommand mirroring `platform status` — human-readable by default, `--json` for programmatic use (consistent with `assistant usage --json`).
- Register the new read-only `platform credits` path in the gateway bash risk registry.

## Original prompt
A Discord feature request (taminoferrari, #feedback) asked for a CLI command to read the assistant's remaining credit balance — today only consumption (`assistant usage`) is available, not the balance. A Jul 3 outage happened silently when platform credits ran out mid-heartbeat. The balance already exists server-side (`/v1/organizations/billing/summary/` returns settled/pending/effective USD), so this just exposes it through the assistant like the existing callback-routes passthrough. With balance + consumption the assistant can compute runway and warn proactively. Runway auto-warnings and last-top-up/auto-refill details were deliberately left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->