### PR TITLE
chore(skills): regenerate catalog.json

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -643,7 +643,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T17:36:51.000Z"
+      "updatedAt": "2026-07-06T18:12:30.000Z"
     },
     {
       "id": "public-ingress",


### PR DESCRIPTION
The catalog's updatedAt values derive from git commit times, which squash-merges rewrite, so the committed catalog goes stale on main after any skills-touching merge and fails the next PR that triggers the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)