### PR TITLE
fix(web): let deleted pinned apps be unpinned from the sidebar

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -4,7 +4,6 @@ import {
     Clock,
     LayoutGrid,
     Pin,
-    Rocket,
     Search,
     SquarePen,
     X,
@@ -25,6 +24,7 @@ import {
 } from "@/domains/chat/components/conversation-nav-section";
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
+import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item";
 import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
 import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
 import { channelSectionKey } from "@/domains/chat/utils/sidebar-group-collapse-storage";
@@ -323,16 +323,12 @@ export function AssistantSideMenu({
               />
             ) : null}
             {pinnedApps.map((app) => (
-              <SideMenu.Item
+              <PinnedAppNavItem
                 key={app.appId}
-                // Apps source their icon as an emoji string on the manifest
-                // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
-                // apps still get a leading icon in the rail.
-                icon={app.icon ?? Rocket}
-                label={app.name}
-                showCollapsedTooltip
+                app={app}
+                collapsed={collapsed}
                 active={activeAppId === app.appId}
-                onSelect={onOpenApp ? () => { onOpenApp(app.appId); onClose?.(); } : undefined}
+                onOpen={onOpenApp ? (appId) => { onOpenApp(appId); onClose?.(); } : undefined}
               />
             ))}
           </div>

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for `PinnedAppNavItem`.
+ *
+ * The design-library `SideMenu.Item` and `ContextMenu` primitives are mocked
+ * with lightweight elements so these tests exercise the component's
+ * composition and store wiring (open, unpin, collapsed omission) rather than
+ * Radix ContextMenu internals. `onSelect` is surfaced as an `onClick` so
+ * happy-dom can drive it.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+mock.module("@vellumai/design-library", () => {
+  const SideMenu = {
+    Item: ({
+      label,
+      onSelect,
+      active,
+    }: {
+      label: string;
+      onSelect?: () => void;
+      active?: boolean;
+    }) =>
+      createElement(
+        "button",
+        {
+          type: "button",
+          "data-testid": "app-row",
+          "data-active": active ? "true" : "false",
+          onClick: onSelect,
+        },
+        label,
+      ),
+  };
+  const ContextMenu = {
+    Root: ({ children }: { children?: ReactNode }) =>
+      createElement("div", { "data-testid": "ctx-root" }, children),
+    Trigger: ({ children }: { children?: ReactNode }) =>
+      createElement("div", { "data-testid": "ctx-trigger" }, children),
+    Content: ({ children }: { children?: ReactNode }) =>
+      createElement("div", { "data-testid": "ctx-content" }, children),
+    Item: ({ children, onSelect }: { children?: ReactNode; onSelect?: () => void }) =>
+      createElement("button", { type: "button", onClick: onSelect }, children),
+  };
+  return { SideMenu, ContextMenu };
+});
+
+import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item";
+import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
+import type { AppSummary } from "@/types/app-types";
+import type { PinnedAppEntry } from "@/utils/app-pin-storage";
+
+const APP: PinnedAppEntry = { appId: "app-1", pinnedOrder: 1, name: "My App", icon: "🚀" };
+
+function seedPin(entry: PinnedAppEntry): void {
+  const app: AppSummary = {
+    id: entry.appId,
+    name: entry.name,
+    icon: entry.icon,
+    createdAt: 0,
+    updatedAt: 0,
+    version: "1.0.0",
+    contentId: "content",
+  };
+  usePinnedAppsStore.getState().togglePin(app);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  usePinnedAppsStore.setState({ pinnedApps: [], pinnedAppIds: new Set() });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PinnedAppNavItem", () => {
+  test("renders the app label and opens the app on select", () => {
+    const onOpen = mock((_appId: string) => {});
+    render(
+      <PinnedAppNavItem app={APP} active={false} collapsed={false} onOpen={onOpen} />,
+    );
+
+    const row = screen.getByTestId("app-row");
+    expect(row.textContent).toBe("My App");
+
+    fireEvent.click(row);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen.mock.calls[0]?.[0]).toBe("app-1");
+  });
+
+  test("expanded: Unpin action clears the pin (the sidebar escape hatch)", () => {
+    seedPin(APP);
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(true);
+
+    render(<PinnedAppNavItem app={APP} active={false} collapsed={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "Unpin" }));
+
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(false);
+  });
+
+  test("collapsed rail: renders the row without the context-menu wrapper", () => {
+    render(<PinnedAppNavItem app={APP} active={false} collapsed />);
+
+    expect(screen.getByTestId("app-row").textContent).toBe("My App");
+    expect(screen.queryByTestId("ctx-root")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Unpin" })).toBeNull();
+  });
+
+  test("marks the row active when active is true", () => {
+    render(<PinnedAppNavItem app={APP} active collapsed={false} />);
+    expect(screen.getByTestId("app-row").getAttribute("data-active")).toBe("true");
+  });
+});

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
@@ -1,0 +1,66 @@
+import { PinOff, Rocket } from "lucide-react";
+
+import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
+import type { PinnedAppEntry } from "@/utils/app-pin-storage";
+import { ContextMenu, SideMenu } from "@vellumai/design-library";
+
+export interface PinnedAppNavItemProps {
+  app: PinnedAppEntry;
+  active: boolean;
+  collapsed: boolean;
+  onOpen?: (appId: string) => void;
+}
+
+/**
+ * A pinned-app row in the assistant sidebar. Renders the app as a
+ * {@link SideMenu.Item} and, when expanded, wraps it in a right-click /
+ * long-press {@link ContextMenu} whose sole action removes the pin.
+ *
+ * The unpin lives here because it is the only place a stale pin can be
+ * cleared: a deleted app never appears in the Library, so its card-level
+ * unpin is unreachable, leaving the sidebar entry orphaned.
+ *
+ * In the collapsed rail the item is wrapped in a Tooltip whose provider
+ * would swallow the context-menu trigger's cloned handlers, so the menu is
+ * omitted there — the overlay and expanded rail (always available on mobile
+ * and the default desktop width) carry the affordance.
+ */
+export function PinnedAppNavItem({
+  app,
+  active,
+  collapsed,
+  onOpen,
+}: PinnedAppNavItemProps) {
+  const unpin = usePinnedAppsStore.use.unpin();
+
+  const item = (
+    <SideMenu.Item
+      // Apps source their icon as an emoji string on the manifest
+      // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
+      // apps still get a leading icon in the rail.
+      icon={app.icon ?? Rocket}
+      label={app.name}
+      showCollapsedTooltip
+      active={active}
+      onSelect={onOpen ? () => onOpen(app.appId) : undefined}
+    />
+  );
+
+  if (collapsed) {
+    return item;
+  }
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{item}</ContextMenu.Trigger>
+      <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
+        <ContextMenu.Item
+          leftIcon={<PinOff size={14} />}
+          onSelect={() => unpin(app.appId)}
+        >
+          Unpin
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
+}

