### PR TITLE
feat(assistant): reconcile plugins from the source-versions sentinel; hook dispatch goes memory-only

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -1,11 +1,13 @@
 /**
- * Tests for the per-surface mtime cache — the pull-based replacement for
- * PluginSourceWatcher.
+ * Tests for the plugin cache orchestrator: boot discovery plus the
+ * source-versions reconcile that drives every steady-state change.
  *
  * Each test materializes a synthetic plugin directory under a per-file
- * tempdir, then exercises observable behavior: cache hit (same mtime),
- * cache miss (changed mtime → re-import), plugin deletion (eviction),
- * and hook collection across multiple plugins.
+ * tempdir. Changes are published the way production publishes them — by
+ * running the resource monitor's watcher pass over the same workspace — and
+ * observed the way production observes them: a hook dispatch, whose
+ * sentinel check applies the published diff. This makes the suite an
+ * end-to-end exercise of detector → sentinel → reconcile → redeploy.
  */
 import {
   existsSync,
@@ -28,12 +30,18 @@ import {
 
 import { _inspectHookCacheForTests } from "../hooks/hook-loader.js";
 import {
+  createSourceWatchState,
+  runSourceWatchPass,
+  type SourceWatchState,
+} from "../monitoring/plugin-source-watch.js";
+import {
   _inspectToolCacheForTests,
   getCachedUserTools,
   getUserHooksFor,
   populateCacheAtBoot,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
+import { getSourceVersionsPath } from "../plugins/source-versions.js";
 import {
   getAllToolDefinitions,
   getPluginToolDefinitions,
@@ -123,6 +131,33 @@ const SIMPLE_PKG = {
   peerDependencies: { "@vellumai/plugin-api": "*" },
 };
 
+/**
+ * Watcher state shared by a test's publishes, reset per test so each test's
+ * first publish takes a fresh baseline (adopting any sentinel on disk).
+ */
+let watchState: SourceWatchState | null = null;
+
+/** Strictly increasing mtime offset for sentinel touches within one test. */
+let sentinelTouchSeq = 0;
+
+/**
+ * Publish pending source changes exactly the way production does: one pass
+ * of the resource monitor's watcher over this workspace. When the pass
+ * rewrites the sentinel, its mtime is bumped to a strictly increasing
+ * timestamp so the daemon's one-stat gate observes every publish even when
+ * two land inside the same filesystem-timestamp granule.
+ */
+function publishSourceChanges(): boolean {
+  if (watchState === null) {
+    watchState = createSourceWatchState();
+  }
+  const wrote = runSourceWatchPass(watchState);
+  if (wrote) {
+    touchFile(getSourceVersionsPath(), (sentinelTouchSeq += 2));
+  }
+  return wrote;
+}
+
 // ─── Setup / teardown ────────────────────────────────────────────────────────
 
 beforeAll(() => {
@@ -132,6 +167,9 @@ beforeAll(() => {
 beforeEach(() => {
   ensurePluginsDir();
   ensureWorkspaceHooksDir();
+  rmSync(getSourceVersionsPath(), { force: true });
+  watchState = null;
+  sentinelTouchSeq = 0;
   resetPluginCacheForTests();
 });
 
@@ -157,53 +195,54 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(hooks).toHaveLength(1);
   });
 
-  test("cache hit: same mtime does not re-import", async () => {
+  test("dispatch serves the cache and ignores disk changes until published", async () => {
     const dir = freshPluginDir("cached-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "cached-plugin" });
-    writeHook(
-      dir,
-      "user-prompt-submit",
-      `export default () => ({ count: 1 });`,
-    );
+    writeHook(dir, "user-prompt-submit", `export default () => "v1";`);
 
     await populateCacheAtBoot();
+    const first = (await getUserHooksFor("user-prompt-submit"))[0];
 
-    const cacheBefore = _inspectHookCacheForTests();
-    expect(cacheBefore).toHaveLength(1);
+    // Edit lands on disk but the watcher hasn't published — dispatch keeps
+    // serving the exact cached function, proving it never re-scans.
+    const hookFile = join(dir, "hooks", "user-prompt-submit.ts");
+    writeFileSync(hookFile, `export default () => "v2";`);
+    touchFile(hookFile);
 
-    // Read again — same mtime, no re-import.
-    await getUserHooksFor("user-prompt-submit");
-
-    const cacheAfter = _inspectHookCacheForTests();
-    expect(cacheAfter).toHaveLength(1);
-    expect(cacheAfter[0]?.sourceMtime).toBe(cacheBefore[0]?.sourceMtime);
+    const again = (await getUserHooksFor("user-prompt-submit"))[0];
+    expect(again).toBe(first!);
+    expect((again as unknown as () => string)()).toBe("v1");
   });
 
-  test("cache miss: editing a hook file triggers re-import", async () => {
+  test("an edited hook takes effect once the watcher publishes", async () => {
     const dir = freshPluginDir("rebuild-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "rebuild-plugin" });
     const hookFile = join(dir, "hooks", "user-prompt-submit.ts");
-    writeHook(
-      dir,
-      "user-prompt-submit",
-      `export default () => ({ count: 1 });`,
-    );
+    writeHook(dir, "user-prompt-submit", `export default () => "v1";`);
 
     await populateCacheAtBoot();
+    expect(
+      (
+        (
+          await getUserHooksFor("user-prompt-submit")
+        )[0] as unknown as () => string
+      )(),
+    ).toBe("v1");
 
-    const mtimeBefore = _inspectHookCacheForTests()[0]?.sourceMtime;
-
-    // Touch the hook file to bump its mtime.
+    writeFileSync(hookFile, `export default () => "v2";`);
     touchFile(hookFile);
+    expect(publishSourceChanges()).toBe(true);
 
-    // Read again — mtime changed, re-import.
-    await getUserHooksFor("user-prompt-submit");
-
-    const mtimeAfter = _inspectHookCacheForTests()[0]?.sourceMtime;
-    expect(mtimeAfter).not.toBe(mtimeBefore);
+    expect(
+      (
+        (
+          await getUserHooksFor("user-prompt-submit")
+        )[0] as unknown as () => string
+      )(),
+    ).toBe("v2");
   });
 
-  test("plugin deletion: removing directory evicts cache entries", async () => {
+  test("plugin deletion: a published removal evicts cache entries", async () => {
     const dir = freshPluginDir("deletable-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "deletable-plugin" });
     writeHook(
@@ -215,16 +254,16 @@ describe("plugin mtime cache (per-surface)", () => {
     await populateCacheAtBoot();
     expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
 
-    // Delete the plugin directory.
     rmSync(dir, { recursive: true, force: true });
+    publishSourceChanges();
 
-    // Read again — plugin gone, hooks evicted.
     const hooks = await getUserHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(0);
 
-    const cacheState = _inspectHookCacheForTests();
     expect(
-      cacheState.find((c) => c.key.startsWith("deletable-plugin/")),
+      _inspectHookCacheForTests().find((key) =>
+        key.startsWith("deletable-plugin/"),
+      ),
     ).toBeUndefined();
   });
 
@@ -261,7 +300,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(hooks).toHaveLength(0);
   });
 
-  test("getUserHooksFor detects newly added plugin without restart", async () => {
+  test("getUserHooksFor detects a newly added plugin once published", async () => {
     const dir1 = freshPluginDir("existing-plugin");
     writePackageJson(dir1, { ...SIMPLE_PKG, name: "existing-plugin" });
     writeHook(dir1, "user-prompt-submit", `export default () => ({ v: 1 });`);
@@ -269,12 +308,12 @@ describe("plugin mtime cache (per-surface)", () => {
     await populateCacheAtBoot();
     expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
 
-    // Add a new plugin directory after boot.
+    // Add a new plugin directory after boot and publish it.
     const dir2 = freshPluginDir("new-plugin");
     writePackageJson(dir2, { ...SIMPLE_PKG, name: "new-plugin" });
     writeHook(dir2, "user-prompt-submit", `export default () => ({ v: 2 });`);
+    publishSourceChanges();
 
-    // The next read should pick it up.
     const hooks = await getUserHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(2);
   });
@@ -295,32 +334,37 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(tools[0]?.name).toBe("my-tool");
   });
 
-  test("editing a tool file triggers re-import on next scan", async () => {
+  test("an edited tool serves its new definition once published", async () => {
     const dir = freshPluginDir("tool-edit-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "tool-edit-plugin" });
-    const toolFile = join(dir, "tools", "my-tool.ts");
+    // Unique tool name: the global tool registry is process-wide state that
+    // survives the per-test cache reset, so a name shared with another test
+    // would resolve to that test's stale registration.
+    const toolFile = join(dir, "tools", "edited-tool.ts");
     writeTool(
       dir,
-      "my-tool",
-      `export default { name: "my-tool", description: "v1", parameters: { type: "object", properties: {} } };`,
+      "edited-tool",
+      `export default { name: "edited-tool", description: "v1", parameters: { type: "object", properties: {} } };`,
     );
 
     await populateCacheAtBoot();
+    expect(getCachedUserTools()[0]?.description).toBe("v1");
 
-    const mtimeBefore = _inspectToolCacheForTests()[0]?.sourceMtime;
-
-    // Edit the tool file and bump mtime.
     writeFileSync(
       toolFile,
-      `export default { name: "my-tool", description: "v2", parameters: { type: "object", properties: {} } };`,
+      `export default { name: "edited-tool", description: "v2", parameters: { type: "object", properties: {} } };`,
     );
     touchFile(toolFile);
-
-    // Trigger a scan by calling getUserHooksFor (which calls scanPlugins).
+    publishSourceChanges();
     await getUserHooksFor("user-prompt-submit");
 
-    const mtimeAfter = _inspectToolCacheForTests()[0]?.sourceMtime;
-    expect(mtimeAfter).not.toBe(mtimeBefore);
+    // Both the cache and the global registry serve the fresh definition —
+    // the redeploy unregistered the old tool and registered the new one.
+    expect(getCachedUserTools()[0]?.description).toBe("v2");
+    expect(
+      getAllToolDefinitions().find((t) => t.name === "edited-tool")
+        ?.description,
+    ).toBe("v2");
   });
 
   test("plugin with no package.json is skipped", async () => {
@@ -465,27 +509,29 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     expect(results[1]!.tag).toBe("workspace");
   });
 
-  test("editing a workspace hook file triggers re-import", async () => {
+  test("an edited workspace hook takes effect once published", async () => {
     const hookFile = join(WORKSPACE_HOOKS_DIR, "post-model-call.ts");
-    writeWorkspaceHook("post-model-call", `export default () => ({ v: 1 });`);
+    writeWorkspaceHook("post-model-call", `export default () => "ws-v1";`);
 
     await populateCacheAtBoot();
+    expect(
+      (
+        (await getUserHooksFor("post-model-call"))[0] as unknown as () => string
+      )(),
+    ).toBe("ws-v1");
 
-    const before = _inspectHookCacheForTests().find((c) =>
-      c.key.startsWith("__workspace__/"),
-    );
-    expect(before).toBeDefined();
-
+    writeFileSync(hookFile, `export default () => "ws-v2";`);
     touchFile(hookFile);
-    await getUserHooksFor("post-model-call");
+    publishSourceChanges();
 
-    const after = _inspectHookCacheForTests().find((c) =>
-      c.key.startsWith("__workspace__/"),
-    );
-    expect(after?.sourceMtime).not.toBe(before?.sourceMtime);
+    expect(
+      (
+        (await getUserHooksFor("post-model-call"))[0] as unknown as () => string
+      )(),
+    ).toBe("ws-v2");
   });
 
-  test("deleting a workspace hook file evicts it on next read", async () => {
+  test("deleting a workspace hook file evicts it once published", async () => {
     const hookFile = join(WORKSPACE_HOOKS_DIR, "stop.ts");
     writeWorkspaceHook("stop", `export default () => ({ v: 1 });`);
 
@@ -493,16 +539,18 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     expect(await getUserHooksFor("stop")).toHaveLength(1);
 
     rmSync(hookFile, { force: true });
+    publishSourceChanges();
 
     const hooks = await getUserHooksFor("stop");
     expect(hooks).toHaveLength(0);
   });
 
-  test("a newly added workspace hook is picked up without restart", async () => {
+  test("a newly added workspace hook is picked up once published", async () => {
     await populateCacheAtBoot();
     expect(await getUserHooksFor("post-compact")).toHaveLength(0);
 
     writeWorkspaceHook("post-compact", `export default () => ({ v: 1 });`);
+    publishSourceChanges();
 
     expect(await getUserHooksFor("post-compact")).toHaveLength(1);
   });
@@ -549,17 +597,19 @@ const TOOL_SRC = (name: string) =>
   `export default { name: ${JSON.stringify(name)}, description: "test", parameters: { type: "object", properties: {} } };`;
 
 /**
- * Simulate the per-turn plugin hook dispatch that drives runtime reconciliation
- * in production: any `getUserHooksFor` call runs `scanPlugins`, which activates
- * newly present plugins and deactivates removed ones. The hook name is
- * irrelevant — the scan runs regardless of whether a plugin defines that hook.
+ * Publish pending source changes through the watcher, then dispatch — the
+ * production sequence: the monitor's pass rewrites the sentinel, and the
+ * next hook dispatch's one-stat gate applies the diff. The hook name is
+ * irrelevant — the reconcile runs regardless of whether a plugin defines
+ * that hook.
  */
-async function triggerScan(): Promise<void> {
+async function publishAndDispatch(): Promise<void> {
+  publishSourceChanges();
   await getUserHooksFor("user-prompt-submit");
 }
 
 describe("plugin runtime activation", () => {
-  test("a plugin installed after boot becomes live on the next scan", async () => {
+  test("a plugin installed after boot becomes live once published", async () => {
     await populateCacheAtBoot(); // empty plugins dir
     expect(getAllToolDefinitions().some((t) => t.name === "late-tool")).toBe(
       false,
@@ -571,7 +621,7 @@ describe("plugin runtime activation", () => {
     const initMarker = join(ROOT, "late-init.log");
     writeMarkerHook(dir, "init", initMarker, "init");
 
-    await triggerScan();
+    await publishAndDispatch();
 
     // Registered into the global registry as a plugin-owned tool, and exposed
     // to the per-turn resolver via getPluginToolDefinitions().
@@ -589,7 +639,7 @@ describe("plugin runtime activation", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
-  test("activation is idempotent — repeated scans do not re-run init", async () => {
+  test("activation is idempotent — republishing without changes does not re-run init", async () => {
     const dir = freshPluginDir("idem-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "idem-plugin" });
     writeTool(dir, "idem-tool", TOOL_SRC("idem-tool"));
@@ -597,8 +647,8 @@ describe("plugin runtime activation", () => {
     writeMarkerHook(dir, "init", initMarker, "init");
 
     await populateCacheAtBoot();
-    await triggerScan();
-    await triggerScan();
+    await publishAndDispatch();
+    await publishAndDispatch();
 
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
     // Registered exactly once (no refcount inflation from re-registration).
@@ -619,7 +669,7 @@ describe("plugin runtime activation", () => {
     expect(getToolOwner("temp-tool")?.kind).toBe("plugin");
 
     rmSync(dir, { recursive: true, force: true });
-    await triggerScan();
+    await publishAndDispatch();
 
     expect(getToolOwner("temp-tool")).toBeUndefined();
     expect(getPluginToolDefinitions().some((t) => t.name === "temp-tool")).toBe(
@@ -656,8 +706,143 @@ describe("plugin runtime activation", () => {
     expect(getToolOwner("disable-tool")?.kind).toBe("plugin");
 
     writeFileSync(join(dir, ".disabled"), "");
-    await triggerScan();
+    await publishAndDispatch();
 
     expect(getToolOwner("disable-tool")).toBeUndefined();
+  });
+});
+
+// ─── Live reload (sentinel-driven redeploy) ──────────────────────────────────
+
+/** Write a helper module at `relPath` inside a plugin dir. */
+function writeLibFile(dir: string, relPath: string, body: string): string {
+  const path = join(dir, relPath);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, body);
+  return path;
+}
+
+/** Dispatch `hookName` and return the single expected hook's result. */
+async function dispatchFirst(hookName: string): Promise<unknown> {
+  const hooks = await getUserHooksFor(hookName);
+  expect(hooks).toHaveLength(1);
+  return (hooks[0] as unknown as () => unknown)();
+}
+
+describe("live reload (sentinel-driven redeploy)", () => {
+  test("editing a helper imported by a hook redeploys the plugin, repeatably", async () => {
+    const dir = freshPluginDir("helper-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "helper-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = "v1";`,
+    );
+    writeHook(
+      dir,
+      "helper-reload",
+      `import { value } from "../lib/helper.ts";\nexport default () => value;`,
+    );
+
+    await populateCacheAtBoot();
+    expect(await dispatchFirst("helper-reload")).toBe("v1");
+
+    // Only the helper changes — the hook file's own mtime never moves, so
+    // any per-entry-file scheme would keep serving v1 here. And a reloaded
+    // plugin must itself stay reloadable.
+    for (const marker of ["v2", "v3"]) {
+      writeFileSync(
+        helperPath,
+        `export const value = ${JSON.stringify(marker)};`,
+      );
+      touchFile(helperPath, sentinelTouchSeq + 2);
+      publishSourceChanges();
+      expect(await dispatchFirst("helper-reload")).toBe(marker);
+    }
+  });
+
+  test("editing a transitive helper (hook → a → b) redeploys consistently", async () => {
+    const dir = freshPluginDir("transitive-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "transitive-plugin" });
+    const bPath = writeLibFile(
+      dir,
+      join("lib", "b.ts"),
+      `export const leaf = "b1";`,
+    );
+    writeLibFile(
+      dir,
+      join("lib", "a.ts"),
+      `import { leaf } from "./b.ts";\nexport const mid = "a:" + leaf;`,
+    );
+    writeHook(
+      dir,
+      "transitive-reload",
+      `import { mid } from "../lib/a.ts";\nexport default () => mid;`,
+    );
+
+    await populateCacheAtBoot();
+    expect(await dispatchFirst("transitive-reload")).toBe("a:b1");
+
+    // The intermediate module `a` is untouched. Whole-plugin eviction is
+    // what keeps a re-imported hook from pairing with a's stale cached
+    // binding to the old `b`.
+    writeFileSync(bPath, `export const leaf = "b2";`);
+    touchFile(bPath, sentinelTouchSeq + 2);
+    publishSourceChanges();
+    expect(await dispatchFirst("transitive-reload")).toBe("a:b2");
+  });
+
+  test("a reload runs the old shutdown (reason: reload) and the new init", async () => {
+    const dir = freshPluginDir("lifecycle-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "lifecycle-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = 1;`,
+    );
+    const initMarker = join(ROOT, "reload-init.log");
+    const shutdownMarker = join(ROOT, "reload-shutdown.log");
+    rmSync(initMarker, { force: true });
+    rmSync(shutdownMarker, { force: true });
+    writeMarkerHook(dir, "init", initMarker, "init");
+    writeHook(
+      dir,
+      "shutdown",
+      `import { appendFileSync } from "node:fs";\nexport default (ctx: { reason: string }) => { appendFileSync(${JSON.stringify(shutdownMarker)}, ctx.reason + "\\n"); };`,
+    );
+
+    await populateCacheAtBoot();
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+    expect(existsSync(shutdownMarker)).toBe(false);
+
+    writeFileSync(helperPath, `export const value = 2;`);
+    touchFile(helperPath, sentinelTouchSeq + 2);
+    await publishAndDispatch();
+
+    // The edit is a redeploy: old version torn down with reason "reload",
+    // new version brought up through the same init path as boot.
+    expect(readFileSync(shutdownMarker, "utf8").trim().split("\n")).toEqual([
+      "reload",
+    ]);
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
+  });
+
+  test("boot adopts a pre-existing sentinel without spurious redeploys", async () => {
+    const dir = freshPluginDir("adopt-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "adopt-plugin" });
+    writeLibFile(dir, join("lib", "helper.ts"), `export const v = 1;`);
+    const initMarker = join(ROOT, "adopt-init.log");
+    rmSync(initMarker, { force: true });
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    // The watcher published before the daemon booted.
+    publishSourceChanges();
+
+    await populateCacheAtBoot();
+    await getUserHooksFor("user-prompt-submit");
+    await getUserHooksFor("user-prompt-submit");
+
+    // One init: the sentinel matching boot's own walk must not redeploy.
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 });

--- a/assistant/src/__tests__/plugin-config-data-migration.test.ts
+++ b/assistant/src/__tests__/plugin-config-data-migration.test.ts
@@ -26,15 +26,13 @@ import {
   test,
 } from "bun:test";
 
-import {
-  computeFingerprint,
-  PRESERVED_ENTRIES,
-} from "../cli/lib/plugin-fingerprint.js";
+import { computeFingerprint } from "../cli/lib/plugin-fingerprint.js";
 import { resetHookCacheForTests } from "../hooks/hook-loader.js";
 import {
   populateCacheAtBoot,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
+import { PRESERVED_ENTRIES } from "../plugins/plugin-tree-walk.js";
 
 const ROOT = join(
   tmpdir(),

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -34,7 +34,7 @@ mock.module("../daemon/conversation-plugin-scope.js", () => ({
   resolveConversationPluginScope: (id: string) => resolveScopeMock(id),
 }));
 
-import { collectUserHooks } from "../hooks/hook-loader.js";
+import { collectUserHooks, preImportHooksDir } from "../hooks/hook-loader.js";
 import { getHooksFor } from "../hooks/registry.js";
 import {
   registerPlugin,
@@ -149,7 +149,9 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  function pluginDirWithHook(name: string): string {
+  // Hooks enter the dispatch cache at owner activation (preImportHooksDir),
+  // so the fixture activates each plugin the way the orchestrator would.
+  async function pluginDirWithHook(name: string): Promise<string> {
     const dir = join(root, name);
     const hooksDir = join(dir, "hooks");
     mkdirSync(hooksDir, { recursive: true });
@@ -157,13 +159,14 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
       join(hooksDir, "user-prompt-submit.ts"),
       "export default () => ({});\n",
     );
+    await preImportHooksDir(hooksDir, name);
     return dir;
   }
 
   test("null set runs both user plugins' hooks (unchanged)", async () => {
     const dirs: Array<readonly [string, string]> = [
-      [pluginDirWithHook("uplug-a"), "uplug-a"],
-      [pluginDirWithHook("uplug-b"), "uplug-b"],
+      [await pluginDirWithHook("uplug-a"), "uplug-a"],
+      [await pluginDirWithHook("uplug-b"), "uplug-b"],
     ];
 
     expect(await collectUserHooks("user-prompt-submit", dirs)).toHaveLength(2);
@@ -174,8 +177,8 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
 
   test("a set excluding plugin b drops b's user-land hook", async () => {
     const dirs: Array<readonly [string, string]> = [
-      [pluginDirWithHook("uplug-a"), "uplug-a"],
-      [pluginDirWithHook("uplug-b"), "uplug-b"],
+      [await pluginDirWithHook("uplug-a"), "uplug-a"],
+      [await pluginDirWithHook("uplug-b"), "uplug-b"],
     ];
 
     expect(

--- a/assistant/src/cli/lib/__tests__/confirm-prompt.test.ts
+++ b/assistant/src/cli/lib/__tests__/confirm-prompt.test.ts
@@ -23,7 +23,7 @@ function buildStreams(): Captured {
 }
 
 describe("confirmPrompt", () => {
-  test("returns \"non-interactive\" without reading when isTTY=false", async () => {
+  test('returns "non-interactive" without reading when isTTY=false', async () => {
     const { stdin, stdout, stderr, outChunks, errChunks } = buildStreams();
     const result = await confirmPrompt({
       question: "Delete? [y/N] ",
@@ -38,7 +38,7 @@ describe("confirmPrompt", () => {
     expect(outChunks.join("")).toBe("");
   });
 
-  test("returns \"confirmed\" for \"y\\n\"", async () => {
+  test('returns "confirmed" for "y\\n"', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -52,7 +52,7 @@ describe("confirmPrompt", () => {
     expect(await pending).toBe("confirmed");
   });
 
-  test("returns \"confirmed\" for \"yes\\n\" (case-insensitive, whitespace-tolerant)", async () => {
+  test('returns "confirmed" for "yes\\n" (case-insensitive, whitespace-tolerant)', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -66,7 +66,7 @@ describe("confirmPrompt", () => {
     expect(await pending).toBe("confirmed");
   });
 
-  test("returns \"denied\" for \"n\\n\"", async () => {
+  test('returns "denied" for "n\\n"', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -80,7 +80,7 @@ describe("confirmPrompt", () => {
     expect(await pending).toBe("denied");
   });
 
-  test("returns \"denied\" for empty input (just Enter)", async () => {
+  test('returns "denied" for empty input (just Enter)', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -94,7 +94,7 @@ describe("confirmPrompt", () => {
     expect(await pending).toBe("denied");
   });
 
-  test("returns \"denied\" on EOF without any data (regression: would have hung)", async () => {
+  test('returns "denied" on EOF without any data (regression: would have hung)', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -108,7 +108,7 @@ describe("confirmPrompt", () => {
     expect(await pending).toBe("denied");
   });
 
-  test("returns \"denied\" on EOF after a partial line with no newline", async () => {
+  test('returns "denied" on EOF after a partial line with no newline', async () => {
     const { stdin, stdout, stderr } = buildStreams();
     const pending = confirmPrompt({
       question: "Delete? [y/N] ",
@@ -131,7 +131,7 @@ describe("confirmPrompt", () => {
   test("writes the question to stdout when interactive", async () => {
     const { stdin, stdout, stderr, outChunks } = buildStreams();
     const pending = confirmPrompt({
-      question: "Delete plugin \"foo\"? [y/N] ",
+      question: 'Delete plugin "foo"? [y/N] ',
       isTTY: true,
       refuseNonInteractiveMessage: "n/a",
       stdin,
@@ -140,7 +140,7 @@ describe("confirmPrompt", () => {
     });
     stdin.write("n\n");
     await pending;
-    expect(outChunks.join("")).toContain("Delete plugin \"foo\"? [y/N] ");
+    expect(outChunks.join("")).toContain('Delete plugin "foo"? [y/N] ');
   });
 
   test("treats stray garbage as denial, never confirmation", async () => {

--- a/assistant/src/cli/lib/diff-plugin.ts
+++ b/assistant/src/cli/lib/diff-plugin.ts
@@ -38,6 +38,7 @@ import { join } from "node:path";
 
 import { createTwoFilesPatch } from "diff";
 
+import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   DEFAULT_PLUGIN_REF,
@@ -55,7 +56,6 @@ import {
   compareFingerprint,
   computeFingerprint,
   type Fingerprint,
-  PRESERVED_ENTRIES,
 } from "./plugin-fingerprint.js";
 import { PluginNotInstalledError } from "./uninstall-plugin.js";
 
@@ -141,7 +141,9 @@ export interface DiffPluginDeps {
 function isBinary(buf: Buffer): boolean {
   const len = Math.min(buf.length, 8000);
   for (let i = 0; i < len; i++) {
-    if (buf[i] === 0) return true;
+    if (buf[i] === 0) {
+      return true;
+    }
   }
   return false;
 }
@@ -214,7 +216,9 @@ function baselineContent(
   recorded: Fingerprint,
   materialized: Fingerprint,
 ): FileContent | null {
-  if (materialized.files[path] !== recorded.files[path]) return null;
+  if (materialized.files[path] !== recorded.files[path]) {
+    return null;
+  }
   return readContent(join(baselineRoot, path));
 }
 

--- a/assistant/src/cli/lib/inspect-plugin.ts
+++ b/assistant/src/cli/lib/inspect-plugin.ts
@@ -16,6 +16,7 @@
  * is a thin wrapper that supplies production deps and formats the result.
  */
 
+import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import {
   DEFAULT_PLUGIN_REF,
   type FetchLike,
@@ -30,7 +31,6 @@ import {
 import {
   compareFingerprint,
   type FingerprintComparison,
-  PRESERVED_ENTRIES,
 } from "./plugin-fingerprint.js";
 import {
   fetchMarketplaceEntries,
@@ -238,15 +238,25 @@ async function fetchCommitDate(
         "User-Agent": "vellum-assistant-cli",
       },
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      return null;
+    }
     const json: unknown = JSON.parse(await res.text());
-    if (typeof json !== "object" || json === null) return null;
+    if (typeof json !== "object" || json === null) {
+      return null;
+    }
     const commit = (json as Record<string, unknown>).commit;
-    if (typeof commit !== "object" || commit === null) return null;
+    if (typeof commit !== "object" || commit === null) {
+      return null;
+    }
     const committer = (commit as Record<string, unknown>).committer;
-    if (typeof committer !== "object" || committer === null) return null;
+    if (typeof committer !== "object" || committer === null) {
+      return null;
+    }
     const date = (committer as Record<string, unknown>).date;
-    if (typeof date !== "string") return null;
+    if (typeof date !== "string") {
+      return null;
+    }
     const ms = Date.parse(date);
     return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
   } catch {
@@ -312,10 +322,18 @@ function classify(
   remote: PluginRemoteInfo | null,
   remoteError: string | null,
 ): PluginUpdateStatus {
-  if (!installed) return "not-installed";
-  if (remoteError && !remote) return "remote-unavailable";
-  if (!remote) return "not-in-marketplace";
-  if (!local?.commit) return "unknown-provenance";
+  if (!installed) {
+    return "not-installed";
+  }
+  if (remoteError && !remote) {
+    return "remote-unavailable";
+  }
+  if (!remote) {
+    return "not-in-marketplace";
+  }
+  if (!local?.commit) {
+    return "unknown-provenance";
+  }
   return local.commit.toLowerCase() === remote.commit.toLowerCase()
     ? "up-to-date"
     : "update-available";

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -39,6 +39,7 @@ import {
 import { dirname, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 
+import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { ensureBun } from "../../util/bun-runtime.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
@@ -46,7 +47,6 @@ import {
   computeFingerprint,
   type Fingerprint,
   parseFingerprint,
-  PRESERVED_ENTRIES,
 } from "./plugin-fingerprint.js";
 import {
   fetchMarketplaceEntries,
@@ -246,7 +246,9 @@ export class PluginSourceUnavailableError extends Error {
  * a 403 without it is a genuine authorization failure and stays hard.
  */
 function isTransientUpstreamStatus(res: Response): boolean {
-  if (res.status === 429 || res.status >= 500) return true;
+  if (res.status === 429 || res.status >= 500) {
+    return true;
+  }
   if (res.status === 403) {
     return res.headers.get("x-ratelimit-remaining") === "0";
   }
@@ -302,7 +304,9 @@ async function resolvePluginSource(
     throw err;
   }
 
-  if (!resolved) return null;
+  if (!resolved) {
+    return null;
+  }
 
   return {
     owner: resolved.owner,
@@ -548,9 +552,13 @@ export function finalizeStagedInstall(
   // user config and runtime data.
   if (existsSync(target)) {
     for (const entry of PRESERVED_ENTRIES) {
-      if (entry === INSTALL_META_FILENAME) continue; // sidecar is rewritten above
+      if (entry === INSTALL_META_FILENAME) {
+        continue;
+      } // sidecar is rewritten above
       const src = join(target, entry);
-      if (!existsSync(src)) continue;
+      if (!existsSync(src)) {
+        continue;
+      }
       const dest = join(stagingDir, entry);
       const stat = statSync(src);
       if (stat.isDirectory()) {
@@ -755,8 +763,9 @@ async function copyExternalViaGit(
       // A missing repo/ref (or a private one we can't reach) is a hard
       // not-found, surfaced as zero files. Anything else — network loss, a
       // transient GitHub outage — is retryable, so map it to a 503.
-      if (isGitRefNotFound(err))
+      if (isGitRefNotFound(err)) {
         return { fileCount: 0, commit: null, committedAt: null };
+      }
       throw new PluginSourceUnavailableError(
         `git clone failed for ${sourceLabel(source)} @ ${source.ref}: ${subprocessErrorText(err)}`,
         503,
@@ -865,10 +874,14 @@ async function applyAdapterStub(
     stagingDir,
     deps.fetch,
   );
-  if (stubFileCount === 0) return false;
+  if (stubFileCount === 0) {
+    return false;
+  }
 
   const script = resolvePostinstallScript(name, stagingDir);
-  if (script === null) return false;
+  if (script === null) {
+    return false;
+  }
 
   const run = deps.runPostinstall ?? defaultPostinstallRunner;
   try {
@@ -891,7 +904,9 @@ type PackageManifest = Record<string, unknown>;
 
 /** Parse the `package.json` at `path`, or null if it's absent or unparseable. */
 function readPackageJson(path: string): PackageManifest | null {
-  if (!existsSync(path)) return null;
+  if (!existsSync(path)) {
+    return null;
+  }
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
     return typeof parsed === "object" &&
@@ -976,7 +991,9 @@ function resolvePostinstallScript(
   stagingDir: string,
 ): string | null {
   const pkgPath = join(stagingDir, "package.json");
-  if (!existsSync(pkgPath)) return null;
+  if (!existsSync(pkgPath)) {
+    return null;
+  }
 
   let parsed: unknown;
   try {
@@ -993,7 +1010,9 @@ function resolvePostinstallScript(
     typeof scripts === "object" && scripts !== null && "postinstall" in scripts
       ? (scripts as { postinstall?: unknown }).postinstall
       : undefined;
-  if (typeof command !== "string" || command.trim() === "") return null;
+  if (typeof command !== "string" || command.trim() === "") {
+    return null;
+  }
 
   const match = /^bun\s+(\S+)$/.exec(command.trim());
   if (!match) {
@@ -1005,7 +1024,9 @@ function resolvePostinstallScript(
   }
 
   let rel = match[1]!;
-  if (rel.startsWith("./")) rel = rel.slice(2);
+  if (rel.startsWith("./")) {
+    rel = rel.slice(2);
+  }
   if (!/\.(?:ts|mts|cts|mjs|cjs|js)$/.test(rel)) {
     throw new PluginPostinstallError(
       name,
@@ -1074,7 +1095,9 @@ function pluginPostinstallEnv(bun: string): NodeJS.ProcessEnv {
       .filter(Boolean)
       .join(":"),
   };
-  if (process.env.HOME) env.HOME = process.env.HOME;
+  if (process.env.HOME) {
+    env.HOME = process.env.HOME;
+  }
   return env;
 }
 
@@ -1090,7 +1113,9 @@ function copyTreeSkippingGit(srcRoot: string, destDir: string): number {
     for (const entry of readdirSync(absDir, { withFileTypes: true })) {
       // Drop git metadata and symlinks: the loader follows neither, and a
       // symlink could otherwise point outside the staging tree.
-      if (relDir === "" && entry.name === ".git") continue;
+      if (relDir === "" && entry.name === ".git") {
+        continue;
+      }
       // Drop a top-level `bunfig.toml`. The adapter postinstall runs `bun` with
       // its cwd at the staged root, and Bun auto-loads `$cwd/bunfig.toml` as
       // project config — including a `preload` list it executes before the
@@ -1101,15 +1126,21 @@ function copyTreeSkippingGit(srcRoot: string, destDir: string): number {
       // consumes `bunfig.toml`. Match case-insensitively because the macOS
       // install target's filesystem is case-insensitive, where Bun would still
       // open a clone-supplied `BUNFIG.TOML`.
-      if (relDir === "" && entry.name.toLowerCase() === "bunfig.toml") continue;
-      if (entry.isSymbolicLink()) continue;
+      if (relDir === "" && entry.name.toLowerCase() === "bunfig.toml") {
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
 
       const rel = relDir ? join(relDir, entry.name) : entry.name;
       if (entry.isDirectory()) {
         walk(rel);
         continue;
       }
-      if (!entry.isFile()) continue;
+      if (!entry.isFile()) {
+        continue;
+      }
 
       const dest = join(destDir, rel);
       mkdirSync(dirname(dest), { recursive: true });
@@ -1168,7 +1199,9 @@ export const defaultGitRunner: GitRunner = async (args, opts) => {
 function pluginGitEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined && !key.startsWith("GIT_")) env[key] = value;
+    if (value !== undefined && !key.startsWith("GIT_")) {
+      env[key] = value;
+    }
   }
   env.GIT_TERMINAL_PROMPT = "0";
   const extraPaths = ["/opt/homebrew/bin", "/usr/local/bin"];
@@ -1199,12 +1232,16 @@ interface WriteInstallMetaParams {
  */
 function readStagedPackageVersion(stagingDir: string): string | undefined {
   const pkgPath = join(stagingDir, "package.json");
-  if (!existsSync(pkgPath)) return undefined;
+  if (!existsSync(pkgPath)) {
+    return undefined;
+  }
   try {
     const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf8"));
     if (typeof parsed === "object" && parsed !== null) {
       const version = (parsed as Record<string, unknown>).version;
-      if (typeof version === "string" && version.length > 0) return version;
+      if (typeof version === "string" && version.length > 0) {
+        return version;
+      }
     }
   } catch {
     // fall through to undefined
@@ -1267,7 +1304,9 @@ function writeInstallMeta(
  */
 export function readInstallMeta(pluginDir: string): InstallMeta | null {
   const metaPath = join(pluginDir, INSTALL_META_FILENAME);
-  if (!existsSync(metaPath)) return null;
+  if (!existsSync(metaPath)) {
+    return null;
+  }
 
   let parsed: unknown;
   try {
@@ -1343,12 +1382,16 @@ async function copyDir(
   fetchFn: FetchLike,
 ): Promise<number> {
   const entries = await listDir(owner, repo, apiPath, ref, fetchFn);
-  if (entries === null) return 0;
+  if (entries === null) {
+    return 0;
+  }
 
   let count = 0;
   for (const entry of entries) {
     // The daemon loader follows neither symlinks nor submodules; skip them.
-    if (entry.type === "symlink" || entry.type === "submodule") continue;
+    if (entry.type === "symlink" || entry.type === "submodule") {
+      continue;
+    }
     assertSafeFilename("entry name", entry.name);
 
     if (entry.type === "dir") {
@@ -1402,7 +1445,9 @@ async function listDir(
     `/contents/${encodeURIComponent(apiPath).replaceAll("%2F", "/")}?ref=${encodeURIComponent(ref)}`;
 
   const res = await githubFetch(url, "application/vnd.github+json", fetchFn);
-  if (res.status === 404) return null;
+  if (res.status === 404) {
+    return null;
+  }
   if (!res.ok) {
     const label = `GitHub contents listing failed for ${apiPath} @ ${ref}: HTTP ${res.status}`;
     if (isTransientUpstreamStatus(res)) {

--- a/assistant/src/cli/lib/ipc-params.ts
+++ b/assistant/src/cli/lib/ipc-params.ts
@@ -10,9 +10,9 @@
 /** Keys that are CLI-presentation concerns, not IPC params. */
 const CLI_ONLY_KEYS = new Set(["json", "verbose"]);
 
-export function optsToQueryParams(
-  opts: Record<string, unknown>,
-): { queryParams: Record<string, string> } {
+export function optsToQueryParams(opts: Record<string, unknown>): {
+  queryParams: Record<string, string>;
+} {
   const queryParams: Record<string, string> = {};
   for (const [k, v] of Object.entries(opts)) {
     if (CLI_ONLY_KEYS.has(k)) continue;

--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -206,9 +206,7 @@ export function listAllPlugins(
   // ── User plugins ───────────────────────────────────────────────────────
   // Filter out default-plugin stub directories (created by `plugins disable
   // default-<name>`) so they don't show up as duplicate user entries.
-  const defaultNames = new Set(
-    readDefaultPluginManifests().map((m) => m.name),
-  );
+  const defaultNames = new Set(readDefaultPluginManifests().map((m) => m.name));
   const userPlugins: AllPluginInfo[] = listInstalledPlugins(opts)
     .filter((entry) => !defaultNames.has(entry.name))
     .map((entry) => ({
@@ -255,7 +253,12 @@ export function listAllPlugins(
   );
   // enabledDefault and disabledDefault keep repo array order (no sort).
 
-  return [...enabledUser, ...disabledUser, ...enabledDefault, ...disabledDefault];
+  return [
+    ...enabledUser,
+    ...disabledUser,
+    ...enabledDefault,
+    ...disabledDefault,
+  ];
 }
 
 interface DefaultPluginManifest {
@@ -309,7 +312,10 @@ function getPluginInstallDate(plugin: AllPluginInfo): number {
   const metaPath = join(plugin.target, "install-meta.json");
   try {
     if (existsSync(metaPath)) {
-      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>;
+      const raw = JSON.parse(readFileSync(metaPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
       if (typeof raw.installedAt === "string") {
         const ms = Date.parse(raw.installedAt);
         if (Number.isFinite(ms)) return ms;

--- a/assistant/src/cli/lib/merge-plugin-tree.ts
+++ b/assistant/src/cli/lib/merge-plugin-tree.ts
@@ -44,10 +44,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
-import {
-  computeFingerprint,
-  PRESERVED_ENTRIES,
-} from "./plugin-fingerprint.js";
+import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
+import { computeFingerprint } from "./plugin-fingerprint.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -122,7 +120,9 @@ interface MergedFile {
 function isBinary(buf: Buffer): boolean {
   const len = Math.min(buf.length, 8000);
   for (let i = 0; i < len; i++) {
-    if (buf[i] === 0) return true;
+    if (buf[i] === 0) {
+      return true;
+    }
   }
   return false;
 }
@@ -153,10 +153,12 @@ async function threeWayMergeFile(
   labels: ConflictLabels,
 ): Promise<MergedFile> {
   if (isBinary(ours) || isBinary(base) || isBinary(theirs)) {
-    if (ours.equals(base))
+    if (ours.equals(base)) {
       return { content: theirs, conflicted: false, binaryConflicted: false };
-    if (theirs.equals(base))
+    }
+    if (theirs.equals(base)) {
       return { content: ours, conflicted: false, binaryConflicted: false };
+    }
     if (strategy === "assistant") {
       return { content: ours, conflicted: false, binaryConflicted: true };
     }
@@ -287,8 +289,12 @@ export async function mergePluginTree({
           labels,
         );
         keep(rel, merged.content);
-        if (merged.conflicted) conflicts.push(rel);
-        if (merged.binaryConflicted) binaryConflicts.push(rel);
+        if (merged.conflicted) {
+          conflicts.push(rel);
+        }
+        if (merged.binaryConflicted) {
+          binaryConflicts.push(rel);
+        }
       }
       continue;
     }

--- a/assistant/src/cli/lib/plugin-fingerprint.ts
+++ b/assistant/src/cli/lib/plugin-fingerprint.ts
@@ -159,12 +159,6 @@ export function parseFingerprint(value: unknown): Fingerprint | null {
   return { algorithm: "sha256", files };
 }
 
-// The preserved-entries constant lives with the shared walk so install
-// fingerprinting and the live-reload source fingerprint can't disagree on
-// what counts as the plugin's source tree; re-exported here for the
-// install/upgrade/diff callers that treat this module as the fingerprint API.
-export { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
-
 /**
  * Aggregate SHA-256 digest over a tree's contents, returned as `v2:<hex>`.
  *

--- a/assistant/src/cli/lib/publish-plugin.ts
+++ b/assistant/src/cli/lib/publish-plugin.ts
@@ -609,7 +609,7 @@ export async function runPublish(
     }
     return false;
   }
-}/**
+} /**
  * Format a publish result for terminal output.
  */
 export function formatPublishResult(result: PublishResult): string {

--- a/assistant/src/cli/lib/unknown-command.ts
+++ b/assistant/src/cli/lib/unknown-command.ts
@@ -46,7 +46,9 @@ export function detectUnknownCommand(
   if (known.has(firstPositional)) return null;
 
   const suggestion = findClosestCommand(firstPositional, [...known]);
-  return suggestion ? { token: firstPositional, suggestion } : { token: firstPositional };
+  return suggestion
+    ? { token: firstPositional, suggestion }
+    : { token: firstPositional };
 }
 
 /**

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -32,6 +32,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   inspectPlugin,
@@ -55,11 +56,7 @@ import {
   sanitizePluginName,
 } from "./install-from-github.js";
 import { type ConflictLabels, mergePluginTree } from "./merge-plugin-tree.js";
-import {
-  computeFingerprint,
-  fingerprintsEqual,
-  PRESERVED_ENTRIES,
-} from "./plugin-fingerprint.js";
+import { computeFingerprint, fingerprintsEqual } from "./plugin-fingerprint.js";
 import { PluginNotInstalledError } from "./uninstall-plugin.js";
 
 /**

--- a/assistant/src/hooks/__tests__/hook-live-reload.test.ts
+++ b/assistant/src/hooks/__tests__/hook-live-reload.test.ts
@@ -1,36 +1,36 @@
 /**
- * End-to-end coverage for hook live-reload through the hook loader: an
- * edited hook file takes effect on the next dispatch, without a daemon
- * restart.
+ * Pins the eviction primitives hook live-reload is built on, driven through
+ * the production import machinery (`preImportHooksDir` →
+ * `collectUserHookEntries`), one layer below the sentinel-driven reconcile
+ * that orchestrates them in production (see `../../plugins/mtime-cache.ts`
+ * and its end-to-end suite).
  *
- * The loader keys each hook on its source file's mtime; when the mtime
- * moves it evicts the module from the runtime registry (`evictModule` in
- * `../../plugins/surface-import.ts`) and re-imports, so the fresh content is
- * what dispatches. These tests drive the public collection API against real
- * hook files on disk, which also makes them the regression guard for the
- * Bun behavior the eviction is built on — `require.cache` deletion
- * invalidating dynamic `import()` is intended per
- * github.com/oven-sh/bun/discussions/10162 but not spec-guaranteed, and a
- * Bun upgrade that breaks it must fail here rather than silently degrade
- * hook edits back to restart-required.
+ * Two invariants live here:
+ *
+ * 1. **The Bun primitive.** Deleting a file's `require.cache` entry makes
+ *    the next dynamic `import()` re-evaluate it from disk. This is
+ *    Node-compat surface, intended per
+ *    github.com/oven-sh/bun/discussions/10162 but not spec-guaranteed — a
+ *    Bun upgrade that breaks it must fail here rather than silently degrade
+ *    hook edits back to restart-required.
+ *
+ * 2. **Whole-owner eviction.** Evicting only a hook's own module re-binds
+ *    the re-imported hook to its stale cached helpers. The reconcile sweeps
+ *    every path in the plugin for exactly this reason, and this suite pins
+ *    the failure mode that rule prevents.
  */
 
-import {
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  unlinkSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
+import { evictModule } from "../../plugins/surface-import.js";
 import type { HookEntry } from "../../plugins/types.js";
-import { getWorkspaceHooksDir } from "../../util/platform.js";
 import {
   collectUserHookEntries,
+  evictHooksForOwner,
+  preImportHooksDir,
   resetHookCacheForTests,
 } from "../hook-loader.js";
 
@@ -46,108 +46,122 @@ beforeEach(() => {
   resetHookCacheForTests();
 });
 
-/**
- * Each write gets an explicitly bumped, strictly increasing mtime: two
- * writes can land inside the same filesystem-timestamp granule, which the
- * loader's mtime check would read as "unchanged". Real edits arrive seconds
- * apart; the tests must not race that granularity.
- */
-let mtimeSeq = 1_750_000_000;
-function writeHookFile(hooksDir: string, marker: string): string {
-  const path = join(hooksDir, `${HOOK_NAME}.ts`);
-  writeFileSync(path, `export default () => ${JSON.stringify(marker)};\n`);
-  const stamp = new Date(++mtimeSeq * 1000);
-  utimesSync(path, stamp, stamp);
-  return path;
-}
-
 /** Fresh plugin fixture: `<root>/<name>/hooks/`, unique name per call. */
 let pluginSeq = 0;
 function makePlugin(): { dir: string; hooksDir: string; name: string } {
   const name = `reload-plugin-${++pluginSeq}`;
   const dir = join(root, name);
   const hooksDir = join(dir, "hooks");
+  mkdirSync(join(dir, "lib"), { recursive: true });
   mkdirSync(hooksDir, { recursive: true });
   return { dir, hooksDir, name };
 }
 
-/** Collect the hook chain for a plugin, exactly as dispatch does. */
-async function collect(
-  pluginDir: string,
-  pluginName: string,
-): Promise<HookEntry[]> {
-  return collectUserHookEntries(HOOK_NAME, [[pluginDir, pluginName]]);
+/**
+ * Redeploy an owner's hooks the way the reconcile does: drop its cache
+ * entries, sweep the given module paths, and re-import from disk.
+ */
+async function redeploy(
+  plugin: { hooksDir: string; name: string },
+  modulePaths: string[],
+): Promise<void> {
+  evictHooksForOwner(plugin.name);
+  for (const path of modulePaths) {
+    evictModule(path);
+  }
+  await preImportHooksDir(plugin.hooksDir, plugin.name);
 }
 
-/** Run the single expected hook in the chain and return its result. */
-async function dispatchOne(
-  pluginDir: string,
-  pluginName: string,
-): Promise<unknown> {
-  const entries = await collect(pluginDir, pluginName);
+/** Collect and run the single expected hook, returning its result. */
+async function dispatchOne(plugin: {
+  dir: string;
+  name: string;
+}): Promise<unknown> {
+  const entries: HookEntry[] = await collectUserHookEntries(HOOK_NAME, [
+    [plugin.dir, plugin.name],
+  ]);
   expect(entries).toHaveLength(1);
   return (entries[0]!.fn as () => unknown)();
 }
 
-describe("hook live-reload", () => {
-  test("an edited hook file takes effect on the next dispatch, repeatably", async () => {
+describe("hook reload primitives", () => {
+  test("evict + re-import serves fresh hook code, repeatably", async () => {
     const plugin = makePlugin();
-    writeHookFile(plugin.hooksDir, "v1");
-    expect(await dispatchOne(plugin.dir, plugin.name)).toBe("v1");
+    const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
+    writeFileSync(hookPath, `export default () => "v1";\n`);
+    await preImportHooksDir(plugin.hooksDir, plugin.name);
+    expect(await dispatchOne(plugin)).toBe("v1");
 
-    // Two edit → dispatch cycles: the first proves reload works at all, the
-    // second proves a reloaded hook is itself reloadable (edits keep landing
-    // turn after turn, not just once).
+    // Two edit → redeploy cycles: the first proves the primitive, the
+    // second proves a re-imported module is itself evictable again.
     for (const marker of ["v2", "v3"]) {
-      writeHookFile(plugin.hooksDir, marker);
-      expect(await dispatchOne(plugin.dir, plugin.name)).toBe(marker);
+      writeFileSync(
+        hookPath,
+        `export default () => ${JSON.stringify(marker)};\n`,
+      );
+      await redeploy(plugin, [hookPath]);
+      expect(await dispatchOne(plugin)).toBe(marker);
     }
   });
 
-  test("an unchanged hook file is served from the cache, not re-imported", async () => {
+  test("dispatch serves the same cached function until an eviction", async () => {
     const plugin = makePlugin();
-    writeHookFile(plugin.hooksDir, "stable");
+    writeFileSync(
+      join(plugin.hooksDir, `${HOOK_NAME}.ts`),
+      `export default () => "stable";\n`,
+    );
+    await preImportHooksDir(plugin.hooksDir, plugin.name);
 
-    const first = await collect(plugin.dir, plugin.name);
-    const second = await collect(plugin.dir, plugin.name);
+    const first = await collectUserHookEntries(HOOK_NAME, [
+      [plugin.dir, plugin.name],
+    ]);
+    const second = await collectUserHookEntries(HOOK_NAME, [
+      [plugin.dir, plugin.name],
+    ]);
 
-    // Same function instance means the cache hit — dispatch after dispatch
-    // costs a stat, not an import.
+    // Same function instance: dispatch is a map lookup, not an import.
     expect(second[0]!.fn).toBe(first[0]!.fn);
   });
 
-  test("a deleted hook stops dispatching; recreating it serves the new content", async () => {
+  test("evicting only the hook re-binds it to a stale helper; the full sweep does not", async () => {
     const plugin = makePlugin();
-    const path = writeHookFile(plugin.hooksDir, "original");
-    expect(await dispatchOne(plugin.dir, plugin.name)).toBe("original");
+    const helperPath = join(plugin.dir, "lib", "helper.ts");
+    const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
+    writeFileSync(helperPath, `export const value = "h1";\n`);
+    writeFileSync(
+      hookPath,
+      `import { value } from "../lib/helper.ts";\nexport default () => value;\n`,
+    );
+    await preImportHooksDir(plugin.hooksDir, plugin.name);
+    expect(await dispatchOne(plugin)).toBe("h1");
 
-    unlinkSync(path);
-    expect(await collect(plugin.dir, plugin.name)).toHaveLength(0);
+    writeFileSync(helperPath, `export const value = "h2";\n`);
 
-    // The recreated file must dispatch its own content, not the module the
-    // registry cached for the deleted original.
-    writeHookFile(plugin.hooksDir, "recreated");
-    expect(await dispatchOne(plugin.dir, plugin.name)).toBe("recreated");
+    // Partial eviction — the hook file only. The re-evaluated hook binds to
+    // the helper module still cached at h1: the version-skew failure mode
+    // whole-plugin sweeping exists to prevent.
+    await redeploy(plugin, [hookPath]);
+    expect(await dispatchOne(plugin)).toBe("h1");
+
+    // The full sweep (hook + helper, as the reconcile's eviction list would
+    // carry) brings the edit through.
+    await redeploy(plugin, [hookPath, helperPath]);
+    expect(await dispatchOne(plugin)).toBe("h2");
   });
 
-  test("standalone workspace hooks reload the same way", async () => {
-    const wsHooksDir = getWorkspaceHooksDir();
-    mkdirSync(wsHooksDir, { recursive: true });
-    const path = writeHookFile(wsHooksDir, "ws-v1");
+  test("re-import after owner eviction drops hooks whose files are gone", async () => {
+    const plugin = makePlugin();
+    const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
+    writeFileSync(hookPath, `export default () => "here";\n`);
+    await preImportHooksDir(plugin.hooksDir, plugin.name);
+    expect(await dispatchOne(plugin)).toBe("here");
 
-    try {
-      const before = await collectUserHookEntries(HOOK_NAME, []);
-      expect(before).toHaveLength(1);
-      expect(before[0]!.owner.kind).toBe("workspace");
-      expect((before[0]!.fn as () => unknown)()).toBe("ws-v1");
+    rmSync(hookPath);
+    await redeploy(plugin, [hookPath]);
 
-      writeHookFile(wsHooksDir, "ws-v2");
-      const after = await collectUserHookEntries(HOOK_NAME, []);
-      expect((after[0]!.fn as () => unknown)()).toBe("ws-v2");
-    } finally {
-      // The workspace hooks dir is shared per-process test state — leave it
-      // the way this test found it.
-      unlinkSync(path);
-    }
+    const entries = await collectUserHookEntries(HOOK_NAME, [
+      [plugin.dir, plugin.name],
+    ]);
+    expect(entries).toHaveLength(0);
   });
 });

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -4,19 +4,27 @@
  *
  * A "hook" is a named lifecycle event (`init`, `shutdown`, `user-prompt-submit`,
  * `post-tool-use`, `stop`, ...) handled by a default export. Hooks come from
- * two surfaces, both cached here keyed by their source file's mtime:
+ * two surfaces:
  *
  * - **Plugin hooks** — `<workspace>/plugins/<name>/hooks/<event>.{ts,js}`,
  *   discovered alongside the owning plugin's tools.
  * - **Workspace hooks** — `<workspace>/hooks/<event>.{ts,js}`, standalone
  *   files not tied to any plugin (no `package.json`, no tools — just hooks).
  *
+ * Hook dispatch is a hot path, so collecting hooks costs no filesystem
+ * operations: every hook function enters the in-memory cache when its owner
+ * is (re)activated ({@link preImportHooksDir}), and dispatch is pure map
+ * lookups. Source changes reach the cache through the source-versions
+ * reconcile in `../plugins/mtime-cache.ts`, which tears the owner down,
+ * evicts its cache entries and modules, and reactivates it — dispatch never
+ * stats, lists, or imports.
+ *
  * This module owns the hook cache and every hook operation (collect, init,
  * shutdown, eviction). Plugin *discovery* (which plugin directories exist, in
  * what order) lives in `../plugins/mtime-cache.ts`; the orchestrator there
  * passes the discovered directories into {@link collectUserHooks} and drives
- * pre-import / init / shutdown at boot. Keeping discovery out of this module
- * lets it sit below the plugin cache with no import cycle.
+ * pre-import / init / shutdown. Keeping discovery out of this module lets it
+ * sit below the plugin cache with no import cycle.
  */
 
 import {
@@ -37,11 +45,7 @@ import type {
   ShutdownContext,
 } from "../plugin-api/types.js";
 import { listSurfaceDir } from "../plugins/external-plugin-loader.js";
-import {
-  evictModule,
-  getMtime,
-  importWithTimeout,
-} from "../plugins/surface-import.js";
+import { evictModule, importWithTimeout } from "../plugins/surface-import.js";
 import type { HookEntry } from "../plugins/types.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspaceHooksDir } from "../util/platform.js";
@@ -60,20 +64,17 @@ const log = getLogger("hook-loader");
  */
 export const WORKSPACE_HOOKS_OWNER = "__workspace__";
 
-/**
- * A cached hook function plus the mtime of its source file. When the on-disk
- * mtime changes, the hook is re-imported and the entry is replaced.
- */
+/** A cached, imported hook function. */
 interface CachedHook {
   readonly hook: HookFunction;
-  /** mtimeMs of the source file this hook was imported from. */
-  readonly sourceMtime: number;
 }
 
 /**
  * Cached hooks keyed by `${ownerName}/${hookName}`. The key includes the
  * owner (plugin name, or {@link WORKSPACE_HOOKS_OWNER}) so hooks from
- * different owners don't collide.
+ * different owners don't collide. Entries are created when an owner is
+ * (re)activated and removed only by owner-level eviction — the cache is the
+ * complete record of an owner's dispatchable hooks.
  */
 const hookCache = new Map<string, CachedHook>();
 
@@ -83,87 +84,17 @@ function hookKey(ownerName: string, hookName: string): string {
 }
 
 /**
- * Resolve a single hook file through the mtime cache: return the cached hook
- * when its source mtime is unchanged, otherwise re-import and refresh the
- * entry. Returns `undefined` when the file was deleted (evicting any stale
- * entry) or the import failed / produced a non-function default export.
- *
- * `ownerName` is the cache-key prefix and the attribution label in logs (a
- * plugin name, or {@link WORKSPACE_HOOKS_OWNER}).
- */
-async function resolveCachedHook<TCtx>(
-  ownerName: string,
-  hookName: string,
-  filePath: string,
-): Promise<HookFunction<TCtx> | undefined> {
-  const key = hookKey(ownerName, hookName);
-  const currentMtime = getMtime(filePath);
-
-  // Cache hit — same mtime.
-  const cached = hookCache.get(key);
-  if (
-    cached !== undefined &&
-    cached.sourceMtime === currentMtime &&
-    currentMtime > 0
-  ) {
-    return cached.hook as HookFunction<TCtx>;
-  }
-
-  // Cache miss — re-import.
-  if (currentMtime === 0) {
-    // File was deleted between listing and stat — evict the cache entry.
-    hookCache.delete(key);
-    return undefined;
-  }
-
-  // The file is new, recreated, or edited since it was last imported. Evict
-  // it from the runtime module registry first: without this, the import
-  // below would return the module Bun cached at the old content and the
-  // edit would never take effect. No-op for a first-ever load.
-  //
-  // Note the reload swaps only the exported function for future dispatches.
-  // The hook file's top-level code runs again on re-import, and nothing
-  // tears down the previous instance — so hook files must keep long-lived
-  // side effects (timers, listeners) in the owner's `init`/`shutdown`
-  // lifecycle, not at module top level.
-  evictModule(filePath);
-
-  try {
-    const hook = await importWithTimeout<HookFunction>(filePath);
-    if (hook === undefined || typeof hook !== "function") {
-      log.error(
-        { plugin: ownerName, hook: hookName, path: filePath },
-        `hook ${hookName} default export must be a function (got ${typeof hook}) — skipping`,
-      );
-      return undefined;
-    }
-    hookCache.set(key, { hook, sourceMtime: currentMtime });
-    return hook as HookFunction<TCtx>;
-  } catch (err) {
-    log.error(
-      { err, plugin: ownerName, hook: hookName, path: filePath },
-      `Failed to import hook ${hookName} from ${filePath}`,
-    );
-    return undefined;
-  }
-}
-
-/**
- * Collect every hook for a given event name across all surfaces, re-importing
- * any whose source file's mtime changed since the cache was populated.
+ * Collect every cached hook for a given event name across all surfaces.
+ * Pure in-memory lookups — no filesystem operations on the dispatch path.
  *
  * `pluginDirs` is the orchestrator's discovered `[dir, ownerName]` set (in
  * install-date order). Each plugin's hook runs first, then the standalone
- * workspace hook under `<workspace>/hooks/<hookName>.{ts,js}` runs last — so
- * a plugin can shape the threaded context before a workspace-wide hook
- * observes or finalizes it.
+ * workspace hook runs last — so a plugin can shape the threaded context
+ * before a workspace-wide hook observes or finalizes it.
  *
- * Added, removed, and edited hook files are all picked up live: discovery is
- * by directory listing, and a changed source mtime evicts the module from
- * the runtime registry before re-import, so the edited hook takes effect on
- * the next dispatch without a daemon restart. Eviction is per-file — an edit
- * to a helper module a hook imports is not detected (the hook file's own
- * mtime is what's watched) and still needs a restart.
+ * The cache holds exactly what each owner's last (re)activation imported;
+ * added, removed, and edited hook files (including helper modules they
+ * import) land when the source-versions reconcile redeploys the owner.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null, a
  * plugin whose name is not in the set is skipped (its hooks do not run for this
@@ -177,47 +108,30 @@ export async function collectUserHookEntries<TCtx = unknown>(
 ): Promise<HookEntry<TCtx>[]> {
   const out: HookEntry<TCtx>[] = [];
 
-  for (const [pluginDir, pluginName] of pluginDirs) {
+  for (const [, pluginName] of pluginDirs) {
     if (
       effectiveEnabledPlugins != null &&
       !effectiveEnabledPlugins.has(pluginName)
     ) {
       continue;
     }
-    const hookFile = listSurfaceDir(join(pluginDir, "hooks")).find(
-      (f) => f.name === hookName,
-    );
-    if (hookFile === undefined) {
-      continue;
-    }
-
-    const hook = await resolveCachedHook<TCtx>(
-      pluginName,
-      hookName,
-      hookFile.path,
-    );
-    if (hook !== undefined) {
-      out.push({ fn: hook, owner: { kind: "plugin", id: pluginName } });
+    const cached = hookCache.get(hookKey(pluginName, hookName));
+    if (cached !== undefined) {
+      out.push({
+        fn: cached.hook as HookFunction<TCtx>,
+        owner: { kind: "plugin", id: pluginName },
+      });
     }
   }
 
   // Standalone workspace hooks: files directly under `<workspace>/hooks/`
   // that are not part of any plugin (no package.json, no tools — just hooks).
-  const wsHookFile = listSurfaceDir(getWorkspaceHooksDir()).find(
-    (f) => f.name === hookName,
-  );
-  if (wsHookFile !== undefined) {
-    const hook = await resolveCachedHook<TCtx>(
-      WORKSPACE_HOOKS_OWNER,
-      hookName,
-      wsHookFile.path,
-    );
-    if (hook !== undefined) {
-      out.push({
-        fn: hook,
-        owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
-      });
-    }
+  const wsCached = hookCache.get(hookKey(WORKSPACE_HOOKS_OWNER, hookName));
+  if (wsCached !== undefined) {
+    out.push({
+      fn: wsCached.hook as HookFunction<TCtx>,
+      owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
+    });
   }
 
   return out;
@@ -242,10 +156,13 @@ export async function collectUserHooks<TCtx = unknown>(
 }
 
 /**
- * Pre-import every hook file under `hooksDir` and cache it keyed by
- * `${ownerName}/${hookName}`, so the first turn doesn't pay the import cost.
- * Best-effort per file: a failing import is logged and skipped. A missing
- * directory yields no files (handled by {@link listSurfaceDir}).
+ * Import every hook file under `hooksDir` into the cache, keyed by
+ * `${ownerName}/${hookName}`. This is the single point where hook code
+ * enters the process: it runs at owner (re)activation, and what it caches
+ * is exactly what dispatch serves until the owner is next redeployed.
+ * Best-effort per file: a failing or non-function import is logged and
+ * skipped (the owner's other hooks still load). A missing directory yields
+ * no files (handled by {@link listSurfaceDir}).
  */
 export async function preImportHooksDir(
   hooksDir: string,
@@ -253,21 +170,23 @@ export async function preImportHooksDir(
 ): Promise<void> {
   for (const file of listSurfaceDir(hooksDir)) {
     const key = hookKey(ownerName, file.name);
-    const currentMtime = getMtime(file.path);
-    if (currentMtime === 0) {
-      continue;
-    }
 
-    // A plugin directory can be removed and reinstalled while the daemon
-    // runs; evict any module cached from the prior install so the
-    // pre-import reflects what's on disk now. No-op at boot.
+    // The same path may hold different content than when it was last
+    // imported (edit, reinstall at the same path); evict so the import
+    // below re-evaluates from disk instead of serving Bun's cached module.
+    // No-op for a first-ever load.
     evictModule(file.path);
 
     try {
       const hook = await importWithTimeout<HookFunction>(file.path);
-      if (hook !== undefined && typeof hook === "function") {
-        hookCache.set(key, { hook, sourceMtime: currentMtime });
+      if (hook === undefined || typeof hook !== "function") {
+        log.error(
+          { plugin: ownerName, hook: file.name, path: file.path },
+          `hook ${file.name} default export must be a function (got ${typeof hook}) — skipping`,
+        );
+        continue;
       }
+      hookCache.set(key, { hook });
     } catch (err) {
       log.error(
         { err, plugin: ownerName, hook: file.name, path: file.path },
@@ -527,11 +446,8 @@ export function resetHookCacheForTests(): void {
   hookCache.clear();
 }
 
-/** Test-only: inspect the hook cache. */
-export function _inspectHookCacheForTests(): Array<{
-  key: string;
-  sourceMtime: number;
-}> {
+/** Test-only: inspect the hook cache's keys. */
+export function _inspectHookCacheForTests(): string[] {
   const isTest =
     process.env.BUN_TEST === "1" || process.env.NODE_ENV === "test";
   if (!isTest) {
@@ -539,8 +455,5 @@ export function _inspectHookCacheForTests(): Array<{
       "_inspectHookCacheForTests may only be called in test environments",
     );
   }
-  return Array.from(hookCache.entries()).map(([key, c]) => ({
-    key,
-    sourceMtime: c.sourceMtime,
-  }));
+  return Array.from(hookCache.keys());
 }

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -12,7 +12,7 @@
  *
  * {@link getHooksFor} combines both sources: in-process hooks from this
  * registry (filtered by `isPluginDisabled` at read time) and user-land hooks
- * from the mtime cache. The read-time filtering is what makes `assistant
+ * from the plugin cache. The read-time filtering is what makes `assistant
  * plugins disable default-*` take effect immediately in a running assistant
  * — the hooks stay registered but are filtered out on the next turn.
  */
@@ -45,7 +45,9 @@ export function registerPluginHooks(
   hooks: Record<string, HookFunction>,
 ): void {
   for (const [hookName, fn] of Object.entries(hooks)) {
-    if (typeof fn !== "function") continue;
+    if (typeof fn !== "function") {
+      continue;
+    }
     let list = hookRegistry.get(hookName);
     if (!list) {
       list = [];
@@ -81,8 +83,8 @@ export function unregisterPluginHooks(pluginName: string): void {
  *
  * In-process default plugin hooks are read from this registry (synchronous)
  * and filtered by the `.disabled` sentinel at read time via
- * {@link isPluginDisabled}. User-land hooks are pulled from the mtime cache
- * (async, may re-import). Default hooks are prepended so they compose
+ * {@link isPluginDisabled}. User-land hooks are pulled from the plugin cache
+ * (async; applies any pending source-versions reconcile first). Default hooks are prepended so they compose
  * innermost, ahead of any user plugins.
  *
  * The `TCtx` generic mirrors {@link HookFunction}'s — callers parameterize
@@ -108,9 +110,8 @@ export async function getHookEntriesFor<TCtx = unknown>(
   // hook-dispatch, well after boot). The module is cached after the first load.
   let effectiveEnabledPlugins: Set<string> | null = null;
   if (options?.conversationId) {
-    const { resolveConversationPluginScope } = await import(
-      "../daemon/conversation-plugin-scope.js"
-    );
+    const { resolveConversationPluginScope } =
+      await import("../daemon/conversation-plugin-scope.js");
     effectiveEnabledPlugins = resolveConversationPluginScope(
       options.conversationId,
     );
@@ -121,7 +122,9 @@ export async function getHookEntriesFor<TCtx = unknown>(
   // registered but are filtered out on the next turn.
   const defaultEntries: HookEntry<TCtx>[] = [];
   for (const entry of hookRegistry.get(name) ?? []) {
-    if (isPluginDisabled(entry.pluginName)) continue;
+    if (isPluginDisabled(entry.pluginName)) {
+      continue;
+    }
     if (
       effectiveEnabledPlugins != null &&
       !effectiveEnabledPlugins.has(entry.pluginName)
@@ -134,7 +137,8 @@ export async function getHookEntriesFor<TCtx = unknown>(
     });
   }
 
-  // User-land hooks from the mtime cache (async, may re-import). The per-chat
+  // User-land hooks from the plugin cache (async; applies any pending
+  // source-versions reconcile first). The per-chat
   // scope is threaded through so a deselected user plugin's hooks are excluded
   // too — standalone workspace hooks (not owned by a plugin) always run.
   const userEntries = await getUserHookEntriesFor<TCtx>(

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -132,8 +132,11 @@ export interface ModelProfileInfo {
  * - `uninstall` — the plugin's directory was removed at runtime.
  * - `disable` — the plugin was disabled at runtime (e.g. a `.disabled`
  *   sentinel was added, or a feature flag turned it off).
+ * - `reload` — a source file inside the plugin directory changed and the
+ *   plugin is being redeployed in place; the old version's `shutdown` runs
+ *   before the new version is imported and its `init` fires.
  */
-export type ShutdownReason = "shutdown" | "uninstall" | "disable";
+export type ShutdownReason = "shutdown" | "uninstall" | "disable" | "reload";
 
 /**
  * Context passed to the `shutdown` hook. Kept intentionally narrower than

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -9,14 +9,21 @@
  * plugins directory, registers tools, and drives hook pre-import / init /
  * shutdown by handing the discovered directories to the hook loader.
  *
- * - A changed tool file triggers a re-import of just that tool, not a full
- *   plugin rebuild. Added and removed surface files are picked up live, since
- *   discovery is by directory listing.
+ * - Boot does one full discovery scan; after that, every change (plugin
+ *   installed, removed, disabled, or any source file inside a plugin edited
+ *   — including helper modules hooks/tools import) arrives through the
+ *   source-versions sentinel published by the resource monitor's watcher.
+ *   The dispatch path stats that one file and otherwise runs on memory.
+ * - A changed plugin is redeployed in place: the old version's `shutdown`
+ *   runs, its hook/tool cache entries and module-registry entries are
+ *   swept, and reactivation re-imports fresh source and runs `init`. The
+ *   whole directory is the reload unit so a re-imported hook can never pair
+ *   with a stale cached helper.
  * - Plugins are never "registered" as a unit — we register their tools into
- *   the global tool registry and cache-bust them using mtime on reads.
+ *   the global tool registry.
  *
- * The cache is populated at boot by `loadUserPlugins()` and read on every
- * `getHooksFor` / `getAllTools` call.
+ * The cache is populated at boot by `loadUserPlugins()`; `getHooksFor`
+ * reads it on every dispatch via {@link getUserHookEntriesFor}.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -42,15 +49,25 @@ import {
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspacePluginsDir } from "../util/platform.js";
+import {
+  getWorkspaceHooksDir,
+  getWorkspacePluginsDir,
+} from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 import {
   deriveToolName,
   listSurfaceDir,
   parsePluginManifest,
 } from "./external-plugin-loader.js";
+import { snapshotPluginSource } from "./source-fingerprint.js";
+import type { PluginSourceVersion } from "./source-versions.js";
+import {
+  getSourceVersionsPath,
+  readSourceVersions,
+} from "./source-versions.js";
 import {
   clearSurfaceImportInflight,
+  evictModule,
   getMtime,
   importWithTimeout,
   setSurfaceImportTimeout,
@@ -93,7 +110,9 @@ const INSTALL_META_FILENAME = "install-meta.json";
  */
 function getInstallDate(pluginDir: string): number {
   const cached = installDateCache.get(pluginDir);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    return cached;
+  }
 
   // Try install-meta.json first.
   const metaPath = join(pluginDir, INSTALL_META_FILENAME);
@@ -171,13 +190,29 @@ const discoveredPluginDirs = new Map<string, string>();
  */
 const disabledPluginDirs = new Set<string>();
 
+/**
+ * The source-versions state this process last applied, keyed by directory
+ * (see `./source-versions.ts`). Seeded at boot from the daemon's own walk —
+ * the same fingerprint algorithm over the same disk yields the same stamps
+ * as the watcher, so the first sentinel publication after boot diffs
+ * correctly even against edits made while the daemon was down.
+ */
+let lastVersions: Record<string, PluginSourceVersion> = {};
+
+/** mtime of the sentinel document as of the last look; 0 = never seen. */
+let lastSentinelMtime = 0;
+
+/** In-flight reconcile — concurrent dispatches await it rather than racing. */
+let reconcileInFlight: Promise<void> | null = null;
+
 // ─── Hook reads ──────────────────────────────────────────────────────────────
 
 /**
  * Get all hooks for a given event name from user plugins and standalone
- * workspace hooks. Refreshes plugin discovery first, then delegates the actual
- * hook resolution to the hook loader. Plugin hooks run in install-date order,
- * the workspace hook runs last.
+ * workspace hooks. Checks the source-versions sentinel first (one stat;
+ * reconciles only when the watcher published a change), then delegates to
+ * the hook loader's in-memory cache. Plugin hooks run in install-date
+ * order, the workspace hook runs last.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
  * user plugins outside the set are skipped (standalone workspace hooks always
@@ -187,7 +222,7 @@ export async function getUserHookEntriesFor<TCtx = unknown>(
   hookName: string,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
-  await scanPlugins();
+  await maybeReconcileFromSentinel();
   return collectUserHookEntries<TCtx>(
     hookName,
     discoveredPluginDirs,
@@ -208,6 +243,246 @@ export async function getUserHooksFor<TCtx = unknown>(
     effectiveEnabledPlugins,
   );
   return entries.map((e) => e.fn);
+}
+
+// ─── Source-versions reconcile ───────────────────────────────────────────────
+
+/**
+ * Dispatch-path gate: one stat of the source-versions sentinel. When its
+ * mtime is unchanged since the last look (the overwhelmingly common case)
+ * this returns immediately, and dispatch runs entirely on memory. When the
+ * watcher published a change, the document is applied before the dispatch
+ * proceeds, so the turn that follows an edit already runs the new code.
+ *
+ * A missing or unreadable sentinel is degraded mode, not an error: the
+ * boot-time state keeps serving, and live reload resumes when the monitor
+ * publishes again.
+ */
+async function maybeReconcileFromSentinel(): Promise<void> {
+  if (reconcileInFlight !== null) {
+    await reconcileInFlight;
+    return;
+  }
+  const mtime = getMtime(getSourceVersionsPath());
+  if (mtime === lastSentinelMtime) {
+    return;
+  }
+  // Claim the mtime before any async work, so a concurrent dispatch either
+  // finds the in-flight promise above or skips on the updated mtime.
+  lastSentinelMtime = mtime;
+  if (mtime === 0) {
+    return;
+  }
+  const doc = readSourceVersions();
+  if (doc === null) {
+    return;
+  }
+  reconcileInFlight = applySourceVersions(doc.plugins).finally(() => {
+    reconcileInFlight = null;
+  });
+  await reconcileInFlight;
+}
+
+/**
+ * Apply a published source-versions map: diff it against the state last
+ * applied and redeploy exactly what changed. Never throws — a failed apply
+ * is logged and the next publication retries from the sentinel's truth.
+ *
+ * Per directory, the transitions are:
+ * - present + enabled with a moved fingerprint → in-place redeploy:
+ *   `shutdown` (reason `reload`) → sweep hook/tool caches and the module
+ *   registry → re-import, re-register tools, `init`. The whole directory is
+ *   the reload unit on purpose: partial eviction would let a re-imported
+ *   hook pair with a stale cached helper, silently mixing versions.
+ * - newly present (installed, or `.disabled` removed) → bring up.
+ * - gone, or newly disabled → tear down (`uninstall` / `disable`).
+ * The workspace hooks pseudo-entry gets the same treatment through its own
+ * `init`/`shutdown` lifecycle.
+ */
+async function applySourceVersions(
+  next: Readonly<Record<string, PluginSourceVersion>>,
+): Promise<void> {
+  try {
+    const workspaceHooksDir = getWorkspaceHooksDir();
+    const prev = lastVersions;
+    const dirs = new Set([...Object.keys(prev), ...Object.keys(next)]);
+    let membershipChanged = false;
+
+    for (const dir of dirs) {
+      if (dir === workspaceHooksDir) {
+        continue;
+      }
+      const before = prev[dir];
+      const after = next[dir];
+      const activeName = discoveredPluginDirs.get(dir);
+      const shouldBeUp = after !== undefined && !after.disabled;
+
+      if (activeName !== undefined && !shouldBeUp) {
+        const reason: ShutdownReason =
+          after === undefined ? "uninstall" : "disable";
+        await deactivatePlugin(activeName, reason);
+        await evictPlugin(dir, activeName);
+        sweepModules(before, after);
+        membershipChanged = true;
+      } else if (activeName === undefined && shouldBeUp) {
+        // Reinstalls land at the same path: sweep any modules cached from a
+        // prior install before the fresh import.
+        sweepModules(before, after);
+        if (await bringUpPlugin(dir)) {
+          membershipChanged = true;
+        }
+      } else if (
+        activeName !== undefined &&
+        before !== undefined &&
+        after !== undefined &&
+        before.fingerprint !== after.fingerprint
+      ) {
+        log.info(
+          { plugin: activeName, dir },
+          "plugin source changed — reloading",
+        );
+        // Shutdown reads the old version's hook from the cache, so it must
+        // run before the hook cache is cleared.
+        await deactivatePlugin(activeName, "reload");
+        evictHooksForOwner(activeName);
+        evictToolCacheEntries(activeName);
+        sweepModules(before, after);
+        // Re-read the manifest — the edit may have renamed the plugin (or
+        // broken the manifest, in which case the plugin stays down until a
+        // later edit fixes it and moves the fingerprint again).
+        const manifest = await parsePluginManifest(dir);
+        if (manifest === undefined) {
+          discoveredPluginDirs.delete(dir);
+          membershipChanged = true;
+        } else {
+          if (manifest.name !== activeName) {
+            discoveredPluginDirs.set(dir, manifest.name);
+            membershipChanged = true;
+          }
+          await reconcilePluginTools(dir, manifest.name);
+          await activatePlugin(dir, manifest.name);
+        }
+      }
+    }
+
+    if (membershipChanged) {
+      sortDiscoveredPluginDirs();
+    }
+
+    await reconcileWorkspaceHooks(
+      prev[workspaceHooksDir],
+      next[workspaceHooksDir],
+    );
+
+    lastVersions = { ...next };
+  } catch (err) {
+    log.error(
+      { err },
+      "source-versions reconcile failed — keeping current state",
+    );
+  }
+}
+
+/**
+ * Bring up a directory the sentinel reports as present and enabled. Returns
+ * whether the plugin joined the discovered set (a malformed manifest is
+ * logged by the parser and the directory is skipped until it changes again).
+ */
+async function bringUpPlugin(dir: string): Promise<boolean> {
+  const manifest = await parsePluginManifest(dir);
+  if (manifest === undefined) {
+    return false;
+  }
+  discoveredPluginDirs.set(dir, manifest.name);
+  disabledPluginDirs.delete(dir);
+  log.info({ plugin: manifest.name, dir }, "plugin discovered");
+  await reconcilePluginTools(dir, manifest.name);
+  await activatePlugin(dir, manifest.name);
+  return true;
+}
+
+/**
+ * Evict the union of two version entries' module paths from the module
+ * registry, so re-imports re-evaluate a mutually consistent set (deleted
+ * files may still be cached — hence the union, not just the new list).
+ */
+function sweepModules(
+  before: PluginSourceVersion | undefined,
+  after: PluginSourceVersion | undefined,
+): void {
+  const paths = new Set([
+    ...(before?.evictionPaths ?? []),
+    ...(after?.evictionPaths ?? []),
+  ]);
+  for (const path of paths) {
+    evictModule(path);
+  }
+}
+
+/**
+ * Reconcile the standalone workspace hooks pseudo-entry: same
+ * shutdown → sweep → re-import → init cycle a plugin gets, through the
+ * workspace owner's lifecycle.
+ */
+async function reconcileWorkspaceHooks(
+  before: PluginSourceVersion | undefined,
+  after: PluginSourceVersion | undefined,
+): Promise<void> {
+  if (before?.fingerprint === after?.fingerprint) {
+    return;
+  }
+  const reason: ShutdownReason = after === undefined ? "uninstall" : "reload";
+  const activeIdx = activatedPlugins.findIndex(
+    (p) => p.name === WORKSPACE_HOOKS_OWNER,
+  );
+  if (activeIdx >= 0) {
+    await runShutdownHook(
+      WORKSPACE_HOOKS_OWNER,
+      { assistantVersion: APP_VERSION, reason },
+      reason,
+    );
+    activatedPlugins.splice(activeIdx, 1);
+  }
+  evictHooksForOwner(WORKSPACE_HOOKS_OWNER);
+  sweepModules(before, after);
+  if (after !== undefined) {
+    await preImportWorkspaceHooks();
+    await runInitHook(WORKSPACE_HOOKS_OWNER);
+    activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });
+    log.info("workspace hooks reloaded");
+  }
+}
+
+/**
+ * Seed the reconcile baseline at boot from the daemon's own walk, and record
+ * the sentinel's current mtime without applying its content. Both sides run
+ * the same fingerprint algorithm over the same disk, so the seed matches
+ * whatever a healthy watcher would publish for the state boot just loaded —
+ * and the first publication that differs (including edits made while the
+ * daemon was down, which the watcher detects against its own adopted state)
+ * diffs correctly against it.
+ */
+function seedVersionBaseline(): void {
+  const seeded: Record<string, PluginSourceVersion> = {};
+  for (const [dir] of discoveredPluginDirs) {
+    const snapshot = snapshotPluginSource(dir);
+    seeded[dir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: false,
+    };
+  }
+  const workspaceHooksDir = getWorkspaceHooksDir();
+  if (existsSync(workspaceHooksDir)) {
+    const snapshot = snapshotPluginSource(workspaceHooksDir);
+    seeded[workspaceHooksDir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: false,
+    };
+  }
+  lastVersions = seeded;
+  lastSentinelMtime = getMtime(getSourceVersionsPath());
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────
@@ -282,7 +557,9 @@ async function reconcilePluginTools(
   // Evict cached tools whose files no longer exist on disk.
   for (const key of toolCache.keys()) {
     const [cachedPluginName, cachedToolName] = key.split("/");
-    if (cachedPluginName !== pluginName) continue;
+    if (cachedPluginName !== pluginName) {
+      continue;
+    }
     if (!onDiskNames.has(cachedToolName)) {
       toolCache.delete(key);
     }
@@ -303,10 +580,10 @@ export function getCachedUserTools(): Tool[] {
  * Scan the plugins directory, update the discovered set, and reconcile
  * tools for each plugin. Also evicts cache entries for deleted plugins.
  *
- * This is the "pull" — called on every hook read and at boot. The cost
- * is one `readdirSync` + N `statSync` calls where N = total surface files
- * across all plugins. For a typical workspace with 2-3 plugins, that's
- * ~10-15 stats — sub-millisecond.
+ * Runs once at boot ({@link populateCacheAtBoot}); steady-state changes —
+ * installs, removals, disables, and source edits — arrive through the
+ * source-versions reconcile instead, so the dispatch path never pays for
+ * this walk.
  */
 async function scanPlugins(): Promise<void> {
   const pluginsDir = getWorkspacePluginsDir();
@@ -330,11 +607,15 @@ async function scanPlugins(): Promise<void> {
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
     try {
-      if (!statSync(pluginDir).isDirectory()) continue;
+      if (!statSync(pluginDir).isDirectory()) {
+        continue;
+      }
     } catch {
       continue;
     }
-    if (!existsSync(join(pluginDir, "package.json"))) continue;
+    if (!existsSync(join(pluginDir, "package.json"))) {
+      continue;
+    }
 
     // Check for the .disabled sentinel. A plugin is disabled when a file
     // named `.disabled` exists inside its plugin directory. Disabled
@@ -358,7 +639,9 @@ async function scanPlugins(): Promise<void> {
     }
 
     const manifest = await parsePluginManifest(pluginDir);
-    if (manifest === undefined) continue;
+    if (manifest === undefined) {
+      continue;
+    }
     const { name: pluginName } = manifest;
 
     currentDirs.set(pluginDir, pluginName);
@@ -383,12 +666,10 @@ async function scanPlugins(): Promise<void> {
   // Update the discovered set, sorted by original install date so
   // hook execution order and tool registration order are deterministic.
   discoveredPluginDirs.clear();
-  const sorted = [...currentDirs.entries()].sort(
-    ([dirA], [dirB]) => getInstallDate(dirA) - getInstallDate(dirB),
-  );
-  for (const [dir, name] of sorted) {
+  for (const [dir, name] of currentDirs) {
     discoveredPluginDirs.set(dir, name);
   }
+  sortDiscoveredPluginDirs();
 
   // Activate any plugin not yet brought up. Idempotent: already-active plugins
   // are skipped by the `activatedNames` guard, so steady-state scans (one per
@@ -397,6 +678,21 @@ async function scanPlugins(): Promise<void> {
   // register here.
   for (const [dir, name] of discoveredPluginDirs) {
     await activatePlugin(dir, name);
+  }
+}
+
+/**
+ * Re-sort the discovered set by original install date, so hook execution
+ * order and tool registration order stay deterministic as membership
+ * changes at runtime.
+ */
+function sortDiscoveredPluginDirs(): void {
+  const sorted = [...discoveredPluginDirs.entries()].sort(
+    ([dirA], [dirB]) => getInstallDate(dirA) - getInstallDate(dirB),
+  );
+  discoveredPluginDirs.clear();
+  for (const [dir, name] of sorted) {
+    discoveredPluginDirs.set(dir, name);
   }
 }
 
@@ -413,12 +709,7 @@ async function evictPlugin(
   evictHooksForOwner(pluginName);
 
   // Evict tools.
-  const toolPrefix = `${pluginName}/`;
-  for (const key of toolCache.keys()) {
-    if (key.startsWith(toolPrefix)) {
-      toolCache.delete(key);
-    }
-  }
+  evictToolCacheEntries(pluginName);
 
   log.info(
     { plugin: pluginName, pluginDir },
@@ -426,6 +717,16 @@ async function evictPlugin(
   );
   discoveredPluginDirs.delete(pluginDir);
   installDateCache.delete(pluginDir);
+}
+
+/** Drop every `toolCache` entry owned by `pluginName`. */
+function evictToolCacheEntries(pluginName: string): void {
+  const toolPrefix = `${pluginName}/`;
+  for (const key of toolCache.keys()) {
+    if (key.startsWith(toolPrefix)) {
+      toolCache.delete(key);
+    }
+  }
 }
 
 /**
@@ -477,7 +778,9 @@ async function activatePlugin(
   pluginDir: string,
   pluginName: string,
 ): Promise<void> {
-  if (activatedNames.has(pluginName)) return;
+  if (activatedNames.has(pluginName)) {
+    return;
+  }
   // Reserve synchronously, before any await, so a re-entrant or concurrent
   // scan observes this plugin as already handled.
   activatedNames.add(pluginName);
@@ -523,10 +826,14 @@ async function deactivatePlugin(
   pluginName: string,
   reason: ShutdownReason,
 ): Promise<void> {
-  if (!activatedNames.has(pluginName)) return;
+  if (!activatedNames.has(pluginName)) {
+    return;
+  }
   activatedNames.delete(pluginName);
   const idx = activatedPlugins.findIndex((p) => p.name === pluginName);
-  if (idx >= 0) activatedPlugins.splice(idx, 1);
+  if (idx >= 0) {
+    activatedPlugins.splice(idx, 1);
+  }
 
   // Unregister tools before running shutdown so the model-visible surface is
   // clean before teardown.
@@ -587,6 +894,10 @@ export async function populateCacheAtBoot(
     await runInitHook(WORKSPACE_HOOKS_OWNER);
     activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });
   }
+
+  // Boot is self-sufficient (the scan above never waits on the monitor);
+  // from here on, changes arrive via the sentinel diffed against this seed.
+  seedVersionBaseline();
 }
 
 // ─── Test hooks ──────────────────────────────────────────────────────────────
@@ -610,6 +921,9 @@ export function resetPluginCacheForTests(): void {
   activatedPlugins.length = 0;
   activatedNames.clear();
   disabledPluginDirs.clear();
+  lastVersions = {};
+  lastSentinelMtime = 0;
+  reconcileInFlight = null;
 }
 
 /**

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -9,8 +9,9 @@
  * place (returning `void`) or returns a partial context whose fields are merged
  * onto the draft. Failed hook drafts are discarded.
  *
- * `getHooksFor` is now async — it pulls user-land hooks from the mtime
- * cache (filesystem-as-truth) and default plugin hooks from the registry
+ * `getHooksFor` is now async — it pulls user-land hooks from the plugin
+ * cache (filesystem-as-truth via the source-versions reconcile) and default
+ * plugin hooks from the registry
  * in a single unified call.
  *
  * Design doc: `.private/plans/agent-plugin-system.md`.


### PR DESCRIPTION
## Prompt / plan

PR 2 of the plugin live-reload sequence (design on #37136; PR 0 #37145, PR 1 #37149/#37155) — the consumer half, and the payoff for the hot path. Hook dispatch previously ran a full plugin scan on every `getHooksFor` call (readdir of the plugins dir, manifest reads, per-surface stats, per-hook-file mtime checks — many times per turn). All of it now sits behind the sentinel the monitor's watcher publishes.

**Dispatch: one stat.** `getUserHookEntriesFor` stats the sentinel; unchanged mtime (the overwhelmingly common case) means `collectUserHookEntries` serves pure in-memory map lookups — no readdir, no manifest parse, no stat, no import on the hot path. Hooks enter the cache only at owner (re)activation (`preImportHooksDir`), which is also where module eviction happens, so the hook-loader loses all per-file mtime bookkeeping.

**Reconcile: diff + redeploy exactly what changed.** On a published change, the daemon diffs per-directory fingerprints against the state it last applied. A changed plugin redeploys in place — `shutdown` (new `ShutdownReason: "reload"`) → sweep its hook/tool cache entries and module-registry paths (union of old+new eviction lists, so deleted files can't linger) → re-import, re-register tools, `init`. Installs, removals, and `.disabled` toggles flow through the same diff as bring-up/uninstall/disable transitions; a mid-flight rename or broken manifest is handled by re-parsing on reload. The standalone workspace hooks dir reconciles through its own `init`/`shutdown` lifecycle as the watcher's pseudo-plugin entry.

**Boot: self-sufficient, then adopt.** One full discovery scan as before (never waits on the monitor), then the reconcile baseline is seeded from the daemon's *own* fingerprint walk and the sentinel's current mtime is recorded without applying it. Both sides run the same algorithm over the same disk, so the first publication that differs — including edits made while the daemon was down — diffs correctly. Missing/stale sentinel = degraded mode: boot state keeps serving; reload resumes when the monitor publishes.

**Contract change to note in review:** freshness is now interval-bounded — installs/edits/removals/disables land within the watcher's publish interval (default 2 s) plus the next dispatch, rather than by the very next dispatch. Concurrent dispatches serialize on one in-flight reconcile.

Also folds in the #37155 review comment (`PRESERVED_ENTRIES` re-export removed; ~6 call sites import from `plugins/plugin-tree-walk.js` directly), and carries pure-prettier fixes to 5 `cli/lib` files that had formatting drift on main (the pre-commit gate requires them formatted once touched — 27 lines, no code changes).

## Test plan

- `mtime-cache.test.ts` reworked end-to-end: changes are published by running the **production watcher pass** over the same workspace, and observed via dispatch — detector → sentinel → reconcile → redeploy in one suite. Covers: dispatch ignoring unpublished disk edits (proves no scanning), edited hook/tool/workspace-hook behavior changes after publish, tool re-registration asserted against the **global registry**, helper and transitive (`hook → a → b`) redeploys, `shutdown("reload")` + `init` lifecycle counts, add/remove/disable transitions, and boot adopting a pre-existing sentinel without spurious redeploys.
- `hook-live-reload.test.ts` repurposed to pin the layer below: the Bun eviction primitive through production import machinery, and the stale-helper version-skew that whole-plugin sweeping prevents (partial eviction is *shown* to serve stale code).
- Mutation-checked three ways: disabling the reconcile fails 13 tests; skipping the module sweep on reload fails 3; skipping the boot baseline seed fails 7.
- Full per-file sweep green (13 suites, 140 tests: mtime-cache, plugin-bootstrap, config-data-migration, disabled-state, effective-enabled-set, user-plugin-loader, hook-live-reload, plugin-source-watch, source-fingerprint, plugin-fingerprint, inspect/upgrade/diff-plugin). eslint, prettier, `tsc --noEmit` clean via pre-commit hooks. No route changes → no OpenAPI regeneration.

## CLI verb checklist

No new routes. A future `assistant plugins reload` verb (manual redeploy trigger) is possible on top of this but intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_