### PR TITLE
refactor(live-voice): drive TTS through the shared synthesis core and sanitize text

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -297,6 +297,65 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
+  test("sanitizes markdown spanning deltas before TTS while deltas stay raw", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const ttsTexts: string[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsTexts.push(options.text);
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("Use **bo"));
+    callbacks?.assistant_text_delta?.(makeTextDelta("ld** and `code` now. 🎉"));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual(["Use bold and code now."]);
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "assistant_text_delta" ? [frame.text] : [],
+      ),
+    ).toEqual(["Use **bo", "ld** and `code` now. 🎉"]);
+  });
+
+  test("skips synthesis entirely for segments that sanitize to nothing", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("### 🎉👍"));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(streamTtsAudio).not.toHaveBeenCalled();
+    expect(frames.some((frame) => frame.type === "tts_audio")).toBe(false);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
   test("interrupt prevents late TTS chunks from reaching the socket", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     let ttsOptions: LiveVoiceTtsOptions | undefined;

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -193,6 +193,50 @@ describe("streamLiveVoiceTtsAudio", () => {
     });
   });
 
+  test("skips the buffered non-PCM emit when the signal aborts mid-stream", async () => {
+    const controller = new AbortController();
+    _setTtsProviderForTests({
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        _request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        onChunk(Buffer.from("chunk-one"));
+        // Let the deferred emit flush so chunk-one is actually buffered
+        // before the abort lands.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        controller.abort();
+        onChunk(Buffer.from("chunk-two"));
+        return {
+          audio: Buffer.from("chunk-onechunk-two"),
+          contentType: "audio/mpeg",
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      signal: controller.signal,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(frames).toEqual([]);
+    expect(result).toMatchObject({
+      provider: "fish-audio",
+      chunks: 0,
+      bytes: 0,
+    });
+  });
+
   test("returns a typed configuration error for a non-streaming provider", async () => {
     config = makeConfig({ provider: "elevenlabs" });
     _setTtsProviderForTests({

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import { sanitizeForTts } from "../calls/tts-text-sanitizer.js";
 import type {
   VoiceTurnHandle,
   VoiceTurnOptions,
@@ -767,7 +768,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     activeTurn.ttsBuffer = remainder;
 
     for (const segment of segments) {
-      this.enqueueTtsSegment(token, segment);
+      // Sanitized per segment (not per delta) so markdown spanning deltas is
+      // stripped; assistant_text_delta frames keep the raw text.
+      const speakable = sanitizeForTts(segment).trim();
+      if (speakable.length === 0) {
+        continue;
+      }
+      this.enqueueTtsSegment(token, speakable);
     }
   }
 

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -1,4 +1,5 @@
 import { getTtsProvider } from "../tts/provider-catalog.js";
+import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type {
   TtsProvider,
@@ -82,8 +83,10 @@ export async function streamLiveVoiceTtsAudio(
   let chunks = 0;
   let bytes = 0;
 
-  const emitAudioFrame = (contentType: string, audio: Uint8Array): void => {
-    if (audio.byteLength === 0) return;
+  const emitAudioFrame = (contentType: string, audio: Buffer): void => {
+    if (audio.byteLength === 0) {
+      return;
+    }
 
     chunks += 1;
     bytes += audio.byteLength;
@@ -91,29 +94,35 @@ export async function streamLiveVoiceTtsAudio(
       type: "tts_audio",
       contentType,
       sampleRate,
-      dataBase64: Buffer.from(audio).toString("base64"),
+      dataBase64: audio.toString("base64"),
     });
   };
 
+  // Non-PCM streams accumulate here and emit one complete frame at the end —
+  // compressed formats (mp3/wav/opus) are only playable as a whole payload.
+  const bufferedAudio: Buffer[] = [];
+
   try {
-    const result = await provider.synthesizeStream!(
-      {
-        text: options.text,
-        useCase: options.useCase ?? "phone-call",
-        voiceId: options.voiceId,
-        signal: options.signal,
-        outputFormat: options.outputFormat,
-      },
-      (audioChunk) => {
+    const result = await synthesizeAndEmit({
+      provider,
+      text: options.text,
+      useCase: options.useCase ?? "phone-call",
+      voiceId: options.voiceId,
+      outputFormat: options.outputFormat,
+      sampleRate,
+      signal: options.signal,
+      onChunk: (chunk) => {
         if (canStreamChunks) {
-          emitAudioFrame(chunkContentType, audioChunk);
+          emitAudioFrame(chunk.contentType || chunkContentType, chunk.audio);
+        } else {
+          bufferedAudio.push(chunk.audio);
         }
       },
-    );
+    });
     const contentType = result.contentType || chunkContentType;
 
     if (!canStreamChunks) {
-      emitAudioFrame(contentType, result.audio);
+      emitAudioFrame(contentType, Buffer.concat(bufferedAudio));
     }
 
     return {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -121,7 +121,9 @@ export async function streamLiveVoiceTtsAudio(
     });
     const contentType = result.contentType || chunkContentType;
 
-    if (!canStreamChunks) {
+    // An abort mid-stream resolves without throwing; skip the buffered emit
+    // so a truncated payload is never delivered after cancellation.
+    if (!canStreamChunks && !options.signal?.aborted) {
       emitAudioFrame(contentType, Buffer.concat(bufferedAudio));
     }
 


### PR DESCRIPTION
## Summary
- streamLiveVoiceTtsAudio now delegates streaming/buffer selection, abort, and empty-guards to tts/synthesis-stream.ts; non-PCM accumulate-and-emit-once stays as a thin wrapper (per the PR 2 review discussion).
- Live-voice speech is now sanitized with sanitizeForTts at the segmentation seam (raw markdown/emoji no longer reaches TTS providers); assistant_text_delta frames still carry raw text.

Part of plan: live-voice-server-barge-in.md (PR 3 of 11)