### PR TITLE
refactor(calls): drive speakSystemPrompt synthesis through the shared core

### DIFF
--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -9,7 +9,8 @@
  *    resolving into guaranteed media-stream silence.
  * 3. `speakSystemPrompt` on a WAV-requiring transport — synthesis failure
  *    retries once via the fallback provider before degrading to an
- *    end-of-turn-only signal.
+ *    end-of-turn-only signal; aborted synthesis short-circuits with no
+ *    fallback and no end-of-turn token.
  *
  * The provider catalog, config loader, credential store, provider registry,
  * audio store, and ingress URL modules are all mocked so the tests exercise
@@ -527,5 +528,63 @@ describe("speakSystemPrompt on a WAV-requiring transport", () => {
     expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
     expect(sentPlayUrls.length).toBe(0);
     expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// speakSystemPrompt — aborted synthesis short-circuits without fallback
+// ---------------------------------------------------------------------------
+
+describe("speakSystemPrompt aborted synthesis", () => {
+  test("WAV transport: abort mid-flight skips the fallback retry and end-of-turn", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    const controller = new AbortController();
+    const deepgramSynthesize = jest.fn(async () => {
+      controller.abort();
+      throw new DOMException("Synthesis aborted", "AbortError");
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(
+      relay,
+      "You have a new message.",
+      controller.signal,
+    );
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).not.toHaveBeenCalled();
+    expect(sentPlayUrls).toEqual([]);
+    expect(sentTokens).toEqual([]);
+  });
+
+  test("non-WAV transport with native-fallback provider: abort skips the text fallback and end-of-turn", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
+
+    const controller = new AbortController();
+    controller.abort();
+    const fishSynthesize = jest.fn(async () => {
+      throw new DOMException("Synthesis aborted", "AbortError");
+    });
+    registerStubProvider("fish-audio", fishSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(false);
+    await speakSystemPrompt(
+      relay,
+      "You have a new message.",
+      controller.signal,
+    );
+
+    expect(fishSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls).toEqual([]);
+    expect(sentTokens).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -587,4 +587,36 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentPlayUrls).toEqual([]);
     expect(sentTokens).toEqual([]);
   });
+
+  test("abort at provider resolution (silent, no throw) skips the end-of-turn token", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    // synthesizeAndEmit does NOT throw when the signal aborts after the
+    // provider resolves but before queued emits run — it resolves normally
+    // with zero emitted chunks. The success path must still honor the abort.
+    const controller = new AbortController();
+    const deepgramSynthesize = jest.fn(async () => {
+      controller.abort();
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(
+      relay,
+      "You have a new message.",
+      controller.signal,
+    );
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).not.toHaveBeenCalled();
+    expect(sentPlayUrls).toEqual([]);
+    expect(sentTokens).toEqual([]);
+  });
 });

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -178,7 +178,7 @@ mock.module("../security/secure-keys.js", () => ({
       : realSecureKeysModule.getSecureKeyAsync(key),
 }));
 
-// -- Audio store + ingress URL (used by call-speech-output) ---------------------
+// -- Audio store + ingress URL (used by the tts/synthesis-stream sink) ----------
 
 const finalizeCalls: string[] = [];
 let audioEntryCounter = 0;

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -15,12 +15,14 @@
  *   via `sendPlayUrl()`.
  */
 
-import { loadConfig } from "../config/loader.js";
-import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import {
+  createAudioStoreSink,
+  synthesizeAndEmit,
+  type AudioStoreSink,
+} from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
-import { createStreamingEntry } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   findPlayableTelephonyTtsFallback,
@@ -45,10 +47,14 @@ const log = getLogger("call-speech-output");
  * before starting teardown timers so that the play URL is delivered to
  * Twilio before the session ends. Interactive mid-call callers can
  * fire-and-forget with `void speakSystemPrompt(...)`.
+ *
+ * The optional `signal` aborts in-flight synthesis on the synthesized path;
+ * the native path sends synchronously and ignores it.
  */
 export async function speakSystemPrompt(
   relay: CallTransport,
   text: string,
+  signal?: AbortSignal,
 ): Promise<void> {
   // When the transport requires WAV (media-stream), request WAV so
   // the audio store entry contains PCM that audioBufferToFrames can
@@ -66,7 +72,7 @@ export async function speakSystemPrompt(
   }
 
   // Synthesized path — synthesize audio and send play URL.
-  return synthesizeAndPlay(relay, provider, text, audioFormat);
+  return synthesizeAndPlay(relay, provider, text, audioFormat, signal);
 }
 
 // ---------------------------------------------------------------------------
@@ -94,10 +100,10 @@ async function synthesizeAndPlay(
   provider: TtsProvider,
   text: string,
   format: "mp3" | "wav" | "opus",
+  signal?: AbortSignal,
   isFallbackRetry = false,
 ): Promise<void> {
-  let handle: ReturnType<typeof createStreamingEntry> | null = null;
-  let playUrlSent = false;
+  let sink: AudioStoreSink | null = null;
   try {
     // When format is WAV (media-stream transport), request raw PCM from
     // the provider so the audio bytes match the store's content-type.
@@ -111,44 +117,20 @@ async function synthesizeAndPlay(
     // but the bytes have no RIFF header, causing audioBufferToFrames to
     // fall through to the wrong decode path.
     const storeFormat = outputFormat ? "pcm" : format;
-    handle = createStreamingEntry(storeFormat);
-    const config = loadConfig();
-    const baseUrl = getPublicBaseUrl(config);
-    const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-    const sendPlayUrlOnce = (): void => {
-      if (playUrlSent) return;
-      relay.sendPlayUrl(url);
-      playUrlSent = true;
-    };
+    sink = createAudioStoreSink({
+      format: storeFormat,
+      onPlayUrl: (url) => relay.sendPlayUrl(url),
+    });
 
-    if (provider.synthesizeStream) {
-      let streamedChunk = false;
-      await provider.synthesizeStream(
-        { text, useCase: "phone-call", outputFormat },
-        (chunk) => {
-          if (chunk.byteLength === 0) return;
-          if (!streamedChunk) {
-            sendPlayUrlOnce();
-            streamedChunk = true;
-          }
-          handle!.push(chunk);
-        },
-      );
-      if (!streamedChunk) {
-        throw new Error("Streaming TTS returned no audio chunks");
-      }
-    } else {
-      const result = await provider.synthesize({
-        text,
-        useCase: "phone-call",
-        outputFormat,
-      });
-      if (result.audio.byteLength === 0) {
-        throw new Error("Buffer TTS returned an empty audio payload");
-      }
-      sendPlayUrlOnce();
-      handle.push(result.audio);
-    }
+    await synthesizeAndEmit({
+      provider,
+      text,
+      useCase: "phone-call",
+      outputFormat,
+      signal,
+      onChunk: sink.onChunk,
+      onFirstAudio: sink.onFirstAudio,
+    });
 
     // Signal end of this turn's speech.  An empty token with `last: true`
     // tells the transport to start listening — it does NOT trigger TTS
@@ -187,13 +169,14 @@ async function synthesizeAndPlay(
             },
             "System prompt TTS synthesis failed — retrying with fallback provider",
           );
-          handle?.finalize();
-          handle = null;
+          sink?.finalize();
+          sink = null;
           return await synthesizeAndPlay(
             relay,
             fallbackProvider,
             text,
             format,
+            signal,
             true,
           );
         }
@@ -239,7 +222,7 @@ async function synthesizeAndPlay(
     // native fallback.
     relay.sendTextToken(text, true);
   } finally {
-    handle?.finalize();
+    sink?.finalize();
   }
 }
 

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -136,6 +136,18 @@ async function synthesizeAndPlay(
       onFirstAudio: sink.onFirstAudio,
     });
 
