### PR TITLE
fix: m0012 status-scoped supersede + revert smuggled feature-flag regression (review round 2)

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -374,17 +374,17 @@
       "id": "research-onboarding",
       "scope": "client",
       "key": "research-onboarding",
-      "label": "Research onboarding (spike)",
-      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Research onboarding",
+      "description": "Replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including the \"Create my personality\" step and a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. On by default (GA); after consent, new web users (non-native, non-local-mode) are routed into this flow instead of the standard hatching path.",
+      "defaultEnabled": true
     },
     {
       "id": "personality-onboarding",
       "scope": "client",
       "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Personality onboarding step",
+      "description": "Show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. On by default (GA); only takes effect where the research-onboarding flow itself is enabled.",
+      "defaultEnabled": true
     },
     {
       "id": "channel-trust-floors",

--- a/gateway/src/__tests__/data-migration-m0012-verification-sessions-backfill.test.ts
+++ b/gateway/src/__tests__/data-migration-m0012-verification-sessions-backfill.test.ts
@@ -336,12 +336,12 @@ describe("m0012-verification-sessions-backfill", () => {
     expect(row.updated_at).toBe(900);
   });
 
-  test("backfills a superseded interceptable session as revoked when the gateway holds a fresh session on the channel", async () => {
+  test("backfills a superseded interceptable session as revoked when the gateway holds a fresh outbound session on the channel", async () => {
     const future = Date.now() + 60_000;
     seedGatewaySession({
       id: "gw-fresh",
       channel: "telegram",
-      status: "pending",
+      status: "awaiting_response",
       expiresAt: future,
     });
     seedAssistantSession({
@@ -355,8 +355,36 @@ describe("m0012-verification-sessions-backfill", () => {
 
     expect(gatewaySession("as-stale")!.status).toBe("revoked");
     const fresh = gatewaySession("gw-fresh")!;
-    expect(fresh.status).toBe("pending");
+    expect(fresh.status).toBe("awaiting_response");
     expect(fresh.updated_at).toBe(200);
+  });
+
+  test("a fresh inbound gateway session supersedes only assistant pending rows — outbound rows coexist (mirrors createInboundSession's narrower revoke scope)", async () => {
+    const future = Date.now() + 60_000;
+    seedGatewaySession({
+      id: "gw-inbound",
+      channel: "telegram",
+      status: "pending",
+      expiresAt: future,
+    });
+    seedAssistantSession({
+      id: "as-outbound",
+      channel: "telegram",
+      status: "awaiting_response",
+      expires_at: future,
+    });
+    seedAssistantSession({
+      id: "as-inbound",
+      channel: "telegram",
+      status: "pending",
+      expires_at: future,
+      challenge_hash: "hash-inbound",
+    });
+
+    expect(await m0012Up()).toBe("done");
+
+    expect(gatewaySession("as-outbound")!.status).toBe("awaiting_response");
+    expect(gatewaySession("as-inbound")!.status).toBe("revoked");
   });
 
   test("backfills an interceptable session with its original status when its channel has no gateway session", async () => {

--- a/gateway/src/db/data-migrations/m0012-verification-sessions-backfill.ts
+++ b/gateway/src/db/data-migrations/m0012-verification-sessions-backfill.ts
@@ -149,24 +149,36 @@ export async function up(): Promise<MigrationResult> {
     const txn = gwDb.transaction(() => {
       // Snapshot channels holding a fresher (post-upgrade) gateway session
       // before inserting, so backfilled rows never shadow one another.
+      // Scoped to mirror the live revoke-prior semantics: an outbound mint
+      // revokes all interceptable statuses, but an inbound mint revokes only
+      // `pending` — so an inbound-only channel must not revoke backfilled
+      // outbound rows.
       const now = Date.now();
-      const supersededChannels = new Set(
-        (
-          gwDb
-            .prepare(
-              `SELECT DISTINCT channel FROM channel_verification_sessions
-                WHERE status IN ('pending', 'pending_bootstrap', 'awaiting_response')
-                  AND expires_at > ?`,
-            )
-            .all(now) as { channel: string }[]
-        ).map((r) => r.channel),
-      );
+      const channelsByStatuses = (statuses: string[]): Set<string> =>
+        new Set(
+          (
+            gwDb
+              .prepare(
+                `SELECT DISTINCT channel FROM channel_verification_sessions
+                  WHERE status IN (${statuses.map(() => "?").join(", ")})
+                    AND expires_at > ?`,
+              )
+              .all(...statuses, now) as { channel: string }[]
+          ).map((r) => r.channel),
+        );
+      const outboundSupersededChannels = channelsByStatuses([
+        "pending_bootstrap",
+        "awaiting_response",
+      ]);
+      const inboundSupersededChannels = channelsByStatuses(["pending"]);
 
       for (const row of sessionRows) {
         const superseded =
           INTERCEPTABLE_STATUSES.includes(row.status) &&
           row.expires_at > now &&
-          supersededChannels.has(row.channel);
+          (outboundSupersededChannels.has(row.channel) ||
+            (row.status === "pending" &&
+              inboundSupersededChannels.has(row.channel)));
 
         const changes = insertSession.run(
           row.id,


### PR DESCRIPTION
## Summary
Fixes the two gaps from self-review round 2 for verif-sessions-gateway-native.md:
- m0012's supersede snapshot now mirrors live revoke-prior scope: an outbound gateway session supersedes all interceptable assistant rows; an inbound (pending) gateway session supersedes only assistant pending rows — coexisting outbound codes survive the backfill (Codex P2 on #37163)
- Reverts the feature-flag-registry.json churn smuggled into #37163 by a stale-worktree bun install, restoring the two GA onboarding flags (research-onboarding, personality step) to enabled