### PR TITLE
fix(slack): render the native plan card regardless of text/plan ordering

### DIFF
--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -6,7 +6,8 @@ mock.module("../../../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => BOT_TOKEN,
 }));
 
-const { getSlackConversationInfo, startSlackStream } = await import("./api.js");
+const { appendSlackStream, getSlackConversationInfo, startSlackStream } =
+  await import("./api.js");
 
 const originalFetch = globalThis.fetch;
 
@@ -98,5 +99,99 @@ describe("startSlackStream", () => {
     const sent = body();
     expect(sent).not.toHaveProperty("recipient_user_id");
     expect(sent).not.toHaveProperty("recipient_team_id");
+  });
+
+  test("serializes the plan title and tasks as chunks", async () => {
+    const body = mockStartStream();
+
+    await startSlackStream({
+      channel: "D123",
+      threadTs: "1700.0",
+      markdownText: "hi",
+      taskDisplayMode: "plan",
+      planTitle: "Quick Briefing",
+      tasks: [
+        {
+          id: "task-0",
+          title: "Check weather",
+          status: "in_progress",
+          details: "Fetching the forecast",
+        },
+        { id: "task-1", title: "Summarize", status: "pending" },
+      ],
+    });
+
+    expect(body()).toMatchObject({
+      task_display_mode: "plan",
+      chunks: [
+        { type: "plan_update", title: "Quick Briefing" },
+        {
+          type: "task_update",
+          id: "task-0",
+          title: "Check weather",
+          status: "in_progress",
+          details: "Fetching the forecast",
+        },
+        {
+          type: "task_update",
+          id: "task-1",
+          title: "Summarize",
+          status: "pending",
+        },
+      ],
+    });
+  });
+
+  test("caps chunk string fields at Slack's 256-character limit", async () => {
+    const body = mockStartStream();
+
+    await startSlackStream({
+      channel: "D123",
+      threadTs: "1700.0",
+      markdownText: "hi",
+      planTitle: "t".repeat(300),
+      tasks: [
+        {
+          id: "task-0",
+          title: "a".repeat(300),
+          status: "in_progress",
+          details: "b".repeat(300),
+        },
+      ],
+    });
+
+    const chunks = body().chunks as Array<Record<string, unknown>>;
+    expect((chunks[0].title as string).length).toBe(256);
+    expect((chunks[1].title as string).length).toBe(256);
+    expect((chunks[1].details as string).length).toBe(256);
+  });
+});
+
+describe("appendSlackStream", () => {
+  test("sends a chunks-only append when no markdown text is given", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    globalThis.fetch = mock(async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await appendSlackStream({
+      channel: "D123",
+      streamTs: "1700.1",
+      tasks: [{ id: "task-0", title: "Check weather", status: "complete" }],
+    });
+
+    expect(capturedBody).not.toHaveProperty("markdown_text");
+    expect(capturedBody.chunks).toEqual([
+      {
+        type: "task_update",
+        id: "task-0",
+        title: "Check weather",
+        status: "complete",
+      },
+    ]);
   });
 });

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -277,24 +277,42 @@ async function callSlackApiGet(
 /** Slack caps `markdown_text` at 12,000 characters per stream call. */
 export const SLACK_STREAM_MARKDOWN_LIMIT = 12_000;
 
+/** Slack caps `task_update` / `plan_update` chunk string fields at 256 characters. */
+const SLACK_STREAM_CHUNK_FIELD_LIMIT = 256;
+
+function capChunkField(value: string): string {
+  return value.slice(0, SLACK_STREAM_CHUNK_FIELD_LIMIT);
+}
+
 /**
- * A `task_update` streaming chunk. Identical in shape to the Slack task card
- * block, used to render plan progress while a stream is open.
+ * Build the `chunks` array for a streaming call: an optional `plan_update`
+ * titling the plan block, followed by one `task_update` per task card
+ * (identical in shape to the Slack task card block).
  *
  * @see https://docs.slack.dev/reference/methods/chat.appendStream/
  */
-function toTaskUpdateChunks(
-  tasks: readonly SlackStreamTask[] | undefined,
-): Record<string, unknown>[] | undefined {
-  if (!tasks || tasks.length === 0) return undefined;
-  return tasks.map((task) => ({
-    type: "task_update",
-    id: task.id,
-    title: task.title,
-    status: task.status,
-    ...(task.details ? { details: task.details } : {}),
-    ...(task.output ? { output: task.output } : {}),
-  }));
+function toStreamChunks(params: {
+  tasks?: readonly SlackStreamTask[];
+  planTitle?: string;
+}): Record<string, unknown>[] | undefined {
+  const chunks: Record<string, unknown>[] = [];
+  if (params.planTitle) {
+    chunks.push({
+      type: "plan_update",
+      title: capChunkField(params.planTitle),
+    });
+  }
+  for (const task of params.tasks ?? []) {
+    chunks.push({
+      type: "task_update",
+      id: task.id,
+      title: capChunkField(task.title),
+      status: task.status,
+      ...(task.details ? { details: capChunkField(task.details) } : {}),
+      ...(task.output ? { output: capChunkField(task.output) } : {}),
+    });
+  }
+  return chunks.length > 0 ? chunks : undefined;
 }
 
 /**
@@ -308,6 +326,7 @@ export async function startSlackStream(params: {
   threadTs: string;
   markdownText?: string;
   taskDisplayMode?: "plan";
+  planTitle?: string;
   tasks?: readonly SlackStreamTask[];
   recipientUserId?: string;
   recipientTeamId?: string;
@@ -321,7 +340,7 @@ export async function startSlackStream(params: {
   // Channel streams must name the reader; DMs infer it and omit both fields.
   if (params.recipientUserId) body.recipient_user_id = params.recipientUserId;
   if (params.recipientTeamId) body.recipient_team_id = params.recipientTeamId;
-  const chunks = toTaskUpdateChunks(params.tasks);
+  const chunks = toStreamChunks(params);
   if (chunks) body.chunks = chunks;
 
   const data = await callSlackApi("chat.startStream", body);
@@ -339,6 +358,7 @@ export async function appendSlackStream(params: {
   channel: string;
   streamTs: string;
   markdownText?: string;
+  planTitle?: string;
   tasks?: readonly SlackStreamTask[];
 }): Promise<void> {
   const body: Record<string, unknown> = {
@@ -346,7 +366,7 @@ export async function appendSlackStream(params: {
     ts: params.streamTs,
   };
   if (params.markdownText) body.markdown_text = params.markdownText;
-  const chunks = toTaskUpdateChunks(params.tasks);
+  const chunks = toStreamChunks(params);
   if (chunks) body.chunks = chunks;
 
   await callSlackApi("chat.appendStream", body);
@@ -363,6 +383,7 @@ export async function stopSlackStream(params: {
   streamTs: string;
   markdownText?: string;
   blocks?: readonly KnownBlock[];
+  planTitle?: string;
   tasks?: readonly SlackStreamTask[];
 }): Promise<void> {
   const body: Record<string, unknown> = {
@@ -371,7 +392,7 @@ export async function stopSlackStream(params: {
   };
   if (params.markdownText) body.markdown_text = params.markdownText;
   if (params.blocks && params.blocks.length > 0) body.blocks = params.blocks;
-  const chunks = toTaskUpdateChunks(params.tasks);
+  const chunks = toStreamChunks(params);
   if (chunks) body.chunks = chunks;
 
   await callSlackApi("chat.stopStream", body);

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -302,6 +302,7 @@ export async function sendSlackStreamOp(
         threadTs: op.threadTs,
         markdownText: op.markdownText,
         taskDisplayMode: op.taskDisplayMode,
+        planTitle: op.planTitle,
         tasks: op.tasks,
         recipientUserId: op.recipientUserId,
         recipientTeamId: op.recipientTeamId,
@@ -314,6 +315,7 @@ export async function sendSlackStreamOp(
         channel,
         streamTs: op.streamTs,
         markdownText: op.markdownText,
+        planTitle: op.planTitle,
         tasks: op.tasks,
       });
       return { ok: true, ts: op.streamTs };
@@ -324,6 +326,7 @@ export async function sendSlackStreamOp(
         streamTs: op.streamTs,
         markdownText: op.markdownText,
         blocks: op.blocks,
+        planTitle: op.planTitle,
         tasks: op.tasks,
       });
       log.info({ channel, ts: op.streamTs }, "Slack stream stopped");

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -438,7 +438,12 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     await flush();
 
     expect(slackStreamOps()).toEqual([
-      { action: "start", threadTs, markdownText: "Streamed DM reply." },
+      {
+        action: "start",
+        threadTs,
+        markdownText: "Streamed DM reply.",
+        taskDisplayMode: "plan",
+      },
       { action: "stop", streamTs },
     ]);
     expect(

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ChannelDeliveryResult } from "@vellumai/gateway-client";
+import { ChannelReplyPayloadSchema } from "@vellumai/gateway-client";
 
 type DeliverCall = { callbackUrl: string; payload: Record<string, unknown> };
 
@@ -18,6 +19,10 @@ mock.module("./gateway-client.js", () => ({
     callbackUrl: string,
     payload: Record<string, unknown>,
   ) => {
+    // Every payload the session emits must be valid on the wire — in
+    // particular a task-only append must satisfy the contract's
+    // markdownText-or-tasks refinement.
+    ChannelReplyPayloadSchema.parse(payload);
     deliverCalls.push({ callbackUrl, payload });
     return deliverImpl(callbackUrl, payload);
   },
@@ -59,7 +64,8 @@ const messageComplete = (messageId: string): ServerMessage =>
 
 const taskProgressShow = (
   surfaceId: string,
-  steps: Array<{ label: string; status: string }>,
+  steps: Array<{ label: string; status: string; detail?: string }>,
+  templateTitle?: string,
 ): ServerMessage =>
   ({
     type: "ui_surface_show",
@@ -69,7 +75,10 @@ const taskProgressShow = (
     data: {
       title: "Task progress",
       template: "task_progress",
-      templateData: { steps },
+      templateData: {
+        ...(templateTitle ? { title: templateTitle } : {}),
+        steps,
+      },
     },
   }) as ServerMessage;
 
@@ -209,6 +218,7 @@ describe("createSlackReplySession", () => {
         action: "start",
         threadTs: THREAD_TS,
         markdownText: "The complete answer.",
+        taskDisplayMode: "plan",
       },
       { action: "stop", streamTs: "stream-ts-1" },
     ]);
@@ -239,6 +249,7 @@ describe("createSlackReplySession", () => {
         action: "start",
         threadTs: THREAD_TS,
         markdownText: "The complete answer.",
+        taskDisplayMode: "plan",
         recipientUserId: "U123",
         recipientTeamId: "T123",
       },
@@ -266,6 +277,7 @@ describe("createSlackReplySession", () => {
         action: "start",
         threadTs: THREAD_TS,
         markdownText: "First half. ",
+        taskDisplayMode: "plan",
       },
       {
         action: "append",
@@ -358,10 +370,9 @@ describe("createSlackReplySession", () => {
     expect(reconciliation).toEqual({ mode: "fallback" });
   });
 
-  test("defers task progress that advances without new body text to stop", async () => {
-    // `chat.appendStream` requires `markdown_text`, so a plan that advances
-    // during tool work without new text is not appended on its own; the
-    // updated task state lands on the final `stopStream`.
+  test("appends task-only progress that advances without new body text", async () => {
+    // `chat.appendStream` accepts a chunks-only call, so a plan that advances
+    // during tool work lands live instead of waiting for the final stop.
     // @see https://docs.slack.dev/reference/methods/chat.appendStream/
     const session = createSlackReplySession({
       sourceChannel: "slack",
@@ -387,15 +398,14 @@ describe("createSlackReplySession", () => {
     );
     await tick(15);
 
-    const ops = slackStreamOps();
-    // No append is emitted for a task-only update, and no append ever omits
-    // its required markdown text.
-    for (const op of ops) {
-      if (op.action === "append") {
-        expect(typeof op.markdownText).toBe("string");
-      }
-    }
-    expect(ops.some((op) => op.action === "append")).toBe(false);
+    expect(slackStreamOps().at(-1)).toEqual({
+      action: "append",
+      streamTs: "stream-ts-1",
+      tasks: [
+        { id: "task-0", title: "Search docs", status: "complete" },
+        { id: "task-1", title: "Summarize", status: "in_progress" },
+      ],
+    });
 
     await session.finish();
 
@@ -406,6 +416,73 @@ describe("createSlackReplySession", () => {
         { id: "task-0", title: "Search docs", status: "complete" },
         { id: "task-1", title: "Summarize", status: "in_progress" },
       ],
+    });
+  });
+
+  test("does not re-append unchanged task progress", async () => {
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(
+      taskProgressShow("surface-1", [
+        { label: "Search docs", status: "in_progress" },
+      ]),
+    );
+    session.observeEvent(textDelta("Working on it."));
+    await tick(15);
+    session.observeEvent(
+      taskProgressUpdate("surface-1", [
+        { label: "Search docs", status: "in_progress" },
+      ]),
+    );
+    await tick(15);
+
+    // The start already delivered this exact plan state; a matching update
+    // must not spend an append on it.
+    expect(slackStreamOps().map((op) => op.action)).toEqual(["start"]);
+  });
+
+  test("leaves progress to stop when the task-only append fails", async () => {
+    deliverImpl = async (_url, payload) => {
+      const op = payload.slackStream as {
+        action: string;
+        markdownText?: string;
+      };
+      if (op.action === "append" && op.markdownText === undefined) {
+        throw new Error("chunks-only append rejected");
+      }
+      return { ok: true, ts: "stream-ts-1" };
+    };
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(textDelta("Working on it."));
+    await tick(15);
+    session.observeEvent(
+      taskProgressShow("surface-1", [
+        { label: "Search docs", status: "in_progress" },
+      ]),
+    );
+    await tick(15);
+    const reconciliation = await session.finish();
+
+    // The failed task-only append does not degrade the stream; the plan
+    // still lands on the final stop.
+    expect(reconciliation.mode).toBe("streamed");
+    expect(slackStreamOps().at(-1)).toEqual({
+      action: "stop",
+      streamTs: "stream-ts-1",
+      tasks: [{ id: "task-0", title: "Search docs", status: "in_progress" }],
     });
   });
 
@@ -629,5 +706,108 @@ describe("createSlackReplySession", () => {
       ],
     });
     expect(reconciliation.mode).toBe("streamed");
+  });
+
+  test("renders a plan created after the stream opened", async () => {
+    // The model typically streams an acknowledgment before it creates the
+    // task_progress surface. Slack fixes the task display mode when the
+    // stream starts, so the start must open in plan mode even with no plan
+    // active yet — otherwise the late-arriving task cards can never render
+    // as a plan.
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(textDelta("On it — starting now."));
+    await tick(15);
+    session.observeEvent(
+      taskProgressShow("surface-1", [
+        { label: "Search docs", status: "in_progress" },
+        { label: "Summarize", status: "pending" },
+      ]),
+    );
+    await tick(15);
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    await session.finish();
+
+    expect(slackStreamOps()).toEqual([
+      {
+        action: "start",
+        threadTs: THREAD_TS,
+        markdownText: "On it — starting now.",
+        taskDisplayMode: "plan",
+      },
+      {
+        action: "append",
+        streamTs: "stream-ts-1",
+        tasks: [
+          { id: "task-0", title: "Search docs", status: "in_progress" },
+          { id: "task-1", title: "Summarize", status: "pending" },
+        ],
+      },
+      {
+        action: "stop",
+        streamTs: "stream-ts-1",
+        tasks: [
+          { id: "task-0", title: "Search docs", status: "in_progress" },
+          { id: "task-1", title: "Summarize", status: "pending" },
+        ],
+      },
+    ]);
+  });
+
+  test("carries the plan title and step details onto stream ops", async () => {
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(
+      taskProgressShow(
+        "surface-1",
+        [
+          {
+            label: "Check weather",
+            status: "in_progress",
+            detail: "Fetching the forecast",
+          },
+          { label: "Summarize", status: "pending" },
+        ],
+        "Quick Briefing",
+      ),
+    );
+    session.observeEvent(textDelta("Working on it."));
+    await tick(15);
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    await session.finish();
+
+    const ops = slackStreamOps();
+    expect(ops[0]).toEqual({
+      action: "start",
+      threadTs: THREAD_TS,
+      markdownText: "Working on it.",
+      taskDisplayMode: "plan",
+      planTitle: "Quick Briefing",
+      tasks: [
+        {
+          id: "task-0",
+          title: "Check weather",
+          status: "in_progress",
+          details: "Fetching the forecast",
+        },
+        { id: "task-1", title: "Summarize", status: "pending" },
+      ],
+    });
+    expect(ops.at(-1)).toMatchObject({
+      action: "stop",
+      planTitle: "Quick Briefing",
+    });
   });
 });

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -474,7 +474,20 @@ describe("createSlackReplySession", () => {
       ]),
     );
     await tick(15);
+    session.observeEvent(
+      taskProgressUpdate("surface-1", [
+        { label: "Search docs", status: "completed" },
+      ]),
+    );
+    await tick(15);
     const reconciliation = await session.finish();
+
+    // The first rejection disables task-only appends for the session, so
+    // later progress updates do not retry a doomed call.
+    const taskOnlyAttempts = slackStreamOps().filter(
+      (op) => op.action === "append" && op.markdownText === undefined,
+    );
+    expect(taskOnlyAttempts.length).toBe(1);
 
     // The failed task-only append does not degrade the stream; the plan
     // still lands on the final stop.
@@ -482,7 +495,7 @@ describe("createSlackReplySession", () => {
     expect(slackStreamOps().at(-1)).toEqual({
       action: "stop",
       streamTs: "stream-ts-1",
-      tasks: [{ id: "task-0", title: "Search docs", status: "in_progress" }],
+      tasks: [{ id: "task-0", title: "Search docs", status: "complete" }],
     });
   });
 

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -92,9 +92,10 @@ type StreamState = "idle" | "streaming" | "fallback";
 
 /**
  * Owns the live-content lifecycle of one Slack DM reply: it consumes the
- * assistant token stream once, opens a streamed message on first deliverable
- * text, coalesces deltas into `appendStream` calls, advances a native plan
- * block from `task_progress` surfaces, and finalizes with `stopStream`.
+ * assistant token stream once, opens a streamed message (in plan display
+ * mode) on first deliverable text, coalesces deltas into `appendStream`
+ * calls, advances a native plan block from `task_progress` surfaces, and
+ * finalizes with `stopStream`.
  *
  * Any stream-call failure degrades gracefully: the session abandons streaming
  * (state `fallback`) and reports back so durable finalize posts the full reply
@@ -141,6 +142,9 @@ export function createSlackReplySession(params: {
 
   const taskProgressBySurfaceId = new Map<string, TaskProgressData>();
   let activeProgress: TaskProgressData | undefined;
+  // Fingerprint of the plan state last delivered to Slack, so progress that
+  // advances without new body text still flushes as a task-only append.
+  let deliveredProgressKey: string | undefined;
 
   let coalesceTimer: ReturnType<typeof setTimeout> | undefined;
   let opChain: Promise<void> = Promise.resolve();
@@ -163,6 +167,12 @@ export function createSlackReplySession(params: {
   const planTasks = (): SlackStreamTask[] | undefined =>
     activeProgress ? toSlackStreamTasks(activeProgress) : undefined;
 
+  const progressKey = (
+    title: string | undefined,
+    tasks: SlackStreamTask[] | undefined,
+  ): string | undefined =>
+    tasks ? JSON.stringify({ title, tasks }) : undefined;
+
   const imageBlocks = (
     text: string,
   ):
@@ -183,7 +193,7 @@ export function createSlackReplySession(params: {
       const clean = streamableText();
       if (clean.trim().length === 0) return;
       const firstChunk = clean.slice(0, SLACK_STREAM_MARKDOWN_LIMIT);
-      const planActive = activeProgress !== undefined;
+      const title = activeProgress?.title;
       const tasks = planTasks();
       try {
         const result = await deliverChannelReply(replyCallbackUrl, {
@@ -193,7 +203,13 @@ export function createSlackReplySession(params: {
             action: "start",
             threadTs,
             markdownText: firstChunk,
-            ...(planActive ? { taskDisplayMode: "plan" as const } : {}),
+            // The task display mode is fixed for the stream's lifetime at
+            // start, while a `task_progress` surface usually appears only
+            // after the first text flush has opened the stream. Plan mode
+            // only affects how task chunks render, so a stream that never
+            // carries tasks still reads as a plain message.
+            taskDisplayMode: "plan" as const,
+            ...(title ? { planTitle: title } : {}),
             ...(tasks ? { tasks } : {}),
             ...(recipientUserId ? { recipientUserId } : {}),
             ...(recipientTeamId ? { recipientTeamId } : {}),
@@ -202,6 +218,7 @@ export function createSlackReplySession(params: {
         if (result.ok && result.ts) {
           streamTs = result.ts;
           confirmedLength = firstChunk.length;
+          deliveredProgressKey = progressKey(title, tasks);
           state = "streaming";
         } else {
           state = "fallback";
@@ -218,13 +235,12 @@ export function createSlackReplySession(params: {
     enqueue(async () => {
       if (state !== "streaming" || !streamTs) return;
       const clean = streamableText();
+      const title = activeProgress?.title;
       const tasks = planTasks();
-      // `chat.appendStream` requires `markdown_text` and caps it per call, so a
-      // delta wider than the limit drains across successive append calls. Each
-      // append carries the current task state, advancing the plan alongside
-      // text. Progress that advances without new text is not appended on its
-      // own (an append with no text is rejected); it lands on the next text
-      // append or on `stopStream`.
+      const key = progressKey(title, tasks);
+      // `chat.appendStream` caps `markdown_text` per call, so a delta wider
+      // than the limit drains across successive append calls. Each append
+      // carries the current task state, advancing the plan alongside text.
       while (confirmedLength < clean.length) {
         const chunk = clean.slice(
           confirmedLength,
@@ -238,16 +254,43 @@ export function createSlackReplySession(params: {
               action: "append",
               streamTs,
               markdownText: chunk,
+              ...(title ? { planTitle: title } : {}),
               ...(tasks ? { tasks } : {}),
             },
           });
           confirmedLength += chunk.length;
+          deliveredProgressKey = key ?? deliveredProgressKey;
         } catch (err) {
           log.warn(
             { err, chatId },
             "Slack appendStream failed; deferring delta",
           );
           return;
+        }
+      }
+      // Progress that advances without new body text still lands live:
+      // `chat.appendStream` accepts a chunks-only call, so the plan block
+      // ticks during tool work instead of waiting for the next text append.
+      // A failure defers the update; the unchanged fingerprint retries it on
+      // the next flush and `stopStream` carries the final state regardless.
+      if (tasks && key !== deliveredProgressKey) {
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId,
+            assistantId,
+            slackStream: {
+              action: "append",
+              streamTs,
+              ...(title ? { planTitle: title } : {}),
+              tasks,
+            },
+          });
+          deliveredProgressKey = key;
+        } catch (err) {
+          log.warn(
+            { err, chatId },
+            "Slack task-only appendStream failed; deferring progress",
+          );
         }
       }
     });
@@ -348,6 +391,7 @@ export function createSlackReplySession(params: {
         const clean = cleanedText();
         const remaining = clean.slice(confirmedLength);
         const blocks = imageBlocks(clean);
+        const title = activeProgress?.title;
         const tasks = planTasks();
         try {
           await deliverChannelReply(replyCallbackUrl, {
@@ -358,6 +402,7 @@ export function createSlackReplySession(params: {
               streamTs,
               ...(remaining.length > 0 ? { markdownText: remaining } : {}),
               ...(blocks ? { blocks } : {}),
+              ...(title ? { planTitle: title } : {}),
               ...(tasks ? { tasks } : {}),
             },
           });

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -145,6 +145,12 @@ export function createSlackReplySession(params: {
   // Fingerprint of the plan state last delivered to Slack, so progress that
   // advances without new body text still flushes as a task-only append.
   let deliveredProgressKey: string | undefined;
+  // Set once a chunks-only append is rejected (e.g. a Slack tier that
+  // requires `markdown_text` on every append): the session stops attempting
+  // them and progress rides the next text append or `stopStream` instead,
+  // so a rejecting workspace pays one failed call per turn, not one per
+  // progress update.
+  let taskOnlyAppendsDisabled = false;
 
   let coalesceTimer: ReturnType<typeof setTimeout> | undefined;
   let opChain: Promise<void> = Promise.resolve();
@@ -271,9 +277,10 @@ export function createSlackReplySession(params: {
       // Progress that advances without new body text still lands live:
       // `chat.appendStream` accepts a chunks-only call, so the plan block
       // ticks during tool work instead of waiting for the next text append.
-      // A failure defers the update; the unchanged fingerprint retries it on
-      // the next flush and `stopStream` carries the final state regardless.
-      if (tasks && key !== deliveredProgressKey) {
+      // A failure disables further task-only appends for the session; the
+      // unchanged fingerprint leaves the update pending, so it rides the
+      // next text append and `stopStream` carries the final state.
+      if (!taskOnlyAppendsDisabled && tasks && key !== deliveredProgressKey) {
         try {
           await deliverChannelReply(replyCallbackUrl, {
             chatId,
@@ -287,9 +294,10 @@ export function createSlackReplySession(params: {
           });
           deliveredProgressKey = key;
         } catch (err) {
+          taskOnlyAppendsDisabled = true;
           log.warn(
             { err, chatId },
-            "Slack task-only appendStream failed; deferring progress",
+            "Slack task-only appendStream failed; deferring progress to text appends",
           );
         }
       }

--- a/assistant/src/runtime/slack-task-progress.test.ts
+++ b/assistant/src/runtime/slack-task-progress.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getTaskProgressDataFromSurfaceData,
+  mergeTaskProgressData,
+  toSlackStreamTasks,
+} from "./slack-task-progress.js";
+
+describe("getTaskProgressDataFromSurfaceData", () => {
+  test("reads title, steps, and step details from a task_progress surface", () => {
+    const progress = getTaskProgressDataFromSurfaceData({
+      template: "task_progress",
+      templateData: {
+        title: "Quick Briefing",
+        steps: [
+          {
+            label: "Check weather",
+            status: "in_progress",
+            detail: "Fetching the forecast",
+          },
+          { label: "Summarize", status: "pending" },
+        ],
+      },
+    });
+
+    expect(progress).toEqual({
+      title: "Quick Briefing",
+      steps: [
+        {
+          label: "Check weather",
+          status: "in_progress",
+          detail: "Fetching the forecast",
+        },
+        { label: "Summarize", status: "pending" },
+      ],
+    });
+  });
+
+  test("omits a blank title and blank details", () => {
+    const progress = getTaskProgressDataFromSurfaceData({
+      template: "task_progress",
+      templateData: {
+        title: "  ",
+        steps: [{ label: "Check weather", status: "pending", detail: "" }],
+      },
+    });
+
+    expect(progress).toEqual({
+      steps: [{ label: "Check weather", status: "pending" }],
+    });
+  });
+
+  test("ignores non-task_progress surfaces", () => {
+    expect(
+      getTaskProgressDataFromSurfaceData({
+        template: "weather_forecast",
+        templateData: { steps: [] },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("mergeTaskProgressData", () => {
+  const existing = {
+    title: "Quick Briefing",
+    steps: [
+      { label: "Check weather", status: "in_progress" as const },
+      { label: "Summarize", status: "pending" as const },
+    ],
+  };
+
+  test("keeps the existing title when a partial update omits it", () => {
+    const merged = mergeTaskProgressData(existing, {
+      templateData: {
+        steps: [
+          { label: "Check weather", status: "completed" },
+          { label: "Summarize", status: "in_progress" },
+        ],
+      },
+    });
+
+    expect(merged).toEqual({
+      title: "Quick Briefing",
+      steps: [
+        { label: "Check weather", status: "completed" },
+        { label: "Summarize", status: "in_progress" },
+      ],
+    });
+  });
+
+  test("replaces the title when a partial update carries one", () => {
+    const merged = mergeTaskProgressData(existing, {
+      templateData: { title: "Quick Briefing (Revised)" },
+    });
+
+    expect(merged).toEqual({
+      title: "Quick Briefing (Revised)",
+      steps: existing.steps,
+    });
+  });
+});
+
+describe("toSlackStreamTasks", () => {
+  test("maps steps onto Slack task cards with stable ids and details", () => {
+    expect(
+      toSlackStreamTasks({
+        title: "Quick Briefing",
+        steps: [
+          {
+            label: "Check weather",
+            status: "completed",
+            detail: "Forecast fetched",
+          },
+          { label: "Summarize", status: "failed" },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "task-0",
+        title: "Check weather",
+        status: "complete",
+        details: "Forecast fetched",
+      },
+      { id: "task-1", title: "Summarize", status: "error" },
+    ]);
+  });
+});

--- a/assistant/src/runtime/slack-task-progress.ts
+++ b/assistant/src/runtime/slack-task-progress.ts
@@ -7,9 +7,12 @@ import type { SlackStreamTask } from "@vellumai/gateway-client";
 export type TaskProgressStep = {
   label: string;
   status: "pending" | "in_progress" | "completed" | "failed";
+  detail?: string;
 };
 
 export type TaskProgressData = {
+  /** Plan title shown above the steps (e.g. "Q2 Launch Plan"). */
+  title?: string;
   steps: TaskProgressStep[];
 };
 
@@ -21,17 +24,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export function getTaskProgressDataFromSurfaceData(
   data: unknown,
 ): TaskProgressData | undefined {
-  if (!isRecord(data)) return undefined;
-  if (data.template !== "task_progress") return undefined;
+  if (!isRecord(data)) {
+    return undefined;
+  }
+  if (data.template !== "task_progress") {
+    return undefined;
+  }
   return parseTaskProgressData(data.templateData);
 }
 
 function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
-  if (!isRecord(value) || !Array.isArray(value.steps)) return undefined;
+  if (!isRecord(value) || !Array.isArray(value.steps)) {
+    return undefined;
+  }
 
   const steps = value.steps.flatMap((step): TaskProgressStep[] => {
-    if (!isRecord(step)) return [];
-    if (typeof step.label !== "string") return [];
+    if (!isRecord(step)) {
+      return [];
+    }
+    if (typeof step.label !== "string") {
+      return [];
+    }
     if (
       step.status !== "pending" &&
       step.status !== "in_progress" &&
@@ -40,10 +53,23 @@ function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
     ) {
       return [];
     }
-    return [{ label: step.label, status: step.status }];
+    const detail =
+      typeof step.detail === "string" && step.detail.trim().length > 0
+        ? step.detail
+        : undefined;
+    return [
+      { label: step.label, status: step.status, ...(detail ? { detail } : {}) },
+    ];
   });
+  if (steps.length === 0) {
+    return undefined;
+  }
 
-  return steps.length > 0 ? { steps } : undefined;
+  const title =
+    typeof value.title === "string" && value.title.trim().length > 0
+      ? value.title
+      : undefined;
+  return { ...(title ? { title } : {}), steps };
 }
 
 /**
@@ -55,12 +81,19 @@ export function mergeTaskProgressData(
   existing: TaskProgressData | undefined,
   data: unknown,
 ): TaskProgressData | undefined {
-  if (!isRecord(data)) return existing;
+  if (!isRecord(data)) {
+    return existing;
+  }
   const update = getTaskProgressDataFromSurfaceData(data);
-  if (update) return update;
-  if (!existing || !("templateData" in data)) return existing;
+  if (update) {
+    return update;
+  }
+  if (!existing || !("templateData" in data)) {
+    return existing;
+  }
 
   return parseTaskProgressData({
+    title: existing.title,
     steps: existing.steps,
     ...(isRecord(data.templateData) ? data.templateData : {}),
   });
@@ -79,8 +112,9 @@ const TASK_PROGRESS_STATUS_TO_SLACK: Record<
 /**
  * Map ordered `task_progress` steps onto Slack streaming task cards. Step
  * position supplies the stable card `id` (a step keeps its index across
- * updates), the label becomes the card title, and the surface status maps onto
- * Slack's task-card status vocabulary.
+ * updates), the label becomes the card title, the step detail becomes the
+ * card details, and the surface status maps onto Slack's task-card status
+ * vocabulary.
  *
  * @see https://docs.slack.dev/ai/developing-agents
  */