+    // synthesizeAndEmit resolves silently (without throwing) when the
+    // signal aborts after the provider resolves but before queued emits
+    // run. Same contract as the catch-side abort: the canceller owns turn
+    // state, so skip the end-of-turn token.
+    if (signal?.aborted) {
+      log.debug(
+        { provider: provider.id },
+        "System prompt TTS synthesis aborted after resolve — skipping end-of-turn",
+      );
+      return;
+    }
+
     // Signal end of this turn's speech.  An empty token with `last: true`
     // tells the transport to start listening — it does NOT trigger TTS
     // synthesis.  This is required even when a synthesized provider handled

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -94,6 +94,10 @@ export async function speakSystemPrompt(
  *   (e.g. Fish Audio) fall back to `sendTextToken(text)` so the caller
  *   still hears the message; providers without one (e.g. Deepgram) log
  *   the error and send only the end-of-turn signal.
+ *
+ * Aborted synthesis (`AbortError` or an aborted `signal`) short-circuits
+ * all of the above: no fallback, no end-of-turn token — the canceller
+ * owns turn state.
  */
 async function synthesizeAndPlay(
   relay: CallTransport,
@@ -140,6 +144,21 @@ async function synthesizeAndPlay(
     // state.
     relay.sendTextToken("", true);
   } catch (err) {
+    // Aborted synthesis (e.g. barge-in cancellation): the canceller owns
+    // turn state, so skip fallback and the end-of-turn signal entirely
+    // (mirrors call-controller's aborted-synthesis handling).
+    const isAbort =
+      signal?.aborted ||
+      ((err instanceof Error || err instanceof DOMException) &&
+        err.name === "AbortError");
+    if (isAbort) {
+      log.debug(
+        { provider: provider.id },
+        "System prompt TTS synthesis aborted — skipping fallback",
+      );
+      return;
+    }
+
     // Extract error class and code for diagnosable log entries.
     const errName = err instanceof Error ? err.name : String(err);
     const errCode =

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -17,9 +17,9 @@
 
 import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
 import {
+  type AudioStoreSink,
   createAudioStoreSink,
   synthesizeAndEmit,
-  type AudioStoreSink,
 } from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";


### PR DESCRIPTION
## Summary
- synthesizeAndPlay now uses tts/synthesis-stream.ts (synthesizeAndEmit + createAudioStoreSink) instead of its copied synthesis body; provider resolution, WAV fallback retry, allowNativeFallback policy, and the end-of-turn sendTextToken contract are unchanged.
- speakSystemPrompt gains an optional AbortSignal (previously this path had no abort at all).

Part of plan: live-voice-server-barge-in.md (PR 4 of 11)