### PR TITLE
feat(stt): add a transport-neutral PCM16 speech-energy detector

### DIFF
--- a/assistant/src/stt/__tests__/speech-energy.test.ts
+++ b/assistant/src/stt/__tests__/speech-energy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_SPEECH_ENERGY_THRESHOLD,
+  detectPcm16SpeechActivity,
+} from "../speech-energy.js";
+
+/** Build a PCM16LE buffer from an array of sample values. */
+function pcm16(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], i * 2);
+  }
+  return buf;
+}
+
+describe("detectPcm16SpeechActivity", () => {
+  test("silence buffer returns false", () => {
+    expect(detectPcm16SpeechActivity(pcm16(new Array(160).fill(0)))).toBe(
+      false,
+    );
+  });
+
+  test("low-level noise below the threshold returns false", () => {
+    const samples = Array.from({ length: 160 }, (_, i) =>
+      i % 2 === 0 ? 300 : -300,
+    );
+    expect(detectPcm16SpeechActivity(pcm16(samples))).toBe(false);
+  });
+
+  test("loud square wave returns true", () => {
+    const samples = Array.from({ length: 160 }, (_, i) =>
+      i % 2 === 0 ? 10000 : -10000,
+    );
+    expect(detectPcm16SpeechActivity(pcm16(samples))).toBe(true);
+  });
+
+  test("mean exactly at the threshold returns false; just above returns true", () => {
+    const at = pcm16(new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD));
+    expect(detectPcm16SpeechActivity(at)).toBe(false);
+
+    const above = pcm16(
+      new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD + 1),
+    );
+    expect(detectPcm16SpeechActivity(above)).toBe(true);
+  });
+
+  test("empty buffer returns false", () => {
+    expect(detectPcm16SpeechActivity(Buffer.alloc(0))).toBe(false);
+  });
+
+  test("single trailing odd byte returns false without throwing", () => {
+    expect(detectPcm16SpeechActivity(Buffer.from([0x7f]))).toBe(false);
+  });
+
+  test("odd-length buffer ignores the trailing byte", () => {
+    const loud = pcm16(new Array(50).fill(10000));
+    const withTrailing = Buffer.concat([loud, Buffer.from([0x01])]);
+    expect(detectPcm16SpeechActivity(withTrailing)).toBe(true);
+  });
+
+  test("custom threshold is respected", () => {
+    const quiet = pcm16(new Array(100).fill(500));
+    expect(detectPcm16SpeechActivity(quiet)).toBe(false);
+    expect(detectPcm16SpeechActivity(quiet, 400)).toBe(true);
+    expect(detectPcm16SpeechActivity(quiet, 500)).toBe(false);
+  });
+});

--- a/assistant/src/stt/speech-energy.ts
+++ b/assistant/src/stt/speech-energy.ts
@@ -1,0 +1,49 @@
+/**
+ * Lightweight energy-based speech activity detector for linear PCM16 audio.
+ *
+ * The PCM16 analog of the telephony mu-law energy gate
+ * (`detectSpeechActivity` in `calls/media-stream-stt-session.ts`): both
+ * compute the mean absolute amplitude on the 16-bit linear scale and
+ * compare it against the same threshold. Intended to feed
+ * `MediaTurnDetector.onMediaChunk(hasSpeech)` for transports that carry
+ * raw PCM16 instead of mu-law (e.g. in-app live voice).
+ *
+ * Transport-neutral: pure buffer analysis, no session or provider state.
+ */
+
+/**
+ * Mean-absolute-amplitude threshold above which a chunk is classified as
+ * speech. Same 16-bit linear scale as the telephony gate, where typical
+ * silence averages ~200-400 and speech >1200.
+ */
+export const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
+
+/**
+ * Detect speech activity in a chunk of little-endian signed 16-bit mono
+ * PCM samples.
+ *
+ * Computes the mean absolute sample amplitude and compares it against the
+ * threshold. Returns `false` for empty buffers. A trailing odd byte is
+ * ignored — client chunk boundaries are arbitrary.
+ *
+ * @param chunk - Raw PCM16LE audio.
+ * @param threshold - Mean-amplitude cutoff on the 16-bit linear scale.
+ * @returns `true` if the chunk likely contains speech, `false` otherwise.
+ */
+export function detectPcm16SpeechActivity(
+  chunk: Buffer,
+  threshold = DEFAULT_SPEECH_ENERGY_THRESHOLD,
+): boolean {
+  const sampleCount = Math.floor(chunk.length / 2);
+  if (sampleCount === 0) {
+    return false;
+  }
+
+  let totalAmplitude = 0;
+  for (let i = 0; i < sampleCount; i++) {
+    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
+  }
+  const avgAmplitude = totalAmplitude / sampleCount;
+
+  return avgAmplitude > threshold;
+}


### PR DESCRIPTION
## Summary
- Adds detectPcm16SpeechActivity + DEFAULT_SPEECH_ENERGY_THRESHOLD in assistant/src/stt/speech-energy.ts — the PCM16 analog of the telephony mu-law energy gate, intended to feed MediaTurnDetector for in-app live-voice VAD.

Part of plan: live-voice-server-barge-in.md (PR 1 of 11)