### PR TITLE
feat(tts): extract a shared synthesize-and-emit core with pluggable sinks

### DIFF
--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -345,6 +345,63 @@ describe("synthesizeAndEmit (streaming)", () => {
     ).rejects.toThrow("provider exploded");
   });
 
+  test("provider rejection drains in-flight sink work before rethrowing", async () => {
+    const events: string[] = [];
+    let releaseSink: () => void = () => {};
+    const sinkGate = new Promise<void>((resolve) => {
+      releaseSink = resolve;
+    });
+    const provider: TtsProvider = {
+      id: "fake-rejecting-stream",
+      capabilities: CAPABILITIES,
+      synthesize: () => Promise.reject(new Error("unused")),
+      async synthesizeStream(_request, onChunk): Promise<TtsSynthesisResult> {
+        onChunk(bytes("a"));
+        // Yield so the sink starts on "a", then queue "b" behind it and fail.
+        await Promise.resolve();
+        onChunk(bytes("b"));
+        throw new Error("provider exploded");
+      },
+    };
+
+    const settled = synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onFirstAudio: () => events.push("firstAudio"),
+      async onChunk(chunk) {
+        const label = chunk.audio.toString("utf8");
+        events.push(`chunk:${label}:start`);
+        await sinkGate;
+        events.push(`chunk:${label}:end`);
+      },
+    }).then(
+      () => {
+        events.push("resolved");
+        return undefined;
+      },
+      (err: unknown) => {
+        events.push("rejected");
+        return err;
+      },
+    );
+
+    // The sink is still blocked on "a" when the provider rejects; the
+    // rejection must wait for the drain instead of settling early.
+    setTimeout(releaseSink, 5);
+    const err = await settled;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("provider exploded");
+    // "b" never reaches the sink, and the rejection settles only after the
+    // in-flight sink call completes — nothing fires after error handling.
+    expect(events).toEqual([
+      "firstAudio",
+      "chunk:a:start",
+      "chunk:a:end",
+      "rejected",
+    ]);
+  });
+
   test("passes text/useCase/voiceId/outputFormat/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -309,6 +309,37 @@ describe("synthesizeAndEmit (streaming)", () => {
     expect(seen).toEqual(["a", "b"]);
   });
 
