### PR TITLE
fix: post-execution rejection path, db_proxy banner prose, stale CODEOWNERS (review round 1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,7 +82,6 @@ assistant/src/tools/verification-control-plane-policy.ts @noanflaherty
 assistant/src/tools/tool-approval-handler.ts @noanflaherty
 assistant/src/security/tool-approval-digest.ts @noanflaherty
 assistant/src/permissions/ @noanflaherty
-assistant/src/contacts/guardian-rate-limits.ts @noanflaherty
 assistant/src/approvals/scoped-approval-grants.ts @noanflaherty
 assistant/src/contacts/canonical-guardian-store.ts @noanflaherty
 assistant/src/calls/guardian-*.ts @noanflaherty

--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -62,9 +62,11 @@ mock.module("../services/published-app-updater.js", () => ({
 mock.module("../daemon/conversation-surfaces.js", () => ({
   refreshSurfacesForApp: mock(() => {}),
 }));
+const mockIsDoordashCommand = mock(() => false);
+const mockUpdateDoordashProgress = mock(() => {});
 mock.module("../daemon/doordash-steps.js", () => ({
-  isDoordashCommand: mock(() => false),
-  updateDoordashProgress: mock(() => {}),
+  isDoordashCommand: mockIsDoordashCommand,
+  updateDoordashProgress: mockUpdateDoordashProgress,
 }));
 
 const mockLogWarn = mock((_obj: unknown, _msg: string) => {});
@@ -320,6 +322,36 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
       "U200",
       "valid-code",
       "aid2",
+    );
+  });
+});
+
+describe("doordash progress side effect", () => {
+  beforeEach(() => {
+    mockIsDoordashCommand.mockReset();
+    mockUpdateDoordashProgress.mockReset();
+    mockLogError.mockReset();
+  });
+
+  test("throwing updateDoordashProgress is swallowed and logged", async () => {
+    mockIsDoordashCommand.mockReturnValue(true);
+    mockUpdateDoordashProgress.mockImplementation(() => {
+      throw new Error("doordash boom");
+    });
+
+    await expect(
+      runPostExecutionSideEffects(
+        "bash",
+        { command: "order food" },
+        { content: "{}", isError: false },
+        dummySideEffectCtx,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockUpdateDoordashProgress).toHaveBeenCalledTimes(1);
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "bash" }),
+      expect.stringContaining("DoorDash progress update failed"),
     );
   });
 });

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -340,7 +340,11 @@ export async function runPostExecutionSideEffects(
   }
 
   // DoorDash progress tracking fires on both success and failure
-  if (isDoordashCommand(name, input)) {
-    updateDoordashProgress(sideEffectCtx.ctx, input, result.isError);
+  try {
+    if (isDoordashCommand(name, input)) {
+      updateDoordashProgress(sideEffectCtx.ctx, input, result.isError);
+    }
+  } catch (err) {
+    log.error({ err, toolName: name }, "DoorDash progress update failed");
   }
 }

--- a/assistant/src/ipc/routes/db-proxy.ts
+++ b/assistant/src/ipc/routes/db-proxy.ts
@@ -13,9 +13,10 @@
  *
  * The gateway callers are pinned by an allowlist guard
  * (gateway `__tests__/db-proxy-allowlist.test.ts`): the contact-merge
- * identity-mirror cluster (pending a merge-shaped op) and one-time data
- * migrations. Slated for removal once the contact-merge cluster gets typed
- * mirror ops.
+ * identity-mirror cluster (pending a merge-shaped op), residual raw-SQL
+ * contact reads in `verification/contact-helpers.ts` (deferred cleanup),
+ * and one-time data migrations. Slated for removal once the contact-merge
+ * cluster gets typed mirror ops.
  *
  * Tracking: ATL-XXX (gateway security migration)
  */

--- a/gateway/src/__tests__/db-proxy-allowlist.test.ts
+++ b/gateway/src/__tests__/db-proxy-allowlist.test.ts
@@ -10,11 +10,13 @@ import { join, sep } from "node:path";
  * either raw-SQL bridge method (`db_proxy` / `db_proxy_transaction`), so the
  * surface can only shrink, never grow.
  *
- * The proxy currently serves two groups (the allowlist below):
+ * The proxy currently serves three groups (the allowlist below):
  *   1. The contact-merge identity-mirror cluster (`contact-store.ts`) — a
  *      notes-only survivor UPDATE and a resolved-slug dual-write INSERT that no
  *      existing typed mirror op expresses; pending a merge-shaped op.
- *   2. Data migrations — one-time backfills that legitimately touch the
+ *   2. Residual raw-SQL contact reads in `verification/contact-helpers.ts` —
+ *      deferred cleanup.
+ *   3. Data migrations — one-time backfills that legitimately touch the
  *      assistant DB broadly.
  */
 

--- a/gateway/src/db/assistant-db-proxy.ts
+++ b/gateway/src/db/assistant-db-proxy.ts
@@ -7,11 +7,13 @@
  * ≤3.51.2), so the gateway reaches the assistant DB only through this route.
  *
  * The caller allowlist is pinned by `__tests__/db-proxy-allowlist.test.ts`.
- * The surface serves exactly two groups:
+ * The surface serves exactly three groups:
  *   (a) the contact-merge identity-mirror cluster in `db/contact-store.ts` —
  *       pending a merge-shaped op that expresses a notes-only survivor UPDATE
- *       and a resolved-slug dual-write INSERT the typed mirror ops cannot, and
- *   (b) data migrations (one-time backfills and drops).
+ *       and a resolved-slug dual-write INSERT the typed mirror ops cannot,
+ *   (b) data migrations (one-time backfills and drops), and
+ *   (c) residual raw-SQL contact reads in `verification/contact-helpers.ts`
+ *       (deferred cleanup).
  *
  * NOT a general-purpose query layer. Slated for removal once the
  * contact-merge cluster gets typed mirror ops.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for verif-sessions-gateway-native.md: updateDoordashProgress moved inside the hook try/catch (no unhandled rejections from the fire-and-forget runner), db_proxy banners now name the surviving contact-helpers allowlist entry, stale CODEOWNERS line for the deleted guardian-rate-limits.ts removed