### PR TITLE
refactor(tools): register core tools only via the manifest, not import side effects

### DIFF
--- a/assistant/src/__tests__/file-edit-tool.test.ts
+++ b/assistant/src/__tests__/file-edit-tool.test.ts
@@ -9,15 +9,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 
-import { getTool } from "../tools/registry.js";
+import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 
 let fileEditTool: Tool;
 const testDirs: string[] = [];
 
 beforeAll(async () => {
-  await import("../tools/filesystem/edit.js");
-  fileEditTool = getTool("file_edit")!;
+  const { fileEditTool: definition } =
+    await import("../tools/filesystem/edit.js");
+  fileEditTool = finalizeTool(definition, "file_edit");
 });
 
 function makeContext(workingDir: string): ToolContext {

--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -9,15 +9,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 
-import { getTool } from "../tools/registry.js";
+import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 
 let fileReadTool: Tool;
 const testDirs: string[] = [];
 
 beforeAll(async () => {
-  await import("../tools/filesystem/read.js");
-  fileReadTool = getTool("file_read")!;
+  const { fileReadTool: definition } =
+    await import("../tools/filesystem/read.js");
+  fileReadTool = finalizeTool(definition, "file_read");
 });
 
 function makeContext(workingDir: string): ToolContext {

--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -50,15 +50,16 @@ function setWorkspaceDir(dir: string): void {
 }
 
 import { PKB_WORKSPACE_SCOPE } from "../plugins/defaults/memory/pkb/types.js";
-import { getTool } from "../tools/registry.js";
+import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 
 let fileWriteTool: Tool;
 const testDirs: string[] = [];
 
 beforeAll(async () => {
-  await import("../tools/filesystem/write.js");
-  fileWriteTool = getTool("file_write")!;
+  const { fileWriteTool: definition } =
+    await import("../tools/filesystem/write.js");
+  fileWriteTool = finalizeTool(definition, "file_write");
 });
 
 function makeContext(workingDir: string): ToolContext {

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -118,7 +118,7 @@ describe("plugin tool contributions", () => {
     resetPluginRegistryForTests();
     // Clear the tool registry completely so we can make vacuous-free
     // assertions about which tools are present. We don't need any of the
-    // eager/host tools for these tests.
+    // core/host tools for these tests.
     __clearRegistryForTesting();
     await rm(TEST_WORKSPACE_DIR, { recursive: true, force: true });
   });

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -20,7 +20,7 @@ import {
   unregisterSkillTools,
   unregisterWorkspaceTool,
 } from "../tools/registry.js";
-import { eagerModuleToolNames, explicitTools } from "../tools/tool-manifest.js";
+import { explicitTools } from "../tools/tool-manifest.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
 
 // Clean up global registry after this file completes to prevent
@@ -110,10 +110,6 @@ describe("tool registry dynamic-tools tools", () => {
 });
 
 describe("tool manifest", () => {
-  test("eager module tool names list contains expected count", () => {
-    expect(eagerModuleToolNames.length).toBe(12);
-  });
-
   test("explicit tools list includes memory tools", () => {
     const names = explicitTools.map((t) => t.name);
     expect(names).toContain("recall");
@@ -121,10 +117,12 @@ describe("tool manifest", () => {
     expect(names).toContain("remember");
   });
 
-  test("registered tool count is at least eager + host", async () => {
+  test("initializeTools registers every explicit manifest tool", async () => {
     await initializeTools();
-    const tools = getAllTools();
-    expect(tools.length).toBeGreaterThanOrEqual(eagerModuleToolNames.length);
+    const registered = new Set(getAllTools().map((t) => t.name));
+    for (const tool of explicitTools) {
+      expect(registered.has(tool.name!), `expected "${tool.name}"`).toBe(true);
+    }
   });
 });
 
@@ -156,7 +154,7 @@ describe("baseline characterization: hardcoded tool loading", () => {
     }
   });
 
-  test("gmail tool names are NOT in eagerModuleToolNames manifest", () => {
+  test("gmail tool names are NOT in the explicit tool manifest", () => {
     const gmailTools = [
       "gmail_search",
       "gmail_list_messages",
@@ -169,8 +167,9 @@ describe("baseline characterization: hardcoded tool loading", () => {
       "gmail_send",
       "gmail_unsubscribe",
     ];
+    const explicitNames = explicitTools.map((t) => t.name);
     for (const name of gmailTools) {
-      expect(eagerModuleToolNames).not.toContain(name);
+      expect(explicitNames).not.toContain(name);
     }
   });
 });

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -54,8 +54,7 @@ mock.module("../config/loader.js", () => ({
   ],
 }));
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 function writeSkill(
   skillId: string,
@@ -74,8 +73,7 @@ function writeSkill(
 async function executeSkillLoad(
   input: Record<string, unknown>,
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir: "/tmp",

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -97,8 +97,7 @@ mock.module("../config/loader.js", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -120,8 +119,7 @@ async function executeSkillLoad(
   input: Record<string, unknown>,
   workingDir = "/tmp",
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir,

--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -101,8 +101,7 @@ mock.module("../config/loader.js", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -132,8 +131,7 @@ async function executeSkillLoad(
   input: Record<string, unknown>,
   workingDir = "/tmp",
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir,

--- a/assistant/src/__tests__/skill-load-plugin-scope.test.ts
+++ b/assistant/src/__tests__/skill-load-plugin-scope.test.ts
@@ -156,8 +156,7 @@ mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => catalogSummaries,
 }));
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 const REJECTION = "not available in this conversation";
 
@@ -165,8 +164,7 @@ async function loadWithScope(
   enabledPluginSet: Set<string> | null | undefined,
   selector = "plug-skill",
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
   const result = await tool.execute(
     { skill: selector },
     {

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -23,8 +23,7 @@ mock.module("../skills/catalog-install.js", () => ({
   resolveCatalog: (_skillId?: string) => Promise.resolve([]),
 }));
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 function writeSkill(
   skillId: string,
@@ -89,8 +88,7 @@ function writeToolsJson(
 async function executeSkillLoad(
   input: Record<string, unknown>,
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir: "/tmp",
@@ -103,8 +101,7 @@ async function executeSkillLoad(
 async function executeSkillLoadCleanup(
   input: Record<string, unknown>,
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir: "/tmp",

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -224,9 +224,7 @@ describe("shell tool — process cleanup on AbortSignal", () => {
 
 describe("file tools — abort signal pre-check", () => {
   test("file_write tool: execute still succeeds when context has no signal", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/filesystem/write.js");
-    const fileWriteTool = getTool("file_write")!;
+    const { fileWriteTool } = await import("../tools/filesystem/write.js");
     const dir = makeTempDir();
 
     const result = await fileWriteTool.execute(
@@ -239,9 +237,7 @@ describe("file tools — abort signal pre-check", () => {
   });
 
   test("file_write tool: execute succeeds with a non-aborted signal", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/filesystem/write.js");
-    const fileWriteTool = getTool("file_write")!;
+    const { fileWriteTool } = await import("../tools/filesystem/write.js");
     const dir = makeTempDir();
     const ac = new AbortController();
 
@@ -255,9 +251,7 @@ describe("file tools — abort signal pre-check", () => {
   });
 
   test("file_read tool: execute succeeds when context has no signal", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/filesystem/read.js");
-    const fileReadTool = getTool("file_read")!;
+    const { fileReadTool } = await import("../tools/filesystem/read.js");
     const dir = makeTempDir();
     writeFileSync(join(dir, "read-me.txt"), "content to read");
 
@@ -271,9 +265,7 @@ describe("file tools — abort signal pre-check", () => {
   });
 
   test("file_read tool: execute succeeds with a non-aborted signal", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/filesystem/read.js");
-    const fileReadTool = getTool("file_read")!;
+    const { fileReadTool } = await import("../tools/filesystem/read.js");
     const dir = makeTempDir();
     writeFileSync(join(dir, "read-me2.txt"), "readable");
     const ac = new AbortController();
@@ -292,14 +284,11 @@ describe("file tools — abort signal pre-check", () => {
     // regardless of the signal. The ToolExecutor.execute() wrapper is
     // responsible for checking signal.aborted before dispatching; the tool
     // itself is not expected to check it. This test documents that contract.
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/filesystem/write.js");
+    const { fileWriteTool } = await import("../tools/filesystem/write.js");
 
     const dir = makeTempDir();
     const ac = new AbortController();
     ac.abort(); // pre-aborted
-
-    const fileWriteTool = getTool("file_write")!;
 
     // When invoked directly (not through ToolExecutor), the sync write runs.
     const result = await fileWriteTool.execute(
@@ -516,13 +505,8 @@ describe("WorkspaceGitService — abort signal propagation", () => {
 
 describe("bash (sandboxed) shell tool — process cleanup on AbortSignal", () => {
   test("kills child process when signal fires mid-execution", async () => {
-    // Import shell.ts (registered as 'bash') after mocks are in place.
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/terminal/shell.js");
-
-    // Assert registration — a missing tool signals a real regression, not a skip.
-    expect(getTool("bash")).toBeDefined();
-    const bashTool = getTool("bash")!;
+    // Import shell.ts (the 'bash' tool) after mocks are in place.
+    const { shellTool: bashTool } = await import("../tools/terminal/shell.js");
 
     const dir = makeTempDir();
     const ac = new AbortController();
@@ -540,11 +524,7 @@ describe("bash (sandboxed) shell tool — process cleanup on AbortSignal", () =>
   });
 
   test("kills child process immediately when signal is pre-aborted", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/terminal/shell.js");
-
-    expect(getTool("bash")).toBeDefined();
-    const bashTool = getTool("bash")!;
+    const { shellTool: bashTool } = await import("../tools/terminal/shell.js");
 
     const dir = makeTempDir();
     const ac = new AbortController();
@@ -559,11 +539,7 @@ describe("bash (sandboxed) shell tool — process cleanup on AbortSignal", () =>
   });
 
   test("short command completes normally with a non-aborted signal attached", async () => {
-    const { getTool } = await import("../tools/registry.js");
-    await import("../tools/terminal/shell.js");
-
-    expect(getTool("bash")).toBeDefined();
-    const bashTool = getTool("bash")!;
+    const { shellTool: bashTool } = await import("../tools/terminal/shell.js");
 
     const dir = makeTempDir();
     const ac = new AbortController();

--- a/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
+++ b/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
@@ -64,8 +64,7 @@ mock.module("../config/loader.js", () => ({
 
 // ── Imports (after mocks) ────────────────────────────────────────────────
 
-await import("../tools/skills/load.js");
-const { getTool } = await import("../tools/registry.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -80,8 +79,7 @@ async function executeSkillLoad(
   input: Record<string, unknown>,
   workingDir = "/tmp",
 ): Promise<{ content: string; isError: boolean }> {
-  const tool = getTool("skill_load");
-  if (!tool) throw new Error("skill_load tool was not registered");
+  const tool = skillLoadTool;
 
   const result = await tool.execute(input, {
     workingDir,

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -112,8 +112,8 @@ export async function initializeProvidersAndTools(
   await initializeTools();
 
   // Validate subagent role tool-allowlists against the now-registered core
-  // tool set (every allowlisted name is an eager core tool, so they are all
-  // present at this point). A renamed tool would otherwise silently strip a
+  // tool set (every allowlisted name is a core manifest tool, so they are
+  // all present at this point). A renamed tool would otherwise silently strip a
   // role's access — the stale name just never matches. Warn-and-continue per
   // the daemon startup philosophy: a stale allowlist is a logic bug, not a
   // reason to refuse boot.

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,5 +1,4 @@
 import { RiskLevel } from "../../permissions/types.js";
-import { registerTool } from "../registry.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatEditDiff } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
@@ -158,5 +157,3 @@ export const fileEditTool = {
     };
   },
 } satisfies ToolDefinition;
-
-registerTool(fileEditTool);

--- a/assistant/src/tools/filesystem/list.ts
+++ b/assistant/src/tools/filesystem/list.ts
@@ -1,5 +1,4 @@
 import { RiskLevel } from "../../permissions/types.js";
-import { registerTool } from "../registry.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
 import type {
@@ -86,5 +85,3 @@ export const fileListTool = {
     return { content: result.value.listing, isError: false };
   },
 } satisfies ToolDefinition;
-
-registerTool(fileListTool);

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -1,7 +1,6 @@
 import { extname } from "node:path";
 
 import { RiskLevel } from "../../permissions/types.js";
-import { registerTool } from "../registry.js";
 import {
   AUDIO_EXTENSIONS,
   readAudioFile,
@@ -127,5 +126,3 @@ export const fileReadTool = {
     return { content: result.value.content, isError: false };
   },
 } satisfies ToolDefinition;
-
-registerTool(fileReadTool);

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -5,7 +5,6 @@ import { minimatch } from "minimatch";
 import { RE2JS } from "re2js";
 
 import { RiskLevel } from "../../permissions/types.js";
-import { registerTool } from "../registry.js";
 import {
   isDeniedBasename,
   sandboxPolicy,
@@ -539,5 +538,3 @@ export const codeSearchTool = {
     };
   },
 } satisfies ToolDefinition;
-
-registerTool(codeSearchTool);

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -6,7 +6,6 @@ import { enqueuePkbIndexJob } from "../../plugins/defaults/memory/jobs/embed-pkb
 import { PKB_WORKSPACE_SCOPE } from "../../plugins/defaults/memory/pkb/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import { registerTool } from "../registry.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
@@ -185,5 +184,3 @@ export const fileWriteTool = {
     };
   },
 } satisfies ToolDefinition;
-
-registerTool(fileWriteTool);

--- a/assistant/src/tools/network/__tests__/web-fetch-firecrawl.test.ts
+++ b/assistant/src/tools/network/__tests__/web-fetch-firecrawl.test.ts
@@ -4,15 +4,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 let mockWebFetchProvider: string | undefined = "default";
 let mockFirecrawlSecureKey: string | undefined;
 
-// Capture the registered tool so we can exercise provider dispatch.
-let capturedTool: any = null;
-
-mock.module("../../registry.js", () => ({
-  registerTool: (tool: any) => {
-    capturedTool = tool;
-  },
-}));
-
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
     services: {
@@ -50,7 +41,8 @@ mock.module("../url-safety.js", () => ({
   resolveHostAddresses: async () => mockResolveAddresses,
 }));
 
-const { executeFirecrawlScrape } = await import("../web-fetch.js");
+const { executeFirecrawlScrape, webFetchTool } =
+  await import("../web-fetch.js");
 
 const SCRAPE_URL = "api.firecrawl.dev/v2/scrape";
 
@@ -204,18 +196,21 @@ describe("executeFirecrawlScrape", () => {
     expect(result.content).toContain("invalid JSON");
   });
 
-  test.each([401, 403])("surfaces %d as an invalid-key error", async (status) => {
-    globalThis.fetch = (async () =>
-      new Response("Unauthorized", { status })) as any;
+  test.each([401, 403])(
+    "surfaces %d as an invalid-key error",
+    async (status) => {
+      globalThis.fetch = (async () =>
+        new Response("Unauthorized", { status })) as any;
 
-    const result = await executeFirecrawlScrape(
-      { url: "https://example.com" },
-      { apiKey: "bad-key" },
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("Invalid or expired Firecrawl API key");
-    expect(result.activityMetadata?.webFetch?.provider).toBe("firecrawl");
-  });
+      const result = await executeFirecrawlScrape(
+        { url: "https://example.com" },
+        { apiKey: "bad-key" },
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Invalid or expired Firecrawl API key");
+      expect(result.activityMetadata?.webFetch?.provider).toBe("firecrawl");
+    },
+  );
 
   test("retries 429 then surfaces a rate-limit error", async () => {
     let callCount = 0;
@@ -241,7 +236,7 @@ describe("web_fetch provider dispatch", () => {
   let originalFetch: typeof globalThis.fetch;
 
   const execute = (input: Record<string, unknown>, ctx: any = {}) =>
-    capturedTool.execute(input, ctx);
+    webFetchTool.execute(input, ctx);
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
@@ -334,7 +329,9 @@ describe("web_fetch provider dispatch", () => {
       return new Response("", { status: 200 });
     }) as any;
 
-    const result = await execute({ url: "https://internal.example/secret?token=abc" });
+    const result = await execute({
+      url: "https://internal.example/secret?token=abc",
+    });
     expect(firecrawlHit).toBe(false); // internal URL never leaked to Firecrawl
     expect(result.isError).toBe(true);
     expect(result.activityMetadata?.webFetch?.provider).toBe("default");

--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -8,15 +8,6 @@ let mockBraveSecureKey: string | undefined;
 let mockPerplexitySecureKey: string | undefined;
 let mockTavilySecureKey: string | undefined;
 
-// Capture the registered tool
-let capturedTool: any = null;
-
-mock.module("../../registry.js", () => ({
-  registerTool: (tool: any) => {
-    capturedTool = tool;
-  },
-}));
-
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
     services: {
@@ -47,8 +38,8 @@ mock.module("../../../permissions/types.js", () => ({
   RiskLevel: { Low: "low", Medium: "medium", High: "high" },
 }));
 
-// Force the module to load (triggers registerTool)
-await import("../web-search.js");
+// Import after the mocks above so the module under test sees them.
+const { webSearchTool } = await import("../web-search.js");
 
 describe("web_search activity metadata", () => {
   let originalFetch: typeof globalThis.fetch;
@@ -65,8 +56,10 @@ describe("web_search activity metadata", () => {
     globalThis.fetch = originalFetch;
   });
 
-  function execute(input: Record<string, unknown>) {
-    return capturedTool.execute(input, {} as any);
+  // Return type is `any` so assertions can poke at provider-specific
+  // metadata shapes without narrowing at every site.
+  function execute(input: Record<string, unknown>): any {
+    return webSearchTool.execute(input, {} as any);
   }
 
   // ---- Brave --------------------------------------------------------------
@@ -221,9 +214,7 @@ describe("web_search activity metadata", () => {
     expect(meta.results[0].score).toBe(0.87);
     // PR 5 backfills a synthesized favicon URL via Google s2 when the
     // provider doesn't supply one, so this result now has a faviconUrl too.
-    expect(meta.results[1].faviconUrl).toContain(
-      "google.com/s2/favicons",
-    );
+    expect(meta.results[1].faviconUrl).toContain("google.com/s2/favicons");
     expect(meta.results[1].score).toBe(0.42);
   });
 
@@ -293,9 +284,7 @@ describe("web_search activity metadata", () => {
     const result = await execute({ query: "whitespace title" });
     const meta = result.activityMetadata?.webSearch;
     expect(meta).toBeDefined();
-    expect(meta.results[0].title).toBe(
-      "https://example.net/whitespace-title",
-    );
+    expect(meta.results[0].title).toBe("https://example.net/whitespace-title");
   });
 
   test("Tavily populates errorMessage on auth failure", async () => {

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -16,15 +16,6 @@ let mockManagedSearchProxyCalls: Array<{
   signal?: AbortSignal;
 }> = [];
 
-// Capture the registered tool
-let capturedTool: any = null;
-
-mock.module("../../registry.js", () => ({
-  registerTool: (tool: any) => {
-    capturedTool = tool;
-  },
-}));
-
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
     services: {
@@ -70,8 +61,8 @@ mock.module("../managed-search-proxy.js", () => ({
   },
 }));
 
-// Force the module to load (triggers registerTool)
-await import("../web-search.js");
+// Import after the mocks above so the module under test sees them.
+const { webSearchTool } = await import("../web-search.js");
 
 describe("web_search tool", () => {
   let originalFetch: typeof globalThis.fetch;
@@ -97,8 +88,10 @@ describe("web_search tool", () => {
     globalThis.fetch = originalFetch;
   });
 
-  function execute(input: Record<string, unknown>, context: any = {}) {
-    return capturedTool.execute(input, context);
+  // Return type is `any` so assertions can poke at provider-specific
+  // metadata shapes without narrowing at every site.
+  function execute(input: Record<string, unknown>, context: any = {}): any {
+    return webSearchTool.execute(input, context);
   }
 
   // ---- Input validation ---------------------------------------------------
@@ -733,10 +726,13 @@ describe("web_search tool", () => {
       capturedUrl = url;
       capturedBody = JSON.parse(init?.body as string);
       capturedHeaders = new Headers(init?.headers);
-      return new Response(JSON.stringify({ success: true, data: { web: [] } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ success: true, data: { web: [] } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }) as any;
 
     await execute({ query: "test query", count: 50, freshness: "pm" });
@@ -755,10 +751,13 @@ describe("web_search tool", () => {
     let capturedBody: any = null;
     globalThis.fetch = (async (_url: string, init?: RequestInit) => {
       capturedBody = JSON.parse(init?.body as string);
-      return new Response(JSON.stringify({ success: true, data: { web: [] } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ success: true, data: { web: [] } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }) as any;
 
     await execute({ query: "test", freshness: "invalid" });
@@ -769,10 +768,13 @@ describe("web_search tool", () => {
     mockWebSearchProvider = "firecrawl";
     mockFirecrawlSecureKey = "fc-key";
     globalThis.fetch = (async () => {
-      return new Response(JSON.stringify({ success: true, data: { web: [] } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ success: true, data: { web: [] } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }) as any;
 
     const result = await execute({ query: "obscure query" });
@@ -872,10 +874,13 @@ describe("web_search tool", () => {
     let capturedUrl = "";
     globalThis.fetch = (async (url: string) => {
       capturedUrl = url;
-      return new Response(JSON.stringify({ success: true, data: { web: [] } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ success: true, data: { web: [] } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }) as any;
 
     const result = await execute({ query: "fallback test" });

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -22,7 +22,6 @@ import {
   sleep,
 } from "../../util/retry.js";
 import { safeStringSlice } from "../../util/unicode.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -1352,7 +1351,11 @@ export async function executeFirecrawlScrape(
     }
 
     if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
-      const delayMs = getHttpRetryDelay(response, attempt, DEFAULT_BASE_DELAY_MS);
+      const delayMs = getHttpRetryDelay(
+        response,
+        attempt,
+        DEFAULT_BASE_DELAY_MS,
+      );
       log.warn(
         { attempt: attempt + 1, delayMs },
         "Firecrawl scrape rate limited, retrying",
@@ -1434,7 +1437,10 @@ export const webFetchTool = {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    if (getWebFetchProvider() === "firecrawl" && (await canRouteToFirecrawl(input))) {
+    if (
+      getWebFetchProvider() === "firecrawl" &&
+      (await canRouteToFirecrawl(input))
+    ) {
       const apiKey = await getProviderKeyAsync("firecrawl");
       if (apiKey) {
         return executeFirecrawlScrape(input, {
@@ -1450,5 +1456,3 @@ export const webFetchTool = {
     return executeWebFetch(input, { signal: context.signal });
   },
 } satisfies ToolDefinition;
-
-registerTool(webFetchTool);

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -15,7 +15,6 @@ import {
   getHttpRetryDelay,
   sleep,
 } from "../../util/retry.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -1270,5 +1269,3 @@ export const webSearchTool = {
     }
   },
 } satisfies ToolDefinition;
-
-registerTool(webSearchTool);

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -83,9 +83,8 @@ function getExternalTools(): Array<{ owner: OwnerInfo; tool: Tool }> {
 }
 
 // Snapshot of core tools captured after initializeTools() completes.
-// Used by __resetRegistryForTesting() to restore eager tools that cannot
-// be re-registered because ESM import caching prevents side effects
-// from running a second time.
+// Lets __resetRegistryForTesting() restore the core baseline synchronously,
+// without re-running the async initializeTools() bootstrap.
 let coreToolsSnapshot: Map<string, Tool> | null = null;
 
 // Tracks how many sessions are currently using each skill's tools.
@@ -168,10 +167,10 @@ function withProviderSafeToolName(tool: Tool): Tool {
 
 /**
  * Memoize `finalizeTool(definition, name)` by the definition reference so
- * idempotent re-registration (test reset helpers, module re-imports) stays a
- * silent no-op — the same `ToolDefinition` always finalizes to the same `Tool`
- * instance, and the existing `existing === tool` short-circuit below keeps
- * working.
+ * idempotent re-registration (e.g. repeated initializeTools() calls across
+ * test files) stays a silent no-op — the same `ToolDefinition` always
+ * finalizes to the same `Tool` instance, and the existing `existing === tool`
+ * short-circuit below keeps working.
  */
 const finalizedByDefinition = new WeakMap<ToolDefinition, Tool>();
 
@@ -934,23 +933,14 @@ export function getAllToolDefinitions(): Tool[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  const {
-    loadEagerModules,
-    eagerModuleToolNames,
-    explicitTools,
-    getCesToolsIfEnabled,
-    cesTools,
-  } = await import("./tool-manifest.js");
+  const { explicitTools, getCesToolsIfEnabled, cesTools } =
+    await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
   // registrations.  In production this is empty; in tests a non-skill tool
   // may have been registered before the first initializeTools() call.
   const preExisting = new Set(tools.keys());
 
-  // Import tool modules to trigger registration side effects.
-  await loadEagerModules();
-
-  // Explicit tool instances - no side-effect import required.
   for (const tool of explicitTools) {
     registerTool(tool);
   }
@@ -967,8 +957,8 @@ export async function initializeTools(): Promise<void> {
     ownersByName.set(tool.name, owner);
   }
 
-  // Host tools are registered explicitly so host access stays opt-in until
-  // this point in startup, rather than as module side effects.
+  // Host tools are registered here so host access stays opt-in until this
+  // point in startup.
   const hostTools = [
     hostFileReadTool,
     hostFileWriteTool,
@@ -995,15 +985,14 @@ export async function initializeTools(): Promise<void> {
   // arbitrary test tools that were registered before init.
   //
   // A pre-existing tool is included only if it is a known manifest tool
-  // (declared in eagerModuleToolNames, explicitTools, hostTools, or any
-  // registered external skill tool).  This handles ESM cache hits where
-  // eager-module tools are already in the registry before init ran.
+  // (declared in explicitTools, hostTools, or any registered external
+  // skill tool) — e.g. a test registered a manifest tool directly before
+  // its first initializeTools() call.
   if (!coreToolsSnapshot) {
     // Core tool literals always set `name` (verified by `registerTool` —
     // it throws on missing name). The `!` assertions reflect that
     // invariant at the iteration sites.
     const manifestToolNames = new Set<string>([
-      ...eagerModuleToolNames,
       ...explicitTools.map((t) => t.name!),
       ...extEntries.map(({ tool }) => tool.name),
       ...hostTools.map((t) => t.name!),
@@ -1089,9 +1078,8 @@ export async function syncFlagGatedTools(): Promise<void> {
  * when multiple test suites share a single Bun process.
  *
  * Restores core tools from a snapshot taken after the first
- * initializeTools() call, because ESM import caching means eager
- * side-effect modules will not re-register their tools on subsequent
- * initializeTools() calls.
+ * initializeTools() call, so the reset is synchronous and does not
+ * depend on re-running the async init bootstrap.
  */
 export function __resetRegistryForTesting(): void {
   tools.clear();

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -1,6 +1,5 @@
 import { RiskLevel } from "../../permissions/types.js";
 import { isUnparseableToolArgs } from "../../providers/unparseable-tool-args.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -200,5 +199,3 @@ export const skillExecuteTool = {
     };
   },
 } satisfies ToolDefinition;
-
-registerTool(skillExecuteTool);

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -25,7 +25,6 @@ import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDirDisplay } from "../../util/platform.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -608,4 +607,3 @@ export const skillLoadTool = {
     };
   },
 } satisfies ToolDefinition;
-registerTool(skillLoadTool);

--- a/assistant/src/tools/subagent/notify-parent.ts
+++ b/assistant/src/tools/subagent/notify-parent.ts
@@ -1,6 +1,5 @@
 import { RiskLevel } from "../../permissions/types.js";
 import { getSubagentManager } from "../../subagent/index.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -72,5 +71,3 @@ export const notifyParentTool = {
     return executeSubagentNotifyParent(input, context);
   },
 } satisfies ToolDefinition;
-
-registerTool(notifyParentTool);

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -1,5 +1,4 @@
 import { RiskLevel } from "../../permissions/types.js";
-import { registerTool } from "../registry.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -108,5 +107,3 @@ export const requestSystemPermissionTool = {
     };
   },
 } satisfies ToolDefinition;
-
-registerTool(requestSystemPermissionTool);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -27,7 +27,6 @@ import {
   getOrStartSession,
   getSessionEnv,
 } from "../network/script-proxy/index.js";
-import { registerTool } from "../registry.js";
 import {
   formatShellOutput,
   MAX_OUTPUT_LENGTH,
@@ -762,5 +761,3 @@ function buildKillTree(
     }
   };
 }
-
-registerTool(shellTool);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -30,54 +30,19 @@ import { requestSystemPermissionTool } from "./system/request-permission.js";
 import { shellTool } from "./terminal/shell.js";
 import type { ToolDefinition } from "./types.js";
 
-// ── Eager side-effect modules ───────────────────────────────────────
-// These static imports trigger top-level `registerTool()` side effects on
-// first evaluation. The named imports above serve double duty: they give us
-// module-level references to each tool instance so that initializeTools()
-// can explicitly re-register them after a test registry reset (ESM caching
-// prevents side effects from re-running on subsequent imports).
+// ── Explicit tool instances ─────────────────────────────────────────
+// Core tools registered by initializeTools(). Tool modules only export
+// their definitions — registration happens exclusively here, so importing
+// a tool module never mutates the registry.
 //
-// IMPORTANT: These MUST be static imports (not dynamic `await import()`).
+// IMPORTANT: The imports above MUST be static (not dynamic `await import()`).
 // When the daemon is compiled with `bun --compile`, dynamic imports with
 // relative string literals resolve against the virtual `/$bunfs/root/`
 // filesystem root rather than the module's own directory, causing
 // "Cannot find module './filesystem/read.js'" crashes in production builds.
 // Static imports are resolved at bundle time and are always safe.
 
-// loadEagerModules is a no-op now that all eager registrations happen via
-// static imports above. Kept for API compatibility with registry.ts callers.
-export function loadEagerModules(): Promise<void> {
-  return Promise.resolve();
-}
-
-// Tool names registered by the eager modules above.  Listed explicitly so
-// initializeTools() can recognise ESM-cached eager-module tools that were
-// already in the registry before init ran (e.g. when a test file imports
-// an eager module at the top level).
-export const eagerModuleToolNames: string[] = [
-  "bash",
-  "file_read",
-  "file_write",
-  "file_edit",
-  "file_list",
-  "code_search",
-  "web_search",
-  "web_fetch",
-  "skill_execute",
-  "skill_load",
-  "request_system_permission",
-  "notify_parent",
-];
-
-// ── Explicit tool instances ─────────────────────────────────────────
-// Tools registered by initializeTools() via explicit instance references.
-// This includes both previously-eager tools (referenced here so they survive
-// a test registry reset) and tools that have always been explicit.
-
 export const explicitTools: ToolDefinition[] = [
-  // Previously-eager tools - kept here so initializeTools() can re-register
-  // them after __resetRegistryForTesting() clears the registry (ESM caching
-  // prevents their side-effect registrations from re-running).
   shellTool,
   fileReadTool,
   fileWriteTool,
@@ -89,7 +54,6 @@ export const explicitTools: ToolDefinition[] = [
   skillExecuteTool,
   skillLoadTool,
   requestSystemPermissionTool,
-  // Always-explicit tools
   rememberTool,
   recallTool,
   notifyParentTool,


### PR DESCRIPTION
## Prompt / plan

Started from a discussion of why `initializeTools()` must be explicitly awaited instead of the registry lazily initializing on first read. That surfaced that the 12 "eager" core tool modules (`bash`, `file_*`, `code_search`, `web_*`, `skill_*`, `request_system_permission`, `notify_parent`) registered themselves into the global registry as a top-level side effect of being imported — **and** were also registered explicitly by `initializeTools()` via `explicitTools`, so every one was registered twice, with the `finalizedByDefinition` WeakMap memo papering over the duplication. `loadEagerModules()` had already decayed into a documented no-op kept only for API compatibility.

The change makes tool modules pure definition exports and `initializeTools()` the single registration path:

- Removed the top-level `registerTool(...)` call (and its import) from all 12 tool modules.
- Deleted `loadEagerModules()` and `eagerModuleToolNames` from `tool-manifest.ts` — both existed only to cope with the side-effect model (ESM caching meant side effects couldn't re-run, so init had to recognize pre-registered eager tools by name).
- Simplified `initializeTools()` and the core-snapshot bookkeeping accordingly, and updated comments that described the eager/side-effect model.
- Updated `registry.test.ts` assertions: the eager-count checks are replaced by a stronger one — every `explicitTools` entry is present in the registry after init.

Importing a tool module is now inert, which removes a class of ordering hazards this repo has been bitten by before (import-time side effects running before the per-test workspace override is set — see "Test machinery isolation" in `assistant/CLAUDE.md`).

## Test plan

- `bunx tsc --noEmit` clean.
- `bun test` (scoped, per repo convention) on: `registry.test.ts`, `always-loaded-tools-guard.test.ts`, `memory-worker-tool-registry-guard.test.ts`, `plugin-tool-contribution.test.ts`, `flag-gated-tools.test.ts`, plus every test file that imports one of the 12 modified tool modules (`terminal-tools`, `shell-credential-ref`, `background-shell-bash`, `shell-tool-proxy-mode`, `web-fetch`, `file-list-tool`, `code-search-tool`, `skill-execute-input`, `subagent-notify-parent`, `managed-skill-lifecycle`, `computer-use-skill-manifest-regression`, `browser-skill-*`, `workflows/leaf-runner`) — all pass individually.
- Note: running the shell-tool test files *combined in one bun process* shows failures on this branch — but the same combined run fails on the unmodified base too (pre-existing cross-file contamination; the repo's AGENTS.md mandates scoped runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMTJwVtEMgnh38Jzwfxspk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMTJwVtEMgnh38Jzwfxspk)_