+  test("queued chunks are owned copies — provider mutations of a reused buffer are not observed", async () => {
+    const reused = new Uint8Array(3);
+    const provider: TtsProvider = {
+      id: "fake-buffer-reusing",
+      capabilities: CAPABILITIES,
+      synthesize: () => Promise.reject(new Error("unused")),
+      async synthesizeStream(_request, onChunk): Promise<TtsSynthesisResult> {
+        reused.set(bytes("aaa"));
+        onChunk(reused);
+        // Both emits are still queued behind the blocked sink when the
+        // provider overwrites the buffer for the second chunk.
+        reused.set(bytes("bbb"));
+        onChunk(reused);
+        return { audio: Buffer.from("aaabbb"), contentType: "audio/mpeg" };
+      },
+    };
+    const seen: string[] = [];
+
+    await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      async onChunk(chunk) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        seen.push(chunk.audio.toString("utf8"));
+      },
+    });
+
+    expect(seen).toEqual(["aaa", "bbb"]);
+  });
+
   test("a rejecting onChunk sink fails the call and stops further emits", async () => {
     const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
     const attempted: string[] = [];

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -1,0 +1,558 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../config/loader.js", () => ({
+  loadConfig: () => ({
+    ingress: { publicBaseUrl: "https://assistant.example.com" },
+  }),
+}));
+
+import type { StreamingAudioHandle } from "../../calls/audio-store.js";
+import {
+  createAudioStoreSink,
+  type SynthesisEmitChunk,
+  synthesizeAndEmit,
+} from "../synthesis-stream.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+const CAPABILITIES = { supportsStreaming: true, supportedFormats: ["mp3"] };
+
+interface StreamingFakeOptions {
+  /** Called between chunk deliveries so tests can abort/stale mid-stream. */
+  betweenChunks?: (deliveredCount: number) => void;
+  contentType?: string;
+}
+
+function makeStreamingProvider(
+  chunks: Uint8Array[],
+  options: StreamingFakeOptions = {},
+): TtsProvider & { requests: TtsSynthesisRequest[] } {
+  const requests: TtsSynthesisRequest[] = [];
+  return {
+    id: "fake-streaming",
+    capabilities: CAPABILITIES,
+    requests,
+    synthesize(): Promise<TtsSynthesisResult> {
+      throw new Error("buffer path should not be used");
+    },
+    async synthesizeStream(request, onChunk): Promise<TtsSynthesisResult> {
+      requests.push(request);
+      let delivered = 0;
+      for (const chunk of chunks) {
+        options.betweenChunks?.(delivered);
+        onChunk(chunk);
+        delivered += 1;
+      }
+      return {
+        audio: Buffer.concat(chunks),
+        contentType: options.contentType ?? "audio/mpeg",
+      };
+    },
+  };
+}
+
+function makeBufferProvider(
+  audio: Buffer,
+  contentType = "audio/mpeg",
+): TtsProvider & { requests: TtsSynthesisRequest[] } {
+  const requests: TtsSynthesisRequest[] = [];
+  return {
+    id: "fake-buffer",
+    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+    requests,
+    async synthesize(request): Promise<TtsSynthesisResult> {
+      requests.push(request);
+      return { audio, contentType };
+    },
+  };
+}
+
+/** Records onFirstAudio/onChunk invocations in a single ordered log. */
+function makeRecordingSink(): {
+  events: string[];
+  chunks: SynthesisEmitChunk[];
+  onChunk: (chunk: SynthesisEmitChunk) => void;
+  onFirstAudio: () => void;
+} {
+  const events: string[] = [];
+  const chunks: SynthesisEmitChunk[] = [];
+  return {
+    events,
+    chunks,
+    onChunk(chunk) {
+      events.push(`chunk:${chunk.audio.toString("utf8")}`);
+      chunks.push(chunk);
+    },
+    onFirstAudio() {
+      events.push("firstAudio");
+    },
+  };
+}
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+// ---------------------------------------------------------------------------
+// synthesizeAndEmit — streaming path
+// ---------------------------------------------------------------------------
+
+describe("synthesizeAndEmit (streaming)", () => {
+  test("emits chunks in order with onFirstAudio exactly once, before the first chunk", async () => {
+    const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual(["firstAudio", "chunk:a", "chunk:b"]);
+    expect(result).toEqual({ emittedChunks: 2, contentType: "audio/mpeg" });
+  });
+
+  test("skips empty chunks", async () => {
+    const provider = makeStreamingProvider([
+      new Uint8Array(0),
+      bytes("a"),
+      new Uint8Array(0),
+      bytes("b"),
+    ]);
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual(["firstAudio", "chunk:a", "chunk:b"]);
+    expect(result.emittedChunks).toBe(2);
+  });
+
+  test("throws when the stream completes with zero emitted chunks", async () => {
+    const provider = makeStreamingProvider([new Uint8Array(0)]);
+    const sink = makeRecordingSink();
+
+    await expect(
+      synthesizeAndEmit({
+        provider,
+        text: "hello",
+        useCase: "phone-call",
+        onChunk: sink.onChunk,
+        onFirstAudio: sink.onFirstAudio,
+      }),
+    ).rejects.toThrow("Streaming TTS returned no audio chunks");
+    expect(sink.events).toEqual([]);
+  });
+
+  test("abort mid-stream stops emission silently", async () => {
+    const abortController = new AbortController();
+    const provider = makeStreamingProvider(
+      [bytes("a"), bytes("b"), bytes("c")],
+      {
+        betweenChunks(delivered) {
+          if (delivered === 1) {
+            abortController.abort();
+          }
+        },
+      },
+    );
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      signal: abortController.signal,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual(["firstAudio", "chunk:a"]);
+    expect(result.emittedChunks).toBe(1);
+  });
+
+  test("isCurrent() returning false mid-stream stops emission silently", async () => {
+    let current = true;
+    const provider = makeStreamingProvider(
+      [bytes("a"), bytes("b"), bytes("c")],
+      {
+        betweenChunks(delivered) {
+          if (delivered === 1) {
+            current = false;
+          }
+        },
+      },
+    );
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      isCurrent: () => current,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual(["firstAudio", "chunk:a"]);
+    expect(result.emittedChunks).toBe(1);
+  });
+
+  test("isCurrent() false before the first chunk emits nothing and does not throw", async () => {
+    const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      isCurrent: () => false,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual([]);
+    expect(result.emittedChunks).toBe(0);
+  });
+
+  test("async onChunk sinks observe chunks in emission order", async () => {
+    const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
+    const seen: string[] = [];
+
+    await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      async onChunk(chunk) {
+        // First chunk resolves last — ordering must still hold.
+        await new Promise((resolve) =>
+          setTimeout(resolve, seen.length === 0 ? 10 : 0),
+        );
+        seen.push(chunk.audio.toString("utf8"));
+      },
+    });
+
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  test("a rejecting onChunk sink fails the call and stops further emits", async () => {
+    const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
+    const attempted: string[] = [];
+
+    await expect(
+      synthesizeAndEmit({
+        provider,
+        text: "hello",
+        useCase: "phone-call",
+        onChunk(chunk) {
+          attempted.push(chunk.audio.toString("utf8"));
+          return Promise.reject(new Error("sink failed"));
+        },
+      }),
+    ).rejects.toThrow("sink failed");
+    expect(attempted).toEqual(["a"]);
+  });
+
+  test("provider errors propagate unmodified", async () => {
+    const provider: TtsProvider = {
+      id: "fake-throwing",
+      capabilities: CAPABILITIES,
+      synthesize: () => Promise.reject(new Error("unused")),
+      synthesizeStream: () => Promise.reject(new Error("provider exploded")),
+    };
+
+    await expect(
+      synthesizeAndEmit({
+        provider,
+        text: "hello",
+        useCase: "phone-call",
+        onChunk: () => {},
+      }),
+    ).rejects.toThrow("provider exploded");
+  });
+
+  test("passes text/useCase/voiceId/outputFormat/signal through on the request", async () => {
+    const provider = makeStreamingProvider([bytes("a")]);
+    const abortController = new AbortController();
+
+    await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "message-playback",
+      voiceId: "voice-123",
+      outputFormat: "pcm",
+      signal: abortController.signal,
+      onChunk: () => {},
+    });
+
+    expect(provider.requests).toHaveLength(1);
+    expect(provider.requests[0]).toEqual({
+      text: "hello",
+      useCase: "message-playback",
+      voiceId: "voice-123",
+      outputFormat: "pcm",
+      signal: abortController.signal,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// synthesizeAndEmit — buffer path
+// ---------------------------------------------------------------------------
+
+describe("synthesizeAndEmit (buffer)", () => {
+  test("emits the whole buffer as one chunk with the result contentType", async () => {
+    const provider = makeBufferProvider(Buffer.from("abc"), "audio/wav");
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual(["firstAudio", "chunk:abc"]);
+    expect(sink.chunks[0]?.contentType).toBe("audio/wav");
+    expect(result).toEqual({ emittedChunks: 1, contentType: "audio/wav" });
+  });
+
+  test("throws on an empty audio payload", async () => {
+    const provider = makeBufferProvider(Buffer.alloc(0));
+    const sink = makeRecordingSink();
+
+    await expect(
+      synthesizeAndEmit({
+        provider,
+        text: "hello",
+        useCase: "phone-call",
+        onChunk: sink.onChunk,
+        onFirstAudio: sink.onFirstAudio,
+      }),
+    ).rejects.toThrow("Buffer TTS returned an empty audio payload");
+    expect(sink.events).toEqual([]);
+  });
+
+  test("stale isCurrent() skips the emit silently", async () => {
+    const provider = makeBufferProvider(Buffer.from("abc"));
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      isCurrent: () => false,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual([]);
+    expect(result.emittedChunks).toBe(0);
+  });
+
+  test("aborted signal skips the emit silently", async () => {
+    const provider = makeBufferProvider(Buffer.from("abc"));
+    const abortController = new AbortController();
+    abortController.abort();
+    const sink = makeRecordingSink();
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      signal: abortController.signal,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
+
+    expect(sink.events).toEqual([]);
+    expect(result.emittedChunks).toBe(0);
+  });
+
+  test("passes the request through to synthesize", async () => {
+    const provider = makeBufferProvider(Buffer.from("abc"));
+
+    await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      voiceId: "voice-123",
+      onChunk: () => {},
+    });
+
+    expect(provider.requests[0]).toEqual({
+      text: "hello",
+      useCase: "phone-call",
+      voiceId: "voice-123",
+      outputFormat: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAudioStoreSink
+// ---------------------------------------------------------------------------
+
+interface FakeEntry extends StreamingAudioHandle {
+  pushed: Uint8Array[];
+  finalized: number;
+}
+
+function makeFakeEntry(audioId = "audio-123"): FakeEntry {
+  const entry: FakeEntry = {
+    audioId,
+    pushed: [],
+    finalized: 0,
+    push(chunk) {
+      entry.pushed.push(chunk);
+    },
+    finalize() {
+      entry.finalized += 1;
+    },
+  };
+  return entry;
+}
+
+describe("createAudioStoreSink", () => {
+  test("sends the play URL exactly once and pushes chunks in order", () => {
+    const entry = makeFakeEntry();
+    const formats: string[] = [];
+    const urls: string[] = [];
+    const sink = createAudioStoreSink({
+      format: "pcm",
+      onPlayUrl: (url) => urls.push(url),
+      createEntry: (format) => {
+        formats.push(format);
+        return entry;
+      },
+    });
+
+    sink.onFirstAudio();
+    sink.onChunk({ audio: Buffer.from("a"), contentType: "" });
+    sink.onChunk({ audio: Buffer.from("b"), contentType: "" });
+
+    expect(formats).toEqual(["pcm"]);
+    expect(urls).toEqual(["https://assistant.example.com/v1/audio/audio-123"]);
+    expect(entry.pushed.map((c) => Buffer.from(c).toString("utf8"))).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  test("onChunk alone still sends the play URL once", () => {
+    const entry = makeFakeEntry();
+    const urls: string[] = [];
+    const sink = createAudioStoreSink({
+      format: "mp3",
+      onPlayUrl: (url) => urls.push(url),
+      createEntry: () => entry,
+    });
+
+    sink.onChunk({ audio: Buffer.from("a"), contentType: "" });
+    sink.onChunk({ audio: Buffer.from("b"), contentType: "" });
+
+    expect(urls).toHaveLength(1);
+  });
+
+  test("finalize marks the entry complete", () => {
+    const entry = makeFakeEntry();
+    const sink = createAudioStoreSink({
+      format: "mp3",
+      onPlayUrl: () => {},
+      createEntry: () => entry,
+    });
+
+    sink.finalize();
+
+    expect(entry.finalized).toBe(1);
+  });
+
+  test("defaults to the real streaming audio store", () => {
+    const urls: string[] = [];
+    const sink = createAudioStoreSink({
+      format: "mp3",
+      onPlayUrl: (url) => urls.push(url),
+    });
+
+    sink.onChunk({ audio: Buffer.from("a"), contentType: "" });
+    sink.finalize();
+
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toMatch(
+      /^https:\/\/assistant\.example\.com\/v1\/audio\/[0-9a-f-]{36}$/,
+    );
+  });
+
+  test("streams synthesizeAndEmit output into the store with finalize in finally", async () => {
+    const entry = makeFakeEntry();
+    const urls: string[] = [];
+    const sink = createAudioStoreSink({
+      format: "mp3",
+      onPlayUrl: (url) => urls.push(url),
+      createEntry: () => entry,
+    });
+    const provider = makeStreamingProvider([bytes("a"), bytes("b")]);
+
+    try {
+      await synthesizeAndEmit({
+        provider,
+        text: "hello",
+        useCase: "phone-call",
+        onChunk: sink.onChunk,
+        onFirstAudio: sink.onFirstAudio,
+      });
+    } finally {
+      sink.finalize();
+    }
+
+    expect(urls).toEqual(["https://assistant.example.com/v1/audio/audio-123"]);
+    expect(entry.pushed.map((c) => Buffer.from(c).toString("utf8"))).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(entry.finalized).toBe(1);
+  });
+
+  test("finalize still runs when synthesis fails before any audio", async () => {
+    const entry = makeFakeEntry();
+    const urls: string[] = [];
+    const sink = createAudioStoreSink({
+      format: "mp3",
+      onPlayUrl: (url) => urls.push(url),
+      createEntry: () => entry,
+    });
+    const provider = makeStreamingProvider([]);
+
+    await expect(
+      (async () => {
+        try {
+          await synthesizeAndEmit({
+            provider,
+            text: "hello",
+            useCase: "phone-call",
+            onChunk: sink.onChunk,
+            onFirstAudio: sink.onFirstAudio,
+          });
+        } finally {
+          sink.finalize();
+        }
+      })(),
+    ).rejects.toThrow("Streaming TTS returned no audio chunks");
+    expect(urls).toEqual([]);
+    expect(entry.finalized).toBe(1);
+  });
+});

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -157,6 +157,8 @@ describe("synthesizeAndEmit (streaming)", () => {
   });
 
   test("abort mid-stream stops emission silently", async () => {
+    // Delivery is synchronous, so chunk "a" is still queued (its sink call
+    // has not started) when the abort fires — it must be suppressed too.
     const abortController = new AbortController();
     const provider = makeStreamingProvider(
       [bytes("a"), bytes("b"), bytes("c")],
@@ -179,8 +181,8 @@ describe("synthesizeAndEmit (streaming)", () => {
       onFirstAudio: sink.onFirstAudio,
     });
 
-    expect(sink.events).toEqual(["firstAudio", "chunk:a"]);
-    expect(result.emittedChunks).toBe(1);
+    expect(sink.events).toEqual([]);
+    expect(result.emittedChunks).toBe(0);
   });
 
   test("isCurrent() returning false mid-stream stops emission silently", async () => {
@@ -206,7 +208,67 @@ describe("synthesizeAndEmit (streaming)", () => {
       onFirstAudio: sink.onFirstAudio,
     });
 
-    expect(sink.events).toEqual(["firstAudio", "chunk:a"]);
+    expect(sink.events).toEqual([]);
+    expect(result.emittedChunks).toBe(0);
+  });
+
+  test("abort while an async sink call is in flight suppresses queued chunks", async () => {
+    const abortController = new AbortController();
+    const provider = makeStreamingProvider([
+      bytes("a"),
+      bytes("b"),
+      bytes("c"),
+    ]);
+    const events: string[] = [];
+    const reached: string[] = [];
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      signal: abortController.signal,
+      onFirstAudio: () => events.push("firstAudio"),
+      async onChunk(chunk) {
+        reached.push(chunk.audio.toString("utf8"));
+        events.push(`chunk:${chunk.audio.toString("utf8")}`);
+        if (reached.length === 1) {
+          // Barge-in mid-write: chunks "b" and "c" are already queued on the
+          // emit chain and must not reach the sink.
+          abortController.abort();
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      },
+    });
+
+    expect(reached).toEqual(["a"]);
+    expect(events).toEqual(["firstAudio", "chunk:a"]);
+    expect(result.emittedChunks).toBe(1);
+  });
+
+  test("isCurrent() flipping false while an async sink call is in flight suppresses queued chunks", async () => {
+    let current = true;
+    const provider = makeStreamingProvider([
+      bytes("a"),
+      bytes("b"),
+      bytes("c"),
+    ]);
+    const reached: string[] = [];
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      isCurrent: () => current,
+      async onChunk(chunk) {
+        reached.push(chunk.audio.toString("utf8"));
+        if (reached.length === 1) {
+          current = false;
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      },
+    });
+
+    expect(reached).toEqual(["a"]);
     expect(result.emittedChunks).toBe(1);
   });
 

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -11,7 +11,12 @@
 import { createStreamingEntry } from "../calls/audio-store.js";
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
-import type { TtsProvider, TtsSynthesisRequest, TtsUseCase } from "./types.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+  TtsUseCase,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
 // synthesizeAndEmit
@@ -113,7 +118,8 @@ export async function synthesizeAndEmit(
     // stream resolves, so no rejection sits unhandled mid-stream.
     let pendingEmits: Promise<void> = Promise.resolve();
     let sinkFailure: { err: unknown } | undefined;
-    const result = await provider.synthesizeStream(request, (chunk) => {
+    let result: TtsSynthesisResult;
+    const streamed = provider.synthesizeStream(request, (chunk) => {
       if (chunk.byteLength === 0) {
         return;
       }
@@ -144,6 +150,16 @@ export async function synthesizeAndEmit(
           stopped = true;
         });
     });
+    try {
+      result = await streamed;
+    } catch (err) {
+      // Provider failure: gate off queued emits and drain the chain (it
+      // never rejects) so no sink call runs after the caller starts error
+      // handling, then surface the provider error.
+      stopped = true;
+      await pendingEmits;
+      throw err;
+    }
     await pendingEmits;
     if (sinkFailure) {
       throw sinkFailure.err;

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -1,0 +1,230 @@
+/**
+ * Shared synthesize-and-emit core for TTS output paths.
+ *
+ * Owns the streaming-vs-buffer provider selection, empty-payload guards,
+ * abort/staleness emission gating, and the first-audio hook that telephony
+ * and live-voice synthesis paths share. Callers resolve the provider and
+ * plug in a sink (`onChunk`/`onFirstAudio`) — e.g. {@link createAudioStoreSink}
+ * for transports that play audio via the audio store's `/v1/audio/:id` URLs.
+ */
+
+import { createStreamingEntry } from "../calls/audio-store.js";
+import { loadConfig } from "../config/loader.js";
+import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import type { TtsProvider, TtsSynthesisRequest, TtsUseCase } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// synthesizeAndEmit
+// ---------------------------------------------------------------------------
+
+/** A single emitted audio chunk. */
+export interface SynthesisEmitChunk {
+  audio: Buffer;
+
+  /**
+   * MIME type of the audio. The buffer path carries the provider-reported
+   * `result.contentType`; streamed chunks carry the empty string because the
+   * `TtsProvider` contract reports content type only with the final result —
+   * streaming sinks derive the type from their own format config (see
+   * {@link SynthesisEmitResult.contentType} for the end-of-stream value).
+   */
+  contentType: string;
+}
+
+export interface SynthesisEmitOptions {
+  /** Pre-resolved TTS provider adapter. */
+  provider: TtsProvider;
+
+  /** Pre-sanitized text to synthesize. */
+  text: string;
+
+  useCase: TtsUseCase;
+
+  voiceId?: string;
+
+  /** Output-encoding hint forwarded on the provider request (e.g. `"pcm"`). */
+  outputFormat?: TtsSynthesisRequest["outputFormat"];
+
+  /**
+   * Advisory playback sample rate for sinks/consumers. Not part of
+   * {@link TtsSynthesisRequest} — providers negotiate sample rate via their
+   * own config.
+   */
+  sampleRate?: number;
+
+  /** Abort signal forwarded to the provider and checked before each emit. */
+  signal?: AbortSignal;
+
+  /**
+   * Staleness predicate (run-version / turn-token) checked before each emit.
+   * Once it returns `false`, emission stops silently — no error is thrown
+   * and no further `onChunk`/`onFirstAudio` calls are made.
+   */
+  isCurrent?: () => boolean;
+
+  /** Sink for emitted audio. Async sinks are applied in emission order. */
+  onChunk: (chunk: SynthesisEmitChunk) => void | Promise<void>;
+
+  /** Fires exactly once, before the first `onChunk`. */
+  onFirstAudio?: () => void;
+}
+
+export interface SynthesisEmitResult {
+  emittedChunks: number;
+
+  /** Provider-reported MIME type of the complete synthesized audio. */
+  contentType: string;
+}
+
+/**
+ * Synthesize text through the provider and emit audio to the sink.
+ *
+ * Streams when the provider supports `synthesizeStream`, otherwise falls
+ * back to buffer-oriented `synthesize`. Empty chunks are skipped; a stream
+ * that completes without emitting anything (and a buffer result with an
+ * empty payload) is an error. Provider failures — including `AbortError`
+ * from an aborted `signal` — propagate to the caller unmodified.
+ */
+export async function synthesizeAndEmit(
+  options: SynthesisEmitOptions,
+): Promise<SynthesisEmitResult> {
+  const { provider, signal, isCurrent, onChunk, onFirstAudio } = options;
+  const request: TtsSynthesisRequest = {
+    text: options.text,
+    useCase: options.useCase,
+    voiceId: options.voiceId,
+    outputFormat: options.outputFormat,
+    signal,
+  };
+
+  let emittedChunks = 0;
+  let stopped = false;
+  const shouldStop = (): boolean => {
+    if (!stopped && (signal?.aborted || isCurrent?.() === false)) {
+      stopped = true;
+    }
+    return stopped;
+  };
+
+  if (provider.synthesizeStream) {
+    // Sink calls are chained so async sinks observe chunks in emission
+    // order. The chain itself never rejects — the first sink error is
+    // captured (stopping further emits) and rethrown after the provider
+    // stream resolves, so no rejection sits unhandled mid-stream.
+    let pendingEmits: Promise<void> = Promise.resolve();
+    let sinkFailure: { err: unknown } | undefined;
+    const result = await provider.synthesizeStream(request, (chunk) => {
+      if (chunk.byteLength === 0) {
+        return;
+      }
+      if (shouldStop()) {
+        return;
+      }
+      if (emittedChunks === 0) {
+        onFirstAudio?.();
+      }
+      emittedChunks += 1;
+      const audio = Buffer.from(
+        chunk.buffer,
+        chunk.byteOffset,
+        chunk.byteLength,
+      );
+      pendingEmits = pendingEmits
+        .then(() => {
+          if (sinkFailure) {
+            return;
+          }
+          return onChunk({ audio, contentType: "" });
+        })
+        .catch((err: unknown) => {
+          sinkFailure ??= { err };
+          stopped = true;
+        });
+    });
+    await pendingEmits;
+    if (sinkFailure) {
+      throw sinkFailure.err;
+    }
+    if (emittedChunks === 0 && !stopped) {
+      throw new Error("Streaming TTS returned no audio chunks");
+    }
+    return { emittedChunks, contentType: result.contentType };
+  }
+
+  const result = await provider.synthesize(request);
+  if (result.audio.byteLength === 0) {
+    throw new Error("Buffer TTS returned an empty audio payload");
+  }
+  if (!shouldStop()) {
+    onFirstAudio?.();
+    emittedChunks = 1;
+    await onChunk({ audio: result.audio, contentType: result.contentType });
+  }
+  return { emittedChunks, contentType: result.contentType };
+}
+
+// ---------------------------------------------------------------------------
+// Audio-store sink
+// ---------------------------------------------------------------------------
+
+/** Audio formats accepted by the audio store. */
+export type AudioStoreFormat = Parameters<typeof createStreamingEntry>[0];
+
+export interface AudioStoreSinkOptions {
+  /** Store format — determines the entry's served content type. */
+  format: AudioStoreFormat;
+
+  /**
+   * Invoked exactly once, when the first audio chunk arrives, with the
+   * entry's public play URL.
+   */
+  onPlayUrl: (url: string) => void;
+
+  /** Streaming-entry factory, injectable for tests. */
+  createEntry?: typeof createStreamingEntry;
+}
+
+export interface AudioStoreSink {
+  onChunk: (chunk: SynthesisEmitChunk) => void;
+  onFirstAudio: () => void;
+
+  /**
+   * Marks the store entry complete. Callers must invoke this in a `finally`
+   * so subscribers of a partially-streamed entry are released on failure.
+   */
+  finalize: () => void;
+}
+
+/**
+ * Create a {@link synthesizeAndEmit} sink that pushes audio into a streaming
+ * audio-store entry and announces its `${baseUrl}/v1/audio/${audioId}` play
+ * URL on first audio.
+ */
+export function createAudioStoreSink(
+  options: AudioStoreSinkOptions,
+): AudioStoreSink {
+  const createEntry = options.createEntry ?? createStreamingEntry;
+  const handle = createEntry(options.format);
+  const baseUrl = getPublicBaseUrl(loadConfig());
+  const url = `${baseUrl}/v1/audio/${handle.audioId}`;
+
+  let playUrlSent = false;
+  const sendPlayUrlOnce = (): void => {
+    if (playUrlSent) {
+      return;
+    }
+    playUrlSent = true;
+    options.onPlayUrl(url);
+  };
+
+  return {
+    onFirstAudio: sendPlayUrlOnce,
+    onChunk(chunk) {
+      sendPlayUrlOnce();
+      handle.push(chunk.audio);
+    },
+    finalize() {
+      handle.finalize();
+    },
+  };
+}

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -126,11 +126,10 @@ export async function synthesizeAndEmit(
       if (shouldStop()) {
         return;
       }
-      const audio = Buffer.from(
-        chunk.buffer,
-        chunk.byteOffset,
-        chunk.byteLength,
-      );
+      // Owned copy (Buffer.from(Uint8Array) copies; the buffer/offset form
+      // would alias): the emit is deferred through the chain, so a provider
+      // reusing its chunk buffer must not mutate what we queued.
+      const audio = Buffer.from(chunk);
       pendingEmits = pendingEmits
         .then(() => {
           // Re-checked at emit time: an abort/staleness flip (or sink

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -120,10 +120,6 @@ export async function synthesizeAndEmit(
       if (shouldStop()) {
         return;
       }
-      if (emittedChunks === 0) {
-        onFirstAudio?.();
-      }
-      emittedChunks += 1;
       const audio = Buffer.from(
         chunk.buffer,
         chunk.byteOffset,
@@ -131,9 +127,16 @@ export async function synthesizeAndEmit(
       );
       pendingEmits = pendingEmits
         .then(() => {
-          if (sinkFailure) {
+          // Re-checked at emit time: an abort/staleness flip (or sink
+          // failure) while an earlier sink call was in flight must
+          // suppress chunks that were queued before it.
+          if (shouldStop()) {
             return;
           }
+          if (emittedChunks === 0) {
+            onFirstAudio?.();
+          }
+          emittedChunks += 1;
           return onChunk({ audio, contentType: "" });
         })
         .catch((err: unknown) => {


### PR DESCRIPTION
## Summary
- Adds tts/synthesis-stream.ts: synthesizeAndEmit (streaming-vs-buffer selection, empty guards, abort + staleness predicates, onFirstAudio hook) and createAudioStoreSink — the shared core for the three copied synthesis bodies (call-controller, call-speech-output, live-voice-tts). No consumers wired yet.

Part of plan: live-voice-server-barge-in.md (PR 2 of 11)