### PR TITLE
fix: dedupe inbound-stage gateway-session mock scaffolding (review round 1)

### DIFF
--- a/assistant/src/__tests__/helpers/gateway-verification-sessions-stub.ts
+++ b/assistant/src/__tests__/helpers/gateway-verification-sessions-stub.ts
@@ -1,0 +1,171 @@
+/**
+ * Configurable stub factory for `channels/gateway-verification-sessions.js`.
+ *
+ * For unit tests that mock the gateway-backed session client module directly:
+ *
+ *   const stub = createGatewayVerificationSessionsStub({
+ *     mintResult: () => ({ sessionId: "sess-1", ... }),
+ *   });
+ *   mock.module("../../../channels/gateway-verification-sessions.js", () => stub.module);
+ *   beforeEach(() => stub.reset());
+ *
+ * Handles: per-method (or global) "gateway unreachable" throw toggles,
+ * call recorders, conflict injection for the conditional create, and
+ * settable session/mint results. Session reads (`findActiveSession` /
+ * `getPendingSession`) record before the unreachable check — the read
+ * IPC attempt itself is what some tests count; all other methods throw
+ * before recording, so an unreachable call never counts as made.
+ *
+ * Stateful integration suites should use `verification-sessions-ipc-sim.ts`
+ * instead — this factory complements the sim, it does not replace it.
+ *
+ * Self-contained by design (assistant/AGENTS.md — test machinery isolation):
+ * no production `src/` imports.
+ */
+
+export interface GatewaySessionMintResult {
+  sessionId: string;
+  secret: string;
+  challengeHash: string;
+  expiresAt: number;
+  ttlSeconds: number;
+}
+
+type StubMethod =
+  | "resolveBootstrapToken"
+  | "bindSessionIdentity"
+  | "updateSessionStatus"
+  | "createOutboundSession"
+  | "createOutboundSessionConditional"
+  | "updateSessionDelivery"
+  | "findActiveSession"
+  | "getPendingSession";
+
+type SessionRecord = Record<string, unknown> | null;
+
+export interface GatewayVerificationSessionsStub {
+  /** Module-shaped object: `mock.module(path, () => stub.module)`. */
+  module: Record<StubMethod, (...args: unknown[]) => Promise<unknown>>;
+  /** Throw toggles: `unreachable.all` or a single method by name. */
+  unreachable: { all: boolean } & Record<StubMethod, boolean>;
+  calls: {
+    resolveBootstrapToken: unknown[][];
+    bindSessionIdentity: unknown[][];
+    updateSessionStatus: unknown[][];
+    /** Params from both mint variants (plain + conditional). */
+    create: unknown[];
+    updateSessionDelivery: unknown[][];
+    /** Method names of verification-read IPC calls, in order. */
+    sessionReads: string[];
+  };
+  state: {
+    bootstrapSession: SessionRecord;
+    activeSession: SessionRecord;
+    pendingSession: SessionRecord;
+    mintResult: GatewaySessionMintResult;
+    /** When set, the conditional create returns `{ conflict: true, reason }`. */
+    conflictReason: string | null;
+  };
+  /** Clears recorders/toggles/sessions and re-mints the default result. */
+  reset(): void;
+}
+
+export function createGatewayVerificationSessionsStub(options: {
+  mintResult: () => GatewaySessionMintResult;
+}): GatewayVerificationSessionsStub {
+  const unreachable = {
+    all: false,
+    resolveBootstrapToken: false,
+    bindSessionIdentity: false,
+    updateSessionStatus: false,
+    createOutboundSession: false,
+    createOutboundSessionConditional: false,
+    updateSessionDelivery: false,
+    findActiveSession: false,
+    getPendingSession: false,
+  };
+
+  const calls: GatewayVerificationSessionsStub["calls"] = {
+    resolveBootstrapToken: [],
+    bindSessionIdentity: [],
+    updateSessionStatus: [],
+    create: [],
+    updateSessionDelivery: [],
+    sessionReads: [],
+  };
+
+  const state: GatewayVerificationSessionsStub["state"] = {
+    bootstrapSession: null,
+    activeSession: null,
+    pendingSession: null,
+    mintResult: options.mintResult(),
+    conflictReason: null,
+  };
+
+  function throwIfUnreachable(method: StubMethod): void {
+    if (unreachable.all || unreachable[method]) {
+      throw new Error("gateway unreachable");
+    }
+  }
+
+  const module: GatewayVerificationSessionsStub["module"] = {
+    resolveBootstrapToken: async (...args: unknown[]) => {
+      throwIfUnreachable("resolveBootstrapToken");
+      calls.resolveBootstrapToken.push(args);
+      return state.bootstrapSession;
+    },
+    bindSessionIdentity: async (...args: unknown[]) => {
+      throwIfUnreachable("bindSessionIdentity");
+      calls.bindSessionIdentity.push(args);
+    },
+    updateSessionStatus: async (...args: unknown[]) => {
+      throwIfUnreachable("updateSessionStatus");
+      calls.updateSessionStatus.push(args);
+    },
+    createOutboundSession: async (params: unknown) => {
+      throwIfUnreachable("createOutboundSession");
+      calls.create.push(params);
+      return state.mintResult;
+    },
+    createOutboundSessionConditional: async (params: unknown) => {
+      throwIfUnreachable("createOutboundSessionConditional");
+      calls.create.push(params);
+      if (state.conflictReason !== null) {
+        return { conflict: true, reason: state.conflictReason };
+      }
+      return state.mintResult;
+    },
+    updateSessionDelivery: async (...args: unknown[]) => {
+      throwIfUnreachable("updateSessionDelivery");
+      calls.updateSessionDelivery.push(args);
+    },
+    findActiveSession: async () => {
+      calls.sessionReads.push("findActiveSession");
+      throwIfUnreachable("findActiveSession");
+      return state.activeSession;
+    },
+    getPendingSession: async () => {
+      calls.sessionReads.push("getPendingSession");
+      throwIfUnreachable("getPendingSession");
+      return state.pendingSession;
+    },
+  };
+
+  function reset(): void {
+    for (const key of Object.keys(unreachable) as Array<
+      keyof typeof unreachable
+    >) {
+      unreachable[key] = false;
+    }
+    for (const recorder of Object.values(calls)) {
+      recorder.length = 0;
+    }
+    state.bootstrapSession = null;
+    state.activeSession = null;
+    state.pendingSession = null;
+    state.mintResult = options.mintResult();
+    state.conflictReason = null;
+  }
+
+  return { module, unreachable, calls, state, reset };
+}

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -13,6 +13,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
 
