### PR TITLE
feat(web): request echoCancellation/noiseSuppression for voice capture

### DIFF
--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -78,7 +78,7 @@ mock.module("@/runtime/native-auth", () => ({
 }));
 mock.module("@/utils/voice-input-device", () => ({
   getVoiceInputMediaStream: async () => fakeStream,
-  voiceInputAudioConstraints: () => true,
+  voiceInputAudioConstraints: () => ({}),
 }));
 
 // Capture the command handler map the component registers so tests can

--- a/clients/web/src/utils/voice-input-device.test.ts
+++ b/clients/web/src/utils/voice-input-device.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  LS_VOICE_INPUT_DEVICE,
+  voiceInputAudioConstraints,
+} from "./voice-input-device";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("voiceInputAudioConstraints", () => {
+  test("requests processing constraints when no device is pinned", () => {
+    expect(voiceInputAudioConstraints()).toEqual({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    });
+  });
+
+  test("preserves the pinned device alongside processing constraints", () => {
+    localStorage.setItem(LS_VOICE_INPUT_DEVICE, "mic-42");
+    expect(voiceInputAudioConstraints()).toEqual({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      deviceId: { exact: "mic-42" },
+    });
+  });
+});

--- a/clients/web/src/utils/voice-input-device.ts
+++ b/clients/web/src/utils/voice-input-device.ts
@@ -14,10 +14,17 @@ export function getPreferredInputDeviceId(): string {
  * Audio constraints for voice capture, honoring the microphone chosen on the
  * Voice settings page. Uses `exact` so Chromium 130+ actually selects the
  * device (ideal constraints are silently ignored since that version).
+ * Always requests echo cancellation, noise suppression, and auto gain so the
+ * mic stays usable while TTS is playing (full-duplex capture).
  */
-export function voiceInputAudioConstraints(): MediaTrackConstraints | true {
+export function voiceInputAudioConstraints(): MediaTrackConstraints {
   const deviceId = getPreferredInputDeviceId();
-  return deviceId ? { deviceId: { exact: deviceId } } : true;
+  return {
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true,
+    ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+  };
 }
 
 /**
@@ -31,11 +38,12 @@ export async function getVoiceInputMediaStream(): Promise<MediaStream> {
     return await navigator.mediaDevices.getUserMedia({ audio: constraints });
   } catch (err) {
     if (
-      constraints !== true &&
+      constraints.deviceId &&
       err instanceof DOMException &&
       err.name === "OverconstrainedError"
     ) {
-      return navigator.mediaDevices.getUserMedia({ audio: true });
+      const { deviceId: _unpinned, ...fallback } = constraints;
+      return navigator.mediaDevices.getUserMedia({ audio: fallback });
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
- voiceInputAudioConstraints() now always requests echoCancellation, noiseSuppression, and autoGainControl (both the default and pinned-device branches) — prerequisite for hands-free live-voice where the mic forwards audio while TTS plays, and a strict improvement for existing dictation capture.

Part of plan: live-voice-server-barge-in.md (PR 9 of 11)