--- a/clients/web/src/stores/pinned-apps-store.test.ts
+++ b/clients/web/src/stores/pinned-apps-store.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AppSummary } from "@/types/app-types";
+import { loadPinnedApps } from "@/utils/app-pin-storage";
+import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
+import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
+
+installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
+
+// The store is a module singleton whose in-memory slice survives across
+// tests; reset it (and the backing storage, cleared by installMemoryStorage)
+// before each case so pin state starts empty.
+beforeEach(() => {
+  usePinnedAppsStore.setState({ pinnedApps: [], pinnedAppIds: new Set() });
+});
+
+function makeApp(overrides: Partial<AppSummary> & { id: string }): AppSummary {
+  return {
+    name: `App ${overrides.id}`,
+    createdAt: 0,
+    updatedAt: 0,
+    version: "1.0.0",
+    contentId: `content_${overrides.id}`,
+    ...overrides,
+  };
+}
+
+function pin(app: AppSummary): void {
+  usePinnedAppsStore.getState().togglePin(app);
+}
+
+describe("togglePin", () => {
+  test("pins an unpinned app and reflects it in state + storage", () => {
+    pin(makeApp({ id: "a1", name: "First", icon: "🚀" }));
+
+    const state = usePinnedAppsStore.getState();
+    expect(state.pinnedAppIds.has("a1")).toBe(true);
+    expect(state.pinnedApps).toEqual([
+      { appId: "a1", pinnedOrder: 1, name: "First", icon: "🚀" },
+    ]);
+    expect(loadPinnedApps()).toEqual([
+      { appId: "a1", pinnedOrder: 1, name: "First", icon: "🚀" },
+    ]);
+  });
+
+  test("unpins a pinned app when toggled again", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+    usePinnedAppsStore.getState().togglePin(makeApp({ id: "a1", name: "First" }));
+
+    expect(usePinnedAppsStore.getState().pinnedAppIds.has("a1")).toBe(false);
+    expect(loadPinnedApps()).toEqual([]);
+  });
+});
+
+describe("unpin", () => {
+  test("removes a pin by id — the sidebar's path for a deleted, unloadable app", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+    pin(makeApp({ id: "a2", name: "Second" }));
+
+    usePinnedAppsStore.getState().unpin("a1");
+
+    const state = usePinnedAppsStore.getState();
+    expect(state.pinnedAppIds.has("a1")).toBe(false);
+    expect(state.pinnedApps.map((a) => a.appId)).toEqual(["a2"]);
+    expect(loadPinnedApps().map((a) => a.appId)).toEqual(["a2"]);
+  });
+
+  test("recompacts order values after removing a middle pin", () => {
+    pin(makeApp({ id: "a1" }));
+    pin(makeApp({ id: "a2" }));
+    pin(makeApp({ id: "a3" }));
+
+    usePinnedAppsStore.getState().unpin("a2");
+
+    expect(usePinnedAppsStore.getState().pinnedApps.map((a) => a.pinnedOrder)).toEqual([1, 2]);
+    expect(usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId)).toEqual(["a1", "a3"]);
+  });
+
+  test("notifies onUnpin listeners with the removed app id", () => {
+    pin(makeApp({ id: "a1" }));
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    usePinnedAppsStore.getState().unpin("a1");
+
+    expect(seen).toEqual(["a1"]);
+    off();
+  });
+
+  test("is a no-op for an id that is not pinned — no state change, no notification", () => {
+    pin(makeApp({ id: "a1" }));
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    usePinnedAppsStore.getState().unpin("ghost");
+
+    expect(seen).toEqual([]);
+    expect(usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId)).toEqual(["a1"]);
+    off();
+  });
+});
+
+describe("togglePin unpin branch", () => {
+  test("also notifies onUnpin listeners", () => {
+    pin(makeApp({ id: "a1" }));
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    usePinnedAppsStore.getState().togglePin(makeApp({ id: "a1" }));
+
+    expect(seen).toEqual(["a1"]);
+    off();
+  });
+});
+
+describe("isPinned", () => {
+  test("tracks pin/unpin transitions", () => {
+    expect(usePinnedAppsStore.getState().isPinned("a1")).toBe(false);
+    pin(makeApp({ id: "a1" }));
+    expect(usePinnedAppsStore.getState().isPinned("a1")).toBe(true);
+    usePinnedAppsStore.getState().unpin("a1");
+    expect(usePinnedAppsStore.getState().isPinned("a1")).toBe(false);
+  });
+});

