### PR TITLE
feat(hooks): expose a first-class message-persisted hook; migrate memory's segment indexing onto it

### DIFF
--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -2,13 +2,15 @@
 //   - a real persist (`addMessage`) enqueues one `index_message_lexical` job
 //     for the message, regardless of whether memory is enabled or disabled
 //     (message-content search is host infrastructure);
+//   - a real persist dispatches the `message-persisted` hook (the memory
+//     plugin's segment indexing rides on it), and a hook throw is contained
+//     by the pipeline without losing the lexical enqueue;
 //   - forking a conversation copies message rows WITHOUT routing through
 //     the persist path, so a fork enqueues ZERO `index_message_lexical`
-//     jobs (the fork-exclusion regression);
-//   - wiping a conversation enqueues one `purge_conversation_lexical` job.
+//     jobs (the fork-exclusion regression).
 //
 // The heavy segment indexer (`indexMessageNow`) is stubbed to a no-op so these
-// tests exercise only the lexical enqueue seam, not the embedding/extraction
+// tests exercise only the enqueue/dispatch seams, not the embedding/extraction
 // machinery. Memory config is real (default-enabled), flipped on disk for the
 // disabled case.
 
@@ -30,18 +32,19 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-// Stub the segment indexer so `onMessagePersisted` runs cheaply. The lexical
-// enqueue in the hook is a separate call and still fires. Other exports are
-// provided so any transitive importer of this module resolves. `throwFromIndex`
-// lets a test simulate a transient segment-indexing failure to prove the
-// lexical enqueue survives it.
+// Stub the segment indexer so the memory plugin's `message-persisted` hook
+// runs cheaply. Other exports are provided so any transitive importer of this
+// module resolves. `throwFromIndex` lets a test simulate a transient
+// segment-indexing failure to prove the persist survives it.
 let throwFromIndex = false;
