### PR TITLE
fix(plugins): address source-watch review — sentinel location, symlink safety, shared tree walk

### DIFF
--- a/assistant/src/cli/lib/plugin-fingerprint.ts
+++ b/assistant/src/cli/lib/plugin-fingerprint.ts
@@ -16,8 +16,9 @@
  */
 
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+import { walkPluginTree } from "../../plugins/plugin-tree-walk.js";
 
 /** Digest algorithm recorded alongside the file map, for forward compatibility. */
 export type FingerprintAlgorithm = "sha256";
@@ -54,34 +55,18 @@ function hashFile(absPath: string): string {
 
 /**
  * Walk `root` and return a content digest for every regular file, keyed by its
- * POSIX-relative path. Symlinks are skipped (the loader does not follow them,
- * and install never materializes them); top-level entries named in `exclude`
- * are skipped so the provenance sidecar never fingerprints itself.
+ * POSIX-relative path. Symlinks are skipped (see {@link walkPluginTree});
+ * top-level entries named in `exclude` are skipped so the provenance sidecar
+ * never fingerprints itself.
  */
 export function computeFingerprint(
   root: string,
   exclude: readonly string[] = [],
 ): Fingerprint {
-  const excluded = new Set(exclude);
   const files: Record<string, string> = {};
-
-  const walk = (relDir: string): void => {
-    const absDir = relDir ? join(root, relDir) : root;
-    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
-      if (relDir === "" && excluded.has(entry.name)) continue;
-      // Only regular files contribute to the digest; symlinks are never part of
-      // a materialized install and a directory is descended into, not hashed.
-      if (entry.isSymbolicLink()) continue;
-      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
-      if (entry.isDirectory()) {
-        walk(rel);
-      } else if (entry.isFile()) {
-        files[rel] = hashFile(join(root, rel));
-      }
-    }
-  };
-
-  walk("");
+  walkPluginTree(root, { excludeRootEntries: exclude }, (rel, abs) => {
+    files[rel] = hashFile(abs);
+  });
   return { algorithm: "sha256", files };
 }
 
