### PR TITLE
fix(web): exclude vellum from the profile provider picker

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -453,6 +453,11 @@ function ProfileEditorModalInner({
   // provider + connection, collapse the sub-form, surface the helper note,
   // and invalidate the connections query so the dropdown picks up the row.
   function handleProviderCreated(connection: ProviderConnection) {
+    // The create form can't produce a vellum connection; bail before touching
+    // any state so the sub-form can't get stuck, and narrow the
+    // ConnectionProvider to the LlmProvider that setProvider accepts.
+    const newProvider = connection.provider;
+    if (newProvider === "vellum") return;
     // Optimistically register the new connection locally so the binding is
     // valid immediately (the parent `connections` refetch below is async).
     setLocallyCreatedConnections((prev) =>
@@ -460,10 +465,7 @@ function ProfileEditorModalInner({
         ? prev
         : [...prev, connection],
     );
-    // The create form can't produce a vellum connection; guard narrows the
-    // ConnectionProvider to the LlmProvider that setProvider accepts.
-    if (connection.provider === "vellum") return;
-    setProvider(connection.provider);
+    setProvider(newProvider);
     setProviderConnection(connection.name);
     setModel("");
     setCreatingProvider(false);

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -361,6 +361,9 @@ function ProfileEditorModalInner({
 
   function handleProviderChange(newProvider: ConnectionProvider) {
     if (newProvider === provider) return;
+    // vellum is a connection type, not a selectable profile LLM provider — it's
+    // filtered out of the picker; this narrows ConnectionProvider to LlmProvider.
+    if (newProvider === "vellum") return;
     setProvider(newProvider);
     setModel("");
     // Auto-select connection: if exactly one connection exists for the new
@@ -457,6 +460,9 @@ function ProfileEditorModalInner({
         ? prev
         : [...prev, connection],
     );
+    // The create form can't produce a vellum connection; guard narrows the
+    // ConnectionProvider to the LlmProvider that setProvider accepts.
+    if (connection.provider === "vellum") return;
     setProvider(connection.provider);
     setProviderConnection(connection.name);
     setModel("");

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -8,10 +8,15 @@ import type { ConnectionProvider } from "@/generated/daemon/types.gen";
 
 const LOCAL_ONLY_PROVIDERS = new Set<string>(["ollama"]);
 
+// vellum is a managed connection type, not a profile LLM provider — it has no
+// entry in LlmProvider, so it can't back a profile's `provider` field.
+const CONNECTION_ONLY_PROVIDERS = new Set<string>(["vellum"]);
+
 export function isProviderSelectableForAssistant(
   provider: string,
   activeAssistantIsSelfHosted: boolean,
 ): boolean {
+  if (CONNECTION_ONLY_PROVIDERS.has(provider)) return false;
   return !LOCAL_ONLY_PROVIDERS.has(provider) || activeAssistantIsSelfHosted;
 }
 


### PR DESCRIPTION
## What

`vellum` landed in the daemon spec's `ConnectionProvider` enum with PR2 (#37081), but it is **not** an `LlmProvider` — so it can't back a profile's `provider` field. The profile editor feeds `ConnectionProvider` values into `setProvider` (typed to `LlmProvider`), which left the web **Type Check broken on `main`** for every web PR since PR2 (first surfaced by the automated OpenAPI-sync PR #37150).

## Fix

Treat vellum as connection-only:
- `provider-availability.ts` — new `CONNECTION_ONLY_PROVIDERS` set filters vellum out of the profile provider picker.
- `profile-editor-modal.tsx` — two guards on the `setProvider` call sites narrow `ConnectionProvider` → `LlmProvider`.

No behavior change beyond keeping vellum (a managed connection, not a selectable profile LLM provider) out of the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->