### PR TITLE
fix(web): bound the chat Connecting state with a stuck watchdog

### DIFF
--- a/clients/web/src/domains/chat/chat-page.tsx
+++ b/clients/web/src/domains/chat/chat-page.tsx
@@ -26,6 +26,7 @@ import { ActiveChatView } from "@/domains/chat/active-chat-view";
 import { CleanupScreen } from "@/domains/chat/components/cleanup-screen";
 import { SelfHostedScreen } from "@/domains/chat/components/self-hosted-screen";
 import { SetupScreen } from "@/domains/chat/components/setup-screen";
+import { useStuckConnecting } from "@/domains/chat/hooks/use-stuck-connecting";
 
 export function ChatPage() {
   const isSessionInitializing = useIsSessionInitializing();
@@ -58,13 +59,25 @@ export function ChatPage() {
       ? "assistant_loading"
       : null;
 
+  // Watchdog: connecting has no natural failure surface, so a wedged auth
+  // init or lifecycle probe would spin forever. Escalate to a retry screen
+  // after a bounded wait (and capture the episode to Sentry).
+  const { connectingStuck, resetStuckConnecting } =
+    useStuckConnecting(connectingReason);
+  const retryStuckConnecting = useCallback(() => {
+    resetStuckConnecting();
+    lifecycleService.retryAssistant();
+  }, [resetStuckConnecting]);
+
   const lastConnectingReasonRef = useRef<string | null>(null);
   useEffect(() => {
     if (connectingReason === null) {
       lastConnectingReasonRef.current = null;
       return;
     }
-    if (lastConnectingReasonRef.current === connectingReason) return;
+    if (lastConnectingReasonRef.current === connectingReason) {
+      return;
+    }
     lastConnectingReasonRef.current = connectingReason;
     Sentry.addBreadcrumb({
       category: "chat.connecting",
@@ -79,6 +92,19 @@ export function ChatPage() {
   }, [connectingReason, assistantState.kind, assistantId]);
 
   if (connectingReason !== null) {
+    if (connectingStuck) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+          <p className="text-[var(--text-secondary)]">
+            Still connecting to your assistant — something seems stuck. Try
+            again, or refresh the page if this keeps happening.
+          </p>
+          <Button variant="primary" onClick={retryStuckConnecting}>
+            Try again
+          </Button>
+        </div>
+      );
+    }
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-[var(--text-secondary)]">Connecting…</p>

--- a/clients/web/src/domains/chat/hooks/use-stuck-connecting.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-stuck-connecting.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for the ChatPage connecting watchdog.
+ *
+ * bun:test has no fake timers, so the hook's injectable `timeoutMs` runs at a
+ * few real milliseconds here; assertions wait past it with real sleeps.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+const captureErrorMock = mock(() => undefined);
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { useStuckConnecting } = await import("./use-stuck-connecting");
+
+const TIMEOUT_MS = 20;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+beforeEach(() => {
+  captureErrorMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useStuckConnecting", () => {
+  test("stays un-stuck while connecting resolves within the bound", async () => {
+    const { result, rerender } = renderHook(
+      ({ reason }: { reason: string | null }) =>
+        useStuckConnecting(reason, TIMEOUT_MS),
+      { initialProps: { reason: "auth_loading" as string | null } },
+    );
+    expect(result.current.connectingStuck).toBe(false);
+
+    // Connecting resolves before the bound — watchdog disarms.
+    rerender({ reason: null });
+    await sleep(TIMEOUT_MS * 2);
+    expect(result.current.connectingStuck).toBe(false);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("escalates to stuck and captures once after the bound", async () => {
+    const { result } = renderHook(() =>
+      useStuckConnecting("assistant_loading", TIMEOUT_MS),
+    );
+    await waitFor(() => {
+      expect(result.current.connectingStuck).toBe(true);
+    });
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    const [error, opts] = captureErrorMock.mock.calls[0] as unknown as [
+      Error,
+      { context: string; tags: Record<string, string> },
+    ];
+    expect(error.message).toContain("assistant_loading");
+    expect(opts.context).toBe("chat.connecting_stuck");
+    expect(opts.tags.reason).toBe("assistant_loading");
+  });
+
+  test("reset re-arms the watchdog for another full episode", async () => {
+    const { result } = renderHook(() =>
+      useStuckConnecting("assistant_loading", TIMEOUT_MS),
+    );
+    await waitFor(() => {
+      expect(result.current.connectingStuck).toBe(true);
+    });
+
+    act(() => {
+      result.current.resetStuckConnecting();
+    });
+    expect(result.current.connectingStuck).toBe(false);
+
+    // Still connecting after the retry — escalates (and captures) again.
+    await waitFor(() => {
+      expect(result.current.connectingStuck).toBe(true);
+    });
+    expect(captureErrorMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("clearing the reason after stuck clears the state", async () => {
+    const { result, rerender } = renderHook(
+      ({ reason }: { reason: string | null }) =>
+        useStuckConnecting(reason, TIMEOUT_MS),
+      { initialProps: { reason: "auth_loading" as string | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.connectingStuck).toBe(true);
+    });
+
+    rerender({ reason: null });
+    expect(result.current.connectingStuck).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-stuck-connecting.ts
+++ b/clients/web/src/domains/chat/hooks/use-stuck-connecting.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { captureError } from "@/lib/sentry/capture-error";
+
+/**
+ * How long the ChatPage "Connecting…" guard may persist before it is treated
+ * as stuck. Auth-session init and the first assistant-lifecycle resolution
+ * normally settle in a few seconds; this bound is generous enough for slow
+ * networks while still giving a wedged handshake a user-visible exit. The
+ * hatching flow is NOT under this bound — `initializing` has its own
+ * 5-minute watchdog in the lifecycle service.
+ */
+export const CONNECTING_STUCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Watchdog for the ChatPage "Connecting…" guard.
+ *
+ * The connecting state has no natural failure surface: if auth-session init
+ * or the first lifecycle probe wedges (hung request, dropped promise), the
+ * spinner shows forever with nothing captured to telemetry — the failure is
+ * invisible in the field and undiagnosable for the user. After
+ * `timeoutMs` of uninterrupted connecting, this flips to `stuck` so the
+ * caller can render a retry affordance, and captures one Sentry event per
+ * episode so wedges become measurable.
+ *
+ * `reset` re-arms the watchdog (used by the retry button): a retry that
+ * wedges again re-escalates after another full timeout.
+ */
+export function useStuckConnecting(
+  connectingReason: string | null,
+  timeoutMs: number = CONNECTING_STUCK_TIMEOUT_MS,
+): { connectingStuck: boolean; resetStuckConnecting: () => void } {
+  const [stuck, setStuck] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (connectingReason === null) {
+      setStuck(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setStuck(true);
+      captureError(
+        new Error(`Chat stuck in Connecting state (${connectingReason})`),
+        {
+          context: "chat.connecting_stuck",
+          tags: { reason: connectingReason },
+          extra: { timeoutMs, attempt },
+        },
+      );
+    }, timeoutMs);
+    return () => clearTimeout(timer);
+  }, [connectingReason, timeoutMs, attempt]);
+
+  const resetStuckConnecting = useCallback(() => {
+    setStuck(false);
+    setAttempt((n) => n + 1);
+  }, []);
+
+  return { connectingStuck: stuck, resetStuckConnecting };
+}


### PR DESCRIPTION
## Problem

The ChatPage `Connecting…` guard — shown while auth-session init or the first assistant-lifecycle resolution is pending — has no failure surface. If either wedges (hung request, dropped promise, silently-aborted handshake), the spinner shows **forever**: no timeout, no retry, and only a Sentry *breadcrumb*, which never reaches Sentry without an accompanying event. The failure is unrecoverable for the user and invisible in telemetry.

This is not hypothetical: a self-hosted embedder hit exactly this shape (their lockfile payload failed a silent gate in an older bundle → handshake chain aborted → indefinite skeleton) and needed days plus server-side instrumentation to diagnose. The sibling states are already bounded — `initializing` has the lifecycle service's 5-minute watchdog, and self-hosted conversation-list failures land on a terminal retry screen. Connecting was the remaining unbounded state.

## Fix

`useStuckConnecting(connectingReason)`:
- After **30s** of uninterrupted connecting, flips to stuck → ChatPage renders the standard error-screen shape with a **Try again** button (resets the watchdog + `lifecycleService.retryAssistant()`), plus refresh guidance.
- Captures **one structured Sentry event per episode** via `captureError` (`context: chat.connecting_stuck`, tagged with the wedged reason, attempt count in extra) — so any real-world wedge becomes measurable instead of silent.
- Clears instantly when connecting resolves; a retry that wedges again re-escalates after another full bound.

30s is deliberately generous for slow networks while far below the initializing bound — hatching is not under this timer.

## Tests

`use-stuck-connecting.test.tsx` (injectable timeout; bun:test has no fake timers): resolves-in-time stays quiet, escalation + single capture with correct tags, retry re-arms and re-captures, reason-cleared-after-stuck resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)