### PR TITLE
feat(live-voice): protocol support for server VAD — speech_started, utterance_end, turn_cancelled

### DIFF
--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -163,35 +163,59 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
-  test("parses start frames with each valid turnDetection mode", () => {
-    for (const turnDetection of ["manual", "server_vad"] as const) {
-      const result = parseLiveVoiceClientTextFrame(
-        JSON.stringify({
-          type: "start",
-          turnDetection,
-          audio: {
-            mimeType: "audio/pcm",
-            sampleRate: 24000,
-            channels: 1,
-          },
-        }),
-      );
-
-      expect(result.ok).toBe(true);
-      if (!result.ok) {
-        continue;
-      }
-
-      expect(result.frame).toEqual({
+  test("parses start frames with turnDetection manual", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
         type: "start",
-        turnDetection,
+        turnDetection: "manual",
         audio: {
           mimeType: "audio/pcm",
           sampleRate: 24000,
           channels: 1,
         },
-      });
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
     }
+
+    expect(result.frame).toEqual({
+      type: "start",
+      turnDetection: "manual",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+  });
+
+  test("rejects turnDetection server_vad until its session lifecycle is implemented", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        turnDetection: "server_vad",
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "turnDetection",
+      frameType: "start",
+      message: "start frame field turnDetection: server_vad is not yet supported",
+    });
   });
 
   test("omits turnDetection when absent from the start frame", () => {

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -163,6 +163,80 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("parses start frames with each valid turnDetection mode", () => {
+    for (const turnDetection of ["manual", "server_vad"] as const) {
+      const result = parseLiveVoiceClientTextFrame(
+        JSON.stringify({
+          type: "start",
+          turnDetection,
+          audio: {
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+          },
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        continue;
+      }
+
+      expect(result.frame).toEqual({
+        type: "start",
+        turnDetection,
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+      });
+    }
+  });
+
+  test("omits turnDetection when absent from the start frame", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect("turnDetection" in result.frame).toBe(false);
+  });
+
+  test("returns typed protocol errors for invalid turnDetection values", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      turnDetection: "client_vad",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "turnDetection",
+      frameType: "start",
+    });
+  });
+
   test("returns typed protocol errors for missing audio configuration fields", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",
@@ -269,6 +343,55 @@ describe("LiveVoiceServerFrameSequencer", () => {
         turnId: "turn-2",
       }).seq,
     ).toBe(1);
+  });
+
+  test("stamps monotonic sequence numbers on server VAD frames", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const speechStarted: LiveVoiceServerFrame = sequencer.next({
+      type: "speech_started",
+    });
+    const utteranceEnd: LiveVoiceServerFrame = sequencer.next({
+      type: "utterance_end",
+      reason: "silence",
+    });
+    const turnCancelled: LiveVoiceServerFrame = sequencer.next({
+      type: "turn_cancelled",
+      turnId: "turn-123",
+    });
+
+    expect(speechStarted).toEqual({ type: "speech_started", seq: 1 });
+    expect(utteranceEnd).toEqual({
+      type: "utterance_end",
+      reason: "silence",
+      seq: 2,
+    });
+    expect(turnCancelled).toEqual({
+      type: "turn_cancelled",
+      turnId: "turn-123",
+      seq: 3,
+    });
+    expect(sequencer.lastSeq).toBe(3);
+  });
+
+  test("sequences both utterance_end reasons", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const silence = sequencer.next({
+      type: "utterance_end",
+      reason: "silence",
+    });
+    const maxDuration = sequencer.next({
+      type: "utterance_end",
+      reason: "max-duration",
+    });
+
+    expect(silence).toEqual({ type: "utterance_end", reason: "silence", seq: 1 });
+    expect(maxDuration).toEqual({
+      type: "utterance_end",
+      reason: "max-duration",
+      seq: 2,
+    });
   });
 
   test("preserves the server frame discriminated union after sequencing", () => {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -11,12 +11,15 @@ type LiveVoiceClientFrameType = (typeof LIVE_VOICE_CLIENT_FRAME_TYPES)[number];
 const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "ready",
   "busy",
+  "speech_started",
+  "utterance_end",
   "stt_partial",
   "stt_final",
   "thinking",
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
+  "turn_cancelled",
   "metrics",
   "archived",
   "error",
@@ -53,10 +56,21 @@ export interface LiveVoiceAudioConfig {
   readonly channels: 1;
 }
 
+const LIVE_VOICE_TURN_DETECTION_MODES = ["manual", "server_vad"] as const;
+
+export type LiveVoiceTurnDetectionMode =
+  (typeof LIVE_VOICE_TURN_DETECTION_MODES)[number];
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
   readonly audio: LiveVoiceAudioConfig;
+  /**
+   * Turn-detection mode for the session. Absent means "manual" (push-to-talk).
+   * "server_vad" also implies a multi-turn session: the server detects
+   * utterance boundaries and runs repeated utterance→turn cycles.
+   */
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
 }
 
 export interface LiveVoiceClientAudioFrame {
@@ -104,6 +118,24 @@ export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
   readonly activeSessionId: string;
 }
 
+/**
+ * Emitted when the server VAD detects user speech. The client MUST
+ * immediately stop local TTS playback — this doubles as the flush-tail-audio
+ * signal (the in-app analog of the phone stack's buffered-audio clear).
+ */
+export interface LiveVoiceSpeechStartedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "speech_started";
+}
+
+/**
+ * Emitted when the server VAD closes the utterance and the turn's
+ * transcription begins (plays the role ptt_release plays in manual mode).
+ */
+export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_end";
+  readonly reason: "silence" | "max-duration";
+}
+
 export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "stt_partial";
   readonly text: string;
