### PR TITLE
fix(assistant): annotate attachments with resolved stored paths so re-uploads aren't read stale

### DIFF
--- a/assistant/src/__tests__/attachment-stored-path-annotation.test.ts
+++ b/assistant/src/__tests__/attachment-stored-path-annotation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression: re-uploading a document with the same filename must not leave
+ * the model pointing at the older upload. Storage resolves the collision with
+ * a -2/-3 suffix in the conversation's attachments/ directory, so the
+ * LLM-facing user message (and the metadata used to rebuild it on history
+ * reload) must carry the resolved stored path of every linked attachment —
+ * otherwise the model's only on-disk handle is the original filename, which
+ * stays bound to the oldest upload.
+ */
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import { reinjectAttachmentPathAnnotations } from "../daemon/conversation-lifecycle.js";
+import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
+import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
+import { createConversation } from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { rawGet } from "../persistence/raw-query.js";
+import type { ContentBlock } from "../providers/types.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function makeCtx(conversationId: string): MessagingConversationContext {
+  return {
+    conversationId,
+    messages: [],
+    abortController: null,
+    currentRequestId: undefined,
+    queue: {} as never,
+    isProcessing: () => false,
+    setProcessing: () => {},
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+  } as unknown as MessagingConversationContext;
+}
+
+function lastAnnotationBlock(ctx: MessagingConversationContext): {
+  type: string;
+  text: string;
+} {
+  const llmMessage = ctx.messages.at(-1)!;
+  return (llmMessage.content as ContentBlock[]).at(-1) as {
+    type: string;
+    text: string;
+  };
+}
+
+describe("persistQueuedMessageBody stored path annotations", () => {
+  beforeEach(resetTables);
+
+  test("same-named re-upload annotates the resolved -2 path", async () => {
+    const conv = createConversation();
+    const ctx = makeCtx(conv.id);
+
+    // "aGVsbG8=" = "hello", "d29ybGQ=" = "world"
+    const first = await persistQueuedMessageBody(ctx, {
+      content: "here is my file",
+      attachments: [
+        { filename: "report.csv", mimeType: "text/csv", data: "aGVsbG8=" },
+      ],
+    });
+    const second = await persistQueuedMessageBody(ctx, {
+      content: "I edited it, take another look",
+      attachments: [
+        { filename: "report.csv", mimeType: "text/csv", data: "d29ybGQ=" },
+      ],
+    });
+
+    // Second turn's persisted metadata records the collision-suffixed copy.
+    const row = rawGet<{ metadata: string }>(
+      "test:secondMessageMetadata",
+      "SELECT metadata FROM messages WHERE id = ?",
+      second.id,
+    );
+    const meta = JSON.parse(row!.metadata) as {
+      attachmentStoredPaths: Record<string, string>;
+    };
+    const storedPath = meta.attachmentStoredPaths["0:report.csv"];
+    expect(storedPath.endsWith("report-2.csv")).toBe(true);
+    expect(readFileSync(storedPath).toString()).toBe("world");
+
+    // The in-memory LLM message points at that copy, not the original name.
+    const annotation = lastAnnotationBlock(ctx);
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      `[Attachment "report.csv" is stored at: ${storedPath}]`,
+    );
+
+    // The first turn's annotation still points at the unsuffixed original.
+    const firstRow = rawGet<{ metadata: string }>(
+      "test:firstMessageMetadata",
+      "SELECT metadata FROM messages WHERE id = ?",
+      first.id,
+    );
+    const firstMeta = JSON.parse(firstRow!.metadata) as {
+      attachmentStoredPaths: Record<string, string>;
+    };
+    const firstStoredPath = firstMeta.attachmentStoredPaths["0:report.csv"];
+    expect(firstStoredPath.endsWith("report.csv")).toBe(true);
+    expect(firstStoredPath.endsWith("report-2.csv")).toBe(false);
+    expect(readFileSync(firstStoredPath).toString()).toBe("hello");
+
+    // History-reload parity: reinjection rebuilds the identical block.
+    const rebuilt = reinjectAttachmentPathAnnotations(
+      [{ type: "text", text: "I edited it, take another look" }],
+      "user",
+      row!.metadata,
+    );
+    const rebuiltBlock = rebuilt.at(-1) as { type: "text"; text: string };
+    expect(rebuiltBlock.text).toBe(annotation.text);
+  });
+
+  test("messages without attachments get no annotation block", async () => {
+    const conv = createConversation();
+    const ctx = makeCtx(conv.id);
+
+    await persistQueuedMessageBody(ctx, { content: "just text" });
+
+    expect(ctx.messages).toHaveLength(1);
+    const content = ctx.messages[0].content as ContentBlock[];
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+  });
+});

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -21,6 +21,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import {
+  attachInlineAttachmentToMessage,
   AttachmentUploadError,
   deleteAttachment,
   deleteOrphanAttachments,
@@ -386,6 +387,41 @@ describe("getAttachmentById", () => {
   test("returns null for nonexistent ID", () => {
     const result = getAttachmentById("no-such-id");
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachInlineAttachmentToMessage — filename collisions
+// ---------------------------------------------------------------------------
+
+describe("attachInlineAttachmentToMessage filename collisions", () => {
+  beforeEach(resetTables);
+
+  test("returns the resolved -N path when a same-named file already exists", async () => {
+    const conv = createConversation();
+    const msg1 = await addMessage(conv.id, "user", "first upload");
+    const msg2 = await addMessage(conv.id, "user", "re-upload after editing");
+
+    // "aGVsbG8=" = "hello", "d29ybGQ=" = "world"
+    const first = attachInlineAttachmentToMessage(
+      msg1.id,
+      0,
+      "report.csv",
+      "text/csv",
+      "aGVsbG8=",
+    );
+    const second = attachInlineAttachmentToMessage(
+      msg2.id,
+      0,
+      "report.csv",
+      "text/csv",
+      "d29ybGQ=",
+    );
+
+    expect(first.filePath.endsWith("report.csv")).toBe(true);
+    expect(second.filePath.endsWith("report-2.csv")).toBe(true);
+    expect(readFileSync(first.filePath).toString()).toBe("hello");
+    expect(readFileSync(second.filePath).toString()).toBe("world");
   });
 });
 

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -254,4 +254,57 @@ describe("enrichMessageWithSourcePaths", () => {
     const annotation = enriched.content[3] as { type: "text"; text: string };
     expect(annotation.text).toBe("[Attached image source: /path/to/a.jpg]");
   });
+
+  test("annotates non-image attachments that have storedPath", () => {
+    const attachments = [
+      {
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        data: "pdfdata",
+        filePath: "/staging/123-report.pdf",
+        storedPath: "/conv/attachments/report-2.pdf",
+      },
+    ];
+    const original = createUserMessage("review my edits", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // text + file = 2 blocks; enriched adds 1 annotation = 3
+    expect(enriched.content).toHaveLength(3);
+    const annotation = enriched.content[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      '[Attachment "report.pdf" is stored at: /conv/attachments/report-2.pdf]',
+    );
+  });
+
+  test("emits image source lines before stored path lines in one block", () => {
+    const attachments = [
+      {
+        filename: "data.csv",
+        mimeType: "text/csv",
+        data: "csvdata",
+        storedPath: "/conv/attachments/data-2.csv",
+      },
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "img",
+        filePath: "/Users/me/Desktop/photo.jpg",
+        storedPath: "/conv/attachments/photo.jpg",
+      },
+    ];
+    const original = createUserMessage("compare", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    const annotation = enriched.content.at(-1) as {
+      type: "text";
+      text: string;
+    };
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]\n" +
+        '[Attachment "data.csv" is stored at: /conv/attachments/data-2.csv]\n' +
+        '[Attachment "photo.jpg" is stored at: /conv/attachments/photo.jpg]',
+    );
+  });
 });

--- a/assistant/src/__tests__/image-source-path-reinject.test.ts
+++ b/assistant/src/__tests__/image-source-path-reinject.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, test } from "bun:test";
 
-import { reinjectImageSourcePaths } from "../daemon/conversation-lifecycle.js";
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
+import { createUserMessage } from "../agent/message-types.js";
+import { reinjectAttachmentPathAnnotations } from "../daemon/conversation-lifecycle.js";
+import {
+  extractAttachmentStoredPaths,
+  extractImageSourcePaths,
+} from "../persistence/conversation-crud.js";
 import type { ContentBlock } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
-// reinjectImageSourcePaths — re-inject [Attached image source: /path]
-// annotations when loading conversation history from DB
+// reinjectAttachmentPathAnnotations — re-inject attachment path annotations
+// (image source paths + resolved stored paths) when loading conversation
+// history from DB
 // ---------------------------------------------------------------------------
 
-describe("reinjectImageSourcePaths", () => {
+describe("reinjectAttachmentPathAnnotations", () => {
   const baseContent: ContentBlock[] = [
     { type: "text", text: "what is this?" },
     {
@@ -21,7 +28,11 @@ describe("reinjectImageSourcePaths", () => {
     const metadata = JSON.stringify({
       imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
 
     expect(result).toHaveLength(3);
     const annotation = result[2] as { type: "text"; text: string };
@@ -35,7 +46,11 @@ describe("reinjectImageSourcePaths", () => {
     const metadata = JSON.stringify({
       imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
     });
-    const result = reinjectImageSourcePaths(baseContent, "assistant", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "assistant",
+      metadata,
+    );
 
     // Should return the original content unchanged
     expect(result).toBe(baseContent);
@@ -43,7 +58,7 @@ describe("reinjectImageSourcePaths", () => {
   });
 
   test("returns content unchanged when metadata is null", () => {
-    const result = reinjectImageSourcePaths(baseContent, "user", null);
+    const result = reinjectAttachmentPathAnnotations(baseContent, "user", null);
     expect(result).toBe(baseContent);
     expect(result).toHaveLength(2);
   });
@@ -52,7 +67,11 @@ describe("reinjectImageSourcePaths", () => {
     const metadata = JSON.stringify({
       userMessageChannel: "desktop",
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
     expect(result).toBe(baseContent);
     expect(result).toHaveLength(2);
   });
@@ -61,7 +80,11 @@ describe("reinjectImageSourcePaths", () => {
     const metadata = JSON.stringify({
       imageSourcePaths: {},
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
     expect(result).toBe(baseContent);
     expect(result).toHaveLength(2);
   });
@@ -73,7 +96,11 @@ describe("reinjectImageSourcePaths", () => {
         "b.png": "/path/to/b.png",
       },
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
 
     expect(result).toHaveLength(3);
     const annotation = result[2] as { type: "text"; text: string };
@@ -84,7 +111,7 @@ describe("reinjectImageSourcePaths", () => {
   });
 
   test("gracefully handles malformed metadata JSON", () => {
-    const result = reinjectImageSourcePaths(
+    const result = reinjectAttachmentPathAnnotations(
       baseContent,
       "user",
       "not-valid-json{{{",
@@ -102,7 +129,11 @@ describe("reinjectImageSourcePaths", () => {
         "also_bad.jpg": null,
       },
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
 
     expect(result).toHaveLength(3);
     const annotation = result[2] as { type: "text"; text: string };
@@ -118,7 +149,11 @@ describe("reinjectImageSourcePaths", () => {
         "also_bad.jpg": null,
       },
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
     expect(result).toBe(baseContent);
     expect(result).toHaveLength(2);
   });
@@ -127,10 +162,116 @@ describe("reinjectImageSourcePaths", () => {
     const metadata = JSON.stringify({
       imageSourcePaths: { "photo.jpg": "/path/photo.jpg" },
     });
-    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
 
     // First two blocks should be identical to the originals
     expect(result[0]).toEqual(baseContent[0]);
     expect(result[1]).toEqual(baseContent[1]);
+  });
+
+  test("adds stored path annotations from attachmentStoredPaths", () => {
+    const metadata = JSON.stringify({
+      attachmentStoredPaths: {
+        "0:report.pdf": "/conv/attachments/report-2.pdf",
+      },
+    });
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.text).toBe(
+      '[Attachment "report.pdf" is stored at: /conv/attachments/report-2.pdf]',
+    );
+  });
+
+  test("recovers filenames containing colons from stored path keys", () => {
+    const metadata = JSON.stringify({
+      attachmentStoredPaths: {
+        "0:notes: draft.txt": "/conv/attachments/notes: draft.txt",
+      },
+    });
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
+
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.text).toBe(
+      '[Attachment "notes: draft.txt" is stored at: /conv/attachments/notes: draft.txt]',
+    );
+  });
+
+  test("emits image source lines before stored path lines in one block", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "1:photo.jpg": "/Users/me/Desktop/photo.jpg" },
+      attachmentStoredPaths: {
+        "0:data.csv": "/conv/attachments/data-2.csv",
+        "1:photo.jpg": "/conv/attachments/photo.jpg",
+      },
+    });
+    const result = reinjectAttachmentPathAnnotations(
+      baseContent,
+      "user",
+      metadata,
+    );
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]\n" +
+        '[Attachment "data.csv" is stored at: /conv/attachments/data-2.csv]\n' +
+        '[Attachment "photo.jpg" is stored at: /conv/attachments/photo.jpg]',
+    );
+  });
+
+  test("rebuilds the exact annotation block enrichMessageWithSourcePaths appends", () => {
+    // Prefix-cache parity tripwire: the block appended at persist time (from
+    // live attachment inputs) and the block rebuilt on history reload (from
+    // persisted metadata) must be byte-identical.
+    const attachments = [
+      {
+        filename: "data.csv",
+        mimeType: "text/csv",
+        data: "csvdata",
+        storedPath: "/conv/attachments/data-2.csv",
+      },
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "img",
+        filePath: "/Users/me/Desktop/photo.jpg",
+        storedPath: "/conv/attachments/photo.jpg",
+      },
+    ];
+    const enriched = enrichMessageWithSourcePaths(
+      createUserMessage("compare", attachments),
+      attachments,
+    );
+    const liveBlock = enriched.content.at(-1) as {
+      type: "text";
+      text: string;
+    };
+
+    const metadata = JSON.stringify({
+      imageSourcePaths: extractImageSourcePaths(attachments),
+      attachmentStoredPaths: extractAttachmentStoredPaths(attachments),
+    });
+    const rebuilt = reinjectAttachmentPathAnnotations(
+      [{ type: "text", text: "compare" }],
+      "user",
+      metadata,
+    );
+    const rebuiltBlock = rebuilt.at(-1) as { type: "text"; text: string };
+
+    expect(rebuiltBlock.text).toBe(liveBlock.text);
   });
 });

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -8,6 +8,13 @@ export interface MessageAttachmentInput {
   data: string;
   extractedText?: string;
   filePath?: string;
+  /**
+   * Path of the canonical copy in the conversation's attachments/ directory,
+   * known once the attachment is linked to a message. Name collisions are
+   * resolved with a -2/-3 suffix, so this may differ from `filename` — and
+   * from `filePath`, which is where the upload originally came from.
+   */
+  storedPath?: string;
 }
 
 export function attachmentsToContentBlocks(
@@ -44,26 +51,61 @@ export function attachmentsToContentBlocks(
 }
 
 /**
- * Return a copy of the message with text annotations for image source paths.
- * The annotations are appended as a text content block so the LLM knows where
- * the images came from on disk. The caller should persist the ORIGINAL message
- * (without annotations) so the UI stays clean.
+ * Annotation line for where an attached image originally came from (e.g. a
+ * desktop client path). Shared with the history-reload reinjection so the
+ * reloaded content block stays byte-identical to the one built at persist
+ * time (prefix-cache parity).
+ */
+export function formatImageSourceAnnotation(filePath: string): string {
+  return `[Attached image source: ${filePath}]`;
+}
+
+/**
+ * Annotation line binding an attachment's user-facing filename to its
+ * canonical on-disk copy. The stored path is the one the model must use to
+ * read the attachment — the plain filename in the attachments/ directory may
+ * belong to an older upload with the same name. Shared with the
+ * history-reload reinjection (prefix-cache parity).
+ */
+export function formatStoredPathAnnotation(
+  filename: string,
+  storedPath: string,
+): string {
+  return `[Attachment "${filename}" is stored at: ${storedPath}]`;
+}
+
+/**
+ * Return a copy of the message with text annotations for attachment paths:
+ * source paths for images (where the file came from) and stored paths for
+ * any attachment whose canonical copy in the conversation's attachments/
+ * directory is known. The annotations are appended as a text content block
+ * so the LLM knows where to find the files on disk. The caller should
+ * persist the ORIGINAL message (without annotations) so the UI stays clean.
  */
 export function enrichMessageWithSourcePaths(
   message: Message,
   attachments: MessageAttachmentInput[],
 ): Message {
-  const imageAttachments = attachments.filter(
-    (a) => a.mimeType.toLowerCase().startsWith("image/") && a.filePath,
-  );
-  if (imageAttachments.length === 0) return message;
-
-  const annotation = imageAttachments
-    .map((a) => `[Attached image source: ${a.filePath}]`)
-    .join("\n");
+  const lines: string[] = [];
+  for (const a of attachments) {
+    if (a.mimeType.toLowerCase().startsWith("image/") && a.filePath) {
+      lines.push(formatImageSourceAnnotation(a.filePath));
+    }
+  }
+  for (const a of attachments) {
+    if (a.storedPath) {
+      lines.push(formatStoredPathAnnotation(a.filename, a.storedPath));
+    }
+  }
+  if (lines.length === 0) {
+    return message;
+  }
 
   return {
     ...message,
-    content: [...message.content, { type: "text" as const, text: annotation }],
+    content: [
+      ...message.content,
+      { type: "text" as const, text: lines.join("\n") },
+    ],
   };
 }

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -4,6 +4,10 @@
  * can delegate without exposing its full surface.
  */
 
+import {
+  formatImageSourceAnnotation,
+  formatStoredPathAnnotation,
+} from "../agent/attachments.js";
 import { getConfig } from "../config/loader.js";
 import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
@@ -32,14 +36,19 @@ import type { SurfaceData, SurfaceType } from "./message-protocol.js";
 const log = getLogger("conversation-lifecycle");
 
 /**
- * Re-inject image source path annotations into message content blocks.
+ * Re-inject attachment path annotations into message content blocks.
  *
- * When the desktop client attaches images from local files, the source paths
- * are stored in `metadata.imageSourcePaths` (keyed by filename). The LLM-facing
- * content omits these paths at persistence time, so we re-inject them when
- * loading history from the DB. Only user messages are annotated.
+ * The LLM-facing content omits path annotations at persistence time, so we
+ * re-inject them when loading history from the DB, from two metadata keys:
+ * `imageSourcePaths` (where desktop-attached images came from) and
+ * `attachmentStoredPaths` (the canonical, collision-suffixed copies in the
+ * conversation's attachments/ directory), both keyed by
+ * `${position}:${filename}`. The rebuilt block must stay byte-identical to
+ * the one `enrichMessageWithSourcePaths` appends at persist time so reloads
+ * and forks keep provider prefix-cache parity. Only user messages are
+ * annotated.
  */
-export function reinjectImageSourcePaths(
+export function reinjectAttachmentPathAnnotations(
   content: ContentBlock[],
   role: string,
   metadataJson: string | null,
@@ -47,17 +56,30 @@ export function reinjectImageSourcePaths(
   if (role !== "user" || !metadataJson) return content;
   try {
     const meta = JSON.parse(metadataJson);
-    if (!meta.imageSourcePaths || typeof meta.imageSourcePaths !== "object") {
+    const lines: string[] = [];
+    if (meta.imageSourcePaths && typeof meta.imageSourcePaths === "object") {
+      for (const p of Object.values(meta.imageSourcePaths)) {
+        if (typeof p === "string") {
+          lines.push(formatImageSourceAnnotation(p));
+        }
+      }
+    }
+    if (
+      meta.attachmentStoredPaths &&
+      typeof meta.attachmentStoredPaths === "object"
+    ) {
+      for (const [key, p] of Object.entries(meta.attachmentStoredPaths)) {
+        if (typeof p !== "string") {
+          continue;
+        }
+        const filename = key.slice(key.indexOf(":") + 1);
+        lines.push(formatStoredPathAnnotation(filename, p));
+      }
+    }
+    if (lines.length === 0) {
       return content;
     }
-    const paths = Object.values(meta.imageSourcePaths).filter(
-      (v): v is string => typeof v === "string",
-    );
-    if (paths.length === 0) return content;
-    const annotation = paths
-      .map((p) => `[Attached image source: ${p}]`)
-      .join("\n");
-    return [...content, { type: "text" as const, text: annotation }];
+    return [...content, { type: "text" as const, text: lines.join("\n") }];
   } catch {
     // metadata parse failure — skip annotation, not critical
     return content;

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -27,16 +27,19 @@ import {
   attachInlineAttachmentToMessage,
   attachmentExists,
   AttachmentUploadError,
+  getFilePathForAttachment,
   linkAttachmentToMessage,
   validateAttachmentUpload,
 } from "../persistence/attachments-store.js";
 import {
   addMessage,
+  extractAttachmentStoredPaths,
   extractImageSourcePaths,
   getConversation,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
+  updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import {
   syncMessageToDisk,
@@ -472,30 +475,18 @@ export async function persistQueuedMessageBody(
     displayContent,
     clientMessageId,
   } = options;
-  const attachmentInputs = attachments.map((attachment) => ({
-    id: attachment.id,
-    filename: attachment.filename,
-    mimeType: attachment.mimeType,
-    data: attachment.data,
-    extractedText: attachment.extractedText,
-    filePath: attachment.filePath,
-  }));
+  const attachmentInputs: MessageAttachmentInput[] = attachments.map(
+    (attachment) => ({
+      id: attachment.id,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      data: attachment.data,
+      extractedText: attachment.extractedText,
+      filePath: attachment.filePath,
+    }),
+  );
   const cleanMessage = createUserMessage(content, attachmentInputs);
-  const llmMessage = enrichMessageWithSourcePaths(
-    cleanMessage,
-    attachmentInputs,
-  );
-  log.info(
-    {
-      requestId,
-      contentBlockTypes: Array.isArray(llmMessage.content)
-        ? llmMessage.content.map((b) => b.type)
-        : typeof llmMessage.content,
-      attachmentCount: attachments.length,
-    },
-    "persistUserMessage: content blocks being sent to model",
-  );
-  ctx.messages.push(llmMessage);
+  let pushedToHistory = false;
 
   try {
     const turnCtx =
@@ -555,7 +546,6 @@ export async function persistQueuedMessageBody(
     );
 
     if (persistedUserMessage.deduplicated) {
-      ctx.messages.pop();
       return { id: persistedUserMessage.id, deduplicated: true };
     }
 
@@ -584,7 +574,11 @@ export async function persistQueuedMessageBody(
       throw new Error("Failed to persist user message");
     }
 
-    // Index user attachments in the attachments table for later retrieval.
+    // Index user attachments in the attachments table for later retrieval,
+    // capturing the resolved stored path of each linked attachment. Name
+    // collisions in the conversation's attachments/ dir get a -2/-3 suffix,
+    // so the stored path — not the original filename — is the only reliable
+    // on-disk handle for the file.
     for (let i = 0; i < attachments.length; i++) {
       const a = attachments[i];
       try {
@@ -593,7 +587,13 @@ export async function persistQueuedMessageBody(
         // re-uploading. This handles the case where data is empty because
         // the attachment content lives on disk.
         if (a.id && attachmentExists(a.id)) {
-          linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
+          const scopedAttachmentId = linkAttachmentToMessage(
+            persistedUserMessage.id,
+            a.id,
+            i,
+          );
+          attachmentInputs[i].storedPath =
+            getFilePathForAttachment(scopedAttachmentId) ?? undefined;
           continue;
         }
 
@@ -607,7 +607,7 @@ export async function persistQueuedMessageBody(
           );
           continue;
         }
-        attachInlineAttachmentToMessage(
+        const stored = attachInlineAttachmentToMessage(
           persistedUserMessage.id,
           i,
           a.filename,
@@ -615,6 +615,7 @@ export async function persistQueuedMessageBody(
           a.data,
           { sourcePath: a.filePath, normalizeImage: true },
         );
+        attachmentInputs[i].storedPath = stored.filePath;
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
           log.warn(
@@ -630,6 +631,31 @@ export async function persistQueuedMessageBody(
       }
     }
 
+    // Persist the resolved paths so history reloads can rebuild the same
+    // annotation block the in-memory message carries below.
+    const attachmentStoredPaths =
+      extractAttachmentStoredPaths(attachmentInputs);
+    if (attachmentStoredPaths) {
+      updateMessageMetadata(persistedUserMessage.id, { attachmentStoredPaths });
+    }
+
+    const llmMessage = enrichMessageWithSourcePaths(
+      cleanMessage,
+      attachmentInputs,
+    );
+    log.info(
+      {
+        requestId,
+        contentBlockTypes: Array.isArray(llmMessage.content)
+          ? llmMessage.content.map((b) => b.type)
+          : typeof llmMessage.content,
+        attachmentCount: attachments.length,
+      },
+      "persistUserMessage: content blocks being sent to model",
+    );
+    ctx.messages.push(llmMessage);
+    pushedToHistory = true;
+
     // Sync the persisted user message (with attachments) to the disk view
     const conv = getConversation(ctx.conversationId);
     if (conv) {
@@ -642,7 +668,9 @@ export async function persistQueuedMessageBody(
 
     return { id: persistedUserMessage.id, deduplicated: false };
   } catch (err) {
-    ctx.messages.pop();
+    if (pushedToHistory) {
+      ctx.messages.pop();
+    }
     throw err;
   }
 }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -117,7 +117,7 @@ import { isToolResultBlock, undo as undoImpl } from "./conversation-history.js";
 import {
   abortConversation,
   disposeConversation,
-  reinjectImageSourcePaths,
+  reinjectAttachmentPathAnnotations,
 } from "./conversation-lifecycle.js";
 import type {
   EnqueueMessageOptions,
@@ -1044,7 +1044,7 @@ export class Conversation {
         content = [{ type: "text", text: m.content }];
       }
 
-      content = reinjectImageSourcePaths(content, role, m.metadata);
+      content = reinjectAttachmentPathAnnotations(content, role, m.metadata);
 
       // Re-inject persisted injection blocks from metadata so it survives
       // conversation reloads (eviction, restart, fork).

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -827,7 +827,7 @@ export function attachInlineAttachmentToMessage(
      */
     normalizeImage?: boolean;
   },
-): StoredAttachment {
+): StoredAttachment & { filePath: string } {
   if (options?.normalizeImage) {
     ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
       filename,
@@ -891,6 +891,7 @@ export function attachInlineAttachmentToMessage(
     kind,
     thumbnailBase64: null,
     createdAt: now,
+    filePath: targetPath,
   };
 }
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -201,6 +201,13 @@ export const messageMetadataSchema = z
     forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),
+    /**
+     * Resolved paths of the canonical attachment copies in the conversation's
+     * attachments/ directory (name collisions get a -2/-3 suffix), keyed by
+     * `${position}:${filename}`. Written after the attachments are linked;
+     * reinjected into LLM-facing content on history reload.
+     */
+    attachmentStoredPaths: z.record(z.string(), z.string()).optional(),
     memoryInjectedBlock: z.string().optional(),
     /** Memory-v3 frozen net-new card block (unwrapped) — the v3 counterpart
      *  of `memoryInjectedBlock`. A row carries at most one of the two. The key
@@ -323,6 +330,23 @@ export function extractImageSourcePaths(
     const a = attachments[i];
     if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
       paths[`${i}:${a.filename}`] = a.filePath;
+    }
+  }
+  return Object.keys(paths).length > 0 ? paths : undefined;
+}
+
+/** Extract resolved stored paths from linked attachments for message metadata. */
+export function extractAttachmentStoredPaths(
+  attachments: ReadonlyArray<{
+    filename: string;
+    storedPath?: string;
+  }>,
+): Record<string, string> | undefined {
+  const paths: Record<string, string> = {};
+  for (let i = 0; i < attachments.length; i++) {
+    const a = attachments[i];
+    if (a.storedPath) {
+      paths[`${i}:${a.filename}`] = a.storedPath;
     }
   }
   return Object.keys(paths).length > 0 ? paths : undefined;


### PR DESCRIPTION
## Summary
- `persistQueuedMessageBody` now links/materializes attachments **before** building the LLM-facing user message, and annotates **every** attachment kind (previously images only) with the resolved path of its canonical copy in the conversation's `attachments/` directory — the `-2`/`-3` suffixed name when a same-named file already exists. `[Attachment "report.csv" is stored at: …/attachments/report-2.csv]` binds the filename the model knows to the file it must actually read.
- The resolved paths are persisted in a new `attachmentStoredPaths` message-metadata key and re-injected on history reload (`reinjectImageSourcePaths` → `reinjectAttachmentPathAnnotations`), byte-identical to the live block so reloads/forks keep provider prefix-cache parity (covered by a parity tripwire test).
- Regression tests: an end-to-end same-named re-upload through `persistQueuedMessageBody` must annotate the `-2` path; `attachInlineAttachmentToMessage` now returns the resolved `filePath`.

## Original prompt
Investigation of two production incidents where a user re-uploaded an edited file under its original name (a cover-letter PDF; a pair of aerodynamics CSVs) and the assistant kept reading the first upload — then confidently disputed the user's own edits with checksum "proof", since the original filename on disk is permanently bound to the oldest upload. The requested fix: link/materialize attachments before building the LLM message, annotate all attachment kinds (not just images) with their resolved stored paths, keep the persisted clean message and `imageSourcePaths` metadata unchanged, and add a regression test that a same-named re-upload annotates the `-2` path.

## Notes for review
- The in-memory push to `ctx.messages` moves from before persistence to after attachment linking; failure semantics are preserved (pop only if pushed, dedup returns before any push).
- Forked conversations intentionally keep the source conversation's stored-path metadata: the cloned paths stay valid, and byte-identical content preserves prefix-cache parity across forks.
- Edge ingress paths that persist user messages without linking attachments (slash-command replies, guardian NL-approval transcripts) set no `storedPath`, so their annotation behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
