### PR TITLE
feat(providers): delete legacy *-managed connection rows (contract step)

### DIFF
--- a/assistant/src/persistence/migrations/319-remove-legacy-managed-connections.ts
+++ b/assistant/src/persistence/migrations/319-remove-legacy-managed-connections.ts
@@ -1,0 +1,47 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Deletes the per-provider `*-managed` connections that the single
+ * provider-agnostic `vellum` connection replaced.
+ *
+ * The flip (repoint every reference onto `vellum`, stop seeding the
+ * per-provider rows, hide the orphans from the connection list) shipped first
+ * and is non-destructive. This migration is the contract step: once nothing
+ * references the old rows, delete them so the list filter is no longer needed
+ * and fresh installs seeded by migration 243 don't carry dead rows.
+ *
+ * Names are hardcoded on purpose — this migration is a frozen historical
+ * snapshot and must not drift with future changes to the canonical list.
+ *
+ * Idempotent: deleting rows that no longer exist is a no-op.
+ */
+const LEGACY_MANAGED_CONNECTION_NAMES = [
+  "anthropic-managed",
+  "openai-managed",
+  "gemini-managed",
+  "fireworks-managed",
+  "together-managed",
+];
+
+export function migrateRemoveLegacyManagedConnections(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // The table may not exist yet on a brand-new install if migration ordering
+  // ever changes; guard so this is safe to run unconditionally.
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'provider_connections'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  const placeholders = LEGACY_MANAGED_CONNECTION_NAMES.map(() => "?").join(
+    ", ",
+  );
+  raw.run(
+    `DELETE FROM provider_connections WHERE name IN (${placeholders})`,
+    LEGACY_MANAGED_CONNECTION_NAMES,
+  );
+}

--- a/assistant/src/persistence/migrations/__tests__/319-remove-legacy-managed-connections.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/319-remove-legacy-managed-connections.test.ts
@@ -1,0 +1,88 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import { migrateCreateProviderConnections } from "../243-provider-connections.js";
+import { migrateRemoveLegacyManagedConnections } from "../319-remove-legacy-managed-connections.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function insertConnection(
+  db: ReturnType<typeof createTestDb>,
+  name: string,
+  provider: string,
+): void {
+  const raw = getSqliteFrom(db);
+  const now = Date.now();
+  raw
+    .query(
+      `INSERT OR IGNORE INTO provider_connections (name, provider, auth, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(name, provider, JSON.stringify({ type: "platform" }), now, now);
+}
+
+function connectionNames(db: ReturnType<typeof createTestDb>): string[] {
+  return (
+    getSqliteFrom(db)
+      .query(`SELECT name FROM provider_connections ORDER BY name`)
+      .all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+const LEGACY = [
+  "anthropic-managed",
+  "openai-managed",
+  "gemini-managed",
+  "fireworks-managed",
+  "together-managed",
+];
+
+describe("migration 319 — remove legacy *-managed connections", () => {
+  test("deletes all five legacy managed connections", () => {
+    const db = createTestDb();
+    migrateCreateProviderConnections(db); // seeds anthropic/openai/gemini-managed
+    for (const name of LEGACY) {
+      insertConnection(db, name, name.replace("-managed", ""));
+    }
+
+    migrateRemoveLegacyManagedConnections(db);
+
+    const names = connectionNames(db);
+    for (const legacy of LEGACY) {
+      expect(names).not.toContain(legacy);
+    }
+  });
+
+  test("leaves the vellum connection and personal connections untouched", () => {
+    const db = createTestDb();
+    migrateCreateProviderConnections(db);
+    insertConnection(db, "vellum", "vellum");
+    insertConnection(db, "anthropic-personal", "anthropic");
+
+    migrateRemoveLegacyManagedConnections(db);
+
+    const names = connectionNames(db);
+    expect(names).toContain("vellum");
+    expect(names).toContain("anthropic-personal");
+  });
+
+  test("is idempotent — second run is a no-op", () => {
+    const db = createTestDb();
+    migrateCreateProviderConnections(db);
+    migrateRemoveLegacyManagedConnections(db);
+    expect(() => migrateRemoveLegacyManagedConnections(db)).not.toThrow();
+  });
+
+  test("no-op when provider_connections table is absent", () => {
+    const db = createTestDb();
+    expect(() => migrateRemoveLegacyManagedConnections(db)).not.toThrow();
+  });
+});

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -426,6 +426,7 @@ import { migrateCreateA2aInvitesTable } from "./migrations/315-create-a2a-invite
 import { migrateDropContactChannelInviteId } from "./migrations/316-drop-contact-channels-invite-id.js";
 import { migrateCanonicalGuardianRequesterSignals } from "./migrations/317-canonical-guardian-requester-signals.js";
 import { migrateDropContactChannelTelemetry } from "./migrations/318-drop-contact-channel-telemetry.js";
+import { migrateRemoveLegacyManagedConnections } from "./migrations/319-remove-legacy-managed-connections.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1323,4 +1324,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateDropContactChannelInviteId,
   migrateCanonicalGuardianRequesterSignals,
   migrateDropContactChannelTelemetry,
+  migrateRemoveLegacyManagedConnections,
 ];


### PR DESCRIPTION
## What

Fast-follow / **contract step** to the vellum consolidation (#37141). Deletes the five legacy per-provider `*-managed` connection rows now that everything is repointed onto `vellum`.

**Stacked on #37141** — merge that first. Both ship in the same release.

## Why separate from the flip

The flip PR (#37141) is non-destructive: it repoints references onto `vellum`, stops seeding the per-provider rows, and hides the orphans from the connections list — but leaves the rows in the DB. This PR is the destructive half. Splitting it means the irreversible `DELETE` lands only after the flip is verified healthy, and gives a one-release safety net (the old rows survive so a repoint bug can be rolled forward).

## Change

- **persistence migration 319** — `DELETE FROM provider_connections WHERE name IN (…the five…)`. Idempotent; guarded on table existence. Runs after migration 243's fresh-install seed, so new installs don't carry dead rows either.

After this lands, the list filter added in #37141 becomes belt-and-suspenders (kept for defense-in-depth).

## Test

Dedicated migration test: deletes the five, leaves `vellum` + personal connections, idempotent, no-op when the table is absent. Migration-parity suite green. Format / lint / typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
