### PR TITLE
refactor(memory): inline host-owned lexical cleanup at its persistence call sites

### DIFF
--- a/assistant/src/__tests__/clear-all-lexical.test.ts
+++ b/assistant/src/__tests__/clear-all-lexical.test.ts
@@ -1,12 +1,10 @@
 // clearAll() must drop the memory feature's bulk per-message index (the whole
 // lexical Qdrant collection) — a "delete all" leaves no conversation ids to key
 // per-conversation purges on, so the points would otherwise survive a
-// "permanently delete everything" action. clearAll routes this through the
-// `MemoryPersistenceHooks.onAllConversationsCleared` seam (persistence stays
-// decoupled from the plugin); the memory plugin's impl calls
-// `clearMessagesLexicalIndex`. This asserts the full chain fires.
+// "permanently delete everything" action. clearAll calls
+// `clearMessagesLexicalIndex` directly and AWAITS it. This asserts both.
 
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "./helpers/mock-logger.js";
 
@@ -14,28 +12,31 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-// Spy on `clearMessagesLexicalIndex` (the plugin's `onAllConversationsCleared`
-// impl calls it) while keeping the rest of the module REAL. `mock.module` is
-// process-global and not undone by `mock.restore()`, so a partial mock that
-// drops the other exports would leak into any later test file in the same
-// process that imports them (e.g. the handler tests importing
+// Replace `clearMessagesLexicalIndex` while keeping the rest of the module
+// REAL. `mock.module` is process-global and not undone by `mock.restore()`, so
+// a partial mock that drops the other exports would leak into any later test
+// file in the same process that imports them (e.g. the handler tests importing
 // `indexMessageLexicalJob`). Spread the real module so only this one export is
 // replaced. Importing the real module here is safe: its deps
 // (`@qdrant/js-client-rest`, `uuid`, the local TF-IDF encoder) resolve in the
 // worktree.
+//
+// The mock yields to the timer queue before completing so the await assertion
+// below is meaningful: if clearAll fired the drop without awaiting it,
+// `clearCalls` would still be 0 when clearAll resolves.
 const actualLexical =
   await import("../persistence/job-handlers/message-lexical.js");
 let clearCalls = 0;
 mock.module("../persistence/job-handlers/message-lexical.js", () => ({
   ...actualLexical,
   clearMessagesLexicalIndex: async () => {
+    await new Promise((r) => setTimeout(r, 10));
     clearCalls += 1;
   },
 }));
 
 import { clearAll } from "../persistence/conversation-crud.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
 
 await initializeDb();
 
@@ -44,30 +45,10 @@ describe("clearAll bulk lexical index cleanup", () => {
     clearCalls = 0;
   });
 
-  test("clearAll fires onAllConversationsCleared, which clears the lexical index", async () => {
-    await clearAll();
-    expect(clearCalls).toBe(1);
-  });
-
-  test("clearAll AWAITS the collection drop before returning", async () => {
+  test("clearAll clears the lexical index and AWAITS the drop before returning", async () => {
     // The drop must complete before clearAll resolves — otherwise a write right
     // after clear-all could land in a collection that is about to be dropped.
-    // Register a hook whose drop yields to the microtask queue before finishing;
-    // if clearAll did not await, `dropCompleted` would still be false here.
-    let dropCompleted = false;
-    const dropSpy = spyOn(
-      memoryPersistenceHooks,
-      "onAllConversationsCleared",
-    ).mockImplementation(async () => {
-      await new Promise((r) => setTimeout(r, 10));
-      dropCompleted = true;
-    });
-
-    try {
-      await clearAll();
-      expect(dropCompleted).toBe(true);
-    } finally {
-      dropSpy.mockRestore();
-    }
+    await clearAll();
+    expect(clearCalls).toBe(1);
   });
 });

--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -363,21 +363,16 @@ describe("messages lexical-index dual-write", () => {
   });
 });
 
-// The delete paths must route their cleanup through the persistence-hook seam
-// rather than importing memory internals directly, so persistence stays
-// decoupled from the plugin: single-message deletes fire `onMessagesDeleted`,
-// and whole-conversation deletes fire `onConversationDeleted` from the shared
+// Whole-conversation deletes must fire the memory plugin's
+// `onConversationDeleted` hook from the shared
 // `deleteConversation`/`deleteConversationGently` primitive (covering every
 // caller, not just the HTTP route).