@@ -102,11 +87,16 @@ export function compareFingerprint(
 
   for (const [path, digest] of Object.entries(current)) {
     const recorded = baseline.files[path];
-    if (recorded === undefined) added.push(path);
-    else if (recorded !== digest) modified.push(path);
+    if (recorded === undefined) {
+      added.push(path);
+    } else if (recorded !== digest) {
+      modified.push(path);
+    }
   }
   for (const path of Object.keys(baseline.files)) {
-    if (current[path] === undefined) removed.push(path);
+    if (current[path] === undefined) {
+      removed.push(path);
+    }
   }
 
   modified.sort();
@@ -127,9 +117,13 @@ export function compareFingerprint(
  */
 export function fingerprintsEqual(a: Fingerprint, b: Fingerprint): boolean {
   const aKeys = Object.keys(a.files);
-  if (aKeys.length !== Object.keys(b.files).length) return false;
+  if (aKeys.length !== Object.keys(b.files).length) {
+    return false;
+  }
   for (const key of aKeys) {
-    if (a.files[key] !== b.files[key]) return false;
+    if (a.files[key] !== b.files[key]) {
+      return false;
+    }
   }
   return true;
 }
@@ -144,7 +138,9 @@ export function parseFingerprint(value: unknown): Fingerprint | null {
     return null;
   }
   const obj = value as Record<string, unknown>;
-  if (obj.algorithm !== "sha256") return null;
+  if (obj.algorithm !== "sha256") {
+    return null;
+  }
   const rawFiles = obj.files;
   if (
     typeof rawFiles !== "object" ||
@@ -155,33 +151,19 @@ export function parseFingerprint(value: unknown): Fingerprint | null {
   }
   const files: Record<string, string> = {};
   for (const [path, digest] of Object.entries(rawFiles)) {
-    if (typeof digest !== "string") return null;
+    if (typeof digest !== "string") {
+      return null;
+    }
     files[path] = digest;
   }
   return { algorithm: "sha256", files };
 }
 
-/**
- * Top-level entries that are preserved across upgrades and excluded from
- * fingerprinting / drift detection / content hashing. These are runtime-owned
- * state, not part of the plugin's source tree at the pinned commit:
- *
- * - `install-meta.json` — provenance sidecar written at install time.
- * - `config.json` — user-editable plugin config (lives in the plugin dir but
- *   is not tracked as source content, so user edits don't count as drift).
- * - `data` — runtime data directory (plugin writes whatever it wants here).
- * - `.disabled` — sentinel file created by `assistant plugins disable`.
- *
- * Without these exclusions, a user editing `config.json` or the plugin writing
- * to `data/` would surface as drift against the install-time baseline, and an
- * upgrade would try to overwrite or merge around user-owned state.
- */
-export const PRESERVED_ENTRIES = [
-  "install-meta.json",
-  "config.json",
-  "data",
-  ".disabled",
-] as const;
+// The preserved-entries constant lives with the shared walk so install
+// fingerprinting and the live-reload source fingerprint can't disagree on
+// what counts as the plugin's source tree; re-exported here for the
+// install/upgrade/diff callers that treat this module as the fingerprint API.
+export { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 
 /**
  * Aggregate SHA-256 digest over a tree's contents, returned as `v2:<hex>`.
@@ -201,23 +183,10 @@ export function computeContentHash(
   root: string,
   exclude: readonly string[] = [],
 ): string {
-  const excluded = new Set(exclude);
   const entries: Array<{ rel: string; abs: string }> = [];
-
-  const walk = (relDir: string): void => {
-    const absDir = relDir ? join(root, relDir) : root;
-    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
-      if (relDir === "" && excluded.has(entry.name)) continue;
-      if (entry.isSymbolicLink()) continue;
-      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
-      if (entry.isDirectory()) {
-        walk(rel);
-      } else if (entry.isFile()) {
-        entries.push({ rel, abs: join(root, rel) });
-      }
-    }
-  };
-  walk("");
+  walkPluginTree(root, { excludeRootEntries: exclude }, (rel, abs) => {
+    entries.push({ rel, abs });
+  });
   entries.sort((a, b) => a.rel.localeCompare(b.rel));
 
   const hash = createHash("sha256");

--- a/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
@@ -72,10 +72,22 @@ function makePlugin(name: string): string {
 beforeEach(() => {
   rmSync(PLUGINS_DIR, { recursive: true, force: true });
   rmSync(WORKSPACE_HOOKS_DIR, { recursive: true, force: true });
+  // The sentinel lives outside the plugins dir, so it must be cleared
+  // explicitly between tests.
+  rmSync(getSourceVersionsPath(), { force: true });
   mkdirSync(PLUGINS_DIR, { recursive: true });
 });
 
 describe("plugin source watch", () => {
+  test("the sentinel lives in the monitoring data dir, not the workspace git surface", () => {
+    // The document carries absolute host paths; parking it under the
+    // plugins dir would let the workspace git service commit it.
+    expect(getSourceVersionsPath().startsWith(PLUGINS_DIR)).toBe(false);
+    expect(
+      getSourceVersionsPath().startsWith(join(ROOT, "data", "monitoring")),
+    ).toBe(true);
+  });
+
   test("first pass publishes a baseline covering plugins and workspace hooks", () => {
     const dirA = makePlugin("plugin-a");
     const dirB = makePlugin("plugin-b");

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -44,6 +44,7 @@ import {
 } from "../plugins/source-versions.js";
 import { getLogger } from "../util/logger.js";
 import {
+  getMonitoringDataDir,
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
 } from "../util/platform.js";
@@ -210,12 +211,12 @@ export function runSourceWatchPass(state: SourceWatchState): boolean {
 
 /**
  * Write the sentinel via temp-file + rename so readers never observe a torn
- * document. The temp file shares the sentinel's dotfile prefix, keeping it
- * outside every fingerprint walk.
+ * document. Both files live in the monitoring data directory, outside every
+ * fingerprint walk and outside the workspace git surface.
  */
 function writeSentinelAtomically(doc: SourceVersionsDocument): void {
   const path = getSourceVersionsPath();
-  mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+  mkdirSync(getMonitoringDataDir(), { recursive: true });
   const tmpPath = `${path}.tmp`;
   writeFileSync(tmpPath, JSON.stringify(doc, null, 2));
   renameSync(tmpPath, path);

--- a/assistant/src/plugins/__tests__/source-fingerprint.test.ts
+++ b/assistant/src/plugins/__tests__/source-fingerprint.test.ts
@@ -126,6 +126,23 @@ describe("snapshotPluginSource", () => {
     expect(evictionPaths).toContain(join(linkDir, "hooks", "stop.ts"));
   });
 
+  test("symlinked entries inside the tree are not followed or watched", () => {
+    const dir = makePluginDir();
+    // A directory symlink pointing back at the plugin root — following it
+    // would cycle the walk forever (or escape the root for links elsewhere).
+    symlinkSync(dir, join(dir, "hooks", "loop"));
+    // A file symlink: not part of the watched tree either.
+    writeStamped(join(dir, "hooks", "real.ts"), "export const r = 1;");
+    symlinkSync(join(dir, "hooks", "real.ts"), join(dir, "hooks", "alias.ts"));
+
+    const { evictionPaths } = snapshotPluginSource(dir);
+    const names = evictionPaths.map((p) => p.slice(dir.length));
+
+    expect(names).toContain("/hooks/real.ts");
+    expect(names).not.toContain("/hooks/alias.ts");
+    expect(names.some((n) => n.includes("/loop/"))).toBe(false);
+  });
+
   test("a missing directory yields an empty snapshot", () => {
     const snapshot = snapshotPluginSource(join(root, "does-not-exist"));
     expect(snapshot.fingerprint).toBe("");

--- a/assistant/src/plugins/defaults/memory/graph/scoring.ts
+++ b/assistant/src/plugins/defaults/memory/graph/scoring.ts
@@ -204,12 +204,12 @@ export const PROCEDURAL_WEIGHTS: ScoringWeights = {
  * what's being discussed right now — not general high-significance memories.
  */
 export const PER_TURN_WEIGHTS: ScoringWeights = {
-  semanticSimilarity: 0.60,
+  semanticSimilarity: 0.6,
   effectiveSignificance: 0.05,
   emotionalIntensity: 0.05,
   temporalBoost: 0.0,
   recencyBoost: 0.05,
-  triggerBoost: 0.20,
+  triggerBoost: 0.2,
   activationBoost: 0.05,
 };
 

--- a/assistant/src/plugins/plugin-tree-walk.ts
+++ b/assistant/src/plugins/plugin-tree-walk.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared plugin-tree walking rules.
+ *
+ * Two subsystems walk installed plugin trees and must agree on what "the
+ * plugin's tree" means: install-time content fingerprinting
+ * (`../cli/lib/plugin-fingerprint.ts`, drift detection against the pinned
+ * commit) and the live-reload source fingerprint
+ * (`./source-fingerprint.ts`, change detection for redeploys). This module
+ * owns the walk and the excluded-entry constants so the two can't drift.
+ *
+ * Symlinks are never followed, at any depth: install never materializes
+ * them, and following a symlinked directory would let a link like
+ * `hooks/loop -> ..` cycle the walk or escape the plugin root entirely. A
+ * plugin whose *root* is a symlink is supported by callers resolving the
+ * root (`realpathSync`) before walking.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Top-level entries that are preserved across upgrades and excluded from
+ * fingerprinting / drift detection / content hashing. These are runtime-owned
+ * state, not part of the plugin's source tree at the pinned commit:
+ *
+ * - `install-meta.json` — provenance sidecar written at install time.
+ * - `config.json` — user-editable plugin config (lives in the plugin dir but
+ *   is not tracked as source content, so user edits don't count as drift).
+ * - `data` — runtime data directory (plugin writes whatever it wants here).
+ * - `.disabled` — sentinel file created by `assistant plugins disable`.
+ *
+ * Without these exclusions, a user editing `config.json` or the plugin writing
+ * to `data/` would surface as drift against the install-time baseline, and an
+ * upgrade would try to overwrite or merge around user-owned state.
+ */
+export const PRESERVED_ENTRIES = [
+  "install-meta.json",
+  "config.json",
+  "data",
+  ".disabled",
+] as const;
+
+/** Options controlling which entries a {@link walkPluginTree} visits. */
+export interface PluginTreeWalkOptions {
+  /** Top-level entry names to skip (e.g. {@link PRESERVED_ENTRIES}). */
+  readonly excludeRootEntries?: Iterable<string>;
+  /** Directory names skipped at any depth (e.g. `node_modules`). */
+  readonly excludeDirsAnywhere?: ReadonlySet<string>;
+  /** Skip entries whose name starts with `.`, at any depth. */
+  readonly excludeDotEntries?: boolean;
+  /**
+   * Skip directories that fail to read instead of throwing. Change
+   * detection wants this (a tree being mutated mid-walk is retried on the
+   * next pass); install fingerprinting does not (a vanished tree is an
+   * error the caller must see).
+   */
+  readonly bestEffort?: boolean;
+}
+
+/**
+ * Visit every regular file under `root`, depth-first in `readdir` order.
+ * `rel` is the POSIX-style (forward-slash) path relative to `root`; `abs`
+ * is the absolute path. Symlinked entries are never visited or followed.
+ */
+export function walkPluginTree(
+  root: string,
+  options: PluginTreeWalkOptions,
+  visit: (rel: string, abs: string) => void,
+): void {
+  const excludedRoot = new Set(options.excludeRootEntries ?? []);
+
+  const walk = (relDir: string): void => {
+    const absDir = relDir ? join(root, relDir) : root;
+    let entries;
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch (err) {
+      if (options.bestEffort === true) {
+        return;
+      }
+      throw err;
+    }
+    for (const entry of entries) {
+      const name = entry.name;
+      if (relDir === "" && excludedRoot.has(name)) {
+        continue;
+      }
+      if (options.excludeDotEntries === true && name.startsWith(".")) {
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+      const rel = relDir ? `${relDir}/${name}` : name;
+      if (entry.isDirectory()) {
+        if (options.excludeDirsAnywhere?.has(name) === true) {
+          continue;
+        }
+        walk(rel);
+      } else if (entry.isFile()) {
+        visit(rel, join(absDir, name));
+      }
+    }
+  };
+
+  walk("");
+}

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -18,24 +18,22 @@
  *
  * Exclusions: dot-entries anywhere (`.disabled`, `.git`, …), `node_modules`
  * anywhere (vendored deps change only through install flows, which recycle
- * the plugin directory), and — at the plugin root only — the `data/` runtime
- * directory and the `config.json` / `install-meta.json` sidecars, none of
- * which are importable source. Imports that reach *outside* the plugin
- * directory are out of scope by design: shared deps keep their module
- * identity across reloads, and cross-plugin imports are unsupported.
+ * the plugin directory), and — at the plugin root only — the runtime-owned
+ * {@link PRESERVED_ENTRIES} (`data/`, `config.json`, `install-meta.json`),
+ * none of which are importable source. Symlinked entries inside the tree are
+ * neither watched nor followed (see {@link walkPluginTree}); a symlinked
+ * plugin *root* is supported via realpath resolution. Imports that reach
+ * *outside* the plugin directory are out of scope by design: shared deps
+ * keep their module identity across reloads, and cross-plugin imports are
+ * unsupported.
  */
 
-import { readdirSync, realpathSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { realpathSync, statSync } from "node:fs";
+
+import { PRESERVED_ENTRIES, walkPluginTree } from "./plugin-tree-walk.js";
 
 /** Directory names skipped at any depth. */
 const EXCLUDED_DIRS_ANYWHERE = new Set(["node_modules"]);
-
-/** Directory names skipped only directly under the plugin root. */
-const EXCLUDED_ROOT_DIRS = new Set(["data"]);
-
-/** File names skipped only directly under the plugin root. */
-const EXCLUDED_ROOT_FILES = new Set(["config.json", "install-meta.json"]);
 
 /**
  * The result of one source walk over a plugin directory.
@@ -75,7 +73,22 @@ export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
   }
 
   const files: Array<{ path: string; mtimeMs: number }> = [];
-  walk(realRoot, realRoot, files);
+  walkPluginTree(
+    realRoot,
+    {
+      excludeRootEntries: PRESERVED_ENTRIES,
+      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
+      excludeDotEntries: true,
+      bestEffort: true,
+    },
+    (_rel, abs) => {
+      try {
+        files.push({ path: abs, mtimeMs: statSync(abs).mtimeMs });
+      } catch {
+        // Deleted between readdir and stat — the next pass sees the removal.
+      }
+    },
+  );
 
   // readdir order is platform-dependent; sort for a stable fingerprint.
   files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
@@ -92,56 +105,4 @@ export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
   }
 
   return { fingerprint, evictionPaths };
-}
-
-function walk(
-  dir: string,
-  root: string,
-  out: Array<{ path: string; mtimeMs: number }>,
-): void {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    const name = entry.name;
-    if (name.startsWith(".")) {
-      continue;
-    }
-
-    const path = join(dir, name);
-    let isDir = entry.isDirectory();
-    let isFile = entry.isFile();
-    if (entry.isSymbolicLink()) {
-      try {
-        const st = statSync(path);
-        isDir = st.isDirectory();
-        isFile = st.isFile();
-      } catch {
-        continue; // dangling symlink
-      }
-    }
-
-    if (isDir) {
-      if (EXCLUDED_DIRS_ANYWHERE.has(name)) {
-        continue;
-      }
-      if (dir === root && EXCLUDED_ROOT_DIRS.has(name)) {
-        continue;
-      }
-      walk(path, root, out);
-    } else if (isFile) {
-      if (dir === root && EXCLUDED_ROOT_FILES.has(name)) {
-        continue;
-      }
-      try {
-        out.push({ path, mtimeMs: statSync(path).mtimeMs });
-      } catch {
-        // Deleted between readdir and stat — the next scan sees the removal.
-      }
-    }
-  }
 }

--- a/assistant/src/plugins/source-versions.ts
+++ b/assistant/src/plugins/source-versions.ts
@@ -21,11 +21,16 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { getWorkspacePluginsDir } from "../util/platform.js";
+import { getMonitoringDataDir } from "../util/platform.js";
 
-/** Sentinel filename, directly under `<workspace>/plugins/`. The leading dot
- * keeps it out of the watcher's own per-plugin walks. */
-export const SOURCE_VERSIONS_FILENAME = ".source-versions.json";
+/**
+ * Sentinel filename, under the monitoring data directory
+ * (`<workspace>/data/monitoring/`). That home is deliberate: it is
+ * runtime-owned state the monitor already writes to, and it sits inside the
+ * workspace git-service ignore rules — the document carries absolute
+ * host-specific paths that must never be committed into workspace history.
+ */
+export const SOURCE_VERSIONS_FILENAME = "plugin-source-versions.json";
 
 /** Document format version; readers ignore documents from a different format. */
 export const SOURCE_VERSIONS_FORMAT = 1;
@@ -73,7 +78,7 @@ export interface SourceVersionsDocument {
 
 /** Absolute path of the sentinel document. */
 export function getSourceVersionsPath(): string {
-  return join(getWorkspacePluginsDir(), SOURCE_VERSIONS_FILENAME);
+  return join(getMonitoringDataDir(), SOURCE_VERSIONS_FILENAME);
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Standalone follow-up addressing the three review threads on #37149, before the daemon-consumer PR:

- **P1 — sentinel out of workspace git.** `plugin-source-versions.json` moves from `<workspace>/plugins/` to the monitoring data dir (`<workspace>/data/monitoring/`), which the workspace git service already ignores (`git-service.ts` ignore list) and which the monitor already owns for its heartbeat and samples. Under `plugins/`, the workspace `git add -A` path would have committed a runtime file full of absolute host-specific paths into user workspace history. The filename drops its leading dot — outside the plugins dir there's no walk to hide from.
- **P2 — never follow symlinks in tree walks.** The source walk previously stat-classified symlinked directories and recursed with no cycle or root-boundary guard, so `hooks/loop -> ..` could cycle the monitor's synchronous scan (starving samples and sentinel updates) or escape the plugin root. The shared walk now skips all symlinked entries at any depth — matching what install fingerprinting already did — and symlinked plugin *roots* keep working via the existing realpath resolution. Regression test covers a root-pointing cycle link and a symlinked file.
- **DRY the constants and the walking.** New `plugins/plugin-tree-walk.ts` owns `walkPluginTree()` and the `PRESERVED_ENTRIES` constant; both install-time content fingerprinting (`cli/lib/plugin-fingerprint.ts` — `computeFingerprint` and `computeContentHash`) and the live-reload source fingerprint (`plugins/source-fingerprint.ts`) now run on it, so the two subsystems can't disagree about what counts as the plugin's source tree. `PRESERVED_ENTRIES` is re-exported from `plugin-fingerprint.ts` so its ~6 install/upgrade/diff importers are untouched. Install behavior is preserved exactly (same exclusions, same symlink policy, read errors still propagate — the walker's `bestEffort` mode is only used by change detection, which retries next pass).

One incidental hunk: `plugins/defaults/memory/graph/scoring.ts` picks up a 2-line prettier fix — the file had formatting drift on main and the pre-commit format gate refuses to commit it un-fixed once touched.

## Test plan

- New fingerprint regression test: a plugin containing a `loop -> <plugin root>` directory symlink and a symlinked file — the walk terminates, neither is watched.
- Watch suite pins the sentinel's new location (under `data/monitoring/`, not under the plugins dir) and clears it between tests now that it lives outside the per-test plugins teardown.
- All `PRESERVED_ENTRIES` / fingerprint consumers green per-file: `plugin-fingerprint` (16), `inspect-plugin` (15), `upgrade-plugin` (18), `plugin-config-data-migration` (6), plus `source-fingerprint` (5), `plugin-source-watch` (8), `mtime-cache` (26), monitoring control (9).
- eslint, prettier, `tsc --noEmit` clean via pre-commit hooks. No route changes; no OpenAPI regeneration needed.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_