### PR TITLE
fix(assistant): correct stale privacy-boundary references in default user persona

### DIFF
--- a/assistant/src/__tests__/workspace-migration-124-correct-default-user-boundary-comments.test.ts
+++ b/assistant/src/__tests__/workspace-migration-124-correct-default-user-boundary-comments.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for workspace migration `124-correct-default-user-boundary-comments`.
+ *
+ * The non-guardian privacy boundary renders from the always-on bundled section
+ * `10a-non-guardian-boundary`, not from `users/default.md`. The greetings-only
+ * seed that migration 122 wrote still had comments pointing at a "privacy
+ * boundary below" as if it lived in this file. This migration rewrites exactly
+ * that seed (or an absent/blank file) to a version whose comments describe the
+ * boundary as built-in, and leaves any customized file untouched.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedDefaultUserGuardrailsMigration } from "../workspace/migrations/121-seed-default-user-guardrails.js";
+import { relocateDefaultUserBoundaryMigration } from "../workspace/migrations/122-relocate-default-user-boundary.js";
+import { correctDefaultUserBoundaryCommentsMigration } from "../workspace/migrations/124-correct-default-user-boundary-comments.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-124-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function defaultPath(): string {
+  return join(workspaceDir, "users", "default.md");
+}
+
+function readDefault(): string {
+  return readFileSync(defaultPath(), "utf-8");
+}
+
+/** The shipped bundled template a fresh install seeds via ensurePromptFiles(). */
+function bundledTemplate(): string {
+  return readFileSync(
+    join(
+      import.meta.dirname!,
+      "..",
+      "prompts",
+      "templates",
+      "users",
+      "default.md",
+    ),
+    "utf-8",
+  );
+}
+
+describe("124-correct-default-user-boundary-comments migration", () => {
+  test("has correct id and description", () => {
+    expect(correctDefaultUserBoundaryCommentsMigration.id).toBe(
+      "124-correct-default-user-boundary-comments",
+    );
+    expect(correctDefaultUserBoundaryCommentsMigration.description).toContain(
+      "default.md",
+    );
+  });
+
+  test("rewrites the migration-122 greetings seed to corrected comments (the real upgrade path)", () => {
+    // Reproduce the exact on-disk state the 121 → 122 chain leaves behind.
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    relocateDefaultUserBoundaryMigration.run(workspaceDir);
+    const beforeCorrection = readDefault();
+    expect(beforeCorrection).toContain("respecting the privacy boundary below");
+    expect(beforeCorrection).toContain("within the privacy boundary below");
+    expect(beforeCorrection).toContain("built in and always renders");
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    const content = readDefault();
+    // Stale directional references are gone...
+    expect(content).not.toContain("privacy boundary below");
+    expect(content).not.toContain("built in and always renders");
+    expect(content).not.toContain("editing this file cannot");
+    // ...replaced by the built-in phrasing.
+    expect(content).toContain("respecting the built-in privacy boundary");
+    expect(content).toContain("within the built-in privacy boundary");
+    expect(content).toContain("so it isn't part of this file");
+    // Greetings are preserved and it stays boundary-free (the boundary is
+    // bundled in `10a-non-guardian-boundary`, not this file).
+    expect(content).toContain("{{#isTrustedContact}}");
+    expect(content).toContain("{{#isStranger}}");
+    expect(content).not.toContain("Protect your guardian's privacy");
+  });
+
+  test("produces content byte-identical to the shipped bundled template", () => {
+    // Fresh installs seed default.md from the bundled template; upgrades run
+    // this migration. Both paths must converge on the same bytes.
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    relocateDefaultUserBoundaryMigration.run(workspaceDir);
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    expect(readDefault()).toBe(bundledTemplate());
+  });
+
+  test("seeds the corrected template when the file is absent", () => {
+    expect(existsSync(defaultPath())).toBe(false);
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    const content = readDefault();
+    expect(content).toContain("{{#isTrustedContact}}");
+    expect(content).toContain("so it isn't part of this file");
+    expect(content).not.toContain("privacy boundary below");
+  });
+
+  test("seeds the corrected template over a blank file", () => {
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), "  \n\t\n", "utf-8");
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    expect(readDefault()).toContain("within the built-in privacy boundary");
+  });
+
+  test("does not clobber a customized default.md", () => {
+    const existing =
+      "# My contacts\n\nBe extra chatty with everyone, and mention the privacy boundary below.\n";
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), existing, "utf-8");
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    expect(readDefault()).toBe(existing);
+  });
+
+  test("leaves an already-corrected file untouched (fresh-install no-op)", () => {
+    // A fresh install already carries the corrected bundled template; the
+    // migration must recognize it as non-matching and leave it alone.
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(defaultPath(), bundledTemplate(), "utf-8");
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    expect(readDefault()).toBe(bundledTemplate());
+  });
+
+  test("idempotent — second run does not rewrite the corrected file", () => {
+    seedDefaultUserGuardrailsMigration.run(workspaceDir);
+    relocateDefaultUserBoundaryMigration.run(workspaceDir);
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+    const afterFirst = readDefault();
+
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+
+    expect(readDefault()).toBe(afterFirst);
+  });
+
+  test("down() is a no-op — file remains", () => {
+    correctDefaultUserBoundaryCommentsMigration.run(workspaceDir);
+    const seeded = readDefault();
+
+    correctDefaultUserBoundaryCommentsMigration.down(workspaceDir);
+
+    expect(existsSync(defaultPath())).toBe(true);
+    expect(readDefault()).toBe(seeded);
+  });
+});