-describe("delete paths route through the memory persistence hooks", () => {
-  const deletedBatches: string[][] = [];
+describe("delete paths fire the memory persistence hook", () => {
   const deletedConversations: string[] = [];
   let conversationDeletedSpy: ReturnType<typeof spyOn>;
-  let messagesDeletedSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     resetMemoryJobs();
-    deletedBatches.length = 0;
     deletedConversations.length = 0;
     conversationDeletedSpy = spyOn(
       memoryPersistenceHooks,
@@ -385,18 +380,11 @@ describe("delete paths route through the memory persistence hooks", () => {
     ).mockImplementation((id: string) => {
       deletedConversations.push(id);
     });
-    messagesDeletedSpy = spyOn(
-      memoryPersistenceHooks,
-      "onMessagesDeleted",
-    ).mockImplementation((ids: string[]) => {
-      deletedBatches.push(ids);
-    });
   });
 
   afterEach(() => {
-    // Restore the real handlers so later tests are unaffected.
+    // Restore the real handler so later tests are unaffected.
     conversationDeletedSpy.mockRestore();
-    messagesDeletedSpy.mockRestore();
   });
 
   test("deleteConversation fires onConversationDeleted (covers all callers, not just the route)", async () => {
@@ -417,31 +405,5 @@ describe("delete paths route through the memory persistence hooks", () => {
     await deleteConversationGently(conv.id);
 
     expect(deletedConversations).toEqual([conv.id]);
-  });
-
-  test("deleteMessageById fires onMessagesDeleted with the single id", async () => {
-    const conv = createConversation("Seam single delete");
-    const message = await addMessage(conv.id, "user", "delete me via seam");
-
-    deletedBatches.length = 0;
-    deleteMessageById(message.id);
-
-    expect(deletedBatches).toEqual([[message.id]]);
-  });
-
-  test("deleteLastExchange fires onMessagesDeleted with every removed id", async () => {
-    const conv = createConversation("Seam undo");
-    await addMessage(conv.id, "user", "first turn");
-    await addMessage(conv.id, "assistant", "first reply");
-    const lastUser = await addMessage(conv.id, "user", "undo this");
-    const lastAssistant = await addMessage(conv.id, "assistant", "and this");
-
-    deletedBatches.length = 0;
-    deleteLastExchange(conv.id);
-
-    expect(deletedBatches).toHaveLength(1);
-    expect(new Set(deletedBatches[0])).toEqual(
-      new Set([lastUser.id, lastAssistant.id]),
-    );
   });
 });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
@@ -73,7 +74,12 @@ import {
   copyForkMessagesViaSubprocess,
   type ForkIdPair,
 } from "./fork-message-copy.js";
-import { enqueueLexicalIndexForMessage } from "./job-handlers/message-lexical.js";
+import {
+  clearMessagesLexicalIndex,
+  enqueueDeleteMessageLexical,
+  enqueueLexicalIndexForMessage,
+  enqueuePurgeConversationLexical,
+} from "./job-handlers/message-lexical.js";
 import {
   rawExec,
   rawGet,
@@ -1507,12 +1513,19 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     removeConversationDir(id, createdAtForDiskCleanup);
   }
 
-  // Let the memory feature purge the conversation's per-message index (e.g. its
-  // lexical points). Fired from the shared primitive so every delete caller —
-  // route, retrospective cleanup/GC — cleans up. Routed through the
-  // persistence-hook seam so this layer stays decoupled from the memory plugin;
-  // a no-op when memory is not present.
+  // Let the memory feature fail its still-pending jobs for this conversation.
+  // Routed through the persistence-hook seam so this layer stays decoupled
+  // from the memory plugin; a no-op when memory is not present.
   memoryPersistenceHooks.onConversationDeleted(id);
+
+  // Purge the conversation's points from the lexical (Qdrant) index. Fired
+  // from the shared primitive so every delete caller — route, retrospective
+  // cleanup/GC — cleans up. Enqueued AFTER the hook above, whose cancellation
+  // pass sweeps pending `conversationId`-keyed jobs — the purge must not be
+  // swept by it. The enqueue helper self-selects: enqueue a job when memory is
+  // enabled, run the delete inline (best-effort, breaker-wrapped) when it is
+  // disabled.
+  enqueuePurgeConversationLexical(id);
 
   return result;
 }
@@ -1620,11 +1633,16 @@ export async function deleteConversationGently(
     removeConversationDir(id, createdAtForDiskCleanup);
   }
 
-  // Let the memory feature purge the conversation's per-message index — the
-  // gentle path is the retrospective-GC caller, which would otherwise leak the
-  // conversation's lexical points. Routed through the persistence-hook seam;
-  // a no-op when memory is not present.
+  // Let the memory feature fail its still-pending jobs for this conversation.
+  // Routed through the persistence-hook seam; a no-op when memory is not
+  // present.
   memoryPersistenceHooks.onConversationDeleted(id);
+
+  // Purge the conversation's points from the lexical (Qdrant) index — the
+  // gentle path is the retrospective-GC caller, which would otherwise leak the
+  // conversation's lexical points. Enqueued AFTER the hook above so the
+  // hook's cancellation pass cannot sweep the purge.
+  enqueuePurgeConversationLexical(id);
 
   return result;
 }
@@ -2706,18 +2724,15 @@ export async function clearAll(): Promise<{
     Date.now(),
   );
 
-  // Let the memory feature drop its bulk per-message index (e.g. the whole
-  // lexical Qdrant collection) — a "delete all" leaves no ids to key
-  // per-message cleanup on. Routed through the persistence-hook seam so this
-  // layer stays decoupled from the memory plugin; a no-op when memory is not
-  // present. AWAITED so the drop completes before clear-all returns and writes
-  // resume — a message created right after must not upsert into a collection
-  // that is about to be dropped. Best-effort — a failure must not fail the
-  // whole clear-all.
+  // Drop the whole lexical (Qdrant) collection — a "delete all" leaves no ids
+  // to key per-message cleanup on. AWAITED so the drop completes before
+  // clear-all returns and writes resume — a message created right after must
+  // not upsert into a collection that is about to be dropped. Best-effort — a
+  // failure must not fail the whole clear-all.
   try {
-    await memoryPersistenceHooks.onAllConversationsCleared();
+    await clearMessagesLexicalIndex(getConfig());
   } catch (err) {
-    log.warn({ err }, "clearAll: failed to clear memory per-message index");
+    log.warn({ err }, "clearAll: failed to clear messages lexical index");
   }
 
   // Clear the disk-view conversations directory and recreate it empty
@@ -2809,11 +2824,14 @@ export function deleteLastExchange(conversationId: string): number {
 
   deleteOrphanAttachments(candidateAttachmentIds);
 
-  // Let the memory feature clean up the undone messages' per-message index
-  // entries. This bulk delete bypasses `deleteMessageById`, so notify the seam
-  // with the collected ids — after the transaction and off the write path. A
-  // no-op when memory is not present.
-  memoryPersistenceHooks.onMessagesDeleted(messageIds);
+  // Remove the undone messages' points from the lexical index. This bulk
+  // delete bypasses `deleteMessageById`, so enqueue the collected ids here —
+  // after the transaction and off the write path. The enqueue helper
+  // self-selects: enqueue a job when memory is enabled, run the delete inline
+  // (best-effort, breaker-wrapped) when it is disabled.
+  for (const deletedMessageId of messageIds) {
+    enqueueDeleteMessageLexical(deletedMessageId);
+  }
 
   return deleted;
 }
@@ -3042,13 +3060,12 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
 
   deleteOrphanAttachments(candidateAttachmentIds);
 
-  // Let the memory feature clean up the deleted message's per-message index
-  // entry. Notified only when the row actually existed (`msgRow` set), after the
-  // transaction and off the write path, via the persistence-hook seam (a no-op
-  // when memory is not present). Covers single-message deletes (consolidation)
-  // that do not go through the conversation-level purge.
+  // Remove the deleted message's point from the lexical index. Enqueued only
+  // when the row actually existed (`msgRow` set), after the transaction and
+  // off the write path. Covers single-message deletes (consolidation) that do
+  // not go through the conversation-level purge.
   if (msgRow) {
-    memoryPersistenceHooks.onMessagesDeleted([messageId]);
+    enqueueDeleteMessageLexical(messageId);
   }
 
   return result;

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,10 +1,4 @@
-import { getConfig } from "../../../config/loader.js";
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
-import {
-  clearMessagesLexicalIndex,
-  enqueueDeleteMessageLexical,
-  enqueuePurgeConversationLexical,
-} from "../../../persistence/job-handlers/message-lexical.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
@@ -154,35 +148,11 @@ export const memoryPersistenceHooks = {
   },
 
   onConversationDeleted(conversationId: string): void {
-    // Fail the conversation's still-pending memory jobs first (graph
-    // extraction, summary builds, …) — the rows they reference are gone. The
-    // cancellation sweeps pending `conversationId`-keyed jobs, so it must run
-    // BEFORE the purge below is enqueued or it would sweep the purge too.
+    // Fail the conversation's still-pending memory jobs (graph extraction,
+    // summary builds, …) — the rows they reference are gone. The cancellation
+    // sweeps pending `conversationId`-keyed jobs, so the delete primitive
+    // fires this hook BEFORE enqueueing the conversation's lexical purge, or
+    // the purge would be swept too.
     cancelPendingJobsForConversation(conversationId);
-
-    // Purge the conversation's points from the lexical (Qdrant) index. Fired
-    // from the shared delete primitive, so every delete caller — route,
-    // retrospective cleanup, GC — cleans up. The enqueue helper self-selects:
-    // enqueue a job when memory is enabled, run the delete inline (best-effort,
-    // breaker-wrapped) when it is disabled.
-    enqueuePurgeConversationLexical(conversationId);
-  },
-
-  onMessagesDeleted(messageIds: string[]): void {
-    // Remove each deleted message's point from the lexical index. The enqueue
-    // helper self-selects: enqueue a job when memory is enabled, run the delete
-    // inline (best-effort, breaker-wrapped) when it is disabled.
-    for (const messageId of messageIds) {
-      enqueueDeleteMessageLexical(messageId);
-    }
-  },
-
-  async onAllConversationsCleared(): Promise<void> {
-    // Drop the whole lexical (Qdrant) collection — a "delete all" leaves no ids
-    // to key per-message cleanup on. Awaited so the drop completes before
-    // clear-all returns and writes resume; otherwise a message created right
-    // after clear-all could upsert into the not-yet-dropped collection and then
-    // be erased when the drop lands.
-    await clearMessagesLexicalIndex(getConfig());
   },
 };


### PR DESCRIPTION
## Why

Next step in the persistence-hooks triage. Three of the `memoryPersistenceHooks` bodies called only **host-owned** lexical-index helpers from `persistence/job-handlers/message-lexical.ts` — the lexical job types (`index_message_lexical`, `purge_conversation_lexical`, `delete_message_lexical`) are in the job-handler guard's `NON_PLUGIN_JOB_TYPES`, i.e. not memory-plugin logic. Routing persistence-layer cleanup through the memory plugin's hook object and back into the persistence layer was indirection without decoupling, so those calls now happen directly at the call sites.

## What

- **`onAllConversationsCleared` — deleted.** `clearAll()` awaits `clearMessagesLexicalIndex(getConfig())` directly (still awaited, still best-effort, for the same reason: a write racing the collection drop must not land in a collection about to disappear).
- **`onMessagesDeleted` — deleted.** `deleteMessageById` and `deleteLastExchange` enqueue `delete_message_lexical` for the removed ids directly.
- **`onConversationDeleted` — reduced to plugin-only logic.** It keeps the pending-job cancellation (`cancelPendingJobsForConversation`); the delete primitives (`deleteConversation`, `deleteConversationGently`) enqueue the conversation's lexical purge directly, **after** the hook, preserving the ordering constraint that the cancellation sweep must not sweep the purge.

The hooks object is now down to three members, each with a plugin-only body: `onMessagePersisted`, `onConversationForked`, `onConversationDeleted` — the surface left to migrate onto the first-class `hooks` system. The plugin's import of the persistence lexical helpers is gone.

## Tests

- `clear-all-lexical.test.ts` reworked: the awaits-the-drop assertion moved from a hook spy into the `clearMessagesLexicalIndex` module mock (it yields to the timer queue before counting, so a fire-and-forget regression would assert 0).
- The `onMessagesDeleted` seam-spy tests are dropped from `lexical-index-dual-write.test.ts` — behavior-level coverage already exists there (direct `delete_message_lexical` enqueue assertions for both message-delete paths). The `onConversationDeleted` spy tests remain since the hook remains.
- Green in isolation: lexical-index-dual-write (15), clear-all-lexical (1), task-memory-cleanup (12), conversation-delete-schedule-cleanup (5), persistence-layering-guard (3), plugin-import-boundary-guard (5). `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_