### PR TITLE
feat(telemetry): stamp the client OS surface into user-message metadata

### DIFF
--- a/assistant/src/__tests__/client-os-metadata-persistence.test.ts
+++ b/assistant/src/__tests__/client-os-metadata-persistence.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Verifies that `persistQueuedMessageBody` stamps the client-reported OS
+ * surface into `metadata.client.os` on persisted user messages.
+ *
+ * The web, iOS, and macOS apps all run the same web renderer and report
+ * `userMessageInterface: "web"` (the transport surface, which host-proxy
+ * capability gating keys off), so `client.os` is the only per-platform
+ * attribution available to turn telemetry (`turn-events-store` forwards
+ * `$.client` onto `TurnTelemetryEvent.client`). Without the stamp, desktop
+ * and mobile usage are indistinguishable from browser usage downstream.
+ *
+ * Mirrors the mock harness of `dm-persistence.test.ts` — exercises
+ * `persistQueuedMessageBody` directly with a captured `addMessage`.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const addMessageCalls: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}> = [];
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    options?: { metadata?: Record<string, unknown> },
+  ) => {
+    addMessageCalls.push({
+      conversationId,
+      role,
+      content,
+      metadata: options?.metadata,
+    });
+    return { id: `persisted-${addMessageCalls.length}` };
+  },
+  getConversation: () => null,
+  provenanceFromTrustContext: () => ({}),
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+  updateMetaFile: () => {},
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  attachmentExists: () => false,
+  linkAttachmentToMessage: () => {},
+  attachInlineAttachmentToMessage: () => {},
+  validateAttachmentUpload: () => ({ ok: true }),
+  AttachmentUploadError: class extends Error {},
+}));
+
+import type {
+  TurnChannelContext,
+  TurnInterfaceContext,
+} from "../channels/types.js";
+import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
+import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
+import type { MessageQueue } from "../daemon/conversation-queue-manager.js";
+
+function createWebTurnContext(
+  clientOs: string | undefined,
+): MessagingConversationContext {
+  const channel: TurnChannelContext = {
+    userMessageChannel: "vellum",
+    assistantMessageChannel: "vellum",
+  };
+  const iface: TurnInterfaceContext = {
+    userMessageInterface: "web",
+    assistantMessageInterface: "web",
+  };
+  const queueStub = {
+    push: () => true,
+    drain: () => [],
+    size: () => 0,
+  } as unknown as MessageQueue;
+  let processing = false;
+  return {
+    conversationId: "conv-client-os-test",
+    messages: [],
+    isProcessing: () => processing,
+    setProcessing: (value: boolean) => {
+      processing = value;
+    },
+    abortController: null,
+    queue: queueStub,
+    clientOs,
+    getTurnChannelContext: () => channel,
+    getTurnInterfaceContext: () => iface,
+  };
+}
+
+function lastUserMetadata(): Record<string, unknown> {
+  expect(addMessageCalls.length).toBeGreaterThan(0);
+  const metadata = addMessageCalls.at(-1)?.metadata;
+  expect(metadata).toBeDefined();
+  return metadata!;
+}
+
+describe("client OS surface metadata persistence", () => {
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+  });
+
+  test.each(["macos", "ios", "android", "web"])(
+    "stamps client.os = %s from the conversation's clientOs",
+    async (os) => {
+      const ctx = createWebTurnContext(os);
+      await persistQueuedMessageBody(ctx, {
+        content: "hello",
+        requestId: `req-${os}`,
+      });
+
+      expect(lastUserMetadata().client).toEqual({ os });
+      // The transport surface is unchanged — client.os must not leak into it.
+      expect(lastUserMetadata().userMessageInterface).toBe("web");
+    },
+  );
+
+  test("omits the client bag when no clientOs is reported", async () => {
+    const ctx = createWebTurnContext(undefined);
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-none",
+    });
+
+    expect(lastUserMetadata().client).toBeUndefined();
+  });
+
+  test("omits the client bag for values outside the ClientOs vocabulary", async () => {
+    const ctx = createWebTurnContext("windows");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-invalid",
+    });
+
+    expect(lastUserMetadata().client).toBeUndefined();
+  });
+
+  test("caller-supplied client metadata wins over the stamp", async () => {
+    const ctx = createWebTurnContext("macos");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-caller",
+      metadata: { client: { os: "ios", interface_version: "1.2.3" } },
+    });
+
+    expect(lastUserMetadata().client).toEqual({
+      os: "ios",
+      interface_version: "1.2.3",
+    });
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -16,7 +16,11 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import {
+  parseChannelId,
+  parseClientOs,
+  parseInterfaceId,
+} from "../channels/types.js";
 import {
   buildSlackTimezoneMetadata,
   type SlackMessageMetadata,
@@ -197,6 +201,14 @@ export interface MessagingConversationContext {
   authContext?: AuthContext;
   currentTurnAuthContext?: AuthContext;
   currentTurnSourceActorPrincipalId?: string;
+  /**
+   * OS surface reported by the connected client ("web" | "ios" | "macos" |
+   * "android"), re-applied from transport metadata on every inbound message.
+   * Persisted under `metadata.client.os` so turn telemetry can attribute the
+   * real platform — the transport `interfaceId` is "web" for the web, iOS,
+   * and macOS apps alike (they share the web renderer).
+   */
+  clientOs?: string;
   getTurnChannelContext(): TurnChannelContext | null;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
@@ -519,6 +531,17 @@ export async function persistQueuedMessageBody(
       turnChannel: turnCtx?.userMessageChannel,
     });
 
+    // OS-surface attribution for turn telemetry. The client-reported OS is
+    // validated through `parseClientOs` and stored under the `client`
+    // metadata bag (`$.client.os`), which `turn-events-store` forwards onto
+    // `TurnTelemetryEvent.client`. Caller-supplied `client` metadata wins —
+    // this only fills the key when absent.
+    const clientOs = parseClientOs(ctx.clientOs);
+    const clientBag =
+      metadataWithoutSlackInbound.client == null && clientOs
+        ? { client: { os: clientOs } }
+        : {};
+
     const mergedMetadata = {
       ...metadataWithoutSlackInbound,
       ...provenance,
@@ -534,6 +557,7 @@ export async function persistQueuedMessageBody(
             assistantMessageInterface: turnIfCtx.assistantMessageInterface,
           }
         : {}),
+      ...clientBag,
       ...(imageSourcePaths ? { imageSourcePaths } : {}),
       ...(slackMeta ? { slackMeta } : {}),
     };

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -163,10 +163,12 @@ export const messageMetadataSchema = z
     userMessageInterface: interfaceIdSchema.optional(),
     assistantMessageInterface: interfaceIdSchema.optional(),
     /**
-     * Optional client-side metadata bag attached to user messages by HTTP
-     * header middleware (reads `x-vellum-browser-family`,
-     * `x-vellum-browser-version`, `x-vellum-client-os`,
-     * `x-vellum-interface-version`). Forwarded verbatim onto
+     * Optional client-side metadata bag attached to user messages at persist
+     * time. `os` carries the client-reported OS surface ("web" | "ios" |
+     * "macos" | "android") from the request body's `clientOs` field, stamped
+     * by `persistQueuedMessageBody` — the transport `userMessageInterface` is
+     * "web" for the web, iOS, and macOS apps alike, so this is the only
+     * per-platform attribution. Forwarded verbatim onto
      * `TurnTelemetryEvent.client` for downstream analytics. Kept as a
      * permissive `record` so adding a new client field doesn't require a
      * migration -- dbt can unpack later via JSON_VALUE.

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -121,11 +121,11 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
 
 /**
  * Optional client metadata bag carried on `TurnTelemetryEvent.client`.
- * Sourced from `messages.metadata.client`, which is populated by HTTP
- * header middleware reading `x-vellum-browser-family`,
- * `x-vellum-browser-version`, `x-vellum-client-os`,
- * `x-vellum-interface-version`. Extensible without a schema change —
- * lives entirely in the JSON metadata column.
+ * Sourced from `messages.metadata.client`. Today only `os` is populated —
+ * stamped by `persistQueuedMessageBody` from the request body's `clientOs`
+ * field; the remaining fields are declared for clients that send them.
+ * Extensible without a schema change — lives entirely in the JSON metadata
+ * column.
  */
 export interface TurnTelemetryClientInfo {
   /** Browser family for `web`/`chrome-extension` interfaces: `"chrome"|"safari"|"firefox"|"edge"`. */
@@ -133,9 +133,11 @@ export interface TurnTelemetryClientInfo {
   /** Major browser version only (`"124"`, not the full UA string). */
   browser_version?: string;
   /**
-   * User's operating system at message time. For `web`/`chrome-extension`
-   * this comes from `navigator.userAgentData`; for `macos`/`ios` it's
-   * implicit from the interface, but clients may still send it explicitly.
+   * OS surface reported by the client at message time
+   * ("web" | "ios" | "macos" | "android"). The web, iOS, and macOS apps all
+   * run the same web renderer and report `interface_id: "web"` (the
+   * transport surface, which host-proxy capability gating keys off), so
+   * this field is the only per-platform attribution in turn telemetry.
    */
   os?: string;
   /**


### PR DESCRIPTION
## Problem

Turn telemetry cannot distinguish desktop / mobile / browser usage. In the last 48h of `pii_turn_raw`: `interface_id` shows `web` for 431 users vs `macos` for 5 (those 5 are the Electron **main process** host-proxy path, not chat), and the `client` column is **null on 100% of turns**.

Two findings from tracing it end to end:

1. `interface: "web"` from all three app shells is **intentional** — it's the transport surface that host-proxy capability gating keys off (`clients/web/src/domains/chat/api/messages.ts` documents this). Changing it would break capability gating; this PR does not touch it.
2. The per-platform signal the clients already send (`clientOs` in the message body — `macos`/`ios`/`android`/`web` via `detectClientOs()`) reaches the conversation object for prompt context but is **never persisted**. Meanwhile the metadata schema's `client` bag and `TurnTelemetryClientInfo.os` are declared, documented, and wired through the whole telemetry export — but nothing ever populated them: the "HTTP header middleware" their docs described does not exist.

## Fix

Stamp `client: { os: <ClientOs> }` into persisted user-message metadata in `persistQueuedMessageBody` — the single choke point every client-app user message flows through — from the conversation's transport-applied `clientOs`:

- validated via the existing `parseClientOs` vocabulary (`web`/`ios`/`macos`/`android`); anything else → no bag
- caller-supplied `client` metadata wins (never overwritten)
- gateway channels (telegram/slack/…) send no `clientOs` → bag stays absent, column stays null
- **transport `userMessageInterface` unchanged** — no behavior change, telemetry only

The existing pipeline (`turn-events-store` `$.client` extraction → `TurnTelemetryEvent.client` → platform export → BigQuery `client` column) lights up with **no schema change and no export change** — the zod `client` record already existed. Stale docs (conversation-crud schema comment + telemetry/types) rewritten to describe the actual source.

## Verification

- New `client-os-metadata-persistence.test.ts` (mirrors the `dm-persistence` harness): stamps each ClientOs value, omits when absent/invalid, caller-provided bag wins, transport interface unaffected.
- After this ships, `JSON_VALUE(client, '$.os')` in `pii_turn_raw` distinguishes surfaces; rows from older app versions simply stay null while adoption ramps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)