### PR TITLE
fix(tools): render thrown non-Error values instead of "[object Object]"

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "../permissions/types.js";
 import { RiskLevel } from "../permissions/types.js";
 import type { Tool, ToolExecutionResult } from "../tools/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 
 const mockConfig = {
   provider: "anthropic",
@@ -1349,5 +1350,77 @@ describe("computePerToolTimeoutMs ask_question budget", () => {
     // execution-timeout budget is shorter than the prompter's own wait, so
     // without the special case the wrapper trips first.
     expect(genericBudgetMs).toBeLessThan(questionResponseTimeoutSec * 1000);
+  });
+});
+
+describe("ToolExecutor thrown-value rendering", () => {
+  beforeEach(() => {
+    fakeToolResult = { content: "ok", isError: false };
+    getToolOverride = undefined;
+    getAllToolsOverride = undefined;
+    checkResultOverride = undefined;
+    checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
+  });
+
+  function throwingTool(name: string, thrown: unknown): void {
+    getToolOverride = (n: string) =>
+      n === name
+        ? ({
+            name,
+            description: "throwing tool",
+            category: "test",
+            defaultRiskLevel: RiskLevel.Low,
+            executionTarget: "sandbox" as const,
+            input_schema: { type: "object" as const, properties: {} },
+            execute: async () => {
+              throw thrown;
+            },
+          } as Tool)
+        : undefined;
+  }
+
+  test("a tagged AbortReason renders as a cancellation, not [object Object]", async () => {
+    throwingTool("web_search", createAbortReason("user_cancel", "test"));
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute("web_search", {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Tool execution was cancelled (user_cancel).");
+    expect(result.content).not.toContain("[object Object]");
+  });
+
+  test("an AbortError carrying a tagged reason names the cancellation kind", async () => {
+    const err = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+      reason: createAbortReason("preempted_by_new_message", "test"),
+    });
+    throwingTool("web_search", err);
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute("web_search", {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(
+      "Tool execution was cancelled (preempted_by_new_message).",
+    );
+  });
+
+  test("a thrown plain object renders as JSON, not [object Object]", async () => {
+    throwingTool("web_search", { status: 429, error: "rate_limited" });
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute("web_search", {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('{"status":429,"error":"rate_limited"}');
+    expect(result.content).not.toContain("[object Object]");
+  });
+
+  test("a thrown string passes through unchanged", async () => {
+    throwingTool("web_search", "boom");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute("web_search", {}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("unexpected error: boom");
   });
 });

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -9,9 +9,10 @@ import { isUntrustedShellLockdownActive } from "../runtime/effective-capabilitie
 import { redactSensitiveFields } from "../security/redaction.js";
 import { getCesClient } from "../security/secure-keys.js";
 import { TokenExpiredError } from "../security/token-manager.js";
+import { type AbortReason, isAbortReason } from "../util/abort-reasons.js";
 import { PermissionDeniedError, ToolError } from "../util/errors.js";
 import { pathExists, safeStatSync } from "../util/fs.js";
-import { getLogger } from "../util/logger.js";
+import { getLogger, truncateForLog } from "../util/logger.js";
 import {
   callerOwnsWorkflowRun,
   manifestGrantsSideEffects,
@@ -468,8 +469,21 @@ export class ToolExecutor {
       }
 
       const durationMs = Date.now() - startTime;
-      const msg = err instanceof Error ? err.message : String(err);
-      const isAbort = err instanceof Error && err.name === "AbortError";
+      // Daemon-owned aborts surface as a tagged AbortReason — a plain object
+      // thrown verbatim by `AbortSignal.throwIfAborted()`, carried on
+      // `error.reason`, or stamped on a provider wrapper's `abortReason`.
+      // Recognize it before the generic stringification below, which would
+      // render it "[object Object]" and misfile the cancellation as an
+      // unexpected failure.
+      const abortReason = extractAbortReason(err);
+      const msg = abortReason
+        ? `Tool execution was cancelled (${abortReason.kind}).`
+        : err instanceof Error
+          ? err.message
+          : describeThrownValue(err);
+      const isAbort =
+        abortReason !== undefined ||
+        (err instanceof Error && err.name === "AbortError");
       const isExpected =
         isAbort ||
         err instanceof PermissionDeniedError ||
@@ -514,6 +528,48 @@ export class ToolExecutor {
       };
     }
   }
+}
+
+/**
+ * Extract the tagged {@link AbortReason} from a thrown value: the value
+ * itself, its `reason` (an `AbortError` carrying the signal's reason), or a
+ * provider wrapper's `abortReason`. Returns `undefined` for anything that is
+ * not a daemon-owned abort.
+ */
+function extractAbortReason(err: unknown): AbortReason | undefined {
+  if (isAbortReason(err)) {
+    return err;
+  }
+  const reason = (err as { reason?: unknown } | null)?.reason;
+  if (isAbortReason(reason)) {
+    return reason;
+  }
+  const abortReason = (err as { abortReason?: unknown } | null)?.abortReason;
+  if (isAbortReason(abortReason)) {
+    return abortReason;
+  }
+  return undefined;
+}
+
+/**
+ * Render a thrown non-Error value for the error result and audit trail.
+ * Objects are JSON-rendered so a thrown `{status: 429}` reads as itself
+ * rather than "[object Object]", bounded so a large payload cannot flood
+ * the audit row; cyclic or non-serializable values fall back to String().
+ */
+function describeThrownValue(err: unknown): string {
+  if (typeof err === "string") {
+    return err;
+  }
+  try {
+    const json = JSON.stringify(err);
+    if (typeof json === "string") {
+      return truncateForLog(json, 500);
+    }
+  } catch {
+    // Cyclic or otherwise non-serializable — fall through to String().
+  }
+  return String(err);
 }
 
 // Re-export from the canonical source so existing consumers of


### PR DESCRIPTION
## Problem

From the 48h telemetry review: a `web_search` failure recorded as literal `error: [object Object]`.

Root cause is in the executor's generic catch (`src/tools/executor.ts`): `err instanceof Error ? err.message : String(err)` renders any thrown plain object as `[object Object]`. The dominant real path is a **daemon-owned abort**: `AbortSignal.throwIfAborted()` throws the tagged `AbortReason` object verbatim (and `web_search`'s `networkFailureResult` re-throws it on user cancel). A tagged reason also fails the `err.name === "AbortError"` check, so the cancellation was additionally **misclassified as an unexpected failure** — model-facing content: `Tool "web_search" encountered an unexpected error: [object Object]` after the user themselves hit Stop.

## Fix

In the executor catch:
- `extractAbortReason(err)` recognizes the tagged reason thrown directly, carried on `error.reason`, or stamped on a provider wrapper's `abortReason` (the same three surfaces `isUserCancellation` / web-search classification already check) → message `Tool execution was cancelled (<kind>).`, abort classification (`isExpected`, `tool_failure` category) — matching how a bare `AbortError` is already treated.
- Other thrown non-Error values render via `describeThrownValue`: strings pass through; objects JSON-render (bounded to 500 chars via `truncateForLog`) so a thrown `{status: 429}` reads as itself; cyclic values fall back to `String()`.

Gate decisions, lifecycle event shape, and Error-instance handling are unchanged.

## Tests

4 new cases in `tool-executor.test.ts`: tagged reason thrown directly → cancellation message; AbortError carrying a tagged `reason` → names the kind; thrown plain object → JSON, never `[object Object]`; thrown string → passthrough. Typecheck verified error-set-identical to baseline (the 3 pre-existing `slack/send.ts` errors in my env are a stale workspace-package-link artifact, absent in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)