### PR TITLE
feat(hooks): expose a first-class conversation-deleted hook; migrate memory's job sweep onto it

### DIFF
--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -13,12 +13,13 @@
 // disabled case.
 
 import {
+  afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
   mock,
-  spyOn,
   test,
 } from "bun:test";
 
@@ -55,6 +56,10 @@ import {
 } from "../config/loader.js";
 import { consolidateAssistantMessages } from "../daemon/conversation-history.js";
 import {
+  registerPluginHooks,
+  unregisterPluginHooks,
+} from "../hooks/registry.js";
+import {
   addMessage,
   createConversation,
   deleteConversation,
@@ -71,9 +76,29 @@ import { enqueueLexicalIndexForMessage } from "../persistence/job-handlers/messa
 import type { MemoryJobType } from "../persistence/jobs-store.js";
 import { enqueueMemoryJob } from "../persistence/jobs-store.js";
 import { memoryJobs } from "../persistence/schema/index.js";
-import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
+import memoryConversationDeleted from "../plugins/defaults/memory/hooks/conversation-deleted.js";
+import type { PluginHooks } from "../plugins/types.js";
 
 await initializeDb();
+
+// Register the memory plugin's `conversation-deleted` hook the way boot does,
+// so the delete primitives' dispatch reaches the plugin's job sweep.
+registerPluginHooks("default-memory", {
+  "conversation-deleted": memoryConversationDeleted,
+} as PluginHooks);
+
+/** Poll until `read()` returns a defined value or the timeout elapses. */
+async function waitFor<T>(
+  read: () => T | undefined,
+  timeoutMs = 2000,
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined || Date.now() > deadline) return value;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
 
 function countJobs(type: MemoryJobType, conversationId?: string): number {
   const rows = getMemoryDb()!
@@ -216,25 +241,25 @@ describe("messages lexical-index dual-write", () => {
     expect(countJobs("purge_conversation_lexical", conv.id)).toBe(1);
   });
 
-  test("deleteConversation fails pending conversation-keyed jobs but not the purge it enqueues", async () => {
+  test("deleteConversation fails its pending memory jobs but leaves host jobs runnable", async () => {
     const conv = createConversation("Cancel pending jobs thread");
     await addMessage(conv.id, "user", "index me then delete me");
 
     resetMemoryJobs();
+    // One memory-plugin job type, one host-owned job type — both keyed by the
+    // conversation id.
     enqueueMemoryJob("graph_extract", { conversationId: conv.id });
+    enqueueMemoryJob("conversation_analyze", { conversationId: conv.id });
 
     deleteConversation(conv.id);
 
-    const jobsByType = new Map(
+    const jobStatus = (type: MemoryJobType): string | undefined =>
       getMemoryDb()!
-        .select({
-          type: memoryJobs.type,
-          status: memoryJobs.status,
-          payload: memoryJobs.payload,
-        })
+        .select({ status: memoryJobs.status, payload: memoryJobs.payload })
         .from(memoryJobs)
+        .where(eq(memoryJobs.type, type))
         .all()
-        .filter((r) => {
+        .find((r) => {
           try {
             return (
               (JSON.parse(r.payload) as { conversationId?: string })
@@ -243,14 +268,19 @@ describe("messages lexical-index dual-write", () => {
           } catch {
             return false;
           }
-        })
-        .map((r) => [r.type, r.status]),
-    );
+        })?.status;
 
-    // The pre-existing conversation-keyed job is swept…
-    expect(jobsByType.get("graph_extract")).toBe("failed");
-    // …but the purge, enqueued after the sweep, stays runnable.
-    expect(jobsByType.get("purge_conversation_lexical")).toBe("pending");
+    // The hook dispatch is fire-and-forget, so wait for the plugin's sweep to
+    // land before asserting.
+    const graphExtractStatus = await waitFor(() =>
+      jobStatus("graph_extract") === "failed" ? "failed" : undefined,
+    );
+    expect(graphExtractStatus).toBe("failed");
+    // The sweep is scoped to the plugin's own job types: host-owned jobs —
+    // including the purge the delete primitive itself enqueued — stay
+    // runnable.
+    expect(jobStatus("conversation_analyze")).toBe("pending");
+    expect(jobStatus("purge_conversation_lexical")).toBe("pending");
   });
 
   test("deleteConversationGently (retrospective GC) enqueues a purge for the conversation", async () => {
@@ -363,47 +393,52 @@ describe("messages lexical-index dual-write", () => {
   });
 });
 
-// Whole-conversation deletes must fire the memory plugin's
-// `onConversationDeleted` hook from the shared
-// `deleteConversation`/`deleteConversationGently` primitive (covering every
-// caller, not just the HTTP route).
-describe("delete paths fire the memory persistence hook", () => {
+// Whole-conversation deletes must dispatch the `conversation-deleted` hook
+// from the shared `deleteConversation`/`deleteConversationGently` primitive
+// (covering every caller, not just the HTTP route). Captured through a
+// registered test hook — the same chain a user plugin would subscribe on.
+describe("delete paths dispatch the conversation-deleted hook", () => {
   const deletedConversations: string[] = [];
-  let conversationDeletedSpy: ReturnType<typeof spyOn>;
+
+  beforeAll(() => {
+    registerPluginHooks("test-conversation-deleted-capture", {
+      "conversation-deleted": async (ctx: { conversationId: string }) => {
+        deletedConversations.push(ctx.conversationId);
+      },
+    } as PluginHooks);
+  });
+
+  afterAll(() => {
+    unregisterPluginHooks("test-conversation-deleted-capture");
+  });
 
   beforeEach(() => {
     resetMemoryJobs();
     deletedConversations.length = 0;
-    conversationDeletedSpy = spyOn(
-      memoryPersistenceHooks,
-      "onConversationDeleted",
-    ).mockImplementation((id: string) => {
-      deletedConversations.push(id);
-    });
   });
 
-  afterEach(() => {
-    // Restore the real handler so later tests are unaffected.
-    conversationDeletedSpy.mockRestore();
-  });
-
-  test("deleteConversation fires onConversationDeleted (covers all callers, not just the route)", async () => {
-    const conv = createConversation("Seam conversation delete");
+  test("deleteConversation dispatches conversation-deleted (covers all callers, not just the route)", async () => {
+    const conv = createConversation("Hook conversation delete");
     await addMessage(conv.id, "user", "hello");
 
-    deletedConversations.length = 0;
     deleteConversation(conv.id);
 
-    expect(deletedConversations).toEqual([conv.id]);
+    // The dispatch is fire-and-forget; wait for the chain to land.
+    const seen = await waitFor(() =>
+      deletedConversations.includes(conv.id) ? true : undefined,
+    );
+    expect(seen).toBe(true);
   });
 
-  test("deleteConversationGently fires onConversationDeleted (the retrospective-GC path)", async () => {
-    const conv = createConversation("Seam gentle delete");
+  test("deleteConversationGently dispatches conversation-deleted (the retrospective-GC path)", async () => {
+    const conv = createConversation("Hook gentle delete");
     await addMessage(conv.id, "user", "hello");
 
-    deletedConversations.length = 0;
     await deleteConversationGently(conv.id);
 
-    expect(deletedConversations).toEqual([conv.id]);
+    const seen = await waitFor(() =>
+      deletedConversations.includes(conv.id) ? true : undefined,
+    );
+    expect(seen).toBe(true);
   });
 });

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -37,7 +37,14 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
+// Replace `publishSchedulesChanged` while keeping the rest of the module REAL
+// — a partial mock that drops the other exports breaks any transitively loaded
+// module that imports them (the conversation write paths reach this module
+// through the hook pipeline).
+const actualSyncEvents =
+  await import("../runtime/sync/resource-sync-events.js");
 mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  ...actualSyncEvents,
   publishSchedulesChanged: () => {},
 }));
 

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -611,3 +611,32 @@ export interface PostModelCallInputContext {
  */
 export interface PostModelCallContext
   extends PostModelCallInputContext, BaseHookContext {}
+
+// ─── Conversation-deleted hook context ───────────────────────────────────────
+
+/**
+ * Context passed to the `conversation-deleted` hook. Fires once per deleted
+ * conversation — from the shared delete primitives, so every delete caller
+ * (route, retrospective cleanup, GC) dispatches it — after the conversation's
+ * rows are removed.
+ *
+ * The dispatch is fire-and-forget: the delete primitives are synchronous and
+ * do not wait for the chain, so hooks run concurrently with whatever the
+ * caller does after the delete and must not assume any ordering relative to
+ * it. By the time a hook runs, the conversation's rows (messages, segments,
+ * attachments, the conversation itself) are gone — a hook can only key its
+ * cleanup on the id. The default memory plugin contributes a hook here that
+ * fails its own still-pending background jobs referencing the conversation.
+ */
+export interface ConversationDeletedInputContext {
+  /** ID of the conversation that was deleted. */
+  readonly conversationId: string;
+}
+
+/**
+ * The full `conversation-deleted` context a hook receives — the dispatching
+ * call site's {@link ConversationDeletedInputContext} plus the
+ * pipeline-stamped {@link BaseHookContext} capabilities.
+ */
+export interface ConversationDeletedContext
+  extends ConversationDeletedInputContext, BaseHookContext {}

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -29,7 +29,10 @@ import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
+import type { ConversationDeletedInputContext } from "../hooks/types.js";
+import { HOOKS } from "../plugin-api/constants.js";
 import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
+import { runHook } from "../plugins/pipeline.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { trustClassSchema } from "../runtime/trust-class.js";
@@ -1513,18 +1516,21 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     removeConversationDir(id, createdAtForDiskCleanup);
   }
 
-  // Let the memory feature fail its still-pending jobs for this conversation.
-  // Routed through the persistence-hook seam so this layer stays decoupled
-  // from the memory plugin; a no-op when memory is not present.
-  memoryPersistenceHooks.onConversationDeleted(id);
+  // Notify `conversation-deleted` hooks (e.g. the memory plugin failing its
+  // still-pending jobs for this conversation). Fire-and-forget from this
+  // synchronous primitive — the pipeline contains per-hook failures, and
+  // hooks carry no ordering guarantee relative to the cleanup below.
+  void runHook(HOOKS.CONVERSATION_DELETED, {
+    conversationId: id,
+  } satisfies ConversationDeletedInputContext);
 
   // Purge the conversation's points from the lexical (Qdrant) index. Fired
   // from the shared primitive so every delete caller — route, retrospective
-  // cleanup/GC — cleans up. Enqueued AFTER the hook above, whose cancellation
-  // pass sweeps pending `conversationId`-keyed jobs — the purge must not be
-  // swept by it. The enqueue helper self-selects: enqueue a job when memory is
-  // enabled, run the delete inline (best-effort, breaker-wrapped) when it is
-  // disabled.
+  // cleanup/GC — cleans up. Safe to enqueue while the hook chain runs: the
+  // memory plugin's job sweep is scoped to its own job types and cannot fail
+  // this host-owned purge job. The enqueue helper self-selects: enqueue a job
+  // when memory is enabled, run the delete inline (best-effort,
+  // breaker-wrapped) when it is disabled.
   enqueuePurgeConversationLexical(id);
 
   return result;
@@ -1633,15 +1639,17 @@ export async function deleteConversationGently(
     removeConversationDir(id, createdAtForDiskCleanup);
   }
 
-  // Let the memory feature fail its still-pending jobs for this conversation.
-  // Routed through the persistence-hook seam; a no-op when memory is not
-  // present.
-  memoryPersistenceHooks.onConversationDeleted(id);
+  // Notify `conversation-deleted` hooks — fire-and-forget, same contract as
+  // the synchronous delete primitive.
+  void runHook(HOOKS.CONVERSATION_DELETED, {
+    conversationId: id,
+  } satisfies ConversationDeletedInputContext);
 
   // Purge the conversation's points from the lexical (Qdrant) index — the
   // gentle path is the retrospective-GC caller, which would otherwise leak the
-  // conversation's lexical points. Enqueued AFTER the hook above so the
-  // hook's cancellation pass cannot sweep the purge.
+  // conversation's lexical points. Safe to enqueue while the hook chain runs:
+  // the memory plugin's job sweep is scoped to its own job types and cannot
+  // fail this host-owned purge job.
   enqueuePurgeConversationLexical(id);
 
   return result;

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -30,6 +30,8 @@ export const HOOKS = {
   POST_MODEL_CALL: "post-model-call",
   /** Fires after the loop successfully compacts a conversation mid-turn. */
   POST_COMPACT: "post-compact",
+  /** Fires once per deleted conversation, after its rows are removed. Fire-and-forget cleanup signal — hooks run async with no ordering guarantee relative to the caller. */
+  CONVERSATION_DELETED: "conversation-deleted",
 } as const;
 
 /** Union of every hook name declared in {@link HOOKS}. */

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -101,6 +101,7 @@ export type {
 export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
+  ConversationDeletedContext,
   HookBroadcast,
   HookFunction,
   InitContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -13,6 +13,7 @@ import type { PluginLogger } from "../hooks/types.js";
 export type {
   AgentLoopExitReason,
   BaseHookContext,
+  ConversationDeletedContext,
   HookBroadcast,
   PluginLogger,
   PostCompactContext,
@@ -56,6 +57,7 @@ export { RiskLevel } from "../tools/types.js";
  *   - `post-tool-use` — {@link PostToolUseContext}
  *   - `stop` — {@link StopContext}
  *   - `post-model-call` — {@link PostModelCallContext}
+ *   - `conversation-deleted` — {@link ConversationDeletedContext}
  */
 export type HookFunction<TCtx = unknown> = (
   ctx: TCtx,

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -60,6 +60,7 @@ import { resetMaxTokensContinueStoreForTests } from "./max-tokens-continue/conti
 import maxTokensContinuePostModelCall from "./max-tokens-continue/hooks/post-model-call.js";
 import maxTokensContinueStop from "./max-tokens-continue/hooks/stop.js";
 import maxTokensContinuePkg from "./max-tokens-continue/package.json" with { type: "json" };
+import memoryConversationDeleted from "./memory/hooks/conversation-deleted.js";
 import memoryInit from "./memory/hooks/init.js";
 import memoryPostCompact from "./memory/hooks/post-compact.js";
 import memoryShutdown from "./memory/hooks/shutdown.js";
@@ -149,9 +150,11 @@ export const defaultEmptyResponsePlugin: Plugin = {
  * runtime injections (the unified `<turn_context>` block, Slack chronological
  * transcript, NOW.md / PKB / memory-v2 / workspace blocks) and houses the
  * memory-v3 orchestration engine (`memory/v3/`) and its injectors. Two hooks
- * drive it: `user-prompt-submit` runs memory-graph retrieval and the initial
- * injection, and `post-compact` re-applies the injections onto the compacted
- * history after a mid-turn compaction. It contributes its personal-memory
+ * drive its turn work: `user-prompt-submit` runs memory-graph retrieval and
+ * the initial injection, and `post-compact` re-applies the injections onto
+ * the compacted history after a mid-turn compaction; a `conversation-deleted`
+ * hook fails the plugin's pending background jobs when a conversation is
+ * deleted. It contributes its personal-memory
  * runtime injectors (PKB context/reminder and the memory-v2 static block, plus
  * the two memory-v3 injectors) to the global injector registry via the
  * `injectors` field; the registry unions them with the domain plugins'
@@ -170,6 +173,7 @@ export const defaultMemoryPlugin: Plugin = {
     shutdown: memoryShutdown,
     "user-prompt-submit": memoryUserPromptSubmit,
     "post-compact": memoryPostCompact,
+    "conversation-deleted": memoryConversationDeleted,
   },
   injectors: [...memoryInjectors, memoryV3Injector, memoryV3SpotlightInjector],
 };

--- a/assistant/src/plugins/defaults/memory/hooks/conversation-deleted.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/conversation-deleted.ts
@@ -1,0 +1,34 @@
+/**
+ * Default `memory` conversation-deleted hook.
+ *
+ * Fails the plugin's own still-pending background jobs referencing the
+ * deleted conversation (graph extraction, embeddings, sweeps, …) so the
+ * worker does not burn cycles — and error noise — on jobs whose conversation
+ * no longer exists.
+ *
+ * The sweep is scoped to the plugin's own job types (derived from its handler
+ * table). The dispatch is fire-and-forget, so the sweep runs concurrently
+ * with the host cleanup jobs the delete primitive enqueues (e.g. the lexical
+ * purge) — scoping by type is what keeps those host jobs out of its blast
+ * radius without needing any ordering between them.
+ */
+
+import type {
+  ConversationDeletedContext,
+  HookFunction,
+} from "@vellumai/plugin-api";
+
+import { memoryJobHandlers } from "../job-handlers.js";
+import { cancelPendingJobsForConversation } from "../task-memory-cleanup.js";
+
+const MEMORY_JOB_TYPES: readonly string[] = memoryJobHandlers.map(
+  (entry) => entry.type,
+);
+
+const conversationDeleted: HookFunction<ConversationDeletedContext> = async (
+  ctx,
+) => {
+  cancelPendingJobsForConversation(ctx.conversationId, MEMORY_JOB_TYPES);
+};
+
+export default conversationDeleted;

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -4,7 +4,6 @@ import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
-import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
 import {
   forkActivationState,
   seedForkActivationState,
@@ -145,14 +144,5 @@ export const memoryPersistenceHooks = {
       forkedMessageIds,
       lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
     });
-  },
-
-  onConversationDeleted(conversationId: string): void {
-    // Fail the conversation's still-pending memory jobs (graph extraction,
-    // summary builds, …) — the rows they reference are gone. The cancellation
-    // sweeps pending `conversationId`-keyed jobs, so the delete primitive
-    // fires this hook BEFORE enqueueing the conversation's lexical purge, or
-    // the purge would be swept too.
-    cancelPendingJobsForConversation(conversationId);
   },
 };

--- a/assistant/src/plugins/defaults/memory/task-memory-cleanup.ts
+++ b/assistant/src/plugins/defaults/memory/task-memory-cleanup.ts
@@ -105,19 +105,28 @@ export function invalidateAssistantInferredItemsForConversation(
 }
 
 /**
- * Fail every pending/running memory job keyed to the given conversation
- * (`json_extract(payload, '$.conversationId')` — e.g. `graph_extract`,
- * `build_conversation_summary`, `conversation_analyze`). Fired from the
- * shared delete primitive via `onConversationDeleted`, so the worker does
- * not burn cycles (and error noise) on jobs whose conversation no longer
- * exists. Deliberately conversationId-keyed only: it runs after the
- * conversation's rows are deleted, and jobs for surviving multi-sourced
- * graph nodes must stay runnable.
+ * Fail every pending/running job of one of `types` keyed to the given
+ * conversation (`json_extract(payload, '$.conversationId')` — e.g.
+ * `graph_extract`, `memory_retrospective`). Fired from the
+ * `conversation-deleted` hook, so the worker does not burn cycles (and error
+ * noise) on jobs whose conversation no longer exists.
+ *
+ * Two deliberate scope limits:
+ * - conversationId-keyed only — it runs after the conversation's rows are
+ *   deleted, and jobs for surviving multi-sourced graph nodes must stay
+ *   runnable;
+ * - restricted to the caller's own job types — the hook dispatch is
+ *   fire-and-forget, so the sweep runs concurrently with the host cleanup
+ *   jobs the delete primitive enqueues (the lexical purge is itself a
+ *   `conversationId`-keyed pending job) and must not be able to fail them.
  */
 export function cancelPendingJobsForConversation(
   conversationId: string,
+  types: readonly string[],
   reason: string = "conversation_deleted",
 ): number {
+  if (types.length === 0) return 0;
+  const placeholders = types.map(() => "?").join(", ");
   const cancelled = rawMemoryRun(
     "taskMemory:cancelJobs:byConversation",
     `UPDATE memory_jobs
@@ -125,9 +134,11 @@ export function cancelPendingJobsForConversation(
             last_error = ?,
             updated_at = ?
       WHERE status IN ('pending', 'running')
+        AND type IN (${placeholders})
         AND json_extract(payload, '$.conversationId') = ?`,
     reason,
     Date.now(),
+    ...types,
     conversationId,
   );
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -643,7 +643,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-03T20:12:42.000Z"
+      "updatedAt": "2026-07-06T17:36:51.000Z"
     },
     {
       "id": "public-ingress",
@@ -950,7 +950,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T14:33:32.000Z"
+      "updatedAt": "2026-07-06T16:01:24.000Z"
     },
     {
       "id": "vellum-github-app-setup",

--- a/skills/plugin-builder/references/hooks.md
+++ b/skills/plugin-builder/references/hooks.md
@@ -22,7 +22,7 @@ The loop moves a conversation turn through a series of **lifecycle events**. The
 
 The loop can iterate several times within a single user turn: every tool result returns to a fresh model call, and a `post-model-call` hook can choose to continue rather than end the turn. Because of this, `pre-model-call`, `post-model-call`, and `post-tool-use` can each fire more than once per turn.
 
-The Assistant also hooks into Lifecycle Events that sit outside the Agent Loop: `init` fires at bootstrap, and `shutdown` fires at teardown.
+The Assistant also hooks into Lifecycle Events that sit outside the Agent Loop: `init` fires at bootstrap, `shutdown` fires at teardown, and `conversation-deleted` fires after a conversation is deleted from storage.
 
 ## Hooks reference
 
@@ -148,6 +148,19 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 | `logger`         | `PluginLogger`           | Read-only | Logger pre-tagged with the hook name, your plugin, and the conversation / request identity. Log through it; no manual tagging needed.                                                                                                   |
 | `broadcast`      | `HookBroadcast`          | Read-only | Emit a transient `hook_event` to any UI watching the conversation. You supply a JSON-serializable `detail` record; the runtime stamps the conversation, hook name, and owner attribution. Best-effort: never throws or blocks the turn. |
 
+### `conversation-deleted`
+
+**Context:** `ConversationDeletedContext`
+**When:** Once per deleted conversation, after its rows are removed. Fires from the shared delete primitives, so every delete caller (route, retrospective cleanup, GC) dispatches it.
+**Use it to:** Clean up per-conversation state your plugin keeps (caches, queued work, external records) keyed by the conversation id. Fire-and-forget: hooks run async with no ordering guarantee relative to the caller, and by the time a hook runs the conversation's rows are gone.
+**Example:** [memory](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/plugins/defaults/memory/hooks/conversation-deleted.ts)
+
+| Field            | Type            | Access    | Description                                                                                                                                                                                                                             |
+| ---------------- | --------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `conversationId` | `string`        | Read-only | ID of the conversation that was deleted.                                                                                                                                                                                                |
+| `logger`         | `PluginLogger`  | Read-only | Logger pre-tagged with the hook name, your plugin, and the conversation identity. Log through it; no manual tagging needed.                                                                                                             |
+| `broadcast`      | `HookBroadcast` | Read-only | Emit a transient `hook_event` to any UI watching the conversation. You supply a JSON-serializable `detail` record; the runtime stamps the conversation, hook name, and owner attribution. Best-effort: never throws or blocks the turn. |
+
 ### `shutdown`
 
 **Context:** `ShutdownContext`
@@ -173,22 +186,23 @@ Within a single plugin, hooks for the same name are not duplicated: each plugin 
 
 These are the hook-related exports from [`@vellumai/plugin-api`](https://github.com/vellum-ai/vellum-assistant/tree/main/assistant/src/plugin-api). Each context type's full field contract is documented in the hook sections above.
 
-| Export                    | Kind  | Purpose                                                                                                                           |
-| ------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `HOOKS`                   | const | Wired hook names keyed by constant (INIT, PRE_MODEL_CALL, and so on). Reference hooks by this instead of free-form strings.       |
-| `HookName`                | type  | Union of every wired hook name declared in HOOKS.                                                                                 |
-| `HookFunction`            | type  | Signature every hook implements: `(ctx) => Promise<Partial<ctx> \| void>`.                                                        |
-| `HookBroadcast`           | type  | Signature of `ctx.broadcast(detail)`: emit a transient `hook_event` to UIs watching the conversation.                             |
-| `InitContext`             | type  | Passed to the init hook at bootstrap.                                                                                             |
-| `ShutdownContext`         | type  | Passed to the shutdown hook at teardown.                                                                                          |
-| `UserPromptSubmitContext` | type  | Passed to user-prompt-submit, before a turn's messages reach the agent loop.                                                      |
-| `PreModelCallContext`     | type  | Passed to pre-model-call, before each provider call.                                                                              |
-| `PostToolUseContext`      | type  | Passed to post-tool-use, once per tool result.                                                                                    |
-| `PostModelCallContext`    | type  | Passed to post-model-call at every model-call outcome (a finalized reply or a provider rejection); carries the continue decision. |
-| `PostCompactContext`      | type  | Passed to post-compact, after the loop compacts a conversation mid-turn.                                                          |
-| `StopContext`             | type  | Passed to stop, the terminal hook, once the turn has committed to ending.                                                         |
-| `PostModelCallDecision`   | type  | The post-model-call decision shape: whether to end the turn or continue.                                                          |
-| `AgentLoopExitReason`     | type  | Which terminal state a turn reached, carried on StopContext.                                                                      |
+| Export                       | Kind  | Purpose                                                                                                                           |
+| ---------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `HOOKS`                      | const | Wired hook names keyed by constant (INIT, PRE_MODEL_CALL, and so on). Reference hooks by this instead of free-form strings.       |
+| `HookName`                   | type  | Union of every wired hook name declared in HOOKS.                                                                                 |
+| `HookFunction`               | type  | Signature every hook implements: `(ctx) => Promise<Partial<ctx> \| void>`.                                                        |
+| `HookBroadcast`              | type  | Signature of `ctx.broadcast(detail)`: emit a transient `hook_event` to UIs watching the conversation.                             |
+| `InitContext`                | type  | Passed to the init hook at bootstrap.                                                                                             |
+| `ShutdownContext`            | type  | Passed to the shutdown hook at teardown.                                                                                          |
+| `UserPromptSubmitContext`    | type  | Passed to user-prompt-submit, before a turn's messages reach the agent loop.                                                      |
+| `PreModelCallContext`        | type  | Passed to pre-model-call, before each provider call.                                                                              |
+| `PostToolUseContext`         | type  | Passed to post-tool-use, once per tool result.                                                                                    |
+| `PostModelCallContext`       | type  | Passed to post-model-call at every model-call outcome (a finalized reply or a provider rejection); carries the continue decision. |
+| `PostCompactContext`         | type  | Passed to post-compact, after the loop compacts a conversation mid-turn.                                                          |
+| `StopContext`                | type  | Passed to stop, the terminal hook, once the turn has committed to ending.                                                         |
+| `ConversationDeletedContext` | type  | Passed to conversation-deleted, after a conversation is deleted from storage.                                                     |
+| `PostModelCallDecision`      | type  | The post-model-call decision shape: whether to end the turn or continue.                                                          |
+| `AgentLoopExitReason`        | type  | Which terminal state a turn reached, carried on StopContext.                                                                      |
 
 ## Anatomy of a hook
 


### PR DESCRIPTION
## Why

Move the first persistence-lifecycle event onto the extensible `hooks` framework: `conversation-deleted`. Beyond migrating the memory plugin off the private seam, this is a genuinely useful extensibility point — any plugin keeping per-conversation state (caches, queued work, external records) can now subscribe to clean up when a conversation is deleted, including user plugins and standalone workspace hooks (hook loading is filename-driven, so a `hooks/conversation-deleted.ts` just works).

## Design: fire-and-forget dispatch + type-scoped sweep

The delete primitives (`deleteConversation`, `deleteConversationGently`) fire the event, and `deleteConversation` is synchronous — so the dispatch is `void runHook(…)` with an explicit **no-ordering contract**: hooks run async, concurrently with whatever the caller does after the delete, and by the time they run the conversation's rows are gone (the context is just `{ conversationId }`).

That contract required one change to the memory plugin's sweep: the lexical purge the delete primitive enqueues is itself a `conversationId`-keyed pending job, and the old ordering guarantee (sweep before purge enqueue) no longer exists. Instead, `cancelPendingJobsForConversation` is now **scoped to the plugin's own job types** (derived from its handler table, `memoryJobHandlers`). Host-owned jobs — the purge, `conversation_analyze`, `build_conversation_summary` — are out of its blast radius by construction, so no ordering between the hook chain and the caller is needed. This is also more honest layering: the plugin sweeps plugin jobs; host jobs for a deleted conversation fail naturally at run time as they always did before the sweep existed.

## What

- `HOOKS.CONVERSATION_DELETED` + `ConversationDeletedContext` (exported from `@vellumai/plugin-api`), documented in the plugin-builder skill's hooks reference.
- Delete primitives dispatch `void runHook(HOOKS.CONVERSATION_DELETED, { conversationId })`; comments now state the type-scoping invariant instead of an ordering constraint.
- Memory plugin subscribes via `memory/hooks/conversation-deleted.ts`; `onConversationDeleted` is deleted from `persistence-hooks.ts`. The seam is down to `onMessagePersisted` and `onConversationForked`.
- With the pipeline owning dispatch, disabled-plugin and per-conversation plugin-scope filtering apply to the sweep — the harness owns those gates.

## Tests

`lexical-index-dual-write.test.ts` registers the real memory hook the way boot does and polls for the fire-and-forget dispatch to land:
- the plugin's `graph_extract` job is failed by the sweep, while a host-owned `conversation_analyze` job **and** the purge stay `pending` (pins the type-scoping);
- both delete primitives dispatch the hook, captured through a registered test hook — the same chain a user plugin would subscribe on.

Green in isolation: lexical-index-dual-write (15), hooks framework (4), task-memory-cleanup (12), clear-all-lexical (1), conversation-delete-schedule-cleanup (5), persistence-layering-guard (3), plugin-import-boundary-guard (5). `bunx tsc --noEmit` clean; catalog check green.

Note: #37168 (message-persisted) was closed unmerged per discussion — this PR is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_