### PR TITLE
feat(live-voice): protocol support for mode negotiation and multi-turn frames

### DIFF
--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -37,6 +37,82 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("parses start frames with an explicit session mode", () => {
+    for (const mode of ["ptt", "open-mic"] as const) {
+      const result = parseLiveVoiceClientTextFrame(
+        JSON.stringify({
+          type: "start",
+          audio: {
+            mimeType: "audio/pcm",
+            sampleRate: 24000,
+            channels: 1,
+          },
+          mode,
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+
+      expect(result.frame).toEqual({
+        type: "start",
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+        mode,
+      });
+    }
+  });
+
+  test("omits mode from start frames when the client does not send one", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.frame).toEqual({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
+    });
+    expect("mode" in result.frame).toBe(false);
+  });
+
+  test("rejects start frames with an unknown session mode", () => {
+    for (const mode of ["banana", 42, null, ""]) {
+      const result = validateLiveVoiceClientFrame({
+        type: "start",
+        audio: {
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          channels: 1,
+        },
+        mode,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+
+      expect(result.error).toMatchObject({
+        code: "invalid_field",
+        field: "mode",
+        frameType: "start",
+      });
+    }
+  });
+
   test("parses base64 JSON audio frames", () => {
     const result = parseLiveVoiceClientTextFrame(
       JSON.stringify({ type: "audio", dataBase64: "AQIDBA==" }),
@@ -269,6 +345,38 @@ describe("LiveVoiceServerFrameSequencer", () => {
         turnId: "turn-2",
       }).seq,
     ).toBe(1);
+  });
+
+  test("sequences turn_boundary and interrupted frames", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const boundary = sequencer.next({ type: "turn_boundary" });
+    const interrupted = sequencer.next({
+      type: "interrupted",
+      turnId: "turn-1",
+    });
+
+    expect(boundary).toEqual({ type: "turn_boundary", seq: 1 });
+    expect(interrupted).toEqual({
+      type: "interrupted",
+      turnId: "turn-1",
+      seq: 2,
+    });
+    expect(sequencer.lastSeq).toBe(2);
+  });
+
+  test("turn_boundary and interrupted frames survive a JSON round-trip", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    for (const frame of [
+      sequencer.next({ type: "turn_boundary" }),
+      sequencer.next({ type: "interrupted", turnId: "turn-42" }),
+    ]) {
+      const roundTripped = JSON.parse(
+        JSON.stringify(frame),
+      ) as LiveVoiceServerFrame;
+      expect(roundTripped).toEqual(frame);
+    }
   });
 
   test("preserves the server frame discriminated union after sequencing", () => {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -13,6 +13,8 @@ const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "busy",
   "stt_partial",
   "stt_final",
+  "turn_boundary",
+  "interrupted",
   "thinking",
   "assistant_text_delta",
   "tts_audio",
@@ -53,10 +55,15 @@ export interface LiveVoiceAudioConfig {
   readonly channels: 1;
 }
 
+const LIVE_VOICE_SESSION_MODES = ["ptt", "open-mic"] as const;
+
+export type LiveVoiceSessionMode = (typeof LIVE_VOICE_SESSION_MODES)[number];
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
   readonly audio: LiveVoiceAudioConfig;
+  readonly mode?: LiveVoiceSessionMode;
 }
 
 export interface LiveVoiceClientAudioFrame {
@@ -112,6 +119,24 @@ export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase
 export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "stt_final";
   readonly text: string;
+}
+
+/**
+ * Server-detected end of user speech; the assistant turn is starting.
+ * Emitted in both modes: in PTT it follows `ptt_release`/final transcript,
+ * in open-mic it is the primary turn signal.
+ */
+export interface LiveVoiceTurnBoundaryServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_boundary";
+}
+
+/**
+ * Barge-in (server-VAD or client `interrupt` frame) was accepted for the
+ * given assistant turn; playback must flush and the session keeps listening.
+ */
+export interface LiveVoiceInterruptedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "interrupted";
+  readonly turnId: string;
 }
 
 export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
@@ -174,6 +199,8 @@ export type LiveVoiceServerFrame =
   | LiveVoiceBusyServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
+  | LiveVoiceTurnBoundaryServerFrame
+  | LiveVoiceInterruptedServerFrame
   | LiveVoiceThinkingServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
@@ -189,6 +216,8 @@ export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceBusyServerFrame>
   | WithoutSeq<LiveVoiceSttPartialServerFrame>
   | WithoutSeq<LiveVoiceSttFinalServerFrame>
+  | WithoutSeq<LiveVoiceTurnBoundaryServerFrame>
+  | WithoutSeq<LiveVoiceInterruptedServerFrame>
   | WithoutSeq<LiveVoiceThinkingServerFrame>
   | WithoutSeq<LiveVoiceAssistantTextDeltaServerFrame>
   | WithoutSeq<LiveVoiceTtsAudioServerFrame>
@@ -357,6 +386,15 @@ function validateStartFrame(
     );
   }
 
+  if ("mode" in value && !isLiveVoiceSessionMode(value.mode)) {
+    return protocolError(
+      "invalid_field",
+      `start frame field mode must be one of: ${LIVE_VOICE_SESSION_MODES.join(", ")}`,
+      "mode",
+      "start",
+    );
+  }
+
   return {
     ok: true,
     frame: {
@@ -365,6 +403,7 @@ function validateStartFrame(
         ? { conversationId: value.conversationId }
         : {}),
       audio: audioConfig.frame,
+      ...(isLiveVoiceSessionMode(value.mode) ? { mode: value.mode } : {}),
     },
   };
 }
@@ -466,6 +505,13 @@ function isLiveVoiceClientFrameType(
   value: string,
 ): value is LiveVoiceClientFrameType {
   return (LIVE_VOICE_CLIENT_FRAME_TYPES as readonly string[]).includes(value);
+}
+
+function isLiveVoiceSessionMode(value: unknown): value is LiveVoiceSessionMode {
+  return (
+    typeof value === "string" &&
+    (LIVE_VOICE_SESSION_MODES as readonly string[]).includes(value)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- start frame gains optional mode: ptt | open-mic (validated)
- New server frames: turn_boundary (server-detected end of user speech) and interrupted (barge-in accepted, flush playback, keep listening)

Part of plan: voice-mode-engine.md (PR 3 of 12)