### PR TITLE
feat(monitoring): run the resource monitor unconditionally at every daemon boot

### DIFF
--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -7,10 +7,13 @@
  *
  * Subcommands:
  *
- *   - `start`  — spawn the monitor process and enable `monitoring.enabled`.
- *   - `stop`   — SIGTERM the monitor process and disable `monitoring.enabled`.
- *   - `status` — report the monitor process state, `monitoring.enabled`,
- *     and the most recent memory/disk sample.
+ *   - `start`  — spawn the monitor process (or report the one already running).
+ *   - `stop`   — SIGTERM the monitor process until the next daemon boot.
+ *   - `status` — report the monitor process state and the most recent
+ *     memory/disk sample.
+ *
+ * The daemon spawns the monitor at every boot; there is no config switch.
+ * `stop` is a runtime-only pause for the current daemon session.
  *
  * All three are thin IPC wrappers (transport: "ipc"): the daemon owns the
  * monitor process so it is spawned as a *child of the daemon* — which is what
@@ -88,20 +91,17 @@ interface LatestSample {
 interface StartResponse {
   pid: number;
   alreadyRunning: boolean;
-  monitoringEnabled: true;
   pidPath: string;
 }
 
 interface StopResponse {
   monitoringWasRunning: boolean;
   pid?: number;
-  monitoringEnabled: false;
 }
 
 interface StatusResponse {
   status: "running" | "not_running";
   pid?: number;
-  monitoringEnabled: boolean;
   dataDir: string;
   latestSample: LatestSample | null;
 }
@@ -125,9 +125,10 @@ recording during a main-thread freeze and its samples survive an OOM SIGKILL.
 The daemon owns the process, so it is spawned as a child of the daemon and shows
 up in \`assistant ps\`.
 
-\`start\` enables monitoring.enabled (so it is respawned on the next boot)
-and \`stop\` disables it. Samples and high-memory snapshots are written under the
-data directory reported by \`status\`.
+The monitor runs by default — the daemon spawns it at every boot. \`stop\`
+pauses it for the current daemon session only; it respawns on the next boot.
+Samples and high-memory snapshots are written under the data directory
+reported by \`status\`.
 
 Examples:
   $ assistant monitoring start
@@ -137,9 +138,7 @@ Examples:
 
       monitor
         .command("start")
-        .description(
-          "Start the resource monitor process and enable monitoring.enabled",
-        )
+        .description("Start the resource monitor process")
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action(async (_opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<StartResponse>("monitoring_start");
@@ -157,15 +156,12 @@ Examples:
               ? `Resource monitor is already running (PID ${res.pid})`
               : `Resource monitor started (PID ${res.pid})`,
           );
-          log.info(
-            "Enabled monitoring.enabled; it will also be respawned automatically on future assistant starts",
-          );
         });
 
       monitor
         .command("stop")
         .description(
-          "Stop the resource monitor process and disable monitoring.enabled",
+          "Stop the resource monitor process until the next daemon boot",
         )
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action(async (_opts: { json?: boolean }, cmd: Command) => {
@@ -184,14 +180,12 @@ Examples:
           } else {
             log.info("Resource monitor process was not running");
           }
-          log.info("Disabled monitoring.enabled");
+          log.info("The monitor respawns on the next daemon boot");
         });
 
       monitor
         .command("status")
-        .description(
-          "Report the monitor process state, monitoring.enabled, and the latest sample",
-        )
+        .description("Report the monitor process state and the latest sample")
         .option("--json", "Emit raw JSON instead of a formatted summary")
         .action(async (_opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<StatusResponse>("monitoring_status");
@@ -209,7 +203,6 @@ Examples:
           } else {
             log.info("Resource monitor process is not running");
           }
-          log.info(`monitoring.enabled: ${res.monitoringEnabled}`);
           log.info(`Data directory: ${res.dataDir}`);
 
           const sample = res.latestSample;

--- a/assistant/src/config/schemas/monitoring.ts
+++ b/assistant/src/config/schemas/monitoring.ts
@@ -6,19 +6,13 @@ import { z } from "zod";
  * The resource monitor runs as a separate OS process (a child of the assistant)
  * that samples the container's own cgroup memory + workspace disk off the main
  * event loop, so it keeps recording during a main-thread freeze and its samples
- * survive an OOM SIGKILL. `assistant monitoring start`/`stop` flip
- * `enabled` (and spawn/stop the process) to switch it on or off at runtime
- * without a restart; when `enabled` is set the assistant also spawns it at
- * startup.
+ * survive an OOM SIGKILL. The assistant spawns it at every startup — it is
+ * platform infrastructure, not an opt-in feature, and there is deliberately no
+ * config switch to turn it off. `assistant monitoring start`/`stop` control the
+ * process at runtime only; a stopped monitor respawns on the next boot.
  */
 export const MonitoringConfigSchema = z
   .object({
-    enabled: z
-      .boolean({ error: "monitoring.enabled must be a boolean" })
-      .default(false)
-      .describe(
-        "Whether the resource monitor process runs. When set, the assistant spawns it at startup and it samples cgroup memory + workspace disk into a ring buffer on the workspace volume. `assistant monitoring start`/`stop` flip this flag at runtime.",
-      ),
     sampleIntervalMs: z
       .number({ error: "monitoring.sampleIntervalMs must be a number" })
       .int("monitoring.sampleIntervalMs must be an integer")

--- a/assistant/src/monitoring/__tests__/control.test.ts
+++ b/assistant/src/monitoring/__tests__/control.test.ts
@@ -2,8 +2,8 @@
  * Tests for the resource monitor process control surface.
  *
  * Focuses on the readiness wait (which gates whether `assistant monitoring
- * start` reports success and flips `monitoring.enabled`) and the PID-file
- * liveness probe, mirroring the memory worker's worker-control tests.
+ * start` reports success) and the PID-file liveness probe, mirroring the
+ * memory worker's worker-control tests.
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -48,13 +48,17 @@ function stubProcessKill(
 ): () => void {
   const original = process.kill.bind(process);
   process.kill = ((pid: number, signal?: string | number) => {
-    if ((signal ?? 0) !== 0) return true;
+    if ((signal ?? 0) !== 0) {
+      return true;
+    }
     if (permissionErrorPids.has(pid)) {
       const err = new Error("kill EPERM") as NodeJS.ErrnoException;
       err.code = "EPERM";
       throw err;
     }
-    if (livePids.has(pid)) return true;
+    if (livePids.has(pid)) {
+      return true;
+    }
     const err = new Error("kill ESRCH") as NodeJS.ErrnoException;
     err.code = "ESRCH";
     throw err;
@@ -218,7 +222,9 @@ describe("stopMonitoringWorkerProcess", () => {
     const signalled: Array<[number, string | number | undefined]> = [];
     const original = process.kill.bind(process);
     process.kill = ((pid: number, signal?: string | number) => {
-      if ((signal ?? 0) === 0) return true; // liveness probe
+      if ((signal ?? 0) === 0) {
+        return true;
+      } // liveness probe
       signalled.push([pid, signal]);
       return true;
     }) as typeof process.kill;

--- a/assistant/src/monitoring/__tests__/daemon-heartbeat.test.ts
+++ b/assistant/src/monitoring/__tests__/daemon-heartbeat.test.ts
@@ -1,36 +1,17 @@
 /**
  * Tests for the daemon heartbeat writer/reader against the per-test workspace.
- * The config loader is mocked so the `monitoring.enabled` gate can be
- * exercised both ways.
  */
 
-import { existsSync, rmSync } from "node:fs";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import * as actualLoader from "../../config/loader.js";
-
-// null → delegate to the real loader. bun's mock.module persists for the
-// whole process, so the mock must turn itself into a passthrough once this
-// suite finishes or it would poison later test files sharing the process.
-let monitoringEnabled: boolean | null = true;
-
-mock.module("../../config/loader.js", () => ({
-  ...actualLoader,
-  getConfigReadOnly: () =>
-    monitoringEnabled == null
-      ? actualLoader.getConfigReadOnly()
-      : { monitoring: { enabled: monitoringEnabled } },
-}));
-
-afterAll(() => {
-  monitoringEnabled = null;
-});
-
-const { getDaemonHeartbeatPath, readDaemonHeartbeat, touchDaemonHeartbeat } =
-  await import("../daemon-heartbeat.js");
+import {
+  getDaemonHeartbeatPath,
+  readDaemonHeartbeat,
+  touchDaemonHeartbeat,
+} from "../daemon-heartbeat.js";
 
 beforeEach(() => {
-  monitoringEnabled = true;
   try {
     rmSync(getDaemonHeartbeatPath());
   } catch {
@@ -61,13 +42,6 @@ describe("daemon heartbeat", () => {
     rmSync(getDaemonHeartbeatPath());
     touchDaemonHeartbeat();
     expect(readDaemonHeartbeat(Date.now())).not.toBeNull();
-  });
-
-  test("no-ops when monitoring is disabled", () => {
-    monitoringEnabled = false;
-    touchDaemonHeartbeat();
-    expect(existsSync(getDaemonHeartbeatPath())).toBe(false);
-    expect(readDaemonHeartbeat(Date.now())).toBeNull();
   });
 
   test("reader returns null for a missing file", () => {

--- a/assistant/src/monitoring/control.ts
+++ b/assistant/src/monitoring/control.ts
@@ -2,13 +2,12 @@
  * Shared control surface for the resource monitor *process* — the background OS
  * process whose entry point is `worker.ts`.
  *
- * Both the `assistant monitoring` CLI and the daemon lifecycle (when
- * `monitoring.enabled` is set) need to probe, spawn, and stop this process.
+ * Both the `assistant monitoring` CLI and the daemon lifecycle (which spawns
+ * the monitor at every boot) need to probe, spawn, and stop this process.
  * The generic PID-file mechanics live in `util/worker-process.ts`; this module
  * binds them to the monitor's PID path and entry point.
  */
 
-import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { getMonitoringPidPath } from "../util/platform.js";
 import {
@@ -69,13 +68,11 @@ export function stopMonitoringWorkerProcess(): WorkerProcessStatus {
 /**
  * Daemon-lifecycle entry point: spawn the monitor as a child of the daemon
  * (`detached: false`, so it appears in `assistant ps` and is torn down on
- * shutdown) when `monitoring.enabled` is set. Fire-and-forget — a monitor
- * failure must never block boot.
+ * shutdown). Runs on every boot — the monitor is platform infrastructure,
+ * not an opt-in feature. Fire-and-forget — a monitor failure must never
+ * block boot.
  */
 export function startMonitoring(): void {
-  if (!getConfig().monitoring.enabled) {
-    return;
-  }
   void spawnMonitoringWorkerProcess({ detached: false })
     .then((r) =>
       log.info(

--- a/assistant/src/monitoring/daemon-heartbeat.ts
+++ b/assistant/src/monitoring/daemon-heartbeat.ts
@@ -8,8 +8,8 @@
  * content is the daemon's pid, so the monitor knows which process's main
  * thread to inspect.
  *
- * Writes are gated on `monitoring.enabled` and never throw — the heartbeat is
- * diagnostics and must never break a tick.
+ * Writes never throw — the heartbeat is diagnostics and must never break a
+ * tick.
  */
 
 import {
@@ -21,7 +21,6 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { getConfigReadOnly } from "../config/loader.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 
 const HEARTBEAT_FILE = "daemon-heartbeat";
@@ -35,9 +34,6 @@ let pidWritten = false;
 /** Daemon-side: refresh the heartbeat mtime. Call from the watchdog tick. */
 export function touchDaemonHeartbeat(): void {
   try {
-    if (!getConfigReadOnly().monitoring.enabled) {
-      return;
-    }
     const path = getDaemonHeartbeatPath();
     // First touch of this process rewrites the content so the recorded pid is
     // ours, not a previous daemon's.

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -1,9 +1,9 @@
 /**
  * Standalone entry point for the resource monitor as its own OS process.
  *
- * Spawned by `assistant monitoring start` (and at daemon startup when
- * `monitoring.enabled` is set). Loads config, starts the sampling loop,
- * writes a PID file, and stays alive until SIGTERM/SIGINT.
+ * Spawned at every daemon startup (and on demand by `assistant monitoring
+ * start`). Loads config, starts the sampling loop, writes a PID file, and
+ * stays alive until SIGTERM/SIGINT.
  *
  * Running as a separate process — off the assistant's main event loop — is the
  * whole point: the sampler keeps recording during a main-thread freeze, and its
@@ -28,7 +28,9 @@ const log = getLogger("monitoring-worker");
 function cleanupPidFile(): void {
   const pidPath = getMonitoringPidPath();
   try {
-    if (existsSync(pidPath)) unlinkSync(pidPath);
+    if (existsSync(pidPath)) {
+      unlinkSync(pidPath);
+    }
   } catch {
     // best-effort
   }

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -4,10 +4,11 @@
  * The route handlers run inside the daemon and own the monitor process. We mock
  * monitoring-control, the config loader, and the sample ring buffer so the
  * tests assert handler behaviour:
- *   - start spawns as a daemon child (detached:false), enables the flag only on
- *     success, and throws on spawn failure (flag untouched).
- *   - stop disables the flag and signals the monitor.
- *   - status reports the monitor process, the flag, and the latest sample.
+ *   - start spawns as a daemon child (detached:false) and throws on spawn
+ *     failure.
+ *   - stop signals the monitor (a runtime pause — the daemon respawns it at
+ *     the next boot).
+ *   - status reports the monitor process and the latest sample.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -21,12 +22,9 @@ class FakeSpawnError extends Error {}
 let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
 let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
 let stopImpl: () => { status: "running" | "not_running"; pid?: number };
-/** Records the `monitoring.enabled` values written via saveRawConfig. */
-let enabledCalls: boolean[] = [];
 let monitoringProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
 };
-let configEnabled = false;
 let latestSample: ResourceSample | null = null;
 
 mock.module("../../../monitoring/control.js", () => ({
@@ -53,44 +51,38 @@ mock.module("../../../monitoring/sample-ring-buffer.js", () => ({
 mock.module("../../../config/loader.js", () => ({
   ...actualLoader,
   getConfigReadOnly: () => ({
-    monitoring: { enabled: configEnabled, ringBufferSize: 4000 },
+    monitoring: { ringBufferSize: 4000 },
   }),
-  loadRawConfig: () => ({}),
-  saveRawConfig: (cfg: { monitoring?: { enabled?: boolean } }) => {
-    enabledCalls.push(cfg.monitoring?.enabled === true);
-  },
 }));
 
 const { ROUTES } = await import("../monitoring-routes.js");
 
 function handler(operationId: string) {
   const route = ROUTES.find((r) => r.operationId === operationId);
-  if (!route) throw new Error(`route ${operationId} not registered`);
+  if (!route) {
+    throw new Error(`route ${operationId} not registered`);
+  }
   return route.handler as () => Promise<Record<string, unknown>>;
 }
 
 beforeEach(() => {
   spawnArgs = [];
-  enabledCalls = [];
   spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
   stopImpl = () => ({ status: "not_running" });
   monitoringProbe = { status: "not_running" };
-  configEnabled = false;
   latestSample = null;
 });
 
 describe("monitoring_start", () => {
-  test("spawns as a daemon child and enables the flag on success", async () => {
+  test("spawns as a daemon child", async () => {
     spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
 
     const res = await handler("monitoring_start")();
 
     expect(spawnArgs).toEqual([{ detached: false, terminateOnTimeout: true }]);
-    expect(enabledCalls).toEqual([true]);
     expect(res).toEqual({
       pid: 4242,
       alreadyRunning: false,
-      monitoringEnabled: true,
       pidPath: getMonitoringPidPath(),
     });
   });
@@ -101,10 +93,9 @@ describe("monitoring_start", () => {
     const res = await handler("monitoring_start")();
 
     expect(res).toMatchObject({ pid: 99, alreadyRunning: true });
-    expect(enabledCalls).toEqual([true]);
   });
 
-  test("throws and leaves the flag untouched when the spawn fails", async () => {
+  test("throws when the spawn fails", async () => {
     spawnImpl = async () => {
       throw new FakeSpawnError("monitor exited during startup");
     };
@@ -112,41 +103,35 @@ describe("monitoring_start", () => {
     await expect(handler("monitoring_start")()).rejects.toThrow(
       "monitor exited during startup",
     );
-    expect(enabledCalls).toEqual([]);
   });
 });
 
 describe("monitoring_stop", () => {
-  test("disables the flag and reports a signalled running monitor", async () => {
+  test("reports a signalled running monitor", async () => {
     stopImpl = () => ({ status: "running", pid: 555 });
 
     const res = await handler("monitoring_stop")();
 
-    expect(enabledCalls).toEqual([false]);
     expect(res).toEqual({
       monitoringWasRunning: true,
       pid: 555,
-      monitoringEnabled: false,
     });
   });
 
-  test("disables the flag and succeeds when no monitor is running", async () => {
+  test("succeeds when no monitor is running", async () => {
     stopImpl = () => ({ status: "not_running" });
 
     const res = await handler("monitoring_stop")();
 
-    expect(enabledCalls).toEqual([false]);
     expect(res).toEqual({
       monitoringWasRunning: false,
-      monitoringEnabled: false,
     });
   });
 });
 
 describe("monitoring_status", () => {
-  test("reports a running monitor with the enabled flag and no sample yet", async () => {
+  test("reports a running monitor with no sample yet", async () => {
     monitoringProbe = { status: "running", pid: 321 };
-    configEnabled = true;
     latestSample = null;
 
     const res = await handler("monitoring_status")();
@@ -154,14 +139,12 @@ describe("monitoring_status", () => {
     expect(res).toMatchObject({
       status: "running",
       pid: 321,
-      monitoringEnabled: true,
       latestSample: null,
     });
   });
 
   test("surfaces the most recent persisted sample", async () => {
     monitoringProbe = { status: "running", pid: 321 };
-    configEnabled = true;
     latestSample = {
       ts: 1000,
       memory: {
@@ -224,14 +207,12 @@ describe("monitoring_status", () => {
     const res = await handler("monitoring_status")();
 
     expect(res).toMatchObject({
-      monitoringEnabled: true,
       latestSample: { ts: 1000, memory: { ratio: 0.75 } },
     });
   });
 
   test("normalizes a legacy sample that predates newer fields", async () => {
     monitoringProbe = { status: "running", pid: 321 };
-    configEnabled = true;
     // A record persisted by an older monitor: only the original fields.
     latestSample = {
       ts: 500,
@@ -265,15 +246,13 @@ describe("monitoring_status", () => {
     });
   });
 
-  test("reports not_running with the flag off", async () => {
+  test("reports not_running when the monitor is down", async () => {
     monitoringProbe = { status: "not_running" };
-    configEnabled = false;
 
     const res = await handler("monitoring_status")();
 
     expect(res).toMatchObject({
       status: "not_running",
-      monitoringEnabled: false,
     });
     expect(res.pid).toBeUndefined();
   });

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -11,12 +11,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import {
-  getConfigReadOnly,
-  loadRawConfig,
-  saveRawConfig,
-  setNestedValue,
-} from "../../config/loader.js";
+import { getConfigReadOnly } from "../../config/loader.js";
 import {
   MonitoringWorkerSpawnError,
   probeMonitoringWorker,
@@ -35,18 +30,6 @@ import { InternalError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
 const log = getLogger("monitoring-routes");
-
-/**
- * Persist `monitoring.enabled` to the on-disk config via the shared
- * raw-config helpers, so only this leaf changes (schema defaults are not baked
- * into the file). The daemon re-reads config from disk, so the change takes
- * effect without a restart.
- */
-function setMonitoringEnabled(enabled: boolean): void {
-  const raw = loadRawConfig();
-  setNestedValue(raw, "monitoring.enabled", enabled);
-  saveRawConfig(raw);
-}
 
 const sampleMemorySchema = z.object({
   currentBytes: z.number(),
@@ -132,29 +115,25 @@ const latestSampleSchema = z.object({
 const startResponseSchema = z.object({
   pid: z.number(),
   alreadyRunning: z.boolean(),
-  monitoringEnabled: z.literal(true),
   pidPath: z.string(),
 });
 
 const stopResponseSchema = z.object({
   monitoringWasRunning: z.boolean(),
   pid: z.number().optional(),
-  monitoringEnabled: z.literal(false),
 });
 
 const statusResponseSchema = z.object({
   status: z.enum(["running", "not_running"]),
   pid: z.number().optional(),
-  monitoringEnabled: z.boolean(),
   dataDir: z.string(),
   latestSample: latestSampleSchema.nullable(),
 });
 
 /**
- * Start (or reuse) the resource monitor process as a child of the daemon, then
- * enable `monitoring.enabled` so it is respawned on the next boot. The
- * flag is only enabled once the monitor is confirmed up — on spawn failure it
- * is left untouched.
+ * Start (or reuse) the resource monitor process as a child of the daemon.
+ * The daemon also spawns it at every boot, so this route exists to bring a
+ * stopped monitor back up without a restart.
  */
 async function handleMonitoringStart() {
   let result: { pid: number; alreadyRunning: boolean };
@@ -174,23 +153,19 @@ async function handleMonitoringStart() {
     throw new InternalError(message);
   }
 
-  setMonitoringEnabled(true);
-
   return {
     pid: result.pid,
     alreadyRunning: result.alreadyRunning,
-    monitoringEnabled: true as const,
     pidPath: getMonitoringPidPath(),
   };
 }
 
 /**
- * Disable `monitoring.enabled` and SIGTERM the monitor process if it is
- * running. A monitor that is not running is not an error.
+ * SIGTERM the monitor process if it is running. A monitor that is not
+ * running is not an error. The stop lasts until the next daemon boot, which
+ * respawns the monitor unconditionally.
  */
 function handleMonitoringStop() {
-  setMonitoringEnabled(false);
-
   let before: ReturnType<typeof stopMonitoringWorkerProcess>;
   try {
     before = stopMonitoringWorkerProcess();
@@ -203,7 +178,6 @@ function handleMonitoringStop() {
   return {
     monitoringWasRunning: before.status === "running",
     ...(before.pid != null ? { pid: before.pid } : {}),
-    monitoringEnabled: false as const,
   };
 }
 
@@ -236,18 +210,16 @@ function readLatestSample(): ResourceSample | null {
 }
 
 /**
- * Report the monitor process state, the `monitoring.enabled` config value,
- * and the most recent persisted sample so a caller can see live memory/disk
- * numbers without the monitor having to push anything.
+ * Report the monitor process state and the most recent persisted sample so a
+ * caller can see live memory/disk numbers without the monitor having to push
+ * anything.
  */
 function handleMonitoringStatus() {
   const monitor = probeMonitoringWorker();
-  const config = getConfigReadOnly();
 
   return {
     status: monitor.status,
     ...(monitor.pid != null ? { pid: monitor.pid } : {}),
-    monitoringEnabled: config.monitoring.enabled,
     dataDir: getMonitoringDataDir(),
     latestSample: readLatestSample(),
   };
@@ -265,7 +237,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleMonitoringStart,
     summary: "Start the resource monitor",
     description:
-      "Spawns (or reuses) the resource monitor process as a child of the daemon and enables monitoring.enabled.",
+      "Spawns (or reuses) the resource monitor process as a child of the daemon. The daemon also spawns it at every boot.",
     tags: ["system"],
     responseBody: startResponseSchema,
   },
@@ -280,7 +252,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleMonitoringStop,
     summary: "Stop the resource monitor",
     description:
-      "Disables monitoring.enabled and SIGTERMs the resource monitor process if it is running.",
+      "SIGTERMs the resource monitor process if it is running. The monitor respawns on the next daemon boot.",
     tags: ["system"],
     responseBody: stopResponseSchema,
   },
@@ -295,7 +267,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleMonitoringStatus,
     summary: "Resource monitor status",
     description:
-      "Reports the resource monitor process state, monitoring.enabled, the forensics data directory, and the most recent persisted memory/disk sample.",
+      "Reports the resource monitor process state, the forensics data directory, and the most recent persisted memory/disk sample.",
     tags: ["system"],
     responseBody: statusResponseSchema,
   },


### PR DESCRIPTION
## Prompt / plan

PR 0 of the plugin live-reload sequence (see the design discussion on #37136). The monitoring worker is about to become platform infrastructure: it will host the plugin source-change detector that drives live reload, so a daemon whose monitor is off silently loses reload semantics. This PR removes the `monitoring.enabled` config flag entirely rather than flipping its default — **there is deliberately no opt-out**, so downstream consumers (the daemon, schedule/memory workers, plugin-spawned workers) can rely on the monitor existing.

- **`config/schemas/monitoring.ts`** — `enabled` removed from the schema. Stale `monitoring.enabled` keys in existing config files are stripped by the loader's unknown-key handling; no migration needed (verified).
- **`monitoring/control.ts`** — `startMonitoring()` spawns at every daemon boot, unconditionally. Still fire-and-forget: a monitor failure never blocks boot, per the daemon startup philosophy.
- **`monitoring/daemon-heartbeat.ts`** — heartbeat written unconditionally (it was gated on the flag).
- **`runtime/routes/monitoring-routes.ts` / `cli/commands/monitoring.ts`** — `start`/`stop` become pure runtime process control: `stop` SIGTERMs the monitor for the current daemon session, and it respawns at the next boot. The config-write plumbing (`setMonitoringEnabled`) is deleted, and the `monitoringEnabled` field is dropped from the start/stop/status responses and CLI output (CLI and daemon ship together — no compat shim, per convention). Help text and route descriptions rewritten to the new semantics.

Nothing outside `assistant/` consumed the flag or the removed response field (checked `clients/`, `cli/`, and for committed OpenAPI artifacts).

## Test plan

- `monitoring-routes.test.ts` — rewritten for the new contract: start spawns as a daemon child and throws on spawn failure; stop reports the signalled process; status reports process state + latest sample. All config-flag mocks and assertions removed.
- `daemon-heartbeat.test.ts` — config-loader mock and the "no-ops when disabled" test removed; heartbeat now always writes.
- `control.test.ts` — unchanged behavior (spawn/probe/stop mechanics), stale header comment updated.
- 22 tests across the three affected files pass run per-file as CI does; config schema suites clean; eslint, prettier, and `tsc --noEmit` clean via pre-commit hooks.

## CLI verb checklist

No new routes — existing `monitoring_start`/`monitoring_stop`/`monitoring_status` routes keep their operation IDs and endpoints; only response shapes and semantics changed, and the existing `assistant monitoring` verbs were updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_