### PR TITLE
feat(monitoring): watch plugin source and publish a source-versions sentinel

### DIFF
--- a/assistant/src/config/schemas/monitoring.ts
+++ b/assistant/src/config/schemas/monitoring.ts
@@ -49,6 +49,17 @@ export const MonitoringConfigSchema = z
       .describe(
         "Minimum interval between high-memory snapshots, in milliseconds, so a sustained spike does not write a snapshot on every sample.",
       ),
+    pluginSourceScanIntervalMs: z
+      .number({
+        error: "monitoring.pluginSourceScanIntervalMs must be a number",
+      })
+      .int("monitoring.pluginSourceScanIntervalMs must be an integer")
+      .min(250, "monitoring.pluginSourceScanIntervalMs must be at least 250ms")
+      .max(60_000, "monitoring.pluginSourceScanIntervalMs must be <= 60000ms")
+      .default(2_000)
+      .describe(
+        "How often the plugin source watcher walks the workspace plugin directories and publishes the source-versions sentinel, in milliseconds. Bounds how quickly a plugin source edit becomes visible to live reload.",
+      ),
     baselineSnapshotIntervalMs: z
       .number({
         error: "monitoring.baselineSnapshotIntervalMs must be a number",

--- a/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the plugin source watcher — the detector half of plugin live
+ * reload, driven one pass at a time (no timers) against a controlled
+ * workspace.
+ *
+ * The contract under test is the one sentinel readers rely on:
+ *   - the sentinel is rewritten iff plugin source changed (edit, add,
+ *     remove, disable-toggle), so its mtime is a change signal;
+ *   - the document carries per-directory fingerprints and eviction paths;
+ *   - a restarted watcher observing unchanged source adopts the existing
+ *     document instead of publishing a spurious change.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+const ROOT = join(
+  tmpdir(),
+  `plugin-source-watch-test-${process.pid}-${Date.now()}`,
+);
+const PLUGINS_DIR = join(ROOT, "plugins");
+const WORKSPACE_HOOKS_DIR = join(ROOT, "hooks");
+
+beforeAll(() => {
+  process.env.VELLUM_WORKSPACE_DIR = ROOT;
+});
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+const { collectSourceVersions, createSourceWatchState, runSourceWatchPass } =
+  await import("../plugin-source-watch.js");
+const { getSourceVersionsPath, readSourceVersions } =
+  await import("../../plugins/source-versions.js");
+
+/** Strictly increasing mtimes so writes never share a timestamp granule. */
+let mtimeSeq = 1_750_000_000;
+function writeStamped(path: string, content: string): void {
+  writeFileSync(path, content);
+  const stamp = new Date(++mtimeSeq * 1000);
+  utimesSync(path, stamp, stamp);
+}
+
+function makePlugin(name: string): string {
+  const dir = join(PLUGINS_DIR, name);
+  mkdirSync(join(dir, "hooks"), { recursive: true });
+  mkdirSync(join(dir, "lib"), { recursive: true });
+  writeStamped(join(dir, "package.json"), `{"name":${JSON.stringify(name)}}`);
+  writeStamped(join(dir, "hooks", "stop.ts"), "export default () => 1;\n");
+  writeStamped(join(dir, "lib", "helper.ts"), "export const v = 1;\n");
+  return dir;
+}
+
+beforeEach(() => {
+  rmSync(PLUGINS_DIR, { recursive: true, force: true });
+  rmSync(WORKSPACE_HOOKS_DIR, { recursive: true, force: true });
+  mkdirSync(PLUGINS_DIR, { recursive: true });
+});
+
+describe("plugin source watch", () => {
+  test("first pass publishes a baseline covering plugins and workspace hooks", () => {
+    const dirA = makePlugin("plugin-a");
+    const dirB = makePlugin("plugin-b");
+    mkdirSync(WORKSPACE_HOOKS_DIR, { recursive: true });
+    writeStamped(join(WORKSPACE_HOOKS_DIR, "stop.ts"), "export default 1;\n");
+
+    const state = createSourceWatchState();
+    expect(runSourceWatchPass(state)).toBe(true);
+
+    const doc = readSourceVersions();
+    expect(doc).not.toBeNull();
+    expect(Object.keys(doc!.plugins).sort()).toEqual(
+      [dirA, dirB, WORKSPACE_HOOKS_DIR].sort(),
+    );
+    expect(doc!.plugins[dirA]!.evictionPaths).toContain(
+      join(dirA, "lib", "helper.ts"),
+    );
+    expect(doc!.plugins[dirA]!.disabled).toBe(false);
+    // Atomic write leaves no temp file behind.
+    expect(existsSync(`${getSourceVersionsPath()}.tmp`)).toBe(false);
+  });
+
+  test("a no-change pass does not rewrite the sentinel", () => {
+    makePlugin("plugin-stable");
+    const state = createSourceWatchState();
+    runSourceWatchPass(state);
+
+    const before = statSync(getSourceVersionsPath()).mtimeMs;
+    const generationBefore = readSourceVersions()!.generation;
+
+    expect(runSourceWatchPass(state)).toBe(false);
+
+    expect(statSync(getSourceVersionsPath()).mtimeMs).toBe(before);
+    expect(readSourceVersions()!.generation).toBe(generationBefore);
+  });
+
+  test("a helper edit rewrites the sentinel with only that plugin's fingerprint moved", () => {
+    const dirA = makePlugin("plugin-edit");
+    const dirB = makePlugin("plugin-bystander");
+    const state = createSourceWatchState();
+    runSourceWatchPass(state);
+    const before = readSourceVersions()!;
+
+    writeStamped(join(dirA, "lib", "helper.ts"), "export const v = 2;\n");
+    expect(runSourceWatchPass(state)).toBe(true);
+
+    const after = readSourceVersions()!;
+    expect(after.generation).toBe(before.generation + 1);
+    expect(after.plugins[dirA]!.fingerprint).not.toBe(
+      before.plugins[dirA]!.fingerprint,
+    );
+    expect(after.plugins[dirB]!.fingerprint).toBe(
+      before.plugins[dirB]!.fingerprint,
+    );
+  });
+
+  test("a .disabled toggle publishes even though the fingerprint is unchanged", () => {
+    const dir = makePlugin("plugin-toggle");
+    const state = createSourceWatchState();
+    runSourceWatchPass(state);
+    const before = readSourceVersions()!;
+
+    writeFileSync(join(dir, ".disabled"), "");
+    expect(runSourceWatchPass(state)).toBe(true);
+
+    const after = readSourceVersions()!;
+    expect(after.plugins[dir]!.disabled).toBe(true);
+    expect(after.plugins[dir]!.fingerprint).toBe(
+      before.plugins[dir]!.fingerprint,
+    );
+
+    unlinkSync(join(dir, ".disabled"));
+    expect(runSourceWatchPass(state)).toBe(true);
+    expect(readSourceVersions()!.plugins[dir]!.disabled).toBe(false);
+  });
+
+  test("plugin removal and addition are published", () => {
+    const dirA = makePlugin("plugin-removed");
+    const state = createSourceWatchState();
+    runSourceWatchPass(state);
+
+    rmSync(dirA, { recursive: true, force: true });
+    expect(runSourceWatchPass(state)).toBe(true);
+    expect(readSourceVersions()!.plugins[dirA]).toBeUndefined();
+
+    const dirB = makePlugin("plugin-added");
+    expect(runSourceWatchPass(state)).toBe(true);
+    expect(readSourceVersions()!.plugins[dirB]).toBeDefined();
+  });
+
+  test("a restarted watcher adopts an unchanged sentinel without rewriting", () => {
+    makePlugin("plugin-restart");
+    const state = createSourceWatchState();
+    runSourceWatchPass(state);
+    const before = statSync(getSourceVersionsPath()).mtimeMs;
+    const generationBefore = readSourceVersions()!.generation;
+
+    // Fresh state, as a new watcher process would build it.
+    const restarted = createSourceWatchState();
+    expect(runSourceWatchPass(restarted)).toBe(false);
+
+    expect(statSync(getSourceVersionsPath()).mtimeMs).toBe(before);
+    expect(readSourceVersions()!.generation).toBe(generationBefore);
+
+    // ...and the adopted generation keeps counting from where it left off.
+    writeStamped(
+      join(PLUGINS_DIR, "plugin-restart", "lib", "helper.ts"),
+      "export const v = 9;\n",
+    );
+    expect(runSourceWatchPass(restarted)).toBe(true);
+    expect(readSourceVersions()!.generation).toBe(generationBefore + 1);
+  });
+
+  test("directories without a package.json are not watched as plugins", () => {
+    mkdirSync(join(PLUGINS_DIR, "not-a-plugin", "hooks"), { recursive: true });
+    writeStamped(
+      join(PLUGINS_DIR, "not-a-plugin", "hooks", "stop.ts"),
+      "export default 1;\n",
+    );
+
+    const versions = collectSourceVersions();
+    expect(versions[join(PLUGINS_DIR, "not-a-plugin")]).toBeUndefined();
+  });
+});

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -1,0 +1,245 @@
+/**
+ * Plugin source watcher — the change-detector half of plugin live reload,
+ * running inside the resource monitor process.
+ *
+ * Hook dispatch in the daemon is a hot path (it runs many times per turn),
+ * so the daemon must not pay for filesystem walks to learn whether plugin
+ * source changed. This watcher does the walking here instead, off every
+ * consumer's event loop: on each tick it discovers plugin directories,
+ * fingerprints their source (see `../plugins/source-fingerprint.ts`), and —
+ * only when something changed — atomically rewrites the source-versions
+ * sentinel (see `../plugins/source-versions.ts`). Consumers stat that one
+ * file to learn about changes.
+ *
+ * Polling by stat is deliberate: inotify-style watchers don't reliably see
+ * host-side writes on virtualized mounts (virtiofs, 9p), while a stat walk
+ * works everywhere the files do. The walk is synchronous, so ticks can't
+ * overlap; a pass over 10 plugins × 100 files measures ~3.6ms warm on ext4.
+ *
+ * A watcher restart observes the existing sentinel and adopts it when the
+ * source is unchanged, so restarts never publish spurious change signals.
+ * Failures are logged and skipped — the monitor must keep sampling even if
+ * a walk trips over a half-written plugin directory.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { snapshotPluginSource } from "../plugins/source-fingerprint.js";
+import type {
+  PluginSourceVersion,
+  SourceVersionsDocument,
+} from "../plugins/source-versions.js";
+import {
+  getSourceVersionsPath,
+  readSourceVersions,
+  SOURCE_VERSIONS_FORMAT,
+} from "../plugins/source-versions.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getWorkspaceHooksDir,
+  getWorkspacePluginsDir,
+} from "../util/platform.js";
+
+const log = getLogger("plugin-source-watch");
+
+/**
+ * Collect the current source version of every watched directory: each
+ * plugin directory under `<workspace>/plugins/` (same discovery rule as the
+ * daemon's plugin scan — a directory with a `package.json`), plus the
+ * standalone workspace hooks directory when it exists. Disabled plugins are
+ * fingerprinted too: consumers need fresh state the moment a plugin is
+ * re-enabled, and the `disabled` field is how they observe the toggle
+ * itself (dotfiles are excluded from the fingerprint).
+ */
+export function collectSourceVersions(): Record<string, PluginSourceVersion> {
+  const out: Record<string, PluginSourceVersion> = {};
+
+  const pluginsDir = getWorkspacePluginsDir();
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch {
+    // No plugins directory yet — nothing to watch there.
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      continue;
+    }
+    const dir = join(pluginsDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(dir, "package.json"))) {
+      continue;
+    }
+    const snapshot = snapshotPluginSource(dir);
+    out[dir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: existsSync(join(dir, ".disabled")),
+    };
+  }
+
+  const workspaceHooksDir = getWorkspaceHooksDir();
+  if (existsSync(workspaceHooksDir)) {
+    const snapshot = snapshotPluginSource(workspaceHooksDir);
+    out[workspaceHooksDir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: false,
+    };
+  }
+
+  return out;
+}
+
+/**
+ * Whether two version maps describe the same source state. Compares key
+ * sets, fingerprints, and disabled flags; eviction paths are derived from
+ * the same walk as the fingerprint, so equal fingerprints imply equal
+ * paths.
+ */
+function sameVersions(
+  a: Readonly<Record<string, PluginSourceVersion>>,
+  b: Readonly<Record<string, PluginSourceVersion>>,
+): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    const other = b[key];
+    if (other === undefined) {
+      return false;
+    }
+    if (
+      other.fingerprint !== a[key]!.fingerprint ||
+      other.disabled !== a[key]!.disabled
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Watcher state across passes. Seeded from the existing sentinel so a
+ * restarted watcher that observes unchanged source adopts the document
+ * instead of rewriting it.
+ */
+export interface SourceWatchState {
+  lastPlugins: Record<string, PluginSourceVersion> | null;
+  generation: number;
+}
+
+/** Create pass state, adopting any existing sentinel document. */
+export function createSourceWatchState(): SourceWatchState {
+  const existing = readSourceVersions();
+  if (existing === null) {
+    return { lastPlugins: null, generation: 0 };
+  }
+  return {
+    lastPlugins: { ...existing.plugins },
+    generation: existing.generation,
+  };
+}
+
+/**
+ * Run one detection pass: walk, compare against the last published state,
+ * and rewrite the sentinel if anything changed. Returns whether a rewrite
+ * happened. Never throws — a failed pass is logged and retried on the next
+ * tick.
+ */
+export function runSourceWatchPass(state: SourceWatchState): boolean {
+  try {
+    const current = collectSourceVersions();
+    if (
+      state.lastPlugins !== null &&
+      sameVersions(state.lastPlugins, current)
+    ) {
+      return false;
+    }
+
+    const changedDirs =
+      state.lastPlugins === null
+        ? Object.keys(current)
+        : [
+            ...new Set([
+              ...Object.keys(state.lastPlugins),
+              ...Object.keys(current),
+            ]),
+          ].filter(
+            (dir) =>
+              state.lastPlugins![dir]?.fingerprint !==
+                current[dir]?.fingerprint ||
+              state.lastPlugins![dir]?.disabled !== current[dir]?.disabled,
+          );
+
+    state.generation += 1;
+    const doc: SourceVersionsDocument = {
+      format: SOURCE_VERSIONS_FORMAT,
+      generation: state.generation,
+      writtenAt: new Date().toISOString(),
+      plugins: current,
+    };
+    writeSentinelAtomically(doc);
+    state.lastPlugins = current;
+
+    log.info(
+      { generation: state.generation, changedDirs },
+      "plugin source change published",
+    );
+    return true;
+  } catch (err) {
+    log.error({ err }, "plugin source watch pass failed — will retry");
+    return false;
+  }
+}
+
+/**
+ * Write the sentinel via temp-file + rename so readers never observe a torn
+ * document. The temp file shares the sentinel's dotfile prefix, keeping it
+ * outside every fingerprint walk.
+ */
+function writeSentinelAtomically(doc: SourceVersionsDocument): void {
+  const path = getSourceVersionsPath();
+  mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(doc, null, 2));
+  renameSync(tmpPath, path);
+}
+
+/** Handle for the running watcher loop. */
+export interface PluginSourceWatchHandle {
+  stop(): void;
+}
+
+/**
+ * Start the watcher loop: one pass immediately (so a fresh boot publishes a
+ * baseline without waiting a full interval), then one per `intervalMs`.
+ * Passes are synchronous, so ticks never overlap.
+ */
+export function startPluginSourceWatch(
+  intervalMs: number,
+): PluginSourceWatchHandle {
+  const state = createSourceWatchState();
+  runSourceWatchPass(state);
+  const timer = setInterval(() => {
+    runSourceWatchPass(state);
+  }, intervalMs);
+  return {
+    stop: () => clearInterval(timer),
+  };
+}

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -19,6 +19,10 @@ import {
   getMonitoringPidPath,
 } from "../util/platform.js";
 import {
+  type PluginSourceWatchHandle,
+  startPluginSourceWatch,
+} from "./plugin-source-watch.js";
+import {
   type ResourceSamplerHandle,
   startResourceSampler,
 } from "./resource-sampler.js";