+let indexedMessageIds: string[] = [];
 mock.module("../plugins/defaults/memory/indexer.js", () => ({
   MIN_SEGMENT_CHARS: 50,
-  indexMessageNow: async () => {
+  indexMessageNow: async (input: { messageId: string }) => {
     if (throwFromIndex) {
       throw new Error("simulated segment-indexing failure");
     }
+    indexedMessageIds.push(input.messageId);
     return { indexedSegments: 0, enqueuedJobs: 0 };
   },
   enqueueBackfillJob: () => "",
@@ -54,6 +57,7 @@ import {
   saveRawConfig,
 } from "../config/loader.js";
 import { consolidateAssistantMessages } from "../daemon/conversation-history.js";
+import { registerPluginHooks } from "../hooks/registry.js";
 import {
   addMessage,
   createConversation,
@@ -71,9 +75,17 @@ import { enqueueLexicalIndexForMessage } from "../persistence/job-handlers/messa
 import type { MemoryJobType } from "../persistence/jobs-store.js";
 import { enqueueMemoryJob } from "../persistence/jobs-store.js";
 import { memoryJobs } from "../persistence/schema/index.js";
+import memoryMessagePersisted from "../plugins/defaults/memory/hooks/message-persisted.js";
 import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
+import type { PluginHooks } from "../plugins/types.js";
 
 await initializeDb();
+
+// Register the memory plugin's `message-persisted` hook the way boot does, so
+// `addMessage`'s dispatch reaches the (indexer-stubbed) plugin implementation.
+registerPluginHooks("default-memory", {
+  "message-persisted": memoryMessagePersisted,
+} as PluginHooks);
 
 function countJobs(type: MemoryJobType, conversationId?: string): number {
   const rows = getMemoryDb()!
@@ -137,6 +149,7 @@ describe("messages lexical-index dual-write", () => {
     // into later tests sharing this process.
     setMemoryEnabled(true);
     throwFromIndex = false;
+    indexedMessageIds = [];
   });
 
   test("addMessage enqueues one index_message_lexical job for the persisted message", async () => {
@@ -148,10 +161,39 @@ describe("messages lexical-index dual-write", () => {
     expect(ids.filter((id) => id === message.id)).toHaveLength(1);
   });
 
+  test("addMessage dispatches message-persisted to the memory plugin's hook", async () => {
+    const conv = createConversation("Hook dispatch thread");
+    const message = await addMessage(conv.id, "user", "segment me");
+
+    expect(indexedMessageIds).toEqual([message.id]);
+  });
+
+  test("hidden machine signals do not dispatch message-persisted", async () => {
+    const conv = createConversation("Hidden signal thread");
+    await addMessage(conv.id, "user", "machine signal", {
+      metadata: { hidden: true },
+    });
+
+    expect(indexedMessageIds).toEqual([]);
+  });
+
+  test("skipIndexing persists do not dispatch message-persisted", async () => {
+    // Paths that run their own post-persist indexing (streaming
+    // reserve+finalize, import) insert with `skipIndexing` and must not
+    // double-feed the memory pipeline.
+    const conv = createConversation("Skip indexing thread");
+    await addMessage(conv.id, "user", "already indexed elsewhere", {
+      skipIndexing: true,
+    });
+
+    expect(indexedMessageIds).toEqual([]);
+  });
+
   test("lexical job is still enqueued when segment indexing (indexMessageNow) throws", async () => {
     // The sparse lexical job is independent of the dense embedding path, so a
     // transient segment-indexing failure must not leave the message missing
-    // from the lexical index. `addMessage` catches the hook throw as non-fatal.
+    // from the lexical index. The hook pipeline contains the throw as
+    // non-fatal.
     throwFromIndex = true;
     const conv = createConversation("Segment failure thread");
     const message = await addMessage(

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -23,6 +23,7 @@ import type {
   Message,
   ToolResultContent,
 } from "../providers/types.js";
+import type { TrustClass } from "../runtime/trust-class.js";
 
 // ─── Logger ──────────────────────────────────────────────────────────────────
 
@@ -611,3 +612,46 @@ export interface PostModelCallInputContext {
  */
 export interface PostModelCallContext
   extends PostModelCallInputContext, BaseHookContext {}
+
+// ─── Message-persisted hook context ──────────────────────────────────────────
+
+/**
+ * Context passed to the `message-persisted` hook. Fires once per message
+ * persisted through the plain persist path (`addMessage`), after the row is
+ * inserted. Rows the persist call excludes from downstream processing —
+ * `skipIndexing` inserts (paths that run their own post-persist indexing,
+ * e.g. streaming reserve+finalize) and transcript-suppressed machine signals
+ * (`metadata.hidden`) — do not fire it.
+ *
+ * Observation-only: the context carries a snapshot of the persisted row and
+ * hooks cannot alter it. The default memory plugin contributes a hook here
+ * that feeds the message into its segment indexing / extraction pipeline.
+ */
+export interface MessagePersistedInputContext {
+  /** Persisted row ID of the message. */
+  readonly messageId: string;
+  /** Conversation the message was persisted to. */
+  readonly conversationId: string;
+  /** Message role (`user`, `assistant`, `system`, ...). */
+  readonly role: string;
+  /** Stored message content (JSON content-block array, serialized). */
+  readonly content: string;
+  /** Row creation time (epoch millis). */
+  readonly createdAt: number;
+  /**
+   * Trust class of the actor who produced the message, captured at persist
+   * time. `null` when the persisting path recorded none (legacy rows and
+   * internal writers) — consumers treat that as trusted-by-provenance.
+   */
+  readonly provenanceTrustClass: TrustClass | null;
+  /** True when the message was auto-sent by the client (e.g. a wake-up greeting). */
+  readonly automated: boolean;
+}
+
+/**
+ * The full `message-persisted` context a hook receives — the dispatching call
+ * site's {@link MessagePersistedInputContext} plus the pipeline-stamped
+ * {@link BaseHookContext} capabilities.
+ */
+export interface MessagePersistedContext
+  extends MessagePersistedInputContext, BaseHookContext {}

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -29,7 +29,10 @@ import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
+import type { MessagePersistedInputContext } from "../hooks/types.js";
+import { HOOKS } from "../plugin-api/constants.js";
 import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
+import { runHook } from "../plugins/pipeline.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { trustClassSchema } from "../runtime/trust-class.js";
@@ -1698,29 +1701,24 @@ export async function addMessage(
     // The direct write seams (streaming finalize, import, edit) enqueue for
     // themselves; this covers the plain addMessage path.
     enqueueLexicalIndexForMessage(message.id);
-    try {
-      const parsed = metadata
-        ? messageMetadataSchema.safeParse(metadata)
-        : null;
-      const provenanceTrustClass = parsed?.success
-        ? parsed.data.provenanceTrustClass
-        : undefined;
-      const automated = parsed?.success ? parsed.data.automated : undefined;
-      await memoryPersistenceHooks.onMessagePersisted({
-        messageId: message.id,
-        conversationId: message.conversationId,
-        role: message.role,
-        content: message.content,
-        createdAt: message.createdAt,
-        provenanceTrustClass,
-        automated,
-      });
-    } catch (err) {
-      log.warn(
-        { err, conversationId, messageId: message.id },
-        "Failed to index message for memory",
-      );
-    }
+
+    // Notify `message-persisted` hooks (e.g. the memory plugin's segment
+    // indexing / extraction). The pipeline contains per-hook failures and
+    // filters disabled plugins, so a failed or disabled consumer never fails
+    // the persist. Awaited so post-persist processing completes before the
+    // caller proceeds, matching the write path's ordering guarantees.
+    const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
+    await runHook(HOOKS.MESSAGE_PERSISTED, {
+      messageId: message.id,
+      conversationId: message.conversationId,
+      role: message.role,
+      content: message.content,
+      createdAt: message.createdAt,
+      provenanceTrustClass:
+        (parsed?.success ? parsed.data.provenanceTrustClass : undefined) ??
+        null,
+      automated: (parsed?.success ? parsed.data.automated : undefined) ?? false,
+    } satisfies MessagePersistedInputContext);
   }
 
   if (role === "assistant") {

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -30,6 +30,8 @@ export const HOOKS = {
   POST_MODEL_CALL: "post-model-call",
   /** Fires after the loop successfully compacts a conversation mid-turn. */
   POST_COMPACT: "post-compact",
+  /** Fires once per transcript-visible message persisted through the plain persist path, after the row is inserted. Observation-only. */
+  MESSAGE_PERSISTED: "message-persisted",
 } as const;
 
 /** Union of every hook name declared in {@link HOOKS}. */

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -104,6 +104,7 @@ export type {
   HookBroadcast,
   HookFunction,
   InitContext,
+  MessagePersistedContext,
   ModelProfileInfo,
   PluginLogger,
   PostCompactContext,
@@ -116,6 +117,7 @@ export type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
+  TrustClass,
   UserPromptSubmitContext,
 } from "./types.js";
 export { RiskLevel } from "./types.js";

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -14,6 +14,7 @@ export type {
   AgentLoopExitReason,
   BaseHookContext,
   HookBroadcast,
+  MessagePersistedContext,
   PluginLogger,
   PostCompactContext,
   PostModelCallContext,
@@ -23,6 +24,7 @@ export type {
   StopContext,
   UserPromptSubmitContext,
 } from "../hooks/types.js";
+export type { TrustClass } from "../runtime/trust-class.js";
 export type {
   ToolContext,
   ToolDefinition,
@@ -56,6 +58,7 @@ export { RiskLevel } from "../tools/types.js";
  *   - `post-tool-use` — {@link PostToolUseContext}
  *   - `stop` — {@link StopContext}
  *   - `post-model-call` — {@link PostModelCallContext}
+ *   - `message-persisted` — {@link MessagePersistedContext}
  */
 export type HookFunction<TCtx = unknown> = (
   ctx: TCtx,

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -61,6 +61,7 @@ import maxTokensContinuePostModelCall from "./max-tokens-continue/hooks/post-mod
 import maxTokensContinueStop from "./max-tokens-continue/hooks/stop.js";
 import maxTokensContinuePkg from "./max-tokens-continue/package.json" with { type: "json" };
 import memoryInit from "./memory/hooks/init.js";
+import memoryMessagePersisted from "./memory/hooks/message-persisted.js";
 import memoryPostCompact from "./memory/hooks/post-compact.js";
 import memoryShutdown from "./memory/hooks/shutdown.js";
 import memoryUserPromptSubmit from "./memory/hooks/user-prompt-submit.js";
@@ -148,10 +149,11 @@ export const defaultEmptyResponsePlugin: Plugin = {
  * `memory` — the assistant's combined memory plugin. Assembles the turn's
  * runtime injections (the unified `<turn_context>` block, Slack chronological
  * transcript, NOW.md / PKB / memory-v2 / workspace blocks) and houses the
- * memory-v3 orchestration engine (`memory/v3/`) and its injectors. Two hooks
+ * memory-v3 orchestration engine (`memory/v3/`) and its injectors. Three hooks
  * drive it: `user-prompt-submit` runs memory-graph retrieval and the initial
- * injection, and `post-compact` re-applies the injections onto the compacted
- * history after a mid-turn compaction. It contributes its personal-memory
+ * injection, `post-compact` re-applies the injections onto the compacted
+ * history after a mid-turn compaction, and `message-persisted` feeds each
+ * persisted message into segment indexing / extraction. It contributes its personal-memory
  * runtime injectors (PKB context/reminder and the memory-v2 static block, plus
  * the two memory-v3 injectors) to the global injector registry via the
  * `injectors` field; the registry unions them with the domain plugins'
@@ -170,6 +172,7 @@ export const defaultMemoryPlugin: Plugin = {
     shutdown: memoryShutdown,
     "user-prompt-submit": memoryUserPromptSubmit,
     "post-compact": memoryPostCompact,
+    "message-persisted": memoryMessagePersisted,
   },
   injectors: [...memoryInjectors, memoryV3Injector, memoryV3SpotlightInjector],
 };

--- a/assistant/src/plugins/defaults/memory/hooks/message-persisted.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/message-persisted.ts
@@ -1,0 +1,40 @@
+/**
+ * Default `memory` message-persisted hook.
+ *
+ * Feeds each persisted transcript-visible message into the memory feature's
+ * segment indexing / extraction pipeline ({@link indexMessageNow}) — the
+ * entry point that chunks the message into memory segments, enqueues
+ * embedding jobs, and (for trusted actors) triggers graph extraction.
+ *
+ * Only the plain persist path dispatches this hook; the direct write seams
+ * (streaming reserve+finalize, conversation import) call `indexMessageNow`
+ * themselves after finalizing their content.
+ */
+
+import type {
+  HookFunction,
+  MessagePersistedContext,
+} from "@vellumai/plugin-api";
+
+import { getMemoryConfig } from "../config.js";
+import { indexMessageNow } from "../indexer.js";
+
+const messagePersisted: HookFunction<MessagePersistedContext> = async (ctx) => {
+  await indexMessageNow(
+    {
+      messageId: ctx.messageId,
+      conversationId: ctx.conversationId,
+      role: ctx.role,
+      content: ctx.content,
+      createdAt: ctx.createdAt,
+      // `null` means the persisting path recorded no provenance (legacy rows,
+      // internal writers); the indexer's trust gate treats absent as trusted.
+      provenanceTrustClass: ctx.provenanceTrustClass ?? undefined,
+      automated: ctx.automated,
+      scopeId: "default",
+    },
+    getMemoryConfig(),
+  );
+};
+
+export default messagePersisted;

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,8 +1,5 @@
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
-import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
-import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
-import { indexMessageNow } from "./indexer.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 import {
@@ -18,20 +15,6 @@ import {
   MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
   seedEverInjectedFromSlugs,
 } from "./v3/ever-injected-store.js";
-
-/** A message that was just persisted to a conversation. */
-export interface MessagePersistedEvent {
-  messageId: string;
-  conversationId: string;
-  role: string;
-  /** Stored message content (JSON content-block array, serialized). */
-  content: string;
-  createdAt: number;
-  /** Trust class of the actor who produced the message, captured at persist time. */
-  provenanceTrustClass?: TrustClass;
-  /** True when the message was auto-sent by the client (e.g. a wake-up greeting). */
-  automated?: boolean;
-}
 
 /** A conversation was forked; the memory feature carries per-conversation state into the child. */
 export interface ConversationForkedEvent {
@@ -68,10 +51,6 @@ export interface ConversationForkedEvent {
  * module.
  */
 export const memoryPersistenceHooks = {
-  async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
-    await indexMessageNow({ ...event, scopeId: "default" }, getMemoryConfig());
-  },
-
   onConversationForked(event: ConversationForkedEvent): void {
     const {
       db,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -643,7 +643,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-03T20:12:42.000Z"
+      "updatedAt": "2026-07-06T17:19:55.000Z"
     },
     {
       "id": "public-ingress",
@@ -950,7 +950,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T14:33:32.000Z"
+      "updatedAt": "2026-07-06T16:01:24.000Z"
     },
     {
       "id": "vellum-github-app-setup",

--- a/skills/plugin-builder/references/hooks.md
+++ b/skills/plugin-builder/references/hooks.md
@@ -22,7 +22,7 @@ The loop moves a conversation turn through a series of **lifecycle events**. The
 
 The loop can iterate several times within a single user turn: every tool result returns to a fresh model call, and a `post-model-call` hook can choose to continue rather than end the turn. Because of this, `pre-model-call`, `post-model-call`, and `post-tool-use` can each fire more than once per turn.
 
-The Assistant also hooks into Lifecycle Events that sit outside the Agent Loop: `init` fires at bootstrap, and `shutdown` fires at teardown.
+The Assistant also hooks into Lifecycle Events that sit outside the Agent Loop: `init` fires at bootstrap, `shutdown` fires at teardown, and `message-persisted` fires after a message row is written to conversation storage.
 
 ## Hooks reference
 
@@ -148,6 +148,25 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 | `logger`         | `PluginLogger`           | Read-only | Logger pre-tagged with the hook name, your plugin, and the conversation / request identity. Log through it; no manual tagging needed.                                                                                                   |
 | `broadcast`      | `HookBroadcast`          | Read-only | Emit a transient `hook_event` to any UI watching the conversation. You supply a JSON-serializable `detail` record; the runtime stamps the conversation, hook name, and owner attribution. Best-effort: never throws or blocks the turn. |
 
+### `message-persisted`
+
+**Context:** `MessagePersistedContext`
+**When:** Once per transcript-visible message persisted through the plain persist path, after the row is inserted. Rows the persist call excludes from downstream processing — `skipIndexing` inserts and hidden machine signals — do not fire it.
+**Use it to:** Observe persisted messages for side effects (for example feeding an index). Observation-only: the context is a snapshot of the persisted row, and changing it does not alter what was stored.
+**Example:** [memory](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/plugins/defaults/memory/hooks/message-persisted.ts)
+
+| Field                  | Type                 | Access    | Description                                                                                                                                                                                                                             |
+| ---------------------- | -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `messageId`            | `string`             | Read-only | Persisted row id of the message.                                                                                                                                                                                                        |
+| `conversationId`       | `string`             | Read-only | Conversation the message was persisted to.                                                                                                                                                                                              |
+| `role`                 | `string`             | Read-only | Message role (`user`, `assistant`, `system`, ...).                                                                                                                                                                                      |
+| `content`              | `string`             | Read-only | Stored message content (JSON content-block array, serialized).                                                                                                                                                                          |
+| `createdAt`            | `number`             | Read-only | Row creation time (epoch millis).                                                                                                                                                                                                       |
+| `provenanceTrustClass` | `TrustClass \| null` | Read-only | Trust class of the actor who produced the message, captured at persist time. Null when the persisting path recorded none (legacy rows and internal writers).                                                                            |
+| `automated`            | `boolean`            | Read-only | True when the message was auto-sent by the client (for example a wake-up greeting).                                                                                                                                                     |
+| `logger`               | `PluginLogger`       | Read-only | Logger pre-tagged with the hook name, your plugin, and the conversation identity. Log through it; no manual tagging needed.                                                                                                             |
+| `broadcast`            | `HookBroadcast`      | Read-only | Emit a transient `hook_event` to any UI watching the conversation. You supply a JSON-serializable `detail` record; the runtime stamps the conversation, hook name, and owner attribution. Best-effort: never throws or blocks the turn. |
+
 ### `shutdown`
 
 **Context:** `ShutdownContext`
@@ -187,6 +206,8 @@ These are the hook-related exports from [`@vellumai/plugin-api`](https://github.
 | `PostModelCallContext`    | type  | Passed to post-model-call at every model-call outcome (a finalized reply or a provider rejection); carries the continue decision. |
 | `PostCompactContext`      | type  | Passed to post-compact, after the loop compacts a conversation mid-turn.                                                          |
 | `StopContext`             | type  | Passed to stop, the terminal hook, once the turn has committed to ending.                                                         |
+| `MessagePersistedContext` | type  | Passed to message-persisted, after a message row is written to conversation storage.                                              |
+| `TrustClass`              | type  | Trust class of the actor who produced a message, carried on MessagePersistedContext.                                              |
 | `PostModelCallDecision`   | type  | The post-model-call decision shape: whether to end the turn or continue.                                                          |
 | `AgentLoopExitReason`     | type  | Which terminal state a turn reached, carried on StopContext.                                                                      |
 


### PR DESCRIPTION
## Why

First of the persistence-lifecycle events to move onto the extensible `hooks` framework, per the triage plan. The memory plugin's `onMessagePersisted` seam member fit the chain-hook shape exactly (async, fired per event, plain-data context), so instead of a plugin-private seam call, the persist path now dispatches a first-class hook that any plugin — including user plugins and standalone workspace hooks — can subscribe to.

## What

**Framework** — new `message-persisted` hook:
- `HOOKS.MESSAGE_PERSISTED` in `plugin-api/constants.ts`.
- `MessagePersistedInputContext` / `MessagePersistedContext` in `hooks/types.ts`, following the plugin-api contract (all fields required, `| null` over `?`): `messageId`, `conversationId`, `role`, `content`, `createdAt`, `provenanceTrustClass: TrustClass | null`, `automated`. Re-exported from `@vellumai/plugin-api` (along with `TrustClass`).
- Fires once per transcript-visible message persisted through the plain persist path (`addMessage`), after the row is inserted. `skipIndexing` inserts (paths that run their own post-persist indexing, e.g. streaming reserve+finalize) and hidden machine signals do not dispatch it. Observation-only.
- Documented in the plugin-builder skill's hooks reference; workspace hooks pick it up automatically since hook loading is filename-driven (`hooks/message-persisted.ts`).

**Migration** — memory's segment indexing rides the hook:
- New `memory/hooks/message-persisted.ts` calls `indexMessageNow` (the previous seam body), registered on `defaultMemoryPlugin.hooks`.
- `addMessage` dispatches `runHook(HOOKS.MESSAGE_PERSISTED, …)` instead of calling the seam object; the pipeline contains per-hook failures, so the old call-site try/catch is gone.
- `onMessagePersisted` + `MessagePersistedEvent` deleted from `persistence-hooks.ts` — the seam is down to `onConversationForked` and `onConversationDeleted`.

**Semantics that intentionally change with the pipeline**: disabled-plugin filtering and per-conversation plugin scope now apply to the indexing dispatch — the harness owns those gates, the plugin no longer self-gates (it still checks `memory.enabled` config inside `indexMessageNow`, unchanged).

## Tests

`lexical-index-dual-write.test.ts` registers the real memory hook the way boot does and now covers: the dispatch reaches the plugin's hook with the persisted row; hidden and `skipIndexing` rows don't dispatch; a hook throw is contained by the pipeline without losing the host-owned lexical enqueue (the old "addMessage catches the throw" test, upgraded to the pipeline's containment). Green in isolation: lexical-index-dual-write (18), hooks framework (4), conversation-agent-loop (67), edit-propagation (6), auto-analysis-end-to-end (10), memory-upsert-concurrency (6), task-compiler (12), conversations-import-system-filter (1), persistence-layering-guard (3), plugin-import-boundary-guard (5), clear-all-lexical (1), task-memory-cleanup (12). `bunx tsc --noEmit` clean; catalog check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_