### PR TITLE
refactor(live-voice): support repeated utterance→turn cycles on one session

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -333,6 +333,32 @@ describe("LiveVoiceSession assistant turn", () => {
     });
   });
 
+  test("rejects audio while an assistant turn is in flight", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 3);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+    ]);
+
+    await session.handleBinaryAudio(new Uint8Array([7]));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      code: "invalid_audio_payload",
+      message: "Live voice audio received after push-to-talk release.",
+    });
+  });
+
   test("interrupt aborts the in-flight turn and ignores late bridge events", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     let signal: AbortSignal | undefined;

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -212,6 +212,16 @@ function frameTypes(frames: LiveVoiceServerFrame[]): string[] {
   return frames.map((frame) => frame.type);
 }
 
+function sessionInternals(session: LiveVoiceSession): {
+  currentUtterance: { userAudioChunks: Buffer[] } | null;
+  activeAssistantTurn: unknown;
+} {
+  return session as unknown as {
+    currentUtterance: { userAudioChunks: Buffer[] } | null;
+    activeAssistantTurn: unknown;
+  };
+}
+
 describe("LiveVoiceSession archive and metrics events", () => {
   test("archives user and assistant audio and emits completion and session metrics", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
@@ -316,21 +326,10 @@ describe("LiveVoiceSession archive and metrics events", () => {
       event: "session_ended",
       sessionId: "session-123",
     });
-    expect(
-      (
-        session as unknown as {
-          currentUserAudioChunks: Buffer[];
-          activeAssistantTurn: unknown;
-        }
-      ).currentUserAudioChunks,
-    ).toHaveLength(0);
-    expect(
-      (
-        session as unknown as {
-          activeAssistantTurn: unknown;
-        }
-      ).activeAssistantTurn,
-    ).toBeNull();
+    const internals = sessionInternals(session);
+    expect(internals.currentUtterance).not.toBeNull();
+    expect(internals.currentUtterance?.userAudioChunks).toHaveLength(0);
+    expect(internals.activeAssistantTurn).toBeNull();
   });
 
   test("uses the TTS chunk content type for socket frames and archive metadata", async () => {
@@ -413,11 +412,7 @@ describe("LiveVoiceSession archive and metrics events", () => {
       },
     });
     expect(
-      (
-        session as unknown as {
-          currentUserAudioChunks: Buffer[];
-        }
-      ).currentUserAudioChunks,
+      sessionInternals(session).currentUtterance?.userAudioChunks,
     ).toHaveLength(0);
   });
 
@@ -463,11 +458,7 @@ describe("LiveVoiceSession archive and metrics events", () => {
       },
     });
     expect(
-      (
-        session as unknown as {
-          currentUserAudioChunks: Buffer[];
-        }
-      ).currentUserAudioChunks,
+      sessionInternals(session).currentUtterance?.userAudioChunks,
     ).toHaveLength(0);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -44,6 +44,8 @@ class FakeStreamingTranscriber implements StreamingTranscriber {
   stopped = false;
   private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
 
+  constructor(private readonly transcript = "hello from live voice") {}
+
   async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
     this.onEvent = onEvent;
   }
@@ -55,7 +57,7 @@ class FakeStreamingTranscriber implements StreamingTranscriber {
 
   stop(): void {
     this.stopped = true;
-    this.emit({ type: "final", text: "hello from live voice" });
+    this.emit({ type: "final", text: this.transcript });
     this.emit({ type: "closed" });
   }
 
@@ -173,6 +175,42 @@ async function waitFor(
 
 function frameTypes(frames: LiveVoiceServerFrame[]): string[] {
   return frames.map((frame) => frame.type);
+}
+
+// Harness for multi-cycle tests: every resolve yields a fresh transcriber
+// whose transcript is "utterance <n>", and turn ids count up per cycle.
+function createMultiCycleHarness(startVoiceTurn: LiveVoiceTurnStarter) {
+  const transcribers: FakeStreamingTranscriber[] = [];
+  const resolveTranscriber = mock(async () => {
+    const transcriber = new FakeStreamingTranscriber(
+      `utterance ${transcribers.length + 1}`,
+    );
+    transcribers.push(transcriber);
+    return transcriber;
+  });
+  const archiveAudio = mock(
+    async (input: LiveVoiceSessionArchiveAudioInput) =>
+      makeArchiveResult(input),
+  );
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+    return makeTtsResult(options.text);
+  });
+  const { context, frames } = createContext();
+  let turnCount = 0;
+  const session = createLiveVoiceSession(context, {
+    resolveTranscriber,
+    startVoiceTurn,
+    streamTtsAudio,
+    archiveAudio,
+    metricsClock: createClock(),
+    createTurnId: () => {
+      turnCount += 1;
+      return `live-turn-${turnCount}`;
+    },
+  });
+
+  return { archiveAudio, frames, session, transcribers };
 }
 
 describe("LiveVoiceSession integration smoke harness", () => {
@@ -355,5 +393,140 @@ describe("LiveVoiceSession integration smoke harness", () => {
         },
       },
     });