@@ -58,9 +62,13 @@ async function main(): Promise<void> {
   const sampler: ResourceSamplerHandle = startResourceSampler(
     config.monitoring,
   );
+  const sourceWatch: PluginSourceWatchHandle = startPluginSourceWatch(
+    config.monitoring.pluginSourceScanIntervalMs,
+  );
 
   const shutdown = (signal: string) => {
     log.info({ signal }, "Resource monitor process shutting down");
+    sourceWatch.stop();
     sampler.stop();
     cleanupPidFile();
     process.exit(0);
@@ -71,6 +79,7 @@ async function main(): Promise<void> {
 
   process.on("uncaughtException", (err) => {
     log.error({ err }, "Uncaught exception in resource monitor process");
+    sourceWatch.stop();
     sampler.stop();
     cleanupPidFile();
     process.exit(1);
@@ -78,12 +87,14 @@ async function main(): Promise<void> {
 
   process.on("unhandledRejection", (reason) => {
     log.error({ reason }, "Unhandled rejection in resource monitor process");
+    sourceWatch.stop();
     sampler.stop();
     cleanupPidFile();
     process.exit(1);
   });
 
   process.on("exit", () => {
+    sourceWatch.stop();
     sampler.stop();
     cleanupPidFile();
   });

--- a/assistant/src/plugins/__tests__/source-fingerprint.test.ts
+++ b/assistant/src/plugins/__tests__/source-fingerprint.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the plugin source fingerprint walk: what is included and
+ * excluded, which changes move the fingerprint, and how symlinked plugin
+ * roots surface in the eviction paths.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { snapshotPluginSource } from "../source-fingerprint.js";
+
+const root = mkdtempSync(join(tmpdir(), "source-fingerprint-"));
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * Writes get explicitly bumped, strictly increasing mtimes so two writes
+ * never land inside the same filesystem-timestamp granule.
+ */
+let mtimeSeq = 1_750_000_000;
+function writeStamped(path: string, content: string): void {
+  writeFileSync(path, content);
+  const stamp = new Date(++mtimeSeq * 1000);
+  utimesSync(path, stamp, stamp);
+}
+
+let fixtureSeq = 0;
+function makePluginDir(): string {
+  const dir = join(root, `plugin-${++fixtureSeq}`);
+  mkdirSync(join(dir, "hooks"), { recursive: true });
+  writeStamped(join(dir, "hooks", "stop.ts"), `export default () => 1;\n`);
+  return dir;
+}
+
+describe("snapshotPluginSource", () => {
+  test("includes nested source files; excludes node_modules, data/, root sidecars, and dotfiles", () => {
+    const dir = makePluginDir();
+    mkdirSync(join(dir, "lib", "deep"), { recursive: true });
+    writeStamped(join(dir, "lib", "deep", "helper.ts"), "export const x = 1;");
+    writeStamped(join(dir, "package.json"), `{"name":"p"}`);
+
+    // Excluded: vendored deps anywhere, runtime data and config sidecars at
+    // the root, dot-entries.
+    mkdirSync(join(dir, "node_modules", "dep"), { recursive: true });
+    writeStamped(join(dir, "node_modules", "dep", "index.js"), "x");
+    mkdirSync(join(dir, "data"), { recursive: true });
+    writeStamped(join(dir, "data", "state.json"), "{}");
+    writeStamped(join(dir, "config.json"), "{}");
+    writeStamped(join(dir, "install-meta.json"), "{}");
+    writeStamped(join(dir, ".disabled"), "");
+
+    // Included: a nested directory named `data` is source, not the runtime
+    // data dir — only the root-level one is excluded.
+    mkdirSync(join(dir, "lib", "data"), { recursive: true });
+    writeStamped(join(dir, "lib", "data", "table.ts"), "export const t = 1;");
+
+    const { evictionPaths } = snapshotPluginSource(dir);
+    const names = evictionPaths.map((p) => p.slice(dir.length));
+
+    expect(names).toContain("/hooks/stop.ts");
+    expect(names).toContain("/lib/deep/helper.ts");
+    expect(names).toContain("/lib/data/table.ts");
+    expect(names).toContain("/package.json");
+    expect(names.some((n) => n.includes("node_modules"))).toBe(false);
+    expect(names).not.toContain("/data/state.json");
+    expect(names).not.toContain("/config.json");
+    expect(names).not.toContain("/install-meta.json");
+    expect(names).not.toContain("/.disabled");
+  });
+
+  test("is stable across identical walks and moves on edit, add, delete, and rename", () => {
+    const dir = makePluginDir();
+    const helper = join(dir, "hooks", "helper.ts");
+    writeStamped(helper, "export const v = 1;");
+
+    const base = snapshotPluginSource(dir).fingerprint;
+    expect(snapshotPluginSource(dir).fingerprint).toBe(base);
+
+    // Edit (mtime moves).
+    writeStamped(helper, "export const v = 2;");
+    const afterEdit = snapshotPluginSource(dir).fingerprint;
+    expect(afterEdit).not.toBe(base);
+
+    // Add.
+    writeStamped(join(dir, "hooks", "extra.ts"), "export const e = 1;");
+    const afterAdd = snapshotPluginSource(dir).fingerprint;
+    expect(afterAdd).not.toBe(afterEdit);
+
+    // Rename — same file count, same mtimes, different path set.
+    renameSync(
+      join(dir, "hooks", "extra.ts"),
+      join(dir, "hooks", "renamed.ts"),
+    );
+    const afterRename = snapshotPluginSource(dir).fingerprint;
+    expect(afterRename).not.toBe(afterAdd);
+
+    // Delete.
+    unlinkSync(join(dir, "hooks", "renamed.ts"));
+    const afterDelete = snapshotPluginSource(dir).fingerprint;
+    expect(afterDelete).not.toBe(afterRename);
+  });
+
+  test("a symlinked plugin root yields both canonical and alias eviction paths", () => {
+    const realDir = makePluginDir();
+    const linkDir = join(root, `link-${fixtureSeq}`);
+    symlinkSync(realDir, linkDir);
+
+    const { evictionPaths } = snapshotPluginSource(linkDir);
+
+    // The registry may key modules under either form depending on the
+    // importer's specifier, so both must be evictable.
+    expect(evictionPaths).toContain(join(realDir, "hooks", "stop.ts"));
+    expect(evictionPaths).toContain(join(linkDir, "hooks", "stop.ts"));
+  });
+
+  test("a missing directory yields an empty snapshot", () => {
+    const snapshot = snapshotPluginSource(join(root, "does-not-exist"));
+    expect(snapshot.fingerprint).toBe("");
+    expect(snapshot.evictionPaths).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-plugin source snapshots — the change detector behind plugin live
+ * reload.
+ *
+ * A hook or tool file may import helper modules from anywhere inside its
+ * plugin directory, and the runtime module registry caches every one of
+ * them independently. Watching only the entry file's mtime therefore misses
+ * helper edits, and evicting only the entry file would re-bind it to stale
+ * cached helpers (or worse, to a stale intermediate module in a
+ * `hook → a → b` chain). Instead of tracking the real import graph, the
+ * source watcher (`../monitoring/plugin-source-watch.ts`) treats the whole
+ * plugin directory as the reload unit: one walk produces both a
+ * **fingerprint** (did any source file change?) and the **eviction list**
+ * (every path that must leave a module registry so the next imports
+ * re-evaluate a mutually consistent set). Evicting a path that was never
+ * imported is a harmless no-op, so the walk doesn't need to know what the
+ * plugin actually imported.
+ *
+ * Exclusions: dot-entries anywhere (`.disabled`, `.git`, …), `node_modules`
+ * anywhere (vendored deps change only through install flows, which recycle
+ * the plugin directory), and — at the plugin root only — the `data/` runtime
+ * directory and the `config.json` / `install-meta.json` sidecars, none of
+ * which are importable source. Imports that reach *outside* the plugin
+ * directory are out of scope by design: shared deps keep their module
+ * identity across reloads, and cross-plugin imports are unsupported.
+ */
+
+import { readdirSync, realpathSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Directory names skipped at any depth. */
+const EXCLUDED_DIRS_ANYWHERE = new Set(["node_modules"]);
+
+/** Directory names skipped only directly under the plugin root. */
+const EXCLUDED_ROOT_DIRS = new Set(["data"]);
+
+/** File names skipped only directly under the plugin root. */
+const EXCLUDED_ROOT_FILES = new Set(["config.json", "install-meta.json"]);
+
+/**
+ * The result of one source walk over a plugin directory.
+ */
+export interface SourceSnapshot {
+  /**
+   * Opaque version stamp for the plugin's source: the sorted
+   * `(path, mtimeMs)` pairs of every included file. Two snapshots compare
+   * equal iff no source file was edited, added, removed, or renamed —
+   * unlike a max-mtime scheme, which misses swaps that don't advance the
+   * clock.
+   */
+  readonly fingerprint: string;
+  /**
+   * Absolute paths to evict from the module registry when the fingerprint
+   * changes. Contains the realpath form of every included file, plus the
+   * symlink-rooted alias of each when the plugin directory is reached
+   * through a symlink — the registry may key a module under either form
+   * depending on the path the importer used.
+   */
+  readonly evictionPaths: readonly string[];
+}
+
+/**
+ * Walk `pluginDir` and snapshot its source files. Best-effort on a directory
+ * that's being mutated mid-walk: unreadable entries are skipped, and a
+ * missing directory yields an empty snapshot (the plugin-deletion path in
+ * the scan handles that case before fingerprints are compared).
+ */
+export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
+  let realRoot = pluginDir;
+  try {
+    realRoot = realpathSync(pluginDir);
+  } catch {
+    // Unresolvable (deleted mid-scan) — walk the given path; it will yield
+    // an empty file list.
+  }
+
+  const files: Array<{ path: string; mtimeMs: number }> = [];
+  walk(realRoot, realRoot, files);
+
+  // readdir order is platform-dependent; sort for a stable fingerprint.
+  files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const fingerprint = files
+    .map((f) => `${f.path}\u0000${f.mtimeMs}`)
+    .join("\n");
+
+  const evictionPaths = files.map((f) => f.path);
+  if (realRoot !== pluginDir) {
+    for (const f of files) {
+      evictionPaths.push(pluginDir + f.path.slice(realRoot.length));
+    }
+  }
+
+  return { fingerprint, evictionPaths };
+}
+
+function walk(
+  dir: string,
+  root: string,
+  out: Array<{ path: string; mtimeMs: number }>,
+): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith(".")) {
+      continue;
+    }
+
+    const path = join(dir, name);
+    let isDir = entry.isDirectory();
+    let isFile = entry.isFile();
+    if (entry.isSymbolicLink()) {
+      try {
+        const st = statSync(path);
+        isDir = st.isDirectory();
+        isFile = st.isFile();
+      } catch {
+        continue; // dangling symlink
+      }
+    }
+
+    if (isDir) {
+      if (EXCLUDED_DIRS_ANYWHERE.has(name)) {
+        continue;
+      }
+      if (dir === root && EXCLUDED_ROOT_DIRS.has(name)) {
+        continue;
+      }
+      walk(path, root, out);
+    } else if (isFile) {
+      if (dir === root && EXCLUDED_ROOT_FILES.has(name)) {
+        continue;
+      }
+      try {
+        out.push({ path, mtimeMs: statSync(path).mtimeMs });
+      } catch {
+        // Deleted between readdir and stat — the next scan sees the removal.
+      }
+    }
+  }
+}

--- a/assistant/src/plugins/source-versions.ts
+++ b/assistant/src/plugins/source-versions.ts
@@ -1,0 +1,103 @@
+/**
+ * The plugin source-versions sentinel — the broadcast contract between the
+ * resource monitor's source watcher (the single writer, running in its own
+ * OS process) and every process that holds plugin code in a module registry
+ * (the readers: the daemon, platform workers, plugin-spawned workers).
+ *
+ * The watcher rewrites the document atomically (temp + rename) and only when
+ * plugin source actually changed, so "the sentinel's mtime moved" is exactly
+ * the signal "some plugin's source is different". A reader keeps the last
+ * document it saw, stats this one file on its own cadence (constant cost,
+ * independent of plugin count and size), and on change diffs per-directory
+ * fingerprints to learn *which* plugins changed and *which* module paths to
+ * evict from its own registry — no walking, no registry enumeration.
+ *
+ * Readers must diff `plugins` fingerprints, never `generation`: generation
+ * is per-writer-lifetime bookkeeping, and a watcher restart that observes
+ * identical source adopts the existing document without rewriting, so
+ * fingerprint diffs stay idempotent across restarts.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspacePluginsDir } from "../util/platform.js";
+
+/** Sentinel filename, directly under `<workspace>/plugins/`. The leading dot
+ * keeps it out of the watcher's own per-plugin walks. */
+export const SOURCE_VERSIONS_FILENAME = ".source-versions.json";
+
+/** Document format version; readers ignore documents from a different format. */
+export const SOURCE_VERSIONS_FORMAT = 1;
+
+/**
+ * One watched directory's source state: a plugin directory, or the
+ * standalone workspace hooks directory.
+ */
+export interface PluginSourceVersion {
+  /**
+   * Opaque stamp over the directory's source files (see
+   * `./source-fingerprint.ts`). Changes iff a source file was edited,
+   * added, removed, or renamed.
+   */
+  readonly fingerprint: string;
+  /**
+   * Absolute module paths a reader must evict from its module registry when
+   * this fingerprint changes — the realpath of every source file, plus
+   * symlink-rooted aliases when the directory is reached through a symlink.
+   * Eviction cost scales with the plugin, not with the reader's whole
+   * module graph.
+   */
+  readonly evictionPaths: readonly string[];
+  /** Whether a `.disabled` sentinel is present. Dotfiles are excluded from
+   * the fingerprint, so this surfaces disable/enable transitions. */
+  readonly disabled: boolean;
+}
+
+/** The on-disk sentinel document. */
+export interface SourceVersionsDocument {
+  readonly format: number;
+  /** Increments on every rewrite within one watcher lifetime. Bookkeeping
+   * only — readers diff fingerprints, not this. */
+  readonly generation: number;
+  /** ISO timestamp of the last rewrite, for staleness logging. */
+  readonly writtenAt: string;
+  /**
+   * Keyed by the absolute directory path as the platform helpers construct
+   * it (`getWorkspacePluginsDir()`-derived plugin dirs, plus
+   * `getWorkspaceHooksDir()` for standalone workspace hooks), so readers
+   * can key their own state the same way without any name resolution.
+   */
+  readonly plugins: Readonly<Record<string, PluginSourceVersion>>;
+}
+
+/** Absolute path of the sentinel document. */
+export function getSourceVersionsPath(): string {
+  return join(getWorkspacePluginsDir(), SOURCE_VERSIONS_FILENAME);
+}
+
+/**
+ * Read and minimally validate the sentinel. Returns `null` when the file is
+ * missing, unparseable, or from a different format version — readers treat
+ * all three as "no live-reload signal available" and keep their last state.
+ */
+export function readSourceVersions(): SourceVersionsDocument | null {
+  try {
+    const raw: unknown = JSON.parse(
+      readFileSync(getSourceVersionsPath(), "utf8"),
+    );
+    if (typeof raw !== "object" || raw === null) {
+      return null;
+    }
+    const doc = raw as SourceVersionsDocument;
+    if (doc.format !== SOURCE_VERSIONS_FORMAT) {
+      return null;
+    }
+    if (typeof doc.plugins !== "object" || doc.plugins === null) {
+      return null;
+    }
+    return doc;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Prompt / plan

PR 1 of the plugin live-reload sequence (design on #37136; PR 0 was #37145). This is the **detector half**: hook dispatch in the daemon is a hot path, so the daemon must never pay for filesystem walks to learn whether plugin source changed. The (now always-on) resource monitor process does the walking instead and broadcasts changes through a sentinel document that any process holding plugin code in its module registry can consume with a single stat.

**Ships inert** — nothing reads the sentinel yet. The daemon consumer (redeploy on change, hot path down to one stat) is the next PR.

- **`plugins/source-fingerprint.ts`** — the walk engine (recovered from #37136): per-directory sorted `(path, mtimeMs)`-pair fingerprint, so edits, adds, deletes, and renames all register (max-mtime schemes miss timestamp-preserving swaps), plus the eviction path list from the same walk. Excludes `node_modules` anywhere, root-level `data/` + `config.json`/`install-meta.json` sidecars, and dotfiles; realpaths the root and emits both canonical and symlink-alias paths since the module registry may key either form.
- **`plugins/source-versions.ts`** — the sentinel contract: `<plugins>/.source-versions.json`, format-versioned, per-directory `{ fingerprint, evictionPaths, disabled }` keyed by absolute directory path, plus a generation counter and `writtenAt` (bookkeeping — readers diff fingerprints, never generation). Eviction lists ship in the document deliberately: eviction cost should scale with the plugin, not the reader's module graph (prefix-scanning `require.cache` measured ~46 ms at 5k entries in Bun, super-linear in total registry size).
- **`monitoring/plugin-source-watch.ts`** — the watcher loop, started from the monitor worker beside the resource sampler on a new `monitoring.pluginSourceScanIntervalMs` config (default 2 s). Rewrites atomically (temp + rename) and **only on change**, so the sentinel's mtime is itself the change signal; a restarted watcher adopts an unchanged document rather than publishing a spurious change; `.disabled` toggles publish as a field since dotfiles sit outside the fingerprint. Passes are synchronous (no overlap) and never throw — a failed walk logs and retries next tick. Polling-by-stat is deliberate: inotify doesn't reliably see host-side writes on virtualized mounts (virtiofs, 9p), and a pass over 10 plugins × 100 files measures ~3.6 ms warm on ext4.
- The standalone workspace hooks directory is watched as a pseudo-plugin entry so helper-grade reload semantics can cover it too.

## Test plan

- `plugins/__tests__/source-fingerprint.test.ts` — inclusion/exclusion rules (incl. nested `data/` dirs being source), fingerprint movement on edit/add/rename/delete and stability across identical walks, symlinked-root alias paths, missing-directory behavior.
- `monitoring/__tests__/plugin-source-watch.test.ts` — drives passes directly (no timers): baseline publish covering plugins + workspace hooks, no-change passes don't rewrite (mtime + generation stable), helper edit moves only that plugin's fingerprint, `.disabled` toggles publish both ways, add/remove publish, watcher restart adopts an unchanged sentinel and continues the generation sequence, no temp file left behind.
- Mutation-checked: forcing the change comparison to always-equal fails 4 tests; removing restart adoption fails the restart test.
- Adjacent suites green per-file as CI runs them (monitoring control/heartbeat/routes, mtime-cache, hook-live-reload). eslint, prettier, `tsc --noEmit` clean via pre-commit hooks. No route changes, so no OpenAPI regeneration needed this time.

## CLI verb checklist

No new routes — monitor-process feature plus a config field. A future `assistant plugins reload` verb, if wanted, belongs with the daemon-consumer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_