@@ -133,6 +165,15 @@ export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
 
 export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+/**
+ * Emitted when an in-flight assistant turn is aborted by barge-in. The client
+ * must drop any buffered tts_audio for that turn; no tts_done will follow.
+ */
+export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_cancelled";
   readonly turnId: string;
 }
 
@@ -172,12 +213,15 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
 export type LiveVoiceServerFrame =
   | LiveVoiceReadyServerFrame
   | LiveVoiceBusyServerFrame
+  | LiveVoiceSpeechStartedServerFrame
+  | LiveVoiceUtteranceEndServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceTurnCancelledServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
   | LiveVoiceErrorServerFrame;
@@ -187,12 +231,15 @@ type WithoutSeq<T extends LiveVoiceServerFrameBase> = Omit<T, "seq">;
 export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceReadyServerFrame>
   | WithoutSeq<LiveVoiceBusyServerFrame>
+  | WithoutSeq<LiveVoiceSpeechStartedServerFrame>
+  | WithoutSeq<LiveVoiceUtteranceEndServerFrame>
   | WithoutSeq<LiveVoiceSttPartialServerFrame>
   | WithoutSeq<LiveVoiceSttFinalServerFrame>
   | WithoutSeq<LiveVoiceThinkingServerFrame>
   | WithoutSeq<LiveVoiceAssistantTextDeltaServerFrame>
   | WithoutSeq<LiveVoiceTtsAudioServerFrame>
   | WithoutSeq<LiveVoiceTtsDoneServerFrame>
+  | WithoutSeq<LiveVoiceTurnCancelledServerFrame>
   | WithoutSeq<LiveVoiceMetricsServerFrame>
   | WithoutSeq<LiveVoiceArchivedServerFrame>
   | WithoutSeq<LiveVoiceErrorServerFrame>;
@@ -357,6 +404,15 @@ function validateStartFrame(
     );
   }
 
+  if ("turnDetection" in value && !isLiveVoiceTurnDetectionMode(value.turnDetection)) {
+    return protocolError(
+      "invalid_field",
+      "start frame field turnDetection must be manual or server_vad",
+      "turnDetection",
+      "start",
+    );
+  }
+
   return {
     ok: true,
     frame: {
@@ -365,6 +421,9 @@ function validateStartFrame(
         ? { conversationId: value.conversationId }
         : {}),
       audio: audioConfig.frame,
+      ...(isLiveVoiceTurnDetectionMode(value.turnDetection)
+        ? { turnDetection: value.turnDetection }
+        : {}),
     },
   };
 }
@@ -466,6 +525,15 @@ function isLiveVoiceClientFrameType(
   value: string,
 ): value is LiveVoiceClientFrameType {
   return (LIVE_VOICE_CLIENT_FRAME_TYPES as readonly string[]).includes(value);
+}
+
+function isLiveVoiceTurnDetectionMode(
+  value: unknown,
+): value is LiveVoiceTurnDetectionMode {
+  return (
+    typeof value === "string" &&
+    (LIVE_VOICE_TURN_DETECTION_MODES as readonly string[]).includes(value)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -413,6 +413,17 @@ function validateStartFrame(
     );
   }
 
+  // Temporary: server_vad is declared in the contract but not yet accepted;
+  // the session lifecycle for it is not implemented.
+  if (value.turnDetection === "server_vad") {
+    return protocolError(
+      "invalid_field",
+      "start frame field turnDetection: server_vad is not yet supported",
+      "turnDetection",
+      "start",
+    );
+  }
+
   return {
     ok: true,
     frame: {


### PR DESCRIPTION
## Summary
- Adds turnDetection: "manual" | "server_vad" to the live-voice start frame (absent = manual, today's behavior).
- Adds server frames speech_started (client must stop local playback), utterance_end {reason}, and turn_cancelled {turnId} to the protocol + sequencer. Contract-only: nothing emits them yet.

Part of plan: live-voice-server-barge-in.md (PR 6 of 11)