### PR TITLE
feat(config): add liveVoice config namespace for voice-mode engine tuning

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -916,6 +916,37 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.safety.denyCategories).toEqual(["spam"]);
   });
 
+  // ── Live voice config ───────────────────────────────────────────────
+
+  test("applies liveVoice defaults", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.liveVoice).toEqual({
+      mode: "ptt",
+      vad: {
+        speechEnergyThreshold: 800,
+        silenceThresholdMs: 800,
+        maxTurnDurationMs: 30000,
+      },
+      maxSessionDurationSeconds: 1800,
+    });
+  });
+
+  test("accepts valid liveVoice config overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      liveVoice: {
+        mode: "open-mic",
+        vad: { speechEnergyThreshold: 1500, silenceThresholdMs: 1000 },
+        maxSessionDurationSeconds: 900,
+      },
+    });
+    expect(result.liveVoice.mode).toBe("open-mic");
+    expect(result.liveVoice.vad.speechEnergyThreshold).toBe(1500);
+    expect(result.liveVoice.vad.silenceThresholdMs).toBe(1000);
+    // Unspecified vad fields still get defaults
+    expect(result.liveVoice.vad.maxTurnDurationMs).toBe(30000);
+    expect(result.liveVoice.maxSessionDurationSeconds).toBe(900);
+  });
+
   test("accepts partial calls config with defaults for missing fields", () => {
     const result = AssistantConfigSchema.parse({
       calls: { maxDurationSeconds: 600 },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -34,6 +34,7 @@ import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 import { HostBrowserConfigSchema } from "./schemas/host-browser.js";
 import { IngressConfigSchema } from "./schemas/ingress.js";
 import { JournalConfigSchema } from "./schemas/journal.js";
+import { LiveVoiceConfigSchema } from "./schemas/live-voice.js";
 import { LLMSchema } from "./schemas/llm.js";
 import { LlmRequestLogsConfigSchema } from "./schemas/llm-request-logs.js";
 import {
@@ -120,6 +121,7 @@ export const AssistantConfigSchema = z
     compactionLogs: CompactionLogsConfigSchema,
     twilio: TwilioConfigSchema.default(TwilioConfigSchema.parse({})),
     calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
+    liveVoice: LiveVoiceConfigSchema.default(LiveVoiceConfigSchema.parse({})),
     whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
     telegram: TelegramConfigSchema.default(TelegramConfigSchema.parse({})),
     slack: SlackConfigSchema.default(SlackConfigSchema.parse({})),

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LiveVoiceConfigSchema,
+  LiveVoiceVadConfigSchema,
+  VALID_LIVE_VOICE_MODES,
+} from "../live-voice.js";
+
+describe("LiveVoiceVadConfigSchema", () => {
+  test("empty object parses to defaults", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({});
+    expect(parsed).toEqual({
+      speechEnergyThreshold: 800,
+      silenceThresholdMs: 800,
+      maxTurnDurationMs: 30_000,
+    });
+  });
+
+  test("accepts overrides", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({
+      speechEnergyThreshold: 1200,
+      silenceThresholdMs: 500,
+      maxTurnDurationMs: 60_000,
+    });
+    expect(parsed.speechEnergyThreshold).toBe(1200);
+    expect(parsed.silenceThresholdMs).toBe(500);
+    expect(parsed.maxTurnDurationMs).toBe(60_000);
+  });
+
+  test("rejects non-positive speechEnergyThreshold", () => {
+    const result = LiveVoiceVadConfigSchema.safeParse({
+      speechEnergyThreshold: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer silenceThresholdMs", () => {
+    const result = LiveVoiceVadConfigSchema.safeParse({
+      silenceThresholdMs: 800.5,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("LiveVoiceConfigSchema", () => {
+  test("empty object parses to defaults", () => {
+    const parsed = LiveVoiceConfigSchema.parse({});
+    expect(parsed).toEqual({
+      mode: "ptt",
+      vad: {
+        speechEnergyThreshold: 800,
+        silenceThresholdMs: 800,
+        maxTurnDurationMs: 30_000,
+      },
+      maxSessionDurationSeconds: 1800,
+    });
+  });
+
+  test("accepts overrides", () => {
+    const parsed = LiveVoiceConfigSchema.parse({
+      mode: "open-mic",
+      vad: { silenceThresholdMs: 1200 },
+      maxSessionDurationSeconds: 600,
+    });
+    expect(parsed.mode).toBe("open-mic");
+    expect(parsed.vad.silenceThresholdMs).toBe(1200);
+    // Unspecified vad fields still get defaults
+    expect(parsed.vad.speechEnergyThreshold).toBe(800);
+    expect(parsed.vad.maxTurnDurationMs).toBe(30_000);
+    expect(parsed.maxSessionDurationSeconds).toBe(600);
+  });
+
+  test("rejects invalid mode", () => {
+    const result = LiveVoiceConfigSchema.safeParse({ mode: "always-on" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(msgs.some((m) => m.includes("liveVoice.mode"))).toBe(true);
+    }
+  });
+
+  test("rejects non-positive maxSessionDurationSeconds", () => {
+    const result = LiveVoiceConfigSchema.safeParse({
+      maxSessionDurationSeconds: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("VALID_LIVE_VOICE_MODES lists ptt and open-mic", () => {
+    expect(VALID_LIVE_VOICE_MODES).toEqual(["ptt", "open-mic"]);
+  });
+});

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const VALID_LIVE_VOICE_MODES = ["ptt", "open-mic"] as const;
+
+export const LiveVoiceVadConfigSchema = z
+  .object({
+    speechEnergyThreshold: z
+      .number({
+        error: "liveVoice.vad.speechEnergyThreshold must be a number",
+      })
+      .int("liveVoice.vad.speechEnergyThreshold must be an integer")
+      .positive(
+        "liveVoice.vad.speechEnergyThreshold must be a positive integer",
+      )
+      .default(800)
+      .describe(
+        "Mean absolute amplitude (16-bit linear scale) above which a frame counts as speech — matches the phone stack's SPEECH_ENERGY_THRESHOLD",
+      ),
+    silenceThresholdMs: z
+      .number({ error: "liveVoice.vad.silenceThresholdMs must be a number" })
+      .int("liveVoice.vad.silenceThresholdMs must be an integer")
+      .positive("liveVoice.vad.silenceThresholdMs must be a positive integer")
+      .default(800)
+      .describe(
+        "Trailing silence duration (ms) after speech that ends the user's turn",
+      ),
+    maxTurnDurationMs: z
+      .number({ error: "liveVoice.vad.maxTurnDurationMs must be a number" })
+      .int("liveVoice.vad.maxTurnDurationMs must be an integer")
+      .positive("liveVoice.vad.maxTurnDurationMs must be a positive integer")
+      .default(30_000)
+      .describe(
+        "Maximum duration (ms) of a single user turn before it is force-ended",
+      ),
+  })
+  .describe(
+    "Voice-activity-detection tuning for live voice sessions (open-mic turn segmentation)",
+  );
+
+export const LiveVoiceConfigSchema = z
+  .object({
+    mode: z
+      .enum(VALID_LIVE_VOICE_MODES, {
+        error: `liveVoice.mode must be one of: ${VALID_LIVE_VOICE_MODES.join(", ")}`,
+      })
+      .default("ptt")
+      .describe(
+        "Default microphone mode for live voice sessions — push-to-talk (ptt) or hands-free (open-mic)",
+      ),
+    vad: LiveVoiceVadConfigSchema.default(LiveVoiceVadConfigSchema.parse({})),
+    maxSessionDurationSeconds: z
+      .number({
+        error: "liveVoice.maxSessionDurationSeconds must be a number",
+      })
+      .int("liveVoice.maxSessionDurationSeconds must be an integer")
+      .positive(
+        "liveVoice.maxSessionDurationSeconds must be a positive integer",
+      )
+      .default(1800)
+      .describe("Maximum duration of a single live voice session in seconds"),
+  })
+  .describe(
+    "Live voice (in-app duplex audio) configuration — mic mode, VAD tuning, and session limits",
+  );
+
+export type LiveVoiceConfig = z.infer<typeof LiveVoiceConfigSchema>;
+export type LiveVoiceVadConfig = z.infer<typeof LiveVoiceVadConfigSchema>;


### PR DESCRIPTION
## Summary
- New liveVoice.* config namespace: mode (ptt|open-mic, default ptt), vad tuning (speechEnergyThreshold/silenceThresholdMs/maxTurnDurationMs), maxSessionDurationSeconds
- Registered in the root config schema with self-defaulting entries; schema + root aggregation tests

Part of plan: voice-mode-engine.md (PR 1 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)