--- a/clients/web/src/stores/pinned-apps-store.ts
+++ b/clients/web/src/stores/pinned-apps-store.ts
@@ -38,6 +38,13 @@ export interface PinnedAppsState {
 
 export interface PinnedAppsActions {
   togglePin: (app: AppSummary) => void;
+  /**
+   * Remove a pin by id. Safe to call for an app that is no longer loadable
+   * (e.g. deleted server-side), which is the sidebar's only way to clear a
+   * stale entry — the app never renders in the Library, so its card-level
+   * unpin is unreachable. A no-op when the id isn't pinned.
+   */
+  unpin: (appId: string) => void;
   isPinned: (appId: string) => boolean;
   onUnpin: (listener: UnpinListener) => () => void;
 }
@@ -64,15 +71,22 @@ const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
   ...loadState(),
 
   togglePin: (app: AppSummary) => {
-    const wasPinned = get().pinnedAppIds.has(app.id);
-    if (wasPinned) {
-      unpinApp(app.id);
+    if (get().pinnedAppIds.has(app.id)) {
+      get().unpin(app.id);
     } else {
       pinApp(app);
+      set(loadState());
     }
+  },
+
+  unpin: (appId: string) => {
+    if (!get().pinnedAppIds.has(appId)) {
+      return;
+    }
+    unpinApp(appId);
     set(loadState());
-    if (wasPinned) {
-      for (const listener of unpinListeners) listener(app.id);
+    for (const listener of unpinListeners) {
+      listener(appId);
     }
   },
 


### PR DESCRIPTION
Fixes LUM-2702 — https://linear.app/vellum/issue/LUM-2702/pinned-apps-that-have-been-deleted-cannot-be-unpinned-from-sidebar

## Prompt / plan

Investigate LUM-2702: a pinned app deleted while pinned leaves a stale entry in the sidebar that the user cannot remove.

**Root cause.** Pin state lives in a single global `vellum:pinnedApps` localStorage key (`clients/web/src/utils/app-pin-storage.ts`), not scoped per assistant. The Library's own delete flow already unpins (`library-view.tsx#handleConfirmDelete`), but any *other* deletion path — the assistant deleting the app, another client, or workspace cleanup — only removes the app bundle. The stale pin survives, and:

- the sidebar row (`SideMenu.Item`) only *opened* the app, which now 404s (`loadApp` falls back to chat), and
- a deleted app never appears in the Library, so its card-level pin toggle is unreachable.

So the pin was orphaned with no removal path — the reported symptom.

**Why not auto-prune.** The web client is genuinely multi-assistant (local + platform, org switching via `resolved-assistants-store.ts`), but pins are stored globally. Reconciling pins against one assistant's app list would delete another assistant's valid pins. The safe fix (and the one the issue endorses) is an explicit, user-initiated unpin affordance in the sidebar.

**Change.**
- `pinned-apps-store.ts`: new `unpin(appId)` action — removes a pin by id, safe for an app that can no longer load, no-op when not pinned, and fires the existing unpin listeners (so the app view closes if it was open). `togglePin` now routes its unpin branch through it (single source of truth).
- `pinned-app-nav-item.tsx` (new): renders each pinned app as a `SideMenu.Item` and, when expanded, wraps it in a right-click / long-press `ContextMenu` whose sole action is **Unpin** — mirroring the conversation-row pattern in the same sidebar. The menu is omitted in the collapsed rail, where the row is wrapped in a `Tooltip` whose provider would swallow the context-menu trigger's cloned handlers (the overlay and expanded rail — always available on mobile and default desktop width — carry the affordance).
- `assistant-side-menu.tsx`: renders `PinnedAppNavItem` instead of the inline `SideMenu.Item`.

## Test plan

- `clients/web/src/stores/pinned-apps-store.test.ts` (new): `unpin` removes by id, recompacts order, notifies `onUnpin` listeners, no-ops for a non-pinned id; `togglePin` unpin branch still notifies; `isPinned` transitions.
- `clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx` (new): opens on select, Unpin clears the pin, collapsed rail omits the menu, active state.
- Verified the real `ContextMenu.Trigger asChild` + `SideMenu.Item` composition renders without error via a throwaway SSR smoke test (ref forwarding through the trigger).
- `bunx tsc --noEmit` clean; `eslint` clean on changed files; existing `assistant-side-menu.test.tsx` and `app-pin-storage.test.ts` still green (113 tests across the touched suites).


---
_Generated by [Claude Code](https://claude.ai/code/session_019AriCixe3wWoqZAcqY4f58)_