### PR TITLE
feat(ui): channels settings copy pass — rename Who Can Reach, drop guardian vocabulary

### DIFF
--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -5,6 +5,7 @@ import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
+import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { DetailCard } from "@/components/detail-card";
@@ -16,7 +17,7 @@ import type { AssistantChannelState } from "@/domains/contacts/types";
 import {
   ADMISSION_POLICY_DEFAULT,
   ADMISSION_POLICY_VALUES,
-  POLICY_DESCRIPTIONS,
+  getPolicyDescriptions,
   POLICY_LABELS,
   type AdmissionPolicy,
 } from "@/lib/channel-admission-policy/types";
@@ -24,12 +25,6 @@ import {
 export type { SlackThreadMode } from "@/components/slack-setup-wizard";
 
 type ChannelKey = AssistantChannelState["key"];
-
-const TRUST_FLOOR_OPTIONS = ADMISSION_POLICY_VALUES.map((value) => ({
-  value,
-  label: POLICY_LABELS[value],
-  tooltip: POLICY_DESCRIPTIONS[value],
-}));
 
 /**
  * Floors that loosen or hard-deny who can reach the assistant and warrant an
@@ -203,6 +198,7 @@ export function AssistantChannelsDetail({
               <ChannelRow
                 channel={channel}
                 assistantName={assistantName}
+                assistantDisplayName={displayName}
                 pending={pendingChannelKey === channel.key}
                 expanded={expandedChannels.has(channel.key)}
                 onToggleExpand={() => toggleExpanded(channel.key)}
@@ -288,6 +284,8 @@ export function AssistantChannelsDetail({
 interface ChannelRowProps {
   channel: AssistantChannelState;
   assistantName: string;
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantDisplayName: string;
   pending: boolean;
   expanded: boolean;
   onToggleExpand: () => void;
@@ -311,6 +309,7 @@ interface ChannelRowProps {
 function ChannelRow({
   channel,
   assistantName,
+  assistantDisplayName,
   pending,
   expanded,
   onToggleExpand,
@@ -400,6 +399,7 @@ function ChannelRow({
         <div className={connected ? "flex flex-col gap-4" : undefined}>
           {connected && onPolicyChange ? (
             <ChannelTrustFloorSection
+              assistantDisplayName={assistantDisplayName}
               policy={policy}
               saving={policySaving}
               loading={policyLoading}
@@ -441,6 +441,7 @@ function ChannelRow({
 // ---------------------------------------------------------------------------
 
 interface ChannelTrustFloorSectionProps {
+  assistantDisplayName: string;
   policy?: AdmissionPolicy;
   saving?: boolean;
   loading?: boolean;
@@ -449,6 +450,7 @@ interface ChannelTrustFloorSectionProps {
 }
 
 function ChannelTrustFloorSection({
+  assistantDisplayName,
   policy,
   saving = false,
   loading = false,
@@ -456,6 +458,12 @@ function ChannelTrustFloorSection({
   onChange,
 }: ChannelTrustFloorSectionProps) {
   const value = policy ?? ADMISSION_POLICY_DEFAULT;
+  const descriptions = getPolicyDescriptions(assistantDisplayName);
+  const options = ADMISSION_POLICY_VALUES.map((floor) => ({
+    value: floor,
+    label: POLICY_LABELS[floor],
+    tooltip: descriptions[floor],
+  }));
 
   return (
     <div className="flex flex-col gap-2 pl-7">
@@ -464,7 +472,7 @@ function ChannelTrustFloorSection({
         variant="body-small-emphasised"
         className="text-[color:var(--content-secondary)]"
       >
-        Who Can Reach
+        Who can message {assistantDisplayName}
       </Typography>
       {loading ? (
         // Hold off on rendering a concrete floor until the GET succeeds — the
@@ -491,9 +499,9 @@ function ChannelTrustFloorSection({
             <Dropdown<AdmissionPolicy>
               value={value}
               onChange={onChange}
-              options={TRUST_FLOOR_OPTIONS}
+              options={options}
               disabled={saving}
-              aria-label="Channel trust floor"
+              aria-label={`Who can message ${assistantDisplayName}`}
             />
           </div>
           <Typography
@@ -501,8 +509,15 @@ function ChannelTrustFloorSection({
             variant="body-small-default"
             className="text-[color:var(--content-tertiary)]"
           >
-            {POLICY_DESCRIPTIONS[value]}
+            {descriptions[value]}
           </Typography>
+          {value === "trusted_contacts" ? (
+            <Notice tone="info" className="max-w-lg">
+              People you haven’t verified yet are silently blocked — even
+              teammates in the same channel. Verify them in Contacts to let
+              them message {assistantDisplayName}.
+            </Notice>
+          ) : null}
         </>
       )}
     </div>

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -513,9 +513,10 @@ function ChannelTrustFloorSection({
           </Typography>
           {value === "trusted_contacts" ? (
             <Notice tone="info" className="max-w-lg">
-              People you haven’t verified yet are silently blocked — even
-              teammates in the same channel. Verify them in Contacts to let
-              them message {assistantDisplayName}.
+              People you haven’t verified yet — even teammates in the same
+              channel — can’t get through: {assistantDisplayName} lets them
+              know they need to be verified and notifies you. You can verify
+              people ahead of time in Contacts.
             </Notice>
           ) : null}
         </>

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -52,12 +52,18 @@ export const POLICY_LABELS: Record<AdmissionPolicy, string> = {
   strangers: "Strangers",
 };
 
-export const POLICY_DESCRIPTIONS: Record<AdmissionPolicy, string> = {
-  no_one: "Hard-deny every inbound message on this channel.",
-  guardian_only: "Only messages sent by you are admitted.",
-  trusted_contacts:
-    "Admit verified contacts and the guardian; deny everyone else.",
-  any_contact:
-    "Admit any matched contact (verified or pending) and the guardian.",
-  strangers: "Admit everyone, including unrecognised senders.",
-};
+/**
+ * Plain-English description of each admission policy, phrased around the
+ * assistant's display name (e.g. "Vex" or "your assistant").
+ */
+export function getPolicyDescriptions(
+  assistantDisplayName: string,
+): Record<AdmissionPolicy, string> {
+  return {
+    no_one: `No one can message ${assistantDisplayName} on this channel — every message is blocked, including yours.`,
+    guardian_only: `Only you can message ${assistantDisplayName}. Everyone else is ignored.`,
+    trusted_contacts: `You and the people you’ve verified can message ${assistantDisplayName}. Everyone else is ignored.`,
+    any_contact: `You and any known contact can message ${assistantDisplayName}, including contacts you haven’t verified yet. Strangers are ignored.`,
+    strangers: `Anyone can message ${assistantDisplayName}, including complete strangers.`,
+  };
+}

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -61,9 +61,9 @@ export function getPolicyDescriptions(
 ): Record<AdmissionPolicy, string> {
   return {
     no_one: `No one can message ${assistantDisplayName} on this channel — every message is blocked, including yours.`,
-    guardian_only: `Only you can message ${assistantDisplayName}. Everyone else is ignored.`,
-    trusted_contacts: `You and the people you’ve verified can message ${assistantDisplayName}. Everyone else is ignored.`,
-    any_contact: `You and any known contact can message ${assistantDisplayName}, including contacts you haven’t verified yet. Strangers are ignored.`,
+    guardian_only: `Only you can message ${assistantDisplayName}. Everyone else is turned away.`,
+    trusted_contacts: `You and the people you’ve verified can message ${assistantDisplayName}. Anyone else is asked to verify first, and you’re notified.`,
+    any_contact: `You and any known contact can message ${assistantDisplayName}, including contacts you haven’t verified yet. Strangers are asked to verify first.`,
     strangers: `Anyone can message ${assistantDisplayName}, including complete strangers.`,
   };
 }


### PR DESCRIPTION
## Prompt / plan

Implements the copy pass described in [LUM-2697](https://linear.app/vellum/issue/LUM-2697/featui-channels-settings-copy-pass-rename-who-can-reach-drop-guardian) (Part of LUM-2697):

- Rename the trust-floor section label from **"Who Can Reach"** to **"Who can message {assistant}"**, using the assistant's display name (the `Dropdown` `aria-label` follows the same text).
- Rewrite `POLICY_DESCRIPTIONS` as `getPolicyDescriptions(assistantDisplayName)` so each admission-policy description is plain English phrased around the assistant's name, with no "guardian"/"admit"/"hard-deny" vocabulary (e.g. Verified contacts → "You and the people you've verified can message Vex. Anyone else is asked to verify first, and you're notified.").
- The rewritten descriptions continue to back the dropdown option tooltips, so every option now has plain-English context while the menu is open.
- Add a contextual `Notice` (tone `info`, design-library primitive) under the **Verified contacts** selection explaining what happens to unverified people. (The issue's example used a specific person's name; the shipped copy is generic per the repo's generic-examples rule.)

The assistant display name (trimmed, "your assistant" fallback) is threaded from `AssistantChannelsDetail` → `ChannelRow` → `ChannelTrustFloorSection` as a new `assistantDisplayName` prop, kept separate from the raw `assistantName` that seeds the Slack app-name field.

**Deviation from the issue text:** the issue asked the tip to say unverified teammates are "silently blocked", but that's not what the runtime does — under `trusted_contacts` a denied sender gets an "I don't recognize you yet" reply plus a verification path, and the guardian is notified (`assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts`, `admission-policy.ts`). Flagged by Codex review; the copy now describes the challenge/notify behavior instead ("asked to verify first, and you're notified"), and `guardian_only` reads "turned away" rather than "ignored".

Note: the mockup referenced in the issue (`f673f18a-…`) was not resolvable from Notion or Linear, so copy otherwise follows the issue text and its examples.

## Test plan

- `cd clients/web && bunx tsc --noEmit` — clean.
- `bunx eslint` on both changed files — clean.
- `bun test src/lib/channel-admission-policy/api.test.ts` and `bun test src/domains/contacts/contacts-page.test.tsx` — pass.
- Verified rendered behavior with a throwaway @testing-library render of `AssistantChannelsDetail` (not committed): label reads "Who can message Vex" with no "guardian"/"Who Can Reach" text anywhere; the helper text matches the selected policy; the unverified-contacts tip appears only for `trusted_contacts`; the dropdown renders all 5 options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iGatQzQmZLcyc2yuHYFDZ