@@ -91,5 +125,6 @@ export function toSlackStreamTasks(
     id: `task-${index}`,
     title: step.label,
     status: TASK_PROGRESS_STATUS_TO_SLACK[step.status],
+    ...(step.detail ? { details: step.detail } : {}),
   }));
 }

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -107,6 +107,8 @@ export const SlackStreamOpSchema = z
       threadTs: z.string(),
       markdownText: z.string().optional(),
       taskDisplayMode: z.literal("plan").optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
       tasks: z.array(SlackStreamTaskSchema).optional(),
       /**
        * Slack user ID of the reader the stream targets. Required by
@@ -123,6 +125,8 @@ export const SlackStreamOpSchema = z
       action: z.literal("append"),
       streamTs: z.string(),
       markdownText: z.string().optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
       tasks: z.array(SlackStreamTaskSchema).optional(),
     }),
     z.object({
@@ -130,6 +134,8 @@ export const SlackStreamOpSchema = z
       streamTs: z.string(),
       markdownText: z.string().optional(),
       blocks: z.array(z.custom<KnownBlock>()).optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
       tasks: z.array(SlackStreamTaskSchema).optional(),
     }),
   ])


### PR DESCRIPTION
## Prompt / plan

Investigation of a report that a channel mention produced only a plain-text Slack thread reply while the desktop app showed a live task-progress plan card. Root cause: Slack fixes a stream's `task_display_mode` at `chat.startStream`, but `createSlackReplySession` only requested plan mode when a `task_progress` surface was already active at the first text flush. The model typically streams an acknowledgment before creating its plan, so the stream opened in default mode and the plan card could never render for that turn. Plan implemented (per discussion, observability deferred):

1. Always open Slack reply streams with `task_display_mode: "plan"` — the mode only affects task-chunk rendering, so task-free turns still read as plain messages.
2. Flush plan progress that advances without new body text as a chunks-only `chat.appendStream` call (deduped by a delivered-state fingerprint) so the card ticks during tool work instead of freezing until `stopStream`. A failed task-only append defers; the final state still lands on `stopStream`.
3. Carry the `task_progress` surface title as a `plan_update` chunk (`planTitle` on the outbound contract) and per-step `detail` as `task_update` `details`, capping chunk string fields at Slack's 256-character limit.

## Test plan

- New: `assistant/src/runtime/slack-task-progress.test.ts` (title/detail parsing, partial-update title merge, Slack task-card mapping).
- `slack-reply-session.test.ts`: new coverage for a plan created after the stream opened (the reported scenario), task-only appends, unchanged-progress dedupe, task-only append failure degrading to `stopStream`, and plan title/detail propagation. The `deliverChannelReply` mock now Zod-parses every emitted payload against `ChannelReplyPayloadSchema`, so chunks-only appends are proven valid on the wire.
- `api.test.ts`: `plan_update`/`task_update` chunk serialization, 256-char field capping, chunks-only `chat.appendStream` body.
- All affected suites pass in isolation (`slack-reply-session`, `slack-task-progress`, `api`, `send`, `background-dispatch`); `tsgo --noEmit` clean in `assistant/`, `tsc --noEmit` clean in `packages/gateway-client` and `gateway/`.
- Not yet verified against a live workspace: Slack's rendering of a plan-mode stream that never receives task chunks, and acceptance of chunks-only appends (the contract/API layers already documented both as supported). Worth one manual smoke test in a real Slack workspace before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U92X7zVAucT6vKzdj9FVD

---
_Generated by [Claude Code](https://claude.ai/code/session_015U92X7zVAucT6vKzdj9FVD)_