### PR TITLE
exclude all `node_modules` from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,7 +34,6 @@
 !skills/meet-join/scripts/**
 
 # Exclude local dependencies and build outputs from included directories.
-assistant/node_modules/
 assistant/dist/
 assistant/out/
 assistant/build/
@@ -42,16 +41,13 @@ assistant/.env
 assistant/.env.*
 # Authoring-reference example plugins are not shipped with the production image.
 assistant/examples/
-credential-executor/node_modules/
 credential-executor/.env
 credential-executor/.env.*
-gateway/node_modules/
 gateway/.env
 gateway/.env.*
-packages/*/node_modules/
 packages/*/.env
 packages/*/.env.*
-skills/meet-join/node_modules/
-skills/meet-join/contracts/node_modules/
 skills/meet-join/**/__tests__/
 skills/meet-join/**/*.test.ts
+
+**/node_modules/


### PR DESCRIPTION
I noticed that `assistant/src/api/node_modules` carried over into the build context.

---

Docker context load times seem fine, but should be a little mindful.

See https://github.com/vellum-ai/vellum-assistant/pull/37042/changes/f75330015d46d20e6219c08dc36f4f8abd0ad684#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5 for context.

We introduced some
```
!clients/macos/package.json
!clients/web/package.json
!clients/web/patches/**
```
whitelists.

Even though the global `**` at the top of dockerignore file correctly excludes most files (including `clients/.build/`) from the final build context, it seems docker's file walker would still traverse that entire directory. Adding a manual (re)exclude rule for `clients/.build/` helped

Should be a little careful the same thing doesn't happen here