### PR TITLE
feat(web): raise GitHub nudge minimum age to 24h

### DIFF
--- a/clients/web/src/hooks/use-github-nudge.ts
+++ b/clients/web/src/hooks/use-github-nudge.ts
@@ -23,7 +23,7 @@ export const GITHUB_REPO_URL =
   "https://github.com/vellum-ai/vellum-assistant";
 
 /** Minimum account age (ms since first observation) before the nudge is eligible. */
-export const GITHUB_MIN_AGE_MS = 5 * 60 * 1000; // 5 minutes
+export const GITHUB_MIN_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /** Minimum user messages sent before the nudge is eligible. */
 export const GITHUB_MIN_USER_MESSAGES = 5;


### PR DESCRIPTION
## What

Bumps `GITHUB_MIN_AGE_MS` from **5 minutes → 24 hours** in `clients/web/src/hooks/use-github-nudge.ts`, so the "Star us on GitHub" chat nudge banner waits a full day of account age before it becomes eligible. This matches the 24h cadence already used by the Discord nudge's post-GitHub-dismiss cooldown.

## ⚠️ Behavior note (please read)

The GitHub nudge engagement gate is an **OR**:

```ts
const engagementMet = ageEligible || messageEligible; // use-github-nudge.ts:98
```

This PR only changes the **age** path. The banner can still appear before 24h once the user has sent **≥ 5 messages** (`GITHUB_MIN_USER_MESSAGES`). If the intent is "never show the GitHub nudge until 24h," we'd also need to raise/remove the message threshold or change the OR to an AND — happy to follow up if that's desired.

## Scope

- One-line constant change + comment. No logic, API, or component changes.
- All existing show/hide/dismiss logic (star, dismiss, cascade with platform + Discord nudges) is unchanged.

## Test plan

- Local-only nudge state (localStorage `vellum:nudge-prefs`); no server/API impact.
- Clearing `githubFirstSeenAt` and confirming the banner no longer appears at 5 min but the 5-message path still triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)