+import { createGatewayVerificationSessionsStub } from "../../../__tests__/helpers/gateway-verification-sessions-stub.js";
+
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
@@ -67,58 +69,22 @@ mock.module("../../access-request-helper.js", () => ({
 // Gateway-backed verification-session client: track challenge minting so the
 // callback exemption (LUM-2673) can assert no session is created for button
 // presses; the throw toggle simulates an unreachable gateway (transport
-// errors surface as thrown errors from the client).
-const createOutboundSessionCalls: unknown[] = [];
-// Verification-read IPC calls (getPendingSession/findActiveSession) — the
+// errors surface as thrown errors from the client). Verification-read IPC
+// calls (getPendingSession/findActiveSession) are recorded because the
 // verdict's session-presence stamp must skip these when present-and-false.
-const sessionReadCalls: string[] = [];
-let gatewaySessionsUnreachable = false;
-let pendingSessionForTest: Record<string, unknown> | null = null;
-let activeSessionForTest: Record<string, unknown> | null = null;
-let bootstrapSessionForTest: Record<string, unknown> | null = null;
-function throwIfUnreachable(): void {
-  if (gatewaySessionsUnreachable) {
-    throw new Error("gateway unreachable");
-  }
-}
-mock.module("../../../channels/gateway-verification-sessions.js", () => ({
-  createOutboundSession: async (params: unknown) => {
-    throwIfUnreachable();
-    createOutboundSessionCalls.push(params);
-    return {
-      sessionId: "session-1",
-      secret: "123456",
-      challengeHash: "hash",
-      expiresAt: Date.now() + 600_000,
-      ttlSeconds: 600,
-    };
-  },
-  createOutboundSessionConditional: async (params: unknown) => {
-    throwIfUnreachable();
-    createOutboundSessionCalls.push(params);
-    return {
-      sessionId: "session-1",
-      secret: "123456",
-      challengeHash: "hash",
-      expiresAt: Date.now() + 600_000,
-      ttlSeconds: 600,
-    };
-  },
-  findActiveSession: async () => {
-    sessionReadCalls.push("findActiveSession");
-    throwIfUnreachable();
-    return activeSessionForTest;
-  },
-  getPendingSession: async () => {
-    sessionReadCalls.push("getPendingSession");
-    throwIfUnreachable();
-    return pendingSessionForTest;
-  },
-  resolveBootstrapToken: async () => {
-    throwIfUnreachable();
-    return bootstrapSessionForTest;
-  },
-}));
+const gatewaySessions = createGatewayVerificationSessionsStub({
+  mintResult: () => ({
+    sessionId: "session-1",
+    secret: "123456",
+    challengeHash: "hash",
+    expiresAt: Date.now() + 600_000,
+    ttlSeconds: 600,
+  }),
+});
+mock.module(
+  "../../../channels/gateway-verification-sessions.js",
+  () => gatewaySessions.module,
+);
 
 import type { AclEnforcementParams } from "./acl-enforcement.js";
 import { enforceIngressAcl } from "./acl-enforcement.js";
@@ -164,18 +130,13 @@ function withVerdict(verdict: TrustVerdict): SourceMetadata {
 }
 
 beforeEach(() => {
+  gatewaySessions.reset();
   findContactChannelCalls.length = 0;
   deliverReplyCalls.length = 0;
   accessRequestCalls.length = 0;
-  createOutboundSessionCalls.length = 0;
-  sessionReadCalls.length = 0;
   accessRequestDeniedForTest = false;
   approvalHandshakeForTest = false;
   guardianDeliveryList = [];
-  gatewaySessionsUnreachable = false;
-  pendingSessionForTest = null;
-  activeSessionForTest = null;
-  bootstrapSessionForTest = null;
 });
 
 describe("enforceIngressAcl — verdict-sourced member resolution", () => {
@@ -232,7 +193,7 @@ describe("enforceIngressAcl — verdict-sourced member resolution", () => {
     expect(result.resolvedMember).toBeNull();
     expect(accessRequestCalls.length).toBe(0);
     expect(deliverReplyCalls.length).toBe(0);
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
   });
 
   test("guardian verdict with an inactive (pending) member row is still admitted", async () => {
@@ -648,7 +609,7 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
     expect(result.earlyResponse).toBeDefined();
     expect(result.earlyResponse!.reason).toBe("not_a_member");
     expect(accessRequestCalls.length).toBe(0);
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     // The deny reply still goes out so the click isn't a silent no-op.
     expect(deliverReplyCalls.length).toBe(1);
   });
@@ -670,7 +631,7 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
 
     expect(result.earlyResponse).toBeDefined();
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     expect(accessRequestCalls.length).toBe(0);
   });
 
@@ -695,7 +656,7 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
 
     expect(result.earlyResponse).toBeDefined();
     expect(result.earlyResponse!.reason).toBe("member_pending");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     expect(accessRequestCalls.length).toBe(0);
   });
 
@@ -739,7 +700,7 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
 
     expect(result.earlyResponse).toBeDefined();
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(gatewaySessions.calls.create.length).toBe(1);
     expect(accessRequestCalls.length).toBe(1);
   });
 