--- a/assistant/src/prompts/templates/users/default.md
+++ b/assistant/src/prompts/templates/users/default.md
@@ -2,19 +2,19 @@ _ Lines starting with _ are comments — they won't appear in the system prompt.
 _ This file shapes how you greet and frame conversations with people who are NOT your
 _ guardian: a trusted contact your guardian has added, or someone you don't recognize.
 _ Your guardian has their own users/<name>.md profile, so editing this file never changes
-_ how you treat your guardian. The privacy boundary itself is built in and always renders
-_ for non-guardian conversations, right after this persona — editing this file cannot
-_ remove it.
+_ how you treat your guardian. Edit the greetings and tone freely — the privacy boundary
+_ that protects your guardian's personal information is built in and renders automatically
+_ for every non-guardian conversation, so it isn't part of this file.
 
 {{#isTrustedContact}}
 # You're talking with a trusted contact
 
-The person you're talking to is a contact your guardian has added — not your guardian. Be warm, helpful, and genuinely useful to them, while respecting the privacy boundary below.
+The person you're talking to is a contact your guardian has added — not your guardian. Be warm, helpful, and genuinely useful to them, while respecting the built-in privacy boundary.
 
 {{/isTrustedContact}}
 {{#isStranger}}
 # You're talking with someone you don't recognize
 
-The person you're talking to is not your guardian, and you don't recognize them. Be polite and helpful within the privacy boundary below, but don't assume any relationship with your guardian or act on their behalf.
+The person you're talking to is not your guardian, and you don't recognize them. Be polite and helpful within the built-in privacy boundary, but don't assume any relationship with your guardian or act on their behalf.
 
 {{/isStranger}}

--- a/assistant/src/workspace/migrations/124-correct-default-user-boundary-comments.ts
+++ b/assistant/src/workspace/migrations/124-correct-default-user-boundary-comments.ts
@@ -1,0 +1,99 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Inlined snapshot of the greetings-only `users/default.md` seed written by
+// migration 122 (and carried by the bundled template of that era). Its comment
+// header and the two greeting lines still point at a "privacy boundary below"
+// as if the boundary lived in this file, but the non-guardian privacy boundary
+// renders from the always-on bundled section `10a-non-guardian-boundary` and
+// never appears here. Kept verbatim so this migration is self-contained and
+// matches the exact on-disk seed it upgrades.
+const GREETINGS_SEED_STALE_COMMENTS = `_ Lines starting with _ are comments — they won't appear in the system prompt.
+_ This file shapes how you greet and frame conversations with people who are NOT your
+_ guardian: a trusted contact your guardian has added, or someone you don't recognize.
+_ Your guardian has their own users/<name>.md profile, so editing this file never changes
+_ how you treat your guardian. The privacy boundary itself is built in and always renders
+_ for non-guardian conversations, right after this persona — editing this file cannot
+_ remove it.
+
+{{#isTrustedContact}}
+# You're talking with a trusted contact
+
+The person you're talking to is a contact your guardian has added — not your guardian. Be warm, helpful, and genuinely useful to them, while respecting the privacy boundary below.
+
+{{/isTrustedContact}}
+{{#isStranger}}
+# You're talking with someone you don't recognize
+
+The person you're talking to is not your guardian, and you don't recognize them. Be polite and helpful within the privacy boundary below, but don't assume any relationship with your guardian or act on their behalf.
+
+{{/isStranger}}
+`;
+
+// Inlined snapshot of the corrected greetings-only template: the comment header
+// explains that the privacy boundary is built in and not part of this file, and
+// the two greeting lines reference the built-in boundary instead of a boundary
+// "below". Byte-for-byte identical to the bundled `users/default.md` template.
+const GREETINGS_SEED_CORRECTED = `_ Lines starting with _ are comments — they won't appear in the system prompt.
+_ This file shapes how you greet and frame conversations with people who are NOT your
+_ guardian: a trusted contact your guardian has added, or someone you don't recognize.
+_ Your guardian has their own users/<name>.md profile, so editing this file never changes
+_ how you treat your guardian. Edit the greetings and tone freely — the privacy boundary
+_ that protects your guardian's personal information is built in and renders automatically
+_ for every non-guardian conversation, so it isn't part of this file.
+
+{{#isTrustedContact}}
+# You're talking with a trusted contact
+
+The person you're talking to is a contact your guardian has added — not your guardian. Be warm, helpful, and genuinely useful to them, while respecting the built-in privacy boundary.
+
+{{/isTrustedContact}}
+{{#isStranger}}
+# You're talking with someone you don't recognize
+
+The person you're talking to is not your guardian, and you don't recognize them. Be polite and helpful within the built-in privacy boundary, but don't assume any relationship with your guardian or act on their behalf.
+
+{{/isStranger}}
+`;
+
+export const correctDefaultUserBoundaryCommentsMigration: WorkspaceMigration = {
+  id: "124-correct-default-user-boundary-comments",
+  description:
+    "Rewrite the migration-122 users/default.md greetings seed so its comments describe the privacy boundary as the always-on bundled section it is, not a boundary living in this file",
+
+  down(_workspaceDir: string): void {
+    // No-op: we don't delete or revert user-editable persona files on rollback.
+  },
+
+  run(workspaceDir: string): void {
+    const usersDir = join(workspaceDir, "users");
+    const defaultPath = join(usersDir, "default.md");
+
+    // Three cases:
+    //   - absent/blank file → seed the corrected greetings template.
+    //   - exactly the migration-122 greetings seed → rewrite it so the comments
+    //     stop describing the privacy boundary as living "below" in this file;
+    //     it renders from the always-on `10a-non-guardian-boundary` section.
+    //   - anything else → the guardian customized the file; leave it untouched.
+    if (existsSync(defaultPath)) {
+      let content: string;
+      try {
+        content = readFileSync(defaultPath, "utf-8");
+      } catch {
+        // Unreadable file: leave it untouched rather than risk overwriting.
+        return;
+      }
+      if (
+        content.trim().length > 0 &&
+        content !== GREETINGS_SEED_STALE_COMMENTS
+      ) {
+        return;
+      }
+    }
+
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(defaultPath, GREETINGS_SEED_CORRECTED, "utf-8");
+  },
+};

--- a/assistant/src/workspace/migrations/124-correct-default-user-boundary-comments.ts
+++ b/assistant/src/workspace/migrations/124-correct-default-user-boundary-comments.ts
@@ -3,13 +3,12 @@ import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";
 
-// Inlined snapshot of the greetings-only `users/default.md` seed written by
-// migration 122 (and carried by the bundled template of that era). Its comment
-// header and the two greeting lines still point at a "privacy boundary below"
-// as if the boundary lived in this file, but the non-guardian privacy boundary
-// renders from the always-on bundled section `10a-non-guardian-boundary` and
-// never appears here. Kept verbatim so this migration is self-contained and
-// matches the exact on-disk seed it upgrades.
+// Snapshot of the greetings-only `users/default.md` seed this migration matches
+// and rewrites. Its comment header and its two greeting lines describe the
+// non-guardian privacy boundary as a "privacy boundary below", as if the
+// boundary were part of this file. That boundary renders from the always-on
+// bundled section `10a-non-guardian-boundary` and is absent from this file, so
+// the wording is inaccurate. Matched byte-for-byte, so it is kept verbatim.
 const GREETINGS_SEED_STALE_COMMENTS = `_ Lines starting with _ are comments — they won't appear in the system prompt.
 _ This file shapes how you greet and frame conversations with people who are NOT your
 _ guardian: a trusted contact your guardian has added, or someone you don't recognize.
@@ -32,10 +31,10 @@ The person you're talking to is not your guardian, and you don't recognize them.
 {{/isStranger}}
 `;
 
-// Inlined snapshot of the corrected greetings-only template: the comment header
-// explains that the privacy boundary is built in and not part of this file, and
-// the two greeting lines reference the built-in boundary instead of a boundary
-// "below". Byte-for-byte identical to the bundled `users/default.md` template.
+// The corrected greetings-only template this migration writes. Its comment
+// header states the privacy boundary is built in and not part of this file, and
+// its two greeting lines reference the built-in privacy boundary. Byte-for-byte
+// identical to the bundled `users/default.md` template.
 const GREETINGS_SEED_CORRECTED = `_ Lines starting with _ are comments — they won't appear in the system prompt.
 _ This file shapes how you greet and frame conversations with people who are NOT your
 _ guardian: a trusted contact your guardian has added, or someone you don't recognize.
@@ -61,7 +60,7 @@ The person you're talking to is not your guardian, and you don't recognize them.
 export const correctDefaultUserBoundaryCommentsMigration: WorkspaceMigration = {
   id: "124-correct-default-user-boundary-comments",
   description:
-    "Rewrite the migration-122 users/default.md greetings seed so its comments describe the privacy boundary as the always-on bundled section it is, not a boundary living in this file",
+    "Rewrite the greetings-only users/default.md seed so its comments describe the non-guardian privacy boundary as the always-on bundled section it is, rather than a boundary living in this file",
 
   down(_workspaceDir: string): void {
     // No-op: we don't delete or revert user-editable persona files on rollback.
@@ -73,9 +72,9 @@ export const correctDefaultUserBoundaryCommentsMigration: WorkspaceMigration = {
 
     // Three cases:
     //   - absent/blank file → seed the corrected greetings template.
-    //   - exactly the migration-122 greetings seed → rewrite it so the comments
-    //     stop describing the privacy boundary as living "below" in this file;
-    //     it renders from the always-on `10a-non-guardian-boundary` section.
+    //   - exact `GREETINGS_SEED_STALE_COMMENTS` match → rewrite it to the
+    //     corrected template so the comments describe the privacy boundary as
+    //     the built-in section it is, not a boundary "below" in this file.
     //   - anything else → the guardian customized the file; leave it untouched.
     if (existsSync(defaultPath)) {
       let content: string;

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -121,6 +121,7 @@ import { reviseOnboardingThreadsMigration } from "./120-revise-onboarding-thread
 import { seedDefaultUserGuardrailsMigration } from "./121-seed-default-user-guardrails.js";
 import { relocateDefaultUserBoundaryMigration } from "./122-relocate-default-user-boundary.js";
 import { swapQualityProfileToFableMigration } from "./123-swap-quality-profile-to-fable.js";
+import { correctDefaultUserBoundaryCommentsMigration } from "./124-correct-default-user-boundary-comments.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -253,4 +254,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedDefaultUserGuardrailsMigration,
   relocateDefaultUserBoundaryMigration,
   swapQualityProfileToFableMigration,
+  correctDefaultUserBoundaryCommentsMigration,
 ];


### PR DESCRIPTION
## Prompt / plan

`assistant/src/prompts/templates/users/default.md` still described the non-guardian privacy boundary as if it lived in that file — a header comment saying the boundary "is built in and always renders … right after this persona — editing this file cannot remove it", plus two greeting lines pointing at "the privacy boundary below". The boundary now renders from the always-on bundled system section `10a-non-guardian-boundary` (automatically, after this persona, for non-guardian conversations) and no longer appears in this file, so those references are inaccurate and confusing to anyone opening the file to customize it.

This change corrects the wording and backfills the same correction to existing installs.

- **Header comment**: rewritten to explain the boundary is built in and renders automatically for every non-guardian conversation, so it isn't part of this file — useful framing for someone customizing the greetings/tone.
- **Inline phrases**: "respecting the privacy boundary below" → "respecting the built-in privacy boundary"; "within the privacy boundary below" → "within the built-in privacy boundary".
- **Greeting text** (headings and sentences) is otherwise unchanged.
- **Workspace migration 124** rewrites the migration-122 greetings seed on existing installs so upgrades converge on the corrected comments. It follows the migration-122 pattern: absent/blank files are seeded with the corrected template, a file matching the exact migration-122 seed is rewritten, and any customized (or already-corrected) file is left untouched.

## Test plan

- New `assistant/src/__tests__/workspace-migration-124-correct-default-user-boundary-comments.test.ts` (9 cases): the 121 → 122 → 124 upgrade path rewrites the greetings seed to the corrected comments; the result is **byte-identical to the shipped bundled template** so fresh and upgraded installs converge; absent/blank files are seeded; customized and already-corrected files are left untouched; idempotent; `down()` is a no-op.
- `bun test` for migrations 121/122/124, the workspace-migrations runner (duplicate-id / ordering guard), and both `system-prompt` suites (129 tests) — all green. The privacy-boundary guardrail assertions are unaffected because the boundary body renders from the bundled section, not from this template.
- `bunx tsc --noEmit` and `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLWRCvgToa5Ym6G3H2dFnY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLWRCvgToa5Ym6G3H2dFnY)_