+  });
+
+  test("runs two full push-to-talk cycles on one session with isolated per-turn archives", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      options.callbacks?.assistant_text_delta?.(
+        makeTextDelta(`Reply to ${options.content}.`),
+      );
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { archiveAudio, frames, session, transcribers } =
+      createMultiCycleHarness(startVoiceTurn);
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1, 1, 1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    await session.handleBinaryAudio(new Uint8Array([2, 2, 2, 2]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+      "utterance 1",
+      "utterance 2",
+    ]);
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "stt_final" ? [frame.text] : [],
+      ),
+    ).toEqual(["utterance 1", "utterance 2"]);
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "tts_done" ? [frame.turnId] : [],
+      ),
+    ).toEqual(["live-turn-1", "live-turn-2"]);
+    expect(
+      archiveAudio.mock.calls.map((call) => [call[0].role, call[0].turnId]),
+    ).toEqual([
+      ["user", "live-turn-1"],
+      ["assistant", "live-turn-1"],
+      ["user", "live-turn-2"],
+      ["assistant", "live-turn-2"],
+    ]);
+    const archivedUserAudio = archiveAudio.mock.calls
+      .filter((call) => call[0].role === "user")
+      .map((call) => [...Buffer.from(call[0].audio.dataBase64, "base64")]);
+    expect(archivedUserAudio).toEqual([
+      [1, 1, 1],
+      [2, 2, 2, 2],
+    ]);
+    const archivedAssistantAudio = archiveAudio.mock.calls
+      .filter((call) => call[0].role === "assistant")
+      .map((call) =>
+        Buffer.from(call[0].audio.dataBase64, "base64").toString(),
+      );
+    expect(archivedAssistantAudio).toEqual([
+      "audio:Reply to utterance 1.",
+      "audio:Reply to utterance 2.",
+    ]);
+    expect(transcribers).toHaveLength(3);
+    expect(transcribers[0]?.stopped).toBe(true);
+    expect(transcribers[1]?.stopped).toBe(true);
+    expect(transcribers[2]?.stopped).toBe(false);
+  });
+
+  test("completes a full second cycle after an interrupt mid-turn", async () => {
+    const abort = mock();
+    let voiceTurnCalls = 0;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      voiceTurnCalls += 1;
+      if (voiceTurnCalls === 1) {
+        options.callbacks?.persisted_user_message_id?.("user-message-123");
+        return { turnId: "bridge-turn-1", abort };
+      }
+      options.callbacks?.assistant_text_delta?.(makeTextDelta("Second reply."));
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-2", abort: mock() };
+    });
+    const { archiveAudio, frames, session } =
+      createMultiCycleHarness(startVoiceTurn);
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1, 2]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    await session.handleClientFrame({ type: "interrupt" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+    expect(abort).toHaveBeenCalledTimes(1);
+
+    await session.handleBinaryAudio(new Uint8Array([3, 4, 5]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(2);
+    expect(startVoiceTurn.mock.calls[1]?.[0]).toMatchObject({
+      content: "utterance 2",
+    });
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-2",
+    });
+    expect(
+      frames.find(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    ).toMatchObject({
+      type: "metrics",
+      event: "turn_completed",
+      turnId: "live-turn-2",
+    });
+    expect(
+      archiveAudio.mock.calls.map((call) => [call[0].role, call[0].turnId]),
+    ).toEqual([
+      ["user", "live-turn-1"],
+      ["user", "live-turn-2"],
+      ["assistant", "live-turn-2"],
+    ]);
+    const archivedUserAudio = archiveAudio.mock.calls
+      .filter((call) => call[0].role === "user")
+      .map((call) => [...Buffer.from(call[0].audio.dataBase64, "base64")]);
+    expect(archivedUserAudio).toEqual([
+      [1, 2],
+      [3, 4, 5],
+    ]);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, mock, test } from "bun:test";
 
+import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -99,6 +100,17 @@ function createSessionWithTranscriber(
   return { frames, resolver, session, transcriber };
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice STT test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
 describe("LiveVoiceSession STT", () => {
   test("resolves streaming STT through the injected resolver and sends ready", async () => {
     const { frames, resolver, session, transcriber } =
@@ -176,6 +188,47 @@ describe("LiveVoiceSession STT", () => {
         code: "invalid_audio_payload",
         message: "Live voice audio received after push-to-talk release.",
       },
+    ]);
+  });
+
+  test("arms a fresh streaming transcriber for the next utterance after a completed turn", async () => {
+    const transcribers: MockStreamingTranscriber[] = [];
+    const resolver = mock(async () => {
+      const transcriber = new MockStreamingTranscriber();
+      transcribers.push(transcriber);
+      return transcriber;
+    });
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { context, frames } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(transcribers).toHaveLength(2);
+    expect(transcribers[1]?.started).toBe(true);
+    expect(transcribers[1]?.stopped).toBe(false);
+
+    await session.handleBinaryAudio(new Uint8Array([2]));
+
+    expect(transcribers[0]?.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [1],
+    ]);
+    expect(transcribers[1]?.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [2],
     ]);
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -232,6 +232,138 @@ describe("LiveVoiceSession STT", () => {
     ]);
   });
 
+  test("sends tts_done even when the next transcriber's startup never resolves", async () => {
+    const firstTranscriber = new MockStreamingTranscriber();
+    let resolverCalls = 0;
+    const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
+      resolverCalls += 1;
+      if (resolverCalls === 1) return firstTranscriber;
+      return new Promise<StreamingTranscriber | null>(() => {});
+    });
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { context, frames } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    await waitFor(() => resolverCalls === 2);
+
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+
+    // Audio ahead of the still-starting transcriber buffers instead of erroring.
+    await session.handleBinaryAudio(new Uint8Array([2]));
+
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+    expect(firstTranscriber.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [1],
+    ]);
+  });
+
+  test("surfaces a re-arm startup failure after tts_done without failing the completed turn", async () => {
+    let resolverCalls = 0;
+    const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
+      resolverCalls += 1;
+      if (resolverCalls === 1) return new MockStreamingTranscriber();
+      throw new Error("next stt unavailable");
+    });
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { context, frames } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+      emitMetrics: true,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    const frameTypes = frames.map((frame) => frame.type);
+    expect(frameTypes.indexOf("tts_done")).toBeGreaterThanOrEqual(0);
+    expect(frameTypes.indexOf("tts_done")).toBeLessThan(
+      frameTypes.indexOf("error"),
+    );
+    const errorFrame = frames.find((frame) => frame.type === "error");
+    if (errorFrame?.type !== "error") {
+      throw new Error("Expected a live voice error frame");
+    }
+    expect(errorFrame.message).toContain("next stt unavailable");
+    expect(
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    ).toBe(true);
+    expect(
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    ).toBe(false);
+  });
+
+  test("stops the late transcriber when the session closes during re-arm", async () => {
+    const secondTranscriber = new MockStreamingTranscriber();
+    let resolveSecond:
+      | ((transcriber: StreamingTranscriber | null) => void)
+      | undefined;
+    let resolverCalls = 0;
+    const resolver: LiveVoiceStreamingTranscriberResolver = mock(() => {
+      resolverCalls += 1;
+      if (resolverCalls === 1) {
+        return Promise.resolve(new MockStreamingTranscriber());
+      }
+      return new Promise<StreamingTranscriber | null>((resolve) => {
+        resolveSecond = resolve;
+      });
+    });
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { context, frames } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    await waitFor(() => resolveSecond !== undefined);
+
+    await session.close("websocket_close");
+    resolveSecond?.(secondTranscriber);
+    await waitFor(() => secondTranscriber.stopped);
+
+    expect(secondTranscriber.started).toBe(false);
+    expect(secondTranscriber.stopped).toBe(true);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+  });
+
   test("returns a readable error frame when streaming STT is unavailable", async () => {
     const { context, frames } = createContext();
     const resolver = mock(async () => null);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -319,6 +319,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
   }
 
+  // Fire-and-forget re-arm: end-of-turn work (terminal frames, archival,
+  // metrics) must never block on the next transcriber's startup. Failures
+  // surface through rearmAfterTurn's error frame.
+  private scheduleRearmAfterTurn(): void {
+    void this.rearmAfterTurn().catch(() => {});
+  }
+
   private async rearmAfterTurn(): Promise<void> {
     if (this.isClosed || this.state === "failed") return;
 
@@ -511,7 +518,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (content.length === 0) {
       utterance.assistantTurnStarted = true;
       await this.finalizePendingUtterance(utterance, "empty_transcript");
-      await this.rearmAfterTurn();
+      this.scheduleRearmAfterTurn();
       return;
     }
 
@@ -639,7 +646,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         )}`,
       });
       await this.finalizePendingUtterance(utterance, "assistant_start_error");
-      await this.rearmAfterTurn();
+      this.scheduleRearmAfterTurn();
     }
   }
 
@@ -659,7 +666,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance) {
       await this.finalizePendingUtterance(utterance, reason);
     }
-    await this.rearmAfterTurn();
+    this.scheduleRearmAfterTurn();
   }
 
   private isActiveAssistantTurn(token: symbol): boolean {
@@ -718,6 +725,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           "completed",
           {
             clearActive: false,
+            rearm: false,
           },
         );
         await this.sendFrame(
@@ -732,6 +740,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           if (currentTurn.handle && currentTurn.finalized) {
             this.activeAssistantTurn = null;
           }
+        }
+
+        // Re-arm only after the terminal tts_done frame so a slow or failing
+        // next transcriber cannot block or precede turn completion. A
+        // cancelled turn re-arms through cancelAssistantTurn instead.
+        if (!currentTurn.abortController.signal.aborted) {
+          this.scheduleRearmAfterTurn();
         }
       });
   }
@@ -888,7 +903,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn: ActiveAssistantTurn,
     status: "completed" | "cancelled",
     reason = "completed",
-    options: { clearActive?: boolean } = {},
+    options: { clearActive?: boolean; rearm?: boolean } = {},
   ): Promise<void> {
     if (turn.finalized) return;
 
@@ -914,7 +929,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.activeAssistantTurn = null;
     }
 
-    await this.rearmAfterTurn();
+    if (options.rearm ?? true) {
+      this.scheduleRearmAfterTurn();
+    }
   }
 
   private async archiveBufferedAudio(input: {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -93,9 +93,39 @@ export interface LiveVoiceSessionOptions {
   createTurnId?: () => string;
 }
 
+type LiveVoiceUtterancePhase =
+  | "pending"
+  | "streaming"
+  | "released"
+  | "transcriber_closed";
+
+// One capture→transcribe→turn cycle. A session runs many of these back to
+// back: each cycle owns its transcriber, transcript, audio buffers, and
+// metrics-turn flags so consecutive turns stay isolated.
+interface UtteranceCycle {
+  phase: LiveVoiceUtterancePhase;
+  released: boolean;
+  assistantTurnStarted: boolean;
+  transcriber: StreamingTranscriber | null;
+  pendingAudioChunks: Buffer[];
+  finalTranscriptSegments: string[];
+  turnId: string | null;
+  userMessageId: string | null;
+  userAudioChunks: Buffer[];
+  metricsTurnStarted: boolean;
+  metricsTurnFinished: boolean;
+}
+
+type UtteranceStartResult =
+  | { status: "started" }
+  | { status: "stale" }
+  | { status: "unavailable"; message: string }
+  | { status: "error"; message: string };
+
 interface ActiveAssistantTurn {
   token: symbol;
   turnId: string;
+  utterance: UtteranceCycle;
   abortController: AbortController;
   handle: VoiceTurnHandle | null;
   assistantCompleted: boolean;
@@ -103,9 +133,7 @@ interface ActiveAssistantTurn {
   finalized: boolean;
   ttsBuffer: string;
   ttsQueue: Promise<void>;
-  userMessageId: string | null;
   assistantMessageId: string | null;
-  userAudioChunks: Buffer[];
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
@@ -122,17 +150,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly createTurnId: () => string;
   private readonly conversationId: string;
   private state: LiveVoiceSessionState = "initializing";
-  private transcriber: StreamingTranscriber | null = null;
-  private readonly finalTranscriptSegments: string[] = [];
+  private currentUtterance: UtteranceCycle | null = null;
   private outboundFrames: Promise<void> = Promise.resolve();
-  private pttReleased = false;
-  private assistantTurnStarted = false;
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
-  private currentTurnId: string | null = null;
-  private currentUserMessageId: string | null = null;
-  private currentUserAudioChunks: Buffer[] = [];
-  private metricsTurnStarted = false;
-  private metricsTurnFinished = false;
   private sessionEndMetricsEmitted = false;
 
   constructor(
@@ -157,56 +177,26 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   get finalTranscriptText(): string {
-    return this.finalTranscriptSegments.join(" ");
+    return this.currentUtterance?.finalTranscriptSegments.join(" ") ?? "";
   }
 
   async start(): Promise<void> {
     if (this.state !== "initializing") return;
 
-    try {
-      const transcriber = await this.resolveTranscriber({
-        sampleRate: this.context.startFrame.audio.sampleRate,
-      });
-
-      if (this.isClosed) {
-        stopTranscriberBestEffort(transcriber);
+    const result = await this.beginUtterance();
+    switch (result.status) {
+      case "stale":
         return;
-      }
-
-      if (!transcriber) {
-        return await this.failStartup(unavailableTranscriberMessage());
-      }
-
-      this.transcriber = transcriber;
-      await transcriber.start((event) => {
-        void this.handleTranscriberEvent(event);
-      });
-
-      if (this.isClosed) {
-        stopTranscriberBestEffort(transcriber);
-        this.transcriber = null;
-        return;
-      }
-
-      this.state = "active";
-      this.metrics.markReady();
-      await this.sendFrame({
-        type: "ready",
-        sessionId: this.context.sessionId,
-        conversationId: this.conversationId,
-      });
-    } catch (err) {
-      if (err instanceof LiveVoiceSessionStartupError) {
-        throw err;
-      }
-
-      stopTranscriberBestEffort(this.transcriber);
-      this.transcriber = null;
-      if (this.isClosed) return;
-
-      await this.failStartup(
-        `Live voice transcription could not be started: ${errorMessage(err)}`,
-      );
+      case "unavailable":
+      case "error":
+        return await this.failStartup(result.message);
+      case "started":
+        this.metrics.markReady();
+        await this.sendFrame({
+          type: "ready",
+          sessionId: this.context.sessionId,
+          conversationId: this.conversationId,
+        });
     }
   }
 
@@ -239,8 +229,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
-    stopTranscriberBestEffort(this.transcriber);
-    this.transcriber = null;
+    const utterance = this.currentUtterance;
+    if (utterance) {
+      stopTranscriberBestEffort(utterance.transcriber);
+      utterance.transcriber = null;
+    }
     await this.cancelAssistantTurn("session_closed");
     if (shouldEmitSessionEndMetrics) {
       await this.emitSessionEndMetrics();
@@ -248,20 +241,123 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.drainOutboundFrames();
   }
 
+  // Creates the next utterance record and arms a fresh streaming transcriber
+  // for it. Called once from start() and again after every finalized turn so
+  // the session cycles: active → utterance_released → transcriber_closed →
+  // (turn) → active.
+  private async beginUtterance(): Promise<UtteranceStartResult> {
+    const utterance: UtteranceCycle = {
+      phase: "pending",
+      released: false,
+      assistantTurnStarted: false,
+      transcriber: null,
+      pendingAudioChunks: [],
+      finalTranscriptSegments: [],
+      turnId: null,
+      userMessageId: null,
+      userAudioChunks: [],
+      metricsTurnStarted: false,
+      metricsTurnFinished: false,
+    };
+    this.currentUtterance = utterance;
+
+    try {
+      const transcriber = await this.resolveTranscriber({
+        sampleRate: this.context.startFrame.audio.sampleRate,
+      });
+
+      if (this.isUtteranceStale(utterance)) {
+        stopTranscriberBestEffort(transcriber);
+        return { status: "stale" };
+      }
+
+      if (!transcriber) {
+        return {
+          status: "unavailable",
+          message: unavailableTranscriberMessage(),
+        };
+      }
+
+      utterance.transcriber = transcriber;
+      await transcriber.start((event) => {
+        void this.handleTranscriberEvent(utterance, event);
+      });
+
+      if (this.isUtteranceStale(utterance)) {
+        stopTranscriberBestEffort(transcriber);
+        utterance.transcriber = null;
+        return { status: "stale" };
+      }
+
+      utterance.phase = "streaming";
+      this.state = "active";
+      await this.flushPendingUtteranceAudio(utterance);
+      if (utterance.released) {
+        await this.stopUtteranceForRelease(utterance);
+      }
+      return { status: "started" };
+    } catch (err) {
+      stopTranscriberBestEffort(utterance.transcriber);
+      utterance.transcriber = null;
+      if (this.isUtteranceStale(utterance)) {
+        return { status: "stale" };
+      }
+      return {
+        status: "error",
+        message: `Live voice transcription could not be started: ${errorMessage(
+          err,
+        )}`,
+      };
+    }
+  }
+
+  private isUtteranceStale(utterance: UtteranceCycle): boolean {
+    return (
+      this.isClosed ||
+      this.state === "failed" ||
+      this.currentUtterance !== utterance
+    );
+  }
+
+  private async rearmAfterTurn(): Promise<void> {
+    if (this.isClosed || this.state === "failed") return;
+
+    const result = await this.beginUtterance();
+    if (result.status === "started" || result.status === "stale") return;
+
+    this.state = "failed";
+    await this.sendFrame({
+      type: "error",
+      code: LiveVoiceProtocolErrorCode.InvalidField,
+      message: result.message,
+    });
+  }
+
   private async handleAudio(chunk: Buffer): Promise<void> {
-    if (
-      this.state === "utterance_released" ||
-      this.state === "transcriber_closed"
-    ) {
+    const utterance = this.currentUtterance;
+    if (!utterance || this.isClosed || this.state === "failed") return;
+
+    if (utterance.released || utterance.phase === "transcriber_closed") {
       await this.sendAudioAfterReleaseError();
       return;
     }
 
-    if (this.state !== "active") return;
+    if (this.state === "initializing") return;
 
-    this.collectUserAudio(chunk);
+    this.collectUserAudio(utterance, chunk);
+    if (utterance.phase === "pending") {
+      utterance.pendingAudioChunks.push(Buffer.from(chunk));
+      return;
+    }
+    await this.forwardAudioToTranscriber(utterance, chunk);
+  }
+
+  private async forwardAudioToTranscriber(
+    utterance: UtteranceCycle,
+    chunk: Buffer,
+  ): Promise<void> {
     try {
-      this.transcriber?.sendAudio(
+      utterance.transcriber?.sendAudio(
         chunk,
         this.context.startFrame.audio.mimeType,
       );
@@ -274,30 +370,51 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
-      await this.finalizePendingTurn("audio_error");
+      await this.finalizePendingUtterance(utterance, "audio_error");
+    }
+  }
+
+  private async flushPendingUtteranceAudio(
+    utterance: UtteranceCycle,
+  ): Promise<void> {
+    const chunks = utterance.pendingAudioChunks.splice(0);
+    for (const chunk of chunks) {
+      await this.forwardAudioToTranscriber(utterance, chunk);
     }
   }
 
   private async releaseUtterance(): Promise<void> {
-    if (this.state === "utterance_released") {
-      return;
-    }
+    const utterance = this.currentUtterance;
+    if (!utterance || this.isClosed || this.state === "failed") return;
 
-    if (this.state === "transcriber_closed") {
-      this.pttReleased = true;
-      this.markPushToTalkReleased();
+    if (utterance.phase === "transcriber_closed") {
+      utterance.released = true;
+      this.markPushToTalkReleased(utterance);
       await this.startAssistantTurnIfReady();
       await this.drainOutboundFrames();
       return;
     }
 
-    if (this.state !== "active") return;
+    if (utterance.released) return;
 
-    this.pttReleased = true;
-    this.markPushToTalkReleased();
+    utterance.released = true;
+    this.markPushToTalkReleased(utterance);
+
+    if (utterance.phase === "pending") {
+      // The transcriber is still starting; beginUtterance completes the release.
+      return;
+    }
+
+    await this.stopUtteranceForRelease(utterance);
+  }
+
+  private async stopUtteranceForRelease(
+    utterance: UtteranceCycle,
+  ): Promise<void> {
+    utterance.phase = "released";
     this.state = "utterance_released";
     try {
-      this.transcriber?.stop();
+      utterance.transcriber?.stop();
     } catch (err) {
       await this.sendFrame({
         type: "error",
@@ -306,6 +423,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
+      utterance.phase = "transcriber_closed";
       this.state = "transcriber_closed";
     }
     await this.startAssistantTurnIfReady();
@@ -313,9 +431,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async handleTranscriberEvent(
+    utterance: UtteranceCycle,
     event: SttStreamServerEvent,
   ): Promise<void> {
     if (
+      this.currentUtterance !== utterance ||
       this.isClosed ||
       this.state === "failed" ||
       this.state === "interrupted"
@@ -325,15 +445,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     switch (event.type) {
       case "partial":
-        this.markFirstPartial();
+        this.markFirstPartial(utterance);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
       case "final": {
         const transcript = event.text.trim();
         if (transcript.length > 0) {
-          this.finalTranscriptSegments.push(transcript);
+          utterance.finalTranscriptSegments.push(transcript);
         }
-        this.markFinalTranscript();
+        this.markFinalTranscript(utterance);
         await this.sendFrame({ type: "stt_final", text: event.text });
         await this.startAssistantTurnIfReady();
         return;
@@ -350,11 +470,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         });
         return;
       case "closed":
-        if (!this.isClosed) {
-          this.state = "transcriber_closed";
-          this.transcriber = null;
-          await this.startAssistantTurnIfReady();
-        }
+        utterance.phase = "transcriber_closed";
+        utterance.transcriber = null;
+        this.state = "transcriber_closed";
+        await this.startAssistantTurnIfReady();
         return;
     }
   }
@@ -363,40 +482,48 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (this.isClosed || this.state === "failed") return;
 
     this.state = "interrupted";
-    stopTranscriberBestEffort(this.transcriber);
-    this.transcriber = null;
+    const utterance = this.currentUtterance;
+    if (utterance) {
+      stopTranscriberBestEffort(utterance.transcriber);
+      utterance.transcriber = null;
+    }
     await this.cancelAssistantTurn("interrupt");
     await this.drainOutboundFrames();
   }
 
   private async startAssistantTurnIfReady(): Promise<void> {
+    const utterance = this.currentUtterance;
     if (
-      !this.pttReleased ||
-      this.assistantTurnStarted ||
+      !utterance ||
+      !utterance.released ||
+      utterance.assistantTurnStarted ||
       this.isClosed ||
       this.state === "failed"
     ) {
       return;
     }
-    if (this.state !== "transcriber_closed") {
+    if (utterance.phase !== "transcriber_closed") {
       return;
     }
     if (!this.startVoiceTurn) return;
 
-    const content = this.finalTranscriptText.trim();
+    const content = utterance.finalTranscriptSegments.join(" ").trim();
     if (content.length === 0) {
-      await this.finalizePendingTurn("empty_transcript");
+      utterance.assistantTurnStarted = true;
+      await this.finalizePendingUtterance(utterance, "empty_transcript");
+      await this.rearmAfterTurn();
       return;
     }
 
-    this.assistantTurnStarted = true;
+    utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
-    const turnId = this.ensureTurnId();
-    this.startMetricsTurnIfNeeded(turnId);
+    const turnId = this.ensureTurnId(utterance);
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     const abortController = new AbortController();
     this.activeAssistantTurn = {
       token,
       turnId,
+      utterance,
       abortController,
       handle: null,
       assistantCompleted: false,
@@ -404,9 +531,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       finalized: false,
       ttsBuffer: "",
       ttsQueue: Promise.resolve(),
-      userMessageId: this.currentUserMessageId,
       assistantMessageId: null,
-      userAudioChunks: this.currentUserAudioChunks,
       assistantAudioChunks: [],
       assistantAudioMimeType: "audio/pcm",
     };
@@ -431,7 +556,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) return;
-            this.markFirstAssistantDelta(turnId);
+            this.markFirstAssistantDelta(utterance, turnId);
             void this.sendFrame({
               type: "assistant_text_delta",
               text: msg.text,
@@ -462,8 +587,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           persisted_user_message_id: (messageId) => {
             const activeTurn = this.activeAssistantTurn;
             if (activeTurn?.token !== token) return;
-            activeTurn.userMessageId = messageId;
-            this.currentUserMessageId = messageId;
+            activeTurn.utterance.userMessageId = messageId;
           },
           persisted_assistant_message_id: (messageId) => {
             const activeTurn = this.activeAssistantTurn;
@@ -514,21 +638,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
-      await this.finalizePendingTurn("assistant_start_error");
+      await this.finalizePendingUtterance(utterance, "assistant_start_error");
+      await this.rearmAfterTurn();
     }
   }
 
   private async cancelAssistantTurn(reason: string): Promise<void> {
     const turn = this.activeAssistantTurn;
-    if (!turn) {
-      await this.finalizePendingTurn(reason);
-      return;
+    this.activeAssistantTurn = null;
+    if (turn) {
+      turn.abortController.abort();
+      turn.handle?.abort();
+      if (!turn.finalized) {
+        await this.finalizeAssistantTurn(turn, "cancelled", reason);
+        return;
+      }
     }
 
-    this.activeAssistantTurn = null;
-    turn.abortController.abort();
-    turn.handle?.abort();
-    await this.finalizeAssistantTurn(turn, "cancelled", reason);
+    const utterance = this.currentUtterance;
+    if (utterance) {
+      await this.finalizePendingUtterance(utterance, reason);
+    }
+    await this.rearmAfterTurn();
   }
 
   private isActiveAssistantTurn(token: symbol): boolean {
@@ -686,62 +817,71 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       });
   }
 
-  private collectUserAudio(chunk: Buffer): void {
-    const turnId = this.ensureTurnId();
-    this.currentUserAudioChunks.push(Buffer.from(chunk));
-    this.startMetricsTurnIfNeeded(turnId);
+  private collectUserAudio(utterance: UtteranceCycle, chunk: Buffer): void {
+    const turnId = this.ensureTurnId(utterance);
+    utterance.userAudioChunks.push(Buffer.from(chunk));
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     this.metrics.markFirstAudio(turnId);
   }
 
-  private markPushToTalkReleased(): void {
-    const turnId = this.ensureTurnId();
-    this.startMetricsTurnIfNeeded(turnId);
+  private markPushToTalkReleased(utterance: UtteranceCycle): void {
+    const turnId = this.ensureTurnId(utterance);
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     this.metrics.markPushToTalkRelease(turnId);
   }
 
-  private markFirstPartial(): void {
-    const turnId = this.ensureTurnId();
-    this.startMetricsTurnIfNeeded(turnId);
+  private markFirstPartial(utterance: UtteranceCycle): void {
+    const turnId = this.ensureTurnId(utterance);
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     this.metrics.markFirstPartial(turnId);
   }
 
-  private markFinalTranscript(): void {
-    const turnId = this.ensureTurnId();
-    this.startMetricsTurnIfNeeded(turnId);
+  private markFinalTranscript(utterance: UtteranceCycle): void {
+    const turnId = this.ensureTurnId(utterance);
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     this.metrics.markFinalTranscript(turnId);
   }
 
-  private markFirstAssistantDelta(turnId: string): void {
-    this.startMetricsTurnIfNeeded(turnId);
+  private markFirstAssistantDelta(
+    utterance: UtteranceCycle,
+    turnId: string,
+  ): void {
+    this.startMetricsTurnIfNeeded(utterance, turnId);
     this.metrics.markFirstAssistantDelta(turnId);
   }
 
-  private ensureTurnId(): string {
-    if (!this.currentTurnId) {
-      this.currentTurnId = this.createTurnId();
+  private ensureTurnId(utterance: UtteranceCycle): string {
+    if (!utterance.turnId) {
+      utterance.turnId = this.createTurnId();
     }
-    return this.currentTurnId;
+    return utterance.turnId;
   }
 
-  private startMetricsTurnIfNeeded(turnId: string): void {
-    if (this.metricsTurnStarted || this.metricsTurnFinished) return;
+  private startMetricsTurnIfNeeded(
+    utterance: UtteranceCycle,
+    turnId: string,
+  ): void {
+    if (utterance.metricsTurnStarted || utterance.metricsTurnFinished) return;
     this.metrics.startTurn(turnId);
-    this.metricsTurnStarted = true;
+    utterance.metricsTurnStarted = true;
   }
 
-  private async finalizePendingTurn(reason: string): Promise<void> {
-    const turnId = this.currentTurnId;
+  private async finalizePendingUtterance(
+    utterance: UtteranceCycle,
+    reason: string,
+  ): Promise<void> {
+    const turnId = utterance.turnId;
     if (!turnId) return;
 
     await this.archiveBufferedAudio({
       turnId,
-      userMessageId: this.currentUserMessageId,
+      userMessageId: utterance.userMessageId,
       assistantMessageId: null,
-      userAudioChunks: this.currentUserAudioChunks,
+      userAudioChunks: utterance.userAudioChunks,
       assistantAudioChunks: [],
       assistantAudioMimeType: "audio/pcm",
     });
-    await this.finishMetricsTurn("cancelled", reason, turnId);
+    await this.finishMetricsTurn(utterance, "cancelled", reason, turnId);
   }
 
   private async finalizeAssistantTurn(
@@ -755,16 +895,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn.finalized = true;
     await this.archiveBufferedAudio({
       turnId: turn.turnId,
-      userMessageId: turn.userMessageId,
+      userMessageId: turn.utterance.userMessageId,
       assistantMessageId: turn.assistantMessageId,
-      userAudioChunks: turn.userAudioChunks,
+      userAudioChunks: turn.utterance.userAudioChunks,
       assistantAudioChunks: turn.assistantAudioChunks,
       assistantAudioMimeType: turn.assistantAudioMimeType,
       ...(turn.assistantAudioSampleRate !== undefined
         ? { assistantAudioSampleRate: turn.assistantAudioSampleRate }
         : {}),
     });
-    await this.finishMetricsTurn(status, reason, turn.turnId);
+    await this.finishMetricsTurn(turn.utterance, status, reason, turn.turnId);
 
     if (
       (options.clearActive ?? true) &&
@@ -773,6 +913,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       this.activeAssistantTurn = null;
     }
+
+    await this.rearmAfterTurn();
   }
 
   private async archiveBufferedAudio(input: {
@@ -885,18 +1027,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async finishMetricsTurn(
+    utterance: UtteranceCycle,
     status: "completed" | "cancelled",
     reason: string,
     turnId: string,
   ): Promise<void> {
-    if (!this.metricsTurnStarted || this.metricsTurnFinished) return;
+    if (!utterance.metricsTurnStarted || utterance.metricsTurnFinished) return;
 
     if (status === "completed") {
       this.metrics.completeTurn(turnId);
     } else {
       this.metrics.cancelTurn(reason, turnId);
     }
-    this.metricsTurnFinished = true;
+    utterance.metricsTurnFinished = true;
 
     if (!this.emitMetrics) return;
     await this.emitMetricsFrame(
@@ -914,7 +1057,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async emitMetricsFrame(
     event: LiveVoiceMetricsEvent,
-    turnId = this.currentTurnId ?? this.context.sessionId,
+    turnId = this.currentUtterance?.turnId ?? this.context.sessionId,
   ): Promise<void> {
     const metrics = this.metrics.getSnapshot();
     await this.sendFrame({


### PR DESCRIPTION
## Summary
- Extracts per-utterance state into a beginUtterance() cycle so a LiveVoiceSession can run many utterance→turn rounds on one socket (each with a fresh streaming transcriber), instead of dying after the first turn.
- Single-turn wire behavior is unchanged; archival and metrics are keyed per turn.

Part of plan: live-voice-server-barge-in.md (PR 7 of 11)