@@ -761,12 +722,12 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
 
     expect(result.earlyResponse).toBeDefined();
     // No verification session is minted — a bot cannot return a code.
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     expect(accessRequestCalls.length).toBe(1);
   });
 
   test("an active session for the same sender suppresses a duplicate challenge", async () => {
-    activeSessionForTest = {
+    gatewaySessions.state.activeSession = {
       id: "existing-session",
       channel: "slack",
       status: "awaiting_response",
@@ -787,11 +748,11 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
 
     // Dedup: no new session, fall through to the standard deny.
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
   });
 
   test("an active session for a DIFFERENT sender does not suppress the challenge", async () => {
-    activeSessionForTest = {
+    gatewaySessions.state.activeSession = {
       id: "existing-session",
       channel: "slack",
       status: "awaiting_response",
@@ -811,7 +772,7 @@ describe("enforceIngressAcl — callback interactions never spawn stranger-lane 
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
+    expect(gatewaySessions.calls.create.length).toBe(1);
   });
 
   test("identity signals from sourceMetadata are forwarded to the access request", async () => {
@@ -864,7 +825,7 @@ describe("enforceIngressAcl — bootstrap deep-link bypass reads via the gateway
   }
 
   test("a valid pending_bootstrap session bypasses the non-member deny", async () => {
-    bootstrapSessionForTest = {
+    gatewaySessions.state.bootstrapSession = {
       id: "bootstrap-session",
       channel: "telegram",
       status: "pending_bootstrap",
@@ -880,7 +841,7 @@ describe("enforceIngressAcl — bootstrap deep-link bypass reads via the gateway
   });
 
   test("an unresolvable token keeps the deny", async () => {
-    bootstrapSessionForTest = null;
+    gatewaySessions.state.bootstrapSession = null;
 
     const result = await enforceIngressAcl(bootstrapParams());
 
@@ -889,19 +850,19 @@ describe("enforceIngressAcl — bootstrap deep-link bypass reads via the gateway
   });
 
   test("gateway unreachable degrades to the plain deny — no throw, no bypass", async () => {
-    gatewaySessionsUnreachable = true;
+    gatewaySessions.unreachable.all = true;
 
     const result = await enforceIngressAcl(bootstrapParams());
 
     expect(result.earlyResponse!.reason).toBe("not_a_member");
     expect(result.validatedBootstrapSession).toBeUndefined();
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
   });
 });
 
 describe("enforceIngressAcl — gateway-unreachable deny branches degrade to a plain deny", () => {
   test("Slack stranger message: session reads throwing skips the challenge, normal deny fires", async () => {
-    gatewaySessionsUnreachable = true;
+    gatewaySessions.unreachable.all = true;
 
     const result = await enforceIngressAcl(
       makeParams({
@@ -918,13 +879,13 @@ describe("enforceIngressAcl — gateway-unreachable deny branches degrade to a p
     // No challenge minted, no throw: the standard deny lane still runs
     // (guardian notified, canned reply delivered).
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     expect(accessRequestCalls.length).toBe(1);
     expect(deliverReplyCalls.length).toBe(1);
   });
 
   test("Slack inactive member: session reads throwing skips the re-verify challenge", async () => {
-    gatewaySessionsUnreachable = true;
+    gatewaySessions.unreachable.all = true;
 
     const result = await enforceIngressAcl(
       makeParams({
@@ -943,12 +904,12 @@ describe("enforceIngressAcl — gateway-unreachable deny branches degrade to a p
     );
 
     expect(result.earlyResponse!.reason).toBe("member_pending");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
     expect(accessRequestCalls.length).toBe(1);
   });
 
   test("email stranger message: session reads throwing skips the challenge", async () => {
-    gatewaySessionsUnreachable = true;
+    gatewaySessions.unreachable.all = true;
 
     const result = await enforceIngressAcl(
       makeParams({
@@ -963,7 +924,7 @@ describe("enforceIngressAcl — gateway-unreachable deny branches degrade to a p
     );
 
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(createOutboundSessionCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(0);
   });
 });
 
@@ -992,8 +953,8 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
-    expect(sessionReadCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(1);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(0);
   });
 
   test("stamp false (email stranger): challenge minted with ZERO verification-read IPC calls", async () => {
@@ -1009,8 +970,8 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
-    expect(sessionReadCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(1);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(0);
   });
 
   test("stamp false (Slack inactive member): re-verify challenge minted with ZERO verification-read IPC calls", async () => {
@@ -1032,14 +993,14 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
-    expect(sessionReadCalls.length).toBe(0);
+    expect(gatewaySessions.calls.create.length).toBe(1);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(0);
   });
 
   test("stamp true: falls back to the IPC reads — same-sender session still dedups", async () => {
     // The stamp is channel-scoped; only `false` is authoritative. A `true`
     // stamp must preserve the sender-scoped dedup via the reads.
-    activeSessionForTest = {
+    gatewaySessions.state.activeSession = {
       id: "existing-session",
       channel: "slack",
       status: "awaiting_response",
@@ -1056,12 +1017,12 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(createOutboundSessionCalls.length).toBe(0);
-    expect(sessionReadCalls.length).toBe(2);
+    expect(gatewaySessions.calls.create.length).toBe(0);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(2);
   });
 
   test("stamp true: a DIFFERENT sender's session does not suppress the challenge", async () => {
-    activeSessionForTest = {
+    gatewaySessions.state.activeSession = {
       id: "existing-session",
       channel: "slack",
       status: "awaiting_response",
@@ -1078,8 +1039,8 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
-    expect(sessionReadCalls.length).toBe(2);
+    expect(gatewaySessions.calls.create.length).toBe(1);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(2);
   });
 
   test("absent stamp (legacy/voice-relay verdict): falls back to the IPC reads", async () => {
@@ -1093,12 +1054,12 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
-    expect(createOutboundSessionCalls.length).toBe(1);
-    expect(sessionReadCalls.length).toBe(2);
+    expect(gatewaySessions.calls.create.length).toBe(1);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(2);
   });
 
   test("stamp false with the gateway unreachable at mint time degrades to a plain deny", async () => {
-    gatewaySessionsUnreachable = true;
+    gatewaySessions.unreachable.all = true;
 
     const result = await enforceIngressAcl(
       makeParams({
@@ -1110,6 +1071,6 @@ describe("enforceIngressAcl — verdict session-presence stamp elides the verifi
     );
 
     expect(result.earlyResponse!.reason).toBe("not_a_member");
-    expect(sessionReadCalls.length).toBe(0);
+    expect(gatewaySessions.calls.sessionReads.length).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.test.ts
@@ -14,6 +14,8 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createGatewayVerificationSessionsStub } from "../../../__tests__/helpers/gateway-verification-sessions-stub.js";
+
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
@@ -21,51 +23,19 @@ mock.module("../../../util/logger.js", () => ({
 
 // Gateway-backed session client (async IPC); throw toggles simulate an
 // unreachable gateway per lifecycle call.
-let bootstrapSessionForTest: Record<string, unknown> | null = null;
-let resolveThrows = false;
-let bindThrows = false;
-let createThrows = false;
-let createConflicts = false;
-let updateDeliveryThrows = false;
-
-const resolveCalls: unknown[][] = [];
-const bindCalls: unknown[][] = [];
-const updateStatusCalls: unknown[][] = [];
-const createCalls: unknown[] = [];
-const updateDeliveryCalls: unknown[][] = [];
-
-mock.module("../../../channels/gateway-verification-sessions.js", () => ({
-  resolveBootstrapToken: async (channel: string, token: string) => {
-    if (resolveThrows) throw new Error("gateway unreachable");
-    resolveCalls.push([channel, token]);
-    return bootstrapSessionForTest;
-  },
-  bindSessionIdentity: async (...args: unknown[]) => {
-    if (bindThrows) throw new Error("gateway unreachable");
-    bindCalls.push(args);
-  },
-  updateSessionStatus: async (...args: unknown[]) => {
-    updateStatusCalls.push(args);
-  },
-  createOutboundSessionConditional: async (params: unknown) => {
-    if (createThrows) throw new Error("gateway unreachable");
-    createCalls.push(params);
-    if (createConflicts) {
-      return { conflict: true, reason: "source_session_not_pending" };
-    }
-    return {
-      sessionId: "new-session-1",
-      secret: "654321",
-      challengeHash: "hash-1",
-      expiresAt: Date.now() + 600_000,
-      ttlSeconds: 600,
-    };
-  },
-  updateSessionDelivery: async (...args: unknown[]) => {
-    if (updateDeliveryThrows) throw new Error("gateway unreachable");
-    updateDeliveryCalls.push(args);
-  },
-}));
+const gatewaySessions = createGatewayVerificationSessionsStub({
+  mintResult: () => ({
+    sessionId: "new-session-1",
+    secret: "654321",
+    challengeHash: "hash-1",
+    expiresAt: Date.now() + 600_000,
+    ttlSeconds: 600,
+  }),
+});
+mock.module(
+  "../../../channels/gateway-verification-sessions.js",
+  () => gatewaySessions.module,
+);
 
 const telegramReplies: Array<{ chatId: string; text: string }> = [];
 mock.module("../../../messaging/providers/telegram-bot/send.js", () => ({
@@ -98,21 +68,12 @@ function makeParams(
 }
 
 beforeEach(() => {
-  bootstrapSessionForTest = {
+  gatewaySessions.reset();
+  gatewaySessions.state.bootstrapSession = {
     id: "bootstrap-session-1",
     channel: "telegram",
     status: "pending_bootstrap",
   };
-  resolveThrows = false;
-  bindThrows = false;
-  createThrows = false;
-  createConflicts = false;
-  updateDeliveryThrows = false;
-  resolveCalls.length = 0;
-  bindCalls.length = 0;
-  updateStatusCalls.length = 0;
-  createCalls.length = 0;
-  updateDeliveryCalls.length = 0;
   telegramReplies.length = 0;
 });
 
@@ -128,12 +89,16 @@ describe("handleBootstrapIntercept", () => {
     });
 
     // Raw token (gv_ prefix stripped); hashing is gateway-side.
-    expect(resolveCalls).toEqual([["telegram", "token123"]]);
-    expect(bindCalls).toEqual([["bootstrap-session-1", "user-42", "chat-123"]]);
+    expect(gatewaySessions.calls.resolveBootstrapToken).toEqual([
+      ["telegram", "token123"],
+    ]);
+    expect(gatewaySessions.calls.bindSessionIdentity).toEqual([
+      ["bootstrap-session-1", "user-42", "chat-123"],
+    ]);
     // The mint revokes the bootstrap session gateway-side; no separate
     // status transition — that would make a mint failure unretryable.
-    expect(updateStatusCalls).toHaveLength(0);
-    expect(createCalls).toEqual([
+    expect(gatewaySessions.calls.updateSessionStatus).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toEqual([
       {
         channel: "telegram",
         expectedExternalUserId: "user-42",
@@ -144,22 +109,24 @@ describe("handleBootstrapIntercept", () => {
         requireSourceSessionPending: "bootstrap-session-1",
       },
     ]);
-    expect(updateDeliveryCalls).toHaveLength(1);
-    expect(updateDeliveryCalls[0][0]).toBe("new-session-1");
+    expect(gatewaySessions.calls.updateSessionDelivery).toHaveLength(1);
+    expect(gatewaySessions.calls.updateSessionDelivery[0][0]).toBe(
+      "new-session-1",
+    );
   });
 
   test("unresolvable token falls through to normal /start handling", async () => {
-    bootstrapSessionForTest = null;
+    gatewaySessions.state.bootstrapSession = null;
 
     const result = await handleBootstrapIntercept(makeParams());
 
     expect(result).toBeNull();
-    expect(bindCalls).toHaveLength(0);
-    expect(createCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.bindSessionIdentity).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("non-pending_bootstrap session falls through", async () => {
-    bootstrapSessionForTest = {
+    gatewaySessions.state.bootstrapSession = {
       id: "bootstrap-session-1",
       channel: "telegram",
       status: "consumed",
@@ -168,7 +135,7 @@ describe("handleBootstrapIntercept", () => {
     const result = await handleBootstrapIntercept(makeParams());
 
     expect(result).toBeNull();
-    expect(bindCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.bindSessionIdentity).toHaveLength(0);
   });
 
   test("non-bootstrap commands fall through untouched", async () => {
@@ -183,11 +150,11 @@ describe("handleBootstrapIntercept", () => {
     expect(
       await handleBootstrapIntercept(makeParams({ rawSenderId: undefined })),
     ).toBeNull();
-    expect(resolveCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.resolveBootstrapToken).toHaveLength(0);
   });
 
   test("gateway unreachable on token resolution returns a handled unavailable response — no fall-through", async () => {
-    resolveThrows = true;
+    gatewaySessions.unreachable.resolveBootstrapToken = true;
 
     const result = await handleBootstrapIntercept(makeParams());
 
@@ -197,14 +164,14 @@ describe("handleBootstrapIntercept", () => {
       eventId: "event-1",
       verificationOutcome: "bootstrap_unavailable",
     });
-    expect(bindCalls).toHaveLength(0);
-    expect(createCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.bindSessionIdentity).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
     expect(telegramReplies).toHaveLength(1);
     expect(telegramReplies[0].text).toContain("tap the link again");
   });
 
   test("gateway unreachable on identity bind leaves the session pending_bootstrap and responds unavailable", async () => {
-    bindThrows = true;
+    gatewaySessions.unreachable.bindSessionIdentity = true;
 
     const result = await handleBootstrapIntercept(makeParams());
 
@@ -212,13 +179,13 @@ describe("handleBootstrapIntercept", () => {
       verificationOutcome: "bootstrap_unavailable",
     });
     // Nothing moved the session out of pending_bootstrap — re-tap retries.
-    expect(updateStatusCalls).toHaveLength(0);
-    expect(createCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.updateSessionStatus).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
     expect(telegramReplies).toHaveLength(1);
   });
 
   test("gateway unreachable on session creation leaves the session pending_bootstrap and responds unavailable", async () => {
-    createThrows = true;
+    gatewaySessions.unreachable.createOutboundSessionConditional = true;
 
     const result = await handleBootstrapIntercept(makeParams());
 
@@ -227,9 +194,9 @@ describe("handleBootstrapIntercept", () => {
     });
     // Bind ran but binding never changes status, so the token is still
     // resolvable and the deep link remains retryable.
-    expect(bindCalls).toHaveLength(1);
-    expect(updateStatusCalls).toHaveLength(0);
-    expect(updateDeliveryCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.bindSessionIdentity).toHaveLength(1);
+    expect(gatewaySessions.calls.updateSessionStatus).toHaveLength(0);
+    expect(gatewaySessions.calls.updateSessionDelivery).toHaveLength(0);
     expect(telegramReplies).toHaveLength(1);
   });
 
@@ -245,12 +212,14 @@ describe("handleBootstrapIntercept", () => {
     );
 
     expect(result).toMatchObject({ verificationOutcome: "bootstrap_bound" });
-    expect(resolveCalls).toHaveLength(0);
-    expect(bindCalls).toEqual([["bootstrap-session-1", "user-42", "chat-123"]]);
+    expect(gatewaySessions.calls.resolveBootstrapToken).toHaveLength(0);
+    expect(gatewaySessions.calls.bindSessionIdentity).toEqual([
+      ["bootstrap-session-1", "user-42", "chat-123"],
+    ]);
   });
 
   test("ACL-threaded session with a failing handoff still returns the handled unavailable response", async () => {
-    bindThrows = true;
+    gatewaySessions.unreachable.bindSessionIdentity = true;
 
     const result = await handleBootstrapIntercept(
       makeParams({
@@ -265,12 +234,12 @@ describe("handleBootstrapIntercept", () => {
     expect(result).toMatchObject({
       verificationOutcome: "bootstrap_unavailable",
     });
-    expect(resolveCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.resolveBootstrapToken).toHaveLength(0);
     expect(telegramReplies).toHaveLength(1);
   });
 
   test("losing the concurrent claim race returns a handled response without a second code", async () => {
-    createConflicts = true;
+    gatewaySessions.state.conflictReason = "source_session_not_pending";
 
     const result = await handleBootstrapIntercept(makeParams());
 
@@ -282,13 +251,13 @@ describe("handleBootstrapIntercept", () => {
       eventId: "event-1",
       verificationOutcome: "bootstrap_already_claimed",
     });
-    expect(createCalls).toHaveLength(1);
-    expect(updateDeliveryCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
+    expect(gatewaySessions.calls.updateSessionDelivery).toHaveLength(0);
     expect(telegramReplies).toHaveLength(0);
   });
 
   test("delivery-tracking failure after the code is sent does not unwind the bootstrap", async () => {
-    updateDeliveryThrows = true;
+    gatewaySessions.unreachable.updateSessionDelivery = true;
 
     const result = await handleBootstrapIntercept(makeParams());
 

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createGatewayVerificationSessionsStub } from "../../../__tests__/helpers/gateway-verification-sessions-stub.js";
+
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
@@ -7,17 +9,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Gateway guardian-delivery list: empty = unbound, one entry = bound,
 // null = gateway unreachable.
 let mockGuardianList: Array<Record<string, unknown>> | null = [];
-let mockActiveSession: Record<string, unknown> | null = null;
-let mockSessionResult = {
-  sessionId: "sess-1",
-  secret: "123456",
-  challengeHash: "hash-1",
-  expiresAt: Date.now() + 600_000,
-  ttlSeconds: 600,
-};
 
 // Track calls manually to avoid TypeScript issues with mock() generics
-let createOutboundSessionCalls: unknown[] = [];
 let deliverChannelReplyCalls: unknown[][] = [];
 let emitNotificationSignalCalls: unknown[] = [];
 let messageIdCounter = 0;
@@ -28,33 +21,24 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: (
     list: Array<{ channelType: string; status: string }>,
     channelType: string,
-  ) =>
-    list.find((g) => g.channelType === channelType && g.status === "active"),
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
 }));
 
 // Gateway-backed session client (async IPC); the throw toggles simulate an
 // unreachable gateway, where the client wrappers throw transport errors.
-let findActiveSessionThrows = false;
-let createOutboundSessionThrows = false;
-let createOutboundSessionConflicts = false;
-mock.module("../../../channels/gateway-verification-sessions.js", () => ({
-  createOutboundSessionConditional: async (params: unknown) => {
-    if (createOutboundSessionThrows) {
-      throw new Error("gateway unreachable");
-    }
-    createOutboundSessionCalls.push(params);
-    if (createOutboundSessionConflicts) {
-      return { conflict: true, reason: "active_session_exists" };
-    }
-    return mockSessionResult;
-  },
-  findActiveSession: async () => {
-    if (findActiveSessionThrows) {
-      throw new Error("gateway unreachable");
-    }
-    return mockActiveSession;
-  },
-}));
+const gatewaySessions = createGatewayVerificationSessionsStub({
+  mintResult: () => ({
+    sessionId: "sess-1",
+    secret: "123456",
+    challengeHash: "hash-1",
+    expiresAt: Date.now() + 600_000,
+    ttlSeconds: 600,
+  }),
+});
+mock.module(
+  "../../../channels/gateway-verification-sessions.js",
+  () => gatewaySessions.module,
+);
 
 mock.module("../../gateway-client.js", () => ({
   deliverChannelReply: (url: unknown, payload: unknown, token: unknown) => {
@@ -120,25 +104,13 @@ function makeParams(
 
 describe("handleGuardianActivationIntercept", () => {
   beforeEach(() => {
+    gatewaySessions.reset();
     mockGuardianList = [];
-    mockActiveSession = null;
-    mockSessionResult = {
-      sessionId: "sess-1",
-      secret: "123456",
-      challengeHash: "hash-1",
-      expiresAt: Date.now() + 600_000,
-      ttlSeconds: 600,
-    };
-    createOutboundSessionCalls = [];
     deliverChannelReplyCalls = [];
     emitNotificationSignalCalls = [];
-    findActiveSessionThrows = false;
-    createOutboundSessionThrows = false;
-    createOutboundSessionConflicts = false;
   });
 
   afterEach(() => {
-    createOutboundSessionCalls = [];
     deliverChannelReplyCalls = [];
     emitNotificationSignalCalls = [];
   });
@@ -151,8 +123,8 @@ describe("handleGuardianActivationIntercept", () => {
     expect(body).toEqual({ accepted: true, guardianActivation: true });
 
     // Verify createOutboundSessionConditional was called with correct params
-    expect(createOutboundSessionCalls).toHaveLength(1);
-    expect(createOutboundSessionCalls[0]).toEqual({
+    expect(gatewaySessions.calls.create).toHaveLength(1);
+    expect(gatewaySessions.calls.create[0]).toEqual({
       channel: "telegram",
       expectedExternalUserId: "user-42",
       expectedChatId: "chat-123",
@@ -188,7 +160,7 @@ describe("handleGuardianActivationIntercept", () => {
 
     const result = await handleGuardianActivationIntercept(makeParams());
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("null guardian list (gateway unreachable) does NOT auto-start", async () => {
@@ -196,7 +168,7 @@ describe("handleGuardianActivationIntercept", () => {
 
     const result = await handleGuardianActivationIntercept(makeParams());
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("/start with payload returns null", async () => {
@@ -208,7 +180,7 @@ describe("handleGuardianActivationIntercept", () => {
       }),
     );
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("non-/start message returns null", async () => {
@@ -218,7 +190,7 @@ describe("handleGuardianActivationIntercept", () => {
       }),
     );
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("no commandIntent returns null", async () => {
@@ -231,7 +203,7 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ sourceMetadata: undefined }),
     );
     expect(result2).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("non-telegram channel returns null", async () => {
@@ -239,7 +211,7 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ sourceChannel: "slack" as any }),
     );
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("missing sender ID returns null", async () => {
@@ -247,11 +219,11 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ rawSenderId: undefined }),
     );
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
   });
 
   test("existing active session from same sender sends 'already in progress' reply", async () => {
-    mockActiveSession = {
+    gatewaySessions.state.activeSession = {
       id: "existing-sess",
       channel: "telegram",
       status: "awaiting_response",
@@ -266,7 +238,7 @@ describe("handleGuardianActivationIntercept", () => {
     expect(body).toEqual({ accepted: true, guardianActivationPending: true });
 
     // createOutboundSession should NOT be called
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
 
     // deliverChannelReply should be called with the "already in progress" message
     expect(deliverChannelReplyCalls).toHaveLength(1);
@@ -281,7 +253,7 @@ describe("handleGuardianActivationIntercept", () => {
   });
 
   test("existing active session from different sender allows superseding", async () => {
-    mockActiveSession = {
+    gatewaySessions.state.activeSession = {
       id: "existing-sess",
       channel: "telegram",
       status: "awaiting_response",
@@ -295,11 +267,11 @@ describe("handleGuardianActivationIntercept", () => {
     expect(result).not.toBeNull();
     const body = result!;
     expect(body).toEqual({ accepted: true, guardianActivation: true });
-    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
     // Deliberate supersede: the create-if-absent guard is omitted so the
     // stale session gets revoked.
     expect(
-      (createOutboundSessionCalls[0] as Record<string, unknown>).ifNoneActive,
+      (gatewaySessions.calls.create[0] as Record<string, unknown>).ifNoneActive,
     ).toBeUndefined();
     expect(emitNotificationSignalCalls).toHaveLength(1);
   });
@@ -307,7 +279,7 @@ describe("handleGuardianActivationIntercept", () => {
   test("losing the concurrent create race does not invalidate the first activation's code", async () => {
     // Both bare /starts read "no active session"; the gateway-side
     // create-if-absent makes the second one conflict instead of minting.
-    createOutboundSessionConflicts = true;
+    gatewaySessions.state.conflictReason = "active_session_exists";
 
     const result = await handleGuardianActivationIntercept(makeParams());
 
@@ -317,7 +289,7 @@ describe("handleGuardianActivationIntercept", () => {
       accepted: true,
       guardianActivationPending: true,
     });
-    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
     expect(deliverChannelReplyCalls).toHaveLength(1);
     expect(deliverChannelReplyCalls[0][1]).toEqual({
       chatId: "chat-123",
@@ -328,19 +300,19 @@ describe("handleGuardianActivationIntercept", () => {
   });
 
   test("gateway unreachable on the session read skips auto-activation without throwing", async () => {
-    findActiveSessionThrows = true;
+    gatewaySessions.unreachable.findActiveSession = true;
 
     const result = await handleGuardianActivationIntercept(makeParams());
 
     // Degrades to the normal pipeline: no session, no reply, no signal.
     expect(result).toBeNull();
-    expect(createOutboundSessionCalls).toHaveLength(0);
+    expect(gatewaySessions.calls.create).toHaveLength(0);
     expect(deliverChannelReplyCalls).toHaveLength(0);
     expect(emitNotificationSignalCalls).toHaveLength(0);
   });
 
   test("gateway unreachable on session creation skips auto-activation and stays retryable", async () => {
-    createOutboundSessionThrows = true;
+    gatewaySessions.unreachable.createOutboundSessionConditional = true;
     const params = makeParams({ externalMessageId: "retry-after-outage" });
 
     const result = await handleGuardianActivationIntercept(params);
@@ -349,10 +321,10 @@ describe("handleGuardianActivationIntercept", () => {
 
     // Not marked processed on failure: the next webhook retry succeeds once
     // the gateway is reachable again.
-    createOutboundSessionThrows = false;
+    gatewaySessions.unreachable.createOutboundSessionConditional = false;
     const retry = await handleGuardianActivationIntercept(params);
     expect(retry).toEqual({ accepted: true, guardianActivation: true });
-    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
   });
 
   test("duplicate webhook retry is silently deduped", async () => {
@@ -363,7 +335,7 @@ describe("handleGuardianActivationIntercept", () => {
     expect(result1).not.toBeNull();
     const body1 = result1!;
     expect(body1).toEqual({ accepted: true, guardianActivation: true });
-    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
     expect(deliverChannelReplyCalls).toHaveLength(1);
     expect(emitNotificationSignalCalls).toHaveLength(1);
 
@@ -374,7 +346,7 @@ describe("handleGuardianActivationIntercept", () => {
     expect(body2).toEqual({ accepted: true, guardianActivation: true });
 
     // No additional session/reply/signal calls
-    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(gatewaySessions.calls.create).toHaveLength(1);
     expect(deliverChannelReplyCalls).toHaveLength(1);
     expect(emitNotificationSignalCalls).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for verif-sessions-gateway-native.md: the three inbound-stage tests hand-rolled near-identical gateway-session mock scaffolds; they now share a configurable stub factory helper (pure test dedup, no semantic change)