### PR TITLE
feat(live-voice): PCM16 energy-based speech activity detector

### DIFF
--- a/assistant/src/live-voice/__tests__/pcm-speech-activity.test.ts
+++ b/assistant/src/live-voice/__tests__/pcm-speech-activity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectPcm16SpeechActivity } from "../pcm-speech-activity.js";
+
+/** Encode an array of 16-bit samples as a PCM16-LE buffer. */
+function pcm16Buffer(samples: number[]): Buffer {
+  const buffer = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i++) {
+    buffer.writeInt16LE(samples[i], i * 2);
+  }
+  return buffer;
+}
+
+/** Generate a sine wave at the given amplitude (160 samples ≈ 10ms @ 16kHz). */
+function sineWave(amplitude: number, sampleCount = 160): Buffer {
+  const samples: number[] = [];
+  for (let i = 0; i < sampleCount; i++) {
+    samples.push(Math.round(amplitude * Math.sin((2 * Math.PI * i) / 20)));
+  }
+  return pcm16Buffer(samples);
+}
+
+describe("detectPcm16SpeechActivity", () => {
+  test("returns false for an all-zero (silent) buffer", () => {
+    expect(detectPcm16SpeechActivity(pcm16Buffer(new Array(160).fill(0)))).toBe(
+      false,
+    );
+  });
+
+  test("returns true for a loud sine wave (amplitude ~8000)", () => {
+    expect(detectPcm16SpeechActivity(sineWave(8000))).toBe(true);
+  });
+
+  test("returns false for quiet noise below the threshold", () => {
+    const samples: number[] = [];
+    for (let i = 0; i < 160; i++) {
+      samples.push(i % 2 === 0 ? 300 : -300);
+    }
+    expect(detectPcm16SpeechActivity(pcm16Buffer(samples))).toBe(false);
+  });
+
+  test("returns false for an empty buffer", () => {
+    expect(detectPcm16SpeechActivity(Buffer.alloc(0))).toBe(false);
+  });
+
+  test("ignores a trailing odd byte without throwing", () => {
+    const loud = sineWave(8000);
+    const oddLength = Buffer.concat([loud, Buffer.from([0x7f])]);
+    expect(detectPcm16SpeechActivity(oddLength)).toBe(true);
+
+    // A single stray byte has no complete samples → treated as empty.
+    expect(detectPcm16SpeechActivity(Buffer.from([0x7f]))).toBe(false);
+  });
+
+  test("respects a custom threshold", () => {
+    const quiet = pcm16Buffer(new Array(160).fill(500));
+    expect(detectPcm16SpeechActivity(quiet)).toBe(false);
+    expect(detectPcm16SpeechActivity(quiet, 400)).toBe(true);
+
+    const loud = sineWave(8000);
+    expect(detectPcm16SpeechActivity(loud, 20_000)).toBe(false);
+  });
+});

--- a/assistant/src/live-voice/pcm-speech-activity.ts
+++ b/assistant/src/live-voice/pcm-speech-activity.ts
@@ -1,0 +1,43 @@
+/**
+ * Default energy threshold on the 16-bit linear amplitude scale.
+ *
+ * Matches the telephony stack's `SPEECH_ENERGY_THRESHOLD` (μ-law decodes to
+ * the same 16-bit linear scale), where typical silence averages ~200-400 and
+ * speech >1200.
+ */
+const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
+
+/**
+ * Lightweight energy-based speech activity detector for PCM16-LE audio.
+ *
+ * Mirrors the telephony μ-law heuristic in
+ * `src/calls/media-stream-stt-session.ts` (`detectSpeechActivity`): compute
+ * the average absolute linear amplitude of the chunk's samples and compare
+ * it against a threshold. Because μ-law decodes to the same 16-bit linear
+ * scale, the same threshold applies to both encodings.
+ *
+ * The threshold is config-driven via `liveVoice.vad.speechEnergyThreshold`
+ * (wired in a later PR).
+ *
+ * @param chunk - Raw PCM16 little-endian mono audio. A trailing odd byte is
+ *   ignored.
+ * @param threshold - Energy threshold on the 16-bit linear amplitude scale.
+ * @returns `true` if the chunk likely contains speech, `false` otherwise.
+ */
+export function detectPcm16SpeechActivity(
+  chunk: Buffer,
+  threshold: number = DEFAULT_SPEECH_ENERGY_THRESHOLD,
+): boolean {
+  const sampleCount = Math.floor(chunk.length / 2);
+  if (sampleCount === 0) {
+    return false;
+  }
+
+  let totalAmplitude = 0;
+  for (let i = 0; i < sampleCount; i++) {
+    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
+  }
+  const avgAmplitude = totalAmplitude / sampleCount;
+
+  return avgAmplitude > threshold;
+}


### PR DESCRIPTION
## Summary
- detectPcm16SpeechActivity: PCM16-LE port of the telephony mu-law energy VAD (same 16-bit-linear scale, default threshold 800)
- Pure function with no calls/ imports; unit tests for silence/speech/edge cases

Part of plan: voice-mode-engine.md (PR 2 of 12)